### PR TITLE
bugfix/10527-networkgraph-datalabels-usehtml

### DIFF
--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -953,7 +953,7 @@ Series.prototype.drawDataLabels = function () {
                         dataLabel.add(dataLabelsGroup);
                     }
 
-                    if (labelOptions.textPath) {
+                    if (labelOptions.textPath && !labelOptions.useHTML) {
                         dataLabel.setTextPath(
                             (
                                 point.getDataLabelPath &&

--- a/samples/unit-tests/datalabels/usehtml/demo.js
+++ b/samples/unit-tests/datalabels/usehtml/demo.js
@@ -47,3 +47,28 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test(
+    '#10527: useHTML and textPath',
+    function (assert) {
+        var chart = Highcharts.chart('container', {
+            series: [{
+                dataLabels: {
+                    enabled: true,
+                    useHTML: true,
+                    textPath: {
+                        enabled: true
+                    }
+                },
+                data: [1, 3, 2]
+            }]
+        });
+
+        chart.series[0].hide();
+        chart.series[0].show();
+
+        assert.ok(
+            'No errors when enabling useHTML and textPath options together.'
+        );
+    }
+);


### PR DESCRIPTION
Fixed #10527, setting `networkgraph.dataLabels.useHTML` to true used to throw errors in JS console.

Note: It was a general issue, not only networkgraph. It was directly caused by `textPath` + HTML labels.