### PR TITLE
bugfix/annotations-rect-placement

### DIFF
--- a/js/annotations/controllable/ControllableLabel.js
+++ b/js/annotations/controllable/ControllableLabel.js
@@ -283,6 +283,24 @@ H.merge(
 
             controllableMixin.redraw.call(this, animation);
         },
+        /**
+         * All basic shapes don't support alignTo() method except label.
+         * For a controllable label, we need to subtract translation from
+         * options.
+         */
+        anchor: function () {
+            var anchor = controllableMixin.anchor.apply(this, arguments),
+                x = this.options.x || 0,
+                y = this.options.y || 0;
+
+            anchor.absolutePosition.x -= x;
+            anchor.absolutePosition.y -= y;
+
+            anchor.relativePosition.x -= x;
+            anchor.relativePosition.y -= y;
+
+            return anchor;
+        },
 
         /**
          * Returns the label position relative to its anchor.

--- a/js/annotations/controllable/controllableMixin.js
+++ b/js/annotations/controllable/controllableMixin.js
@@ -113,8 +113,8 @@ var controllableMixin = {
             }, point),
 
             anchor = {
-                x: box[0],
-                y: box[1],
+                x: box[0] + (this.options.x || 0),
+                y: box[1] + (this.options.y || 0),
                 height: box[2] || 0,
                 width: box[3] || 0
             };


### PR DESCRIPTION
Annotations: Fixed missing options.x and options.y for basic shapes.