### PR TITLE
bugfix/10187-setData-old-null-values

### DIFF
--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -2949,7 +2949,8 @@ H.Series = H.seriesType(
             } else if (equalLength) {
                 data.forEach(function (point, i) {
                     // .update doesn't exist on a linked, hidden series (#3709)
-                    if (oldData[i].update && point !== options.data[i]) {
+                    // (#10187)
+                    if (oldData[i].update && point !== oldData[i].y) {
                         oldData[i].update(point, false, null, false);
                     }
                 });

--- a/samples/unit-tests/series/setdata/demo.js
+++ b/samples/unit-tests/series/setdata/demo.js
@@ -332,6 +332,20 @@ QUnit.test('Series.setData with updatePoints', function (assert) {
         'Old points have markers when redraw is set to false (#8060)'
     );
 
+    chart = Highcharts.chart('container', {
+        series: [{
+            data: [4, 5, 5]
+        }]
+    });
+
+    chart.series[0].setData([null, null, 1]);
+    chart.series[0].setData([4, 5, 5]);
+
+    assert.deepEqual(
+        chart.series[0].yData,
+        [4, 5, 5],
+        'Data is set correctly when oldData has null values and the same length (#10187)'
+    );
 });
 
 QUnit.test('Boosted series with updatePoints', function (assert) {


### PR DESCRIPTION
On the current master branch, the `update()` method was working correctly. However, this bug was occurring when using `setData()` what was fixed.