### PR TITLE
Bugfix/10470 grid axis tickpositions

### DIFF
--- a/js/parts-gantt/GridAxis.js
+++ b/js/parts-gantt/GridAxis.js
@@ -695,8 +695,6 @@ addEvent(
             min = linkedMin || axis.min,
             max = linkedMax || axis.max,
             tickInterval = axis.tickInterval,
-            moreThanMin = firstPos > min,
-            lessThanMax = lastPos < max,
             endMoreThanMin = firstPos < min && firstPos + tickInterval > min,
             startLessThanMax = lastPos > max && lastPos - tickInterval < max;
 
@@ -705,11 +703,11 @@ addEvent(
             !categoryAxis &&
             (axis.horiz || axis.isLinked)
         ) {
-            if ((moreThanMin || endMoreThanMin) && !options.startOnTick) {
+            if (endMoreThanMin && !options.startOnTick) {
                 tickPositions[0] = min;
             }
 
-            if ((lessThanMax || startLessThanMax) && !options.endOnTick) {
+            if (startLessThanMax && !options.endOnTick) {
                 tickPositions[tickPositions.length - 1] = max;
             }
         }

--- a/samples/unit-tests/gantt/grid-axis/demo.js
+++ b/samples/unit-tests/gantt/grid-axis/demo.js
@@ -1127,7 +1127,7 @@ QUnit.module('labels alignment', function () {
  * Checks that the last tick label does not pop out of its cell if there was no
  * room.
  */
-QUnit.test('Last tick label does not pop out of its cell', function (assert) {
+QUnit.only('Last tick label does not pop out of its cell', function (assert) {
     var labelBox,
         axisBox,
         axisRight,
@@ -1185,6 +1185,39 @@ QUnit.test('Last tick label does not pop out of its cell', function (assert) {
     assert.ok(
         labelBox.x < axisRight,
         'Last tick label does not pop out'
+    );
+
+    /*
+     * Make sure the tickPositions are not adjusted when they are within min and
+     * max.
+     */
+    const start = 1483225200000; // 1st January 2017
+    const month = 2678400000;
+    const userTickPositions = [start + month, start + 2 * month];
+    const end = start + 3 * month;
+    // Reassign tickPositions
+    ({ xAxis: [{ tickPositions }] } = Highcharts.chart('container', {
+        xAxis: [{
+            type: 'datetime',
+            tickPositions: userTickPositions,
+            grid: {
+                enabled: true
+            }
+        }],
+        series: [{
+            data: [{
+                x: start,
+                y: 0
+            }, {
+                x: end,
+                y: 0
+            }]
+        }]
+    }));
+    assert.deepEqual(
+        tickPositions,
+        userTickPositions,
+        'should not adjust last or first tick when they are within axis min and max. #10470'
     );
 });
 

--- a/samples/unit-tests/gantt/grid-axis/demo.js
+++ b/samples/unit-tests/gantt/grid-axis/demo.js
@@ -1127,7 +1127,7 @@ QUnit.module('labels alignment', function () {
  * Checks that the last tick label does not pop out of its cell if there was no
  * room.
  */
-QUnit.only('Last tick label does not pop out of its cell', function (assert) {
+QUnit.test('Last tick label does not pop out of its cell', function (assert) {
     var labelBox,
         axisBox,
         axisRight,


### PR DESCRIPTION
Fixed #10470, grid axis tampered with tick positions.

---
# Description
The grid axis adjusts the first and last tick positions to have them at the axis min and max to create walls.
What it wants to avoid:
```
-----------
   | x |
-----------
```
What it is adjusted into:
```
-----------
|    x    |
-----------
```
This maybe looks prettier, but the positions of the ticks are wrong.

Solved by modifying `trimTicks` event in grid axis to not adjust the tick positions in these cases.

# Example(s)
- [Demo of issue](https://jsfiddle.net/BlackLabel/f5pm8qoy/1/)
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/4o0ufpj9/)

# Related issue(s)
- Closes #10470 