### PR TITLE
tests/firefox-getbbox-symbol

### DIFF
--- a/samples/unit-tests/series/marker/demo.js
+++ b/samples/unit-tests/series/marker/demo.js
@@ -1,24 +1,23 @@
 
 
 QUnit.test('Marker size and position', function (assert) {
-    var stateMarkerGraphicBBox,
-        series = Highcharts.chart('container', {
-            chart: {
-                animation: false
-            },
-            series: [{
-                data: [1, 2, 3],
+    var series = Highcharts.chart('container', {
+        chart: {
+            animation: false
+        },
+        series: [{
+            data: [1, 2, 3],
+            animation: false,
+            marker: {
                 animation: false,
-                marker: {
-                    animation: false,
-                    states: {
-                        hover: {
-                            animation: false
-                        }
+                states: {
+                    hover: {
+                        animation: false
                     }
                 }
-            }]
-        }).series[0];
+            }
+        }]
+    }).series[0];
 
     // Default size
     assert.strictEqual(
@@ -87,17 +86,16 @@ QUnit.test('Marker size and position', function (assert) {
     });
 
     series.points[1].setState('hover');
-    stateMarkerGraphicBBox = series.stateMarkerGraphic.getBBox(true);
 
     assert.strictEqual(
         Math.floor(series.points[1].plotX),
-        stateMarkerGraphicBBox.x,
+        series.stateMarkerGraphic.attr('x'),
         'Correct image x-position (#7273)'
     );
 
     assert.strictEqual(
         Math.floor(series.points[1].plotY),
-        Math.floor(stateMarkerGraphicBBox.y),
+        Math.floor(series.stateMarkerGraphic.attr('y')),
         'Correct image y-position (#7273)'
     );
 


### PR DESCRIPTION
It's a general issue with `renderer.image` vs `renderer.symbol`, demo: http://jsfiddle.net/or4eprf5/3/

Should I create a ticket for it? It's not breaking anything (AFAIK) in the library core.