### PR TITLE
Update the package.json api-docs reference to point to the remote

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "gulp": "^3.9.1",
     "gulp-jsdoc3": "^2.0.0",
     "gzip-size": "^3.0.0",
-    "highcharts-api-docs": "../api-docs",
+    "highcharts-api-docs": "github:highcharts/api-docs",
     "highcharts-assembler": "github:highcharts/highcharts-assembler#v1.0.27",
     "highcharts-docstrap": "github:highcharts/highcharts-docstrap",
     "husky": "^0.14.3",


### PR DESCRIPTION
Unsure if it was intentionally or unintentionally changed, but when doing an `npm install` without the api-docs repository in the parent directory, it will fail. It makes more sense to point this to the remote so that it clones correctly.

Steps to reproduce:
 1. Clone a clean copy of highcharts without api-docs in the parent directory
 2. run `npm install`

I checked the git history and it used to be like this without a version, but let me know if you would like this versioned!