### PR TITLE
Tooltips do not show up if chart is within a container with overflow auto and a fixed height

### DIFF
--- a/js/parts/MouseTracker.js
+++ b/js/parts/MouseTracker.js
@@ -58,15 +58,15 @@ MouseTracker.prototype = {
 		ePos = e.touches ? e.touches.item(0) : e;
 
 		// get mouse position
-		this.chartPosition = chartPosition = offset(this.chart.container);
+		this.chartPosition = chartPosition = this.chart.container.getPosition();
 
 		// chartX and chartY
 		if (ePos.pageX === UNDEFINED) { // IE < 9. #886.
 			chartX = e.x;
 			chartY = e.y;
 		} else {
-			chartX = ePos.pageX - chartPosition.left;
-			chartY = ePos.pageY - chartPosition.top;
+			chartX = ePos.pageX - chartPosition.x;
+			chartY = ePos.pageY - chartPosition.y;
 		}
 
 		return extend(e, {
@@ -320,8 +320,8 @@ MouseTracker.prototype = {
 
 			// If we're outside, hide the tooltip
 			if (mouseTracker.chartPosition && chart.hoverSeries && chart.hoverSeries.isCartesian &&
-				!chart.isInsidePlot(e.pageX - mouseTracker.chartPosition.left - chart.plotLeft,
-				e.pageY - mouseTracker.chartPosition.top - chart.plotTop)) {
+				!chart.isInsidePlot(e.pageX - mouseTracker.chartPosition.x - chart.plotLeft,
+				e.pageY - mouseTracker.chartPosition.y - chart.plotTop)) {
 					mouseTracker.resetTracker();
 			}
 		};
@@ -539,9 +539,9 @@ MouseTracker.prototype = {
 
 					// add page position info
 					extend(hoverPoint, {
-						pageX: mouseTracker.chartPosition.left + chart.plotLeft +
+						pageX: mouseTracker.chartPosition.x + chart.plotLeft +
 							(chart.inverted ? chart.plotWidth - plotY : plotX),
-						pageY: mouseTracker.chartPosition.top + chart.plotTop +
+						pageY: mouseTracker.chartPosition.y + chart.plotTop +
 							(chart.inverted ? chart.plotHeight - plotX : plotY)
 					});
 


### PR DESCRIPTION
This issue happened when using the mootools adapter. Don't really know if this happens for others. Here's a [fiddle](http://jsfiddle.net/U8Dwf/3/) so you can quickly reproduce the bug.

The main problem lies in the adapter. It was calling an undocumented `getOffsets()` mootools function. This function does not account for the scroll position, causing wrong calculations when the chart is deep within the overflowed container.
