### PR TITLE
bugfix/10160-stacking-null-points

### DIFF
--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -3641,6 +3641,14 @@ H.Series = H.seriesType(
                 );
 
                 // Calculate the bottom y value for stacked series
+                if (stacking) {
+                    stackIndicator = series.getStackIndicator(
+                        stackIndicator,
+                        xValue,
+                        series.index
+                    );
+                }
+
                 if (
                     stacking &&
                     series.visible &&
@@ -3648,11 +3656,6 @@ H.Series = H.seriesType(
                     stack &&
                     stack[xValue]
                 ) {
-                    stackIndicator = series.getStackIndicator(
-                        stackIndicator,
-                        xValue,
-                        series.index
-                    );
                     pointStack = stack[xValue];
                     stackValues = pointStack.points[stackIndicator.key];
                     yBottom = stackValues[0];

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -3641,14 +3641,6 @@ H.Series = H.seriesType(
                 );
 
                 // Calculate the bottom y value for stacked series
-                if (stacking) {
-                    stackIndicator = series.getStackIndicator(
-                        stackIndicator,
-                        xValue,
-                        series.index
-                    );
-                }
-
                 if (
                     stacking &&
                     series.visible &&
@@ -3656,8 +3648,16 @@ H.Series = H.seriesType(
                     stack &&
                     stack[xValue]
                 ) {
+                    stackIndicator = series.getStackIndicator(
+                        stackIndicator,
+                        xValue,
+                        series.index
+                    );
                     pointStack = stack[xValue];
                     stackValues = pointStack.points[stackIndicator.key];
+                }
+
+                if (isArray(stackValues)) {
                     yBottom = stackValues[0];
                     yValue = stackValues[1];
 

--- a/samples/unit-tests/series/stacking/demo.js
+++ b/samples/unit-tests/series/stacking/demo.js
@@ -223,21 +223,32 @@ QUnit.test('Updating to null value (#7493)', function (assert) {
     );
 
     chart.update({
+        chart: {
+            type: "column"
+        },
         xAxis: {
-            type: 'category'
+            type: "category"
+        },
+        plotOptions: {
+            series: {
+                stacking: "normal"
+            }
         },
         series: [{
-            type: 'column',
-            stacking: 'normal',
             data: [{
-                name: '2',
-                y: null
-            }, {
-                name: '2',
-                y: 2
+                name: "name1",
+                y: 27.06
             }]
+        }, {
+            data: [{
+                name: "name1",
+                y: 17.77
+            }, {
+                name: "name2",
+                y: 20.66
+            }, null]
         }]
-    });
+    }, true, true, false);
 
     assert.ok(true, 'Stacking the same column series with null values (#10160)');
 

--- a/samples/unit-tests/series/stacking/demo.js
+++ b/samples/unit-tests/series/stacking/demo.js
@@ -222,6 +222,25 @@ QUnit.test('Updating to null value (#7493)', function (assert) {
         'Graph should be broken after update with null'
     );
 
+    chart.update({
+        xAxis: {
+            type: 'category'
+        },
+        series: [{
+            type: 'column',
+            stacking: 'normal',
+            data: [{
+                name: '2',
+                y: null
+            }, {
+                name: '2',
+                y: 2
+            }]
+        }]
+    });
+
+    assert.ok(true, 'Stacking the same column series with null values (#10160)');
+
 });
 
 QUnit.test("StackLabels position with multiple yAxis (#7798)", function (assert) {


### PR DESCRIPTION
Fixed #10160, Stacking null points from the same series threw unhandled exception.

