### PR TITLE
Add showEmpty to defaultOptions in Axis

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -1620,11 +1620,9 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
          *         When clicking the legend to hide series, one axis preserves
          *         line and title, the other doesn't
          *
-         * @type      {boolean}
-         * @default   true
          * @since     1.1
-         * @apioption xAxis.showEmpty
          */
+        showEmpty: true,
 
         /**
          * Whether to show the first tick label.

--- a/samples/unit-tests/series/showempty/demo.js
+++ b/samples/unit-tests/series/showempty/demo.js
@@ -1,67 +1,73 @@
 QUnit.test('Testing showEmpty feature and hasData function - #10106', function (assert) {
     // eslint-disable-next-line prefer-const
-    let chart = Highcharts.chart('container', {
-
-        yAxis: [{
-            showEmpty: false
-        }],
+    const { yAxis: [axis] } = Highcharts.chart('container', {
+        yAxis: [{}],
         series: [{
             data: []
         }]
     });
 
     assert.strictEqual(
-        chart.yAxis[0].showAxis,
+        axis.options.showEmpty,
+        true,
+        'should have options.showEmpty default to true'
+    );
+
+    axis.update({
+        showEmpty: false
+    });
+    assert.strictEqual(
+        axis.showAxis,
         false,
         'The yAxis should be invisible'
     );
     assert.strictEqual(
-        chart.yAxis[0].hasData(),
+        axis.hasData(),
         false,
         'Series has no data, so hasData function should return false'
     );
 
-    chart.yAxis[0].update({
+    axis.update({
         showEmpty: true
     });
     assert.strictEqual(
-        chart.yAxis[0].showAxis,
+        axis.showAxis,
         true,
         'The yAxis should be visible'
     );
     assert.strictEqual(
-        chart.yAxis[0].hasData(),
+        axis.hasData(),
         false,
         'Data is empty and there is no min and max values, so hasData function should return false'
     );
 
-    chart.yAxis[0].update({
+    axis.update({
         showEmpty: true,
         min: 0,
         max: 10
     });
     assert.strictEqual(
-        chart.yAxis[0].showAxis,
+        axis.showAxis,
         true,
         'The yAxis should be visible'
     );
     assert.strictEqual(
-        chart.yAxis[0].hasData(),
+        axis.hasData(),
         true,
         'HasData function should return true'
     );
 
-    chart.yAxis[0].update({
+    axis.update({
         showEmpty: false
     });
 
     assert.strictEqual(
-        chart.yAxis[0].showAxis,
+        axis.showAxis,
         false,
         'The yAxis should be invisible'
     );
     assert.strictEqual(
-        chart.yAxis[0].hasData(),
+        axis.hasData(),
         false,
         'ShowEmpty feature is set to false, so hasData function should return false'
     );


### PR DESCRIPTION
# Description
The new Axis.hasData looks for `axis.options.showEmpty` which will default to `undefined` as it is not defined in the defaultOptions. Solved by defining showEmpty as true in defaultOptions.

Fixes regression from #10386