### PR TITLE
Fade markers when series are faded out from legend interaction

### DIFF
--- a/css/highcharts.scss
+++ b/css/highcharts.scss
@@ -168,10 +168,11 @@ $highlight-color-10: #e6ebf5; // Pressed button, color axis min color.
 }
 
 /* Legend hover affects points and series */
-g.highcharts-series, .highcharts-point {
+g.highcharts-series, .highcharts-point, .highcharts-markers {
     transition: opacity 250ms;
 }
 .highcharts-legend-series-active g.highcharts-series:not(.highcharts-series-hover),
+.highcharts-legend-series-active .highcharts-markers:not(.highcharts-series-hover),
 .highcharts-legend-point-active .highcharts-point:not(.highcharts-point-hover) {
     opacity: 0.2;
 }


### PR DESCRIPTION
Example: In a line chart when hovering over Series 1 in the legend, Series 2 fades out. But its markers were not fading out. This fixes that.