### PR TITLE
Allow nested ternary

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@ rules:
     no-console: 2
     no-debugger: 2
     no-else-return: 2
+    no-nested-ternary: 0
     no-unmodified-loop-condition: 0
     object-curly-spacing: [2, "always"]
     operator-linebreak: [2, "after"]


### PR DESCRIPTION
Allow syntax like...
```javascript
[].sort((a, b) => (a.a < b.a ? -1 : a.a === b.a ? 0 : 1));

delta = delta < 0 ?
    (axis.reversed ? -1 : 1) :
    (axis.reversed ? 1 : -1);
```