### PR TITLE
bugfix/10471-fixing-pareto-baseSeries-0

### DIFF
--- a/js/mixins/derived-series.js
+++ b/js/mixins/derived-series.js
@@ -64,7 +64,7 @@ var derivedSeriesMixin = {
         var chart = this.chart,
             baseSeriesOptions = this.options.baseSeries,
             baseSeries =
-        baseSeriesOptions &&
+        H.defined(baseSeriesOptions) &&
         (chart.series[baseSeriesOptions] || chart.get(baseSeriesOptions));
 
         this.baseSeries = baseSeries || null;

--- a/samples/unit-tests/series-pareto/pareto/demo.js
+++ b/samples/unit-tests/series-pareto/pareto/demo.js
@@ -1,4 +1,3 @@
-
 QUnit.test('Pareto', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {
@@ -86,5 +85,28 @@ QUnit.test('Pareto', function (assert) {
         [10.504201680672, 42.226890756303, 60.294117647059, 75.420168067227, 86.134453781513, 93.697478991597, 95.798319327731, 100],
         'Series points are correctly calculated'
     );
+});
 
+QUnit.test('Pareto wasnt working with baseSeries set to 0 - #10471', function (assert) {
+    var chart = Highcharts.chart('container', {
+
+        series: [{
+            type: 'column',
+            data: [155, 55, 231, 22, 72, 51, 36, 10]
+        }, {
+            type: 'column',
+            data: [755, 222, 151, 86, 72, 51, 36, 10]
+        },
+        {
+            type: 'pareto',
+            baseSeries: 0
+        }
+        ]
+    });
+
+    assert.deepEqual(
+        chart.series[2].points.length,
+        chart.series[0].points.length,
+        'Number of points in pareto series should be equal amount of point in assigned series'
+    );
 });


### PR DESCRIPTION
Fixed #10471, Pareto series wasn't rendering when baseSeries was set to the first series by 0 number.