### PR TITLE
bugfix/10062-packedbubble-ignored-thousandsSep

### DIFF
--- a/samples/highcharts/demo/packed-bubble-split/demo.js
+++ b/samples/highcharts/demo/packed-bubble-split/demo.js
@@ -8,7 +8,7 @@ Highcharts.chart('container', {
     },
     tooltip: {
         useHTML: true,
-        pointFormat: '<b>{point.name}:</b> {point.y}m CO<sub>2</sub>'
+        pointFormat: '<b>{point.name}:</b> {point.value}m CO<sub>2</sub>'
     },
     plotOptions: {
         packedbubble: {

--- a/samples/highcharts/demo/packed-bubble/demo.js
+++ b/samples/highcharts/demo/packed-bubble/demo.js
@@ -8,7 +8,7 @@ Highcharts.chart('container', {
     },
     tooltip: {
         useHTML: true,
-        pointFormat: '<b>{point.name}:</b> {point.y}m CO<sub>2</sub>'
+        pointFormat: '<b>{point.name}:</b> {point.value}m CO<sub>2</sub>'
     },
     plotOptions: {
         packedbubble: {


### PR DESCRIPTION
Fixed #10062, packed bubble series ignored `lang.thousandsSep`.