### PR TITLE
bugfix/8376-psar-macd-limit-points

### DIFF
--- a/js/indicators/macd.src.js
+++ b/js/indicators/macd.src.js
@@ -312,6 +312,10 @@ seriesType('macd', 'sma',
                 longEMA,
                 i;
 
+            if (series.xData.length < params.longPeriod) {
+                return false;
+            }
+
             // Calculating the short and long EMA used when calculating the MACD
             shortEMA = EMA.prototype.getValues(series,
                 {

--- a/js/indicators/psar.src.js
+++ b/js/indicators/psar.src.js
@@ -126,7 +126,6 @@ H.seriesType('psar', 'sma',
             }
         },
         /**
-         * @excluding index
          * @excluding period
          */
         params: {
@@ -208,6 +207,10 @@ H.seriesType('psar', 'sma',
                 prevPrevHigh,
                 newExtremePoint,
                 high, low, ind;
+
+            if (index >= yVal.length) {
+                return false;
+            }
 
             for (ind = 0; ind < index; ind++) {
                 extremePoint = Math.max(yVal[ind][1], extremePoint);

--- a/samples/unit-tests/indicator-macd/recalculations/demo.js
+++ b/samples/unit-tests/indicator-macd/recalculations/demo.js
@@ -295,4 +295,18 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
         chart.series[1].currentDataGrouping !== undefined,
         'DataGrouping applied to MACD series too (#7823).'
     );
+
+
+    Highcharts.seriesTypes.macd.prototype.getValues(
+        {
+            xData: [0],
+            yData: [1]
+        },
+        Highcharts.getOptions().plotOptions.macd.params
+    );
+
+    assert.ok(
+        true,
+        'No error when periods are greater than data length (#8376).'
+    );
 });

--- a/samples/unit-tests/indicator-psar/recalculations/demo.js
+++ b/samples/unit-tests/indicator-psar/recalculations/demo.js
@@ -225,4 +225,17 @@ QUnit.test('Test PSAR calculations on data updates.', function (assert) {
         Highcharts.getOptions().plotOptions.psar.params
     );
     assert.ok(true, 'No errors when data contains multiple null points.');
+
+    Highcharts.seriesTypes.psar.prototype.getValues(
+        {
+            xData: [0],
+            yData: [1]
+        },
+        Highcharts.getOptions().plotOptions.psar.params
+    );
+
+    assert.ok(
+        true,
+        'No error when index is greater than data length (#8376).'
+    );
 });


### PR DESCRIPTION
Additionally removed "index" from exclude - this option is configurable and should be in our API.