### PR TITLE
samples/stock-tools-custom-gui

### DIFF
--- a/samples/stock/demo/stock-tools-custom-gui/demo.html
+++ b/samples/stock/demo/stock-tools-custom-gui/demo.html
@@ -179,10 +179,6 @@
             	<span class="highcharts-menu-item-btn"></span>
               <span class="highcharts-menu-item-title">Arrow</span>
             </li>
-            <li class="highcharts-vertical-double-arrow" title="Vertical double arrow">
-            	<span class="highcharts-menu-item-btn"></span>
-              <span class="highcharts-menu-item-title">Double arrow</span>
-            </li>
           </ul>
         </li>
         <li class="highcharts-flag-circlepin" title="Flags">


### PR DESCRIPTION
Samples: Removed undefined double-arrow button from custom-gui demo.