### PR TITLE
Avoid calling a null event handler.

### DIFF
--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -1187,6 +1187,10 @@ fireEvent = function (el, type, eventArguments, defaultFunction) {
 		
 		for (i = 0; i < len; i++) {
 			fn = events[i];
+			// Avoid calling a null event handler
+			if (!fn) {
+			    continue;
+			}
 
 			// If the event handler return false, prevent the default handler from executing
 			if (fn.call(el, eventArguments) === false) {


### PR DESCRIPTION
This bit me when I wanted to quickly register an event handler conditionally. 
For example, I had something like

```
  events: {
      redraw: allowSelection ? (e) => this.updateSelectionRectangle() : null,
  }
```