### PR TITLE
Fixed issue with initialValue was always supplied to reduce.

### DIFF
--- a/js/indicators/mfi.src.js
+++ b/js/indicators/mfi.src.js
@@ -13,12 +13,13 @@
 import H from '../parts/Globals.js';
 import '../parts/Utilities.js';
 
-var isArray = H.isArray;
+var isArray = H.isArray,
+    reduce = H.reduce;
 
     // Utils:
 function sumArray(array) {
 
-    return array.reduce(function (prev, cur) {
+    return reduce(array, function (prev, cur) {
         return prev + cur;
     });
 }

--- a/js/indicators/wma.src.js
+++ b/js/indicators/wma.src.js
@@ -9,6 +9,7 @@ import H from '../parts/Globals.js';
 import '../parts/Utilities.js';
 
 var isArray = H.isArray,
+    reduce = H.reduce,
     seriesType = H.seriesType;
 
 // Utils:
@@ -26,7 +27,7 @@ function weightedSumArray(array, pLen) {
     var denominator = (pLen + 1) / 2 * pLen;
 
     // reduce VS loop => reduce
-    return array.reduce(function (prev, cur, i) {
+    return reduce(array, function (prev, cur, i) {
         return [null, prev[1] + cur[1] * (i + 1)];
     })[1] / denominator;
 }

--- a/js/modules/oldie.src.js
+++ b/js/modules/oldie.src.js
@@ -170,9 +170,10 @@ if (!Object.prototype.keys) {
 if (!Array.prototype.reduce) {
     H.reducePolyfill = function (func, initialValue) {
         var context = this,
-            accumulator = initialValue || {},
+            i = arguments.length > 1 ? 0 : 1,
+            accumulator = arguments.length > 1 ? initialValue : this[0],
             len = this.length;
-        for (var i = 0; i < len; ++i) {
+        for (; i < len; ++i) {
             accumulator = func.call(context, accumulator, this[i], i, this);
         }
         return accumulator;

--- a/js/modules/tilemap.src.js
+++ b/js/modules/tilemap.src.js
@@ -437,7 +437,7 @@ H.wrap(H.Axis.prototype, 'setAxisTranslation', function (proceed) {
                 series.getSeriesPixelPadding(axis);
         }), function (a, b) {
             return (a && a.padding) > (b && b.padding) ? a : b;
-        }) || {
+        }, undefined) || {
             padding: 0,
             axisLengthFactor: 1
         },

--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -1585,10 +1585,10 @@ H.keys = function (obj) {
  * @returns {Mixed} - The reduced value.
  */
 H.reduce = function (arr, func, initialValue) {
-    return (H.reducePolyfill || Array.prototype.reduce).call(
+    var fn = (H.reducePolyfill || Array.prototype.reduce);
+    return fn.apply(
         arr,
-        func,
-        initialValue
+        (arguments.length > 2 ? [func, initialValue] : [func])
     );
 };
 

--- a/samples/unit-tests/utilities/utilities/demo.js
+++ b/samples/unit-tests/utilities/utilities/demo.js
@@ -807,4 +807,67 @@
 
         document.body.removeChild(div);
     });
+
+    QUnit.test('reduce', function (assert) {
+        var reduce = Highcharts.reduce,
+            arr = [0, 1, 2, 3],
+            accumulations = [],
+            values = [],
+            result;
+
+        // Call reduce without an initialValue.
+        result = reduce(arr, function (accumulation, value) {
+            accumulations.push(accumulation);
+            values.push(value);
+            return accumulation + value;
+        });
+
+        assert.strictEqual(
+            result,
+            6,
+            'No initialValue - should return sum of values in array.'
+        );
+
+        assert.deepEqual(
+            accumulations,
+            [0, 1, 3],
+            'No initialValue - should use first value as initialValue.'
+        );
+
+        assert.deepEqual(
+            values,
+            [1, 2, 3],
+            'No initialValue - should iterate from second value in array.'
+        );
+
+        // Empty arrays before next test.
+        accumulations = [];
+        values = [];
+
+        // Call reduce with an initialValue.
+        result = reduce(arr, function (accumulation, value) {
+            accumulations.push(accumulation);
+            values.push(value);
+            return accumulation + value;
+        }, 1);
+
+        assert.strictEqual(
+            result,
+            7,
+            'initialValue = 1 - should return sum of values in array plus intialValue.'
+        );
+
+        assert.deepEqual(
+            accumulations,
+            [1, 1, 2, 4],
+            'initialValue = 1 - should use initialValue.'
+        );
+
+        assert.deepEqual(
+            values,
+            [0, 1, 2, 3],
+            'initialValue = 1 - should iterate from first value in array.'
+        );
+
+    });
 }());


### PR DESCRIPTION
# Description
When initalValue is not supplied to reduce it should use the first value in the array as intialValue. Currently intialValue will be set to `undefined` when it is not supplied.

The following example will currently return `NaN` because the intialValue will be set to `undefined` when it should be `1` :
```javascript
var sum = reduce([1, 2, 3], function (sum, value) {
  return sum + value;
});
```