### PR TITLE
bugfix/9994/navigator-wrong-min-with-ordinal

### DIFF
--- a/js/parts/Navigator.js
+++ b/js/parts/Navigator.js
@@ -1726,6 +1726,10 @@ Navigator.prototype = {
             navAxis = this.xAxis,
             navAxisOptions = navAxis.options,
             baseAxisOptions = baseAxis.options,
+            min = (navAxisOptions && navAxisOptions.ordinal) ?
+                null : baseAxisOptions.min,
+            max = (navAxisOptions && navAxisOptions.ordinal) ?
+                null : baseAxisOptions.max,
             ret;
 
         if (!returnFalseOnNoBaseSeries || baseAxis.dataMin !== null) {
@@ -1734,7 +1738,7 @@ Navigator.prototype = {
                     navAxisOptions && navAxisOptions.min,
                     numExt(
                         'min',
-                        baseAxisOptions.min,
+                        min, // #9994
                         baseAxis.dataMin,
                         navAxis.dataMin,
                         navAxis.min
@@ -1744,7 +1748,7 @@ Navigator.prototype = {
                     navAxisOptions && navAxisOptions.max,
                     numExt(
                         'max',
-                        baseAxisOptions.max,
+                        max, // #9994
                         baseAxis.dataMax,
                         navAxis.dataMax,
                         navAxis.max

--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -41,6 +41,32 @@ QUnit.test(
             0,
             'All series, including navSeries, removed without errors (#5581)'
         );
+
+        chart = Highcharts.stockChart('container', {
+            xAxis: {
+                min: 1318607700000
+            },
+            series: [{
+                data: [
+                    [1318607640000, 420.32],
+                    [1318607700000, 420.58],
+                    [1318607760000, 421.07],
+                    [1318607820000, 421.46],
+                    [1318607880000, 421.69],
+                    [1318607940000, 421.94]
+                ]
+            }]
+        });
+
+        chart.series[0].addPoint([1318608000000, 422.03], false, true);
+        chart.series[0].addPoint([1318608060000, 421.23], false, true);
+        chart.series[0].addPoint([1318608120000, 421.97], true, true);
+
+        assert.strictEqual(
+            chart.navigator.xAxis.min,
+            1318607820000,
+            'xAxis.min should be omitted in navigator when ordinal is enabled (#9994)'
+        );
     }
 );
 


### PR DESCRIPTION
`navigator.xAxis.min` was wrong with the main `xAxis.min` set and ordinal enabled after addPoint with a shift.