### PR TITLE
Fixed #9803, networkgraph throwing maximum call stack error with cyclical links.

### DIFF
--- a/js/modules/networkgraph/layouts.js
+++ b/js/modules/networkgraph/layouts.js
@@ -212,10 +212,16 @@ H.extend(
                 rootNodes = nodes.filter(function (node) {
                     return node.linksTo.length === 0;
                 }),
-                sortedNodes = [];
+                sortedNodes = [],
+                visitedLinks = [];
 
             function addToNodes(node) {
                 node.linksFrom.forEach(function (link) {
+                    if (visitedLinks.indexOf(link) !== -1) {
+                        return;
+                    }
+
+                    visitedLinks.push(link);
                     sortedNodes.push(link.toNode);
                     addToNodes(link.toNode);
                 });

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.details
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.html
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/networkgraph.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.js
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.js
@@ -1,0 +1,23 @@
+QUnit.test('Network Graph', function (assert) {
+    var chart = Highcharts.chart('container', {});
+
+    chart.addSeries({
+        layoutAlgorithm: {
+            enableSimulation: false
+        },
+        keys: ['from', 'to'],
+        data: [
+            ['A', 'B'],
+            ['B', 'A'],
+            ['C', 'A']
+        ],
+        type: 'networkgraph'
+    });
+
+    assert.strictEqual(
+        chart.series[0].points.length,
+        3,
+        'Series successfully added'
+    );
+
+});


### PR DESCRIPTION
This PR fixes the issue described in #9803.

The issue appears to be that it was possible to have cyclical links, which recursively add each other to a sortedNodes list. By detecting those cycles we avoid hitting the maximum call stack.