### PR TITLE
bugfix/9150-heatmap-boost-canvas

### DIFF
--- a/js/modules/boost-canvas.src.js
+++ b/js/modules/boost-canvas.src.js
@@ -35,7 +35,9 @@ var win = H.win,
 H.initCanvasBoost = function () {
     if (H.seriesTypes.heatmap) {
         H.wrap(H.seriesTypes.heatmap.prototype, 'drawPoints', function () {
-            var ctx = this.getContext();
+            var ctx = this.getContext(),
+                plotLeft = this.chart.plotLeft,
+                plotTop = this.chart.plotTop;
             if (ctx) {
 
                 // draw the columns
@@ -59,8 +61,8 @@ H.initCanvasBoost = function () {
 
                         ctx.fillStyle = pointAttr.fill;
                         ctx.fillRect(
-                            shapeArgs.x,
-                            shapeArgs.y,
+                            shapeArgs.x + plotLeft,
+                            shapeArgs.y + plotTop,
                             shapeArgs.width,
                             shapeArgs.height
                         );

--- a/samples/highcharts/boost/bubble/demo.html
+++ b/samples/highcharts/boost/bubble/demo.html
@@ -1,5 +1,6 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
+<script src="https://code.highcharts.com/modules/boost-canvas.js"></script>
 <script src="https://code.highcharts.com/modules/boost.js"></script>
 <script src="https://code.highcharts.com/modules/exporting.js"></script>
 


### PR DESCRIPTION
All other series implement `plotLeft` and `plotTop` on a point level except heatmap - fixed.