### PR TITLE
Bugfix/9685 venn maximum call stack

### DIFF
--- a/js/modules/venn.src.js
+++ b/js/modules/venn.src.js
@@ -168,9 +168,10 @@ var range = function range(start, end, step) {
  */
 var getDistanceBetweenCirclesByOverlap =
 function getDistanceBetweenCirclesByOverlap(r1, r2, overlap) {
-    var error = 0.01,
-        maxDistance = r1 + r2,
-        list = range(0, maxDistance, 0.001),
+    var maxDistance = r1 + r2,
+        error = maxDistance / 100, // Allow 1% error
+        interval = maxDistance / 10000, // Use a list with 10000 values
+        list = range(0, maxDistance, interval),
         index = binarySearch(list, 0, function (x) {
             var actualOverlap = getOverlapBetweenCirclesByDistance(r1, r2, x),
                 diff = overlap - actualOverlap;

--- a/samples/unit-tests/series-venn/members/demo.js
+++ b/samples/unit-tests/series-venn/members/demo.js
@@ -30,8 +30,8 @@ QUnit.test('addOverlapToRelations', function (assert) {
     assert.deepEqual(
         set.overlapping,
         {
-            'B': 1,
-            'C': 2
+            B: 1,
+            C: 2
         },
         'should set the property overlapping on set A to include a map from id of overlapping set to the amount of overlap.'
     );
@@ -45,8 +45,8 @@ QUnit.test('addOverlapToRelations', function (assert) {
     assert.deepEqual(
         set.overlapping,
         {
-            'A': 1,
-            'C': 3
+            A: 1,
+            C: 3
         },
         'should set the property overlapping on set B to include a map from id of overlapping set to the amount of overlap.'
     );
@@ -60,8 +60,8 @@ QUnit.test('addOverlapToRelations', function (assert) {
     assert.deepEqual(
         set.overlapping,
         {
-            'A': 2,
-            'B': 3
+            A: 2,
+            B: 3
         },
         'should set the property overlapping on set C to include a map from id of overlapping set to the amount of overlap.'
     );
@@ -114,7 +114,7 @@ QUnit.test('getAreaOfIntersectionBetweenCircles', function (assert) {
     var vennPrototype = Highcharts.seriesTypes.venn.prototype,
         getAreaOfIntersectionBetweenCircles =
             vennPrototype.utils.geometryCircles
-            .getAreaOfIntersectionBetweenCircles;
+                .getAreaOfIntersectionBetweenCircles;
 
     assert.deepEqual(
         getAreaOfIntersectionBetweenCircles([
@@ -164,7 +164,7 @@ QUnit.test('getOverlapBetweenCircles', function (assert) {
     var vennPrototype = Highcharts.seriesTypes.venn.prototype,
         getOverlapBetweenCircles =
             vennPrototype.utils.geometryCircles
-            .getOverlapBetweenCircles;
+                .getOverlapBetweenCircles;
 
     assert.strictEqual(
         getOverlapBetweenCircles(3, 4, 5),
@@ -209,7 +209,7 @@ QUnit.test('getDistanceBetweenCirclesByOverlap', function (assert) {
         getDistanceBetweenCirclesByOverlap(25.2313252202016, 25.2313252202016, 1000),
         20.39195704296693,
         'should return a distance of 20.39195704296693 when r1=r2=25.2313252202016 and overlap=1000.'
-    )
+    );
 });
 
 QUnit.test('getDistanceBetweenPoints', function (assert) {
@@ -320,9 +320,9 @@ QUnit.test('loss', function (assert) {
     var vennPrototype = Highcharts.seriesTypes.venn.prototype,
         loss = vennPrototype.utils.loss,
         map = {
-            'A': { x: 0, y: 0, r: 3 },
-            'B': { x: 6, y: 0, r: 3 },
-            'C': { x: 5.074, y: 0, r: 3 }
+            A: { x: 0, y: 0, r: 3 },
+            B: { x: 6, y: 0, r: 3 },
+            C: { x: 5.074, y: 0, r: 3 }
         };
 
     assert.strictEqual(

--- a/samples/unit-tests/series-venn/members/demo.js
+++ b/samples/unit-tests/series-venn/members/demo.js
@@ -195,17 +195,21 @@ QUnit.test('getDistanceBetweenCirclesByOverlap', function (assert) {
     var vennPrototype = Highcharts.seriesTypes.venn.prototype,
         getDistanceBetweenCirclesByOverlap =
             vennPrototype.utils.getDistanceBetweenCirclesByOverlap;
-
     assert.strictEqual(
         getDistanceBetweenCirclesByOverlap(3, 4, 6.64),
-        5.002,
-        'should return a distance of 5.002 when r1=3, r2=4 and overlap=6.64.'
+        5.0029,
+        'should return a distance of 5.0029 when r1=3, r2=4 and overlap=6.64.'
     );
     assert.strictEqual(
         getDistanceBetweenCirclesByOverlap(1.1283791670955126, 0.5641895835477563, 1),
-        0.422,
-        'should return a distance of 5.002 when r1=3, r2=4 and overlap=6.64.'
+        0.42297293078575,
+        'should return a distance of 0.42297293078575 when r1=1.1283791670955126, r2=0.5641895835477563 and overlap=1.'
     );
+    assert.strictEqual(
+        getDistanceBetweenCirclesByOverlap(25.2313252202016, 25.2313252202016, 1000),
+        20.39195704296693,
+        'should return a distance of 20.39195704296693 when r1=r2=25.2313252202016 and overlap=1000.'
+    )
 });
 
 QUnit.test('getDistanceBetweenPoints', function (assert) {


### PR DESCRIPTION
# Description
The size of the binary search array in `getDistanceBetweenCirclesByOverlap` was influenced by the maximum distance between the two circles. This would cause the error `maximum call stack size exceeded` when the data values was of very large numbers.
Solved by having a fixed size for the binary search array and a range interval that is relative to the maximum distance.

# Example(s)
- [Demo of issue](https://jsfiddle.net/edwtvrf2/)
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/15wcykp0/)

# Related issue(s)
- Closes #9685 