### PR TITLE
Fixed Windows path compatibility in scripts task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1555,11 +1555,11 @@ function defaultWatch() {
     ];
     const msgBuildAll = 'Built JS files from modules.'.cyan;
     let watcher;
-    const onChange = p => {
-        const path = p.split(sep).join('/');
+    const onChange = path => {
+        const posixPath = path.split(sep).join('/');
         let promise;
 
-        if (path.startsWith('css')) {
+        if (posixPath.startsWith('css')) {
             // Stop the watcher temporarily.
             watcher.close();
             watcher = null;
@@ -1574,12 +1574,12 @@ function defaultWatch() {
                 // Start watcher again.
                 watcher = gulp.watch(watchlist).on('change', onChange);
             });
-        } else if (path.startsWith('js')) {
+        } else if (posixPath.startsWith('js')) {
             // Build es-modules
-            promise = mapOfWatchFn['js/**/*.js']({ path, type: 'change' });
-        } else if (path.startsWith('code/es-modules')) {
+            promise = mapOfWatchFn['js/**/*.js']({ posixPath, type: 'change' });
+        } else if (posixPath.startsWith('code/es-modules')) {
             // Build dist files in classic mode.
-            promise = mapOfWatchFn['code/es-modules/**/*.js']({ path, type: 'change' });
+            promise = mapOfWatchFn['code/es-modules/**/*.js']({ posixPath, type: 'change' });
         }
 
         return promise;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1555,13 +1555,16 @@ function defaultWatch() {
     ];
     const msgBuildAll = 'Built JS files from modules.'.cyan;
     let watcher;
-    const onChange = path => {
+    const onChange = p => {
+        const path = p.split(sep).join('/');
+        let promise;
+
         if (path.startsWith('css')) {
             // Stop the watcher temporarily.
             watcher.close();
             watcher = null;
             // Run styles and build all files.
-            styles().then(() => {
+            promise = styles().then(() => {
                 if (shouldBuild()) {
                     fnFirstBuild();
                     console.log(msgBuildAll);
@@ -1573,11 +1576,13 @@ function defaultWatch() {
             });
         } else if (path.startsWith('js')) {
             // Build es-modules
-            mapOfWatchFn['js/**/*.js']({ path, type: 'change' });
+            promise = mapOfWatchFn['js/**/*.js']({ path, type: 'change' });
         } else if (path.startsWith('code/es-modules')) {
             // Build dist files in classic mode.
-            mapOfWatchFn['code/es-modules/**/*.js']({ path, type: 'change' });
+            promise = mapOfWatchFn['code/es-modules/**/*.js']({ path, type: 'change' });
         }
+
+        return promise;
     };
     return styles().then(() => {
         if (shouldBuild()) {


### PR DESCRIPTION
# Description
The path passed from `gulp@4` is using backwards slashes on Windows causing a conditional to "fail" in the watch task of `gulp default`. Solved by parsing all paths to use forward slashes (`/`).

Additionally the promise is now returned so that the `onChange` function is not completing prematurily.