### PR TITLE
Fix memory leak with reduced variable scope

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -932,8 +932,7 @@ pathAnim = {
 			// extend some methods to check for elem.attr, which means it is a Highcharts SVG object
 			$.each(['cur', '_default', 'width', 'height', 'opacity'], function (i, fn) {
 				var obj = Step,
-					base,
-					elem;
+					base;
 					
 				// Handle different parent objects
 				if (fn === 'cur') {
@@ -950,6 +949,7 @@ pathAnim = {
 		
 					// create the extended function replacement
 					obj[fn] = function (fx) {
+						var elem;
 		
 						// Fx.prototype.cur does not use fx argument
 						fx = i ? fx : this;


### PR DESCRIPTION
`elem` is being set in the outer scope but is only used in the modified jQuery methods so the last one bleeds out and as a result I am seeing detached DOM tree referenced by that there variable.

![](https://f.cloud.github.com/assets/441581/1623822/e0098812-56b8-11e3-8f17-4256e74482ac.png)
