### PR TITLE
Reformat readme.md

### DIFF
--- a/assembler/README.md
+++ b/assembler/README.md
@@ -1,14 +1,14 @@
-#How to create custom Highcharts files
+# How to create custom Highcharts files
 By using the Highcharts assembler you can create your own custom Highcharts files. A benefit of using a custom file can be optimization of browser load speed due to lower filesize and less files to request.
 Follow the steps below to get started.
-##Download the Highcharts parts files
+## Download the Highcharts parts files
 Go to the Highcharts repository and click on “Clone or download” and select “Download ZIP”. Once the zip file is downloaded unpack it. Create a new folder in your project and name it highcharts. Copy the folders "assembler", "js" and "css" from the unpacked zip file into the new highcharts folder.
 
-##Install dependencies
+## Install dependencies
 The Highcharts assembler has to be executed in a Node.js environment, and you will therefore need to have Node.js installed. You can find more about it on [Node.js offical website](https://nodejs.org/en/)
 
 Another dependency is [js-beautify](https://www.npmjs.com/package/js-beautify), which is used to format the resulting file. To install js-beautify open a CLI in your project folder and run `npm install --save-dev js-beautify`.
-##Create a custom setup
+## Create a custom setup
 Start by creating a new file `./highcharts/js/masters/custom.src.js`. In this example we want a basic line chart with some interactivity. To achieve this we will need a setup that looks something like this:
 ```javascript
 'use strict';
@@ -21,7 +21,7 @@ export default Highcharts;
 ```
 Modify the setup according to your needs, then proceed with the next step.
 
-##Configure and run the Highcharts assembler
+## Configure and run the Highcharts assembler
 Create a new file `./custom-builder.js`. Add the following configuration to the file:
 ```javascript
 'use strict';
@@ -33,7 +33,7 @@ build({
 });
 ```
 Open a CLI in your project folder and run `node custom-builder.js` to execute the build script. Once the script has completed you should find the resulting script `./dist/custom.src.js`.
-##Create custom Highcharts CSS files
+## Create custom Highcharts CSS files
 To create a custom CSS version you will have to make a few modifications to the build procedure. This example assumes that you have read and followed the procedures already mentioned above in this article. 
 The Highcharts assembler has an option named `type`, let us set this to `css`. The configuration in `./custom-builder.js` should now look like this:
 ```javascript
@@ -59,7 +59,7 @@ sass.render({
 });
 ```
 Then run `node custom-builder.js` again to create all the files for your custom Highcharts Styled version.
-##Options
+## Options
 | Option | Default | Description |
 | ------------- | ------------- | ------------- |
 | base | null | Path to where the build files are located |


### PR DESCRIPTION
Reformatted markdown - md needs a space between the heading marker and the heading text.