### PR TITLE
Bugfix/stop compile when error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -495,8 +495,7 @@ const compileLib = () => {
     const sourceFolder = './vendor/';
     const files = ['canvg.src.js', 'rgbcolor.src.js'];
     return compile(files, sourceFolder)
-        .then(console.log)
-        .catch(console.log);
+        .then(console.log);
 };
 
 const cleanCode = () => {
@@ -516,15 +515,14 @@ const cleanCode = () => {
 const cleanDist = () => {
     return removeDirectory('./build/dist').then(() => {
         console.log('Successfully removed dist directory.');
-    }).catch(console.log);
+    });
 };
 
 const cleanApi = () => {
     return removeDirectory('./build/api')
         .then(() => {
             console.log('Successfully removed api directory.');
-        })
-        .catch(console.log);
+        });
 };
 
 const copyFile = (source, target) => new Promise((resolve, reject) => {
@@ -843,8 +841,7 @@ const filesize = () => {
             const values = obj[key];
             report(key, values.new, values.head);
         });
-    })
-    .catch(console.log);
+    });
 };
 
 /**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -429,52 +429,53 @@ const generateClassReferences = ({ templateDir, destination }) => {
     });
 };
 
-const compile = (files, sourceFolder) => {
-    const createSourceMap = true;
-
-    console.log(colors.yellow('Warning: This task may take a few minutes on Mac, and even longer on Windows.'));
+const compileSingleFile = (path, sourceFolder, createSourceMap) => {
+    const closureCompiler = require('google-closure-compiler-js');
+    const sourcePath = sourceFolder + path;
+    const outputPath = sourcePath.replace('.src.js', '.js');
+    const src = getFile(sourcePath);
+    const getErrorMessage = (e) => {
+        return [
+            'Compile error in file: ' + path,
+            '- Type: ' + e.type,
+            '- Line: ' + e.lineNo,
+            '- Char : ' + e.charNo,
+            '- Description: ' + e.description
+        ].join('\n');
+    };
     return new Promise((resolve, reject) => {
-        files.forEach(path => {
-            const closureCompiler = require('google-closure-compiler-js');
-            // const fs = require('fs');
-            const sourcePath = sourceFolder + path;
-            const outputPath = sourcePath.replace('.src.js', '.js');
-            const src = getFile(sourcePath);
-            const getErrorMessage = (e) => {
-                return [
-                    'Compile error in file: ' + path,
-                    '- Type: ' + e.type,
-                    '- Line: ' + e.lineNo,
-                    '- Char : ' + e.charNo,
-                    '- Description: ' + e.description
-                ].join('\n');
-            };
-            const out = closureCompiler.compile({
-                compilationLevel: 'SIMPLE_OPTIMIZATIONS',
-                jsCode: [{
-                    src: src
-                }],
-                languageIn: 'ES5',
-                languageOut: 'ES5',
-                createSourceMap: createSourceMap
-            });
-            const errors = out.errors;
-            if (errors.length) {
-                const msg = errors.map((e) => {
-                    return getErrorMessage(e);
-                }).join('\n');
-                reject(msg);
-            } else {
-                writeFile(outputPath, out.compiledCode);
-                if (createSourceMap) {
-                    writeFile(outputPath + '.map', out.sourceMap);
-                }
-                // @todo add filesize information
-                console.log(colors.green('Compiled ' + sourcePath + ' => ' + outputPath));
-            }
-        });
-        resolve('Compile is complete');
+      const out = closureCompiler.compile({
+          compilationLevel: 'SIMPLE_OPTIMIZATIONS',
+          jsCode: [{
+              src: src
+          }],
+          languageIn: 'ES5',
+          languageOut: 'ES5',
+          createSourceMap: createSourceMap
+      });
+      const errors = out.errors;
+      if (errors.length) {
+          const msg = errors.map(getErrorMessage).join('\n');
+          reject(msg);
+      } else {
+          writeFile(outputPath, out.compiledCode);
+          if (createSourceMap) {
+              writeFile(outputPath + '.map', out.sourceMap);
+          }
+          // @todo add filesize information
+          console.log(colors.green('Compiled ' + sourcePath + ' => ' + outputPath));
+      }
     });
+}
+
+const compile = (files, sourceFolder) => {
+    console.log(
+      colors.yellow('Warning: This task may take a few minutes on Mac, and even longer on Windows.')
+    );
+    const createSourceMap = true;
+    const promises = files
+      .map(path => compileSingleFile(path, sourceFolder, createSourceMap))
+    return Promise.all(promises);
 };
 
 /**
@@ -482,10 +483,9 @@ const compile = (files, sourceFolder) => {
  */
 const compileScripts = () => {
     const sourceFolder = './code/';
-    const files = getFilesInFolder(sourceFolder, true, '').filter(path => path.endsWith('.src.js'));
-    return compile(files, sourceFolder)
-        .then(console.log)
-        .catch(console.log);
+    const files = getFilesInFolder(sourceFolder, true, '')
+      .filter(path => path.endsWith('.src.js'));
+    return compile(files, sourceFolder);
 };
 
 /**


### PR DESCRIPTION
# Description
Errors caused in the `compile` task during `dist` was only outputted to the console, and did not stop the work chain. This made the `dist` task appear as completing succesfully, while it should have stopped in the `compile` step. 

Also removed othere similar cases in `gulpfile.js`

# Related issue(s)
- #7775