### PR TITLE
bugfix/10506-named-colors-boost

### DIFF
--- a/js/modules/boost/boost.js
+++ b/js/modules/boost/boost.js
@@ -14,6 +14,7 @@ import H from '../../parts/Globals.js';
 import butils from './boost-utils.js';
 import init from './boost-init.js';
 import './boost-overrides.js';
+import './named-colors.js';
 
 // These need to be fixed when we support named imports
 var hasWebGLSupport = butils.hasWebGLSupport;


### PR DESCRIPTION
Fixed #10506, named colors did not work in boost mode.

I guess we didn't do that on purpose.