### PR TITLE
bugfix/3d-grouping-column-inactive

### DIFF
--- a/js/parts-3d/Column.js
+++ b/js/parts-3d/Column.js
@@ -326,9 +326,27 @@ function pointAttribs(proceed) {
     return attr;
 }
 
+// In 3D mode, all column-series are rendered in one main group.
+// Because of that we need to apply inactive state on all points.
+function setState(proceed, state, inherit) {
+    var is3d = this.chart.is3d && this.chart.is3d();
+
+    if (is3d) {
+        this.options.inactiveOtherPoints = true;
+    }
+
+    proceed.call(this, state, inherit);
+
+    if (is3d) {
+        this.options.inactiveOtherPoints = false;
+    }
+}
+
 wrap(seriesTypes.column.prototype, 'pointAttribs', pointAttribs);
+wrap(seriesTypes.column.prototype, 'setState', setState);
 if (seriesTypes.columnrange) {
     wrap(seriesTypes.columnrange.prototype, 'pointAttribs', pointAttribs);
+    wrap(seriesTypes.columnrange.prototype, 'setState', setState);
     seriesTypes.columnrange.prototype.plotGroup =
         seriesTypes.column.prototype.plotGroup;
     seriesTypes.columnrange.prototype.setVisible =

--- a/js/parts-3d/SVGRenderer.js
+++ b/js/parts-3d/SVGRenderer.js
@@ -397,9 +397,6 @@ cuboidMethods = H.merge(element3dMethods, {
         this.color = this.fill = fill;
 
         return this;
-    },
-    opacitySetter: function (opacity) {
-        return this.singleSetterForParts('opacity', opacity);
     }
 });
 


### PR DESCRIPTION
Regression: Inactive state didn't work correctly for grouped columns in 3D.

Much better solution than the previous one - does not require shady code in the core. 

I couldn't find any reason for opacitySetter in 3D columns, tested all visual 3D column samples and it works fine.