### PR TITLE
Fixed typos with intialize vs initiate

### DIFF
--- a/js/modules/drag-panes.src.js
+++ b/js/modules/drag-panes.src.js
@@ -200,7 +200,7 @@ H.AxisResizer = function (axis) {
 
 H.AxisResizer.prototype = {
     /**
-     * Initiate the AxisResizer object.
+     * Initialize the AxisResizer object.
      *
      * @function Highcharts.AxisResizer#init
      *

--- a/js/modules/series-label.src.js
+++ b/js/modules/series-label.src.js
@@ -660,7 +660,7 @@ Series.prototype.checkClearPoint = function (x, y, bBox, checkDistance) {
 };
 
 /**
- * The main initiator method that runs on chart level after initiation and
+ * The main initialize method that runs on chart level after initialization and
  * redraw. It runs in  a timeout to prevent locking, and loops over all series,
  * taking all series and labels into account when placing the labels.
  *

--- a/js/modules/vector.src.js
+++ b/js/modules/vector.src.js
@@ -253,7 +253,7 @@ seriesType('vector', 'scatter'
     */
 
         /**
-     * Fade in the arrows on initiating series.
+     * Fade in the arrows on initializing series.
      *
      * @private
      * @function Highcharts.seriesTypes.vector#animate

--- a/js/modules/windbarb.src.js
+++ b/js/modules/windbarb.src.js
@@ -280,7 +280,7 @@ seriesType('windbarb', 'column'
             }, this);
         },
 
-        // Fade in the arrows on initiating series.
+        // Fade in the arrows on initializing series.
         animate: function (init) {
             if (init) {
                 this.markerGroup.attr({

--- a/js/parts-map/MapNavigation.js
+++ b/js/parts-map/MapNavigation.js
@@ -45,7 +45,7 @@ function MapNavigation(chart) {
 }
 
 /**
- * Initiator function.
+ * Initialize function.
  *
  * @function MapNavigation#init
  *

--- a/js/parts-more/Pane.js
+++ b/js/parts-more/Pane.js
@@ -38,7 +38,7 @@ extend(Pane.prototype, {
     coll: 'pane', // Member of chart.pane
 
     /**
-     * Initiate the Pane object
+     * Initialize the Pane object
      *
      * @private
      * @function Highcharts.Pane#init

--- a/js/parts/DataGrouping.js
+++ b/js/parts/DataGrouping.js
@@ -541,7 +541,7 @@ seriesProto.groupData = function (xData, yData, groupPositions, approximation) {
 
     for (i; i <= dataLength; i++) {
 
-        // when a new group is entered, summarize and initiate
+        // when a new group is entered, summarize and initialize
         // the previous group
         while ((
             groupPositions[pos + 1] !== undefined &&

--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -1006,8 +1006,8 @@ extend(Series.prototype, /** @lends Series.prototype */ {
     /**
      * Update the series with a new set of options. For a clean and precise
      * handling of new options, all methods and elements from the series are
-     * removed, and it is initiated from scratch. Therefore, this method is more
-     * performance expensive than some other utility methods like {@link
+     * removed, and it is initialized from scratch. Therefore, this method is
+     * more performance expensive than some other utility methods like {@link
      * Series#setData} or {@link Series#setVisible}.
      *
      * Note that `Series.update` may mutate the passed `data` options.

--- a/js/parts/Navigator.js
+++ b/js/parts/Navigator.js
@@ -1523,7 +1523,7 @@ Navigator.prototype = {
     },
 
     /**
-     * Initiate the Navigator object
+     * Initialize the Navigator object
      *
      * @private
      * @function Highcharts.Navigator#init
@@ -2444,7 +2444,7 @@ addEvent(Chart, 'update', function (e) {
 
 });
 
-// Initiate navigator, if no scrolling exists yet
+// Initialize navigator, if no scrolling exists yet
 addEvent(Chart, 'afterUpdate', function () {
 
     if (!this.navigator && !this.scroller &&
@@ -2474,7 +2474,7 @@ Chart.prototype.callbacks.push(function (chart) {
     var extremes,
         navigator = chart.navigator;
 
-    // Initiate the navigator
+    // Initialize the navigator
     if (navigator && chart.xAxis[0]) {
         extremes = chart.xAxis[0].getExtremes();
         navigator.render(extremes.min, extremes.max);

--- a/js/parts/Options.js
+++ b/js/parts/Options.js
@@ -251,7 +251,7 @@ H.defaultOptions = {
 
     /**
      * The language object is global and it can't be set on each chart
-     * initiation. Instead, use `Highcharts.setOptions` to set it before any
+     * initialization. Instead, use `Highcharts.setOptions` to set it before any
      * chart is initialized.
      *
      * <pre>Highcharts.setOptions({

--- a/js/parts/PieSeries.js
+++ b/js/parts/PieSeries.js
@@ -946,7 +946,7 @@ seriesType('pie', 'line',
     }, /** @lends seriesTypes.pie.prototype.pointClass.prototype */ {
 
         /**
-     * Initiate the pie slice
+     * Initialize the pie slice
      *
      * @private
      * @function Highcharts.seriesTypes.pie#pointClass#init

--- a/js/parts/RangeSelector.js
+++ b/js/parts/RangeSelector.js
@@ -523,7 +523,7 @@ defaultOptions.lang = merge(
 
     /**
      * Language object. The language object is global and it can't be set
-     * on each chart initiation. Instead, use `Highcharts.setOptions` to
+     * on each chart initialization. Instead, use `Highcharts.setOptions` to
      * set it before any chart is initialized.
      *
      * <pre>Highcharts.setOptions({

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -2990,8 +2990,8 @@ H.Series = H.seriesType(
 
         /**
          * Set the series options by merging from the options tree. Called
-         * internally on initiating and updating series. This function will not
-         * redraw the series. For API usage, use {@link Series#update}.
+         * internally on initializing and updating series. This function will
+         * not redraw the series. For API usage, use {@link Series#update}.
          *
          * @function Highcharts.Series#setOptions
          *

--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -426,7 +426,7 @@ extend(SVGElement.prototype, /** @lends Highcharts.SVGElement.prototype */ {
 
     /**
      * Initialize the SVG element. This function only exists to make the
-     * initiation process overridable. It should not be called directly.
+     * initialization process overridable. It should not be called directly.
      *
      * @function Highcharts.SVGElement#init
      *
@@ -2535,7 +2535,7 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
     SVG_NS: SVG_NS,
 
     /**
-     * Initialize the SVGRenderer. Overridable initiator function that takes
+     * Initialize the SVGRenderer. Overridable initializer function that takes
      * the same parameters as the constructor.
      *
      * @function Highcharts.SVGRenderer#init

--- a/js/parts/Time.js
+++ b/js/parts/Time.js
@@ -254,7 +254,7 @@ Highcharts.Time.prototype = {
 
     /**
      * Update the Time object with current options. It is called internally on
-     * initiating Highcharts, after running `Highcharts.setOptions` and on
+     * initializing Highcharts, after running `Highcharts.setOptions` and on
      * `Chart.update`.
      *
      * @private


### PR DESCRIPTION
# Description
Fixed some cases of typos where the word `initialize` should have been used instead of `initiate`.