### PR TITLE
grid axis borderwidth default

### DIFF
--- a/js/parts-gantt/GridAxis.js
+++ b/js/parts-gantt/GridAxis.js
@@ -383,6 +383,10 @@ H.addEvent(Axis, 'afterSetOptions', function (e) {
                 month: ['%b']
             },
 
+            grid: {
+                borderWidth: 1
+            },
+
             labels: {
                 ranges: true,
                 style: {
@@ -451,6 +455,11 @@ H.addEvent(Axis, 'afterSetOptions', function (e) {
              */
             options.minPadding = pick(userOptions.minPadding, 0);
             options.maxPadding = pick(userOptions.maxPadding, 0);
+        }
+
+        // If borderWidth is set, then use its value for tick and line width.
+        if (isNumber(options.grid.borderWidth)) {
+            options.tickWidth = options.lineWidth = gridOptions.borderWidth;
         }
 
     }
@@ -694,9 +703,6 @@ wrap(Axis.prototype, 'init', function (proceed, chart, userOptions) {
         if (axis.horiz) {
             options.tickLength = options.cellHeight ||
                     fontMetrics.h * fontSizeToCellHeightRatio;
-        } else {
-            options.tickWidth = pick(options.tickWidth, 1);
-            options.lineWidth = pick(options.lineWidth, 1);
         }
 
         /**
@@ -711,10 +717,6 @@ wrap(Axis.prototype, 'init', function (proceed, chart, userOptions) {
         if (defined(gridOptions.borderColor)) {
             userOptions.tickColor =
                 userOptions.lineColor = gridOptions.borderColor;
-        }
-        if (defined(gridOptions.borderWidth)) {
-            userOptions.tickWidth =
-                userOptions.lineWidth = gridOptions.borderWidth;
         }
 
         // Handle columns, each column is a grid axis

--- a/samples/unit-tests/gantt/grid-axis/demo.js
+++ b/samples/unit-tests/gantt/grid-axis/demo.js
@@ -90,8 +90,7 @@ QUnit.test('dateFormats', function (assert) {
  */
 QUnit.test('Vertical Linear axis horizontal placement', function (assert) {
     var chart,
-        axes = [],
-        error;
+        axes = [];
 
     // Chart 1
     chart = Highcharts.chart('container', {
@@ -137,19 +136,15 @@ QUnit.test('Vertical Linear axis horizontal placement', function (assert) {
     axes[2] = chart.yAxis[2].axisGroup.getBBox();
     axes[3] = chart.yAxis[3].axisGroup.getBBox();
 
-    error = 0.00001;
-
-    assert.close(
+    assert.strictEqual(
         axes[1].x + axes[1].width,
-        Math.round(axes[0].x),
-        error,
+        axes[0].x,
         'Left outer linear axis horizontal placement'
     );
 
-    assert.close(
+    assert.strictEqual(
         axes[3].x,
-        Math.round(axes[2].x + axes[2].width),
-        error,
+        axes[2].x + axes[2].width,
         'Right outer linear axis horizontal placement'
     );
 });
@@ -1120,5 +1115,101 @@ QUnit.test('Reversed axis', function (assert) {
         +tickLabel.element.getAttribute('x'),
         center,
         'Last tick label is centered in its grid'
+    );
+});
+
+
+QUnit.test('defaultOptions.borderWidth', function (assert) {
+    var createGridAxis = function () {
+            var obj = function () {};
+            // Copy values from Axis.
+            obj.prototype = Highcharts.Axis.prototype;
+            return new obj();
+        },
+        axis = createGridAxis(),
+        options;
+
+    // Set side to top
+    axis.side = 0;
+    // Several cases where there is no check if chart exists
+    axis.chart = {};
+
+
+    /**
+     * grid.borderWidth should default to 1
+     */
+    axis.setOptions({
+        grid: {
+            enabled: true
+        }
+    });
+    options = axis.options;
+
+    assert.strictEqual(
+        options.grid.borderWidth,
+        1,
+        'should default to 1 when grid.enabled is true.'
+    );
+
+    assert.strictEqual(
+        options.lineWidth,
+        1,
+        'should set the value of grid.borderWidth on lineWidth.'
+    );
+
+    assert.strictEqual(
+        options.tickWidth,
+        1,
+        'should set the value of grid.borderWidth on tickWidth.'
+    );
+
+    /**
+     * grid.borderWidth should override tickWidth and lineWidth
+     */
+    axis.setOptions({
+        grid: {
+            enabled: true
+        },
+        tickWidth: 2,
+        lineWidth: 2
+    });
+    options = axis.options;
+
+    assert.strictEqual(
+        options.lineWidth,
+        1,
+        'borderWidth should override lineWidth.'
+    );
+
+    assert.strictEqual(
+        options.tickWidth,
+        1,
+        'borderWidth should override tickWidth.'
+    );
+
+    /**
+     * should use value from lineWidth/tickWidth when borderWidth is not a
+     * number.
+     */
+    axis.setOptions({
+        grid: {
+            enabled: true,
+            borderWidth: null
+        },
+        tickWidth: 2,
+        lineWidth: 2
+    });
+    options = axis.options;
+
+    assert.strictEqual(
+        options.lineWidth,
+        2,
+        'should use value from lineWidth when borderWidth is not a number.'
+    );
+
+    assert.strictEqual(
+        options.tickWidth,
+        2,
+        'should use value from tickWidth when borderWidth is not a number.'
     );
 });


### PR DESCRIPTION
# Description
Set default value for `grid.borderWidth` to equal `1` when `grid.enabled` is `true`.

Also modified the test named "Vertical Linear axis horizontal placement" because it failed after the changes. Likely caused by the use of `assert.close` and `Math.round`, so I removed the rounding and used `assert.strictEqual`. This solved the problem and the test should also be more accurate now. 

# Example(s)
- [Current default behaviour](https://jsfiddle.net/jon_a_nygaard/tg85q7hc/)
- [New default behaviour](https://jsfiddle.net/jon_a_nygaard/uzw9312x/)

# Related issue(s)
- Related #8525 