### PR TITLE
bugfix/9020-columnrange-datagrouping-datalabels

### DIFF
--- a/js/parts-more/AreaRangeSeries.js
+++ b/js/parts-more/AreaRangeSeries.js
@@ -330,7 +330,7 @@ seriesType('arearange', 'area', {
      */
     drawDataLabels: function () {
 
-        var data = this.data,
+        var data = this.points,
             length = data.length,
             i,
             originalDataLabels = [],

--- a/samples/unit-tests/series-arearange/datagrouping/demo.js
+++ b/samples/unit-tests/series-arearange/datagrouping/demo.js
@@ -24,6 +24,9 @@ QUnit.test('dataGrouping for area range', function (assert) {
                 ],
                 dataGrouping: {
                     approximation: 'averages'
+                },
+                dataLabels: {
+                    enabled: true
                 }
             }, {
                 data: [
@@ -58,5 +61,15 @@ QUnit.test('dataGrouping for area range', function (assert) {
     assert.ok(
         chart.series[0].points.length === chart.series[1].points.length,
         'approximations.averages() returns undefined if needed (#7377)'
+    );
+
+    assert.ok(
+        chart.series[0].points[0].dataLabelUpper !== undefined,
+        'Top label rendered (#9020)'
+    );
+
+    assert.ok(
+        chart.series[0].points[0].dataLabel !== undefined,
+        'Bottom label rendered (#9020)'
     );
 });


### PR DESCRIPTION
Highstock: Fixed #9020, columnrange bottom dataLabels were not rendered when dataGrouping was enabled.