### PR TITLE
Fixed #10176, scrollbar error when collapsed treegrid

### DIFF
--- a/js/modules/broken-axis.src.js
+++ b/js/modules/broken-axis.src.js
@@ -205,10 +205,10 @@ Axis.prototype.setBreaks = function (breaks, redraw) {
                     breaks = this.options.breaks;
 
                 while ((axisBreak = findBreakAt(newMin, breaks))) {
-                    newMin = axisBreak.from;
+                    newMin = axisBreak.to;
                 }
                 while ((axisBreak = findBreakAt(newMax, breaks))) {
-                    newMax = axisBreak.to;
+                    newMax = axisBreak.from;
                 }
 
                 // If both min and max is within the same break.

--- a/js/modules/broken-axis.src.js
+++ b/js/modules/broken-axis.src.js
@@ -15,6 +15,7 @@ var addEvent = H.addEvent,
     pick = H.pick,
     extend = H.extend,
     isArray = H.isArray,
+    find = H.find,
     fireEvent = H.fireEvent,
     Axis = H.Axis,
     Series = H.Series;
@@ -29,7 +30,7 @@ var addEvent = H.addEvent,
  * false if no break is found.
  */
 var findBreakAt = function (x, breaks) {
-    return breaks.find(function (b) {
+    return find(breaks, function (b) {
         return b.from < x && x < b.to;
     });
 };

--- a/js/modules/broken-axis.src.js
+++ b/js/modules/broken-axis.src.js
@@ -19,6 +19,21 @@ var addEvent = H.addEvent,
     Axis = H.Axis,
     Series = H.Series;
 
+/**
+ * Returns the first break found where the x is larger then break.from and
+ * smaller then break.to.
+ *
+ * @param {number} x The number which should be within a break.
+ * @param {array} breaks The array of breaks to search within.
+ * @return {object|boolean} Returns the first break found that matches, returns
+ * false if no break is found.
+ */
+var findBreakAt = function (x, breaks) {
+    return breaks.find(function (b) {
+        return b.from < x && x < b.to;
+    });
+};
+
 extend(Axis.prototype, {
     isInBreak: function (brk, val) {
         var ret,
@@ -183,14 +198,22 @@ Axis.prototype.setBreaks = function (breaks, redraw) {
             animation,
             eventArguments
         ) {
-            // If trying to set extremes inside a break, extend it to before and
-            // after the break ( #3857 )
+            // If trying to set extremes inside a break, extend min to after,
+            // and max to before the break ( #3857 )
             if (this.isBroken) {
-                while (this.isInAnyBreak(newMin)) {
-                    newMin -= this.closestPointRange;
+                var axisBreak,
+                    breaks = this.options.breaks;
+
+                while ((axisBreak = findBreakAt(newMin, breaks))) {
+                    newMin = axisBreak.from;
                 }
-                while (this.isInAnyBreak(newMax)) {
-                    newMax -= this.closestPointRange;
+                while ((axisBreak = findBreakAt(newMax, breaks))) {
+                    newMax = axisBreak.to;
+                }
+
+                // If both min and max is within the same break.
+                if (newMax < newMin) {
+                    newMax = newMin;
                 }
             }
             Axis.prototype.setExtremes.call(


### PR DESCRIPTION
# Description
Setting extremes on the `yAxis` while it is broken will cause an error. This is due to the use of `closestPointRange` when modifying the `newMin` and `newMax`. `closestPointRange` is not set on `yAxis`.

Solved by looking at `from` and `to` on the axis breaks to modify the extremes instead.

This PR is not doing much to improve the usability of scrollbar with Gantt, but it solves the script error at least.

# Example(s)
Open a demo, click on "New Offices" to collapse it, then drag the scrollbar handle.
- [Demo of issue](https://jsfiddle.net/kr4c0wz3/)
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/zyw1r8Lj/)

# Related issue(s)
- Closes #9547 
- Closes #10176 