### PR TITLE
Fixed js error when chart rendered in fancybox modal

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -6128,7 +6128,9 @@ function Chart (options, callback) {
 		// remove container and all SVG
 		container.innerHTML = '';
 		container.onmousedown = container.onmousemove = container.onmouseup = container.onclick = null;
-		container.parentNode.removeChild(container);
+		if (container.parentNode) {
+		  container.parentNode.removeChild(container);
+	  }
 		
 		// IE6 leak 
 		container =	null;


### PR DESCRIPTION
Came across an issue where the chart container doesn't have a parentNode because it was rendered in a fancybox modal. This might create a memory leak but I'm not sure how to determine that for sure.
