### PR TITLE
Exposing the reflow method on chart objects. Fixes #2212

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -11527,6 +11527,7 @@ Chart.prototype = {
 				chart.containerHeight = height;
 			}
 		}
+		chart.reflow = reflow;
 		addEvent(win, 'resize', reflow);
 		addEvent(chart, 'destroy', function () {
 			removeEvent(win, 'resize', reflow);

--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -11527,6 +11527,7 @@ Chart.prototype = {
 				chart.containerHeight = height;
 			}
 		}
+		chart.reflow = reflow;
 		addEvent(win, 'resize', reflow);
 		addEvent(chart, 'destroy', function () {
 			removeEvent(win, 'resize', reflow);

--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -1032,6 +1032,7 @@ Chart.prototype = {
 				chart.containerHeight = height;
 			}
 		}
+		chart.reflow = reflow;
 		addEvent(win, 'resize', reflow);
 		addEvent(chart, 'destroy', function () {
 			removeEvent(win, 'resize', reflow);


### PR DESCRIPTION
- Exposing the reflow method definied in the initReflow to chart
  objects, so users don't have to trigger window resize events to make
  charts fit in their resized containers.
