### PR TITLE
tests/skip-exporting-server

### DIFF
--- a/samples/unit-tests/exporting/scale/demo.js
+++ b/samples/unit-tests/exporting/scale/demo.js
@@ -1,4 +1,4 @@
-QUnit.test('Exported chart scale', function (assert) {
+QUnit.skip('Exported chart scale', function (assert) {
 
     var chart = Highcharts
             .chart('container', {

--- a/samples/unit-tests/exporting/sourcewidth/demo.js
+++ b/samples/unit-tests/exporting/sourcewidth/demo.js
@@ -1,4 +1,4 @@
-QUnit.test('Exported chart sourceWidth and sourceHeight', function (assert) {
+QUnit.skip('Exported chart sourceWidth and sourceHeight', function (assert) {
 
     var chart = Highcharts
             .chart('container', {

--- a/samples/unit-tests/exporting/width/demo.js
+++ b/samples/unit-tests/exporting/width/demo.js
@@ -1,4 +1,4 @@
-QUnit.test('Exported chart width', function (assert) {
+QUnit.skip('Exported chart width', function (assert) {
 
     var chart = Highcharts
             .chart('container', {


### PR DESCRIPTION
Tools: Skipped tests of exporting server because of Chrome 74 issues.

Tests have to be ported to https://github.com/highcharts/highcharts-export-server