### PR TITLE
bugfix/annotations-crisp

### DIFF
--- a/js/annotations/controllable/ControllablePath.js
+++ b/js/annotations/controllable/ControllablePath.js
@@ -99,7 +99,9 @@ H.merge(
                 showPath = point.series.visible;
             }
 
-            return showPath ? d : null;
+            return showPath ? this.chart.renderer.crispLine(
+                    d, this.graphic.strokeWidth()
+                ) : null;
         },
 
         shouldBeDrawn: function () {


### PR DESCRIPTION
Added missing crisping for lines in annotations.

Is this a correct way to get `strokeWidth` for both styled and not styled mode?