### PR TITLE
docs/10078-resetZoomButton-theme

### DIFF
--- a/js/parts/Options.js
+++ b/js/parts/Options.js
@@ -1108,15 +1108,12 @@ H.defaultOptions = {
              * @sample {highstock} highcharts/chart/resetzoombutton-theme/
              *         Theming the button
              *
-             * @type {Highcharts.SVGAttributes}
-             * @since 2.2
+             * @type    {Highcharts.SVGAttributes}
+             * @default {"zIndex":6}
+             * @since   2.2
              */
             theme: {
-
-                /**
-                 * The Z index for the reset zoom button. The default value
-                 * places it below the tooltip that has Z index 7.
-                 */
+                /** @ignore-option */
                 zIndex: 6
             },
 


### PR DESCRIPTION
Changed theme option for resetZoomButton to a leaf node. Fixed #10078 