### PR TITLE
bugfix/9235-liveredraw-scrollbar

### DIFF
--- a/js/parts/Scrollbar.js
+++ b/js/parts/Scrollbar.js
@@ -1008,7 +1008,28 @@ addEvent(Axis, 'afterInit', function () {
                 from = unitedMin + range * (1 - this.to);
             }
 
-            axis.setExtremes(from, to, true, false, e);
+            if (
+                pick(
+                    this.options.liveRedraw,
+                    H.svg && !H.isTouchDevice && !this.chart.isBoosting
+                ) ||
+                // Mouseup always should change extremes
+                e.DOMType === 'mouseup' ||
+                // Internal events
+                !defined(e.DOMType)
+            ) {
+                axis.setExtremes(
+                    from,
+                    to,
+                    true,
+                    e.DOMType !== 'mousemove',
+                    e
+                );
+            } else {
+                // When live redraw is disabled, don't change extremes
+                // Only change the position of the scollbar thumb
+                this.setRange(this.from, this.to);
+            }
         });
     }
 });

--- a/samples/unit-tests/scrollbar/events/demo.js
+++ b/samples/unit-tests/scrollbar/events/demo.js
@@ -7,7 +7,7 @@ QUnit.test('#6334 - double afterSetExtremes for scrollbar and navigator', functi
                 min: 3,
                 max: 3.05,
                 events: {
-                    afterSetExtremes: function () {
+                    afterSetExtremes() {
                         counter++;
                     }
                 }
@@ -54,8 +54,8 @@ QUnit.test('#1716 - very small range in navigator and scrollbar events', functio
         options = {
             xAxis: {
                 minRange: 0.000001,
-                min: min,
-                max: max
+                min,
+                max
             },
             rangeSelector: {
                 enabled: false
@@ -84,4 +84,54 @@ QUnit.test('#1716 - very small range in navigator and scrollbar events', functio
         );
         done();
     }, 5);
+});
+
+
+QUnit.test('Scrollbar.liverRedraw option', function (assert) {
+    var iterator = 0,
+        chart = Highcharts.stockChart('container', {
+            chart: {
+                events: {
+                    redraw() {
+                        iterator++;
+                    }
+                }
+            },
+            xAxis: {
+                scrollbar: {
+                    enabled: true,
+                    liveRedraw: false
+                },
+                min: 3
+            },
+            navigator: {
+                height: 15
+            },
+            series: [{
+                data: [1, 2, 3, 4, 5]
+            }]
+        }),
+        controller = TestController(chart),
+        scrollbar = chart.xAxis[0].scrollbar,
+        group = scrollbar.group,
+        scrollbarWidth = group.getBBox(true).width;
+
+    controller.mouseDown(
+        group.translateX + scrollbarWidth - 25,
+        group.translateY + 5
+    );
+    controller.mouseMove(
+        group.translateX + scrollbarWidth - 55,
+        group.translateY + 5
+    );
+    controller.mouseUp(
+        group.translateX + scrollbarWidth - 55,
+        group.translateY + 5
+    );
+
+    assert.strictEqual(
+        iterator,
+        1,
+        'Scrollbar redraws chart only once when liveRedraw is disabled (#9235).'
+    );
 });


### PR DESCRIPTION
Highstock: Fixed #9235, option `Axis.scrollbar.liveRedraw` did not block events and redraw.

ESLint has thrown errors like this:

>   57:17  error  Expected property shorthand  object-shorthand
>   95:21  error  Expected method shorthand    object-shorthand

So functions are now defined as:
```javascript
             chart: {
                 events: {
                     redraw() {
                         iterator++;
                     }
                 }
             },
```
AFAIK this won't work in old IE. Is that expected @TorsteinHonsi ?

