### PR TITLE
Expose dateFormat function like numberFormat is so it can be overridden

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -394,7 +394,7 @@ Axis.prototype = {
 			ret = value;
 
 		} else if (dateTimeLabelFormat) { // datetime axis
-			ret = dateFormat(dateTimeLabelFormat, value);
+			ret = Highcharts.dateFormat(dateTimeLabelFormat, value);
 
 		} else if (i && numericSymbolDetector >= 1000) {
 			// Decide whether we should add a numeric symbol like k (thousands) or M (millions).

--- a/js/parts/DataGrouping.js
+++ b/js/parts/DataGrouping.js
@@ -429,9 +429,9 @@ wrap(Tooltip.prototype, 'tooltipFooterHeaderFormatter', function (proceed, label
 		}
 
 		// now format the key
-		formattedKey = dateFormat(xDateFormat, labelConfig.key);
+		formattedKey = Highcharts.dateFormat(xDateFormat, labelConfig.key);
 		if (xDateFormatEnd) {
-			formattedKey += dateFormat(xDateFormatEnd, labelConfig.key + currentDataGrouping.totalRange - 1);
+			formattedKey += Highcharts.dateFormat(xDateFormatEnd, labelConfig.key + currentDataGrouping.totalRange - 1);
 		}
 
 		// return the replaced format

--- a/js/parts/Facade.js
+++ b/js/parts/Facade.js
@@ -15,7 +15,6 @@ extend(Highcharts, {
 	arrayMax: arrayMax,
 	charts: charts,
 	correctFloat: correctFloat,
-	dateFormat: dateFormat,
 	error: error,
 	format: format,
 	pathAnim: pathAnim,

--- a/js/parts/Globals.js
+++ b/js/parts/Globals.js
@@ -32,7 +32,6 @@ var UNDEFINED,
 	idCounter = 0,
 	garbageBin,
 	defaultOptions,
-	dateFormat, // function
 	pathAnim,
 	timeUnits,
 	noop = function () {},

--- a/js/parts/OrdinalAxis.js
+++ b/js/parts/OrdinalAxis.js
@@ -98,7 +98,7 @@ wrap(Axis.prototype, 'getTimeTicks', function (proceed, normalizedInterval, min,
 
 		// Compare points two by two
 		for (start = 1; start < end; start++) {
-			if (dateFormat('%d', groupPositions[start]) !== dateFormat('%d', groupPositions[start - 1])) {
+			if (Highcharts.dateFormat('%d', groupPositions[start]) !== Highcharts.dateFormat('%d', groupPositions[start - 1])) {
 				higherRanks[groupPositions[start]] = 'day';
 				hasCrossedHigherRank = true;
 			}

--- a/js/parts/RangeSelector.js
+++ b/js/parts/RangeSelector.js
@@ -398,12 +398,12 @@ RangeSelector.prototype = {
 			this[name + 'Input'].HCTime = time;
 		}
 
-		this[name + 'Input'].value = dateFormat(
+		this[name + 'Input'].value = Highcharts.dateFormat(
 			options.inputEditDateFormat || '%Y-%m-%d',
 			this[name + 'Input'].HCTime
 		);
 		this[name + 'DateBox'].attr({
-			text: dateFormat(options.inputDateFormat || '%b %e, %Y', this[name + 'Input'].HCTime)
+			text: Highcharts.dateFormat(options.inputDateFormat || '%b %e, %Y', this[name + 'Input'].HCTime)
 		});
 	},
 

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -441,11 +441,11 @@ Tooltip.prototype = {
 			lastN = 'millisecond'; // for sub-millisecond data, #4223
 
 		if (closestPointRange) {
-			date = dateFormat('%m-%d %H:%M:%S.%L', point.x);
+			date = Highcharts.dateFormat('%m-%d %H:%M:%S.%L', point.x);
 			for (n in timeUnits) {
 
 				// If the range is exactly one week and we're looking at a Sunday/Monday, go for the week format
-				if (closestPointRange === timeUnits.week && +dateFormat('%w', point.x) === xAxis.options.startOfWeek &&
+				if (closestPointRange === timeUnits.week && + Highcharts.dateFormat('%w', point.x) === xAxis.options.startOfWeek &&
 						date.substr(6) === blank.substr(6)) {
 					n = 'week';
 					break;

--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -613,7 +613,7 @@ function getTZOffset(timestamp) {
  * @param {Number} timestamp
  * @param {Boolean} capitalize
  */
-dateFormat = function (format, timestamp, capitalize) {
+Highcharts.dateFormat = function (format, timestamp, capitalize) {
 	if (!defined(timestamp) || isNaN(timestamp)) {
 		return defaultOptions.lang.invalidDate || '';
 	}
@@ -698,7 +698,7 @@ function formatSingle(format, val) {
 			);
 		}
 	} else {
-		val = dateFormat(format, val);
+		val = Highcharts.dateFormat(format, val);
 	}
 	return val;
 }


### PR DESCRIPTION
I'd like to be able to specify my own dateFormat function.

The plan is that want to use [Intl.DateTimeFormat](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat). I can replace the `dateTimeLabelFormats` with a string that indicates which formatter to use.

``` js
    Highcharts.dateFormat = (format, time, capitalize) => {
      switch (format) {
        case 'millisecond':
          return this.dateFormatters.millisecond.format(time);
        case 'second':
          return this.dateFormatters.second.format(time);
        case 'minute':
        default:
          return this.dateFormatters.minute.format(time);
          // etc
      }
    }

    let options = {
      dateTimeLabelFormats: {
        millisecond: 'millisecond',
        second: 'second',
        minute: 'minute'
        //etc
      }
    };
```

I can do this with the `numberFormat` because it is exposed and used in exactly the same way as I'm proposing `dateFormat` should be.

**Disclaimer:** I only replaced all instances I could find in the `parts` directory. I'm not sure how to build and test this myself so this needs checking out and testing.

P.S. I am working for a company that is a paying customer. If there's any support I can get or any other way this needs raising so that it may become a priority I can do so.
