### PR TITLE
New feature for the issue #901

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -1779,6 +1779,8 @@ defaultPlotOptions.pie = merge(defaultSeriesOptions, {
 		// connectorWidth: 1,
 		// connectorColor: point.color,
 		// connectorPadding: 5,
+		// connectorZIndex: 3,
+		
 		distance: 30,
 		enabled: true,
 		formatter: function () {
@@ -13324,6 +13326,7 @@ var PieSeries = extendClass(Series, {
 			options = series.options.dataLabels,
 			connectorPadding = pick(options.connectorPadding, 10),
 			connectorWidth = pick(options.connectorWidth, 1),
+			connectorZIndex = pick(options.connectorZIndex,3),
 			connector,
 			connectorPath,
 			softConnector = pick(options.softConnector, true),
@@ -13548,7 +13551,7 @@ var PieSeries = extendClass(Series, {
 							'stroke-width': connectorWidth,
 							stroke: options.connectorColor || point.color || '#606060',
 							visibility: visibility,
-							zIndex: 3
+							zIndex: connectorZIndex
 						})
 						.translate(chart.plotLeft, chart.plotTop)
 						.add();

--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -1779,6 +1779,8 @@ defaultPlotOptions.pie = merge(defaultSeriesOptions, {
 		// connectorWidth: 1,
 		// connectorColor: point.color,
 		// connectorPadding: 5,
+		// connectorZIndex: 3,
+		
 		distance: 30,
 		enabled: true,
 		formatter: function () {
@@ -13324,6 +13326,7 @@ var PieSeries = extendClass(Series, {
 			options = series.options.dataLabels,
 			connectorPadding = pick(options.connectorPadding, 10),
 			connectorWidth = pick(options.connectorWidth, 1),
+			connectorZIndex = pick(options.connectorZIndex,3),
 			connector,
 			connectorPath,
 			softConnector = pick(options.softConnector, true),
@@ -13548,7 +13551,7 @@ var PieSeries = extendClass(Series, {
 							'stroke-width': connectorWidth,
 							stroke: options.connectorColor || point.color || '#606060',
 							visibility: visibility,
-							zIndex: 3
+							zIndex: connectorZIndex
 						})
 						.translate(chart.plotLeft, chart.plotTop)
 						.add();

--- a/js/parts/Options.js
+++ b/js/parts/Options.js
@@ -531,6 +531,8 @@ defaultPlotOptions.pie = merge(defaultSeriesOptions, {
 		// connectorWidth: 1,
 		// connectorColor: point.color,
 		// connectorPadding: 5,
+		// connectorZIndex: 3,
+		
 		distance: 30,
 		enabled: true,
 		formatter: function () {

--- a/js/parts/PieSeries.js
+++ b/js/parts/PieSeries.js
@@ -382,6 +382,7 @@ var PieSeries = extendClass(Series, {
 			options = series.options.dataLabels,
 			connectorPadding = pick(options.connectorPadding, 10),
 			connectorWidth = pick(options.connectorWidth, 1),
+			connectorZIndex = pick(options.connectorZIndex,3),
 			connector,
 			connectorPath,
 			softConnector = pick(options.softConnector, true),
@@ -606,7 +607,7 @@ var PieSeries = extendClass(Series, {
 							'stroke-width': connectorWidth,
 							stroke: options.connectorColor || point.color || '#606060',
 							visibility: visibility,
-							zIndex: 3
+							zIndex: connectorZIndex
 						})
 						.translate(chart.plotLeft, chart.plotTop)
 						.add();


### PR DESCRIPTION
Introduced a new property called connectionZIndex for pie chart so that the user can define the z-index for the inner series. If the user wishes to display the data label outside the chart with the connector starting from the inner series and extending outside the chart overlaying the outer series, this attribute is needed. Please see the fiddle with the new parameter, http://jsfiddle.net/sivakumar_kailasam/UZcNG/embedded/result/
