### PR TITLE
feature/10416-scrollableplotarea-opacity 

### DIFF
--- a/js/parts/ScrollablePlotArea.js
+++ b/js/parts/ScrollablePlotArea.js
@@ -46,6 +46,26 @@ var addEvent = H.addEvent,
  * @apioption chart.scrollablePlotArea.scrollPositionX
  */
 
+/**
+ * The opacity of mask applied on one of the sides of the plot
+ * area.
+ *
+ * @sample {highcharts} highcharts/chart/scrollable-plotarea-opacity
+ *         Disabled opacity for the mask
+ *
+ * @type        {number}
+ * @default     0.85
+ * @since       7.1.1
+ * @apioption   chart.scrollablePlotArea.opacity
+ */
+H.setOptions({
+    chart: {
+        scrollablePlotArea: {
+            opacity: 0.85
+        }
+    }
+});
+
 addEvent(Chart, 'afterSetChartSize', function (e) {
 
     var scrollablePlotArea = this.options.chart.scrollablePlotArea,
@@ -140,7 +160,8 @@ Chart.prototype.applyFixed = function () {
     var container = this.container,
         fixedRenderer,
         scrollableWidth,
-        firstTime = !this.fixedDiv;
+        firstTime = !this.fixedDiv,
+        scrollableOptions = this.options.chart.scrollablePlotArea;
 
     // First render
     if (firstTime) {
@@ -176,7 +197,7 @@ Chart.prototype.applyFixed = function () {
             .attr({
                 fill: H.color(
                     this.options.chart.backgroundColor || '#fff'
-                ).setOpacity(0.85).get(),
+                ).setOpacity(scrollableOptions.opacity).get(),
                 zIndex: -1
             })
             .addClass('highcharts-scrollable-mask')
@@ -231,11 +252,10 @@ Chart.prototype.applyFixed = function () {
 
     // Set scroll position
     if (firstTime) {
-        var options = this.options.chart.scrollablePlotArea;
 
-        if (options.scrollPositionX) {
+        if (scrollableOptions.scrollPositionX) {
             this.scrollingContainer.scrollLeft =
-                this.scrollablePixels * options.scrollPositionX;
+                this.scrollablePixels * scrollableOptions.scrollPositionX;
         }
     }
 

--- a/samples/highcharts/chart/scrollable-plotarea-opacity/demo.css
+++ b/samples/highcharts/chart/scrollable-plotarea-opacity/demo.css
@@ -1,0 +1,5 @@
+#container {
+    max-width: 800px;
+    min-width: 320px;
+    height: 400px;
+}

--- a/samples/highcharts/chart/scrollable-plotarea-opacity/demo.details
+++ b/samples/highcharts/chart/scrollable-plotarea-opacity/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+...

--- a/samples/highcharts/chart/scrollable-plotarea-opacity/demo.html
+++ b/samples/highcharts/chart/scrollable-plotarea-opacity/demo.html
@@ -1,0 +1,5 @@
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="container"></div>

--- a/samples/highcharts/chart/scrollable-plotarea-opacity/demo.js
+++ b/samples/highcharts/chart/scrollable-plotarea-opacity/demo.js
@@ -1,0 +1,64 @@
+Highcharts.chart('container', {
+    chart: {
+        type: 'spline',
+        scrollablePlotArea: {
+            minWidth: 700,
+            scrollPositionX: 1,
+            opacity: 0
+        }
+    },
+    title: {
+        text: 'Scrollable plot area without mask'
+    },
+    subtitle: {
+        text: 'Open on mobile and scroll sideways'
+    },
+    xAxis: {
+        type: 'datetime',
+        labels: {
+            overflow: 'justify'
+        }
+    },
+    yAxis: {
+        tickWidth: 1,
+        title: {
+            text: 'Wind speed (m/s)'
+        },
+        lineWidth: 1,
+        opposite: true
+    },
+    tooltip: {
+        valueSuffix: ' m/s',
+        split: true
+    },
+
+    plotOptions: {
+        spline: {
+            lineWidth: 4,
+            states: {
+                hover: {
+                    lineWidth: 5
+                }
+            },
+            marker: {
+                enabled: false
+            },
+            pointInterval: 3600000, // one hour
+            pointStart: Date.UTC(2015, 4, 31, 0, 0, 0)
+        }
+    },
+    series: [{
+        name: 'Hestavollane',
+        data: [0.2, 0.8, 0.8, 0.8, 1, 1.3, 1.5, 2.9, 1.9, 2.6, 1.6, 3, 4, 3.6,
+            5.5, 6.2, 5.5, 4.5, 4, 3.1, 2.7, 4, 2.7, 2.3, 2.3, 4.1, 7.7, 7.1,
+            5.6, 6.1, 5.8, 8.6, 7.2, 9, 10.9, 11.5, 11.6, 11.1, 12, 12.3, 10.7,
+            9.4, 9.8, 9.6, 9.8, 9.5, 8.5, 7.4, 7.6]
+
+    }, {
+        name: 'Vik',
+        data: [0, 0, 0.6, 0.9, 0.8, 0.2, 0, 0, 0, 0.1, 0.6, 0.7, 0.8, 0.6, 0.2,
+            0, 0.1, 0.3, 0.3, 0, 0.1, 0, 0, 0, 0.2, 0.1, 0, 0.3, 0, 0.1, 0.2,
+            0.1, 0.3, 0.3, 0, 3.1, 3.1, 2.5, 1.5, 1.9, 2.1, 1, 2.3, 1.9, 1.2,
+            0.7, 1.3, 0.4, 0.3]
+    }]
+});


### PR DESCRIPTION
Added new option, `chart.scrollablePlotArea.opacity`, to control opacity of the scrollable mask. Closes #10416.

This is the simples solution for `opacity` (aka disabled mask).

Actually, we can consider general `maskStyles: { ... }` option, that could include fill, opacity, border, dash style etc. Of course we would need to resolve `styledMode` too + define default styles for mask in CSS file. I don't know if we need that so I decided to solve the issue in the easiest way. Let me know if you think we should use `maskStyles` instead of `opacity` option only.