### PR TITLE
Links in labels are opened in new tabs/windows

### DIFF
--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -2227,7 +2227,7 @@ SVGRenderer.prototype = {
 							attr(tspan, 'style', spanStyle);
 						}
 						if (hrefRegex.test(span) && !forExport) { // Not for export - #1529
-							attr(tspan, 'onclick', 'location.href=\"' + span.match(hrefRegex)[1] + '\"');
+							attr(tspan, 'onclick', 'window.open(\"' + span.match(hrefRegex)[1] + '\")');
 							css(tspan, { cursor: 'pointer' });
 						}
 


### PR DESCRIPTION
Right now `onclick` replaces the contents of `window.location`. Instead use `window.open` (ideally the tspan would be enclosed in an <a> tag, though)