### PR TITLE
Fix tick animation when there is no label

### DIFF
--- a/js/parts/Tick.js
+++ b/js/parts/Tick.js
@@ -463,7 +463,6 @@ H.Tick.prototype = {
 				label.attr('y', -9999); // #1338
 				tick.isNewLabel = true;
 			}
-			tick.isNew = false;
 		}
 	},
 
@@ -497,6 +496,8 @@ H.Tick.prototype = {
 
 		// the label is created on init - now move it into place
 		this.renderLabel(xy, old, opacity, index);
+
+		tick.isNew = false;
 	},
 
 	/**


### PR DESCRIPTION
We should _always_ clear tick.isNew, even if it doesn't have a label.

Reproduction: http://jsfiddle.net/w578q7y1/ -- The leftmost tick doesn't follow the animation

(Looks like #5520 came back from the dead to haunt me again)