### PR TITLE
bugfix/8965-stochastic-indicator-d-value-calculation

### DIFF
--- a/js/indicators/stochastic.src.js
+++ b/js/indicators/stochastic.src.js
@@ -189,7 +189,7 @@ H.seriesType('stochastic', 'sma',
 
             // Stochastic requires close value
             if (
-                xVal.length < periodK ||
+                yValLen < periodK ||
                 !isArray(yVal[0]) ||
                 yVal[0].length !== 4
             ) {
@@ -208,11 +208,14 @@ H.seriesType('stochastic', 'sma',
                 HL = maxInArray(slicedY, high) - LL;
                 K = CL / HL * 100;
 
+                xData.push(xVal[i]);
+                yData.push([K, null]);
+
                 // Calculate smoothed %D, which is SMA of %K
-                if (i >= periodK + periodD) {
+                if (i >= (periodK - 1) + (periodD - 1)) {
                     points = SMA.prototype.getValues.call(this, {
-                        xData: xData.slice(i - periodD - periodK, i - periodD),
-                        yData: yData.slice(i - periodD - periodK, i - periodD)
+                        xData: xData.slice(-periodD),
+                        yData: yData.slice(-periodD)
                     }, {
                         period: periodD
                     });
@@ -220,8 +223,7 @@ H.seriesType('stochastic', 'sma',
                 }
 
                 SO.push([xVal[i], K, D]);
-                xData.push(xVal[i]);
-                yData.push([K, D]);
+                yData[yData.length - 1][1] = D;
             }
 
             return {

--- a/samples/unit-tests/indicator-stochastic/recalculations/demo.js
+++ b/samples/unit-tests/indicator-stochastic/recalculations/demo.js
@@ -27,9 +27,9 @@ QUnit.test('Test Stochastic calculations on data updates.', function (assert) {
         }]
     });
 
-    function toFastStochasticWithRound(arr) {
+    function toFastStochasticWithRound(arr, index) {
         return Highcharts.map(arr, function (point) {
-            return parseFloat(point[0].toFixed(5));
+            return point[index] ? parseFloat(point[index].toFixed(5)) : point[index];
         });
     }
 
@@ -93,7 +93,7 @@ QUnit.test('Test Stochastic calculations on data updates.', function (assert) {
     });
 
     assert.deepEqual(
-        toFastStochasticWithRound(chart.series[1].yData),
+        toFastStochasticWithRound(chart.series[1].yData, 0),
         [
             70.43822,
             67.60891,
@@ -124,7 +124,7 @@ QUnit.test('Test Stochastic calculations on data updates.', function (assert) {
     chart.series[0].points[chart.series[0].points.length - 1].remove();
 
     assert.deepEqual(
-        toFastStochasticWithRound(chart.series[1].yData),
+        toFastStochasticWithRound(chart.series[1].yData, 0),
         [
             70.43822,
             67.60891,
@@ -144,5 +144,28 @@ QUnit.test('Test Stochastic calculations on data updates.', function (assert) {
             66.82855
         ],
         'Correct values after point.remove()'
+    );
+
+    assert.deepEqual(
+        toFastStochasticWithRound(chart.series[1].yData, 1),
+        [
+            null,
+            null,
+            75.74975,
+            74.20719,
+            78.92012,
+            70.69402,
+            73.60043,
+            79.21167,
+            81.07192,
+            80.58069,
+            72.1928,
+            69.23506,
+            65.20178,
+            54.19122,
+            47.24283,
+            49.20025
+        ],
+        'Correct %D values.'
     );
 });


### PR DESCRIPTION
Visual test is not succeed, because the `%d` line has different values, and from now on, it starts from appropriate place.