### PR TITLE
Fix axis plot line length in highstock

### DIFF
--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -21726,7 +21726,7 @@ Axis.prototype.getPlotLinePath = function (value, lineWidth, old, force, transla
 		if (axis.horiz) {
 			each(uniqueAxes, function (axis2) {
 				y1 = axis2.top;
-				y2 = y1 + axis2.len;
+				y2 = y1 + axis2.height;
 				x1 = x2 = mathRound(translatedValue + axis.transB);
 
 				if ((x1 >= axisLeft && x1 <= axisLeft + axis.width) || force) {


### PR DESCRIPTION
Tick lines are drawn too long on coloraxis using highstock.

This can be reproduced replacing highcharts with the latest version of highstock in this heatmap example:
http://jsfiddle.net/gh/get/jquery/1.9.1/highslide-software/highcharts.com/tree/master/samples/highcharts/demo/heatmap-canvas/
vs
http://jsfiddle.net/pr20vbx4/

Changing axis2.len to axis2.height fixes this problem.
