### PR TITLE
bugfix/10201-stocktools-stochastic-pane

### DIFF
--- a/js/modules/stock-tools-bindings.js
+++ b/js/modules/stock-tools-bindings.js
@@ -186,6 +186,7 @@ bindingsUtils.manageIndicators = function (data) {
             'ppo',
             'natr',
             'williamsr',
+            'stochastic',
             'linearRegression',
             'linearRegressionSlope',
             'linearRegressionIntercept',


### PR DESCRIPTION
Highstock: Fixed #10201, stochastic indicator did not open it's pane from GUI.