### PR TITLE
bugfix/8680-responsive-annotations

### DIFF
--- a/js/annotations/annotations.src.js
+++ b/js/annotations/annotations.src.js
@@ -82,6 +82,8 @@ var Annotation = H.Annotation = function (chart, options) {
      */
     this.controlPoints = [];
 
+    this.coll = 'annotations';
+
     /**
      * The array of labels which belong to the annotation.
      *
@@ -831,6 +833,13 @@ merge(
             destroyObjectProperties(this, chart);
         },
 
+        /**
+         * See {@link Highcharts.Annotation#destroy}.
+         */
+        remove: function () {
+            return this.destroy();
+        },
+
         update: function (userOptions) {
             var chart = this.chart,
                 options = H.merge(true, this.options, userOptions);
@@ -983,6 +992,9 @@ H.extendAnnotation = function (
  * EXTENDING CHART PROTOTYPE
  *
  ******************************************************************** */
+
+// Let chart.update() work with annotations
+H.Chart.prototype.collectionsWithUpdate.push('annotations');
 
 H.extend(H.Chart.prototype, /** @lends Highcharts.Chart# */ {
     initAnnotation: function (userOptions) {

--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -277,6 +277,19 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
     ],
 
     /**
+     * These collections (arrays) implement update() methods with support for
+     * one-to-one option.
+     */
+    collectionsWithUpdate: [
+        'xAxis',
+        'yAxis',
+        'zAxis',
+        'series',
+        'colorAxis',
+        'pane'
+    ],
+
+    /**
      * A generic function to update any element of the chart. Elements can be
      * enabled and disabled, moved, re-styled, re-formatted etc.
      *
@@ -428,14 +441,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         // update the first series in the chart. Setting two series without
         // an id will update the first and the second respectively (#6019)
         // chart.update and responsive.
-        each([
-            'xAxis',
-            'yAxis',
-            'zAxis',
-            'series',
-            'colorAxis',
-            'pane'
-        ], function (coll) {
+        each(this.collectionsWithUpdate, function (coll) {
             var indexMap;
 
             if (options[coll]) {

--- a/samples/unit-tests/responsive/responsive/demo.html
+++ b/samples/unit-tests/responsive/responsive/demo.html
@@ -1,6 +1,7 @@
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/stock/highcharts-more.js"></script>
 <script src="https://code.highcharts.com/stock/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/stock/modules/annotations.js"></script>
 
 
 <div id="qunit"></div>

--- a/samples/unit-tests/responsive/responsive/demo.js
+++ b/samples/unit-tests/responsive/responsive/demo.js
@@ -168,13 +168,25 @@ QUnit.test('Responsive on chart.update', function (assert) {
 });
 
 QUnit.test(
-    'Nested property names like series or xAxis (#6208)',
+    'Nested property names like series, xAxis or annotations (#6208, #8680)',
     function (assert) {
         var chart = Highcharts.chart('container', {
 
             chart: {
                 animation: false
             },
+
+            annotations: [{
+                labels: [{
+                    point: {
+                        xAxis: 0,
+                        yAxis: 0,
+                        x: 1,
+                        y: 3
+                    },
+                    text: 'Label'
+                }]
+            }],
 
             series: [{
                 data: [1, 4, 3],
@@ -204,6 +216,9 @@ QUnit.test(
                         },
                         series: [{
                             yAxis: 1
+                        }],
+                        annotations: [{
+                            visible: false
                         }]
                     }
                 }]
@@ -220,6 +235,11 @@ QUnit.test(
             chart.yAxis[0],
             'Initial axis'
         );
+        assert.strictEqual(
+            chart.annotations[0].graphic.visibility,
+            'visible',
+            'Initial annotation visible'
+        );
 
         chart.setSize(400);
 
@@ -232,6 +252,11 @@ QUnit.test(
             chart.series[0].yAxis,
             chart.yAxis[1],
             'Responsive axis'
+        );
+        assert.strictEqual(
+            chart.annotations[0].graphic.visibility,
+            'hidden',
+            'Initial annotation hidden'
         );
 
     }


### PR DESCRIPTION
### Note:
PR goes to **hs7 branch**, because on this branch `annotation.update()` has been implemented.