### PR TITLE
doc/fix-exporting-buttons

### DIFF
--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -686,7 +686,7 @@ defaultOptions.exporting = {
      * See [navigation.buttonOptions](#navigation.buttonOptions) for general
      * options.
      *
-     * @type {Highcharts.Dictionary<*>}
+     * @type {Highcharts.Dictionary<Highcharts.ExportingButtonsContextButtonOptions>}
      */
     buttons: {
 


### PR DESCRIPTION
- Docs: Fixed #9658 options type for `exporting.buttons`.