### PR TITLE
Prevent tooltips from being visible when mouse exits the plot area.

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -9671,7 +9671,7 @@ Pointer.prototype = {
 		e = this.normalize(e, chartPosition);
 
 		// If we're outside, hide the tooltip
-		if (chartPosition && hoverSeries && !this.inClass(e.target, 'highcharts-tracker') &&
+		if (chartPosition && !chart.tooltip.isHidden && !this.inClass(e.target, 'highcharts-tracker') &&
 				!chart.isInsidePlot(e.chartX - chart.plotLeft, e.chartY - chart.plotTop)) {
 			this.reset();
 		}

--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -9671,7 +9671,7 @@ Pointer.prototype = {
 		e = this.normalize(e, chartPosition);
 
 		// If we're outside, hide the tooltip
-		if (chartPosition && hoverSeries && !this.inClass(e.target, 'highcharts-tracker') &&
+		if (chartPosition && !chart.tooltip.isHidden && !this.inClass(e.target, 'highcharts-tracker') &&
 				!chart.isInsidePlot(e.chartX - chart.plotLeft, e.chartY - chart.plotTop)) {
 			this.reset();
 		}


### PR DESCRIPTION
this check (highcharts current master's version) only resets the tooltip if your mouse is over a series and you leave the plot area OR you leave the entire container of the chart. The problem is that if you move up your mouse leaves the series (the colored column or whatever) and enters the space between that and our tooltip. When it leaves the plot area (where our tip is) there's no longer a hoverSeries defined, because you aren't on one. So the current conditional breaks and our tooltip remains. I swapped this for !chart.tooltip.isHidden as this conditional is run on mousemove (whether you're in the chart or not) and a boolean check here makes it relatively inexpensive.

An optimization to consider there is to remove this mousemove event from the document when your mouse leaves the chart (not in this pull).

![image](https://f.cloud.github.com/assets/13230/1451858/3022e1da-42b0-11e3-84b3-a7bb9d6e4211.png)
