### PR TITLE
enhancement/boost-glsl-error-checks

### DIFF
--- a/js/modules/boost.src.js
+++ b/js/modules/boost.src.js
@@ -808,8 +808,19 @@ function GLShader(gl) {
         // Uniform for invertion
         isInverted,
         plotHeightUniform,
+        // Error stack
+        errors = [],
         // Texture uniform
         uSamplerUniform;
+
+    /*
+     * Handle errors accumulated in errors stack
+     */
+    function handleErrors() {
+        if (errors.length) {
+            H.error('[highcharts boost] shader error - ' + errors.join('\n'));
+        }
+    }
 
     /* String to shader program
      * @param {string} str - the program source
@@ -825,7 +836,13 @@ function GLShader(gl) {
         gl.compileShader(shader);
 
         if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
-            // console.error('shader error:', gl.getShaderInfoLog(shader));
+            errors.push(
+                'when compiling ' +
+                type +
+                ' shader:\n' +
+                gl.getShaderInfoLog(shader)
+            );
+
             return false;
         }
         return shader;
@@ -842,7 +859,7 @@ function GLShader(gl) {
 
         if (!v || !f) {
             shaderProgram = false;
-            // console.error('error creating shader program');
+            handleErrors();
             return false;
         }
 
@@ -854,7 +871,15 @@ function GLShader(gl) {
 
         gl.attachShader(shaderProgram, v);
         gl.attachShader(shaderProgram, f);
+
         gl.linkProgram(shaderProgram);
+
+        if (!gl.getProgramParameter(shaderProgram, gl.LINK_STATUS)) {
+            errors.push(gl.getProgramInfoLog(shaderProgram));
+            handleErrors();
+            shaderProgram = false;
+            return false;
+        }
 
         gl.useProgram(shaderProgram);
 
@@ -871,6 +896,7 @@ function GLShader(gl) {
         isCircleUniform = uloc('isCircle');
         isInverted = uloc('isInverted');
         plotHeightUniform = uloc('plotHeight');
+
         return true;
     }
 
@@ -878,11 +904,9 @@ function GLShader(gl) {
      * Destroy the shader
      */
     function destroy() {
-        if (gl) {
-            if (shaderProgram) {
-                gl.deleteProgram(shaderProgram);
-                shaderProgram = false;
-            }
+        if (gl && shaderProgram) {
+            gl.deleteProgram(shaderProgram);
+            shaderProgram = false;
         }
     }
 
@@ -892,7 +916,9 @@ function GLShader(gl) {
      * or until 0 is bound.
      */
     function bind() {
-        gl.useProgram(shaderProgram);
+        if (gl && shaderProgram) {
+            gl.useProgram(shaderProgram);
+        }
     }
 
     /*
@@ -902,9 +928,14 @@ function GLShader(gl) {
      * @param val {float} - the value to set
      */
     function setUniform(name, val) {
-        var u = uLocations[name] = uLocations[name] ||
-                                    gl.getUniformLocation(shaderProgram, name);
-        gl.uniform1f(u, val);
+        if (gl && shaderProgram) {
+            var u = uLocations[name] = uLocations[name] ||
+                                       gl.getUniformLocation(
+                                          shaderProgram,
+                                          name
+                                       );
+            gl.uniform1f(u, val);
+        }
     }
 
     /*
@@ -912,7 +943,9 @@ function GLShader(gl) {
      * @param texture - the texture
      */
     function setTexture(texture) {
-        gl.uniform1i(uSamplerUniform, texture);
+        if (gl && shaderProgram) {
+            gl.uniform1i(uSamplerUniform, texture);
+        }
     }
 
     /*
@@ -920,26 +953,34 @@ function GLShader(gl) {
      * @flag is the state
      */
     function setInverted(flag) {
-        gl.uniform1i(isInverted, flag);
+        if (gl && shaderProgram) {
+            gl.uniform1i(isInverted, flag);
+        }
     }
 
     /*
      * Enable/disable circle drawing
      */
     function setDrawAsCircle(flag) {
-        gl.uniform1i(isCircleUniform, flag ? 1 : 0);
+        if (gl && shaderProgram) {
+            gl.uniform1i(isCircleUniform, flag ? 1 : 0);
+        }
     }
 
     function setPlotHeight(n) {
-        gl.uniform1f(plotHeightUniform, n);
+        if (gl && shaderProgram) {
+            gl.uniform1f(plotHeightUniform, n);
+        }
     }
 
     /*
      * Flush
      */
     function reset() {
-        gl.uniform1i(isBubbleUniform, 0);
-        gl.uniform1i(isCircleUniform, 0);
+        if (gl && shaderProgram) {
+            gl.uniform1i(isBubbleUniform, 0);
+            gl.uniform1i(isCircleUniform, 0);
+        }
     }
 
     /*
@@ -951,7 +992,7 @@ function GLShader(gl) {
             zMin = Number.MAX_VALUE,
             zMax = -Number.MAX_VALUE;
 
-        if (series.type === 'bubble') {
+        if (gl && shaderProgram && series.type === 'bubble') {
             zMin = pick(seriesOptions.zMin, Math.min(
                 zMin,
                 Math.max(
@@ -987,20 +1028,24 @@ function GLShader(gl) {
      * @param color {Array<float>} - an array with RGBA values
      */
     function setColor(color) {
-        gl.uniform4f(
-            fillColorUniform,
-            color[0] / 255.0,
-            color[1] / 255.0,
-            color[2] / 255.0,
-            color[3]
-        );
+        if (gl && shaderProgram) {
+            gl.uniform4f(
+                fillColorUniform,
+                color[0] / 255.0,
+                color[1] / 255.0,
+                color[2] / 255.0,
+                color[3]
+            );
+        }
     }
 
     /*
      * Set skip translation
      */
     function setSkipTranslation(flag) {
-        gl.uniform1i(skipTranslationUniform, flag === true ? 1 : 0);
+        if (gl && shaderProgram) {
+            gl.uniform1i(skipTranslationUniform, flag === true ? 1 : 0);
+        }
     }
 
     /*
@@ -1008,7 +1053,9 @@ function GLShader(gl) {
      * @param m {Matrix4x4} - the matrix
      */
     function setPMatrix(m) {
-        gl.uniformMatrix4fv(pUniform, false, m);
+        if (gl && shaderProgram) {
+            gl.uniformMatrix4fv(pUniform, false, m);
+        }
     }
 
     /*
@@ -1016,7 +1063,9 @@ function GLShader(gl) {
      * @param p {float} - point size
      */
     function setPointSize(p) {
-        gl.uniform1f(psUniform, p);
+        if (gl && shaderProgram) {
+            gl.uniform1f(psUniform, p);
+        }
     }
 
     /*
@@ -1028,7 +1077,9 @@ function GLShader(gl) {
     }
 
     if (gl) {
-        createShader();
+        if (!createShader()) {
+            return false;
+        }
     }
 
     return {
@@ -2079,7 +2130,7 @@ function GLRenderer(postRenderCallback) {
             return false;
         }
 
-        if (!gl || !width || !height) {
+        if (!gl || !width || !height || !shader) {
             return false;
         }
 
@@ -2307,8 +2358,8 @@ function GLRenderer(postRenderCallback) {
      * @param h {Integer} - the height of the viewport
      */
     function setSize(w, h) {
-        // Skip if there's no change
-        if (width === w && h === h) {
+        // Skip if there's no change, or if we have no valid shader
+        if ((width === w && h === h) || !shader) {
             return;
         }
 
@@ -2367,6 +2418,12 @@ function GLRenderer(postRenderCallback) {
         gl.depthFunc(gl.LESS);
 
         shader = GLShader(gl); // eslint-disable-line new-cap
+
+        if (!shader) {
+            // We need to abort, there's no shader context
+            return false;
+        }
+
         vbuffer = GLVertexBuffer(gl, shader); // eslint-disable-line new-cap
 
         function createTexture(name, fn) {
@@ -2691,7 +2748,13 @@ function createAndAttachRenderer(chart, series) {
 
         }); // eslint-disable-line new-cap
 
-        target.ogl.init(target.canvas);
+        if (!target.ogl.init(target.canvas)) {
+            // The OGL renderer couldn't be inited.
+            // This likely means a shader error as we wouldn't get to this point
+            // if there was no WebGL support.
+            H.error('[highcharts boost] - unable to init WebGL renderer');
+        }
+
         // target.ogl.clear();
         target.ogl.setOptions(chart.options.boost || {});
 


### PR DESCRIPTION
Better shader error checks in the boost module. See #8364.

Basically the actual shader errors where suppressed previously, making it very hard to find issues with hardware configurations and so on. This fix will use `Highcharts.error` to report actual shader errors, which should make it easier to figure out the issues we've been seeing regarding e.g. chrome 68 and older hardware.