### PR TITLE
 bugfix/9767-annotations-exporting

### DIFF
--- a/js/annotations/annotations.src.js
+++ b/js/annotations/annotations.src.js
@@ -703,7 +703,7 @@ merge(
 
         addShapes: function () {
             (this.options.shapes || []).forEach(function (shapeOptions, i) {
-                var shape = this.initShape(shapeOptions);
+                var shape = this.initShape(shapeOptions, i);
 
                 this.options.shapes[i] = shape.options;
             }, this);
@@ -711,7 +711,7 @@ merge(
 
         addLabels: function () {
             (this.options.labels || []).forEach(function (labelOptions, i) {
-                var label = this.initLabel(labelOptions);
+                var label = this.initLabel(labelOptions, i);
 
                 this.options.labels[i] = label.options;
             }, this);
@@ -937,6 +937,7 @@ merge(
                     this.userOptions,
                     userOptions
                 ),
+                userOptionsIndex = chart.annotations.indexOf(this),
                 options = H.merge(true, this.userOptions, userOptions);
 
             options.labels = labelsAndShapes.labels;
@@ -944,6 +945,9 @@ merge(
 
             this.destroy();
             this.constructor(chart, options);
+
+            // Update options in chart options, used in exporting (#9767):
+            chart.options.annotations[userOptionsIndex] = options;
 
             this.redraw();
         },
@@ -958,7 +962,7 @@ merge(
          *
          * @param {Object} shapeOptions - a confg object for a single shape
          **/
-        initShape: function (shapeOptions) {
+        initShape: function (shapeOptions, index) {
             var options = merge(
                     this.options.shapeOptions,
                     {
@@ -968,7 +972,8 @@ merge(
                 ),
                 shape = new Annotation.shapesMap[options.type](
                     this,
-                    options
+                    options,
+                    index
                 );
 
             shape.itemType = 'shape';
@@ -983,7 +988,7 @@ merge(
          *
          * @param {Object} labelOptions
          **/
-        initLabel: function (labelOptions) {
+        initLabel: function (labelOptions, index) {
             var options = merge(
                     this.options.labelOptions,
                     {
@@ -993,7 +998,8 @@ merge(
                 ),
                 label = new ControllableLabel(
                     this,
-                    options
+                    options,
+                    index
                 );
 
             label.itemType = 'label';

--- a/js/annotations/controllable/ControllableCircle.js
+++ b/js/annotations/controllable/ControllableCircle.js
@@ -13,9 +13,11 @@ import ControllablePath from './ControllablePath.js';
  *
  * @param {Highcharts.Annotation} annotation an annotation instance
  * @param {Object} options a shape's options
+ * @param {number} index of the circle
  **/
-function ControllableCircle(annotation, options) {
-    this.init(annotation, options);
+function ControllableCircle(annotation, options, index) {
+    this.init(annotation, options, index);
+    this.collection = 'shapes';
 }
 
 /**
@@ -67,7 +69,13 @@ H.merge(
         },
 
         translate: function (dx, dy) {
+            var annotationOptions = this.annotation.userOptions,
+                shapeOptions = annotationOptions[this.collection][this.index];
+
             this.translatePoint(dx, dy, 0);
+
+            // Options stored in chart:
+            shapeOptions.point = this.options.point;
         },
 
         /**

--- a/js/annotations/controllable/ControllableImage.js
+++ b/js/annotations/controllable/ControllableImage.js
@@ -13,9 +13,11 @@ import ControllableLabel from './ControllableLabel.js';
  *
  * @param {Highcharts.Annotation} annotation - an annotation instance
  * @param {Object} options a controllable's options
+ * @param {number} index of the image
  **/
-function ControllableImage(annotation, options) {
-    this.init(annotation, options);
+function ControllableImage(annotation, options, index) {
+    this.init(annotation, options, index);
+    this.collection = 'shapes';
 }
 
 /**
@@ -85,7 +87,13 @@ H.merge(
         },
 
         translate: function (dx, dy) {
+            var annotationOptions = this.annotation.userOptions,
+                shapeOptions = annotationOptions[this.collection][this.index];
+
             this.translatePoint(dx, dy, 0);
+
+            // Options stored in chart:
+            shapeOptions.point = this.options.point;
         }
     });
 

--- a/js/annotations/controllable/ControllableLabel.js
+++ b/js/annotations/controllable/ControllableLabel.js
@@ -14,9 +14,11 @@ import MockPoint from './../MockPoint.js';
  *
  * @param {Highcharts.Annotation} annotation an annotation instance
  * @param {Object} options a label's options
+ * @param {number} index of the label
  **/
-function ControllableLabel(annotation, options) {
-    this.init(annotation, options);
+function ControllableLabel(annotation, options, index) {
+    this.init(annotation, options, index);
+    this.collection = 'labels';
 }
 
 /**
@@ -193,8 +195,16 @@ H.merge(
          * @param {number} dy translation for y coordinate
          **/
         translate: function (dx, dy) {
+            var annotationOptions = this.annotation.userOptions,
+                labelOptions = annotationOptions[this.collection][this.index];
+
+            // Local options:
             this.options.x += dx;
             this.options.y += dy;
+
+            // Options stored in chart:
+            labelOptions.x = this.options.x;
+            labelOptions.y = this.options.y;
         },
 
         render: function (parent) {

--- a/js/annotations/controllable/ControllablePath.js
+++ b/js/annotations/controllable/ControllablePath.js
@@ -17,9 +17,11 @@ var TRACKER_FILL = 'rgba(192,192,192,' + (H.svg ? 0.0001 : 0.002) + ')';
  *
  * @param {Highcharts.Annotation}
  * @param {Object} options a path's options object
+ * @param {number} index of the path
  **/
-function ControllablePath(annotation, options) {
-    this.init(annotation, options);
+function ControllablePath(annotation, options, index) {
+    this.init(annotation, options, index);
+    this.collection = 'shapes';
 }
 
 /**

--- a/js/annotations/controllable/ControllableRect.js
+++ b/js/annotations/controllable/ControllableRect.js
@@ -12,9 +12,11 @@ import ControllablePath from './ControllablePath.js';
  *
  * @param {Highcharts.Annotation} annotation an annotation instance
  * @param {Object} options a rect's options
+ * @param {number} index of the rectangle
  **/
-function ControllableRect(annotation, options) {
-    this.init(annotation, options);
+function ControllableRect(annotation, options, index) {
+    this.init(annotation, options, index);
+    this.collection = 'shapes';
 }
 
 /**
@@ -77,7 +79,13 @@ H.merge(
         },
 
         translate: function (dx, dy) {
+            var annotationOptions = this.annotation.userOptions,
+                shapeOptions = annotationOptions[this.collection][this.index];
+
             this.translatePoint(dx, dy, 0);
+
+            // Options stored in chart:
+            shapeOptions.point = this.options.point;
         }
     }
 );

--- a/js/annotations/controllable/controllableMixin.js
+++ b/js/annotations/controllable/controllableMixin.js
@@ -18,13 +18,15 @@ var controllableMixin = {
      *
      * @param {Annotation} annotation - an annotation instance
      * @param {Object} options - options specific for controllable
+     * @param {number} index - index of the controllable element
      **/
-    init: function (annotation, options) {
+    init: function (annotation, options, index) {
         this.annotation = annotation;
         this.chart = annotation.chart;
         this.options = options;
         this.points = [];
         this.controlPoints = [];
+        this.index = index;
 
         this.linkPoints();
         this.addControlPoints();

--- a/js/annotations/eventEmitterMixin.js
+++ b/js/annotations/eventEmitterMixin.js
@@ -131,7 +131,14 @@ var eventEmitterMixin = {
      * @param {Object} e event
      */
     onMouseUp: function () {
+        var chart = this.chart,
+            annotation = this.target || this,
+            annotationsOptions = chart.options.annotations,
+            index = chart.annotations.indexOf(annotation);
+
         this.removeDocEvents();
+
+        annotationsOptions[index] = annotation.options;
     },
 
     /**

--- a/js/annotations/navigationBindings.js
+++ b/js/annotations/navigationBindings.js
@@ -37,18 +37,16 @@ var bindingsUtils = {
      */
     updateRectSize: function (event, annotation) {
         var options = annotation.options.typeOptions,
-            xStart = this.chart.xAxis[0].toPixels(options.point.x),
-            yStart = this.chart.yAxis[0].toPixels(options.point.y),
-            x = event.chartX,
-            y = event.chartY,
-            width = x - xStart,
-            height = y - yStart;
+            x = this.chart.xAxis[0].toValue(event.chartX),
+            y = this.chart.yAxis[0].toValue(event.chartY),
+            width = x - options.point.x,
+            height = options.point.y - y;
 
         annotation.update({
             typeOptions: {
                 background: {
-                    width: width + 'px',
-                    height: height + 'px'
+                    width: width,
+                    height: height
                 }
             }
         });
@@ -972,8 +970,9 @@ H.setOptions({
                                     // TRANSFORM RADIUS ACCORDING TO Y
                                     // TRANSLATION
                                     drag: function (e, target) {
-                                        var position = this
-                                            .mouseMoveToTranslation(e);
+                                        var annotation = target.annotation,
+                                            position = this
+                                                .mouseMoveToTranslation(e);
 
                                         target.setRadius(
                                             Math.max(
@@ -983,6 +982,10 @@ H.setOptions({
                                                 5
                                             )
                                         );
+
+                                        annotation.options.shapes[0] =
+                                            annotation.userOptions.shapes[0] =
+                                            target.options;
 
                                         target.redraw(false);
                                     }
@@ -1056,8 +1059,9 @@ H.setOptions({
                                     },
                                     events: {
                                         drag: function (e, target) {
-                                            var xy = this
-                                                .mouseMoveToTranslation(e);
+                                            var annotation = target.annotation,
+                                                xy = this
+                                                    .mouseMoveToTranslation(e);
 
                                             target.options.width = Math.max(
                                                 target.options.width + xy.x,
@@ -1067,6 +1071,11 @@ H.setOptions({
                                                 target.options.height + xy.y,
                                                 5
                                             );
+
+                                            annotation.options.shapes[0] =
+                                                target.options;
+                                            annotation.userOptions.shapes[0] =
+                                                target.options;
 
                                             target.redraw(false);
                                         }
@@ -1154,6 +1163,10 @@ H.setOptions({
                                         var xy = this.mouseMoveToTranslation(e);
 
                                         target.translatePoint(xy.x, xy.y);
+
+                                        target.annotation.labels[0].options =
+                                            target.options;
+
                                         target.redraw(false);
                                     }
                                 }
@@ -1182,6 +1195,10 @@ H.setOptions({
                                         var xy = this.mouseMoveToTranslation(e);
 
                                         target.translate(xy.x, xy.y);
+
+                                        target.annotation.labels[0].options =
+                                            target.options;
+
                                         target.redraw(false);
                                     }
                                 }

--- a/js/annotations/types/CrookedLine.js
+++ b/js/annotations/types/CrookedLine.js
@@ -170,6 +170,12 @@ H.extendAnnotation(CrookedLine, null,
                             this.index
                         );
 
+                        // Update options:
+                        target.options.typeOptions.points[this.index].x =
+                            target.points[this.index].x;
+                        target.options.typeOptions.points[this.index].y =
+                            target.points[this.index].y;
+
                         target.redraw(false);
                     }
                 }

--- a/js/annotations/types/Measure.js
+++ b/js/annotations/types/Measure.js
@@ -302,6 +302,7 @@ H.extendAnnotation(Measure, null,
 
             // background shape
             var bckShape = this.shapes[2];
+
             if (selectType === 'x') {
                 if (cpIndex === 0) {
                     bckShape.translatePoint(dx, 0, 0);
@@ -327,6 +328,13 @@ H.extendAnnotation(Measure, null,
             this.calculations.updateStartPoints
                 .call(this, false, true, cpIndex, dx, dy);
 
+            this.options.typeOptions.background.height = Math.abs(
+                this.startYMax - this.startYMin
+            );
+
+            this.options.typeOptions.background.width = Math.abs(
+                this.startXMax - this.startXMin
+            );
         },
         /**
          * Redraw event which render elements and update start points
@@ -362,6 +370,9 @@ H.extendAnnotation(Measure, null,
             this.shapes.forEach(function (item) {
                 item.translate(dx, dy);
             });
+
+            this.options.typeOptions.point.x = this.startXMin;
+            this.options.typeOptions.point.y = this.startYMin;
         },
         calculations: {
             /*


### PR DESCRIPTION
Highstock: Fixed #9767, annotations' dynamic updates (update, remove, resize, drag and drop) were not applied in the exported chart.