### PR TITLE
Using plotX instead of clientX because clientX has a rounding error

### DIFF
--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -2,7 +2,7 @@
 // @compilation_level SIMPLE_OPTIMIZATIONS
 
 /**
- * @license Highcharts JS v4.2.5-modified (2016-06-22)
+ * @license Highcharts JS v4.2.5-modified (2016-07-15)
  *
  * (c) 2009-2016 Torstein Honsi
  *

--- a/js/highmaps.src.js
+++ b/js/highmaps.src.js
@@ -9875,7 +9875,7 @@
             if (shared) {
                 i = kdpoints.length;
                 while (i--) {
-                    if (kdpoints[i].clientX !== kdpoint[1].clientX || kdpoints[i].series.noSharedTooltip) {
+                    if (kdpoints[i].plotX !== kdpoint[1].plotX || kdpoints[i].series.noSharedTooltip) {
                         kdpoints.splice(i, 1);
                     }
                 }

--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -2,7 +2,7 @@
 // @compilation_level SIMPLE_OPTIMIZATIONS
 
 /**
- * @license Highstock JS v4.2.5-modified (2016-06-22)
+ * @license Highstock JS v4.2.5-modified (2016-07-15)
  *
  * (c) 2009-2016 Torstein Honsi
  *
@@ -10354,7 +10354,7 @@
             if (shared) {
                 i = kdpoints.length;
                 while (i--) {
-                    if (kdpoints[i].clientX !== kdpoint[1].clientX || kdpoints[i].series.noSharedTooltip) {
+                    if (kdpoints[i].plotX !== kdpoint[1].plotX || kdpoints[i].series.noSharedTooltip) {
                         kdpoints.splice(i, 1);
                     }
                 }
@@ -20374,7 +20374,7 @@
      * End ordinal axis logic                                                   *
      *****************************************************************************/
     /**
-     * Highstock JS v4.2.5-modified (2016-06-22)
+     * Highstock JS v4.2.5-modified (2016-07-15)
      * Highcharts Broken Axis module
      * 
      * License: www.highcharts.com/license

--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -192,7 +192,7 @@ Pointer.prototype = {
 		if (shared) {
 			i = kdpoints.length;
 			while (i--) {
-				if (kdpoints[i].clientX !== kdpoint[1].clientX || kdpoints[i].series.noSharedTooltip) {
+				if (kdpoints[i].plotX !== kdpoint[1].plotX || kdpoints[i].series.noSharedTooltip) {
 					kdpoints.splice(i, 1);
 				}
 			}


### PR DESCRIPTION
This might be a fix for issue #5495

We tried to run the tests, but ran into an error.

$ gulp test
ReferenceError: Can't find variable: process