### PR TITLE
Using custom Legend Symbols

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -6771,22 +6771,40 @@ function Chart (options, callback) {
 						} else {
 							fireEvent(item, strLegendItemClick, null, fnLegendItemClick);
 						}
-						// checking if the legend symbol is an object
-                        // if so, it will attempt to change it to a disabled object look
-                        // if that object doesn't exist, it will just show no object when disabled
+						// If the legend symbol is an object, will attempt to
+                        // change the img to a disabled form, if the image is not
+                        // available, it will keep the same image
+                        // Requirement: disabled image needs to be named *_disabled.*
+                        // Example: [image.png, image_disabled.png]
                         if(typeof item.legendSymbol == 'object') {
                             var imgLoc = item.legendSymbol.element.href.baseVal;
-                            var enabledImg = '.png';
-                            var disabledImg = '_disabled.png';
+                            var imgLocSplit = imgLoc.split('.');
 
-                            if(imgLoc.search(disabledImg) > 0) {
-                                imgLoc = imgLoc.replace(disabledImg, enabledImg);
-                                item.legendSymbol.element.href.baseVal = imgLoc;
+                            var imageSRC = imgLocSplit[0];
+                            var imageTYPE = imgLocSplit[1]
+
+                            var disabledString = '_disabled';
+
+                            if(imageSRC.search(disabledString) > 0) {
+                                imageSRC = imageSRC.replace(disabledString, '');
                             } else {
-                                imgLoc = imgLoc.replace(enabledImg, disabledImg);
+                                imageSRC += disabledString;
+                            }
+
+                            // Checking if the image exists
+                            // If the image exists, it will change it to the new image,
+                            // if not, then it will keep the same image there
+                            var http = new XMLHttpRequest();
+                            http.open('HEAD', imageSRC + "." + imageTYPE, false);
+                            http.send();
+
+                            if(http.status != 404) {
+                                item.legendSymbol.element.href.baseVal = imageSRC + "." + imageTYPE;
+                            }
+                            else {
                                 item.legendSymbol.element.href.baseVal = imgLoc;
                             }
-                        }
+						}
 					})
 					.attr({ zIndex: 2 })
 					.add(legendGroup);


### PR DESCRIPTION
Added the ability when the user is using custom legend symbols to display a "disabled" version of that symbol when the series is disabled. If the user doesn't have these imaged defined, it will just keep the same image there.

Requirements: User has images defined as: image.\* and image_disabled.*
