### PR TITLE
Bugfix/grid axis ticksize

### DIFF
--- a/js/parts-gantt/GridAxis.js
+++ b/js/parts-gantt/GridAxis.js
@@ -186,7 +186,10 @@ wrap(Tick.prototype, 'getLabelPosition', function (proceed, x, y, label, horiz,
         tickSize = axis.tickSize('tick', true),
         tickWidth = isArray(tickSize) ? tickSize[0] : 0,
         crispCorr = tickSize[1] / 2,
+        labelHeight,
         lblMetrics,
+        labelDiff,
+        lines,
         result,
         bottom,
         top,
@@ -223,12 +226,12 @@ wrap(Tick.prototype, 'getLabelPosition', function (proceed, x, y, label, horiz,
             right = axis.left + axis.offset;
             left = right - tickWidth;
         } else {
-            left = axis.left + axis.translate(
+            left = Math.round(axis.left + axis.translate(
                 reversed ? nextTickPos : tickPos
-            );
-            right = axis.left + axis.translate(
+            )) - crispCorr;
+            right = Math.round(axis.left + axis.translate(
                 reversed ? tickPos : nextTickPos
-            );
+            )) - crispCorr;
         }
 
         tick.slotWidth = right - left;
@@ -253,17 +256,35 @@ wrap(Tick.prototype, 'getLabelPosition', function (proceed, x, y, label, horiz,
             )
         };
 
-        // Align the baseline of the label.
-        // Would be better to have a setter or similar for this.
         lblMetrics = chart.renderer.fontMetrics(
             labelOpts.style.fontSize,
             label.element
         );
-        result.y += (lblMetrics.b / 2) - ((lblMetrics.h - lblMetrics.f) / 2);
+        labelHeight = label.getBBox().height;
 
-        // Adjust for crisping logic and round the resulting number
-        result.x = Math.round(result.x - crispCorr) +
-            (axis.horiz && labelOpts.x || 0);
+        // Adjustment to y position to align the label correctly.
+        // Would be better to have a setter or similar for this.
+        if (!labelOpts.useHTML) {
+            labelDiff = labelHeight % lblMetrics.h;
+            lines = ((labelHeight - labelDiff) / lblMetrics.h);
+
+            result.y += (
+                // Adjust for difference between actual label height and line
+                // height.
+                labelDiff +
+                // Adjust for height of additional lines.
+                -(((lines - 1) * lblMetrics.h) / 2)
+            );
+        } else {
+            result.y += (
+                // Readjust yCorr in htmlUpdateTransform
+                lblMetrics.b +
+                // Adjust for height of html label
+                -(labelHeight / 2)
+            );
+        }
+
+        result.x += (axis.horiz && labelOpts.x || 0);
     } else {
         result = proceed.apply(tick, argsToArray(arguments));
     }

--- a/js/parts-gantt/GridAxis.js
+++ b/js/parts-gantt/GridAxis.js
@@ -85,30 +85,37 @@ Axis.prototype.isOuterAxis = function () {
 };
 
 /**
- * Get the longest label length.
- * This function can be used in states where the axis.maxLabelLength has not
- * been set.
- *
- * @param  {boolean} force - Optional parameter to force a new calculation, even
- *                           if a value has already been set
- * @return {number} maxLabelLength - the maximum label length of the axis
+ * Get the largest label width and height.
+ * @param {object} ticks All the ticks on one axis.
+ * @param {array} tickPositions All the tick positions on one axis.
+ * @return {object} object containing the properties height and width.
  */
-Axis.prototype.getMaxLabelLength = function (force) {
-    var axis = this,
-        tickPositions = axis.tickPositions,
-        ticks = axis.ticks,
-        maxLabelLength = 0;
+Axis.prototype.getMaxLabelDimensions = function (ticks, tickPositions) {
+    var dimensions = {
+        width: 0,
+        height: 0
+    };
 
-    if (!axis.maxLabelLength || force) {
-        each(tickPositions, function (tick) {
-            tick = ticks[tick];
-            if (tick && tick.labelLength > maxLabelLength) {
-                maxLabelLength = tick.labelLength;
-            }
-        });
-        axis.maxLabelLength = maxLabelLength;
-    }
-    return axis.maxLabelLength;
+    each(tickPositions, function (pos) {
+        var tick = ticks[pos],
+            tickHeight = 0,
+            tickWidth = 0,
+            label;
+
+        if (isObject(tick)) {
+            label = isObject(tick.label) ? tick.label : {};
+
+            // Find width and height of tick
+            tickHeight = label.getBBox ? label.getBBox().height : 0;
+            tickWidth = isNumber(label.textPxLength) ? label.textPxLength : 0;
+
+            // Update the result if width and/or height are larger
+            dimensions.height = Math.max(tickHeight, dimensions.height);
+            dimensions.width = Math.max(tickWidth, dimensions.width);
+        }
+    });
+
+    return dimensions;
 };
 
 /**
@@ -272,6 +279,7 @@ wrap(Tick.prototype, 'getLabelPosition', function (proceed, x, y, label, horiz,
  */
 wrap(Axis.prototype, 'tickSize', function (proceed) {
     var axis = this,
+        dimensions = axis.maxLabelDimensions,
         options = axis.options,
         gridOptions = (options && isObject(options.grid)) ? options.grid : {},
         retVal = proceed.apply(axis, argsToArray(arguments)),
@@ -280,9 +288,8 @@ wrap(Axis.prototype, 'tickSize', function (proceed) {
 
     if (gridOptions.enabled === true) {
         labelPadding = (Math.abs(axis.defaultLeftAxisOptions.labels.x) * 2);
-        distance = labelPadding + (axis.horiz ?
-            axis.labelMetrics().f :
-            axis.getMaxLabelLength());
+        distance = labelPadding +
+            (axis.horiz ? dimensions.height : dimensions.width);
 
         if (isArray(retVal)) {
             retVal[0] = distance;
@@ -679,7 +686,11 @@ wrap(Axis.prototype, 'render', function (proceed) {
         // TODO acutual label padding (top, bottom, left, right)
         // Label padding is needed to figure out where to draw the outer line.
         labelPadding = (Math.abs(axis.defaultLeftAxisOptions.labels.x) * 2);
-        distance = axis.getMaxLabelLength() + labelPadding;
+        axis.maxLabelDimensions = axis.getMaxLabelDimensions(
+            axis.ticks,
+            axis.tickPositions
+        );
+        distance = axis.maxLabelDimensions.width + labelPadding;
         lineWidth = options.lineWidth;
 
         // Remove right wall before rendering if updating

--- a/js/parts-gantt/TreeGrid.js
+++ b/js/parts-gantt/TreeGrid.js
@@ -487,11 +487,11 @@ override(GridAxis.prototype, {
         }
     },
     /**
-     * Override to add indentation to axis.maxLabelLength.
+     * Override to add indentation to axis.maxLabelDimensions.
      * @param  {Function}   proceed the original function
      * @returns {undefined}
      */
-    getMaxLabelLength: function (proceed) {
+    getMaxLabelDimensions: function (proceed) {
         var axis = this,
             options = axis.options,
             labelOptions = options && options.labels,
@@ -506,7 +506,7 @@ override(GridAxis.prototype, {
 
         if (isTreeGrid) {
             treeDepth = axis.mapOfPosToGridNode[-1].height;
-            retVal += indentation * (treeDepth - 1);
+            retVal.width += indentation * (treeDepth - 1);
         }
 
         return retVal;

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -4402,7 +4402,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
             className = options.className,
             axisParent = axis.axisParent, // Used in color axis
             lineHeightCorrection,
-            tickSize = this.tickSize('tick');
+            tickSize;
 
         // For reuse in Axis.render
         hasData = axis.hasData();
@@ -4527,6 +4527,17 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
         }
 
         axis.axisTitleMargin = pick(titleOffsetOption, labelOffsetPadded);
+
+        if (axis.getMaxLabelDimensions) {
+            axis.maxLabelDimensions = axis.getMaxLabelDimensions(
+                ticks,
+                tickPositions
+            );
+        }
+
+        // Due to GridAxis.tickSize, tickSize should be calculated after ticks
+        // has rendered.
+        tickSize = this.tickSize('tick');
 
         axisOffset[side] = Math.max(
             axisOffset[side],

--- a/samples/unit-tests/gantt/grid-axis-stock/demo.js
+++ b/samples/unit-tests/gantt/grid-axis-stock/demo.js
@@ -1165,9 +1165,10 @@ QUnit.test('Leftmost ticklabel appears', function (assert) {
         'First tick gets pos from axis.min'
     );
 
-    assert.strictEqual(
+    assert.close(
         +tickLabel.getAttribute('x'),
         axisCenter,
+        1,
         'First tick label is centered in its grid'
     );
     assert.strictEqual(


### PR DESCRIPTION
# Description
`Axis.tickSize` returned the wrong length of ticks when the axis is on the top or bottom side. This caused the grid cells to have gaps.
This PR also includes correcting of the vertical alignment of labels with multiple lines within a grid axis, and a unit tests which test vertical align middle, and align center for both svg and html labels.

# Examples
- [Example of behaviour before](http://jsfiddle.net/jon_a_nygaard/gueqL5hd/)
- [Example of behaviour after](http://jsfiddle.net/jon_a_nygaard/nmxsw0ur/)

# Related issue(s)
- #8525 