### PR TITLE
Fix for uncaught exception

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -2329,7 +2329,7 @@ SVGRenderer.prototype = {
 							rest = [];
 							
 						while (words.length || rest.length) {
-							actualWidth = textNode.getBBox().width;
+							actualWidth = wrapper.getBBox().width;
 							tooLong = actualWidth > width;
 							if (!tooLong || words.length === 1) { // new line needed
 								words = rest;


### PR DESCRIPTION
Fix for this exception:

uncaught exception: [Exception... "Component returned failure code: 0x80004005 (NS_ERROR_FAILURE) [nsIDOMSVGLocatable.getBBox]" nsresult: "0x80004005 (NS_ERROR_FAILURE)" location: "JS frame :: http://x.x.x.x:xxxx/highchart_zooming/js/highcharts.js :: <TOP_LEVEL> :: line 102" data: no]

See this forum thread for more information:
http://highslide.com/forum/viewtopic.php?f=9&t=11420&p=52012#p51452
