### PR TITLE
Fixed 9206, draggable points did not work with dynamic series.

### DIFF
--- a/js/modules/draggable-points.src.js
+++ b/js/modules/draggable-points.src.js
@@ -1103,7 +1103,7 @@ function isSeriesDraggable(series) {
  *        True if the chart is drag/droppable.
  */
 function isChartDraggable(chart) {
-    var i = chart.series.length;
+    var i = chart.series ? chart.series.length : 0;
     if (chart.hasCartesianSeries && !chart.polar) {
         while (i--) {
             if (
@@ -2231,8 +2231,14 @@ H.Chart.prototype.zoomOrPanKeyPressed = function (e) {
 };
 
 
-// Add events to document and chart after chart has been created
-H.Chart.prototype.callbacks.push(function (chart) {
+/**
+ * Add events to document and chart if the chart is draggable.
+ *
+ * @private
+ * @param {Highcharts.Chart} chart
+ *      The chart to add events to.
+ */
+function addDragDropEvents(chart) {
     var container = chart.container,
         doc = H.doc;
 
@@ -2260,6 +2266,9 @@ H.Chart.prototype.callbacks.push(function (chart) {
             mouseUp(e, chart);
         });
 
+        // Add flag to avoid doing this again
+        chart.hasAddedDragDropEvents = true;
+
         // Add cleanup to make sure we don't pollute document
         addEvent(chart, 'destroy', function () {
             if (chart.unbindDragDropMouseUp) {
@@ -2269,5 +2278,15 @@ H.Chart.prototype.callbacks.push(function (chart) {
                 chart.unbindDragDropTouchEnd();
             }
         });
+    }
+}
+
+
+// Add event listener to Chart.render that checks whether or not we should add
+// dragdrop.
+addEvent(H.Chart, 'render', function () {
+    // If we don't have dragDrop events, see if we should add them
+    if (!this.hasAddedDragDropEvents) {
+        addDragDropEvents(this);
     }
 });

--- a/samples/unit-tests/dragdrop/dynamic/demo.css
+++ b/samples/unit-tests/dragdrop/dynamic/demo.css
@@ -1,0 +1,6 @@
+#container {
+    min-width: 300px;
+    max-width: 800px;
+    height: 300px;
+    margin: 1em auto;
+}

--- a/samples/unit-tests/dragdrop/dynamic/demo.details
+++ b/samples/unit-tests/dragdrop/dynamic/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/dragdrop/dynamic/demo.html
+++ b/samples/unit-tests/dragdrop/dynamic/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/draggable-points.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/dragdrop/dynamic/demo.js
+++ b/samples/unit-tests/dragdrop/dynamic/demo.js
@@ -1,0 +1,41 @@
+
+QUnit.test('Dragdrop enabled in dynamic chart', function (assert) {
+
+    var chart = Highcharts.chart('container', {
+            series: []
+        }),
+        assertNoEvents = function () {
+            assert.notOk(chart.unbindDragDropMouseUp, 'No mouse up event');
+            assert.notOk(chart.unbindDragDropTouchEnd, 'No touch end event');
+            assert.notOk(chart.hasAddedDragDropEvents, 'No events added flag');
+        };
+
+    assertNoEvents();
+
+    chart.addSeries({
+        data: [1, 2, 3]
+    });
+
+    assertNoEvents();
+
+    chart.series[0].remove();
+
+    assertNoEvents();
+
+    chart.addSeries({
+        data: [4, 5, 6]
+    });
+
+    assertNoEvents();
+
+    chart.addSeries({
+        data: [7, 8, 9],
+        dragDrop: {
+            draggableY: true
+        }
+    });
+
+    assert.ok(chart.unbindDragDropMouseUp, 'Has mouse up event');
+    assert.ok(chart.unbindDragDropTouchEnd, 'Has touch end event');
+    assert.ok(chart.hasAddedDragDropEvents, 'Has events added flag');
+});


### PR DESCRIPTION
Moved logic for checking if chart is draggable to `Chart.render` event. The events are added only once.