### PR TITLE
Highstock: Made showLastLabel default for category yAxes.

### DIFF
--- a/js/parts/StockChart.js
+++ b/js/parts/StockChart.js
@@ -193,7 +193,11 @@ H.StockChart = H.stockChart = function (a, b, c) {
 			 * @default {highstock} false
 			 * @apioption yAxis.showLastLabel
 			 */
-			showLastLabel: false,
+			showLastLabel: !!(
+				// #6104, show last label by default for category axes
+				yAxisOptions.categories ||
+				yAxisOptions.type === 'category'
+			),
 
 			title: {
 				text: null

--- a/samples/unit-tests/axis/category/demo.html
+++ b/samples/unit-tests/axis/category/demo.html
@@ -1,4 +1,4 @@
-<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/modules/data.js"></script>
 
 

--- a/samples/unit-tests/axis/category/demo.js
+++ b/samples/unit-tests/axis/category/demo.js
@@ -532,7 +532,7 @@ QUnit.test(
                 lineWidth: 1,
                 title: {
                     text: 'Primary Axis'
-                },
+                }
             }, {
                 lineWidth: 1,
                 opposite: true,
@@ -590,3 +590,40 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test(
+    'Show last label on category axes by default in Highstock (#6104)',
+    function (assert) {
+        var chart = Highcharts.stockChart('container', {
+                yAxis: [{
+                    categories: []
+                }, {
+                    opposite: false
+                }, {
+                    opposite: false,
+                    type: 'category'
+                }],
+                series: [{
+                    data: [1, 2, 2, 1]
+                }, {
+                    data: [10, 12, 12, 11],
+                    yAxis: 1
+                }, {
+                    data: [20, 22, 22, 21],
+                    yAxis: 2
+                }]
+            }),
+            yAxes = chart.yAxis;
+
+        assert.ok(yAxes[0].categories && yAxes[0].options.showLastLabel,
+            'First axis has categories and shows last label');
+
+        assert.notOk(yAxes[1].categories || yAxes[1].options.showLastLabel,
+            '2nd axis does not have categories or shows last label');
+
+        assert.ok(yAxes[2].categories && yAxes[2].options.showLastLabel,
+            '3rd axis has categories and shows last label');
+    }
+);
+
+


### PR DESCRIPTION
Fixes #6104, #7546.

Very simplistic unit test, just testing for options. Looks like we have other tests checking that `showLastLabel` works, but we can make this test smarter if desired.