### PR TITLE
bugfix/10625-setdata-networkgraph

### DIFF
--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -494,7 +494,6 @@ seriesType(
          * @private
          */
         createNode: H.NodesMixin.createNode,
-        setData: H.NodesMixin.setData,
         destroy: H.NodesMixin.destroy,
 
         /**
@@ -521,6 +520,9 @@ seriesType(
          * @private
          */
         generatePoints: function () {
+            var node,
+                i;
+
             H.NodesMixin.generatePoints.apply(this, arguments);
 
             // In networkgraph, it's fine to define stanalone nodes, create
@@ -537,9 +539,19 @@ seriesType(
                 );
             }
 
-            this.nodes.forEach(function (node) {
+            for (i = this.nodes.length - 1; i >= 0; i--) {
+                node = this.nodes[i];
+
                 node.degree = node.getDegree();
-            });
+
+                // If node exists, but it's not available in nodeLookup,
+                // then it's leftover from previous runs (e.g. setData)
+                if (!this.nodeLookup[node.id]) {
+                    node.remove();
+                }
+            }
+
+
             this.data.forEach(function (link) {
                 link.formatPrefix = 'link';
             });

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.js
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.js
@@ -118,7 +118,7 @@ QUnit.test('Network Graph', function (assert) {
             ['4.0', '1.0']
         ]
     });
-    // debugger;
+
     rSeries.nodes[0].remove();
 
     assert.strictEqual(
@@ -133,5 +133,17 @@ QUnit.test('Network Graph', function (assert) {
         'Removed all links for node = 1.0'
     );
 
+    // Remove all nodes but 2 and 4, set testing reference:
+    rSeries.nodes[0].survived = true;
+
+    rSeries.setData([
+        ['2.0', '4.0']
+    ]);
+
+    assert.strictEqual(
+        rSeries.nodes[0].survived,
+        true,
+        'Node survived `setData()` (#10625)'
+    );
 
 });


### PR DESCRIPTION
Fixed #10625, `setData()` in networkgraph series caused simulation to run from the initial state.