### PR TITLE
networkgraph/stickyTracking

### DIFF
--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -161,6 +161,7 @@ seriesType(
      * @optionparent plotOptions.networkgraph
      */
     {
+        stickyTracking: false,
         inactiveOtherPoints: true,
         marker: {
             enabled: true,


### PR DESCRIPTION
Networkgraph: Changed default `stickyTracking`.

Now inactive state fades away when mouse cursor is leaving a node, not when leaving chart's container.