### PR TITLE
bugfix/#9525/variwide-update-zoomed-chart

### DIFF
--- a/js/modules/variwide.src.js
+++ b/js/modules/variwide.src.js
@@ -57,10 +57,10 @@ seriesType('variwide', 'column'
 }, {
     pointArrayMap: ['y', 'z'],
     parallelArrays: ['x', 'y', 'z'],
-    processData: function () {
+    processData: function (force) {
         this.totalZ = 0;
         this.relZ = [];
-        seriesTypes.column.prototype.processData.call(this);
+        seriesTypes.column.prototype.processData.call(this, force);
 
         (this.xAxis.reversed ?
                 this.zData.slice().reverse() :

--- a/samples/unit-tests/series-variwide/variwide/demo.js
+++ b/samples/unit-tests/series-variwide/variwide/demo.js
@@ -65,6 +65,36 @@ QUnit.test('variwide', function (assert) {
     chart.xAxis[0].update({ crosshair: false });
     chart.series[0].points[0].onMouseOver();
     assert.ok(true, "No errors with disabled crosshair (#8173)");
+
+
+    chart.update({
+        xAxis: {
+            minRange: 1
+        },
+        series: [{
+            type: 'variwide',
+            borderWidth: 0,
+            cropThreshold: 1,
+
+            data: [
+                [0, 1, 1],
+                [1, 2, 1],
+                [2, 3, 1],
+                [3, 2, 1]
+            ]
+        }]
+    }, true, true, false);
+
+    chart.xAxis[0].setExtremes(0, 1, true, false);
+    chart.reflow();
+    chart.xAxis[0].setExtremes(0, 3, true, false);
+
+    assert.strictEqual(
+        chart.series[0].points.length,
+        4,
+        'Correct number of points after zoom and redraw (#9525)'
+    );
+
 });
 
 QUnit.test('variwide null points', function (assert) {


### PR DESCRIPTION
Fixed #9525, Wrong number of points after update zoomed chart.