### PR TITLE
bugfix/9740-bindings-update

### DIFF
--- a/js/annotations/navigationBindings.js
+++ b/js/annotations/navigationBindings.js
@@ -5,10 +5,12 @@
  */
 'use strict';
 import H from '../parts/Globals.js';
+import chartNavigationMixin from '../mixins/navigation.js';
 
 var doc = H.doc,
     addEvent = H.addEvent,
     pick = H.pick,
+    merge = H.merge,
     extend = H.extend,
     isNumber = H.isNumber,
     fireEvent = H.fireEvent,
@@ -219,6 +221,23 @@ extend(H.NavigationBindings.prototype, {
             addEvent(chart.container, 'mousemove', function (e) {
                 navigation.bindingsContainerMouseMove(this, e);
             })
+        );
+    },
+
+    /**
+     * Common chart.update() delegation, shared between bindings and exporting.
+     *
+     * @private
+     * @function Highcharts.NavigationBindings#initUpdate
+     */
+    initUpdate: function () {
+        var navigation = this;
+
+        chartNavigationMixin.addUpdate(
+            function (options) {
+                navigation.update(options);
+            },
+            this.chart
         );
     },
 
@@ -703,7 +722,8 @@ extend(H.NavigationBindings.prototype, {
      * @private
      * @function Highcharts.NavigationBindings#update
      */
-    update: function () {
+    update: function (options) {
+        this.options = merge(true, this.options, options);
         this.removeEvents();
         this.initEvents();
     },
@@ -741,6 +761,7 @@ H.Chart.prototype.initNavigationBindings = function () {
             options.navigation
         );
         chart.navigationBindings.initEvents();
+        chart.navigationBindings.initUpdate();
     }
 };
 
@@ -751,14 +772,6 @@ addEvent(H.Chart, 'load', function () {
 addEvent(H.Chart, 'destroy', function () {
     if (this.navigationBindings) {
         this.navigationBindings.destroy();
-    }
-});
-
-addEvent(H.Chart, 'afterUpdate', function () {
-    if (this.navigationBindings) {
-        this.navigationBindings.update();
-    } else {
-        this.initNavigationBindings();
     }
 });
 

--- a/js/annotations/navigationBindings.js
+++ b/js/annotations/navigationBindings.js
@@ -731,7 +731,7 @@ extend(H.NavigationBindings.prototype, {
     utils: bindingsUtils
 });
 
-addEvent(H.Chart, 'load', function () {
+H.Chart.prototype.initNavigationBindings = function () {
     var chart = this,
         options = chart.options;
 
@@ -742,11 +742,23 @@ addEvent(H.Chart, 'load', function () {
         );
         chart.navigationBindings.initEvents();
     }
+};
+
+addEvent(H.Chart, 'load', function () {
+    this.initNavigationBindings();
 });
 
 addEvent(H.Chart, 'destroy', function () {
     if (this.navigationBindings) {
         this.navigationBindings.destroy();
+    }
+});
+
+addEvent(H.Chart, 'afterUpdate', function () {
+    if (this.navigationBindings) {
+        this.navigationBindings.update();
+    } else {
+        this.initNavigationBindings();
     }
 });
 

--- a/js/mixins/navigation.js
+++ b/js/mixins/navigation.js
@@ -1,0 +1,59 @@
+/**
+ * (c) 2010-2018 Paweł Fus
+ *
+ * License: www.highcharts.com/license
+ */
+
+'use strict';
+
+var chartNavigation = {
+    /**
+     * Initializes `chart.navigation` object which delegates `update()` methods
+     * to all other common classes (used in exporting and navigationBindings).
+     *
+     * @private
+     *
+     * @param {Highcharts.Chart} chart
+     *        The chart instance.
+     */
+    initUpdate: function (chart) {
+        if (!chart.navigation) {
+            chart.navigation = {
+                updates: [],
+                update: function (options, redraw) {
+                    this.updates.forEach(function (updateConfig) {
+                        updateConfig.update.call(
+                            updateConfig.context,
+                            options,
+                            redraw
+                        );
+                    });
+                }
+            };
+        }
+    },
+    /**
+     * Registers an `update()` method in the `chart.navigation` object.
+     *
+     * @private
+     *
+     * @param {function} update
+     *        The `update()` method that will be called in `chart.update()`.
+     *
+     * @param {Highcharts.Chart} chart
+     *        The chart instance. `update()` will use that as a context
+     *        (`this`).
+     */
+    addUpdate: function (update, chart) {
+        if (!chart.navigation) {
+            this.initUpdate(chart);
+        }
+
+        chart.navigation.updates.push({
+            update: update,
+            context: chart
+        });
+    }
+};
+
+export default chartNavigation;

--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -51,6 +51,7 @@ import H from '../parts/Globals.js';
 import '../parts/Utilities.js';
 import '../parts/Options.js';
 import '../parts/Chart.js';
+import chartNavigationMixin from '../mixins/navigation.js';
 
 // create shortcuts
 var defaultOptions = H.defaultOptions,
@@ -2084,13 +2085,22 @@ addEvent(Chart, 'init', function () {
             chart.redraw();
         }
     }
-    ['exporting', 'navigation'].forEach(function (prop) {
-        chart[prop] = {
-            update: function (options, redraw) {
-                update(prop, options, redraw);
-            }
-        };
-    });
+
+    chart.exporting = {
+        update: function (options, redraw) {
+            update('exporting', options, redraw);
+        }
+    };
+
+    // Register update() method for navigation. Can not be set the same way as
+    // for exporting, becuase navigation options are shared with bindigs which
+    // has separate update() logic.
+    chartNavigationMixin.addUpdate(
+        function (options, redraw) {
+            update('navigation', options, redraw);
+        },
+        chart
+    );
 });
 
 Chart.prototype.callbacks.push(function (chart) {

--- a/js/modules/stock-tools-bindings.js
+++ b/js/modules/stock-tools-bindings.js
@@ -1623,7 +1623,7 @@ var stockToolsBindings = {
      */
     zoomY: {
         /** @ignore */
-        className: 'highcharts-highcharts-zoom-y',
+        className: 'highcharts-zoom-y',
         /** @ignore */
         init: function (button) {
             this.chart.update({

--- a/samples/unit-tests/stock-tools/bindings/demo.js
+++ b/samples/unit-tests/stock-tools/bindings/demo.js
@@ -359,7 +359,13 @@ QUnit.test('Bindings general tests', function (assert) {
     );
 
     // #9740:
-    chart.update({}, true, false, false);
+    chart.update({
+        stockTools: {
+            gui: {
+                buttons: ['toggleAnnotations']
+            }
+        }
+    }, true);
 
     selectButton('toggle-annotations');
 

--- a/samples/unit-tests/stock-tools/bindings/demo.js
+++ b/samples/unit-tests/stock-tools/bindings/demo.js
@@ -358,6 +358,19 @@ QUnit.test('Bindings general tests', function (assert) {
         'Annotations toolbar hidden.'
     );
 
+    // #9740:
+    chart.update({}, true, false, false);
+
+    selectButton('toggle-annotations');
+
+    assert.strictEqual(
+        chart.annotations[0].options.visible,
+        false,
+        'After chart.update() events are correctly bound.'
+    );
+    // Restore default button state:
+    selectButton('toggle-annotations');
+
     // Restore details:
     if (qunitContainer) {
         qunitContainer.style.display = 'block';


### PR DESCRIPTION
Fixes two issues:
- bindings after chart.update()
- wrong class name for zoom-y button (reported by Kacper in his comment)

Let me know if this is a correct way to add an `update()` action for `navigationBindings`.