### PR TITLE
bugfix/5268-boost-threshold-null

### DIFF
--- a/js/modules/boost/wgl-renderer.js
+++ b/js/modules/boost/wgl-renderer.js
@@ -647,7 +647,10 @@ function GLRenderer(postRenderCallback) {
                 }
 
                 if (!isRange && !isStacked) {
-                    minVal = Math.max(threshold, yMin); // #8731
+                    minVal = Math.max(
+                        threshold === null ? yMin : threshold, // #5268
+                        yMin
+                    ); // #8731
                 }
                 if (!settings.useGPUTranslations) {
                     minVal = yAxis.toPixels(minVal, true);

--- a/samples/highcharts/boost/area-threshold/demo.details
+++ b/samples/highcharts/boost/area-threshold/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - PAweł Fus
+ js_wrap: b
+...

--- a/samples/highcharts/boost/area-threshold/demo.html
+++ b/samples/highcharts/boost/area-threshold/demo.html
@@ -1,0 +1,5 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/boost.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
+
+<div id="container" style="height: 400px; max-width: 800px; margin: 0 auto"></div>

--- a/samples/highcharts/boost/area-threshold/demo.js
+++ b/samples/highcharts/boost/area-threshold/demo.js
@@ -1,0 +1,27 @@
+Highcharts.chart('container', {
+
+    chart: {
+        type: 'area'
+    },
+
+    boost: {
+        useGPUTranslations: true
+    },
+
+    series: [{
+        boostThreshold: 1,
+        data: [[0, 0], [1, -15], [2, 15]],
+        threshold: null,
+        name: 'Series starts from yAxis.min'
+    }, {
+        boostThreshold: 1,
+        data: [[3, 0], [4, -15], [5, 15]],
+        threshold: -10,
+        name: 'Series starts from -10'
+    }, {
+        boostThreshold: 1,
+        data: [[6, 0], [7, -15], [8, 15]],
+        threshold: 10,
+        name: 'Series starts from 10'
+    }]
+});


### PR DESCRIPTION
Fixed #5268, `series.threshold = null` was ignored in boost mode.