### PR TITLE
bugfix/7051-gettimeticks-missing-week

### DIFF
--- a/js/parts/Time.js
+++ b/js/parts/Time.js
@@ -630,7 +630,10 @@ Highcharts.Time.prototype = {
             minDate = new Date(min),
             interval = normalizedInterval.unitRange,
             count = normalizedInterval.count || 1,
-            variableDayLength;
+            variableDayLength,
+            minDay;
+
+        startOfWeek = pick(startOfWeek, 1);
 
         if (defined(min)) { // #1300
             time.set(
@@ -700,13 +703,16 @@ Highcharts.Time.prototype = {
             // week is a special case that runs outside the hierarchy
             if (interval === timeUnits.week) {
                 // get start of current week, independent of count
+                minDay = time.get('Day', minDate);
                 time.set(
                     'Date',
                     minDate,
                     (
                         time.get('Date', minDate) -
-                        time.get('Day', minDate) +
-                        pick(startOfWeek, 1)
+                        minDay + startOfWeek +
+                        // We don't want to skip days that are before
+                        // startOfWeek (#7051)
+                        (minDay < startOfWeek ? -7 : 0)
                     )
                 );
             }

--- a/samples/unit-tests/time/timeticks/demo.js
+++ b/samples/unit-tests/time/timeticks/demo.js
@@ -393,4 +393,36 @@
         })))
         // */
     });
+
+    QUnit.test('Time ticks, week', function (assert) {
+        var time = new Highcharts.Time({
+            useUTC: true
+        });
+
+        var ticks = time.getTimeTicks({
+            unitRange: 7 * 24 * 36e5,
+                count: 1,
+                unitName: "week"
+            },
+            Date.UTC(2018, 8, 9, 12), // Sunday at noon
+            Date.UTC(2018, 9, 9),
+            1
+        );
+
+        assert.deepEqual(
+            ticks.map(function (tick) {
+                return time.dateFormat('%d-%m-%Y', tick);
+            }),
+            [
+              "03-09-2018",
+              "10-09-2018",
+              "17-09-2018",
+              "24-09-2018",
+              "01-10-2018",
+              "08-10-2018",
+              "15-10-2018"
+            ],
+            'All ticks created (#7051).'
+        )
+    });
 }());


### PR DESCRIPTION
Issue fixed in getTimeTicks method. 

There is more visual tests that are not passing now (mostly because of navigator) - example: http://utils.highcharts.local/samples/#test/stock/chart/marginleft - but it's fine.

The problem is now with for example this demo: 
- http://utils.highcharts.local/samples/#test/stock/demo/column

Calculated ticks are: `04. Feb`, `11. Feb`, `18. Feb` etc. (old ticks started from `11. Feb`). Because of the small size of the chart (I guess it's overlapping labels logic), only every second tick is rendered resulting with ticks `04. Feb`, `18. Feb` etc., instead of `11. Feb`, `25. Feb` etc. Is that accepted behaviour or should we somewhere comprehend this to keep ticks as it used to be?

Reminder:
These test should fail:
- http://utils.highcharts.local/samples/#test/stock/issues/2696 - chart is no longer disconnected
- http://utils.highcharts.local/samples/#test/stock/issues/datagrouping-series - first point in dataset is actually new Date(1388538000000) -> Wed Jan 01 2014 02:00:00 GMT+0100 (Central European Standard Time) and was never rendered