### PR TITLE
Fixed `Tooltip::renderSplit` to render all point tooltips regardless …

### DIFF
--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -565,8 +565,8 @@ H.Tooltip.prototype = {
 			headerHeight,
 			tooltipLabel = this.getLabel();
 
-		// Create the individual labels
-		each(labels.slice(0, labels.length - 1), function (str, i) {
+		// Create the individual labels for header and points, ignore footer
+		each(labels.slice(0, points.length + 1), function (str, i) {
 			var point = points[i - 1] ||
 					// Item 0 is the header. Instead of this, we could also use the crosshair label
 					{ isHeader: true, plotX: points[0].plotX },


### PR DESCRIPTION
…of whether a footer label is supplied or not.

The current code requires `tooltip.formatter` to return a "footer" label even though it's not used in the `split` tooltip mode. If the additional label isn't supplied, the tooltip for the last series doesn't get rendered.