### PR TITLE
Fixed #9709, missing values when exporting xls in venn.

### DIFF
--- a/js/modules/venn.src.js
+++ b/js/modules/venn.src.js
@@ -875,6 +875,7 @@ var vennSeries = {
     isCartesian: false,
     axisTypes: [],
     directTouch: true,
+    pointArrayMap: ['value'],
     translate: function () {
 
         var chart = this.chart;


### PR DESCRIPTION
# Description
The venn series was using a `pointArrayMap` with value `['y']`, causing xls export to not find the values in the series. Solved by adding a `pointArrayMap` with value `['value']`.

# Example(s)
- [Demo of issue](https://jsfiddle.net/4vfghkcw/)
- [Demo of applied fix](https://jsfiddle.net/jon_a_nygaard/zom8yxt7/)

# Related issue(s)
- Closes #9709 