### PR TITLE
Rendering <a> tag with target attribute

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -2191,7 +2191,7 @@ SVGRenderer.prototype = {
 						);
 					}
 					if (hrefRegex.test(span)) {
-						targetMatch = span.test(targetRegex) ? span.match(targetRegex)[1] : '_self';
+						targetMatch = targetRegex.test(span) ? span.match(targetRegex)[1] : '_self';
 						attr(tspan, 'onclick', 'window.open(\"'+ span.match(hrefRegex)[1] +'\", \"'+ targetMatch +'\")');
 						css(tspan, { cursor: 'pointer' });
 					}


### PR DESCRIPTION
Using window.open() method instead of location.href gives ability to use <a> tag with target attribute. So, this code will generate links that will be opened in new window:
    xAxis: {
        labels: {
            formatter: function() {
              return '<a href=\"' + this.value + '\" target="_blank">' + this.value + '</a>';
            }
        }
    },
