### PR TITLE
Barchart Data labels for Zero values overlap with X-Axis label

### DIFF
--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -1233,7 +1233,7 @@ Series.prototype = {
 					plotY = pick(point.plotY, -999),
 					dataLabel = point.dataLabel,
 					align = options.align,
-					individualYDelta = yIsNull ? (point.y > 0 ? -6 : 12) : options.y;
+					individualYDelta = yIsNull ? (point.y >= 0 ? -6 : 12) : options.y;
 
 				// get the string
 				str = options.formatter.call(point.getLabelConfig());


### PR DESCRIPTION
If the datalabel y is not specified, Highcharts calculates it based on whether the value is positive or negative. Ideally, 0 and up should appear above the bar and negative should be below the bar, but 0 is displayed below the 'bar' overlapping it with the X-axis label.

Here is a test case-
http://jsfiddle.net/QbGPV/529/

This patch will make 0 behave same as positive values.
