### PR TITLE
Changed version of karma-browserstack-launcher to 1.4.0 as 1.5.x does…

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "js-yaml": "^3.13.0",
     "jsdoc": "^3.5.5",
     "karma": "^4.0.1",
-    "karma-browserstack-launcher": "^1.5.0",
+    "karma-browserstack-launcher": "1.4.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-edge-launcher": "^0.4.2",
     "karma-firefox-launcher": "^1.0.1",

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -542,25 +542,33 @@ module.exports = function (config) {
 
 
     if (browsers.some(browser => /^(Mac|Win)\./.test(browser))) {
-
-        console.log(
-            'BrowserStack initialized. Please wait while tests are ' +
-            'uploaded and VMs prepared...'
-        );
-
         let properties = getProperties();
 
         options.browserStack = {
             username: properties['browserstack.username'],
-            accessKey: properties['browserstack.accesskey']
+            accessKey: properties['browserstack.accesskey'],
+            project: 'highcharts',
+            build: `highcharts-build-${process.env.CIRCLE_BUILD_NUM || Math.random().toString(36).substring(7)} `,
+            name: `circle-ci-karma-highcharts`,
+            localIdentifier: Math.random().toString(36).substring(7), // to avoid instances interfering with each other.
+            video: false,
         };
         options.customLaunchers = browserStackBrowsers;
+        options.logLevel = config.LOG_INFO;
+
 
         // to avoid DISCONNECTED messages when connecting to BrowserStack
-        options.browserDisconnectTimeout = 10000; // default 2000
+        options.concurrency = 1;
+        options.browserDisconnectTimeout = 20000; // default 2000
         options.browserDisconnectTolerance = 1; // default 0
         options.browserNoActivityTimeout = 4 * 60 * 1000; // default 10000
         options.captureTimeout = 4 * 60 * 1000; // default 60000
+
+        console.log(
+            'BrowserStack initialized. Please wait while tests are uploaded and VMs prepared.' +
+            `Any other test runs must complete before this test run will start. Current Browserstack concurrency rate is ${options.concurrency}..`
+        );
+
     }
 
     config.set(options);


### PR DESCRIPTION
… not pass browserstack options properly to the browser stack local client. Ref: https://github.com/karma-runner/karma-browserstack-launcher/issues/150

Added explicit localIdentifier for tunnel to avoid two instances interfering with each other.
Setting karma-launcher concurrency option to 1 when running BrowserStack tests.


NOTE: This might only be part of a possible solution. @bre1470 has also identified some tests that might cause issues. I have not excluded those yet (will test more tomorrow).