### PR TITLE
bugfix/boost-unsorted-scatter-points-unsorted

### DIFF
--- a/js/modules/boost.src.js
+++ b/js/modules/boost.src.js
@@ -1853,7 +1853,7 @@ function GLRenderer(postRenderCallback) {
 
             if (!settings.useGPUTranslations &&
                 !settings.usePreallocated &&
-                (lastX && x - lastX < cullXThreshold) &&
+                (lastX && Math.abs(x - lastX) < cullXThreshold) &&
                 (lastY && Math.abs(y - lastY) < cullYThreshold)
             ) {
                 if (settings.debug.showSkipSummary) {


### PR DESCRIPTION
Fixes boost issue with unsorted points in scatter/bubble charts.

More here: https://github.com/highcharts/highcharts/issues/8629