### PR TITLE
bugfix/10516-chrome-axis-labels-workaround

### DIFF
--- a/js/parts/Tick.js
+++ b/js/parts/Tick.js
@@ -374,6 +374,9 @@ H.Tick.prototype = {
                 )
         };
 
+        // Chrome workaround for #10516
+        pos.y = Math.max(Math.min(pos.y, 1e5), -1e5);
+
         fireEvent(this, 'afterGetPosition', { pos: pos });
 
         return pos;


### PR DESCRIPTION
Fixed #10516, extreme large zoom in Chrome did not render yAxis labels after zooming out.

Tested manually both, inverted and non inverted charts. Used the same value (1e5) as in #3923