### PR TITLE
Allow label to declare that auto-title on too-long text is not needed

### DIFF
--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -504,6 +504,8 @@ SVGElement.prototype = {
 			}
 		}
 
+		if (styles) { elem.usesCustomTitle = styles.usesCustomTitle; }
+
 		return elemWrapper;
 	},
 
@@ -1600,7 +1602,8 @@ SVGRenderer.prototype = {
 										tspan.appendChild(doc.createTextNode(words.join(' ').replace(/- /g, '-')));
 									}
 								}
-								if (wasTooLong) {
+								var usesCustomTitle = (wrapper.element.parentElement) ?  wrapper.element.parentElement.usesCustomTitle : false;
+								if (wasTooLong && !usesCustomTitle) {
 									wrapper.attr('title', wrapper.textStr);
 								}
 								wrapper.rotation = rotation;


### PR DESCRIPTION
I encountered a use case with highcharts where I wanted to implement my own custom tooltip for a renderer label.  I found that, when text overflows, highcharts helpfully adds a title element to the label text.  That's usually what I'd want, but in this case I ended up with my own tooltip plus the auto-added title, which looked bad.  In this PR, I'm proposing a way to opt out of the auto-title feature.

Related fiddle for scenario that I'm describing above: http://jsfiddle.net/davewingate/4h5s15y1/1/