### PR TITLE
Updated Toolbar button removal to check if button exists.

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -6638,8 +6638,10 @@ function Chart(options, callback) {
 		/*jslint unparam: false*/
 
 		function remove(id) {
-			discardElement(buttons[id].element);
-			buttons[id] = null;
+			if(buttons[id]){
+				discardElement(buttons[id].element);
+				buttons[id] = null;
+			}
 		}
 
 		// public


### PR DESCRIPTION
This failed when calling toolbar.remove("zoom") when button was not showing.
