### PR TITLE
bugfix/10628-chart-callbacks-orders

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -2305,8 +2305,8 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      */
     onload: function () {
 
-        // Run callbacks
-        [this.callback].concat(this.callbacks).forEach(function (fn) {
+        // Run callbacks, first the ones registered by modules, then user's one
+        this.callbacks.concat([this.callback]).forEach(function (fn) {
             // Chart destroyed in its own callback (#3600)
             if (fn && this.index !== undefined) {
                 fn.apply(this, [this]);

--- a/samples/unit-tests/annotations/annotations-dynamic/demo.js
+++ b/samples/unit-tests/annotations/annotations-dynamic/demo.js
@@ -24,6 +24,15 @@ QUnit.test('Annotation\'s dynamic methods', function (assert) {
                 }
             }]
         }]
+    }, function (chart) {
+        var annotation = chart.addAnnotation({});
+
+        assert.ok(
+            true,
+            'No errors after adding an annotation in callback (#10628).'
+        );
+
+        chart.removeAnnotation(annotation);
     });
 
     assert.strictEqual(

--- a/samples/unit-tests/chart/events-load/demo.js
+++ b/samples/unit-tests/chart/events-load/demo.js
@@ -133,8 +133,8 @@
         }, function () {
             assert.strictEqual(
                 this.container.querySelectorAll('image').length,
-                0,
-                'callback: Image not yet added'
+                1,
+                'callback: Image added after modules\'s callbacks'
             );
 
             done();


### PR DESCRIPTION
Fixed #10628, adding annotations in chart's callback threw errors.

I have modified test for 1791c93310931d70b4f284c29edcf19c4cb60d8a - unless there's a reason why user's callback (this one: `chart(container, options, `**`callback`**`)`) should be called **before** all modules' callbacks. I think it's important to call user's callback **after** other modules, otherwise we may have some unexpected errors. For example rangeSelector and navigator use that callbacks.