### PR TITLE
Fixed #10490, correct zIndex on venn graphics

### DIFF
--- a/js/modules/venn.src.js
+++ b/js/modules/venn.src.js
@@ -1007,12 +1007,14 @@ var vennSeries = {
 
         // Iterate all points and calculate and draw their graphics.
         points.forEach(function (point) {
-            var attribs,
+            var attribs = {
+                    zIndex: isArray(point.sets) ? point.sets.length : 0
+                },
                 shapeArgs = point.shapeArgs;
 
             // Add point attribs
             if (!chart.styledMode) {
-                attribs = series.pointAttribs(point, point.state);
+                extend(attribs, series.pointAttribs(point, point.state));
             }
             // Draw the point graphic.
             point.draw({

--- a/samples/unit-tests/series-venn/integration/demo.details
+++ b/samples/unit-tests/series-venn/integration/demo.details
@@ -1,0 +1,5 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+...

--- a/samples/unit-tests/series-venn/integration/demo.html
+++ b/samples/unit-tests/series-venn/integration/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/venn.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/series-venn/integration/demo.js
+++ b/samples/unit-tests/series-venn/integration/demo.js
@@ -1,0 +1,50 @@
+QUnit.test('zIndex. #10490', assert => {
+    const unsortedData = [{
+        sets: ['A', 'B'],
+        value: 1
+    }, {
+        sets: ['B', 'C', 'A'],
+        value: 1
+    }, {
+        sets: ['A'],
+        value: 2
+    }, {
+        sets: ['C'],
+        value: 2
+    }, {
+        sets: ['A', 'C'],
+        value: 1
+    }, {
+        sets: ['B', 'C'],
+        value: 1
+    }, {
+        sets: ['B'],
+        value: 2
+    }];
+
+    const { series: [{ points }] } = Highcharts.chart('container', {
+        series: [{
+            type: 'venn',
+            data: unsortedData
+        }]
+    });
+
+    const mapOfIdToZIndex = points.reduce((map, point) => {
+        map[point.sets.join()] = point.graphic.attr('zIndex');
+        return map;
+    }, {});
+
+    assert.deepEqual(
+        mapOfIdToZIndex,
+        {
+            A: 1,
+            B: 1,
+            C: 1,
+            'A,B': 2,
+            'A,C': 2,
+            'B,C': 2,
+            'A,B,C': 3
+        },
+        'should order the point graphics by its number of sets in the relation'
+    );
+});


### PR DESCRIPTION
# Description
Currently the order of the data is determining the order the graphics in venn are arranged in the series group, causing the overlapping relations to be hidden if the data is not sorted.
Solved by setting the zIndex attribute on the point graphic to have them ordered properly.

# Example(s)
- [Demo of issue](https://jsfiddle.net/jon_a_nygaard/r9asekf1/)
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/08fraokv/)

# Related issue(s)
- Closes #10490 