### PR TITLE
axis.isZAxis flag was lost after axis.update()

### DIFF
--- a/js/parts-3d/Axis.js
+++ b/js/parts-3d/Axis.js
@@ -308,11 +308,11 @@ Axis.prototype.swapZ = function (p, insidePlotArea) {
 };
 
 ZAxis = H.ZAxis = function () {
-	this.isZAxis = true;
 	this.init.apply(this, arguments);
 };
 extend(ZAxis.prototype, Axis.prototype);
 extend(ZAxis.prototype, {
+	isZAxis: true,
 	setOptions: function (userOptions) {
 		userOptions = merge({
 			offset: 0,


### PR DESCRIPTION
I'm not sure why it the flag was being lost, but puting it on the prototype of ZAxis seems to work.

(Let me know if you have a better suggestion).

Reproduction: http://jsfiddle.net/paulo_raca/881qpkxg/
Drag the chart, and the ZAxis labels and ticks disappear)