### PR TITLE
Fix stickMin detection on redraw

### DIFF
--- a/js/parts/StockNavigation.js
+++ b/js/parts/StockNavigation.js
@@ -650,7 +650,7 @@ Highcharts.Scroller = function (chart) {
 				// detect whether to move the range
 				stickToMax = baseMax >=
 					navigatorSeries.xData[navigatorSeries.xData.length - 1];
-				stickToMin = baseMin - range <=
+				stickToMin = baseMax - range <=
 					navigatorSeries.xData[0];
 
 				// set the navigator series data to the new data of the base series


### PR DESCRIPTION
Encountered this defect while implementing an auto-updating chart with the Series `setData` method. I think the intent was to ensure that the new range (newMin -> newMax) cannot fall off the left edge of the chart, but that should be measured from baseMax and not baseMin. 
