### PR TITLE
AMD dependencies

### DIFF
--- a/js/masters/highcharts-3d.src.js
+++ b/js/masters/highcharts-3d.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/highcharts-3d
+ * @requires highcharts
  *
  * 3D features for Highcharts JS
  *

--- a/js/masters/highcharts-gantt.src.js
+++ b/js/masters/highcharts-gantt.src.js
@@ -1,5 +1,6 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/highcharts-gantt
  *
  * (c) 2017-2018 Lars Cabrera, Torstein Honsi, Jon Arild Nygard & Oystein Moseng
  *

--- a/js/masters/highcharts-more.src.js
+++ b/js/masters/highcharts-more.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/highcharts-more
+ * @requires highcharts
  *
  * (c) 2009-2018 Torstein Honsi
  *

--- a/js/masters/highcharts.src.js
+++ b/js/masters/highcharts.src.js
@@ -1,5 +1,6 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/highcharts
  *
  * (c) 2009-2018 Torstein Honsi
  *

--- a/js/masters/highmaps.src.js
+++ b/js/masters/highmaps.src.js
@@ -1,5 +1,6 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/highmaps
  *
  * (c) 2011-2018 Torstein Honsi
  *

--- a/js/masters/highstock.src.js
+++ b/js/masters/highstock.src.js
@@ -1,5 +1,6 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/highstock
  *
  * (c) 2009-2018 Torstein Honsi
  *

--- a/js/masters/indicators/acceleration-bands.src.js
+++ b/js/masters/indicators/acceleration-bands.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/acceleration-bands
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/accumulation-distribution.src.js
+++ b/js/masters/indicators/accumulation-distribution.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/accumulation-distribution
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/ao.src.js
+++ b/js/masters/indicators/ao.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/ao
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/apo.src.js
+++ b/js/masters/indicators/apo.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/apo
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/aroon-oscillator.src.js
+++ b/js/masters/indicators/aroon-oscillator.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/aroon-oscillator
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/aroon.src.js
+++ b/js/masters/indicators/aroon.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/aroon
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/atr.src.js
+++ b/js/masters/indicators/atr.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/atr
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/bollinger-bands.src.js
+++ b/js/masters/indicators/bollinger-bands.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/bollinger-bands
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/cci.src.js
+++ b/js/masters/indicators/cci.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/cci
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/chaikin.src.js
+++ b/js/masters/indicators/chaikin.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/chaikin
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/cmf.src.js
+++ b/js/masters/indicators/cmf.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/cmf
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * (c) 2010-2019 Highsoft AS
  * Author: Sebastian Domas

--- a/js/masters/indicators/dema.src.js
+++ b/js/masters/indicators/dema.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/dema
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/dpo.src.js
+++ b/js/masters/indicators/dpo.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/dpo
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/ema.src.js
+++ b/js/masters/indicators/ema.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/ema
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/ichimoku-kinko-hyo.src.js
+++ b/js/masters/indicators/ichimoku-kinko-hyo.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/ichimoku-kinko-hyo
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/indicators-all.src.js
+++ b/js/masters/indicators/indicators-all.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/indicators-all
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * All technical indicators for Highstock
  *

--- a/js/masters/indicators/indicators.src.js
+++ b/js/masters/indicators/indicators.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/indicators
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/keltner-channels.src.js
+++ b/js/masters/indicators/keltner-channels.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/keltner-channels
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/macd.src.js
+++ b/js/masters/indicators/macd.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/macd
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/mfi.src.js
+++ b/js/masters/indicators/mfi.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/mfi
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Money Flow Index indicator for Highstock
  *

--- a/js/masters/indicators/momentum.src.js
+++ b/js/masters/indicators/momentum.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/momentum
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/natr.src.js
+++ b/js/masters/indicators/natr.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/natr
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/pivot-points.src.js
+++ b/js/masters/indicators/pivot-points.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/pivot-points
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/ppo.src.js
+++ b/js/masters/indicators/ppo.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/ppo
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/price-channel.src.js
+++ b/js/masters/indicators/price-channel.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/price-channel
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/price-envelopes.src.js
+++ b/js/masters/indicators/price-envelopes.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/price-envelopes
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/psar.src.js
+++ b/js/masters/indicators/psar.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/psar
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Parabolic SAR Indicator for Highstock
  *

--- a/js/masters/indicators/regressions.src.js
+++ b/js/masters/indicators/regressions.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/regressions
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/roc.src.js
+++ b/js/masters/indicators/roc.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/roc
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/rsi.src.js
+++ b/js/masters/indicators/rsi.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/rsi
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/stochastic.src.js
+++ b/js/masters/indicators/stochastic.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/stochastic
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/supertrend.src.js
+++ b/js/masters/indicators/supertrend.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/supertrend
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/tema.src.js
+++ b/js/masters/indicators/tema.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/tema
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/trix.src.js
+++ b/js/masters/indicators/trix.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/trix
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/volume-by-price.src.js
+++ b/js/masters/indicators/volume-by-price.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/volume-by-price
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/vwap.src.js
+++ b/js/masters/indicators/vwap.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/vwap
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/williams-r.src.js
+++ b/js/masters/indicators/williams-r.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/williams-r
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/wma.src.js
+++ b/js/masters/indicators/wma.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/wma
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/indicators/zigzag.src.js
+++ b/js/masters/indicators/zigzag.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/indicators/zigzag
+ * @requires highcharts
+ * @requires highcharts/modules/stock
  *
  * Indicator series type for Highstock
  *

--- a/js/masters/modules/accessibility.src.js
+++ b/js/masters/modules/accessibility.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/accessibility
+ * @requires highcharts
+ *
  * Accessibility module
  *
  * (c) 2010-2019 Highsoft AS

--- a/js/masters/modules/annotations-advanced.src.js
+++ b/js/masters/modules/annotations-advanced.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/annotations-advanced
+ * @requires highcharts
+ *
  * Annotations module
  *
  * (c) 2009-2019 Torstein Honsi

--- a/js/masters/modules/annotations.src.js
+++ b/js/masters/modules/annotations.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/annotations
+ * @requires highcharts
+ *
  * Annotations module
  *
  * (c) 2009-2019 Torstein Honsi

--- a/js/masters/modules/arrow-symbols.src.js
+++ b/js/masters/modules/arrow-symbols.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/arrow-symbols
+ * @requires highcharts
+ *
  * Arrow Symbols
  *
  * (c) 2017-2019 Lars A. V. Cabrera

--- a/js/masters/modules/boost-canvas.src.js
+++ b/js/masters/modules/boost-canvas.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/boost-canvas
+ * @requires highcharts
+ *
  * Boost module
  *
  * (c) 2010-2019 Highsoft AS

--- a/js/masters/modules/boost.src.js
+++ b/js/masters/modules/boost.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/boost
+ * @requires highcharts
+ *
  * Boost module
  *
  * (c) 2010-2019 Highsoft AS

--- a/js/masters/modules/broken-axis.src.js
+++ b/js/masters/modules/broken-axis.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/broken-axis
+ * @requires highcharts
  *
  * (c) 2009-2019 Torstein Honsi
  *

--- a/js/masters/modules/bullet.src.js
+++ b/js/masters/modules/bullet.src.js
@@ -1,5 +1,7 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/bullet
+ * @requires highcharts
  *
  * Bullet graph series type for Highcharts
  *

--- a/js/masters/modules/current-date-indicator.src.js
+++ b/js/masters/modules/current-date-indicator.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/current-date-indicator
+ * @requires highcharts
+ *
  * CurrentDateIndicator
  *
  * (c) 2010-2019 Lars A. V. Cabrera

--- a/js/masters/modules/cylinder.src.js
+++ b/js/masters/modules/cylinder.src.js
@@ -1,5 +1,9 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/cylinder
+ * @requires highcharts
+ * @requires highcharts/highcharts-3d
+ *
  * Highcharts cylinder module
  *
  * (c) 2010-2019 Kacper Madej

--- a/js/masters/modules/data.src.js
+++ b/js/masters/modules/data.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/data
+ * @requires highcharts
+ *
  * Data module
  *
  * (c) 2012-2019 Torstein Honsi

--- a/js/masters/modules/datagrouping.src.js
+++ b/js/masters/modules/datagrouping.src.js
@@ -1,5 +1,7 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/datagrouping
+ * @requires highcharts
  *
  * Data grouping module
  *

--- a/js/masters/modules/debugger.src.js
+++ b/js/masters/modules/debugger.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/debugger
+ * @requires highcharts
+ *
  * Debugger module
  *
  * (c) 2012-2019 Torstein Honsi

--- a/js/masters/modules/dependency-wheel.src.js
+++ b/js/masters/modules/dependency-wheel.src.js
@@ -1,5 +1,9 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/dependency-wheel
+ * @requires highcharts
+ * @requires highcharts/modules/sankey
+ *
  * Dependency wheel module
  *
  * (c) 2010-2018 Torstein Honsi

--- a/js/masters/modules/dotplot.src.js
+++ b/js/masters/modules/dotplot.src.js
@@ -1,5 +1,7 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/dotplot
+ * @requires highcharts
  *
  * Dot plot series type for Highcharts
  *

--- a/js/masters/modules/drag-panes.src.js
+++ b/js/masters/modules/drag-panes.src.js
@@ -1,5 +1,9 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/drag-panes
+ * @requires highcharts
+ * @requires highcharts/modules/stock
+ *
  * Drag-panes module
  *
  * (c) 2010-2019 Highsoft AS

--- a/js/masters/modules/draggable-points.src.js
+++ b/js/masters/modules/draggable-points.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/draggable-points
+ * @requires highcharts
  *
  * (c) 2009-2019 Torstein Honsi
  *

--- a/js/masters/modules/drilldown.src.js
+++ b/js/masters/modules/drilldown.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/drilldown
+ * @requires highcharts
+ *
  * Highcharts Drilldown module
  *
  * Author: Torstein Honsi

--- a/js/masters/modules/export-data.src.js
+++ b/js/masters/modules/export-data.src.js
@@ -1,5 +1,9 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/export-data
+ * @requires highcharts
+ * @requires highcharts/modules/exporting
+ *
  * Exporting module
  *
  * (c) 2010-2019 Torstein Honsi

--- a/js/masters/modules/exporting.src.js
+++ b/js/masters/modules/exporting.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/exporting
+ * @requires highcharts
+ *
  * Exporting module
  *
  * (c) 2010-2019 Torstein Honsi

--- a/js/masters/modules/full-screen.src.js
+++ b/js/masters/modules/full-screen.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/full-screen
+ * @requires highcharts
+ *
  * Advanced Highstock tools
  *
  * (c) 2010-2019 Highsoft AS

--- a/js/masters/modules/funnel.src.js
+++ b/js/masters/modules/funnel.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/funnel
+ * @requires highcharts
+ *
  * Highcharts funnel module
  *
  * (c) 2010-2019 Torstein Honsi

--- a/js/masters/modules/gantt.src.js
+++ b/js/masters/modules/gantt.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/gantt
+ * @requires highcharts
+ *
  * Gantt series
  *
  * (c) 2016-2019 Lars A. V. Cabrera

--- a/js/masters/modules/grid-axis.src.js
+++ b/js/masters/modules/grid-axis.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/grid-axis
+ * @requires highcharts
+ *
  * GridAxis
  *
  * (c) 2016-2019 Lars A. V. Cabrera

--- a/js/masters/modules/heatmap.src.js
+++ b/js/masters/modules/heatmap.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/heatmap
+ * @requires highcharts
  *
  * (c) 2009-2019 Torstein Honsi
  *

--- a/js/masters/modules/histogram-bellcurve.src.js
+++ b/js/masters/modules/histogram-bellcurve.src.js
@@ -1,5 +1,7 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/histogram-bellcurve
+ * @requires highcharts
  *
  * (c) 2010-2019 Highsoft AS
  * Author: Sebastian Domas

--- a/js/masters/modules/item-series.src.js
+++ b/js/masters/modules/item-series.src.js
@@ -1,5 +1,7 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/item-series
+ * @requires highcharts
  *
  * Item series type for Highcharts
  *

--- a/js/masters/modules/map-parser.src.js
+++ b/js/masters/modules/map-parser.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/map-parser
+ * @requires highcharts
+ * @requires highcharts/modules/data
  *
  * (c) 2009-2019 Torstein Honsi
  *

--- a/js/masters/modules/map.src.js
+++ b/js/masters/modules/map.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/map
+ * @requires highcharts
+ *
  * Highmaps as a plugin for Highcharts or Highstock.
  *
  * (c) 2011-2019 Torstein Honsi

--- a/js/masters/modules/networkgraph.src.js
+++ b/js/masters/modules/networkgraph.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/networkgraph
+ * @requires highcharts
+ *
  * Force directed graph module
  *
  * (c) 2010-2019 Torstein Honsi

--- a/js/masters/modules/no-data-to-display.src.js
+++ b/js/masters/modules/no-data-to-display.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/no-data-to-display
+ * @requires highcharts
+ *
  * Plugin for displaying a message when there is no data visible in chart.
  *
  * (c) 2010-2019 Highsoft AS

--- a/js/masters/modules/offline-exporting.src.js
+++ b/js/masters/modules/offline-exporting.src.js
@@ -1,5 +1,9 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/offline-exporting
+ * @requires highcharts
+ * @requires highcharts/modules/exporting
+ *
  * Client side exporting module
  *
  * (c) 2015-2019 Torstein Honsi / Oystein Moseng

--- a/js/masters/modules/oldie-polyfills.src.js
+++ b/js/masters/modules/oldie-polyfills.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/oldie-polyfills
+ * @requires highcharts
+ *
  * Old IE (v6, v7, v8) array polyfills for Highcharts v7+.
  *
  * (c) 2010-2019 Highsoft AS

--- a/js/masters/modules/oldie.src.js
+++ b/js/masters/modules/oldie.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/oldie
+ * @requires highcharts
+ *
  * Old IE (v6, v7, v8) module for Highcharts v6+.
  *
  * (c) 2010-2019 Highsoft AS

--- a/js/masters/modules/organization.src.js
+++ b/js/masters/modules/organization.src.js
@@ -1,5 +1,9 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/organization
+ * @requires highcharts
+ * @requires highcharts/modules/sankey
+ *
  * Highcharts organization chart module
  *
  * (c) 2019 Torstein Honsi

--- a/js/masters/modules/overlapping-datalabels.src.js
+++ b/js/masters/modules/overlapping-datalabels.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/overlapping-datalabels
+ * @requires highcharts
  *
  * (c) 2009-2019 Torstein Honsi
  *

--- a/js/masters/modules/parallel-coordinates.src.js
+++ b/js/masters/modules/parallel-coordinates.src.js
@@ -1,5 +1,7 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/parallel-coordinates
+ * @requires highcharts
  *
  * Support for parallel coordinates in Highcharts
  *

--- a/js/masters/modules/pareto.src.js
+++ b/js/masters/modules/pareto.src.js
@@ -1,5 +1,7 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/pareto
+ * @requires highcharts
  *
  * Pareto series type for Highcharts
  *

--- a/js/masters/modules/pathfinder.src.js
+++ b/js/masters/modules/pathfinder.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/pathfinder
+ * @requires highcharts
+ *
  * Pathfinder
  *
  * (c) 2016-2019 Øystein Moseng

--- a/js/masters/modules/pattern-fill.src.js
+++ b/js/masters/modules/pattern-fill.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/pattern-fill
+ * @requires highcharts
+ *
  * Module for adding patterns and images as point fills.
  *
  * (c) 2010-2019 Highsoft AS

--- a/js/masters/modules/price-indicator.src.js
+++ b/js/masters/modules/price-indicator.src.js
@@ -1,5 +1,9 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/price-indicator
+ * @requires highcharts
+ * @requires highcharts/modules/stock
+ *
  * Advanced Highstock tools
  *
  * (c) 2010-2019 Highsoft AS

--- a/js/masters/modules/sankey.src.js
+++ b/js/masters/modules/sankey.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/sankey
+ * @requires highcharts
+ *
  * Sankey diagram module
  *
  * (c) 2010-2019 Torstein Honsi

--- a/js/masters/modules/series-label.src.js
+++ b/js/masters/modules/series-label.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/series-label
+ * @requires highcharts
  *
  * (c) 2009-2019 Torstein Honsi
  *

--- a/js/masters/modules/solid-gauge.src.js
+++ b/js/masters/modules/solid-gauge.src.js
@@ -1,5 +1,9 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/solid-gauge
+ * @requires highcharts
+ * @requires highcharts/highcharts-more
+ *
  * Solid angular gauge module
  *
  * (c) 2010-2019 Torstein Honsi

--- a/js/masters/modules/sonification.src.js
+++ b/js/masters/modules/sonification.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/sonification
+ * @requires highcharts
+ *
  * Sonification module
  *
  * (c) 2012-2019 Øystein Moseng

--- a/js/masters/modules/static-scale.src.js
+++ b/js/masters/modules/static-scale.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/static-scale
+ * @requires highcharts
+ *
  * StaticScale
  *
  * (c) 2016-2019 Torstein Honsi, Lars A. V. Cabrera

--- a/js/masters/modules/stock-tools.src.js
+++ b/js/masters/modules/stock-tools.src.js
@@ -1,5 +1,9 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/stock-tools
+ * @requires highcharts
+ * @requires highcharts/modules/stock
+ *
  * Advanced Highstock tools
  *
  * (c) 2010-2019 Highsoft AS

--- a/js/masters/modules/stock.src.js
+++ b/js/masters/modules/stock.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/stock
+ * @requires highcharts
+ *
  * Highstock as a plugin for Highcharts
  *
  * (c) 2010-2019 Torstein Honsi

--- a/js/masters/modules/streamgraph.src.js
+++ b/js/masters/modules/streamgraph.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/streamgraph
+ * @requires highcharts
+ *
  * Streamgraph module
  *
  * (c) 2010-2019 Torstein Honsi

--- a/js/masters/modules/sunburst.src.js
+++ b/js/masters/modules/sunburst.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/sunburst
+ * @requires highcharts
  *
  * (c) 2016-2019 Highsoft AS
  * Authors: Jon Arild Nygard

--- a/js/masters/modules/tilemap.src.js
+++ b/js/masters/modules/tilemap.src.js
@@ -1,5 +1,9 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/tilemap
+ * @requires highcharts
+ * @requires highcharts/modules/map
+ *
  * Tilemap module
  *
  * (c) 2010-2019 Highsoft AS

--- a/js/masters/modules/timeline.src.js
+++ b/js/masters/modules/timeline.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/timeline
+ * @requires highcharts
+ *
  * Timeline series
  *
  * (c) 2010-2019 Highsoft AS

--- a/js/masters/modules/treegrid.src.js
+++ b/js/masters/modules/treegrid.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/treegrid
+ * @requires highcharts
+ *
  * Tree Grid
  *
  * (c) 2016-2019 Jon Arild Nygard

--- a/js/masters/modules/treemap.src.js
+++ b/js/masters/modules/treemap.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/treemap
+ * @requires highcharts
  *
  * (c) 2014-2019 Highsoft AS
  * Authors: Jon Arild Nygard / Oystein Moseng

--- a/js/masters/modules/variable-pie.src.js
+++ b/js/masters/modules/variable-pie.src.js
@@ -1,5 +1,7 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/variable-pie
+ * @requires highcharts
  *
  * Variable Pie module for Highcharts
  *

--- a/js/masters/modules/variwide.src.js
+++ b/js/masters/modules/variwide.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/variwide
+ * @requires highcharts
+ *
  * Highcharts variwide module
  *
  * (c) 2010-2019 Torstein Honsi

--- a/js/masters/modules/vector.src.js
+++ b/js/masters/modules/vector.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/vector
+ * @requires highcharts
+ *
  * Vector plot series module
  *
  * (c) 2010-2019 Torstein Honsi

--- a/js/masters/modules/venn.src.js
+++ b/js/masters/modules/venn.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/venn
+ * @requires highcharts
  *
  * (c) 2017-2019 Highsoft AS
  * Authors: Jon Arild Nygard

--- a/js/masters/modules/windbarb.src.js
+++ b/js/masters/modules/windbarb.src.js
@@ -1,5 +1,8 @@
 /**
  * @license  @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/windbarb
+ * @requires highcharts
+ *
  * Wind barb series module
  *
  * (c) 2010-2019 Torstein Honsi

--- a/js/masters/modules/wordcloud.src.js
+++ b/js/masters/modules/wordcloud.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/wordcloud
+ * @requires highcharts
  *
  * (c) 2016-2019 Highsoft AS
  * Authors: Jon Arild Nygard

--- a/js/masters/modules/xrange.src.js
+++ b/js/masters/modules/xrange.src.js
@@ -1,5 +1,8 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/modules/xrange
+ * @requires highcharts
+ *
  * X-range series
  *
  * (c) 2010-2019 Torstein Honsi, Lars A. V. Cabrera

--- a/js/masters/themes/avocado.src.js
+++ b/js/masters/themes/avocado.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/themes/avocado
+ * @requires highcharts
  *
  * (c) 2009-2019 Highsoft AS
  *

--- a/js/masters/themes/dark-blue.src.js
+++ b/js/masters/themes/dark-blue.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/themes/dark-blue
+ * @requires highcharts
  *
  * (c) 2009-2019 Torstein Honsi
  *

--- a/js/masters/themes/dark-green.src.js
+++ b/js/masters/themes/dark-green.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/themes/dark-green
+ * @requires highcharts
  *
  * (c) 2009-2019 Torstein Honsi
  *

--- a/js/masters/themes/dark-unica.src.js
+++ b/js/masters/themes/dark-unica.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/themes/dark-unica
+ * @requires highcharts
  *
  * (c) 2009-2019 Torstein Honsi
  *

--- a/js/masters/themes/gray.src.js
+++ b/js/masters/themes/gray.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/themes/gray
+ * @requires highcharts
  *
  * (c) 2009-2019 Torstein Honsi
  *

--- a/js/masters/themes/grid-light.src.js
+++ b/js/masters/themes/grid-light.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/themes/grid-light
+ * @requires highcharts
  *
  * (c) 2009-2019 Torstein Honsi
  *

--- a/js/masters/themes/grid.src.js
+++ b/js/masters/themes/grid.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/themes/grid
+ * @requires highcharts
  *
  * (c) 2009-2019 Torstein Honsi
  *

--- a/js/masters/themes/sand-signika.src.js
+++ b/js/masters/themes/sand-signika.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/themes/sand-signika
+ * @requires highcharts
  *
  * (c) 2009-2019 Torstein Honsi
  *

--- a/js/masters/themes/skies.src.js
+++ b/js/masters/themes/skies.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/themes/skies
+ * @requires highcharts
  *
  * (c) 2009-2019 Torstein Honsi
  *

--- a/js/masters/themes/sunset.src.js
+++ b/js/masters/themes/sunset.src.js
@@ -1,5 +1,7 @@
 /**
  * @license @product.name@ JS v@product.version@ (@product.date@)
+ * @module highcharts/themes/sunset
+ * @requires highcharts
  *
  * (c) 2009-2019 Highsoft AS
  *

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "gulp": "^4.0.0",
     "gulp-jsdoc3": "^2.0.0",
     "gzip-size": "^5.0.0",
-    "highcharts-assembler": "github:highcharts/highcharts-assembler#v1.2.3",
+    "highcharts-assembler": "github:highcharts/highcharts-assembler#v1.3.2",
     "highcharts-documentation-generators": "github:highcharts/highcharts-documentation-generators#v0.3.1",
     "husky": "latest",
     "js-yaml": "^3.12.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "gulp": "^4.0.0",
     "gulp-jsdoc3": "^2.0.0",
     "gzip-size": "^5.0.0",
-    "highcharts-assembler": "github:highcharts/highcharts-assembler#v1.3.2",
+    "highcharts-assembler": "github:highcharts/highcharts-assembler#v1.3.3",
     "highcharts-documentation-generators": "github:highcharts/highcharts-documentation-generators#v0.3.1",
     "husky": "latest",
     "js-yaml": "^3.12.1",

--- a/tools/build.js
+++ b/tools/build.js
@@ -26,7 +26,6 @@ const {
 const build = require('highcharts-assembler');
 
 // TODO move to a utils file
-const replaceAll = (str, search, replace) => str.split(search).join(replace);
 const isArray = x => Array.isArray(x);
 const isUndefined = x => typeof x === 'undefined';
 
@@ -38,68 +37,6 @@ const isUndefined = x => typeof x === 'undefined';
 const getProductVersion = () => {
     const properties = readFileSync('./build.properties', 'utf8');
     return regexGetCapture(/product\.version=(.+)/, properties);
-};
-
-/**
- * Returns fileOptions for the build script
- * @todo Move this functionality to the build script,
- *   and reuse it on github.highcharts.com
- * @return {Object} Object containing all fileOptions
- */
-const getFileOptions = files => {
-    const highchartsFiles = replaceAll(
-        getOrderedDependencies('js/masters/highcharts.src.js')
-            .map(path => relative('js', path))
-            .join('|'),
-        sep,
-        `\\${sep}`
-    );
-    // Modules should not be standalone, and they should exclude all parts files.
-    const fileOptions = files
-        .reduce((obj, file) => {
-            if (file.indexOf('modules') > -1 ||
-                file.indexOf('themes') > -1 ||
-                file.indexOf('indicators') > -1
-            ) {
-                obj[file] = {
-                    exclude: new RegExp(highchartsFiles),
-                    umd: false
-                };
-            }
-            return obj;
-        }, {});
-
-    /**
-     * Special cases
-     * solid-gauge should also exclude gauge-series
-     * highcharts-more and highcharts-3d is also not standalone.
-     */
-    if (fileOptions['modules/solid-gauge.src.js']) {
-        fileOptions['modules/solid-gauge.src.js'].exclude = new RegExp([highchartsFiles, 'GaugeSeries\.js$'].join('|'));
-    }
-    if (fileOptions['modules/map.src.js']) {
-        fileOptions['modules/map.src.js'].product = 'Highmaps';
-    }
-    if (fileOptions['modules/map-parser.src.js']) {
-        fileOptions['modules/map-parser.src.js'].product = 'Highmaps';
-    }
-    Object.assign(fileOptions, {
-        'highcharts-more.src.js': {
-            exclude: new RegExp(highchartsFiles),
-            umd: false
-        },
-        'highcharts-3d.src.js': {
-            exclude: new RegExp(highchartsFiles),
-            umd: false
-        },
-        'highmaps.src.js': {
-            product: 'Highmaps'
-        },
-        'highstock.src.js': {
-            product: 'Highstock'
-        }
-    });
-    return fileOptions;
 };
 
 const getBuildOptions = input => {
@@ -115,7 +52,6 @@ const getBuildOptions = input => {
             getFilesInFolder(base, true)
     );
     const type = ['classic'];
-    const fileOptions = getFileOptions(files);
     const mapTypeToSource = {
         classic: './code/es-modules',
         css: './code/js/es-modules'
@@ -123,7 +59,6 @@ const getBuildOptions = input => {
     return {
         base,
         debug,
-        fileOptions,
         files,
         output,
         type,
@@ -303,7 +238,6 @@ const getBuildScripts = params => {
 
 module.exports = {
     getBuildScripts,
-    getFileOptions,
     getProductVersion,
     scripts
 };


### PR DESCRIPTION
# Description
Loading our modules in AMD is currently a bit cumbersome as it requires the user to load all modules and its dependencies and apply them to the Highcharts instance. It also requires the user to have knowledge of said dependencies and which order to apply them.

This could be made a lot easier by defining the dependencies when we declare a AMD module in our UMD pattern, and let RequireJS or similar libraries handle the order of the loading.

Solved by updating the `highcharts-assembler` to `v1.3.2` to have support for `@module` and `@requires` tags in our files, and then add these necessary tags to all our master files which we build our distributed files from.

# Related issue(s)
- Closes #8890 