### PR TITLE
Fixed #8065, added options minFontSize and maxFontSize to Wordcloud.

### DIFF
--- a/js/modules/wordcloud.src.js
+++ b/js/modules/wordcloud.src.js
@@ -407,6 +407,17 @@ var wordCloudOptions = {
      */
     colorByPoint: true,
     /**
+     * A threshold determining the minimum font size that can be applied to a
+     * word.
+     */
+    minFontSize: 1,
+    /**
+     * The word with the largest weight will have a font size equal to this
+     * value. The font size of a word is the ratio between its weight and the
+     * largest occuring weight, multiplied with the value of maxFontSize.
+     */
+    maxFontSize: 25,
+    /**
      * This option decides which algorithm is used for placement, and rotation
      * of a word. The choice of algorith is therefore a crucial part of the
      * resulting layout of the wordcloud.
@@ -486,12 +497,24 @@ var wordCloudSeries = {
     /**
      * deriveFontSize - Calculates the fontSize of a word based on its weight.
      *
-     * @param  {number} relativeWeight The weight of the word, on a scale 0-1.
-     * @return {number} Returns the resulting fontSize of a word.
+     * @param {number} [relativeWeight] The weight of the word, on a scale 0-1.
+     * Defaults to 0.
+     * @param {number} [maxFontSize] The maximum font size of a word. Defaults
+     * to 1.
+     * @param {number} [minFontSize] The minimum font size of a word. Defaults
+     * to 1.
+     * @returns {number} Returns the resulting fontSize of a word. If
+     * minFontSize is larger then maxFontSize the result will equal minFontSize.
      */
-    deriveFontSize: function deriveFontSize(relativeWeight) {
-        var maxFontSize = 25;
-        return Math.floor(maxFontSize * relativeWeight);
+    deriveFontSize: function deriveFontSize(
+        relativeWeight,
+        maxFontSize,
+        minFontSize
+    ) {
+        var weight = isNumber(relativeWeight) ? relativeWeight : 0,
+            max = isNumber(maxFontSize) ? maxFontSize : 1,
+            min = isNumber(minFontSize) ? minFontSize : 1;
+        return Math.floor(Math.max(min, weight * max));
     },
     drawPoints: function () {
         var series = this,
@@ -526,8 +549,13 @@ var wordCloudSeries = {
         // Used in calculating the playing field.
         each(data, function (point) {
             var relativeWeight = 1 / maxWeight * point.weight,
+                fontSize = series.deriveFontSize(
+                    relativeWeight,
+                    options.maxFontSize,
+                    options.minFontSize
+                ),
                 css = extend({
-                    fontSize: series.deriveFontSize(relativeWeight) + 'px'
+                    fontSize: fontSize + 'px'
                 }, options.style),
                 bBox;
 
@@ -551,8 +579,13 @@ var wordCloudSeries = {
         // Draw all the points.
         each(data, function (point) {
             var relativeWeight = 1 / maxWeight * point.weight,
+                fontSize = series.deriveFontSize(
+                    relativeWeight,
+                    options.maxFontSize,
+                    options.minFontSize
+                ),
                 css = extend({
-                    fontSize: series.deriveFontSize(relativeWeight) + 'px',
+                    fontSize: fontSize + 'px',
                     fill: point.color
                 }, options.style),
                 placement = placementStrategy(point, {

--- a/js/parts-map/HeatmapSeries.js
+++ b/js/parts-map/HeatmapSeries.js
@@ -27,13 +27,16 @@ var colorPointMixin = H.colorPointMixin,
  * A heatmap is a graphical representation of data where the individual values
  * contained in a matrix are represented as colors.
  *
- * @sample highcharts/demo/heatmap/
- *         Simple heatmap
- * @sample highcharts/demo/heatmap-canvas/
- *         Heavy heatmap
- * @extends {plotOptions.scatter}
- * @excluding marker,pointRange,pointPlacement
- * @product highcharts highmaps
+ * @sample       highcharts/demo/heatmap/
+ *               Simple heatmap
+ * @sample       highcharts/demo/heatmap-canvas/
+ *               Heavy heatmap
+ * @extends      {plotOptions.scatter}
+ * @excluding    animationLimit,connectEnds,connectNulls,dashStyle,
+ *               findNearestPointBy,getExtremesFromAll,linecap,lineWidth,marker,
+ *               pointInterval,pointIntervalUnit,pointRange,pointStart,shadow,
+ *               softThreshold,stacking,step,threshold
+ * @product      highcharts highmaps
  * @optionparent plotOptions.heatmap
  */
 seriesType('heatmap', 'scatter', {

--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -902,7 +902,13 @@ if (seriesTypes.pie) {
                         if (isNew) {
                             point.connector = connector = chart.renderer.path()
                                 .addClass('highcharts-data-label-connector ' +
-                                    ' highcharts-color-' + point.colorIndex)
+                                    ' highcharts-color-' + point.colorIndex +
+                                    (
+                                        point.className ?
+                                            ' ' + point.className :
+                                            ''
+                                    )
+                                )
                                 .add(series.dataLabelsGroup);
 
                             /*= if (build.classic) { =*/

--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -816,7 +816,8 @@ extend(Point.prototype, /** @lends Highcharts.Point.prototype */ {
             });
             halo.attr({
                 'class': 'highcharts-halo highcharts-color-' +
-                    pick(point.colorIndex, series.colorIndex)
+                    pick(point.colorIndex, series.colorIndex) +
+                    (point.className ? ' ' + point.className : '')
             });
             halo.point = point; // #6055
 

--- a/js/parts/ScatterSeries.js
+++ b/js/parts/ScatterSeries.js
@@ -18,6 +18,7 @@ var Series = H.Series,
  * @sample       {highcharts} highcharts/demo/scatter/
  *               Scatter plot
  * @extends      {plotOptions.line}
+ * @excluding    pointPlacement, shadow
  * @product      highcharts highstock
  * @optionparent plotOptions.scatter
  */

--- a/samples/unit-tests/point/point/demo.js
+++ b/samples/unit-tests/point/point/demo.js
@@ -200,3 +200,42 @@ QUnit.test('Select and unselect', function (assert) {
         'Unselected point out of range (#6445)'
     );
 });
+
+QUnit.test('Point className on other elements', function (assert) {
+    var chart = Highcharts.chart('container', {
+        series: [{
+            data: [{
+                y: 1
+            }, {
+                y: 2,
+                className: 'my-class'
+            }, {
+                y: 3
+            }],
+            type: 'pie'
+        }]
+    });
+
+    assert.notEqual(
+        chart.series[0].points[1].connector.element
+            .getAttribute('class').indexOf('my-class'),
+        -1,
+        'The connector should have the point className'
+    );
+
+    chart.series[0].points[1].onMouseOver();
+    assert.notEqual(
+        chart.series[0].halo.element
+            .getAttribute('class').indexOf('my-class'),
+        -1,
+        'The halo should have the point className'
+    );
+
+    chart.series[0].points[0].onMouseOver();
+    assert.strictEqual(
+        chart.series[0].halo.element
+            .getAttribute('class').indexOf('my-class'),
+        -1,
+        'The halo for other points should not have the point className'
+    );
+});

--- a/samples/unit-tests/series-wordcloud/members/demo.js
+++ b/samples/unit-tests/series-wordcloud/members/demo.js
@@ -103,3 +103,62 @@ QUnit.test('getRotation', function (assert) {
         'should return 60 which is the 3rd of 3 orientations between -60 to 60.'
     );
 });
+
+QUnit.test('deriveFontSize', function (assert) {
+    var wordcloudPrototype = Highcharts.seriesTypes.wordcloud.prototype,
+        deriveFontSize = wordcloudPrototype.deriveFontSize;
+
+    assert.strictEqual(
+        deriveFontSize(),
+        1,
+        'should return 1 when no parameters are given.'
+    );
+
+    assert.strictEqual(
+        deriveFontSize(undefined, 10, 1),
+        1,
+        'should have relativeWeight default to 0.'
+    );
+
+    assert.strictEqual(
+        deriveFontSize(1, undefined, 1),
+        1,
+        'should have maxFontSize default to 1.'
+    );
+
+    assert.strictEqual(
+        deriveFontSize(1, 1),
+        1,
+        'should have minFontSize default to 1.'
+    );
+
+    assert.strictEqual(
+        deriveFontSize(1, 10, 1),
+        10,
+        'should return result equal to maxFontSize when relativeWeight is 1.'
+    );
+
+    assert.strictEqual(
+        deriveFontSize(0, 10, 1),
+        1,
+        'should return result equal to minFontSize when relativeWeight is 0.'
+    );
+
+    assert.strictEqual(
+        deriveFontSize(1, 1.5),
+        1,
+        'should round the result down to the nearest integer.'
+    );
+
+    assert.strictEqual(
+        deriveFontSize(0.5, 10, 1),
+        5,
+        'should return the relativeWeight times the maxFontSize.'
+    );
+
+    assert.strictEqual(
+        deriveFontSize(0.1, 10, 5),
+        5,
+        'should return the minFontSize if the result of relativeWeight times maxFontSize is lower.'
+    );
+});

--- a/tools/jsdoc/plugins/highcharts.jsdoc.js
+++ b/tools/jsdoc/plugins/highcharts.jsdoc.js
@@ -724,7 +724,7 @@ Highcharts.chart('container', {
         }
     },
     series: [{
-        // specific options for only to this series instance
+        // specific options for this series instance
         type: '${type}'
     }]
 });


### PR DESCRIPTION
# Description
Adds the options minFontSize and maxFontSize to the wordcloud series.

# Option(s)
### series.wordcloud.minFontSize
- **description:** A threshold determining the minimum font size that can be applied to a word.
- **type:** number
- **default:** 1 

### series.wordcloud.maxFontSize
- **description:** The word with the largest weight will have a font size equal to this value. The font size of a word is the ratio between its weight and the largest occuring weight, multiplied with the value of maxFontSize.
- **type:** number
- **default:** 25

# Related issue(s)
- #8065 

# Example(s)
- https://jsfiddle.net/o2arkcch