### PR TITLE
Fixed #10161, wrong extremes in single category axis

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -4690,7 +4690,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
 
             // Substract half a unit (#2619, #2846, #2515, #3390),
             // but not in case of multiple ticks (#6897)
-            if (this.single && tickPositions.length < 2 && !this.hasNames) {
+            if (this.single && tickPositions.length < 2 && !this.categories) {
                 this.min -= 0.5;
                 this.max += 0.5;
             }

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -3291,6 +3291,11 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
          */
         axis.min = null;
 
+        var tooltipCrosshairs = (
+            chart.options &&
+            chart.options.tooltip &&
+            chart.options.tooltip.crosshairs
+        );
         /**
          * The processed crosshair options.
          *
@@ -3299,7 +3304,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
          */
         axis.crosshair = pick(
             options.crosshair,
-            splat(chart.options.tooltip.crosshairs)[isXAxis ? 0 : 1],
+            splat(tooltipCrosshairs)[isXAxis ? 0 : 1],
             false
         );
 
@@ -4191,19 +4196,21 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
             if (linkedParent) {
                 minPointOffset = linkedParent.minPointOffset;
                 pointRangePadding = linkedParent.pointRangePadding;
+            } else if (hasCategories) {
+                pointRange = Math.max(pointRange, 1);
+                pointRangePadding = 1;
+                minPointOffset = 0.5;
             } else {
                 axis.series.forEach(function (series) {
-                    var seriesPointRange = hasCategories ?
-                            1 :
-                            (
-                                isXAxis ?
-                                    pick(
-                                        series.options.pointRange,
-                                        closestPointRange,
-                                        0
-                                    ) :
-                                    (axis.axisPointRange || 0)
-                            ), // #2806
+                    var seriesPointRange = (
+                            isXAxis ?
+                                pick(
+                                    series.options.pointRange,
+                                    closestPointRange,
+                                    0
+                                ) :
+                                (axis.axisPointRange || 0)
+                        ), // #2806
                         pointPlacement = series.options.pointPlacement;
 
                     pointRange = Math.max(pointRange, seriesPointRange);
@@ -4683,7 +4690,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
 
             // Substract half a unit (#2619, #2846, #2515, #3390),
             // but not in case of multiple ticks (#6897)
-            if (this.single && tickPositions.length < 2) {
+            if (this.single && tickPositions.length < 2 && !this.hasNames) {
                 this.min -= 0.5;
                 this.max += 0.5;
             }

--- a/samples/unit-tests/axis/members/demo.details
+++ b/samples/unit-tests/axis/members/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/axis/members/demo.html
+++ b/samples/unit-tests/axis/members/demo.html
@@ -1,4 +1,6 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/xrange.js"></script>
+<script src="https://code.highcharts.com/modules/static-scale.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/axis/members/demo.html
+++ b/samples/unit-tests/axis/members/demo.html
@@ -1,0 +1,6 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; height: 250px; margin: 0 auto"></div>

--- a/samples/unit-tests/axis/members/demo.js
+++ b/samples/unit-tests/axis/members/demo.js
@@ -1,19 +1,15 @@
 QUnit.test('setAxisTranslation', assert => {
-    const { Axis } = Highcharts;
-    const chart = {
-        axes: [],
-        xAxis: [{}],
-        yAxis: []
-    };
-    const axis = new Axis(chart, {
-        categories: ['Test'],
-        isX: false,
-        max: 0,
-        min: 0
+    const { yAxis: [axis] } = Highcharts.chart('container', {
+        yAxis: {
+            type: 'category',
+            categories: ['Category 1'],
+            staticScale: 50
+        },
+        series: [{
+            type: 'xrange',
+            data: [{ x: 1, x2: 2, y: 0 }]
+        }]
     });
-
-    axis.staticScale = 50;
-    axis.setAxisTranslation();
 
     assert.strictEqual(
         axis.minPointOffset,
@@ -38,16 +34,14 @@ QUnit.test('setAxisTranslation', assert => {
 });
 
 QUnit.test('setTickPositions', assert => {
-    const { Axis } = Highcharts;
-    const axis = Object.assign({}, Axis.prototype, {
-        options: {
-            tickPositions: ['Test']
-        },
-        min: 0,
-        max: 0
+    const chart = Highcharts.chart('container', {
+        series: [{
+            type: 'xrange',
+            data: [{ x: 0, x2: 1, y: 0 }]
+        }]
     });
+    const axis = chart.yAxis[0];
 
-    axis.setTickPositions();
     assert.strictEqual(
         axis.max,
         0.5,
@@ -62,9 +56,12 @@ QUnit.test('setTickPositions', assert => {
     /**
      * Should not modify min and max when axis type is category.
      */
-    axis.categories = ['Test'];
-    axis.min = axis.max = 0;
-    axis.setTickPositions();
+    chart.update({
+        yAxis: {
+            type: 'category',
+            categories: ['Category 1']
+        }
+    });
     assert.strictEqual(
         axis.max,
         0,

--- a/samples/unit-tests/axis/members/demo.js
+++ b/samples/unit-tests/axis/members/demo.js
@@ -62,7 +62,7 @@ QUnit.test('setTickPositions', assert => {
     /**
      * Should not modify min and max when axis type is category.
      */
-    axis.hasNames = true;
+    axis.categories = ['Test'];
     axis.min = axis.max = 0;
     axis.setTickPositions();
     assert.strictEqual(

--- a/samples/unit-tests/axis/members/demo.js
+++ b/samples/unit-tests/axis/members/demo.js
@@ -1,0 +1,78 @@
+QUnit.test('setAxisTranslation', assert => {
+    const { Axis } = Highcharts;
+    const chart = {
+        axes: [],
+        xAxis: [{}],
+        yAxis: []
+    };
+    const axis = new Axis(chart, {
+        categories: ['Test'],
+        isX: false,
+        max: 0,
+        min: 0
+    });
+
+    axis.staticScale = 50;
+    axis.setAxisTranslation();
+
+    assert.strictEqual(
+        axis.minPointOffset,
+        0.5,
+        'should have minPointOffset equal 0.5 when type is "category".'
+    );
+    assert.strictEqual(
+        axis.pointRangePadding,
+        1,
+        'should have pointRangePadding equal 1 when type is "category".'
+    );
+    assert.strictEqual(
+        axis.pointRange,
+        0,
+        'should have pointRange equal 0 when min and max is 0.'
+    );
+    assert.strictEqual(
+        axis.minPixelPadding,
+        25,
+        'should have minPixelPadding equal 25 when staticScale is 50 and minPointOffset is 0.5.'
+    );
+});
+
+QUnit.test('setTickPositions', assert => {
+    const { Axis } = Highcharts;
+    const axis = Object.assign({}, Axis.prototype, {
+        options: {
+            tickPositions: ['Test']
+        },
+        min: 0,
+        max: 0
+    });
+
+    axis.setTickPositions();
+    assert.strictEqual(
+        axis.max,
+        0.5,
+        'should have max equal 0.5 when only 1 point and tickPositions.length < 2.'
+    );
+    assert.strictEqual(
+        axis.min,
+        -0.5,
+        'should have min equal -0.5 when only 1 point and tickPositions.length < 2.'
+    );
+
+    /**
+     * Should not modify min and max when axis type is category.
+     */
+    axis.hasNames = true;
+    axis.min = axis.max = 0;
+    axis.setTickPositions();
+    assert.strictEqual(
+        axis.max,
+        0,
+        'should have min equal 0 when only 1 point, tickPositions.length < 2, and hasNames is true.'
+    );
+    assert.strictEqual(
+        axis.min,
+        0,
+        'should have max equal 0 when only 1 point, tickPositions.length < 2, and hasNames is true..'
+    );
+});


### PR DESCRIPTION
# Description
When the axis is of type category and there is only a single category, then it will modify the extremes to center the point. This causes the grid axis align its labels and lines incorrectly.

# Example(s)
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/0mbg7z56/)
- [Demo of issue](https://jsfiddle.net/hiroko3/9ftmnh5o/81/)
- [Demo of single category as is today](https://jsfiddle.net/jon_a_nygaard/d5w163fk/)
- [Demo of single category with fix applied](https://jsfiddle.net/jon_a_nygaard/2mekqtyp/)

# Related issue(s)
- Closes #10161 