### PR TITLE
hiding ticks + perf

### DIFF
--- a/js/parts/Tick.js
+++ b/js/parts/Tick.js
@@ -315,7 +315,7 @@ Tick.prototype = {
 		}
 
 		// create the tick mark
-		if (tickWidth) {
+		if (tickWidth && tickLength) {
 
 			// negate the length
 			if (tickPosition === 'inside') {


### PR DESCRIPTION
Hiding ticks with `axis.tickLength: 0` was a performance hit vs `axis.tickWidth: 0` due to the lack of a check for length.  This is still rather hacky in my opinion and I would love to see an `enableTicks` option.
