### PR TITLE
Added avoidLegend option to tooltip

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -1,4 +1,4 @@
-// ==ClosureCompiler==
+﻿// ==ClosureCompiler==
 // @compilation_level SIMPLE_OPTIMIZATIONS
 
 /**
@@ -8712,6 +8712,65 @@ Tooltip.prototype = {
 		// point than to disappear outside the chart. #834.
 		if (y + boxHeight > plotTop + plotHeight) {
 			y = mathMax(plotTop, plotTop + plotHeight - boxHeight - distance); // below
+		}
+
+		if (this.options.avoidLegend && this.chart.legend.options.enabled) {
+		    var legend = this.chart.legend,
+                        // Should it abide by the legend margin?
+                        legendMargin = 0, //legend.options.margin == null ? 15 : legend.options.margin,
+                        legendWidth = legend.legendWidth + legendMargin * 2,
+                        legendHeight = legend.legendHeight + legendMargin * 2,
+                        // Only reliable legend position cross browser
+                        legendX = legend.group.attr('translateX') - legendMargin,
+                        legendY = legend.group.attr('translateY') - legendMargin,
+                        legendRight = legendX + legendWidth,
+                        legendBottom = legendY + legendHeight,
+                        intersect = !(legendX > (x + boxWidth) || legendRight < x ||
+                            legendY > (y + boxHeight) || legendBottom < y);
+
+                    if (intersect) {
+                        var x_left = Math.abs((x + boxWidth) - legendX),
+                            x_right = Math.abs(x - legendRight),
+                            y_top = Math.abs((y + boxHeight) - legendY),
+                            y_bottom = Math.abs(y - legendBottom),
+                            x_overlap = 0,
+                            y_overlap = 0;
+
+                        // Check to make sure that the position will be visible
+                        if (x_left > x_right) {
+                            if ((x + boxWidth) + x_right > (plotLeft + plotWidth)) {
+                                x_overlap = -x_left;
+                            } else {
+                                x_overlap = x_right;
+                            }
+                        } else {
+                            if (x - x_left < 7) {
+                                x_overlap = x_right;
+                            } else {
+                                x_overlap = -x_left;
+                            }
+                        }
+
+                        if (y_top > y_bottom) {
+                            if ((y + boxHeight) + y_bottom > (plotTop + plotHeight)) {
+                                y_overlap = -y_top;
+                            } else {
+                                y_overlap = y_bottom;
+                            }
+                        } else {
+                            if (y - y_top < plotTop + 5) {
+                                y_overlap = y_bottom;
+                            } else {
+                                y_overlap = -y_top;
+                            }
+                        }
+
+                        if (Math.abs(x_overlap) < Math.abs(y_overlap)) {
+                            x += x_overlap;
+                        } else {
+                            y += y_overlap;
+                        }
+                    }
 		}
 	
 		return {x: x, y: y};

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -251,6 +251,65 @@ Tooltip.prototype = {
 		if (y + boxHeight > plotTop + plotHeight) {
 			y = mathMax(plotTop, plotTop + plotHeight - boxHeight - distance); // below
 		}
+
+		if (this.options.avoidLegend && this.chart.legend.options.enabled) {
+		    var legend = this.chart.legend,
+                        // Should it abide by the legend margin?
+                        legendMargin = 0, //legend.options.margin == null ? 15 : legend.options.margin,
+                        legendWidth = legend.legendWidth + legendMargin * 2,
+                        legendHeight = legend.legendHeight + legendMargin * 2,
+                        // Only reliable legend position cross browser
+                        legendX = legend.group.attr('translateX') - legendMargin,
+                        legendY = legend.group.attr('translateY') - legendMargin,
+                        legendRight = legendX + legendWidth,
+                        legendBottom = legendY + legendHeight,
+                        intersect = !(legendX > (x + boxWidth) || legendRight < x ||
+                            legendY > (y + boxHeight) || legendBottom < y);
+
+                    if (intersect) {
+                        var x_left = Math.abs((x + boxWidth) - legendX),
+                            x_right = Math.abs(x - legendRight),
+                            y_top = Math.abs((y + boxHeight) - legendY),
+                            y_bottom = Math.abs(y - legendBottom),
+                            x_overlap = 0,
+                            y_overlap = 0;
+
+                        // Check to make sure that the position will be visible
+                        if (x_left > x_right) {
+                            if ((x + boxWidth) + x_right > (plotLeft + plotWidth)) {
+                                x_overlap = -x_left;
+                            } else {
+                                x_overlap = x_right;
+                            }
+                        } else {
+                            if (x - x_left < 7) {
+                                x_overlap = x_right;
+                            } else {
+                                x_overlap = -x_left;
+                            }
+                        }
+
+                        if (y_top > y_bottom) {
+                            if ((y + boxHeight) + y_bottom > (plotTop + plotHeight)) {
+                                y_overlap = -y_top;
+                            } else {
+                                y_overlap = y_bottom;
+                            }
+                        } else {
+                            if (y - y_top < plotTop + 5) {
+                                y_overlap = y_bottom;
+                            } else {
+                                y_overlap = -y_top;
+                            }
+                        }
+
+                        if (Math.abs(x_overlap) < Math.abs(y_overlap)) {
+                            x += x_overlap;
+                        } else {
+                            y += y_overlap;
+                        }
+                    }
+		}
 	
 		return {x: x, y: y};
 	},

--- a/samples/highcharts/tooltip/avoidLegend/demo.details
+++ b/samples/highcharts/tooltip/avoidLegend/demo.details
@@ -1,0 +1,6 @@
+﻿---
+ name: Highcharts Demo
+ authors:
+   - TJ Higgins
+ requiresManualTesting: true
+...

--- a/samples/highcharts/tooltip/avoidLegend/demo.html
+++ b/samples/highcharts/tooltip/avoidLegend/demo.html
@@ -1,0 +1,3 @@
+<script src="http://code.highcharts.com/highcharts.js"></script>
+
+<div id="container" style="height: 400px"></div>

--- a/samples/highcharts/tooltip/avoidLegend/demo.js
+++ b/samples/highcharts/tooltip/avoidLegend/demo.js
@@ -1,0 +1,34 @@
+$(function () {
+    $('#container').highcharts({
+
+        chart: {},
+
+        xAxis: {
+            categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul',
+                'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+            ]
+        },
+        
+        legend: {
+            align: 'left',
+            verticalAlign: 'top',
+            x: 250,
+            y: 100,
+            floating: true
+        },
+
+        tooltip: {
+            avoidLegend: true,
+            shared: true
+        },
+
+        series: [{
+            data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4],
+            type: 'column'
+
+        }, {
+            data: [216.4, 194.1, 95.6, 54.4, 29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5]
+        }]
+
+    });
+});


### PR DESCRIPTION
This solves the problem of the tooltip covering the legend. This is
especially bad in shared tooltip mode because it makes the legend unable
to edit in a lot of situations.