### PR TITLE
bugfix/10633-touch-panning-extremes

### DIFF
--- a/js/parts/TouchPointer.js
+++ b/js/parts/TouchPointer.js
@@ -247,10 +247,16 @@ extend(Pointer.prototype, /** @lends Pointer.prototype */ {
                     var bounds = chart.bounds[axis.horiz ? 'h' : 'v'],
                         minPixelPadding = axis.minPixelPadding,
                         min = axis.toPixels(
-                            pick(axis.options.min, axis.dataMin)
+                            Math.min(
+                                pick(axis.options.min, axis.dataMin),
+                                axis.dataMin
+                            )
                         ),
                         max = axis.toPixels(
-                            pick(axis.options.max, axis.dataMax)
+                            Math.max(
+                                pick(axis.options.max, axis.dataMax),
+                                axis.dataMax
+                            )
                         ),
                         absMin = Math.min(min, max),
                         absMax = Math.max(min, max);

--- a/samples/unit-tests/pointer/touch/demo.js
+++ b/samples/unit-tests/pointer/touch/demo.js
@@ -317,3 +317,62 @@ QUnit.test('followPointer and followTouchMove', function (assert) {
         'The tooltip should show Apples'
     );
 });
+
+QUnit.test('Touch and panning', function (assert) {
+    var chart = Highcharts.chart('container', {
+            chart: {
+                type: 'column',
+                pinchType: 'x',
+                panning: true
+            },
+            xAxis: {
+                min: 4,
+                max: 6
+            },
+            tooltip: {
+                followTouchMove: false
+            },
+            series: [{
+                data: [49.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]
+            }]
+        }),
+        offset = Highcharts.offset(chart.container);
+
+    Array.prototype.item = function (i) { // eslint-disable-line no-extend-native
+        return this[i];
+    };
+
+
+    chart.pointer.onContainerTouchStart({
+        type: 'touchstart',
+        touches: [{
+            pageX: offset.left + chart.plotLeft + chart.plotWidth / 2,
+            pageY: offset.top + chart.plotTop + 10
+        }],
+        preventDefault: function () {}
+    });
+
+    chart.pointer.onContainerTouchMove({
+        type: 'touchmove',
+        touches: [{
+            pageX: offset.left + chart.plotLeft + 10,
+            pageY: offset.top + chart.plotTop + 10
+        }],
+        preventDefault: function () {}
+    });
+
+    chart.pointer.onDocumentTouchEnd({
+        type: 'touchend',
+        touches: [{
+            pageX: offset.left + chart.plotLeft + 10,
+            pageY: offset.top + chart.plotTop + 10
+        }]
+    });
+
+    assert.strictEqual(
+        chart.xAxis[0].max > chart.xAxis[0].options.max,
+        true,
+        'Touch-device panning allows panning outside the xAxis options: min & max (#10633)'
+    );
+
+});


### PR DESCRIPTION
Fixed #10633, panning on mobile devices did not work when `xAxis.max` or `xAxis.min` options were set.