### PR TITLE
Automatically select buttons when they match set range

### DIFF
--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -22540,7 +22540,6 @@
             // Select this button
             if (buttons[i]) {
                 buttons[i].setState(2);
-                rangeSelector.lastSelected = i;
             }
 
             // Update the chart
@@ -22712,7 +22711,7 @@
                 // The new zoom area happens to match the range for a button - mark it selected.
                 // This happens when scrolling across an ordinal gap. It can be seen in the intraday
                 // demos when selecting 1h and scroll across the night gap.
-                if (isSelectedForExport || (isSameRange && i !== selected) && i === rangeSelector.lastSelected) {
+                if (isSelectedForExport || (isSameRange && i !== selected)) {
                     rangeSelector.setSelected(i);
                     buttons[i].setState(2);
 

--- a/js/parts/RangeSelector.js
+++ b/js/parts/RangeSelector.js
@@ -177,7 +177,6 @@ RangeSelector.prototype = {
 		// Select this button
 		if (buttons[i]) {
 			buttons[i].setState(2);
-			rangeSelector.lastSelected = i;
 		}
 
 		// Update the chart
@@ -349,7 +348,7 @@ RangeSelector.prototype = {
 			// The new zoom area happens to match the range for a button - mark it selected.
 			// This happens when scrolling across an ordinal gap. It can be seen in the intraday
 			// demos when selecting 1h and scroll across the night gap.
-			if (isSelectedForExport || (isSameRange && i !== selected) && i === rangeSelector.lastSelected) {
+			if (isSelectedForExport || (isSameRange && i !== selected)) {
 				rangeSelector.setSelected(i);
 				buttons[i].setState(2);
 


### PR DESCRIPTION
I was fixing the issue I had with new version of Highcharts and prepared this fix, but now I am seeing that this was added with #3375 and 916f37cb479e36032b097a739b8c2bc5ec1b21be.

So maybe a better fix is needed. Current code breaks prior behavior: if I use `setExtremes` to set range to one which matches one of buttons I expect that the corresponding button gets selected. With latest code this is not true, but before it was. This pull request fixes the problem, but probably reintroduces the problem from #3375.
