### PR TITLE
give navigator handles crisp lines

### DIFF
--- a/js/parts/Scroller.js
+++ b/js/parts/Scroller.js
@@ -199,7 +199,8 @@ Navigator.prototype = {
 				.attr({
 					fill: handlesOptions.backgroundColor,
 					stroke: handlesOptions.borderColor,
-					'stroke-width': 1
+					'stroke-width': 1,
+					'shape-rendering': 'crispEdges'
 				})
 				.css({ cursor: 'ew-resize' });
 			/*= } =*/


### PR DESCRIPTION
A small thing, but isn't this:

![image](https://cloud.githubusercontent.com/assets/681288/19911547/7754a348-a051-11e6-948c-5d6358069dac.png)

so much nicer than this:

![image](https://cloud.githubusercontent.com/assets/681288/19911574/9e2b40c6-a051-11e6-8a1c-6c3d8205106d.png)

?