### PR TITLE
Bugfix/10211 treegrid series show hide

### DIFF
--- a/js/modules/xrange.src.js
+++ b/js/modules/xrange.src.js
@@ -240,6 +240,7 @@ seriesType('xrange', 'column'
                 // Search in data, since broken-axis can remove points inside a
                 // break.
                 points = series.data,
+                oldData = series.points,
                 id = options.id,
                 point,
                 pointIndex;
@@ -255,7 +256,8 @@ seriesType('xrange', 'column'
                 point = points.find(function (point) {
                     return (
                         point.x === options.x &&
-                        point.x2 === options.x2
+                        point.x2 === options.x2 &&
+                        !(oldData[pointIndex] && oldData[pointIndex].touched)
                     );
                 });
                 pointIndex = point ? point.index : undefined;

--- a/js/modules/xrange.src.js
+++ b/js/modules/xrange.src.js
@@ -225,7 +225,49 @@ seriesType('xrange', 'column'
 
             return crop;
         },
+        /**
+         * Finds the index of an existing point that matches the given point
+         * options.
+         *
+         * @private
+         * @function Highcharts.Series#computePointIndex
+         * @param {object} options The options of the point.
+         * @returns {number|undefined} Returns index of a matching point,
+         * returns undefined if no match is found.
+         */
+        computePointIndex: function (options) {
+            var series = this,
+                // Search in data, since broken-axis can remove points inside a
+                // break.
+                points = series.data,
+                id = options.id,
+                point,
+                pointIndex;
 
+            if (id) {
+                point = points.find(function (point) {
+                    return point.id === id;
+                });
+                pointIndex = point ? point.index : undefined;
+            }
+
+            if (pointIndex === undefined) {
+                point = points.find(function (point) {
+                    return (
+                        point.x === options.x &&
+                        point.x2 === options.x2
+                    );
+                });
+                pointIndex = point ? point.index : undefined;
+            }
+
+            // Reduce pointIndex if data is cropped
+            if (series.cropped && pointIndex >= series.cropStart) {
+                pointIndex -= series.cropStart;
+            }
+
+            return pointIndex;
+        },
         /**
      * @private
      * @function Highcharts.Series#translatePoint

--- a/js/parts-gantt/TreeGrid.js
+++ b/js/parts-gantt/TreeGrid.js
@@ -310,12 +310,15 @@ var onBeforeRender = function (e) {
             axis.updateYNames();
 
             // Update yData now that we have calculated the y values
-            // TODO: it would be better to be able to calculate y values
-            // before Series.setData
             axis.series.forEach(function (series) {
-                series.yData = series.options.data.map(function (data) {
-                    return data.y;
+                var data = series.options.data.map(function (d) {
+                    return isObject(d) ? merge(d) : d;
                 });
+
+                // Avoid destroying points when series is not visible
+                if (series.visible) {
+                    series.setData(data, false);
+                }
             });
 
             // Calculate the label options for each level in the tree.

--- a/js/parts-gantt/TreeGrid.js
+++ b/js/parts-gantt/TreeGrid.js
@@ -287,65 +287,6 @@ var onTickHoverExit = function (label, options) {
 };
 
 /**
- * Builds the tree of categories and calculates its positions.
- *
- * @param {object} e Event object
- * @param {object} e.target The chart instance which the event was fired on.
- * @param {object[]} e.target.axes The axes of the chart.
- */
-var onBeforeRender = function (e) {
-    var chart = e.target,
-        axes = chart.axes;
-
-    axes
-        .filter(function (axis) {
-            return axis.options.type === 'treegrid';
-        })
-        .forEach(function (axis) {
-            var labelOptions = axis.options && axis.options.labels,
-                removeFoundExtremesEvent;
-
-            // setScale is fired after all the series is initialized,
-            // which is an ideal time to update the axis.categories.
-            axis.updateYNames();
-
-            // Update yData now that we have calculated the y values
-            axis.series.forEach(function (series) {
-                var data = series.options.data.map(function (d) {
-                    return isObject(d) ? merge(d) : d;
-                });
-
-                // Avoid destroying points when series is not visible
-                if (series.visible) {
-                    series.setData(data, false);
-                }
-            });
-
-            // Calculate the label options for each level in the tree.
-            axis.mapOptionsToLevel = getLevelOptions({
-                defaults: labelOptions,
-                from: 1,
-                levels: labelOptions.levels,
-                to: axis.tree.height
-            });
-
-            // Collapse all the nodes belonging to a point where collapsed
-            // equals true.
-            // Can be called from beforeRender, if getBreakFromNode removes
-            // its dependency on axis.max.
-            removeFoundExtremesEvent =
-                H.addEvent(axis, 'foundExtremes', function () {
-                    axis.collapsedNodes.forEach(function (node) {
-                        var breaks = collapse(axis, node);
-
-                        axis.setBreaks(breaks, false);
-                    });
-                    removeFoundExtremesEvent();
-                });
-        });
-};
-
-/**
  * Creates a tree structure of the data, and the treegrid. Calculates
  * categories, and y-values of points based on the tree.
  *
@@ -521,6 +462,65 @@ var getTreeGridFromData = function (data, uniqueNames, numberOfSeries) {
         collapsedNodes: collapsedNodes,
         tree: tree
     };
+};
+
+/**
+ * Builds the tree of categories and calculates its positions.
+ *
+ * @param {object} e Event object
+ * @param {object} e.target The chart instance which the event was fired on.
+ * @param {object[]} e.target.axes The axes of the chart.
+ */
+var onBeforeRender = function (e) {
+    var chart = e.target,
+        axes = chart.axes;
+
+    axes
+        .filter(function (axis) {
+            return axis.options.type === 'treegrid';
+        })
+        .forEach(function (axis) {
+            var labelOptions = axis.options && axis.options.labels,
+                removeFoundExtremesEvent;
+
+            // setScale is fired after all the series is initialized,
+            // which is an ideal time to update the axis.categories.
+            axis.updateYNames();
+
+            // Update yData now that we have calculated the y values
+            axis.series.forEach(function (series) {
+                var data = series.options.data.map(function (d) {
+                    return isObject(d) ? merge(d) : d;
+                });
+
+                // Avoid destroying points when series is not visible
+                if (series.visible) {
+                    series.setData(data, false);
+                }
+            });
+
+            // Calculate the label options for each level in the tree.
+            axis.mapOptionsToLevel = getLevelOptions({
+                defaults: labelOptions,
+                from: 1,
+                levels: labelOptions.levels,
+                to: axis.tree.height
+            });
+
+            // Collapse all the nodes belonging to a point where collapsed
+            // equals true.
+            // Can be called from beforeRender, if getBreakFromNode removes
+            // its dependency on axis.max.
+            removeFoundExtremesEvent =
+                H.addEvent(axis, 'foundExtremes', function () {
+                    axis.collapsedNodes.forEach(function (node) {
+                        var breaks = collapse(axis, node);
+
+                        axis.setBreaks(breaks, false);
+                    });
+                    removeFoundExtremesEvent();
+                });
+        });
 };
 
 override(GridAxis.prototype, {

--- a/js/parts-gantt/TreeGrid.js
+++ b/js/parts-gantt/TreeGrid.js
@@ -516,8 +516,6 @@ var onBeforeRender = function (e) {
             // Assign values to the axis.
             axis.categories = treeGrid.categories;
             axis.mapOfPosToGridNode = treeGrid.mapOfPosToGridNode;
-            // Used on init to start a node as collapsed
-            axis.collapsedNodes = treeGrid.collapsedNodes;
             axis.hasNames = true;
             axis.tree = treeGrid.tree;
 
@@ -547,7 +545,7 @@ var onBeforeRender = function (e) {
             // its dependency on axis.max.
             removeFoundExtremesEvent =
                 H.addEvent(axis, 'foundExtremes', function () {
-                    axis.collapsedNodes.forEach(function (node) {
+                    treeGrid.collapsedNodes.forEach(function (node) {
                         var breaks = collapse(axis, node);
 
                         axis.setBreaks(breaks, false);

--- a/js/parts-gantt/TreeGrid.js
+++ b/js/parts-gantt/TreeGrid.js
@@ -481,11 +481,18 @@ var onBeforeRender = function (e) {
         })
         .forEach(function (axis) {
             var labelOptions = axis.options && axis.options.labels,
-                removeFoundExtremesEvent;
+                removeFoundExtremesEvent,
+                // setScale is fired after all the series is initialized,
+                // which is an ideal time to update the axis.categories.
+                treeGrid = axis.updateYNames();
 
-            // setScale is fired after all the series is initialized,
-            // which is an ideal time to update the axis.categories.
-            axis.updateYNames();
+            // Assign values to the axis.
+            axis.categories = treeGrid.categories;
+            axis.mapOfPosToGridNode = treeGrid.mapOfPosToGridNode;
+            // Used on init to start a node as collapsed
+            axis.collapsedNodes = treeGrid.collapsedNodes;
+            axis.hasNames = true;
+            axis.tree = treeGrid.tree;
 
             // Update yData now that we have calculated the y values
             axis.series.forEach(function (series) {
@@ -959,7 +966,6 @@ GridAxis.prototype.updateYNames = function () {
         isYAxis = !axis.isXAxis,
         series = axis.series,
         numberOfSeries = 0,
-        treeGrid,
         data;
 
     if (isTreeGrid && isYAxis) {
@@ -984,19 +990,11 @@ GridAxis.prototype.updateYNames = function () {
         }, []);
 
         // Calculate categories and the hierarchy for the grid.
-        treeGrid = getTreeGridFromData(
+        return getTreeGridFromData(
             data,
             uniqueNames,
             (uniqueNames === true) ? numberOfSeries : 1
         );
-
-        // Assign values to the axis.
-        axis.categories = treeGrid.categories;
-        axis.mapOfPosToGridNode = treeGrid.mapOfPosToGridNode;
-        // Used on init to start a node as collapsed
-        axis.collapsedNodes = treeGrid.collapsedNodes;
-        axis.hasNames = true;
-        axis.tree = treeGrid.tree;
     }
 };
 

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -2853,9 +2853,9 @@ H.Series = H.seriesType(
                     if (
                         pointIndex === -1 ||
                         pointIndex === undefined ||
+                        oldData[pointIndex] === undefined ||
                         (
                             !matchedById &&
-                            oldData[pointIndex] &&
                             oldData[pointIndex].touched
                         )
                     ) {

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -2768,7 +2768,58 @@ H.Series = H.seriesType(
                 this.chart.options.symbols
             );
         },
+        /**
+         * Finds the index of an existing point that matches the given point
+         * options.
+         *
+         * @private
+         * @function Highcharts.Series#computePointIndex
+         * @param {object} optionsObject The options of the point.
+         * @param {number} lastIndex The index of the last point. Used to
+         * optimize series with required sorting.
+         * @returns {number|undefined} Returns index of a matching point,
+         * returns undefined if no match is found.
+         */
+        computePointIndex: function (optionsObject, lastIndex) {
+            var id = optionsObject.id,
+                x = optionsObject.x,
+                oldData = this.points,
+                matchingPoint,
+                matchedById,
+                pointIndex;
 
+            if (id) {
+                matchingPoint = oldData.find(function (point) {
+                    return point.id === id;
+                });
+                pointIndex = matchingPoint && matchingPoint.index;
+                if (pointIndex !== undefined) {
+                    matchedById = true;
+                }
+            }
+
+            // Search for the same X in the existing data set
+            if (pointIndex === undefined && isNumber(x)) {
+                pointIndex = this.xData.indexOf(x, lastIndex);
+            }
+
+            // Reduce pointIndex if data is cropped
+            if (pointIndex !== -1 &&
+                pointIndex !== undefined &&
+                this.cropped
+            ) {
+                pointIndex = (pointIndex >= this.cropStart) ?
+                    pointIndex - this.cropStart : pointIndex;
+            }
+
+            if (
+                !matchedById &&
+                oldData[pointIndex] && oldData[pointIndex].touched
+            ) {
+                pointIndex = undefined;
+            }
+            return pointIndex;
+        },
         /**
          * @private
          * @borrows LegendSymbolMixin.drawLineMarker as Highcharts.Series#drawLegendSymbol
@@ -2799,7 +2850,6 @@ H.Series = H.seriesType(
                 lastIndex,
                 requireSorting = this.requireSorting,
                 equalLength = data.length === oldData.length,
-                matchedById,
                 succeeded = true;
 
             this.xIncrement = null;
@@ -2807,7 +2857,6 @@ H.Series = H.seriesType(
             // Iterate the new data
             data.forEach(function (pointOptions, i) {
                 var id,
-                    matchingPoint,
                     x,
                     pointIndex,
                     optionsObject = (
@@ -2823,41 +2872,17 @@ H.Series = H.seriesType(
                 id = optionsObject.id;
 
                 if (id || isNumber(x)) {
-                    if (id) {
-                        matchingPoint = oldData.find(function (point) {
-                            return point.id === id;
-                        });
-                        pointIndex = matchingPoint && matchingPoint.index;
-                        if (pointIndex !== undefined) {
-                            matchedById = true;
-                        }
-                    }
-
-                    // Search for the same X in the existing data set
-                    if (pointIndex === undefined && isNumber(x)) {
-                        pointIndex = this.xData.indexOf(x, lastIndex);
-                    }
-
-                    // Reduce pointIndex if data is cropped
-                    if (pointIndex !== -1 &&
-                        pointIndex !== undefined &&
-                        this.cropped
-                    ) {
-                        pointIndex = (pointIndex >= this.cropStart) ?
-                            pointIndex - this.cropStart : pointIndex;
-                    }
+                    pointIndex = this.computePointIndex(
+                        optionsObject,
+                        lastIndex
+                    );
 
                     // Matching X not found
                     // or used already due to ununique x values (#8995),
                     // add point (but later)
                     if (
                         pointIndex === -1 ||
-                        pointIndex === undefined ||
-                        oldData[pointIndex] === undefined ||
-                        (
-                            !matchedById &&
-                            oldData[pointIndex].touched
-                        )
+                        pointIndex === undefined
                     ) {
                         pointsToAdd.push(pointOptions);
 

--- a/samples/unit-tests/gantt/treegrid/demo.js
+++ b/samples/unit-tests/gantt/treegrid/demo.js
@@ -214,3 +214,81 @@ QUnit.test('Chart.addSeries', assert => {
         'should have axis min equal to 0.'
     );
 });
+
+QUnit.test('Series.setVisible', assert => {
+    const {
+        series: [series1, series2, series3],
+        yAxis: [axis]
+    } = Highcharts.chart('container', {
+        series: [0, 1, 2].map(x => ({
+            data: [{ x, name: `Point ${x + 1}` }]
+        })),
+        legend: { enabled: true },
+        yAxis: [{ type: 'treegrid' }]
+    });
+
+    assert.strictEqual(
+        series1.points[0].y,
+        0,
+        'should have "Point 1" y-value equal 0.'
+    );
+    assert.strictEqual(
+        series2.points[0].y,
+        1,
+        'should have "Point 2" y-value equal 1.'
+    );
+    assert.strictEqual(
+        series3.points[0].y,
+        2,
+        'should have "Point 3" y-value equal 3.'
+    );
+    assert.deepEqual(
+        [axis.min, axis.max],
+        [0, 2],
+        'should have axis [min, max] equal [0, 2].'
+    );
+
+    series2.hide();
+    assert.strictEqual(
+        series1.points[0].y,
+        0,
+        'should have "Point 1" y-value equal 0 when "Series 2" is hidden.'
+    );
+    assert.strictEqual(
+        series3.points[0].y,
+        1,
+        'should have "Point 3" y-value equal 1  when "Series 2" is hidden.'
+    );
+    assert.strictEqual(
+        series2.visible,
+        false,
+        'should have "Series 2" visible equal false.'
+    );
+    assert.deepEqual(
+        [axis.min, axis.max],
+        [0, 1],
+        'should have axis [min, max] equal [0, 1]  when "Series 2" is hidden.'
+    );
+
+    series2.show();
+    assert.strictEqual(
+        series1.points[0].y,
+        0,
+        'should have "Point 1" y-value equal 0 when "Series 2" is visible again.'
+    );
+    assert.strictEqual(
+        series2.points[0].y,
+        1,
+        'should have "Point 2" y-value equal 1 when "Series 2" is visible again.'
+    );
+    assert.strictEqual(
+        series3.points[0].y,
+        2,
+        'should have "Point 3" y-value equal 3 when "Series 2" is visible again.'
+    );
+    assert.deepEqual(
+        [axis.min, axis.max],
+        [0, 2],
+        'should have axis [min, max] equal [0, 2] when "Series 2" is visible again.'
+    );
+});


### PR DESCRIPTION
# Description
Switched to using `Series#setData` in Treegrid to avoid problems with wrong series extremes and y data.
To be able to use updateData with Treegrid I added a seperate calculation of pointIndex in xrange that not only looks at the x value, but also x2 to find the correct point.

Did a refactor in TreeGrid.js, which I now regret to include in this PR since it is obfuscating the diff, but the https://github.com/highcharts/highcharts/commit/f754ee1ffa5da2d3e782ad93101419091b1e144b should clearly show the changes of functionality in TreeGrid.

# Example(s)
- [Demo of issue](https://jsfiddle.net/dunkoh/y7d24whq/)
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/97b5nw0k/)

# Related issue(s)
- Closes #10211 
