### PR TITLE
Added missing exportChart param

### DIFF
--- a/lib/modules/offline-exporting.src.js
+++ b/lib/modules/offline-exporting.src.js
@@ -316,7 +316,7 @@
 						throw 'Fallback to export server disabled';
 					}
 				} else {
-					chart.exportChart(options);
+					chart.exportChart(options, chartOptions);
 				}
 			},
 			svgSuccess = function (svg) {


### PR DESCRIPTION
The second parameter of `exportChart` is lost during the fallback to export server