### PR TITLE
Use correct license format for Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,5 +35,5 @@
         "build.properties",
         "build.xml"
     ],
-    "license": "SEE LICENSE IN <license.txt>"
+    "license": "https://raw.githubusercontent.com/highcharts/highcharts/master/license.txt"
 }


### PR DESCRIPTION
https://github.com/bower/spec/blob/master/json.md#license defines the license value as "SPDX license identifier or path/url to a license.". "SEE LICENSE IN" is used by npm (package.json)