### PR TITLE
Fix unstable sort in some versions of Chrome

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -6919,9 +6919,9 @@ function Chart(options, callback) {
 			});
 			
 			// sort by legendIndex
-			allItems.sort(function (a, b) {
-				return (a.options.legendIndex || 0) - (b.options.legendIndex || 0);
-			});
+			// allItems.sort(function (a, b) {
+			// 	return (a.options.legendIndex || 0) - (b.options.legendIndex || 0);
+			// });
 			
 			// reversed legend
 			if (reversedLegend) {


### PR DESCRIPTION
Recent versions of Chrome have broken the tradition of stable sort in Javascript. This means that if the comparator function returns 0, the original order of elements in the array is not guaranteed. This breaks the legend sorting (grouping, really?) in Highcharts. Here is a [test case](http://jsfiddle.net/fXHB5/4694/). In my version of Chrome (14.0.835.8), the order of legends is broken. Oddly this behavior seems to happen only if the number of series is more than 10.

Here is an even simpler test case:

```
[1,2,3,4,5,6,7,8,9,10,11].sort(function(a,b) { return 0; })
```

Anyhow, the sorting code seems unnecessary at this point since the option `legendIndex` is neither used nor documented. So it seems wise at this point to just remove the block of code that breaks Chrome and implement it later using a stable sort algorithm.

I have only commented out the problem code in my commit, please feel free to fix it the right way if necessary.
