### PR TITLE
bugfix/7191-treemap-wrong-levels-options

### DIFF
--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -976,7 +976,7 @@ seriesType('treemap', 'scatter', {
 		tree = series.tree = series.getTree(); // @todo Only if series.isDirtyData is true
 		rootNode = series.nodeMap[rootId];
 		series.mapOptionsToLevel = getLevelOptions({
-			from: rootNode.level > 0 ? rootNode.level : 1,
+			from: rootNode.level + 1,
 			levels: options.levels,
 			to: tree.height,
 			defaults: {


### PR DESCRIPTION
## Description
The series.levels options was not applied to the correct level when `levelIsConstant: false`. 
## Demo(s)
- [Treemap large dataset](http://jsfiddle.net/tvo97swx/1/)
## Related issue(s)
- #7191
