### PR TITLE
Fixed #9214, distribute themes Sass files.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -465,6 +465,9 @@ const copyToDist = () => {
     const additionals = {
         'gfx/vml-radial-gradient.png': 'gfx/vml-radial-gradient.png',
         'code/css/highcharts.scss': 'css/highcharts.scss',
+        'code/css/themes/dark-unica.scss': 'css/themes/dark-unica.scss',
+        'code/css/themes/grid-light.scss': 'css/themes/grid-light.scss',
+        'code/css/themes/sand-signika.scss': 'css/themes/sand-signika.scss',
         'code/lib/canvg.js': 'vendor/canvg.js',
         'code/lib/canvg.src.js': 'vendor/canvg.src.js',
         'code/lib/jspdf.js': 'vendor/jspdf.js',


### PR DESCRIPTION
# Description
Our `highcharts.scss` file is currently distributed, which is handy for our users on NPM, but our themes scss files are missing. This PR adds them to the list of files in `copyToDist` which ensures that they are added in our upcoming releases.

# Related issue(s)
- Closes #9214