### PR TITLE
 bugfix/10646-column-negative-zero

### DIFF
--- a/js/parts/ColumnSeries.js
+++ b/js/parts/ColumnSeries.js
@@ -664,7 +664,9 @@ seriesType(
                 // postprocessed for border width
                 seriesBarW = series.barW =
                 Math.max(seriesPointWidth, 1 + 2 * borderWidth),
-                seriesXOffset = series.pointXOffset = metrics.offset;
+                seriesXOffset = series.pointXOffset = metrics.offset,
+                dataMin = series.dataMin,
+                dataMax = series.dataMax;
 
             if (chart.inverted) {
                 translatedThreshold -= 0.5; // #3355
@@ -707,8 +709,12 @@ seriesType(
                     // in visible range (#7046)
                     if (
                         point.y === threshold &&
-                    series.dataMax <= threshold &&
-                    yAxis.min < threshold // and if there's room for it (#7311)
+                        series.dataMax <= threshold &&
+                        // and if there's room for it (#7311)
+                        yAxis.min < threshold &&
+                        // if all points are the same value (i.e zero) not draw
+                        // as negative points (#10646)
+                        dataMin !== dataMax
                     ) {
                         up = !up;
                     }

--- a/samples/unit-tests/series-column/minpointlength/demo.js
+++ b/samples/unit-tests/series-column/minpointlength/demo.js
@@ -21,3 +21,25 @@ QUnit.test('Negative or positive minPointLength', function (assert) {
         'Not negative is there is no space in the yAxis (#7311)'
     );
 });
+
+QUnit.test('All zero values', function (assert) {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            type: 'column'
+        },
+        plotOptions: {
+            series: {
+                minPointLength: 10
+            }
+        },
+        series: [{
+            data: [0, 0, 0, 0, 0]
+        }]
+    });
+
+    assert.strictEqual(
+        chart.series[0].points[0].shapeArgs.y < 145, // 145 value of negative point
+        true,
+        'Zero values are draw as positive columns (#10646)'
+    );
+});


### PR DESCRIPTION
Fixed #10646, `plotOptions.column.minPointLength` drew zero points as negative.