### PR TITLE
[3D] Hide sideways faces on the 3D Frame.

### DIFF
--- a/js/parts-3d/Chart.js
+++ b/js/parts-3d/Chart.js
@@ -706,12 +706,19 @@ Chart.prototype.get3dFrame = function () {
 		yp = chart.plotTop + chart.plotHeight,
 		zm = 0,
 		zp = options3d.depth,
-		bottomOrientation = H.shapeArea3d([{ x: xm, y: yp, z: zp }, { x: xp, y: yp, z: zp }, { x: xp, y: yp, z: zm }, { x: xm, y: yp, z: zm }], chart),
-		topOrientation    = H.shapeArea3d([{ x: xm, y: ym, z: zm }, { x: xp, y: ym, z: zm }, { x: xp, y: ym, z: zp }, { x: xm, y: ym, z: zp }], chart),
-		leftOrientation   = H.shapeArea3d([{ x: xm, y: ym, z: zm }, { x: xm, y: ym, z: zp }, { x: xm, y: yp, z: zp }, { x: xm, y: yp, z: zm }], chart),
-		rightOrientation  = H.shapeArea3d([{ x: xp, y: ym, z: zp }, { x: xp, y: ym, z: zm }, { x: xp, y: yp, z: zm }, { x: xp, y: yp, z: zp }], chart),
-		frontOrientation  = H.shapeArea3d([{ x: xm, y: yp, z: zm }, { x: xp, y: yp, z: zm }, { x: xp, y: ym, z: zm }, { x: xm, y: ym, z: zm }], chart),
-		backOrientation   = H.shapeArea3d([{ x: xm, y: ym, z: zp }, { x: xp, y: ym, z: zp }, { x: xp, y: yp, z: zp }, { x: xm, y: yp, z: zp }], chart),
+		faceOrientation = function(vertexes) {
+			var area = H.shapeArea3d(vertexes, chart);
+			// Give it 0.5 squared-pixel as a margin for rounding errors.
+			if (area > 0.5) return 1;
+			if (area < -0.5) return -1;
+			return 0;
+		},
+		bottomOrientation = faceOrientation([{ x: xm, y: yp, z: zp }, { x: xp, y: yp, z: zp }, { x: xp, y: yp, z: zm }, { x: xm, y: yp, z: zm }]),
+		topOrientation    = faceOrientation([{ x: xm, y: ym, z: zm }, { x: xp, y: ym, z: zm }, { x: xp, y: ym, z: zp }, { x: xm, y: ym, z: zp }]),
+		leftOrientation   = faceOrientation([{ x: xm, y: ym, z: zm }, { x: xm, y: ym, z: zp }, { x: xm, y: yp, z: zp }, { x: xm, y: yp, z: zm }]),
+		rightOrientation  = faceOrientation([{ x: xp, y: ym, z: zp }, { x: xp, y: ym, z: zm }, { x: xp, y: yp, z: zm }, { x: xp, y: yp, z: zp }]),
+		frontOrientation  = faceOrientation([{ x: xm, y: yp, z: zm }, { x: xp, y: yp, z: zm }, { x: xp, y: ym, z: zm }, { x: xm, y: ym, z: zm }]),
+		backOrientation   = faceOrientation([{ x: xm, y: ym, z: zp }, { x: xp, y: ym, z: zp }, { x: xp, y: yp, z: zp }, { x: xm, y: yp, z: zp }]),
 		defaultShowBottom = false,
 		defaultShowTop = false,
 		defaultShowLeft = false,
@@ -759,7 +766,7 @@ Chart.prototype.get3dFrame = function () {
 		if (options.visible === true || options.visible === false) {
 			isVisible = options.visible;
 		} else if (options.visible === 'auto') {
-			isVisible = faceOrientation >= 0;
+			isVisible = faceOrientation > 0;
 		}
 
 		return {


### PR DESCRIPTION
A small follow-up for #6603. When a 3D frame face has `visible === 'auto'`, it should only be visible if it is facing the user.

But the behavior when the face is 90º from the user isn't very clear -- Should it be shown or not?
My initial decision was to show it, but I changed my mind -- It looks bad, doesn't display any information and sometimes gets on the way of axis labels.

This patch also adds some protection agains rounding errors.

It looks particularly bad when looking at a chart from above: http://jsfiddle.net/ujczcbwk/