### PR TITLE
Bugfix/7383 title tooltip a11y

### DIFF
--- a/js/modules/a11y-i18n.src.js
+++ b/js/modules/a11y-i18n.src.js
@@ -271,7 +271,6 @@ H.setOptions({
 			viewAsDataTable: 'View as data table.',
 			chartHeading: 'Chart graphic.',
 			chartContainerLabel: 'Interactive chart. {title}. Use up and down arrows to navigate with most screen readers.',
-			svgContainerTitle: '{chartTitle}',
 			rangeSelectorMinInput: 'Select start date.',
 			rangeSelectorMaxInput: 'Select end date.',
 			tableSummary: 'Table representation of chart.',
@@ -279,6 +278,16 @@ H.setOptions({
 			mapZoomOut: 'Zoom out chart',
 			rangeSelectorButton: 'Select range {buttonText}',
 			legendItem: 'Toggle visibility of series {itemName}',
+
+			/**
+			 * Title element text for the chart SVG element. Leave this
+			 * empty to disable adding the title element. Browsers will display
+			 * this content when hovering over elements in the chart. Assistive
+			 * technology may use this element to label the chart.
+			 *
+			 * @since 6.0.8
+			 */
+			svgContainerTitle: '{chartTitle}',
 
 			/**
 			 * Descriptions of lesser known series types. The relevant

--- a/js/modules/a11y-i18n.src.js
+++ b/js/modules/a11y-i18n.src.js
@@ -271,6 +271,7 @@ H.setOptions({
 			viewAsDataTable: 'View as data table.',
 			chartHeading: 'Chart graphic.',
 			chartContainerLabel: 'Interactive chart. {title}. Use up and down arrows to navigate with most screen readers.',
+			svgContainerTitle: '{chartTitle}',
 			rangeSelectorMinInput: 'Select start date.',
 			rangeSelectorMaxInput: 'Select end date.',
 			tableSummary: 'Table representation of chart.',

--- a/js/modules/screen-reader.src.js
+++ b/js/modules/screen-reader.src.js
@@ -6,7 +6,7 @@
  *
  * License: www.highcharts.com/license
  */
-    
+
 'use strict';
 import H from '../parts/Globals.js';
 import '../parts/Utilities.js';
@@ -702,10 +702,7 @@ H.Chart.prototype.callbacks.push(function (chart) {
 		return;
 	}
 
-	var	titleElement = doc.createElementNS(
-			'http://www.w3.org/2000/svg',
-			'title'
-		),
+	var	titleElement,
 		exportGroupElement = doc.createElementNS(
 			'http://www.w3.org/2000/svg',
 			'g'
@@ -717,12 +714,24 @@ H.Chart.prototype.callbacks.push(function (chart) {
 		hiddenSectionId = 'highcharts-information-region-' + chart.index,
 		chartTitle = options.title.text || chart.langFormat(
 			'accessibility.defaultChartTitle', { chart: chart }
-		);
+		),
+		svgContainerTitle = stripTags(chart.langFormat(
+			'accessibility.svgContainerTitle', {
+				chartTitle: chartTitle
+			}
+		));
 
-	// Add SVG title/desc tags
-	titleElement.textContent = htmlencode(chartTitle);
-	titleElement.id = titleId;
-	descElement.parentNode.insertBefore(titleElement, descElement);
+	// Add SVG title tag if it is set
+	if (svgContainerTitle.length) {
+		titleElement = doc.createElementNS(
+				'http://www.w3.org/2000/svg',
+				'title'
+			);
+		titleElement.textContent = svgContainerTitle;
+		titleElement.id = titleId;
+		descElement.parentNode.insertBefore(titleElement, descElement);
+	}
+	
 	chart.renderTo.setAttribute('role', 'region');
 	chart.renderTo.setAttribute(
 		'aria-label',


### PR DESCRIPTION
We add an SVG `<title>` element to the SVG for accessibility, but browsers pick this up and show it as a tooltip when hovering over chart elements. In addition, this title currently uses html encoding of characters, which is not supported in SVG.

I added an `svgContainerTitle` option to `lang.accessibility` to configure the content. If this is empty, we don't add the title. Default is still the chart title. Also used `stripTags` instead of `htmlencode` for the text content. This seems to be similar to what we do with other text in the SVG.