### PR TITLE
Bugfix/7491-cloud-missing-tags

### DIFF
--- a/js/modules/wordcloud.src.js
+++ b/js/modules/wordcloud.src.js
@@ -264,10 +264,10 @@ var outsidePlayingField = function outsidePlayingField(wrapper, field) {
 			bottom: field.height / 2
 		};
 	return !(
-		playingField.left < rect.x &&
-		playingField.right > (rect.x + rect.width) &&
-		playingField.top < rect.y &&
-		playingField.bottom > (rect.y + rect.height)
+		playingField.left < (rect.x - rect.width / 2) &&
+		playingField.right > (rect.x + rect.width / 2) &&
+		playingField.top < (rect.y - rect.height / 2) &&
+		playingField.bottom > (rect.y + rect.height / 2)
 	);
 };
 


### PR DESCRIPTION
## Description
`getPlayingField` did not consider size of the words which could result in a much to small playing field. This would in turn cause a number of high weighted words to be excluded from the visualization during intersection testing.
## Issue(s)
- 7491