### PR TITLE
Remove forEach to improve performance

### DIFF
--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -1539,8 +1539,14 @@ H.stop = function (el, prop) {
  * * arr - The array that each is being applied to.
  * @param {Object} [ctx] The context.
  */
-H.each = function (arr, fn, ctx) { // modern browsers
-	return Array.prototype.forEach.call(arr, fn, ctx);
+H.each = function (arr, fn, ctx) { // legacy
+	var i = 0, 
+		len = arr.length;
+	for (; i < len; i++) {
+		if (fn.call(ctx, arr[i], i, arr) === false) {
+			return i;
+		}
+	}
 };
 
 /**
@@ -1958,18 +1964,6 @@ if (doc && !doc.defaultView) {
 		}
 		
 		return val === '' ? 1 : H.pInt(val);
-	};
-}
-
-if (!Array.prototype.forEach) {
-	H.each = function (arr, fn, ctx) { // legacy
-		var i = 0, 
-			len = arr.length;
-		for (; i < len; i++) {
-			if (fn.call(ctx, arr[i], i, arr) === false) {
-				return i;
-			}
-		}
 	};
 }
 


### PR DESCRIPTION
This PR is for improving the Highcharts performance. Since `forEach` is ~95% slower than traditional `for`, it i better to opt for traditional approach. Here's the performance comparison of various ways to iterate: [https://jsperf.com/for-vs-foreach-vs-lodash-foreach](https://jsperf.com/for-vs-foreach-vs-lodash-foreach).

Issue reference: https://github.com/highcharts/highcharts/issues/6532