### PR TITLE
samples/stocktools-trhesholds-lang

### DIFF
--- a/samples/stock/stocktools/stocktools-thresholds/demo.js
+++ b/samples/stock/stocktools/stocktools-thresholds/demo.js
@@ -90,6 +90,7 @@ $.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (d
                         });
 
                         chart.addAnnotation({
+                            langKey: 'thresholds',
                             zoneIndex: zones.length - 1,
                             type: 'infinity-line',
                             draggable: 'y',


### PR DESCRIPTION
StockTools: Fixed missing translation for a custom annotation.