### PR TITLE
bugfix/treemap-disabled-inactive

### DIFF
--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -162,7 +162,10 @@ seriesType(
      */
     {
         stickyTracking: false,
+
+        /** @ignore-option */
         inactiveOtherPoints: true,
+
         marker: {
             enabled: true,
             states: {

--- a/js/modules/sankey.src.js
+++ b/js/modules/sankey.src.js
@@ -213,7 +213,10 @@ seriesType('sankey', 'column'
             /** @ignore-option */
             inside: true
         },
+
+        /** @ignore-option */
         inactiveOtherPoints: true,
+
         /**
          * Set options on specific levels. Takes precedence over series options,
          * but not point options.

--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -1706,6 +1706,19 @@ seriesType(
             H.extend(this.yAxis.options, treeAxis);
             H.extend(this.xAxis.options, treeAxis);
         },
+
+        /**
+        * Workaround for `inactive` state. Since `series.opacity` option is
+        * already reserved, don't use that state at all by disabling
+        * `inactiveOtherPoints` and not inheriting states by points.
+        *
+        * @private
+        */
+        setState: function (state) {
+            this.options.inactiveOtherPoints = true;
+            Series.prototype.setState.call(this, state, false);
+            this.options.inactiveOtherPoints = false;
+        },
         utils: {
             recursive: recursive
         }

--- a/js/parts/PieSeries.js
+++ b/js/parts/PieSeries.js
@@ -335,7 +335,9 @@ seriesType('pie', 'line',
          */
         ignoreHiddenPoint: true,
 
+        /** @ignore-option */
         inactiveOtherPoints: true,
+
         /**
          * The size of the inner diameter for the pie. A size greater than 0
          * renders a donut chart. Can be a percentage or pixel value.


### PR DESCRIPTION
Inactive state: Disabled inactive state in treemap, removed `inactiveOtherPoints` options from API docs.