### PR TITLE
added support for multipane plotbands

### DIFF
--- a/js/parts/StockChart.js
+++ b/js/parts/StockChart.js
@@ -225,6 +225,38 @@ Axis.prototype.getPlotLinePath = function (value, lineWidth, old, force, transla
 	}
 };
 
+// Override getPlotBandPath to allow for multipane charts
+Axis.prototype.getPlotBandPath = function (from, to) {
+	var toPath = this.getPlotLinePath(to),
+		path = this.getPlotLinePath(from),
+		i,
+		j;
+
+	if (path && toPath) {
+		if (path.length === toPath.length && path.length > 6) { // support for multipane charts
+			for (i = 0, j = 6; i < toPath.length; i += 6, j += 10) {
+				path.splice(j, 0,
+					toPath[i + 4],
+					toPath[i + 5],
+					toPath[i + 1],
+					toPath[i + 2]
+				);
+			}
+		} else {
+			path.push(
+				toPath[4],
+				toPath[5],
+				toPath[1],
+				toPath[2]
+			);
+		}
+	} else { // outside the axis area
+		path = null;
+	}
+
+	return path;
+};
+
 // Function to crisp a line with multiple segments
 SVGRenderer.prototype.crispPolyLine = function (points, width) {
 	// points format: [M, 0, 0, L, 100, 0]		


### PR DESCRIPTION
Fixes #2827 - The problem is that PlotBands are calculated using PlotLines for the left and right side and then combined to form a rectangle. However, the PlotBand function was not multipane aware, so it would not combine the PlotLines correctly.
