### PR TITLE
Update standalone-framework.src.js

### DIFF
--- a/js/adapters/standalone-framework.src.js
+++ b/js/adapters/standalone-framework.src.js
@@ -437,7 +437,7 @@ return {
 					start = 0;
 					end = 1;
 				} else if (el.attr) {
-					start = el.attr(name);
+					start = parseFloat(el.attr(name)) || 0;
 				} else {
 					start = parseFloat(HighchartsAdapter._getStyle(el, name)) || 0;
 					if (name !== 'opacity') {


### PR DESCRIPTION
The line 440 codes: 
          `start = el.attr(name);` 
should be sourround by `parseFloat`(like `start = parseFloat(el.attr(name)) || 0;`), 

otherwise the latter codes `this.now = this.start + ((this.end - this.start) * this.pos)` will throw a error (Error: Invalid value for <text> attribute y="-919.4375550.19401314") inside the function of `fx.custom(start, end, unit)`.

Because the `this.start` is a number in String type.