### PR TITLE
 bugfix/8445-roc-wrong-name

### DIFF
--- a/js/indicators/roc.src.js
+++ b/js/indicators/roc.src.js
@@ -67,7 +67,6 @@ seriesType('roc', 'sma',
      * @optionparent plotOptions.roc
      */
     {
-        name: 'Rate of Change (9)',
         params: {
             index: 3,
             period: 9


### PR DESCRIPTION
Note: 

Test http://utils.highcharts.local/samples/#test/stock/indicators/roc - will, and should, fail. No extra test needed. 