### PR TITLE
bugfix/7826-annotations-points-without-marker

### DIFF
--- a/js/modules/annotations.src.js
+++ b/js/modules/annotations.src.js
@@ -85,9 +85,9 @@ var defaultMarkers = {
 		children: [{
 			tagName: 'path',
 			d: 'M 0 0 L 10 5 L 0 10 Z', // triangle (used as an arrow)
-      /*= if (build.classic) { =*/
+			/*= if (build.classic) { =*/
 			strokeWidth: 0
-      /*= } =*/
+			/*= } =*/
 		}]
 	}
 };
@@ -116,7 +116,7 @@ H.SVGRenderer.prototype.definition = function (def) {
 			var node = ren.createElement(item.tagName),
 				attr = {};
 
-      // Set attributes
+			// Set attributes
 			objectEach(item, function (val, key) {
 				if (
           key !== 'tagName' &&
@@ -128,23 +128,23 @@ H.SVGRenderer.prototype.definition = function (def) {
 			});
 			node.attr(attr);
 
-      // Add to the tree
+			// Add to the tree
 			node.add(parent || ren.defs);
 
-      // Add text content
+			// Add text content
 			if (item.textContent) {
 				node.element.appendChild(
           doc.createTextNode(item.textContent)
         );
 			}
 
-      // Recurse
+			// Recurse
 			recurse(item.children || [], node);
 
 			ret = node;
 		});
 
-    // Return last node added (on top level it's the only one)
+		// Return last node added (on top level it's the only one)
 		return ret;
 	}
 	return recurse(def);
@@ -154,7 +154,7 @@ H.SVGRenderer.prototype.definition = function (def) {
 H.SVGRenderer.prototype.addMarker = function (id, markerOptions) {
 	var options = { id: id };
 
-  /*= if (build.classic) { =*/
+	/*= if (build.classic) { =*/
 	var attrs  = {
 		stroke: markerOptions.color || 'none',
 		fill: markerOptions.color || 'rgba(0, 0, 0, 0.75)'
@@ -163,7 +163,7 @@ H.SVGRenderer.prototype.addMarker = function (id, markerOptions) {
 	options.children = H.map(markerOptions.children, function (child) {
 		return merge(attrs, child);
 	});
-  /*= } =*/
+	/*= } =*/
 
 	var marker = this.definition(merge({
 		markerWidth: 20,
@@ -287,24 +287,17 @@ MockPoint.prototype = {
 	translate: function () {
 		var series = this.series,
 			xAxis = series.xAxis,
-			yAxis = series.yAxis,
-			plotX = this.plotX,
-			plotY = this.plotY,
-			isInside = true;
+			yAxis = series.yAxis;
 
 		if (xAxis) {
-			this.plotX = plotX = xAxis.toPixels(this.x, true);
-
-			isInside = plotX >= 0 && plotX <= xAxis.len;
+			this.plotX = xAxis.toPixels(this.x, true);
 		}
 
 		if (yAxis) {
-			this.plotY = plotY = yAxis.toPixels(this.y, true);
-
-			isInside = isInside && plotY >= 0 && plotY <= yAxis.len;
+			this.plotY = yAxis.toPixels(this.y, true);
 		}
 
-		this.isInside = isInside;
+		this.isInside = this.isInsidePane();
 	},
 
 	/**
@@ -358,6 +351,27 @@ MockPoint.prototype = {
 			y: this.y,
 			point: this
 		};
+	},
+
+	isInsidePane: function () {
+		var	plotX = this.plotX,
+			plotY = this.plotY,
+			xAxis = this.series.xAxis,
+			yAxis = this.series.yAxis,
+			isInside = true;
+
+		if (xAxis) {
+			isInside = defined(plotX) && plotX >= 0 && plotX <= xAxis.len;
+		}
+
+		if (yAxis) {
+			isInside =
+				isInside &&
+				defined(plotY) &&
+				plotY >= 0 && plotY <= yAxis.len;
+		}
+
+		return isInside;
 	}
 };
 
@@ -1441,8 +1455,7 @@ Annotation.prototype = {
 
 			showItem =
 				point.series.visible &&
-				point.isInside !== false &&
-				(point.mock || point.graphic);
+				MockPoint.prototype.isInsidePane.call(point);
 
 		if (showItem) {
 

--- a/samples/unit-tests/annotations/annotations-cropthreshold/demo.js
+++ b/samples/unit-tests/annotations/annotations-cropthreshold/demo.js
@@ -5,18 +5,52 @@ QUnit.test('#7534: Annotations positioning with series cropThreshold', function 
             keys: ['y', 'id'],
             data: [[12, 'anno'], 0, 7, 0, 10, 1, 2, 14, 5, 11, 9, 9, 19, 6, 15, 18, 2, 3, 5, 17],
             cropTreshold: 1
+        }, {
+            keys: ['y', 'id'],
+            data: [4, 0, 7, 0, [15, 'anno2'], 10, 1, 2, 14, 5, 11, 9, 9, 19, 6, 15, 18, 2, 3, 5, 17],
+            marker: { enabled: false },
+            cropTreshold: 1
         }],
 
         annotations: [{
             labels: [{
                 point: 'anno'
             }]
+        }, {
+            labels: [{
+                point: 'anno2',
+                align: 'left',
+                verticalAlign: 'top',
+                x: 0,
+                y: 0
+            }]
         }]
     });
 
+
+    var annotationLabel = chart.annotations[1].labels[0];
+    var point = chart.get('anno2');
+
+    assert.strictEqual(
+        Math.round(annotationLabel.attr('y')),
+        Math.round(point.plotY + point.series.group.translateY),
+        'For series without marker - label is placed correctly - y coordinate'
+    );
+
+    assert.strictEqual(
+        Math.round(annotationLabel.attr('x')),
+        Math.round(point.plotX + point.series.group.translateX),
+        'For series without marker - label is placed correctly - x coordinate'
+    );
+
+    assert.ok(
+        annotationLabel.placed,
+        'For series without markers - label.placed is set to true'
+    );
+
     chart.xAxis[0].setExtremes(5, 10, true, false);
 
-    var annotationLabel = chart.annotations[0].labels[0];
+    annotationLabel = chart.annotations[0].labels[0];
 
     assert.strictEqual(
         annotationLabel.attr('y'),
@@ -24,9 +58,22 @@ QUnit.test('#7534: Annotations positioning with series cropThreshold', function 
         'Label is placed outside of the chart'
     );
 
-    assert.strictEqual(
+    assert.notOk(
         annotationLabel.placed,
-        false,
         'Label.placed is set to false'
     );
+
+    annotationLabel = chart.annotations[1].labels[0];
+
+    assert.strictEqual(
+        annotationLabel.attr('y'),
+        -9e9,
+        'For series without marker - Label is placed outside the chart'
+    );
+
+    assert.notOk(
+        annotationLabel.placed,
+        'For series without markers - label.placed is set to false'
+    );
+
 });

--- a/samples/unit-tests/annotations/annotations-labels-mock-point/demo.js
+++ b/samples/unit-tests/annotations/annotations-labels-mock-point/demo.js
@@ -15,6 +15,27 @@ QUnit.test('Mock Point translations from x/y in the options to plotX/plotY', fun
             }, {
                 xAxis: 1,
                 data: [[0, 1]]
+            }, {
+                data: [
+                    [-20, 5],
+                    [2, 5], {
+                        x: 5,
+                        y: 2,
+                        marker: {
+                            enabled: false
+                        }
+                    }, {
+                        x: 110,
+                        y: 4,
+                        marker: {
+                            enabled: false
+                        }
+                    },
+                    [112, 4]
+                ],
+                marker: {
+                    enabled: true
+                }
             }]
         }),
 
@@ -80,5 +101,56 @@ QUnit.test('Mock Point translations from x/y in the options to plotX/plotY', fun
         Math.round(point.plotX),
         Math.round(options.x),
         'plotX translation from pixels'
+    );
+
+
+    var isInsidePane = Highcharts.MockPoint.prototype.isInsidePane;
+    var points = chart.series[2].points;
+
+    assert.notOk(
+        isInsidePane.call(points[0]),
+        'The real point is outside the pane area'
+    );
+
+    assert.ok(
+        isInsidePane.call(points[1]),
+        'The real point is inside the pane area'
+    );
+
+    assert.ok(
+        isInsidePane.call(points[2]),
+        'The real point without marker is inside the pane area'
+    );
+
+    assert.notOk(
+        isInsidePane.call(points[3]),
+        'The real point without marker is outside the pane area'
+    );
+
+    chart.xAxis[0].setExtremes(109, 113);
+
+    assert.notOk(
+        isInsidePane.call(points[0]),
+        'After set extremes - the real point is outside the pane area'
+    );
+
+    assert.notOk(
+        isInsidePane.call(points[1]),
+        'After set extremes - the real point is outside the pane area'
+    );
+
+    assert.notOk(
+        isInsidePane.call(points[2]),
+        'After set extremes - the real point without marker is outside the pane area'
+    );
+
+    assert.ok(
+        isInsidePane.call(points[3]),
+        'After set extreems - the real point without marker is inside the pane area'
+    );
+
+    assert.ok(
+        isInsidePane.call(points[4]),
+        'After set extreems - the real point is inside the pane area'
     );
 });


### PR DESCRIPTION
Fixed #7826, annotations are hidden if the points have disabled markers.