### PR TITLE
Avoid direct reference to css object

### DIFF
--- a/lib/highcharts.src.js
+++ b/lib/highcharts.src.js
@@ -2447,7 +2447,6 @@
         css: function (styles) {
             var elemWrapper = this,
                 oldStyles = elemWrapper.styles,
-                newStyles = {},
                 elem = elemWrapper.element,
                 textWidth,
                 n,
@@ -2464,8 +2463,8 @@
             if (oldStyles) {
                 for (n in styles) {
                     if (styles[n] !== oldStyles[n]) {
-                        newStyles[n] = styles[n];
                         hasNew = true;
+                        break;
                     }
                 }
             }
@@ -2475,12 +2474,10 @@
                     elemWrapper.textWidth; // #3501
 
                 // Merge the new styles with the old ones
-                if (oldStyles) {
                     styles = extend(
                         oldStyles,
-                        newStyles
+                        styles
                     );
-                }
 
                 // store object
                 elemWrapper.styles = styles;


### PR DESCRIPTION
Prevent highcharts from holding a direct reference to a css object. and unintentionally modifying it This occurs in case when oldStyles is undefined.
See my comment on the commit for clear explanation. 
