### PR TITLE
don't create multiple children for attr('title')

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -2157,9 +2157,19 @@ SVGElement.prototype = {
 
 					// Title requires a subnode, #431
 					} else if (key === 'title') {
-						var title = doc.createElementNS(SVG_NS, 'title');
-						title.appendChild(doc.createTextNode(value));
-						element.appendChild(title);
+						var found = false;
+						for (i = 0; i < element.childNodes.length; i++) {
+							if (element.childNodes[i].nodeName === 'title') {
+								element.childNodes[i].textContent = value;
+								found = true;
+								break;
+							}
+						}
+						if (!found) {
+							var title = doc.createElementNS(SVG_NS, 'title');
+							title.appendChild(doc.createTextNode(value));
+							element.appendChild(title);
+						}
 					}
 
 					// jQuery animate changes case

--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -2157,9 +2157,19 @@ SVGElement.prototype = {
 
 					// Title requires a subnode, #431
 					} else if (key === 'title') {
-						var title = doc.createElementNS(SVG_NS, 'title');
-						title.appendChild(doc.createTextNode(value));
-						element.appendChild(title);
+						var found = false;
+						for (i = 0; i < element.childNodes.length; i++) {
+							if (element.childNodes[i].nodeName === 'title') {
+								element.childNodes[i].textContent = value;
+								found = true;
+								break;
+							}
+						}
+						if (!found) {
+							var title = doc.createElementNS(SVG_NS, 'title');
+							title.appendChild(doc.createTextNode(value));
+							element.appendChild(title);
+						}
 					}
 
 					// jQuery animate changes case

--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -197,9 +197,19 @@ SVGElement.prototype = {
 
 					// Title requires a subnode, #431
 					} else if (key === 'title') {
-						var title = doc.createElementNS(SVG_NS, 'title');
-						title.appendChild(doc.createTextNode(value));
-						element.appendChild(title);
+						var found = false;
+						for (i = 0; i < element.childNodes.length; i++) {
+							if (element.childNodes[i].nodeName === 'title') {
+								element.childNodes[i].textContent = value;
+								found = true;
+								break;
+							}
+						}
+						if (!found) {
+							var title = doc.createElementNS(SVG_NS, 'title');
+							title.appendChild(doc.createTextNode(value));
+							element.appendChild(title);
+						}
 					}
 
 					// jQuery animate changes case


### PR DESCRIPTION
My initial call to attr('title') works as expected, but subsequent calls have no effect. The first child element sets the tooltip in-browser, and the rest are ignored.
