### PR TITLE
Bugfix/7730-boost-connect-null-ignored-when-zooming

### DIFF
--- a/js/modules/boost.src.js
+++ b/js/modules/boost.src.js
@@ -1884,7 +1884,10 @@ function GLRenderer(postRenderCallback) {
 			);
 		}
 
-		if (!lastX && connectNulls !== false) {
+		if (!lastX &&
+			connectNulls !== false &&
+			closestLeft > Number.MIN_VALUE &&
+			closestRight < Number.MAX_VALUE) {
 			// There are no points within the selected range
 			pushSupplementPoint(closestLeft);
 			pushSupplementPoint(closestRight);

--- a/js/modules/boost.src.js
+++ b/js/modules/boost.src.js
@@ -1884,7 +1884,7 @@ function GLRenderer(postRenderCallback) {
 			);
 		}
 
-		if (!lastX) {
+		if (!lastX && connectNulls !== false) {
 			// There are no points within the selected range
 			pushSupplementPoint(closestLeft);
 			pushSupplementPoint(closestRight);
@@ -2799,7 +2799,7 @@ wrap(Series.prototype, 'processData', function (proceed) {
 		) {
 			proceed.apply(this, Array.prototype.slice.call(arguments, 1));
 			dataToMeasure = this.processedXData;
-		}		
+		}
 
 		// Set the isBoosting flag, second pass with processedXData to see if we
 		// have zoomed.

--- a/js/modules/boost.src.js
+++ b/js/modules/boost.src.js
@@ -1405,7 +1405,7 @@ function GLRenderer(postRenderCallback) {
 			color,
 			scolor,
 			sdata = isStacked ? series.data : (xData || rawData),
-			closestLeft = { x: Number.MIN_VALUE, y: 0 },
+			closestLeft = { x: -Number.MAX_VALUE, y: 0 },
 			closestRight = { x: Number.MIN_VALUE, y: 0 },
 
 			skipped = 0,
@@ -1886,7 +1886,7 @@ function GLRenderer(postRenderCallback) {
 
 		if (!lastX &&
 			connectNulls !== false &&
-			closestLeft > Number.MIN_VALUE &&
+			closestLeft > -Number.MAX_VALUE &&
 			closestRight < Number.MAX_VALUE) {
 			// There are no points within the selected range
 			pushSupplementPoint(closestLeft);


### PR DESCRIPTION
Fixes an issue where `connectNull = false` was ignored when zooming, and an issue where non-existent points where padded to (hard to explain, see here: https://github.com/highcharts/highcharts/issues/7716).