### PR TITLE
HighchartsAdapter: expose adapter

### DIFF
--- a/js/adapters/standalone-framework.src.js
+++ b/js/adapters/standalone-framework.src.js
@@ -8,7 +8,7 @@
 
 
 /*global Highcharts */
-var HighchartsAdapter = (function () {
+var HighchartsAdapter = window.HighchartsAdapter = (function () {
 
 var UNDEFINED,
 	doc = document,


### PR DESCRIPTION
This PR relates to issue #3616 in some sense and it allows webpack users to easily require the Standalone Framework adapter.

With 'highcharts-adapter' defined as a `resolve.alias` within the webpack.config file that points to the Standalone Framework file, the following hold true:

1. Simply requiring 'highcharts-adapter' will make it available to Highcharts (or Highmaps), which, as pointed out by the documentation, should be required after the adapter.

2. `var HighchartsAdapter
   = require('exports?HighchartsAdapter!highcharts-adapter');` will
   return the actual adapter, while also making it available to Highcharts, as in 1).

Admittedly, there may be better ways to go about it, but it does the job for now.