### PR TITLE
Bugfix/treegrid uniquenames

### DIFF
--- a/js/parts-gantt/TreeGrid.js
+++ b/js/parts-gantt/TreeGrid.js
@@ -277,7 +277,7 @@ var onTickHoverExit = function (label) {
  * categories, and y-values of points based on the tree.
  * @param {Array} data All the data points to display in the axis.
  * @param {boolean} uniqueNames Wether or not the data node with the same name
- * should share grid cell. If true they do not share cell. False by default.
+ * should share grid cell. If true they do share cell. False by default.
  * @returns {object} Returns an object containing categories, mapOfIdToNode,
  * mapOfPosToGridNode, and tree.
  * @todo There should be only one point per line.
@@ -290,7 +290,7 @@ var getTreeGridFromData = function (data, uniqueNames, numberOfSeries) {
         mapOfIdToNode = {},
         mapOfPosToGridNode = {},
         posIterator = -1,
-        uniqueNamesEnabled = isBoolean(uniqueNames) ? uniqueNames : true,
+        uniqueNamesEnabled = isBoolean(uniqueNames) ? uniqueNames : false,
         tree,
         treeParams,
         updateYValuesAndTickPos;
@@ -330,7 +330,7 @@ var getTreeGridFromData = function (data, uniqueNames, numberOfSeries) {
 
             // If not unique names, look for a sibling node with the same name.
             if (
-                !uniqueNamesEnabled &&
+                uniqueNamesEnabled &&
                 isObject(parentGridNode) &&
                 !!(gridNode = find(parentGridNode.children, hasSameName))
             ) {
@@ -451,7 +451,8 @@ override(GridAxis.prototype, {
                 },
                 labels: {
                     align: 'left'
-                }
+                },
+                uniqueNames: false
             }, userOptions, { // User options
                 // Forced options
                 reversed: true
@@ -737,7 +738,7 @@ GridAxis.prototype.updateYNames = function () {
                 });
 
                 // Increment series index
-                if (uniqueNames === false) {
+                if (uniqueNames === true) {
                     numberOfSeries++;
                 }
             }
@@ -748,7 +749,7 @@ GridAxis.prototype.updateYNames = function () {
         treeGrid = getTreeGridFromData(
             data,
             uniqueNames,
-            (uniqueNames === false) ? numberOfSeries : 1
+            (uniqueNames === true) ? numberOfSeries : 1
         );
 
         // Assign values to the axis.

--- a/samples/gantt/treegrid-axis/uniquenames-true/demo.css
+++ b/samples/gantt/treegrid-axis/uniquenames-true/demo.css
@@ -1,0 +1,5 @@
+#container {
+    max-width: 800px;
+    height: 400px;
+    margin: 1em auto;
+}

--- a/samples/gantt/treegrid-axis/uniquenames-true/demo.details
+++ b/samples/gantt/treegrid-axis/uniquenames-true/demo.details
@@ -1,0 +1,6 @@
+---
+ name: TreeGrid Demo
+ js_wrap: b
+ authors:
+   - Jon Arild Nygård
+...

--- a/samples/gantt/treegrid-axis/uniquenames-true/demo.html
+++ b/samples/gantt/treegrid-axis/uniquenames-true/demo.html
@@ -1,0 +1,4 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/treegrid.js"></script>
+
+<div id="container"></div>

--- a/samples/gantt/treegrid-axis/uniquenames-true/demo.js
+++ b/samples/gantt/treegrid-axis/uniquenames-true/demo.js
@@ -1,0 +1,70 @@
+var today = +(new Date().setHours(0, 0, 0, 0)),
+    msDay = 24 * 60 * 60 * 1000;
+
+// THE CHART
+Highcharts.chart('container', {
+    chart: {
+        type: 'scatter',
+        marginLeft: 150,
+        marginRight: 150
+    },
+    title: {
+        text: 'Highcharts TreeGrid'
+    },
+    xAxis: [{
+        type: 'datetime'
+    }],
+    yAxis: [{
+        title: '',
+        type: 'treegrid',
+        labels: {
+            align: 'left'
+        },
+        uniqueNames: true
+    }],
+    series: [{
+        name: 'Project 1',
+        data: [{
+            id: 'a1',
+            name: 'Node 1',
+            x: today
+        }, {
+            id: 'a2',
+            parent: 'a1',
+            name: 'Node 1.1',
+            x: today + 1 * msDay
+        }, {
+            id: 'a3',
+            parent: 'a2',
+            name: 'Node 1.1.1',
+            x: today + 2 * msDay
+        }, {
+            id: 'a4',
+            parent: 'a2',
+            name: 'Node 1.1.1',
+            x: today + 3 * msDay
+        }]
+    }, {
+        name: 'Project 2',
+        data: [{
+            id: 'b1',
+            name: 'Node 1',
+            x: today + 4 * msDay
+        }, {
+            id: 'b2',
+            parent: 'b1',
+            name: 'Node 1.2',
+            x: today + 5 * msDay
+        }, {
+            id: 'b3',
+            parent: 'b1',
+            name: 'Node 1.1',
+            x: today + 6 * msDay
+        }, {
+            id: 'b4',
+            parent: 'b2',
+            name: 'Node 1.2.1',
+            x: today + 7 * msDay
+        }]
+    }]
+});


### PR DESCRIPTION
# Description
Updated the treegrid `uniqueNames` option to behave more similar to `uniqueNames` in other axis types. 

When `true` the nodes on the same level with the same name, will share the same cell. The nodes belonging to the same series will be on the same line, the next series will be lined underneath.
When `false` the all the nodes will have a seperate cell.

The default value of `uniqueNames` in treegrid is set to `false`.

# Example(s)
- [treegrid.uniqueNames: false - by default](http://jsfiddle.net/jon_a_nygaard/ndbw6j53/)
- [treegrud.uniqueNames: true](http://jsfiddle.net/jon_a_nygaard/woa85xeq/)