### PR TITLE
ColorAxis's ticks  should never be drawn in 3D.

### DIFF
--- a/js/parts-3d/Axis.js
+++ b/js/parts-3d/Axis.js
@@ -216,7 +216,7 @@ wrap(Tick.prototype, 'getMarkPath', function (proceed) {
 	var path = proceed.apply(this, [].slice.call(arguments, 1));	
 
 	// Do not do this if the chart is not 3D
-	if (!this.axis.chart.is3d() || this.coll === 'colorAxis') {
+	if (!this.axis.chart.is3d() || this.axis.coll === 'colorAxis') {
 		return path;
 	}
 
@@ -237,7 +237,7 @@ wrap(Tick.prototype, 'getLabelPosition', function (proceed) {
 	var pos = proceed.apply(this, [].slice.call(arguments, 1));
 
 	// Do not do this if the chart is not 3D
-	if (this.axis.chart.is3d() && this.coll !== 'colorAxis') {
+	if (this.axis.chart.is3d() && this.axis.coll !== 'colorAxis') {
 		pos = perspective([this.axis.swapZ({ x: pos.x, y: pos.y, z: 0 })], this.axis.chart, false)[0];
 	}
 	return pos;


### PR DESCRIPTION
Since ColorAxis is displayed 'flat' within the legend, the 3D effects should not be used on it.

This problem was previously addressed on #5498, but the final commit included a copy-paste mistake