### PR TITLE
Addition to fix #7669, annotations styled mode

### DIFF
--- a/js/modules/annotations.src.js
+++ b/js/modules/annotations.src.js
@@ -24,6 +24,8 @@ var	merge = H.merge,
 	find = H.find,
 	format = H.format,
 	pick = H.pick,
+	objectEach = H.objectEach,
+	uniqueKey = H.uniqueKey,
 	destroyObjectProperties = H.destroyObjectProperties,
 
 	tooltipPrototype = H.Tooltip.prototype,
@@ -46,6 +48,7 @@ var	merge = H.merge,
  * {
  *   arrow: {
  *     id: 'arrow',
+ *     tagName: 'marker',
  *     refY: 5,
  *     refX: 5,
  *     markerWidth: 10,
@@ -63,11 +66,14 @@ var	merge = H.merge,
  * @type {Object}
  * @sample highcharts/annotations/custom-markers/
  *         Define a custom marker for annotations
+ * @sample highcharts/css/annotations-markers/
+ *         Define markers in a styled mode
  * @since 6.0.0
- * @apioption defs.markers
+ * @apioption defs
  */
 var defaultMarkers = {
 	arrow: {
+		tagName: 'marker',
 		render: false,
 		id: 'arrow',
 		refY: 5,
@@ -78,7 +84,9 @@ var defaultMarkers = {
 			tagName: 'path',
 			attrs: {
 				d: 'M 0 0 L 10 5 L 0 10 Z', // triangle (used as an arrow)
+        /*= if (build.classic) { =*/
 				strokeWidth: 0
+        /*= } =*/
 			}
 		}]
 	}
@@ -99,7 +107,7 @@ extend(MarkerMixin, {
 
 
 H.SVGRenderer.prototype.addMarker = function (id, markerOptions) {
-	var markerId = pick(id, H.uniqueKey()),
+	var markerId = pick(id, uniqueKey()),
 		marker = this.createElement('marker').attr({
 			id: markerId,
 			markerWidth: pick(markerOptions.markerWidth, 20),
@@ -109,12 +117,15 @@ H.SVGRenderer.prototype.addMarker = function (id, markerOptions) {
 			orient: markerOptions.orient || 'auto'
 		}).add(this.defs),
 
-		attrs = {
-			stroke: markerOptions.color || 'none',
-			fill: markerOptions.color || 'rgba(0, 0, 0, 0.75)'
-		},
+		attrs = {},
 		children = markerOptions.children;
 
+  /*= if (build.classic) { =*/
+	attrs  = {
+		stroke: markerOptions.color || 'none',
+		fill: markerOptions.color || 'rgba(0, 0, 0, 0.75)'
+	};
+  /*= } =*/
 	marker.id = markerId;
 
 	each(children, function (child) {
@@ -1188,7 +1199,7 @@ Annotation.prototype = {
 
 	redrawPath: function (pathItem, isNew) {
 		var points = pathItem.points,
-			strokeWidth = pathItem['stroke-width'],
+			strokeWidth = pathItem['stroke-width'] || 1,
 			d = ['M'],
 			pointIndex = 0,
 			dIndex = 0,
@@ -1252,29 +1263,30 @@ Annotation.prototype = {
 	setItemMarkers: function (item) {
 		var itemOptions = item.options,
 			chart = this.chart,
-			markers = chart.options.defs.markers,
+			defs = chart.options.defs,
 			fill = itemOptions.fill,
 			color = defined(fill) && fill !== 'none' ? fill : itemOptions.stroke,
 
 
 			setMarker = function (markerType) {
 				var markerId = itemOptions[markerType],
-					marker,
+					def,
 					predefinedMarker,
-					key;
+					key,
+					marker;
 
 				if (markerId) {
-					for (key in markers) {
-						marker = markers[key];
-						if (markerId === marker.id) {
-							predefinedMarker = marker;
+					for (key in defs) {
+						def = defs[key];
+						if (markerId === def.id && def.tagName === 'marker') {
+							predefinedMarker = def;
 							break;
 						}
 					}
 
 					if (predefinedMarker) {
 						marker = item[markerType] = chart.renderer.addMarker(
-							null, 
+							(itemOptions.id || uniqueKey()) + '-' + predefinedMarker.id, 
 							merge(predefinedMarker, { color: color })
 						);
 
@@ -1636,26 +1648,20 @@ chartPrototype.callbacks.push(function (chart) {
 });
 
 
+
+/*= if (build.classic) { =*/
 H.wrap(chartPrototype, 'getContainer', function (p) {
 	p.call(this);
 
-	var renderer = this.renderer,
-		options = this.options,
-		key,
-		markers,
-		marker;
+	var defs = this.options.defs = merge(defaultMarkers, this.options.defs || {});
 
-	options.defs = merge(options.defs || {}, { markers: defaultMarkers });
-	markers = options.defs.markers;
-
-	for (key in markers) {
-		marker = markers[key];
-		
-		if (pick(marker.render, true)) {
-			renderer.addMarker(marker.id, marker);			
+	objectEach(defs, function (def) {
+		if (def.tagName === 'marker' && def.render !== false) {
+			this.renderer.addMarker(def.id, def);
 		}
-	}
+	}, this);
 });
+/*= } =*/
 
 
 /* ************************************************************************* */

--- a/samples/highcharts/annotations/custom-markers/demo.js
+++ b/samples/highcharts/annotations/custom-markers/demo.js
@@ -26,11 +26,9 @@ Highcharts.chart('container', {
             id: 'custom-shape',
             children: [{
                 tagName: 'path',
-                attrs: {
-                    d: 'M 10,0 C 0,0 0,10 10,10 C 12.5,7.5 12.5,7.5 20,5 C 12.5,2.5 12.5,2.5 10,0 Z'
+                d: 'M 10,0 C 0,0 0,10 10,10 C 12.5,7.5 12.5,7.5 20,5 C 12.5,2.5 12.5,2.5 10,0 Z'
           // fill: 'black'
           // if the child does not have define fill/stroke attributes it inherits fill or stroke from the referencer element
-                }
             }],
             markerWidth: 40,
             markerHeight: 40,
@@ -40,23 +38,18 @@ Highcharts.chart('container', {
         marker1: {
             children: [{
                 tagName: 'circle',
-                attrs: {
-                    r: 9,
-                    cx: 11,
-                    cy: 11,
-                    fill: 'rgba(224, 101, 0, 0.6'
-                }
+                r: 9,
+                cx: 11,
+                cy: 11,
+                fill: 'rgba(224, 101, 0, 0.6'
             }, {
                 tagName: 'circle',
-                attrs: {
-                    r: 10,
-                    cx: 11,
-                    cy: 11,
-                    fill: 'none',
-                    'stroke-width': 2,
-                    stroke: 'black'
-                }
-
+                r: 10,
+                cx: 11,
+                cy: 11,
+                fill: 'none',
+                'stroke-width': 2,
+                stroke: 'black'
             }],
             tagName: 'marker',
             id: 'circle',

--- a/samples/highcharts/css/annotations-markers/demo.css
+++ b/samples/highcharts/css/annotations-markers/demo.css
@@ -1,0 +1,26 @@
+@import 'https://code.highcharts.com/css/highcharts.css';
+#container {
+    max-width: 800px;
+    height: 400px;
+    margin: 1em auto;
+}
+
+.shape {
+  fill: none;
+  stroke-width: 1;
+  stroke: red;
+}
+
+#shape-custom-shape path {
+  fill: red;
+}
+
+#shape-circle circle:first-child {
+  fill: rgba(224, 101, 0, 0.6);
+}
+
+#shape-circle circle:nth-child(2) {
+  fill: none;
+  stroke-width: 2;
+  stroke: black;
+}

--- a/samples/highcharts/css/annotations-markers/demo.details
+++ b/samples/highcharts/css/annotations-markers/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Sebastian Domas
+ js_wrap: b
+...

--- a/samples/highcharts/css/annotations-markers/demo.html
+++ b/samples/highcharts/css/annotations-markers/demo.html
@@ -1,0 +1,6 @@
+<script src="https://code.highcharts.com/js/highcharts.js"></script>
+<script src="https://code.highcharts.com/js/modules/annotations.js"></script>
+<script src="https://code.highcharts.com/js/modules/exporting.js"></script>
+
+<div id="container" style="height: 400px; min-width: 380px"></div>
+

--- a/samples/highcharts/css/annotations-markers/demo.js
+++ b/samples/highcharts/css/annotations-markers/demo.js
@@ -25,9 +25,7 @@ Highcharts.chart('container', {
             id: 'custom-shape',
             children: [{
                 tagName: 'path',
-                attrs: {
-                    d: 'M 10,0 C 0,0 0,10 10,10 C 12.5,7.5 12.5,7.5 20,5 C 12.5,2.5 12.5,2.5 10,0 Z'
-                }
+                d: 'M 10,0 C 0,0 0,10 10,10 C 12.5,7.5 12.5,7.5 20,5 C 12.5,2.5 12.5,2.5 10,0 Z'
             }],
             markerWidth: 40,
             markerHeight: 40,
@@ -37,19 +35,14 @@ Highcharts.chart('container', {
         marker1: {
             children: [{
                 tagName: 'circle',
-                attrs: {
-                    r: 9,
-                    cx: 11,
-                    cy: 11
-                }
+                r: 9,
+                cx: 11,
+                cy: 11
             }, {
                 tagName: 'circle',
-                attrs: {
-                    r: 10,
-                    cx: 11,
-                    cy: 11
-                }
-
+                r: 10,
+                cx: 11,
+                cy: 11
             }],
             tagName: 'marker',
             id: 'circle',

--- a/samples/highcharts/css/annotations-markers/demo.js
+++ b/samples/highcharts/css/annotations-markers/demo.js
@@ -22,14 +22,11 @@ Highcharts.chart('container', {
     defs: {
         marker0: {
             tagName: 'marker',
-            render: false, // if false it does not render the element to the dom
             id: 'custom-shape',
             children: [{
                 tagName: 'path',
                 attrs: {
                     d: 'M 10,0 C 0,0 0,10 10,10 C 12.5,7.5 12.5,7.5 20,5 C 12.5,2.5 12.5,2.5 10,0 Z'
-          // fill: 'black'
-          // if the child does not have define fill/stroke attributes it inherits fill or stroke from the referencer element
                 }
             }],
             markerWidth: 40,
@@ -43,18 +40,14 @@ Highcharts.chart('container', {
                 attrs: {
                     r: 9,
                     cx: 11,
-                    cy: 11,
-                    fill: 'rgba(224, 101, 0, 0.6'
+                    cy: 11
                 }
             }, {
                 tagName: 'circle',
                 attrs: {
                     r: 10,
                     cx: 11,
-                    cy: 11,
-                    fill: 'none',
-                    'stroke-width': 2,
-                    stroke: 'black'
+                    cy: 11
                 }
 
             }],
@@ -77,8 +70,11 @@ Highcharts.chart('container', {
             type: 'path',
             fill: 'none',
             stroke: 'red',
+            id: 'shape',
+            className: 'shape',
             markerStart: 'circle',
             markerEnd: 'custom-shape'
         }]
     }]
 });
+

--- a/samples/unit-tests/annotations/annotations-shapes/demo.js
+++ b/samples/unit-tests/annotations/annotations-shapes/demo.js
@@ -105,20 +105,20 @@ QUnit.test('Drawing path with a marker', function (assert) {
         },
 
         defs: {
-            markers: {
-                marker0: {
-                    id: 'arrow-marker',
-                    refY: 5,
-                    refX: 5,
-                    markerWidth: 10,
-                    markerHeight: 10,
-                    children: [{
-                        tagName: 'path',
-                        attrs: {
-                            d: 'M 0 0 L 10 5 L 0 10 Z' // triangle (used as an arrow)
-                        }
-                    }]
-                }
+            marker0: {
+                render: false,
+                id: 'arrow-marker',
+                tagName: 'marker',
+                refY: 5,
+                refX: 5,
+                markerWidth: 10,
+                markerHeight: 10,
+                children: [{
+                    tagName: 'path',
+                    attrs: {
+                        d: 'M 0 0 L 10 5 L 0 10 Z' // triangle (used as an arrow)
+                    }
+                }]
             }
         },
 
@@ -140,12 +140,18 @@ QUnit.test('Drawing path with a marker', function (assert) {
                 type: 'path',
                 points: [{ x: 200, y: 100 }, '2'],
                 markerEnd: 'arrow-marker',
-                markerStart: 'arrow-marker'
+                markerStart: 'arrow-marker',
+                id: 'shape'
             }]
         }]
     });
 
-    var marker = document.getElementById('arrow-marker');
+    assert.notOk(
+        document.getElementById('arrow-marker'),
+        'The base marker is not created with the render = false'
+    );
+
+    var marker = document.getElementById('shape-arrow-marker');
     assert.ok(marker, 'Marker is created');
     assert.strictEqual(marker.parentNode.nodeName, 'defs', 'Marker is placed in defs tag');
 

--- a/samples/unit-tests/annotations/annotations-shapes/demo.js
+++ b/samples/unit-tests/annotations/annotations-shapes/demo.js
@@ -115,9 +115,7 @@ QUnit.test('Drawing path with a marker', function (assert) {
                 markerHeight: 10,
                 children: [{
                     tagName: 'path',
-                    attrs: {
-                        d: 'M 0 0 L 10 5 L 0 10 Z' // triangle (used as an arrow)
-                    }
+                    d: 'M 0 0 L 10 5 L 0 10 Z' // triangle (used as an arrow)
                 }]
             }
         },


### PR DESCRIPTION
Styled mode changes creating defs from a chart - currently it is not possible to have markers for shapes in annotations styled mode. I changed the API for defining markers to be consistent with defining other defs.

- markers are defined exactly the same as other defs,
- renderer.definition is used for creating markers, children can be nested now,
- a marker specific for a shape can be accessed by id: `:shapeId-markerId`, where shapeId is the id defined in the shape options (`annotations.shapes.id`) and the markerId is defined in the marker options (`defs.marker.id`) - used in stylesheets