### PR TITLE
Provide option for custom positioning of the tooltip

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -2076,6 +2076,7 @@ function Chart(options, callback) {
 				pointConfig = [],
 				tooltipPos = point.tooltipPos,
 				formatter = options.formatter || defaultFormatter,
+				positioner = options.positioner || placeBox,
 				hoverPoints = chart.hoverPoints,
 				placedTooltipPoint;
 
@@ -2159,7 +2160,9 @@ function Chart(options, callback) {
 					stroke: options.borderColor || point.color || currentSeries.color || '#606060'
 				});
 
-				placedTooltipPoint = placeBox(boxWidth, boxHeight, plotLeft, plotTop, plotWidth, plotHeight, {x: x, y: y});
+				placedTooltipPoint =
+					positioner(boxWidth, boxHeight, plotLeft, plotTop, plotWidth,
+							       plotHeight, {x: x, y: y});
 
 				// do the move
 				move(mathRound(placedTooltipPoint.x - boxOffLeft), mathRound(placedTooltipPoint.y - boxOffLeft));


### PR DESCRIPTION
(Successor to pull request 243 (https://github.com/highslide-software/highcharts.com/pull/243); patched for Highcharts 2.1.9.)

This trivial commit makes it possible to define a custom positioner for the tooltip.  That is, the user may define a custom replacement for the placeBox() method that positions the tooltip.  This is useful for graphs that require strict control over tooltip positioning.
