### PR TITLE
Fixed MooTools Adapter for MooTools 1.4

### DIFF
--- a/js/adapters/mootools-adapter.src.js
+++ b/js/adapters/mootools-adapter.src.js
@@ -198,7 +198,6 @@ win.HighchartsAdapter = {
 			}
 
 			win.HighchartsAdapter.extendWithEvents(el);
-
 			el.addEvent(type, fn);
 		}
 	},
@@ -223,7 +222,7 @@ win.HighchartsAdapter = {
 
 	fireEvent: function (el, event, eventArguments, defaultFunction) {
 		// create an event object that keeps all functions
-		event = new Event({
+		event = new DOMEvent({
 			type: event,
 			target: el
 		});


### PR DESCRIPTION
A really simple fix, see the commit:

In MooTools 1.4 they changed Event to DOMEvent.
