### PR TITLE
bugfix/10163-networkgraph-setdata

### DIFF
--- a/js/mixins/nodes.js
+++ b/js/mixins/nodes.js
@@ -1,6 +1,7 @@
 import H from '../parts/Globals.js';
 
-var pick = H.pick;
+var pick = H.pick,
+    defined = H.defined;
 
 H.NodesMixin = {
     // Create a single node that holds information on incoming and outgoing
@@ -84,5 +85,79 @@ H.NodesMixin = {
             this.nodes.push(node);
         }
         return node;
+    },
+
+    // Extend generatePoints by adding the nodes, which are Point objects
+    // but pushed to the this.nodes array.
+    generatePoints: function () {
+        var nodeLookup = {},
+            chart = this.chart;
+
+        H.Series.prototype.generatePoints.call(this);
+
+        if (!this.nodes) {
+            this.nodes = []; // List of Point-like node items
+        }
+        this.colorCounter = 0;
+
+        // Reset links from previous run
+        this.nodes.forEach(function (node) {
+            node.linksFrom.length = 0;
+            node.linksTo.length = 0;
+        });
+
+        // Create the node list and set up links
+        this.points.forEach(function (point) {
+            if (defined(point.from)) {
+                if (!nodeLookup[point.from]) {
+                    nodeLookup[point.from] = this.createNode(point.from);
+                }
+                nodeLookup[point.from].linksFrom.push(point);
+                point.fromNode = nodeLookup[point.from];
+
+                // Point color defaults to the fromNode's color
+                if (chart.styledMode) {
+                    point.colorIndex = pick(
+                        point.options.colorIndex,
+                        nodeLookup[point.from].colorIndex
+                    );
+                } else {
+                    point.color =
+                        point.options.color || nodeLookup[point.from].color;
+                }
+
+            }
+            if (defined(point.to)) {
+                if (!nodeLookup[point.to]) {
+                    nodeLookup[point.to] = this.createNode(point.to);
+                }
+                nodeLookup[point.to].linksTo.push(point);
+                point.toNode = nodeLookup[point.to];
+            }
+
+            point.name = point.name || point.id; // for use in formats
+        }, this);
+
+        // Store lookup table for later use
+        this.nodeLookup = nodeLookup;
+    },
+
+    // Destroy all nodes on setting new data
+    setData: function () {
+        if (this.nodes) {
+            this.nodes.forEach(function (node) {
+                node.destroy();
+            });
+            this.nodes.length = 0;
+        }
+        H.Series.prototype.setData.apply(this, arguments);
+    },
+
+    // Destroy alll nodes and links
+    destroy: function () {
+        // Nodes must also be destroyed (#8682, #9300)
+        this.data = [].concat(this.points, this.nodes);
+
+        return H.Series.prototype.destroy.apply(this, arguments);
     }
 };

--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -757,14 +757,18 @@ addEvent(
                                 chart.container,
                                 'mousemove',
                                 function (e) {
-                                    return point.series.onMouseMove(point, e);
+                                    return point &&
+                                        point.series &&
+                                        point.series.onMouseMove(point, e);
                                 }
                             ));
                             unbinders.push(addEvent(
                                 chart.container.ownerDocument,
                                 'mouseup',
                                 function (e) {
-                                    return point.series.onMouseUp(point, e);
+                                    return point &&
+                                        point.series &&
+                                        point.series.onMouseUp(point, e);
                                 }
                             ));
                         }

--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -532,12 +532,25 @@ seriesType('networkgraph', 'line', {
         }
     },
     /**
+     * Destroy all nodes (points), generatePoints() will take care of creating
+     * them again.
+     */
+    setData: function () {
+        if (this.nodes) {
+            this.nodes.forEach(function (node) {
+                node.destroy();
+            });
+            this.nodes.length = 0;
+        }
+
+        Series.prototype.setData.apply(this, arguments);
+    },
+    /**
      * Destroy all nodes (points) that were created for this series.
      */
     destroy: function () {
-        this.nodes.forEach(function (node) {
-            node.destroy();
-        });
+        this.data = [].concat(this.points, this.nodes);
+
         return Series.prototype.destroy.apply(this, arguments);
     }
 }, {
@@ -664,23 +677,10 @@ seriesType('networkgraph', 'line', {
             to.plotY
         ];*/
     },
-    /**
-     * Remove point, first from the layout, then run original method.
-     *
-     * @return {undefined}
-     */
-    remove: function () {
-        if (this.isNode) {
-            this.series.layout.removeNode(this);
-        } else {
-            this.series.layout.removeLink(this);
-        }
-
-        return Point.prototype.remove.apply(this, arguments);
-    },
 
     /**
      * Destroy point. If it's a node, remove all links coming out of this node.
+     * Then remove point from the layout.
      *
      * @return {undefined}
      */
@@ -693,6 +693,9 @@ seriesType('networkgraph', 'line', {
                     }
                 }
             );
+            this.series.layout.removeNode(this);
+        } else {
+            this.series.layout.removeLink(this);
         }
 
         return Point.prototype.destroy.apply(this, arguments);

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.js
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.js
@@ -85,4 +85,12 @@ QUnit.test('Network Graph', function (assert) {
         '2,6',
         'Custom series.data.dashStyle is correct (#9798)'
     );
+
+    chart.series[1].setData([['XX', 'XY']]);
+
+    assert.strictEqual(
+        chart.series[1].nodes.length,
+        2,
+        'Correct number of nodes (#10163)'
+    );
 });


### PR DESCRIPTION
Fixed #10163, `series.setData()` did not remove old nodes for a networkgraph.

I know, this fix will be delayed until v7.1, but we will have conflicts otherwise. 