### PR TITLE
Added clearer error reporting to offline exporting. Closes #8226.

### DIFF
--- a/errors/errors.xml
+++ b/errors/errors.xml
@@ -181,4 +181,18 @@
 		</description>
 	</error>
 
+    <error id="28">
+		<title>Fallback to export server disabled</title>
+		<description>
+			<p>This happens when the offline export module encounters a chart it can not export successfully, and the
+            fallback to the online export server is disabled. The offline exporting module will fail for certain browsers,
+            and certain features (e.g. <a href="https://api.highcharts.com/highcharts/exporting.allowHTML">allowHTML</a>),
+            depending on the type of image exporting to. For a compatibility overview,
+            see <a href="https://www.highcharts.com/docs/export-module/client-side-export">Client Side Export</a>. For very complex
+            charts, it is possible that export can fail in browsers that don't support Blob objects, due to data URL length limits.
+            It is always recommended to define the <a href="https://api.highcharts.com/highcharts/exporting.error">exporting.error</a>
+            callback if you disable fallback, so that you can provide details to your users if export is not working for them.</p>
+		</description>
+	</error>
+
 </errors>

--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -443,7 +443,8 @@ defaultOptions.exporting = {
      * Function to call if the offline-exporting module fails to export
      * a chart on the client side, and [fallbackToExportServer](
      * #exporting.fallbackToExportServer) is disabled. If left undefined, an
-     * exception is thrown instead.
+     * exception is thrown instead. Receives two parameters, the exporting
+     * options, and the error from the module.
      *
      * @type {Function}
      * @see [fallbackToExportServer](#exporting.fallbackToExportServer)
@@ -454,7 +455,14 @@ defaultOptions.exporting = {
 
     /**
      * Whether or not to fall back to the export server if the offline-exporting
-     * module is unable to export the chart on the client side.
+     * module is unable to export the chart on the client side. This happens for
+     * certain browsers, and certain features (e.g.
+     * [allowHTML](#exporting.allowHTML)), depending on the image type exporting
+     * to. For very complex charts, it is possible that export can fail in
+     * browsers that don't support Blob objects, due to data URL length limits.
+     * It is recommended to define the [exporting.error](#exporting.error)
+     * handler if disabling fallback, in order to notify users in case export
+     * fails.
      *
      * @type {Boolean}
      * @default true

--- a/js/modules/offline-exporting.src.js
+++ b/js/modules/offline-exporting.src.js
@@ -334,7 +334,7 @@ Highcharts.downloadSVGLocal = function (
                 successCallback();
             }
         } catch (e) {
-            failCallback();
+            failCallback(e);
         }
     }
 
@@ -355,7 +355,7 @@ Highcharts.downloadSVGLocal = function (
                 successCallback();
             }
         } catch (e) {
-            failCallback();
+            failCallback(e);
         }
     } else if (imageType === 'application/pdf') {
         if (win.jsPDF && win.svg2pdf) {
@@ -396,7 +396,7 @@ Highcharts.downloadSVGLocal = function (
                         successCallback();
                     }
                 } catch (e) {
-                    failCallback();
+                    failCallback(e);
                 }
             }, function () {
                 // Failed due to tainted canvas
@@ -422,7 +422,7 @@ Highcharts.downloadSVGLocal = function (
                                 successCallback();
                             }
                         } catch (e) {
-                            failCallback();
+                            failCallback(e);
                         } finally {
                             finallyHandler();
                         }
@@ -543,7 +543,7 @@ Highcharts.Chart.prototype.getSVGForLocalExport = function (
             );
         }
     } catch (e) {
-        failCallback();
+        failCallback(e);
     }
 };
 
@@ -565,12 +565,12 @@ Highcharts.Chart.prototype.exportChartLocal = function (
 ) {
     var chart = this,
         options = Highcharts.merge(chart.options.exporting, exportingOptions),
-        fallbackToExportServer = function () {
+        fallbackToExportServer = function (err) {
             if (options.fallbackToExportServer === false) {
                 if (options.error) {
-                    options.error(options);
+                    options.error(options, err);
                 } else {
-                    throw 'Fallback to export server disabled';
+                    Highcharts.error(28, true); // Fallback disabled
                 }
             } else {
                 chart.exportChart(options);
@@ -583,7 +583,9 @@ Highcharts.Chart.prototype.exportChartLocal = function (
                 svg.indexOf('<foreignObject') > -1 &&
                 options.type !== 'image/svg+xml'
             ) {
-                fallbackToExportServer();
+                fallbackToExportServer(
+                    'Image type not supported for charts with embedded HTML'
+                );
             } else {
                 Highcharts.downloadSVGLocal(
                     svg,
@@ -647,7 +649,9 @@ Highcharts.Chart.prototype.exportChartLocal = function (
             chart.container.getElementsByTagName('image').length
         )
     ) {
-        fallbackToExportServer();
+        fallbackToExportServer(
+            'Image type not supported for this chart/browser.'
+        );
         return;
     }
 

--- a/samples/highcharts/exporting/offline-download-usehtml/demo.js
+++ b/samples/highcharts/exporting/offline-download-usehtml/demo.js
@@ -15,6 +15,9 @@ Highcharts.chart('container', {
         },
         scale: 3,
         fallbackToExportServer: false,
+        error: function (opt, err) {
+            console.log('Failed with error: "' + err + '". Options:', opt);
+        },
         allowHTML: true
     },
 


### PR DESCRIPTION
Added a new, more informative, error for when offline exporting tries to fallback, but can't. Also improved info that is passed along when this happens, and referenced `exporting.error` handler more clearly in API.

We might want to mention `allowHTML` in the docs here: https://www.highcharts.com/docs/export-module/client-side-export.