### PR TITLE
Bugfix/9153 treegrid destroy points

### DIFF
--- a/js/modules/xrange.src.js
+++ b/js/modules/xrange.src.js
@@ -528,7 +528,9 @@ seriesType('xrange', 'column'
         if (series.options.colorByPoint && !point.options.color) {
             colorByPoint = getColorByCategory(series, point);
             point.color = colorByPoint.color;
-            point.colorIndex = colorByPoint.colorIndex;
+            if (!point.options.colorIndex) {
+                point.colorIndex = colorByPoint.colorIndex;
+            }
         }
 
         return point;

--- a/js/modules/xrange.src.js
+++ b/js/modules/xrange.src.js
@@ -161,7 +161,7 @@ seriesType('xrange', 'column'
     animate: seriesTypes.line.prototype.animate,
     cropShoulder: 1,
     getExtremesFromAll: true,
-
+    autoIncrement: H.noop,
     /**
      * Borrow the column series metrics, but with swapped axes. This gives free
      * access to features like groupPadding, grouping, pointWidth etc.

--- a/js/parts-gantt/Tree.js
+++ b/js/parts-gantt/Tree.js
@@ -112,8 +112,8 @@ var getNode = function (id, parent, level, data, mapOfIdToChildren, options) {
 
     // Calculate start and end for point if it is not already explicitly set.
     if (data) {
-        data.start = isNumber(data.start) ? data.start : start;
-        data.end = isNumber(data.end) ? data.end : end;
+        data.start = data.x = isNumber(data.start) ? data.start : start;
+        data.end = data.x2 = isNumber(data.end) ? data.end : end;
     }
 
     extend(node, {

--- a/js/parts-gantt/Tree.js
+++ b/js/parts-gantt/Tree.js
@@ -112,8 +112,8 @@ var getNode = function (id, parent, level, data, mapOfIdToChildren, options) {
 
     // Calculate start and end for point if it is not already explicitly set.
     if (data) {
-        data.start = data.x = isNumber(data.start) ? data.start : start;
-        data.end = data.x2 = isNumber(data.end) ? data.end : end;
+        data.start = data.x = pick(data.start, data.x, start);
+        data.end = data.x2 = pick(data.end, data.x2, end);
     }
 
     extend(node, {

--- a/js/parts-gantt/Tree.js
+++ b/js/parts-gantt/Tree.js
@@ -112,8 +112,8 @@ var getNode = function (id, parent, level, data, mapOfIdToChildren, options) {
 
     // Calculate start and end for point if it is not already explicitly set.
     if (data) {
-        data.start = data.x = pick(data.start, data.x, start);
-        data.end = data.x2 = pick(data.end, data.x2, end);
+        data.start = pick(data.start, start);
+        data.end = pick(data.end, end);
     }
 
     extend(node, {

--- a/js/parts-gantt/TreeGrid.js
+++ b/js/parts-gantt/TreeGrid.js
@@ -397,7 +397,13 @@ var getTreeGridFromData = function (data, uniqueNames, numberOfSeries) {
             each(nodes, function (node) {
                 var data = node.data;
                 if (isObject(data)) {
-                    data.y = start + data.seriesIndex;
+                    // Update point
+                    data.update(
+                        {
+                            y: start + data.seriesIndex
+                        },
+                        false
+                    );
                     // Remove the property once used
                     delete data.seriesIndex;
                 }
@@ -863,8 +869,14 @@ GridAxis.prototype.updateYNames = function () {
         // Concatenate data from all series assigned to this axis.
         data = reduce(series, function (arr, s) {
             if (s.visible) {
+                // If we do not have points, then generate them.
+                if (!s.points) {
+                    s.processData();
+                    s.generatePoints();
+                }
+
                 // Push all data to array
-                each(s.options.data, function (data) {
+                each(s.points, function (data) {
                     if (isObject(data)) {
                         // Set series index on data. Removed again after use.
                         data.seriesIndex = numberOfSeries;
@@ -894,12 +906,6 @@ GridAxis.prototype.updateYNames = function () {
         axis.collapsedNodes = treeGrid.collapsedNodes;
         axis.hasNames = true;
         axis.tree = treeGrid.tree;
-
-        // We have to set the series data again to correct the y-values
-        // which was set too early.
-        each(axis.series, function (series) {
-            series.setData(series.options.data, false, false, true);
-        });
     }
 };
 

--- a/js/parts-gantt/TreeGrid.js
+++ b/js/parts-gantt/TreeGrid.js
@@ -898,7 +898,7 @@ GridAxis.prototype.updateYNames = function () {
         // We have to set the series data again to correct the y-values
         // which was set too early.
         each(axis.series, function (series) {
-            series.setData(series.options.data, false, false, false);
+            series.setData(series.options.data, false, false, true);
         });
     }
 };


### PR DESCRIPTION
# Description
Treegrid broke referances to point due to its use of setData. Now it updates yData manually instead.

_Note: Could not use setData with updateData because it was unable to update the correct points._

Once this PR is merged in, the https://github.com/highcharts/highcharts/pull/9158 should be safe to merge in as well.

# Example(s)
- See https://github.com/highcharts/highcharts/issues/9153 for example

# Related issue(s)
- Closes https://github.com/highcharts/highcharts/issues/9153
