### PR TITLE
Fixed draggable points capturing click events

### DIFF
--- a/js/modules/draggable-points.src.js
+++ b/js/modules/draggable-points.src.js
@@ -1595,8 +1595,6 @@ function initDragDrop(e, point) {
     )) {
         chart.dragGuideBox = guideBox = series.getGuideBox(groupedPoints);
         chart.setGuideBoxState('default', series.options.dragDrop.guideBox)
-            // Use pointerEvents 'none' to avoid capturing the click event
-            .css({ pointerEvents: 'none' })
             .add(series.group);
     }
 
@@ -1858,7 +1856,9 @@ H.Chart.prototype.setGuideBoxState = function (state, options) {
         fill: stateOptions.color,
         cursor: stateOptions.cursor,
         zIndex: stateOptions.zIndex
-    });
+    })
+    // Use pointerEvents 'none' to avoid capturing the click event
+    .css({ pointerEvents: 'none' });
 };
 
 

--- a/js/modules/draggable-points.src.js
+++ b/js/modules/draggable-points.src.js
@@ -1595,6 +1595,8 @@ function initDragDrop(e, point) {
     )) {
         chart.dragGuideBox = guideBox = series.getGuideBox(groupedPoints);
         chart.setGuideBoxState('default', series.options.dragDrop.guideBox)
+            // Use pointerEvents 'none' to avoid capturing the click event
+            .css({ pointerEvents: 'none' })
             .add(series.group);
     }
 


### PR DESCRIPTION
# Description
The drag guide box would in most cases capture the click event and prevent the click event from being fired on the point. This is solved by setting the style property `pointer-events` to `none` on the drag guide box element.