### PR TITLE
Fix to JSDoc comment, was fouling Google closure compiler

### DIFF
--- a/js/adapters/standalone-framework.src.js
+++ b/js/adapters/standalone-framework.src.js
@@ -568,7 +568,7 @@ return {
 		el.stopAnimation = true;
 	},
 
-	/*
+	/**
 	 * Utility for iterating over an array. Parameters are reversed compared to jQuery.
 	 * @param {Array} arr
 	 * @param {Function} fn


### PR DESCRIPTION
Adapter works great - this minor tweak to JSDoc comment stops Google Closure raising a warning on minification.
