### PR TITLE
bugfix/7833-linewidth-in-boost

### DIFF
--- a/js/modules/boost.src.js
+++ b/js/modules/boost.src.js
@@ -2071,6 +2071,7 @@ function GLRenderer(postRenderCallback) {
 		each(series, function (s, si) {
 			var options = s.series.options,
 				sindex,
+				lineWidth = typeof options.lineWidth !== 'undefined' ? options.lineWidth : 1,
 				threshold = options.threshold,
 				hasThreshold = isNumber(threshold),
 				yBottom = s.series.yAxis.getThreshold(threshold),
@@ -2165,13 +2166,15 @@ function GLRenderer(postRenderCallback) {
 			shader.setDrawAsCircle((asCircle[s.series.type] && textureIsReady) || false);
 
 			// Do the actual rendering
-			// vbuffer.render(s.from, s.to, s.drawMode);
-			for (sindex = 0; sindex < s.segments.length; sindex++) {
-				vbuffer.render(
-					s.segments[sindex].from,
-					s.segments[sindex].to,
-					s.drawMode
-				);
+			// If the line width is < 0, skip rendering of the lines. See #7833.
+			if (lineWidth > 0 || s.drawMode !== 'line_strip') {
+				for (sindex = 0; sindex < s.segments.length; sindex++) {
+					vbuffer.render(
+						s.segments[sindex].from,
+						s.segments[sindex].to,
+						s.drawMode
+					);
+				}
 			}
 
 			if (s.hasMarkers && showMarkers) {


### PR DESCRIPTION
Fixes boost so that line rendering is skipped if `series.lineWidth = 0`.