### PR TITLE
bugfix/8104-xrange-selected-point

### DIFF
--- a/js/modules/xrange.src.js
+++ b/js/modules/xrange.src.js
@@ -352,15 +352,24 @@ seriesType('xrange', 'column', {
 
     drawPoints: function () {
         var series = this,
-            chart = this.chart,
-            options = series.options,
-            animationLimit = options.animationLimit || 250,
-            verb = chart.pointCount < animationLimit ? 'animate' : 'attr';
+            verb = series.getAnimationVerb();
 
-        // draw the columns
+        // Draw the columns
         each(series.points, function (point) {
             series.drawPoint(point, verb);
         });
+    },
+
+
+    /**
+     * Returns "animate", or "attr" if the number of points is above the
+     * animation limit.
+     *
+     * @returns {String}
+     */
+    getAnimationVerb: function () {
+        return this.chart.pointCount < (this.options.animationLimit || 250) ?
+             'animate' : 'attr';
     }
 
     /**
@@ -408,6 +417,12 @@ seriesType('xrange', 'column', {
         this.colorIndex = pick(this.options.colorIndex, this.y % colorCount);
 
         return this;
+    },
+
+    setState: function () {
+        Point.prototype.setState.apply(this, arguments);
+
+        this.series.drawPoint(this, this.series.getAnimationVerb());
     },
 
     // Add x2 and yCategory to the available properties for tooltip formats

--- a/samples/unit-tests/series-xrange/xrange/demo.js
+++ b/samples/unit-tests/series-xrange/xrange/demo.js
@@ -126,6 +126,13 @@ QUnit.test('X-Range', function (assert) {
         (point.x2 - point.x) * point.partialFill,
         'Clip rect ends at correct position after zoom (#7617).'
     );
+
+    point.select();
+    assert.strictEqual(
+        point.graphicOriginal.attr('fill'),
+        point.series.options.states.select.color,
+        'Correct fill for a point upon point selection (#8104).'
+    );
 });
 
 QUnit.test('X-range data labels', function (assert) {


### PR DESCRIPTION
I'm open for suggestions for `getAnimationVerb()` name :) 

Another thing: maybe it's unnecessary to check number of points in `setState()` and always run `animate`?