### PR TITLE
Fixed positioning of axis labels in an inverted Gantt chart

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -4232,6 +4232,9 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
                 widthOption = labelStyleOptions.width,
                 css = {};
             if (label) {
+                // This needs to go before the CSS in old IE (#4502)
+                label.attr(attr);
+
                 if (
                     commonWidth &&
                     !widthOption &&
@@ -4252,6 +4255,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
                             commonTextOverflow
                         );
                     }
+                    label.css(css);
 
                 // Reset previously shortened label (#8210)
                 } else if (
@@ -4260,10 +4264,8 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
                     !css.width &&
                     !widthOption
                 ) {
-                    css.width = null;
+                    label.css({ width: null });
                 }
-                // attr needs to go before the CSS in old IE (#4502)
-                label.attr(attr).css(css);
 
                 delete label.specificTextOverflow;
                 tick.rotation = attr.rotation;

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -3949,8 +3949,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
                 options[prefix + 'Width'],
                 prefix === 'tick' && this.isXAxis ? 1 : 0 // X axis default 1
             );
-
-        if (tickWidth && tickLength) {
+        if (isNumber(tickWidth) && isNumber(tickLength)) {
             // Negate the length
             if (options[prefix + 'Position'] === 'inside') {
                 tickLength = -tickLength;
@@ -4233,9 +4232,6 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
                 widthOption = labelStyleOptions.width,
                 css = {};
             if (label) {
-                // This needs to go before the CSS in old IE (#4502)
-                label.attr(attr);
-
                 if (
                     commonWidth &&
                     !widthOption &&
@@ -4256,7 +4252,6 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
                             commonTextOverflow
                         );
                     }
-                    label.css(css);
 
                 // Reset previously shortened label (#8210)
                 } else if (
@@ -4265,8 +4260,10 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
                     !css.width &&
                     !widthOption
                 ) {
-                    label.css({ width: null });
+                    css.width = null;
                 }
+                // attr needs to go before the CSS in old IE (#4502)
+                label.attr(attr).css(css);
 
                 delete label.specificTextOverflow;
                 tick.rotation = attr.rotation;
@@ -4726,7 +4723,8 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
             if (!ticks[pos]) {
                 ticks[pos] = new Tick(this, pos);
             }
-
+            // NOTE this seems like overkill. Could be handled in tick.render by
+            // setting old position in attr, then set new position in animate.
             // render new ticks in old position
             if (slideInTicks && ticks[pos].isNew) {
                 // Start with negative opacity so that it is visible from

--- a/samples/unit-tests/gantt/grid-axis-stock/demo.js
+++ b/samples/unit-tests/gantt/grid-axis-stock/demo.js
@@ -820,7 +820,9 @@ QUnit.test('Horizontal axis tick labels centered', function (assert) {
         }]
     });
 
-    axes = chart.xAxis;
+    axes = Highcharts.grep(chart.xAxis, function (axis) {
+        return !axis.isNavigatorAxis();
+    });
 
     Highcharts.each(axes, function (axis) {
         var axisType = axis.options.type || 'linear',

--- a/samples/unit-tests/gantt/grid-axis/demo.js
+++ b/samples/unit-tests/gantt/grid-axis/demo.js
@@ -741,7 +741,9 @@ QUnit.test('Horizontal axis tick labels centered', function (assert) {
         }]
     });
 
-    axes = chart.xAxis;
+    axes = Highcharts.grep(chart.xAxis, function (axis) {
+        return !axis.isNavigatorAxis();
+    });
 
     Highcharts.each(axes, function (axis) {
         var axisType = axis.options.type || 'linear',


### PR DESCRIPTION
# Description
Positioning of axis labels was incorrect in Gantt when the chart was inverted. To fix this I did a refactor of the `getLabelPosition` in GridAxis. 

# Related issue(s)
- Related to #8525