### PR TITLE
Fixed allowOverlap with multiple data labels.

### DIFF
--- a/js/modules/overlapping-datalabels.src.js
+++ b/js/modules/overlapping-datalabels.src.js
@@ -13,6 +13,7 @@ import '../parts/Chart.js';
  */
 var Chart = H.Chart,
     each = H.each,
+    isArray = H.isArray,
     objectEach = H.objectEach,
     pick = H.pick,
     addEvent = H.addEvent;
@@ -42,29 +43,25 @@ addEvent(Chart, 'render', function collectAndHide() {
     });
 
     each(this.series || [], function (series) {
-        var dlOptions = series.options.dataLabels;
-
-        if (
-            (dlOptions.enabled || series._hasPointLabels) &&
-            !dlOptions.allowOverlap &&
-            series.visible
-        ) { // #3866
+        if (series.visible) { // #3866
             each(series.points, function (point) {
-                if (point.dataLabels) {
-                    each(point.dataLabels, function (label) {
-                        label.labelrank = pick(
-                            point.labelrank,
-                            point.shapeArgs && point.shapeArgs.height
-                        ); // #4118
-                        labels.push(label);
-                    });
-                } else if (point.dataLabel) {
-                    point.dataLabel.labelrank = pick(
+                var dataLabels = (
+                    isArray(point.dataLabels) ?
+                    point.dataLabels :
+                    (point.dataLabel ? [point.dataLabel] : [])
+                );
+                each(dataLabels, function (label) {
+                    var options = label.options;
+                    label.labelrank = pick(
+                        options.labelrank,
                         point.labelrank,
                         point.shapeArgs && point.shapeArgs.height
                     ); // #4118
-                    labels.push(point.dataLabel);
-                }
+
+                    if (!options.allowOverlap) {
+                        labels.push(label);
+                    }
+                });
             });
         }
     });

--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -452,6 +452,9 @@ Series.prototype.drawDataLabels = function () {
                         attr.text = labelText;
                     }
 
+                    // Store data label options for later access
+                    dataLabel.options = labelOptions;
+
                     dataLabel.attr(attr);
                     /*= if (build.classic) { =*/
                     // Styles must be applied before add in order to read text


### PR DESCRIPTION
# Description
Modified `collectAndHide` in `overlapping-datalabels.src.js` to account for the new multiple data labels logic.

# Example(s)
- [Example of before fix](http://jsfiddle.net/jon_a_nygaard/3yufo9kg/)
- [Example of after fix](http://jsfiddle.net/jon_a_nygaard/r42w5cxf/)