### PR TITLE
bugfix/10540-pie-animation

### DIFF
--- a/js/parts/PieSeries.js
+++ b/js/parts/PieSeries.js
@@ -934,7 +934,7 @@ seriesType(
                                 .shadow(shadow, shadowGroup);
                         }
 
-                        point.delayRendering = false;
+                        point.delayedRendering = false;
                     }
 
                     graphic.attr({


### PR DESCRIPTION
Fixed #10540, pie series did not animate slices when toggling legend items.