### PR TITLE
Fix gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -300,7 +300,7 @@ gulp.task('nightly', function () {
  * Automated generation for internal Class reference.
  * Run with --watch argument to watch for changes in the JS files.
  */
-const generateClassReferences = ({ templateDir, destination }) => {
+const generateClassReferences = (templateDir, destination) => {
     const jsdoc = require('gulp-jsdoc3');
     const sourceFiles = [
         'README.md',
@@ -934,7 +934,7 @@ const generateAPI = (input, output, onlyBuildCurrent) => new Promise((resolve, r
  *  only latest version or all of them.
  * @return {Promise} A Promise which resolves into undefined when done.
  */
-const generateAPIDocs = ({ treeFile, output, onlyBuildCurrent }) => {
+const generateAPIDocs = (treeFile, output, onlyBuildCurrent) => {
     const version = getBuildProperties().version;
     const message = {
         'successJSDoc': colors.green('Created tree.json')


### PR DESCRIPTION
I currently see this error:

```
const generateClassReferences = ({ templateDir, destination, callback }) => {
                                 ^

SyntaxError: Unexpected token {
```

I have no idea if this is a new JS lambda syntax or what, but it doesn't work for me ¯\_(ツ)_/¯