### PR TITLE
hs7/exporting-option-titlekey

### DIFF
--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -673,9 +673,24 @@ defaultOptions.exporting = {
              * button's title tooltip. When the key is `contextButtonTitle`, it
              * refers to [lang.contextButtonTitle](#lang.contextButtonTitle)
              * that defaults to "Chart context menu".
-             * @type {String}
+             *
+             * @since 7.0
              */
-            _titleKey: 'contextButtonTitle',
+            titleKey: 'contextButtonTitle',
+
+            /**
+             * This option is deprecated, use
+             * [titleKey](#exporting.buttons.contextButton.titleKey) instead.
+             *
+             * The key to a [lang](#lang) option setting that is used for the
+             * button's title tooltip. When the key is `contextButtonTitle`, it
+             * refers to [lang.contextButtonTitle](#lang.contextButtonTitle)
+             * that defaults to "Chart context menu".
+             *
+             * @deprecated
+             * @type      {string}
+             * @apioption exporting.buttons.contextButton._titleKey
+             */
 
             /**
              * A collection of strings pointing to config options for the menu
@@ -1471,7 +1486,12 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                 /*= if (build.classic) { =*/
                 'stroke-linecap': 'round',
                 /*= } =*/
-                title: pick(chart.options.lang[btnOptions._titleKey], '')
+                title: pick(
+                    chart.options.lang[
+                        btnOptions._titleKey || btnOptions.titleKey
+                    ],
+                    ''
+                )
             });
         button.menuClassName = (
             options.menuClassName ||


### PR DESCRIPTION
Bugfix: Switch from contextButton._titleKey option to contextButton.titleKey option.