### PR TITLE
Fixed #10329, remove excessive path in simpleConnect

### DIFF
--- a/js/parts-gantt/PathfinderAlgorithms.js
+++ b/js/parts-gantt/PathfinderAlgorithms.js
@@ -277,8 +277,8 @@ var algorithms = {
             // If we are going back again, switch direction to get around start
             // obstacle.
             if (
-                waypoint[dir] > start[dir] === // Going towards max from start
-                waypoint[dir] > endPoint[dir] // Going towards min to end
+                waypoint[dir] >= start[dir] === // Going towards max from start
+                waypoint[dir] >= endPoint[dir] // Going towards min to end
             ) {
                 dir = dir === 'y' ? 'x' : 'y';
                 useMax = start[dir] < end[dir];

--- a/samples/unit-tests/gantt/pathfinder/demo.js
+++ b/samples/unit-tests/gantt/pathfinder/demo.js
@@ -417,4 +417,34 @@
             'Start and End markers are appplied when enabled'
         );
     });
+
+    QUnit.module('pathfinderAlgorithms', () => {
+        const { algorithms } = Highcharts.Pathfinder.prototype;
+
+        QUnit.test('simpleConnect', assert => {
+            const { simpleConnect } = algorithms;
+            const options = {
+                chartObstacles: [
+                    { xMin: -33.5, xMax: 611.5, yMin: -20.5, yMax: 71.5 },
+                    { xMin: 613.5, xMax: 705.5, yMin: -20.5, yMax: 71.5 }
+                ],
+                startDirectionX: true
+            };
+            assert.deepEqual(
+                simpleConnect(
+                    { x: 647.5, y: 25.5 },
+                    { x: 577.5, y: 25.5 },
+                    options
+                ).path,
+                [
+                    'M', 647.5, 25.5,
+                    'L', 612.5, 25.5,
+                    'L', 612.5, 25.5,
+                    'L', 612.5, 25.5,
+                    'L', 577.5, 25.5
+                ],
+                'should not switch direction when waypoint equals start or end. #10329.'
+            );
+        });
+    });
 }());


### PR DESCRIPTION
# Description
The simpleConnect algorithm switched direction when the start or end was equal to the waypoint.

Solved by checking for equal values as well.

# Example(s)
- [Demo of issue](https://jsfiddle.net/jon_a_nygaard/sa9Lkbo3/)
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/evdzLupy/)

# Related issue(s)
- Closes #10329 