### PR TITLE
Legacy IE event handling issue of standalone-framework adapter

### DIFF
--- a/js/adapters/standalone-framework.src.js
+++ b/js/adapters/standalone-framework.src.js
@@ -105,7 +105,7 @@ function augment(obj) {
 						el.HCGuid = guid++;
 					}
 
-					var key = HighchartsAdapter.getProxiedHandlerKey(el, type, fn);
+					var key = HighchartsAdapter.getProxiedHandlerKey(el, name, fn);
 					// ignore already registered handler (equivalent to addEventListener)
 					if (proxiedHandlers[key]) {
 						return;

--- a/js/adapters/standalone-framework.src.js
+++ b/js/adapters/standalone-framework.src.js
@@ -15,7 +15,9 @@ var UNDEFINED,
 	emptyArray = [],
 	timers = [],
 	timerId,
-	Fx;
+	Fx,
+	proxiedHandlers = {},
+	handlerId = 0;
 
 Math.easeInOutSine = function (t, b, c, d) {
 	return -c / 2 * (Math.cos(Math.PI * t / d) - 1) + b;
@@ -32,8 +34,9 @@ function augment(obj) {
 	}
 
 	function IERemoveOneEvent(el, type, fn) {
-		fn = el.HCProxiedMethods[fn.toString()];
+		fn = proxiedHandlers[fn.HCHandlerId];
 		el.detachEvent('on' + type, fn);
+		delete proxiedHandlers[fn.HCHandlerId];
 	}
 
 	function removeAllEvents(el, type) {
@@ -91,12 +94,9 @@ function augment(obj) {
 						fn.call(el, e);
 					};
 
-					if (!el.HCProxiedMethods) {
-						el.HCProxiedMethods = {};
-					}
-
 					// link wrapped fn with original fn, so we can get this in removeEvent
-					el.HCProxiedMethods[fn.toString()] = wrappedFn;
+					fn.HCHandlerId = handlerId++;
+					proxiedHandlers[fn.HCHandlerId] = wrappedFn;
 
 					el.attachEvent('on' + name, wrappedFn);
 				}


### PR DESCRIPTION
In standalone-framework adapter, legacy IE cannot unbind event handlers in some case.

It use `fn.toString()` as a key of proxied handler caching.

```javascript
/// in bind
el.HCProxiedMethods[fn.toString()] = wrappedFn;

/// in unbind
function IERemoveOneEvent(el, type, fn) {
  fn = el.HCProxiedMethods[fn.toString()];
  el.detachEvent('on' + type, fn);
}
```

But different handlers can return same value for `toString()`.

For example: Parts#setDOMEvents()
```javascript
setDOMEvents: function () {
    var pointer = this, 
        container = pointer.chart.container,
        events;

    this._events = events = [
        [container, 'onmousedown', 'onContainerMouseDown'],
        [container, 'onmousemove', 'onContainerMouseMove'],
        [container, 'onclick', 'onContainerClick'],
        [container, 'mouseleave', 'onContainerMouseLeave'],
        [doc, 'mousemove', 'onDocumentMouseMove'],
        [doc, 'mouseup', 'onDocumentMouseUp']
    ];

    // ...
  
    each(events, function (eventConfig) {
        pointer['_' + eventConfig[2]] = function (e) {
            pointer[eventConfig[2]](e);
        };

        if (eventConfig[1].indexOf('on') === 0) {
            eventConfig[0][eventConfig[1]] = pointer['_' + eventConfig[2]];
        } else {
            addEvent(eventConfig[0], eventConfig[1], pointer['_' + eventConfig[2]]);
        }
    });
},
```

In the above, every `pointer['_' + eventConfig[2]].toString()` (3rd arg of `addEvent()`) is:
```
function (e) {
    pointer[eventConfig[2]](e);
};
```
So `document.HCProxiedMethods[fn.toString()]` of mouseup overwrites previous one (=mousemove handler).

As a result, after init and destroy Pointer, the mousemove handler remains.
And if multiple Pointers are initialized, many mousemove and mouseup handlers remain.
The mouseup handler occurs JS error: http://jsfiddle.net/teppeis/qQB22/
(iframe src: http://fiddle.jshell.net/teppeis/qQB22/show/light/)

----

To fix it, I introduced `guid` as a global counter for objects like jQuery.