### PR TITLE
bugfix/9075-addpoint-navigator-sticktomin

### DIFF
--- a/js/parts/Navigator.js
+++ b/js/parts/Navigator.js
@@ -2065,6 +2065,24 @@ Navigator.prototype = {
     },
 
     /**
+     * Get minimum from all base series connected to the navigator
+     *
+     * @param  {number} currentSeriesMin
+     *         Minium from the current series
+     *
+     * @return {number} Minimum from all series
+     */
+    getBaseSeriesMin: function (currentSeriesMin) {
+        return H.reduce(
+            this.baseSeries,
+            function (min, series) {
+                return Math.min(min, series.xData[0]);
+            },
+            currentSeriesMin
+        );
+    },
+
+    /**
      * Set the navigator x axis extremes to reflect the total. The navigator
      * extremes should always be the extremes of the union of all series in the
      * chart as well as the navigator series.
@@ -2140,8 +2158,11 @@ Navigator.prototype = {
                 if (!stickToMin) {
                     newMin = Math.max(
                         newMax - range,
-                        navigatorSeries && navigatorSeries.xData ?
-                            navigatorSeries.xData[0] : -Number.MAX_VALUE
+                        navigator.getBaseSeriesMin(
+                            navigatorSeries && navigatorSeries.xData ?
+                                navigatorSeries.xData[0] :
+                                -Number.MAX_VALUE
+                        )
                     );
                 }
             }
@@ -2171,7 +2192,8 @@ Navigator.prototype = {
     updatedDataHandler: function () {
         var navigator = this.chart.navigator,
             baseSeries = this,
-            navigatorSeries = this.navigatorSeries;
+            navigatorSeries = this.navigatorSeries,
+            xDataMin = navigator.getBaseSeriesMin(baseSeries.xData[0]);
 
         // If the scrollbar is scrolled all the way to the right, keep right as
         // new data  comes in.
@@ -2183,7 +2205,7 @@ Navigator.prototype = {
         // maximum. If the current axis minimum falls outside the new updated
         // dataset, we must adjust.
         navigator.stickToMin = isNumber(baseSeries.xAxis.min) &&
-            (baseSeries.xAxis.min <= baseSeries.xData[0]) &&
+            (baseSeries.xAxis.min <= xDataMin) &&
             (!this.chart.fixedRange || !navigator.stickToMax);
 
         // Set the navigator series data to the new data of the base series

--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -660,3 +660,63 @@ QUnit.test(
 
     }
 );
+
+
+QUnit.test('stickToMin and stickToMax', function (assert) {
+    var chart = new Highcharts.stockChart('container', {
+            xAxis: {
+                min: 5,
+                minRange: 1
+            },
+            plotOptions: {
+                series: {
+                    showInNavigator: true
+                }
+            },
+            rangeSelector: {
+                buttons: [{
+                    count: 2,
+                    type: 'millisecond',
+                    text: '2ms'
+                }]
+            },
+            series: [{
+                pointStart: 0,
+                data: [1, 2, 1, 2, 1, 2, 1, 2, 1, 2]
+            }, {
+                pointStart: 5,
+                data: [3, 2, 1, 1, 2]
+            }]
+        }),
+        extremes;
+
+    chart.series[0].addPoint(5, false, false);
+    chart.series[1].addPoint(5, false, false);
+    chart.redraw();
+
+    extremes = chart.xAxis[0].getExtremes();
+
+    assert.strictEqual(
+        extremes.min,
+        5,
+        'stickToMin, multiple series with different ranges: ' +
+            'Correct extremes after adding points(#9075)'
+    );
+
+    chart.series[0].update({
+        pointStart: extremes.max,
+        data: [4]
+    });
+
+    chart.rangeSelector.clickButton(0, true);
+    chart.series[0].addPoint(5);
+    chart.series[1].addPoint(5);
+    extremes = chart.xAxis[0].getExtremes();
+
+    assert.strictEqual(
+        extremes.min,
+        extremes.max - chart.fixedRange,
+        'stickToMax, multiple series with different ranges: ' +
+            'Correct extremes after rangeSelector use and adding points(#9075)'
+    );
+});


### PR DESCRIPTION
Highstock: Fixed #9075, adding a point used to reset zoom when series had different ranges.

Previously, minimum extreme was taken always from first series, now it takes min from all series in navigator.