### PR TITLE
doc/fix-series-types

### DIFF
--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -76,7 +76,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      *
      * @function Highcharts.Chart#addSeries
      *
-     * @param {Highcharts.SeriesOptions} options
+     * @param {Highcharts.SeriesOptionsType} options
      *        The config options for the series.
      *
      * @param {boolean} [redraw=true]
@@ -1004,7 +1004,7 @@ extend(Series.prototype, /** @lends Series.prototype */ {
      *
      * @function Highcharts.Series#update
      *
-     * @param {Highcharts.SeriesOptions} options
+     * @param {Highcharts.SeriesOptionsType} options
      *        New options that will be merged with the series' existing options.
      *
      * @param {boolean} [redraw=true]

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -215,7 +215,7 @@ var addEvent = H.addEvent,
  * @param {Highcharts.Chart} chart
  *        The chart instance.
  *
- * @param {Highcharts.SeriesOptions|object} options
+ * @param {Highcharts.SeriesOptionsType|object} options
  *        The series options.
  *//**
  * The line series is the base type and is therefor the series base prototype.


### PR DESCRIPTION
Docs: Fixed #9659 - Chart.addSeries allowed only base series options.