### PR TITLE
Add missing check if series.animate exists in render-function

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -14021,7 +14021,7 @@ Series.prototype = {
 		);
 
 		// initiate the animation
-		if (animDuration) {
+		if (animDuration && series.animate) {
 			series.animate(true);
 		}
 


### PR DESCRIPTION
In some cases `series.animate` is `null`. This PR adds a check before calling the function.
