### PR TITLE
bugfix/9209-unexpected-zoom-extremes-after-update

### DIFF
--- a/js/parts/RangeSelector.js
+++ b/js/parts/RangeSelector.js
@@ -962,8 +962,7 @@ RangeSelector.prototype = {
         // should be cleared (#9209)
         if (
             btnSelected === undefined &&
-            selected !== null &&
-            selected !== undefined
+            defined(selected)
         ) {
             rangeSelector.setSelected(null);
         } else if (

--- a/js/parts/RangeSelector.js
+++ b/js/parts/RangeSelector.js
@@ -875,7 +875,8 @@ RangeSelector.prototype = {
             selected = rangeSelector.selected,
             selectedExists = isNumber(selected),
             allButtonsEnabled = rangeSelector.options.allButtonsEnabled,
-            buttons = rangeSelector.buttons;
+            buttons = rangeSelector.buttons,
+            btnSelected;
 
         rangeSelector.buttonOptions.forEach(function (rangeOptions, i) {
             var range = rangeOptions._range,
@@ -948,6 +949,7 @@ RangeSelector.prototype = {
             } else if (select) {
                 selectedExists = true; // Only one button can be selected
                 state = 2;
+                btnSelected = i;
             }
 
             // If state has changed, update the button
@@ -955,6 +957,21 @@ RangeSelector.prototype = {
                 button.setState(state);
             }
         });
+
+        // When all buttons are unchecked selected property
+        // should be cleared (#9209)
+        if (
+            btnSelected === undefined &&
+            selected !== null &&
+            selected !== undefined
+        ) {
+            rangeSelector.setSelected(null);
+        } else if (
+            btnSelected !== undefined &&
+            btnSelected !== selected
+        ) {
+            rangeSelector.setSelected(btnSelected);
+        }
     },
 
     /**

--- a/samples/unit-tests/rangeselector/members/demo.js
+++ b/samples/unit-tests/rangeselector/members/demo.js
@@ -85,6 +85,24 @@ QUnit.test('RangeSelector.updateButtonStates', function (assert) {
         [0, 0, 2, 0, 0, 0],
         'allButtonsEnabled.'
     );
+
+    rangeSelector.setSelected = RangeSelector.prototype.setSelected;
+    rangeSelector.setSelected(1);
+
+    rangeSelector.chart.xAxis[0].min = now - (1.2 * month);
+    updateButtonStates.call(rangeSelector);
+
+    assert.deepEqual(
+        rangeSelector.selected,
+        null,
+        'rangeSelector.selected is cleared when all buttons are unchecked (#9209).'
+    );
+
+    assert.deepEqual(
+        rangeSelector.options.selected,
+        null,
+        'rangeSelector.options.selected is cleared when all buttons are unchecked (#9209).'
+    );
 });
 
 QUnit.test('RangeSelector.getYTDExtremes', function (assert) {


### PR DESCRIPTION
`rangeSelector.selected` and `rangeSelector.options.selected` were not cleared when all buttons were unchecked. After chart update, this option was used as a pre-selected button index what should be performed only on chart initialization.