### PR TITLE
Fix bare epoch time on datetime axes with one data sample

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -13063,7 +13063,7 @@ Series.prototype = {
 		if (options.pointRange === null) { // null means auto, as for columns, candlesticks and OHLC
 			series.pointRange = closestPointRange || 1;
 		}
-		series.closestPointRange = closestPointRange;
+		series.closestPointRange = closestPointRange || xAxis.minRange || 0;
 		
 	},
 


### PR DESCRIPTION
On datetime axes with a single data point, the loop to find the closest distance fails, resulting in a bare epoch time label in the tooltip since closestPointRange is undefined. Setting it to 0 would default it to milliseconds, but we have a little more information than that - if the user has set a minRange, we know the appropriate resolution to use at max zoom. Fallback to 0 anyway, in case they haven't set anything.
