### PR TITLE
bugfix/annotations-update-labeloptions

### DIFF
--- a/js/annotations/annotations.src.js
+++ b/js/annotations/annotations.src.js
@@ -732,19 +732,17 @@ merge(
         },
 
         addShapes: function () {
-            (this.options.shapes || []).forEach(function (shapeOptions, i) {
-                var shape = this.initShape(shapeOptions, i);
-
-                this.options.shapes[i] = shape.options;
-            }, this);
+            (this.options.shapes || []).forEach(
+                this.initShape,
+                this
+            );
         },
 
         addLabels: function () {
-            (this.options.labels || []).forEach(function (labelOptions, i) {
-                var label = this.initLabel(labelOptions, i);
-
-                this.options.labels[i] = label.options;
-            }, this);
+            (this.options.labels || []).forEach(
+                this.initLabel,
+                this
+            );
         },
 
         addClipPaths: function () {

--- a/samples/unit-tests/annotations/annotations-dynamic/demo.js
+++ b/samples/unit-tests/annotations/annotations-dynamic/demo.js
@@ -1,4 +1,3 @@
-
 QUnit.test('Annotation\'s dynamic methods', function (assert) {
     var labelCollector;
     var chart = Highcharts.chart('container', {
@@ -84,7 +83,8 @@ QUnit.test('Annotation\'s dynamic methods', function (assert) {
 
     thirdAnnotation.update({
         labelOptions: {
-            format: 'custom format'
+            format: 'custom format',
+            backgroundColor: 'red'
         }
     });
 
@@ -92,6 +92,18 @@ QUnit.test('Annotation\'s dynamic methods', function (assert) {
         thirdAnnotation.labels[0].options.format,
         'custom format',
         'Correct annotations text after update (annotations.labels)'
+    );
+
+    thirdAnnotation.update({
+        labelOptions: {
+            backgroundColor: 'green'
+        }
+    });
+
+    assert.strictEqual(
+        thirdAnnotation.labels[0].graphic.attr('fill'),
+        'green',
+        'Correct annotations label fill after update (annotations.labels)'
     );
 
     var annotation = chart.addAnnotation({


### PR DESCRIPTION
Highstock: Fixed #10460, updated options in annotations prevent updates from popup.

Creating labels changed options in the config - we should not do that. If that cases any new issues, we should resolve those issues in a different way.