### PR TITLE
My workaround for issue #2022

### DIFF
--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -337,8 +337,15 @@ extend(Chart.prototype, {
 		options = options || {};
 
 		var chart = this,
-			chartExportingOptions = chart.options.exporting,
-			svg = chart.getSVG(merge(
+			chartExportingOptions = chart.options.exporting || { chartOptions: { } };
+			
+		//merge axis options
+        	chartExportingOptions.xAxis = chartExportingOptions.xAxis ||[];
+        	chartExportingOptions.chartOptions.yAxis = chartExportingOptions.chartOptions.yAxis || [];
+        	chartExportingOptions.chartOptions.xAxis = merge(chart.options.xAxis, chartExportingOptions.chartOptions.xAxis);
+        	chartExportingOptions.chartOptions.yAxis = merge(chart.options.yAxis, chartExportingOptions.chartOptions.yAxis);	
+			
+		var svg = chart.getSVG(merge(
 				{ chart: { borderRadius: 0 } },
 				chartExportingOptions.chartOptions,
 				chartOptions,


### PR DESCRIPTION
Allows an array of axis options to be used in chart.exporting.chartOptions without overwriting existing chart's axis options.
