### PR TITLE
bugfix/9962-boost-outside-extremes-points

### DIFF
--- a/js/modules/boost.src.js
+++ b/js/modules/boost.src.js
@@ -1937,7 +1937,12 @@ function GLRenderer(postRenderCallback) {
                 continue;
             }
 
-            if (x >= xMin && x <= xMax) {
+            // The first point before and first after extremes should be
+            // rendered (#9962)
+            if (
+                (nx >= xMin || x >= xMin) &&
+                (px <= xMax || x <= xMax)
+            ) {
                 isXInside = true;
             }
 


### PR DESCRIPTION
Fixed #9962, line series was not rendered in the boost mode, when all points were outside the extremes.