### PR TITLE
bugfix/10545-networkgraph-link-datalabels-border

### DIFF
--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -79,15 +79,19 @@
  * @type {Highcharts.PlotNetworkDataLabelsFormatterCallbackFunction|undefined}
  * @since 7.1.0
  *//**
- * Options for a _link_ label text which should follow link connection.
- * **Note:** Only SVG-based renderer supports this option.
+ * Options for a _link_ label text which should follow link connection. Border
+ * and background are disabled for a label that follows a path.
+ * **Note:** Only SVG-based renderer supports this option. Setting `useHTML` to
+ * true will disable this option.
  * @see {@link Highcharts.PlotNetworkDataLabelsTextPath#textPath}
  * @name Highcharts.PlotNetworkDataLabelsOptionsObject#linkTextPath
  * @type {Highcharts.PlotNetworkDataLabelsTextPath}
  * @since 7.1.0
  *//**
- * Options for a _node_ label text which should follow marker's shape.
- * **Note:** Only SVG-based renderer supports this option.
+ * Options for a _node_ label text which should follow marker's shape. Border
+ * and background are disabled for a label that follows a path.
+ * **Note:** Only SVG-based renderer supports this option. Setting `useHTML` to
+ * true will disable this option.
  * @see {@link Highcharts.PlotNetworkDataLabelsTextPath#linkTextPath}
  * @name Highcharts.PlotNetworkDataLabelsOptionsObject#textPath
  * @type {Highcharts.PlotNetworkDataLabelsTextPath}

--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -2527,6 +2527,16 @@ extend(SVGElement.prototype, /** @lends Highcharts.SVGElement.prototype */ {
                 [].slice.call(elem.getElementsByTagName('tspan'))
             );
 
+            // Remove background and border for label(), see #10545
+            // Alternatively, we can disable setting background rects in
+            // series.drawDataLabels()
+            if (this.text && !this.renderer.styledMode) {
+                this.attr({
+                    fill: 'none',
+                    'stroke-width': 0
+                });
+            }
+
             // Disable some functions
             this.updateTransform = noop;
             this.applyTextOutline = noop;

--- a/samples/highcharts/series-networkgraph/link-datalabels-borders/demo.css
+++ b/samples/highcharts/series-networkgraph/link-datalabels-borders/demo.css
@@ -1,0 +1,6 @@
+#container {
+	min-width: 320px;
+	max-width: 800px;
+	margin: 0 auto;
+	height: 500px;
+}

--- a/samples/highcharts/series-networkgraph/link-datalabels-borders/demo.details
+++ b/samples/highcharts/series-networkgraph/link-datalabels-borders/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Paweł Fus
+ js_wrap: b
+...

--- a/samples/highcharts/series-networkgraph/link-datalabels-borders/demo.html
+++ b/samples/highcharts/series-networkgraph/link-datalabels-borders/demo.html
@@ -1,0 +1,4 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/networkgraph.js"></script>
+
+<div id="container"></div>

--- a/samples/highcharts/series-networkgraph/link-datalabels-borders/demo.js
+++ b/samples/highcharts/series-networkgraph/link-datalabels-borders/demo.js
@@ -1,0 +1,21 @@
+Highcharts.chart('container', {
+    chart: {
+        type: 'networkgraph'
+    },
+
+    series: [{
+        dataLabels: {
+            enabled: true,
+            borderColor: "#000000",
+            borderWidth: 1,
+            allowOverlap: true
+        },
+        marker: {
+            radius: 35
+        },
+        data: [{
+            from: 'A',
+            to: 'B'
+        }]
+    }]
+});


### PR DESCRIPTION
Fixed #10545, `networkgraph.dataLabels.linkTextPath` did not remove artifical border around label.

**+** updated docs. There's alternative solution (as always - an `if-else` condition in `drawDataLabels`) - but I think it's better to keep all `textPath` logic in one place.