### PR TITLE
bugfix/10432-boost-category-tooltip

### DIFF
--- a/js/modules/boost/boost-overrides.js
+++ b/js/modules/boost/boost-overrides.js
@@ -115,7 +115,10 @@ Series.prototype.getPoint = function (boostPoint) {
             xData ? xData[boostPoint.i] : undefined
         );
 
-        point.category = point.x;
+        point.category = pick(
+            this.xAxis.categories ? this.xAxis.categories[point.x] : point.x,
+            point.x
+        );
 
         point.dist = boostPoint.dist;
         point.distX = boostPoint.distX;

--- a/samples/unit-tests/boost/tooltip/demo.details
+++ b/samples/unit-tests/boost/tooltip/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/boost/tooltip/demo.html
+++ b/samples/unit-tests/boost/tooltip/demo.html
@@ -1,0 +1,9 @@
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+<script src="https://code.highcharts.com/modules/boost.js"></script>
+<script src="https://code.highcharts.com/modules/data.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/boost/tooltip/demo.js
+++ b/samples/unit-tests/boost/tooltip/demo.js
@@ -1,0 +1,19 @@
+QUnit.test('Tooltip on a boosted chart with categories', function (assert) {
+    var chart = Highcharts.chart('container', {
+            xAxis: {
+                categories: ['categoryName', 'B', 'C']
+            },
+            series: [{
+                boostThreshold: 1,
+                data: [0, 1, 2]
+            }]
+        }),
+        controller = new TestController(chart);
+
+    controller.moveTo(chart.plotLeft + 5, chart.plotTop + 5);
+
+    assert.ok(
+        document.getElementsByClassName('highcharts-tooltip')[0].innerHTML.match('categoryName') !== null,
+        '`categoryName` found in the tooltip (#10432).'
+    );
+});


### PR DESCRIPTION
Fixed #10432, missing category name in tooltip when using boost module.
