### PR TITLE
bugfix/7991-treemap-wrong-level-exported

### DIFF
--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -1011,13 +1011,16 @@ seriesType('treemap', 'scatter', {
 	translate: function () {
 		var series = this,
 			options = series.options,
-			rootId = series.rootNode =
-				pick(series.rootNode, series.options.rootId, ''),
+			rootId = pick(series.rootNode, options.rootId, ''),
 			rootNode,
 			pointValues,
 			seriesArea,
 			tree,
 			val;
+
+		// Set rootId on series.userOptions to pick it up in exporting.
+		// Set rootId on series to pick it up on next translate.
+		series.userOptions.rootId = series.rootNode = rootId;
 
 		// Call prototype function
 		Series.prototype.translate.call(series);


### PR DESCRIPTION
# Description
When drilling down in a treemap chart and then exporting, the exported image would be of the top node in the tree, in stead of the current root node.

# Issue(s)
- #7991 