### PR TITLE
Fixed issue with legend navigation sometimes not focusing for single …

### DIFF
--- a/js/modules/keyboard-navigation.src.js
+++ b/js/modules/keyboard-navigation.src.js
@@ -423,7 +423,7 @@ H.Chart.prototype.setFocusToElement = function (svgElement, focusElement) {
 			browserFocusElement.css({ outline: 'none' });
 		}
 	}
-	if (focusBorderOptions.enabled && svgElement !== this.focusElement) {
+	if (focusBorderOptions.enabled) {
 		// Remove old focus border
 		if (this.focusElement) {
 			this.focusElement.removeFocusBorder();
@@ -1113,7 +1113,8 @@ H.Chart.prototype.addKeyboardNavigationModules = function () {
 				// Try to highlight next/prev legend item
 				if (!chart.highlightLegendItem(
 					chart.highlightedLegendItemIx + direction
-				)) {
+				) && chart.legend.allItems.length > 1) {
+					// Wrap around if more than 1 item
 					this.init(direction);
 				}
 			}],

--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -236,7 +236,8 @@ Highcharts.Pointer.prototype = {
 		var series = point.series,
 			xAxis = series.xAxis,
 			yAxis = series.yAxis,
-			plotX = pick(point.clientX, point.plotX);
+			plotX = pick(point.clientX, point.plotX),
+			shapeArgs = point.shapeArgs;
 
 		if (xAxis && yAxis) {
 			return inverted ? {
@@ -245,6 +246,12 @@ Highcharts.Pointer.prototype = {
 			} : {
 				chartX: plotX + xAxis.pos,
 				chartY: point.plotY + yAxis.pos
+			};
+		} else if (shapeArgs && shapeArgs.x && shapeArgs.y) {
+			// E.g. pies do not have axes
+			return {
+				chartX: shapeArgs.x,
+				chartY: shapeArgs.y
 			};
 		}
 	},


### PR DESCRIPTION
Fixed issue with legend navigation sometimes not focusing for single legend item charts.

Issue compounded with pie issue when calling `.onMouseOver` on points without an event object.

Issue reported by user directly via email.

Not added unit test for now due to time constraints, but we should take a day or two and make proper unit tests for the keyboard navigation in general. Currently all tests on keyboard nav are manual.