### PR TITLE
Fix symbol image resize issue.

### DIFF
--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -3377,7 +3377,7 @@ SVGRenderer.prototype = {
 				});
 
 			if (imageSize) {
-				centerImage(obj, imageSize);
+				setTimeout(function () { centerImage(obj, imageSize); }, 0);
 			} else {
 				// initialize image to be 0 size so export will still function if there's no cached sizes
 				obj.attr({ width: 0, height: 0 });
@@ -3387,7 +3387,7 @@ SVGRenderer.prototype = {
 					onload: function () {
 						var img = this;
 
-						centerImage(obj, symbolSizes[imageSrc] = [img.width, img.height]);
+						setTimeout(function () { centerImage(obj, symbolSizes[imageSrc] = [img.width, img.height]); }, 0);
 					},
 					src: imageSrc
 				});


### PR DESCRIPTION
We were having a problem when using a significant number of symbol images on a page (with multiple charts). The images were not resizing correctly. Adding a 0 second timeout to the centerImage function call solved the problem.

Thought others might find this useful.

Joel
