### PR TITLE
Fixed #9787, set supertrend cropThreshold equal to main series one on…

### DIFF
--- a/js/indicators/supertrend.src.js
+++ b/js/indicators/supertrend.src.js
@@ -18,6 +18,7 @@ var ATR = H.seriesTypes.atr,
 // Utils:
 function createPointObj(mainSeries, index, close) {
     return {
+        index: index,
         close: mainSeries.yData[index][close],
         x: mainSeries.xData[index]
     };
@@ -44,10 +45,10 @@ H.seriesType('supertrend', 'sma',
      * @extends      plotOptions.sma
      * @since        7.0.0
      * @product      highstock
-     * @excluding    allAreas, color, negativeColor, colorAxis, joinBy, keys,
-     *               navigatorOptions, pointInterval, pointIntervalUnit,
-     *               pointPlacement, pointRange, pointStart, showInNavigator,
-     *               stacking, threshold
+     * @excluding    allAreas, color, cropThreshold, negativeColor, colorAxis,
+     *               joinBy, keys, navigatorOptions, pointInterval,
+     *               pointIntervalUnit, pointPlacement, pointRange, pointStart,
+     *               showInNavigator, stacking, threshold
      * @optionparent plotOptions.supertrend
      */
     {
@@ -133,13 +134,27 @@ H.seriesType('supertrend', 'sma',
         nameBase: 'Supertrend',
         nameComponents: ['multiplier', 'period'],
         requiredIndicators: ['atr'],
+        init: function () {
+            var options,
+                parentOptions;
+
+            SMA.prototype.init.apply(this, arguments);
+
+            options = this.options;
+            parentOptions = this.linkedParent.options;
+
+            // Indicator cropThreshold has to be equal linked series one
+            // reduced by period due to points comparison in drawGraph method
+            // (#9787)
+            options.cropThreshold =
+                parentOptions.cropThreshold - (options.params.period - 1);
+        },
         drawGraph: function () {
             var indicator = this,
-                chart = indicator.chart,
                 indicOptions = indicator.options,
 
-                // series that indicator is linked to
-                mainSeries = chart.get(indicOptions.linkedTo),
+                // Series that indicator is linked to
+                mainSeries = indicator.linkedParent,
                 mainLinePoints = mainSeries ? mainSeries.points : [],
                 indicPoints = indicator.points,
                 indicPath = indicator.graph,
@@ -264,27 +279,30 @@ H.seriesType('supertrend', 'sma',
 
                 // Check if points are shifted relative to each other
                 if (
+                    point &&
                     mainPoint &&
                     prevMainPoint &&
                     nextMainPoint &&
                     point.x !== mainPoint.x
                 ) {
-                    if (point && point.x === prevMainPoint.x) {
+                    if (point.x === prevMainPoint.x) {
                         nextMainPoint = mainPoint;
                         mainPoint = prevMainPoint;
-                    } else if (point && point.x === nextMainPoint.x) {
+                    } else if (point.x === nextMainPoint.x) {
                         mainPoint = nextMainPoint;
                         nextMainPoint = {
                             close: mainSeries.yData[mainPoint.index - 1][close],
                             x: mainSeries.xData[mainPoint.index - 1]
                         };
-                    } else if (point && point.x === prevPrevMainPoint.x) {
+                    } else if (
+                        prevPrevMainPoint && point.x === prevPrevMainPoint.x
+                    ) {
                         mainPoint = prevPrevMainPoint;
                         nextMainPoint = prevMainPoint;
                     }
                 }
 
-                if (nextPoint && nextMainPoint) {
+                if (nextPoint && nextMainPoint && mainPoint) {
 
                     newNextPoint = {
                         x: nextPoint.x,
@@ -519,9 +537,9 @@ H.seriesType('supertrend', 'sma',
  * @extends   series,plotOptions.supertrend
  * @since     7.0.0
  * @product   highstock
- * @excluding allAreas, color, colorAxis, data, dataParser, dataURL, joinBy,
- *            keys, navigatorOptions, negativeColor, pointInterval,
- *            pointIntervalUnit, pointPlacement, pointRange, pointStart,
- *            showInNavigator, stacking, threshold
+ * @excluding allAreas, color, colorAxis, cropThreshold, data, dataParser,
+ *            dataURL, joinBy, keys, navigatorOptions, negativeColor,
+ *            pointInterval, pointIntervalUnit, pointPlacement, pointRange,
+ *            pointStart, showInNavigator, stacking, threshold
  * @apioption series.supertrend
  */

--- a/samples/unit-tests/indicator-supertrend/recalculations/demo.js
+++ b/samples/unit-tests/indicator-supertrend/recalculations/demo.js
@@ -5,6 +5,7 @@ QUnit.test('Test Absolute Price Oscillator calculations on data updates.', funct
         series: [{
             id: 'main',
             type: 'ohlc',
+            cropThreshold: 30,
             data: [
                 [1474378200000, 113.05, 114.12, 112.51, 113.57],
                 [1474464600000, 113.85, 113.99, 112.44, 113.55],
@@ -248,5 +249,15 @@ QUnit.test('Test Absolute Price Oscillator calculations on data updates.', funct
         chart.series[1].graphintersectLine.attr('stroke-width'),
         0.5,
         'Intersect line width changed'
+    );
+
+    // Indicator cropThreshold has to be equal linked series one
+    // reduced by period due to points comparison in drawGraph method
+    // (#9787)
+    assert.strictEqual(
+        chart.series[1].options.cropThreshold +
+        chart.series[1].options.params.period - 1,
+        30,
+        'Indicator cropThreshold equal main series cropThreshold reduced by period.'
     );
 });


### PR DESCRIPTION
Supertrend drawGrahp method compare points to the main series. To render the indicator correctly it is required to have cropThreshold equal the main series.