### PR TITLE
enhancement/ajax-refactor-and-extension

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -390,6 +390,7 @@ const generateClassReferences = ({ templateDir, destination }) => {
         './js/modules/drilldown.src.js',
         './js/modules/exporting.src.js',
         './js/modules/export-data.src.js',
+        './js/modules/data.src.js',
         './js/modules/offline-exporting.src.js'
     ];
     const optionsJSDoc = {

--- a/js/modules/data.src.js
+++ b/js/modules/data.src.js
@@ -44,6 +44,91 @@ if (!Array.prototype.some) {
 }
 
 /**
+ * @typedef {Object} AjaxSettings
+ * @property {String} url - The URL to call
+ * @property {('get'|'post'|'update'|'delete')} type - The verb to use
+ * @property {('json'|'xml'|'text'|'octet')} dataType - The data type expected
+ * @property {Function} success - Function to call on success
+ * @property {Function} error - Function to call on error
+ * @property {Object} data - The payload to send
+ * @property {Object} headers - The headers; keyed on header name
+ */
+
+/**
+ * Perform an Ajax call.
+ *
+ * @memberof Highcharts
+ * @param {AjaxSettings} - The Ajax settings to use
+ *
+ */
+Highcharts.ajax = function (attr) {
+	var options = Highcharts.merge(true, {
+			url: false,
+			type: 'GET',
+			dataType: 'json',
+			success: false,
+			error: false,
+			data: false,
+			headers: {}
+	}, attr),
+	headers = {
+			json: 'application/json',
+			xml: 'application/xml',
+			text: 'text/plain',
+			octet: 'application/octet-stream'
+	},
+	r = new XMLHttpRequest();
+
+	function handleError(xhr, err) {
+		if (options.error) {
+			options.error(xhr, err);
+		} else {
+			// Maybe emit a highcharts error event here
+		}
+	}
+
+	if (!options.url) {
+		return false;
+	}
+
+	r.open(options.type.toUpperCase(), options.url, true);
+	r.setRequestHeader(
+		'Content-Type',
+		headers[options.dataType] || headers.text
+	);
+
+	Highcharts.objectEach(options.headers, function (val, key) {
+		r.setRequestHeader(key, val);
+	});
+
+	r.onreadystatechange = function () {
+		var res;
+
+		if (r.readyState === 4) {
+			if (r.status === 200) {
+				res = r.responseText;
+				if (options.dataType === 'json') {
+					try {
+						res = JSON.parse(res);
+					} catch (e) {
+						return handleError(r, e);
+					}
+				}
+				return options.success && options.success(res);
+			}
+
+			handleError(r, r.responseText);
+		}
+	};
+
+	try {
+		options.data = JSON.stringify(options.data);
+	} catch (e) {}
+
+	r.send(options.data || true);
+};
+
+/**
  * The Data module provides a simplified interface for adding data to
  * a chart from sources like CVS, HTML tables or grid views. See also
  * the [tutorial article on the Data module](http://www.highcharts.com/docs/working-
@@ -1027,34 +1112,20 @@ Highcharts.extend(Data.prototype, {
 		 */
 		function fetchSheet(fn) {
 			var url = [
-					'https://spreadsheets.google.com/feeds/cells',
-					googleSpreadsheetKey,
-					worksheet,
-					'public/values?alt=json'
-				].join('/'),
-				r = new XMLHttpRequest();
+				'https://spreadsheets.google.com/feeds/cells',
+				googleSpreadsheetKey,
+				worksheet,
+				'public/values?alt=json'
+				].join('/');
 
-			r.open('GET', url, true);
-			r.setRequestHeader('Content-Type', 'application/json');
-
-			r.onreadystatechange = function () {
-				var json;
-
-				if (r.readyState === 4 && r.status === 200) {
-					if (r.status === 200) {
-						try {
-							json = JSON.parse(r.responseText);
-						} catch (e) {
-							return options.error && options.error(e, r);
-						}
-						return fn && fn(json);
-					}
-
-					return options.error && options.error(r.responseText, r);
+			Highcharts.ajax({
+				url: url,
+				dataType: 'json',
+				success: fn,
+				error: function (xhr, text) {
+					return options.error && options.error(text, xhr);
 				}
-			};
-
-			r.send(true);
+			});
 		}
 
 		if (googleSpreadsheetKey) {

--- a/samples/highcharts/studies/edit-in-cloud/demo.js
+++ b/samples/highcharts/studies/edit-in-cloud/demo.js
@@ -26,6 +26,17 @@
             });
         }
 
+        function openInCloud(data, direct) {
+            // Open new tab
+            var a = document.createElement('a');
+            a.href = 'https://cloud.highcharts.com/create?' +
+                     (direct ? 'c' : 'q') + '=' + data;
+            a.target = '_blank';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+        }
+
         var options = H.merge(this.userOptions);
         removeFunctions(options);
         var params = {
@@ -42,14 +53,22 @@
         params = JSON.stringify(params);
         params = btoa(encodeURIComponent(params));
 
-        // Open new tab
-        var a = document.createElement('a');
-        a.href = 'https://cloud.highcharts.com/create?c=' + params;
-        a.target = '_blank';
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
+        if (params.length < 2500) {
+            // We can skip the storage and just open it directly
+            return openInCloud(params, true);
+        }
 
+        Highcharts.ajax({
+            url: 'https://cloud-api.highcharts.com/openincloud',
+            type: 'post',
+            dataType: 'json',
+            data: params,
+            success: function (result) {
+                if (result && result.ok && result.id) {
+                    openInCloud(result.id);
+                }
+            }
+        });
     };
 
     H.getOptions().lang.editInCloud = 'Edit in Cloud';


### PR DESCRIPTION
* Adds `Highcharts.ajax()` 
* `Highcharts.ajax()` now used by the gspreadsheet fetcher
* Adds the data module to the list of things to include when building the class reference
* Adds an Ajax POST call to the "edit in cloud"-study, which is used if the chart data is too large for a `GET` request *

_* note that as of writing on 26th Jan/16:30 the cloud side of this change has not been deployed to production, because Friday afternoon_
