### PR TITLE
add health check for GET /status that is need for AWS EC2 load banlance

### DIFF
--- a/exporting-server/phantomjs/highcharts-convert.js
+++ b/exporting-server/phantomjs/highcharts-convert.js
@@ -578,8 +578,8 @@
 					if (request.url == "/status") {						
 						response.statusCode = 200;
 						response.headers = {
-    							'Content-Type': 'text/html',
-    							'Content-Length': 2
+							'Content-Type': 'text/html',
+							'Content-Length': 2
 						};
 						response.write('OK');
 						response.close();
@@ -594,6 +594,10 @@
 					} else {
 						render(params, function (result) {
 							response.statusCode = 200;
+							response.headers = {
+    							'Content-Type': 'text/html',
+    							'Content-Length': result.length
+							};
 							response.write(result);
 							response.close();
 						});

--- a/exporting-server/phantomjs/highcharts-convert.js
+++ b/exporting-server/phantomjs/highcharts-convert.js
@@ -574,6 +574,17 @@
 					params,
 					msg;
 				try {
+					// for server health validation
+					if (request.url == "/status") {						
+						response.statusCode = 200;
+						response.headers = {
+    							'Content-Type': 'text/html',
+    							'Content-Length': 2
+						};
+						response.write('OK');
+						response.close();
+						return;
+					}
 					params = JSON.parse(jsonStr);
 					if (params.status) {
 						// for server health validation


### PR DESCRIPTION
I found the phantomjs server side export chart is no way to work with AWS EC2 load banlance.
To check the phantaomjs server status EC2 can only send GET request or POST without body request.
So I add add this to make the export server can work with it.
