### PR TITLE
Fixed #9258, remove use of id in treemap data labels.

### DIFF
--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -170,9 +170,7 @@ seriesType('treemap', 'scatter', {
         enabled: true,
         defer: false,
         verticalAlign: 'middle',
-        formatter: function () { // #2945
-            return this.point.name || this.point.id;
-        },
+        format: '{point.name}',
         inside: true
     },
 

--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -170,7 +170,11 @@ seriesType('treemap', 'scatter', {
         enabled: true,
         defer: false,
         verticalAlign: 'middle',
-        format: '{point.name}',
+        formatter: function () {
+            var point = this && this.point ? this.point : {},
+                name = isString(point.name) ? point.name : '';
+            return name;
+        },
         inside: true
     },
 

--- a/samples/unit-tests/series-treemap/options/demo.details
+++ b/samples/unit-tests/series-treemap/options/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series-treemap/options/demo.html
+++ b/samples/unit-tests/series-treemap/options/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/treemap.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/series-treemap/options/demo.js
+++ b/samples/unit-tests/series-treemap/options/demo.js
@@ -3,38 +3,105 @@ QUnit.module('defaultOptions', function () {
         treemap = options.plotOptions.treemap;
 
     QUnit.test('dataLabels', function (assert) {
+        var dataLabels = treemap.dataLabels,
+            formatter = dataLabels.formatter,
+            ctx = {};
+
+        /**
+         * dataLabels
+         */
         assert.strictEqual(
-            typeof treemap.dataLabels,
+            typeof dataLabels,
             'object',
             'should have dataLabels default to object.'
         );
+
+        /**
+         * dataLabels.align
+         */
         assert.strictEqual(
-            treemap.dataLabels.align,
+            dataLabels.align,
             'center',
             'should have dataLabels.align default to "center".'
         );
+
+        /**
+         * dataLabels.defer
+         */
         assert.strictEqual(
-            treemap.dataLabels.defer,
+            dataLabels.defer,
             false,
             'should have dataLabels.defer default to false.'
         );
+
+        /**
+         * dataLabels.enabled
+         */
         assert.strictEqual(
-            treemap.dataLabels.enabled,
+            dataLabels.enabled,
             true,
             'should have dataLabels.enabled default to true.'
         );
+
+        /**
+         * dataLabels.format
+         */
         assert.strictEqual(
-            treemap.dataLabels.format,
-            '{point.name}',
-            'should have dataLabels.format default to "{point.name}".'
+            typeof dataLabels.format,
+            'undefined',
+            'should have dataLabels.format default to undefined.'
         );
+
+        /**
+         * dataLabels.formatter
+         */
         assert.strictEqual(
-            treemap.dataLabels.inside,
+            formatter.call(undefined),
+            '',
+            'should have dataLabels.formatter return "" when context is undefined.'
+        );
+
+        assert.strictEqual(
+            formatter.call(ctx),
+            '',
+            'should have dataLabels.formatter return "" when point is undefined.'
+        );
+
+        ctx.point = {};
+        assert.strictEqual(
+            formatter.call(ctx),
+            '',
+            'should have dataLabels.formatter return "" when point.name is undefined.'
+        );
+
+        ctx.point.name = {};
+        assert.strictEqual(
+            formatter.call(ctx),
+            '',
+            'should have dataLabels.formatter return "" when point.name is not a string.'
+        );
+
+        ctx.point.name = 'My Name';
+        assert.strictEqual(
+            formatter.call(ctx),
+            'My Name',
+            'should have dataLabels.formatter return point.name when it is a string.'
+        );
+
+        /**
+         * dataLabels.inside
+         */
+        assert.strictEqual(
+            dataLabels.inside,
             true,
             'should have dataLabels.inside default to true.'
         );
+
+        /**
+         * dataLabels.verticalAlign
+         */
         assert.strictEqual(
-            treemap.dataLabels.verticalAlign,
+            dataLabels.verticalAlign,
             'middle',
             'should have dataLabels.verticalAlign default to "middle".'
         );

--- a/samples/unit-tests/series-treemap/options/demo.js
+++ b/samples/unit-tests/series-treemap/options/demo.js
@@ -1,0 +1,42 @@
+QUnit.module('defaultOptions', function () {
+    var options = Highcharts.getOptions(),
+        treemap = options.plotOptions.treemap;
+
+    QUnit.test('dataLabels', function (assert) {
+        assert.strictEqual(
+            typeof treemap.dataLabels,
+            'object',
+            'should have dataLabels default to object.'
+        );
+        assert.strictEqual(
+            treemap.dataLabels.align,
+            'center',
+            'should have dataLabels.align default to "center".'
+        );
+        assert.strictEqual(
+            treemap.dataLabels.defer,
+            false,
+            'should have dataLabels.defer default to false.'
+        );
+        assert.strictEqual(
+            treemap.dataLabels.enabled,
+            true,
+            'should have dataLabels.enabled default to true.'
+        );
+        assert.strictEqual(
+            treemap.dataLabels.format,
+            '{point.name}',
+            'should have dataLabels.format default to "{point.name}".'
+        );
+        assert.strictEqual(
+            treemap.dataLabels.inside,
+            true,
+            'should have dataLabels.inside default to true.'
+        );
+        assert.strictEqual(
+            treemap.dataLabels.verticalAlign,
+            'middle',
+            'should have dataLabels.verticalAlign default to "middle".'
+        );
+    });
+});


### PR DESCRIPTION
# Description
Currently `point.id` is used as a fallback when `point.name` is not defined, which caused unexpected issues after [point.id started to get assigned a value by default](https://github.com/highcharts/highcharts/pull/9140). This PR solves the issue by removing the use of `point.id` in the data labels.

Additionally, it also adds a unit test which checks that default options for dataLabels in treemap is assigned the correct values.

# Example(s)
- [current behaviour](https://jsfiddle.net/gc3rx9fo/)
- [new behaviour](https://jsfiddle.net/jon_a_nygaard/w0t9mnzs/)

# Related issue(s)
- Closes #9258 