### PR TITLE
Fix Dynamics: addPoint() does not take account of the requireSorting option

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -14609,7 +14609,7 @@ extend(Series.prototype, {
 
 		// Get the insertion point
 		i = xData.length;
-		if (series.requireSorting && x < xData[i - 1]) {
+		if (seriesOptions.requireSorting && x < xData[i - 1]) {
 			isInTheMiddle = true;
 			while (i && xData[i - 1] > x) {
 				i--;

--- a/js/highmaps.src.js
+++ b/js/highmaps.src.js
@@ -13823,7 +13823,7 @@ extend(Series.prototype, {
 
 		// Get the insertion point
 		i = xData.length;
-		if (series.requireSorting && x < xData[i - 1]) {
+		if (seriesOptions.requireSorting && x < xData[i - 1]) {
 			isInTheMiddle = true;
 			while (i && xData[i - 1] > x) {
 				i--;

--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -14609,7 +14609,7 @@ extend(Series.prototype, {
 
 		// Get the insertion point
 		i = xData.length;
-		if (series.requireSorting && x < xData[i - 1]) {
+		if (seriesOptions.requireSorting && x < xData[i - 1]) {
 			isInTheMiddle = true;
 			while (i && xData[i - 1] > x) {
 				i--;

--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -286,7 +286,7 @@ extend(Series.prototype, {
 
 		// Get the insertion point
 		i = xData.length;
-		if (series.requireSorting && x < xData[i - 1]) {
+		if (seriesOptions.requireSorting && x < xData[i - 1]) {
 			isInTheMiddle = true;
 			while (i && xData[i - 1] > x) {
 				i--;


### PR DESCRIPTION
When addPoint() is called and if requireSorting option is set to true,
the point is added at the end. requireSorting is not retrieved from
the right object.
