### PR TITLE
bugfix/6423-addaxis-update

### DIFF
--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -1032,8 +1032,17 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
     update: function (options, redraw) {
         var chart = this.chart;
 
-        options = chart.options[this.coll][this.options.index] =
-            merge(this.userOptions, options);
+        options = merge(this.userOptions, options);
+
+        // Color Axis is not an array,
+        // This change is applied in the ColorAxis wrapper
+        if (chart.options[this.coll].indexOf) {
+            // Don't use this.options.index,
+            // StockChart has Axes in navigator too
+            chart.options[this.coll][
+                chart.options[this.coll].indexOf(this.userOptions)
+            ] = options;
+        }
 
         this.destroy(true);
 

--- a/samples/unit-tests/axis/update/demo.js
+++ b/samples/unit-tests/axis/update/demo.js
@@ -32,6 +32,20 @@ QUnit.test('Redraw without series (#5323)', function (assert) {
     );
 });
 
+QUnit.test('Updates after new Axis', function (assert) {
+
+    var chart = new Highcharts.stockChart('container', {});
+
+    chart.addAxis({});
+    chart.yAxis[2].update({});
+
+    assert.strictEqual(
+        chart.options.yAxis.length,
+        2,
+        'Only two entries in options.yAxis: default + new one (#6423)'
+    );
+});
+
 // Highcharts 4.1.1, Issue #3830
 // After updating "xAxis" categories empty (Data defined in a HTML table)
 QUnit.test('Update axis names (#3830)', function (assert) {

--- a/samples/unit-tests/coloraxis/coloraxis-update/demo.js
+++ b/samples/unit-tests/coloraxis/coloraxis-update/demo.js
@@ -1,4 +1,4 @@
-QUnit.test('Color axis update and resize. #6025', function (assert) {
+QUnit.test('Color axis updates', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {
             type: 'heatmap',
@@ -40,7 +40,7 @@ QUnit.test('Color axis update and resize. #6025', function (assert) {
     assert.strictEqual(
         chart.plotHeight,
         plotHeight,
-        'Geometry ok after update'
+        'Geometry ok after update (#6025)'
     );
 
     // Trigger a chart.redraw
@@ -49,6 +49,13 @@ QUnit.test('Color axis update and resize. #6025', function (assert) {
     assert.strictEqual(
         chart.plotHeight,
         plotHeight,
-        'Geometry ok after resize'
+        'Geometry ok after resize (#6025)'
+    );
+
+    // On Update, no memory leak in colorAxis.undefined.undefined.undefined...
+    assert.strictEqual(
+        chart.options.colorAxis.undefined,
+        undefined,
+        'No extra undefined properties after update'
     );
 });


### PR DESCRIPTION
A couple of things to mention:

- at this moment update of `colorAxis` stores old option in `options.colorAxis.undefined` on each update. Bug not reported anywhere, but fixed in this PR too.
- there is another way we can solve the issue: indexing is done according to `chart.yAxis` which in Highstock has one more axis (Navigator). We can apply re-indexing in Highstock only (all indexes above navigator's axis are decreased by one) - but that will cause problems with `bindAxes` as we will have two axes with the same indexes and series will be linked to two axes (different `yAxis.series` arrays will have a reference to the same series).  I think this solution is more fragile.

`bindAxes` reference:
https://github.com/highcharts/highcharts/blob/aa64d87cb64e6b59c33f07aaaaa99395bd21072a/js/parts/Series.js#L2491-L2494