### PR TITLE
allow specifying series.index when calling addSeries()

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -6854,7 +6854,11 @@ function Chart (options, callback) {
 			hasCartesianSeries = serie.isCartesian;
 		}
 		
-		series.push(serie);
+		if (typeof (options.index) == 'number') {
+			series.splice(options.index, 0, serie);
+		} else {
+			series.push(serie);
+		}
 		
 		return serie;
 	}
@@ -8389,18 +8393,18 @@ Series.prototype = {
 	init: function(chart, options) {
 		var series = this,
 			eventType,
-			events,
+			events;
 			//pointEvent,
-			index = chart.series.length;
+			//index = chart.series.length;
 			
 		series.chart = chart;
 		options = series.setOptions(options); // merge with plotOptions
 		
 		// set some variables
 		extend(series, {
-			index: index,
+			index: typeof (options.index) == 'number' ? options.index : chart.series.length,
 			options: options,
-			name: options.name || 'Series '+ (index + 1),
+			name: options.name || 'Series '+ (chart.series.length + 1),
 			state: NORMAL_STATE,
 			pointAttr: {},
 			visible: options.visible !== false, // true by default


### PR DESCRIPTION
It seems like addSeries() only allows pushing a series on to the end of the series array.  I needed to insert series at a specific index, so I added support for that.
