### PR TITLE
bugfix/1289/multiple-panes-zoom

### DIFF
--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -449,7 +449,8 @@ extend(Chart.prototype, /** @lends Chart.prototype */ {
             hasZoomed,
             pointer = chart.pointer,
             displayButton = false,
-            mouseDownY = pointer.mouseDownY,
+            mouseDownPos =
+                chart.inverted ? pointer.mouseDownX : pointer.mouseDownY,
             resetZoomButton;
 
         // If zoom is called with no arguments, reset the axes
@@ -462,8 +463,9 @@ extend(Chart.prototype, /** @lends Chart.prototype */ {
         } else { // else, zoom in on all axes
             event.xAxis.concat(event.yAxis).forEach(function (axisData) {
                 var axis = axisData.axis,
-                    axisTop = axis.top,
-                    axisBottom = axisTop + axis.height,
+                    axisStartPos = chart.inverted ? axis.left : axis.top,
+                    axisEndPos = chart.inverted ?
+                        axisStartPos + axis.width : axisStartPos + axis.height,
                     isXAxis = axis.isXAxis,
                     isWithinPane = false;
 
@@ -471,10 +473,10 @@ extend(Chart.prototype, /** @lends Chart.prototype */ {
                 // In case of multiple panes only one pane should be zoomed.
                 if (
                     (!isXAxis &&
-                    mouseDownY >= axisTop &&
-                    mouseDownY <= axisBottom) ||
+                    mouseDownPos >= axisStartPos &&
+                    mouseDownPos <= axisEndPos) ||
                     isXAxis ||
-                    !H.defined(mouseDownY)
+                    !H.defined(mouseDownPos)
                 ) {
                     isWithinPane = true;
                 }

--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -449,6 +449,7 @@ extend(Chart.prototype, /** @lends Chart.prototype */ {
             hasZoomed,
             pointer = chart.pointer,
             displayButton = false,
+            mouseDownY = pointer.mouseDownY,
             resetZoomButton;
 
         // If zoom is called with no arguments, reset the axes
@@ -461,10 +462,25 @@ extend(Chart.prototype, /** @lends Chart.prototype */ {
         } else { // else, zoom in on all axes
             event.xAxis.concat(event.yAxis).forEach(function (axisData) {
                 var axis = axisData.axis,
-                    isXAxis = axis.isXAxis;
+                    axisTop = axis.top,
+                    axisBottom = axisTop + axis.height,
+                    isXAxis = axis.isXAxis,
+                    isWithinPane = false;
+
+                // Check if zoomed area is within the pane (#1289).
+                // In case of multiple panes only one pane should be zoomed.
+                if (
+                    (!isXAxis &&
+                    mouseDownY >= axisTop &&
+                    mouseDownY <= axisBottom) ||
+                    isXAxis ||
+                    !H.defined(mouseDownY)
+                ) {
+                    isWithinPane = true;
+                }
 
                 // don't zoom more than minRange
-                if (pointer[isXAxis ? 'zoomX' : 'zoomY']) {
+                if (pointer[isXAxis ? 'zoomX' : 'zoomY'] && isWithinPane) {
                     hasZoomed = axis.zoom(axisData.min, axisData.max);
                     if (axis.displayBtn) {
                         displayButton = true;

--- a/samples/unit-tests/chart/zoomtype/demo.js
+++ b/samples/unit-tests/chart/zoomtype/demo.js
@@ -358,3 +358,83 @@ QUnit.test('Zooming scatter charts', function (assert) {
     );
 
 });
+
+QUnit.test('Zooming chart with multiple panes', function (assert) {
+    var chart = Highcharts.stockChart('container', {
+        chart: {
+            zoomType: 'xy'
+        },
+        yAxis: [{
+            height: '60%'
+        }, {
+            top: '65%',
+            height: '35%'
+        }],
+        series: [{
+            type: 'candlestick',
+            name: 'AAPL',
+            data: [
+                [1543242600000, 174.24, 174.95, 170.26, 174.62],
+                [1543329000000, 171.51, 174.77, 170.88, 174.24],
+                [1543415400000, 176.73, 181.29, 174.93, 180.94],
+                [1543501800000, 182.66, 182.81, 177.78, 179.55],
+                [1543588200000, 180.29, 180.33, 177.03, 178.58],
+                [1543847400000, 184.46, 184.94, 181.21, 184.82]
+            ]
+        }, {
+            type: 'column',
+            name: 'Volume',
+            data: [
+                [1543242600000, 44998500],
+                [1543329000000, 41387400],
+                [1543415400000, 46062500],
+                [1543501800000, 41770000],
+                [1543588200000, 39531500],
+                [1543847400000, 40802500]
+            ],
+            yAxis: 1
+        }]
+    });
+
+    var controller = TestController(chart);
+
+    // Zoom on the first pane
+    controller.pan([100, 80], [200, 120]);
+
+    assert.deepEqual(
+        [
+            chart.yAxis[0].min,
+            chart.yAxis[0].max,
+            chart.yAxis[1].min,
+            chart.yAxis[1].max
+        ],
+        [
+            170,
+            185,
+            0,
+            50000000
+        ],
+        'y-zoom on the first pane did not affect y-zoom on the second pane (#1289)'
+    );
+
+    chart.zoomOut();
+
+    // Zoom on the second pane
+    controller.pan([50, 210], [550, 270]);
+
+    assert.deepEqual(
+        [
+            chart.yAxis[0].min,
+            chart.yAxis[0].max,
+            chart.yAxis[1].min,
+            chart.yAxis[1].max
+        ],
+        [
+            160,
+            190,
+            35000000,
+            45000000
+        ],
+        'y-zoom on the second pane did not affect y-zoom on the first pane (#1289)'
+    );
+});

--- a/samples/unit-tests/chart/zoomtype/demo.js
+++ b/samples/unit-tests/chart/zoomtype/demo.js
@@ -437,4 +437,80 @@ QUnit.test('Zooming chart with multiple panes', function (assert) {
         ],
         'y-zoom on the second pane did not affect y-zoom on the first pane (#1289)'
     );
+
+    chart = Highcharts.stockChart('container', {
+        chart: {
+            zoomType: 'y',
+            inverted: true
+        },
+        yAxis: [{
+            width: '60%'
+        }, {
+            left: '65%',
+            width: '35%'
+        }],
+        series: [{
+            type: 'candlestick',
+            name: 'AAPL',
+            data: [
+                [1543242600000, 174.24, 174.95, 170.26, 174.62],
+                [1543329000000, 171.51, 174.77, 170.88, 174.24],
+                [1543415400000, 176.73, 181.29, 174.93, 180.94],
+                [1543501800000, 182.66, 182.81, 177.78, 179.55],
+                [1543588200000, 180.29, 180.33, 177.03, 178.58],
+                [1543847400000, 184.46, 184.94, 181.21, 184.82]
+            ]
+        }, {
+            type: 'column',
+            name: 'Volume',
+            data: [
+                [1543242600000, 44998500],
+                [1543329000000, 41387400],
+                [1543415400000, 46062500],
+                [1543501800000, 41770000],
+                [1543588200000, 39531500],
+                [1543847400000, 40802500]
+            ],
+            yAxis: 1
+        }]
+    });
+
+    controller = TestController(chart);
+    controller.pan([180, 200], [250, 300]);
+
+    assert.deepEqual(
+        [
+            chart.yAxis[0].min,
+            chart.yAxis[0].max,
+            chart.yAxis[1].min,
+            chart.yAxis[1].max
+        ],
+        [
+            170,
+            175,
+            0,
+            60000000
+        ],
+        'y-zoom on the first pane did not affect y-zoom on the second pane when chart inverted (#1289)'
+    );
+
+    chart.zoomOut();
+
+    controller.pan([500, 200], [530, 300]);
+
+    assert.deepEqual(
+        [
+            chart.yAxis[0].min,
+            chart.yAxis[0].max,
+            chart.yAxis[1].min,
+            chart.yAxis[1].max
+        ],
+        [
+            165,
+            190,
+            39531499.5,
+            39531500.5
+        ],
+        'y-zoom on the second pane did not affect y-zoom on the first pane when chart inverted (#1289)'
+    );
 });


### PR DESCRIPTION
Wrong extremes on second pane yAxis when zoomed the first one. The solution is to zoom only the pane where an area was selected.