### PR TITLE
correct reference from axis.userOptions to options object

### DIFF
--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -41,14 +41,16 @@ extend(Chart.prototype, {
 		var key = isX ? 'xAxis' : 'yAxis',
 			chartOptions = this.options;
 
-		new Axis(this, merge(options, { // eslint-disable-line no-new
+		var userOptions = merge(options, {
 			index: this[key].length,
 			isX: isX
-		}));
+		});
+
+		new Axis(this, userOptions);
 
 		// Push the new axis options to the chart options
 		chartOptions[key] = splat(chartOptions[key] || {});
-		chartOptions[key].push(options);
+		chartOptions[key].push(userOptions);
 
 		if (pick(redraw, true)) {
 			this.redraw(animation);


### PR DESCRIPTION
`axis.userOptions` is supposed to be reference to `chart.options.yAxis`.., right?   I had issue when I was adding yAxis using `addAxis` method and than using `addPlotBand`, because only `axis.userOptions` got updated, but not `chart.options` - basically it ends up out of sync.  Which is issue for example in svg export where `chart.options` is source of truth.

I am not sure if `index` and `isX` is supposed to be in `chart.options.yAxis` as well, it might be necessary pass these separately to Axis constructor.