### PR TITLE
Regard `startOfWeek` option in data grouping

### DIFF
--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -18600,7 +18600,7 @@ seriesProto.processData = function () {
 				xAxis.normalizeTimeTickInterval(interval, dataGroupingOptions.units || defaultDataGroupingUnits),
 				xMin,
 				xMax,
-				null,
+				xAxis.options.startOfWeek,
 				processedXData,
 				series.closestPointRange
 			),

--- a/js/parts/DataGrouping.js
+++ b/js/parts/DataGrouping.js
@@ -305,7 +305,7 @@ seriesProto.processData = function () {
 				xAxis.normalizeTimeTickInterval(interval, dataGroupingOptions.units || defaultDataGroupingUnits),
 				xMin,
 				xMax,
-				null,
+				xAxis.options.startOfWeek,
 				processedXData,
 				series.closestPointRange
 			),


### PR DESCRIPTION
Currently `xAxis.options.startOfWeek` doesn't affect date grouping, and date grouping always group weeks starting from Mondays.
