### PR TITLE
bugfix/3158-chrome-text-break

### DIFF
--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -2681,7 +2681,8 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
 
                                         // a single word is pressing it out
                                         if (actualWidth > width) {
-                                            width = actualWidth;
+                                            // one more pixel for Chrome, #3158
+                                            width = actualWidth + 1;
                                         }
                                     } else { // append to existing line tspan
                                         tspan.removeChild(tspan.firstChild);


### PR DESCRIPTION
Resolves #3158 in Chrome caused by oversized words.