### PR TITLE
Fix support for 'inverted' on 3D charts

### DIFF
--- a/js/parts-3d/Chart.js
+++ b/js/parts-3d/Chart.js
@@ -538,25 +538,19 @@ Chart.prototype.get3dFrame = function () {
 		defaultShowBack = true;
 
 	// The 'default' criteria to visible faces of the frame is looking up every axis to decide whenever the left/right//top/bottom sides of the frame will be shown
-	each(chart.xAxis, function (axis) {
-		if (axis.opposite) {
-			defaultShowTop = true;
+	each([].concat(chart.xAxis, chart.yAxis, chart.zAxis), function (axis) {
+		if (axis.horiz) {
+			if (axis.opposite) {
+				defaultShowTop = true;
+			} else {
+				defaultShowBottom = true;
+			}
 		} else {
-			defaultShowBottom = true;
-		}
-	});
-	each(chart.zAxis, function (axis) {
-		if (axis.opposite) {
-			defaultShowTop = true;
-		} else {
-			defaultShowBottom = true;
-		}
-	});
-	each(chart.yAxis, function (axis) {
-		if (axis.opposite) {
-			defaultShowRight = true;
-		} else {
-			defaultShowLeft = true;
+			if (axis.opposite) {
+				defaultShowRight = true;
+			} else {
+				defaultShowLeft = true;
+			}
 		}
 	});
 

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -303,7 +303,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
 		axis.chart = chart;
 
 		// Flag, is the axis horizontal
-		axis.horiz = chart.inverted ? !isXAxis : isXAxis;
+		axis.horiz = chart.inverted && !axis.isZAxis ? !isXAxis : isXAxis;
 
 		// Flag, isXAxis
 		axis.isXAxis = isXAxis;
@@ -432,7 +432,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
 		axis.series = axis.series || []; // populated by Series
 
 		// inverted charts have reversed xAxes as default
-		if (chart.inverted && isXAxis && axis.reversed === undefined) {
+		if (chart.inverted && !axis.isZAxis  && isXAxis && axis.reversed === undefined) {
 			axis.reversed = true;
 		}
 
@@ -2231,7 +2231,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
 			ticks = axis.ticks,
 			horiz = axis.horiz,
 			side = axis.side,
-			invertedSide = chart.inverted ? [1, 0, 3, 2][side] : side,
+			invertedSide = chart.inverted  && !axis.isZAxis ? [1, 0, 3, 2][side] : side,
 			hasData,
 			showAxis,
 			titleOffset = 0,


### PR DESCRIPTION
Basically, we cannot "invert" the Z Axis

Also, when deciding which frames are visible on the 3D box, we must check `axis.isHoriz` instead of blindly relying on chart.xAxis being horizontal

Example of broken chart: http://jsfiddle.net/eactyefx/