### PR TITLE
Fix for #5518 and #5383 (same issue). pointPlacement: "between"..

### DIFF
--- a/lib/highcharts.src.js
+++ b/lib/highcharts.src.js
@@ -14580,7 +14580,7 @@
 
 
                 // Set client related positions for mouse tracking
-                point.clientX = dynamicallyPlaced ? correctFloat(xAxis.translate(xValue, 0, 0, 0, 1)) : plotX; // #1514
+                point.clientX = dynamicallyPlaced ? correctFloat(xAxis.translate(xValue, 0, 0, 0, 1, pointPlacement)) : plotX; // #1514
 
                 point.negative = point.y < (threshold || 0);
 


### PR DESCRIPTION
This is regarding pointPlacement: "between". The logic to find the nearest data point (to the mouse pointer) to highlight, was not taking into account the x-axis offset to the data points when using 'between' or a non-zero numeric value..