### PR TITLE
Clear pointer events added on Document when destrying pointer

### DIFF
--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -754,6 +754,10 @@ H.Pointer.prototype = {
 	 */
 	destroy: function () {
 		var prop;
+		
+		if(this.unDocMouseMove){
+			this.unDocMouseMove();
+		}
 
 		removeEvent(this.chart.container, 'mouseleave', this.onContainerMouseLeave);
 		if (!H.chartCount) {


### PR DESCRIPTION
Issue:
Chart pointer adds "mousemove" handler on document. But it's not cleared after the chart is destroyed.

Solution:
Clear 'mousemove' event handler added by pointer when destroy this pointer.