### PR TITLE
Steady alternateGridColor

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -1807,7 +1807,9 @@ Axis.prototype = {
 			hasData = axis.hasData,
 			showAxis = axis.showAxis,
 			from,
-			to;
+			to,
+			aGCtickPositions,
+			modPos;
 
 		// Mark all elements inActive before we go over and mark the active ones
 		each([ticks, minorTicks, alternateBands], function (coll) {
@@ -1873,8 +1875,16 @@ Axis.prototype = {
 
 			// alternate grid color
 			if (alternateGridColor) {
-				each(tickPositions, function (pos, i) {
-					if (i % 2 === 0 && pos < axis.max) {
+				aGCtickPositions = axis.tickPositions.info ? [axis.min].concat(tickPositions) : tickPositions;
+				each(aGCtickPositions, function (pos, i) {
+					if (axis.tickPositions.info) {
+						modPos = i ? pos : tickPositions[i] - axis.tickPositions.info.totalRange;
+						modPos = Math.floor((axis.dataMax - modPos) / axis.tickPositions.info.totalRange);
+						i -= 1;
+					} else {
+						modPos = i
+					}
+					if (modPos % 2 === 0 && pos < axis.max) {
 						if (!alternateBands[pos]) {
 							alternateBands[pos] = new PlotLineOrBand(axis);
 						}


### PR DESCRIPTION
fixes #1801

Original behavior is unchanged in cases where the tickPositions are not calculated dynamically.

When this change does apply, instead of determining even/odd position among currently visible ticks, it considers its position relative to the max value of the axis. This also applies a band from the minimum visible position to the first tick when appropriate.
