### PR TITLE
SvgRenderer.label missing useHTML in JSDoc.

### DIFF
--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -4559,28 +4559,28 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
      *         The y position of the label's top side or baseline, depending on
      *         the `baseline` parameter.
      *
-     * @param  {string} shape
+     * @param  {string} [shape='rect']
      *         The shape of the label's border/background, if any. Defaults to
      *         `rect`. Other possible values are `callout` or other shapes
      *         defined in {@link Highcharts.SVGRenderer#symbols}.
      *
-     * @param  {number} anchorX
+     * @param  {number} [anchorX]
      *         In case the `shape` has a pointer, like a flag, this is the
      *         coordinates it should be pinned to.
      *
-     * @param  {number} anchorY
+     * @param  {number} [anchorY]
      *         In case the `shape` has a pointer, like a flag, this is the
      *         coordinates it should be pinned to.
      *
-     * @param  {boolean} useHTML
+     * @param  {boolean} [useHTML=false]
      *         Wether to use HTML to render the label.
      *
-     * @param  {boolean} baseline
+     * @param  {boolean} [baseline=false]
      *         Whether to position the label relative to the text baseline,
      *         like {@link Highcharts.SVGRenderer#text|renderer.text}, or to the
      *         upper border of the rectangle.
      *
-     * @param  {string} className
+     * @param  {string} [className]
      *         Class name for the group.
      *
      * @return {Highcharts.SVGElement}

--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -4559,28 +4559,28 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
      *         The y position of the label's top side or baseline, depending on
      *         the `baseline` parameter.
      *
-     * @param  {string} [shape='rect']
+     * @param  {string|undefined} [shape='rect']
      *         The shape of the label's border/background, if any. Defaults to
      *         `rect`. Other possible values are `callout` or other shapes
      *         defined in {@link Highcharts.SVGRenderer#symbols}.
      *
-     * @param  {number} [anchorX]
+     * @param  {number|undefined} [anchorX]
      *         In case the `shape` has a pointer, like a flag, this is the
      *         coordinates it should be pinned to.
      *
-     * @param  {number} [anchorY]
+     * @param  {number|undefined} [anchorY]
      *         In case the `shape` has a pointer, like a flag, this is the
      *         coordinates it should be pinned to.
      *
-     * @param  {boolean} [useHTML=false]
+     * @param  {boolean|undefined} [useHTML=false]
      *         Wether to use HTML to render the label.
      *
-     * @param  {boolean} [baseline=false]
+     * @param  {boolean|undefined} [baseline=false]
      *         Whether to position the label relative to the text baseline,
      *         like {@link Highcharts.SVGRenderer#text|renderer.text}, or to the
      *         upper border of the rectangle.
      *
-     * @param  {string} [className]
+     * @param  {string|undefined} [className]
      *         Class name for the group.
      *
      * @return {Highcharts.SVGElement}

--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -4572,6 +4572,9 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
      *         In case the `shape` has a pointer, like a flag, this is the
      *         coordinates it should be pinned to.
      *
+     * @param  {boolean} useHTML
+     *         Wether to use HTML to render the label.
+     *
      * @param  {boolean} baseline
      *         Whether to position the label relative to the text baseline,
      *         like {@link Highcharts.SVGRenderer#text|renderer.text}, or to the


### PR DESCRIPTION
# Description
Found that [Highcharts.SVGRenderer#label](https://api.highcharts.com/class-reference/Highcharts.SVGRenderer#label) was missing the parameter `useHTML`.
Copied the description of `useHTML` from [xAxis.labels.useHTML](https://api.highcharts.com/highcharts/xAxis.labels.useHTML).

Feel free to edit the PR if necessary, or request changes.