### PR TITLE
Gantt: Added missing API options.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -328,6 +328,7 @@ const generateClassReferences = ({ templateDir, destination }) => {
         './js/parts/SVGRenderer.js',
         './js/parts/Tick.js',
         './js/parts/Time.js',
+        './js/parts-gantt/GanttChart.js',
         './js/parts-gantt/TreeGrid.js',
         './js/parts-map/GeoJSON.js',
         './js/parts-map/Map.js',

--- a/js/parts-gantt/GanttChart.js
+++ b/js/parts-gantt/GanttChart.js
@@ -15,14 +15,35 @@ var each = H.each,
     Chart = H.Chart;
 
 /**
- * The GanttChart class.
- * @class Highcharts.ganttChart
- * @memberOf Highcharts
- * @param {String|HTMLDOMElement} renderTo The DOM element to render to, or
- *                                         its id.
- * @param {ChartOptions}          options  The chart options structure.
- * @param {Function}              callback Function to run when the chart has
- *                                         loaded.
+ * Factory function for Gantt charts.
+ *
+ * @example
+ * // Render a chart in to div#container
+ * var chart = Highcharts.ganttChart('container', {
+ *     title: {
+ *         text: 'My chart'
+ *     },
+ *     series: [{
+ *         data: ...
+ *     }]
+ * });
+ *
+ * @function Highcharts.ganttChart
+ *
+ * @param {string|Highcharts.HTMLDOMElement} [renderTo]
+ *        The DOM element to render to, or its id.
+ *
+ * @param {Highcharts.Options} options
+ *        The chart options structure.
+ *
+ * @param {Highcharts.ChartCallbackFunction} [callback]
+ *        Function to run when the chart has loaded and and all external images
+ *        are loaded. Defining a
+ *        [chart.event.load](https://api.highcharts.com/highcharts/chart.events.load)
+ *        handler is equivalent.
+ *
+ * @return {Highcharts.Chart}
+ *         Returns the Chart object.
  */
 H.ganttChart = function (renderTo, options, callback) {
     var hasRenderToArg = typeof renderTo === 'string' || renderTo.nodeName,

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -297,7 +297,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
          *         Without
          *
          * @type      {Array<string>}
-         * @product   highcharts
+         * @product   highcharts gantt
          * @apioption xAxis.categories
          */
 

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -868,7 +868,7 @@ H.Series = H.seriesType('line', null
      *
      * @type      {Function}
      * @since     4.0
-     * @product   highcharts highstock
+     * @product   highcharts highstock gantt
      * @context   Highcharts.Series
      * @apioption plotOptions.series.events.afterAnimate
      */
@@ -5352,7 +5352,7 @@ H.Series = H.seriesType('line', null
  *
  * @type      {string}
  * @since     5.0.0
- * @product   highcharts
+ * @product   highcharts gantt
  * @apioption series.line.data.className
  */
 
@@ -5367,7 +5367,7 @@ H.Series = H.seriesType('line', null
  *         Mark the highest point
  *
  * @type      {Highcharts.ColorString}
- * @product   highcharts highstock
+ * @product   highcharts highstock gantt
  * @apioption series.line.data.color
  */
 
@@ -5380,7 +5380,7 @@ H.Series = H.seriesType('line', null
  *
  * @type      {number}
  * @since     5.0.0
- * @product   highcharts
+ * @product   highcharts gantt
  * @apioption series.line.data.colorIndex
  */
 
@@ -5393,7 +5393,7 @@ H.Series = H.seriesType('line', null
  *         Show a label for the last value
  *
  * @type      {Highcharts.PlotSeriesDataLabelsOptions}
- * @product   highcharts highstock
+ * @product   highcharts highstock gantt
  * @apioption series.line.data.dataLabels
  */
 
@@ -5415,7 +5415,7 @@ H.Series = H.seriesType('line', null
  *
  * @type      {string}
  * @since     1.2.0
- * @product   highcharts highstock
+ * @product   highcharts highstock gantt
  * @apioption series.line.data.id
  */
 
@@ -5446,7 +5446,7 @@ H.Series = H.seriesType('line', null
  *
  * @type      {boolean}
  * @default   false
- * @product   highcharts highstock
+ * @product   highcharts highstock gantt
  * @apioption series.line.data.selected
  */
 
@@ -5471,7 +5471,7 @@ H.Series = H.seriesType('line', null
  * Individual point events
  *
  * @extends   plotOptions.series.point.events
- * @product   highcharts highstock
+ * @product   highcharts highstock gantt
  * @apioption series.line.data.events
  */
 


### PR DESCRIPTION
Gantt chart constructor was missing in class reference, and some API options were missing.