### PR TITLE
[Patch] Can't use Chart.get if a serie wasn't visible first

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -3512,8 +3512,7 @@ function Chart(options, callback) {
 
 		// search points
 		for (i = 0; i < series.length; i++) {
-			points = series[i].points;
-			if(typeof points === "undefined" || points === null) continue;
+			points = series[i].points || [];
 			for (j = 0; j < points.length; j++) {
 				if (points[j].id === id) {
 					return points[j];


### PR DESCRIPTION
If you add a series with _visible: false_  and you do a _Chart.get(not_existing_id)_ you will get an exception.

ex: http://jsfiddle.net/5eFpg/4/

The problem is located in the _Chart.get_ function who search for points in a series with an matching _id_. If the series set _visible: false_ when it was added there's no _points_.

The for loop who search for points with matching id didn't check if it has been initialized.

This patch check if there's no point in the serie. If it's the case it skip to the next serie.
