### PR TITLE
Update treemap.src.js

### DIFF
--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -849,7 +849,7 @@
 				)
 				.attr({
 					align: buttonOptions.position.align,
-					zIndex: 9
+					zIndex: 7
 				})
 				.add()
 				.align(buttonOptions.position, false, buttonOptions.relativeTo || 'plotBox');


### PR DESCRIPTION
zIndex 9 is in collision with tooltip zIndex 8, therefore button is overlapping tooltip