### PR TITLE
Fixed two exceptions thrown when some Points are destroyed but the Se…

### DIFF
--- a/js/parts/DataGrouping.js
+++ b/js/parts/DataGrouping.js
@@ -439,7 +439,7 @@ seriesProto.destroy = function () {
 		i = groupedData.length;
 
 	while (i--) {
-		if (groupedData[i]) {
+		if (groupedData[i] && groupedData[i].destroy) {
 			groupedData[i].destroy();
 		}
 	}

--- a/js/parts/DataGrouping.js
+++ b/js/parts/DataGrouping.js
@@ -439,7 +439,7 @@ seriesProto.destroy = function () {
 		i = groupedData.length;
 
 	while (i--) {
-		if (groupedData[i] && groupedData[i].destroy) {
+		if (groupedData[i]) {
 			groupedData[i].destroy();
 		}
 	}

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -1835,6 +1835,10 @@ Series.prototype = {
 				nPoint1,
 				nPoint2;
 
+			if (point[axis] === null) {
+				// Check that the point is not already destroyed.
+				return;
+			}
 			setDistance(search, point);
 
 			// Pick side based on distance to splitting point


### PR DESCRIPTION
…ries is not yet redrawn.

My code calls `series.setData(data, false)` and waits a few milliseconds before calling `redraw()`. `setData()` destroys all points in `series.points`, but leaves them in the array, and I think it causes some exceptions that happen some time to time.

The change in DataGrouping.js prevents an exception when `groupedData[i].destroy` equals null and I destroy() the chart.

The change in Series.js prevents an exception at Pointer.js:204 when `kdpoint[0].series` equals null and I hover the mouse over the chart.

I'd be happy to make adjustments if this PR is missing something. Thank you!