### PR TITLE
Candlestick UP state detection fix

### DIFF
--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -16118,6 +16118,44 @@ var CandlestickSeries = extendClass(OHLCSeries, {
 	},
 	upColorProp: 'fill',
 
+  /**
+   * Detect UP candles and apply attributes accordingly
+   *
+   * Just for reference:
+   * a candle is UP whenever it's CLOSE value is greater than OPEN value
+   *
+   * For better explanation, read "Candlestick chart topics" here:
+   * http://en.wikipedia.org/wiki/Candlestick_chart
+   */
+  getAttribs = function () {
+    seriesTypes.column.prototype.getAttribs.apply(this, arguments);
+
+    var series = this,
+      options = series.options,
+      stateOptions = options.states,
+      upColor = options.upColor || series.color,
+      seriesDownPointAttr = HC.merge(series.pointAttr),
+      upColorProp = series.upColorProp,
+      points = series.points || [],
+      length = points.length,
+      isUpDay,
+      point,
+      i;
+
+    seriesDownPointAttr[''][upColorProp] = upColor;
+    seriesDownPointAttr.hover[upColorProp] = stateOptions.hover.upColor || upColor;
+    seriesDownPointAttr.select[upColorProp] = stateOptions.select.upColor || upColor;
+
+    for (i = 0; i < length; i++) {
+      point = points[i];
+      isUpDay = point.close > point.open;
+
+      if (isUpDay) {
+        point.pointAttr = seriesDownPointAttr;
+      }
+    }
+  },
+
 	/**
 	 * Draw the data points
 	 */


### PR DESCRIPTION
Hi,
A candle's state is UP whenever it's CLOSE value is greater than OPEN, regardless of previous candle's values. For details refer to Wiki: http://en.wikipedia.org/wiki/Candlestick_chart

![240px-Candle_definition_en svg](https://f.cloud.github.com/assets/720339/131249/509697be-7050-11e2-8062-aba31ca5967b.png)

Because I'm not confident whether this rule should be applied for OHLC I didn't modify it's implementation.

Added notes in the source code so should be clear for everyone I hope.
Regards
