### PR TITLE
features/annotation-events

### DIFF
--- a/js/annotations/ControlPoint.js
+++ b/js/annotations/ControlPoint.js
@@ -53,6 +53,14 @@ H.extend(
 );
 
 /**
+ * List of events for `anntation.options.events` that should not be
+ * added to `annotation.graphic` but to the `annotation`.
+ *
+ * @type {Array<string>}
+ */
+ControlPoint.prototype.nonDOMEvents = ['drag'];
+
+/**
  * Set the visibility.
  *
  * @param {boolean} [visible]

--- a/js/annotations/annotations.src.js
+++ b/js/annotations/annotations.src.js
@@ -19,6 +19,7 @@ import ControlPoint from './ControlPoint.js';
 
 var merge = H.merge,
     addEvent = H.addEvent,
+    fireEvent = H.fireEvent,
     defined = H.defined,
     erase = H.erase,
     find = H.find,
@@ -166,6 +167,13 @@ merge(
     Annotation.prototype,
     controllableMixin,
     eventEmitterMixin, /** @lends Annotation# */ {
+        /**
+         * List of events for `annotation.options.events` that should not be
+         * added to `annotation.graphic` but to the `annotation`.
+         *
+         * @type {Array<string>}
+         */
+        nonDOMEvents: ['add', 'afterUpdate', 'remove'],
         /**
          * A basic type of an annotation. It allows to add custom labels
          * or shapes. The items  can be tied to points, axis coordinates
@@ -658,7 +666,28 @@ merge(
 
 
             /**
+             * Events available in annotations.
+             *
              * @type {Object}
+             */
+            /**
+             * Event callback when annotation is added to the chart.
+             *
+             * @since 7.1.0
+             * @apioption annotations.crookedLine.events.add
+             */
+            /**
+             * Event callback when annotation is updated (e.g. drag and
+             * droppped or resized by control points).
+             *
+             * @since 7.1.0
+             * @apioption annotations.crookedLine.events.afterUpdate
+             */
+            /**
+             * Event callback when annotation is removed from the chart.
+             *
+             * @since 7.1.0
+             * @apioption annotations.crookedLine.events.remove
              */
             events: {},
 
@@ -950,7 +979,10 @@ merge(
             // Update options in chart options, used in exporting (#9767):
             chart.options.annotations[userOptionsIndex] = options;
 
+            this.isUpdating = true;
             this.redraw();
+            this.isUpdating = false;
+            fireEvent(this, 'afterUpdate');
         },
 
         /* *************************************************************
@@ -1186,6 +1218,7 @@ H.extend(H.Chart.prototype, /** @lends Highcharts.Chart# */ {
             ) : idOrAnnotation;
 
         if (annotation) {
+            fireEvent(annotation, 'remove');
             erase(this.options.annotations, annotation.options);
             erase(annotations, annotation);
             annotation.destroy();

--- a/js/annotations/eventEmitterMixin.js
+++ b/js/annotations/eventEmitterMixin.js
@@ -1,6 +1,8 @@
 import H from '../parts/Globals.js';
 import '../parts/Utilities.js';
 
+var fireEvent = H.fireEvent;
+
 /**
  * It provides methods for:
  * - adding and handling DOM events and a drag event,
@@ -37,10 +39,10 @@ var eventEmitterMixin = {
                 }
             };
 
-            if (type !== 'drag') {
+            if (H.inArray(type, emitter.nonDOMEvents || []) === -1) {
                 emitter.graphic.on(type, eventHandler);
             } else {
-                H.addEvent(emitter, 'drag', eventHandler);
+                H.addEvent(emitter, type, eventHandler);
             }
         });
 
@@ -56,6 +58,10 @@ var eventEmitterMixin = {
                     }[emitter.options.draggable]
                 });
             }
+        }
+
+        if (!emitter.isUpdating) {
+            fireEvent(emitter, 'add');
         }
     },
 
@@ -106,7 +112,7 @@ var eventEmitterMixin = {
                 e.prevChartX = prevChartX;
                 e.prevChartY = prevChartY;
 
-                H.fireEvent(emitter, 'drag', e);
+                fireEvent(emitter, 'drag', e);
 
                 prevChartX = e.chartX;
                 prevChartY = e.chartY;
@@ -119,7 +125,8 @@ var eventEmitterMixin = {
             function (e) {
                 emitter.cancelClick = emitter.hasDragged;
                 emitter.hasDragged = false;
-
+                // ControlPoints vs Annotation:
+                fireEvent(H.pick(emitter.target, emitter), 'afterUpdate');
                 emitter.onMouseUp(e);
             }
         );

--- a/js/modules/annotations-legacy.src.js
+++ b/js/modules/annotations-legacy.src.js
@@ -1015,7 +1015,33 @@ Annotation.prototype = {
         /**
          * The Z index of the annotation.
          */
-        zIndex: 6
+        zIndex: 6,
+
+        /**
+         * Events available in annotations.
+         *
+         * @type {Object}
+         */
+        /**
+         * Event callback when annotation is added to the chart.
+         *
+         * @since 7.1.0
+         * @apioption annotations.events.add
+         */
+        /**
+         * Event callback when annotation is updated (e.g. drag and
+         * droppped or resized by control points).
+         *
+         * @since 7.1.0
+         * @apioption annotations.events.afterUpdate
+         */
+        /**
+         * Event callback when annotation is removed from the chart.
+         *
+         * @since 7.1.0
+         * @apioption annotations.events.remove
+         */
+        events: {}
     },
 
     /**

--- a/samples/unit-tests/annotations/annotations-events/demo.details
+++ b/samples/unit-tests/annotations/annotations-events/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/annotations/annotations-events/demo.html
+++ b/samples/unit-tests/annotations/annotations-events/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/annotations.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/annotations/annotations-events/demo.js
+++ b/samples/unit-tests/annotations/annotations-events/demo.js
@@ -1,0 +1,83 @@
+QUnit.test('Annotations events - general', function (assert) {
+    var addEventCalled = 0,
+        afterUpdateEventCalled = 0,
+        removeEventCalled = 0,
+        chart = Highcharts.chart('container', {
+            annotations: [{
+                shapes: [{
+                    strokeWidth: 3,
+                    type: 'path',
+                    points: [{
+                        x: 2,
+                        y: 10,
+                        xAxis: 0,
+                        yAxis: 0
+                    }, {
+                        x: 2,
+                        y: 15,
+                        xAxis: 0,
+                        yAxis: 0
+                    }]
+                }],
+                draggable: true,
+                events: {
+                    add: function () {
+                        addEventCalled++;
+                    },
+                    afterUpdate: function () {
+                        afterUpdateEventCalled++;
+                    },
+                    remove: function () {
+                        removeEventCalled++;
+                    }
+                }
+            }],
+            series: [{
+                data: [7.0, 6.9, 9.5, 14.5, 18.2, 21.5, 25.2, 23.3, 18.3, 13.9, 9.6]
+            }]
+        }),
+        annotation = chart.annotations[0],
+        point = chart.series[0].points[2],
+        controller = new TestController(chart);
+
+    assert.strictEqual(
+        addEventCalled,
+        1,
+        'annotations.events.add called just once.'
+    );
+
+    annotation.update({
+        shapes: [{
+            strokeWidth: 15
+        }]
+    });
+    assert.strictEqual(
+        afterUpdateEventCalled,
+        1,
+        'annotations.events.afterUpdate called just once - after' +
+            '`annotation.update()`.'
+    );
+
+    controller.mouseDown(
+        chart.plotLeft + point.plotX,
+        chart.plotTop + point.plotY - 20
+    );
+    controller.mouseMove(
+        chart.plotLeft + point.plotX + 50,
+        chart.plotTop + point.plotY - 20
+    );
+    controller.mouseUp();
+
+    assert.strictEqual(
+        afterUpdateEventCalled,
+        2,
+        'annotations.events.afterUpdate called just once - after drag&drop'
+    );
+
+    chart.removeAnnotation(annotation);
+    assert.strictEqual(
+        removeEventCalled,
+        1,
+        'annotations.events.remove called just once.'
+    );
+});


### PR DESCRIPTION
New events are really useful when using `bindings` (e.g. StockTools). Now, users have an option to send to backend info about annotations immediately after change.