### PR TITLE
bugfix/8777-some-polyfill

### DIFF
--- a/js/modules/oldie.src.js
+++ b/js/modules/oldie.src.js
@@ -146,9 +146,10 @@ if (!Array.prototype.some) {
 
         for (; i < len; i++) {
             if (fn.call(ctx, this[i], i, this) === true) {
-                return;
+                return true;
             }
         }
+        return false;
     };
 }
 


### PR DESCRIPTION
Addition to #8777, `H.somePolyfill()` was not returning the same value as `Array.prototype.some()`.

Docs:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some#Polyfill