### PR TITLE
bugfix/oldie-indexof-polyfill

### DIFF
--- a/js/modules/oldie.src.js
+++ b/js/modules/oldie.src.js
@@ -105,15 +105,16 @@ if (!Array.prototype.forEach) {
 }
 
 if (!Array.prototype.indexOf) {
-    H.indexOfPolyfill = function (arr) {
-        var len,
-            i = 0;
+    H.indexOfPolyfill = function (member, fromIndex) {
+        var arr = this, // #8874
+            len,
+            i = fromIndex || 0; // #8346
 
         if (arr) {
             len = arr.length;
 
             for (; i < len; i++) {
-                if (arr[i] === this) {
+                if (arr[i] === member) {
                     return i;
                 }
             }


### PR DESCRIPTION
Fixed #8874, fixed #8346, Highcharts.indexOfPolyfill wasn't supporting all required arguments.