### PR TITLE
Specify charset when minifying to prevent garbled non-ascii characters

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -319,12 +319,16 @@
             <arg value="${param.src}"/>
             <arg value="--js_output_file"/>
             <arg value="${param.out}"/>
+            <arg value="--charset"/>
+            <arg value="UTF-8"/>
         </java>
         <java jar="${yuicomp.jar}" fork="true">
             <arg value="--type"/>
             <arg value="js"/>
             <arg value="-o"/>
             <arg value="${param.out}.yui-min.js"/>
+            <arg value="--charset"/>
+            <arg value="UTF-8"/>
             <arg value="${param.src}"/>
         </java>
         <length file="${param.src}" property="input.length"/>


### PR DESCRIPTION
I noticed that the 'ø' i 'Hønsi' was being garbled in the minification process. This patch specifies a charset for both minifiers (GCC and YUI) to avoid this problem.
