### PR TITLE
Preserve untransformed `plotZ` attribute on 3D scatter charts as 'plotZold`

### DIFF
--- a/js/highcharts-3d.src.js
+++ b/js/highcharts-3d.src.js
@@ -1728,6 +1728,7 @@
 
             rawPoint.plotXold = rawPoint.plotX;
             rawPoint.plotYold = rawPoint.plotY;
+            rawPoint.plotZold = rawPoint.plotZ;
 
             rawPoint.plotX = projectedPoint.x;
             rawPoint.plotY = projectedPoint.y;

--- a/js/parts-3d/Scatter.js
+++ b/js/parts-3d/Scatter.js
@@ -42,6 +42,7 @@ Highcharts.wrap(Highcharts.seriesTypes.scatter.prototype, 'translate', function 
 
 		rawPoint.plotXold = rawPoint.plotX;
 		rawPoint.plotYold = rawPoint.plotY;
+		rawPoint.plotZold = rawPoint.plotZ;
 
 		rawPoint.plotX = projectedPoint.x;
 		rawPoint.plotY = projectedPoint.y;


### PR DESCRIPTION
`plotXold` and `plotYold` are already being stored, it makes sense to store it too.

This won't have any immediate use on Highcharts core, but will be used on
my contour curves plugin (https://github.com/paulo-raca/highcharts-contour/blob/master/highcharts-contour.js#L379)