### PR TITLE
Android 2.x: y missing in tooltip formatter callback

### DIFF
--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -293,7 +293,8 @@ Tooltip.prototype = {
 			});
 
 			textConfig = {
-				x: point[0].category
+				x: point[0].category,
+				y: point[0].y
 			};
 			textConfig.points = pointConfig;
 			point = point[0];


### PR DESCRIPTION
We're long time Highcharts users. We're adding support for Android 2.x now and noticed the y value there for our tooltips were displaying as "undefined".

According to http://www.highcharts.com/documentation/compatibility "shared tooltip is always enabled" for Android 2.x Looking at Tooltip.js for shared mode, it passes the x value to the formatter but not the y value.

This adds the y value.
