### PR TITLE
Add a printWidth option for exporting chart

### DIFF
--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -98,7 +98,8 @@ defaultOptions.exporting = {
 	type: 'image/png',
 	url: 'http://export.highcharts.com/',
 	//width: undefined,
-	//scale: 2
+	//scale: 2,
+        //printWidth: undefined
 	buttons: {
 		contextButton: {
 			menuClassName: PREFIX + 'contextmenu',
@@ -382,6 +383,12 @@ extend(Chart.prototype, {
 		}
 
 		chart.isPrinting = true;
+		
+		if(chart.options.exporting.printWidth !== undefined) {
+                	chart._screenMediaWidth = chart.chartWidth;
+                	chart._hasUserSize = chart.hasUserSize;
+                	chart.setSize(chart.options.exporting.printWidth, chart.chartHeight, false);
+        	}
 
 		// hide all body content
 		each(childNodes, function (node, i) {
@@ -410,7 +417,11 @@ extend(Chart.prototype, {
 					node.style.display = origDisplay[i];
 				}
 			});
-
+			
+			if(chart.options.exporting.printWidth !== undefined) {
+	                    chart.setSize(chart._screenMediaWidth, chart.chartHeight, false);
+	                    chart.hasUserSize = chart._hasUserSize;
+	                }
 			chart.isPrinting = false;
 
 		}, 1000);

--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -99,7 +99,7 @@ defaultOptions.exporting = {
 	url: 'http://export.highcharts.com/',
 	//width: undefined,
 	//scale: 2,
-        //printWidth: undefined
+    //printWidth: undefined
 	buttons: {
 		contextButton: {
 			menuClassName: PREFIX + 'contextmenu',
@@ -385,10 +385,10 @@ extend(Chart.prototype, {
 		chart.isPrinting = true;
 		
 		if(chart.options.exporting.printWidth !== undefined) {
-                	chart._screenMediaWidth = chart.chartWidth;
-                	chart._hasUserSize = chart.hasUserSize;
-                	chart.setSize(chart.options.exporting.printWidth, chart.chartHeight, false);
-        	}
+	    	chart._screenMediaWidth = chart.chartWidth;
+	    	chart._hasUserSize = chart.hasUserSize;
+	    	chart.setSize(chart.options.exporting.printWidth, chart.chartHeight, false);
+		}
 
 		// hide all body content
 		each(childNodes, function (node, i) {
@@ -419,9 +419,9 @@ extend(Chart.prototype, {
 			});
 			
 			if(chart.options.exporting.printWidth !== undefined) {
-	                    chart.setSize(chart._screenMediaWidth, chart.chartHeight, false);
-	                    chart.hasUserSize = chart._hasUserSize;
-	                }
+                chart.setSize(chart._screenMediaWidth, chart.chartHeight, false);
+                chart.hasUserSize = chart._hasUserSize;
+            }
 			chart.isPrinting = false;
 
 		}, 1000);


### PR DESCRIPTION
The goal is to be able to set the chart width during print.
I used some of the code provided in this issue to create this code: #2088 

Here you can see the option in action: http://jsfiddle.net/ydfzsh6u/3/