### PR TITLE
Fix for issue #68

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -8379,6 +8379,7 @@ MouseTracker.prototype = {
 
 			// If we're outside, hide the tooltip
 			if (mouseTracker.chartPosition &&
+				chart.hoverSeries && chart.hoverSeries.isCartesian &&
 				!chart.isInsidePlot(e.pageX - mouseTracker.chartPosition.left - chart.plotLeft,
 				e.pageY - mouseTracker.chartPosition.top - chart.plotTop)) {
 					mouseTracker.resetTracker();


### PR DESCRIPTION
Fix for issue #68 - it checks to see if chart.hoverSeries.isCartesian before hiding the tooltip when the mouse is outside of the plot area. This allows tooltips to work on pie charts that are outside of the plot area.
