### PR TITLE
Fixed #10282, overlap larger than smallest circle

### DIFF
--- a/js/mixins/geometry-circles.js
+++ b/js/mixins/geometry-circles.js
@@ -10,6 +10,19 @@ var round = function round(x, decimals) {
 };
 
 /**
+ * Calculates the area of a circle based on its radius.
+ *
+ * @param {number} r The radius of the circle.
+ * @returns {number} Returns the area of the circle.
+ */
+var getAreaOfCircle = function (r) {
+    if (r <= 0) {
+        throw new Error('radius of circle must be a positive number.');
+    }
+    return Math.PI * r * r;
+};
+
+/**
  * Calculates the area of a circular segment based on the radius of the circle
  * and the height of the segment.
  * See http://mathworld.wolfram.com/CircularSegment.html
@@ -39,16 +52,13 @@ function getOverlapBetweenCircles(r1, r2, d) {
     // If the distance is larger than the sum of the radiuses then the circles
     // does not overlap.
     if (d < r1 + r2) {
-        var r1Square = r1 * r1,
-            r2Square = r2 * r2;
-
         if (d <= Math.abs(r2 - r1)) {
             // If the circles are completely overlapping, then the overlap
             // equals the area of the smallest circle.
-            overlap = Math.PI * Math.min(r1Square, r2Square);
+            overlap = getAreaOfCircle(r1 < r2 ? r1 : r2);
         } else {
             // Height of first triangle segment.
-            var d1 = (r1Square - r2Square + d * d) / (2 * d),
+            var d1 = (r1 * r1 - r2 * r2 + d * d) / (2 * d),
                 // Height of second triangle segment.
                 d2 = d - d1;
 
@@ -286,6 +296,7 @@ function getAreaOfIntersectionBetweenCircles(circles) {
 };
 
 var geometryCircles = {
+    getAreaOfCircle: getAreaOfCircle,
     getAreaOfIntersectionBetweenCircles: getAreaOfIntersectionBetweenCircles,
     getCircleCircleIntersection: getCircleCircleIntersection,
     getCirclesIntersectionPoints: getCirclesIntersectionPoints,

--- a/js/modules/venn.src.js
+++ b/js/modules/venn.src.js
@@ -21,6 +21,7 @@ import '../parts/Series.js';
 
 var color = H.Color,
     extend = H.extend,
+    getAreaOfCircle = geometryCircles.getAreaOfCircle,
     getAreaOfIntersectionBetweenCircles =
         geometryCircles.getAreaOfIntersectionBetweenCircles,
     getCircleCircleIntersection = geometryCircles.getCircleCircleIntersection,
@@ -172,9 +173,16 @@ var bisect = function bisect(f, a, b, tolerance, maxIterations) {
 var getDistanceBetweenCirclesByOverlap =
 function getDistanceBetweenCirclesByOverlap(r1, r2, overlap) {
     var maxDistance = r1 + r2,
-        distance = maxDistance;
+        distance;
 
-    if (overlap > 0) {
+    if (overlap <= 0) {
+        // If overlap is below or equal to zero, then there is no overlap.
+        distance = maxDistance;
+    } else if (getAreaOfCircle(r1 < r2 ? r1 : r2) <= overlap) {
+        // When area of overlap is larger than the area of the smallest circle,
+        // then it is completely overlapping.
+        distance = 0;
+    } else {
         distance = bisect(function (x) {
             var actualOverlap = getOverlapBetweenCirclesByDistance(r1, r2, x);
 

--- a/samples/unit-tests/series-venn/members/demo.js
+++ b/samples/unit-tests/series-venn/members/demo.js
@@ -79,6 +79,35 @@ QUnit.test('addOverlapToRelations', function (assert) {
     );
 });
 
+QUnit.test('getAreaOfCircle', assert => {
+    const { prototype: vennPrototype } = Highcharts.seriesTypes.venn;
+    const { getAreaOfCircle } = vennPrototype.utils.geometryCircles;
+
+    assert.strictEqual(
+        getAreaOfCircle(1),
+        3.141592653589793,
+        'should have area equal 3.141592653589793 when r = 1.'
+    );
+
+    assert.strictEqual(
+        getAreaOfCircle(3),
+        Math.PI * 3 * 3,
+        'should have area equal 28.274333882308138 when r = 3.'
+    );
+
+    assert.throws(
+        () => getAreaOfCircle(0),
+        new Error('radius of circle must be a positive number.'),
+        'should throw an error when r is zero.'
+    );
+
+    assert.throws(
+        () => getAreaOfCircle(-1),
+        new Error('radius of circle must be a positive number.'),
+        'should throw an error when r is negative.'
+    );
+});
+
 QUnit.test('getAreaOfIntersectionBetweenCircles', function (assert) {
     var vennPrototype = Highcharts.seriesTypes.venn.prototype,
         getAreaOfIntersectionBetweenCircles =
@@ -187,6 +216,12 @@ QUnit.test('getDistanceBetweenCirclesByOverlap', assert => {
         getDistanceBetweenCirclesByOverlap(600, 300, 250000),
         387.2988213671704,
         'should return a distance of 387.2988213671704 when r1=600, r2=300 and overlap=250000.'
+    );
+
+    assert.strictEqual(
+        getDistanceBetweenCirclesByOverlap(3, 4, 30),
+        0,
+        'should return a distance of 0 when r1=3, r2=4, and overlap=30. Complete overlap.'
     );
 });
 


### PR DESCRIPTION
# Description
In cases where the smallest circle in an intersection has an area smaller than the area of overlap, the `getDistanceBetweenCirclesByOverlap` functionality could get into trouble when trying to do a bisection to find the distance. This is because in some of these cases the result of `f(a)` and `f(b)` in `bisect` could have the same signs.
This is solved by checking for this case before trying to do a bisect in the `getDistanceBetweenCirclesByOverlap`, and then setting the distance to `0`.

# Example(s)
- [Demo of issue](https://jsfiddle.net/BlackLabel/ad5b6m8v/)
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/qm0L1z5f/)

# Related issue(s)
- Closes #10282 