### PR TITLE
Highcharts mangles labels like "Retail < 84 Days"

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -2769,7 +2769,8 @@ SVGRenderer.prototype = {
 						css(tspan, { cursor: 'pointer' });
 					}
 
-					span = (span.replace(/<(.|\n)*?>/g, '') || ' ')
+					span = (span.replace(/<([^\/]|\n)*?>/g, '') || ' ')
+						.replace(/<\/(.|\n)*?>/g, '')
 						.replace(/&lt;/g, '<')
 						.replace(/&gt;/g, '>');
 


### PR DESCRIPTION
It seems that Highcharts will choke on this label, and you end up with "Retail " instead of the full "Retail < 84 Days".
