### PR TITLE
bugfix/10504-inactive-after-select

### DIFF
--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -710,17 +710,22 @@ extend(Point.prototype, /** @lends Highcharts.Point.prototype */ {
                 // unselect all other points unless Ctrl or Cmd + click
                 if (!accumulate) {
                     chart.getSelectedPoints().forEach(function (loopPoint) {
+                        var loopSeries = loopPoint.series;
+
                         if (loopPoint.selected && loopPoint !== point) {
                             loopPoint.selected = loopPoint.options.selected =
                                 false;
-                            series.options.data[
-                                series.data.indexOf(loopPoint)
+                            loopSeries.options.data[
+                                loopSeries.data.indexOf(loopPoint)
                             ] = loopPoint.options;
+
                             // Programatically selecting a point should restore
                             // normal state, but when click happened on other
                             // point, set inactive state to match other points
                             loopPoint.setState(
-                                chart.hoverPoints ? 'inactive' : ''
+                                chart.hoverPoints &&
+                                    loopSeries.options.inactiveOtherPoints ?
+                                    'inactive' : ''
                             );
                             loopPoint.firePointEvent('unselect');
                         }

--- a/samples/unit-tests/point/point/demo.js
+++ b/samples/unit-tests/point/point/demo.js
@@ -76,7 +76,8 @@ QUnit.test(
                     data: [5, 10, 15]
                 }, {
                     type: 'column',
-                    data: [15, 15, 13, 16]
+                    data: [15, 15, 13, 16],
+                    allowPointSelect: true
                 }]
             }),
             legend = chart.legend,
@@ -150,6 +151,28 @@ QUnit.test(
             ) !== '0.1',
             'Legend hover: correct hovered series opacity'
         );
+
+        controller.click(
+            chart.plotLeft + chart.series[1].points[3].plotX,
+            chart.plotTop + chart.series[1].points[3].plotY + 5
+        );
+
+        controller.mouseOver(
+            chart.plotLeft + chart.series[1].points[0].plotX,
+            chart.plotTop + chart.series[1].points[0].plotY + 5
+        );
+
+        controller.click(
+            chart.plotLeft + chart.series[1].points[0].plotX,
+            chart.plotTop + chart.series[1].points[0].plotY + 5
+        );
+
+        assert.strictEqual(
+            chart.series[1].points[3].state,
+            '',
+            'Correct state for column after deselection (#10504)'
+        );
+
     }
 );
 
@@ -575,5 +598,34 @@ QUnit.test('Point className on other elements', function (assert) {
             .getAttribute('class').indexOf('my-class'),
         -1,
         'The halo for other points should not have the point className'
+    );
+});
+
+QUnit.test('Deselecting points', function (assert) {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            type: 'column'
+        },
+        plotOptions: {
+            series: {
+                allowPointSelect: true
+            }
+        },
+        series: [{
+            data: [1, 2, 3]
+        }, {
+            data: [1, 2, 3]
+        }]
+    });
+
+    chart.series[0].points[1].select(true, true);
+    chart.series[0].points[2].select(true, true);
+
+    chart.series[1].points[1].select(true, false);
+
+    assert.strictEqual(
+        chart.series[0].options.data['-1'],
+        undefined,
+        'No fake points in series.options.data after deselecting other points.'
     );
 });


### PR DESCRIPTION
Fixed #10504, after deselecting a column, inactive state was used instead of normal state.

Additionally, I realized that multiple series had a bug, demo: https://jsfiddle.net/BlackLabel/1zwt4spf/ - we always updated point.options for a point that was from the current series :)) (see console):
```js
> [1, {…}, 3, -1: {…}]
> 0: 1
> 1: {y: 2, selected: true}
> 2: 3
> -1: {y: 3, selected: false}
> length: 3
```

Fixed too.