### PR TITLE
Fixed #9156, export data download failed on iOS.

### DIFF
--- a/js/mixins/download-url.js
+++ b/js/mixins/download-url.js
@@ -1,0 +1,96 @@
+/**
+ * Mixin for downloading content in the browser
+ *
+ * (c) 2018 Oystein Moseng
+ *
+ * License: www.highcharts.com/license
+ */
+
+'use strict';
+
+import Highcharts from '../parts/Globals.js';
+
+var win = Highcharts.win,
+    nav = win.navigator,
+    doc = win.document,
+    domurl = win.URL || win.webkitURL || win,
+    isEdgeBrowser = /Edge\/\d+/.test(nav.userAgent);
+
+// Convert base64 dataURL to Blob if supported, otherwise returns undefined
+Highcharts.dataURLtoBlob = function (dataURL) {
+    var parts = dataURL.match(/data:([^;]*)(;base64)?,([0-9A-Za-z+/]+)/);
+    if (
+        parts &&
+        parts.length > 3 &&
+        win.atob &&
+        win.ArrayBuffer &&
+        win.Uint8Array &&
+        win.Blob &&
+        domurl.createObjectURL
+    ) {
+        // Try to convert data URL to Blob
+        var binStr = win.atob(parts[3]),
+            buf = new win.ArrayBuffer(binStr.length),
+            binary = new win.Uint8Array(buf),
+            blob;
+
+        for (var i = 0; i < binary.length; ++i) {
+            binary[i] = binStr.charCodeAt(i);
+        }
+
+        blob = new win.Blob([binary], { 'type': parts[1] });
+        return domurl.createObjectURL(blob);
+    }
+};
+
+
+/**
+ * Download a data URL in the browser. Can also take a blob as first param.
+ *
+ * @param  {string|object} dataURL The dataURL/Blob to download
+ * @param  {string} filename The name of the resulting file (w/extension)
+ */
+Highcharts.downloadURL = function (dataURL, filename) {
+    var a = doc.createElement('a'),
+        windowRef;
+
+    // IE specific blob implementation
+    // Don't use for normal dataURLs
+    if (
+        typeof dataURL !== 'string' &&
+        !(dataURL instanceof String) &&
+        nav.msSaveOrOpenBlob
+    ) {
+        nav.msSaveOrOpenBlob(dataURL, filename);
+        return;
+    }
+
+    // Some browsers have limitations for data URL lengths. Try to convert to
+    // Blob or fall back. Edge always needs that blob.
+    if (isEdgeBrowser || dataURL.length > 2000000) {
+        dataURL = Highcharts.dataURLtoBlob(dataURL);
+        if (!dataURL) {
+            throw 'Failed to convert to blob';
+        }
+    }
+
+    // Try HTML5 download attr if supported
+    if (a.download !== undefined) {
+        a.href = dataURL;
+        a.download = filename; // HTML5 download attribute
+        doc.body.appendChild(a);
+        a.click();
+        doc.body.removeChild(a);
+    } else {
+        // No download attr, just opening data URI
+        try {
+            windowRef = win.open(dataURL, 'chart');
+            if (windowRef === undefined || windowRef === null) {
+                throw 'Failed to open window';
+            }
+        } catch (e) {
+            // window.open failed, trying location.href
+            win.location.href = dataURL;
+        }
+    }
+};

--- a/js/modules/export-data.src.js
+++ b/js/modules/export-data.src.js
@@ -16,6 +16,7 @@ import Highcharts from '../parts/Globals.js';
 import '../parts/Utilities.js';
 import '../parts/Chart.js';
 import '../mixins/ajax.js';
+import '../mixins/download-url.js';
 
 var defined = Highcharts.defined,
     each = Highcharts.each,
@@ -23,7 +24,7 @@ var defined = Highcharts.defined,
     win = Highcharts.win,
     doc = win.document,
     seriesTypes = Highcharts.seriesTypes,
-    downloadAttrSupported = doc.createElement('a').download !== undefined;
+    downloadURL = Highcharts.downloadURL;
 
 // Can we add this to utils? Also used in screen-reader.js
 /**
@@ -753,53 +754,41 @@ Highcharts.Chart.prototype.getTable = function (useLocalDecimalPoint) {
     return html;
 };
 
+
 /**
- * File download using download attribute if supported.
+ * Get the filename for a chart that is being downloaded
  *
  * @private
- * @function Highcharts.Chart#fileDownload
- *
- * @param {string} href
- *
- * @param {string} extension
- *
- * @param {string} content
+ * @return {String} The filename.
  */
-Highcharts.Chart.prototype.fileDownload = function (href, extension, content) {
-    var a,
-        blobObject,
-        name;
-
+Highcharts.Chart.prototype.getFilename = function () {
     if (this.options.exporting.filename) {
-        name = this.options.exporting.filename;
-    } else if (this.title && this.title.textStr) {
-        name = this.title.textStr.replace(/ /g, '-').toLowerCase();
-    } else {
-        name = 'chart';
+        return this.options.exporting.filename;
     }
-
-    // MS specific. Check this first because of bug with Edge (#76)
-    if (win.Blob && win.navigator.msSaveOrOpenBlob) {
-        // Falls to msSaveOrOpenBlob if download attribute is not supported
-        blobObject = new win.Blob(
-            ['\uFEFF' + content], // #7084
-            { type: 'text/csv' }
-        );
-        win.navigator.msSaveOrOpenBlob(blobObject, name + '.' + extension);
-
-    // Download attribute supported
-    } else if (downloadAttrSupported) {
-        a = doc.createElement('a');
-        a.href = href;
-        a.download = name + '.' + extension;
-        this.container.appendChild(a); // #111
-        a.click();
-        a.remove();
-
-    } else {
-        Highcharts.error('The browser doesn\'t support downloading files');
-    }
+    return this.title && this.title.textStr ?
+        this.title.textStr.replace(/ /g, '-').toLowerCase() :
+        'chart';
 };
+
+
+/**
+ * Get a blob object from content, if blob is supported
+ *
+ * @private
+ *
+ * @param {String} content The content to create the blob from.
+ * @param {String} type The type of the content.
+ * @return {object} The blob object, or undefined if not supported.
+ */
+function getBlobFromContent(content, type) {
+    if (win.Blob && win.navigator.msSaveOrOpenBlob) {
+        return new win.Blob(
+            ['\uFEFF' + content], // #7084
+            { type: type }
+        );
+    }
+}
+
 
 /**
  * Call this on click of 'Download CSV' button
@@ -809,11 +798,10 @@ Highcharts.Chart.prototype.fileDownload = function (href, extension, content) {
  */
 Highcharts.Chart.prototype.downloadCSV = function () {
     var csv = this.getCSV(true);
-    this.fileDownload(
-        'data:text/csv,\uFEFF' + encodeURIComponent(csv),
-        'csv',
-        csv,
-        'text/csv'
+    downloadURL(
+        getBlobFromContent(csv, 'text/csv') ||
+            'data:text/csv,\uFEFF' + encodeURIComponent(csv),
+        this.getFilename() + '.csv'
     );
 };
 
@@ -845,11 +833,11 @@ Highcharts.Chart.prototype.downloadXLS = function () {
         base64 = function (s) {
             return win.btoa(unescape(encodeURIComponent(s))); // #50
         };
-    this.fileDownload(
-        uri + base64(template),
-        'xls',
-        template,
-        'application/vnd.ms-excel'
+
+    downloadURL(
+        getBlobFromContent(template, 'application/vnd.ms-excel') ||
+            uri + base64(template),
+        this.getFilename() + '.xls'
     );
 };
 


### PR DESCRIPTION
Exporting CSV or XLS failed on iOS because download attribute is not supported on `a` elements.

Pulled in download logic from offline exporting that makes use of Blobs, window.open or setting location to data URLs. Tested on various browser combinations, including IE and Edge.