### PR TITLE
 docs/annotations-id

### DIFF
--- a/js/modules/annotations.src.js
+++ b/js/modules/annotations.src.js
@@ -539,6 +539,14 @@ Annotation.prototype = /** @lends Highcharts.Annotation# */ {
      * @optionparent annotations
      */
     defaultOptions: {
+        /**
+         * Sets an ID for an annotation. Can be user later when removing an
+         * annotation in [Chart#removeAnnotation(id)](
+         * /class-reference/Highcharts.Chart#removeAnnotation) method.
+         *
+         * @apioption annotations.id
+         * @default undefined
+         */
 
         /**
          * Whether the annotation is visible.


### PR DESCRIPTION
Fixed #9252, added missing `annotations.id` documentation.