### PR TITLE
fix: boost rendering overflows plot area

### DIFF
--- a/js/modules/boost.src.js
+++ b/js/modules/boost.src.js
@@ -1983,7 +1983,7 @@ function createAndAttachRenderer(chart, series) {
 			chart.plotLeft,
 			chart.plotTop,
 			chart.plotWidth,
-			chart.chartHeight
+			chart.plotHeight
 		);
 
 		target.image.clip(target.boostClipRect);
@@ -2016,7 +2016,7 @@ function createAndAttachRenderer(chart, series) {
 		x: chart.plotLeft,
 		y: chart.plotTop,
 		width: chart.plotWidth,
-		height: chart.chartHeight
+		height: chart.plotHeight
 	});
 	
 	if (!target.ogl) {


### PR DESCRIPTION
As described in [https://github.com/highcharts/highcharts/issues/6895](url) boost rendering overflows plot area.

Following the suggestion of [https://github.com/AndreiKoriagin](url) this pull request fixes that issue