### PR TITLE
feature/10036-datalabels-inside-funnel

### DIFF
--- a/js/modules/funnel.src.js
+++ b/js/modules/funnel.src.js
@@ -311,6 +311,13 @@ seriesType('funnel', 'pie',
                 point.plotY
             ];
 
+            point.dlBox = {
+                x: x3,
+                y: y1,
+                width: x4 - x3,
+                height: Math.abs(pick(y3, y5) - y1)
+            };
+
             // Slice is a noop on funnel points
             point.slice = noop;
 
@@ -394,8 +401,11 @@ seriesType('funnel', 'pie',
             };
         }
 
-        seriesTypes.pie.prototype.drawDataLabels.call(this);
-    }
+        seriesTypes[series.options.dataLabels.inside ? 'column' : 'pie']
+            .prototype.drawDataLabels.call(this);
+    },
+
+    alignDataLabel: seriesTypes.column.prototype.alignDataLabel
 
 });
 

--- a/js/modules/funnel.src.js
+++ b/js/modules/funnel.src.js
@@ -314,7 +314,8 @@ seriesType('funnel', 'pie',
             point.dlBox = {
                 x: x3,
                 y: y1,
-                width: x4 - x3,
+                topWidth: x2 - x1,
+                bottomWidth: x4 - x3,
                 height: Math.abs(pick(y3, y5) - y1)
             };
 
@@ -405,8 +406,74 @@ seriesType('funnel', 'pie',
             .prototype.drawDataLabels.call(this);
     },
 
-    alignDataLabel: seriesTypes.column.prototype.alignDataLabel
+    alignDataLabel: function (
+        point,
+        dataLabel,
+        options,
+        alignTo,
+        isNew
+    ) {
+        var series = point.series,
+            reversed = series.options.reversed,
+            dlBox = point.dlBox || point.shapeArgs,
+            align = options.align,
+            verticalAlign = options.verticalAlign,
+            centerY = series.center[1],
+            pointPlotY = reversed ? 2 * centerY - point.plotY : point.plotY,
+            widthAtLabel = series.getWidthAt(
+                pointPlotY - dlBox.height / 2 + dataLabel.height
+            ),
+            offset = verticalAlign === 'middle' ?
+                (dlBox.topWidth - dlBox.bottomWidth) / 4 :
+                (widthAtLabel - dlBox.bottomWidth) / 2,
+            y = dlBox.y,
+            x = dlBox.x;
 
+        if (verticalAlign === 'middle') {
+            y = dlBox.y - dlBox.height / 2 + dataLabel.height / 2;
+        } else if (verticalAlign === 'top') {
+            y = dlBox.y - dlBox.height + dataLabel.height +
+                options.padding;
+        }
+
+        if (
+            verticalAlign === 'top' && !reversed ||
+            verticalAlign === 'bottom' && reversed ||
+            verticalAlign === 'middle'
+        ) {
+            if (align === 'right') {
+                x = dlBox.x - options.padding + offset;
+            } else if (align === 'left') {
+                x = dlBox.x + options.padding - offset;
+            }
+        }
+
+        alignTo = {
+            x: x,
+            y: reversed ? y - dlBox.height : y,
+            width: dlBox.bottomWidth,
+            height: dlBox.height
+        };
+
+        options.verticalAlign = 'bottom';
+
+        // Call the parent method
+        Highcharts.Series.prototype.alignDataLabel.call(
+            this,
+            point,
+            dataLabel,
+            options,
+            alignTo,
+            isNew
+        );
+
+        // If label was justified and we have contrast, set it:
+        if (point.isLabelJustified && point.contrastColor) {
+            dataLabel.css({
+                color: point.contrastColor
+            });
+        }
+    }
 });
 
 

--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -1787,10 +1787,9 @@ if (seriesTypes.column) {
             series = point.series,
             // data label box for alignment
             dlBox = point.dlBox || point.shapeArgs,
-            yAxis = series.yAxis,
             below = pick(
                 point.below, // range series
-                point.plotY > pick(this.translatedThreshold, yAxis && yAxis.len)
+                point.plotY > pick(this.translatedThreshold, series.yAxis.len)
             ),
             // draw it inside the box?
             inside = pick(options.inside, !!this.options.stacking),
@@ -1804,12 +1803,12 @@ if (seriesTypes.column) {
                 alignTo.height += alignTo.y;
                 alignTo.y = 0;
             }
-            overshoot = yAxis ? alignTo.y + alignTo.height - yAxis.len : 0;
+            overshoot = alignTo.y + alignTo.height - series.yAxis.len;
             if (overshoot > 0) {
                 alignTo.height -= overshoot;
             }
 
-            if (inverted && yAxis) {
+            if (inverted) {
                 alignTo = {
                     x: series.yAxis.len - alignTo.y - alignTo.height,
                     y: series.xAxis.len - alignTo.x - alignTo.width,

--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -1787,9 +1787,10 @@ if (seriesTypes.column) {
             series = point.series,
             // data label box for alignment
             dlBox = point.dlBox || point.shapeArgs,
+            yAxis = series.yAxis,
             below = pick(
                 point.below, // range series
-                point.plotY > pick(this.translatedThreshold, series.yAxis.len)
+                point.plotY > pick(this.translatedThreshold, yAxis && yAxis.len)
             ),
             // draw it inside the box?
             inside = pick(options.inside, !!this.options.stacking),
@@ -1803,12 +1804,12 @@ if (seriesTypes.column) {
                 alignTo.height += alignTo.y;
                 alignTo.y = 0;
             }
-            overshoot = alignTo.y + alignTo.height - series.yAxis.len;
+            overshoot = yAxis ? alignTo.y + alignTo.height - yAxis.len : 0;
             if (overshoot > 0) {
                 alignTo.height -= overshoot;
             }
 
-            if (inverted) {
+            if (inverted && yAxis) {
                 alignTo = {
                     x: series.yAxis.len - alignTo.y - alignTo.height,
                     y: series.xAxis.len - alignTo.x - alignTo.width,

--- a/samples/unit-tests/series-funnel/funnel/demo.js
+++ b/samples/unit-tests/series-funnel/funnel/demo.js
@@ -1,4 +1,3 @@
-
 QUnit.test('Visible funnel items', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {
@@ -82,5 +81,145 @@ QUnit.test('Top path of funnel intact', function (assert) {
             }).length,
         14,
         'The path should have the neck intact (#8277)'
+    );
+});
+
+QUnit.test('Funnel dataLabels', function (assert) {
+    var chart = Highcharts.chart('container', {
+            chart: {
+                type: 'funnel'
+            },
+            plotOptions: {
+                series: {
+                    center: ['50%', '50%'],
+                    dataLabels: {
+                        inside: true,
+                        verticalAlign: 'middle'
+                    },
+                    reversed: false,
+                    width: '50%'
+                }
+            },
+            series: [{
+                name: 'Unique users',
+                data: [
+                    ['Website visits', 5654],
+                    ['Downloads', 4064],
+                    ['Requested price list', 1987],
+                    ['Invoice sent', 1976],
+                    ['Finalized', 4201]
+                ]
+            }]
+        }),
+        series = chart.series[0],
+        point = series.points[2],
+        pointBBox = point.graphic.getBBox(),
+        pointWidth;
+
+    assert.strictEqual(
+        Math.round(
+            pointBBox.x + pointBBox.width / 2 - point.dataLabel.width / 2
+        ),
+        point.dataLabel.x,
+        'DataLabels centered horizontally inside the funnel (#10036)'
+    );
+
+    series.update({
+        dataLabels: {
+            align: 'left'
+        }
+    });
+
+    point = series.points[2];
+    pointWidth = series.getWidthAt(point.plotY);
+
+    assert.strictEqual(
+        Math.round(point.plotX - pointWidth / 2 + point.dataLabel.padding),
+        point.dataLabel.x,
+        'DataLabels inside the funnel and left aligned (#10036)'
+    );
+
+    series.update({
+        center: ['58%', '47%'],
+        reversed: true
+    });
+
+    point = series.points[2];
+    pointWidth = series.getWidthAt(2 * series.center[1] - point.plotY);
+
+    assert.strictEqual(
+        Math.round(point.plotX - pointWidth / 2 + point.dataLabel.padding),
+        point.dataLabel.x,
+        'DataLabels aligned correctly when funnel is reversed (#10036)'
+    );
+
+    series.update({
+        dataLabels: {
+            align: 'right'
+        }
+    });
+
+    point = series.points[2];
+    pointWidth = series.getWidthAt(2 * series.center[1] - point.plotY);
+
+    assert.strictEqual(
+        Math.round(
+            point.plotX + pointWidth / 2 -
+            point.dataLabel.padding - point.dataLabel.width
+        ),
+        point.dataLabel.x,
+        'DataLabels inside the funnel and right aligned (#10036)'
+    );
+
+    series.update({
+        dataLabels: {
+            verticalAlign: 'bottom'
+        }
+    });
+
+    point = series.points[2];
+    pointBBox = point.graphic.getBBox();
+
+    assert.strictEqual(
+        Math.round(
+            pointBBox.y + pointBBox.height +
+            point.dataLabel.options.y - point.dataLabel.height
+        ),
+        point.dataLabel.y,
+        'DataLabels inside the funnel and bottom aligned (#10036)'
+    );
+
+    series.update({
+        dataLabels: {
+            verticalAlign: 'top'
+        }
+    });
+
+    point = series.points[4];
+    pointBBox = point.graphic.getBBox();
+
+    assert.strictEqual(
+        Math.round(
+            pointBBox.y + point.dataLabel.padding + point.dataLabel.options.y
+        ),
+        point.dataLabel.y,
+        'DataLabels inside the funnel and top aligned (#10036)'
+    );
+
+    series.update({
+        dataLabels: {
+            verticalAlign: 'middle'
+        }
+    });
+
+    point = series.points[1];
+    pointBBox = point.graphic.getBBox();
+
+    assert.strictEqual(
+        Math.round(
+            pointBBox.y + pointBBox.height / 2 - point.dataLabel.height / 2
+        ),
+        point.dataLabel.y,
+        'DataLabels inside the funnel and centered vertically (#10036)'
     );
 });


### PR DESCRIPTION
Borrowed implementation of `alignDataLabel` from the column series was not able to align labels properly in the funnel (reversed series etc). I managed to make it by adding `alignDataLabel` method to funnel with additional logic. Now only funnel module is extended.