### PR TITLE
fix bug #6394

### DIFF
--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -900,9 +900,11 @@ seriesType('treemap', 'scatter', {
 	},
 	setState: function (state) {
 		H.Point.prototype.setState.call(this, state);
-		this.graphic.attr({
-			zIndex: state === 'hover' ? 1 : 0
-		});
+		if (this.graphic) {
+			this.graphic.attr({
+				zIndex: state === 'hover' ? 1 : 0
+			});
+		}
 	},
 	setVisible: seriesTypes.pie.prototype.pointClass.prototype.setVisible
 });


### PR DESCRIPTION
[Treemap with null value crashes on legend in Highcharts 5 #6394](https://github.com/highcharts/highcharts/issues/6394)