### PR TITLE
Use camel cased CSS identifiers for default text settings in SVGRenderer

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -2700,8 +2700,8 @@ SVGRenderer.prototype = {
 				text: str	
 			})
 			.css({
-				'font-family': defaultChartStyle.fontFamily,
-				'font-size': defaultChartStyle.fontSize
+				fontFamily: defaultChartStyle.fontFamily,
+				fontSize: defaultChartStyle.fontSize
 			});
 			
 		wrapper.x = x;


### PR DESCRIPTION
I noticed a bug while calling chart.getSVG where it appeared that the xAxis.labels.style.fontSize settings weren't being overridden correctly. After investigation I found it was caused by using hyphenated identifiers for the default text settings (font-family and font-size) which were stored and therefore not overridden by fontSize. They were all hyphenated when setting the element's style attribute causing two values to be created for font-size.

Verified on a number of internal test cases.
