### PR TITLE
Links in labels need not be absolute

### DIFF
--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -2172,7 +2172,7 @@ SVGRenderer.prototype = {
 
 			clsRegex = /<.*class="([^"]+)".*>/;
 			styleRegex = /<.*style="([^"]+)".*>/;
-			hrefRegex = /<.*href="(http[^"]+)".*>/;
+			hrefRegex = /<.*href="([^"]+)".*>/;
 
 			if (tempParent) {
 				tempParent.appendChild(textNode); // attach it to the DOM to read offset width


### PR DESCRIPTION
hrefRegex tests that the href field in the label markup must start with `http` to have an `onclick` property.