### PR TITLE
Allow changing `Date` class used to support other calendars

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -82,6 +82,7 @@ var UNDEFINED,
 	STROKE_WIDTH = 'stroke-width',
 
 	// time methods, changed based on whether or not UTC is used
+	Date,  // Allow using a different Date class
 	makeTime,
 	timezoneOffset,
 	getMinutes,
@@ -1595,6 +1596,7 @@ function setTimeMethods() {
 		SET = useUTC ? 'setUTC' : 'set';
 
 
+	Date = defaultOptions.global.Date || window.Date;
 	timezoneOffset = ((useUTC && defaultOptions.global.timezoneOffset) || 0) * 60000;
 	makeTime = useUTC ? Date.UTC : function (year, month, date, hours, minutes, seconds) {
 		return new Date(

--- a/js/highmaps.src.js
+++ b/js/highmaps.src.js
@@ -82,6 +82,7 @@ var UNDEFINED,
 	STROKE_WIDTH = 'stroke-width',
 
 	// time methods, changed based on whether or not UTC is used
+	Date,  // Allow using a different Date class
 	makeTime,
 	timezoneOffset,
 	getMinutes,
@@ -1595,6 +1596,7 @@ function setTimeMethods() {
 		SET = useUTC ? 'setUTC' : 'set';
 
 
+	Date = defaultOptions.global.Date || window.Date;
 	timezoneOffset = ((useUTC && defaultOptions.global.timezoneOffset) || 0) * 60000;
 	makeTime = useUTC ? Date.UTC : function (year, month, date, hours, minutes, seconds) {
 		return new Date(

--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -82,6 +82,7 @@ var UNDEFINED,
 	STROKE_WIDTH = 'stroke-width',
 
 	// time methods, changed based on whether or not UTC is used
+	Date,  // Allow using a different Date class
 	makeTime,
 	timezoneOffset,
 	getMinutes,
@@ -1595,6 +1596,7 @@ function setTimeMethods() {
 		SET = useUTC ? 'setUTC' : 'set';
 
 
+	Date = defaultOptions.global.Date || window.Date;
 	timezoneOffset = ((useUTC && defaultOptions.global.timezoneOffset) || 0) * 60000;
 	makeTime = useUTC ? Date.UTC : function (year, month, date, hours, minutes, seconds) {
 		return new Date(

--- a/js/parts/Globals.js
+++ b/js/parts/Globals.js
@@ -67,6 +67,7 @@ var UNDEFINED,
 	STROKE_WIDTH = 'stroke-width',
 
 	// time methods, changed based on whether or not UTC is used
+	Date,  // Allow using a different Date class
 	makeTime,
 	timezoneOffset,
 	getMinutes,

--- a/js/parts/Options.js
+++ b/js/parts/Options.js
@@ -363,6 +363,7 @@ function setTimeMethods() {
 		SET = useUTC ? 'setUTC' : 'set';
 
 
+	Date = defaultOptions.global.Date || window.Date;
 	timezoneOffset = ((useUTC && defaultOptions.global.timezoneOffset) || 0) * 60000;
 	makeTime = useUTC ? Date.UTC : function (year, month, date, hours, minutes, seconds) {
 		return new Date(


### PR DESCRIPTION
I worked a lot to make highstock charts with non-gregorian dates. Changing `dateFormats` is not sufficient because some features like YTD zoom option and date input-boxes still works in gregorian calendar.

I found that the best way for changing highstock calendar, is changing the `Date` class entirely. Fortunately, in source files, Date class is used in the best way, and hacking `window.Date` with another Date-like class is sufficient to change calendar.

This is a Date-like class for Persian calendar: [JDate](https://github.com/tahajahangir/jdate). And there is [highstock demo](http://tahajahangir.github.io/jdate/jalali-highcharts-demo.html) that demonstrates the use of this class.

In this two-line change, an option is made to change the `Date` class in use. ant lint is running successfully, and size of minified files is reduced (because Date is now a local variable)
