### PR TITLE
Tools: Add required semicolon in gulp.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -420,7 +420,7 @@ const cleanDist = () => {
             console.log('Successfully removed dist directory.');
         })
         .catch(() => {
-            console.log('Tried to remove ./build/dist but it was never there. Moving on...')
+            console.log('Tried to remove ./build/dist but it was never there. Moving on...');
         });
 };
 


### PR DESCRIPTION
Just a little fix of a syntax problem, that prevents every commit with latest master, because ESLint fails.