### PR TITLE
EndOfMonth ticks on StockChart (via Axis.options)

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -70,6 +70,7 @@ H.Axis.prototype = {
 			month: '%b \'%y',
 			year: '%Y'
 		},
+		endOfMonth: false,
 		endOnTick: false,
 		// reversed: false,
 

--- a/js/parts/DateTimeAxis.js
+++ b/js/parts/DateTimeAxis.js
@@ -34,6 +34,7 @@ Axis.prototype.getTimeTicks = function (normalizedInterval, min, max, startOfWee
 		i,
 		higherRanks = {},
 		useUTC = defaultOptions.global.useUTC,
+		endOfMonth = this.options.endOfMonth,
 		minYear, // used in months and years as a basis for Date.UTC()
 		minDate = new Date(min - getTZOffset(min)),
 		makeTime = Date.hcMakeTime,
@@ -127,7 +128,8 @@ Axis.prototype.getTimeTicks = function (normalizedInterval, min, max, startOfWee
 
 			// if the interval is months, use Date.UTC to increase months
 			} else if (interval === timeUnits.month) {
-				time = makeTime(minYear, minMonth + i * count);
+				var minDay = endOfMonth ? 0 : 1;
+				time = makeTime(minYear, minMonth + i * count, minDay);
 
 			// if we're using global time, the interval is not fixed as it jumps
 			// one hour at the DST crossover


### PR DESCRIPTION
At present, highstocks displays time-series data on weekly, monthly, and yearly intervals by drawing the tick at the start of the year. For certain financial applications, it makes more sense to draw the ticks at the end of the month, rather than the beginning (ie. if the final price for March happens on the 31st, there would be a point there, immediately followed by a tick for April. With this option you can prefer to have it draw the tick on the 31st and label it March there). 