### PR TITLE
bugfix/stock-tools-lang-measure

### DIFF
--- a/js/modules/stock-tools-gui.js
+++ b/js/modules/stock-tools-gui.js
@@ -132,6 +132,7 @@ H.setOptions({
                 pitchfork: 'Pitchfork',
                 parallelChannel: 'Parallel channel',
                 infinityLine: 'Infinity line',
+                measure: 'Measure',
                 measureXY: 'Measure XY',
                 measureX: 'Measure X',
                 measureY: 'Measure Y',


### PR DESCRIPTION
Fixed missing translation of `measure` key in `lang.navigation.popup`.

Seems that after all I missed a translation for something..