### PR TITLE
bugfix/8060-setdata-flickering-markers

### DIFF
--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -2877,6 +2877,9 @@ H.Series = H.seriesType('line', null, { // base series options
                     if (requireSorting) {
                         lastIndex = pointIndex;
                     }
+                // Point exists, no changes, don't remove it
+                } else if (oldData[pointIndex]) {
+                    oldData[pointIndex].touched = true;
                 }
                 hasUpdatedByKey = true;
             }

--- a/samples/unit-tests/series/setdata/demo.js
+++ b/samples/unit-tests/series/setdata/demo.js
@@ -211,7 +211,18 @@ QUnit.test('Series.setData with updatePoints', function (assert) {
         'Pie with equal length, reuse all points'
     );
 
+    // #8060
+    // No redraw, keep previous markers on a chart:
+    s.setData([[0, 0], [1, 1]]);
+    s.setData([[0, 0], [1, 1], [2, 2]], false, false, true);
 
+    assert.deepEqual(
+        s.points.map(function (p) {
+            return Highcharts.defined(p.graphic);
+        }),
+        [true, true],
+        'Old points have markers when redraw is set to false (#8060)'
+    );
 });
 
 


### PR DESCRIPTION
Examples:

- before: http://jsfiddle.net/BlackLabel/vmw9xgbe/80/
- current master: http://jsfiddle.net/BlackLabel/vmw9xgbe/81/ (it's even worse - we are messing with number of points on a chart)
- after: http://jsfiddle.net/BlackLabel/vmw9xgbe/79/