### PR TITLE
Added new option, `tooltip.outside`

### DIFF
--- a/js/parts/Options.js
+++ b/js/parts/Options.js
@@ -2540,6 +2540,23 @@ H.defaultOptions = {
          */
 
         /**
+         * Whether to allow the tooltip to render outside the chart's SVG
+         * element box. By default (`false`), the tooltip is rendered within the
+         * chart's SVG element, which results in the tooltip being aligned
+         * inside the chart area. For small charts, this may result in clipping
+         * or overlapping. When `true`, a separate SVG element is created and
+         * overlaid on the page, allowing the tooltip to be aligned inside the
+         * page itself.
+         *
+         * @type {Boolean}
+         * @sample highcharts/tooltip/outside
+         *         Small charts with tooltips outside
+         * @default false
+         * @since 6.1.1
+         * @apioption tooltip.outside
+         */
+
+        /**
          * A callback function for formatting the HTML output for a single point
          * in the tooltip. Like the `pointFormat` string, but with more
          * flexibility.

--- a/samples/highcharts/tooltip/outside/demo.css
+++ b/samples/highcharts/tooltip/outside/demo.css
@@ -1,0 +1,9 @@
+#outer {
+	max-width: 420px;
+	margin: 1em auto;
+}
+.container {
+	width: 200px;
+    height: 200px;
+    display: inline-block;
+}

--- a/samples/highcharts/tooltip/outside/demo.details
+++ b/samples/highcharts/tooltip/outside/demo.details
@@ -1,0 +1,7 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+ requiresManualTesting: true
+...

--- a/samples/highcharts/tooltip/outside/demo.html
+++ b/samples/highcharts/tooltip/outside/demo.html
@@ -1,0 +1,8 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<h1>Tooltip outside the box</h1>
+<div id="outer">
+	<div class="container" id="container1"></div>
+	<div class="container" id="container2"></div>
+	<div class="container" id="container3"></div>
+</div>

--- a/samples/highcharts/tooltip/outside/demo.js
+++ b/samples/highcharts/tooltip/outside/demo.js
@@ -1,0 +1,126 @@
+
+Highcharts.chart('container1', {
+
+    chart: {
+        type: 'column',
+        borderWidth: 1
+    },
+
+    title: {
+        text: 'Column chart'
+    },
+
+    xAxis: {
+        categories: ['Jan', 'Feb', 'Mar', 'Apr']
+    },
+
+    legend: {
+        enabled: false
+    },
+
+    tooltip: {
+        outside: true
+    },
+
+    series: [{
+        name: 'Really, really long series name 1',
+        data: [1, 4, 2, 3]
+    }, {
+        name: 'Really, really long series name 2',
+        data: [4, 2, 5, 3]
+    }, {
+        name: 'Really, really long series name 2',
+        data: [6, 5, 3, 1]
+    }, {
+        name: 'Really, really long series name 2',
+        data: [6, 4, 2, 1]
+    }]
+
+});
+
+
+Highcharts.chart('container2', {
+
+    chart: {
+        type: 'line',
+        borderWidth: 1
+    },
+
+    title: {
+        text: 'Line chart'
+    },
+
+    xAxis: {
+        categories: ['Jan', 'Feb', 'Mar', 'Apr']
+    },
+
+    legend: {
+        enabled: false
+    },
+
+    tooltip: {
+        outside: true
+    },
+
+    series: [{
+        name: 'Really, really long series name 1',
+        data: [1, 4, 2, 3]
+    }, {
+        name: 'Really, really long series name 2',
+        data: [4, 2, 5, 3]
+    }, {
+        name: 'Really, really long series name 2',
+        data: [6, 5, 3, 1]
+    }, {
+        name: 'Really, really long series name 2',
+        data: [6, 4, 2, 1]
+    }]
+
+});
+
+
+Highcharts.chart('container3', {
+
+    chart: {
+        type: 'bar',
+        borderWidth: 1
+    },
+
+    title: {
+        text: 'Bar chart'
+    },
+
+    subtitle: {
+        text: 'tooltip.useHTML = true'
+    },
+
+    xAxis: {
+        categories: ['Jan', 'Feb', 'Mar', 'Apr']
+    },
+
+    legend: {
+        enabled: false
+    },
+
+    tooltip: {
+        outside: true,
+        useHTML: true
+    },
+
+    series: [{
+        name: 'Really, really long series name 1',
+        data: [1, 4, 2, 3]
+    }, {
+        name: 'Really, really long series name 2',
+        data: [4, 2, 5, 3]
+    }, {
+        name: 'Really, really long series name 2',
+        data: [6, 5, 3, 1]
+    }, {
+        name: 'Really, really long series name 2',
+        data: [6, 4, 2, 1]
+    }]
+
+});
+
+


### PR DESCRIPTION
To allow the tooltip to render outside the confinement of the chart area. Closes #5784.