### PR TITLE
bugfix/7828-stock-panning-performance

### DIFF
--- a/js/parts/OrdinalAxis.js
+++ b/js/parts/OrdinalAxis.js
@@ -222,6 +222,7 @@ extend(Axis.prototype, /** @lends Axis.prototype */ {
         var axis = this,
             len,
             ordinalPositions = [],
+            uniqueOrdinalPositions,
             useOrdinal = false,
             dist,
             extremes = axis.getExtremes(),
@@ -263,6 +264,7 @@ extend(Axis.prototype, /** @lends Axis.prototype */ {
         if (isOrdinal || hasBreaks) { // #4167 YAxis is never ordinal ?
 
             each(axis.series, function (series, i) {
+                uniqueOrdinalPositions = [];
 
                 if (
                     (!ignoreHiddenSeries || series.visible !== false) &&
@@ -288,12 +290,29 @@ extend(Axis.prototype, /** @lends Axis.prototype */ {
                     );
 
                     if (len) {
-                        i = len - 1;
-                        while (i--) {
-                            if (ordinalPositions[i] === ordinalPositions[i + 1]) {
-                                ordinalPositions.splice(i, 1);
+
+                        i = 0;
+                        while (i < len - 1) {
+                            if (
+                                ordinalPositions[i] !== ordinalPositions[i + 1]
+                            ) {
+                                uniqueOrdinalPositions.push(
+                                    ordinalPositions[i + 1]
+                                );
                             }
+                            i++;
                         }
+
+                        // Check first item:
+                        if (
+                            uniqueOrdinalPositions[0] !== ordinalPositions[0]
+                        ) {
+                            uniqueOrdinalPositions.unshift(
+                                ordinalPositions[0]
+                            );
+                        }
+
+                        ordinalPositions = uniqueOrdinalPositions;
                     }
                 }
 


### PR DESCRIPTION
Performance comparison:

- v6.1.0: http://jsfiddle.net/BlackLabel/yrkry3dr/35/ ~30sec
- bugfix branch: http://jsfiddle.net/BlackLabel/yrkry3dr/36/ ~1sec

Still, rendering 500 000, or 1 000 000 of points, then panning is very laggy. Boost is recommended.