### PR TITLE
Prototype uses "afterFinish" instead of "complete" for effects.

### DIFF
--- a/js/adapters/prototype-adapter.src.js
+++ b/js/adapters/prototype-adapter.src.js
@@ -146,6 +146,7 @@ return {
 		options = options || {};
 		options.delay = 0;
 		options.duration = (options.duration || 500) / 1000;
+		options.afterFinish = options.complete;
 
 		// animate wrappers and DOM elements
 		if (hasEffect) {
@@ -157,6 +158,9 @@ return {
 		} else {
 			for (key in params) {
 				el.attr(key, params[key]);
+			}
+			if( options.complete ) {
+				options.complete();
 			}
 		}
 


### PR DESCRIPTION
Solves problem for chart.hideLoading() where the loading div has opacity:0, but is still displayed (and prevents interaction with the chart), because the complete function which should hide the div is not called.
