### PR TITLE
Updated highcharts-assembler to v1.1.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "gulp-util": "^3.0.8",
     "gzip-size": "^3.0.0",
     "highcharts-api-docs": "github:highcharts/api-docs",
-    "highcharts-assembler": "github:highcharts/highcharts-assembler#v1.0.28",
+    "highcharts-assembler": "github:highcharts/highcharts-assembler#v1.1.0",
     "highcharts-docstrap": "github:highcharts/highcharts-docstrap",
     "husky": "latest",
     "js-yaml": "^3.12.0",


### PR DESCRIPTION
# Description
Updated dev dependency `highcharts-assembler` to `v1.1.0`. 
The update includes a change which introduces the property `default` on the factory function that is returned to `module.exports`. This allows for TypeScript users to import the Highcharts from default as following `import Highcharts from 'highcharts';` instead of using import whole module as following `import * as Highcharts from 'highcharts';`.
Both of these mentioned cases will now supported in TypeScript.

# Related issue(s)
- https://github.com/highcharts/highcharts-angular/issues/101