### PR TITLE
Fix tick animation when `showFirstLabel` or `showLastLabel` are disabled

### DIFF
--- a/js/highcharts-3d.src.js
+++ b/js/highcharts-3d.src.js
@@ -2,7 +2,7 @@
 // @compilation_level SIMPLE_OPTIMIZATIONS
 
 /**
- * @license Highcharts JS v4.2.5-modified (2016-07-21)
+ * @license Highcharts JS v4.2.5-modified (2016-07-22)
  *
  * 3D features for Highcharts JS
  *

--- a/js/highcharts.src.js
+++ b/js/highcharts.src.js
@@ -2,7 +2,7 @@
 // @compilation_level SIMPLE_OPTIMIZATIONS
 
 /**
- * @license Highcharts JS v4.2.5-modified (2016-07-21)
+ * @license Highcharts JS v4.2.5-modified (2016-07-22)
  *
  * (c) 2009-2016 Torstein Honsi
  *
@@ -6675,11 +6675,11 @@
                 if (show && isNumber(xy.y)) {
                     xy.opacity = opacity;
                     label[tick.isNew ? 'attr' : 'animate'](xy);
-                    tick.isNew = false;
                 } else {
                     stop(label); // #5332
                     label.attr('y', -9999); // #1338
                 }
+                tick.isNew = false;
             }
         },
 

--- a/js/highmaps.src.js
+++ b/js/highmaps.src.js
@@ -1,5 +1,5 @@
 /**
- * @license Highmaps JS v4.2.5-modified (2016-07-21)
+ * @license Highmaps JS v4.2.5-modified (2016-07-22)
  *
  * (c) 2011-2016 Torstein Honsi
  *
@@ -6673,11 +6673,11 @@
                 if (show && isNumber(xy.y)) {
                     xy.opacity = opacity;
                     label[tick.isNew ? 'attr' : 'animate'](xy);
-                    tick.isNew = false;
                 } else {
                     stop(label); // #5332
                     label.attr('y', -9999); // #1338
                 }
+                tick.isNew = false;
             }
         },
 

--- a/js/highstock.src.js
+++ b/js/highstock.src.js
@@ -2,7 +2,7 @@
 // @compilation_level SIMPLE_OPTIMIZATIONS
 
 /**
- * @license Highstock JS v4.2.5-modified (2016-07-21)
+ * @license Highstock JS v4.2.5-modified (2016-07-22)
  *
  * (c) 2009-2016 Torstein Honsi
  *
@@ -6675,11 +6675,11 @@
                 if (show && isNumber(xy.y)) {
                     xy.opacity = opacity;
                     label[tick.isNew ? 'attr' : 'animate'](xy);
-                    tick.isNew = false;
                 } else {
                     stop(label); // #5332
                     label.attr('y', -9999); // #1338
                 }
+                tick.isNew = false;
             }
         },
 
@@ -20374,7 +20374,7 @@
      * End ordinal axis logic                                                   *
      *****************************************************************************/
     /**
-     * Highstock JS v4.2.5-modified (2016-07-21)
+     * Highstock JS v4.2.5-modified (2016-07-22)
      * Highcharts Broken Axis module
      * 
      * License: www.highcharts.com/license

--- a/js/parts/Tick.js
+++ b/js/parts/Tick.js
@@ -355,11 +355,11 @@ Tick.prototype = {
 			if (show && isNumber(xy.y)) {
 				xy.opacity = opacity;
 				label[tick.isNew ? 'attr' : 'animate'](xy);
-				tick.isNew = false;
 			} else {
 				stop(label); // #5332
 				label.attr('y', -9999); // #1338
 			}
+			tick.isNew = false;
 		}
 	},
 


### PR DESCRIPTION
the flag `tick.isNew` wasn't being cleared on the first/last ticks when  `showFirstLabel`/`showLastLabel` are disabled.

When `tick.isNew` is set, the animation isn't played, making these lines inconsistent with the rest of them.

Reproduction: http://jsfiddle.net/paulo_raca/j0w15gpd/

(I'm not sure this is the correct solution for this, but seems reasonable for me)