### PR TITLE
bugfix/10618-scrollbar-overlapping

### DIFF
--- a/js/parts/Scrollbar.js
+++ b/js/parts/Scrollbar.js
@@ -1053,7 +1053,9 @@ if (!H.Scrollbar) {
                 pick(axis.dataMax, axis.max) // #6930
             ),
             scrollbar = axis.scrollbar,
-            titleOffset = axis.titleOffset || 0,
+            offset = axis.axisTitleMargin + (axis.titleOffset || 0),
+            scrollbarsOffsets = axis.chart.scrollbarsOffsets,
+            axisMargin = axis.options.margin || 0,
             offsetsIndex,
             from,
             to;
@@ -1061,39 +1063,51 @@ if (!H.Scrollbar) {
         if (scrollbar) {
 
             if (axis.horiz) {
+
+                // Reserve space for labels/title
+                if (!axis.opposite) {
+                    scrollbarsOffsets[1] += offset;
+                }
+
                 scrollbar.position(
                     axis.left,
-                    axis.top + axis.height + 2 +
-                        axis.chart.scrollbarsOffsets[1] +
-                        (axis.opposite ?
-                            0 :
-                            titleOffset + axis.axisTitleMargin + axis.offset
-                        ),
+                    axis.top + axis.height + 2 + scrollbarsOffsets[1] -
+                        (axis.opposite ? axisMargin : 0),
                     axis.width,
                     axis.height
                 );
+
+                // Next scrollbar should reserve space for margin (if set)
+                if (!axis.opposite) {
+                    scrollbarsOffsets[1] += axisMargin;
+                }
+
                 offsetsIndex = 1;
             } else {
+
+                // Reserve space for labels/title
+                if (axis.opposite) {
+                    scrollbarsOffsets[0] += offset;
+                }
+
                 scrollbar.position(
-                    axis.left + axis.width + 2 +
-                        axis.chart.scrollbarsOffsets[0] +
-                        (axis.opposite ?
-                            titleOffset + axis.axisTitleMargin + axis.offset :
-                            0
-                        ),
+                    axis.left + axis.width + 2 + scrollbarsOffsets[0] -
+                        (axis.opposite ? 0 : axisMargin),
                     axis.top,
                     axis.width,
                     axis.height
                 );
+
+                // Next scrollbar should reserve space for margin (if set)
+                if (axis.opposite) {
+                    scrollbarsOffsets[0] += axisMargin;
+                }
+
                 offsetsIndex = 0;
             }
 
-            if (
-                (!axis.opposite && !axis.horiz) || (axis.opposite && axis.horiz)
-            ) {
-                axis.chart.scrollbarsOffsets[offsetsIndex] +=
-                    axis.scrollbar.size + axis.scrollbar.options.margin;
-            }
+            scrollbarsOffsets[offsetsIndex] += scrollbar.size +
+                scrollbar.options.margin;
 
             if (
                 isNaN(scrollMin) ||

--- a/samples/unit-tests/scrollbar/positions/demo.js
+++ b/samples/unit-tests/scrollbar/positions/demo.js
@@ -155,3 +155,92 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test(
+    'Overlapping scrollbars',
+    assert => {
+        const chart = Highcharts.chart('container', {
+                yAxis: [{
+                    opposite: true,
+                    scrollbar: {
+                        enabled: true
+                    }
+                }, {
+                    opposite: true,
+                    scrollbar: {
+                        enabled: true
+                    }
+                }, {
+                    scrollbar: {
+                        enabled: true
+                    }
+                }, {
+                    scrollbar: {
+                        enabled: true
+                    }
+                }],
+                xAxis: [{
+                    scrollbar: {
+                        enabled: true
+                    }
+                }, {
+                    scrollbar: {
+                        enabled: true
+                    }
+                }, {
+                    opposite: true,
+                    scrollbar: {
+                        enabled: true
+                    }
+                }, {
+                    opposite: true,
+                    scrollbar: {
+                        enabled: true
+                    }
+                }],
+                series: [{
+                    data: [1, 2, 3]
+                }, {
+                    data: [3, 2, 1],
+                    yAxis: 1,
+                    xAxis: 1
+                }, {
+                    data: [2, 1, 3],
+                    yAxis: 2,
+                    xAxis: 2
+                }, {
+                    data: [3, 1, 2],
+                    yAxis: 3,
+                    xAxis: 3
+                }]
+            }),
+            yAxes = chart.yAxis,
+            xAxes = chart.xAxis,
+            yAxesLen = yAxes.length,
+            xAxesLen = xAxes.length;
+
+        let i;
+
+        yAxes.forEach((yAxis, index) => {
+            for (i = index + 1; i < yAxesLen; i++) {
+
+                assert.strictEqual(
+                    yAxis.scrollbar.x + yAxis.scrollbar.width < yAxes[i].scrollbar.x,
+                    true,
+                    'Vertical scrollbar: ' + index + ' should not overlap scrollbar: ' + i
+                );
+            }
+        });
+
+        xAxes.forEach((xAxis, index) => {
+            for (i = index + 1; i < xAxesLen; i++) {
+
+                assert.strictEqual(
+                    xAxis.scrollbar.y + xAxis.scrollbar.height < xAxes[i].scrollbar.y,
+                    true,
+                    'Horizontal scrollbar: ' + index + ' should not overlap scrollbar: ' + i
+                );
+            }
+        });
+    }
+);


### PR DESCRIPTION
Highstock: Fixed #10618, different `yAxis.opposite` settings caused scrollbars to overlap.