### PR TITLE
Fix handling of HTML entities invalid in XML

### DIFF
--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -318,6 +318,10 @@ extend(Chart.prototype, {
 				return s.toLowerCase();
 			});
 			
+		// replace HTML entities not valid in XML with actual characters
+		svg = svg.replace(/&nbsp;/g, '\u00A0'); // NO-BREAK SPACE
+		svg = svg.replace(/&shy;/g,  '\u00AD'); // SOFT HYPHEN
+
 		// IE9 beta bugs with innerHTML. Test again with final IE9.
 		svg = svg.replace(/(url\(#highcharts-[0-9]+)&quot;/g, '$1')
 			.replace(/&quot;/g, "'");


### PR DESCRIPTION
The export module relies on `innerHTML` to retrieve the SVG representation of the current chart. Unfortunately, HTML is **not** XML. Specifically, if a node contains U+00A0 (NO-BREAK SPACE) or U+00AD (SOFT HYPHEN), some browsers will return an HTML entity (`&nbsp;` and `&shy;`, respectively) rather than the actual character. Since these entities are not defined in XML, the SVG document is invalid and processing it into an image fails.

This change simply replaces all occurrences of `&nbsp;` and `&shy;` with the correct characters.

I created two fiddles to demonstrate this behavior:
1. [HTML entities in SVG](http://jsfiddle.net/jasonmp85/T2WKB/) — A reproduction of the bug forked from [this Highcharts demo](http://jsfiddle.net/fXHB5/20/). The demo has been modified to add a non-breaking space to the labels, which breaks the export functionality.
2. [Non-Preserved Special Characters](http://jsfiddle.net/jasonmp85/XQypG/) — This script iterates over all HTML characters which have entities defined and prints out a list of those which innerHTML modifies. I used this to build my list of affected characters.

I looked for somewhere to add a unit test, but none yet existed for the SVG exporter so I just left that alone. This change does however fix my repro case.

The fiddles were tested in Firefox 5.0.1, Chrome 13, IE 9, and the IE 8 mode of IE 9. While `&amp;`, `&lt;`, and `&gt;` are also transformed by `innerHTML`, they do not need special handling as they are also valid entities in XML.
