### PR TITLE
Added initial animation to pathfinder. Closes #9151.

### DIFF
--- a/js/parts-gantt/GanttSeries.js
+++ b/js/parts-gantt/GanttSeries.js
@@ -109,6 +109,9 @@ seriesType('gantt', 'xrange', {
     },
     pathfinder: {
         type: 'simpleConnect',
+        animation: {
+            reversed: true // Dependencies go from child to parent
+        },
         startMarker: {
             enabled: true,
             symbol: 'arrow-filled',

--- a/js/parts-gantt/Pathfinder.js
+++ b/js/parts-gantt/Pathfinder.js
@@ -450,10 +450,10 @@ function getEndCoords(path) {
                 } else {
                     // We have a solid point for both dimensions
                     if (x === undefined) {
-                        x = segment[segment.length - 1] + xAcc;
+                        x = segment[1] + xAcc;
                     }
                     if (y === undefined) {
-                        y = segment[segment.length - 2] + yAcc;
+                        y = segment[0] + yAcc;
                     }
                     break;
                 }
@@ -465,8 +465,8 @@ function getEndCoords(path) {
                     xAcc += segment[0];
                 } else {
                     // Update both dimensions
-                    yAcc += segment[segment.length - 2];
-                    xAcc += segment[segment.length - 1];
+                    yAcc += segment[0];
+                    xAcc += segment[1];
                 }
             }
             segment = [];


### PR DESCRIPTION
Adds initial animation to pathfinder. We draw the paths after animating the series, by animating the path from its starting point (path.d and opacity). The markers are added after the path has finished animating.

There is currently a bug in TreeGrid that invalidates point references, so this code breaks in the Gantt demo sample. Should be fine once the TreeGrid bug has been resolved.