### PR TITLE
Use fitToBin when initializing frequencies array

### DIFF
--- a/js/modules/histogram.src.js
+++ b/js/modules/histogram.src.js
@@ -164,7 +164,7 @@ seriesType('histogram', 'column', {
 		fitToBin = fitToBinLeftClosed(binWidth);
 
 		for (x = fitToBin(min); x <= max; x += binWidth) {
-			frequencies[correctFloat(x)] = 0;
+			frequencies[correctFloat(fitToBin(x))] = 0;
 		}
 
 		each(baseData, function (y) {


### PR DESCRIPTION
It seems like #7438 was caused by the fact that the code that initializes the `frequencies` array was not always normalizing the array indexes correctly. In [the fiddle referenced in the issue](http://jsfiddle.net/7jntfmjL/), the last computed index in the initialization code is `6.9388939039072e-18`, while it should really be `0`. Adding a `fitToBin` seems to address the issue.

Should close #7438 