### PR TITLE
Fixed incorrect y-axis label splitting on "-"

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -3073,7 +3073,8 @@ SVGRenderer.prototype = {
 
 					// check width and apply soft breaks
 					if (width) {
-						var words = span.replace(/-/g, '- ').split(' '),
+					var spanText = (span.match(/^[^-].+$/)) ? span.replace(/-/g, '- ') :span,
+							words = spanText.split(' '),
 							tooLong,
 							actualWidth,
 							rest = [];


### PR DESCRIPTION
If you look at http://jsfiddle.net/pQXq7 you'll see that the y-axis label is breaking "-5M" into two different lines which does not seem right. I imagine the original intention was to break labels like "50-75" into two different lines, which makes sense.

Added a patch to make it work with both these cases http://jsfiddle.net/pQXq7/2/
