### PR TITLE
bugfix/8660-drag-panes-resize-overlap

### DIFF
--- a/js/modules/drag-panes.src.js
+++ b/js/modules/drag-panes.src.js
@@ -403,6 +403,9 @@ H.AxisResizer.prototype = {
             plotHeight = chart.plotHeight,
             plotBottom = plotTop + plotHeight,
             yDelta,
+            calculatePercent = function (value) {
+                return value * 100 / plotHeight + '%';
+            },
             normalize = function (val, min, max) {
                 return Math.round(Math.min(Math.max(val, min), max));
             };
@@ -495,8 +498,8 @@ H.AxisResizer.prototype = {
                     axesConfigs.push({
                         axis: axis,
                         options: {
-                            top: Math.round(top),
-                            height: height
+                            top: calculatePercent(top - plotTop),
+                            height: calculatePercent(height)
                         }
                     });
                 } else {
@@ -513,7 +516,7 @@ H.AxisResizer.prototype = {
                     axesConfigs.push({
                         axis: axis,
                         options: {
-                            height: height
+                            height: calculatePercent(height)
                         }
                     });
                 }

--- a/samples/unit-tests/drag-panes/pointer-interactions/demo.js
+++ b/samples/unit-tests/drag-panes/pointer-interactions/demo.js
@@ -20,7 +20,8 @@ QUnit.test("Drag panes on zoomable chart", function (assert) {
             }]
         }),
         controller = new TestController(chart),
-        strartingNavYAxisLen = chart.yAxis[1].len;
+        strartingNavYAxisLen = chart.yAxis[1].len,
+        yAxisHeight;
 
     // Drag
     controller.pan([200, 190], [260, 100]);
@@ -36,5 +37,15 @@ QUnit.test("Drag panes on zoomable chart", function (assert) {
         0,
         0.5,
         "Zoom not triggered when dragging panes (#7563)"
+    );
+
+    // #8660
+    yAxisHeight = chart.yAxis[0].height;
+    chart.setSize(null, 300);
+
+    assert.notEqual(
+        yAxisHeight,
+        chart.yAxis[0].height,
+        "The height of the yAxis is proportionally adjusted after resize (#8660)"
     );
 });


### PR DESCRIPTION
Highstock: Fixed #8660, yAxes in separate panes were misaligned after panning and chart resize.