### PR TITLE
Fix export when image markers on chart

### DIFF
--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -284,6 +284,10 @@ extend(Chart.prototype, {
 			.replace(/&shy;/g,  '\u00AD') // soft hyphen
 
 			// IE specific
+			.replace(/<IMG /g, '<image ')
+			.replace(/height=([^" ]+)/g, 'height="$1"')
+			.replace(/width=([^" ]+)/g, 'width="$1"')
+			.replace(/hc-svg-href="([^"]+)">/g, 'xlink:href="$1"/>')
 			.replace(/id=([^" >]+)/g, 'id="$1"')
 			.replace(/class=([^" ]+)/g, 'class="$1"')
 			.replace(/ transform /g, ' ')


### PR DESCRIPTION
Image markers generate invalid SVG. Try downloading the chart as an image: http://www.highcharts.com/demo/spline-symbols
