### PR TITLE
Option 'scrollbar.showButtons' (true by default) for ability hide left/right arrow buttons in scrollbar for a cleaner appearance

### DIFF
--- a/js/parts/Scroller.js
+++ b/js/parts/Scroller.js
@@ -99,6 +99,7 @@ extend(defaultOptions, {
 		barBorderRadius: 0,
 		barBorderWidth: 1,
 		barBorderColor: '#bfc8d1',
+		showButtons: true,
 		buttonArrowColor: '#666',
 		buttonBackgroundColor: '#ebe7e8',
 		buttonBorderColor: '#bbb',
@@ -310,7 +311,11 @@ Scroller.prototype = {
 		);
 		scroller.navigatorWidth = navigatorWidth = pick(xAxis.len, chart.plotWidth - 2 * scrollbarHeight);
 		scroller.scrollerLeft = scrollerLeft = navigatorLeft - scrollbarHeight;
-		scroller.scrollerWidth = scrollerWidth = scrollerWidth = navigatorWidth + 2 * scrollbarHeight;
+		if (scrollbarOptions.showButtons) {
+			scroller.scrollerWidth = scrollerWidth = scrollerWidth = navigatorWidth + 2 * scrollbarHeight;
+		} else {
+			scroller.scrollerWidth = scrollerWidth = scrollerWidth = navigatorWidth;
+		}
 
 		// Set the scroller x axis extremes to reflect the total. The navigator extremes
 		// should always be the extremes of the union of all series in the chart as
@@ -468,8 +473,10 @@ Scroller.prototype = {
 		if (scrollbarEnabled && scrollbarGroup) {
 
 			// draw the buttons
-			scroller.drawScrollbarButton(0);
-			scroller.drawScrollbarButton(1);
+			if (scrollbarOptions.showButtons) {
+				scroller.drawScrollbarButton(0);
+				scroller.drawScrollbarButton(1);
+			}
 
 			scrollbarGroup[verb]({
 				translateX: scrollerLeft,
@@ -480,8 +487,12 @@ Scroller.prototype = {
 				width: scrollerWidth
 			});
 
-			// prevent the scrollbar from drawing to small (#1246)
-			scrX = scrollbarHeight + zoomedMin;
+			// prevent the scrollbar from drawing too small (#1246)
+			if (scrollbarOptions.showButtons) {
+				scrX = scrollbarHeight + zoomedMin;
+			} else {
+				scrX = zoomedMin;
+			}
 			scrWidth = range - scrollbarStrokeWidth;
 			if (scrWidth < scrollbarMinWidth) {
 				scrollbarPad = (scrollbarMinWidth - scrWidth) / 2;


### PR DESCRIPTION
I wanted it to look like this:

![screenshot 2015-01-26 16 03 45](https://cloud.githubusercontent.com/assets/97612/5910948/ee49ac3e-a574-11e4-8cef-dbbdeb5d3f3e.png)
