### PR TITLE
bugfix/8638-nulls-proximate-legend

### DIFF
--- a/js/parts/Legend.js
+++ b/js/parts/Legend.js
@@ -688,7 +688,8 @@ Highcharts.Legend.prototype = {
                 height = item.legendGroup.getBBox().height;
                 boxes.push({
                     target: item.visible ?
-                        lastPoint.plotY - 0.3 * height :
+                        (lastPoint ? lastPoint.plotY : item.xAxis.height) -
+                            0.3 * height :
                         chart.plotHeight,
                     size: height,
                     item: item

--- a/samples/unit-tests/legend/layout/demo.js
+++ b/samples/unit-tests/legend/layout/demo.js
@@ -16,13 +16,17 @@ QUnit.test(
                 data: [2, 2, 2]
             }, {
                 data: [4, 4, 4]
+            }, {
+                data: [null, null, null] // #8638
             }]
         });
 
         chart.series.forEach(function (s) {
+            var y = s.points[2].plotY || s.yAxis.height;
+
             assert.close(
                 s.legendGroup.translateY,
-                chart.plotTop - chart.spacing[0] + s.points[2].plotY,
+                chart.plotTop - chart.spacing[0] + y,
                 20,
                 'Label should be next to last point'
             );


### PR DESCRIPTION
When all points are nullified, legend is rendered on bottom of the plotting area. 

In the future, can consider `yAxis.reversed` to render that legendItem on `yAxis.line`.