### PR TITLE
IE9 fix for percentage measures

### DIFF
--- a/js/adapters/mootools-adapter.src.js
+++ b/js/adapters/mootools-adapter.src.js
@@ -79,7 +79,7 @@ win.HighchartsAdapter = {
 		// This currently works for getting inner width and height. If adding
 		// more methods later, we need a conditional implementation for each.
 		if (method === 'width' || method === 'height') {
-			return parseInt($(el).getStyle(method), 10);
+			return parseInt($(el).getDimensions()[method], 10);
 		}
 	},
 


### PR DESCRIPTION
getStyle doesn't work very well with percetnage measures in IE9. Use the method getDimensions instead fix those problems
