### PR TITLE
Using document.id in mootools adapter instead of the more volitile $.

### DIFF
--- a/js/adapters/mootools-adapter.src.js
+++ b/js/adapters/mootools-adapter.src.js
@@ -79,7 +79,7 @@ win.HighchartsAdapter = {
 		// This currently works for getting inner width and height. If adding
 		// more methods later, we need a conditional implementation for each.
 		if (method === 'width' || method === 'height') {
-			return parseInt($(el).getStyle(method), 10);
+			return parseInt(document.id(el).getStyle(method), 10);
 		}
 	},
 
@@ -127,7 +127,7 @@ win.HighchartsAdapter = {
 
 		// define and run the effect
 		effect = new Fx.Morph(
-			isSVGElement ? el : $(el),
+			isSVGElement ? el : document.id(el),
 			$extend({
 				transition: Fx.Transitions.Quad.easeInOut
 			}, options)
@@ -209,7 +209,7 @@ win.HighchartsAdapter = {
 		// like series or point
 		if (!el.addEvent) {
 			if (el.nodeName) {
-				el = $(el); // a dynamically generated node
+				el = document.id(el); // a dynamically generated node
 			} else {
 				$extend(el, new Events()); // a custom object
 			}


### PR DESCRIPTION
Mootools several years back deprecated the use of `$` in favor of document.id to avoid possible collisions with other libraries.

http://mootools.net/blog/2009/06/22/the-dollar-safe-mode/
