### PR TITLE
bugfix/9119-overlapping-datalabels-stacklabels

### DIFF
--- a/js/modules/overlapping-datalabels.src.js
+++ b/js/modules/overlapping-datalabels.src.js
@@ -110,7 +110,7 @@ Chart.prototype.hideOverlappingLabels = function (labels) {
                 parent,
                 bBox,
                 // Substract the padding if no background or border (#4333)
-                padding = 2 * (label.box ? 0 : (label.padding || 0)),
+                padding = label.box ? 0 : (label.padding || 0),
                 lineHeightCorrection = 0;
 
             if (
@@ -135,10 +135,11 @@ Chart.prototype.hideOverlappingLabels = function (labels) {
                         .fontMetrics(null, label.element).h;
                 }
                 return {
-                    x: pos.x + (parent.translateX || 0),
-                    y: pos.y + (parent.translateY || 0) - lineHeightCorrection,
-                    width: label.width - padding,
-                    height: label.height - padding
+                    x: pos.x + (parent.translateX || 0) + padding,
+                    y: pos.y + (parent.translateY || 0) + padding -
+                        lineHeightCorrection,
+                    width: label.width - 2 * padding,
+                    height: label.height - 2 * padding
                 };
 
             }

--- a/samples/unit-tests/datalabels/overlapping/demo.js
+++ b/samples/unit-tests/datalabels/overlapping/demo.js
@@ -92,3 +92,45 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test(
+    'Overlapping labels with paddings',
+    function (assert) {
+        var chart = Highcharts.chart('container', {
+            chart: {
+                type: 'bar',
+                width: 570
+            },
+            yAxis: {
+                min: -10,
+                stackLabels: {
+                    enabled: true
+                }
+            },
+            plotOptions: {
+                series: {
+                    stacking: 'normal',
+                    dataLabels: {
+                        enabled: true
+                    }
+                }
+            },
+            series: [{
+                name: 'John',
+                data: [2.89765436543]
+            }, {
+                name: 'Jane',
+                data: [1.89765436543]
+            }, {
+                name: 'Joe',
+                data: [5.89765436543]
+            }]
+        });
+
+        assert.strictEqual(
+            chart.series[0].points[0].dataLabel.visibility === 'hidden',
+            true,
+            'Overlapping dataLabel is hidden (#9119).'
+        );
+    }
+);


### PR DESCRIPTION
Fixed #9119, dataLabels sometimes overlapped stackLabels.

I was thinking about direct test for `hideOverlappingLabels` but it looks like creating labels would be overdoing this. Let me know if you prefer test without creating a chart instance.