### PR TITLE
bugfix/compile-task-improvements

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -411,9 +411,7 @@ const compileSingleFile = (path, sourceFolder, createSourceMap) => {
 };
 
 const compile = (files, sourceFolder) => {
-    console.log(
-      colors.yellow('Warning: This task may take a few minutes on Mac, and even longer on Windows.')
-    );
+    console.log(colors.yellow('Warning: This task may take a few minutes.'));
     const createSourceMap = true;
     const promises = files
       .map(path => compileSingleFile(path, sourceFolder, createSourceMap));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -361,7 +361,7 @@ const generateClassReferences = ({ templateDir, destination }) => {
 /**
  * Compile the JS files in the /code folder
  */
-const compileScripts = () => {
+const compileScripts = (args = {}) => {
     const sourceFolder = './code/';
     // Compile all files ending with .src.js.
     // Do not compile files in ./es-modules or ./js/es-modules.
@@ -369,8 +369,8 @@ const compileScripts = () => {
         path.endsWith('.src.js') && !path.includes('es-modules')
     );
     const files = (
-        (argv.file) ?
-        argv.file.split(',') :
+        (args.files) ?
+        args.files :
         getFilesInFolder(sourceFolder, true, '').filter(isSourceFile)
     );
     return compile(files, sourceFolder);
@@ -1333,7 +1333,31 @@ gulp.task('scripts', () => {
 gulp.task('build-modules', buildESModules);
 gulp.task('lint', lint);
 gulp.task('lint-samples', lintSamples);
-gulp.task('compile', compileScripts);
+gulp.task('compile', () => {
+    const messages = {
+        usage: 'Run "gulp compile --help" for information on usage.',
+        help: [
+            '',
+            'Usage: gulp compile [OPTIONS]',
+            '',
+            'Options:',
+            '    --file: Specify a list of files to compile. Files are comma separated e.g "file1,file2".',
+            '    --help: Displays help information.',
+            ''
+        ].join('\n')
+    };
+    let promise = Promise.resolve();
+    if (argv.help) {
+        console.log(messages.help);
+    } else {
+        const files = (argv.file) ? argv.file.split(',') : null;
+        console.log(messages.usage);
+        promise = compileScripts({
+            files
+        });
+    }
+    return promise;
+});
 gulp.task('compile-lib', compileLib);
 gulp.task('copy-graphics-to-dist', copyGraphicsToDist);
 gulp.task('examples', createAllExamples);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -423,10 +423,16 @@ const compile = (files, sourceFolder) => {
  */
 const compileScripts = () => {
     const sourceFolder = './code/';
-    const files = getFilesInFolder(sourceFolder, true, '')
-        // Compile all files ending with .src.js.
-        // Do not compile files in ./es-modules or ./js/es-modules.
-      .filter(path => (path.endsWith('.src.js') && !path.includes('es-modules')));
+    // Compile all files ending with .src.js.
+    // Do not compile files in ./es-modules or ./js/es-modules.
+    const isSourceFile = (path) => (
+        path.endsWith('.src.js') && !path.includes('es-modules')
+    );
+    const files = (
+        (argv.file) ?
+        argv.file.split(',') :
+        getFilesInFolder(sourceFolder, true, '').filter(isSourceFile)
+    );
     return compile(files, sourceFolder);
 };
 

--- a/tools/build.js
+++ b/tools/build.js
@@ -231,7 +231,7 @@ const watchESModules = (event, options, type, dependencies, pathESMasters) => {
         fileOptions,
         version
     } = options;
-    buildDistFromModules({
+    return buildDistFromModules({
         base: pathESMasters,
         debug: debug,
         fileOptions: fileOptions,
@@ -259,10 +259,10 @@ const fnFirstBuild = (options) => {
         output: pathESModules,
         type: types
     });
-    types.forEach((type) => {
+    const promises = types.map((type) => {
         const pathSource = mapTypeToSource[type];
         const pathESMasters = join(pathSource, 'masters');
-        buildDistFromModules({
+        return buildDistFromModules({
             base: pathESMasters,
             debug: debug,
             fileOptions: fileOptions,
@@ -272,6 +272,7 @@ const fnFirstBuild = (options) => {
             version: version
         });
     });
+    return Promise.all(promises);
 };
 
 const getBuildScripts = (params) => {
@@ -303,7 +304,7 @@ const getBuildScripts = (params) => {
                 fileOptions,
                 pathSource
             );
-            watchESModules(
+            return watchESModules(
                 event,
                 options,
                 type,

--- a/tools/compile.js
+++ b/tools/compile.js
@@ -1,0 +1,75 @@
+/* eslint-env node, es6 */
+/* eslint no-console:0, no-path-concat:0, no-nested-ternary:0, valid-jsdoc:0 */
+/* eslint-disable func-style */
+const closureCompiler = require('google-closure-compiler-js');
+const statSync = require('fs').statSync;
+const {
+    getFile,
+    writeFile
+} = require('highcharts-assembler/src/utilities.js');
+const colors = require('colors');
+
+const compileSingleFile = (path, sourceFolder, createSourceMap) => {
+    const sourcePath = sourceFolder + path;
+    const outputPath = sourcePath.replace('.src.js', '.js');
+    const src = getFile(sourcePath);
+    const getErrorMessage = (e) => {
+        return [
+            'Compile error in file: ' + path,
+            '- Type: ' + e.type,
+            '- Line: ' + e.lineNo,
+            '- Char : ' + e.charNo,
+            '- Description: ' + e.description
+        ].join('\n');
+    };
+    return new Promise((resolve, reject) => {
+        const out = closureCompiler.compile({
+            compilationLevel: 'SIMPLE_OPTIMIZATIONS',
+            jsCode: [{
+                src: src
+            }],
+            languageIn: 'ES5',
+            languageOut: 'ES5',
+            createSourceMap: createSourceMap
+        });
+        const errors = out.errors;
+        if (errors.length) {
+            const msg = errors.map(getErrorMessage).join('\n');
+            reject(msg);
+        } else {
+            writeFile(outputPath, out.compiledCode);
+            const filesize = statSync(outputPath).size;
+            const filesizeKb = (filesize / 1000).toFixed(2) + ' kB';
+
+            if (filesize < 10) {
+                const msg = 'Compiled ' + sourcePath + ' => ' + outputPath +
+                    ', filesize suspiciously small (' + filesizeKb + ')';
+                console.log(colors.red(msg));
+                reject(msg);
+                return;
+            }
+
+            if (createSourceMap) {
+                writeFile(outputPath + '.map', out.sourceMap);
+            }
+            console.log(
+                colors.green('Compiled ' + sourcePath + ' => ' + outputPath) +
+                colors.gray(' (' + filesizeKb + ')')
+            );
+            resolve();
+        }
+    });
+};
+
+const compile = (files, sourceFolder) => {
+    console.log(colors.yellow('Warning: This task may take a few minutes.'));
+    const createSourceMap = true;
+    const promises = files
+      .map(path => compileSingleFile(path, sourceFolder, createSourceMap));
+    return Promise.all(promises);
+};
+
+module.exports = {
+    compile,
+    compileSingleFile
+};


### PR DESCRIPTION
# Description
Various changes affecting the `gulp compile` task.
- Fixed issue with scripts task returning before result was written to file. Affected compile task in `gulp dist`
- Added argument `--file` to `gulp compile`
- Added usage instructions to `gulp compile`
- Moved compile code to tools/compile.js in order to clean up gulpfile.js