### PR TITLE
Fixed checking for 0 on datalabel

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -11544,7 +11544,7 @@ Series.prototype = {
 					str = options.formatter.call(point.getLabelConfig(), options);
 					
 					var barX = point.barX,
-						plotX = (barX && barX + point.barW / 2) || point.plotX || -999,
+						plotX = (barX && barX + point.barW / 2) || (point.plotX ||point.plotX === 0) ? point.plotX : -999,
 						plotY = pick(point.plotY, -999),
 						align = options.align,
 						individualYDelta = yIsNull ? (point.y >= 0 ? -6 : 12) : options.y;


### PR DESCRIPTION
if you define plotOptions: { line:{ dataLabels: {x:0} } } it would inter.pret x as -999, fixed by checking for 0.
