### PR TITLE
[3D] Fix perspective of Axis labels

### DIFF
--- a/js/parts-3d/Chart.js
+++ b/js/parts-3d/Chart.js
@@ -792,48 +792,48 @@ Chart.prototype.get3dFrame = function () {
 
 		var yEdges = [];
 		if (isValidEdge(ret.left, ret.front)) {
-			yEdges.push({ y: (ym + yp) / 2, x: xm, z: zm });
+			yEdges.push({ y: (ym + yp) / 2, x: xm, z: zm, xDir: { x: 1, y: 0, z: 0 }});
 		}
 		if (isValidEdge(ret.left, ret.back)) {
-			yEdges.push({ y: (ym + yp) / 2, x: xm, z: zp });
+			yEdges.push({ y: (ym + yp) / 2, x: xm, z: zp, xDir: { x: 0, y: 0, z: -1 }});
 		}
 		if (isValidEdge(ret.right, ret.front)) {
-			yEdges.push({ y: (ym + yp) / 2, x: xp, z: zm });
+			yEdges.push({ y: (ym + yp) / 2, x: xp, z: zm, xDir: { x: 0, y: 0, z: 1 }});
 		}
 		if (isValidEdge(ret.right, ret.back)) {
-			yEdges.push({ y: (ym + yp) / 2, x: xp, z: zp });
+			yEdges.push({ y: (ym + yp) / 2, x: xp, z: zp, xDir: { x: -1, y: 0, z: 0 }});
 		}
 
 		var xBottomEdges = [];
 		if (isValidEdge(ret.bottom, ret.front)) {
-			xBottomEdges.push({ x: (xm + xp) / 2, y: yp, z: zm });
+			xBottomEdges.push({ x: (xm + xp) / 2, y: yp, z: zm, xDir: { x: 1, y: 0, z: 0 }});
 		}
 		if (isValidEdge(ret.bottom, ret.back)) {
-			xBottomEdges.push({ x: (xm + xp) / 2, y: yp, z: zp });
+			xBottomEdges.push({ x: (xm + xp) / 2, y: yp, z: zp, xDir: { x: -1, y: 0, z: 0 }});
 		}
 
 		var xTopEdges = [];
 		if (isValidEdge(ret.top, ret.front)) {
-			xTopEdges.push({ x: (xm + xp) / 2, y: ym, z: zm });
+			xTopEdges.push({ x: (xm + xp) / 2, y: ym, z: zm, xDir: { x: 1, y: 0, z: 0 }});
 		}
 		if (isValidEdge(ret.top, ret.back)) {
-			xTopEdges.push({ x: (xm + xp) / 2, y: ym, z: zp });
+			xTopEdges.push({ x: (xm + xp) / 2, y: ym, z: zp, xDir: { x: -1, y: 0, z: 0 }});
 		}
 
 		var zBottomEdges = [];
 		if (isValidEdge(ret.bottom, ret.left)) {
-			zBottomEdges.push({ z: (zm + zp) / 2, y: yp, x: xm });
+			zBottomEdges.push({ z: (zm + zp) / 2, y: yp, x: xm, xDir: { x: 0, y: 0, z: -1 }});
 		}
 		if (isValidEdge(ret.bottom, ret.right)) {
-			zBottomEdges.push({ z: (zm + zp) / 2, y: yp, x: xp });
+			zBottomEdges.push({ z: (zm + zp) / 2, y: yp, x: xp, xDir: { x: 0, y: 0, z: 1 }});
 		}
 
 		var zTopEdges = [];
 		if (isValidEdge(ret.top, ret.left)) {
-			zTopEdges.push({ z: (zm + zp) / 2, y: ym, x: xm });
+			zTopEdges.push({ z: (zm + zp) / 2, y: ym, x: xm, xDir: { x: 0, y: 0, z: -1 }});
 		}
 		if (isValidEdge(ret.top, ret.right)) {
-			zTopEdges.push({ z: (zm + zp) / 2, y: ym, x: xp });
+			zTopEdges.push({ z: (zm + zp) / 2, y: ym, x: xp, xDir: { x: 0, y: 0, z: 1 }});
 		}
 
 		var pickEdge = function (edges, axis, mult) {
@@ -870,16 +870,16 @@ Chart.prototype.get3dFrame = function () {
 	} else {
 		ret.axes = {
 			y: {
-				'left': { x: xm, z: zm },
-				'right': { x: xp, z: zm }
+				'left': { x: xm, z: zm, xDir: { x: 1, y: 0, z: 0 }},
+				'right': { x: xp, z: zm, xDir: { x: 0, y: 0, z: 1 }}
 			},
 			x: {
-				'top': { y: ym, z: zm },
-				'bottom': { y: yp, z: zm }
+				'top': { y: ym, z: zm, xDir: { x: 1, y: 0, z: 0 }},
+				'bottom': { y: yp, z: zm, xDir: { x: 1, y: 0, z: 0 }}
 			},
 			z: {
-				'top': { x: defaultShowLeft ? xp : xm, y: ym },
-				'bottom': { x: defaultShowLeft ? xp : xm, y: yp }
+				'top': { x: defaultShowLeft ? xp : xm, y: ym, xDir: defaultShowLeft ? { x: 0, y: 0, z: 1 } : { x: 0, y: 0, z: -1 } },
+				'bottom': { x: defaultShowLeft ? xp : xm, y: yp, xDir: defaultShowLeft ? { x: 0, y: 0, z: 1 } : { x: 0, y: 0, z: -1 } },
 			}
 		};
 	}

--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -1039,6 +1039,7 @@ extend(SVGElement.prototype, /** @lends Highcharts.SVGElement.prototype */ {
 			scaleY = wrapper.scaleY,
 			inverted = wrapper.inverted,
 			rotation = wrapper.rotation,
+			matrix = wrapper.matrix,
 			element = wrapper.element,
 			transform;
 
@@ -1054,6 +1055,13 @@ extend(SVGElement.prototype, /** @lends Highcharts.SVGElement.prototype */ {
 		// #1846).
 		transform = ['translate(' + translateX + ',' + translateY + ')'];
 
+		// apply matrix
+		if (defined(matrix)) {
+			transform.push(
+				'matrix(' + matrix.join(",") + ')'
+			);
+		}
+		
 		// apply rotation
 		if (inverted) {
 			transform.push('rotate(90) scale(-1,1)');
@@ -1830,7 +1838,8 @@ extend(SVGElement.prototype, /** @lends Highcharts.SVGElement.prototype */ {
 SVGElement.prototype.yGetter = SVGElement.prototype.xGetter;
 SVGElement.prototype.translateXSetter = SVGElement.prototype.translateYSetter =
 		SVGElement.prototype.rotationSetter = SVGElement.prototype.verticalAlignSetter =
-		SVGElement.prototype.scaleXSetter = SVGElement.prototype.scaleYSetter = function (value, key) {
+		SVGElement.prototype.scaleXSetter = SVGElement.prototype.scaleYSetter = 
+		SVGElement.prototype.matrixSetter = function (value, key) {
 			this[key] = value;
 			this.doTransform = true;
 		};

--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -417,6 +417,28 @@ H.Fx.prototype.strokeSetter = function () {
 	);
 };
 
+H.Fx.prototype.matrixSetter = function () {
+	var interpolated;
+	if (this.pos < 1 && 
+			(Array.isArray(this.start) || Array.isArray(this.end))) {
+		var start = this.start || [ 1, 0, 0, 1, 0, 0];
+		var end   = this.end   || [ 1, 0, 0, 1, 0, 0];
+		interpolated = [];
+		for (var i=0; i<6; i++) {
+			interpolated.push( this.pos * end[i] + (1 - this.pos) * start[i] );
+		}
+	} else {
+		interpolated = this.end;
+	}
+	
+	this.elem.attr(
+		this.prop,
+		interpolated,
+		null,
+		true
+	);
+};
+
 
 /**
  * Utility function to extend an object with the members of another.


### PR DESCRIPTION
Highcharts goes to great effort to position Axis labels in a way that looks good -- Proper spacing, no overlaps, etc. And they do look great!

Unless you use 3-D, that is.

In 3D, the label positions always stay bellow their ticks, but the text stays flat despite the perspective projetion, creating overlaps and mayhem.

This patch adds 2 options to 3-D chart axis:
 - `labels.skew3d` and `title.skew3d`: Enables skewing the text to follow the perspective. By itself, it fixes the overlaps.
    
 - `labels.position3d` and `title.position3d`: Modifies the position of axis labels/titles according to the chart orientation. It can be:
    - `'offset'`: Maintain a fixed horizontal/vertical distance from the tick marks, despite the chart orientation.
      This is the backwards-compatible behavior, and causes skewing of X and Z axes.
    - `'chart'`: Preserve 3D position relative to the chart.
      This looks nice, but hard to read if the text isn't forward-facing.
    - `'flap'`: Rotated text along the axis to compensate for the chart orientation.
      This tries to maintain text as legible as possible on all orientations.
    - `'ortho'`: Rotated text along the axis direction so that the labels are orthogonal to the axis.
      This is very similar to `'flap'`, but prevents skewing the labels (X and Y scaling are still present).



### Demo

http://jsfiddle.net/mruko5m2/

### Perspective
SVG doesn't really support perspective projection, which means "label skewing" won't make the label's text shrink with the distance.

Despite that limitation, skewing is calculated around each label's anchor point, which yields very convincing results.