### PR TITLE
feature/10036-dataLabels-inside-pyramid

### DIFF
--- a/samples/unit-tests/series-funnel/funnel/demo.js
+++ b/samples/unit-tests/series-funnel/funnel/demo.js
@@ -1,4 +1,3 @@
-
 QUnit.test('Visible funnel items', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {
@@ -82,5 +81,120 @@ QUnit.test('Top path of funnel intact', function (assert) {
             }).length,
         14,
         'The path should have the neck intact (#8277)'
+    );
+});
+
+QUnit.test('Funnel dataLabels', function (assert) {
+    var chart = Highcharts.chart('container', {
+            chart: {
+                type: 'funnel'
+            },
+            plotOptions: {
+                series: {
+                    center: ['45%', '55%'],
+                    dataLabels: {
+                        inside: true,
+                        verticalAlign: 'center'
+                    },
+                    reversed: false,
+                    width: '50%'
+                }
+            },
+            series: [{
+                name: 'Unique users',
+                data: [
+                    ['Website visits', 5654],
+                    ['Downloads', 4064],
+                    ['Requested price list', 1987],
+                    ['Invoice sent', 1976],
+                    ['Finalized', 4201]
+                ]
+            }]
+        }),
+        series = chart.series[0],
+        point = series.points[2],
+        pointBBox = point.graphic.getBBox(),
+        pointWidth;
+
+    assert.strictEqual(
+        (point.dataLabel.x + point.dataLabel.width / 2).toFixed(4),
+        (pointBBox.x + pointBBox.width / 2).toFixed(4),
+        'DataLabels centered inside the funnel (#10036)'
+    );
+
+    series.update({
+        dataLabels: {
+            align: 'left'
+        }
+    });
+
+    point = series.points[2];
+    pointWidth = series.getWidthAt(point.plotY);
+
+    assert.strictEqual(
+        point.plotX - pointWidth / 2 + point.dataLabel.padding,
+        point.labelPosition.final.x,
+        'DataLabels inside the funnel and left aligned (#10036)'
+    );
+
+    series.update({
+        center: ['58%', '47%'],
+        reversed: true
+    });
+
+    point = series.points[2];
+    pointWidth = series.getWidthAt(2 * series.center[1] - point.plotY);
+
+    assert.strictEqual(
+        point.plotX - pointWidth / 2 + point.dataLabel.padding,
+        point.labelPosition.final.x,
+        'DataLabels aligned correctly when funnel is reversed (#10036)'
+    );
+
+    series.update({
+        dataLabels: {
+            align: 'right'
+        }
+    });
+
+    point = series.points[2];
+    pointWidth = series.getWidthAt(2 * series.center[1] - point.plotY);
+
+    assert.strictEqual(
+        point.plotX + pointWidth / 2 - point.dataLabel.padding - point.dataLabel.width,
+        point.labelPosition.final.x,
+        'DataLabels inside the funnel and right aligned (#10036)'
+    );
+
+    series.update({
+        dataLabels: {
+            verticalAlign: 'bottom'
+        }
+    });
+
+    point = series.points[2];
+    pointBBox = point.graphic.getBBox();
+
+    assert.strictEqual(
+        (pointBBox.y + pointBBox.height -
+        point.dataLabel.padding + point.dataLabel.options.y -
+        point.dataLabel.height).toFixed(4),
+        (point.labelPosition.final.y).toFixed(4),
+        'DataLabels inside the funnel and bottom aligned (#10036)'
+    );
+
+    series.update({
+        dataLabels: {
+            verticalAlign: 'top'
+        }
+    });
+
+    point = series.points[2];
+    pointBBox = point.graphic.getBBox();
+
+    assert.strictEqual(
+        (pointBBox.y + point.dataLabel.padding - point.dataLabel.options.y).toFixed(4),
+        (point.labelPosition.final.y).toFixed(4),
+        'DataLabels inside the funnel and top aligned (#10036)'
     );
 });


### PR DESCRIPTION
Added `dataLabels.inside` property in funnel and pyramid series types.

Now labels can be aligned inside points:

- vertically (top, center, bottom)

- horizontally (left, center, right)