### PR TITLE
bugfix/8652-wordcloud-ie11

### DIFF
--- a/js/mixins/polygon.js
+++ b/js/mixins/polygon.js
@@ -166,8 +166,8 @@ var getBoundingBoxFromPolygon = function (points) {
         return obj;
     }, {
         left: Number.MAX_VALUE,
-        right: Number.MIN_VALUE,
-        bottom: Number.MIN_VALUE,
+        right: -Number.MAX_VALUE,
+        bottom: -Number.MAX_VALUE,
         top: Number.MAX_VALUE
     });
 };


### PR DESCRIPTION
# Description
Wordcloud did not render in IE11 due to the use of `Number.MAX_SAFE_INTEGER` and `Number.MIN_SAFE_INTEGER`. Replaced them with the use of `Number.MAX_VALUE` and `Number.MIN_VALUE`.

# Example(s)
Follow https://github.com/highcharts/highcharts/issues/8652#issue-342800706 to reproduce issue.

# Related issue(s)
- Closes #8652