### PR TITLE
Fixed #7894, legend.verticalAlign top failed with no chart title.

### DIFF
--- a/js/parts/Legend.js
+++ b/js/parts/Legend.js
@@ -606,11 +606,12 @@ Highcharts.Legend.prototype = {
 							pick(options.margin, 12) +
 							spacing[side] +
 							(
-								side === 0 ?
+								side === 0 &&
+								chart.options.title.margin !== undefined ?
 									chart.titleOffset +
 										chart.options.title.margin :
 									0
-							) // #7428
+							) // #7428, #7894
 						)
 					);
 				}

--- a/samples/unit-tests/legend/legend-align/demo.details
+++ b/samples/unit-tests/legend/legend-align/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/legend/legend-align/demo.html
+++ b/samples/unit-tests/legend/legend-align/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/legend/legend-align/demo.js
+++ b/samples/unit-tests/legend/legend-align/demo.js
@@ -1,0 +1,20 @@
+
+QUnit.test('Legend vertical align top with no title', function (assert) {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            height: 300
+        },
+        title: null,
+        legend: {
+            verticalAlign: 'top'
+        },
+        series: [{
+            data: [1, 3, 2, 4]
+        }]
+    });
+
+    assert.ok(
+        chart.legend.group.translateY < 100,
+        'Legend is aligned top'
+    );
+});


### PR DESCRIPTION
Trying to add the title margin to the legend spacing despite there not being a title in the chart caused `NaN` problems.