### PR TITLE
Fix upper/lower case typo on SvgRenderer's file name.

### DIFF
--- a/js/modules/canvasrenderer.experimental.src.js
+++ b/js/modules/canvasrenderer.experimental.src.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 import Highcharts from '../parts/Globals.js';
-import '../parts/SVGRenderer.js';
+import '../parts/SvgRenderer.js';
 Highcharts.extend(Highcharts.SVGElement.prototype, {
 	init: function (renderer, nodeName) {
 		this.element = {


### PR DESCRIPTION
Otherwise I get 

```
$ gulp 
[11:39:53] Using gulpfile /media/Paulo/highcharts/highcharts.com/gulpfile.js                                                       
[11:39:53] Starting 'styles'...                                                                                                    
[11:39:53] Finished 'styles' after 28 ms                                                                                           
[11:39:53] Starting 'scripts'...                                                                                                   
[11:39:57] 'scripts' errored after 3.93 s                                                                                          
[11:39:57] Error: File ./js/parts/SVGRenderer.js does not exist. Listed dependency in ./js/modules/canvasrenderer.experimental.src.js                                                                                                                                 
    at formatError (/usr/local/lib/node_modules/gulp-cli/lib/versioned/^3.7.0/formatError.js:20:10)                                
    at Gulp.<anonymous> (/usr/local/lib/node_modules/gulp-cli/lib/versioned/^3.7.0/log/events.js:41:15)                            
    at emitOne (events.js:77:13)                                                                                                   
    at Gulp.emit (events.js:169:7)                                                                                                 
    at Gulp.Orchestrator._emitTaskDone (/media/Paulo/highcharts/highcharts.com/node_modules/orchestrator/index.js:264:8)
    at /media/Paulo/highcharts/highcharts.com/node_modules/orchestrator/index.js:275:23
    at finish (/media/Paulo/highcharts/highcharts.com/node_modules/orchestrator/lib/runTask.js:21:8)
    at module.exports (/media/Paulo/highcharts/highcharts.com/node_modules/orchestrator/lib/runTask.js:36:10)
    at Gulp.Orchestrator._runTask (/media/Paulo/highcharts/highcharts.com/node_modules/orchestrator/index.js:273:3)
    at Gulp.Orchestrator._runStep (/media/Paulo/highcharts/highcharts.com/node_modules/orchestrator/index.js:214:10)
```

_You've been using Windows, haven't you? :)_