### PR TITLE
samples/stock-tools

### DIFF
--- a/samples/stock/demo/stock-tools-custom-gui/demo.html
+++ b/samples/stock/demo/stock-tools-custom-gui/demo.html
@@ -1,17 +1,20 @@
 <link rel="stylesheet" type="text/css" href="https://code.highcharts.com/css/annotations/popup.css">
 
+<script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
+
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
-<script src="https://code.highcharts.com/modules/drag-panes.js"></script>
+<script src="https://code.highcharts.com/stock/modules/drag-panes.js"></script>
 
-<script src="https://code.highcharts.com/indicators/indicators.js"></script>
-<script src="https://code.highcharts.com/indicators/bollinger-bands.js"></script>
-<script src="https://code.highcharts.com/indicators/ema.js"></script>
+<script src="https://code.highcharts.com/stock/indicators/indicators.js"></script>
+<script src="https://code.highcharts.com/stock/indicators/bollinger-bands.js"></script>
+<script src="https://code.highcharts.com/stock/indicators/ema.js"></script>
 
-<script src="https://code.highcharts.com/modules/annotations-advanced.js"></script>
-<script src="https://code.highcharts.com/modules/full-screen.js"></script>
-<script src="https://code.highcharts.com/modules/stock-tools.js"></script>
-<script src="https://code.highcharts.com/modules/price-indicator.js"></script>
+<script src="https://code.highcharts.com/stock/modules/annotations-advanced.js"></script>
+
+<script src="https://code.highcharts.com/stock/modules/full-screen.js"></script>
+<script src="https://code.highcharts.com/stock/modules/price-indicator.js"></script>
+<script src="https://code.highcharts.com/stock/modules/stock-tools.js"></script>
 
 <div class="chart-wrapper">
   <div class="highcharts-popup highcharts-popup-indicators">

--- a/samples/stock/demo/stock-tools-gui/demo.html
+++ b/samples/stock/demo/stock-tools-gui/demo.html
@@ -1,11 +1,13 @@
 <link rel="stylesheet" type="text/css" href="https://code.highcharts.com/css/stocktools/gui.css">
 <link rel="stylesheet" type="text/css" href="https://code.highcharts.com/css/annotations/popup.css">
 
+<script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
+
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
-<script src="https://code.highcharts.com/indicators/indicators-all.js"></script>
+<script src="https://code.highcharts.com/stock/indicators/indicators-all.js"></script>
+<script src="https://code.highcharts.com/stock/modules/drag-panes.js"></script>
 
-<script src="https://code.highcharts.com/modules/drag-panes.js"></script>
 <script src="https://code.highcharts.com/modules/annotations-advanced.js"></script>
 <script src="https://code.highcharts.com/modules/price-indicator.js"></script>
 <script src="https://code.highcharts.com/modules/full-screen.js"></script>

--- a/samples/stock/stocktools/stocktools-thresholds/demo.html
+++ b/samples/stock/stocktools/stocktools-thresholds/demo.html
@@ -1,14 +1,17 @@
 <link rel="stylesheet" type="text/css" href="https://code.highcharts.com/css/stocktools/gui.css">
 <link rel="stylesheet" type="text/css" href="https://code.highcharts.com/css/annotations/popup.css">
+
+<script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
+
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
-<script src="https://code.highcharts.com/indicators/indicators-all.js"></script>
+<script src="https://code.highcharts.com/stock/indicators/indicators-all.js"></script>
 
-<script src="https://code.highcharts.com/modules/drag-panes.js"></script>
-<script src="https://code.highcharts.com/modules/annotations-advanced.js"></script>
-<script src="https://code.highcharts.com/modules/price-indicator.js"></script>
-<script src="https://code.highcharts.com/modules/full-screen.js"></script>
+<script src="https://code.highcharts.com/stock/modules/drag-panes.js"></script>
+<script src="https://code.highcharts.com/stock/modules/annotations-advanced.js"></script>
+<script src="https://code.highcharts.com/stock/modules/price-indicator.js"></script>
+<script src="https://code.highcharts.com/stock/modules/full-screen.js"></script>
 
-<script src="https://code.highcharts.com/modules/stock-tools.js"></script>
+<script src="https://code.highcharts.com/stock/modules/stock-tools.js"></script>
 
 <div id="container" class="chart"></div>


### PR DESCRIPTION
Samples: Fixed wrong URLs for libraries in stock-tools demos. Added missing jQuery.

I don't know why it works in our /stock/demo/ but is broken in jsfiddle. Either old releases had `code.highcharts.com/indicators/` available or it's just a silly mistake. Anyway we should encourage using `code.highcharts.com/stock/indicators` (and `stock/modules`).

Additionally we load data through `$.getJSON()` so I added jQuery.