### PR TITLE
doc/types-extends-fix

### DIFF
--- a/js/modules/bullet.src.js
+++ b/js/modules/bullet.src.js
@@ -28,7 +28,7 @@ seriesType('bullet', 'column',
      * of qualitative ranges of performance that could be set using
      * [plotBands](#yAxis.plotBands) on [yAxis](#yAxis).
      *
-     * @extends      {plotOptions.column}
+     * @extends      plotOptions.column
      * @product      highcharts
      * @sample       {highcharts} highcharts/demo/bullet-graph/ Bullet graph
      * @since        6.0.0

--- a/js/modules/funnel.src.js
+++ b/js/modules/funnel.src.js
@@ -27,7 +27,7 @@ seriesType('funnel', 'pie',
  * It requires that the modules/funnel.js file is loaded.
  *
  * @sample       highcharts/demo/funnel/ Funnel demo
- * @extends      {plotOptions.pie}
+ * @extends      plotOptions.pie
  * @excluding    size
  * @product      highcharts
  * @optionparent plotOptions.funnel

--- a/js/modules/sankey.src.js
+++ b/js/modules/sankey.src.js
@@ -22,7 +22,7 @@ var defined = H.defined,
  * A sankey diagram is a type of flow diagram, in which the width of the
  * link between two nodes is shown proportionally to the flow quantity.
  *
- * @extends      {plotOptions.column}
+ * @extends      plotOptions.column
  * @product      highcharts
  * @sample       highcharts/demo/sankey-diagram/
  *               Sankey diagram

--- a/js/modules/xrange.src.js
+++ b/js/modules/xrange.src.js
@@ -61,7 +61,7 @@ seriesType('xrange', 'column'
  * The X-range series displays ranges on the X axis, typically time intervals
  * with a start and end date.
  *
- * @extends      {plotOptions.column}
+ * @extends      plotOptions.column
  * @excluding    boostThreshold,crisp,cropThreshold,depth,edgeColor,edgeWidth,
  *               findNearestPointBy,getExtremesFromAll,negativeColor,
  *               pointInterval,pointIntervalUnit,pointPlacement,

--- a/js/parts-map/HeatmapSeries.js
+++ b/js/parts-map/HeatmapSeries.js
@@ -43,7 +43,7 @@ seriesType('heatmap', 'scatter',
      * @sample highcharts/demo/heatmap-canvas/
      *         Heavy heatmap
      *
-     * @extends      {plotOptions.scatter}
+     * @extends      plotOptions.scatter
      * @excluding    animationLimit, connectEnds, connectNulls, dashStyle,
      *               findNearestPointBy, getExtremesFromAll, linecap, lineWidth,
      *               marker, pointInterval, pointIntervalUnit, pointRange,

--- a/js/parts-more/BoxPlotSeries.js
+++ b/js/parts-more/BoxPlotSeries.js
@@ -35,7 +35,7 @@ var each = H.each,
  * @sample highcharts/demo/box-plot/
  *         Box plot
  *
- * @extends      {plotOptions.column}
+ * @extends      plotOptions.column
  * @excluding    borderColor, borderRadius, borderWidth, groupZPadding, states
  * @product      highcharts
  * @optionparent plotOptions.boxplot

--- a/js/parts-more/ErrorBarSeries.js
+++ b/js/parts-more/ErrorBarSeries.js
@@ -26,7 +26,7 @@ var each = H.each,
  * @sample highcharts/series-errorbar/on-scatter/
  *         Error bars on a scatter series
  *
- * @extends      {plotOptions.boxplot}
+ * @extends      plotOptions.boxplot
  * @product      highcharts highstock
  * @optionparent plotOptions.errorbar
  */

--- a/js/parts-more/GaugeSeries.js
+++ b/js/parts-more/GaugeSeries.js
@@ -30,7 +30,7 @@ var each = H.each,
  * @sample highcharts/demo/gauge-speedometer/
  *         Gauge chart
  *
- * @extends      {plotOptions.line}
+ * @extends      plotOptions.line
  * @excluding    animationLimit, boostThreshold, connectEnds, connectNulls,
  *               cropThreshold, dashStyle, findNearestPointBy,
  *               getExtremesFromAll, marker, negativeColor, pointPlacement,

--- a/js/parts-more/WaterfallSeries.js
+++ b/js/parts-more/WaterfallSeries.js
@@ -31,7 +31,7 @@ var correctFloat = H.correctFloat,
  * @sample highcharts/plotoptions/waterfall-stacked/
  *         Stacked waterfall chart
  *
- * @extends      {plotOptions.column}
+ * @extends      plotOptions.column
  * @product      highcharts
  * @optionparent plotOptions.waterfall
  */

--- a/js/parts/FlagsSeries.js
+++ b/js/parts/FlagsSeries.js
@@ -42,7 +42,7 @@ seriesType('flags', 'column'
  * @sample stock/demo/flags-general/
  *         Flags on a line series
  *
- * @extends      {plotOptions.column}
+ * @extends      plotOptions.column
  * @excluding    animation, borderColor, borderRadius, borderWidth,
  *               colorByPoint, dataGrouping, pointPadding, pointWidth,
  *               turboThreshold

--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -51,8 +51,7 @@
  * relative to the {@link Chart.container}.
  *
  * @interface Highcharts.PointerEventObject
- *
- * @extends {global.PointerEvent}
+ * @extends global.PointerEvent
  *//**
  * The X coordinate of the pointer interaction relative to the chart.
  *


### PR DESCRIPTION
Fixed doclet syntax of `@extends` tag.