### PR TITLE
docs/10084-data-y-null

### DIFF
--- a/js/modules/cylinder.src.js
+++ b/js/modules/cylinder.src.js
@@ -122,7 +122,7 @@ seriesType(
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|Array<(number|string),number>|*>}
+ * @type      {Array<number|Array<(number|string),(number|null)>|null|*>}
  * @extends   series.column.data
  * @product   highcharts highstock
  * @apioption series.cylinder.data

--- a/js/modules/funnel.src.js
+++ b/js/modules/funnel.src.js
@@ -448,7 +448,7 @@ seriesType('funnel', 'pie',
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|*>}
+ * @type      {Array<number|null|*>}
  * @extends   series.pie.data
  * @excluding sliced
  * @product   highcharts
@@ -544,7 +544,7 @@ seriesType('pyramid', 'funnel',
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|*>}
+ * @type      {Array<number|null|*>}
  * @extends   series.pie.data
  * @excluding sliced
  * @product   highcharts

--- a/js/modules/sankey.src.js
+++ b/js/modules/sankey.src.js
@@ -822,7 +822,7 @@ seriesType('sankey', 'column'
 /**
  * The weight of the link.
  *
- * @type      {number}
+ * @type      {number|null}
  * @product   highcharts
  * @apioption series.sankey.data.weight
  */

--- a/js/modules/solid-gauge.src.js
+++ b/js/modules/solid-gauge.src.js
@@ -453,7 +453,7 @@ H.seriesType('solidgauge', 'gauge', solidGaugeOptions, {
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|*>}
+ * @type      {Array<number|null|*>}
  * @extends   series.gauge.data
  * @product   highcharts
  * @apioption series.solidgauge.data

--- a/js/modules/streamgraph.src.js
+++ b/js/modules/streamgraph.src.js
@@ -73,46 +73,44 @@ seriesType('streamgraph', 'areaspline'
  * An array of data points for the series. For the `streamgraph` series type,
  * points can be given in the following ways:
  *
- * 1.  An array of numerical values. In this case, the numerical values
- * will be interpreted as `y` options. The `x` values will be automatically
- * calculated, either starting at 0 and incremented by 1, or from `pointStart`
- * and `pointInterval` given in the series options. If the axis has
- * categories, these will be used. Example:
+ * 1. An array of numerical values. In this case, the numerical values will be
+ *    interpreted as `y` options. The `x` values will be automatically
+ *    calculated, either starting at 0 and incremented by 1, or from
+ *    `pointStart` and `pointInterval` given in the series options. If the axis
+ *    has categories, these will be used. Example:
+ *    ```js
+ *    data: [0, 5, 3, 5]
+ *    ```
  *
- *  ```js
- *  data: [0, 5, 3, 5]
- *  ```
+ * 2. An array of arrays with 2 values. In this case, the values correspond to
+ *    `x,y`. If the first value is a string, it is applied as the name of the
+ *    point, and the `x` value is inferred.
+ *    ```js
+ *        data: [
+ *            [0, 9],
+ *            [1, 7],
+ *            [2, 6]
+ *        ]
+ *    ```
  *
- * 2.  An array of arrays with 2 values. In this case, the values correspond
- * to `x,y`. If the first value is a string, it is applied as the name
- * of the point, and the `x` value is inferred.
- *
- *  ```js
- *     data: [
- *         [0, 9],
- *         [1, 7],
- *         [2, 6]
- *     ]
- *  ```
- *
- * 3.  An array of objects with named values. The following snippet shows only a
- * few settings, see the complete options set below. If the total number of data
- * points exceeds the series' [turboThreshold](#series.area.turboThreshold),
- * this option is not available.
- *
- *  ```js
- *     data: [{
- *         x: 1,
- *         y: 9,
- *         name: "Point2",
- *         color: "#00FF00"
- *     }, {
- *         x: 1,
- *         y: 6,
- *         name: "Point1",
- *         color: "#FF00FF"
- *     }]
- *  ```
+ * 3. An array of objects with named values. The following snippet shows only a
+ *    few settings, see the complete options set below. If the total number of
+ *    data points exceeds the series'
+ *    [turboThreshold](#series.area.turboThreshold),
+ *    this option is not available.
+ *    ```js
+ *        data: [{
+ *            x: 1,
+ *            y: 9,
+ *            name: "Point2",
+ *            color: "#00FF00"
+ *        }, {
+ *            x: 1,
+ *            y: 6,
+ *            name: "Point1",
+ *            color: "#FF00FF"
+ *        }]
+ *    ```
  *
  * @sample {highcharts} highcharts/chart/reflow-true/
  *         Numerical values
@@ -125,7 +123,7 @@ seriesType('streamgraph', 'areaspline'
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|Array<(number|string),number>|*>}
+ * @type      {Array<number|Array<(number|string),(number|null)>|null|*>}
  * @extends   series.line.data
  * @product   highcharts highstock
  * @apioption series.streamgraph.data

--- a/js/modules/sunburst.src.js
+++ b/js/modules/sunburst.src.js
@@ -983,7 +983,7 @@ var sunburstPoint = {
  */
 
 /**
- * @type      {Array<number|*>}
+ * @type      {Array<number|null|*>}
  * @extends   series.treemap.data
  * @excluding x, y
  * @product   highcharts
@@ -994,7 +994,7 @@ var sunburstPoint = {
  * The value of the point, resulting in a relative area of the point
  * in the sunburst.
  *
- * @type      {number}
+ * @type      {number|null}
  * @since     6.0.0
  * @product   highcharts
  * @apioption series.sunburst.data.value

--- a/js/modules/timeline.src.js
+++ b/js/modules/timeline.src.js
@@ -718,7 +718,7 @@ addEvent(H.Chart, 'afterHideOverlappingLabels', function () {
  * @sample {highcharts} highcharts/series-timeline/alternate-labels
  *         Alternate labels
  *
- * @type      {Array<number|*>}
+ * @type      {Array<*>}
  * @extends   series.line.data
  * @excluding marker, x, y
  * @product   highcharts

--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -1729,36 +1729,35 @@ seriesType(
  * An array of data points for the series. For the `treemap` series
  * type, points can be given in the following ways:
  *
- * 1.  An array of numerical values. In this case, the numerical values
- * will be interpreted as `value` options. Example:
+ * 1. An array of numerical values. In this case, the numerical values will be
+ *    interpreted as `value` options. Example:
+ *    ```js
+ *    data: [0, 5, 3, 5]
+ *    ```
  *
- *  ```js
- *  data: [0, 5, 3, 5]
- *  ```
- *
- * 2.  An array of objects with named values. The following snippet shows only a
- * few settings, see the complete options set below. If the total number of data
- * points exceeds the series' [turboThreshold](#series.treemap.turboThreshold),
- * this option is not available.
- *
- *  ```js
- *     data: [{
- *         value: 9,
- *         name: "Point2",
- *         color: "#00FF00"
- *     }, {
- *         value: 6,
- *         name: "Point1",
- *         color: "#FF00FF"
- *     }]
- *  ```
+ * 2. An array of objects with named values. The following snippet shows only a
+ *    few settings, see the complete options set below. If the total number of
+ *    data points exceeds the series'
+ *    [turboThreshold](#series.treemap.turboThreshold),
+ *    this option is not available.
+ *    ```js
+ *        data: [{
+ *            value: 9,
+ *            name: "Point2",
+ *            color: "#00FF00"
+ *        }, {
+ *            value: 6,
+ *            name: "Point1",
+ *            color: "#FF00FF"
+ *        }]
+ *    ```
  *
  * @sample {highcharts} highcharts/chart/reflow-true/
  *         Numerical values
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|*>}
+ * @type      {Array<number|null|*>}
  * @extends   series.heatmap.data
  * @excluding x, y
  * @product   highcharts
@@ -1769,7 +1768,7 @@ seriesType(
  * The value of the point, resulting in a relative area of the point
  * in the treemap.
  *
- * @type      {number}
+ * @type      {number|null}
  * @product   highcharts
  * @apioption series.treemap.data.value
  */

--- a/js/parts-map/MapBubbleSeries.js
+++ b/js/parts-map/MapBubbleSeries.js
@@ -223,32 +223,32 @@ if (seriesTypes.bubble) {
  * An array of data points for the series. For the `mapbubble` series
  * type, points can be given in the following ways:
  *
- * 1.  An array of numerical values. In this case, the numerical values
- * will be interpreted as `z` options. Example:
+ * 1. An array of numerical values. In this case, the numerical values
+ *    will be interpreted as `z` options. Example:
  *
- *  ```js
- *  data: [0, 5, 3, 5]
- *  ```
+ *    ```js
+ *    data: [0, 5, 3, 5]
+ *    ```
  *
- * 2.  An array of objects with named values. The following snippet shows only a
- * few settings, see the complete options set below. If the total number of data
- * points exceeds the series' [turboThreshold](
- * #series.mapbubble.turboThreshold),
- * this option is not available.
+ * 2. An array of objects with named values. The following snippet shows only a
+ *    few settings, see the complete options set below. If the total number of
+ *    data points exceeds the series'
+ *    [turboThreshold](#series.mapbubble.turboThreshold),
+ *    this option is not available.
  *
- *  ```js
- *     data: [{
- *         z: 9,
- *         name: "Point2",
- *         color: "#00FF00"
- *     }, {
- *         z: 10,
- *         name: "Point1",
- *         color: "#FF00FF"
- *     }]
- *  ```
+ *    ```js
+ *        data: [{
+ *            z: 9,
+ *            name: "Point2",
+ *            color: "#00FF00"
+ *        }, {
+ *            z: 10,
+ *            name: "Point1",
+ *            color: "#FF00FF"
+ *        }]
+ *    ```
  *
- * @type      {Array<number|*>}
+ * @type      {Array<number|null|*>}
  * @extends   series.mappoint.data
  * @excluding labelrank, middleX, middleY, path, value, x, y, lat, lon
  * @product   highmaps
@@ -263,7 +263,7 @@ if (seriesTypes.bubble) {
  * @sample {highmaps} maps/demo/map-bubble/
  *         Bubble
  *
- * @type      {number}
+ * @type      {number|null}
  * @product   highmaps
  * @apioption series.mapbubble.data.z
  */

--- a/js/parts-map/MapLineSeries.js
+++ b/js/parts-map/MapLineSeries.js
@@ -137,7 +137,7 @@ seriesType('mapline', 'map'
  *     }]
  *  ```
  *
- * @type      {Array<number|Array<string,number>|object>}
+ * @type      {Array<number|Array<string,(number|null)>|null|*>}
  * @product   highmaps
  * @apioption series.mapline.data
  */

--- a/js/parts-map/MapPointSeries.js
+++ b/js/parts-map/MapPointSeries.js
@@ -90,48 +90,46 @@ seriesType(
  * An array of data points for the series. For the `mappoint` series
  * type, points can be given in the following ways:
  *
- * 1.  An array of numerical values. In this case, the numerical values
- * will be interpreted as `y` options. The `x` values will be automatically
- * calculated, either starting at 0 and incremented by 1, or from `pointStart`
- * and `pointInterval` given in the series options. If the axis has
- * categories, these will be used. Example:
+ * 1. An array of numerical values. In this case, the numerical values will be
+ *    interpreted as `y` options. The `x` values will be automatically
+ *    calculated, either starting at 0 and incremented by 1, or from
+ *    `pointStart` and `pointInterval` given in the series options. If the axis
+ *    has categories, these will be used. Example:
+ *    ```js
+ *    data: [0, 5, 3, 5]
+ *    ```
  *
- *  ```js
- *  data: [0, 5, 3, 5]
- *  ```
+ * 2. An array of arrays with 2 values. In this case, the values correspond to
+ *    `x,y`. If the first value is a string, it is applied as the name of the
+ *    point, and the `x` value is inferred.
+ *    ```js
+ *        data: [
+ *            [0, 1],
+ *            [1, 8],
+ *            [2, 7]
+ *        ]
+ *    ```
  *
- * 2.  An array of arrays with 2 values. In this case, the values correspond
- * to `x,y`. If the first value is a string, it is applied as the name
- * of the point, and the `x` value is inferred.
+ * 3. An array of objects with named values. The following snippet shows only a
+ *    few settings, see the complete options set below. If the total number of
+ *    data points exceeds the series'
+ *    [turboThreshold](#series.mappoint.turboThreshold),
+ *    this option is not available.
+ *    ```js
+ *        data: [{
+ *            x: 1,
+ *            y: 7,
+ *            name: "Point2",
+ *            color: "#00FF00"
+ *        }, {
+ *            x: 1,
+ *            y: 4,
+ *            name: "Point1",
+ *            color: "#FF00FF"
+ *        }]
+ *    ```
  *
- *  ```js
- *     data: [
- *         [0, 1],
- *         [1, 8],
- *         [2, 7]
- *     ]
- *  ```
- *
- * 3.  An array of objects with named values. The following snippet shows only a
- * few settings, see the complete options set below. If the total number of data
- * points exceeds the series' [turboThreshold](#series.mappoint.turboThreshold),
- * this option is not available.
- *
- *  ```js
- *     data: [{
- *         x: 1,
- *         y: 7,
- *         name: "Point2",
- *         color: "#00FF00"
- *     }, {
- *         x: 1,
- *         y: 4,
- *         name: "Point1",
- *         color: "#FF00FF"
- *     }]
- *  ```
- *
- * @type      {Array<number|Array<number,number>|*>}
+ * @type      {Array<number|Array<number,(number|null)>|null|*>}
  * @extends   series.map.data
  * @excluding labelrank, middleX, middleY, path, value
  * @product   highmaps
@@ -181,7 +179,7 @@ seriesType(
  * @sample {highmaps} maps/demo/mapline-mappoint/
  *         Map point demo
  *
- * @type      {number}
+ * @type      {number|null}
  * @product   highmaps
  * @apioption series.mappoint.data.y
  */

--- a/js/parts-map/MapSeries.js
+++ b/js/parts-map/MapSeries.js
@@ -1130,43 +1130,41 @@ seriesType(
  * An array of data points for the series. For the `map` series type, points can
  * be given in the following ways:
  *
- * 1.  An array of numerical values. In this case, the numerical values will be
- * interpreted as `value` options. Example:
+ * 1. An array of numerical values. In this case, the numerical values will be
+ *    interpreted as `value` options. Example:
+ *    ```js
+ *    data: [0, 5, 3, 5]
+ *    ```
  *
- *  ```js
- *  data: [0, 5, 3, 5]
- *  ```
+ * 2. An array of arrays with 2 values. In this case, the values correspond to
+ *    `[hc-key, value]`. Example:
+ *    ```js
+ *        data: [
+ *            ['us-ny', 0],
+ *            ['us-mi', 5],
+ *            ['us-tx', 3],
+ *            ['us-ak', 5]
+ *        ]
+ *    ```
  *
- * 2.  An array of arrays with 2 values. In this case, the values correspond to
- * `[hc-key, value]`. Example:
+ * 3. An array of objects with named values. The following snippet shows only a
+ *    few settings, see the complete options set below. If the total number of
+ *    data points exceeds the series'
+ *    [turboThreshold](#series.map.turboThreshold),
+ *    this option is not available.
+ *    ```js
+ *        data: [{
+ *            value: 6,
+ *            name: "Point2",
+ *            color: "#00FF00"
+ *        }, {
+ *            value: 6,
+ *            name: "Point1",
+ *            color: "#FF00FF"
+ *        }]
+ *    ```
  *
- *  ```js
- *     data: [
- *         ['us-ny', 0],
- *         ['us-mi', 5],
- *         ['us-tx', 3],
- *         ['us-ak', 5]
- *     ]
- *  ```
- *
- * 3.  An array of objects with named values. The following snippet shows only a
- * few settings, see the complete options set below. If the total number of data
- * points exceeds the series' [turboThreshold](#series.map.turboThreshold), this
- * option is not available.
- *
- *  ```js
- *     data: [{
- *         value: 6,
- *         name: "Point2",
- *         color: "#00FF00"
- *     }, {
- *         value: 6,
- *         name: "Point1",
- *         color: "#FF00FF"
- *     }]
- *  ```
- *
- * @type      {Array<number|Array<string,number>|*>}
+ * @type      {Array<number|Array<string,(number|null)>|null|*>}
  * @product   highmaps
  * @apioption series.map.data
  */
@@ -1282,7 +1280,7 @@ seriesType(
 /**
  * The numeric value of the data point.
  *
- * @type      {number}
+ * @type      {number|null}
  * @product   highmaps
  * @apioption series.map.data.value
  */

--- a/js/parts-more/ColumnPyramidSeries.js
+++ b/js/parts-more/ColumnPyramidSeries.js
@@ -280,7 +280,7 @@ seriesType('columnpyramid', 'column'
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|Array<(number|string),number>|*>}
+ * @type      {Array<number|Array<(number|string),(number|null)>|null|*>}
  * @extends   series.line.data
  * @excluding marker
  * @product   highcharts highstock

--- a/js/parts-more/GaugeSeries.js
+++ b/js/parts-more/GaugeSeries.js
@@ -610,7 +610,7 @@ seriesType('gauge', 'line', {
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|*>}
+ * @type      {Array<number|null|*>}
  * @extends   series.line.data
  * @excluding drilldown, marker, x
  * @product   highcharts

--- a/js/parts-more/PackedBubbleSeries.js
+++ b/js/parts-more/PackedBubbleSeries.js
@@ -546,7 +546,7 @@ H.addEvent(H.Chart, 'beforeRedraw', function () {
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|*>}
+ * @type      {Array<number|null|*>}
  * @extends   series.line.data
  * @excluding marker,x,y
  * @product   highcharts

--- a/js/parts-more/PolygonSeries.js
+++ b/js/parts-more/PolygonSeries.js
@@ -144,7 +144,7 @@ seriesType('polygon', 'scatter', {
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|Array<(number|string),number>|*>}
+ * @type      {Array<number|Array<(number|string),(number|null)>|null|*>}
  * @extends   series.line.data
  * @product   highcharts highstock
  * @apioption series.polygon.data

--- a/js/parts-more/WaterfallSeries.js
+++ b/js/parts-more/WaterfallSeries.js
@@ -729,7 +729,7 @@ seriesType('waterfall', 'column', {
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|Array<(number|string),number>|*>}
+ * @type      {Array<number|Array<(number|string),(number|null)>|null|*>}
  * @extends   series.line.data
  * @excluding marker
  * @product   highcharts

--- a/js/parts/AreaSeries.js
+++ b/js/parts/AreaSeries.js
@@ -571,7 +571,7 @@ seriesType('area', 'line',
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|Array<(number|string),number>|*>}
+ * @type      {Array<number|Array<(number|string),(number|null)>|null|*>}
  * @extends   series.line.data
  * @product   highcharts highstock
  * @apioption series.area.data

--- a/js/parts/AreaSplineSeries.js
+++ b/js/parts/AreaSplineSeries.js
@@ -115,7 +115,7 @@ seriesType('areaspline', 'spline',
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|Array<(number|string),number>|*>}
+ * @type      {Array<number|Array<(number|string),(number|null)>|null|*>}
  * @extends   series.line.data
  * @product   highcharts highstock
  * @apioption series.areaspline.data

--- a/js/parts/BarSeries.js
+++ b/js/parts/BarSeries.js
@@ -110,7 +110,7 @@ seriesType('bar', 'column',
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|Array<(number|string),number>|*>}
+ * @type      {Array<number|Array<(number|string),(number|null)>|null|*>}
  * @extends   series.column.data
  * @product   highcharts
  * @apioption series.bar.data

--- a/js/parts/ColumnSeries.js
+++ b/js/parts/ColumnSeries.js
@@ -1076,7 +1076,7 @@ seriesType('column', 'line'
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|Array<(number|string),number>|*>}
+ * @type      {Array<number|Array<(number|string),(number|null)>|null|*>}
  * @extends   series.line.data
  * @excluding marker
  * @product   highcharts highstock

--- a/js/parts/PieSeries.js
+++ b/js/parts/PieSeries.js
@@ -1244,28 +1244,28 @@ seriesType('pie', 'line',
  * An array of data points for the series. For the `pie` series type,
  * points can be given in the following ways:
  *
- * 1.  An array of numerical values. In this case, the numerical values
- * will be interpreted as `y` options. Example:
+ * 1. An array of numerical values. In this case, the numerical values will be
+ *    interpreted as `y` options. Example:
+ *    ```js
+ *    data: [0, 5, 3, 5]
+ *    ```
  *
- *  ```js
- *  data: [0, 5, 3, 5]
- *  ```
- *
- * 2.  An array of objects with named values. The following snippet shows only a
- * few settings, see the complete options set below. If the total number of data
- * points exceeds the series' [turboThreshold](#series.pie.turboThreshold),
- * this option is not available.
- *
- *  ```js
- *     data: [{
- *     y: 1,
- *     name: "Point2",
- *     color: "#00FF00"
- * }, {
- *     y: 7,
- *     name: "Point1",
- *     color: "#FF00FF"
- * }]</pre>
+ * 2. An array of objects with named values. The following snippet shows only a
+ *    few settings, see the complete options set below. If the total number of
+ *    data points exceeds the series'
+ *    [turboThreshold](#series.pie.turboThreshold),
+ *    this option is not available.
+ *    ```js
+ *    data: [{
+ *        y: 1,
+ *        name: "Point2",
+ *        color: "#00FF00"
+ *    }, {
+ *        y: 7,
+ *        name: "Point1",
+ *        color: "#FF00FF"
+ *    }]
+ *    ```
  *
  * @sample {highcharts} highcharts/chart/reflow-true/
  *         Numerical values
@@ -1278,7 +1278,7 @@ seriesType('pie', 'line',
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|Array<string,number>|*>}
+ * @type      {Array<number|Array<string,(number|null)>|null|*>}
  * @extends   series.line.data
  * @excluding marker, x
  * @product   highcharts

--- a/js/parts/ScatterSeries.js
+++ b/js/parts/ScatterSeries.js
@@ -271,7 +271,7 @@ H.addEvent(Series, 'afterTranslate', function () {
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|Array<(number|string),number>|*>}
+ * @type      {Array<number|Array<(number|string),(number|null)>|null|*>}
  * @extends   series.line.data
  * @product   highcharts highstock
  * @apioption series.scatter.data

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -5286,8 +5286,8 @@ H.Series = H.seriesType(
  * 3. An array of objects with named values. The following snippet shows only a
  *    few settings, see the complete options set below. If the total number of
  *    data points exceeds the series'
- *    [turboThreshold](#series.line.turboThreshold), this option is not
- *    available.
+ *    [turboThreshold](#series.line.turboThreshold),
+ *    this option is not available.
  *    ```js
  *    data: [{
  *        x: 1,
@@ -5313,7 +5313,7 @@ H.Series = H.seriesType(
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|Array<(number|string),number>|*>}
+ * @type      {Array<number|Array<(number|string),(number|null)>|null|*>}
  * @apioption series.line.data
  */
 
@@ -5433,7 +5433,7 @@ H.Series = H.seriesType(
 /**
  * The y value of the point.
  *
- * @type      {number}
+ * @type      {number|null}
  * @product   highcharts highstock
  * @apioption series.line.data.y
  */

--- a/js/parts/SplineSeries.js
+++ b/js/parts/SplineSeries.js
@@ -233,8 +233,8 @@ seriesType(
  * 3. An array of objects with named values. The following snippet shows only a
  *    few settings, see the complete options set below. If the total number of
  *    data points exceeds the series'
- *    [turboThreshold](#series.spline.turboThreshold), this option is not
- *    available.
+ *    [turboThreshold](#series.spline.turboThreshold),
+ *    this option is not available.
  *    ```js
  *    data: [{
  *        x: 1,
@@ -260,7 +260,7 @@ seriesType(
  * @sample {highcharts} highcharts/series/data-array-of-objects/
  *         Config objects
  *
- * @type      {Array<number|Array<(number|string),number>|*>}
+ * @type      {Array<number|Array<(number|string),(number|null)>|null|*>}
  * @extends   series.line.data
  * @product   highcharts highstock
  * @apioption series.spline.data

--- a/test/typescript/highcharts.ts
+++ b/test/typescript/highcharts.ts
@@ -202,7 +202,7 @@ function test_seriesLine() {
         }, {
             type: 'line',
             name: 'Project Development',
-            data: [0, 0, 7988, 12169, 15112, 22452, 34400, 34227]
+            data: [null, { y: null }, 7988, 12169, 15112, 22452, 34400, 34227]
         }, {
             type: 'line',
             name: 'Other',

--- a/test/typescript/tsconfig.json
+++ b/test/typescript/tsconfig.json
@@ -19,12 +19,15 @@
         },
         "types": []
     },
+    "include": [
+        "../../test/typescript/classes/**/*.ts",
+        "../../test/typescript/issues/**/*.ts"
+    ],
     "files": [
         "../../code/highcharts.d.ts",
         "../../code/highcharts.src.d.ts",
         "../../test/typescript/globals.ts",
         "../../test/typescript/highcharts.ts",
-        "../../test/typescript/classes/Series.ts",
 
         "../../code/highcharts-3d.d.ts",
         "../../code/highcharts-3d.src.d.ts",


### PR DESCRIPTION
Added null as possible `value` / `y` / `z` value. Fixed #10084