### PR TITLE
9046-boost-allow-force-ignores-visibility

### DIFF
--- a/js/modules/boost.src.js
+++ b/js/modules/boost.src.js
@@ -520,7 +520,10 @@ function shouldForceChartSeriesBoosting(chart) {
 
             // Don't count series with boostThreshold set to 0
             // See #8950
-            if (series.options.boostThreshold === 0) {
+            // Also don't count if the series is hidden.
+            // See #9046
+            if (series.options.boostThreshold === 0 ||
+                series.visible === false) {
                 continue;
             }
 


### PR DESCRIPTION
Fixed #9046, force boost check now takes series.visible into account. 

This means that it will not count hidden series towards the threshold for forcing chart-wide boosting.