### PR TITLE
Add other options to justify DataLabels of pie charts

### DIFF
--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -506,6 +506,28 @@ if (seriesTypes.pie) {
 						}
 					}
 
+					// move labels to other slot if it overflows for fixed size pie chart
+					if (options.overflow === 'crawlUp' &&
+						options.size !== null) {
+						var getSlotWidth = function (index, left) {
+							var xPos = series.getX(slots[index], left);
+							return left ? xPos :
+							chart.chartWidth - (xPos + 2 + distanceOption + point.dataLabel.padding + (options.connectorPadding || 5));
+						}
+						var slotWidth = getSlotWidth(slotIndex, i);
+						var labelWidth = point.dataLabel.width - 10;
+
+						if (slotWidth < labelWidth) {
+							var direction = (centerY >= slots[slotIndex]) ? -1 : 1;
+							while (slots[slotIndex + direction] !== null &&
+							slotWidth < labelWidth) {
+								slotIndex += direction;
+								slotWidth = getSlotWidth(slotIndex, i);
+							}
+							point.dataLabel.crawled = true;
+						}
+					}
+
 					usedSlots.push({ i: slotIndex, y: slots[slotIndex] });
 					slots[slotIndex] = null; // mark as taken
 				}
@@ -531,8 +553,9 @@ if (seriesTypes.pie) {
 					// if the slot next to currrent slot is free, the y value is allowed
 					// to fall back to the natural position
 					y = slot.y;
-					if ((naturalY > y && slots[slotIndex + 1] !== null) ||
-							(naturalY < y &&  slots[slotIndex - 1] !== null)) {
+					if (!dataLabel.crawled &&
+							((naturalY > y && slots[slotIndex + 1] !== null) ||
+							(naturalY < y &&  slots[slotIndex - 1] !== null))) {
 						y = mathMin(mathMax(0, naturalY), chart.plotHeight);
 					}
 

--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -519,7 +519,7 @@ if (seriesTypes.pie) {
 
 						if (slotWidth < labelWidth) {
 							var direction = (centerY >= slots[slotIndex]) ? -1 : 1;
-							while (slots[slotIndex + direction] !== null &&
+							while (slots[slotIndex + direction] != null &&
 							slotWidth < labelWidth) {
 								slotIndex += direction;
 								slotWidth = getSlotWidth(slotIndex, i);

--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -569,6 +569,16 @@ if (seriesTypes.pie) {
 					seriesCenter[0] + (i ? -1 : 1) * (radius + distanceOption) :
 					series.getX(y === centerY - radius - distanceOption || y === centerY + radius + distanceOption ? naturalY : y, i);
 
+				// push labels inside of the chart if it overflows for fixed size pie chart
+				if (options.overflow === 'pushIn' &&
+					series.options.size !== null) {
+					var labelWidth = dataLabel.width - 10;
+					var slotWidth = i ? x - (2 + (options.connectorPadding || 5)) : chart.chartWidth - (x + 2 + distanceOption + dataLabel.padding + (options.connectorPadding || 5));
+					if (slotWidth < labelWidth) {
+						x += i ? labelWidth - slotWidth : slotWidth - labelWidth;
+						dataLabel.pushed = true;
+					}
+				}
 
 				// Record the placement and visibility
 				dataLabel._attr = {
@@ -643,6 +653,15 @@ if (seriesTypes.pie) {
 							L,
 							labelPos[4], labelPos[5] // base
 						];
+
+						if (dataLabel.pushed) {
+							if (labelPos[6] === 'right' && labelPos[4] < x ||
+									labelPos[6] === 'left' && labelPos[4] > x) {
+								connectorPath = []
+							} else {
+								connectorPath.splice(3, connectorPath.length - 6);
+							}
+						}
 
 						if (connector) {
 							connector.animate({ d: connectorPath });


### PR DESCRIPTION
The goal is to be able to justify DataLabels of fixed size pie charts which cannot shrink by 'justify' option
about [issue 3880](https://github.com/highcharts/highcharts/issues/3880)

I added two options in 'pie.dataLabels.overflow'
1. crawlUp
- This option moves overflowed label to other slot which has enough langth for that label. example: https://jsfiddle.net/1more/nmzj81ch/

2.pushIn
- This option moves overflowed label to inside of the pie chart (works like reducing dataLabels.distance value). example: http://jsfiddle.net/1more/kkfjjL6w/
