### PR TITLE
Fixed #9838, dissappearing traverseUpButton

### DIFF
--- a/js/modules/sunburst.src.js
+++ b/js/modules/sunburst.src.js
@@ -863,6 +863,9 @@ var sunburstSeries = {
         Series.prototype.translate.call(series);
         // @todo Only if series.isDirtyData is true
         tree = series.tree = series.getTree();
+
+        // Render traverseUpButton, after series.nodeMap i calculated.
+        series.renderTraverseUpButton(rootId);
         mapIdToNode = series.nodeMap;
         nodeRoot = mapIdToNode[rootId];
         idTop = isString(nodeRoot.parent) ? nodeRoot.parent : '';

--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -1163,6 +1163,7 @@ seriesType(
             // @todo Only if series.isDirtyData is true
             tree = series.tree = series.getTree();
             rootNode = series.nodeMap[rootId];
+            series.renderTraverseUpButton(rootId);
             series.mapOptionsToLevel = getLevelOptions({
                 from: rootNode.level + 1,
                 levels: options.levels,
@@ -1561,21 +1562,11 @@ seriesType(
              * directly.
              */
             var defaultFn = function (args) {
-                var series = args.series,
-                    newRootId = args.newRootId,
-                    nodeMap = series.nodeMap,
-                    node = nodeMap[newRootId];
+                var series = args.series;
 
                 // Store previous and new root ids on the series.
                 series.idPreviousRoot = args.previousRootId;
-                series.rootNode = newRootId;
-
-                // Remove or update the drill up button.
-                if (newRootId === '') {
-                    series.drillUpButton = series.drillUpButton.destroy();
-                } else {
-                    series.showDrillUpButton((node && node.name || newRootId));
-                }
+                series.rootNode = args.newRootId;
 
                 // Redraw the chart
                 series.isDirty = true; // Force redraw
@@ -1587,17 +1578,21 @@ seriesType(
             // Fire setRootNode event.
             fireEvent(series, 'setRootNode', eventArgs, defaultFn);
         },
-        showDrillUpButton: function (name) {
+        renderTraverseUpButton: function (rootId) {
             var series = this,
-                backText = (name || '< Back'),
+                nodeMap = series.nodeMap,
+                node = nodeMap[rootId],
+                name = node.name,
                 buttonOptions = series.options.traverseUpButton,
+                backText = pick(buttonOptions.text, name, '< Back'),
                 attr,
                 states;
 
-            if (buttonOptions.text) {
-                backText = buttonOptions.text;
-            }
-            if (!this.drillUpButton) {
+            if (rootId === '') {
+                if (series.drillUpButton) {
+                    series.drillUpButton = series.drillUpButton.destroy();
+                }
+            } else if (!this.drillUpButton) {
                 attr = buttonOptions.theme;
                 states = attr && attr.states;
 

--- a/samples/unit-tests/series-treemap/members/demo.js
+++ b/samples/unit-tests/series-treemap/members/demo.js
@@ -160,19 +160,9 @@ QUnit.module('setRootNode', () => {
         },
         nodeMap: {
             '': {},
-            A: { parent: '' }
+            A: { parent: '', name: 'A' }
         },
-        drillUpButton: {
-            name: undefined,
-            destroy: function () {
-                this.name = undefined;
-                return this;
-            }
-        },
-        rootNode: '',
-        showDrillUpButton: function (name) {
-            this.drillUpButton.name = name;
-        }
+        rootNode: ''
     };
 
     QUnit.test('should set property rootNode on the series.', assert => {
@@ -182,11 +172,6 @@ QUnit.module('setRootNode', () => {
             series.rootNode,
             'A',
             'Drill to A: Root node updated'
-        );
-        assert.strictEqual(
-            series.drillUpButton.name,
-            'A',
-            'Drill to A: drill up button displayed'
         );
         assert.strictEqual(
             series.chart.redrawed,
@@ -200,11 +185,6 @@ QUnit.module('setRootNode', () => {
             series.rootNode,
             '',
             'Drill to \'\': Root node updated'
-        );
-        assert.strictEqual(
-            series.drillUpButton.name,
-            undefined,
-            'Drill to \'\': drill up button destroyed'
         );
         assert.strictEqual(
             series.chart.redrawed,
@@ -290,4 +270,56 @@ QUnit.test('seriesTypes.treemap.onClickDrillToNode', function (assert) {
         '',
         'On click drill to \'\': point.state is updated.'
     );
+});
+
+QUnit.test('traverseUpButton', assert => {
+    const { treemap: options } = Highcharts.defaultOptions.plotOptions;
+    const { renderTraverseUpButton } = Highcharts.seriesTypes.treemap.prototype;
+    const { SVGRenderer } = Highcharts;
+    const container = document.getElementById('container');
+    const renderer = new SVGRenderer(
+        container,
+        200,
+        200
+    );
+    const series = {
+        chart: { renderer: renderer },
+        nodeMap: {
+            '': {},
+            A: { parent: '', name: 'A' }
+        },
+        options: options
+    };
+    const after = () => {
+        container.removeChild(renderer.box);
+        renderer.destroy();
+    };
+
+    // Render button when root id is ''
+    renderTraverseUpButton.call(series, '');
+    assert.strictEqual(
+        series.drillUpButton,
+        undefined,
+        'should destroy traverseUpButton when root id is \'\'.'
+    );
+
+    // Render button when root id is 'A'
+    renderTraverseUpButton.call(series, 'A');
+    assert.strictEqual(
+        series.drillUpButton.text.textStr,
+        'A',
+        'should set name to "A" when root is "A" and traverseUpButton.text is undefined.'
+    );
+
+    // Render button with custom text
+    series.options.traverseUpButton.text = 'My Custom Text';
+    renderTraverseUpButton.call(series, 'A');
+    assert.strictEqual(
+        series.drillUpButton.text.textStr,
+        'My Custom Text',
+        'should set name to "My Custom Text" when traverseUpButton.text is set to "My Custom Text".'
+    );
+
+    // Clean up after the tests
+    after();
 });


### PR DESCRIPTION
# Description
If `Series.update` is called after the user has traversed down a treemap, the `traverseUpButton` will dissapear. This is caused by the button is only rendered when `setRootNode` is called, which does not cover all scenarios. Solved by moving the rendering of the button to `Series.translate`.

# Example(s)
- [Demo of issue](https://jsfiddle.net/nvom2u13/)
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/ftLrj4d3/)

# Related issue(s)
- Closes #9838 