### PR TITLE
syntax error due to wrong variable name 'globalOptions' in highcharts-convert.js

### DIFF
--- a/exporting-server/phantomjs/highcharts-convert.js
+++ b/exporting-server/phantomjs/highcharts-convert.js
@@ -391,8 +391,8 @@
 			options.chart.height = (options.exporting && options.exporting.sourceHeight) || options.chart.height || 400;
 
 			// Load globalOptions
-			if (globalOptions) {
-				Highcharts.setOptions(globalOptions);
+			if (globalOptionsArg) {
+				Highcharts.setOptions(globalOptionsArg);
 			}
 
 			// Load data


### PR DESCRIPTION
Running the converter while setting the parameter globaloptions results in the following error message:

Highcharts.options.parsed
SyntaxError: Parse error

Highcharts.customCode.parsed
ReferenceError: Can't find variable: globalOptions

  phantomjs://webpage.evaluate():79
  phantomjs://webpage.evaluate():132
  phantomjs://webpage.evaluate():132
TypeError: 'null' is not an object (evaluating 'svg.imgUrls')

  /usr/local/phantomjs/lib/highcharts/highcharts-convert.js:228
  /usr/local/phantomjs/lib/highcharts/highcharts-convert.js:503
  :/modules/webpage.js:281

This is due to the wrong variable name globalOptions which should be globalOptionsArg
