### PR TITLE
fixes linebreak in documentation link

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -2408,9 +2408,9 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
          * item is a float between 0 and 1 assigning the relative position in
          * the gradient, and the second item is the color.
          *
-         * For solid gauges, the Y axis also inherits the concept of [data classes](http://api.
-         * highcharts.com/highmaps#colorAxis.dataClasses) from the Highmaps
-         * color axis.
+         * For solid gauges, the Y axis also inherits the concept of
+         * [data classes](http://api.highcharts.com/highmaps#colorAxis.dataClasses)
+         * from the Highmaps color axis.
          *
          * @see [minColor](#yAxis.minColor)
          * @see [maxColor](#yAxis.maxColor)


### PR DESCRIPTION
otherwise the docs (now) read

```
For solid gauges, the Y axis also inherits the concept of [data classes](http://api. highcharts.com/highmaps#colorAxis.dataClasses) from the Highmaps color axis
```
