### PR TITLE
Defining element.getComputedStyle for SVG items so that Highchart's anim...

### DIFF
--- a/js/adapters/mootools-adapter.src.js
+++ b/js/adapters/mootools-adapter.src.js
@@ -120,6 +120,9 @@ win.HighchartsAdapter = {
 			};
 			// dirty hack to trick Moo into handling el as an element wrapper
 			el.$family = function () { return true; };
+			el.getComputedStyle = function(){
+				return el.element.getComputedStyle.apply(el.element, arguments);
+			};
 		}
 
 		// stop running animations


### PR DESCRIPTION
...ation calls work with Fx.CSS.js

Calls to `.animate` in the MooTools adapter reference `Fx.Morph`. This in turn invokes methods in `Fx.CSS` including `Element::getComputedStyle`, a method not present on SVG elements. This pull adds this method to prevent errors from occurring.
