### PR TITLE
docs/fix-doclets

### DIFF
--- a/js/parts-more/PackedBubbleSeries.js
+++ b/js/parts-more/PackedBubbleSeries.js
@@ -514,7 +514,7 @@ H.addEvent(H.Chart, 'beforeRedraw', function () {
  *
  * @extends   series,plotOptions.packedbubble
  * @excluding dataParser, dataURL, stack
- * @product   highcharts highstock
+ * @product   highcharts
  * @apioption series.packedbubble
  */
 

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -1019,7 +1019,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
              * `"justify"` labels inside the chart area. If there is room to
              * move it, it will be aligned to the edge, else it will be removed.
              *
-             * @type       {boolean|string}
+             * @type       {string}
              * @default    justify
              * @since      2.2.5
              * @validvalue ["allow", "justify"]

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -750,7 +750,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
          * maximum in axis values. The actual data extremes are found in
          * `event.dataMin` and `event.dataMax`.
          *
-         * @type      {Highcharts.AxisEventCallbackFunction}
+         * @type      {Highcharts.AxisSetExtremesEventCallbackFunction}
          * @since     2.3
          * @context   Axis
          * @apioption xAxis.events.afterSetExtremes

--- a/js/parts/Options.js
+++ b/js/parts/Options.js
@@ -135,11 +135,47 @@
  * @param {Highcharts.Chart} this
  *        The chart on which the event occured.
  *
- * @param {global.Event} event
+ * @param {global.ChartSelectionContextObject} event
  *        Event informations
  *
  * @return {boolean|undefined}
  *         Return false to prevent the default action, usually zoom.
+ */
+
+/**
+ * The primary axes are `xAxis[0]` and `yAxis[0]`. Remember the unit of a
+ * datetime axis is milliseconds since 1970-01-01 00:00:00.
+ *
+ * @interface Highcharts.ChartSelectionContextObject
+ * @extends global.Event
+ *//**
+ * Arrays containing the axes of each dimension and each axis' min and max
+ * values.
+ * @name Highcharts.ChartSelectionContextObject#xAxis
+ * @type {Array<Highcharts.ChartSelectionAxisContextObject>}
+ *//**
+ * Arrays containing the axes of each dimension and each axis' min and max
+ * values.
+ * @name Highcharts.ChartSelectionContextObject#yAxis
+ * @type {Array<Highcharts.ChartSelectionAxisContextObject>}
+ */
+
+/**
+ * Axis context of the selection.
+ *
+ * @interface Highcharts.ChartSelectionAxisContextObject
+ *//**
+ * The selected Axis.
+ * @name Highcharts.ChartSelectionAxisContextObject#axis
+ * @type {Highcharts.Axis}
+ *//**
+ * The maximum axis value, either automatic or set manually.
+ * @name Highcharts.ChartSelectionAxisContextObject#max
+ * @type {number}
+ *//**
+ * The minimum axis value, either automatic or set manually.
+ * @name Highcharts.ChartSelectionAxisContextObject#min
+ * @type {number}
  */
 
 /**

--- a/js/parts/Options.js
+++ b/js/parts/Options.js
@@ -1067,6 +1067,7 @@ H.defaultOptions = {
              * @sample {highstock} highcharts/chart/resetzoombutton-theme/
              *         Theming the button
              *
+             * @type {Highcharts.SVGAttributes}
              * @since 2.2
              */
             theme: {

--- a/js/parts/RangeSelector.js
+++ b/js/parts/RangeSelector.js
@@ -268,7 +268,7 @@ extend(defaultOptions, {
          * @sample {highstock} stock/rangeselector/styling/
          *         Styling the buttons and inputs
          *
-         * @type {Highcharts.CSSObject}
+         * @type {Highcharts.SVGAttributes}
          */
         buttonTheme: {
             /** @ignore */

--- a/js/parts/Time.js
+++ b/js/parts/Time.js
@@ -596,7 +596,7 @@ Highcharts.Time.prototype = {
                  *         Adding support for week number
                  *
                  * @name Highcharts.dateFormats
-                 * @type {Highcharts.Dictionary<Highcharts.TimeFormatCallbackFunction>|undefined}
+                 * @type {Highcharts.Dictionary<Highcharts.TimeFormatCallbackFunction>}
                  */
                 H.dateFormats
             );

--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -7,16 +7,6 @@
  * */
 
 /**
- * Reference to the global SVGElement class as a workaround for a name conflict
- * in the Highcharts namespace.
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGElement
- *
- * @global
- * @typedef {global.SVGElement} GlobalSVGElement
- */
-
-/**
  * An animation configuration. Animation configurations can also be defined as
  * booleans, where `false` turns off animation and `true` defaults to a duration
  * of 500ms.

--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -273,7 +273,7 @@
  * @interface Highcharts.SVGAttributes
  *//**
  * @name Highcharts.SVGAttributes#[key:string]
- * @type {boolean|number|string|Array<number|string>|undefined}
+ * @type {boolean|number|string|Array<number|string>|Dictionary<boolean|number|string|undefined>|undefined}
  *//**
  * @name Highcharts.SVGAttributes#d
  * @type {string|Highcharts.SVGPathArray|undefined}
@@ -283,9 +283,6 @@
  *//**
  * @name Highcharts.SVGAttributes#matrix
  * @type {Array<number>|undefined}
- *//**
- * @name Highcharts.SVGAttributes#stroke
- * @type {Highcharts.ColorString|undefined}
  *//**
  * @name Highcharts.SVGAttributes#rotation
  * @type {string|undefined}
@@ -301,6 +298,12 @@
  *//**
  * @name Highcharts.SVGAttributes#scaleY
  * @type {number|undefined}
+ *//**
+ * @name Highcharts.SVGAttributes#stroke
+ * @type {Highcharts.ColorString|undefined}
+ *//**
+ * @name Highcharts.SVGAttributes#style
+ * @type {string|Highcharts.CSSObject|undefined}
  *//**
  * @name Highcharts.SVGAttributes#translateX
  * @type {number|undefined}


### PR DESCRIPTION
Several fixes:
- Moved (DOM) SVGElement from Utilities.js to Globals.js (probably a merge restored it in Utilities.js)
- SVGAttributes dictionary supports now styles dictionary/string
- Fixed several theme types
- dateFormats is again always defined, but we need a decision to solve the problem (see #9920)
- Improved callback types
- Clarifies labels overflow option because of confusion with backwards compatible boolean type
