### PR TITLE
Feature/build script update

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -575,7 +575,7 @@ const createProductJS = () => {
     },
     "Highstock": {
         "date": "${date}",
-        "nr": "${version}"<
+        "nr": "${version}"
     },
     "Highmaps": {
         "date": "${date}",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -406,7 +406,9 @@ const compile = (files, sourceFolder) => {
 const compileScripts = () => {
     const sourceFolder = './code/';
     const files = getFilesInFolder(sourceFolder, true, '')
-      .filter(path => path.endsWith('.src.js'));
+        // Compile all files ending with .src.js.
+        // Do not compile files in ./es-modules or ./js/es-modules.
+      .filter(path => (path.endsWith('.src.js') && !path.includes('es-modules')));
     return compile(files, sourceFolder);
 };
 
@@ -1367,7 +1369,7 @@ gulp.task('dist', () => {
     return Promise.resolve()
         .then(gulpify('cleanCode', cleanCode))
         .then(gulpify('styles', styles))
-        .then(gulpify('scripts', scripts))
+        .then(gulpify('scripts', getBuildScripts({}).fnFirstBuild))
         .then(gulpify('lint', lint))
         .then(gulpify('compile', compileScripts))
         .then(gulpify('cleanDist', cleanDist))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,16 +39,19 @@ const buildESModules = () => {
 const styles = () => {
     const sass = require('node-sass');
     const fileName = 'highcharts';
+    const input = './css/' + fileName + '.scss';
+    const output = './code/css/' + fileName + '.css';
     return new Promise((resolve, reject) => {
         sass.render({
-            file: './css/' + fileName + '.scss',
+            file: input,
             outputStyle: 'expanded'
         }, (err, result) => {
             if (err) {
                 console.error(err);
                 reject(err);
             } else {
-                writeFile('./code/css/' + fileName + '.css', result.css);
+                writeFile(output, result.css);
+                console.log(`Completed rendering of ${input} to ${output}`);
                 resolve();
             }
         });
@@ -89,16 +92,6 @@ const lintSamples = () => {
     ]);
     console.log(formatter(report.results));
 };
-
-/**
- * Watch changes to JS and SCSS files
- */
-gulp.task('default', ['styles', 'scripts'], () => {
-    // If styling changes, then build new css and js files.
-    gulp.watch(['./css/*.scss'], ['styles', 'scripts']);
-    // If js parts files changes, then build new js files.
-    gulp.watch(['./js/!(adapters|builds)/*.js'], ['scripts']);
-});
 
 gulp.task('ftp', function () {
     const ftp = require('vinyl-ftp');
@@ -1344,15 +1337,26 @@ gulp.task('styles', styles);
  */
 gulp.task('scripts', () => {
     const options = {
+        debug: argv.d || false,
         files: (
             (argv.file) ?
             argv.file.split(',') :
             null
         ),
         type: (argv.type) ? argv.type : null,
-        debug: argv.d || false
+        watch: argv.watch || false
     };
-    return scripts(options);
+    const {
+        fnFirstBuild,
+        mapOfWatchFn
+    } = getBuildScripts(options);
+    fnFirstBuild();
+    if (options.watch) {
+        Object.keys(mapOfWatchFn).forEach((key) => {
+            const fn = mapOfWatchFn[key];
+            gulp.watch(key, fn);
+        });
+    }
 });
 gulp.task('build-modules', buildESModules);
 gulp.task('lint', lint);
@@ -1361,6 +1365,60 @@ gulp.task('compile', compileScripts);
 gulp.task('compile-lib', compileLib);
 gulp.task('copy-graphics-to-dist', copyGraphicsToDist);
 gulp.task('examples', createAllExamples);
+
+/**
+ * Watch changes to JS and SCSS files
+ */
+gulp.task('default', () => {
+    const {
+        fnFirstBuild,
+        mapOfWatchFn
+    } = getBuildScripts({});
+    const {
+        relative,
+        sep
+    } = require('path');
+    const watchlist = [
+        './css/*.scss',
+        './js/**/*.js',
+        './code/es-modules/**/*.js',
+        './code/js/es-modules/**/*.js'
+    ];
+    const msgBuildAll = 'Completed building of all JS files.';
+    let watcher;
+    const onChange = (event) => {
+        const path = relative('.', event.path).split(sep).join('/');
+        if (path.startsWith('css')) {
+            // Stop the watcher temporarily.
+            watcher.end();
+            watcher = null;
+            // Run styles and build all files.
+            styles()
+            .then(() => {
+                fnFirstBuild();
+                console.log(msgBuildAll);
+                // Start watcher again.
+                watcher = gulp.watch(watchlist, onChange);
+            });
+        } else if (path.startsWith('js')) {
+            // Build es-modules
+            mapOfWatchFn['js/**/*.js'](event);
+        } else if (path.startsWith('code/es-modules')) {
+            // Build dist files in classic mode.
+            mapOfWatchFn['code/es-modules/**/*.js'](event);
+        } else if (path.startsWith('code/js/es-modules')) {
+            // Build dist files in styled mode.
+            mapOfWatchFn['code/js/es-modules/**/*.js'](event);
+        }
+    };
+    return styles()
+    .then(() => {
+        fnFirstBuild();
+        console.log(msgBuildAll);
+        // Start watching source files.
+        watcher = gulp.watch(watchlist, onChange);
+    });
+});
 
 /**
  * Create distribution files
@@ -1378,30 +1436,6 @@ gulp.task('dist', () => {
         .then(gulpify('createExamples', createAllExamples))
         .then(gulpify('copyGraphicsToDist', copyGraphicsToDist))
         .then(gulpify('ant-dist', antDist));
-});
-
-gulp.task('scripts-new', () => {
-    const watch = argv.watch || false;
-    const {
-        fnFirstBuild,
-        mapOfWatchFn
-    } = getBuildScripts({
-        debug: argv.d || false,
-        files: (
-            (argv.file) ?
-            argv.file.split(',') :
-            null
-        ),
-        type: (argv.type) ? argv.type : null,
-        watch
-    });
-    fnFirstBuild();
-    if (watch) {
-        Object.keys(mapOfWatchFn).forEach((key) => {
-            const fn = mapOfWatchFn[key];
-            gulp.watch(key, fn);
-        });
-    }
 });
 
 gulp.task('browserify', function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,113 +11,20 @@ const fs = require('fs');
 const {
     getFilesInFolder
 } = require('highcharts-assembler/src/build.js');
-
 const {
     getFile,
     removeDirectory,
     writeFile
 } = require('highcharts-assembler/src/utilities.js');
 const {
+    getFileOptions,
+    getProductVersion,
+    scripts
+} = require('./tools/build.js');
+const {
   checkDependency
 } = require('./tools/filesystem.js');
 
-
-/**
- * Get the product version from build.properties.
- * The product version is used in license headers and in package names.
- * @return {string|null} Returns version number or null if not found.
- */
-const getProductVersion = () => {
-    const {
-        regexGetCapture
-    } = require('highcharts-assembler/src/dependencies.js');
-    const properties = fs.readFileSync('./build.properties', 'utf8');
-    return regexGetCapture(/product\.version=(.+)/, properties);
-};
-
-/**
- * Returns fileOptions for the build script
- * @todo Move this functionality to the build script,
- *   and reuse it on github.highcharts.com
- * @return {Object} Object containing all fileOptions
- */
-const getFileOptions = (files) => {
-    const highchartsFiles = replaceAll(
-      getOrderedDependencies('js/masters/highcharts.src.js').join('|'),
-      sep,
-      `\\${sep}`
-    );
-
-    // Modules should not be standalone, and they should exclude all parts files.
-    const fileOptions = files
-        .reduce((obj, file) => {
-            if (file.indexOf('modules') > -1 || file.indexOf('themes') > -1 || file.indexOf('indicators') > -1) {
-                obj[file] = {
-                    exclude: new RegExp(folders.parts),
-                    umd: false
-                };
-            }
-            return obj;
-        }, {});
-
-    /**
-     * Special cases
-     * solid-gauge should also exclude gauge-series
-     * highcharts-more and highcharts-3d is also not standalone.
-     */
-    fileOptions['modules/solid-gauge.src.js'].exclude = new RegExp([folders.parts, 'GaugeSeries\.js$'].join('|'));
-    fileOptions['modules/map.src.js'].product = 'Highmaps';
-    fileOptions['modules/map-parser.src.js'].product = 'Highmaps';
-    fileOptions['modules/stock.src.js'].exclude = new RegExp(folders.highchartsFiles.join('|'));
-    Object.assign(fileOptions, {
-        'highcharts-more.src.js': {
-            exclude: new RegExp(folders.parts),
-            umd: false
-        },
-        'highcharts-3d.src.js': {
-            exclude: new RegExp(folders.parts),
-            umd: false
-        },
-        'highmaps.src.js': {
-            product: 'Highmaps'
-        },
-        'highstock.src.js': {
-            product: 'Highstock'
-        }
-    });
-    return fileOptions;
-};
-
-/**
- * Gulp task to run the building process of distribution files. By default it builds all the distribution files. Usage: "gulp build".
- * @param {string} --file Optional command line argument. Use to build a one or sevral files. Usage: "gulp build --file highcharts.js,modules/data.src.js"
- * @return undefined
- */
-const scripts = () => {
-    // Check if the installed version of the assembler matches the dependency.
-    checkDependency('highcharts-assembler', 'err', 'devDependencies');
-    const build = require('highcharts-assembler');
-    const base = './js/masters/';
-    const files = (
-      (argv.file) ?
-      argv.file.split(',') :
-      getFilesInFolder(base, true, '')
-    )
-    const type = (argv.type) ? argv.type : 'both';
-    const debug = argv.d || false;
-    const version = getProductVersion();
-    const fileOptions = getFileOptions(files);
-
-    return build({
-        base: base,
-        debug: debug,
-        fileOptions: fileOptions,
-        files: files,
-        output: './code/',
-        type: type,
-        version: version
-    });
-};
 
 /**
  * Creates a set of ES6-modules which is distributable.
@@ -678,7 +585,7 @@ const createProductJS = () => {
     },
     "Highstock": {
         "date": "${date}",
-        "nr": "${version}"
+        "nr": "${version}"<
     },
     "Highmaps": {
         "date": "${date}",
@@ -1430,7 +1337,26 @@ gulp.task('copy-to-dist', copyToDist);
 gulp.task('filesize', filesize);
 gulp.task('jsdoc', jsdoc);
 gulp.task('styles', styles);
-gulp.task('scripts', scripts);
+/**
+ * Gulp task to run the building process of distribution files. By default it
+ * builds all the distribution files. Usage: "gulp build".
+ * @param {string} --file Optional command line argument. Use to build a one
+ * or sevral files. Usage: "gulp build --file highcharts.js,modules/data.src.js"
+ * TODO add --help command to inform about usage.
+ * @return undefined
+ */
+gulp.task('scripts', () => {
+    const options = {
+        files: (
+            (argv.file) ?
+            argv.file.split(',') :
+            null
+        ),
+        type: (argv.type) ? argv.type : null,
+        debug: argv.d || false
+    };
+    return scripts(options);
+});
 gulp.task('build-modules', buildESModules);
 gulp.task('lint', lint);
 gulp.task('lint-samples', lintSamples);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,52 +41,14 @@ const getProductVersion = () => {
  *   and reuse it on github.highcharts.com
  * @return {Object} Object containing all fileOptions
  */
-const getFileOptions = (base) => {
-    const DS = '[\\\\\\\/]';
-    const NOTDS = '[^\\\\\\\/]';
-    const SINGLEDS = DS + NOTDS; // Regex: Single directory seperator
-    const folders = {
-        'parts': 'parts' + SINGLEDS + '+\.js$',
-        'parts-more': 'parts-more' + SINGLEDS + '+\.js$',
-        'highchartsFiles': [
-            'parts' + DS + 'Globals\.js$',
-            'parts' + DS + 'SvgRenderer\.js$',
-            'parts' + DS + 'Html\.js$',
-            'parts' + DS + 'VmlRenderer\.js$',
-            'parts' + DS + 'Axis\.js$',
-            'parts' + DS + 'DateTimeAxis\.js$',
-            'parts' + DS + 'LogarithmicAxis\.js$',
-            'parts' + DS + 'Tooltip\.js$',
-            'parts' + DS + 'Pointer\.js$',
-            'parts' + DS + 'TouchPointer\.js$',
-            'parts' + DS + 'MSPointer\.js$',
-            'parts' + DS + 'Legend\.js$',
-            'parts' + DS + 'Chart\.js$',
-            'parts' + DS + 'Stacking\.js$',
-            'parts' + DS + 'Dynamics\.js$',
-            'parts' + DS + 'AreaSeries\.js$',
-            'parts' + DS + 'SplineSeries\.js$',
-            'parts' + DS + 'AreaSplineSeries\.js$',
-            'parts' + DS + 'ColumnSeries\.js$',
-            'parts' + DS + 'BarSeries\.js$',
-            'parts' + DS + 'ScatterSeries\.js$',
-            'parts' + DS + 'PieSeries\.js$',
-            'parts' + DS + 'DataLabels\.js$',
-            'modules' + DS + 'overlapping-datalabels.src\.js$',
-            'parts' + DS + 'Interaction\.js$',
-            'parts' + DS + 'Responsive\.js$',
-            'parts' + DS + 'Color\.js$',
-            'parts' + DS + 'Options\.js$',
-            'parts' + DS + 'PlotLineOrBand\.js$',
-            'parts' + DS + 'Tick\.js$',
-            'parts' + DS + 'Point\.js$',
-            'parts' + DS + 'Series\.js$',
-            'parts' + DS + 'Utilities\.js$'
-        ]
-    };
+const getFileOptions = (files) => {
+    const highchartsFiles = replaceAll(
+      getOrderedDependencies('js/masters/highcharts.src.js').join('|'),
+      sep,
+      `\\${sep}`
+    );
 
     // Modules should not be standalone, and they should exclude all parts files.
-    const files = getFilesInFolder(base, true, '');
     const fileOptions = files
         .reduce((obj, file) => {
             if (file.indexOf('modules') > -1 || file.indexOf('themes') > -1 || file.indexOf('indicators') > -1) {
@@ -135,13 +97,16 @@ const scripts = () => {
     // Check if the installed version of the assembler matches the dependency.
     checkDependency('highcharts-assembler', 'err', 'devDependencies');
     const build = require('highcharts-assembler');
-    // const argv = require('yargs').argv; Already declared in the upper scope
-    const files = (argv.file) ? argv.file.split(',') : null;
+    const base = './js/masters/';
+    const files = (
+      (argv.file) ?
+      argv.file.split(',') :
+      getFilesInFolder(base, true, '')
+    )
     const type = (argv.type) ? argv.type : 'both';
     const debug = argv.d || false;
     const version = getProductVersion();
-    const base = './js/masters/';
-    const fileOptions = getFileOptions(base);
+    const fileOptions = getFileOptions(files);
 
     return build({
         base: base,
@@ -1510,16 +1475,16 @@ gulp.task('scripts-new', () => {
     const isUndefined = (x) => typeof x === 'undefined';
     const version = getProductVersion();
     const pathMasters = './js/masters/';
-    const fileOptions = getFileOptions(pathMasters);
-    const mapTypeToSource = {
-        'classic': './code/es-modules',
-        'css': './code/js/es-modules'
-    };
     const files = (
       (argv.file) ?
       argv.file.split(',') :
       getFilesInFolder(pathMasters, true)
     );
+    const fileOptions = getFileOptions(files);
+    const mapTypeToSource = {
+        'classic': './code/es-modules',
+        'css': './code/js/es-modules'
+    };
     const dependencyList = {
         'classic': {},
         'css': {}

--- a/js/parts/Point.js
+++ b/js/parts/Point.js
@@ -23,7 +23,7 @@ var Point,
 /**
  * The Point object. The point objects are generated from the `series.data` 
  * configuration objects or raw numbers. They can be accessed from the
- * `Series.points` array. Other ways to instaniate points are through {@link
+ * `Series.points` array. Other ways to instantiate points are through {@link
  * Highcharts.Series#addPoint} or {@link Highcharts.Series#setData}.
  *
  * @class

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "gulp-jsdoc3": "^1.0.1",
     "gzip-size": "^3.0.0",
     "highcharts-api-doc-gen": "github:highcharts/api-docs",
-    "highcharts-assembler": "github:highcharts/highcharts-assembler#v1.0.12",
+    "highcharts-assembler": "github:highcharts/highcharts-assembler#v1.0.25",
     "husky": "^0.14.3",
     "js-yaml": "^3.10.0",
     "karma": "^1.7.1",

--- a/tools/build.js
+++ b/tools/build.js
@@ -286,7 +286,7 @@ const getBuildScripts = (params) => {
             return fnFirstBuild(options);
         },
         mapOfWatchFn: {
-            './js/**/*.js': (event) => {
+            'js/**/*.js': (event) => {
                 return watchSourceFiles(event, types);
             }
         }
@@ -301,7 +301,7 @@ const getBuildScripts = (params) => {
         const pathSource = mapTypeToSource[type];
         const typeList = dependencyList[type];
         const pathESMasters = join(pathSource, 'masters');
-        const key = join(pathSource, '**/*.js');
+        const key = join(pathSource, '**/*.js').split(sep).join('/');
         const fn = (event) => {
             watchESModules(
                 event,

--- a/tools/build.js
+++ b/tools/build.js
@@ -1,0 +1,130 @@
+/* eslint-env node, es6 */
+/* eslint no-console:0, no-path-concat:0, valid-jsdoc:0 */
+/* eslint-disable func-style */
+const {
+    sep
+} = require('path');
+const {
+    readFileSync
+} = require('fs');
+const {
+    getFilesInFolder
+} = require('highcharts-assembler/src/build.js');
+const {
+    getOrderedDependencies,
+    regexGetCapture
+} = require('highcharts-assembler/src/dependencies.js');
+const {
+    checkDependency
+  } = require('./filesystem.js');
+const build = require('highcharts-assembler');
+
+// TODO move to a utils file
+const replaceAll = (str, search, replace) => str.split(search).join(replace);
+const isArray = x => Array.isArray(x);
+const isString = x => typeof x === 'string';
+
+/**
+ * Get the product version from build.properties.
+ * The product version is used in license headers and in package names.
+ * @return {string|null} Returns version number or null if not found.
+ */
+const getProductVersion = () => {
+    const properties = readFileSync('./build.properties', 'utf8');
+    return regexGetCapture(/product\.version=(.+)/, properties);
+};
+
+/**
+ * Returns fileOptions for the build script
+ * @todo Move this functionality to the build script,
+ *   and reuse it on github.highcharts.com
+ * @return {Object} Object containing all fileOptions
+ */
+const getFileOptions = (files) => {
+    const highchartsFiles = replaceAll(
+        getOrderedDependencies('js/masters/highcharts.src.js').join('|'),
+        sep,
+        `\\${sep}`
+    );
+    // Modules should not be standalone, and they should exclude all parts files.
+    const fileOptions = files
+        .reduce((obj, file) => {
+            if (
+              file.indexOf('modules') > -1 ||
+              file.indexOf('themes') > -1 ||
+              file.indexOf('indicators') > -1
+            ) {
+                obj[file] = {
+                    exclude: new RegExp(highchartsFiles),
+                    umd: false
+                };
+            }
+            return obj;
+        }, {});
+
+    /**
+     * Special cases
+     * solid-gauge should also exclude gauge-series
+     * highcharts-more and highcharts-3d is also not standalone.
+     */
+    fileOptions['modules/solid-gauge.src.js'].exclude = new RegExp([highchartsFiles, 'GaugeSeries\.js$'].join('|'));
+    fileOptions['modules/map.src.js'].product = 'Highmaps';
+    fileOptions['modules/map-parser.src.js'].product = 'Highmaps';
+    Object.assign(fileOptions, {
+        'highcharts-more.src.js': {
+            exclude: new RegExp(highchartsFiles),
+            umd: false
+        },
+        'highcharts-3d.src.js': {
+            exclude: new RegExp(highchartsFiles),
+            umd: false
+        },
+        'highmaps.src.js': {
+            product: 'Highmaps'
+        },
+        'highstock.src.js': {
+            product: 'Highstock'
+        }
+    });
+    return fileOptions;
+};
+
+const scripts = (options) => {
+    checkDependency('highcharts-assembler', 'err', 'devDependencies');
+    const {
+        base = './js/masters/',
+        debug = false,
+        version = getProductVersion(),
+        output = './code/'
+    } = options;
+    const files = (
+        isArray(options.files) ?
+        options.files :
+        getFilesInFolder(base, true)
+    );
+    const type = (
+        isArray(options.type) ?
+        options.type :
+        (
+            isString(options.type) ?
+            options.type.split(',') :
+            ['classic', 'css']
+        )
+    );
+    const fileOptions = getFileOptions(files);
+    return build({
+        base: base,
+        debug: debug,
+        fileOptions: fileOptions,
+        files: files,
+        output: output,
+        type: type,
+        version: version
+    });
+};
+
+module.exports = {
+    getFileOptions,
+    getProductVersion,
+    scripts
+};


### PR DESCRIPTION
## Description
- Some spring cleaning in `gulpfile.js` by moving most of the build script related code into `tools/build.js`
- Updated dependency `highcharts-assembler` to `v1.0.25` which gives a major performance boost.
- Updated `getFileOptions` to dynamically get the list of source files in `highcharts.src.js`. This avoids situations where source files was wrongfully excluded from a module. Related to fix of #7630, where `parts/DataGrouping.js` was excluded from `modules/windbarbs.js` in the build process.
- Updated gulp tasks `scripts` and `default` to use smarter watch, and rebuild only the files which changed.
- Included building of ES modules in the distribution scripts. Fixes #7186.
## Related issue(s)
- #7630 
- #7186