### PR TITLE
Extended heatmap class to display a "smooth" surface instead of discrete rectangles.

### DIFF
--- a/js/modules/contour.src.js
+++ b/js/modules/contour.src.js
@@ -34,6 +34,16 @@ defaultOptions.plotOptions.contour = merge(defaultOptions.plotOptions.heatmap, {
 	})
 });
 
+/**
+* Normalize a value into 0-1 range
+*/
+Highcharts.ColorAxis.prototype.toRelativePosition = function(value) {
+    if (this.isLog) {
+        value = this.val2lin(value);
+    }
+    return (value - this.min) / ((this.max - this.min) || 1);
+};
+
 // The Heatmap series type
 seriesTypes.contour = extendClass(seriesTypes.heatmap, {
 	type: 'contour',
@@ -196,7 +206,6 @@ seriesTypes.contour = extendClass(seriesTypes.heatmap, {
 				}
 			});
 			this.base_gradient_id = /(#.*)[)]/.exec(fake_rect.attr('fill'))[1];
-			console.log(this.base_gradient_id);
 		}
 		
 		var group = series.surface_group;

--- a/js/modules/heatmap.src.js
+++ b/js/modules/heatmap.src.js
@@ -193,16 +193,6 @@ extend(ColorAxis.prototype, {
 		}
 	},
 
-	/**
-	* Normalize a value into 0-1 range
-	*/
-	toRelativePosition: function(value) {
-		if (this.isLog) {
-			value = this.val2lin(value);
-		}
-		return (value - this.min) / ((this.max - this.min) || 1);
-        },
-       
 	/** 
 	 * Translate from a value to a color
 	 */
@@ -232,7 +222,11 @@ extend(ColorAxis.prototype, {
 			}
 
 		} else {
-			pos = this.toRelativePosition(value);
+
+			if (this.isLog) {
+				value = this.val2lin(value);
+			}
+			pos = 1 - ((this.max - value) / ((this.max - this.min) || 1));
 			i = stops.length;
 			while (i--) {
 				if (pos > stops[i][0]) {


### PR DESCRIPTION
This extension works by triangulating all the data points and filling each triangle with a linear gradient that interpolates the values assigned with each vertex.

Triangulation is performed either on a regular grid (Every 'grid_width' vertexes make a row/column) or using Delaunay (In case your data is irregular or you are just too lazy)

Also, if you configure your gradient colors right, and it will create pretty countour lines. E.g.:
   3% - rgb(255,255,255)
  10% - rgb(255,255,255)
  15% - rgb(219,219,219)
  23% - rgb(219,219,219)
  28% - rgb(182,182,182)
  35% - rgb(182,182,182)
  40% - rgb(146,146,146)
  48% - rgb(146,146,146)
  53% - rgb(109,109,109)
  60% - rgb(109,109,109)
  65% - rgb(73,73,73)
  73% - rgb(73,73,73)
  78% - rgb(36,36,36)
  85% - rgb(36,36,36)
  90% - rgb(0,0,0)

An minimal example can be seen here: http://jsfiddle.net/948768ae/2/.
The tool that currently uses it looks like this: http://i.imgur.com/nEOqeb5.png
