### PR TITLE
bugfix/9565-dot-date-delimiter-in-cvs

### DIFF
--- a/js/modules/data.src.js
+++ b/js/modules/data.src.js
@@ -854,7 +854,6 @@ Highcharts.extend(Data.prototype, {
                     pushType('string');
                 }
 
-
                 if (columns.length < column + 1) {
                     columns.push([]);
                 }
@@ -1062,6 +1061,7 @@ Highcharts.extend(Data.prototype, {
                             .trim()
                             .replace(/\//g, ' ')
                             .replace(/\-/g, ' ')
+                            .replace(/\./g, ' ')
                             .split(' ');
 
                     guessedFormat = [


### PR DESCRIPTION
Fixed #9565, dot delimiter on dates in CSV caused the format deduction to fail.

Fixed by adding support for `.` delimiter in the date format deduction.