### PR TITLE
Bugfix/10129 treegrid collapsed regression

### DIFF
--- a/js/parts-gantt/TreeGrid.js
+++ b/js/parts-gantt/TreeGrid.js
@@ -540,18 +540,20 @@ var onBeforeRender = function (e) {
             });
 
             // Collapse all the nodes belonging to a point where collapsed
-            // equals true.
+            // equals true. Only do this on init.
             // Can be called from beforeRender, if getBreakFromNode removes
             // its dependency on axis.max.
-            removeFoundExtremesEvent =
-                H.addEvent(axis, 'foundExtremes', function () {
-                    treeGrid.collapsedNodes.forEach(function (node) {
-                        var breaks = collapse(axis, node);
+            if (e.type === 'beforeRender') {
+                removeFoundExtremesEvent =
+                    H.addEvent(axis, 'foundExtremes', function () {
+                        treeGrid.collapsedNodes.forEach(function (node) {
+                            var breaks = collapse(axis, node);
 
-                        axis.setBreaks(breaks, false);
+                            axis.setBreaks(breaks, false);
+                        });
+                        removeFoundExtremesEvent();
                     });
-                    removeFoundExtremesEvent();
-                });
+            }
         });
 };
 

--- a/samples/unit-tests/gantt/treegrid/demo.js
+++ b/samples/unit-tests/gantt/treegrid/demo.js
@@ -292,3 +292,58 @@ QUnit.test('Series.setVisible', assert => {
         'should have axis [min, max] equal [0, 2] when "Series 2" is visible again.'
     );
 });
+
+QUnit.test('series.data[].collapsed', assert => {
+    const { fireEvent } = Highcharts;
+    const chart = Highcharts.chart('container', {
+        yAxis: [{
+            type: 'treegrid'
+        }],
+        series: [{
+            type: 'scatter',
+            data: [{
+                collapsed: true,
+                id: '1',
+                name: 'Node 1',
+                x: 1
+            }, {
+                id: '2',
+                parent: '1',
+                name: 'Node 2',
+                x: 2
+            }, {
+                id: '3',
+                parent: '2',
+                name: 'Node 3',
+                x: 3
+            }]
+        }]
+    });
+    const {
+        yAxis: [axis]
+    } = chart;
+    const label = axis.ticks[0].label;
+
+    assert.strictEqual(
+        axis.min,
+        0,
+        'should have axis.min equal 0 when "Node 1" is collapsed.'
+    );
+    assert.strictEqual(
+        axis.max,
+        0,
+        'should have axis.max equal 0 when "Node 1" is collapsed.'
+    );
+
+    fireEvent(label.element, 'click');
+    assert.strictEqual(
+        axis.min,
+        0,
+        'should have axis.min equal 0 when "Node 1" is expanded.'
+    );
+    assert.strictEqual(
+        axis.max,
+        2,
+        'should have axis.max equal 2 when "Node 1" is expanded.'
+    );
+});


### PR DESCRIPTION
Fixed #10129, regression with `point.collapsed` in treegrid. When set to true in the options, the point could never be expanded.

---
# Description
Solved by running point.collapsed logic only on `beforeRender` and not on `beforeRedraw`.

# Example(s)
- [Demo of issue](https://jsfiddle.net/jon_a_nygaard/8nm3xzdv/) Click on the axis label to try and expand the point.
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/04pw95qL/) Click on the axis label to expand the point.

# Related issue(s)
- Closes #10129 