### PR TITLE
bugfix/3d-columns-inactive

### DIFF
--- a/js/parts-3d/Column.js
+++ b/js/parts-3d/Column.js
@@ -312,6 +312,8 @@ addEvent(Series, 'afterInit', function () {
 
         seriesOptions.zIndex = z;
     }
+
+    this.preventGroupOpacity = this.chart.is3d();
 });
 
 function pointAttribs(proceed) {

--- a/js/parts-3d/SVGRenderer.js
+++ b/js/parts-3d/SVGRenderer.js
@@ -397,9 +397,6 @@ cuboidMethods = H.merge(element3dMethods, {
         this.color = this.fill = fill;
 
         return this;
-    },
-    opacitySetter: function (opacity) {
-        return this.singleSetterForParts('opacity', opacity);
     }
 });
 

--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -1232,8 +1232,10 @@ extend(Series.prototype, /** @lends Highcharts.Series.prototype */ {
                 // resolved on a point level
                 if (!inactiveOtherPoints) {
                     [
-                        series.group,
-                        series.markerGroup,
+                        // For 3D columns, all series are in one main group,
+                        // don't change it's opacity
+                        series.preventGroupOpacity ? null : series.group,
+                        series.preventGroupOpacity ? null : series.markerGroup,
                         series.dataLabelsGroup,
                         series.labelBySeries
                     ].forEach(
@@ -1254,7 +1256,12 @@ extend(Series.prototype, /** @lends Highcharts.Series.prototype */ {
 
         // Don't loop over points on a series that doesn't apply inactive state
         // to siblings markers (e.g. line, column)
-        if (inherit && inactiveOtherPoints && series.points) {
+        if (
+            inherit && series.points && (
+                series.preventGroupOpacity ||
+                inactiveOtherPoints
+            )
+        ) {
             series.points.forEach(function (point) {
                 if (point.setState) {
                     point.setState(state);


### PR DESCRIPTION
Regression: Inactive state didn't work correctly for grouped columns in 3D.

I couldn't find any reason for `opacitySetter` in 3D columns, tested all visual 3D column samples and it works fine. I don't like the solution below (random `preventGroupOpacity` property) but it's the easiest way to change how opacity works in 3D columns.