### PR TITLE
bugfix/10605-dragged-annotations-exporting

### DIFF
--- a/js/annotations/controllable/ControllableCircle.js
+++ b/js/annotations/controllable/ControllableCircle.js
@@ -36,6 +36,8 @@ H.merge(
          */
         type: 'circle',
 
+        translate: controllableMixin.translateShape,
+
         render: function (parent) {
             var attrs = this.attrsFromOptions(this.options);
 
@@ -66,16 +68,6 @@ H.merge(
             this.graphic.placed = Boolean(position);
 
             controllableMixin.redraw.call(this, animation);
-        },
-
-        translate: function (dx, dy) {
-            var annotationOptions = this.annotation.userOptions,
-                shapeOptions = annotationOptions[this.collection][this.index];
-
-            this.translatePoint(dx, dy, 0);
-
-            // Options stored in chart:
-            shapeOptions.point = this.options.point;
         },
 
         /**

--- a/js/annotations/controllable/ControllableImage.js
+++ b/js/annotations/controllable/ControllableImage.js
@@ -47,6 +47,8 @@ H.merge(
          */
         type: 'image',
 
+        translate: controllableMixin.translateShape,
+
         render: function (parent) {
             var attrs = this.attrsFromOptions(this.options),
                 options = this.options;
@@ -84,16 +86,6 @@ H.merge(
             this.graphic.placed = Boolean(position);
 
             controllableMixin.redraw.call(this, animation);
-        },
-
-        translate: function (dx, dy) {
-            var annotationOptions = this.annotation.userOptions,
-                shapeOptions = annotationOptions[this.collection][this.index];
-
-            this.translatePoint(dx, dy, 0);
-
-            // Options stored in chart:
-            shapeOptions.point = this.options.point;
         }
     }
 );

--- a/js/annotations/controllable/ControllableLabel.js
+++ b/js/annotations/controllable/ControllableLabel.js
@@ -195,16 +195,24 @@ H.merge(
          * @param {number} dy translation for y coordinate
          **/
         translate: function (dx, dy) {
-            var annotationOptions = this.annotation.userOptions,
-                labelOptions = annotationOptions[this.collection][this.index];
+            var chart = this.annotation.chart,
+                // Annotation.options
+                labelOptions = this.annotation.userOptions,
+                // Chart.options.annotations
+                annotationIndex = chart.annotations.indexOf(this.annotation),
+                chartAnnotations = chart.options.annotations,
+                chartOptions = chartAnnotations[annotationIndex];
 
             // Local options:
             this.options.x += dx;
             this.options.y += dy;
 
             // Options stored in chart:
-            labelOptions.x = this.options.x;
-            labelOptions.y = this.options.y;
+            chartOptions[this.collection][this.index].x = this.options.x;
+            chartOptions[this.collection][this.index].y = this.options.y;
+
+            labelOptions[this.collection][this.index].x = this.options.x;
+            labelOptions[this.collection][this.index].y = this.options.y;
         },
 
         render: function (parent) {

--- a/js/annotations/controllable/ControllableRect.js
+++ b/js/annotations/controllable/ControllableRect.js
@@ -45,6 +45,8 @@ H.merge(
          */
         type: 'rect',
 
+        translate: controllableMixin.translateShape,
+
         render: function (parent) {
             var attrs = this.attrsFromOptions(this.options);
 
@@ -76,16 +78,6 @@ H.merge(
             this.graphic.placed = Boolean(position);
 
             controllableMixin.redraw.call(this, animation);
-        },
-
-        translate: function (dx, dy) {
-            var annotationOptions = this.annotation.userOptions,
-                shapeOptions = annotationOptions[this.collection][this.index];
-
-            this.translatePoint(dx, dy, 0);
-
-            // Options stored in chart:
-            shapeOptions.point = this.options.point;
         }
     }
 );

--- a/js/annotations/controllable/controllableMixin.js
+++ b/js/annotations/controllable/controllableMixin.js
@@ -333,6 +333,30 @@ var controllableMixin = {
     },
 
     /**
+     * Translate shape within controllable item.
+     * Replaces `controllable.translate` method.
+     *
+     * @param {number} dx translation for x coordinate
+     * @param {number} dy translation for y coordinate
+     */
+    translateShape: function (dx, dy) {
+        var chart = this.annotation.chart,
+            // Annotation.options
+            shapeOptions = this.annotation.userOptions,
+            // Chart.options.annotations
+            annotationIndex = chart.annotations.indexOf(this.annotation),
+            chartOptions = chart.options.annotations[annotationIndex];
+
+        this.translatePoint(dx, dy, 0);
+
+        // Options stored in:
+        // - chart (for exporting)
+        // - current config (for redraws)
+        chartOptions[this.collection][this.index].point = this.options.point;
+        shapeOptions[this.collection][this.index].point = this.options.point;
+    },
+
+    /**
      * Rotate a controllable.
      *
      * @param {number} cx origin x rotation

--- a/samples/unit-tests/annotations/annotations-draggable/demo.details
+++ b/samples/unit-tests/annotations/annotations-draggable/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/annotations/annotations-draggable/demo.html
+++ b/samples/unit-tests/annotations/annotations-draggable/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/annotations.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/annotations/annotations-draggable/demo.js
+++ b/samples/unit-tests/annotations/annotations-draggable/demo.js
@@ -1,0 +1,70 @@
+QUnit.test('Draggable annotation - exporting', function (assert) {
+    var chart = Highcharts.chart('container', {
+            series: [{
+                data: [3, 6]
+            }],
+            annotations: [{
+                labels: [{
+                    point: {
+                        xAxis: 0,
+                        yAxis: 0,
+                        x: 0.25,
+                        y: 5
+                    },
+                    y: 0,
+                    text: 'Annotation'
+                }]
+            }, {
+                shapes: [{
+                    point: {
+                        xAxis: 0,
+                        yAxis: 0,
+                        x: 0.75,
+                        y: 5
+                    },
+                    type: 'rect',
+                    width: 30,
+                    height: 30,
+                    x: -15,
+                    y: -15
+                }]
+            }]
+        }),
+        annoattionOptions = chart.options.annotations,
+        controller = new TestController(chart);
+
+    // Label tests:
+    controller.mouseDown(
+        chart.xAxis[0].toPixels(0.25),
+        chart.yAxis[0].toPixels(5)
+    );
+    controller.mouseMove(
+        chart.xAxis[0].toPixels(0.25),
+        chart.yAxis[0].toPixels(3)
+    );
+    controller.mouseUp();
+
+
+    assert.strictEqual(
+        annoattionOptions[0].labels[0].y,
+        chart.yAxis[0].toPixels(3) - chart.yAxis[0].toPixels(5),
+        'Correctly updated options for annotation\'s label (#10605).'
+    );
+
+    // Shape tests:
+    controller.mouseDown(
+        chart.xAxis[0].toPixels(0.75) - 5,
+        chart.yAxis[0].toPixels(5)
+    );
+    controller.mouseMove(
+        chart.xAxis[0].toPixels(0.75) - 5,
+        chart.yAxis[0].toPixels(3)
+    );
+    controller.mouseUp();
+
+    assert.strictEqual(
+        annoattionOptions[1].shapes[0].point.y,
+        3,
+        'Correctly updated options for annotation\'s shape (#10605).'
+    );
+});


### PR DESCRIPTION
Highstock: Fixed #10605, simple annotations (label, circle, rectangle) added using stock-tools were misplaced in exported chart.

Note: It was general issue with basic annotations; after drag&drop exported chart used old configs. 