### PR TITLE
Improvements to playing field and spiral in Wordcloud

### DIFF
--- a/js/modules/wordcloud.src.js
+++ b/js/modules/wordcloud.src.js
@@ -103,7 +103,7 @@ var archimedeanSpiral = function archimedeanSpiral(attempt, params) {
     var field = params.field,
         result = false,
         maxDelta = (field.width * field.width) + (field.height * field.height),
-        t = attempt * 0.2;
+        t = attempt * 0.8; // 0.2 * 4 = 0.8. Enlarging the spiral.
     // Emergency brake. TODO make spiralling logic more foolproof.
     if (attempt <= 10000) {
         result = {
@@ -126,7 +126,8 @@ var archimedeanSpiral = function archimedeanSpiral(attempt, params) {
  * should be dropped from the visualization.
  */
 var squareSpiral = function squareSpiral(attempt) {
-    var k = Math.ceil((Math.sqrt(attempt) - 1) / 2),
+    var a = attempt * 4,
+        k = Math.ceil((Math.sqrt(a) - 1) / 2),
         t = 2 * k + 1,
         m = Math.pow(t, 2),
         isBoolean = function (x) {
@@ -135,31 +136,31 @@ var squareSpiral = function squareSpiral(attempt) {
         result = false;
     t -= 1;
     if (attempt <= 10000) {
-        if (isBoolean(result) && attempt >= m - t) {
+        if (isBoolean(result) && a >= m - t) {
             result = {
-                x: k - (m - attempt),
+                x: k - (m - a),
                 y: -k
             };
         }
         m -= t;
-        if (isBoolean(result) && attempt >= m - t) {
+        if (isBoolean(result) && a >= m - t) {
             result = {
                 x: -k,
-                y: -k + (m - attempt)
+                y: -k + (m - a)
             };
         }
 
         m -= t;
         if (isBoolean(result)) {
-            if (attempt >= m - t) {
+            if (a >= m - t) {
                 result = {
-                    x: -k + (m - attempt),
+                    x: -k + (m - a),
                     y: k
                 };
             } else {
                 result = {
                     x: k,
-                    y: k - (m - attempt - t)
+                    y: k - (m - a - t)
                 };
             }
         }
@@ -339,7 +340,6 @@ var intersectionTesting = function intersectionTesting(point, options) {
         polygon = options.polygon,
         spiral = options.spiral,
         attempt = 1,
-        interval = 4,
         delta = {
             x: 0,
             y: 0
@@ -362,7 +362,7 @@ var intersectionTesting = function intersectionTesting(point, options) {
             outsidePlayingField(rect, field)
         ) && delta !== false
     ) {
-        delta = spiral(interval * attempt, {
+        delta = spiral(attempt, {
             field: field
         });
         if (isObject(delta)) {

--- a/js/modules/wordcloud.src.js
+++ b/js/modules/wordcloud.src.js
@@ -233,13 +233,14 @@ var getPlayingField = function getPlayingField(
 ) {
     var ratio = targetWidth / targetHeight,
         info = reduce(data, function (obj, point) {
-            var dimensions = point.dimensions;
+            var dimensions = point.dimensions,
+                x = Math.max(dimensions.width, dimensions.height);
             // Find largest height.
             obj.maxHeight = Math.max(obj.maxHeight, dimensions.height);
             // Find largest width.
             obj.maxWidth = Math.max(obj.maxWidth, dimensions.width);
-            // Sum up the total area of all the words.
-            obj.area += dimensions.width * dimensions.height;
+            // Sum up the total maximum area of all the words.
+            obj.area += x * x;
             return obj;
         }, {
             maxHeight: 0,
@@ -249,9 +250,13 @@ var getPlayingField = function getPlayingField(
         /**
          * Use largest width, largest height, or root of total area to give size
          * to the playing field.
-         * Add extra 100 percentage to ensure enough space.
          */
-        x = 1.1 * Math.max(info.maxHeight, info.maxWidth, Math.sqrt(info.area));
+        x = Math.max(
+            info.maxHeight, // Have enough space for the tallest word
+            info.maxWidth, // Have enough space for the broadest word
+            // Adjust 15% to account for close packing of words
+            Math.sqrt(info.area) * 0.85
+        );
     return {
         width: x * ratio,
         height: x,

--- a/js/modules/wordcloud.src.js
+++ b/js/modules/wordcloud.src.js
@@ -183,7 +183,8 @@ var rectangularSpiral = function rectangularSpiral(attempt, params) {
     var result = squareSpiral(attempt, params),
         field = params.field;
     if (result) {
-        result.x *= field.ratio;
+        result.x *= field.ratioX;
+        result.y *= field.ratioY;
     }
     return result;
 };
@@ -233,8 +234,7 @@ var getPlayingField = function getPlayingField(
     targetHeight,
     data
 ) {
-    var ratio = targetWidth / targetHeight,
-        info = reduce(data, function (obj, point) {
+    var info = reduce(data, function (obj, point) {
             var dimensions = point.dimensions,
                 x = Math.max(dimensions.width, dimensions.height);
             // Find largest height.
@@ -258,11 +258,14 @@ var getPlayingField = function getPlayingField(
             info.maxWidth, // Have enough space for the broadest word
             // Adjust 15% to account for close packing of words
             Math.sqrt(info.area) * 0.85
-        );
+        ),
+        ratioX = targetWidth > targetHeight ? targetWidth / targetHeight : 1,
+        ratioY = targetHeight > targetWidth ? targetHeight / targetWidth : 1;
     return {
-        width: x * ratio,
-        height: x,
-        ratio: ratio
+        width: x * ratioX,
+        height: x * ratioY,
+        ratioX: ratioX,
+        ratioY: ratioY
     };
 };
 

--- a/js/modules/wordcloud.src.js
+++ b/js/modules/wordcloud.src.js
@@ -210,8 +210,8 @@ var getRandomPosition = function getRandomPosition(size) {
 var getScale = function getScale(targetWidth, targetHeight, field) {
     var height = Math.max(Math.abs(field.top), Math.abs(field.bottom)) * 2,
         width = Math.max(Math.abs(field.left), Math.abs(field.right)) * 2,
-        scaleX = 1 / width * targetWidth,
-        scaleY = 1 / height * targetHeight;
+        scaleX = width > 0 ? 1 / width * targetWidth : 1,
+        scaleY = height > 0 ? 1 / height * targetHeight : 1;
     return Math.min(scaleX, scaleY);
 };
 


### PR DESCRIPTION
# Description
Adjusted the calculation of the playing field to avoid it beeing to small for all the words, and still not so large that there is a lot of empty space in the wordcloud.

Also introduced caching of the resulting positions from the spiral algorithm to improve performance a little.

# Related issue(s)
- Closes #8184
- Closes #8565

# Demo
- [Example from #8184](https://jsfiddle.net/5vm379kn/)
- [Example from #8565](http://jsfiddle.net/4m8zgjde/2/)