### PR TITLE
Fixed issue with inverted heat indicators in logistics demo.

### DIFF
--- a/samples/gantt/demo/logistics/demo.js
+++ b/samples/gantt/demo/logistics/demo.js
@@ -140,8 +140,8 @@
                         indicator.start : xAxis.min,
                     end = isNumber(indicator.end) ?
                         indicator.end : xAxis.max,
-                    x1 = xAxis.translate(start, 0, 0, 0, 1),
-                    x2 = xAxis.translate(end, 0, 0, 0, 1),
+                    x1 = xAxis.translate(start > end ? start : end, 0, 0, 0, 1),
+                    x2 = xAxis.translate(start > end ? end : start, 0, 0, 0, 1),
                     plotY = yAxis.translate(indicator.y, 0, 1, 0, 1),
                     y1 = plotY,
                     y2 = plotY + metrics.width / 2,


### PR DESCRIPTION
# Description
Regression in the custom HeatIndicator module in the logistics demo, causing the indicators to break when the chart is inverted.

# Example(s)
- Open [/samples/gantt/demo/logistics/ ](http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/gantt/demo/logistics/) and add `chart: { inverted: true }` to the chart config.