### PR TITLE
Safeguards for "cant read property 'hoverSeries' of undefined"

### DIFF
--- a/js/parts/Navigator.js
+++ b/js/parts/Navigator.js
@@ -1916,6 +1916,7 @@ Navigator.prototype = {
 
 		// Set the navigator series data to the new data of the base series
 		if (navigatorSeries && !navigator.hasNavigatorData) {
+			navigatorSeries.options = navigatorSeries.options || {};
 			navigatorSeries.options.pointStart = baseSeries.xData[0];
 			navigatorSeries.setData(
 				baseSeries.options.data,

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -2464,6 +2464,7 @@ H.Series = H.seriesType('line', null, { // base series options
 					var val = key === 'y' && series.toYData ?
 						series.toYData(point) :
 						point[key];
+						if (!series[key + 'Data']) series[key + 'Data'] = [];
 					series[key + 'Data'][i] = val;
 				} :
 				// Apply the method specified in i with the following arguments
@@ -2794,6 +2795,7 @@ H.Series = H.seriesType('line', null, { // base series options
 
 			// Update parallel arrays
 			each(this.parallelArrays, function (key) {
+				if (!series[key + 'Data']) series[key + 'Data'] = [];
 				series[key + 'Data'].length = 0;
 			});
 
@@ -2858,6 +2860,7 @@ H.Series = H.seriesType('line', null, { // base series options
 			}
 
 			series.data = [];
+			series.userOptions = series.userOptions || {};
 			series.options.data = series.userOptions.data = data;
 
 			// destroy old points
@@ -2874,6 +2877,7 @@ H.Series = H.seriesType('line', null, { // base series options
 			}
 
 			// redraw
+			chart = chart || {};
 			series.isDirty = chart.isDirtyBox = true;
 			series.isDirtyData = !!oldData;
 			animation = false;
@@ -2886,7 +2890,7 @@ H.Series = H.seriesType('line', null, { // base series options
 			this.generatePoints();
 		}
 
-		if (redraw) {
+		if (chart.redraw && redraw) {
 			chart.redraw(animation);
 		}
 	},
@@ -3868,11 +3872,13 @@ H.Series = H.seriesType('line', null, { // base series options
 		});
 
 		// remove from hoverSeries
-		if (chart.hoverSeries === series) {
-			chart.hoverSeries = null;
+		if (chart) {
+			if (chart.hoverSeries === series) {
+				chart.hoverSeries = null;
+			}
+			erase(chart.series, series);
+			chart.orderSeries();
 		}
-		erase(chart.series, series);
-		chart.orderSeries();
 
 		// clear all members
 		objectEach(series, function (val, prop) {


### PR DESCRIPTION
Happy to provide more insight into each of these changes in the form of screenshots but I'd probably just make a short video, but maybe you can see the changes are pretty reasonable safeguards in the first place and this wouldn't be necessary. I am using highcharts through the ember-highcharts addon for ember.

Basically, we have a stock chart, we have an option to draw a line horizontally across it, but that often fails with "cannot read property "hoverSeries" of undefined" (where chart.hoverSeries is the bad property access)

There other fixes are all solving undefined references. I took preference to defining empty objects/arrays where properties were being added/built up.

:)