### PR TITLE
defaults/inactive-opacity-maps

### DIFF
--- a/js/parts-map/MapSeries.js
+++ b/js/parts-map/MapSeries.js
@@ -328,6 +328,10 @@ seriesType(
                  * @apioption plotOptions.series.states.select.color
                  */
                 color: '${palette.neutralColor20}'
+            },
+
+            inactive: {
+                opacity: 1
             }
         }
 


### PR DESCRIPTION
Changed default `states.inactive.opacity` for map and mapline series to prevent dimming map shapes.