### PR TITLE
Added script checkDependency to allow enforcing of package versions.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,9 @@ const {
     removeDirectory,
     writeFile
 } = require('highcharts-assembler/src/utilities.js');
+const {
+  checkDependency
+} = require('./tools/filesystem.js');
 
 
 /**
@@ -128,6 +131,8 @@ const getFileOptions = (base) => {
  * @return undefined
  */
 const scripts = () => {
+    // Check if the installed version of the assembler matches the dependency.
+    checkDependency('highcharts-assembler', 'err', 'devDependencies');
     const build = require('highcharts-assembler');
     // const argv = require('yargs').argv; Already declared in the upper scope
     const files = (argv.file) ? argv.file.split(',') : null;
@@ -1416,6 +1421,7 @@ gulp.task('dist', () => {
 });
 
 gulp.task('scripts-new', () => {
+    checkDependency('highcharts-assembler', 'err', 'devDependencies');
     const {
         join,
         relative,

--- a/tools/filesystem.js
+++ b/tools/filesystem.js
@@ -1,0 +1,51 @@
+/* eslint-env node, es6 */
+/* eslint-disable func-style */
+
+'use strict';
+const {
+  resolve
+} = require('path');
+
+const log = (txt) => {
+    console.log(txt); // eslint-disable-line no-console
+};
+
+const error = (txt) => {
+    throw new Error(txt);
+};
+
+/**
+ * A script to check the listed version of a dependency mathes the one
+ * installed by NPM.
+ * @param {string} name Package name
+ * @param {string} severity The level of severity if there is a mismatch.
+ * Possible values are 'warn' and 'err'. Defaults to 'warn'.
+ * @param {string} type What type of dependency. Possible values are
+ * 'dependencies' and 'devDependencies'. Defaults to 'dependencies'.
+ * @return {undefined}
+ */
+const checkDependency = (name, severity = 'warn', type = 'dependencies') => {
+    const pathPackage = resolve('./package.json');
+    const dependency = require(pathPackage)[type][name];
+    if (!dependency) {
+        error(`Package ${name} is not listed in ${type}`);
+    }
+
+    const actual = require(`${name}/package.json`).version;
+    const mismatch = !dependency.endsWith(actual);
+    const action = {
+        warn: (message) => log(message),
+        err: (message) => error(message)
+    };
+    if (mismatch) {
+        if (action[severity]) {
+            action[severity](`The installed version of ${name} is ${actual}, while listed version in ${type} is ${dependency}. Please update to the required version by executing "npm install ${name}"`);
+        } else {
+            error(`Parameter "severity" has invalid value: ${severity}`);
+        }
+    }
+};
+
+module.exports = {
+    checkDependency
+};


### PR DESCRIPTION
Added a script which can remind us, or as in this use case, enforce us to update an installed package to the version described as a dependency in package.json.

I believe this can be useful in some cases to ensure that everybody is using the same version.