### PR TITLE
Bugfix/7491-extend-playing-field

### DIFF
--- a/js/modules/wordcloud.src.js
+++ b/js/modules/wordcloud.src.js
@@ -18,6 +18,7 @@ var each = H.each,
     isNumber = H.isNumber,
     isObject = H.isObject,
     map = H.map,
+    merge = H.merge,
     find = H.find,
     reduce = H.reduce,
     getBoundingBoxFromPolygon = polygon.getBoundingBoxFromPolygon,
@@ -399,6 +400,34 @@ var intersectionTesting = function intersectionTesting(point, options) {
 };
 
 /**
+ * extendPlayingField - Extends the playing field to have enough space to fit a
+ * given word.
+ * @param {object} field The width, height and ratios of a playing field.
+ * @param {object} rectangle The bounding box of the word to add space for.
+ * @return Returns the extended playing field with updated height and width.
+ */
+var extendPlayingField = function extendPlayingField(field, rectangle) {
+    var height = (rectangle.bottom - rectangle.top),
+        width = (rectangle.right - rectangle.left),
+        ratioX = field.ratioX,
+        ratioY = field.ratioY,
+        // Use the same variable to extend both the height and width.
+        x = ((width * ratioX) > (height * ratioY)) ? width : height,
+        // Multiply variable with ratios to preserve aspect ratio.
+        extendWidth = x * ratioX,
+        extendHeight = x * ratioY,
+        // Calculate the size of the new field after adding space for the word.
+        extendedField = merge(field, {
+            // Add space on the left and right.
+            width: field.width + (extendWidth * 2),
+            // Add space on the top and bottom.
+            height: field.height + (extendHeight * 2)
+        });
+    // Return the new extended field.
+    return extendedField;
+};
+
+/**
  * updateFieldBoundaries - If a rectangle is outside a give field, then the
  * boundaries of the field is adjusted accordingly. Modifies the field object
  * which is passed as the first parameter.
@@ -443,6 +472,16 @@ var updateFieldBoundaries = function updateFieldBoundaries(field, rectangle) {
  * @optionparent plotOptions.wordcloud
  */
 var wordCloudOptions = {
+    /**
+     * If there is no space for a word on the playing field, then this option
+     * will allow the playing field to be extended to fit the word.
+     * If false then the word will be dropped from the visualization.
+     * NB! This option is currently not decided to be published in the API, and
+     * is therefore marked as private.
+     *
+     * @private
+     */
+    allowExtendPlayingField: true,
     animation: {
         duration: 500
     },
@@ -575,6 +614,7 @@ var wordCloudSeries = {
             group = series.group,
             options = series.options,
             animation = options.animation,
+            allowExtendPlayingField = options.allowExtendPlayingField,
             renderer = chart.renderer,
             testElement = renderer.text().add(group),
             placed = [],
@@ -670,6 +710,21 @@ var wordCloudSeries = {
                 }),
                 animate;
 
+            // If there is no space for the word, extend the playing field.
+            if (!delta && allowExtendPlayingField) {
+                // Extend the playing field to fit the word.
+                field = extendPlayingField(field, rectangle);
+
+                // Run intersection testing one more time to place the word.
+                delta = intersectionTesting(point, {
+                    rectangle: rectangle,
+                    polygon: polygon,
+                    field: field,
+                    placed: placed,
+                    spiral: spiral,
+                    rotation: placement.rotation
+                });
+            }
             /**
              * Check if point was placed, if so delete it,
              * otherwise place it on the correct positions.

--- a/js/modules/wordcloud.src.js
+++ b/js/modules/wordcloud.src.js
@@ -407,24 +407,34 @@ var intersectionTesting = function intersectionTesting(point, options) {
  * @return Returns the extended playing field with updated height and width.
  */
 var extendPlayingField = function extendPlayingField(field, rectangle) {
-    var height = (rectangle.bottom - rectangle.top),
-        width = (rectangle.right - rectangle.left),
-        ratioX = field.ratioX,
-        ratioY = field.ratioY,
+    var height, width, ratioX, ratioY, x, extendWidth, extendHeight, result;
+
+    if (isObject(field) && isObject(rectangle)) {
+        height = (rectangle.bottom - rectangle.top);
+        width = (rectangle.right - rectangle.left);
+        ratioX = field.ratioX;
+        ratioY = field.ratioY;
+
         // Use the same variable to extend both the height and width.
-        x = ((width * ratioX) > (height * ratioY)) ? width : height,
+        x = ((width * ratioX) > (height * ratioY)) ? width : height;
+
         // Multiply variable with ratios to preserve aspect ratio.
-        extendWidth = x * ratioX,
-        extendHeight = x * ratioY,
+        extendWidth = x * ratioX;
+        extendHeight = x * ratioY;
+
         // Calculate the size of the new field after adding space for the word.
-        extendedField = merge(field, {
+        result = merge(field, {
             // Add space on the left and right.
             width: field.width + (extendWidth * 2),
             // Add space on the top and bottom.
             height: field.height + (extendHeight * 2)
         });
+    } else {
+        result = field;
+    }
+
     // Return the new extended field.
-    return extendedField;
+    return result;
 };
 
 /**
@@ -828,6 +838,7 @@ var wordCloudSeries = {
         'square': squareSpiral
     },
     utils: {
+        extendPlayingField: extendPlayingField,
         getRotation: getRotation,
         isPolygonsColliding: isPolygonsColliding,
         rotate2DToOrigin: polygon.rotate2DToOrigin,

--- a/samples/unit-tests/series-wordcloud/members/demo.js
+++ b/samples/unit-tests/series-wordcloud/members/demo.js
@@ -49,6 +49,51 @@ QUnit.test('hasData', function (assert) {
     );
 });
 
+QUnit.test('extendPlayingField', function (assert) {
+    var wordcloudPrototype = Highcharts.seriesTypes.wordcloud.prototype,
+        extendPlayingField = wordcloudPrototype.utils.extendPlayingField,
+        field = {
+            width: 20,
+            height: 40,
+            ratioX: 1,
+            ratioY: 2
+        },
+        rectangle = {
+            left: -5,
+            right: 5,
+            top: -10,
+            bottom: 10
+        };
+
+    assert.deepEqual(
+        extendPlayingField(undefined, rectangle),
+        undefined,
+        'should return the existing field if parameter field is invalid.'
+    );
+
+    assert.deepEqual(
+        extendPlayingField(field, undefined),
+        {
+            width: 20,
+            height: 40,
+            ratioX: 1,
+            ratioY: 2
+        },
+        'should return the existing field if parameter rectangle is invalid.'
+    );
+
+    assert.deepEqual(
+        extendPlayingField(field, rectangle),
+        {
+            width: 60,
+            height: 120,
+            ratioX: 1,
+            ratioY: 2
+        },
+        'should return the existing field if parameter rectangle is invalid.'
+    );
+});
+
 QUnit.test('getRotation', function (assert) {
     var wordcloudPrototype = Highcharts.seriesTypes.wordcloud.prototype,
         getRotation = wordcloudPrototype.utils.getRotation;


### PR DESCRIPTION
# Description
In certain cases the playing field in a wordcloud will still be to small. To avoid this issue, the playing field will now be extended if there is not enough space for a word.

There is a new option added `allowExtendPlayingField`, it is however marked as private to hide it from the API. It was added for possible use in the future, in case some would prefer to turn off the added functionality.
# Example(s)
- [Example where issue is solved](http://jsfiddle.net/jon_a_nygaard/k4p5vo38/1/)
- [Example where issue exists](http://jsfiddle.net/BlackLabel/w9Lx2yv1/10/)

# Related issue(s)
- Closes https://github.com/highcharts/highcharts/issues/7491