### PR TITLE
Use https for loading PDF library

### DIFF
--- a/js/modules/offline-exporting.src.js
+++ b/js/modules/offline-exporting.src.js
@@ -393,7 +393,7 @@ Highcharts.Chart.prototype.exportChartLocal = function (exportingOptions, chartO
 
 // Extend the default options to use the local exporter logic
 merge(true, Highcharts.getOptions().exporting, {
-	libURL: 'http://code.highcharts.com/@product.version@/lib/',
+	libURL: 'https://code.highcharts.com/@product.version@/lib/',
 	buttons: {
 		contextButton: {
 			menuItems: [{


### PR DESCRIPTION
The existing http link cannot be loaded if the site using the export module is hosted on a secure https domain.

https://github.com/highcharts/highcharts/issues/5278