### PR TITLE
Fix an issue with empty string category label.

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -4065,7 +4065,7 @@ function Chart (options, callback) {
 						isFirst: pos == tickPositions[0],
 						isLast: pos == tickPositions[tickPositions.length - 1],
 						dateTimeLabelFormat: dateTimeLabelFormat,
-						value: (categories && categories[pos] !== UNDEFINED ? categories[pos] : pos)
+						value: (categories && defined(categories[pos]) ? categories[pos] : pos)
 					});
 				
 				// prepare CSS


### PR DESCRIPTION
I have a use case where I need to show a blank labels on X-axis for certain x-values. If a set a categories array of say 

```
["segment a", "", "segment c", "segment e"], 
```

the X-axis labels will show up as

```
segment a | 1 | segment c | segment e
```

That's because the check for the presence of category label returns `false` for a falsy value of `""`.

This fix does a better check for `null` or `undefined` category label.
