### PR TITLE
hc7/9531-stocktools-click-point

### DIFF
--- a/js/modules/stock-tools-bindings.js
+++ b/js/modules/stock-tools-bindings.js
@@ -2881,8 +2881,16 @@ addEvent(H.Chart, 'load', function () {
 
     if (toolbar) {
         toolbar.eventsToUnbind.push(
-            addEvent(chart, 'click', function (e) {
-                toolbar.bindingsChartClick(this, e);
+            addEvent(chart.container, 'click', function (e) {
+                if (
+                    !chart.cancelClick &&
+                    chart.isInsidePlot(
+                        e.chartX - chart.plotLeft,
+                        e.chartY - chart.plotTop
+                    )
+                ) {
+                    toolbar.bindingsChartClick(this, e);
+                }
             })
         );
         toolbar.eventsToUnbind.push(


### PR DESCRIPTION
StockTools: Fixed #9531, click on series/point did not add an annotation.

Instead of `chart.click` I decided to use `container.click` + checking if click is inside the plotting area.