### PR TITLE
bugfix/7862-no-lines-when-negativeColor

### DIFF
--- a/js/parts-more/WaterfallSeries.js
+++ b/js/parts-more/WaterfallSeries.js
@@ -121,6 +121,12 @@ seriesType('waterfall', 'column', {
 	pointValKey: 'y',
 
 	/**
+	 * Property needed to prevent lines between the columns from disappearing
+	 * when negativeColor is used.
+	 */
+	showLine: true,
+
+	/**
 	 * Translate data points from raw values
 	 */
 	translate: function () {

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -4402,7 +4402,9 @@ H.Series = H.seriesType('line', null, { // base series options
 			horiz = axis.horiz;
 			// The use of the Color Threshold assumes there are no gaps
 			// so it is safe to hide the original graph and area
-			if (graph) {
+			// unless it is not waterfall series, then use showLine property to 
+			// set lines between columns to be visible (#7862)
+			if (graph && !this.showLine) {
 				graph.hide();
 			}
 			if (area) {

--- a/samples/unit-tests/series-waterfall/negative-color/demo.details
+++ b/samples/unit-tests/series-waterfall/negative-color/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series-waterfall/negative-color/demo.html
+++ b/samples/unit-tests/series-waterfall/negative-color/demo.html
@@ -1,0 +1,8 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/series-waterfall/negative-color/demo.js
+++ b/samples/unit-tests/series-waterfall/negative-color/demo.js
@@ -1,0 +1,16 @@
+QUnit.test('The negativeColor in waterfall (#7862)', function (assert) {
+    var chart = Highcharts.chart('container', {
+        series: [{
+            type: 'waterfall',
+            negativeColor: '#FF0000',
+            data: [120000, 569000, 231000, -342000, -233000]
+        }]
+    });
+
+    // Test: the visibility of the graph
+    assert.notEqual(
+        chart.series[0].graph.attr('visibility'),
+        'hidden',
+        'The lines between columns are visible.'
+    );
+});


### PR DESCRIPTION
Connector lines were not visible in waterfall series when negativeColor was used.