### PR TITLE
Initial implementation of support for AMD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 /.project
 /git-ignore-me.properties
 /highcharts.com.sublime-project
+*.iml
+*.ipr
+*.iws

--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -10,9 +10,10 @@
  */
 
 // JSLint options:
-/*global Highcharts, document, window, navigator, setInterval, clearInterval, clearTimeout, setTimeout, location, jQuery, $, console */
+/*global Highcharts, document, window, navigator, setInterval, clearInterval, clearTimeout, setTimeout, location, jQuery, $, console, define */
 
 (function () {
+	function init(jQuery) {
 // encapsulated variables
 var UNDEFINED,
 	doc = document,
@@ -115,10 +116,10 @@ var UNDEFINED,
 
 
 	// lookup over the types and the associated classes
-	seriesTypes = {};
+	seriesTypes = {},
 
-// The Highcharts namespace
-win.Highcharts = win.Highcharts ? error(16, true) : {};
+	// The Highcharts namespace
+	Highcharts = {};
 
 /**
  * Extend an object with the members of another
@@ -1295,7 +1296,7 @@ pathAnim = {
 			$(el).stop();
 		}
 	});
-}(win.jQuery));
+}(jQuery));
 
 
 // check for a custom HighchartsAdapter defined prior to this file
@@ -15410,4 +15411,12 @@ extend(Highcharts, {
 	product: 'Highcharts',
 	version: '2.3.5'
 });
+		return Highcharts;
+	} // End of init function
+
+	if (typeof define === 'function' && define.amd) {
+		define('highcharts', ['jquery'], init);
+	} else {
+		window.Highcharts = window.Highcharts ? error(16, true) : init(window.jQuery);
+	}
 }());

--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -10,9 +10,10 @@
  */
 
 // JSLint options:
-/*global Highcharts, document, window, navigator, setInterval, clearInterval, clearTimeout, setTimeout, location, jQuery, $, console */
+/*global Highcharts, document, window, navigator, setInterval, clearInterval, clearTimeout, setTimeout, location, jQuery, $, console, define */
 
 (function () {
+	function init(jQuery) {
 // encapsulated variables
 var UNDEFINED,
 	doc = document,
@@ -115,10 +116,10 @@ var UNDEFINED,
 
 
 	// lookup over the types and the associated classes
-	seriesTypes = {};
+	seriesTypes = {},
 
-// The Highcharts namespace
-win.Highcharts = win.Highcharts ? error(16, true) : {};
+	// The Highcharts namespace
+	Highcharts = {};
 
 /**
  * Extend an object with the members of another
@@ -1295,7 +1296,7 @@ pathAnim = {
 			$(el).stop();
 		}
 	});
-}(win.jQuery));
+}(jQuery));
 
 
 // check for a custom HighchartsAdapter defined prior to this file
@@ -18973,4 +18974,12 @@ extend(Highcharts, {
 	product: 'Highstock',
 	version: '1.2.5'
 });
+		return Highcharts;
+	} // End of init function
+
+	if (typeof define === 'function' && define.amd) {
+		define('highcharts', ['jquery'], init);
+	} else {
+		window.Highcharts = window.Highcharts ? error(16, true) : init(window.jQuery);
+	}
 }());

--- a/js/parts/Adapters.js
+++ b/js/parts/Adapters.js
@@ -313,7 +313,7 @@
 			$(el).stop();
 		}
 	});
-}(win.jQuery));
+}(jQuery));
 
 
 // check for a custom HighchartsAdapter defined prior to this file

--- a/js/parts/Globals.js
+++ b/js/parts/Globals.js
@@ -100,7 +100,7 @@ var UNDEFINED,
 
 
 	// lookup over the types and the associated classes
-	seriesTypes = {};
+	seriesTypes = {},
 
-// The Highcharts namespace
-win.Highcharts = win.Highcharts ? error(16, true) : {};
+	// The Highcharts namespace
+	Highcharts = {};

--- a/js/parts/Intro.js
+++ b/js/parts/Intro.js
@@ -10,6 +10,7 @@
  */
 
 // JSLint options:
-/*global Highcharts, document, window, navigator, setInterval, clearInterval, clearTimeout, setTimeout, location, jQuery, $, console */
+/*global Highcharts, document, window, navigator, setInterval, clearInterval, clearTimeout, setTimeout, location, jQuery, $, console, define */
 
 (function () {
+	function init(jQuery) {

--- a/js/parts/Outro.js
+++ b/js/parts/Outro.js
@@ -1,2 +1,10 @@
 
+		return Highcharts;
+	} // End of init function
+
+	if (typeof define === 'function' && define.amd) {
+		define('highcharts', ['jquery'], init);
+	} else {
+		window.Highcharts = window.Highcharts ? error(16, true) : init(window.jQuery);
+	}
 }());


### PR DESCRIPTION
- HighchartsAdapter is still being written directly to `window`
- The various parts of Highcharts can now be written as modules. This means
  that the high*.debug.js files can be dropped, as the AMD implementation will
  take care of dependency management. For production releases one would simply
  concatinate all the dependencies together to get a single dist file. There are
  tools which can detect dependencies and handle the bundling automatically, such
  as require.js' optimizer, r.js.
