### PR TITLE
 bugfix/9803-networkgraph-call-stack

### DIFF
--- a/js/modules/networkgraph/layouts.js
+++ b/js/modules/networkgraph/layouts.js
@@ -212,12 +212,16 @@ H.extend(
                 rootNodes = nodes.filter(function (node) {
                     return node.linksTo.length === 0;
                 }),
-                sortedNodes = [];
+                sortedNodes = [],
+                visitedNodes = {};
 
             function addToNodes(node) {
                 node.linksFrom.forEach(function (link) {
-                    sortedNodes.push(link.toNode);
-                    addToNodes(link.toNode);
+                    if (!visitedNodes[link.toNode.id]) {
+                        visitedNodes[link.toNode.id] = true;
+                        sortedNodes.push(link.toNode);
+                        addToNodes(link.toNode);
+                    }
                 });
             }
 

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.js
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.js
@@ -1,5 +1,9 @@
 QUnit.test('Network Graph', function (assert) {
-    var chart = Highcharts.chart('container', {});
+    var chart = Highcharts.chart('container', {
+        chart: {
+            type: 'networkgraph'
+        }
+    });
 
     assert.notStrictEqual(
         chart.container.querySelector('.highcharts-no-data'),
@@ -23,8 +27,7 @@ QUnit.test('Network Graph', function (assert) {
             ['C', 'D'],
 
             ['D', 'A']
-        ],
-        type: 'networkgraph'
+        ]
     });
 
     assert.strictEqual(
@@ -39,4 +42,14 @@ QUnit.test('Network Graph', function (assert) {
         'No-data label should NOT display when there is data (#9801)'
     );
 
+    chart.addSeries({
+        keys: ['from', 'to'],
+        data: [
+            ['1', '2'],
+            ['2', '1'],
+            ['3', '1']
+        ]
+    });
+
+    assert.ok(true, 'No errors in cyclical graphs (#9803)');
 });


### PR DESCRIPTION
Fixed #9803, networkgraph throwing maximum call stack error with cyclical links.

A follow-up commit for #9804 PR. 