### PR TITLE
ColorAxis should never be drawn in 3D.

### DIFF
--- a/js/parts-map/ColorAxis.js
+++ b/js/parts-map/ColorAxis.js
@@ -413,6 +413,19 @@ extend(ColorAxis.prototype, {
 			Axis.prototype.getPlotLinePath.call(this, a, b, c, d);
 	},
 
+	render: function () {
+		// ColorAxis should never be drawn in 3D, therefore the
+		// 3D flag is temporarialy disabled while it is rendered in the legend
+		var is3d = this.chart.is3d && this.chart.is3d();
+		if (is3d) {
+			this.chart.options.chart.options3d.enabled = false;
+		}
+		Axis.prototype.render.call(this, arguments);
+		if (is3d) {
+			this.chart.options.chart.options3d.enabled = true;
+		}
+	},
+
 	update: function (newOptions, redraw) {
 		var chart = this.chart,
 			legend = chart.legend;


### PR DESCRIPTION
Since it is displayed 'flat' withing the legend, the 3D effects don't really work for the ColorAxis.

This solution simply disables the 3d flag during the `ColorAxis.render()` and restores it afterwards.

Here is a simple reproduction of the issues when rendering the colorAxis in a 3D chart:
http://jsfiddle.net/paulo_raca/bk051w7h/

I'm not confident that this is the best possible solution, so I've also developed an alternative fix on https://github.com/paulo-raca/highcharts.com/commit/colorAxis3D_2
