### PR TITLE
feature/networkgraph-hover-opacity

### DIFF
--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -497,25 +497,60 @@ seriesType('networkgraph', 'line', {
         return Series.prototype.destroy.apply(this, arguments);
     }
 }, {
-    init: function () {
-        Point.prototype.init.apply(this, arguments);
+    onMouseOver: function () {
+        if (this.series.draggable) {
+            H.css(this.series.chart.container, { cursor: 'move' });
+        }
 
-        addEvent(
-            this,
-            'mouseOver',
-            function () {
-                H.css(this.series.chart.container, { cursor: 'move' });
-            }
-        );
-        addEvent(
-            this,
-            'mouseOut',
-            function () {
-                H.css(this.series.chart.container, { cursor: 'default' });
-            }
-        );
+        this.series.nodes.forEach(function (node) {
+            node.graphic.attr({
+                opacity: 0.25
+            });
+        });
 
-        return this;
+        this.series.points.forEach(function (link) {
+            link.graphic.attr({
+                opacity: 0.25
+            });
+        });
+
+        this.linksFrom.forEach(function (link) {
+            link.graphic.attr({ opacity: 1 }).toFront();
+            link.toNode.graphic.attr({
+                opacity: 1
+            });
+        });
+        this.linksTo.forEach(function (link) {
+            link.graphic.attr({ opacity: 1 }).toFront();
+            link.fromNode.graphic.attr({
+                opacity: 1
+            });
+        });
+
+        this.graphic.attr({
+            opacity: 1
+        });
+
+        return Point.prototype.onMouseOver.apply(this, arguments);
+    },
+    onMouseOut: function () {
+        if (this.series.draggable) {
+            H.css(this.series.chart.container, { cursor: 'default' });
+        }
+
+        this.series.nodes.forEach(function (node) {
+            node.graphic.attr({
+                opacity: 1
+            });
+        });
+
+        this.series.points.forEach(function (link) {
+            link.graphic.attr({
+                opacity: 1
+            });
+        });
+
+        return Point.prototype.onMouseOut.apply(this, arguments);
     },
     getDegree: function () {
         var deg = this.isNode ? this.linksFrom.length + this.linksTo.length : 0;


### PR DESCRIPTION
Networkgraph: Added transparency to nodes that are not hovered. 

By highlighting only hovered nodes we greatly improve readability of the graph:
![screen shot 2019-02-04 at 12 32 43](https://user-images.githubusercontent.com/1453926/52205938-00bc3900-2879-11e9-9797-4e4d75b8de78.png)
![screen shot 2019-02-04 at 12 32 34](https://user-images.githubusercontent.com/1453926/52205939-00bc3900-2879-11e9-9459-ade6d37cac8b.png)


Demo: http://jsfiddle.net/BlackLabel/k4bs02gh/690/show

Issue: Where should we place an option (options?) to control this from API? Sounds like a `series/marker.states.hover`, but actually we change opacity of inactive nodes (and links). I'm open for suggestions here.