### PR TITLE
[Html] Fix bug where label styles aren't reset on resize

### DIFF
--- a/js/parts/Html.js
+++ b/js/parts/Html.js
@@ -128,6 +128,7 @@ extend(SVGElement.prototype, {
 						display: '',
 						whiteSpace: (styles && styles.whiteSpace) || 'nowrap'
 					});
+					width = pick(wrapper.elemWidth, elem.offsetWidth);
 				}
 
 				wrapper.getSpanCorrection(width, baseline, alignCorrection, rotation, align);

--- a/js/parts/Html.js
+++ b/js/parts/Html.js
@@ -122,6 +122,12 @@ extend(SVGElement.prototype, {
 						whiteSpace: (styles && styles.whiteSpace) || 'normal' // #3331
 					});
 					width = textWidth;
+				} else {
+					css(elem, {
+						width: '',
+						display: '',
+						whiteSpace: (styles && styles.whiteSpace) || 'nowrap'
+					});
 				}
 
 				wrapper.getSpanCorrection(width, baseline, alignCorrection, rotation, align);


### PR DESCRIPTION
useHTML uses spans for axis labels, and applies css when the width > textWidth. This happens when the chart is really small. When you expand the chart and reflow it doesn't reset the css applied to the spans.

Applies to Highcharts 3 as well which is what I'm actually using. 

Example of bug:
http://codepen.io/TJHiggins/pen/rxzXdx