### PR TITLE
Fixed issues in sonification with hidden series.

### DIFF
--- a/js/modules/sonification/pointSonify.js
+++ b/js/modules/sonification/pointSonify.js
@@ -259,8 +259,8 @@ function pointSonify(options) {
     signalHandler.clearSignalCallbacks();
     signalHandler.registerSignalCallbacks({ onEnd: options.onEnd });
 
-    // If we have a null point, just return
-    if (point.isNull) {
+    // If we have a null point or invisible point, just return
+    if (point.isNull || !point.visible || !point.series.visible) {
         signalHandler.emitSignal('onEnd');
         return;
     }

--- a/js/modules/sonification/utilities.js
+++ b/js/modules/sonification/utilities.js
@@ -83,11 +83,14 @@ SignalHandler.prototype.clearSignalCallbacks = function (signalNames) {
  * @param   {*} data Data to pass to the callback.
  */
 SignalHandler.prototype.emitSignal = function (signalName, data) {
+    var retval;
     if (this.signals[signalName]) {
         this.signals[signalName].forEach(function (handler) {
-            handler(data);
+            var result = handler(data);
+            retval = result !== undefined ? result : retval;
         });
     }
+    return retval;
 };
 
 

--- a/samples/highcharts/sonification/demo/demo.js
+++ b/samples/highcharts/sonification/demo/demo.js
@@ -40,7 +40,7 @@ var poiTime = Date.UTC(2018, 4, 6),
                         return time * 1760 + 440;
                     },
                     volume: 0.1,
-                    duration: 150
+                    duration: 200
                 }
             }]
         }),
@@ -135,8 +135,11 @@ var chart = Highcharts.chart('container', {
 
 // Utility function that highlights a point
 function highlightPoint(event, point) {
-    var chart = point.series.chart;
-    if (!point.isNull) {
+    var chart = point.series.chart,
+        hasVisibleSeries = chart.series.some(function (series) {
+            return series.visible;
+        });
+    if (!point.isNull && hasVisibleSeries) {
         point.onMouseOver(); // Show the hover marker and tooltip
     } else {
         if (chart.tooltip) {
@@ -170,9 +173,11 @@ document.getElementById('play').onclick = function () {
                 instruments: nyInstruments,
                 onPointStart: highlightPoint
             }],
-            // Reset cursor on end
+            // Delete timeline on end
             onEnd: function () {
-                chart.resetSonifyCursor();
+                if (chart.sonification.timeline) {
+                    delete chart.sonification.timeline;
+                }
             }
         });
     } else {
@@ -183,8 +188,5 @@ document.getElementById('pause').onclick = function () {
     chart.pauseSonify();
 };
 document.getElementById('rewind').onclick = function () {
-    if (!chart.sonification.timeline || chart.sonification.timeline.atStart()) {
-        chart.resetSonifyCursorEnd();
-    }
     chart.rewindSonify();
 };


### PR DESCRIPTION
Hiding a series no longer crashes sonification, but mutes the series being hidden.

If all series are hidden, the sonification stops.

Ideally we would want this to be somewhat smarter and also mute Earcons on the series that is being hidden. We will also want to handle sequentially sonified series smarter, as you would probably expect the sonification to jump to the next series if you hid a series in that case. Starting sonification with a hidden series also skips this series completely, and it would be nice to be able to show it mid-sonification and hear it (for simultaneous series). For now, the current behavior should be acceptable. I will add a bug report for the enhancements mentioned.