### PR TITLE
Make startColumn option work in parseTable

### DIFF
--- a/js/modules/data.src.js
+++ b/js/modules/data.src.js
@@ -232,9 +232,8 @@
 			startRow = options.startRow || 0,
 			endRow = options.endRow || Number.MAX_VALUE,
 			startColumn = options.startColumn || 0,
-			endColumn = options.endColumn || Number.MAX_VALUE,
-			colNo;
-			
+			endColumn = options.endColumn || Number.MAX_VALUE;
+
 		if (table) {
 			
 			if (typeof table === 'string') {
@@ -242,16 +241,14 @@
 			}
 			
 			each(table.getElementsByTagName('tr'), function (tr, rowNo) {
-				colNo = 0; 
 				if (rowNo >= startRow && rowNo <= endRow) {
-					each(tr.childNodes, function (item) {
+					each(tr.children, function (item, colNo) {
 						if ((item.tagName === 'TD' || item.tagName === 'TH') && colNo >= startColumn && colNo <= endColumn) {
-							if (!columns[colNo]) {
-								columns[colNo] = [];					
+							if (!columns[colNo - startColumn]) {
+								columns[colNo - startColumn] = [];					
 							}
-							columns[colNo][rowNo - startRow] = item.innerHTML;
 							
-							colNo += 1;
+							columns[colNo - startColumn][rowNo - startRow] = item.innerHTML;
 						}
 					});
 				}


### PR DESCRIPTION
Specifying a non-zero startColumn did not work correctly in parseTable (it would never pass the innermost conditional check and so never get incremented, resulting in an empty columns array). It now follows the format used in parseCSV. A call to tr.childNodes has been replaced by a call to tr.children as tr.childNodes includes whitespace "nodes" that mess up the function.
