### PR TITLE
Improve Performance When Hoverring on Series

### DIFF
--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -1921,6 +1921,8 @@ H.Series = H.seriesType('line', null, { // base series options
 	},
 
 	buildKDTree: function () {
+		this.buildingKdTree = true;
+
 		var series = this,
 			dimensions = series.kdDimensions;
 
@@ -1962,6 +1964,7 @@ H.Series = H.seriesType('line', null, { // base series options
 				dimensions,
 				dimensions
 			);
+			series.buildingKdTree = false;
 		}
 		delete series.kdTree;
 
@@ -2018,7 +2021,7 @@ H.Series = H.seriesType('line', null, { // base series options
 			return ret;
 		}
 
-		if (!this.kdTree) {
+		if (!this.kdTree && !this.buildingKdTree) {
 			this.buildKDTree();
 		}
 


### PR DESCRIPTION
Issue:
It's really slow when hovering on the series (shared tooltip) if there're lots of lines.

Cause:
When hovering on the series, it'll always build KD tree if there's not one. And the building process is async. So it could cause unnecessary duplicate KD tree building. 

Solution:
Add flag to indicate that the series is building KD tree, thus do not build again.