### PR TITLE
Bugfix/9289 wordcloud drilldown

### DIFF
--- a/js/modules/drilldown.src.js
+++ b/js/modules/drilldown.src.js
@@ -470,7 +470,6 @@ Chart.prototype.addSingleSeriesAsDrilldown = function (point, ddOptions) {
     // Run fancy cross-animation on supported and equal types
     if (oldSeries.type === newSeries.type) {
         newSeries.animate = newSeries.animateDrilldown || noop;
-        newSeries.options.animation = true;
     }
 };
 
@@ -970,6 +969,13 @@ H.Point.prototype.doDrilldown = function (
             inArray(this.drilldown, chart.ddDupes) === -1
         ) {
             seriesOptions = drilldown.series[i];
+
+            // Set series animation.
+            seriesOptions.animation = pick(
+                seriesOptions.animation,
+                drilldown.animation
+            );
+
             chart.ddDupes.push(this.drilldown);
         }
     }

--- a/js/modules/wordcloud.src.js
+++ b/js/modules/wordcloud.src.js
@@ -19,6 +19,7 @@ var each = H.each,
     isObject = H.isObject,
     map = H.map,
     merge = H.merge,
+    noop = H.noop,
     find = H.find,
     reduce = H.reduce,
     getBoundingBoxFromPolygon = polygon.getBoundingBoxFromPolygon,
@@ -572,6 +573,7 @@ var wordCloudOptions = {
  */
 var wordCloudSeries = {
     animate: Series.prototype.animate,
+    animateDrilldown: noop,
     bindAxes: function () {
         var wordcloudAxis = {
             endOnTick: false,


### PR DESCRIPTION
# Description
The current `animateDrilldown` functionality does not work well with Wordcloud, causing it to position the words outside the plot area. This PR disables the `animateDrilldown` on Wordcloud which allows it to render correctly.

In the future a custom `animateDrilldown` functionality could be added for improved visual understanding of the actual drilling down event.

**NB!** Additional improvement included. While debugging this issue I found that the new series options would always have `series.options.animation: true`, which was a bit inconvenient because the series would always believe it should animate. To avoid this the drilldown animation options is copied onto the new series options, instead of always setting it to true.

# Example(s)
- [Demo of current behaviour](https://jsfiddle.net/Naimikan/se2da6rz/)
- [Demo of new behaviour](https://jsfiddle.net/jon_a_nygaard/ueL6t39a/)

# Related issue(s)
- Closes #9289