### PR TITLE
bugfix/10013-boost-hide-show-series

### DIFF
--- a/js/modules/boost/boost-init.js
+++ b/js/modules/boost/boost-init.js
@@ -136,6 +136,12 @@ function init() {
             // If we're rendering per. series we should create the marker groups
             // as usual.
             if (!chart.isChartSeriesBoosting()) {
+                // If all series were boosting, but are not anymore
+                // restore private markerGroup
+                if (this.markerGroup === chart.markerGroup) {
+                    this.markerGroup = undefined;
+                }
+
                 this.markerGroup = series.plotGroup(
                     'markerGroup',
                     'markers',
@@ -144,6 +150,14 @@ function init() {
                     chart.seriesGroup
                 );
             } else {
+                // If series has a private markeGroup, remove that
+                // and use common markerGroup
+                if (
+                    this.markerGroup &&
+                    this.markerGroup !== chart.markerGroup
+                ) {
+                    this.markerGroup.destroy();
+                }
                 // Use a single group for the markers
                 this.markerGroup = chart.markerGroup;
 

--- a/samples/unit-tests/boost/setvisible/demo.js
+++ b/samples/unit-tests/boost/setvisible/demo.js
@@ -42,3 +42,26 @@ QUnit.test('Boosted series show/hide', function (assert) {
     );
 
 });
+
+QUnit.test('Boosted and not boosted series - visibility', function (assert) {
+    var chart = Highcharts.chart('container', {
+            series: [{
+                boostThreshold: 1000,
+                data: [10, 3]
+            }, {
+                boostThreshold: 1,
+                data: [5, 10]
+            }]
+        }),
+        series = chart.series[0];
+
+    series.hide();
+    series.show();
+    series.hide();
+
+    assert.strictEqual(
+        series.markerGroup.attr('visibility'),
+        'hidden',
+        'Markers are hidden altogether with series even in the not boosted series (#10013).'
+    );
+});


### PR DESCRIPTION
Fixed #10013, series did not hide markers when other series were in boosted mode.

Checked also boost visual tests.

Maybe I misunderstand [`boost.allowForce`](https://api.highcharts.com/highcharts/boost.allowForce) option:

> allowForce: boolean Since 1.0.0
> If set to true, the whole chart will be boosted if one of the series crosses its threshold, and all the series can be boosted.

 Description is a bit vague: **"and all the series can be boosted"** - suggests support for boosting, but from the source code it seems `series.boostThreshold` is taken into account too. What is the point of that option if only one crosses it's `boostThreshold` and other don't? Do I miss something?