### PR TITLE
Added tracking to default credit link.

### DIFF
--- a/js/parts/Options.js
+++ b/js/parts/Options.js
@@ -3319,7 +3319,7 @@ H.defaultOptions = {
          * @sample {highmaps} maps/credits/customized/
          *         Custom URL and text
          */
-        href: 'https://www.highcharts.com',
+        href: 'https://www.highcharts.com?credits',
 
         /**
          * Position configuration for the credits label.


### PR DESCRIPTION
By Vidar's request: Add query string to default credit link for tracking purposes.