### PR TITLE
feature/commit-msg-linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
   "scripts": {
     "test": "gulp test --all",
     "testall": "gulp test --all --browsers all",
-    "precommit": "lint-staged && gulp test",
     "post-merge": "gulp styles && gulp scripts && npm test",
-    "jsdoc": "gulp jsdoc --watch"
+    "jsdoc": "gulp jsdoc --watch",
+    "precommit": "lint-staged && gulp test",
+    "commitmsg": "node tools/validate-commit-msg.js ${GIT_PARAMS}"
   },
   "devDependencies": {
     "aws-sdk": "^2.94.0",

--- a/tools/validate-commit-msg.js
+++ b/tools/validate-commit-msg.js
@@ -1,0 +1,55 @@
+// Validates the commit message.
+// Used by the commit-msg hook
+
+/* eslint-env node, es6 */
+/* eslint-disable func-style */
+/* eslint-disable no-console */
+/* eslint-disable no-process-exit */
+
+'use strict';
+
+// Add validation functions here.
+const validators = [
+    (msg) => msg.indexOf('Fixes') >= 0 ? 'Use past tense (Fixed, not Fixes)' : 0,
+    (msg) => msg[0].toUpperCase() !== msg[0] ? 'First letter should be caps' : 0
+];
+
+const args = process.argv;
+const fs = require('fs');
+
+require('colors');
+
+if (args.length < 3) {
+    // This is not ran correctly
+    console.log('Expected commit message link, unable to validate');
+    process.exit(1);
+}
+
+// Get the commit message
+fs.readFile(args[2], 'utf8', (err, commitMessage) => {
+    if (err) {
+        return console.log(err.red) && process.exit(1);
+    }
+
+    // Do validation of commitMessage
+    let errors = [];
+
+    validators.forEach((fn) => {
+        let res = fn(commitMessage);
+        if (res !== 0) {
+            errors.push(res);
+        }
+    });
+
+    if (errors.length) {
+        console.log('Commit message does not follow spec:');
+        errors.forEach((msg) => console.log('  ' + msg.red));
+        return process.exit(1);
+    }
+
+    console.log('Commit message is OK, proceeding.'.green);
+
+    // All is a-ok
+    return process.exit(0);
+});
+


### PR DESCRIPTION
Adds a hook to validate commit messages.

The script that performs the validation is located in `tools/validate-commit-msg.js`.

It contains an array at the top in which new validator functions can be added.