### PR TITLE
Fix for Toolbar#remove

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -1749,8 +1749,10 @@ function Chart (options, callback) {
 			}
 		}
 		function remove(id) {
-			discardElement(buttons[id].element);
-			buttons[id] = null;
+			if (buttons[id]) {
+				discardElement(buttons[id].element);
+				buttons[id] = null;
+			}
 		}
 		
 		// public


### PR DESCRIPTION
Pushing a fix for Toolbar#remove

Generally there is no public API that could be used to check what buttons are in the Toolbar or at least check for specific button ids like hasButton(id) : boolean. Note that it is not possible to add button with already taken id as Toolbar#add does check for this but attempt to remove non existing button fails with "no element for undefined" or something like that.
