### PR TITLE
Fixed #9298, zooming with dragdrop.

### DIFF
--- a/js/modules/draggable-points.src.js
+++ b/js/modules/draggable-points.src.js
@@ -2251,9 +2251,6 @@ function mouseDown(e, chart) {
         return;
     }
 
-    // Prevent zooming
-    chart.mouseIsDown = false;
-
     // If we somehow get a mousedown event while we are dragging, cancel
     if (chart.dragDropData && chart.dragDropData.isDragging) {
         mouseUp(e, chart);
@@ -2262,6 +2259,7 @@ function mouseDown(e, chart) {
 
     // If this point is movable, start dragging it
     if (dragPoint && isPointMovable(dragPoint)) {
+        chart.mouseIsDown = false; // Prevent zooming
         initDragDrop(e, dragPoint);
         dragPoint.firePointEvent('dragStart', e);
     }

--- a/samples/highcharts/dragdrop/drag-bubble/demo.details
+++ b/samples/highcharts/dragdrop/drag-bubble/demo.details
@@ -2,5 +2,6 @@
  name: Highcharts Demo
  authors:
    - Torstein Hønsi
+ requiresManualTesting: true
  js_wrap: b
 ...

--- a/samples/highcharts/dragdrop/drag-xrange/demo.details
+++ b/samples/highcharts/dragdrop/drag-xrange/demo.details
@@ -2,5 +2,6 @@
  name: Highcharts Demo
  authors:
    - Øystein Moseng
+ requiresManualTesting: true
  js_wrap: b
 ...

--- a/samples/highcharts/dragdrop/drag-xrange/demo.js
+++ b/samples/highcharts/dragdrop/drag-xrange/demo.js
@@ -14,10 +14,6 @@ Highcharts.chart('container', {
         text: 'Highcharts draggable xrange demo'
     },
 
-    subtitle: {
-        text: 'Test zoom and dragging/resizing of points'
-    },
-
     tooltip: {
         headerFormat: '<span style="font-size: 10px">{point.yCategory}</span><br/>',
         pointFormat: '{point.name}'

--- a/samples/highcharts/dragdrop/drag-xrange/demo.js
+++ b/samples/highcharts/dragdrop/drag-xrange/demo.js
@@ -6,11 +6,16 @@ var setDragStatus = function (status) {
 Highcharts.chart('container', {
     chart: {
         animation: false,
-        type: 'xrange'
+        type: 'xrange',
+        zoomType: 'x'
     },
 
     title: {
         text: 'Highcharts draggable xrange demo'
+    },
+
+    subtitle: {
+        text: 'Test zoom and dragging/resizing of points'
     },
 
     tooltip: {

--- a/samples/highcharts/dragdrop/drag-xrange/test-notes.md
+++ b/samples/highcharts/dragdrop/drag-xrange/test-notes.md
@@ -1,0 +1,5 @@
+1. Test zoom (x axis)
+2. Test that points are draggable. 
+    - "Grouped, no prototyping" should not be draggable to "Prototype" row.
+    - "No drag Y" should only be draggable in the x dimension
+3. Test that non-grouped points can be resized.

--- a/samples/highcharts/dragdrop/resize-column/demo.details
+++ b/samples/highcharts/dragdrop/resize-column/demo.details
@@ -2,5 +2,6 @@
  name: Highcharts Demo
  authors:
    - Torstein Hønsi
+ requiresManualTesting: true
  js_wrap: b
 ...


### PR DESCRIPTION
Zoom was prevented even when we didn't have a draggable point on mousedown.

Added zoom to one of the visual tests, and made note to remember to test this.