### PR TITLE
Always round the chartX and chartY values

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -2256,8 +2256,8 @@ function Chart(options, callback) {
 			}
 
 			return extend(e, {
-				chartX: chartX,
-				chartY: chartY
+				chartX: mathRound(chartX),
+				chartY: mathRound(chartY)
 			});
 		}
 


### PR DESCRIPTION
The container offset can return floating values based on the window size, and this can prevent the mouseover event to work properly.

/cc @fabioyamate
