### PR TITLE
Added `gulp` to `devDependencies`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "colors": "~1.1.2",
     "grunt": "^0.4.5",
     "grunt-jslint": "^1.1.12",
+    "gulp": "^3.9.1",
     "gulp-sass": "^2.3.1",
     "gzip-size": "^3.0.0",
     "js-beautify": "^1.6.2",


### PR DESCRIPTION
I cloned the repo and tried to build using the guide in the README. To my surprise `gulp` was missing from `devDependencies` and had to be installed manually. Since I found no issue or pull request regarding this and the README was quite clear on `gulp` being expected to run right after `npm install`, here's a tiny patch adding it :)

Please explain the reason if declining the patch and possibly update the README.