### PR TITLE
Fix getTimeTicks: ensure min value of 1 for setUTCDate

### DIFF
--- a/js/parts/Time.js
+++ b/js/parts/Time.js
@@ -725,7 +725,12 @@ Highcharts.Time.prototype = {
                     minDate,
                     interval >= timeUnits.month ?
                         1 :
-                        count * Math.floor(time.get('Date', minDate) / count)
+                        Math.max(
+                            1,
+                            count * Math.floor(
+                                time.get('Date', minDate) / count
+                            )
+                        )
                     );
             }
 


### PR DESCRIPTION
#### Expected behaviour
I have a chart that shows duration values on the y-axis. The axis has type `datetime` as the duration values are defined in milliseconds. Using this type of axis also has the benefit that ticks are placed on sensible intervals (like half an hour or an hour).

The minimum duration is 0 (defined as `min: 0` on the y-axis) as it is not possible to have negative durations. 

Because of that defined minimum, I expect the chart to start at 0 or (`00:00`).

#### Actual behaviour
The first tick is rendered at a negative value of `-86400000` (which shows as `0-24:NaN` because the function does not handle negative values).

#### Live demo with steps to reproduce
See: http://jsfiddle.net/ae1yxk9j/

The chart width has to be below 1330px for this behavior to occur.

#### Cause & Solution
This is caused by the following code from the `getTimeTicks` function:

    time.set(
      'Date',
      minDate,
      interval >= timeUnits.month ? 1 :
        count * Math.floor(time.get('Date', minDate) / count))
    );

This code returns the incorrect result when:
- `minDate` is the Unix epoch (e.g. when `min` on axis is 0),
- `count` is bigger than 1 (depends on chart width)
This would eventually call `setUTCDate` with 0, which is incorrect because that function only accepts integers from 1 to 31.

Difference in results when calling with 0 or 1:
```
new Date(0).setUTCDate(0) => -86400000`
new Date(0).setUTCDate(1) => 0
```

Ensuring the parameter is always bigger than 1 (using `Math.max`) fixes this issue.