### PR TITLE
Handle case where chart.get is called after a series change but before a redraw

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -3447,6 +3447,12 @@ function Chart(options, callback) {
 		// search points
 		for (i = 0; i < series.length; i++) {
 			points = series[i].points;
+
+			// Check if the series was changed but not redrawn yet
+			if(points === null){
+				continue;
+			}
+
 			for (j = 0; j < points.length; j++) {
 				if (points[j].id === id) {
 					return points[j];


### PR DESCRIPTION
The `Chart.get()` method searches series, axes, and points for an ID matching the supplied string. If a series has been changed through a call such as `setData(data, false)` that doesn't do a redraw, the currents points array appears to be null until the next call to `@chart.redraw()`. The following patch prevents the library from trying to access the `length` property on `null`.
