### PR TITLE
bugfix/8817-stacking-ohlc

### DIFF
--- a/js/parts/OHLCSeries.js
+++ b/js/parts/OHLCSeries.js
@@ -25,7 +25,7 @@ var each = H.each,
  *
  * @sample stock/demo/ohlc/ OHLC chart
  * @extends plotOptions.column
- * @excluding borderColor,borderRadius,borderWidth,crisp
+ * @excluding borderColor,borderRadius,borderWidth,crisp,stacking,stack
  * @product highstock
  * @optionparent plotOptions.ohlc
  */
@@ -132,6 +132,12 @@ seriesType('ohlc', 'column', {
     pointAttrToOptions: {
         'stroke': 'color',
         'stroke-width': 'lineWidth'
+    },
+
+    init: function () {
+        seriesTypes.column.prototype.init.apply(this, arguments);
+
+        this.options.stacking = false; // #8817
     },
 
     /**

--- a/samples/unit-tests/series-ohlc/options/demo.js
+++ b/samples/unit-tests/series-ohlc/options/demo.js
@@ -7,3 +7,28 @@ QUnit.test('defaultOptions', function (assert) {
         'stickyTracking should default to true.'
     );
 });
+
+QUnit.test('Disabled options', function (assert) {
+    var chart = Highcharts.stockChart('container', {
+        series: [{
+            type: 'ohlc'
+        }, {
+            type: 'ohlc',
+            stacking: true
+        }, {
+            type: 'ohlc',
+            stacking: 'percent'
+        }, {
+            type: 'ohlc',
+            stacking: 'normal'
+        }]
+    });
+
+    Highcharts.each(chart.series, function (series) {
+        assert.strictEqual(
+            series.options.stacking,
+            false,
+            'Stacking should be disabled (#8817)'
+        );
+    });
+});


### PR DESCRIPTION
Can we simply disable this option on init? Or should we create another property in the prototype, like `supportsStacking`? 