### PR TITLE
Fixed Highstock issue with calling setData on an empty series (#1698)

### DIFF
--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -17629,7 +17629,19 @@ Scroller.prototype = {
 				newMax = mathMax(baseExtremes.dataMax, navExtremes.dataMax);
 
 			if (!noBase && (newMin !== navExtremes.min || newMax !== navExtremes.max)) {
+				var wasRendered = scroller.rendered;
 				xAxis.setExtremes(newMin, newMax, true, false);
+
+				// setExtremes can call the render function that we're in, which may render the scrollbar
+				// for the first time.  If that happened, some of the variables that were initialized at
+				// the top need to be reset. (#1698)
+				if (!wasRendered && scroller.rendered)
+				{
+					navigatorGroup = scroller.navigatorGroup;
+					scrollbarGroup = scroller.scrollbarGroup;
+					scrollbarTrack = scroller.scrollbarTrack;
+					scrollbar = scroller.scrollbar;
+				}
 			}
 		}
 


### PR DESCRIPTION
This is my first ever pull request to any project.  This is intended to fix issue #1698.  The problem is that the render function may be called recursively.  Once the recursion unrolls back to the first call, some of the variables that were initialized are no longer correct if the recursive call resulted in the scroller being rendered for the first time.  My approach simply re-assigns those variables to their current state if the scroller had not been rendered, but is now.
