### PR TITLE
Catch the removeDirectory error as to not break the gulp dist pipeline

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -415,9 +415,13 @@ const cleanCode = () => {
 };
 
 const cleanDist = () => {
-    return removeDirectory('./build/dist').then(() => {
-        console.log('Successfully removed dist directory.');
-    });
+    return removeDirectory('./build/dist')
+        .then(() => {
+            console.log('Successfully removed dist directory.');
+        })
+        .catch(() => {
+            console.log('Tried to remove ./build/dist but it was never there. Moving on...')
+        });
 };
 
 const cleanApi = () => {


### PR DESCRIPTION
When running gulp dist, it cleans out the build/dist by removing it but the highcharts-assembler throws an error if the directory you are removing is not there. This breaks the dist pipeline unless you create an empty build/dist folder. This PR introduces a catch statement for the error as to not break the pipeline.

Steps to reproduce:
 1. Have no `build` folder (this happens on a clean copy because it is in the `.gitignore`)
 2. Run `gulp dist` or just `gulp cleanDist`

The error:

```bash
[08:41:38] Finished 'compile' after 5m 30s 161ms
[08:41:38] Starting 'cleanDist'...
[08:41:38] 'dist' errored after 5.65 min
[08:41:38] Error: Directory does not exist: ./build/dist
    at Promise (jim-highcharts/node_modules/highcharts-assembler/src/utilities.js:119:12)
    at Promise (<anonymous>)
    at removeDirectory (jim-highcharts/node_modules/highcharts-assembler/src/utilities.js:108:33)
    at cleanDist (jim-highcharts/gulpfile.js:418:12)
    at jim-highcharts/gulpfile.js:640:27
    at <anonymous>
```

Let me know if you want different text in the console log!
