### PR TITLE
Only rebuild plain object when merging options

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -159,11 +159,11 @@ function merge() {
 					}
 						
 					// Copy the contents of objects, but not arrays or DOM nodes
-					if (value && typeof value === 'object' && Object.prototype.toString.call(value) !== '[object Array]'
+					if (value && isPlainObject(value) && Object.prototype.toString.call(value) !== '[object Array]'
 							&& typeof value.nodeType !== 'number') {
 						copy[key] = doCopy(copy[key] || {}, value);
 				
-					// Primitives and arrays are copied over directly
+					// Primitives, arrays and class objects are copied over directly
 					} else {
 						copy[key] = original[key];
 					}
@@ -178,6 +178,38 @@ function merge() {
 	}
 
 	return ret;
+}
+
+function isPlainObject(obj) {
+    var class2type = {};
+    var core_hasOwn = class2type.hasOwnProperty;
+
+	// Must be an Object.
+	// Because of IE, we also have to check the presence of the constructor property.
+	// Make sure that DOM nodes and window objects don't pass through, as well
+	if ( !obj || typeof obj !== "object" || obj.nodeType || (obj != null && obj == obj.window) ) {
+		return false;
+	}
+
+	try {
+		// Not own constructor property must be Object
+		if ( obj.constructor &&
+			!core_hasOwn.call(obj, "constructor") &&
+			!core_hasOwn.call(obj.constructor.prototype, "isPrototypeOf") ) {
+			return false;
+		}
+	} catch ( e ) {
+		// IE8,9 Will throw exceptions on certain host objects #9897
+		return false;
+	}
+
+	// Own properties are enumerated firstly, so to speed up,
+	// if last one is own, then all properties are own.
+
+	var key;
+	for ( key in obj ) {}
+
+	return key === undefined || core_hasOwn.call( obj, key );
 }
 
 /**


### PR DESCRIPTION
In my use case, I have a bunch of javascript to manage Highcharts charts and options. And that bunch of javascript store data and behaviours in the options of the charts. Some of these data are instances of javascript "classes".
This used to work fine with Highcharts 2.2. I have tried to upgrade to Highcharts 3; my custom data are rebuild in plain objects, which then break my js code.
So here is the suggested patch which doesn't rebuild class instances. It is based on the isPlainObject from jQuery (which is used by jQuery.extend).
