### PR TITLE
Bugfix/changelog urls

### DIFF
--- a/changelog/changelog.html
+++ b/changelog/changelog.html
@@ -20,7 +20,7 @@
             </p>
             <ul>
               <li>Added support for
-                <a href="http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/plotoptions/series-datalabels-multiple/">multiple data labels</a> on each single point.</li>
+                <a href="https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/plotoptions/series-datalabels-multiple/">multiple data labels</a> on each single point.</li>
               <li>Added
                 <a href="httpd://api.highcharts.com/highcharts/series.line.dragDrop">draggable points plugin</a> as module.</li>
               <li>Added support for <code>pointPlacement</code> in X range charts, affecting the category Y axis. Closed
@@ -1518,7 +1518,7 @@
                 <a href="https://github.com/highcharts/highcharts/issues/5755">#5755</a>
               </li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/plotOptions.series.findNearestPointBy">findNearestPointBy</a> to declare how the tooltip searches for points.
+                <a href="https://api.highcharts.com/highcharts/plotOptions.series.findNearestPointBy">findNearestPointBy</a> to declare how the tooltip searches for points.
                 <a href="https://github.com/highcharts/highcharts/issues/6231">#6231</a>.</li>
               <li>Refactored the Pane object to keep track of its own backgrounds, more decoupled from Axis.</li>
             </ul>
@@ -1634,13 +1634,13 @@
             <ul>
               <li>Added a refactored Boost module based on WebGL. Details and API to be announced.</li>
               <li>Added
-                <a href="http://api.highcharts.com/highcharts/plotOptions.series.states.hover.animation">animation</a> on graph mouse over and mouse out.</li>
+                <a href="https://api.highcharts.com/highcharts/plotOptions.series.states.hover.animation">animation</a> on graph mouse over and mouse out.</li>
               <li>Added hooks so that users can define their own log axis conversion functions, and can advertise that the log axis should allow
-                <a href="http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/samples/highcharts/yaxis/type-log-negative/">negative values</a>.</li>
+                <a href="https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/samples/highcharts/yaxis/type-log-negative/">negative values</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/plotOptions.solidgauge.rounded">solidgauge.rounded</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/plotOptions.solidgauge.rounded">solidgauge.rounded</a>.</li>
               <li>Added support for relative
-                <a href="http://api.highcharts.com/highcharts/chart.height">chart.height</a> as a percentage of the width. This allows for fixed aspect ratio.</li>
+                <a href="https://api.highcharts.com/highcharts/chart.height">chart.height</a> as a percentage of the width. This allows for fixed aspect ratio.</li>
             </ul>
             <div id="accordion" class="panel-group">
               <div class="panel panel-default">
@@ -1730,14 +1730,14 @@
               <li>Added Legend keyboard navigation to accessibility module.</li>
               <li>Added chart render and predraw events needed by the new Boost module.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/global.timezone">global.timezone</a>, as a convenient shortcut to timezones defined with moment.js.</li>
+                <a href="https://api.highcharts.com/highcharts/global.timezone">global.timezone</a>, as a convenient shortcut to timezones defined with moment.js.</li>
               <li>Added optional redraw to <code>drillToNode</code>, related to
                 <a href="https://github.com/highcharts/highcharts/issues/6180">#6180</a>.</li>
               <li>Added support for
-                <a href="http://api.highcharts.com/highcharts/plotOptions.bubble.marker.symbol">marker.symbol</a> setting on bubble charts.</li>
+                <a href="https://api.highcharts.com/highcharts/plotOptions.bubble.marker.symbol">marker.symbol</a> setting on bubble charts.</li>
               <li>Changed the <code>Highcharts.addEvent</code> function to return a callback to be used to remove the same event.</li>
               <li>Changed the
-                <a href="http://api.highcharts.com/highcharts/Highcharts.error">Highcharts.error</a> function to handle strings.</li>
+                <a href="https://api.highcharts.com/highcharts/Highcharts.error">Highcharts.error</a> function to handle strings.</li>
             </ul>
             <div id="accordion" class="panel-group">
               <div class="panel panel-default">
@@ -1845,7 +1845,7 @@
             </p>
             <ul>
               <li>Added a common hook,
-                <a href="http://api.highcharts.com/highcharts/Highcharts.error">Highcharts.error</a>, for user defined error handling.</li>
+                <a href="https://api.highcharts.com/highcharts/Highcharts.error">Highcharts.error</a>, for user defined error handling.</li>
             </ul>
             <div id="accordion" class="panel-group">
               <div class="panel panel-default">
@@ -1991,9 +1991,9 @@
             </p>
             <ul>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/lang.numericSymbolMagnitude">lang.numericSymbolMagnitude</a>, to support numeric symbol shortening in Japanese, Korean and certain Chinese locales.</li>
+                <a href="https://api.highcharts.com/highcharts/lang.numericSymbolMagnitude">lang.numericSymbolMagnitude</a>, to support numeric symbol shortening in Japanese, Korean and certain Chinese locales.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/plotOptions.solidgauge.threshold">threshold</a>, for solid gauge series.</li>
+                <a href="https://api.highcharts.com/highcharts/plotOptions.solidgauge.threshold">threshold</a>, for solid gauge series.</li>
               <li>Added new CSS custom property, <code>textOutline</code>, and at the same time removed the <code>textShadow</code> shim. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/5849">#5849</a>.</li>
               <li>Better implementation of the
@@ -2226,60 +2226,60 @@
               <li>Added
                 <a href="/docs/chart-design-and-style/style-by-css">styled mode</a> for optional separation of SVG and CSS.</li>
               <li>Added
-                <a href="http://api.highcharts.com/highcharts/responsive">responsive</a> option set.</li>
+                <a href="https://api.highcharts.com/highcharts/responsive">responsive</a> option set.</li>
               <li>Added
-                <a href="http://api.highcharts.com/highcharts/accessibility">accessibility</a> option set.</li>
+                <a href="https://api.highcharts.com/highcharts/accessibility">accessibility</a> option set.</li>
               <li>Added new function,
-                <a href="http://api.highcharts.com/highcharts/Chart.update">Chart.update</a> in order to update the chart options after render time.</li>
+                <a href="https://api.highcharts.com/highcharts/Chart.update">Chart.update</a> in order to update the chart options after render time.</li>
               <li>Added new function,
-                <a href="http://api.highcharts.com/highcharts/Chart.addCredits">Chart.addCredits</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/Chart.addCredits">Chart.addCredits</a>.</li>
               <li>Added new function,
-                <a href="http://api.highcharts.com/highcharts/Chart.title">Chart.title.update</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/Chart.title">Chart.title.update</a>.</li>
               <li>Added new function,
-                <a href="http://api.highcharts.com/highcharts/Chart.credits">Chart.credits.update</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/Chart.credits">Chart.credits.update</a>.</li>
               <li>Added new function,
-                <a href="http://api.highcharts.com/highcharts/Legend.update">Legend.update</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/Legend.update">Legend.update</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/Renderer.definition">Renderer.definition</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/Renderer.definition">Renderer.definition</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/exporting.error">exporting.error</a> for catching errors in offline exporting.</li>
+                <a href="https://api.highcharts.com/highcharts/exporting.error">exporting.error</a> for catching errors in offline exporting.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/exporting.libURL">exporting.libURL</a> for use with offline exporting.</li>
+                <a href="https://api.highcharts.com/highcharts/exporting.libURL">exporting.libURL</a> for use with offline exporting.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/pane.background.className">pane.background.className</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/pane.background.className">pane.background.className</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/xAxis.className">xAxis.className</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/xAxis.className">xAxis.className</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/xAxis.crosshair.className">xAxis.crosshair.className</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/xAxis.crosshair.className">xAxis.crosshair.className</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/plotOptions.series.dataLabels.className">plotOptions.series.dataLabels.className</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/plotOptions.series.dataLabels.className">plotOptions.series.dataLabels.className</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/plotOptions.series.className">plotOptions.series.className</a> for styling individual series.</li>
+                <a href="https://api.highcharts.com/highcharts/plotOptions.series.className">plotOptions.series.className</a> for styling individual series.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/xAxis.plotBands.className">xAxis.plotBands.className</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/xAxis.plotBands.className">xAxis.plotBands.className</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/xAxis.plotLines.className">xAxis.plotLines.className</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/xAxis.plotLines.className">xAxis.plotLines.className</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/plotOptions.series.zones.className">plotOptions.series.zones.className</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/plotOptions.series.zones.className">plotOptions.series.zones.className</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/chart.colorCount">chart.colorCount</a> for use in styled mode.</li>
+                <a href="https://api.highcharts.com/highcharts/chart.colorCount">chart.colorCount</a> for use in styled mode.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/defs">defs</a> for defining reusable elements in styled mode.</li>
+                <a href="https://api.highcharts.com/highcharts/defs">defs</a> for defining reusable elements in styled mode.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/tooltip.padding">tooltip.padding</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/tooltip.padding">tooltip.padding</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/series%3Cline%3E.data.colorIndex">series
+                <a href="https://api.highcharts.com/highcharts/series%3Cline%3E.data.colorIndex">series
                   <line>.data.colorIndex</a> for coloring points in styled mode.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/tooltip.split">tooltip.split</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/tooltip.split">tooltip.split</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/chart.description">chart.description</a> for use with the accessibility module.</li>
+                <a href="https://api.highcharts.com/highcharts/chart.description">chart.description</a> for use with the accessibility module.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/chart.typeDescription">chart.typeDescription</a> for use with the accessibility module.</li>
+                <a href="https://api.highcharts.com/highcharts/chart.typeDescription">chart.typeDescription</a> for use with the accessibility module.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/xAxis.description">xAxis.description</a> for use with the accessibility module.</li>
+                <a href="https://api.highcharts.com/highcharts/xAxis.description">xAxis.description</a> for use with the accessibility module.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/plotOptions.series.description">plotOptions.series.description</a> for use with the accessibility module.</li>
+                <a href="https://api.highcharts.com/highcharts/plotOptions.series.description">plotOptions.series.description</a> for use with the accessibility module.</li>
               <li>Refactored build system to use ES6 imports and node-based build script.</li>
               <li>Changed all default colors (except series data colors) to a simplified color scheme based on just a few shared colors.</li>
             </ul>
@@ -2502,11 +2502,11 @@
             </p>
             <ul>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts#exporting.printMaxWidth">exporting.printMaxWidth</a>, to prevent printed charts cut off on the right side. Closes
+                <a href="https://api.highcharts.com/highcharts#exporting.printMaxWidth">exporting.printMaxWidth</a>, to prevent printed charts cut off on the right side. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/2088">#2088</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts#title.widthAdjust">title.widthAdjust</a> and sub
-                <a href="http://api.highcharts.com/highcharts#title.widthAdjust">title.widthAdjust</a>, to prevent titles from flowing over elements.</li>
+                <a href="https://api.highcharts.com/highcharts#title.widthAdjust">title.widthAdjust</a> and sub
+                <a href="https://api.highcharts.com/highcharts#title.widthAdjust">title.widthAdjust</a>, to prevent titles from flowing over elements.</li>
               <li>Added support for JPEG in offline download module, ref
                 <a href="https://github.com/highcharts/highcharts/issues/5157">#5157</a>.</li>
             </ul>
@@ -2576,19 +2576,19 @@
               <li>Added <code>e.originalEvent</code> to drilldown event in order to catch modifier keys and other properties. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/5113">#5113</a>.</li>
               <li>Added new drilldown event,
-                <a href="http://api.highcharts.com/highcharts#chart.events.drillupall">chart.events.drillupall</a>, that is triggered after multiple single drillup events. Closes
+                <a href="https://api.highcharts.com/highcharts#chart.events.drillupall">chart.events.drillupall</a>, that is triggered after multiple single drillup events. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/5158">#5158</a>. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/5159">#5159</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts#chart.options3d.fitToPlot">chart.options3d.fitToPlot</a> to fit 3D charts into the available plotting area. This may affect the layout of existing 3D charts if the layout was adjusted by <code>chart.margin</code>. The <code>chart.margin</code> setting can now normally
+                <a href="https://api.highcharts.com/highcharts#chart.options3d.fitToPlot">chart.options3d.fitToPlot</a> to fit 3D charts into the available plotting area. This may affect the layout of existing 3D charts if the layout was adjusted by <code>chart.margin</code>. The <code>chart.margin</code> setting can now normally
                 be removed. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/4933">#4933</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts#lang.shortWeekdays">lang.shortWeekdays</a>, to specify short weekdays other than the first three letters of the weekday.</li>
+                <a href="https://api.highcharts.com/highcharts#lang.shortWeekdays">lang.shortWeekdays</a>, to specify short weekdays other than the first three letters of the weekday.</li>
               <li>Added new value, <code>day</code>, for
-                <a href="http://api.highcharts.com/highcharts#plotOptions.series.pointIntervalUnit">pointIntervalUnit</a>.</li>
+                <a href="https://api.highcharts.com/highcharts#plotOptions.series.pointIntervalUnit">pointIntervalUnit</a>.</li>
               <li>Added option,
-                <a href="http://api.highcharts.com/highcharts#legend.navigation.enabled">legend.navigation.enabled</a>, to allow disabling legend scroll.</li>
+                <a href="https://api.highcharts.com/highcharts#legend.navigation.enabled">legend.navigation.enabled</a>, to allow disabling legend scroll.</li>
             </ul>
             <div id="accordion" class="panel-group">
               <div class="panel panel-default">
@@ -2738,9 +2738,9 @@
             </p>
             <ul>
               <li>Added new option,
-                <a href="http://api.highcharts.com#plotOptions.solidgauge.linecap">linecap</a>, to allow round corners on solid gauge.</li>
+                <a href="https://api.highcharts.com#plotOptions.solidgauge.linecap">linecap</a>, to allow round corners on solid gauge.</li>
               <li>Changed
-                <a href="http://api.highcharts.com#chart.events.load">chart.load</a> event to wait for external symbol images, so that their size is set correctly in the SVG. This comes in handy for export and server generated images.</li>
+                <a href="https://api.highcharts.com#chart.events.load">chart.load</a> event to wait for external symbol images, so that their size is set correctly in the SVG. This comes in handy for export and server generated images.</li>
             </ul>
             <div id="accordion" class="panel-group">
               <div class="panel panel-default">
@@ -2874,10 +2874,10 @@
               <li>Added new feature, <code>borderColor: null</code> for pies, which inherits the slice color. This allows a simple workaround for antialiasing gaps between slices when not using a real border (
                 <a href="https://github.com/highcharts/highcharts/issues/1828">#1828</a>).</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts#xAxis.labels.reserveSpace">xAxis.labels.reserveSpace</a>, to control whether the labels should take up space in the layout. Closes
+                <a href="https://api.highcharts.com/highcharts#xAxis.labels.reserveSpace">xAxis.labels.reserveSpace</a>, to control whether the labels should take up space in the layout. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/3479">#3479</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts#plotOptions.treemap.sortIndex">treemap.sortIndex</a>.</li>
+                <a href="https://api.highcharts.com/highcharts#plotOptions.treemap.sortIndex">treemap.sortIndex</a>.</li>
               <li>Better animation on 3D pie drilldown (
                 <a href="https://github.com/highcharts/highcharts/issues/3534">#3534</a>).</li>
             </ul>
@@ -2999,12 +2999,12 @@
             </p>
             <ul>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts#xAxis.visible">axis.visible</a>.</li>
+                <a href="https://api.highcharts.com/highcharts#xAxis.visible">axis.visible</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts#plotOptions.bubble.sizeByAbsoluteValue">bubble.sizeByAbsoluteValue</a>, to allow negative bubbles sizes to be based on the absolute value rather than a scalar difference from smallest to greatest. Closes
+                <a href="https://api.highcharts.com/highcharts#plotOptions.bubble.sizeByAbsoluteValue">bubble.sizeByAbsoluteValue</a>, to allow negative bubbles sizes to be based on the absolute value rather than a scalar difference from smallest to greatest. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/4498">#4498</a>.</li>
               <li>Added new series option,
-                <a href="http://api.highcharts.com/highcharts#plotOptions.series.softThreshold">softThreshold</a>, to prevent showing subzero axis ticks for line series that consist of positive data only.</li>
+                <a href="https://api.highcharts.com/highcharts#plotOptions.series.softThreshold">softThreshold</a>, to prevent showing subzero axis ticks for line series that consist of positive data only.</li>
               <li>Added support for <code>legendType: &#39;point&#39;</code> on more series types than just pie and its derivatives.</li>
             </ul>
             <div id="accordion" class="panel-group">
@@ -3116,10 +3116,10 @@
             </p>
             <ul>
               <li>Added experimental support for using HTML in exported charts through the
-                <a href="http://api.highcharts.com/#exporting.allowHTML">exporting.allowHTML option</a>. Discussed in
+                <a href="https://api.highcharts.com/#exporting.allowHTML">exporting.allowHTML option</a>. Discussed in
                 <a href="https://github.com/highcharts/highcharts/issues/2473">#2473</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts#plotOptions.column.maxPointWidth">maxPointWidth</a>, to the column chart type and its derivatives.</li>
+                <a href="https://api.highcharts.com/highcharts#plotOptions.column.maxPointWidth">maxPointWidth</a>, to the column chart type and its derivatives.</li>
               <li>Add <code>%k</code>, hours with no padding, in dateFormat.</li>
               <li>Don&#39;t cache undefined bounding box key. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/4328">#4328</a>.</li>
@@ -3310,7 +3310,7 @@
             </p>
             <ul>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts#plotOptions.series.getExtremesFromAll">series.getExtremesFromAll</a>, that tells the y axis to be scaled to the whole series range, not only the visible part.</li>
+                <a href="https://api.highcharts.com/highcharts#plotOptions.series.getExtremesFromAll">series.getExtremesFromAll</a>, that tells the y axis to be scaled to the whole series range, not only the visible part.</li>
               <li>Added scaling support for Z axis on 3D charts.</li>
               <li>Added xAxis.title.x and xAxis.title.y options for positioning.</li>
               <li>Export: Added missing treemaps.js, fixes
@@ -3414,9 +3414,9 @@
             </p>
             <ul>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts#plotOptions.series.keys">series.keys</a>.</li>
+                <a href="https://api.highcharts.com/highcharts#plotOptions.series.keys">series.keys</a>.</li>
               <li>Added now option,
-                <a href="http://api.highcharts.com/highcharts#xAxis.labels.autoRotationLimit">autoRotationLimit</a>, as an upper limit for when to apply auto rotation. Closes
+                <a href="https://api.highcharts.com/highcharts#xAxis.labels.autoRotationLimit">autoRotationLimit</a>, as an upper limit for when to apply auto rotation. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/3941">#3941</a>.</li>
               <li>Added options to solidgauge, <code>radius</code> and <code>innerRadius</code> on individual points.</li>
               <li>Changed tooltip behaviour in line charts and derivatives. This made swithching between series easier when the other series was covered by the tooltip.</li>
@@ -3716,29 +3716,29 @@
             </p>
             <ul>
               <li>Added
-                <a href="http://api.highcharts.com/#plotOptions.polygon">polygon</a> series type.</li>
+                <a href="https://api.highcharts.com/#plotOptions.polygon">polygon</a> series type.</li>
               <li>Added <code>e.category</code> event argument in drilldown events to make it clear when a category is clicked. Related to
                 <a href="https://github.com/highcharts/highcharts/issues/3771">#3771</a>.</li>
               <li>Added new option to the data module,
-                <a href="http://api.highcharts.com/#data.firstRowAsNames">firstRowAsNames</a>.</li>
+                <a href="https://api.highcharts.com/#data.firstRowAsNames">firstRowAsNames</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/#plotOptions.series.pointIntervalUnit">pointIntervalUnit</a>, in order to allow months and years as point intervals. Closes
+                <a href="https://api.highcharts.com/#plotOptions.series.pointIntervalUnit">pointIntervalUnit</a>, in order to allow months and years as point intervals. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/3329">#3329</a>.</li>
               <li>Added
-                <a href="http://api.highcharts.com/#chart.events.beforePrint">beforePrint</a> and
-                <a href="http://api.highcharts.com/#chart.events.afterPrint">afterPrint</a> events. Related to
+                <a href="https://api.highcharts.com/#chart.events.beforePrint">beforePrint</a> and
+                <a href="https://api.highcharts.com/#chart.events.afterPrint">afterPrint</a> events. Related to
                 <a href="https://github.com/highcharts/highcharts/issues/2284">#2284</a> and
                 <a href="https://github.com/highcharts/highcharts/issues/3729">#3729</a>.</li>
               <li>Added new method,
-                <a href="http://api.highcharts.com/#Series.removePoint">Series.removePoint</a>, to allow removing points that are not instanciated on demand.</li>
+                <a href="https://api.highcharts.com/#Series.removePoint">Series.removePoint</a>, to allow removing points that are not instanciated on demand.</li>
               <li>Added new option, global.getTimezoneOffset, to allow integration with third party timezone libraries like moment-timezone.js.</li>
               <li>Added new Axis option,
-                <a href="http://api.highcharts.com/#yAxis.tickAmount">tickAmount</a>. Refactored alignTicks on multi-axis charts to first compute a
-                <a href="http://api.highcharts.com/#yAxis.tickAmount">tickAmount</a>, then make all axes comply with that.</li>
+                <a href="https://api.highcharts.com/#yAxis.tickAmount">tickAmount</a>. Refactored alignTicks on multi-axis charts to first compute a
+                <a href="https://api.highcharts.com/#yAxis.tickAmount">tickAmount</a>, then make all axes comply with that.</li>
               <li>Added new Axis option,
-                <a href="http://api.highcharts.com/#xAxis.labels.autoRotation">autoRotation</a> as an array of possible values.</li>
+                <a href="https://api.highcharts.com/#xAxis.labels.autoRotation">autoRotation</a> as an array of possible values.</li>
               <li>Added new callback option,
-                <a href="http://api.highcharts.com/#tooltip.pointFormatter">tooltip.pointFormatter</a>.</li>
+                <a href="https://api.highcharts.com/#tooltip.pointFormatter">tooltip.pointFormatter</a>.</li>
               <li>Added polar support for arearange. Issue
                 <a href="https://github.com/highcharts/highcharts/issues/3419">#3419</a>.</li>
               <li>In solid gauges, added support for initial animation as well as setting animation object for updates. Closes
@@ -3993,13 +3993,13 @@
             </p>
             <ul>
               <li>Added 3d options
-                <a href="http://api.highcharts.com#plotOptions.column.edgeColor">edgeColor</a> and
-                <a href="http:/api.highcharts.com#plotOptions.column.edgeWidth">edgeWidth</a> to distinguish from borders that have different defaults.</li>
+                <a href="https://api.highcharts.com#plotOptions.column.edgeColor">edgeColor</a> and
+                <a href="https:/api.highcharts.com#plotOptions.column.edgeWidth">edgeWidth</a> to distinguish from borders that have different defaults.</li>
               <li>Added option,
-                <a href="http://api.highcharts.com#chart.panKey">chart.panKey</a>, to allow panning and zooming on the same chart. The chart can now be configured so the user can pan by holding down the shift key while dragging.</li>
+                <a href="https://api.highcharts.com#chart.panKey">chart.panKey</a>, to allow panning and zooming on the same chart. The chart can now be configured so the user can pan by holding down the shift key while dragging.</li>
               <li>Added features
-                <a href="http://api.highcharts.com#plotOptions.bubble.zMin">zMin</a> and
-                <a href="http://api.highcharts.com#plotOptions.bubble.zMax">zMax</a> for bubble series, to set the Z value corresponding to <code>minSize</code> and <code>maxSize</code> independently from the data.</li>
+                <a href="https://api.highcharts.com#plotOptions.bubble.zMin">zMin</a> and
+                <a href="https://api.highcharts.com#plotOptions.bubble.zMax">zMax</a> for bubble series, to set the Z value corresponding to <code>minSize</code> and <code>maxSize</code> independently from the data.</li>
               <li>Changed default top position for loading label to 45%, which results in a vertically centered label.</li>
               <li>Better handling of data label heights on pie charts, related to
                 <a href="https://github.com/highcharts/highcharts/issues/2630">#2630</a>.</li>
@@ -4131,7 +4131,7 @@
               <li>For news, see the
                 <a href="/component/content/article/2-news/134-announcing-highcharts-4/">release announcement</a>.</li>
               <li>The default design has been updated with Highcharts 4, but all aspects of design can be reverted to the Highcharts 3 looks by applying options. See
-                <a href="http://jsfiddle.net/highcharts/Y5ak7/">this design compatibilty demo</a> for a listing of what options it applies to.</li>
+                <a href="https://jsfiddle.net/highcharts/Y5ak7/">this design compatibilty demo</a> for a listing of what options it applies to.</li>
             </ul>
             <p class="release-header" style="position: relative">
               <a id="highcharts-v3.0.10" style="position: absolute; top: -60px"></a>
@@ -4140,10 +4140,10 @@
             <ul>
               <li>Improved performance by 35% in our benchmark suite.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/#plotOptions.gauge.overshoot">plotOptions.gauge.overshoot</a>, that takes a value in degrees for how much the dial should overshoot when the value is off the chart.</li>
+                <a href="https://api.highcharts.com/#plotOptions.gauge.overshoot">plotOptions.gauge.overshoot</a>, that takes a value in degrees for how much the dial should overshoot when the value is off the chart.</li>
               <li>Added smarter logic to <code>Series.setData</code>, where instead of re-creating all the data points, existing points are updated. This allows animation, performs faster and is less prone to memory issues.</li>
               <li>Added option,
-                <a href="http://api.highcharts.com/#yAxis.reversedStacks">yAxis.reversedStacks</a>, to choose whether to stack from the top down or from the bottom of the stack and up.</li>
+                <a href="https://api.highcharts.com/#yAxis.reversedStacks">yAxis.reversedStacks</a>, to choose whether to stack from the top down or from the bottom of the stack and up.</li>
               <li>Added support for drilldown on multi-series column charts. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/2604">#2604</a>.</li>
               <li>Added &#39;pyramid&#39; type of series.</li>
@@ -4420,7 +4420,7 @@
                       <li>Fixed issue with updating the visibility of a pie slice causing it to go invisible. Closes
                         <a href="https://github.com/highcharts/highcharts/issues/2430">#2430</a>.</li>
                       <li>Added new option,
-                        <a href="http://api.highcharts.com/#global.timezoneOffset">global.timezoneOffset</a>, to allow setting which timezone the data is displayed in even though the input data is defined as UTC.</li>
+                        <a href="https://api.highcharts.com/#global.timezoneOffset">global.timezoneOffset</a>, to allow setting which timezone the data is displayed in even though the input data is defined as UTC.</li>
                       <li>Fixed bad positioning of rotated elements when useHTML was true. Closes
                         <a href="https://github.com/highcharts/highcharts/issues/2404">#2404</a>.</li>
                       <li>Added error message on trying to add an object literal point configuration on a series with more data points than the turboThreshold.</li>
@@ -4447,12 +4447,12 @@
             <ul>
               <li>Performance improvement by moving color parsing regexes out of the Color class to a global definition in order to be instanciated only once.</li>
               <li>Made new option,
-                <a href="http://api.highcharts.com/#plotOptions.line.linecap">linecap</a>, for line series. Closes
+                <a href="https://api.highcharts.com/#plotOptions.line.linecap">linecap</a>, for line series. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/2358">#2358</a>.</li>
               <li>Allow disabling the hover state for a specific point marker. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/1610">#1610</a>.</li>
               <li>Made
-                <a href="http://api.highcharts.com/#plotOptions.series.showInLegend">showInLegend</a> option overridable for linked series.</li>
+                <a href="https://api.highcharts.com/#plotOptions.series.showInLegend">showInLegend</a> option overridable for linked series.</li>
               <li>Worked around Firefox/Win issue with median lines on box plot spilling over the edges of the box. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/1638">#1638</a>.</li>
               <li>Made the data labels inherit the series&#39; cursor setting.</li>
@@ -4462,7 +4462,7 @@
                 <a href="https://github.com/highcharts/highcharts/issues/1651">#1651</a>, which introduced an error with stack data labels not being moved on update. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/2336">#2336</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/#plotOptions.bubble.sizeBy">sizeBy</a>, to bubble charts to set whether the area or the width should reflect the data value.</li>
+                <a href="https://api.highcharts.com/#plotOptions.bubble.sizeBy">sizeBy</a>, to bubble charts to set whether the area or the width should reflect the data value.</li>
               <li>Improved workaround for IE11 text positioning issue by not applying it to exported charts, closes
                 <a href="https://github.com/highcharts/highcharts/issues/2030">#2030</a>.</li>
             </ul>
@@ -4735,7 +4735,7 @@
               <li>Added support for automatic text wrapping in long title names. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/776">#776</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com#legend.itemDistance">legend.itemDistance</a>, to allow control over the distance between items of a horizontally laid out legend. Closes
+                <a href="https://api.highcharts.com#legend.itemDistance">legend.itemDistance</a>, to allow control over the distance between items of a horizontally laid out legend. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/832">#832</a>.</li>
               <li>Added context and event information to click handlers on touch devices. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/1830">#1830</a>.</li>
@@ -5003,7 +5003,7 @@
             </p>
             <ul>
               <li>Added new option,
-                <a href="http://api.highcharts.com#tooltip.followTouchMove">tooltip.followTouchMove</a>. When this is true, the tooltip can be moved by dragging a single finger across the chart, like in Highcharts 2. When it is false, dragging a single finger is ignored by the chart, and causes the whole page
+                <a href="https://api.highcharts.com#tooltip.followTouchMove">tooltip.followTouchMove</a>. When this is true, the tooltip can be moved by dragging a single finger across the chart, like in Highcharts 2. When it is false, dragging a single finger is ignored by the chart, and causes the whole page
                 to scroll. This applies only when zooming is not enabled.
                 <a href="https://github.com/highcharts/highcharts/issues/1644">#1644</a>.
                 <a href="https://github.com/highcharts/highcharts/issues/1662">#1662</a>.</li>
@@ -5084,7 +5084,7 @@
             </p>
             <ul>
               <li>Added
-                <a href="http://api.highcharts.com/highcharts/#plotOptions.pie.startAngle">pie.startAngle</a> option.</li>
+                <a href="https://api.highcharts.com/highcharts/#plotOptions.pie.startAngle">pie.startAngle</a> option.</li>
               <li>Added a delay before hiding exporting menu to prevent the menu from hiding in IE when hovering over neighbour elements and button title.
                 <a href="https://github.com/highcharts/highcharts/issues/1357">#1357</a>.</li>
               <li>Implemented warning on unsorted data for line charts and stock charts.
@@ -5261,7 +5261,7 @@
               <li>Added support for rotation of text when useHTML = true in modern browsers.
                 <a href="https://github.com/highcharts/highcharts/issues/916">#916</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/#plotOptions.pie.ignoreHiddenPoint">ignoreHiddenPoint</a>, for pies.</li>
+                <a href="https://api.highcharts.com/highcharts/#plotOptions.pie.ignoreHiddenPoint">ignoreHiddenPoint</a>, for pies.</li>
               <li>Changed the default line width for area range charts to 1 to avoid the area disappearing altogether in ranges where the min and max are equal.
                 <a href="https://github.com/highcharts/highcharts/issues/1213">#1213</a>.</li>
               <li>Reorganized VMLRenderer to move groups (divs) out of the viewport instead of toggling CSS visibility. This provides a faster and more compact fix for
@@ -5592,7 +5592,7 @@
                       <li>Fixed issue with tooltips covering point in certain cases.</li>
                       <li>Fixed issues with latest MooTools.</li>
                       <li>Fixed issues as listed at
-                        <a href="http://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5619,7 +5619,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed issues as listed at
-                        <a href="http://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5650,7 +5650,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed issues as listed at
-                        <a href="http://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5679,7 +5679,7 @@
                       <li>Fixed issue with charts not displaying in IE on pages with large background images or external resources.</li>
                       <li>Fixed issue Safari Mobile crashing after removing a series dynamically.</li>
                       <li>Fixed minor issues as listed at
-                        <a href="http://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5706,7 +5706,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed bugs as listed at
-                        <a href="http://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5734,7 +5734,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed bugs as listed at
-                        <a href="http://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5761,7 +5761,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed bugs as listed at
-                        <a href="http://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5813,7 +5813,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed bugs as listed at
-                        <a href="http://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5842,7 +5842,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed bugs as listed at
-                        <a href="http://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5866,7 +5866,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed bugs as listed at
-                        <a href="http://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5916,7 +5916,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed minor bugs as listed at
-                        <a href="http://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -7075,7 +7075,7 @@
             <ul>
               <li>Most changes listed under Highcharts 5.0.7 above also apply to Highstock 5.0.7.</li>
               <li>Added support for
-                <a href="http://jsfiddle.net/gh/get/jquery/3.1.1/highcharts/highcharts/tree/master/samples/stock/navigator/inverted/">navigator in inverted charts</a>.</li>
+                <a href="https://jsfiddle.net/gh/get/jquery/3.1.1/highcharts/highcharts/tree/master/samples/stock/navigator/inverted/">navigator in inverted charts</a>.</li>
               <li>Created new module <code>stock.src.js</code> so Highstock can be loaded as a module for Highcharts.</li>
             </ul>
             <div id="accordion" class="panel-group">
@@ -7281,12 +7281,12 @@
             <ul>
               <li>Most changes listed under Highcharts 5.0.0 above also apply to Highstock 5.0.0.</li>
               <li>Added support for multiple series in the navigator, see
-                <a href="http://api.highcharts.com/highstock/plotOptions.series.showInNavigator">series.showInNavigator</a> and
-                <a href="http://api.highcharts.com/highstock/plotOptions.series.navigatorOptions">series.navigatorOptions</a>.</li>
+                <a href="https://api.highcharts.com/highstock/plotOptions.series.showInNavigator">series.showInNavigator</a> and
+                <a href="https://api.highcharts.com/highstock/plotOptions.series.navigatorOptions">series.navigatorOptions</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highcharts/plotOptions.flags.textAlign">plotOptions.flags.textAlign</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/plotOptions.flags.textAlign">plotOptions.flags.textAlign</a>.</li>
               <li>Deprecated the
-                <a href="http://api.highcharts.com/highstock/navigator.baseSeries">baseSeries</a> option, now replaced by <code>showInNavigator</code>.</li>
+                <a href="https://api.highcharts.com/highstock/navigator.baseSeries">baseSeries</a> option, now replaced by <code>showInNavigator</code>.</li>
             </ul>
             <p class="release-header" style="position: relative">
               <a id="highstock-v4.2.7" style="position: absolute; top: -60px"></a>
@@ -7295,7 +7295,7 @@
             <ul>
               <li>Most changes listed under Highcharts 4.2.7 above also apply to Highstock 4.2.7.</li>
               <li>Added <code>Series.dataGroupInfo</code> to allow accessing data grouping information from the
-                <a href="http://api.highcharts.com/highstock/plotOptions.series.dataGrouping.approximation">approximation</a> function.</li>
+                <a href="https://api.highcharts.com/highstock/plotOptions.series.dataGrouping.approximation">approximation</a> function.</li>
               <li>Added warning on trying to update grouped point.</li>
             </ul>
             <div id="accordion" class="panel-group">
@@ -7347,7 +7347,7 @@
             <ul>
               <li>Most changes listed under Highcharts 4.2.6 above also apply to Highstock 4.2.6.</li>
               <li>Added new option set,
-                <a href="http://api.highcharts.com/highstock#yAxis.scrollbar">yAxis.scrollbar</a>, to allow scrollbars on Y axis (or in fact any axis) in Highstock.
+                <a href="https://api.highcharts.com/highstock#yAxis.scrollbar">yAxis.scrollbar</a>, to allow scrollbars on Y axis (or in fact any axis) in Highstock.
                 <a href="/component/content/article/2-news/224-scrollbars-for-any-axis">Read announcement</a>.</li>
               <li>Refactored sideways graph animation to allow smooth navigation when clicking scrollbar buttons, adding multiple points etc.</li>
             </ul>
@@ -7436,7 +7436,7 @@
             <ul>
               <li>Most changes listed under Highcharts 4.2.4 above also apply to Highstock 4.2.4.</li>
               <li>Added new Point property,
-                <a href="http://api.highcharts.com/highstock#Point.dataGroup">dataGroup</a>, that holds information of what raw data points are included in a grouped point.</li>
+                <a href="https://api.highcharts.com/highstock#Point.dataGroup">dataGroup</a>, that holds information of what raw data points are included in a grouped point.</li>
             </ul>
             <div id="accordion" class="panel-group">
               <div class="panel panel-default">
@@ -7500,7 +7500,7 @@
             <ul>
               <li>Most changes listed under Highcharts 4.2.2 above also apply to Highstock 4.2.2.</li>
               <li>Added new option to flag series,
-                <a href="http://api.highcharts.com/highstock#plotOptions.flags.onKey">onKey</a>, to configure what key the flag should be placed on. Closes
+                <a href="https://api.highcharts.com/highstock#plotOptions.flags.onKey">onKey</a>, to configure what key the flag should be placed on. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/4873">#4873</a>.</li>
             </ul>
             <div id="accordion" class="panel-group">
@@ -7609,7 +7609,7 @@
             <ul>
               <li>Most changes listed under Highcharts 4.1.9 above also apply to Highstock 2.1.9.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highstock#rangeSelector.height">rangeSelector.height</a>, to reserve space for buttons and input.</li>
+                <a href="https://api.highcharts.com/highstock#rangeSelector.height">rangeSelector.height</a>, to reserve space for buttons and input.</li>
             </ul>
             <div id="accordion" class="panel-group">
               <div class="panel panel-default">
@@ -7763,7 +7763,7 @@
             <ul>
               <li>Most changes listed under Highcharts 4.1.5 above also apply to Highstock 2.1.5.</li>
               <li>Added feature, forced data grouping tied to range selector buttons.
-                <a href="http://jsfiddle.net/gh/get/jquery/1.7.2/highslide-software/highcharts.com/tree/master/samples/stock/rangeselector/datagrouping/">View demo</a>.</li>
+                <a href="https://jsfiddle.net/gh/get/jquery/1.7.2/highslide-software/highcharts.com/tree/master/samples/stock/rangeselector/datagrouping/">View demo</a>.</li>
             </ul>
             <div id="accordion" class="panel-group">
               <div class="panel panel-default">
@@ -7998,7 +7998,7 @@
             <ul>
               <li>Most issues listed under Highcharts 4.0.3 above also apply to Highstock 2.0.3.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highstock#rangeSelector.allButtonsEnabled">rangeSelector.allButtonsEnabled</a> to force auto-disabled buttons on inadequate range to be clickable. Closes
+                <a href="https://api.highcharts.com/highstock#rangeSelector.allButtonsEnabled">rangeSelector.allButtonsEnabled</a> to force auto-disabled buttons on inadequate range to be clickable. Closes
                 <a href="https://github.com/highcharts/highcharts/issues/2418">#2418</a>.</li>
             </ul>
             <div id="accordion" class="panel-group">
@@ -8037,7 +8037,7 @@
               <li>See the
                 <a href="/component/content/article/2-news/134-announcing-highcharts-4/">release announcement</a>.</li>
               <li>The default design has been updated with Highstock 2, but all aspects of design can be reverted to the Highstock 1.3 looks by applying options. See
-                <a href="http://jsfiddle.net/highcharts/Y5ak7/">this design compatibilty demo</a> for a listing of what options it applies to.</li>
+                <a href="https://jsfiddle.net/highcharts/Y5ak7/">this design compatibilty demo</a> for a listing of what options it applies to.</li>
             </ul>
             <p class="release-header" style="position: relative">
               <a id="highstock-v1.3.10" style="position: absolute; top: -60px"></a>
@@ -8418,7 +8418,7 @@
             </p>
             <ul>
               <li>Added new option,
-                <a href="http://api.highcharts.com#tooltip.followTouchMove">tooltip.followTouchMove</a>. When this is true, the tooltip can be moved by dragging a single finger across the chart, like in Highcharts 2. When it is false, dragging a single finger is ignored by the chart, and causes the whole page
+                <a href="https://api.highcharts.com#tooltip.followTouchMove">tooltip.followTouchMove</a>. When this is true, the tooltip can be moved by dragging a single finger across the chart, like in Highcharts 2. When it is false, dragging a single finger is ignored by the chart, and causes the whole page
                 to scroll. This applies only when zooming is not enabled.
                 <a href="https://github.com/highcharts/highcharts/issues/1644">#1644</a>.
                 <a href="https://github.com/highcharts/highcharts/issues/1662">#1662</a>.</li>
@@ -8512,7 +8512,7 @@
             <ul>
               <li>Applied fixes for Highcharts Basic version 2.3.5.</li>
               <li>Added
-                <a href="http://api.highcharts.com/highstock/#scrollbar.minWidth">scrollbar.minWidth</a> option in Highstock.
+                <a href="https://api.highcharts.com/highstock/#scrollbar.minWidth">scrollbar.minWidth</a> option in Highstock.
                 <a href="https://github.com/highcharts/highcharts/issues/1246">#1246</a>.</li>
             </ul>
             <div id="accordion" class="panel-group">
@@ -8536,7 +8536,7 @@
                         <a href="https://github.com/highcharts/highcharts/issues/1370">#1370</a>.</li>
                       <li>Fixed issue with Exporting dropdown menu being covered by the range selector inputs.</li>
                       <li>Made the range selector inputs visible in exported charts. Added
-                        <a href="http://api.highcharts.com/highstock/#rangeSelector.inputPosition">rangeSelector.inputPosition</a> option.</li>
+                        <a href="https://api.highcharts.com/highstock/#rangeSelector.inputPosition">rangeSelector.inputPosition</a> option.</li>
                       <li>Fixed Highstock issue with YTD button when not using UTC.
                         <a href="https://github.com/highcharts/highcharts/issues/941">#941</a>.</li>
                       <li>Fixed Highstock issue with unresponsive range selector buttons by applying clipping to the mouse tracker.
@@ -8951,7 +8951,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed issues as listed at
-                        <a href="http://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -9029,7 +9029,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed issues as listed at
-                        <a href="http://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -9054,7 +9054,7 @@
                     <ul>
                       <li>Fixed compatibility issue with jQuery 1.7.</li>
                       <li>Fixed issues as listed at
-                        <a href="http://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -9083,7 +9083,7 @@
                     <ul>
                       <li>Fixed error on chart.addSeries.</li>
                       <li>Fixed issues as listed at
-                        <a href="http://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -9422,7 +9422,7 @@
             <ul>
               <li>Most changes listed under Highcharts 5.0.8 above also apply to Highmaps 5.0.8.</li>
               <li>New advanced demo for
-                <a href="http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/samples/maps/demo/map-pies/">map pies</a>.</li>
+                <a href="https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/samples/maps/demo/map-pies/">map pies</a>.</li>
             </ul>
             <div id="accordion" class="panel-group">
               <div class="panel panel-default">
@@ -9631,10 +9631,10 @@
             <ul>
               <li>Most changes listed under Highcharts 5.0.0 above also apply to Highmaps 5.0.0.</li>
               <li>Simplified the map configuration by setting a general
-                <a href="http://api.highcharts.com/highcharts/chart.map">chart.map</a> option and allowing tuples in the
-                <a href="http://api.highcharts.com/highmaps/series%3Cmap%3E.data">data description</a>.</li>
+                <a href="https://api.highcharts.com/highcharts/chart.map">chart.map</a> option and allowing tuples in the
+                <a href="https://api.highcharts.com/highmaps/series%3Cmap%3E.data">data description</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highmaps/chart.mapTransforms">chart.mapTransforms</a>.</li>
+                <a href="https://api.highcharts.com/highmaps/chart.mapTransforms">chart.mapTransforms</a>.</li>
             </ul>
             <p class="release-header" style="position: relative">
               <a id="highmaps-v4.2.7" style="position: absolute; top: -60px"></a>
@@ -9643,9 +9643,9 @@
             <ul>
               <li>Most changes listed under Highcharts 4.2.7 above also apply to Highmaps 4.2.7.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highmaps/colorAxis.showInLegend">colorAxis.showInLegend</a>.</li>
+                <a href="https://api.highcharts.com/highmaps/colorAxis.showInLegend">colorAxis.showInLegend</a>.</li>
               <li>Added new option,
-                <a href="http://api.highcharts.com/highmaps/plotOptions.map.nullInteraction">series.nullInteraction</a> to allow tooltips and mouse events on null points.</li>
+                <a href="https://api.highcharts.com/highmaps/plotOptions.map.nullInteraction">series.nullInteraction</a> to allow tooltips and mouse events on null points.</li>
             </ul>
             <div id="accordion" class="panel-group">
               <div class="panel panel-default">
@@ -9736,7 +9736,7 @@
             <ul>
               <li>Most changes listed under Highcharts 4.2.4 above also apply to Highmaps 4.2.4.</li>
               <li>Added
-                <a href="http://api.highcharts.com/highmaps#mapNavigation.mouseWheelSensitivity">mapNavigation.mouseWheelSensitivity</a> option for zooming.</li>
+                <a href="https://api.highcharts.com/highmaps#mapNavigation.mouseWheelSensitivity">mapNavigation.mouseWheelSensitivity</a> option for zooming.</li>
             </ul>
             <div id="accordion" class="panel-group">
               <div class="panel panel-default">

--- a/changelog/changelog.html
+++ b/changelog/changelog.html
@@ -5283,7 +5283,7 @@
                       <li>Fixed JS error in IE7.
                         <a href="https://github.com/highcharts/highcharts/issues/1214">#1214</a>.</li>
                       <li>Fixed JS error on zooming in to an arearange series in IE9. Prevented arearange data labels from being orphaned when zooming in below cropThreshold. &lt;ahref=&quot;
-                        <a href="https://github.com/highslide-software/highcharts.com/issues/1209&quot;&gt;Issue">https://github.com/highslide-software/highcharts.com/issues/1209&quot;&gt;Issue</a>
+                        <a href="https://github.com/highcharts/highcharts/issues/1209&quot;&gt;Issue">https://github.com/highcharts/highcharts/issues/1209&quot;&gt;Issue</a>
                         <a href="https://github.com/highcharts/highcharts/issues/1209">#1209</a>.</li>
                       <li>Fixed issue with data labels appearing outside plot area on initial load.</li>
                       <li>Fixed 2.3 regression regarding unstable sorting in Chrome.
@@ -5592,7 +5592,7 @@
                       <li>Fixed issue with tooltips covering point in certain cases.</li>
                       <li>Fixed issues with latest MooTools.</li>
                       <li>Fixed issues as listed at
-                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highcharts/highcharts/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5619,7 +5619,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed issues as listed at
-                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highcharts/highcharts/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5650,7 +5650,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed issues as listed at
-                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highcharts/highcharts/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5679,7 +5679,7 @@
                       <li>Fixed issue with charts not displaying in IE on pages with large background images or external resources.</li>
                       <li>Fixed issue Safari Mobile crashing after removing a series dynamically.</li>
                       <li>Fixed minor issues as listed at
-                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highcharts/highcharts/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5706,7 +5706,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed bugs as listed at
-                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highcharts/highcharts/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5734,7 +5734,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed bugs as listed at
-                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highcharts/highcharts/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5761,7 +5761,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed bugs as listed at
-                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highcharts/highcharts/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5813,7 +5813,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed bugs as listed at
-                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highcharts/highcharts/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5842,7 +5842,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed bugs as listed at
-                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highcharts/highcharts/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5866,7 +5866,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed bugs as listed at
-                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highcharts/highcharts/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -5916,7 +5916,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed minor bugs as listed at
-                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highcharts/highcharts/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -7763,7 +7763,7 @@
             <ul>
               <li>Most changes listed under Highcharts 4.1.5 above also apply to Highstock 2.1.5.</li>
               <li>Added feature, forced data grouping tied to range selector buttons.
-                <a href="https://jsfiddle.net/gh/get/jquery/1.7.2/highslide-software/highcharts.com/tree/master/samples/stock/rangeselector/datagrouping/">View demo</a>.</li>
+                <a href="https://jsfiddle.net/gh/get/jquery/1.7.2/highcharts/highcharts/tree/master/samples/stock/rangeselector/datagrouping/">View demo</a>.</li>
             </ul>
             <div id="accordion" class="panel-group">
               <div class="panel panel-default">
@@ -8913,7 +8913,7 @@
             </p>
             <ul>
               <li>Added temporary workaround for
-                <a href="https://github.com/highslide-software/highcharts.com/issues/732">text rendering bug</a> in Chrome 18 Beta.</li>
+                <a href="https://github.com/highcharts/highcharts/issues/732">text rendering bug</a> in Chrome 18 Beta.</li>
               <li>Added support for setting height in chart.setSize().</li>
             </ul>
             <div id="accordion" class="panel-group">
@@ -8951,7 +8951,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed issues as listed at
-                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highcharts/highcharts/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -9029,7 +9029,7 @@
                   <div class="panel-body">
                     <ul>
                       <li>Fixed issues as listed at
-                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highcharts/highcharts/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -9054,7 +9054,7 @@
                     <ul>
                       <li>Fixed compatibility issue with jQuery 1.7.</li>
                       <li>Fixed issues as listed at
-                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highcharts/highcharts/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>
@@ -9083,7 +9083,7 @@
                     <ul>
                       <li>Fixed error on chart.addSeries.</li>
                       <li>Fixed issues as listed at
-                        <a href="https://github.com/highslide-software/highcharts.com/commits/master">GitHub</a> under dates since the last maintenance version.</li>
+                        <a href="https://github.com/highcharts/highcharts/commits/master">GitHub</a> under dates since the last maintenance version.</li>
                     </ul>
 
                   </div>

--- a/changelog/changelog.html
+++ b/changelog/changelog.html
@@ -22,7 +22,7 @@
               <li>Added support for
                 <a href="https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/plotoptions/series-datalabels-multiple/">multiple data labels</a> on each single point.</li>
               <li>Added
-                <a href="httpd://api.highcharts.com/highcharts/series.line.dragDrop">draggable points plugin</a> as module.</li>
+                <a href="https://api.highcharts.com/highcharts/series.line.dragDrop">draggable points plugin</a> as module.</li>
               <li>Added support for <code>pointPlacement</code> in X range charts, affecting the category Y axis. Closed
                 <a href="https://github.com/highcharts/highcharts/issues/7419">#7419</a>.</li>
             </ul>

--- a/changelog/highcharts/2.0.2.md
+++ b/changelog/highcharts/2.0.2.md
@@ -3,4 +3,4 @@
 - Added linked axes.
 
 ## Bug fixes
-- Fixed minor bugs as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed minor bugs as listed at [GitHub](https://github.com/highcharts/highcharts/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.0.2.md
+++ b/changelog/highcharts/2.0.2.md
@@ -3,4 +3,4 @@
 - Added linked axes.
 
 ## Bug fixes
-- Fixed minor bugs as listed at [GitHub](http://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed minor bugs as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.0.4.md
+++ b/changelog/highcharts/2.0.4.md
@@ -2,4 +2,4 @@
         
 
 ## Bug fixes
-- Fixed bugs as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed bugs as listed at [GitHub](https://github.com/highcharts/highcharts/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.0.4.md
+++ b/changelog/highcharts/2.0.4.md
@@ -2,4 +2,4 @@
         
 
 ## Bug fixes
-- Fixed bugs as listed at [GitHub](http://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed bugs as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.0.5.md
+++ b/changelog/highcharts/2.0.5.md
@@ -5,4 +5,4 @@
 - Added text parameter for showLoading().
 
 ## Bug fixes
-- Fixed bugs as listed at [GitHub](http://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed bugs as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.0.5.md
+++ b/changelog/highcharts/2.0.5.md
@@ -5,4 +5,4 @@
 - Added text parameter for showLoading().
 
 ## Bug fixes
-- Fixed bugs as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed bugs as listed at [GitHub](https://github.com/highcharts/highcharts/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.1.0.md
+++ b/changelog/highcharts/2.1.0.md
@@ -16,4 +16,4 @@
 - Legend positioning: Since version 2.1 Highcharts is aware of the size of the titles and legend and will try to make room for these in the chart's margins. When upgrading from older versions, this may lead to too great margins depending on where your legend is positioned. To prevent this, set a new option, floating to true in your legend options. Furthermore, the x and y values of the legend position is now relative to the chart.spacingTop and chart.spacingLeft etc. properties instead of the chart's outer edge.
 
 ## Bug fixes
-- Fixed bugs as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed bugs as listed at [GitHub](https://github.com/highcharts/highcharts/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.1.0.md
+++ b/changelog/highcharts/2.1.0.md
@@ -16,4 +16,4 @@
 - Legend positioning: Since version 2.1 Highcharts is aware of the size of the titles and legend and will try to make room for these in the chart's margins. When upgrading from older versions, this may lead to too great margins depending on where your legend is positioned. To prevent this, set a new option, floating to true in your legend options. Furthermore, the x and y values of the legend position is now relative to the chart.spacingTop and chart.spacingLeft etc. properties instead of the chart's outer edge.
 
 ## Bug fixes
-- Fixed bugs as listed at [GitHub](http://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed bugs as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.1.1.md
+++ b/changelog/highcharts/2.1.1.md
@@ -3,4 +3,4 @@
 - Added Highcharts.version property.
 
 ## Bug fixes
-- Fixed bugs as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed bugs as listed at [GitHub](https://github.com/highcharts/highcharts/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.1.1.md
+++ b/changelog/highcharts/2.1.1.md
@@ -3,4 +3,4 @@
 - Added Highcharts.version property.
 
 ## Bug fixes
-- Fixed bugs as listed at [GitHub](http://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed bugs as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.1.2.md
+++ b/changelog/highcharts/2.1.2.md
@@ -4,4 +4,4 @@
 - Added vertical centering logic for data labels on bars when y not given.
 
 ## Bug fixes
-- Fixed bugs as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed bugs as listed at [GitHub](https://github.com/highcharts/highcharts/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.1.2.md
+++ b/changelog/highcharts/2.1.2.md
@@ -4,4 +4,4 @@
 - Added vertical centering logic for data labels on bars when y not given.
 
 ## Bug fixes
-- Fixed bugs as listed at [GitHub](http://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed bugs as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.1.3.md
+++ b/changelog/highcharts/2.1.3.md
@@ -3,4 +3,4 @@
 - Added soft line breaks for long category labels.
 
 ## Bug fixes
-- Fixed bugs as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed bugs as listed at [GitHub](https://github.com/highcharts/highcharts/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.1.3.md
+++ b/changelog/highcharts/2.1.3.md
@@ -3,4 +3,4 @@
 - Added soft line breaks for long category labels.
 
 ## Bug fixes
-- Fixed bugs as listed at [GitHub](http://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed bugs as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.1.4.md
+++ b/changelog/highcharts/2.1.4.md
@@ -5,4 +5,4 @@
 ## Bug fixes
 - Fixed issue with charts not displaying in IE on pages with large background images or external resources.
 - Fixed issue Safari Mobile crashing after removing a series dynamically.
-- Fixed minor issues as listed at [GitHub](http://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed minor issues as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.1.4.md
+++ b/changelog/highcharts/2.1.4.md
@@ -5,4 +5,4 @@
 ## Bug fixes
 - Fixed issue with charts not displaying in IE on pages with large background images or external resources.
 - Fixed issue Safari Mobile crashing after removing a series dynamically.
-- Fixed minor issues as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed minor issues as listed at [GitHub](https://github.com/highcharts/highcharts/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.1.5.md
+++ b/changelog/highcharts/2.1.5.md
@@ -7,4 +7,4 @@
 - Added data labels for stack totals and improved positioning of column and bar data labels.
 
 ## Bug fixes
-- Fixed issues as listed at [GitHub](http://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed issues as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.1.5.md
+++ b/changelog/highcharts/2.1.5.md
@@ -7,4 +7,4 @@
 - Added data labels for stack totals and improved positioning of column and bar data labels.
 
 ## Bug fixes
-- Fixed issues as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed issues as listed at [GitHub](https://github.com/highcharts/highcharts/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.1.6.md
+++ b/changelog/highcharts/2.1.6.md
@@ -3,4 +3,4 @@
 - Rewrote data label positioning for pies.
 
 ## Bug fixes
-- Fixed issues as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed issues as listed at [GitHub](https://github.com/highcharts/highcharts/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.1.6.md
+++ b/changelog/highcharts/2.1.6.md
@@ -3,4 +3,4 @@
 - Rewrote data label positioning for pies.
 
 ## Bug fixes
-- Fixed issues as listed at [GitHub](http://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed issues as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.1.7.md
+++ b/changelog/highcharts/2.1.7.md
@@ -9,4 +9,4 @@
 - Fixed issues with data label positioning for pies.
 - Fixed issue with tooltips covering point in certain cases.
 - Fixed issues with latest MooTools.
-- Fixed issues as listed at [GitHub](http://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed issues as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.1.7.md
+++ b/changelog/highcharts/2.1.7.md
@@ -9,4 +9,4 @@
 - Fixed issues with data label positioning for pies.
 - Fixed issue with tooltips covering point in certain cases.
 - Fixed issues with latest MooTools.
-- Fixed issues as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed issues as listed at [GitHub](https://github.com/highcharts/highcharts/commits/master) under dates since the last maintenance version.

--- a/changelog/highcharts/2.3.2.md
+++ b/changelog/highcharts/2.3.2.md
@@ -8,7 +8,7 @@
 
 ## Bug fixes
 - Fixed JS error in IE7. #1214.
-- Fixed JS error on zooming in to an arearange series in IE9. Prevented arearange data labels from being orphaned when zooming in below cropThreshold. <ahref="https://github.com/highslide-software/highcharts.com/issues/1209">Issue #1209.
+- Fixed JS error on zooming in to an arearange series in IE9. Prevented arearange data labels from being orphaned when zooming in below cropThreshold. <ahref="https://github.com/highcharts/highcharts/issues/1209">Issue #1209.
 - Fixed issue with data labels appearing outside plot area on initial load.
 - Fixed 2.3 regression regarding unstable sorting in Chrome. #337.
 - Fixed auto connect calculation in polar charts when category values are skipped. #1197.

--- a/changelog/highcharts/2.3.2.md
+++ b/changelog/highcharts/2.3.2.md
@@ -1,7 +1,7 @@
 # Changelog for Highcharts v2.3.2 (2012-08-31)
         
 - Added support for rotation of text when useHTML = true in modern browsers. #916.
-- Added new option, [ignoreHiddenPoint](http://api.highcharts.com/highcharts/#plotOptions.pie.ignoreHiddenPoint), for pies.
+- Added new option, [ignoreHiddenPoint](https://api.highcharts.com/highcharts/#plotOptions.pie.ignoreHiddenPoint), for pies.
 - Changed the default line width for area range charts to 1 to avoid the area disappearing altogether in ranges where the min and max are equal. #1213.
 - Reorganized VMLRenderer to move groups (divs) out of the viewport instead of toggling CSS visibility. This provides a faster and more compact fix for #61 and #586.
 - Rendering performance improvement due to better caching of bounding box for texts, leading to less DOM traffic.

--- a/changelog/highcharts/2.3.5.md
+++ b/changelog/highcharts/2.3.5.md
@@ -1,6 +1,6 @@
 # Changelog for Highcharts v2.3.5 (2012-12-19)
         
-- Added [pie.startAngle](http://api.highcharts.com/highcharts/#plotOptions.pie.startAngle) option.
+- Added [pie.startAngle](https://api.highcharts.com/highcharts/#plotOptions.pie.startAngle) option.
 - Added a delay before hiding exporting menu to prevent the menu from hiding in IE when hovering over neighbour elements and button title. #1357.
 - Implemented warning on unsorted data for line charts and stock charts. #725. Also throw a Highcharts error on unsorted column data, because the column distance and width logic relies on sorted data. Related to #987.
 - Added line.step options: "left", "center", "right". Fixed issue with step in area ranges. #1330.

--- a/changelog/highcharts/3.0.1.md
+++ b/changelog/highcharts/3.0.1.md
@@ -1,6 +1,6 @@
 # Changelog for Highcharts v3.0.1 (2013-04-09)
         
-- Added new option, [tooltip.followTouchMove](http://api.highcharts.com#tooltip.followTouchMove). When this is true, the tooltip can be moved by dragging a single finger across the chart, like in Highcharts 2. When it is false, dragging a single finger is ignored by the chart, and causes the whole page to scroll. This applies only when zooming is not enabled. #1644. #1662.
+- Added new option, [tooltip.followTouchMove](https://api.highcharts.com#tooltip.followTouchMove). When this is true, the tooltip can be moved by dragging a single finger across the chart, like in Highcharts 2. When it is false, dragging a single finger is ignored by the chart, and causes the whole page to scroll. This applies only when zooming is not enabled. #1644. #1662.
 - Added internationalization for the Print chart text. #1656.
 
 ## Bug fixes

--- a/changelog/highcharts/3.0.10.md
+++ b/changelog/highcharts/3.0.10.md
@@ -1,9 +1,9 @@
 # Changelog for Highcharts v3.0.10 (2014-03-10)
         
 - Improved performance by 35% in our benchmark suite.
-- Added new option, [plotOptions.gauge.overshoot](http://api.highcharts.com/#plotOptions.gauge.overshoot), that takes a value in degrees for how much the dial should overshoot when the value is off the chart.
+- Added new option, [plotOptions.gauge.overshoot](https://api.highcharts.com/#plotOptions.gauge.overshoot), that takes a value in degrees for how much the dial should overshoot when the value is off the chart.
 - Added smarter logic to `Series.setData`, where instead of re-creating all the data points, existing points are updated. This allows animation, performs faster and is less prone to memory issues.
-- Added option, [yAxis.reversedStacks](http://api.highcharts.com/#yAxis.reversedStacks), to choose whether to stack from the top down or from the bottom of the stack and up.
+- Added option, [yAxis.reversedStacks](https://api.highcharts.com/#yAxis.reversedStacks), to choose whether to stack from the top down or from the bottom of the stack and up.
 - Added support for drilldown on multi-series column charts. Closes #2604.
 - Added 'pyramid' type of series.
 - Added 'reversed' option to funnel series.

--- a/changelog/highcharts/3.0.3.md
+++ b/changelog/highcharts/3.0.3.md
@@ -2,7 +2,7 @@
         
 - Added automatic stagger lines for colliding labels on horizontal axis.
 - Added support for automatic text wrapping in long title names. Closes #776.
-- Added new option, [legend.itemDistance](http://api.highcharts.com#legend.itemDistance), to allow control over the distance between items of a horizontally laid out legend. Closes #832.
+- Added new option, [legend.itemDistance](https://api.highcharts.com#legend.itemDistance), to allow control over the distance between items of a horizontally laid out legend. Closes #832.
 - Added context and event information to click handlers on touch devices. Closes #1830.
 - Added useHTML option for plot line and plot band labels. Closes #1916.
 - Added support for multidimensional series (arearange, ohlc, box plot etc.) in data module.

--- a/changelog/highcharts/3.0.7.md
+++ b/changelog/highcharts/3.0.7.md
@@ -1,14 +1,14 @@
 # Changelog for Highcharts v3.0.7 (2013-10-24)
         
 - Performance improvement by moving color parsing regexes out of the Color class to a global definition in order to be instanciated only once.
-- Made new option, [linecap](http://api.highcharts.com/#plotOptions.line.linecap), for line series. Closes #2358.
+- Made new option, [linecap](https://api.highcharts.com/#plotOptions.line.linecap), for line series. Closes #2358.
 - Allow disabling the hover state for a specific point marker. Closes #1610.
-- Made [showInLegend](http://api.highcharts.com/#plotOptions.series.showInLegend) option overridable for linked series.
+- Made [showInLegend](https://api.highcharts.com/#plotOptions.series.showInLegend) option overridable for linked series.
 - Worked around Firefox/Win issue with median lines on box plot spilling over the edges of the box. Closes #1638.
 - Made the data labels inherit the series' cursor setting.
 - Improved fix for #2030 to work with IE11 quirks mode.
 - Reverted fix for #1651, which introduced an error with stack data labels not being moved on update. Closes #2336.
-- Added new option, [sizeBy](http://api.highcharts.com/#plotOptions.bubble.sizeBy), to bubble charts to set whether the area or the width should reflect the data value.
+- Added new option, [sizeBy](https://api.highcharts.com/#plotOptions.bubble.sizeBy), to bubble charts to set whether the area or the width should reflect the data value.
 - Improved workaround for IE11 text positioning issue by not applying it to exported charts, closes #2030.
 
 ## Bug fixes

--- a/changelog/highcharts/3.0.8.md
+++ b/changelog/highcharts/3.0.8.md
@@ -45,7 +45,7 @@
 - Added symbolHeight and symbolRadius options for legend.
 - Fixed issue with orphaned stack labels after Series.destroy and Series.update. Closes #2440.
 - Fixed issue with updating the visibility of a pie slice causing it to go invisible. Closes #2430.
-- Added new option, [global.timezoneOffset](http://api.highcharts.com/#global.timezoneOffset), to allow setting which timezone the data is displayed in even though the input data is defined as UTC.
+- Added new option, [global.timezoneOffset](https://api.highcharts.com/#global.timezoneOffset), to allow setting which timezone the data is displayed in even though the input data is defined as UTC.
 - Fixed bad positioning of rotated elements when useHTML was true. Closes #2404.
 - Added error message on trying to add an object literal point configuration on a series with more data points than the turboThreshold.
 - Fixed issue with flags on the last point dropping down to the X axis when the main series enters data grouping. Closes #2374.

--- a/changelog/highcharts/4.0.0.md
+++ b/changelog/highcharts/4.0.0.md
@@ -1,4 +1,4 @@
 # Changelog for Highcharts v4.0.0 (2014-04-22)
         
 - For news, see the [release announcement](/component/content/article/2-news/134-announcing-highcharts-4/).
-- The default design has been updated with Highcharts 4, but all aspects of design can be reverted to the Highcharts 3 looks by applying options. See [this design compatibilty demo](http://jsfiddle.net/highcharts/Y5ak7/) for a listing of what options it applies to.
+- The default design has been updated with Highcharts 4, but all aspects of design can be reverted to the Highcharts 3 looks by applying options. See [this design compatibilty demo](https://jsfiddle.net/highcharts/Y5ak7/) for a listing of what options it applies to.

--- a/changelog/highcharts/4.0.3.md
+++ b/changelog/highcharts/4.0.3.md
@@ -1,8 +1,8 @@
 # Changelog for Highcharts v4.0.3 (2014-07-03)
         
-- Added 3d options [edgeColor](http://api.highcharts.com#plotOptions.column.edgeColor) and [edgeWidth](http:/api.highcharts.com#plotOptions.column.edgeWidth) to distinguish from borders that have different defaults.
-- Added option, [chart.panKey](http://api.highcharts.com#chart.panKey), to allow panning and zooming on the same chart. The chart can now be configured so the user can pan by holding down the shift key while dragging.
-- Added features [zMin](http://api.highcharts.com#plotOptions.bubble.zMin) and [zMax](http://api.highcharts.com#plotOptions.bubble.zMax) for bubble series, to set the Z value corresponding to `minSize` and `maxSize` independently from the data.
+- Added 3d options [edgeColor](https://api.highcharts.com#plotOptions.column.edgeColor) and [edgeWidth](https:/api.highcharts.com#plotOptions.column.edgeWidth) to distinguish from borders that have different defaults.
+- Added option, [chart.panKey](https://api.highcharts.com#chart.panKey), to allow panning and zooming on the same chart. The chart can now be configured so the user can pan by holding down the shift key while dragging.
+- Added features [zMin](https://api.highcharts.com#plotOptions.bubble.zMin) and [zMax](https://api.highcharts.com#plotOptions.bubble.zMax) for bubble series, to set the Z value corresponding to `minSize` and `maxSize` independently from the data.
 - Changed default top position for loading label to 45%, which results in a vertically centered label.
 - Better handling of data label heights on pie charts, related to #2630.
 - Better handling of dynamic font sizes. Adjust tooltip text-wrapping. Apply dynamic font size (em) on line breaks. Fixed placement of title and axis labels when using ems for font size. Added support for em font-size in legend.itemStyle.

--- a/changelog/highcharts/4.1.0.md
+++ b/changelog/highcharts/4.1.0.md
@@ -1,15 +1,15 @@
 # Changelog for Highcharts v4.1.0 (2015-02-16)
         
-- Added [polygon](http://api.highcharts.com/#plotOptions.polygon) series type.
+- Added [polygon](https://api.highcharts.com/#plotOptions.polygon) series type.
 - Added `e.category` event argument in drilldown events to make it clear when a category is clicked. Related to #3771.
-- Added new option to the data module, [firstRowAsNames](http://api.highcharts.com/#data.firstRowAsNames).
-- Added new option, [pointIntervalUnit](http://api.highcharts.com/#plotOptions.series.pointIntervalUnit), in order to allow months and years as point intervals. Closes #3329.
-- Added [beforePrint](http://api.highcharts.com/#chart.events.beforePrint) and [afterPrint](http://api.highcharts.com/#chart.events.afterPrint) events. Related to #2284 and #3729.
-- Added new method, [Series.removePoint](http://api.highcharts.com/#Series.removePoint), to allow removing points that are not instanciated on demand.
+- Added new option to the data module, [firstRowAsNames](https://api.highcharts.com/#data.firstRowAsNames).
+- Added new option, [pointIntervalUnit](https://api.highcharts.com/#plotOptions.series.pointIntervalUnit), in order to allow months and years as point intervals. Closes #3329.
+- Added [beforePrint](https://api.highcharts.com/#chart.events.beforePrint) and [afterPrint](https://api.highcharts.com/#chart.events.afterPrint) events. Related to #2284 and #3729.
+- Added new method, [Series.removePoint](https://api.highcharts.com/#Series.removePoint), to allow removing points that are not instanciated on demand.
 - Added new option, global.getTimezoneOffset, to allow integration with third party timezone libraries like moment-timezone.js.
-- Added new Axis option, [tickAmount](http://api.highcharts.com/#yAxis.tickAmount). Refactored alignTicks on multi-axis charts to first compute a [tickAmount](http://api.highcharts.com/#yAxis.tickAmount), then make all axes comply with that.
-- Added new Axis option, [autoRotation](http://api.highcharts.com/#xAxis.labels.autoRotation) as an array of possible values.
-- Added new callback option, [tooltip.pointFormatter](http://api.highcharts.com/#tooltip.pointFormatter).
+- Added new Axis option, [tickAmount](https://api.highcharts.com/#yAxis.tickAmount). Refactored alignTicks on multi-axis charts to first compute a [tickAmount](https://api.highcharts.com/#yAxis.tickAmount), then make all axes comply with that.
+- Added new Axis option, [autoRotation](https://api.highcharts.com/#xAxis.labels.autoRotation) as an array of possible values.
+- Added new callback option, [tooltip.pointFormatter](https://api.highcharts.com/#tooltip.pointFormatter).
 - Added polar support for arearange. Issue #3419.
 - In solid gauges, added support for initial animation as well as setting animation object for updates. Closes #3135.
 - Made the entire numberFormat method settable and wrappable from the outside.

--- a/changelog/highcharts/4.1.10.md
+++ b/changelog/highcharts/4.1.10.md
@@ -1,8 +1,8 @@
 # Changelog for Highcharts v4.1.10 (2015-12-07)
         
 - Added new feature, `borderColor: null` for pies, which inherits the slice color. This allows a simple workaround for antialiasing gaps between slices when not using a real border (#1828).
-- Added new option, [xAxis.labels.reserveSpace](http://api.highcharts.com/highcharts#xAxis.labels.reserveSpace), to control whether the labels should take up space in the layout. Closes #3479.
-- Added new option, [treemap.sortIndex](http://api.highcharts.com/highcharts#plotOptions.treemap.sortIndex).
+- Added new option, [xAxis.labels.reserveSpace](https://api.highcharts.com/highcharts#xAxis.labels.reserveSpace), to control whether the labels should take up space in the layout. Closes #3479.
+- Added new option, [treemap.sortIndex](https://api.highcharts.com/highcharts#plotOptions.treemap.sortIndex).
 - Better animation on 3D pie drilldown (#3534).
 
 ## Bug fixes

--- a/changelog/highcharts/4.1.5.md
+++ b/changelog/highcharts/4.1.5.md
@@ -1,7 +1,7 @@
 # Changelog for Highcharts v4.1.5 (2015-04-13)
         
-- Added new option, [series.keys](http://api.highcharts.com/highcharts#plotOptions.series.keys).
-- Added now option, [autoRotationLimit](http://api.highcharts.com/highcharts#xAxis.labels.autoRotationLimit), as an upper limit for when to apply auto rotation. Closes #3941.
+- Added new option, [series.keys](https://api.highcharts.com/highcharts#plotOptions.series.keys).
+- Added now option, [autoRotationLimit](https://api.highcharts.com/highcharts#xAxis.labels.autoRotationLimit), as an upper limit for when to apply auto rotation. Closes #3941.
 - Added options to solidgauge, `radius` and `innerRadius` on individual points.
 - Changed tooltip behaviour in line charts and derivatives. This made swithching between series easier when the other series was covered by the tooltip.
 

--- a/changelog/highcharts/4.1.6.md
+++ b/changelog/highcharts/4.1.6.md
@@ -1,6 +1,6 @@
 # Changelog for Highcharts v4.1.6 (2015-06-12)
         
-- Added new option, [series.getExtremesFromAll](http://api.highcharts.com/highcharts#plotOptions.series.getExtremesFromAll), that tells the y axis to be scaled to the whole series range, not only the visible part.
+- Added new option, [series.getExtremesFromAll](https://api.highcharts.com/highcharts#plotOptions.series.getExtremesFromAll), that tells the y axis to be scaled to the whole series range, not only the visible part.
 - Added scaling support for Z axis on 3D charts.
 - Added xAxis.title.x and xAxis.title.y options for positioning.
 - Export: Added missing treemaps.js, fixes #4092.

--- a/changelog/highcharts/4.1.8.md
+++ b/changelog/highcharts/4.1.8.md
@@ -1,7 +1,7 @@
 # Changelog for Highcharts v4.1.8 (2015-08-20)
         
-- Added experimental support for using HTML in exported charts through the [exporting.allowHTML option](http://api.highcharts.com/#exporting.allowHTML). Discussed in #2473.
-- Added new option, [maxPointWidth](http://api.highcharts.com/highcharts#plotOptions.column.maxPointWidth), to the column chart type and its derivatives.
+- Added experimental support for using HTML in exported charts through the [exporting.allowHTML option](https://api.highcharts.com/#exporting.allowHTML). Discussed in #2473.
+- Added new option, [maxPointWidth](https://api.highcharts.com/highcharts#plotOptions.column.maxPointWidth), to the column chart type and its derivatives.
 - Add `%k`, hours with no padding, in dateFormat.
 - Don't cache undefined bounding box key. Closes #4328.
 

--- a/changelog/highcharts/4.1.9.md
+++ b/changelog/highcharts/4.1.9.md
@@ -1,8 +1,8 @@
 # Changelog for Highcharts v4.1.9 (2015-10-07)
         
-- Added new option, [axis.visible](http://api.highcharts.com/highcharts#xAxis.visible).
-- Added new option, [bubble.sizeByAbsoluteValue](http://api.highcharts.com/highcharts#plotOptions.bubble.sizeByAbsoluteValue), to allow negative bubbles sizes to be based on the absolute value rather than a scalar difference from smallest to greatest. Closes #4498.
-- Added new series option, [softThreshold](http://api.highcharts.com/highcharts#plotOptions.series.softThreshold), to prevent showing subzero axis ticks for line series that consist of positive data only.
+- Added new option, [axis.visible](https://api.highcharts.com/highcharts#xAxis.visible).
+- Added new option, [bubble.sizeByAbsoluteValue](https://api.highcharts.com/highcharts#plotOptions.bubble.sizeByAbsoluteValue), to allow negative bubbles sizes to be based on the absolute value rather than a scalar difference from smallest to greatest. Closes #4498.
+- Added new series option, [softThreshold](https://api.highcharts.com/highcharts#plotOptions.series.softThreshold), to prevent showing subzero axis ticks for line series that consist of positive data only.
 - Added support for `legendType: 'point'` on more series types than just pie and its derivatives.
 
 ## Bug fixes

--- a/changelog/highcharts/4.2.2.md
+++ b/changelog/highcharts/4.2.2.md
@@ -1,7 +1,7 @@
 # Changelog for Highcharts v4.2.2 (2016-02-04)
         
-- Added new option, [linecap](http://api.highcharts.com#plotOptions.solidgauge.linecap), to allow round corners on solid gauge.
-- Changed [chart.load](http://api.highcharts.com#chart.events.load) event to wait for external symbol images, so that their size is set correctly in the SVG. This comes in handy for export and server generated images.
+- Added new option, [linecap](https://api.highcharts.com#plotOptions.solidgauge.linecap), to allow round corners on solid gauge.
+- Changed [chart.load](https://api.highcharts.com#chart.events.load) event to wait for external symbol images, so that their size is set correctly in the SVG. This comes in handy for export and server generated images.
 
 ## Bug fixes
 - Fixed #1977, bubble series shadow was not moved when moving bubbles.

--- a/changelog/highcharts/4.2.4.md
+++ b/changelog/highcharts/4.2.4.md
@@ -2,11 +2,11 @@
         
 - Added support for polar columnrange series.
 - Added `e.originalEvent` to drilldown event in order to catch modifier keys and other properties. Closes #5113.
-- Added new drilldown event, [chart.events.drillupall](http://api.highcharts.com/highcharts#chart.events.drillupall), that is triggered after multiple single drillup events. Closes #5158. Closes #5159.
-- Added new option, [chart.options3d.fitToPlot](http://api.highcharts.com/highcharts#chart.options3d.fitToPlot) to fit 3D charts into the available plotting area. This may affect the layout of existing 3D charts if the layout was adjusted by ``chart.margin``. The ``chart.margin`` setting can now normally be removed. Closes #4933.
-- Added new option, [lang.shortWeekdays](http://api.highcharts.com/highcharts#lang.shortWeekdays), to specify short weekdays other than the first three letters of the weekday.
-- Added new value, `day`, for [pointIntervalUnit](http://api.highcharts.com/highcharts#plotOptions.series.pointIntervalUnit).
-- Added option, [legend.navigation.enabled](http://api.highcharts.com/highcharts#legend.navigation.enabled), to allow disabling legend scroll.
+- Added new drilldown event, [chart.events.drillupall](https://api.highcharts.com/highcharts#chart.events.drillupall), that is triggered after multiple single drillup events. Closes #5158. Closes #5159.
+- Added new option, [chart.options3d.fitToPlot](https://api.highcharts.com/highcharts#chart.options3d.fitToPlot) to fit 3D charts into the available plotting area. This may affect the layout of existing 3D charts if the layout was adjusted by ``chart.margin``. The ``chart.margin`` setting can now normally be removed. Closes #4933.
+- Added new option, [lang.shortWeekdays](https://api.highcharts.com/highcharts#lang.shortWeekdays), to specify short weekdays other than the first three letters of the weekday.
+- Added new value, `day`, for [pointIntervalUnit](https://api.highcharts.com/highcharts#plotOptions.series.pointIntervalUnit).
+- Added option, [legend.navigation.enabled](https://api.highcharts.com/highcharts#legend.navigation.enabled), to allow disabling legend scroll.
 
 ## Bug fixes
 - Fixed #3450, tooltip did not display after zooming on Android.

--- a/changelog/highcharts/4.2.5.md
+++ b/changelog/highcharts/4.2.5.md
@@ -1,7 +1,7 @@
 # Changelog for Highcharts v4.2.5 (2016-05-06)
         
-- Added new option, [exporting.printMaxWidth](http://api.highcharts.com/highcharts#exporting.printMaxWidth), to prevent printed charts cut off on the right side. Closes #2088.
-- Added new option, [title.widthAdjust](http://api.highcharts.com/highcharts#title.widthAdjust) and sub[title.widthAdjust](http://api.highcharts.com/highcharts#title.widthAdjust), to prevent titles from flowing over elements.
+- Added new option, [exporting.printMaxWidth](https://api.highcharts.com/highcharts#exporting.printMaxWidth), to prevent printed charts cut off on the right side. Closes #2088.
+- Added new option, [title.widthAdjust](https://api.highcharts.com/highcharts#title.widthAdjust) and sub[title.widthAdjust](https://api.highcharts.com/highcharts#title.widthAdjust), to prevent titles from flowing over elements.
 - Added support for JPEG in offline download module, ref #5157.
 
 ## Bug fixes

--- a/changelog/highcharts/5.0.0.md
+++ b/changelog/highcharts/5.0.0.md
@@ -1,32 +1,32 @@
 # Changelog for Highcharts v5.0.0 (2016-09-29)
         
 - Added [styled mode](/docs/chart-design-and-style/style-by-css) for optional separation of SVG and CSS.
-- Added [responsive](http://api.highcharts.com/highcharts/responsive) option set.
-- Added [accessibility](http://api.highcharts.com/highcharts/accessibility) option set.
-- Added new function, [Chart.update](http://api.highcharts.com/highcharts/Chart.update) in order to update the chart options after render time.
-- Added new function, [Chart.addCredits](http://api.highcharts.com/highcharts/Chart.addCredits).
-- Added new function, [Chart.title.update](http://api.highcharts.com/highcharts/Chart.title).
-- Added new function, [Chart.credits.update](http://api.highcharts.com/highcharts/Chart.credits).
-- Added new function, [Legend.update](http://api.highcharts.com/highcharts/Legend.update).
-- Added new option, [Renderer.definition](http://api.highcharts.com/highcharts/Renderer.definition).
-- Added new option, [exporting.error](http://api.highcharts.com/highcharts/exporting.error) for catching errors in offline exporting.
-- Added new option, [exporting.libURL](http://api.highcharts.com/highcharts/exporting.libURL) for use with offline exporting.
-- Added new option, [pane.background.className](http://api.highcharts.com/highcharts/pane.background.className).
-- Added new option, [xAxis.className](http://api.highcharts.com/highcharts/xAxis.className).
-- Added new option, [xAxis.crosshair.className](http://api.highcharts.com/highcharts/xAxis.crosshair.className).
-- Added new option, [plotOptions.series.dataLabels.className](http://api.highcharts.com/highcharts/plotOptions.series.dataLabels.className).
-- Added new option, [plotOptions.series.className](http://api.highcharts.com/highcharts/plotOptions.series.className) for styling individual series.
-- Added new option, [xAxis.plotBands.className](http://api.highcharts.com/highcharts/xAxis.plotBands.className).
-- Added new option, [xAxis.plotLines.className](http://api.highcharts.com/highcharts/xAxis.plotLines.className).
-- Added new option, [plotOptions.series.zones.className](http://api.highcharts.com/highcharts/plotOptions.series.zones.className).
-- Added new option, [chart.colorCount](http://api.highcharts.com/highcharts/chart.colorCount) for use in styled mode.
-- Added new option, [defs](http://api.highcharts.com/highcharts/defs) for defining reusable elements in styled mode.
-- Added new option, [tooltip.padding](http://api.highcharts.com/highcharts/tooltip.padding).
-- Added new option, [series<line>.data.colorIndex](http://api.highcharts.com/highcharts/series<line>.data.colorIndex) for coloring points in styled mode.
-- Added new option, [tooltip.split](http://api.highcharts.com/highcharts/tooltip.split).
-- Added new option, [chart.description](http://api.highcharts.com/highcharts/chart.description) for use with the accessibility module.
-- Added new option, [chart.typeDescription](http://api.highcharts.com/highcharts/chart.typeDescription) for use with the accessibility module.
-- Added new option, [xAxis.description](http://api.highcharts.com/highcharts/xAxis.description) for use with the accessibility module.
-- Added new option, [plotOptions.series.description](http://api.highcharts.com/highcharts/plotOptions.series.description) for use with the accessibility module.
+- Added [responsive](https://api.highcharts.com/highcharts/responsive) option set.
+- Added [accessibility](https://api.highcharts.com/highcharts/accessibility) option set.
+- Added new function, [Chart.update](https://api.highcharts.com/highcharts/Chart.update) in order to update the chart options after render time.
+- Added new function, [Chart.addCredits](https://api.highcharts.com/highcharts/Chart.addCredits).
+- Added new function, [Chart.title.update](https://api.highcharts.com/highcharts/Chart.title).
+- Added new function, [Chart.credits.update](https://api.highcharts.com/highcharts/Chart.credits).
+- Added new function, [Legend.update](https://api.highcharts.com/highcharts/Legend.update).
+- Added new option, [Renderer.definition](https://api.highcharts.com/highcharts/Renderer.definition).
+- Added new option, [exporting.error](https://api.highcharts.com/highcharts/exporting.error) for catching errors in offline exporting.
+- Added new option, [exporting.libURL](https://api.highcharts.com/highcharts/exporting.libURL) for use with offline exporting.
+- Added new option, [pane.background.className](https://api.highcharts.com/highcharts/pane.background.className).
+- Added new option, [xAxis.className](https://api.highcharts.com/highcharts/xAxis.className).
+- Added new option, [xAxis.crosshair.className](https://api.highcharts.com/highcharts/xAxis.crosshair.className).
+- Added new option, [plotOptions.series.dataLabels.className](https://api.highcharts.com/highcharts/plotOptions.series.dataLabels.className).
+- Added new option, [plotOptions.series.className](https://api.highcharts.com/highcharts/plotOptions.series.className) for styling individual series.
+- Added new option, [xAxis.plotBands.className](https://api.highcharts.com/highcharts/xAxis.plotBands.className).
+- Added new option, [xAxis.plotLines.className](https://api.highcharts.com/highcharts/xAxis.plotLines.className).
+- Added new option, [plotOptions.series.zones.className](https://api.highcharts.com/highcharts/plotOptions.series.zones.className).
+- Added new option, [chart.colorCount](https://api.highcharts.com/highcharts/chart.colorCount) for use in styled mode.
+- Added new option, [defs](https://api.highcharts.com/highcharts/defs) for defining reusable elements in styled mode.
+- Added new option, [tooltip.padding](https://api.highcharts.com/highcharts/tooltip.padding).
+- Added new option, [series<line>.data.colorIndex](https://api.highcharts.com/highcharts/series<line>.data.colorIndex) for coloring points in styled mode.
+- Added new option, [tooltip.split](https://api.highcharts.com/highcharts/tooltip.split).
+- Added new option, [chart.description](https://api.highcharts.com/highcharts/chart.description) for use with the accessibility module.
+- Added new option, [chart.typeDescription](https://api.highcharts.com/highcharts/chart.typeDescription) for use with the accessibility module.
+- Added new option, [xAxis.description](https://api.highcharts.com/highcharts/xAxis.description) for use with the accessibility module.
+- Added new option, [plotOptions.series.description](https://api.highcharts.com/highcharts/plotOptions.series.description) for use with the accessibility module.
 - Refactored build system to use ES6 imports and node-based build script.
 - Changed all default colors (except series data colors) to a simplified color scheme based on just a few shared colors.

--- a/changelog/highcharts/5.0.10.md
+++ b/changelog/highcharts/5.0.10.md
@@ -2,7 +2,7 @@
         
 - Added `!default` statement to SASS variables for easier configuration. Closes #6436.
 - Added new option, [plotOptions.column.crisp, to allow disabling crisp columns and subsequent rendering issues with densely packed items. Closes](https://api.highcharts.com/highcharts/plotOptions.column.crisp) #5755
-- Added new option, [findNearestPointBy](http://api.highcharts.com/highcharts/plotOptions.series.findNearestPointBy) to declare how the tooltip searches for points. #6231.
+- Added new option, [findNearestPointBy](https://api.highcharts.com/highcharts/plotOptions.series.findNearestPointBy) to declare how the tooltip searches for points. #6231.
 - Refactored the Pane object to keep track of its own backgrounds, more decoupled from Axis.
 
 ## Bug fixes

--- a/changelog/highcharts/5.0.3.md
+++ b/changelog/highcharts/5.0.3.md
@@ -1,7 +1,7 @@
 # Changelog for Highcharts v5.0.3 (2016-11-18)
         
-- Added new option, [lang.numericSymbolMagnitude](http://api.highcharts.com/highcharts/lang.numericSymbolMagnitude), to support numeric symbol shortening in Japanese, Korean and certain Chinese locales.
-- Added new option, [threshold](http://api.highcharts.com/highcharts/plotOptions.solidgauge.threshold), for solid gauge series.
+- Added new option, [lang.numericSymbolMagnitude](https://api.highcharts.com/highcharts/lang.numericSymbolMagnitude), to support numeric symbol shortening in Japanese, Korean and certain Chinese locales.
+- Added new option, [threshold](https://api.highcharts.com/highcharts/plotOptions.solidgauge.threshold), for solid gauge series.
 - Added new CSS custom property, `textOutline`, and at the same time removed the `textShadow` shim. Closes #5849.
 - Better implementation of the [chart.pinchType](https://api.highcharts.com/highcharts/chart.pinchType) option. Allow `pinchType` and `zoomType` to be set independently. When `tooltip.followTouchMove` is true, `pinchType` only applies to two-finger touches. Closes #5840.
 - Changed the `Highcharts.addEvent` function to return a callback to be used to remove the same event.

--- a/changelog/highcharts/5.0.6.md
+++ b/changelog/highcharts/5.0.6.md
@@ -1,6 +1,6 @@
 # Changelog for Highcharts v5.0.6 (2016-12-07)
         
-- Added a common hook, [Highcharts.error](http://api.highcharts.com/highcharts/Highcharts.error), for user defined error handling.
+- Added a common hook, [Highcharts.error](https://api.highcharts.com/highcharts/Highcharts.error), for user defined error handling.
 
 ## Bug fixes
 - Fixed #4175, missed ticks when `xAxis.reversed` was used.

--- a/changelog/highcharts/5.0.7.md
+++ b/changelog/highcharts/5.0.7.md
@@ -2,11 +2,11 @@
         
 - Added Legend keyboard navigation to accessibility module.
 - Added chart render and predraw events needed by the new Boost module.
-- Added new option, [global.timezone](http://api.highcharts.com/highcharts/global.timezone), as a convenient shortcut to timezones defined with moment.js.
+- Added new option, [global.timezone](https://api.highcharts.com/highcharts/global.timezone), as a convenient shortcut to timezones defined with moment.js.
 - Added optional redraw to `drillToNode`, related to #6180.
-- Added support for [marker.symbol](http://api.highcharts.com/highcharts/plotOptions.bubble.marker.symbol) setting on bubble charts.
+- Added support for [marker.symbol](https://api.highcharts.com/highcharts/plotOptions.bubble.marker.symbol) setting on bubble charts.
 - Changed the `Highcharts.addEvent` function to return a callback to be used to remove the same event.
-- Changed the [Highcharts.error](http://api.highcharts.com/highcharts/Highcharts.error) function to handle strings.
+- Changed the [Highcharts.error](https://api.highcharts.com/highcharts/Highcharts.error) function to handle strings.
 
 ## Bug fixes
 - Fixed compliance with Checkmarx security checker.

--- a/changelog/highcharts/5.0.8.md
+++ b/changelog/highcharts/5.0.8.md
@@ -1,10 +1,10 @@
 # Changelog for Highcharts v5.0.8 (2017-03-08)
         
 - Added a refactored Boost module based on WebGL. Details and API to be announced.
-- Added [animation](http://api.highcharts.com/highcharts/plotOptions.series.states.hover.animation) on graph mouse over and mouse out.
-- Added hooks so that users can define their own log axis conversion functions, and can advertise that the log axis should allow [negative values](http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/samples/highcharts/yaxis/type-log-negative/).
-- Added new option, [solidgauge.rounded](http://api.highcharts.com/highcharts/plotOptions.solidgauge.rounded).
-- Added support for relative [chart.height](http://api.highcharts.com/highcharts/chart.height) as a percentage of the width. This allows for fixed aspect ratio.
+- Added [animation](https://api.highcharts.com/highcharts/plotOptions.series.states.hover.animation) on graph mouse over and mouse out.
+- Added hooks so that users can define their own log axis conversion functions, and can advertise that the log axis should allow [negative values](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/samples/highcharts/yaxis/type-log-negative/).
+- Added new option, [solidgauge.rounded](https://api.highcharts.com/highcharts/plotOptions.solidgauge.rounded).
+- Added support for relative [chart.height](https://api.highcharts.com/highcharts/chart.height) as a percentage of the width. This allows for fixed aspect ratio.
 
 ## Bug fixes
 - Fixed #223, pie chart data labels overflowed after pie reached minimum size.

--- a/changelog/highcharts/6.2.0.md
+++ b/changelog/highcharts/6.2.0.md
@@ -1,7 +1,7 @@
 # Changelog for Highcharts v6.2.0 (2018-10-17)
 
 - Added support for [multiple data labels](http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/plotoptions/series-datalabels-multiple/) on each single point.
-- Added [draggable points plugin](httpd://api.highcharts.com/highcharts/series.line.dragDrop) as module.
+- Added [draggable points plugin](https://api.highcharts.com/highcharts/series.line.dragDrop) as module.
 - Added support for `pointPlacement` in X range charts, affecting the category Y axis. Closed #7419.
 
 ## Bug fixes

--- a/changelog/highcharts/6.2.0.md
+++ b/changelog/highcharts/6.2.0.md
@@ -1,6 +1,6 @@
 # Changelog for Highcharts v6.2.0 (2018-10-17)
 
-- Added support for [multiple data labels](http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/plotoptions/series-datalabels-multiple/) on each single point.
+- Added support for [multiple data labels](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/plotoptions/series-datalabels-multiple/) on each single point.
 - Added [draggable points plugin](https://api.highcharts.com/highcharts/series.line.dragDrop) as module.
 - Added support for `pointPlacement` in X range charts, affecting the category Y axis. Closed #7419.
 

--- a/changelog/highmaps/4.2.4.md
+++ b/changelog/highmaps/4.2.4.md
@@ -1,7 +1,7 @@
 # Changelog for Highmaps v4.2.4 (2016-04-14)
         
 - Most changes listed under Highcharts 4.2.4 above also apply to Highmaps 4.2.4.
-- Added [mapNavigation.mouseWheelSensitivity](http://api.highcharts.com/highmaps#mapNavigation.mouseWheelSensitivity) option for zooming.
+- Added [mapNavigation.mouseWheelSensitivity](https://api.highcharts.com/highmaps#mapNavigation.mouseWheelSensitivity) option for zooming.
 
 ## Bug fixes
 - Fixed #4505, errors from crosshairs while dragging after zooming.

--- a/changelog/highmaps/4.2.7.md
+++ b/changelog/highmaps/4.2.7.md
@@ -1,8 +1,8 @@
 # Changelog for Highmaps v4.2.7 (2016-09-21)
         
 - Most changes listed under Highcharts 4.2.7 above also apply to Highmaps 4.2.7.
-- Added new option, [colorAxis.showInLegend](http://api.highcharts.com/highmaps/colorAxis.showInLegend).
-- Added new option, [series.nullInteraction](http://api.highcharts.com/highmaps/plotOptions.map.nullInteraction) to allow tooltips and mouse events on null points.
+- Added new option, [colorAxis.showInLegend](https://api.highcharts.com/highmaps/colorAxis.showInLegend).
+- Added new option, [series.nullInteraction](https://api.highcharts.com/highmaps/plotOptions.map.nullInteraction) to allow tooltips and mouse events on null points.
 
 ## Bug fixes
 - Fixed #5201, lineWidth ignored for mapline in IE11.

--- a/changelog/highmaps/5.0.0.md
+++ b/changelog/highmaps/5.0.0.md
@@ -1,5 +1,5 @@
 # Changelog for Highmaps v5.0.0 (2016-09-29)
         
 - Most changes listed under Highcharts 5.0.0 above also apply to Highmaps 5.0.0.
-- Simplified the map configuration by setting a general [chart.map](http://api.highcharts.com/highcharts/chart.map) option and allowing tuples in the [data description](http://api.highcharts.com/highmaps/series%3Cmap%3E.data).
-- Added new option, [chart.mapTransforms](http://api.highcharts.com/highmaps/chart.mapTransforms).
+- Simplified the map configuration by setting a general [chart.map](https://api.highcharts.com/highcharts/chart.map) option and allowing tuples in the [data description](https://api.highcharts.com/highmaps/series%3Cmap%3E.data).
+- Added new option, [chart.mapTransforms](https://api.highcharts.com/highmaps/chart.mapTransforms).

--- a/changelog/highmaps/5.0.8.md
+++ b/changelog/highmaps/5.0.8.md
@@ -1,7 +1,7 @@
 # Changelog for Highmaps v5.0.8 (2017-03-08)
         
 - Most changes listed under Highcharts 5.0.8 above also apply to Highmaps 5.0.8.
-- New advanced demo for [map pies](http://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/samples/maps/demo/map-pies/).
+- New advanced demo for [map pies](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/samples/maps/demo/map-pies/).
 
 ## Bug fixes
 - Fixed #6025, color axis got misplaced after update then resizing chart.

--- a/changelog/highstock/1.0.1.md
+++ b/changelog/highstock/1.0.1.md
@@ -4,4 +4,4 @@
 
 ## Bug fixes
 - Fixed error on chart.addSeries.
-- Fixed issues as listed at [GitHub](http://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed issues as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.

--- a/changelog/highstock/1.0.1.md
+++ b/changelog/highstock/1.0.1.md
@@ -4,4 +4,4 @@
 
 ## Bug fixes
 - Fixed error on chart.addSeries.
-- Fixed issues as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed issues as listed at [GitHub](https://github.com/highcharts/highcharts/commits/master) under dates since the last maintenance version.

--- a/changelog/highstock/1.0.2.md
+++ b/changelog/highstock/1.0.2.md
@@ -3,4 +3,4 @@
 
 ## Bug fixes
 - Fixed compatibility issue with jQuery 1.7.
-- Fixed issues as listed at [GitHub](http://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed issues as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.

--- a/changelog/highstock/1.0.2.md
+++ b/changelog/highstock/1.0.2.md
@@ -3,4 +3,4 @@
 
 ## Bug fixes
 - Fixed compatibility issue with jQuery 1.7.
-- Fixed issues as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed issues as listed at [GitHub](https://github.com/highcharts/highcharts/commits/master) under dates since the last maintenance version.

--- a/changelog/highstock/1.1.0.md
+++ b/changelog/highstock/1.1.0.md
@@ -4,4 +4,4 @@
 - Added a few advanced options for axis and legend object.
 
 ## Bug fixes
-- Fixed issues as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed issues as listed at [GitHub](https://github.com/highcharts/highcharts/commits/master) under dates since the last maintenance version.

--- a/changelog/highstock/1.1.0.md
+++ b/changelog/highstock/1.1.0.md
@@ -4,4 +4,4 @@
 - Added a few advanced options for axis and legend object.
 
 ## Bug fixes
-- Fixed issues as listed at [GitHub](http://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed issues as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.

--- a/changelog/highstock/1.1.3.md
+++ b/changelog/highstock/1.1.3.md
@@ -2,4 +2,4 @@
         
 
 ## Bug fixes
-- Fixed issues as listed at [GitHub](http://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed issues as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.

--- a/changelog/highstock/1.1.3.md
+++ b/changelog/highstock/1.1.3.md
@@ -2,4 +2,4 @@
         
 
 ## Bug fixes
-- Fixed issues as listed at [GitHub](https://github.com/highslide-software/highcharts.com/commits/master) under dates since the last maintenance version.
+- Fixed issues as listed at [GitHub](https://github.com/highcharts/highcharts/commits/master) under dates since the last maintenance version.

--- a/changelog/highstock/1.1.4.md
+++ b/changelog/highstock/1.1.4.md
@@ -1,6 +1,6 @@
 # Changelog for Highstock v1.1.4 (2012-02-15)
         
-- Added temporary workaround for [text rendering bug](https://github.com/highslide-software/highcharts.com/issues/732) in Chrome 18 Beta.
+- Added temporary workaround for [text rendering bug](https://github.com/highcharts/highcharts/issues/732) in Chrome 18 Beta.
 - Added support for setting height in chart.setSize().
 
 ## Bug fixes

--- a/changelog/highstock/1.2.5.md
+++ b/changelog/highstock/1.2.5.md
@@ -1,7 +1,7 @@
 # Changelog for Highstock v1.2.5 (2012-12-19)
         
 - Applied fixes for Highcharts Basic version 2.3.5.
-- Added [scrollbar.minWidth](http://api.highcharts.com/highstock/#scrollbar.minWidth) option in Highstock. #1246.
+- Added [scrollbar.minWidth](https://api.highcharts.com/highstock/#scrollbar.minWidth) option in Highstock. #1246.
 
 ## Bug fixes
 - Fixed JS error on quickly scrolling a chart with image markers. #1390.
@@ -9,6 +9,6 @@
 - Fixed issue when adding points to hidden OHLC or candlestick series. #1377.
 - Fixed issue with zoomed range increasing when moving the range without resizing it. #1370.
 - Fixed issue with Exporting dropdown menu being covered by the range selector inputs.
-- Made the range selector inputs visible in exported charts. Added [rangeSelector.inputPosition](http://api.highcharts.com/highstock/#rangeSelector.inputPosition) option.
+- Made the range selector inputs visible in exported charts. Added [rangeSelector.inputPosition](https://api.highcharts.com/highstock/#rangeSelector.inputPosition) option.
 - Fixed Highstock issue with YTD button when not using UTC. #941.
 - Fixed Highstock issue with unresponsive range selector buttons by applying clipping to the mouse tracker. #484.

--- a/changelog/highstock/1.3.1.md
+++ b/changelog/highstock/1.3.1.md
@@ -1,6 +1,6 @@
 # Changelog for Highstock v1.3.1 (2013-04-09)
         
-- Added new option, [tooltip.followTouchMove](http://api.highcharts.com#tooltip.followTouchMove). When this is true, the tooltip can be moved by dragging a single finger across the chart, like in Highcharts 2. When it is false, dragging a single finger is ignored by the chart, and causes the whole page to scroll. This applies only when zooming is not enabled. #1644. #1662.
+- Added new option, [tooltip.followTouchMove](https://api.highcharts.com#tooltip.followTouchMove). When this is true, the tooltip can be moved by dragging a single finger across the chart, like in Highcharts 2. When it is false, dragging a single finger is ignored by the chart, and causes the whole page to scroll. This applies only when zooming is not enabled. #1644. #1662.
 - Added internationalization for the Print chart text. #1656.
 - Made loading mask use the current chart size, not the initial one. #1601.
 

--- a/changelog/highstock/2.0.0.md
+++ b/changelog/highstock/2.0.0.md
@@ -1,4 +1,4 @@
 # Changelog for Highstock v2.0.0 (2014-04-22)
         
 - See the [release announcement](/component/content/article/2-news/134-announcing-highcharts-4/).
-- The default design has been updated with Highstock 2, but all aspects of design can be reverted to the Highstock 1.3 looks by applying options. See [this design compatibilty demo](http://jsfiddle.net/highcharts/Y5ak7/) for a listing of what options it applies to.
+- The default design has been updated with Highstock 2, but all aspects of design can be reverted to the Highstock 1.3 looks by applying options. See [this design compatibilty demo](https://jsfiddle.net/highcharts/Y5ak7/) for a listing of what options it applies to.

--- a/changelog/highstock/2.0.3.md
+++ b/changelog/highstock/2.0.3.md
@@ -1,7 +1,7 @@
 # Changelog for Highstock v2.0.3 (2014-07-03)
         
 - Most issues listed under Highcharts 4.0.3 above also apply to Highstock 2.0.3.
-- Added new option, [rangeSelector.allButtonsEnabled](http://api.highcharts.com/highstock#rangeSelector.allButtonsEnabled) to force auto-disabled buttons on inadequate range to be clickable. Closes #2418.
+- Added new option, [rangeSelector.allButtonsEnabled](https://api.highcharts.com/highstock#rangeSelector.allButtonsEnabled) to force auto-disabled buttons on inadequate range to be clickable. Closes #2418.
 
 ## Bug fixes
 - Fixed #3150 causing error when setting dataGrouping options for flag series.

--- a/changelog/highstock/2.1.5.md
+++ b/changelog/highstock/2.1.5.md
@@ -1,7 +1,7 @@
 # Changelog for Highstock v2.1.5 (2015-04-13)
         
 - Most changes listed under Highcharts 4.1.5 above also apply to Highstock 2.1.5.
-- Added feature, forced data grouping tied to range selector buttons. [View demo](http://jsfiddle.net/gh/get/jquery/1.7.2/highslide-software/highcharts.com/tree/master/samples/stock/rangeselector/datagrouping/).
+- Added feature, forced data grouping tied to range selector buttons. [View demo](https://jsfiddle.net/gh/get/jquery/1.7.2/highslide-software/highcharts.com/tree/master/samples/stock/rangeselector/datagrouping/).
 
 ## Bug fixes
 - Fixed #3983, plot band labels outside axis range were visible.

--- a/changelog/highstock/2.1.5.md
+++ b/changelog/highstock/2.1.5.md
@@ -1,7 +1,7 @@
 # Changelog for Highstock v2.1.5 (2015-04-13)
         
 - Most changes listed under Highcharts 4.1.5 above also apply to Highstock 2.1.5.
-- Added feature, forced data grouping tied to range selector buttons. [View demo](https://jsfiddle.net/gh/get/jquery/1.7.2/highslide-software/highcharts.com/tree/master/samples/stock/rangeselector/datagrouping/).
+- Added feature, forced data grouping tied to range selector buttons. [View demo](https://jsfiddle.net/gh/get/jquery/1.7.2/highcharts/highcharts/tree/master/samples/stock/rangeselector/datagrouping/).
 
 ## Bug fixes
 - Fixed #3983, plot band labels outside axis range were visible.

--- a/changelog/highstock/2.1.9.md
+++ b/changelog/highstock/2.1.9.md
@@ -1,7 +1,7 @@
 # Changelog for Highstock v2.1.9 (2015-10-07)
         
 - Most changes listed under Highcharts 4.1.9 above also apply to Highstock 2.1.9.
-- Added new option, [rangeSelector.height](http://api.highcharts.com/highstock#rangeSelector.height), to reserve space for buttons and input.
+- Added new option, [rangeSelector.height](https://api.highcharts.com/highstock#rangeSelector.height), to reserve space for buttons and input.
 
 ## Bug fixes
 - Fixed #2920, dataGrouping.smoothed made graph extend to series extremes.

--- a/changelog/highstock/4.2.2.md
+++ b/changelog/highstock/4.2.2.md
@@ -1,7 +1,7 @@
 # Changelog for Highstock v4.2.2 (2016-02-04)
         
 - Most changes listed under Highcharts 4.2.2 above also apply to Highstock 4.2.2.
-- Added new option to flag series, [onKey](http://api.highcharts.com/highstock#plotOptions.flags.onKey), to configure what key the flag should be placed on. Closes #4873.
+- Added new option to flag series, [onKey](https://api.highcharts.com/highstock#plotOptions.flags.onKey), to configure what key the flag should be placed on. Closes #4873.
 
 ## Bug fixes
 - Fixed #4907, data grouping didn't give correct distance to points immediately outside the plot area.

--- a/changelog/highstock/4.2.4.md
+++ b/changelog/highstock/4.2.4.md
@@ -1,7 +1,7 @@
 # Changelog for Highstock v4.2.4 (2016-04-14)
         
 - Most changes listed under Highcharts 4.2.4 above also apply to Highstock 4.2.4.
-- Added new Point property, [dataGroup](http://api.highcharts.com/highstock#Point.dataGroup), that holds information of what raw data points are included in a grouped point.
+- Added new Point property, [dataGroup](https://api.highcharts.com/highstock#Point.dataGroup), that holds information of what raw data points are included in a grouped point.
 
 ## Bug fixes
 - Fixed #3477, range selector did not update axis extremes after pressing enter in IE.

--- a/changelog/highstock/4.2.6.md
+++ b/changelog/highstock/4.2.6.md
@@ -1,7 +1,7 @@
 # Changelog for Highstock v4.2.6 (2016-08-02)
         
 - Most changes listed under Highcharts 4.2.6 above also apply to Highstock 4.2.6.
-- Added new option set, [yAxis.scrollbar](http://api.highcharts.com/highstock#yAxis.scrollbar), to allow scrollbars on Y axis (or in fact any axis) in Highstock. [Read announcement](/component/content/article/2-news/224-scrollbars-for-any-axis).
+- Added new option set, [yAxis.scrollbar](https://api.highcharts.com/highstock#yAxis.scrollbar), to allow scrollbars on Y axis (or in fact any axis) in Highstock. [Read announcement](/component/content/article/2-news/224-scrollbars-for-any-axis).
 - Refactored sideways graph animation to allow smooth navigation when clicking scrollbar buttons, adding multiple points etc.
 
 ## Bug fixes

--- a/changelog/highstock/4.2.7.md
+++ b/changelog/highstock/4.2.7.md
@@ -1,7 +1,7 @@
 # Changelog for Highstock v4.2.7 (2016-09-21)
         
 - Most changes listed under Highcharts 4.2.7 above also apply to Highstock 4.2.7.
-- Added `Series.dataGroupInfo` to allow accessing data grouping information from the [approximation](http://api.highcharts.com/highstock/plotOptions.series.dataGrouping.approximation) function.
+- Added `Series.dataGroupInfo` to allow accessing data grouping information from the [approximation](https://api.highcharts.com/highstock/plotOptions.series.dataGrouping.approximation) function.
 - Added warning on trying to update grouped point.
 
 ## Bug fixes

--- a/changelog/highstock/5.0.0.md
+++ b/changelog/highstock/5.0.0.md
@@ -1,6 +1,6 @@
 # Changelog for Highstock v5.0.0 (2016-09-29)
         
 - Most changes listed under Highcharts 5.0.0 above also apply to Highstock 5.0.0.
-- Added support for multiple series in the navigator, see [series.showInNavigator](http://api.highcharts.com/highstock/plotOptions.series.showInNavigator) and [series.navigatorOptions](http://api.highcharts.com/highstock/plotOptions.series.navigatorOptions).
-- Added new option, [plotOptions.flags.textAlign](http://api.highcharts.com/highcharts/plotOptions.flags.textAlign).
-- Deprecated the [baseSeries](http://api.highcharts.com/highstock/navigator.baseSeries) option, now replaced by `showInNavigator`.
+- Added support for multiple series in the navigator, see [series.showInNavigator](https://api.highcharts.com/highstock/plotOptions.series.showInNavigator) and [series.navigatorOptions](https://api.highcharts.com/highstock/plotOptions.series.navigatorOptions).
+- Added new option, [plotOptions.flags.textAlign](https://api.highcharts.com/highcharts/plotOptions.flags.textAlign).
+- Deprecated the [baseSeries](https://api.highcharts.com/highstock/navigator.baseSeries) option, now replaced by `showInNavigator`.

--- a/changelog/highstock/5.0.7.md
+++ b/changelog/highstock/5.0.7.md
@@ -1,7 +1,7 @@
 # Changelog for Highstock v5.0.7 (2017-01-17)
         
 - Most changes listed under Highcharts 5.0.7 above also apply to Highstock 5.0.7.
-- Added support for [navigator in inverted charts](http://jsfiddle.net/gh/get/jquery/3.1.1/highcharts/highcharts/tree/master/samples/stock/navigator/inverted/).
+- Added support for [navigator in inverted charts](https://jsfiddle.net/gh/get/jquery/3.1.1/highcharts/highcharts/tree/master/samples/stock/navigator/inverted/).
 - Created new module `stock.src.js` so Highstock can be loaded as a module for Highcharts.
 
 ## Bug fixes


### PR DESCRIPTION
# Description
The changelog source files contained an invalid url which would break when clicked on in our website.
This PR also makes some various improvements to the urls as well:
- Fixes invalid url
- Replaces `http` with `https`
- Replaces `highslide-software/highcharts.com` with `highcharts/highcharts` 