### PR TITLE
bugfix/9049-lines-to-culled-points-boost

### DIFF
--- a/js/modules/boost.src.js
+++ b/js/modules/boost.src.js
@@ -1837,7 +1837,7 @@ function GLRenderer(postRenderCallback) {
             }
 
             // Cull points outside the extremes
-            if (y === null || !isYInside) {
+            if (y === null || (!isYInside && !nextInside && !prevInside)) {
                 beginSegment();
                 continue;
             }


### PR DESCRIPTION
Fixed #9049, Issue with lines to culled points in boost.

Basically line to's to culled away points where skipped. This was a regression after fixing the culling code for y-values a few weeks ago.

Demo: http://jsfiddle.net/yan68ku1/52/