### PR TITLE
bugfix/8214-wrong-data-labels-class-name-format

### DIFF
--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -364,7 +364,7 @@ Series.prototype.drawDataLabels = function () {
                     dataLabel.addClass(
                         ' highcharts-data-label-color-' + point.colorIndex +
                         ' ' + (options.className || '') +
-                        (options.useHTML ? 'highcharts-tracker' : '') // #3398
+                        (options.useHTML ? ' highcharts-tracker' : '') // #3398
                     );
                 } else {
                     attr.text = str;


### PR DESCRIPTION
Fixed #8214, missing space character before tracker class definition.