### PR TITLE
Boost: Fixes rendering issues for area range

### DIFF
--- a/js/modules/boost.src.js
+++ b/js/modules/boost.src.js
@@ -1238,7 +1238,8 @@ function GLRenderer(postRenderCallback) {
 		asBar = {
 			'column': true,
 			'bar': true,
-			'area': true
+			'area': true,
+			'arearange': true
 		},
 		asCircle = {
 			'scatter': true,
@@ -1763,12 +1764,7 @@ function GLRenderer(postRenderCallback) {
 			if (drawAsBar) {
 
 				maxVal = y;
-				minVal = 0;
-
-				if (y < 0) {
-					minVal = y;
-					y = 0;
-				}
+				minVal = low;
 
 				if (!settings.useGPUTranslations) {
 					minVal = yAxis.toPixels(minVal, true);

--- a/js/modules/boost.src.js
+++ b/js/modules/boost.src.js
@@ -1766,6 +1766,14 @@ function GLRenderer(postRenderCallback) {
 				maxVal = y;
 				minVal = low;
 
+				if (low === false || typeof low === 'undefined') {
+					if (y < 0) {
+						minVal = y;
+					} else {
+						minVal = 0;
+					}
+				}
+
 				if (!settings.useGPUTranslations) {
 					minVal = yAxis.toPixels(minVal, true);
 				}
@@ -3105,7 +3113,7 @@ if (!H.hasWebGLSupport()) {
 					clientX,
 					plotY,
 					isNull,
-					low,
+					low = false,
 					chartDestroyed = typeof chart.index === 'undefined',
 					isYInside = true;
 


### PR DESCRIPTION
Fixes the issue where area range are drawn as lines from high -> high, rather than as segments from low -> high.

The issue:

http://jsfiddle.net/xp42ggLx/2/

The fix in action:
http://jsfiddle.net/xp42ggLx/1/