### PR TITLE
bugfix/7051-datagrouping-week

### DIFF
--- a/js/parts/DataGrouping.js
+++ b/js/parts/DataGrouping.js
@@ -505,7 +505,20 @@ seriesProto.groupData = function (xData, yData, groupPositions, approximation) {
 
     // Start with the first point within the X axis range (#2696)
     for (i = 0; i <= dataLength; i++) {
-        if (xData[i] >= groupPositions[0]) {
+        var diff = xData[i] - groupPositions[0];
+        if (diff >= 0) {
+            break;
+        } else if (
+            groupPositions.info.unitName === 'week' &&
+            diff > -groupPositions.info.unitRange / 7
+        ) {
+            // Add an extra position before first position, becasue
+            // getTimeTicks trims first position if it starts on Sunday (#7051)
+            groupPositions.splice(
+                0,
+                0,
+                groupPositions[0] - groupPositions.info.unitRange
+            );
             break;
         }
     }

--- a/samples/unit-tests/series/datagrouping/demo.js
+++ b/samples/unit-tests/series/datagrouping/demo.js
@@ -296,3 +296,37 @@ QUnit.test('Switch from grouped to non-grouped', function (assert) {
     );
 
 });
+
+QUnit.test('Weekly grouped data should not trim Sunday points (#7051)', function (assert) {
+    var chart = Highcharts.stockChart('container', {
+        series: [{
+            dataGrouping: {
+                forced: true,
+                units: [
+                    ['week', [1]]
+                ]
+            },
+            data: [
+                [1313964000000, 23.17],
+                [1314050400000, 23.78],
+                [1314136800000, 24.10],
+                [1314223200000, 23.86],
+                [1314309600000, 24.54],
+                [1314568800000, 25.51],
+                [1314655200000, 25.19],
+                [1314741600000, 25.24],
+                [1314828000000, 24.77],
+                [1314914400000, 24.15],
+                [1315260000000, 23.74],
+                [1315346400000, 25.30],
+                [1315432800000, 24.99]
+            ]
+        }]
+    });
+
+    assert.strictEqual(
+        chart.series[0].processedXData.join(','),
+        '1313366400000,1313971200000,1314576000000,1315180800000',
+        'All points rendered'
+    );
+});


### PR DESCRIPTION
I did it 😄 

The problem is for all our build-in data grouping for weeks (under specific conditions, first grouped point is never calculated&rendered). What happens:

When calculating `groupPositions` for weeks, we start on Monday (`startOfWeek = 1`), so any datapoint (on the beginning of the dataset) that is placed in a previous day will not create extra group, because we translate this min-date back in `getTimeTicks` to Monday here:

https://github.com/highcharts/highcharts/blob/5980b76465ea293a88ccf982fe42fff4aff8c536/js/parts/Time.js#L701-L712

For example: `minDay` is Sunday, so translation goes back to Monday, always:
```
         ( 
             time.get('Date', minDate) -  // any Sunday date
             time.get('Day', minDate) + // returns 0 !
             pick(startOfWeek, 1)  // 1
         ) 
```

Known visual tests that fail (and should fail):
- http://utils.highcharts.local/samples/#test/stock/issues/2696 - chart is no longer disconnected
- http://utils.highcharts.local/samples/#test/stock/issues/datagrouping-series - first point in dataset is actually `new Date(1388538000000) -> Wed Jan 01 2014 02:00:00 GMT+0100 (Central European Standard Time)` and was never rendered 😄