### PR TITLE
Document the relationship between ordinal:false and gapSize

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -1380,7 +1380,8 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
          * regardless of the actual time or x distance between them. This means
          * that missing data periods (e.g. nights or weekends for a stock chart)
          * will not take up space in the chart.
-         * Having `ordinal: false` will ignore the `gapSize` setting in series.
+         * Having `ordinal: false` will show any gaps created by the `gapSize`
+         * setting proportionate to their duration.
          *
          * @sample {highstock} stock/xaxis/ordinal-true/
          *         True by default

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -1378,8 +1378,9 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
         /**
          * In an ordinal axis, the points are equally spaced in the chart
          * regardless of the actual time or x distance between them. This means
-         * that missing data for nights or weekends will not take up space in
-         * the chart.
+         * that missing data periods (e.g. nights or weekends for a stock chart)
+         * will not take up space in the chart.
+         * Having `ordinal: false` will ignore the `gapSize` setting in series.
          *
          * @sample {highstock} stock/xaxis/ordinal-true/
          *         True by default


### PR DESCRIPTION
This is my understanding; feel free to change.

Also, the documentation for gapSize should be updated to reflect the relationship with `ordinal: false`.