### PR TITLE
Fixed #8440, keyboard navigation in stock charts throwing errors.

### DIFF
--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -1250,14 +1250,14 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             menu = chart[cacheName],
             menuPadding = Math.max(width, height), // for mouse leave detection
             innerMenu,
-            hide,
             menuStyle;
 
         // create the menu only the first time
         if (!menu) {
 
             // create a HTML element above the SVG
-            chart[cacheName] = menu = createElement('div', {
+            chart.exportContextMenu = chart[cacheName] = menu =
+            createElement('div', {
                 className: className
             }, {
                 position: 'absolute',
@@ -1283,18 +1283,19 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             /*= } =*/
 
             // hide on mouse out
-            hide = function () {
+            menu.hideMenu = function () {
                 css(menu, { display: 'none' });
                 if (button) {
                     button.setState(0);
                 }
                 chart.openMenu = false;
+                H.clearTimeout(menu.hideTimer);
             };
 
             // Hide the menu some time after mouse leave (#1357)
             chart.exportEvents.push(
                 addEvent(menu, 'mouseleave', function () {
-                    menu.hideTimer = setTimeout(hide, 500);
+                    menu.hideTimer = setTimeout(menu.hideMenu, 500);
                 }),
                 addEvent(menu, 'mouseenter', function () {
                     H.clearTimeout(menu.hideTimer);
@@ -1304,13 +1305,13 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                 // #2335, #2407)
                 addEvent(doc, 'mouseup', function (e) {
                     if (!chart.pointer.inClass(e.target, className)) {
-                        hide();
+                        menu.hideMenu();
                     }
                 }),
 
                 addEvent(menu, 'click', function () {
                     if (chart.openMenu) {
-                        hide();
+                        menu.hideMenu();
                     }
                 })
             );
@@ -1335,7 +1336,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                                 if (e) { // IE7
                                     e.stopPropagation();
                                 }
-                                hide();
+                                menu.hideMenu();
                                 if (item.onclick) {
                                     item.onclick.apply(chart, arguments);
                                 }

--- a/js/modules/keyboard-navigation.src.js
+++ b/js/modules/keyboard-navigation.src.js
@@ -87,6 +87,29 @@ function stripTags(s) {
 
 
 /**
+ * Get the index of a point in a series. This is needed when using e.g. data
+ * grouping.
+ *
+ * @param {Point} point The point to find index of.
+ * @return {number} The index in the series.points array of the point.
+ */
+function getPointIndex(point) {
+    var index = point.index,
+        points = point.series.points,
+        i = points.length;
+    if (points[index] !== point) {
+        while (i--) {
+            if (points[i] === point) {
+                return i;
+            }
+        }
+    } else {
+        return index;
+    }
+}
+
+
+/**
  * Set default keyboard navigation options
  */
 H.setOptions({
@@ -343,17 +366,25 @@ function fakeClickEvent(element) {
 }
 
 
+// Determine if a series should be skipped
+function isSkipSeries(series) {
+    var a11yOptions = series.chart.options.accessibility;
+    return series.options.skipKeyboardNavigation ||
+        series.options.enableMouseTracking === false || // #8440
+        !series.visible ||
+        // Skip all points in a series where pointDescriptionThreshold is
+        // reached
+        (a11yOptions.pointDescriptionThreshold &&
+        a11yOptions.pointDescriptionThreshold <= series.points.length);
+}
+
+
 // Determine if a point should be skipped
 function isSkipPoint(point) {
     var a11yOptions = point.series.chart.options.accessibility;
     return point.isNull && a11yOptions.keyboardNavigation.skipNullPoints ||
-        point.series.options.skipKeyboardNavigation ||
-        !point.series.visible ||
         point.visible === false ||
-        // Skip all points in a series where pointDescriptionThreshold is
-        // reached
-        (a11yOptions.pointDescriptionThreshold &&
-        a11yOptions.pointDescriptionThreshold <= point.series.points.length);
+        isSkipSeries(point.series);
 }
 
 
@@ -471,7 +502,7 @@ H.Chart.prototype.highlightAdjacentPoint = function (next) {
     var chart = this,
         series = chart.series,
         curPoint = chart.highlightedPoint,
-        curPointIndex = curPoint && curPoint.index || 0,
+        curPointIndex = curPoint && getPointIndex(curPoint) || 0,
         curPoints = curPoint && curPoint.series.points,
         lastSeries = chart.series && chart.series[chart.series.length - 1],
         lastPoint = lastSeries && lastSeries.points &&
@@ -490,23 +521,13 @@ H.Chart.prototype.highlightAdjacentPoint = function (next) {
         newPoint = next ? series[0].points[0] : lastPoint;
     } else {
         // We have a highlighted point.
-        // Find index of current point in series.points array. Necessary for
-        // dataGrouping (and maybe zoom?)
-        if (curPoints[curPointIndex] !== curPoint) {
-            for (var i = 0; i < curPoints.length; ++i) {
-                if (curPoints[i] === curPoint) {
-                    curPointIndex = i;
-                    break;
-                }
-            }
-        }
-
         // Grab next/prev point & series
         newSeries = series[curPoint.series.index + (next ? 1 : -1)];
-        newPoint = curPoints[curPointIndex + (next ? 1 : -1)] ||
-                    // Done with this series, try next one
-                    newSeries &&
-                    newSeries.points[next ? 0 : newSeries.points.length - 1];
+        newPoint = curPoints[curPointIndex + (next ? 1 : -1)];
+        if (!newPoint && newSeries) {
+            // Done with this series, try next one
+            newPoint = newSeries.points[next ? 0 : newSeries.points.length - 1];
+        }
 
         // If there is no adjacent point, we return false
         if (!newPoint) {
@@ -514,9 +535,20 @@ H.Chart.prototype.highlightAdjacentPoint = function (next) {
         }
     }
 
-    // Recursively skip null points or points in series that should be skipped
+    // Recursively skip points
     if (isSkipPoint(newPoint)) {
-        chart.highlightedPoint = newPoint;
+        // If we skip this whole series, move to the end of the series before we
+        // recurse, just to optimize
+        newSeries = newPoint.series;
+        if (isSkipSeries(newSeries)) {
+            chart.highlightedPoint = next ?
+                newSeries.points[newSeries.points.length - 1] :
+                newSeries.points[0];
+        } else {
+            // Otherwise, just move one point
+            chart.highlightedPoint = newPoint;
+        }
+        // Retry
         return chart.highlightAdjacentPoint(next);
     }
 
@@ -530,7 +562,9 @@ H.Chart.prototype.highlightAdjacentPoint = function (next) {
 // use that as starting point.
 H.Series.prototype.highlightFirstValidPoint = function () {
     var curPoint = this.chart.highlightedPoint,
-        start = (curPoint && curPoint.series) === this ? curPoint.index : 0,
+        start = (curPoint && curPoint.series) === this ?
+            getPointIndex(curPoint) :
+            0,
         points = this.points;
 
     if (points) {
@@ -584,7 +618,7 @@ H.Chart.prototype.highlightAdjacentSeries = function (down) {
     }
 
     // New series and point exists, but we might want to skip it
-    if (!newSeries.visible) {
+    if (isSkipSeries(newSeries)) {
         // Skip the series
         newPoint.highlight();
         adjacentNewPoint = chart.highlightAdjacentSeries(down); // Try recurse
@@ -613,6 +647,9 @@ H.Chart.prototype.highlightAdjacentPointVertical = function (down) {
         return false;
     }
     each(this.series, function (series) {
+        if (isSkipSeries(series)) {
+            return;
+        }
         each(series.points, function (point) {
             if (point.plotY === undefined || point.plotX === undefined ||
                 point === curPoint) {
@@ -658,23 +695,20 @@ H.Chart.prototype.showExportMenu = function () {
 
 // Hide export menu
 H.Chart.prototype.hideExportMenu = function () {
-    var exportList = this.exportDivElements;
-    if (exportList) {
+    var chart = this,
+        exportList = chart.exportDivElements;
+    if (exportList && chart.exportContextMenu) {
+        // Reset hover states etc.
         each(exportList, function (el) {
-            fireEvent(el, 'mouseleave');
+            if (el.className === 'highcharts-menu-item' && el.onmouseout) {
+                el.onmouseout();
+            }
         });
-        if (
-            exportList[this.highlightedExportItem] &&
-            exportList[this.highlightedExportItem].onmouseout
-        ) {
-            exportList[this.highlightedExportItem].onmouseout();
-        }
-        this.highlightedExportItem = 0;
-        if (hasSVGFocusSupport) {
-            // Only focus if we can set focus back to the elements after
-            // destroying the menu (#7422)
-            this.renderTo.focus();
-        }
+        chart.highlightedExportItem = 0;
+        // Hide the menu div
+        chart.exportContextMenu.hideMenu();
+        // Make sure the chart has focus and can capture keyboard events
+        chart.container.focus();
     }
 };
 

--- a/samples/highcharts/accessibility/art-grants/demo.js
+++ b/samples/highcharts/accessibility/art-grants/demo.js
@@ -131,6 +131,9 @@ Highcharts.chart('container', {
         seriesDescriptionFormatter: function (series) {
             return series.type !== 'line' ? series.buildSeriesInfoString() :
                 series.name + ', ' + dollarFormat(series.points[0].y);
+        },
+        keyboardNavigation: {
+            mode: 'serialize'
         }
     },
 


### PR DESCRIPTION
Keyboard navigation on stock charts failed with errors in some cases. Caused by series with `enableMouseInteraction: false` (such as navigator series).

Fixing this bug immediately unearthed several others, so I added better handling of series that should be ignored by the module, and fixed issues with hiding the export menu when leaving it using the keyboard.

On the topic of hiding the export menu: It seems we currently store a reference to the context menu `div` on `chart['cache-' + className]`, where className can be configured by the user (https://github.com/highcharts/highcharts/compare/bugfix/8440-keyboard-navigation-stock#diff-8c6bf8acef37c90d2cc3aab9b3bf8258L1260). I didn't find any references to this outside of the export module. Any particular reason for the naming? I now added it to `chart.exportContextMenu` as well, in order to pick it up in the keyboard navigation module.