### PR TITLE
Fix error when panes is null

### DIFF
--- a/js/parts-more/Polar.js
+++ b/js/parts-more/Polar.js
@@ -624,6 +624,9 @@ if (!H.polarExtended) {
     });
 
     H.addEvent(H.Chart, 'afterDrawChartBox', function () {
+        if (!this.pane) {
+            this.pane = [];
+        }
         each(this.pane, function (pane) {
             pane.render();
         });


### PR DESCRIPTION
# Description

I'm rendering a chart in my UI and the chart appears fine. However when I open an unrelated modal in my UI with the chart still showing behind the modal the UI crashes with the following error:

```
react-dom.production.min.js:188 TypeError: Array.prototype.forEach called on null or undefined
    at forEach (<anonymous>)
    at t.each (highstock.js:28)
    at t.Chart.<anonymous> (highcharts-more.js:69)
    at highstock.js:31
    at Array.forEach (<anonymous>)
    at Object.t.each (highstock.js:28)
    at t.fireEvent (highstock.js:30)
    at t.Chart.drawChartBox (highstock.js:264)
    at t.Chart.redraw (highstock.js:248)
    at t.Chart.<anonymous> (highstock.js:533)
```

After digging through the minified code I discovered `this.pane` is ` null` when the error fires and thus my change simply sets this variable to an empty array when it runs into this case.