### PR TITLE
Fixed #9978, horizontal scrollbar on RTL charts with a11y module.

### DIFF
--- a/js/modules/keyboard-navigation.src.js
+++ b/js/modules/keyboard-navigation.src.js
@@ -1447,8 +1447,7 @@ H.Chart.prototype.addExitAnchor = function () {
     // Hide exit anchor
     merge(true, chart.tabExitAnchor.style, {
         position: 'absolute',
-        left: '-9999px',
-        top: 'auto',
+        top: '-999em',
         width: '1px',
         height: '1px',
         overflow: 'hidden'

--- a/js/modules/screen-reader.src.js
+++ b/js/modules/screen-reader.src.js
@@ -24,8 +24,7 @@ var win = H.win,
     // screen readers
     hiddenStyle = {
         position: 'absolute',
-        left: '-9999px',
-        top: 'auto',
+        top: '-999em',
         width: '1px',
         height: '1px',
         overflow: 'hidden'
@@ -729,7 +728,7 @@ H.Chart.prototype.addScreenReaderRegion = function (id, tableId) {
         hiddenSection = chart.screenReaderRegion = doc.createElement('div'),
         tableShortcut = doc.createElement('h4'),
         tableShortcutAnchor = doc.createElement('a'),
-        chartHeading = doc.createElement('h4');
+        chartHeading = chart.screenReaderHeading = doc.createElement('h4');
 
     hiddenSection.setAttribute('id', id);
     hiddenSection.setAttribute('role', 'region');


### PR DESCRIPTION
Changed hidden styles of screen reader elements to use negative `top` instead of `left` per Torstein's suggestion. `display: none` can not be used for these elements as it would hide them from screen readers.

Also exposed the heading screen reader element on the chart object as this was missing. (We'll consider rewriting the accessibility module to use the class pattern as part of the upcoming refactoring, so in that case these elements would all be stored on a chart's accessibility object. This would reduce cluttering of the chart object.)