### PR TITLE
chart.resetColors() - Reset the default color when a new series is added

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -7754,6 +7754,13 @@ function Chart (options, callback) {
 		});
 	}
 	
+  /**
+   * Reset the default color that the next series will use 
+   */
+	function resetColors() {
+    colorCounter = 0;
+  }
+  
 	// Run chart
 		
 	
@@ -7798,7 +7805,8 @@ function Chart (options, callback) {
 	chart.redraw = redraw;
 	chart.setSize = resize;
 	chart.setTitle = setTitle;
-	chart.showLoading = showLoading;	
+	chart.showLoading = showLoading;
+	chart.resetColors = resetColors;	
 	chart.pointCount = 0;
 	/*
 	if ($) $(function() {


### PR DESCRIPTION
I needed the ability to reset the default color when a new series is added because I'm using AJAX to dynamically add and remove charts. I noticed someone else wanted the same feature: http://highslide.com/forum/viewtopic.php?f=9&t=8725&start=0&st=0&sk=t&sd=a&hilit=reset+color
