### PR TITLE
fix createElement bug for IE

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -3552,7 +3552,7 @@ VMLRenderer.prototype = merge(SVGRenderer.prototype, { // inherit SVGRenderer
 	clipRect: function (x, y, width, height) {
 
 		// create a dummy element
-		var clipRect = this.createElement();
+		var clipRect = this.createElement('clipPath');
 
 		// mimic a rectangle with its style object for automatic updating in attr
 		return extend(clipRect, {

--- a/js/prerelease/highcharts.1.3.src.js
+++ b/js/prerelease/highcharts.1.3.src.js
@@ -2717,7 +2717,7 @@ VMLRenderer.prototype = merge( SVGRenderer.prototype, { // inherit SVGRenderer
 	clipRect: function (x, y, width, height) {
 				
 		// create a dummy element
-		var clipRect = this.createElement();
+		var clipRect = this.createElement('clipPath');
 		
 		// mimic a rectangle with its style object for automatic updating in attr
 		return extend(clipRect, {


### PR DESCRIPTION
function createElement takes a parameter nodeName and for IE,
createElement was being called without one. I just copied the same
nodename that was being called for other browsers and that seems to
have fixed it. Tested to work in IE8, IE9.
