### PR TITLE
bugfix/755-boost-wrong-marker-color

### DIFF
--- a/js/modules/boost.src.js
+++ b/js/modules/boost.src.js
@@ -2161,7 +2161,13 @@ function GLRenderer(postRenderCallback) {
 					shader.setPointSize(10);
 				}
 				shader.setDrawAsCircle(true);
-				vbuffer.render(s.from, s.to, 'POINTS');
+				for (sindex = 0; sindex < s.segments.length; sindex++) {
+					vbuffer.render(
+						s.segments[sindex].from,
+						s.segments[sindex].to,
+						'POINTS'
+					);
+				}
 			}
 		});
 


### PR DESCRIPTION
Fixes marker colors that were broken due to a regression after the `connectNulls` fix.