### PR TITLE
bugfix/inactive-3d

### DIFF
--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -766,6 +766,12 @@ extend(Point.prototype, /** @lends Highcharts.Point.prototype */ {
 
         point.firePointEvent('mouseOut');
 
+        if (!point.series.options.inactiveOtherPoints) {
+            (chart.hoverPoints || []).forEach(function (p) {
+                p.setState();
+            });
+        }
+
         chart.hoverPoints = chart.hoverPoint = null;
     },
 


### PR DESCRIPTION
Fixed missing `setState()` for hover points in 3D. 

Actually it's partially a revert from 7.0.0:

```
            onMouseOut: function () {
                var point = this,
                    chart = point.series.chart;

                point.firePointEvent('mouseOut');
                (chart.hoverPoints || []).forEach(function (p) {
                    p.setState();
                });
                chart.hoverPoints = chart.hoverPoint = null;
            },
```