### PR TITLE
bugfix/8374-navigator-series-visibility-inheritance

### DIFF
--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -1091,11 +1091,12 @@ extend(Series.prototype, /** @lends Highcharts.Series.prototype */ {
         if (ignoreHiddenSeries) {
             chart.isDirtyBox = true;
         }
+
+        fireEvent(series, showOrHide);
+
         if (redraw !== false) {
             chart.redraw();
         }
-
-        fireEvent(series, showOrHide);
     },
 
     /**

--- a/js/parts/Navigator.js
+++ b/js/parts/Navigator.js
@@ -1658,8 +1658,7 @@ Navigator.prototype = {
                 yAxis: 'navigator-y-axis',
                 showInLegend: false,
                 stacking: false, // #4823
-                isInternal: true,
-                visible: true
+                isInternal: true
             },
             // Remove navigator series that are no longer in the baseSeries
             navigatorSeries = navigator.series = H.grep(
@@ -1690,9 +1689,10 @@ Navigator.prototype = {
             each(baseSeries, function eachBaseSeries(base) {
                 var linkedNavSeries = base.navigatorSeries,
                     userNavOptions = extend(
-                        // Grab color from base as default
+                        // Grab color and visibility from base as default
                         {
-                            color: base.color
+                            color: base.color,
+                            visible: base.visible
                         },
                         !isArray(chartNavigatorSeriesOptions) ?
                             chartNavigatorSeriesOptions :

--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -537,3 +537,70 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test(
+    'Navigator series visibility should be in sync with master series (#8374)',
+    function (assert) {
+        var chart = Highcharts.stockChart('container', {
+                legend: {
+                    enabled: true
+                },
+                series: [{
+                    data: [1, 2, 3],
+                    visible: false
+                }, {
+                    showInNavigator: true,
+                    data: [30, 22, 10]
+                }]
+            }),
+            series0 = chart.series[0],
+            series1 = chart.series[1];
+
+        assert.strictEqual(
+            // This returns false, when series is hidden:
+            series0.navigatorSeries.visible === true,
+            // Directly visibile = false
+            series0.visible,
+            'Both series[0] and series[0].navigator should be hidden.'
+        );
+
+        assert.strictEqual(
+            series1.navigatorSeries.visible === true,
+            series1.visible,
+            'Both series[1] and series[1].navigator should be visible.'
+        );
+
+        series0.update({
+            visible: true
+        });
+
+        assert.strictEqual(
+            series0.navigatorSeries.visible === true,
+            series0.visible,
+            'Both series[0] and series[0].navigator should be visible.'
+        );
+
+        series1.update({
+            visible: false
+        });
+
+        assert.strictEqual(
+            series1.navigatorSeries.visible === true,
+            series1.visible,
+            'Both series[1] and series[1].navigator should be hidden.'
+        );
+
+        // Order of the events:
+        // - first execute callback for series.hide(), to show navigator series
+        // - then redraw the chart, including navigator series
+        series1.setVisible();
+
+        assert.strictEqual(
+            Highcharts.defined(series1.navigatorSeries.graph) &&
+                series1.navigatorSeries.group.visibility !== 'hidden',
+            true,
+            'Navigator series should be visible.'
+        );
+
+    }
+);


### PR DESCRIPTION
To fix this issue, I needed to call "hide" and "show" events **before** redrawing the chart.

Tests passed, but are we aware of a case when this may fail? 