### PR TITLE
bugfix/10055-annotations-replaced-9e9

### DIFF
--- a/js/annotations/controllable/ControllableLabel.js
+++ b/js/annotations/controllable/ControllableLabel.js
@@ -216,7 +216,7 @@ H.merge(
                 .label(
                     '',
                     0,
-                    -9e9,
+                    -9999, // #10055
                     options.shape,
                     null,
                     null,
@@ -282,7 +282,7 @@ H.merge(
             } else {
                 label.attr({
                     x: 0,
-                    y: -9e9
+                    y: -9999 // #10055
                 });
             }
 

--- a/samples/unit-tests/annotations/annotations-cropthreshold/demo.js
+++ b/samples/unit-tests/annotations/annotations-cropthreshold/demo.js
@@ -1,4 +1,3 @@
-
 QUnit.test('#7534: Annotations positioning with series cropThreshold', function (assert) {
     var chart = Highcharts.chart('container', {
         series: [{
@@ -54,7 +53,7 @@ QUnit.test('#7534: Annotations positioning with series cropThreshold', function 
 
     assert.strictEqual(
         annotationLabel.attr('y'),
-        -9e9,
+        -9999,
         'Label is placed outside of the chart'
     );
 
@@ -67,7 +66,7 @@ QUnit.test('#7534: Annotations positioning with series cropThreshold', function 
 
     assert.strictEqual(
         annotationLabel.attr('y'),
-        -9e9,
+        -9999,
         'For series without marker - Label is placed outside the chart'
     );
 


### PR DESCRIPTION
Fixed #10055, exporting custom annotation did not work for other types than SVG.