### PR TITLE
bugfix/9088-pie-tooltip-errors

### DIFF
--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -647,11 +647,13 @@ Highcharts.Pointer.prototype = {
                 if (tooltip.shared && hoverPoints) { // #8284
                     each(hoverPoints, function (point) {
                         point.setState(point.state, true);
-                        if (point.series.xAxis.crosshair) {
-                            point.series.xAxis.drawCrosshair(null, point);
-                        }
-                        if (point.series.yAxis.crosshair) {
-                            point.series.yAxis.drawCrosshair(null, point);
+                        if (point.series.isCartesian) {
+                            if (point.series.xAxis.crosshair) {
+                                point.series.xAxis.drawCrosshair(null, point);
+                            }
+                            if (point.series.yAxis.crosshair) {
+                                point.series.yAxis.drawCrosshair(null, point);
+                            }
                         }
                     });
                 } else if (hoverPoint) { // #2500

--- a/samples/unit-tests/series-pie/mouseover/demo.js
+++ b/samples/unit-tests/series-pie/mouseover/demo.js
@@ -255,3 +255,31 @@ QUnit.test('Halo sliced point (#3016)', function (assert) {
     });
 
 });
+
+QUnit.test('Update point hwen hovering slice (#9088)', function (assert) {
+    TestTemplate.test('highcharts/pie', {
+        tooltip: {
+            shared: true
+        },
+        series: [{
+            type: 'pie',
+            data: [5, 10, 15]
+        }]
+    }, function (template) {
+        var chart = template.chart,
+            controller = TestController(chart),
+            pointBox = chart.series[0].points[1].graphic.getBBox();
+
+        controller.mouseOver(
+            (chart.plotLeft + pointBox.x + (pointBox.width / 2)),
+            (chart.plotTop + pointBox.y + (pointBox.height / 2))
+        );
+
+        chart.series[0].points[0].update(10);
+
+        assert.ok(
+            true,
+            'No errors'
+        );
+    });
+});

--- a/samples/unit-tests/series-pie/mouseover/demo.js
+++ b/samples/unit-tests/series-pie/mouseover/demo.js
@@ -256,7 +256,7 @@ QUnit.test('Halo sliced point (#3016)', function (assert) {
 
 });
 
-QUnit.test('Update point hwen hovering slice (#9088)', function (assert) {
+QUnit.test('Update point when hovering slice (#9088)', function (assert) {
     TestTemplate.test('highcharts/pie', {
         tooltip: {
             shared: true


### PR DESCRIPTION
Fixed #9088, updating a point in a pie chart threw errors when another slice was hovered.