### PR TITLE
Added property outerArcLength to Sunburst

### DIFF
--- a/js/modules/sunburst.src.js
+++ b/js/modules/sunburst.src.js
@@ -545,10 +545,8 @@ var sunburstSeries = {
 			var values = childrenValues[index],
 				angle = values.start + ((values.end - values.start) / 2),
 				radius = values.innerR + ((values.r - values.innerR) / 2),
-				isCircle = (
-					values.innerR === 0 &&
-					(values.end - values.start) > 6.28
-				),
+				radians = (values.end - values.start),
+				isCircle = (values.innerR === 0 && radians > 6.28),
 				center = (
 					isCircle ?
 					{ x: values.x, y: values.y } :
@@ -562,14 +560,11 @@ var sunburstSeries = {
 						child.val
 					) :
 					child.childrenTotal
-				),
-				innerArcFraction = (values.end - values.start) / (2 * Math.PI),
-				perimeter = 2 * Math.PI * values.innerR;
-
+				);
 			// The inner arc length is a convenience for data label filters.
 			if (this.points[child.i]) {
-				this.points[child.i].innerArcLength =
-					innerArcFraction * perimeter;
+				this.points[child.i].innerArcLength = radians * values.innerR;
+				this.points[child.i].outerArcLength = radians * values.r;
 			}
 
 			child.shapeArgs = merge(values, {

--- a/js/modules/sunburst.src.js
+++ b/js/modules/sunburst.src.js
@@ -539,14 +539,15 @@ var sunburstSeries = {
 			// Collect all children which should be included
 			children = grep(parent.children, function (n) {
 				return n.visible;
-			});
+			}),
+			twoPi = 6.28; // Two times Pi.
 		childrenValues = this.layoutAlgorithm(parentValues, children, options);
 		each(children, function (child, index) {
 			var values = childrenValues[index],
 				angle = values.start + ((values.end - values.start) / 2),
 				radius = values.innerR + ((values.r - values.innerR) / 2),
 				radians = (values.end - values.start),
-				isCircle = (values.innerR === 0 && radians > 6.28),
+				isCircle = (values.innerR === 0 && radians > twoPi),
 				center = (
 					isCircle ?
 					{ x: values.x, y: values.y } :

--- a/samples/highcharts/demo/sunburst/demo.js
+++ b/samples/highcharts/demo/sunburst/demo.js
@@ -1405,6 +1405,17 @@ Highcharts.chart('container', {
             }
         },
         levels: [{
+            level: 1,
+            levelIsConstant: false,
+            dataLabels: {
+                rotationMode: 'parallel',
+                filter: {
+                    property: 'outerArcLength',
+                    operator: '>',
+                    value: 64
+                }
+            }
+        }, {
             level: 2,
             colorByPoint: true,
             dataLabels: {


### PR DESCRIPTION
# Description
Added the property `outerArcLength` to use as an alternative filter instead of `innerArcLength`.
In the case of points where `innerR` is 0, the `innerArcLength` will also be 0, which may cause unwanted behaviour.
It can be seen in our current [Sunburst demo](https://www.highcharts.com/demo/sunburst) that the data label in the top node is filtered away, even though there is enough space for the data label.

The sample `highcharts/demo/sunburst` is modified to use `outerArcLength` on level 1, but it is depedent upon the changes in https://github.com/highcharts/highcharts/pull/7680 for `level.levelIsConstant` to work properly.

**Note:** I removed `innerArcFraction` and `perimeter`, because I found that `innerArcLength` could be expressed as `radians * values.innerR`.

# Example(s)
- https://utils.highcharts.local/samples/#view/highcharts/demo/sunburst
# Related issue(s)
- #7597