### PR TITLE
Removed option axis.pointProperty from grid axis.

### DIFF
--- a/samples/gantt/grid-axis/left-axis-as-table/demo.js
+++ b/samples/gantt/grid-axis/left-axis-as-table/demo.js
@@ -49,35 +49,41 @@ Highcharts.chart('container', {
             columns: [{
                 title: {
                     text: 'Project'
-                },
-                pointProperty: 'name'
+                }
             }, {
                 title: {
                     text: 'Assignee'
                 },
-                pointProperty: 'assignee'
+                labels: {
+                    format: '{point.assignee}'
+                }
             }, {
                 title: {
                     text: 'Est. days'
                 },
-                pointProperty: function (point) {
-                    var number = (point.x2 - point.x) / (1000 * 60 * 60 * 24);
-                    return Math.round(number * 100) / 100;
-                },
-                dataType: 'linear'
+                labels: {
+                    formatter: function () {
+                        var point = this.point,
+                            days = (1000 * 60 * 60 * 24),
+                            number = (point.x2 - point.x) / days;
+                        return Math.round(number * 100) / 100;
+                    }
+                }
             }, {
+                labels: {
+                    format: '{point.x:%e. %b}'
+                },
                 title: {
                     text: 'Start date'
-                },
-                pointProperty: 'x',
-                dataType: 'datetime'
+                }
             }, {
                 title: {
                     text: 'End date'
                 },
                 offset: 30,
-                pointProperty: 'x2',
-                dataType: 'datetime'
+                labels: {
+                    format: '{point.x2:%e. %b}'
+                }
             }]
         }
     },


### PR DESCRIPTION
# Description
Removed option `axis.pointProperty` from grid axis, and exposed `point` on `this` in the `axis.labels.formatter` instead. This is more aligned with how formatting of labels already works.

The existing option structure:
```javascript
yAxis: {
  pointProperty: 'name'
}
```
can now be achieved with the following:
```javascript
yAxis: {
  labels: {
    format: '{point.name}'
  }
}
```

# Demo(s)
- [Copy of samples\gantt\grid-axis\left-axis-as-table](http://jsfiddle.net/d8ewq7yc/2/)