### PR TITLE
Fix for export error on stacked columns with data as {x:n,y:n} values

### DIFF
--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -230,13 +230,17 @@ extend(Chart.prototype, {
 				
 				// extend the options by those values that can be expressed in a number or array config
 				config = point.config;
-				pointOptions = extend(
-					typeof config == 'object' && point.config && config.constructor != Array, {
-						x: point.x,
-						y: point.y,
-						name: point.name
-					}
-				);
+
+        pointOptions = {
+          x: point.x,
+          y: point.y,
+          name: point.name
+        };
+
+        if (typeof config == 'object' && point.config && config.constructor != Array) {
+          extend(pointOptions, config);
+        }
+
 				seriesOptions.data.push(pointOptions); // copy fresh updated data
 								
 				// remove image markers


### PR DESCRIPTION
I tracked the problem down to where the series data is duplicated to create the separate SVG chart. I'm confident that the problem was with the orignal pointOptions = extend(Boolean, Object). When the point was a object the extend test was passing so would then attempt to extend the Boolean value true and use this as a point.

I've updated the point copying to use the default options and then run the extend of the copied options with the config if the object type test passes.

Tested locally on a number of charts that we have in our application. Requires further testing.
