### PR TITLE
bugfix/10081-update-chart-with-parallelCoordinates

### DIFF
--- a/js/modules/parallel-coordinates.src.js
+++ b/js/modules/parallel-coordinates.src.js
@@ -186,15 +186,21 @@ addEvent(Chart, 'update', function (e) {
             this.hasParallelCoordinates = options.chart.parallelCoordinates;
         }
 
-        if (this.hasParallelCoordinates && options.chart.parallelAxes) {
-            this.options.chart.parallelAxes = merge(
-                this.options.chart.parallelAxes,
-                options.chart.parallelAxes
-            );
-            this.yAxis.forEach(function (axis) {
-                axis.update({}, false);
-            });
+        this.options.chart.parallelAxes = merge(
+            this.options.chart.parallelAxes,
+            options.chart.parallelAxes
+        );
+    }
+
+    if (this.hasParallelCoordinates) {
+        // (#10081)
+        if (options.series) {
+            this.setParallelInfo(options);
         }
+
+        this.yAxis.forEach(function (axis) {
+            axis.update({}, false);
+        });
     }
 });
 

--- a/samples/unit-tests/chart/parallel-coordinates-updates/demo.js
+++ b/samples/unit-tests/chart/parallel-coordinates-updates/demo.js
@@ -107,5 +107,28 @@ QUnit.test('Update parallel coordinates plot', function (assert) {
         'On series toggle yAxis extremes have been changed. (#9248)'
     );
 
+    chart = Highcharts.chart('container', {
+        chart: {
+            parallelCoordinates: true
+        },
+        series: [{
+            data: [1012518000000, 5, 2311020, 0, 462180, 1, 0]
+        }, {
+            data: [1012690800000, 5, 2464980, 0, 493020.00000000006, 1, 0]
+        }]
+    });
 
+    chart.update({
+        series: [{
+            data: [1012518000000, 5, 2311020, 0]
+        }, {
+            data: [1012690800000, 5, 2464980, 0]
+        }]
+    });
+
+    assert.strictEqual(
+        chart.parallelInfo.counter,
+        3,
+        'After chart update parallelInfo.counter has correct value (#10081).'
+    );
 });


### PR DESCRIPTION
Chart with `parallelCoordinates` was not resizing properly after update.