### PR TITLE
 bugfix/4608-boost-inverted-reversed

### DIFF
--- a/js/modules/boost/boost-overrides.js
+++ b/js/modules/boost/boost-overrides.js
@@ -26,6 +26,7 @@ var boostEnabled = butils.boostEnabled,
     shouldForceChartSeriesBoosting = butils.shouldForceChartSeriesBoosting,
     Chart = H.Chart,
     Series = H.Series,
+    Point = H.Point,
     seriesTypes = H.seriesTypes,
     addEvent = H.addEvent,
     isNumber = H.isNumber,
@@ -132,6 +133,54 @@ wrap(Series.prototype, 'searchPoint', function (proceed) {
     return this.getPoint(
         proceed.apply(this, [].slice.call(arguments, 1))
     );
+});
+
+// For inverted series, we need to swap X-Y values before running base methods
+wrap(Point.prototype, 'haloPath', function (proceed) {
+    var halo,
+        point = this,
+        series = point.series,
+        chart = series.chart,
+        plotX = point.plotX,
+        plotY = point.plotY,
+        inverted = chart.inverted;
+
+    if (series.isSeriesBoosting && inverted) {
+        point.plotX = series.yAxis.len - plotY;
+        point.plotY = series.xAxis.len - plotX;
+    }
+
+    halo = proceed.apply(this, Array.prototype.slice.call(arguments, 1));
+
+    if (series.isSeriesBoosting && inverted) {
+        point.plotX = plotX;
+        point.plotY = plotY;
+    }
+
+    return halo;
+});
+
+wrap(Series.prototype, 'markerAttribs', function (proceed, point) {
+    var attribs,
+        series = this,
+        chart = series.chart,
+        plotX = point.plotX,
+        plotY = point.plotY,
+        inverted = chart.inverted;
+
+    if (series.isSeriesBoosting && inverted) {
+        point.plotX = series.yAxis.len - plotY;
+        point.plotY = series.xAxis.len - plotX;
+    }
+
+    attribs = proceed.apply(this, Array.prototype.slice.call(arguments, 1));
+
+    if (series.isSeriesBoosting && inverted) {
+        point.plotX = plotX;
+        point.plotY = plotY;
+    }
+
+    return attribs;
 });
 
 /*

--- a/js/modules/boost/wgl-renderer.js
+++ b/js/modules/boost/wgl-renderer.js
@@ -866,6 +866,7 @@ function GLRenderer(postRenderCallback) {
         shader.setUniform('xAxisLen', axis.len);
         shader.setUniform('xAxisPos', axis.pos);
         shader.setUniform('xAxisCVSCoord', !axis.horiz);
+        shader.setUniform('xAxisReversed', !!axis.reversed);
     }
 
     /*
@@ -884,6 +885,7 @@ function GLRenderer(postRenderCallback) {
         shader.setUniform('yAxisLen', axis.len);
         shader.setUniform('yAxisPos', axis.pos);
         shader.setUniform('yAxisCVSCoord', !axis.horiz);
+        shader.setUniform('yAxisReversed', !!axis.reversed);
     }
 
     /*
@@ -928,7 +930,6 @@ function GLRenderer(postRenderCallback) {
 
         gl.viewport(0, 0, width, height);
         shader.setPMatrix(orthoMatrix(width, height));
-        shader.setPlotHeight(chart.plotHeight);
 
         if (settings.lineWidth > 1 && !H.isMS) {
             gl.lineWidth(settings.lineWidth);

--- a/samples/highcharts/boost/scatter-inverted-reversed/demo.css
+++ b/samples/highcharts/boost/scatter-inverted-reversed/demo.css
@@ -1,0 +1,5 @@
+#container {
+	min-width: 380;
+	max-width: 600px;
+	margin: 0 auto;
+}

--- a/samples/highcharts/boost/scatter-inverted-reversed/demo.details
+++ b/samples/highcharts/boost/scatter-inverted-reversed/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Paweł Fus
+ js_wrap: b
+...

--- a/samples/highcharts/boost/scatter-inverted-reversed/demo.html
+++ b/samples/highcharts/boost/scatter-inverted-reversed/demo.html
@@ -1,0 +1,6 @@
+
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/boost.js"></script>
+
+
+<div id="container"></div>

--- a/samples/highcharts/boost/scatter-inverted-reversed/demo.js
+++ b/samples/highcharts/boost/scatter-inverted-reversed/demo.js
@@ -1,0 +1,31 @@
+Highcharts.chart('container', {
+
+    chart: {
+        inverted: true
+    },
+
+    boost: {
+        useGPUTranslations: true,
+        usePreallocated: true
+    },
+
+    plotOptions: {
+        series: {
+            boostThreshold: 1
+        }
+    },
+
+    xAxis: {
+        reversed: true
+    },
+
+    yAxis: {
+        reversed: true
+    },
+
+    series: [{
+        type: 'scatter',
+        data: [0, 1, 12, 3, 14, 5]
+    }]
+
+});


### PR DESCRIPTION
Fixed #4608, boost module highlighted wrong point on hover when chart was inverted. Added support for reversed axes in boost.

Actually we had two bugs here:
- general issue with halo and shared marker position
- when setting `useGPUTranslations`, inverted chart points were mispositioned. Additionally, when comparing `translate` from the core, I realized `reversed` was missing, so added it too. Now inverted & reversed axes with `useGPUTranslations` works without issues.

And I have replaced `plotHeight` with `yAxisLen`. In general:
```
                    'if (v > yAxisLen) {',
                        'v = yAxisLen;',
                    '}',
```
looks a bit nasty - why markers outside extremes should be rendered on the edge of canvas?

**Edit:**
Probably shouldn't be rendered on canvas edge and should be removed like here:
https://github.com/highcharts/highcharts/blob/0d1986da9b79c00bb14d18b431d00a0acd6eadf5/js/modules/boost/wgl-renderer.js#L611-L618