### PR TITLE
bugfix/boost-scatter-culling

### DIFF
--- a/js/modules/boost.src.js
+++ b/js/modules/boost.src.js
@@ -1795,6 +1795,13 @@ function GLRenderer(postRenderCallback) {
                 }
 
                 if (x > plotWidth) {
+                    // If this is  rendered as a point, just skip drawing it
+                    // entirely, as we're not dependandt on lineTo'ing to it.
+                    // See #8197
+                    if (inst.drawMode === 'points') {
+                        continue;
+                    }
+
                     x = plotWidth;
                 }
 


### PR DESCRIPTION
Fixes an issue with visible artifacts when zooming into a scatter graph.

Issue was related to clamping meant to make lineTo's work with line-based charts.

See https://github.com/highcharts/highcharts/issues/8197