### PR TITLE
Fixed #7534, point.isInside is set to true in a cropped point - added extra check for a point's graphic prop.

### DIFF
--- a/js/modules/annotations.src.js
+++ b/js/modules/annotations.src.js
@@ -1325,7 +1325,10 @@ Annotation.prototype = {
 			itemPosRelativeX,
 			itemPosRelativeY,
 
-			showItem = point.series.visible && point.isInside !== false;
+			showItem =
+				point.series.visible &&
+				point.isInside !== false &&
+				(point.mock || point.graphic);
 
 		if (showItem) {
 

--- a/samples/unit-tests/annotations/annotations-cropthreshold/demo.details
+++ b/samples/unit-tests/annotations/annotations-cropthreshold/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/annotations/annotations-cropthreshold/demo.html
+++ b/samples/unit-tests/annotations/annotations-cropthreshold/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/annotations.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/annotations/annotations-cropthreshold/demo.js
+++ b/samples/unit-tests/annotations/annotations-cropthreshold/demo.js
@@ -1,0 +1,32 @@
+
+QUnit.test('#7534: Annotations positioning with series cropThreshold', function (assert) {
+    var chart = Highcharts.chart('container', {
+        series: [{
+            keys: ['y', 'id'],
+            data: [[12, 'anno'], 0, 7, 0, 10, 1, 2, 14, 5, 11, 9, 9, 19, 6, 15, 18, 2, 3, 5, 17],
+            cropTreshold: 1
+        }],
+
+        annotations: [{
+            labels: [{
+                point: 'anno'
+            }]
+        }]
+    });
+
+    chart.xAxis[0].setExtremes(5, 10, true, false);
+
+    var annotationLabel = chart.annotations[0].labels[0];
+
+    assert.strictEqual(
+        annotationLabel.attr('y'),
+        -9e9,
+        'Label is placed outside of the chart'
+    );
+
+    assert.strictEqual(
+        annotationLabel.placed,
+        false,
+        'Label.placed is set to false'
+    );
+});


### PR DESCRIPTION
Fixed #7534, point.isInside is set to true in a cropped point - added extra check for a point's graphic prop.