### PR TITLE
networkgraph/defaults

### DIFF
--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -294,7 +294,7 @@ seriesType('networkgraph', 'line', {
          * @sample       highcharts/demo/network-graph/
          *               Live simulation enabled
          */
-        enableSimulation: false,
+        enableSimulation: true,
         /**
          * Barnes-Hut approximation only.
          * Deteremines when distance between cell and node is small enough to
@@ -359,7 +359,7 @@ seriesType('networkgraph', 'line', {
          *              Comparison of Verlet and Euler integrations
          * @validvalue  ["euler", "verlet"]
          */
-        integration: 'verlet',
+        integration: 'euler',
         /**
          * Max number of iterations before algorithm will stop. In general,
          * algorithm should find positions sooner, but when rendering huge

--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -793,8 +793,9 @@ Series.prototype.drawDataLabels = function () {
                     // Create individual options structure that can be extended
                     // without affecting others
                     labelConfig = point.getLabelConfig();
-                    formatString = (
-                        labelOptions[point.formatPrefix + 'Format'] ||
+
+                    formatString = pick(
+                        labelOptions[point.formatPrefix + 'Format'],
                         labelOptions.format
                     );
 

--- a/samples/highcharts/demo/network-graph/demo.js
+++ b/samples/highcharts/demo/network-graph/demo.js
@@ -61,9 +61,7 @@ Highcharts.chart('container', {
     series: [{
         dataLabels: {
             enabled: true,
-            linkFormatter: function () {
-                return '';
-            }
+            linkFormat: ''
         },
         data: [
             ['Proto Indo-European', 'Balto-Slavic'],

--- a/samples/highcharts/demo/network-graph/demo.js
+++ b/samples/highcharts/demo/network-graph/demo.js
@@ -53,7 +53,8 @@ Highcharts.chart('container', {
         networkgraph: {
             keys: ['from', 'to'],
             layoutAlgorithm: {
-                enableSimulation: true
+                enableSimulation: true,
+                friction: -0.9
             }
         }
     },

--- a/samples/highcharts/demo/network-graph/demo.js
+++ b/samples/highcharts/demo/network-graph/demo.js
@@ -59,7 +59,10 @@ Highcharts.chart('container', {
     },
     series: [{
         dataLabels: {
-            enabled: true
+            enabled: true,
+            linkFormatter: function () {
+                return '';
+            }
         },
         data: [
             ['Proto Indo-European', 'Balto-Slavic'],

--- a/samples/highcharts/series-networkgraph/dicsonnected-graphs/demo.js
+++ b/samples/highcharts/series-networkgraph/dicsonnected-graphs/demo.js
@@ -27,7 +27,8 @@ Highcharts.chart('container', {
         networkgraph: {
             keys: ['from', 'to'],
             layoutAlgorithm: {
-                enableSimulation: true
+                enableSimulation: true,
+                integration: 'verlet'
             }
         }
     },

--- a/samples/highcharts/series-networkgraph/textpath-datalabels/demo.js
+++ b/samples/highcharts/series-networkgraph/textpath-datalabels/demo.js
@@ -65,9 +65,7 @@ Highcharts.chart('container', {
             textPath: {
                 enabled: true
             },
-            linkFormatter: function () {
-                return '';
-            },
+            linkFormat: '',
             allowOverlap: true
         },
         data: [

--- a/samples/highcharts/series-networkgraph/textpath-datalabels/demo.js
+++ b/samples/highcharts/series-networkgraph/textpath-datalabels/demo.js
@@ -37,7 +37,8 @@ Highcharts.addEvent(
 
 Highcharts.chart('container', {
     chart: {
-        type: 'networkgraph'
+        type: 'networkgraph',
+        marginTop: 80
     },
     title: {
         text: 'The Indo-European Laungauge Tree'
@@ -50,6 +51,7 @@ Highcharts.chart('container', {
             keys: ['from', 'to'],
             layoutAlgorithm: {
                 enableSimulation: true,
+                integration: 'verlet',
                 linkLength: 100
             }
         }


### PR DESCRIPTION
I think we can now enable the simulation by default. 

Additionally, for me `Euler` gives better results in most cases than `Verlet` + we keep similar layout between v7.0 and v7.1, so I suggest to stick to `Euler`.