### PR TITLE
Fixed #8406, colorAxis did not get new series extremes after chart update

### DIFF
--- a/js/parts-map/ColorAxis.js
+++ b/js/parts-map/ColorAxis.js
@@ -768,6 +768,7 @@ if (!H.ColorAxis) {
             this.dataMin = Infinity;
             this.dataMax = -Infinity;
             while (i--) {
+                series[i].getExtremes();
                 if (series[i].valueMin !== undefined) {
                     this.dataMin = Math.min(this.dataMin, series[i].valueMin);
                     this.dataMax = Math.max(this.dataMax, series[i].valueMax);

--- a/samples/unit-tests/coloraxis/members/demo.details
+++ b/samples/unit-tests/coloraxis/members/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/coloraxis/members/demo.html
+++ b/samples/unit-tests/coloraxis/members/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/maps/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/heatmap.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/coloraxis/members/demo.js
+++ b/samples/unit-tests/coloraxis/members/demo.js
@@ -1,0 +1,38 @@
+/**
+ * Related issues: #8406
+ */
+QUnit.test('getSeriesExtremes', function (assert) {
+    var chart = Highcharts.chart("container", {
+            colorAxis: {
+                minColor: '#ffffff',
+                maxColor: Highcharts.getOptions().colors[0]
+            },
+            series: []
+        }),
+        series;
+
+    chart.addAxis({ id: "yAxis" }, false, true);
+    series = chart.addSeries({
+        type: 'heatmap',
+        yAxis: 'yAxis',
+        data: [[1, 1, 1], [1, 2, 2], [1, 3, 3]]
+    });
+
+    assert.strictEqual(
+        series.points[0].color,
+        'rgb(255,255,255)',
+        'should give first point on series the color rgb(255,255,255)'
+    );
+
+    assert.strictEqual(
+        series.points[1].color,
+        'rgb(190,218,246)',
+        'should give second point on series the color rgb(190,218,246)'
+    );
+
+    assert.strictEqual(
+        series.points[2].color,
+        'rgb(124,181,236)',
+        'should give third point on series the color rgb(124,181,236)'
+    );
+});


### PR DESCRIPTION
# Description
In certain cases during redraw the series extremes has not been updated when the color axis is calling getSeriesExtremes. This can cause the extremes to be undefined, which will render the points with invalid colors.

# Example(s)
- [Before: Treemap example](https://jsfiddle.net/pme2Lfkn/2/)
- [Before: Heatmap example](https://jsfiddle.net/7jLuxcnb/4/)
- [After: Treemap example](https://jsfiddle.net/pme2Lfkn/)
- [After: Heatmap example](https://jsfiddle.net/7jLuxcnb/)

# Related issue(s)
- #8406