### PR TITLE
Fixed issue where image patterns could not have translucent opacity w…

### DIFF
--- a/js/modules/pattern-fill.src.js
+++ b/js/modules/pattern-fill.src.js
@@ -198,6 +198,7 @@ H.Point.prototype.calculatePatternDimensions = function (pattern) {
 H.SVGRenderer.prototype.addPattern = function (options, animation) {
     var pattern,
         animate = H.pick(animation, true),
+        animationOptions = H.animObject(animate),
         path,
         defaultSize = 32,
         width = options.width || options._width || defaultSize,
@@ -266,7 +267,7 @@ H.SVGRenderer.prototype.addPattern = function (options, animation) {
                     // Onload
                     this.animate({
                         opacity: pick(options.opacity, 1)
-                    }, animate);
+                    }, animationOptions);
                     H.removeEvent(this.element, 'load');
                 }
             ).attr({ opacity: 0 }).add(pattern);
@@ -424,11 +425,11 @@ H.addEvent(H.SVGRenderer, 'complexColor', function (args) {
 
         // Add it. This function does nothing if an element with this ID
         // already exists.
-        this.addPattern(pattern, !this.forExport && H.animObject(H.pick(
+        this.addPattern(pattern, !this.forExport && H.pick(
             pattern.animation,
             this.globalAnimation,
             { duration: 100 }
-        )));
+        ));
 
         value = 'url(' + this.url + '#' + pattern.id + ')';
 

--- a/js/modules/pattern-fill.src.js
+++ b/js/modules/pattern-fill.src.js
@@ -12,7 +12,8 @@ import '../parts/Utilities.js';
 
 var wrap = H.wrap,
     each = H.each,
-    merge = H.merge;
+    merge = H.merge,
+    pick = H.pick;
 
 
 /**
@@ -263,7 +264,9 @@ H.SVGRenderer.prototype.addPattern = function (options, animation) {
             this.image(
                 options.image, 0, 0, width, height, function () {
                     // Onload
-                    this.animate({ opacity: options.opacity || 1 }, animate);
+                    this.animate({
+                        opacity: pick(options.opacity, 1)
+                    }, animate);
                     H.removeEvent(this.element, 'load');
                 }
             ).attr({ opacity: 0 }).add(pattern);
@@ -272,7 +275,8 @@ H.SVGRenderer.prototype.addPattern = function (options, animation) {
         }
     }
 
-    if (options.opacity !== undefined) {
+    // For non-animated patterns, set opacity now
+    if (!(options.image && animate) && options.opacity !== undefined) {
         each(pattern.element.childNodes, function (child) {
             child.setAttribute('opacity', options.opacity);
         });

--- a/js/modules/pattern-fill.src.js
+++ b/js/modules/pattern-fill.src.js
@@ -263,7 +263,7 @@ H.SVGRenderer.prototype.addPattern = function (options, animation) {
             this.image(
                 options.image, 0, 0, width, height, function () {
                     // Onload
-                    this.animate({ opacity: 1 }, animate);
+                    this.animate({ opacity: options.opacity || 1 }, animate);
                     H.removeEvent(this.element, 'load');
                 }
             ).attr({ opacity: 0 }).add(pattern);

--- a/samples/unit-tests/color/pattern-fill/demo.js
+++ b/samples/unit-tests/color/pattern-fill/demo.js
@@ -549,7 +549,15 @@ QUnit.test('Image animation opacity', function (assert) {
                             image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==',
                             opacity: 0.5,
                             animation: {
-                                duration: 50
+                                duration: 50,
+                                complete: function () {
+                                    assert.strictEqual(
+                                        columnPattern.firstChild.getAttribute('opacity'),
+                                        '0.5',
+                                        'Pattern should end at 0.5 opacity'
+                                    );
+                                    done();
+                                }
                             }
                         }
                     }
@@ -563,15 +571,6 @@ QUnit.test('Image animation opacity', function (assert) {
             '0',
             'Pattern should start at 0 opacity'
         );
-
-        setTimeout(function () {
-            assert.strictEqual(
-                columnPattern.firstChild.getAttribute('opacity'),
-                '0.5',
-                'Pattern should end at 0.5 opacity'
-            );
-            done();
-        }, 100);
 
         TestUtilities.lolexRunAndUninstall(clock);
     } finally {

--- a/samples/unit-tests/color/pattern-fill/demo.js
+++ b/samples/unit-tests/color/pattern-fill/demo.js
@@ -522,3 +522,59 @@ QUnit.test('Image auto resize with aspect ratio - column', function (assert) {
     chart.setSize(200, 200);
     test();
 });
+
+
+QUnit.test('Image animation opacity', function (assert) {
+    var clock = TestUtilities.lolexInstall(),
+        done = assert.async(),
+        columnPattern;
+
+    try {
+        Highcharts.chart('container', {
+            chart: {
+                type: 'column',
+                animation: {
+                    enabled: true
+                }
+            },
+            series: [{
+                animation: {
+                    enabled: true
+                },
+                data: [{
+                    y: 1,
+                    color: {
+                        pattern: {
+                            id: 'test-pattern',
+                            image: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==',
+                            opacity: 0.5,
+                            animation: {
+                                duration: 50
+                            }
+                        }
+                    }
+                }]
+            }]
+        });
+        columnPattern = document.getElementById('test-pattern');
+
+        assert.strictEqual(
+            columnPattern.firstChild.getAttribute('opacity'),
+            '0',
+            'Pattern should start at 0 opacity'
+        );
+
+        setTimeout(function () {
+            assert.strictEqual(
+                columnPattern.firstChild.getAttribute('opacity'),
+                '0.5',
+                'Pattern should end at 0.5 opacity'
+            );
+            done();
+        }, 100);
+
+        TestUtilities.lolexRunAndUninstall(clock);
+    } finally {
+        TestUtilities.lolexUninstall(clock);
+    }
+});


### PR DESCRIPTION
…ith default animation.

We animate image patterns by opacity by default, to avoid choppy loading of images. We should obviously take opacity setting into consideration when deciding what opacity to animate to.