### PR TITLE
Fixed incorrect calculations in getOverlapBetweenCircles

### DIFF
--- a/js/mixins/geometry-circles.js
+++ b/js/mixins/geometry-circles.js
@@ -9,6 +9,19 @@ var round = function round(x, decimals) {
 };
 
 /**
+ * Calculates the area of a circular segment based on the radius of the circle
+ * and the height of the segment.
+ * See http://mathworld.wolfram.com/CircularSegment.html
+ *
+ * @param {number} r The radius of the circle.
+ * @param {number} h The height of the circular segment.
+ * @returns {number} Returns the area of the circular segment.
+ */
+var getCircularSegmentArea = function getCircularSegmentArea(r, h) {
+    return r * r * Math.acos(1 - h / r) - (r - h) * Math.sqrt(h * (2 * r - h));
+};
+
+/**
  * Calculates the area of overlap between two circles based on their radiuses
  * and the distance between them.
  * See http://mathworld.wolfram.com/Circle-CircleIntersection.html
@@ -33,15 +46,14 @@ function getOverlapBetweenCircles(r1, r2, d) {
             // equals the area of the smallest circle.
             overlap = Math.PI * Math.min(r1Square, r2Square);
         } else {
-            // d^2 - r^2 + R^2 / 2d
-            var x = (r1Square - r2Square + d * d) / (2 * d),
-                // y^2 = R^2 - x^2
-                y = Math.sqrt(r1Square - x * x);
+            // Height of first triangle segment.
+            var d1 = (r1Square - r2Square + d * d) / (2 * d),
+                // Height of second triangle segment.
+                d2 = d - d1;
 
             overlap = (
-                r1Square * Math.asin(y / r1) +
-                r2Square * Math.asin(y / r2) -
-                y * (x + Math.sqrt(x * x + r2Square - r1Square))
+                getCircularSegmentArea(r1, r1 - d1) +
+                getCircularSegmentArea(r2, r2 - (d - d1))
             );
         }
         // Round the result to two decimals.
@@ -273,6 +285,7 @@ var geometryCircles = {
     getAreaOfIntersectionBetweenCircles: getAreaOfIntersectionBetweenCircles,
     getCircleCircleIntersection: getCircleCircleIntersection,
     getCirclesIntersectionPoints: getCirclesIntersectionPoints,
+    getCircularSegmentArea: getCircularSegmentArea,
     getOverlapBetweenCircles: getOverlapBetweenCircles,
     isPointInsideCircle: isPointInsideCircle,
     isPointInsideAllCircles: isPointInsideAllCircles,

--- a/samples/unit-tests/series-venn/members/demo.js
+++ b/samples/unit-tests/series-venn/members/demo.js
@@ -160,11 +160,9 @@ QUnit.test('getCenterOfPoints', function (assert) {
     );
 });
 
-QUnit.test('getOverlapBetweenCircles', function (assert) {
-    var vennPrototype = Highcharts.seriesTypes.venn.prototype,
-        getOverlapBetweenCircles =
-            vennPrototype.utils.geometryCircles
-                .getOverlapBetweenCircles;
+QUnit.test('getOverlapBetweenCircles', assert => {
+    var { prototype: vennPrototype } = Highcharts.seriesTypes.venn,
+        { getOverlapBetweenCircles } = vennPrototype.utils.geometryCircles;
 
     assert.strictEqual(
         getOverlapBetweenCircles(3, 4, 5),
@@ -176,6 +174,12 @@ QUnit.test('getOverlapBetweenCircles', function (assert) {
         getOverlapBetweenCircles(8, 6, 1),
         113.09733552923257,
         'should return 113.09733552923257 when r1=8, r2=6 and d=1. The circles completely overlaps.'
+    );
+
+    assert.strictEqual(
+        getOverlapBetweenCircles(2.5231325220201604, 3.0901936161855166, 0.7011044346618891),
+        19.68884261304518,
+        'should return 19.68884261304518 when r1=2.5231325220201604, r2=3.0901936161855166 and d=0.7011044346618891.'
     );
 
     assert.strictEqual(
@@ -275,6 +279,23 @@ QUnit.test('getCirclesIntersectionPoints', function (assert) {
             { x: 0, y: 3, indexes: [0, 2] }
         ],
         'should return a list of all the intersection points between the circles.'
+    );
+});
+
+QUnit.test('getCircularSegmentArea', assert => {
+    var { prototype: vennPrototype } = Highcharts.seriesTypes.venn,
+        { getCircularSegmentArea } = vennPrototype.utils.geometryCircles;
+
+    assert.strictEqual(
+        getCircularSegmentArea(1, 1),
+        Math.PI / 2,
+        'should return PI/2 when r=1 and h=1 and circle area is equal to PI.'
+    );
+
+    assert.strictEqual(
+        getCircularSegmentArea(1, 2),
+        Math.PI,
+        'should return PI when r=1 and h=2 and circle area is equal to PI.'
     );
 });
 


### PR DESCRIPTION
# Description
In certain cases the previous formula of `getOverlapBetweenCircles` was returning incorrect values causing the positioning of the circles to fault. This is solved by modifying `getOverlapBetweenCircles` to calculate the overlap by first calculate the area of each circular segment and adding these together to get a correct result.

# Example(s)
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/3o798y2v/)
- [Demo of the issue](https://jsfiddle.net/k2xvL7y6/)

# Related issue(s)
- Closes #9718 
- Closes #9768 