### PR TITLE
Possibility to extend form data for exporting

### DIFF
--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -355,13 +355,13 @@ extend(Chart.prototype, {
 		options = merge(chart.options.exporting, options);
 
 		// do the post
-		Highcharts.post(options.url, {
-			filename: options.filename || 'chart',
-			type: options.type,
-			width: options.width || 0, // IE8 fails to post undefined correctly, so use 0
-			scale: options.scale || 2,
-			svg: svg
-		}, options.formAttributes);
+		Highcharts.post(options.url, merge({
+      filename: options.filename || 'chart',
+      type: options.type,
+      width: options.width || 0, // IE8 fails to post undefined correctly, so use 0
+      scale: options.scale || 2,
+      svg: svg
+    }, options.data), options.formAttributes);
 
 	},
 


### PR DESCRIPTION
Add the possibility to add form data in exporting post.
We would like to add some form data because we want to make an excel export with the data and the chart picture. We have to known some other informations to execute a sql query to have the correct data.
