### PR TITLE
trim before split by space

### DIFF
--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -1470,7 +1470,7 @@ SVGRenderer.prototype = {
 				var spans,
 					spanNo = 0;
 
-				line = line.replace(/<span/g, '|||<span').replace(/<\/span>/g, '</span>|||');
+				line = line.replace(/<span/g, '|||<span').replace(/<\/span>/g, '</span>|||').replace(/^\s+|\s+$/g, '');
 				spans = line.split('|||');
 
 				each(spans, function buildTextSpans(span) {
@@ -1532,7 +1532,7 @@ SVGRenderer.prototype = {
 
 							// Check width and apply soft breaks or ellipsis
 							if (width) {
-								var words = span.replace(/([^\^])-/g, '$1- ').replace(/^\s+|\s+$/g, '').split(' '), // #1273
+								var words = span.replace(/([^\^])-/g, '$1- ').split(' '), // #1273
 									hasWhiteSpace = spans.length > 1 || lineNo || (words.length > 1 && textStyles.whiteSpace !== 'nowrap'),
 									tooLong,
 									wasTooLong,

--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -1469,8 +1469,8 @@ SVGRenderer.prototype = {
 			each(lines, function buildTextLines(line, lineNo) {
 				var spans,
 					spanNo = 0;
-
-				line = line.replace(/<span/g, '|||<span').replace(/<\/span>/g, '</span>|||').replace(/^\s+|\s+$/g, '');
+				line = line.replace(/^\s+|\s+$/g, ''); // trim to prevent useless/costly process on the spaces
+				line = line.replace(/<span/g, '|||<span').replace(/<\/span>/g, '</span>|||');
 				spans = line.split('|||');
 
 				each(spans, function buildTextSpans(span) {

--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -1532,7 +1532,7 @@ SVGRenderer.prototype = {
 
 							// Check width and apply soft breaks or ellipsis
 							if (width) {
-								var words = span.replace(/([^\^])-/g, '$1- ').split(' '), // #1273
+								var words = span.replace(/([^\^])-/g, '$1- ').replace(/^\s+|\s+$/g, '').split(' '), // #1273
 									hasWhiteSpace = spans.length > 1 || lineNo || (words.length > 1 && textStyles.whiteSpace !== 'nowrap'),
 									tooLong,
 									wasTooLong,


### PR DESCRIPTION
When the categories have lots of tailing space, there will be performance issue, see http://jsfiddle.net/rj4gc49L/1/ 

Trailing spaces are somehow usual in DB, which one time I meet and cause the chart shows very slow.

This patch is trying to prevent this issue by do a trim before split the text by space.