### PR TITLE
Added configuration options so that users can define their own log ax…

### DIFF
--- a/js/parts-3d/Axis.js
+++ b/js/parts-3d/Axis.js
@@ -365,7 +365,7 @@ extend(ZAxis.prototype, {
 				axis.hasVisibleSeries = true;
 
 				// Validate threshold in logarithmic axes
-				if (axis.isLog && threshold <= 0) {
+				if (axis.positiveValuesOnly && threshold <= 0) {
 					threshold = null;
 				}
 

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -138,6 +138,7 @@ H.Axis.prototype = {
 			//y: 0
 		},
 		type: 'linear', // linear, logarithmic or datetime
+		allowNegativeLog: false,
 		//visible: true
 		/*= if (build.classic) { =*/
 		minorGridLineColor: '${palette.neutralColor5}',
@@ -309,6 +310,7 @@ H.Axis.prototype = {
 		// Shorthand types
 		axis.isLog = type === 'logarithmic';
 		axis.isDatetimeAxis = isDatetimeAxis;
+		axis.positiveValuesOnly = axis.isLog && !options.allowNegativeLog;
 
 		// Flag, if axis is linked to another axis
 		axis.isLinked = defined(options.linkedTo);
@@ -407,6 +409,8 @@ H.Axis.prototype = {
 		}
 
 		// extend logarithmic axis
+		axis.log2lin = options.logToLinearConverter || axis.log2lin;
+		axis.lin2log = options.linearToLogConverter || axis.lin2log;
 		if (axis.isLog) {
 			axis.val2lin = axis.log2lin;
 			axis.lin2val = axis.lin2log;
@@ -446,7 +450,7 @@ H.Axis.prototype = {
 			formatOption = axis.options.labels.format,
 
 			// make sure the same symbol is added for all labels on a linear axis
-			numericSymbolDetector = axis.isLog ? value : axis.tickInterval;
+			numericSymbolDetector = axis.isLog ? Math.abs(value) : axis.tickInterval;
 
 		if (formatOption) {
 			ret = format(formatOption, this);
@@ -510,7 +514,7 @@ H.Axis.prototype = {
 				axis.hasVisibleSeries = true;
 
 				// Validate threshold in logarithmic axes
-				if (axis.isLog && threshold <= 0) {
+				if (axis.positiveValuesOnly && threshold <= 0) {
 					threshold = null;
 				}
 
@@ -555,7 +559,7 @@ H.Axis.prototype = {
 						axis.threshold = threshold;
 					}
 					// If any series has a hard threshold, it takes precedence
-					if (!seriesOptions.softThreshold || axis.isLog) {
+					if (!seriesOptions.softThreshold || axis.positiveValuesOnly) {
 						axis.softThreshold = false;
 					}
 				}
@@ -1046,6 +1050,7 @@ H.Axis.prototype = {
 			chart = axis.chart,
 			options = axis.options,
 			isLog = axis.isLog,
+			positiveValuesOnly = axis.positiveValuesOnly,
 			log2lin = axis.log2lin,
 			isDatetimeAxis = axis.isDatetimeAxis,
 			isXAxis = axis.isXAxis,
@@ -1103,7 +1108,7 @@ H.Axis.prototype = {
 		}
 
 		if (isLog) {
-			if (!secondPass && Math.min(axis.min, pick(axis.dataMin, axis.min)) <= 0) { // #978
+			if (positiveValuesOnly && !secondPass && Math.min(axis.min, pick(axis.dataMin, axis.min)) <= 0) { // #978
 				H.error(10, 1); // Can't plot negative values on log axis
 			}
 			// The correctFloat cures #934, float errors on full tens. But it

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -855,7 +855,7 @@ H.Series = H.seriesType('line', null, { // base series options
 
 			// For points within the visible range, including the first point outside the
 			// visible range, consider y extremes
-			validValue = (isNumber(y, true) || isArray(y)) && (!yAxis.isLog || (y.length || y > 0));
+			validValue = (isNumber(y, true) || isArray(y)) && (!yAxis.positiveValuesOnly || (y.length || y > 0));
 			withinRange = this.getExtremesFromAll || this.options.getExtremesFromAll || this.cropped ||
 				((xData[i + 1] || x) >= xMin &&	(xData[i - 1] || x) <= xMax);
 
@@ -929,7 +929,7 @@ H.Series = H.seriesType('line', null, { // base series options
 				stackValues;
 
 			// Discard disallowed y values for log axes (#3434)
-			if (yAxis.isLog && yValue !== null && yValue <= 0) {
+			if (yAxis.positiveValuesOnly && yValue !== null && yValue <= 0) {
 				point.isNull = true;
 			}
 
@@ -957,7 +957,7 @@ H.Series = H.seriesType('line', null, { // base series options
 				if (yBottom === stackThreshold && stackIndicator.key === stack[xValue].base) {
 					yBottom = pick(threshold, yAxis.min);
 				}
-				if (yAxis.isLog && yBottom <= 0) { // #1200, #1232
+				if (yAxis.positiveValuesOnly && yBottom <= 0) { // #1200, #1232
 					yBottom = null;
 				}
 


### PR DESCRIPTION
…is conversion functions, and can advertise that the log axis should allow negative values.

Continuing from discussion on https://github.com/highcharts/highcharts/issues/6348, this is what I had in mind.  You can see it in action here:  http://jsfiddle.net/sfishel18/Lft5r5au/1/.  Sorry for the massive blog of Highcharts source at the top, if there's a better way to show fiddles of un-published branches, let me know.