### PR TITLE
bugfix/8129-tickpixelinterval-one-pixel

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -3899,7 +3899,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
             getStep = function (spaceNeeded) {
                 var step = spaceNeeded / (slotSize || 1);
                 step = step > 1 ? Math.ceil(step) : 1;
-                return step * tickInterval;
+                return correctFloat(step * tickInterval);
             };
 
         if (horiz) {

--- a/samples/unit-tests/axis/ticks/demo.js
+++ b/samples/unit-tests/axis/ticks/demo.js
@@ -207,3 +207,28 @@ QUnit.test(
 
     }
 );
+
+QUnit.test(
+    'tickPixelInterval option',
+    function (assert) {
+        var chart = Highcharts.chart('container', {
+            chart: {
+                height: 300
+            },
+            subtitle: {
+                text: 'test'
+            },
+            yAxis: {
+                tickPixelInterval: 1
+            },
+            series: [{
+                data: [6, -8.4, 6.5, 4]
+            }]
+        });
+
+        assert.ok(
+            chart.yAxis[0].tickPositions.indexOf(0) !== -1,
+            '0-tick on yAxis exists (#8129)'
+        );
+    }
+);


### PR DESCRIPTION
Simple correctFloat resolves the issue - tickInterval is calculated as 1.4 instead of 1.40000000001