### PR TITLE
This diff makes major changes to the implementation of the `perspective()` function:

### DIFF
--- a/js/parts-3d/Column.js
+++ b/js/parts-3d/Column.js
@@ -1,4 +1,4 @@
-/*** 
+/***
 	EXTENSION FOR 3D COLUMNS
 ***/
 Highcharts.wrap(Highcharts.seriesTypes.column.prototype, 'translate', function (proceed) {
@@ -12,20 +12,10 @@ Highcharts.wrap(Highcharts.seriesTypes.column.prototype, 'translate', function (
 	var series = this,
 		chart = series.chart,
 		options = chart.options,
-		seriesOptions = series.options,		
-		options3d = options.chart.options3d,
+		seriesOptions = series.options,
+		depth = seriesOptions.depth || 25;
 
-		depth = seriesOptions.depth || 25,
-		origin = {
-			x: chart.plotWidth / 2,
-			y: chart.plotHeight / 2, 
-			z: options3d.depth,
-			vd: options3d.viewDistance
-		},
-		alpha = options3d.alpha,
-		beta = options3d.beta * (chart.yAxis[0].opposite ? -1 : 1);
-
-	var stack = seriesOptions.stacking ? (seriesOptions.stack || 0) : series._i; 
+	var stack = seriesOptions.stacking ? (seriesOptions.stack || 0) : series._i;
 	var z = stack * (depth + (seriesOptions.groupZPadding || 1));
 
 	if (seriesOptions.grouping !== false) { z = 0; }
@@ -38,14 +28,12 @@ Highcharts.wrap(Highcharts.seriesTypes.column.prototype, 'translate', function (
 				tooltipPos = point.tooltipPos;
 
 			point.shapeType = 'cuboid';
-			shapeArgs.alpha = alpha;
-			shapeArgs.beta = beta; 
 			shapeArgs.z = z;
-			shapeArgs.origin = origin;
 			shapeArgs.depth = depth;
+			shapeArgs.insidePlotArea = true;
 
 			// Translate the tooltip position in 3d space
-			tooltipPos = perspective([{ x: tooltipPos[0], y: tooltipPos[1], z: z }], alpha, beta, origin)[0];
+			tooltipPos = perspective([{ x: tooltipPos[0], y: tooltipPos[1], z: z }], chart, false)[0];
 			point.tooltipPos = [tooltipPos.x, tooltipPos.y];
 		}
 	});	    
@@ -159,23 +147,13 @@ Highcharts.wrap(Highcharts.Series.prototype, 'alignDataLabel', function (proceed
 	// Only do this for 3D columns and columnranges
 	if (this.chart.is3d() && (this.type === 'column' || this.type === 'columnrange')) {
 		var series = this,
-			chart = series.chart,
-			options = chart.options,		
-			options3d = options.chart.options3d,
-			origin = {
-				x: chart.plotWidth / 2,
-				y: chart.plotHeight / 2, 
-				z: options3d.depth,
-				vd: options3d.viewDistance
-			},
-			alpha = options3d.alpha,
-			beta = options3d.beta * (chart.yAxis[0].opposite ? -1 : 1);
+			chart = series.chart;
 
 		var args = arguments,
 			alignTo = args[4];
 		
 		var pos = ({x: alignTo.x, y: alignTo.y, z: 0});
-		pos = perspective([pos], alpha, beta, origin)[0];
+		pos = perspective([pos], chart, true)[0];
 		alignTo.x = pos.x;
 		alignTo.y = pos.y;
 	}

--- a/js/parts-3d/Math.js
+++ b/js/parts-3d/Math.js
@@ -5,49 +5,71 @@ var PI = Math.PI,
 	deg2rad = (PI / 180), // degrees to radians 
 	sin = Math.sin,
 	cos = Math.cos, 
-
+	pick = Highcharts.pick,
 	round = Math.round;
 
-function perspective(points, angle2, angle1, origin) {
-	angle1 *= deg2rad;
-	angle2 *= deg2rad;
+function perspective(points, chart, insidePlotArea) {
+	var options3d = chart.options.chart.options3d,
+		inverted = false;
+	if (insidePlotArea) {
+		inverted = chart.inverted;
+		origin = {
+			x: chart.plotWidth / 2,
+			y: chart.plotHeight / 2,
+			z: options3d.depth / 2,
+			vd: pick(options3d.depth, 1) * pick(options3d.viewDistance, 0)
+		};
+	} else {
+		origin = {
+			x: chart.plotLeft + (chart.plotWidth / 2),
+			y: chart.plotTop + (chart.plotHeight / 2),
+			z: options3d.depth / 2,
+			vd: pick(options3d.depth, 1) * pick(options3d.viewDistance, 0)
+		};
+	}
 
 	var result = [],
-		xe, 
-		ye, 
-		ze;
-
-	angle1 *= -1;
-	
-	xe = origin.x;
-	ye = origin.y;
-	ze = (origin.z === 0 ? 0.0001 : origin.z) * (origin.vd || 25);
-	
-	// some kind of minimum?
-	ze = Math.max(500, ze);
-
-	var s1 = sin(angle1),
+		xe = origin.x,
+		ye = origin.y,
+		ze = origin.z,
+		vd = origin.vd,
+		angle1 = deg2rad * (inverted ?  options3d.beta  : -options3d.beta),
+		angle2 = deg2rad * (inverted ? -options3d.alpha :  options3d.alpha),
+		s1 = sin(angle1),
 		c1 = cos(angle1),
 		s2 = sin(angle2),
 		c2 = cos(angle2);
 
-	var x, y, z, p;
+	var x, y, z, px, py, pz, p;
 
 	Highcharts.each(points, function (point) {
-		x = point.x - xe;
-		y = point.y - ye;
-		z = point.z || 0;
+		x = (inverted ? point.y : point.x) - xe;
+		y = (inverted ? point.x : point.y) - ye;
+		z = (point.z || 0) - ze;
 
-		p = {
-			x: c1 * x - s1 * z,
-			y: -s1 * s2 * x - c1 * s2 * z + c2 * y,		
-			z: s1 * c2 * x + c1 * c2 * z + s2 * y
-		};
+		//Apply 3-D rotation
+		px = c1 * x - s1 * z;
+		py = -s1 * s2 * x - c1 * s2 * z + c2 * y;
+		pz = s1 * c2 * x + c1 * c2 * z + s2 * y;
 
-		p.x = p.x * ((ze - p.z) / ze) + xe;
-		p.y = p.y * ((ze - p.z) / ze) + ye;
+		//Apply perspective
+		if ((vd > 0) && (vd < Number.POSITIVE_INFINITY)) {
+			px = px * (vd / (pz + ze + vd));
+			py = py * (vd / (pz + ze + vd));
+		}
 
-		result.push({x: round(p.x), y: round(p.y), z: round(p.z)});
+		//Apply translation
+		px = px + xe;
+		py = py + ye;
+		pz = pz + ze;
+
+		result.push({
+			x: (inverted ? py : px),
+			y: (inverted ? px : py),
+			z: pz
+		});
 	});
 	return result;
 }
+// Make function acessible to plugins
+Highcharts.perspective = perspective;

--- a/js/parts-3d/SVGRenderer.js
+++ b/js/parts-3d/SVGRenderer.js
@@ -135,9 +135,9 @@ Highcharts.SVGRenderer.prototype.cuboidPath = function (shapeArgs) {
 		h = shapeArgs.height,
 		w = shapeArgs.width,
 		d = shapeArgs.depth,
-		alpha = shapeArgs.alpha,
-		beta = shapeArgs.beta,
-		origin = shapeArgs.origin;
+		chart = Highcharts.charts[this.box.parentElement.parentElement.getAttribute("data-highcharts-chart")],
+		alpha = chart.options.chart.options3d.alpha,
+		beta = chart.options.chart.options3d.beta;
 
 	var pArr = [
 		{x: x, y: y, z: z},
@@ -150,7 +150,7 @@ Highcharts.SVGRenderer.prototype.cuboidPath = function (shapeArgs) {
 		{x: x, y: y, z: z + d}
 	];
 
-	pArr = perspective(pArr, alpha, beta, origin);
+	pArr = perspective(pArr, chart, shapeArgs.insidePlotArea);
 
 	var path1, // FRONT
 		path2, // TOP OR BOTTOM

--- a/js/parts-3d/Scatter.js
+++ b/js/parts-3d/Scatter.js
@@ -11,36 +11,38 @@ Highcharts.wrap(Highcharts.seriesTypes.scatter.prototype, 'translate', function 
 
 	var series = this,
 		chart = series.chart,
-		options3d = series.chart.options.chart.options3d,
-		alpha = options3d.alpha,
-		beta = options3d.beta,
-		origin = {
-			x: chart.inverted ? chart.plotHeight / 2 : chart.plotWidth / 2,
-			y: chart.inverted ? chart.plotWidth / 2 : chart.plotHeight / 2, 
-			z: options3d.depth,
-			vd: options3d.viewDistance
-		},
-		depth = options3d.depth,
+		depth = chart.options.chart.options3d.depth,
 		zAxis = chart.options.zAxis || { min : 0, max: depth };
-	
-	var rangeModifier = depth / (zAxis.max - zAxis.min);
-	
-	Highcharts.each(series.data, function (point) {
-		var pCo = { 
-			x: point.plotX,
-			y: point.plotY,
-			z: (point.z - zAxis.min) * rangeModifier
-		};
 
-		pCo = perspective([pCo], alpha, beta, origin)[0];		
+	var rangeModifier = depth / (zAxis.max - zAxis.min),
+		raw_points = [],
+		raw_point,
+		projected_points,
+		projected_point,
+		i;
 
-		point.plotXold = point.plotX;
-		point.plotYold = point.plotY;
-		
-		point.plotX = pCo.x;
-		point.plotY = pCo.y;
-		point.plotZ = pCo.z;
-	});	  
+	for (i = 0; i < series.data.length; i++) {
+		raw_point = series.data[i];
+		raw_points.push({
+			x: raw_point.plotX,
+			y: raw_point.plotY,
+			z: (raw_point.z - zAxis.min) * rangeModifier
+		});
+	}
+
+	projected_points = perspective(raw_points, chart, true);
+
+	for (i = 0; i < series.data.length; i++) {
+		raw_point = series.data[i];
+		projected_point = projected_points[i];
+
+		raw_point.plotXold = raw_point.plotX;
+		raw_point.plotYold = raw_point.plotY;
+
+		raw_point.plotX = projected_point.x;
+		raw_point.plotY = projected_point.y;
+		raw_point.plotZ = projected_point.z;
+	}
 });
 
 Highcharts.wrap(Highcharts.seriesTypes.scatter.prototype, 'init', function (proceed) {


### PR DESCRIPTION
- Fix perspective formula to be Rectilinear. Otherwise we get funny misalignment artifacts -- Notice that the vertical grid lines in http://jsfiddle.net/r3y93qpe/ don't end in the expected place
- Rotate around `ze=depth/2`. Otherwise, the chart is off-center when rotated -- See http://jsfiddle.net/07LL525c/
- Exports the perspective function as Highcharts.perspective, so it can be used by plugins.
- Uses isometric mode (No perspective projection) when `viewDistance==0`
- Most importantly, Projection parameters (alpha, beta, origin) are now calculated inside of perspective() function, instead of in every call place.
  - Simpler code at call place
  - Avoids inconsistent calculations at each origin -- In particular when using `inverted=true` and `axis.reversed=true` -- E.g., http://jsfiddle.net/m8ppj1mx/
  - caller must specify if the element is being drawn inside the plot area or not, so that we can compensate the SVG transform.

This change doesn't affect Renderer.arc3d(), pie charts and donut charts.
