### PR TITLE
feature/improvements-to-uploadapifiles

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,6 +26,10 @@ const {
     getBuildScripts
 } = require('./tools/build.js');
 const compile = require('./tools/compile.js').compile;
+const {
+    asyncForeach,
+    uploadFiles
+} = require('./tools/upload.js');
 
 /**
  * Creates a set of ES6-modules which is distributable.
@@ -1009,33 +1013,6 @@ const ProgressBar = function (user) {
     return this;
 };
 
-const asyncForeach = (arr, fn) => {
-    const length = arr.length;
-    const generator = (j) => {
-        let promise;
-        if (j < length) {
-            promise = fn(arr[j], j, arr).then(() => generator(j + 1));
-        }
-        return promise;
-    };
-    return generator(0);
-};
-
-const asyncBatchForeach = (batchSize, arr, fn) => {
-    const length = arr.length;
-    const generator = (from, to) => {
-        let result;
-        if (from < length) {
-            const batch = arr.slice(from, to);
-            const promises = batch.map((el, i) => fn(el, from + i, arr));
-            const next = () => generator(to, to + batchSize);
-            result = Promise.all(promises).then(next);
-        }
-        return result;
-    };
-    return generator(0, batchSize);
-};
-
 gulp.task('testing', () => {
     let messages = [];
     const min = 500;
@@ -1064,78 +1041,7 @@ gulp.task('testing', () => {
     });
 });
 
-const isFunction = x => typeof x === 'function';
-const isArray = x => Array.isArray(x);
 const isString = x => typeof x === 'string';
-
-const uploadFiles = (params) => {
-    const storage = require('./tools/jsdoc/storage/cdn.storage');
-    const mimeType = {
-        'css': 'text/css',
-        'html': 'text/html',
-        'js': 'text/javascript',
-        'json': 'application/json',
-        'svg': 'image/svg+xml'
-    };
-    const {
-        batchSize,
-        bucket,
-        callback,
-        onError = Promise.reject,
-        files
-    } = params;
-    const errors = [];
-    let result;
-    if (isString(bucket) && isArray(files)) {
-        const cdn = storage.strategy.s3({
-            Bucket: bucket
-        });
-        const uploadFile = (file) => {
-            const { from, to } = file;
-            let filePromise;
-            if (isString(from) && isString(to)) {
-                const content = getFile(from);
-                if (isString(content)) {
-                    const fileType = from.split('.').pop();
-                    filePromise = storage.push(cdn, to, content, mimeType[fileType])
-                        .then(() => isFunction(callback) && callback())
-                        .catch((err) => {
-                            const error = {
-                                message: `S3: ${err.pri && err.pri.message}`,
-                                from: from,
-                                to: to
-                            };
-                            errors.push(error);
-                            return onError(error);
-                        });
-                } else {
-                    const error = {
-                        message: 'Path is not a file',
-                        from: from,
-                        to: to
-                    };
-                    errors.push(error);
-                    filePromise = onError(error);
-                }
-            } else {
-                const error = {
-                    message: 'Invalid file information!',
-                    from: from,
-                    to: to
-                };
-                errors.push(error);
-                filePromise = onError(error);
-            }
-            return filePromise;
-        };
-        result = asyncBatchForeach(batchSize, files, uploadFile).then(() => ({
-            errors
-        }));
-    } else {
-        result = Promise.reject();
-    }
-    return result;
-};
 
 const uploadAPIDocs = () => {
     const sourceFolder = './build/api/';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1013,34 +1013,6 @@ const ProgressBar = function (user) {
     return this;
 };
 
-gulp.task('testing', () => {
-    let messages = [];
-    const min = 500;
-    const max = 2000;
-    for (let i = 0; i < 1000; i++) {
-        messages.push({
-            m: i,
-            time: Math.random() * (max - min) + min
-        });
-    }
-    const bar = new ProgressBar({
-        total: messages.length
-    });
-    const func = (time) => {
-        return new Promise((resolve) => {
-            let interval = setInterval(() => {
-                clearInterval(interval);
-                resolve();
-            }, time);
-        });
-    };
-    return asyncBatchForeach(100, messages, (entry) => {
-        return func(entry.time).then(() => {
-            bar.tick();
-        });
-    });
-});
-
 const isString = x => typeof x === 'string';
 
 const uploadAPIDocs = () => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@ const {
     asyncForeach,
     uploadFiles
 } = require('./tools/upload.js');
-
+const ProgressBar = require('./tools/progress-bar.js');
 /**
  * Creates a set of ES6-modules which is distributable.
  * @return {undefined}
@@ -966,51 +966,6 @@ const generateAPIDocs = ({ treeFile, output, onlyBuildCurrent }) => {
     })
     .then(() => generateAPI(treeFile, output, onlyBuildCurrent))
     .then(() => testTree(treeFile));
-};
-
-const logUpdate = require('log-update');
-const ProgressBar = function (user) {
-    const getBar = (options) => {
-        const length = options.length;
-        const percentage = options.count / options.total;
-        const chars = Math.floor(percentage * length);
-        return options.complete.repeat(chars) + options.incomplete.repeat(length - chars);
-    };
-    const getMsg = (options) => {
-        const protectedKeys = ['message', 'bar'];
-        const reduceFn = (msg, key) => (
-            protectedKeys.includes(key) ?
-            msg :
-            msg.replace(`:${key}`, options[key])
-        );
-        return Object.keys(options)
-            .reduce(reduceFn, options.message.replace(':bar', getBar(options)));
-    };
-    const options = Object.assign({
-        count: 0,
-        complete: '=',
-        incomplete: '-',
-        length: 30,
-        message: '[:bar] - :count of :total',
-        total: 100
-    }, user);
-    this.render = () => {
-        logUpdate(getMsg(options));
-    };
-    this.complete = function () {
-        this.tick = () => {};
-        logUpdate.done();
-    };
-    this.tick = function (editOptions = {}) {
-        options.count++;
-        Object.assign(options, editOptions);
-        this.render();
-        if (options.count === options.total) {
-            this.complete();
-        }
-    };
-    this.render();
-    return this;
 };
 
 const isString = x => typeof x === 'string';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -968,10 +968,14 @@ const ProgressBar = function (user) {
         return options.complete.repeat(chars) + options.incomplete.repeat(length - chars);
     };
     const getMsg = (options) => {
-        return options.message
-            .replace(':bar', getBar(options))
-            .replace(':count', options.count)
-            .replace(':total', options.total);
+        const protectedKeys = ['message', 'bar'];
+        const reduceFn = (msg, key) => (
+            protectedKeys.includes(key) ?
+            msg :
+            msg.replace(`:${key}`, options[key])
+        );
+        return Object.keys(options)
+            .reduce(reduceFn, options.message.replace(':bar', getBar(options)));
     };
     const options = Object.assign({
         count: 0,
@@ -988,8 +992,9 @@ const ProgressBar = function (user) {
         this.tick = () => {};
         logUpdate.done();
     };
-    this.tick = function () {
+    this.tick = function (editOptions = {}) {
         options.count++;
+        Object.assign(options, editOptions);
         this.render();
         if (options.count === options.total) {
             this.complete();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -845,42 +845,6 @@ const createAllExamples = () => new Promise((resolve) => {
     resolve();
 });
 
-/**
- * Copy new current version files into a versioned folder
- */
-/*
-const copyAPIFiles = (dist, version) => {
-    const B = require('./assembler/build.js');
-    const notVersionedFolder = (file) => !(
-        (file.split('/').length > 1) && // is folder
-        !isNaN(file.charAt(0)) // is numbered
-    );
-    const message = {
-        'start': 'Started process of copying API files from to a versioned folder.',
-        'successCopy': 'Finished with copying current API to '
-    };
-    console.log(message.start);
-    const paths = ['highcharts', 'highstock', 'highmaps'].reduce((obj, lib) => {
-        const files = B.getFilesInFolder(`${dist}/${lib}/`, true, '');
-        files
-            .filter(notVersionedFolder)
-            .forEach((filename) => {
-                const from = `${dist}/${lib}/${filename}`;
-                const to = `${dist}/${lib}/${version}/${filename}`;
-                obj[from] = to;
-            });
-        return obj;
-    }, {});
-    const promises = Object.keys(paths).map((from) => {
-        const to = paths[from];
-        return copyFile(from, to);
-    });
-    return Promise.all(promises).then(() => {
-        console.log(message.successCopy);
-    });
-};
-*/
-
 const generateAPI = (input, output, onlyBuildCurrent) => new Promise((resolve, reject) => {
     // const generate = require('highcharts-api-doc-gen/lib/index.js');
     const generate = require('./../api-docs/lib/index.js');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1009,10 +1009,7 @@ const asyncForeach = (arr, fn) => {
     const generator = (j) => {
         let promise;
         if (j < length) {
-            promise = fn(arr[j], j, arr).then(() => {
-                // console.log('then ' + j)
-                return generator(j + 1);
-            });
+            promise = fn(arr[j], j, arr).then(() => generator(j + 1));
         }
         return promise;
     };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1022,12 +1022,9 @@ const asyncBatchForeach = (batchSize, arr, fn) => {
         let result;
         if (from < length) {
             const batch = arr.slice(from, to);
-            const promises = batch.map((el, i) => {
-                return fn(el, from + i, arr);
-            });
-            result = Promise.all(promises).then(() => {
-                return generator(to, to + batchSize);
-            });
+            const promises = batch.map((el, i) => fn(el, from + i, arr));
+            const next = () => generator(to, to + batchSize);
+            result = Promise.all(promises).then(next);
         }
         return result;
     };

--- a/tools/progress-bar.js
+++ b/tools/progress-bar.js
@@ -1,0 +1,50 @@
+/* eslint-env node, es6 */
+/* eslint-disable func-style */
+
+'use strict';
+const logUpdate = require('log-update');
+const ProgressBar = function (user) {
+    const getBar = (options) => {
+        const length = options.length;
+        const percentage = options.count / options.total;
+        const chars = Math.floor(percentage * length);
+        return options.complete.repeat(chars) + options.incomplete.repeat(length - chars);
+    };
+    const getMsg = (options) => {
+        const protectedKeys = ['message', 'bar'];
+        const reduceFn = (msg, key) => (
+            protectedKeys.includes(key) ?
+            msg :
+            msg.replace(`:${key}`, options[key])
+        );
+        return Object.keys(options)
+            .reduce(reduceFn, options.message.replace(':bar', getBar(options)));
+    };
+    const options = Object.assign({
+        count: 0,
+        complete: '=',
+        incomplete: '-',
+        length: 30,
+        message: '[:bar] - :count of :total',
+        total: 100
+    }, user);
+    this.render = () => {
+        logUpdate(getMsg(options));
+    };
+    this.complete = function () {
+        this.tick = () => {};
+        logUpdate.done();
+    };
+    this.tick = function (editOptions = {}) {
+        options.count++;
+        Object.assign(options, editOptions);
+        this.render();
+        if (options.count === options.total) {
+            this.complete();
+        }
+    };
+    this.render();
+    return this;
+};
+
+module.exports = ProgressBar;

--- a/tools/upload.js
+++ b/tools/upload.js
@@ -1,0 +1,111 @@
+/* eslint-env node, es6 */
+/* eslint-disable func-style */
+
+'use strict';
+
+const isString = x => typeof x === 'string';
+const isFunction = x => typeof x === 'function';
+const isArray = x => Array.isArray(x);
+
+const getFile = require('highcharts-assembler/src/utilities.js').getFile;
+
+const asyncForeach = (arr, fn) => {
+    const length = arr.length;
+    const generator = (j) => {
+        let promise;
+        if (j < length) {
+            promise = fn(arr[j], j, arr).then(() => generator(j + 1));
+        }
+        return promise;
+    };
+    return generator(0);
+};
+
+const asyncBatchForeach = (batchSize, arr, fn) => {
+    const length = arr.length;
+    const generator = (from, to) => {
+        let result;
+        if (from < length) {
+            const batch = arr.slice(from, to);
+            const promises = batch.map((el, i) => fn(el, from + i, arr));
+            const next = () => generator(to, to + batchSize);
+            result = Promise.all(promises).then(next);
+        }
+        return result;
+    };
+    return generator(0, batchSize);
+};
+
+const uploadFiles = (params) => {
+    const storage = require('./tools/jsdoc/storage/cdn.storage');
+    const mimeType = {
+        'css': 'text/css',
+        'html': 'text/html',
+        'js': 'text/javascript',
+        'json': 'application/json',
+        'svg': 'image/svg+xml'
+    };
+    const {
+        batchSize,
+        bucket,
+        callback,
+        onError = Promise.reject,
+        files
+    } = params;
+    const errors = [];
+    let result;
+    if (isString(bucket) && isArray(files)) {
+        const cdn = storage.strategy.s3({
+            Bucket: bucket
+        });
+        const uploadFile = (file) => {
+            const { from, to } = file;
+            let filePromise;
+            if (isString(from) && isString(to)) {
+                const content = getFile(from);
+                if (isString(content)) {
+                    const fileType = from.split('.').pop();
+                    filePromise = storage.push(cdn, to, content, mimeType[fileType])
+                        .then(() => isFunction(callback) && callback())
+                        .catch((err) => {
+                            const error = {
+                                message: `S3: ${err.pri && err.pri.message}`,
+                                from: from,
+                                to: to
+                            };
+                            errors.push(error);
+                            return onError(error);
+                        });
+                } else {
+                    const error = {
+                        message: 'Path is not a file',
+                        from: from,
+                        to: to
+                    };
+                    errors.push(error);
+                    filePromise = onError(error);
+                }
+            } else {
+                const error = {
+                    message: 'Invalid file information!',
+                    from: from,
+                    to: to
+                };
+                errors.push(error);
+                filePromise = onError(error);
+            }
+            return filePromise;
+        };
+        result = asyncBatchForeach(batchSize, files, uploadFile).then(() => ({
+            errors
+        }));
+    } else {
+        result = Promise.reject();
+    }
+    return result;
+};
+
+module.exports = {
+    asyncForeach,
+    uploadFiles
+};


### PR DESCRIPTION
Improved logging and error handling in the gulp task `upload-api`. The task will now list the uploads which failed, and suggest a command to retry upload of these failed files.

Moved some of the scripts to their own seperate files under `./tools` to improve structure and reusability, and to clean up `gulpfile.js`. Also removed some redundant code related to these scripts.