### PR TITLE
bugfix/9238/omitted-axis-label

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -1943,10 +1943,14 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             axes = chart.axes,
             renderer = chart.renderer,
             options = chart.options,
+            correction = 0, // correction for X axis labels
+            xAxes = chart.xAxis,
             tempWidth,
             tempHeight,
             redoHorizontal,
-            redoVertical;
+            redoVertical,
+            xAxis,
+            i;
 
         // Title
         chart.setTitle();
@@ -1970,9 +1974,25 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
 
         // Record preliminary dimensions for later comparison
         tempWidth = chart.plotWidth;
-        // 21 is the most common correction for X axis labels
+
+        for (i = 0; i < xAxes.length; i++) {
+            xAxis = xAxes[i];
+
+            // #9238 make correction only if X axis labels are visible
+            if (
+                xAxis.visible &&
+                xAxis.options.labels.enabled &&
+                xAxis.series.length
+            ) {
+                // 21 is the most common correction for X axis labels
+                correction = 21;
+                i = xAxes.length;
+            }
+        }
+
         // use Math.max to prevent negative plotHeight
-        tempHeight = chart.plotHeight = Math.max(chart.plotHeight - 21, 0);
+        chart.plotHeight = Math.max(chart.plotHeight - correction, 0);
+        tempHeight = chart.plotHeight;
 
         // Get margins by pre-rendering axes
         axes.forEach(function (axis) {

--- a/samples/unit-tests/axis/labels/demo.js
+++ b/samples/unit-tests/axis/labels/demo.js
@@ -713,3 +713,84 @@ QUnit.test('Column pointrange (#2806)', function (assert) {
     );
 
 });
+
+// Highcharts 7.0.1, Issue #9238
+// Yaxis label hidden despite enough space
+QUnit.test('Correction for X axis labels (#9238)', function (assert) {
+
+    var chart = Highcharts.chart('container', {
+        chart: {
+            marginLeft: 100,
+            height: 72
+        },
+        title: {
+            text: ''
+        },
+        credits: {
+            enabled: false
+        },
+        legend: {
+            enabled: false
+        },
+        xAxis: [{
+            visible: true,
+            labels: {
+                enabled: false
+            }
+        }],
+        yAxis: {
+            categories: [
+                "First label",
+                "Second label"
+            ],
+            title: {
+                text: ''
+            },
+            startOnTick: false,
+            endOnTick: false
+        },
+        series: [{
+            data: [{
+                x: 8,
+                y: 0
+            }]
+        }, {
+            data: [{
+                x: -88,
+                y: 1
+            }]
+        }]
+      });
+
+    assert.strictEqual(
+        chart.yAxis[0].labelGroup.element.childNodes.length,
+        2,
+        'There should be 2 labels on the yAxis when axis labels are disabled.'
+    );
+
+    chart.update({
+        xAxis: [{
+            visible: false
+        }, {
+            visible: true
+        }],
+    });
+
+    assert.strictEqual(
+        chart.yAxis[0].labelGroup.element.childNodes.length,
+        2,
+        'There should be 2 labels on the yAxis when additional axis does not have series linked to it.'
+    );
+
+    chart.update({
+        xAxis: [{
+            visible: false
+        }, {
+            visible: true,
+            labels: {
+                enabled: false
+            }
+        }]
+    });
+
+});


### PR DESCRIPTION
Changed the way of calculating the correction for xAxis labels. The correction is equal 21 only if Xaxis labels are visible.