### PR TITLE
Check if chart is actually 3d prior to applying camera translations o n scatter

### DIFF
--- a/js/parts-3d/Scatter.js
+++ b/js/parts-3d/Scatter.js
@@ -97,7 +97,7 @@ wrap(seriesTypes.scatter.prototype, 'init', function (proceed, chart, options) {
  */
 wrap(seriesTypes.scatter.prototype, 'pointAttribs', function (proceed, point) {
 	var pointOptions = proceed.apply(this, [].slice.call(arguments, 1));
-	if (point) {
+	if (this.chart.is3d() && point) {
 		pointOptions.zIndex = H.pointCameraDistance(point, this.chart);
 	}
 	return pointOptions;


### PR DESCRIPTION
Not checking will cause severe performance degradation with large scatter charts that aren't 3d.