### PR TITLE
Added scripts get-filesizes and compare-filesizes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1312,6 +1312,14 @@ const uploadAPIDocs = () => {
 };
 gulp.task('upload-api', uploadAPIDocs);
 
+/**
+ * Usage: npx gulp get-filesizes --out old.json
+ *
+ * Options:
+ *   --file     Specify which files to get filesizes of. If not specified it
+ *              will default to all distributed files.
+ *   --out      Specify where to store the result. Defaults "./filesizes.json"
+ */
 gulp.task('get-filesizes', () => {
     const isSourceFile = path => (
         path.endsWith('.src.js') && !path.includes('es-modules')
@@ -1325,6 +1333,15 @@ gulp.task('get-filesizes', () => {
     return getFileSizes(files, out);
 });
 
+/**
+ * Usage: npx gulp compare-filesizes --old old.json --new new.json
+ *
+ * Options:
+ *   --old      Specify path to the "oldest" filesizes to compare. Required.
+ *   --new      Specify path to the "newest" filesizes to compare. Required.
+ *   --out      Specify where to store the resulting information. If not
+ *              specifyed then the information will be outputted to the console.
+ */
 gulp.task('compare-filesizes', () => {
     const out = argv.out;
     const pathOld = argv.old;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,6 +28,10 @@ const {
     scripts,
     getBuildScripts
 } = require('./tools/build.js');
+const {
+    getCompareFileSizeTable,
+    getFileSizes
+} = require('./tools/compareFilesize.js');
 const compile = require('./tools/compile.js').compile;
 const {
     copyFile,
@@ -1307,6 +1311,31 @@ const uploadAPIDocs = () => {
         });
 };
 gulp.task('upload-api', uploadAPIDocs);
+
+gulp.task('get-filesizes', () => {
+    const isSourceFile = path => (
+        path.endsWith('.src.js') && !path.includes('es-modules')
+    );
+    const jsFolder = './js/masters/';
+    const out = argv.out || './filesizes.json';
+    const files = argv.file ?
+        argv.file.split(',') :
+        getFilesInFolder(jsFolder, true, '').filter(isSourceFile);
+
+    return getFileSizes(files, out);
+});
+
+gulp.task('compare-filesizes', () => {
+    const out = argv.out;
+    const pathOld = argv.old;
+    const pathNew = argv.new;
+    if (!pathOld || !pathNew) {
+        throw new Error(
+            'This task requires paths to the files --old and --new'
+        );
+    }
+    return getCompareFileSizeTable(pathOld, pathNew, out);
+});
 
 const jsdocServer = () => {
     // Start a server serving up the api reference

--- a/tools/compareFilesize.js
+++ b/tools/compareFilesize.js
@@ -1,0 +1,125 @@
+/* eslint-disable func-style, no-confusing-arrow */
+const { getBuildScripts } = require('./build.js');
+const { compile } = require('./compile.js');
+const { sync: gzipSize } = require('gzip-size');
+const { getFile, writeFilePromise: writeFile } =
+    require('highcharts-assembler/src/utilities.js');
+const { join, resolve } = require('path');
+
+// TODO: write JSDoc
+const log = x => {
+    console.log(x); // eslint-disable-line no-console
+};
+
+// TODO: write JSDoc
+const pad = (x, length) => x.padEnd(length, ' ');
+
+// TODO: write JSDoc
+const getMaxStringLength = arr => arr
+    .reduce((max, str) => ((max > str.length) ? max : str.length), 0);
+
+// TODO: write JSDoc
+const formatColumn = (rows, length) => rows
+    .map(str => `| ${pad(str, length)} `);
+
+// TODO: write JSDoc
+const formatColumns = obj => {
+    const headers = Object.keys(obj);
+    headers.forEach(header => {
+        const length = getMaxStringLength(obj[header]);
+        const head = [header, '-'.repeat(length)];
+        obj[header] = formatColumn(
+            head.concat(obj[header]),
+            length
+        );
+    });
+
+    const length = obj[headers[0]].length;
+    const rows = Array.from({ length })
+        .map((_, i) => (
+            headers
+                .map(header => obj[header][i])
+                .join('')
+        ) + ' |');
+    rows.push('-'.repeat(rows[0].length));
+    return rows;
+};
+
+/**
+ * Creates a list of bytesize for the new file, old file, and the difference.
+ *
+ * @param {string} key The key to check againts. Can be gzip, compiled, or size.
+ * @param {object} oldFileSizes The map from filename to size for the old files.
+ * @param {object} newFileSizes The map from filename to size for the new files.
+ * @return {object} The map
+ */
+const getNewOldDiff = (key, oldFileSizes, newFileSizes) => Object
+    .keys(oldFileSizes)
+    .reduce((obj, filename) => {
+        const N = newFileSizes[filename][key];
+        const O = oldFileSizes[filename][key];
+        const D = N - O;
+        obj.New.push(N + ' B');
+        obj.Old.push(O + ' B');
+        obj.Diff.push(D + ' B');
+        return obj;
+    }, {
+        New: [],
+        Old: [],
+        Diff: []
+    });
+
+const getCompareFileSizeTable = (pathOld, pathNew, out) => {
+    const oldObj = require(resolve(pathOld));
+    const newObj = require(resolve(pathNew));
+
+    // Create columns for gzip, compiled and size
+    const gzip = getNewOldDiff('gzip', oldObj, newObj);
+    const compiled = getNewOldDiff('compiled', oldObj, newObj);
+    const size = getNewOldDiff('size', oldObj, newObj);
+
+    const columns = {
+        'Filename:': ['', ''].concat(Object.keys(oldObj)),
+        'Gzipped:': formatColumns(gzip),
+        'Compiled:': formatColumns(compiled),
+        'Size:': formatColumns(size)
+    };
+    const table = formatColumns(columns).join('\n');
+    return out ? writeFile(out, table) : Promise.resolve(log(table));
+};
+
+const getFileSizes = (files, out) => {
+    const sourceFolder = './code/';
+
+    // Output the result to the console, or a file if filePath is defined
+    const outputResult = (obj, filePath) => {
+        const str = JSON.stringify(obj, null, '  ');
+        return filePath ? writeFile(filePath, str) : Promise.resolve(log(str));
+    };
+
+    // Finds
+    const getSizeOfSourceCompiledAndGzip = filenames => filenames.reduce(
+        (obj, filename) => {
+            const compileName = filename.replace('.src.js', '.js');
+            const compiled = getFile(join(sourceFolder, compileName));
+            obj[filename] = {
+                gzip: gzipSize(compiled),
+                size: getFile(join(sourceFolder, filename)).length,
+                compiled: compiled.length
+            };
+            return obj;
+        },
+        {}
+    );
+
+    return Promise.resolve()
+        .then(getBuildScripts({ files }).fnFirstBuild)
+        .then(() => compile(files, sourceFolder))
+        .then(() => getSizeOfSourceCompiledAndGzip(files))
+        .then(result => outputResult(result, out));
+};
+
+module.exports = {
+    getCompareFileSizeTable,
+    getFileSizes
+};


### PR DESCRIPTION
# Description
Added two new utility scripts to gulp, `get-filesizes` and `compare-filesizes`.

**Note:** These scripts are similar to the `gulp filesize` script, and can achieve the same result.

## Arguments
`get-filesizes` has support for the following arguments:
- `--file`, specifyes which files get filesizes of. If not specified it will default to all distributed files.
- `--out`, specify where to store the result. Defaults `filesizes.json`

`compare-filesizes` has support for the following arguments:
- `--old`, specify path to the "oldest" filesizes to compare. Required.
- `--new`, specify path to the "newest" filesizes to compare. Required. 
- `--out`, specify where to store the resulting information. If not specifyed then the information will be outputted to the console.
 
## Example use case
```
npx gulp get-filesizes --out old.json
# Do wanted modifications to files before running the next commands
npx gulp get-filesizes --out new.json
npx gulp compare-filesizes --old old.json --new new.json
# Will output information about the filesizes for new vs old
```