### PR TITLE
hs7/required-indicators-mixin-improvement

### DIFF
--- a/js/indicators/acceleration-bands.src.js
+++ b/js/indicators/acceleration-bands.src.js
@@ -2,12 +2,11 @@
 
 import H from '../parts/Globals.js';
 import '../parts/Utilities.js';
-import requiredIndicatorMixin from '../mixins/indicator-required.js';
+import multipleLinesMixin from '../mixins/multipe-lines.js';
 
-var BB = H.seriesTypes.bb,
-    SMA = H.seriesTypes.sma,
-    correctFloat = H.correctFloat,
-    parentLoaded = requiredIndicatorMixin.isParentIndicatorLoaded;
+var SMA = H.seriesTypes.sma,
+    merge = H.merge,
+    correctFloat = H.correctFloat;
 
 function getBaseForBand(low, high, factor) {
     return ((
@@ -24,13 +23,13 @@ function getPointLB(low, base) {
     return low * (correctFloat(1 - 2 * base));
 }
 
-H.seriesType('abands', 'bb',
+H.seriesType('abands', 'sma',
     /**
      * Acceleration bands (ABANDS). This series requires the `linkedTo` option
-     * to be set and should be loaded after the `stock/indicators/indicators.js`
-     * and `stock/indicators/bollinger-bands.js` files.
+     * to be set and should be loaded after the
+     * `stock/indicators/indicators.js`.
      *
-     * @extends plotOptions.bb
+     * @extends plotOptions.sma
      * @product highstock
      * @sample {highstock} stock/indicators/acceleration-bands
      *        Acceleration Bands
@@ -42,10 +41,6 @@ H.seriesType('abands', 'bb',
      * @optionparent plotOptions.abands
      */
     {
-        /**
-         * @excluding
-         *    standardDeviation
-         */
         params: {
             period: 20,
             /**
@@ -54,25 +49,39 @@ H.seriesType('abands', 'bb',
              * @type {Number}
              * @product highstock
              */
-            factor: 0.001
+            factor: 0.001,
+            index: 3
         },
-        lineWidth: 1
-    }, /** @lends Highcharts.Series.prototype */ {
+        lineWidth: 1,
+        topLine: {
+            styles: {
+                /**
+                 * Pixel width of the line.
+                 *
+                 * @type {Number}
+                 */
+                lineWidth: 1
+            }
+        },
+        bottomLine: {
+            styles: {
+                /**
+                 * Pixel width of the line.
+                 *
+                 * @type {Number}
+                 */
+                lineWidth: 1
+            }
+        },
+        dataGrouping: {
+            approximation: 'averages'
+        }
+    }, /** @lends Highcharts.Series.prototype */ merge(multipleLinesMixin, {
+        pointArrayMap: ['top', 'middle', 'bottom'],
+        pointValKey: 'middle',
         nameBase: 'Acceleration Bands',
         nameComponents: ['period', 'factor'],
-        init: function () {
-            var args = arguments,
-                ctx = this;
-
-            parentLoaded(
-                BB,
-                'bollinger-bands',
-                ctx.type,
-                function (indicator) {
-                    indicator.prototype.init.apply(ctx, args);
-                }
-            );
-        },
+        linesApiNames: ['topLine', 'bottomLine'],
         getValues: function (series, params) {
             var period = params.period,
                 factor = params.factor,
@@ -155,7 +164,7 @@ H.seriesType('abands', 'bb',
                 yData: yData
             };
         }
-    }
+    })
 );
 
 /**

--- a/js/indicators/apo.src.js
+++ b/js/indicators/apo.src.js
@@ -5,7 +5,7 @@ import requiredIndicatorMixin from '../mixins/indicator-required.js';
 
 var EMA = H.seriesTypes.ema,
     error = H.error,
-    parentLoaded = requiredIndicatorMixin.isParentIndicatorLoaded;
+    requiredIndicator = requiredIndicatorMixin;
 
 H.seriesType('apo', 'ema',
     /**
@@ -46,7 +46,7 @@ H.seriesType('apo', 'ema',
             var args = arguments,
                 ctx = this;
 
-            parentLoaded(
+            requiredIndicator.isParentLoaded(
                 EMA,
                 'ema',
                 ctx.type,

--- a/js/indicators/aroon-oscillator.src.js
+++ b/js/indicators/aroon-oscillator.src.js
@@ -4,7 +4,7 @@ import multipleLinesMixin from '../mixins/multipe-lines.js';
 import requiredIndicatorMixin from '../mixins/indicator-required.js';
 
 var AROON = H.seriesTypes.aroon,
-    parentLoaded = requiredIndicatorMixin.isParentIndicatorLoaded;
+    requiredIndicator = requiredIndicatorMixin;
 
 /**
  * The Aroon Oscillator series type.
@@ -54,7 +54,7 @@ H.seriesType('aroonoscillator', 'aroon',
             var args = arguments,
                 ctx = this;
 
-            parentLoaded(
+            requiredIndicator.isParentLoaded(
                 AROON,
                 'aroon',
                 ctx.type,

--- a/js/indicators/chaikin.src.js
+++ b/js/indicators/chaikin.src.js
@@ -8,7 +8,7 @@ var EMA = H.seriesTypes.ema,
     AD = H.seriesTypes.ad,
     error = H.error,
     correctFloat = H.correctFloat,
-    parentLoaded = requiredIndicatorMixin.isParentIndicatorLoaded;
+    requiredIndicator = requiredIndicatorMixin;
 
 H.seriesType('chaikin', 'ema',
     /**
@@ -59,7 +59,7 @@ H.seriesType('chaikin', 'ema',
             var args = arguments,
                 ctx = this;
 
-            parentLoaded(
+            requiredIndicator.isParentLoaded(
                 EMA,
                 'ema',
                 ctx.type,

--- a/js/indicators/dema.src.js
+++ b/js/indicators/dema.src.js
@@ -1,9 +1,11 @@
 'use strict';
 import H from '../parts/Globals.js';
 import '../parts/Utilities.js';
+import requiredIndicatorMixin from '../mixins/indicator-required.js';
 
 var isArray = H.isArray,
     EMAindicator = H.seriesTypes.ema,
+    requiredIndicator = requiredIndicatorMixin,
     correctFloat = H.correctFloat;
 
 /**
@@ -16,7 +18,8 @@ var isArray = H.isArray,
 H.seriesType('dema', 'ema',
     /**
      * Normalized average true range indicator (NATR). This series requires
-     * `linkedTo` option to be set.
+     * `linkedTo` option to be set and should be loaded after the
+     * `stock/indicators/indicators.js` and `stock/indicators/ema.js`.
      *
      * @extends plotOptions.ema
      * @product highstock
@@ -29,6 +32,19 @@ H.seriesType('dema', 'ema',
      * @optionparent plotOptions.dema
      */
     {}, {
+        init: function () {
+            var args = arguments,
+                ctx = this;
+
+            requiredIndicator.isParentLoaded(
+                EMAindicator,
+                'ema',
+                ctx.type,
+                function (indicator) {
+                    indicator.prototype.init.apply(ctx, args);
+                }
+            );
+        },
         getEMA: function (
             yVal,
             prevEMA,

--- a/js/indicators/indicators.src.js
+++ b/js/indicators/indicators.src.js
@@ -1,6 +1,7 @@
 'use strict';
 import H from '../parts/Globals.js';
 import '../parts/Utilities.js';
+import requiredIndicatorMixin from '../mixins/indicator-required.js';
 
 var pick = H.pick,
     error = H.error,
@@ -8,7 +9,9 @@ var pick = H.pick,
     isArray = H.isArray,
     addEvent = H.addEvent,
     seriesType = H.seriesType,
-    ohlcProto = H.seriesTypes.ohlc.prototype;
+    seriesTypes = H.seriesTypes,
+    ohlcProto = H.seriesTypes.ohlc.prototype,
+    generateMessage = requiredIndicatorMixin.generateMessage;
 
 /**
  * The parameter allows setting line series type and use OHLC indicators.
@@ -132,8 +135,35 @@ seriesType('sma', 'line',
         nameComponents: ['period'],
         nameSuffixes: [], // e.g. Zig Zag uses extra '%'' in the legend name
         calculateOn: 'init',
+        // Defines on which other indicators is this indicator based on.
+        requiredIndicators: [],
+        requireIndicators: function () {
+            var obj = {
+                allLoaded: true
+            };
+
+            // Check whether all required indicators are loaded, else return
+            // the object with missing indicator's name.
+            this.requiredIndicators.forEach(function (indicator) {
+                if (seriesTypes[indicator]) {
+                    seriesTypes[indicator].prototype.requireIndicators();
+                } else {
+                    obj.allLoaded = false;
+                    obj.needed = indicator;
+                }
+            });
+            return obj;
+        },
         init: function (chart, options) {
-            var indicator = this;
+            var indicator = this,
+                requiredIndicators = indicator.requireIndicators();
+
+            // Check whether all required indicators are loaded.
+            if (!requiredIndicators.allLoaded) {
+                return error(
+                    generateMessage(indicator.type, requiredIndicators.needed)
+                );
+            }
 
             Series.prototype.init.call(
                 indicator,

--- a/js/indicators/keltner-channels.src.js
+++ b/js/indicators/keltner-channels.src.js
@@ -2,8 +2,6 @@
 
 import H from '../parts/Globals.js';
 import '../parts/Utilities.js';
-import './ema.src.js';
-import './atr.src.js';
 import multipleLinesMixin from '../mixins/multipe-lines.js';
 
 var SMA = H.seriesTypes.sma,
@@ -16,7 +14,8 @@ H.seriesType('keltnerchannels', 'sma',
     /**
      * Keltner Channels. This series requires the `linkedTo`
      * option to be set and should be loaded after the
-     * `stock/indicators/indicators.js`.
+     * `stock/indicators/indicators.js`, `stock/indicators/atr.js`, and
+     * `stock/ema/.js`.
      *
      * @extends plotOptions.sma
      * @product highstock
@@ -97,6 +96,7 @@ H.seriesType('keltnerchannels', 'sma',
         nameBase: 'Keltner Channels',
         nameComponents: ['period', 'periodATR', 'multiplierATR'],
         linesApiNames: ['topLine', 'bottomLine'],
+        requiredIndicators: ['ema', 'atr'],
         init: function () {
             SMA.prototype.init.apply(this, arguments);
             // Set default color for lines:

--- a/js/indicators/macd.src.js
+++ b/js/indicators/macd.src.js
@@ -20,7 +20,8 @@ var seriesType = H.seriesType,
 seriesType('macd', 'sma',
     /**
      * Moving Average Convergence Divergence (MACD). This series requires
-     * `linkedTo` option to be set.
+     * `linkedTo` option to be set and should be loaded after the
+     * `stock/indicators/indicators.js` and `stock/indicators/ema.js`.
      *
      * @extends plotOptions.sma
      * @product highstock
@@ -140,6 +141,7 @@ seriesType('macd', 'sma',
         minPointLength: 0
     }, {
         nameComponents: ['longPeriod', 'shortPeriod', 'signalPeriod'],
+        requiredIndicators: ['ema'],
         // "y" value is treated as Histogram data
         pointArrayMap: ['y', 'signal', 'MACD'],
         parallelArrays: ['x', 'y', 'signal', 'MACD'],
@@ -152,33 +154,37 @@ seriesType('macd', 'sma',
         init: function () {
             SMA.prototype.init.apply(this, arguments);
 
-            // Set default color for a signal line and the histogram:
-            this.options = merge({
-                signalLine: {
-                    styles: {
-                        lineColor: this.color
+            // Check whether series is initialized. It may be not initialized,
+            // when any of required indicators is missing.
+            if (this.options) {
+                // Set default color for a signal line and the histogram:
+                this.options = merge({
+                    signalLine: {
+                        styles: {
+                            lineColor: this.color
+                        }
+                    },
+                    macdLine: {
+                        styles: {
+                            color: this.color
+                        }
                     }
-                },
-                macdLine: {
-                    styles: {
-                        color: this.color
-                    }
-                }
-            }, this.options);
+                }, this.options);
 
-            // Zones have indexes automatically calculated, we need to
-            // translate them to support multiple lines within one indicator
-            this.macdZones = {
-                zones: this.options.macdLine.zones,
-                startIndex: 0
-            };
-            this.signalZones = {
-                zones: this.macdZones.zones.concat(
-                    this.options.signalLine.zones
-                ),
-                startIndex: this.macdZones.zones.length
-            };
-            this.resetZones = true;
+                // Zones have indexes automatically calculated, we need to
+                // translate them to support multiple lines within one indicator
+                this.macdZones = {
+                    zones: this.options.macdLine.zones,
+                    startIndex: 0
+                };
+                this.signalZones = {
+                    zones: this.macdZones.zones.concat(
+                        this.options.signalLine.zones
+                    ),
+                    startIndex: this.macdZones.zones.length
+                };
+                this.resetZones = true;
+            }
         },
         toYData: function (point) {
             return [point.y, point.signal, point.MACD];

--- a/js/indicators/natr.src.js
+++ b/js/indicators/natr.src.js
@@ -1,7 +1,6 @@
 'use strict';
 import H from '../parts/Globals.js';
 import '../parts/Utilities.js';
-import './atr.src.js';
 
 var ATR = H.seriesTypes.atr;
 
@@ -14,7 +13,8 @@ var ATR = H.seriesTypes.atr;
 H.seriesType('natr', 'sma',
     /**
      * Normalized average true range indicator (NATR). This series requires
-     * `linkedTo` option to be set.
+     * `linkedTo` option to be set and should be loaded after the
+     * `stock/indicators/indicators.js` and `stock/indicators/atr.js`.
      *
      * @extends plotOptions.atr
      * @product highstock
@@ -27,6 +27,7 @@ H.seriesType('natr', 'sma',
             valueSuffix: '%'
         }
     }, {
+        requiredIndicators: ['atr'],
         getValues: function (series, params) {
             var atrData = ATR.prototype.getValues.apply(this, arguments),
                 atrLength = atrData.values.length,

--- a/js/indicators/ppo.src.js
+++ b/js/indicators/ppo.src.js
@@ -6,7 +6,7 @@ import requiredIndicatorMixin from '../mixins/indicator-required.js';
 var EMA = H.seriesTypes.ema,
     error = H.error,
     correctFloat = H.correctFloat,
-    parentLoaded = requiredIndicatorMixin.isParentIndicatorLoaded;
+    requiredIndicator = requiredIndicatorMixin;
 
 H.seriesType('ppo', 'ema',
     /**
@@ -47,7 +47,7 @@ H.seriesType('ppo', 'ema',
             var args = arguments,
                 ctx = this;
 
-            parentLoaded(
+            requiredIndicator.isParentLoaded(
                 EMA,
                 'ema',
                 ctx.type,

--- a/js/indicators/price-channel.src.js
+++ b/js/indicators/price-channel.src.js
@@ -3,19 +3,17 @@
 import H from '../parts/Globals.js';
 import '../parts/Utilities.js';
 import reduceArrayMixin from '../mixins/reduce-array.js';
-import requiredIndicatorMixin from '../mixins/indicator-required.js';
+import multipleLinesMixin from '../mixins/multipe-lines.js';
 
 var getArrayExtremes = reduceArrayMixin.getArrayExtremes,
-    BB = H.seriesTypes.bb,
-    parentLoaded = requiredIndicatorMixin.isParentIndicatorLoaded;
+    merge = H.merge;
 
-H.seriesType('pc', 'bb',
+H.seriesType('pc', 'sma',
     /**
      * Price channel (PC). This series requires the `linkedTo` option to be
-     * set and should be loaded after the `stock/indicators/indicators.js`
-     * and `stock/indicators/bollinger-bands.js` files.
+     * set and should be loaded after the `stock/indicators/indicators.js`.
      *
-     * @extends plotOptions.bb
+     * @extends plotOptions.sma
      * @product highstock
      * @sample {highstock} stock/indicators/price-channel Price Channel
      * @excluding
@@ -28,9 +26,11 @@ H.seriesType('pc', 'bb',
     {
         /**
          * @excluding
-         *    index, standardDeviation
+         *    index
          */
-        params: {},
+        params: {
+            period: 20
+        },
         lineWidth: 1,
         topLine: {
             styles: {
@@ -41,7 +41,13 @@ H.seriesType('pc', 'bb',
                  * @type {String}
                  * @product highstock
                  */
-                lineColor: '${palette.colors}'.split(' ')[2]
+                lineColor: '${palette.colors}'.split(' ')[2],
+                /**
+                 * Pixel width of the line.
+                 *
+                 * @type {Number}
+                 */
+                lineWidth: 1
             }
         },
         bottomLine: {
@@ -53,25 +59,24 @@ H.seriesType('pc', 'bb',
                  * @type {String}
                  * @product highstock
                  */
-                lineColor: '${palette.colors}'.split(' ')[8]
+                lineColor: '${palette.colors}'.split(' ')[8],
+                /**
+                 * Pixel width of the line.
+                 *
+                 * @type {Number}
+                 */
+                lineWidth: 1
             }
+        },
+        dataGrouping: {
+            approximation: 'averages'
         }
-    }, /** @lends Highcharts.Series.prototype */ {
+    }, /** @lends Highcharts.Series.prototype */ merge(multipleLinesMixin, {
+        pointArrayMap: ['top', 'middle', 'bottom'],
+        pointValKey: 'middle',
         nameBase: 'Price Channel',
         nameComponents: ['period'],
-        init: function () {
-            var args = arguments,
-                ctx = this;
-
-            parentLoaded(
-                BB,
-                'bollinger-bands',
-                ctx.type,
-                function (indicator) {
-                    indicator.prototype.init.apply(ctx, args);
-                }
-            );
-        },
+        linesApiNames: ['topLine', 'bottomLine'],
         getValues: function (series, params) {
             var period = params.period,
                 xVal = series.xData,
@@ -110,7 +115,7 @@ H.seriesType('pc', 'bb',
                 yData: yData
             };
         }
-    }
+    })
 );
 
 /**

--- a/js/indicators/tema.src.js
+++ b/js/indicators/tema.src.js
@@ -1,9 +1,11 @@
 'use strict';
 import H from '../parts/Globals.js';
 import '../parts/Utilities.js';
+import requiredIndicatorMixin from '../mixins/indicator-required.js';
 
 var isArray = H.isArray,
     EMAindicator = H.seriesTypes.ema,
+    requiredIndicator = requiredIndicatorMixin,
     correctFloat = H.correctFloat;
 
 /**
@@ -16,7 +18,8 @@ var isArray = H.isArray,
 H.seriesType('tema', 'ema',
     /**
      * Normalized average true range indicator (NATR). This series requires
-     * `linkedTo` option to be set.
+     * `linkedTo` option to be set and should be loaded after the
+     * `stock/indicators/indicators.js` and `stock/indicators/ema.js`.
      *
      * Requires https://code.highcharts.com/stock/indicators/ema.js.
      *
@@ -31,6 +34,19 @@ H.seriesType('tema', 'ema',
      * @optionparent plotOptions.tema
      */
     {}, {
+        init: function () {
+            var args = arguments,
+                ctx = this;
+
+            requiredIndicator.isParentLoaded(
+                EMAindicator,
+                'ema',
+                ctx.type,
+                function (indicator) {
+                    indicator.prototype.init.apply(ctx, args);
+                }
+            );
+        },
         getEMA: function (
             yVal,
             prevEMA,

--- a/js/mixins/indicator-required.js
+++ b/js/mixins/indicator-required.js
@@ -14,32 +14,35 @@ var requiredIndicatorMixin = {
     /**
      * Check whether given indicator is loaded, else throw error.
      * @param {function} indicator Indicator constructor function.
-     * @param {string} indicatorName Given indicator name.
-     * @param {string} type Type of indicator where function was called.
+     * @param {string} requiredIndicator required indicator type.
+     * @param {string} type Type of indicator where function was called (parent).
      * @param {function} callback Callback which is triggered if the given
-     *                            indicator is loaded.
+     *                            indicator is loaded. Takes indicator as
+     *                            an argument.
      * @param {string} errMessage Error message that will be logged in console.
      * @returns {boolean} Returns false when there is no required indicator loaded.
      */
-    isParentIndicatorLoaded: function (
+    isParentLoaded: function (
         indicator,
-        indicatorName,
+        requiredIndicator,
         type,
         callback,
         errMessage
     ) {
-        var apiLink = 'https://api.highcharts.com/highstock/';
-
         if (indicator) {
-            return callback(indicator);
+            return callback ? callback(indicator) : true;
         }
         error(
-            errMessage || 'Error: "' + type +
-            '" indicator type requires ' + indicatorName +
-            ' indicator loaded before. Please read docs: ' +
-            '' + apiLink + 'plotOptions.' + type
+            errMessage || this.generateMessage(type, requiredIndicator)
         );
         return false;
+    },
+    generateMessage: function (indicatorType, required) {
+        return 'Error: "' + indicatorType +
+            '" indicator type requires "' + required +
+            '" indicator loaded before. Please read docs: ' +
+            'https://api.highcharts.com/highstock/plotOptions.' +
+            indicatorType;
     }
 };
 export default requiredIndicatorMixin;


### PR DESCRIPTION
- Checking indicators dependencies added by `requiredIndicators` parameter.
- From now on, user should care about loading all required indicators manually. If some indicator is missing, there is error thrown in browsers console. This type of approach prevents loading the same indicator's code many times.
- All existing indicators are adjusted to this approach.
