### PR TITLE
bugfix/10232-solidgauge-legend-item

### DIFF
--- a/js/modules/solid-gauge.src.js
+++ b/js/modules/solid-gauge.src.js
@@ -257,7 +257,7 @@ var solidGaugeOptions = {
 
 // The solidgauge series type
 H.seriesType('solidgauge', 'gauge', solidGaugeOptions, {
-
+    drawLegendSymbol: H.LegendSymbolMixin.drawRectangle,
     // Extend the translate function to extend the Y axis with the necessary
     // decoration (#5895).
     translate: function () {

--- a/samples/unit-tests/series-solidgauge/solidgauge/demo.js
+++ b/samples/unit-tests/series-solidgauge/solidgauge/demo.js
@@ -157,6 +157,23 @@ QUnit.test('Solid gauge animated color', function (assert) {
         done();
     }, 200);
 
+});
 
+QUnit.test('Solid gauge: legend', function (assert) {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            type: 'solidgauge'
+        },
+        series: [{
+            showInLegend: true,
+            colorByPoint: false,
+            data: [10]
+        }]
+    });
 
+    assert.strictEqual(
+        chart.legend.allItems[0].legendSymbol.element.getAttribute('fill'),
+        chart.series[0].points[0].graphic.element.getAttribute('fill'),
+        'Series legend item: color taken from series'
+    );
 });


### PR DESCRIPTION
Fixed #10232, solidgauge series had wrong legend symbol.

Internal notes:
- didn't change default `colorByPoint` for solidgauge which sets grey color for legend items
- didn't implement `legendType="point"` which could be cool feature (solid gauge has color axis which could change color in legend too)