### PR TITLE
Keep an internal reference to Highcharts

### DIFF
--- a/js/parts/Globals.js
+++ b/js/parts/Globals.js
@@ -108,4 +108,4 @@ var UNDEFINED,
 	seriesTypes = {};
 
 // The Highcharts namespace
-win.Highcharts = win.Highcharts ? error(16, true) : {};
+var Highcharts = win.Highcharts = win.Highcharts ? error(16, true) : {};


### PR DESCRIPTION
This allows module loaders to clear the global scope after Highcharts and its plugins have loaded without causing issues.  Without this patch, `window.Highcharts` _has_ to exist, even after Highcharts has loaded, making it impossible to ensure that your modules are only acquiring their dependencies from the module system (rather than the global scope).

See [this JSFiddle](http://jsfiddle.net/Vt7b4/1/) for an example of the bug.
