### PR TITLE
fix footerFormat default value

### DIFF
--- a/js/parts/Options.js
+++ b/js/parts/Options.js
@@ -2394,7 +2394,7 @@ H.defaultOptions = {
 		 * @type {String}
 		 * @sample {highcharts} highcharts/tooltip/footerformat/ A table for value alignment
 		 * @sample {highmaps} maps/tooltip/format/ Format demo
-		 * @default false
+		 * @default ''
 		 * @since 2.2
 		 */
 		footerFormat: '',


### PR DESCRIPTION
The [doc](https://api.highcharts.com/highstock/series.flags.tooltip) says that the default value for `footerFormat` is `false`, which is actually empty string.

Is the doc automatically generated based on the annotations in this file? If yes, this change could fix the doc.