### PR TITLE
bugfix/10571-split-tooltip-label-color

### DIFF
--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -990,12 +990,6 @@ H.Tooltip.prototype = {
 
                     if (!chart.styledMode) {
                         attribs.fill = options.backgroundColor;
-                        attribs.stroke = (
-                            options.borderColor ||
-                            point.color ||
-                            series.color ||
-                            '${palette.neutralColor80}'
-                        );
                         attribs['stroke-width'] = options.borderWidth;
                     }
 
@@ -1023,7 +1017,15 @@ H.Tooltip.prototype = {
                 });
                 if (!chart.styledMode) {
                     tt.css(options.style)
-                        .shadow(options.shadow);
+                        .shadow(options.shadow)
+                        .attr({
+                            stroke: (
+                                options.borderColor ||
+                                point.color ||
+                                series.color ||
+                                '${palette.neutralColor80}'
+                            )
+                        });
                 }
 
                 // Get X position now, so we can move all to the other side in

--- a/samples/unit-tests/tooltip/split/demo.js
+++ b/samples/unit-tests/tooltip/split/demo.js
@@ -250,3 +250,33 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test('Split tooltip - points with different colors in one series (#10571)', function (assert) {
+    var chart = Highcharts.chart('container', {
+        series: [{
+            data: [{ y: 50, color: '#17541c' }, { y: 100, color: '#ea33d2' }]
+        }],
+        tooltip: {
+            split: true
+        }
+    });
+    const firstPointColor = chart.series[0].points[0].color,
+        secondPointColor = chart.series[0].points[1].color;
+
+    chart.series[0].points[0].onMouseOver();
+
+    assert.strictEqual(
+        chart.series[0].tt.box.stroke,
+        firstPointColor,
+        'Label stroke should be the same as the first point color.'
+    );
+
+    chart.series[0].points[1].onMouseOver();
+
+    assert.strictEqual(
+        chart.series[0].tt.box.stroke,
+        secondPointColor,
+        'Label stroke should be the same as the second point color.'
+    );
+
+});


### PR DESCRIPTION
Fixed #10571, Split tooltip wasn't changed stroke color while hovering when points in a single series have different colors.