### PR TITLE
Fixed #9801, networkgraph not compatible with no-data module.

### DIFF
--- a/js/modules/no-data-to-display.src.js
+++ b/js/modules/no-data-to-display.src.js
@@ -136,6 +136,7 @@ defaultOptions.noData = {
     'bubble',
     'gauge',
     'heatmap',
+    'networkgraph',
     'pie',
     'sankey',
     'treemap',

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.details
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.html
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.html
@@ -1,0 +1,8 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/networkgraph.js"></script>
+<script src="https://code.highcharts.com/modules/no-data-to-display.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.js
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.js
@@ -1,0 +1,42 @@
+QUnit.test('Network Graph', function (assert) {
+    var chart = Highcharts.chart('container', {});
+
+    assert.notStrictEqual(
+        chart.container.querySelector('.highcharts-no-data'),
+        null,
+        'No-data label should display when there is no data (#9801)'
+    );
+
+    chart.addSeries({
+        layoutAlgorithm: {
+            enableSimulation: false
+        },
+        keys: ['from', 'to'],
+        data: [
+            ['A', 'B'],
+            ['A', 'C'],
+            ['A', 'D'],
+
+            ['B', 'A'],
+            ['B', 'C'],
+
+            ['C', 'D'],
+
+            ['D', 'A']
+        ],
+        type: 'networkgraph'
+    });
+
+    assert.strictEqual(
+        chart.series[0].points.length,
+        7,
+        'Series successfully added'
+    );
+
+    assert.strictEqual(
+        chart.container.querySelector('.highcharts-no-data'),
+        null,
+        'No-data label should NOT display when there is data (#9801)'
+    );
+
+});


### PR DESCRIPTION
This PR fixes the issue described in #9801. The solution was to add `networkgraph` to the list of series types that use a `hasData` function that simply checks if any `points` exist in the series.