### PR TITLE
feature/inactive-navigator-series

### DIFF
--- a/js/parts/Navigator.js
+++ b/js/parts/Navigator.js
@@ -1876,7 +1876,12 @@ Navigator.prototype = {
                 yAxis: 'navigator-y-axis',
                 showInLegend: false,
                 stacking: false, // #4823
-                isInternal: true
+                isInternal: true,
+                states: {
+                    inactive: {
+                        opacity: 1
+                    }
+                }
             },
             // Remove navigator series that are no longer in the baseSeries
             navigatorSeries = navigator.series =


### PR DESCRIPTION
Inactive state: Replaced default opacity in navigator series. Users still can change that through `series.navigatorOptions.states.inactive` option.