### PR TITLE
bugfix/10192-sma-volume-pane

### DIFF
--- a/js/modules/stock-tools-bindings.js
+++ b/js/modules/stock-tools-bindings.js
@@ -240,6 +240,8 @@ bindingsUtils.manageIndicators = function (data) {
             }, false, false);
             seriesConfig.yAxis = yAxis.options.id;
             navigation.resizeYAxes();
+        } else {
+            seriesConfig.yAxis = chart.get(data.linkedTo).options.yAxis;
         }
 
         if (indicatorsWithVolume.indexOf(data.type) >= 0) {


### PR DESCRIPTION
Highstock: Fixed #10192, technical indicators added via stock tools for a volume series were rendered on a wrong yAxis.