### PR TITLE
bugfix/indicators-popup-separate-yaxes

### DIFF
--- a/js/modules/stock-tools-bindings.js
+++ b/js/modules/stock-tools-bindings.js
@@ -176,7 +176,20 @@ bindingsUtils.manageIndicators = function (data) {
             'mfi',
             'roc',
             'rsi',
-            'vwap'
+            'vwap',
+            'ao',
+            'aroon',
+            'aroonoscillator',
+            'trix',
+            'apo',
+            'dpo',
+            'ppo',
+            'natr',
+            'williamsr',
+            'linearRegression',
+            'linearRegressionSlope',
+            'linearRegressionIntercept',
+            'linearRegressionAngle'
         ],
         yAxis,
         series;


### PR DESCRIPTION
Fixed issue in stock-tools where separate yAxes should be created for certain indicators.

All indicators in v6 are fine, I forgot to update list with v7 tech. indicators.