### PR TITLE
Added a trailing file separator check for tmpDir

### DIFF
--- a/exporting-server/java/highcharts-export/highcharts-export-convert/src/main/java/com/highcharts/export/pool/ServerObjectFactory.java
+++ b/exporting-server/java/highcharts-export/highcharts-export-convert/src/main/java/com/highcharts/export/pool/ServerObjectFactory.java
@@ -29,7 +29,7 @@ public class ServerObjectFactory implements ObjectFactory<Server> {
 	private int readTimeout;
 	private int connectTimeout;
 	private int maxTimeout;
-	public static String tmpDir = System.getProperty("java.io.tmpdir");
+	public static String tmpDir = System.getProperty("java.io.tmpdir").endsWith(File.separator)?System.getProperty("java.io.tmpdir"):System.getProperty("java.io.tmpdir") + File.separator;
 	private static HashMap<Integer, PortStatus> portUsage = new HashMap<Integer, PortStatus>();
 	protected static Logger logger = Logger.getLogger("pool");
 


### PR DESCRIPTION
![screen shot 2013-06-28 at 2 05 58 pm](https://f.cloud.github.com/assets/158026/723675/d47fc5a4-e01d-11e2-8fa4-d771f3d76622.png)
The js resources were not copied on tomcat due to tmpDir missing a trailing file separator.
App tried creating /var/tmpphantomjs rather than /var/tmp/phantomjs
