### PR TITLE
Fixed #10031, Pie - dataLabels with useHTML: true, were generated with negative width.

### DIFF
--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -1651,7 +1651,8 @@ if (seriesTypes.pie) {
                     // after the pie has reached minSize (#223).
                     if (dataLabel.sideOverflow) {
                         dataLabel._attr.width =
-                            dataLabel.getBBox().width - dataLabel.sideOverflow;
+                            Math.max(dataLabel.getBBox().width -
+                            dataLabel.sideOverflow, 0);
 
                         dataLabel.css({
                             width: dataLabel._attr.width + 'px',

--- a/samples/unit-tests/series-pie/datalabel/demo.js
+++ b/samples/unit-tests/series-pie/datalabel/demo.js
@@ -1,5 +1,3 @@
-
-
 QUnit.test('Pie Point dataLabel distance (#1174)', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {
@@ -234,4 +232,35 @@ QUnit.test('Wide data labels', function (assert) {
     );
 });
 
+QUnit.test('Pie with long dataLabels with useHTML: true wrongly rendered', function (assert) {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            width: 100
+        },
+        series: [{
+            type: 'pie',
+            dataLabels: {
+                useHTML: true
+            },
+            data: [{
+                name: '<div>Test</div>',
+                y: 550
+            }, {
+                name: '<div>Testing two test test test test</div>',
+                y: 432
+            }, {
+                name: '<div>Testing s three</div>',
+                y: 320
+            }, {
+                name: '<div>Testing four test test</div>',
+                y: 210.009
+            }]
+        }]
+    });
 
+    assert.ok(
+        // eslint-disable-next-line no-underscore-dangle
+        chart.series[0].points[2].dataLabels[0]._attr.width >= 0,
+        'Data label width cannot be negative'
+    );
+});


### PR DESCRIPTION
Long dataLabels for pie with useHTML: true, were generated with the width less than 0.