### PR TITLE
Fix issue with IE8 where a space is placed at the beginning of an

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -2009,7 +2009,7 @@ SVGElement.prototype = {
 			currentClassName = attr(element, 'class') || '';
 
 		if (currentClassName.indexOf(className) === -1) {
-			attr(element, 'class', currentClassName + ' ' + className);
+			attr(element, 'class', currentClassName === "" ? className : currentClassName + ' ' + className);
 		}
 		return this;
 	},


### PR DESCRIPTION
attribute when calling SVGElement.addClass().
