### PR TITLE
Bugfix/9479 treegrid addseries

### DIFF
--- a/js/parts-gantt/TreeGrid.js
+++ b/js/parts-gantt/TreeGrid.js
@@ -16,7 +16,8 @@ import Tree from './Tree.js';
 import mixinTreeSeries from '../mixins/tree-series.js';
 import '../modules/broken-axis.src.js';
 
-var argsToArray = function (args) {
+var addEvent = H.addEvent,
+    argsToArray = function (args) {
         return Array.prototype.slice.call(args, 1);
     },
     defined = H.defined,
@@ -88,7 +89,6 @@ var getTickPositions = function (axis) {
     return Object.keys(axis.mapOfPosToGridNode).reduce(
         function (arr, key) {
             var pos = +key;
-
             if (
                 axis.min <= pos &&
                 axis.max >= pos &&
@@ -287,6 +287,62 @@ var onTickHoverExit = function (label, options) {
 };
 
 /**
+ * Builds the tree of categories and calculates its positions.
+ *
+ * @param {object} e Event object
+ * @param {object} e.target The chart instance which the event was fired on.
+ * @param {object[]} e.target.axes The axes of the chart.
+ */
+var onBeforeRender = function (e) {
+    var chart = e.target,
+        axes = chart.axes;
+
+    axes
+        .filter(function (axis) {
+            return axis.options.type === 'treegrid';
+        })
+        .forEach(function (axis) {
+            var labelOptions = axis.options && axis.options.labels,
+                removeFoundExtremesEvent;
+
+            // setScale is fired after all the series is initialized,
+            // which is an ideal time to update the axis.categories.
+            axis.updateYNames();
+
+            // Update yData now that we have calculated the y values
+            // TODO: it would be better to be able to calculate y values
+            // before Series.setData
+            axis.series.forEach(function (series) {
+                series.yData = series.options.data.map(function (data) {
+                    return data.y;
+                });
+            });
+
+            // Calculate the label options for each level in the tree.
+            axis.mapOptionsToLevel = getLevelOptions({
+                defaults: labelOptions,
+                from: 1,
+                levels: labelOptions.levels,
+                to: axis.tree.height
+            });
+
+            // Collapse all the nodes belonging to a point where collapsed
+            // equals true.
+            // Can be called from beforeRender, if getBreakFromNode removes
+            // its dependency on axis.max.
+            removeFoundExtremesEvent =
+                H.addEvent(axis, 'foundExtremes', function () {
+                    axis.collapsedNodes.forEach(function (node) {
+                        var breaks = collapse(axis, node);
+
+                        axis.setBreaks(breaks, false);
+                    });
+                    removeFoundExtremesEvent();
+                });
+        });
+};
+
+/**
  * Creates a tree structure of the data, and the treegrid. Calculates
  * categories, and y-values of points based on the tree.
  *
@@ -464,51 +520,6 @@ var getTreeGridFromData = function (data, uniqueNames, numberOfSeries) {
     };
 };
 
-H.addEvent(H.Chart, 'beforeRender', function () {
-
-    this.axes.forEach(function (axis) {
-        if (axis.userOptions.type === 'treegrid') {
-            var labelOptions = axis.options && axis.options.labels,
-                removeFoundExtremesEvent;
-
-            // beforeRender is fired after all the series is initialized,
-            // which is an ideal time to update the axis.categories.
-            axis.updateYNames();
-
-            // Update yData now that we have calculated the y values
-            // TODO: it would be better to be able to calculate y values
-            // before Series.setData
-            axis.series.forEach(function (series) {
-                series.yData = series.options.data.map(function (data) {
-                    return data.y;
-                });
-            });
-
-            // Calculate the label options for each level in the tree.
-            axis.mapOptionsToLevel = getLevelOptions({
-                defaults: labelOptions,
-                from: 1,
-                levels: labelOptions.levels,
-                to: axis.tree.height
-            });
-
-            // Collapse all the nodes belonging to a point where collapsed
-            // equals true.
-            // Can be called from beforeRender, if getBreakFromNode removes
-            // its dependency on axis.max.
-            removeFoundExtremesEvent =
-                H.addEvent(axis, 'foundExtremes', function () {
-                    axis.collapsedNodes.forEach(function (node) {
-                        var breaks = collapse(axis, node);
-
-                        axis.setBreaks(breaks, false);
-                    });
-                    removeFoundExtremesEvent();
-                });
-        }
-    });
-});
-
 override(GridAxis.prototype, {
     init: function (proceed, chart, userOptions) {
         var axis = this,
@@ -516,6 +527,12 @@ override(GridAxis.prototype, {
 
         // Set default and forced options for TreeGrid
         if (isTreeGrid) {
+
+            // Add event for updating the categories of a treegrid.
+            // NOTE Preferably these events should be set on the axis.
+            addEvent(chart, 'beforeRender', onBeforeRender);
+            addEvent(chart, 'beforeRedraw', onBeforeRender);
+
             userOptions = merge({
                 // Default options
                 grid: {

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -4863,7 +4863,15 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
      */
     setScale: function () {
         var axis = this,
-            isDirtyData,
+            isDirtyData = axis.series.some(function (series) {
+                return (
+                    series.isDirtyData ||
+                    series.isDirty ||
+                    // When x axis is dirty, we need new data extremes for y as
+                    // well
+                    series.xAxis.isDirty
+                );
+            }),
             isDirtyAxisLength;
 
         axis.oldMin = axis.min;
@@ -4873,18 +4881,6 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
         // set the new axisLength
         axis.setAxisSize();
         isDirtyAxisLength = axis.len !== axis.oldAxisLength;
-
-        // is there new data?
-        axis.series.forEach(function (series) {
-            if (
-                series.isDirtyData ||
-                series.isDirty ||
-                // When x axis is dirty, we need new data extremes for y as well
-                series.xAxis.isDirty
-            ) {
-                isDirtyData = true;
-            }
-        });
 
         // do we really need to go through all this?
         if (

--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -558,10 +558,6 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             // set axes scales
             axes.forEach(function (axis) {
                 axis.updateNames();
-                // Update categories in a Gantt chart
-                if (axis.updateYNames) {
-                    axis.updateYNames();
-                }
                 axis.setScale();
             });
         }

--- a/samples/unit-tests/gantt/treegrid/demo.js
+++ b/samples/unit-tests/gantt/treegrid/demo.js
@@ -95,7 +95,7 @@ QUnit.test('Indentation', function (assert) {
 QUnit.test('Tree.getNode', function (assert) {
     var getNode = Highcharts.Axis.prototype.utils.getNode,
         mapOfIdToChildren = {
-            'test': [{
+            test: [{
                 start: 5,
                 end: 10
             }, {
@@ -138,7 +138,7 @@ QUnit.test('Tree.getNode', function (assert) {
     // Test aggregation of data from milestones.
     data = {};
     mapOfIdToChildren = {
-        'test': [{
+        test: [{
             start: 1,
             milestone: true
         }]
@@ -153,5 +153,64 @@ QUnit.test('Tree.getNode', function (assert) {
         node.data.end,
         1,
         'should use child.start as end if child is a milestone.'
+    );
+});
+
+QUnit.test('Chart.addSeries', assert => {
+    const chart = Highcharts.chart('container', {
+        yAxis: [{
+            type: 'treegrid'
+        }]
+    });
+    const series = {
+        data: [{
+            start: 1,
+            end: 2,
+            name: 'Category 1'
+        }, {
+            start: 0,
+            end: 3,
+            name: 'Category 2'
+        }, {
+            start: 2,
+            end: 3,
+            name: 'Category 3'
+        }]
+    };
+    const getYValues = ({ series }) => series.reduce(
+        (arr, series) => arr.concat(series.points.map(point => point.y)), []
+    );
+
+    assert.deepEqual(
+        getYValues(chart),
+        [],
+        'should y values in the chart should equal []'
+    );
+    assert.strictEqual(
+        chart.yAxis[0].min,
+        undefined,
+        'should have axis min equal to undefined when no series.'
+    );
+    assert.strictEqual(
+        chart.yAxis[0].max,
+        undefined,
+        'should have axis max equal to undefined.'
+    );
+
+    chart.addSeries(series);
+    assert.deepEqual(
+        getYValues(chart),
+        [0, 1, 2],
+        'should y values in the chart should equal [0, 1, 2]'
+    );
+    assert.strictEqual(
+        chart.yAxis[0].min,
+        0,
+        'should have axis min equal to 0.'
+    );
+    assert.strictEqual(
+        chart.yAxis[0].max,
+        2,
+        'should have axis min equal to 0.'
     );
 });


### PR DESCRIPTION
# Description
Treegrid axis did not update itself properly when dynamic methods like `Chart.addSeries` was called.
Solved by also listening to the `redraw` event on the chart, and run the the same logic as in the `beforeRender` event.

# Example(s)
- [Demo of issue](https://jsfiddle.net/jyuqxf5b/)
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/kjthrfn5/)

# Related issue(s)
- Closes #9479 
