### PR TITLE
bugfix/9917-pane-update

### DIFF
--- a/js/parts-more/Pane.js
+++ b/js/parts-more/Pane.js
@@ -382,8 +382,9 @@ extend(Pane.prototype, {
      * @param {boolean} redraw
      */
     update: function (options, redraw) {
-
         merge(true, this.options, options);
+        merge(true, this.chart.options.pane, options); // #9917
+
         this.setOptions(this.options);
         this.render();
         this.chart.axes.forEach(function (axis) {
@@ -393,7 +394,6 @@ extend(Pane.prototype, {
             }
         }, this);
     }
-
 });
 
 H.Pane = Pane;

--- a/samples/unit-tests/pane/pane-update/demo.js
+++ b/samples/unit-tests/pane/pane-update/demo.js
@@ -73,6 +73,12 @@ QUnit.test('Pane update, single', function (assert) {
         'New border width'
     );
 
+    assert.strictEqual(
+        chart.pane[0].options.endAngle,
+        chart.options.pane.endAngle,
+        'Pane options in chart options are updated (#9917)'
+    );
+
 });
 
 QUnit.test('Pane update through chart.update', function (assert) {


### PR DESCRIPTION
Fixed #9917, chart.update with initial pane options did not change the pane.

