### PR TITLE
[3D] Fix vanishing tick labels

### DIFF
--- a/js/parts-3d/Axis.js
+++ b/js/parts-3d/Axis.js
@@ -442,7 +442,7 @@ wrap(Tick.prototype, 'getMarkPath', function (proceed) {
 	return this.axis.chart.renderer.toLineSegments(pArr);
 });
 
-wrap(Tick.prototype, 'getLabelPosition', function (proceed) {
+wrap(Tick.prototype, 'fixLabelPosition', function (proceed) {
 	var pos = proceed.apply(this, [].slice.call(arguments, 1));
 	return fix3dPosition(this.axis, pos);
 });

--- a/js/parts/Tick.js
+++ b/js/parts/Tick.js
@@ -491,6 +491,9 @@ H.Tick.prototype = {
 				show = false;
 			}
 
+			//Fix label position in 3D charts.
+			xy = this.fixLabelPosition(xy);
+
 			// Set the new position, and show or hide
 			if (show && isNumber(xy.y)) {
 				xy.opacity = opacity;
@@ -501,6 +504,14 @@ H.Tick.prototype = {
 				tick.isNewLabel = true;
 			}
 		}
+	},
+
+	/**
+	 * This is a hook for applying 3D projection on the label position.
+	 * On 2D charts, it is a no-op.
+	 */
+	fixLabelPosition: function (xy) {
+		return xy;
 	},
 
 	/**


### PR DESCRIPTION
Sometimes, when seeing an axis from "the back side", it's tick labels disappear.
It doesn't happens consistently (I actually didn't notice it until a few days ago), and I couldn't explain what triggers it.

Here is a reproduction: https://jsfiddle.net/uxrzdbdt/

I did, however, found what happens:
`Tick.handleOverflow` expects flat 2D coordinates to work, but those had already been 3D projected by `Tick.getLabelPosition()`.
It goes crazy and sometimes decides to replace tick labels with invisible elipsis.

This patch adds a new hook, `Tick.fixLabelPosition()`. It is a no-op on 2D charts, and performs the projection on 3D charts -- After `Tick.handleOverflow` has executed.