### PR TITLE
Fixed #7484, update tooltip position when dragging and followTouchMov…

### DIFF
--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -391,7 +391,11 @@ Highcharts.Pointer.prototype = {
         hoverPoint = hoverData.hoverPoint;
         points = hoverData.hoverPoints;
         hoverSeries = hoverData.hoverSeries;
-        followPointer = hoverSeries && hoverSeries.tooltipOptions.followPointer;
+        followPointer = (
+            e && e.type === 'touchmove' ?
+            pointer.followTouchMove === true :
+            hoverSeries && hoverSeries.tooltipOptions.followPointer
+        );
         useSharedTooltip = (
             shared &&
             hoverSeries &&

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -308,6 +308,7 @@ H.Tooltip.prototype = {
     getAnchor: function (points, mouseEvent) {
         var ret,
             chart = this.chart,
+            pointer = chart.pointer,
             inverted = chart.inverted,
             plotTop = chart.plotTop,
             plotLeft = chart.plotLeft,
@@ -318,21 +319,27 @@ H.Tooltip.prototype = {
 
         points = splat(points);
 
-        // Pie uses a special tooltipPos
-        ret = points[0].tooltipPos;
-
         // When tooltip follows mouse, relate the position to the mouse
-        if (this.followPointer && mouseEvent) {
+        if (
+            (this.followPointer && mouseEvent) ||
+            (
+                pointer.followTouchMove &&
+                mouseEvent &&
+                mouseEvent.type === 'touchmove'
+            )
+        ) {
             if (mouseEvent.chartX === undefined) {
-                mouseEvent = chart.pointer.normalize(mouseEvent);
+                mouseEvent = pointer.normalize(mouseEvent);
             }
             ret = [
                 mouseEvent.chartX - chart.plotLeft,
                 mouseEvent.chartY - plotTop
             ];
-        }
+        // Pie uses a special tooltipPos
+        } else if (points[0].tooltipPos) {
+            ret = points[0].tooltipPos;
         // When shared, use the average position
-        if (!ret) {
+        } else {
             each(points, function (point) {
                 yAxis = point.series.yAxis;
                 xAxis = point.series.xAxis;


### PR DESCRIPTION
…e is enabled.

# Description
`tooltip.followTouchMove` was ignored when dragging.

# Related issue(s)
- Closes #7484