### PR TITLE
bugfix/treemap-missing-parent-breaks

### DIFF
--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -22,6 +22,7 @@ var seriesType = H.seriesType,
     getColor = mixinTreeSeries.getColor,
     getLevelOptions = mixinTreeSeries.getLevelOptions,
     grep = H.grep,
+    isArray = H.isArray,
     isBoolean = function (x) {
         return typeof x === 'boolean';
     },
@@ -527,18 +528,22 @@ seriesType('treemap', 'scatter', {
      * Creates an object map from parent id to childrens index.
      * @param {Array} data List of points set in options.
      * @param {string} data[].parent Parent id of point.
-     * @param {Array} ids List of all point ids.
+     * @param {Array} existingIds List of all point ids.
      * @return {Object} Map from parent id to children index in data.
      */
-    getListOfParents: function (data, ids) {
-        var listOfParents = reduce(data || [], function (prev, curr, i) {
-            var parent = pick(curr.parent, '');
-            if (prev[parent] === undefined) {
-                prev[parent] = [];
-            }
-            prev[parent].push(i);
-            return prev;
-        }, {});
+    getListOfParents: function (data, existingIds) {
+        var arr = isArray(data) ? data : [],
+            ids = isArray(existingIds) ? existingIds : [],
+            listOfParents = reduce(arr, function (prev, curr, i) {
+                var parent = pick(curr.parent, '');
+                if (prev[parent] === undefined) {
+                    prev[parent] = [];
+                }
+                prev[parent].push(i);
+                return prev;
+            }, {
+                '': [] // Root of tree
+            });
 
         // If parent does not exist, hoist parent to root of tree.
         eachObject(listOfParents, function (children, parent, list) {

--- a/samples/unit-tests/series-treemap/members/demo.js
+++ b/samples/unit-tests/series-treemap/members/demo.js
@@ -7,6 +7,52 @@ QUnit.test('directTouch', function (assert) {
     );
 });
 
+QUnit.test('getListOfParents', function (assert) {
+    var series = Highcharts.seriesTypes.treemap,
+        getListOfParents = series.prototype.getListOfParents;
+
+    assert.deepEqual(
+        getListOfParents(),
+        {
+            '': []
+        },
+        'should return map with only root node when no parameters are provided.'
+    );
+
+    assert.deepEqual(
+        getListOfParents(true, ['random-id']),
+        {
+            '': []
+        },
+        'should return map with only root node when data is invalid.'
+    );
+
+    assert.deepEqual(
+        getListOfParents([{ parent: 'non-existing' }], true),
+        {
+            '': [0]
+        },
+        'should hoist all points to root node if existingIds is invalid.'
+    );
+
+    assert.deepEqual(
+        getListOfParents([{ parent: 'non-existing' }], ['exists']),
+        {
+            '': [0]
+        },
+        'should hoist point to root node if parent does not exist.'
+    );
+
+    assert.deepEqual(
+        getListOfParents([{ parent: 'exists' }], ['exists']),
+        {
+            '': [],
+            'exists': [0]
+        },
+        'should add point under parent when it exists.'
+    );
+});
+
 QUnit.test('seriesTypes.treemap.pointClass.setState', function (assert) {
     var series = Highcharts.seriesTypes.treemap,
         setState = series.prototype.pointClass.prototype.setState,


### PR DESCRIPTION
# Description
If there is no point in the series data with a matching id of the one set as parent id on another point, then treemap will crash.

# Example(s)
- Example where the issue is fixed http://jsfiddle.net/jon_a_nygaard/gkjvzn41/17/
- Example where it is broken https://jsfiddle.net/gkjvzn41/4/

# Related issue(s)
- Discovered in #8756 
