### PR TITLE
Map: mouseWheel zoom in smaller steps

### DIFF
--- a/js/parts-map/Map.js
+++ b/js/parts-map/Map.js
@@ -40,7 +40,8 @@ defaultOptions.mapNavigation = {
 			text: '-',
 			y: 28
 		}
-	}
+	},
+	mouseWheelSensitivity: 1.1
 	// enabled: false,
 	// enableButtons: null, // inherit from enabled
 	// enableTouchZoom: null, // inherit from enabled

--- a/js/parts-map/MapPointer.js
+++ b/js/parts-map/MapPointer.js
@@ -39,8 +39,7 @@ extend(Pointer.prototype, {
 		delta = e.detail || -(e.wheelDelta / 120);
 		if (chart.isInsidePlot(e.chartX - chart.plotLeft, e.chartY - chart.plotTop)) {
 			chart.mapZoom(
-				//delta > 0 ? 2 : 0.5,
-				Math.pow(2, delta),
+				Math.pow(chart.options.mapNavigation.mouseWheelSensitivity, delta),
 				chart.xAxis[0].toValue(e.chartX),
 				chart.yAxis[0].toValue(e.chartY),
 				e.chartX,

--- a/samples/maps/mapnavigation/mousewheelsensitivity/demo.css
+++ b/samples/maps/mapnavigation/mousewheelsensitivity/demo.css
@@ -1,0 +1,11 @@
+#container {
+    height: 500px; 
+    min-width: 310px; 
+    max-width: 800px; 
+    margin: 0 auto; 
+}
+.loading {
+    margin-top: 10em;
+    text-align: center;
+    color: gray;
+}

--- a/samples/maps/mapnavigation/mousewheelsensitivity/demo.details
+++ b/samples/maps/mapnavigation/mousewheelsensitivity/demo.details
@@ -1,0 +1,5 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Torstein Hønsi
+...

--- a/samples/maps/mapnavigation/mousewheelsensitivity/demo.html
+++ b/samples/maps/mapnavigation/mousewheelsensitivity/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/maps/highmaps.js"></script>
+<script src="https://code.highcharts.com/maps/modules/data.js"></script>
+<script src="https://code.highcharts.com/maps/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/mapdata/custom/world.js"></script>
+
+
+<div id="container" style="max-width: 1000px"></div>

--- a/samples/maps/mapnavigation/mousewheelsensitivity/demo.js
+++ b/samples/maps/mapnavigation/mousewheelsensitivity/demo.js
@@ -1,0 +1,38 @@
+$(function () {
+
+    $.getJSON('https://www.highcharts.com/samples/data/jsonp.php?filename=world-population-density.json&callback=?', function (data) {
+
+        $('#container').highcharts('Map', {
+
+            title : {
+                text : 'Increase mouse wheel sensitivity to zoom faster'
+            },
+
+            mapNavigation: {
+                enabled: true,
+                mouseWheelSensitivity: 2  // Default in 4.2.3 and lower
+            },
+
+            colorAxis: {
+                min: 1,
+                max: 1000,
+                type: 'logarithmic'
+            },
+
+            series : [{
+                data : data,
+                mapData: Highcharts.maps['custom/world'],
+                joinBy: ['iso-a2', 'code'],
+                name: 'Population density',
+                states: {
+                    hover: {
+                        color: '#BADA55'
+                    }
+                },
+                tooltip: {
+                    valueSuffix: '/km²'
+                }
+            }]
+        });
+    });
+});


### PR DESCRIPTION
With a typical mouse wheel, 5 to 6 mousewheel events (or magnitude 1 or -1) would be generated by a single full finger scroll. Likewise, some 5 to 6 wheel events could easily be triggered by a finger dragged over touchpad devices.

Highmaps zoomed-in to 200% and zoomed-out to 50% per each such event. It was pretty easy to [zoom too much too fast](http://highcharts.uservoice.com/forums/55896-highcharts-javascript-api/suggestions/6602290-implement-option-in-highmaps-to-adjust-mouse-wheel).

This commit reduces the percent amount to 110% and 90%, respectively, which should work much better, and more precise, in most situations.

Thanks!