### PR TITLE
Check "redraw" flag in "point.update" function.

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -11509,7 +11509,7 @@ Point.prototype = {
 			point.applyOptions(options);
 
 			// update visuals
-			if (isObject(options)) {
+			if (redraw && isObject(options)) {
 				series.getAttribs();
 				if (graphic) {
 					graphic.attr(point.pointAttr[series.state]);

--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -12772,6 +12772,7 @@ Series.prototype = {
 
 					if (graphic) { // update
 						graphic
+							.attr(pointAttr)
 							.attr({ // Since the marker group isn't clipped, each individual marker must be toggled
 								visibility: isInside ? (hasSVG ? 'inherit' : VISIBLE) : HIDDEN
 							})

--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -11509,7 +11509,7 @@ Point.prototype = {
 			point.applyOptions(options);
 
 			// update visuals
-			if (isObject(options)) {
+			if (redraw && isObject(options)) {
 				series.getAttribs();
 				if (graphic) {
 					graphic.attr(point.pointAttr[series.state]);

--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -12772,6 +12772,7 @@ Series.prototype = {
 
 					if (graphic) { // update
 						graphic
+							.attr(pointAttr)
 							.attr({ // Since the marker group isn't clipped, each individual marker must be toggled
 								visibility: isInside ? (hasSVG ? 'inherit' : VISIBLE) : HIDDEN
 							})

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -1569,6 +1569,7 @@ Series.prototype = {
 
 					if (graphic) { // update
 						graphic
+							.attr(pointAttr)
 							.attr({ // Since the marker group isn't clipped, each individual marker must be toggled
 								visibility: isInside ? (hasSVG ? 'inherit' : VISIBLE) : HIDDEN
 							})

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -306,7 +306,7 @@ Point.prototype = {
 			point.applyOptions(options);
 
 			// update visuals
-			if (isObject(options)) {
+			if (redraw && isObject(options)) {
 				series.getAttribs();
 				if (graphic) {
 					graphic.attr(point.pointAttr[series.state]);


### PR DESCRIPTION
Added check of "redraw" flag in "point.update" function for preventing unnecessary calls of "serie.getAttribs()" if redraw set to "false".
With many updating points (about 300+) in IE 8 user see a warning about slow script, because "serie.getAttribs()" is pretty heavy.
