### PR TITLE
ISSUE-6378: fix drill down not responding & clip issue

### DIFF
--- a/js/modules/drilldown.src.js
+++ b/js/modules/drilldown.src.js
@@ -645,11 +645,11 @@ H.Axis.prototype.getDDPoints = function (x) {
 	each(this.series, function (series) {
 		var i,
 			xData = series.xData,
-			points = series.points;
+			points = series.points || [];
 		
-		for (i = 0; i < xData.length; i++) {
-			if (xData[i] === x && series.options.data[i] && series.options.data[i].drilldown) {
-				ret.push(points ? points[i] : true);
+		for (i = 0; i < points.length; i++) {
+			if (points[i] && points[i].x === x && points[i].drilldown) {
+				ret.push(points[i]);
 				break;
 			}
 		}

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -1066,7 +1066,7 @@ H.Series = H.seriesType('line', null, { // base series options
 			}
 		}
 
-		if (options.clip !== false) {
+		if (options.clip) {
 			this.group.clip(animation || seriesClipBox ? clipRect : chart.clipRect);
 			this.markerGroup.clip(markerClipRect);
 			this.sharedClipKey = sharedClipKey;


### PR DESCRIPTION
PR for issue [Drilldown doesn't work if rangeSelector doesn't select all and drilldown.allowPointDrilldown=true #6378](https://github.com/highcharts/highcharts/issues/6378).

1. Fix the index not matching in `H.Axis.prototype.getDDPoints`(file _js/modules/drilldown.src.js_). In fact, the length of `series.xData` is the length of the full series while the length of `series.points` is the length of the visible parts of the series.

2. Fix ineffective condition judgement in `setClip` function (file _Series.js_).