### PR TITLE
bugfix/wordcloud-random-rotation

### DIFF
--- a/js/modules/wordcloud.src.js
+++ b/js/modules/wordcloud.src.js
@@ -217,16 +217,35 @@ var getPlayingField = function getPlayingField(targetWidth, targetHeight) {
  * getRotation - Calculates a number of degrees to rotate, based upon a number
  *     of orientations within a range from-to.
  *
- * @param  {type} orientations Number of orientations.
- * @param  {type} from The smallest degree of rotation.
- * @param  {type} to The largest degree of rotation.
- * @return {type} Returns the resulting rotation for the word.
+ * @param  {number} orientations Number of orientations.
+ * @param  {number} index Index of point, used to decide orientation.
+ * @param  {number} from The smallest degree of rotation.
+ * @param  {number} to The largest degree of rotation.
+ * @return {boolean|number} Returns the resulting rotation for the word. Returns
+ * false if invalid input parameters.
  */
-var getRotation = function getRotation(orientations, from, to) {
-	var range = to - from,
-		intervals = range / (orientations - 1),
-		orientation = Math.floor(Math.random() * orientations);
-	return from + (orientation * intervals);
+var getRotation = function getRotation(orientations, index, from, to) {
+	var result = false, // Default to false
+		range,
+		intervals,
+		orientation;
+
+	// Check if we have valid input parameters.
+	if (
+		isNumber(orientations) &&
+		isNumber(index) &&
+		isNumber(from) &&
+		isNumber(to) &&
+		orientations > -1 &&
+		index > -1 &&
+		to > from
+	) {
+		range = to - from;
+		intervals = range / (orientations - 1);
+		orientation = index % orientations;
+		result = from + (orientation * intervals);
+	}
+	return result;
 };
 
 /**
@@ -591,7 +610,7 @@ var wordCloudSeries = {
 			return {
 				x: getRandomPosition(field.width) - (field.width / 2),
 				y: getRandomPosition(field.height) - (field.height / 2),
-				rotation: getRotation(r.orientations, r.from, r.to)
+				rotation: getRotation(r.orientations, point.index, r.from, r.to)
 			};
 		},
 		center: function centerPlacement(point, options) {
@@ -599,7 +618,7 @@ var wordCloudSeries = {
 			return {
 				x: 0,
 				y: 0,
-				rotation: getRotation(r.orientations, r.from, r.to)
+				rotation: getRotation(r.orientations, point.index, r.from, r.to)
 			};
 		}
 	},
@@ -614,6 +633,9 @@ var wordCloudSeries = {
 		'archimedean': archimedeanSpiral,
 		'rectangular': rectangularSpiral,
 		'square': squareSpiral
+	},
+	utils: {
+		getRotation: getRotation
 	},
 	getPlotBox: function () {
 		var series = this,

--- a/samples/unit-tests/series-wordcloud/members/demo.js
+++ b/samples/unit-tests/series-wordcloud/members/demo.js
@@ -48,3 +48,58 @@ QUnit.test('hasData', function (assert) {
       'should return true if series.visible is true, and series.points has length > 0'
     );
 });
+
+QUnit.test('getRotation', function (assert) {
+    var wordcloudPrototype = Highcharts.seriesTypes.wordcloud.prototype,
+        getRotation = wordcloudPrototype.utils.getRotation;
+    assert.strictEqual(
+        getRotation(undefined, 0, -60, 60),
+        false,
+        'should return false when orientations is not a Number.'
+    );
+    assert.strictEqual(
+        getRotation(-1, 2, -60, 60),
+        false,
+        'should return false if orientations is negative.'
+    );
+    assert.strictEqual(
+        getRotation(3, undefined, -60, 60),
+        false,
+        'should return false when index is not a Number.'
+    );
+    assert.strictEqual(
+        getRotation(3, -1, -60, 60),
+        false,
+        'should return false if index is negative.'
+    );
+    assert.strictEqual(
+        getRotation(3, 0, undefined, 60),
+        false,
+        'should return false when from is not a Number.'
+    );
+    assert.strictEqual(
+        getRotation(1, 2, 60, -60),
+        false,
+        'should return false if from is larger then to.'
+    );
+    assert.strictEqual(
+        getRotation(3, 0, -60, undefined),
+        false,
+        'should return false when from is not a Number.'
+    );
+    assert.strictEqual(
+        getRotation(3, 0, -60, 60),
+        -60,
+        'should return -60 which is the 1st of 3 orientations between -60 to 60.'
+    );
+    assert.strictEqual(
+        getRotation(3, 1, -60, 60),
+        0,
+        'should return 0 which is the 2nd of 3 orientations between -60 to 60.'
+    );
+    assert.strictEqual(
+        getRotation(3, 2, -60, 60),
+        60,
+        'should return 60 which is the 3rd of 3 orientations between -60 to 60.'
+    );
+});


### PR DESCRIPTION
## Description
The rotation of a word in a wordcloud is currently random, causing different resulting visualizations for each rendering. This PR changes this behaviour by determine the rotation based on the index of the point.
## Demo(s)
- http://jsfiddle.net/h2zz6ha6/2/
## Related issue(s)
- #7682 