### PR TITLE
 bugfix/8092-sizeByAbsoluteValue-marker-size

### DIFF
--- a/js/parts-more/BubbleSeries.js
+++ b/js/parts-more/BubbleSeries.js
@@ -316,7 +316,10 @@ seriesType('bubble', 'scatter', {
             // the size of the bubble.
             if (options.sizeByAbsoluteValue && value !== null) {
                 value = Math.abs(value - zThreshold);
-                zMax = Math.max(zMax - zThreshold, Math.abs(zMin - zThreshold));
+                zMax = zRange = Math.max(
+                    zMax - zThreshold,
+                    Math.abs(zMin - zThreshold)
+                );
                 zMin = 0;
             }
 

--- a/samples/unit-tests/series-bubble/sizebyabsolutevalue/demo.js
+++ b/samples/unit-tests/series-bubble/sizebyabsolutevalue/demo.js
@@ -62,4 +62,19 @@ QUnit.test('Size by threshold', function (assert) {
         'Equal difference to zThreshold gives equal bubble size'
     );
 
+    chart.series[0].update({
+        zThreshold: 0,
+        data: [
+            [0, -3, 3.8],
+            [1, 2, 3.799]
+        ]
+    });
+
+
+    assert.strictEqual(
+        chart.series[0].points[0].marker.radius,
+        chart.series[0].maxPxSize / 2,
+        'Correct size of the marker (#8092).'
+    );
+
 });


### PR DESCRIPTION
Note:

Visual test: http://utils.highcharts.local/samples/#test/highcharts/plotoptions/bubble-sizebyabsolutevalue will not fail 

This is expected. `maxSize` was not properly handled with `sizeByAbsoluteValue` and max radius was too big. Old versions had wrong sizing: http://jsfiddle.net/BlackLabel/f6mb4ubt/26/