### PR TITLE
#1 : JDK 8.0 Compatibility with highcharts-export-server

### DIFF
--- a/exporting-server/java/highcharts-export/highcharts-export-web/pom.xml
+++ b/exporting-server/java/highcharts-export/highcharts-export-web/pom.xml
@@ -37,12 +37,12 @@
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.7</version>
+			<version>1.9</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>
-			<version>2.5</version>
+			<version>2.6</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-fileupload</groupId>
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
-			<version>3.0.1</version>
+			<version>3.1.0</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
@@ -69,7 +69,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>2.1.1</version>
+				<version>2.5</version>
 				<configuration>
 					<warName>${project.artifactId}</warName>
 					<webXml>src/main/webapp/WEB-INF/web.xml</webXml>
@@ -85,7 +85,7 @@
 			<plugin>
 				<groupId>org.mortbay.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>8.1.15.v20140411</version>
+				<version>9.2.3.v20140905</version>
 				<configuration>
 					<webApp>
 						<contextPath>/export</contextPath>

--- a/exporting-server/java/highcharts-export/pom.xml
+++ b/exporting-server/java/highcharts-export/pom.xml
@@ -16,8 +16,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
-		<spring.version>3.2.0.RELEASE</spring.version>
-		<cglib.version>2.2.2</cglib.version>
+		<spring.version>4.1.1.RELEASE</spring.version>
 		<maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
 		<beanstalk.versionLabel>export-${maven.build.timestamp}</beanstalk.versionLabel>
 	</properties>
@@ -35,7 +34,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>1.3.2</version>
+			<version>2.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -52,14 +51,9 @@
 		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
-			<version>1.2.14</version>
+			<version>1.2.17</version>
 			<type>jar</type>
 			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>cglib</groupId>
-			<artifactId>cglib</artifactId>
-			<version>${cglib.version}</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
When we use JDK 8.0, it produces an error (very difficult to understand) with a java.lang.IllegalArgumentException.

The test was done on JDK 1.7.55 and JDK 1.8.20 and both are oks !

http://stackoverflow.com/questions/26761191/highcharts-export-server-java-lang-illegalargumentexception-when-running-the-a

It's due to spring-version and cglib version which is too old (cglib was removed because it's not necessary anymore !).
