### PR TITLE
Fix doc of legend.floating and legend.layout

### DIFF
--- a/js/parts/Options.js
+++ b/js/parts/Options.js
@@ -1993,7 +1993,7 @@ H.defaultOptions = {
          * @type       {string}
          * @default    horizontal
          * @validvalue ["horizontal", "vertical", "proximate"]
-         * @apioption  legend.floating
+         * @apioption  legend.layout
          */
         layout: 'horizontal',
 


### PR DESCRIPTION
Text of legend.layout was shown among legend.floating in doc, on the other hand text of legend.layout was empty.