### PR TITLE
Fix position of the plotLine label with more than one axis

### DIFF
--- a/js/parts/PlotLineOrBand.js
+++ b/js/parts/PlotLineOrBand.js
@@ -159,8 +159,18 @@ Highcharts.PlotLineOrBand.prototype = {
 
 		// get the bounding box and align the label
 		// #3000 changed to better handle choice between plotband or plotline
-		xs = [path[1], path[4], (isBand ? path[6] : path[1])];
-		ys = [path[2], path[5], (isBand ? path[7] : path[2])];
+		if (isBand) {
+			xs = [path[1], path[4], path[6]];
+			ys = [path[2], path[5], path[7]];
+		} else {
+			// some lines can be drown through more than one axis. To include all of them use cycle. 
+			xs = [];
+			ys = [];
+			for (var n = 0; n < path.length; n += 3) {
+				xs.push(path[n + 1]);
+				ys.push(path[n + 2]);
+			}
+		}
 		x = arrayMin(xs);
 		y = arrayMin(ys);
 


### PR DESCRIPTION
Some plot lines can be drown through more than one axis. To include all of them use cycle.
Without fix:
![image](https://cloud.githubusercontent.com/assets/4582016/16047062/e38ae584-324e-11e6-8cfd-9a3c519360cc.png)

With fix:
![image](https://cloud.githubusercontent.com/assets/4582016/16047099/0778e752-324f-11e6-9a8c-e1c4d5a1d02b.png)
