### PR TITLE
bugfix/10144-stocktools-remove-flags

### DIFF
--- a/js/modules/stock-tools-bindings.js
+++ b/js/modules/stock-tools-bindings.js
@@ -69,7 +69,7 @@ bindingsUtils.addFlagFromForm = function (type) {
     return function (e) {
         var navigation = this,
             chart = navigation.chart,
-            toolbar = chart.toolbar,
+            toolbar = chart.stockTools,
             getFieldType = bindingsUtils.getFieldType,
             point = bindingsUtils.attractToPoint(e, chart),
             pointConfig = {
@@ -110,12 +110,16 @@ bindingsUtils.addFlagFromForm = function (type) {
                                         ]
                                     },
                                     onSubmit: function (updated) {
-                                        point.update(
-                                            navigation.fieldsToOptions(
-                                                updated.fields,
-                                                {}
-                                            )
-                                        );
+                                        if (updated.actionType === 'remove') {
+                                            point.remove();
+                                        } else {
+                                            point.update(
+                                                navigation.fieldsToOptions(
+                                                    updated.fields,
+                                                    {}
+                                                )
+                                            );
+                                        }
                                     }
                                 }
                             );
@@ -1777,7 +1781,7 @@ var stockToolsBindings = {
                 lastVisiblePrice = options.lastVisiblePrice &&
                                 options.lastVisiblePrice.enabled,
                 lastPrice = options.lastPrice && options.lastPrice.enabled,
-                gui = this.chart.stockToolbar;
+                gui = this.chart.stockTools;
 
             if (gui && gui.guiEnabled) {
                 if (lastPrice) {
@@ -1856,7 +1860,7 @@ var stockToolsBindings = {
         className: 'highcharts-toggle-annotations',
         /** @ignore */
         init: function (button) {
-            var gui = this.chart.stockToolbar;
+            var gui = this.chart.stockTools;
 
             this.toggledAnnotations = !this.toggledAnnotations;
 

--- a/samples/unit-tests/stock-tools/bindings/demo.js
+++ b/samples/unit-tests/stock-tools/bindings/demo.js
@@ -142,36 +142,6 @@ QUnit.test('Bindings general tests', function (assert) {
         }
     );
 
-
-    // Flags tests:
-    // TO DO: Enable once Flag form will be ready
-    /*
-    Highcharts.each(
-        [
-            'flag-circlepin',
-            'flag-diamondpin',
-            'flag-squarepin',
-            'flag-simplepin'
-        ],
-        function (name) {
-            var seriesLength = chart.series.length;
-
-            selectButton(name);
-
-            controller.click(
-                points[2].plotX,
-                points[2].plotY
-            );
-
-            assert.strictEqual(
-                chart.series.length,
-                seriesLength + 1,
-                'Flag: ' + name + ' added without errors.'
-            );
-        }
-    );
-    */
-
     // Individual button events:
 
     // Current Price Indicator
@@ -339,9 +309,7 @@ QUnit.test('Bindings general tests', function (assert) {
     var button = document.querySelectorAll(
             '.highcharts-popup .highcharts-annotation-remove-button'
         )[0],
-        buttonOffset = Highcharts.offset(
-            button
-        );
+        buttonOffset = Highcharts.offset(button);
 
     controller.click(
         buttonOffset.left + 5,
@@ -356,6 +324,40 @@ QUnit.test('Bindings general tests', function (assert) {
         chart.navigationBindings.popup.container.style.display,
         'none',
         'Annotations toolbar hidden.'
+    );
+
+    // Test flags:
+    var seriesLength = chart.series.length;
+
+    selectButton('flag-circlepin');
+    // Register flag position
+    controller.click(
+        points[2].plotX,
+        points[2].plotY
+    );
+
+    // Styles in Karma are not loaded!
+    chart.navigationBindings.popup.container.style.position = 'absolute';
+    chart.navigationBindings.popup.container.style.top = '0px';
+    button = document.querySelectorAll(
+        '.highcharts-popup .highcharts-popup-bottom-row button'
+    )[0];
+    buttonOffset = Highcharts.offset(button);
+    controller.click(
+        buttonOffset.left + 5,
+        buttonOffset.top + 5
+    );
+
+    assert.strictEqual(
+        chart.series.length,
+        seriesLength + 1,
+        'Flag: flag-circlepin series created.'
+    );
+
+    assert.strictEqual(
+        chart.series[seriesLength].points.length,
+        1,
+        'Flag: no duplicated flags.'
     );
 
     // #9740:


### PR DESCRIPTION
Highstock: Fixed #10144, delete button in GUI did not work for flags.

Additionally, I realized flag series was added twice - bug introduced accidentally when moving bindings into annotations. Also fixed.