### PR TITLE
bugfix/8031-columns-overlapped-xaxis-correction

### DIFF
--- a/js/parts/StockChart.js
+++ b/js/parts/StockChart.js
@@ -870,7 +870,7 @@ wrap(Series.prototype, 'render', function (proceed) {
         !this.xAxis.isRadial // Gauge, #6192
     ) {
         // Include xAxis line width, #8031
-        clipHeight = this.yAxis.len - (this.xAxisLine ?
+        clipHeight = this.yAxis.len - (this.xAxis.axisLine ?
             Math.floor(this.xAxis.axisLine.strokeWidth() / 2) :
             0);
 

--- a/samples/unit-tests/series-column/axis-line-width/demo.html
+++ b/samples/unit-tests/series-column/axis-line-width/demo.html
@@ -1,4 +1,4 @@
-<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/series-column/axis-line-width/demo.js
+++ b/samples/unit-tests/series-column/axis-line-width/demo.js
@@ -7,7 +7,6 @@ QUnit.test('Column with xAxis lineWidth in Highstock (#8031).', function (assert
             lineWidth: 17
         },
         series: [{
-            clip: true,
             data: [400, 124]
         }]
     });


### PR DESCRIPTION
Highstock: Fixed #8031, columns overlapped xAxis - correction.