### PR TITLE
Fix bug with title margin. Resolves issue #2397

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -501,7 +501,7 @@ Chart.prototype = {
 			subtitle
 				.css({ width: (subtitleOptions.width || autoWidth) + PX })
 				.align(extend({ 
-					y: titleOffset + (titleOptions.margin - 13) + renderer.fontMetrics(titleOptions.style.fontSize, subtitle).b 
+					y: titleOffset + renderer.fontMetrics(titleOptions.style.fontSize, subtitle).b 
 				}, subtitleOptions), false, 'spacingBox');
 			
 			if (!subtitleOptions.floating && !subtitleOptions.verticalAlign) {


### PR DESCRIPTION
This seems to fix the problem for me. Looks like the existing logic was using the title margin to determine the y position for subtitle when it didn't need to.
