### PR TITLE
Update highcharts-assembler to v1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "gulp-jsdoc3": "^2.0.0",
     "gzip-size": "^5.0.0",
     "highcharts-api-docs": "github:highcharts/api-docs#v0.2.7",
-    "highcharts-assembler": "github:highcharts/highcharts-assembler#v1.2.3",
+    "highcharts-assembler": "github:highcharts/highcharts-assembler#v1.3.2",
     "highcharts-docstrap": "github:highcharts/highcharts-docstrap#v1.3.0",
     "husky": "latest",
     "js-yaml": "^3.12.1",


### PR DESCRIPTION
# Description
The updated assembler includes a fix which make a module fall back to using an empty object if Highcharts is missing. This avoids it breaking when a module is not dependent upon Highcharts, and can be loaded in advance.

# Related issue(s)
- Closes #10288  