### PR TITLE
Added zIndex option to tooltip container

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -7374,7 +7374,7 @@ function Chart(userOptions, callback) {
 				fill: options.backgroundColor,
 				'stroke-width': borderWidth,
 				r: options.borderRadius,
-				zIndex: 8
+				zIndex: options.zIndex || 8
 			})
 			.css(style)
 			.hide()


### PR DESCRIPTION
We are adding custom images to the graph, that appear above points on lines, but below the tooltip.  It seems as though you can't adjust zIndex after chart creation, so we did it during.
