### PR TITLE
Bugfix: Add 'allow' label overflow option in addition to 'justify'.

### DIFF
--- a/js/modules/annotations.src.js
+++ b/js/modules/annotations.src.js
@@ -681,7 +681,7 @@ Annotation.prototype = /** @lends Highcharts.Annotation# */ {
              * How to handle the annotation's label that flow outside the plot
              * area. The justify option aligns the label inside the plot area.
              *
-             * @validvalue ["none", "justify"]
+             * @validvalue ["allow", "justify"]
              * @sample highcharts/annotations/label-crop-overflow/
              *         Crop or justify labels
              **/

--- a/js/parts/Tick.js
+++ b/js/parts/Tick.js
@@ -161,7 +161,10 @@ H.Tick.prototype = {
 
         // Check if the label overshoots the chart spacing box. If it does, move
         // it. If it now overshoots the slotWidth, add ellipsis.
-        if (!rotation && labelOptions.overflow !== false) {
+        if (!rotation &&
+            labelOptions.overflow !== false &&
+            labelOptions.overflow !== 'allow'
+        ) {
             leftPos = pxPos - factor * labelWidth;
             rightPos = pxPos + (1 - factor) * labelWidth;
 

--- a/js/parts/Tick.js
+++ b/js/parts/Tick.js
@@ -161,10 +161,7 @@ H.Tick.prototype = {
 
         // Check if the label overshoots the chart spacing box. If it does, move
         // it. If it now overshoots the slotWidth, add ellipsis.
-        if (!rotation &&
-            labelOptions.overflow !== false &&
-            labelOptions.overflow !== 'allow'
-        ) {
+        if (!rotation && pick(labelOptions.overflow, 'justify') === 'justify') {
             leftPos = pxPos - factor * labelWidth;
             rightPos = pxPos + (1 - factor) * labelWidth;
 


### PR DESCRIPTION
This includes in combination with other branches the following changes:

- annotations.labelOptions.overflow: "allow" | "justify" (previously: "justify" | "none")
- series.dataLabels.overflow: "allow" | "justify" (previously: "justify" | "none")
- xAxis.labels.overflow: "allow" | "justify" (previously: "justify" | false)

In all cases the default behaviour continues to be "justify", and "allow" requires to disable crop.