### PR TITLE
bugfix/8024-waterfall-connectors-not-visible

### DIFF
--- a/js/parts-more/WaterfallSeries.js
+++ b/js/parts-more/WaterfallSeries.js
@@ -261,6 +261,9 @@ seriesType('waterfall', 'column', {
                     point.minPointLengthOffset = halfMinPointLength;
                 }
             } else {
+                if (point.isNull) {
+                    shapeArgs.width = 0;
+                }
                 point.minPointLengthOffset = 0;
             }
 

--- a/samples/unit-tests/series-waterfall/null-value/demo.details
+++ b/samples/unit-tests/series-waterfall/null-value/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series-waterfall/null-value/demo.html
+++ b/samples/unit-tests/series-waterfall/null-value/demo.html
@@ -1,0 +1,8 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/series-waterfall/null-value/demo.js
+++ b/samples/unit-tests/series-waterfall/null-value/demo.js
@@ -1,0 +1,25 @@
+QUnit.test('The connector line in waterfall in case of a null value (#8024)', function (assert) {
+    var chart = Highcharts.chart('container', {
+            series: [{
+                type: 'waterfall',
+                data: [120000, null, 231000, -342000, -233000]
+            }]
+        }),
+        splittedPath = chart.series[0].graph.d.split(' '),
+        startPoint = [splittedPath[4], splittedPath[5]],
+        endPoint = [splittedPath[7], splittedPath[8]];
+
+    // Test: the eqality of path's x coordinate of points next to each other
+    assert.strictEqual(
+        startPoint[0],
+        endPoint[0],
+        'The x coordinates are equal.'
+    );
+
+    // Test: the eqality of path's y coordinate of points next to each other
+    assert.strictEqual(
+        startPoint[1],
+        endPoint[1],
+        'The y coordinates are equal.'
+    );
+});


### PR DESCRIPTION
Fixed #8024, Empty gap in connector line in place of a null value.