### PR TITLE
fix legacy IE issue with ampersands

### DIFF
--- a/js/parts/Html.js
+++ b/js/parts/Html.js
@@ -182,6 +182,7 @@ extend(SVGRenderer.prototype, {
 
 		// Text setter
 		wrapper.textSetter = function (value) {
+			value = value.replace(/&(?!amp;)/g, '&amp;'); // fix legacy IE issue with ampersands
 			if (value !== element.innerHTML) {
 				delete this.bBox;
 			}


### PR DESCRIPTION
Fixes #796

IE version 6-8 had issues with setting innerHTML with & (ampersand characters). This manifested as a bug in Highcharts. See this fiddle http://jsfiddle.net/W7972/3/ for a test case.

See http://jsfiddle.net/hexRz/ for the fixed case.

The fix involves replacing '&' characters (that are not already &amp;amp;) with &amp;amp; before setting it as HTML. This code runs for other standards compliant browsers too with useHTML set to true but is harmless.

PS: I didn't stage the assembled files in the commit because they were showing diffs that aren't mine.
