### PR TITLE
Sunburst used wrong value to calculate size of root node.

### DIFF
--- a/js/modules/sunburst.src.js
+++ b/js/modules/sunburst.src.js
@@ -636,7 +636,7 @@ var sunburstSeries = {
 			r: innerRadius,
 			radius: radiusPerLevel,
 			start: radians.start,
-			val: nodeTop.val,
+			val: nodeRoot.val,
 			x: positions[0],
 			y: positions[1]
 		};


### PR DESCRIPTION
# Description
Sunburst used wrong value to calculate size of root node. 
An example of the error it caused can be seen below:
![example of chart](https://user-images.githubusercontent.com/7830487/33878287-f883214e-df50-11e7-990d-d73566a6c6a8.PNG)
# Demo(s)
[Example of reproduced issue](http://jsfiddle.net/h1ogdw09/)
[Example of fixed issue](http://jsfiddle.net/3gffaf72/)

# Related issue(s)
- #7517
