### PR TITLE
Fixed #7677, after removing an annotation the chart throws errors.

### DIFF
--- a/js/modules/annotations.src.js
+++ b/js/modules/annotations.src.js
@@ -24,6 +24,7 @@ var	merge = H.merge,
 	format = H.format,
 	pick = H.pick,
 	destroyObjectProperties = H.destroyObjectProperties,
+	grep = H.grep,
 
 	tooltipPrototype = H.Tooltip.prototype,
 	seriesPrototype = H.Series.prototype,
@@ -807,15 +808,13 @@ Annotation.prototype = {
 
 		// Push the callback that reports to the overlapping-labels module which
 		// labels it should account for.
-		this.chart.labelCollectors.push(function () {
-			var labels = [];
-			each(anno.labels, function (label) {
-				if (!label.options.allowOverlap) {
-					labels.push(label);
-				}
+		this.labelCollector = function () {
+			return grep(anno.labels, function (label) {
+				return !label.options.allowOverlap;
 			});
-			return labels;
-		});
+		};
+
+		this.chart.labelCollectors.push(this.labelCollector);
 	},
 
 	/**
@@ -909,6 +908,8 @@ Annotation.prototype = {
 	**/
 	destroy: function () {
 		var chart = this.chart;
+
+		erase(this.chart.labelCollectors, this.labelCollector);
 
 		each(this.labels, function (label) {
 			label.destroy();

--- a/samples/unit-tests/annotations/annotations-remove/demo.details
+++ b/samples/unit-tests/annotations/annotations-remove/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/annotations/annotations-remove/demo.html
+++ b/samples/unit-tests/annotations/annotations-remove/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/annotations.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/annotations/annotations-remove/demo.js
+++ b/samples/unit-tests/annotations/annotations-remove/demo.js
@@ -1,0 +1,38 @@
+
+QUnit.test('#7677: Removing an annotations does not destroy its label collector', function (assert) {
+    var labelCollector;
+    var chart = Highcharts.chart('container', {
+        chart: {
+            events: {
+                load: function () {
+                    labelCollector = this.annotations[0].labelCollector;
+                }
+            }
+        },
+
+        series: [{
+            data: [43934, 52503, 57177, 69658, 97031, 119931, 137133, 154175]
+        }],
+
+        annotations: [{
+            id: '1',
+            labels: [{
+                point: {
+                    x: 2,
+                    y: 100000,
+                    xAxis: 0,
+                    yAxis: 0
+                }
+            }]
+        }]
+    });
+
+
+    chart.removeAnnotation('1');
+
+    assert.strictEqual(
+        chart.labelCollectors.indexOf(labelCollector),
+        -1,
+        'Annotation label collector is not kept in the chart\'s label collectors'
+    );
+});


### PR DESCRIPTION
Fixed #7677, after removing an annotation the chart throws errors.