### PR TITLE
Pathfinder: Renamed options to connectors.

### DIFF
--- a/js/parts-gantt/GanttSeries.js
+++ b/js/parts-gantt/GanttSeries.js
@@ -106,7 +106,7 @@ seriesType('gantt', 'xrange', {
             return retVal;
         }
     },
-    pathfinder: {
+    connectors: {
         type: 'simpleConnect',
         animation: {
             reversed: true // Dependencies go from child to parent
@@ -331,7 +331,7 @@ seriesType('gantt', 'xrange', {
 /**
  * The ID of the point (task) that this point depends on in Gantt charts.
  * Aliases [connect](series.xrange.data.connect). Can also be an object,
- * specifying further connecting [options](series.gantt.pathfinder) between the
+ * specifying further connecting [options](series.gantt.connectors) between the
  * points. Multiple connections can be specified by providing an array.
  *
  * @type {Array<string|*>|string|*}

--- a/js/parts-gantt/Pathfinder.js
+++ b/js/parts-gantt/Pathfinder.js
@@ -32,39 +32,38 @@ var defined = H.defined,
 // Set default Pathfinder options
 extend(H.defaultOptions, {
     /**
-     * The Pathfinder allows you to define connections between any two points,
-     * represented as lines - optionally with markers for the start and/or end
-     * points. Multiple algorithms are available for calculating how the
-     * connecting lines are drawn.
+     * The Pathfinder module allows you to define connections between any two
+     * points, represented as lines - optionally with markers for the start
+     * and/or end points. Multiple algorithms are available for calculating how
+     * the connecting lines are drawn.
      *
-     * Pathfinder functionality requires Highcharts Gantt to be loaded. In Gantt
-     * charts, the Pathfinder is used to draw dependencies between tasks.
+     * Connector functionality requires Highcharts Gantt to be loaded. In Gantt
+     * charts, the connectors are used to draw dependencies between tasks.
      *
      * @product gantt
      * @see [dependency](series.gantt.data.dependency)
      *
      * @sample  gantt/pathfinder/demo Pathfinder connections
      *
-     * @optionparent pathfinder
+     * @optionparent connectors
      */
-    pathfinder: {
+    connectors: {
         /**
-         * Enable the pathfinder for this chart. Requires Highcharts Gantt.
+         * Enable connectors for this chart. Requires Highcharts Gantt.
          *
          * @type {boolean}
          * @default true
          * @since 6.2.0
-         * @apioption pathfinder.enabled
+         * @apioption connectors.enabled
          */
 
         /**
-         * Set the default dash style for this chart's Pathfinder connecting
-         * lines.
+         * Set the default dash style for this chart's connecting lines.
          *
          * @type {string}
          * @default solid
          * @since 6.2.0
-         * @apioption pathfinder.dashStyle
+         * @apioption connectors.dashStyle
          */
 
         /**
@@ -74,7 +73,7 @@ extend(H.defaultOptions, {
          * @type {Color}
          * @default null
          * @since 6.2.0
-         * @apioption pathfinder.lineColor
+         * @apioption connectors.lineColor
          */
 
         /**
@@ -92,13 +91,13 @@ extend(H.defaultOptions, {
          * @default null
          * @since 6.2.0
          * @sample gantt/pathfinder/algorithm-margin Small algorithmMargin
-         * @apioption pathfinder.algorithmMargin
+         * @apioption connectors.algorithmMargin
          */
 
         /**
          * Set the default pathfinder algorithm to use for this chart. It is
          * possible to define your own algorithms by adding them to the
-         * Highcharts.Pathfinder.prototype.algorithms object after the chart
+         * Highcharts.Pathfinder.prototype.algorithms object before the chart
          * has been created.
          *
          * The default algorithms are as follows:
@@ -123,7 +122,7 @@ extend(H.defaultOptions, {
          * @default straight|simpleConnect
          * @since 6.2.0
          * @sample gantt/pathfinder/demo Different types used
-         * @apioption pathfinder.type
+         * @apioption connectors.type
          */
         type: 'straight',
 
@@ -134,7 +133,7 @@ extend(H.defaultOptions, {
          * @type {number}
          * @default 1
          * @since 6.2.0
-         * @apioption pathfinder.lineWidth
+         * @apioption connectors.lineWidth
          */
         lineWidth: 1,
 
@@ -145,11 +144,11 @@ extend(H.defaultOptions, {
          *
          * @type {object}
          * @since 6.2.0
-         * @apioption pathfinder.marker
+         * @apioption connectors.marker
          */
         marker: {
             /**
-             * Set the radius of the pathfinder markers. The default is
+             * Set the radius of the connector markers. The default is
              * automatically computed based on the algorithmMargin setting.
              *
              * Setting marker.width and marker.height will override this
@@ -158,47 +157,47 @@ extend(H.defaultOptions, {
              * @type {number}
              * @default null
              * @since 6.2.0
-             * @apioption pathfinder.marker.radius
+             * @apioption connectors.marker.radius
              */
 
             /**
-             * Set the width of the pathfinder markers. If not supplied, this
+             * Set the width of the connector markers. If not supplied, this
              * is inferred from the marker radius.
              *
              * @type {number}
              * @default null
              * @since 6.2.0
-             * @apioption pathfinder.marker.width
+             * @apioption connectors.marker.width
              */
 
             /**
-             * Set the height of the pathfinder markers. If not supplied, this
+             * Set the height of the connector markers. If not supplied, this
              * is inferred from the marker radius.
              *
              * @type {number}
              * @default null
              * @since 6.2.0
-             * @apioption pathfinder.marker.height
+             * @apioption connectors.marker.height
              */
 
             /**
-             * Set the color of the pathfinder markers. By default this is the
+             * Set the color of the connector markers. By default this is the
              * same as the connector color.
              *
              * @type {Color}
              * @default null
              * @since 6.2.0
-             * @apioption pathfinder.marker.color
+             * @apioption connectors.marker.color
              */
 
             /**
-             * Set the line/border color of the pathfinder markers. By default
+             * Set the line/border color of the connector markers. By default
              * this is the same as the marker color.
              *
              * @type {Color}
              * @default null
              * @since 6.2.0
-             * @apioption pathfinder.marker.lineColor
+             * @apioption connectors.marker.lineColor
              */
 
             /**
@@ -233,12 +232,12 @@ extend(H.defaultOptions, {
          *
          * @type {object}
          * @since 6.2.0
-         * @extends pathfinder.marker
-         * @apioption pathfinder.startMarker
+         * @extends connectors.marker
+         * @apioption connectors.startMarker
          */
         startMarker: {
             /**
-             * Set the symbol of the pathfinder start markers.
+             * Set the symbol of the connector start markers.
              */
             symbol: 'diamond'
         },
@@ -249,12 +248,12 @@ extend(H.defaultOptions, {
          *
          * @type {object}
          * @since 6.2.0
-         * @extends pathfinder.marker
-         * @apioption pathfinder.endMarker
+         * @extends connectors.marker
+         * @apioption connectors.endMarker
          */
         endMarker: {
             /**
-             * Set the symbol of the pathfinder end markers.
+             * Set the symbol of the connector end markers.
              */
             symbol: 'arrow-filled'
         }
@@ -262,13 +261,13 @@ extend(H.defaultOptions, {
 });
 
 /**
- * Override Pathfinder options for a series. Requires Highcharts Gantt or the
- * Pathfinder module.
+ * Override Pathfinder connector options for a series. Requires Highcharts Gantt
+ * to be loaded.
  *
  * @since 6.2.0
- * @extends pathfinder
+ * @extends connectors
  * @product gantt
- * @apioption plotOptions.series.pathfinder
+ * @apioption plotOptions.series.connectors
  * @excluding enabled,algorithmMargin
  */
 
@@ -280,7 +279,7 @@ extend(H.defaultOptions, {
  *
  * @type {Array<string|*>|string|*}
  * @since 6.2.0
- * @extends plotOptions.series.pathfinder
+ * @extends plotOptions.series.connectors
  * @excluding enabled
  * @product gantt
  * @sample gantt/pathfinder/demo Different connection types
@@ -644,7 +643,7 @@ Connection.prototype = {
      * @function Highcharts.Connection#getPath
      *
      * @param   {object} options
-     *          Pathfinder options. Not calculated or merged with other options.
+     *          Connector options. Not calculated or merged with other options.
      *
      * @return  {Array}
      *          Calculated SVG path data in array format.
@@ -670,7 +669,7 @@ Connection.prototype = {
 
             // If the algorithmMargin was computed, store the result in default
             // options.
-            chart.options.pathfinder.algorithmMargin = options.algorithmMargin;
+            chart.options.connectors.algorithmMargin = options.algorithmMargin;
 
             // Cache some metrics too
             pathfinder.chartObstacleMetrics =
@@ -717,8 +716,8 @@ Connection.prototype = {
             pathResult,
             path,
             options = merge(
-                chart.options.pathfinder, series.options.pathfinder,
-                fromPoint.options.pathfinder, connection.options
+                chart.options.connectors, series.options.connectors,
+                fromPoint.options.connectors, connection.options
             ),
             attribs = {};
 
@@ -1249,10 +1248,26 @@ extend(H.Point.prototype, /** @lends Point.prototype */ {
     }
 });
 
+
+// Warn if using legacy options
+function warnLegacy(chart) {
+    if (
+        chart.options.pathfinder ||
+        H.reduce(chart.series, function (acc, series) {
+            return acc || series.options && series.options.pathfinder;
+        }, false)
+    ) {
+        H.error('Pathfinder options have been renamed. ' +
+            'Use "chart.connectors" or "series.connectors" instead.');
+    }
+}
+
+
 // Initialize Pathfinder for charts
 H.Chart.prototype.callbacks.push(function (chart) {
     var options = chart.options;
-    if (options.pathfinder.enabled !== false) {
+    if (options.connectors.enabled !== false) {
+        warnLegacy(chart);
         this.pathfinder = new Pathfinder(this);
         this.pathfinder.update(true); // First draw, defer render
     }

--- a/js/parts-gantt/Pathfinder.js
+++ b/js/parts-gantt/Pathfinder.js
@@ -1249,15 +1249,28 @@ extend(H.Point.prototype, /** @lends Point.prototype */ {
 });
 
 
-// Warn if using legacy options
+// Warn if using legacy options. Copy the options over. Note that this will
+// still break if using the legacy options in chart.update, addSeries etc.
 function warnLegacy(chart) {
     if (
         chart.options.pathfinder ||
         H.reduce(chart.series, function (acc, series) {
+            if (series.options) {
+                merge(true,
+                    (
+                        series.options.connectors = series.options.connectors ||
+                        {}
+                    ), series.options.pathfinder
+                );
+            }
             return acc || series.options && series.options.pathfinder;
         }, false)
     ) {
-        H.error('Pathfinder options have been renamed. ' +
+        merge(true,
+            (chart.options.connectors = chart.options.connectors || {}),
+            chart.options.pathfinder
+        );
+        H.error('WARNING: Pathfinder options have been renamed. ' +
             'Use "chart.connectors" or "series.connectors" instead.');
     }
 }

--- a/samples/gantt/gantt/demo/demo.js
+++ b/samples/gantt/gantt/demo/demo.js
@@ -22,7 +22,7 @@ Highcharts.ganttChart('container', {
     /*
     plotOptions: {
         gantt: {
-            pathfinder: {
+            connectors: {
                 type: 'simpleConnect'
             }
         }

--- a/samples/gantt/pathfinder/algorithm-margin/demo.js
+++ b/samples/gantt/pathfinder/algorithm-margin/demo.js
@@ -13,7 +13,7 @@ Highcharts.ganttChart('container', {
     plotOptions: {
         series: {
             colorByPoint: false,
-            pathfinder: {
+            connectors: {
                 algorithmMargin: 2,
                 startMarker: {
                     symbol: 'square',

--- a/samples/gantt/pathfinder/auto-marker-placement/demo.js
+++ b/samples/gantt/pathfinder/auto-marker-placement/demo.js
@@ -1,6 +1,6 @@
 Highcharts.chart('container', {
     series: [{
-        pathfinder: {
+        connectors: {
             marker: {
                 enabled: true
             }

--- a/samples/gantt/pathfinder/demo/demo.details
+++ b/samples/gantt/pathfinder/demo/demo.details
@@ -1,5 +1,5 @@
 ---
- name: Pathfinder Demo
+ name: Connectors Demo
  js_wrap: b
  authors:
    - Øystein Moseng

--- a/samples/gantt/pathfinder/demo/demo.js
+++ b/samples/gantt/pathfinder/demo/demo.js
@@ -22,7 +22,7 @@ Highcharts.chart('container', {
                 enabled: true
             },
             // Set default connection options here
-            pathfinder: {
+            connectors: {
                 lineWidth: 2
             }
         }

--- a/samples/gantt/pathfinder/simple-connect/demo.details
+++ b/samples/gantt/pathfinder/simple-connect/demo.details
@@ -1,5 +1,5 @@
 ---
- name: Pathfinder Demo
+ name: Connectors Demo
  js_wrap: b
  authors:
    - Øystein Moseng

--- a/samples/gantt/pathfinder/simple-connect/demo.js
+++ b/samples/gantt/pathfinder/simple-connect/demo.js
@@ -1,5 +1,5 @@
 Highcharts.chart('container', {
-    pathfinder: {
+    connectors: {
         marker: {
             enabled: true
         },

--- a/samples/unit-tests/gantt/pathfinder/demo.js
+++ b/samples/unit-tests/gantt/pathfinder/demo.js
@@ -37,7 +37,7 @@
                 height: 400,
                 spacing: [15, 15, 15, 15]
             },
-            pathfinder: {
+            connectors: {
                 animation: false
             },
 
@@ -45,7 +45,7 @@
             // bottom, left, right and all cordners, and connect them to the
             // center
             series: [{
-                pathfinder: {
+                connectors: {
                     marker: {
                         enabled: true
                     }
@@ -252,7 +252,7 @@
         var error = 0.1,
             chart,
             series = squareChartConfig.series[0],
-            opts = series.pathfinder,
+            opts = series.connectors,
             aligns = ['left', 'center', 'right'],
             verticalAligns = ['top', 'middle', 'bottom'];
 
@@ -366,7 +366,7 @@
         var pathWithoutMarkers,
             pathWithMarkers,
             chart = Highcharts.chart('container', {
-                pathfinder: {
+                connectors: {
                     animation: false
                 },
                 series: [{
@@ -381,7 +381,7 @@
                         connect: 'one-one'
                     }]
                 }, {
-                    pathfinder: {
+                    connectors: {
                         marker: {
                             enabled: true
                         }


### PR DESCRIPTION
`chart.options.pathfinder` and `series.options.pathfinder` have now been renamed to `chart.options.connectors` and `series.options.connectors` respectively. A console warning has been added if the old options are used. The old options are not supported, and using them will have no effect.