### PR TITLE
Improve animation timers removal performances

### DIFF
--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -163,12 +163,9 @@ H.Fx.prototype = {
 					setTimeout(step, 13);
 				},
 			step = function () {
-				var i;
-				for (i = 0; i < timers.length; i++) {
-					if (!timers[i]()) {
-						timers.splice(i--, 1);
-					}
-				}
+				timers = H.grep(timers, function (timer) {
+					return timer();
+				});
 
 				if (timers.length) {
 					requestAnimationFrame(step);


### PR DESCRIPTION
When a lot of animations occurs, the timers collection may be quite huge.  Removing timers one by one is inefficient because all subsequent timers need to be moved in the array for each timer removed.  Using
`array.filter` is much more efficient.

As you can see it the following flamechart, a big chunk of time is used by "ArraySpliceFallback" (the native function behind `array.splice`).
![Before](https://user-images.githubusercontent.com/61787/31236327-14ab284a-a9f4-11e7-9e36-a5321e45e67b.png)

Replacing the loop with a `array.filter` call 
![After](https://user-images.githubusercontent.com/61787/31236443-679f1958-a9f4-11e7-91a9-a6ab799d0fd7.png)


Browser: Chromium 61.0.3163.79)