### PR TITLE
Improve finding chart size with no offsetWidth.

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -7512,8 +7512,11 @@ function Chart (options, callback) {
 				top: '-9999px',
 				display: ''
 			});
-			while(!currentParent.offsetWidth && currentParent.parentNode) {
+			while (!currentParent.offsetWidth && currentParent.parentNode) {
 				currentParent = currentParent.parentNode;
+			}
+			if (!currentParent.offsetWidth && !currentParent.parentNode) {
+				currentParent = doc.body;
 			}
 			currentParent.appendChild(renderToClone);
 		}

--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -3605,8 +3605,11 @@ function Chart (options, callback) {
 				top: '-9999px',
 				display: ''
 			});
-			while(!currentParent.offsetWidth && currentParent.parentNode) {
+			while (!currentParent.offsetWidth && currentParent.parentNode) {
 				currentParent = currentParent.parentNode;
+			}
+			if (!currentParent.offsetWidth && !currentParent.parentNode) {
+				currentParent = doc.body;
 			}
 			currentParent.appendChild(renderToClone);
 		}


### PR DESCRIPTION
I've modified getContainer() to do a better job of approximating the size that the chart should be rendered at when it is actually shown.
