### PR TITLE
 hs7/tooltip-split-positioner

### DIFF
--- a/js/parts/Options.js
+++ b/js/parts/Options.js
@@ -2575,6 +2575,13 @@ H.defaultOptions = {
          * where the reference point is in the plot area. Add `chart.plotLeft`
          * and `chart.plotTop` to get the full coordinates.
          *
+         * Since v7, when [tooltip.split](#tooltip.split) option is enabled,
+         * positioner is called for each of the boxes separately, including
+         * xAxis header. xAxis header is not a point, instead `point` argument
+         * contains info:
+         * `{ plotX: Number, plotY: Number, isHeader: Boolean }`
+         *
+         *
          * The return should be an object containing x and y values, for example
          * `{ x: 100, y: 100 }`.
          *
@@ -2585,13 +2592,18 @@ H.defaultOptions = {
          *         A fixed tooltip position on top of the chart
          * @sample {highmaps} maps/tooltip/positioner/
          *         A fixed tooltip position
+         * @sample {highstock} stock/tooltip/split-positioner/
+         *         Split tooltip with fixed positions
          * @since 2.2.4
          * @apioption tooltip.positioner
          */
 
         /**
          * The name of a symbol to use for the border around the tooltip. Can
-         * be one of: `"callout"`, `"circle"` or `"square"`.
+         * be one of: `"callout"`, `"circle"` or `"square"`. When
+         * [tooltip.split](#tooltip.split) option is enabled, shape is applied
+         * to all boxes except header, which is controlled by
+         * [tooltip.headerShape](#tooltip.headerShape).
          *
          * Custom callbacks for symbol path generation can also be added to
          * `Highcharts.SVGRenderer.prototype.symbols` the same way as for
@@ -2602,6 +2614,25 @@ H.defaultOptions = {
          * @validvalue ["callout", "square"]
          * @since 4.0
          * @apioption tooltip.shape
+         */
+
+         /**
+         * The name of a symbol to use for the border around the tooltip
+         * header. Applies only when [tooltip.split](#tooltip.split) is
+         * enabled.
+         *
+         * Custom callbacks for symbol path generation can also be added to
+         * `Highcharts.SVGRenderer.prototype.symbols` the same way as for
+         * [series.marker.symbol](plotOptions.line.marker.symbol).
+         *
+         * @see [tooltip.shape](#tooltip.shape)
+         * @type {String}
+         * @default callout
+         * @sample {highstock} stock/tooltip/split-positioner/
+         *         Different shapes for header and split boxes
+         * @validvalue ["callout", "square"]
+         * @since 7.0
+         * @apioption tooltip.headerShape
          */
 
         /**

--- a/samples/stock/tooltip/split-positioner/demo.details
+++ b/samples/stock/tooltip/split-positioner/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Stock Demo
+ authors:
+   - Paweł Fus
+ js_wrap: b
+...

--- a/samples/stock/tooltip/split-positioner/demo.html
+++ b/samples/stock/tooltip/split-positioner/demo.html
@@ -1,0 +1,10 @@
+<script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
+
+<div id="container" style="height: 600px; min-width: 600px"></div>
+
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+<script src="https://code.highcharts.com/stock/modules/exporting.js"></script>
+
+<script src="https://code.highcharts.com/stock/indicators/indicators.js"></script>
+<script src="https://code.highcharts.com/stock/indicators/atr.js"></script>
+<script src="https://code.highcharts.com/stock/indicators/macd.js"></script>

--- a/samples/stock/tooltip/split-positioner/demo.js
+++ b/samples/stock/tooltip/split-positioner/demo.js
@@ -1,0 +1,103 @@
+$.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+
+    Highcharts.stockChart('container', {
+
+        tooltip: {
+            shape: 'square',
+            headerShape: 'callout',
+            borderWidth: 0,
+            shadow: false,
+            positioner: function (width, height, point) {
+                var chart = this.chart,
+                    position;
+
+                if (point.isHeader) {
+                    position = {
+                        x: Math.max(
+                            // Left side limit
+                            0,
+                            Math.min(
+                                point.plotX + chart.plotLeft - width / 2,
+                                // Right side limit
+                                chart.chartWidth - width - chart.marginRight
+                            )
+                        ),
+                        y: point.plotY
+                    };
+                } else {
+                    position = {
+                        x: point.series.chart.plotLeft,
+                        y: point.series.yAxis.top - chart.plotTop
+                    };
+                }
+
+                return position;
+            }
+        },
+
+        rangeSelector: {
+            selected: 2
+        },
+
+        yAxis: [{
+            height: '34%',
+            resize: {
+                enabled: true
+            },
+            labels: {
+                align: 'right',
+                x: -3
+            }
+        }, {
+            top: '34%',
+            height: '33%',
+            labels: {
+                align: 'right',
+                x: -3
+            },
+            offset: 0
+        }, {
+            top: '67%',
+            height: '33%',
+            labels: {
+                align: 'right',
+                x: -3
+            },
+            offset: 0
+        }],
+
+
+        series: [{
+            name: 'USD to EUR',
+            type: 'candlestick',
+            data: data,
+            id: 'usdeur',
+            tooltip: {
+                pointFormat: '<span style="color:{point.color}">●</span>' +
+                    '<b> {series.name} </b>' +
+                    'Open: {point.open} ' +
+                    'High: {point.high} ' +
+                    'Low: {point.low} ' +
+                    'Close: {point.close}'
+            }
+        }, {
+            type: 'sma',
+            linkedTo: 'usdeur'
+        }, {
+            type: 'atr',
+            yAxis: 1,
+            linkedTo: 'usdeur'
+        }, {
+            type: 'macd',
+            yAxis: 2,
+            linkedTo: 'usdeur',
+            tooltip: {
+                pointFormat: '<span style="color:{point.color}">●</span>' +
+                    '<b> {series.name} </b>' +
+                    'Value: {point.MACD} ' +
+                    'Signal: {point.signal} ' +
+                    'Histogram: {point.y}'
+            }
+        }]
+    });
+});

--- a/samples/stock/tooltip/split-positioner/test.js
+++ b/samples/stock/tooltip/split-positioner/test.js
@@ -1,0 +1,15 @@
+function test(chart) { // eslint-disable-line no-unused-vars
+    var point = chart.series[0].points[2],
+        offset = $(chart.container).offset();
+
+    chart.pointer.onContainerMouseMove({
+        type: 'mousemove',
+        pageX: point.plotX + chart.plotLeft + offset.left,
+        pageY: point.plotY + chart.plotTop + offset.top,
+        target: chart.container
+    });
+
+    chart.getSVG = function () {
+        return this.container.innerHTML;
+    };
+}


### PR DESCRIPTION
PR adds two features
- `tooltip.headerShape` to control shape of header when `tooltip.split = true`. For example we want rectangle boxes, but header should be rendered as anchored label (callout)
- `tooltip.positioner` is now called even when `split` is enabled. For each box, `tooltip.positioner` is called separately

Discussion points:
- at this moment, `tooltip.positioner` is called for `header` too. That may be confusing for users, and might be a problem for wrappers (to be confirmed - different arguments in the same callback for strong typing). Maybe `tooltip.headerPositioner` is a better idea? We already have `tooltip.headerFormat`, now added `tooltip.headerShape`, then `tooltip.headerPositioner` makes sense.

Demo: 
- [Tooltip box rendered in the top left corner of the pane](http://jsfiddle.net/BlackLabel/841k7wjn/43/)

Note:
- Even though docs says it's ready since v7, it's safe to merge it with v6 and release.