### PR TITLE
bugfix/6644-plotline-panes-stock

### DIFF
--- a/js/parts-3d/Axis.js
+++ b/js/parts-3d/Axis.js
@@ -238,8 +238,8 @@ wrap(Axis.prototype, 'getPlotBandPath', function (proceed) {
         from = args[1],
         to = args[2],
         path = [],
-        fromPath = this.getPlotLinePath(from),
-        toPath = this.getPlotLinePath(to);
+        fromPath = this.getPlotLinePath({ value: from }),
+        toPath = this.getPlotLinePath({ value: to });
 
     if (fromPath && toPath) {
         for (var i = 0; i < fromPath.length; i += 6) {

--- a/js/parts-map/ColorAxis.js
+++ b/js/parts-map/ColorAxis.js
@@ -889,7 +889,7 @@ extend(ColorAxis.prototype, {
         }
     },
 
-    getPlotLinePath: function (a, b, c, d, pos) {
+    getPlotLinePath: function (options, old, pos) {
         // crosshairs only
         return isNumber(pos) ? // pos can be 0 (#3969)
             (
@@ -909,7 +909,7 @@ extend(ColorAxis.prototype, {
                     'Z'
                 ]
             ) :
-            Axis.prototype.getPlotLinePath.call(this, a, b, c, d);
+            Axis.prototype.getPlotLinePath.apply(this, arguments);
     },
 
     update: function (newOptions, redraw) {

--- a/js/parts-map/ColorAxis.js
+++ b/js/parts-map/ColorAxis.js
@@ -889,7 +889,9 @@ extend(ColorAxis.prototype, {
         }
     },
 
-    getPlotLinePath: function (options, old, pos) {
+    getPlotLinePath: function (options) {
+        var pos = options.translatedValue;
+
         // crosshairs only
         return isNumber(pos) ? // pos can be 0 (#3969)
             (

--- a/js/parts-more/RadialAxis.js
+++ b/js/parts-more/RadialAxis.js
@@ -322,8 +322,8 @@ radialAxisMixin = {
 
         // Polygonal plot bands
         if (this.options.gridLineInterpolation === 'polygon') {
-            ret = this.getPlotLinePath(from).concat(
-                this.getPlotLinePath(to, true)
+            ret = this.getPlotLinePath({ value: from }).concat(
+                this.getPlotLinePath({ value: to }, true)
             );
 
         // Circular grid bands
@@ -408,10 +408,11 @@ radialAxisMixin = {
     /* *
      * Find the path for plot lines perpendicular to the radial axis.
      */
-    getPlotLinePath: function (value, reverse) {
+    getPlotLinePath: function (options, reverse) {
         var axis = this,
             center = axis.center,
             chart = axis.chart,
+            value = options.value,
             end = axis.getPosition(value),
             xAxis,
             xy,
@@ -462,6 +463,7 @@ radialAxisMixin = {
             });
 
         }
+
         return ret;
     },
 

--- a/js/parts-more/RadialAxis.js
+++ b/js/parts-more/RadialAxis.js
@@ -323,7 +323,7 @@ radialAxisMixin = {
         // Polygonal plot bands
         if (this.options.gridLineInterpolation === 'polygon') {
             ret = this.getPlotLinePath({ value: from }).concat(
-                this.getPlotLinePath({ value: to }, true)
+                this.getPlotLinePath({ value: to, reverse: true })
             );
 
         // Circular grid bands
@@ -408,11 +408,12 @@ radialAxisMixin = {
     /* *
      * Find the path for plot lines perpendicular to the radial axis.
      */
-    getPlotLinePath: function (options, reverse) {
+    getPlotLinePath: function (options) {
         var axis = this,
             center = axis.center,
             chart = axis.chart,
             value = options.value,
+            reverse = options.reverse,
             end = axis.getPosition(value),
             xAxis,
             xy,

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -26,6 +26,20 @@
  * will be rendered on all axes when defined on the first axis.
  * @name Highcharts.AxisPlotLinePathOptionsObject#acrossPanes
  * @type {boolean|undefined}
+ *//**
+ * Use old coordinates (for resizing and rescaling).
+ * If not set, defaults to `false`.
+ * @name Highcharts.AxisPlotLinePathOptionsObject#old
+ * @type {boolean|undefined}
+ *//**
+ * If given, return the plot line path of a pixel position on the axis.
+ * @name Highcharts.AxisPlotLinePathOptionsObject#translatedValue
+ * @type {number|undefined}
+ *//**
+ * Used in Polar axes. Reverse the positions for concatenation of polygonal
+ * plot bands
+ * @name Highcharts.AxisPlotLinePathOptionsObject#reverse
+ * @type {boolean|undefined}
  */
 
 /**
@@ -3725,22 +3739,17 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
      * @param {Highcharts.AxisPlotLinePathOptionsObject} options
      *        Options for the path.
      *
-     * @param {boolean} [old=false]
-     *        Use old coordinates (for resizing and rescaling).
-     *
-     * @param {number} [translatedValue]
-     *        If given, return the plot line path of a pixel position on the
-     *        axis.
-     *
      * @return {Array<string|number>}
      *         The SVG path definition for the plot line.
      */
-    getPlotLinePath: function (options, old, translatedValue) {
+    getPlotLinePath: function (options) {
         var axis = this,
             chart = axis.chart,
             axisLeft = axis.left,
             axisTop = axis.top,
+            old = options.old,
             value = options.value,
+            translatedValue = options.translatedValue,
             lineWidth = options.lineWidth,
             force = options.force,
             x1,
@@ -6444,10 +6453,9 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
                         value: point && (this.isXAxis ?
                             point.x :
                             pick(point.stackY, point.y)
-                        )
-                    },
-                    null,
-                    pos // Translated position
+                        ),
+                        translatedValue: pos
+                    }
                 ) || null; // #3189
             }
 

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -21,6 +21,11 @@
  * sides if it falls outside. If `pass`, it will return a path outside.
  * @name Highcharts.AxisPlotLinePathOptionsObject#force
  * @type {string|boolean|undefined}
+ *//**
+ * Used in Highstock. When `true`, plot paths (crosshair, plotLines, gridLines)
+ * will be rendered on all axes when defined on the first axis.
+ * @name Highcharts.AxisPlotLinePathOptionsObject#acrossPanes
+ * @type {boolean|undefined}
  */
 
 /**

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -5,6 +5,25 @@
  */
 
 /**
+ * Options for the path on the Axis to be calculated.
+ * @interface Highcharts.AxisPlotLinePathOptionsObject
+ *//**
+ * Axis value.
+ * @name Highcharts.AxisPlotLinePathOptionsObject#value
+ * @type {number|undefined}
+ *//**
+ * Line width used for calculation crisp line coordinates. Defaults to 1.
+ * @name Highcharts.AxisPlotLinePathOptionsObject#lineWidth
+ * @type {number|undefined}
+ *//**
+ * If `false`, the function will return null when it falls outside the axis
+ * bounds. If `true`, the function will return a path aligned to the plot area
+ * sides if it falls outside. If `pass`, it will return a path outside.
+ * @name Highcharts.AxisPlotLinePathOptionsObject#force
+ * @type {string|boolean|undefined}
+ */
+
+/**
  * Options for crosshairs on axes.
  *
  * @product highstock
@@ -3698,20 +3717,11 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
      *
      * @function Highcharts.Axis#getPlotLinePath
      *
-     * @param {number} value
-     *        Axis value.
-     *
-     * @param {number} [lineWidth=1]
-     *        Used for calculation crisp line coordinates.
+     * @param {Highcharts.AxisPlotLinePathOptionsObject} options
+     *        Options for the path.
      *
      * @param {boolean} [old=false]
      *        Use old coordinates (for resizing and rescaling).
-     *
-     * @param {boolean|string} [force=false]
-     *        If `false`, the function will return null when it falls outside
-     *        the axis bounds. If `true`, the function will return a path
-     *        aligned to the plot area sides if it falls outside. If `pass`, it
-     *        will return a path outside.
      *
      * @param {number} [translatedValue]
      *        If given, return the plot line path of a pixel position on the
@@ -3720,11 +3730,14 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
      * @return {Array<string|number>}
      *         The SVG path definition for the plot line.
      */
-    getPlotLinePath: function (value, lineWidth, old, force, translatedValue) {
+    getPlotLinePath: function (options, old, translatedValue) {
         var axis = this,
             chart = axis.chart,
             axisLeft = axis.left,
             axisTop = axis.top,
+            value = options.value,
+            lineWidth = options.lineWidth,
+            force = options.force,
             x1,
             y1,
             x2,
@@ -6420,13 +6433,13 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
 
             if (defined(pos)) {
                 path = this.getPlotLinePath(
-                    // First argument, value, only used on radial
-                    point && (this.isXAxis ?
-                        point.x :
-                        pick(point.stackY, point.y)
-                    ),
-                    null,
-                    null,
+                    {
+                        // value, only used on radial
+                        value: point && (this.isXAxis ?
+                            point.x :
+                            pick(point.stackY, point.y)
+                        )
+                    },
                     null,
                     pos // Translated position
                 ) || null; // #3189

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -3767,6 +3767,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
             lineWidth: lineWidth,
             old: old,
             force: force,
+            acrossPanes: options.acrossPanes,
             translatedValue: translatedValue
         };
         fireEvent(this, 'getPlotLinePath', evt, function (e) {

--- a/js/parts/PlotLineOrBand.js
+++ b/js/parts/PlotLineOrBand.js
@@ -159,7 +159,8 @@ H.PlotLineOrBand.prototype = {
         if (isLine) {
             path = axis.getPlotLinePath({
                 value: value,
-                lineWidth: svgElem.strokeWidth()
+                lineWidth: svgElem.strokeWidth(),
+                acrossPanes: options.acrossPanes
             });
         } else if (isBand) { // plot band
             path = axis.getPlotBandPath(from, to, options);
@@ -326,6 +327,16 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      * @type      {Array<*>}
      * @product   highcharts highstock gantt
      * @apioption xAxis.plotBands
+     */
+
+    /**
+     * Flag to decide if plotBand should be rendered across all panes.
+     *
+     * @since     7.1.2
+     * @product   highstock
+     * @type      {boolean}
+     * @default   true
+     * @apioption xAxis.plotBands.acrossPanes
      */
 
     /**
@@ -567,6 +578,19 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      * @type      {Array<*>}
      * @product   highcharts highstock gantt
      * @apioption xAxis.plotLines
+     */
+
+    /**
+     * Flag to decide if plotLine should be rendered across all panes.
+     *
+     * @sample {highstock} highcharts/xaxis/plotlines-acrosspane/
+     *         Plot lines on different panes
+     *
+     * @since     7.1.2
+     * @product   highstock
+     * @type      {boolean}
+     * @default   true
+     * @apioption xAxis.plotLines.acrossPanes
      */
 
     /**
@@ -869,11 +893,13 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
     getPlotBandPath: function (from, to) {
         var toPath = this.getPlotLinePath({
                 value: to,
-                force: true
+                force: true,
+                acrossPanes: this.options.acrossPanes
             }),
             path = this.getPlotLinePath({
                 value: from,
-                force: true
+                force: true,
+                acrossPanes: this.options.acrossPanes
             }),
             result = [],
             i,

--- a/js/parts/PlotLineOrBand.js
+++ b/js/parts/PlotLineOrBand.js
@@ -157,7 +157,10 @@ H.PlotLineOrBand.prototype = {
 
         // Set the path or return
         if (isLine) {
-            path = axis.getPlotLinePath(value, svgElem.strokeWidth());
+            path = axis.getPlotLinePath({
+                value: value,
+                lineWidth: svgElem.strokeWidth()
+            });
         } else if (isBand) { // plot band
             path = axis.getPlotBandPath(from, to, options);
         } else {
@@ -864,8 +867,14 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      *         The SVG path definition in array form.
      */
     getPlotBandPath: function (from, to) {
-        var toPath = this.getPlotLinePath(to, null, null, true),
-            path = this.getPlotLinePath(from, null, null, true),
+        var toPath = this.getPlotLinePath({
+                value: to,
+                force: true
+            }),
+            path = this.getPlotLinePath({
+                value: from,
+                force: true
+            }),
             result = [],
             i,
             // #4964 check if chart is inverted or plotband is on yAxis

--- a/js/parts/StockChart.js
+++ b/js/parts/StockChart.js
@@ -378,8 +378,13 @@ addEvent(Axis, 'getPlotLinePath', function (e) {
         });
     }
 
-    // Ignore in case of colorAxis or zAxis. #3360, #3524, #6720
-    if (axis.coll === 'xAxis' || axis.coll === 'yAxis') {
+    if (
+        // For stock chart, by default render paths across the panes
+        // except the case when `acrossPanes` is disabled by user (#6644)
+        (chart.options.isStock && e.acrossPanes !== false) &&
+        // Ignore in case of colorAxis or zAxis. #3360, #3524, #6720
+        axis.coll === 'xAxis' || axis.coll === 'yAxis'
+    ) {
 
         e.preventDefault();
 

--- a/js/parts/Tick.js
+++ b/js/parts/Tick.js
@@ -531,10 +531,12 @@ H.Tick.prototype = {
 
         if (gridLine) {
             gridLinePath = axis.getPlotLinePath(
-                pos + tickmarkOffset,
-                gridLine.strokeWidth() * reverseCrisp,
-                old,
-                'pass'
+                {
+                    value: pos + tickmarkOffset,
+                    lineWidth: gridLine.strokeWidth() * reverseCrisp,
+                    force: 'pass'
+                },
+                old
             );
 
             // If the parameter 'old' is set, the current call will be followed

--- a/js/parts/Tick.js
+++ b/js/parts/Tick.js
@@ -534,9 +534,9 @@ H.Tick.prototype = {
                 {
                     value: pos + tickmarkOffset,
                     lineWidth: gridLine.strokeWidth() * reverseCrisp,
-                    force: 'pass'
-                },
-                old
+                    force: 'pass',
+                    old: old
+                }
             );
 
             // If the parameter 'old' is set, the current call will be followed

--- a/samples/stock/xaxis/plotlines-acrosspanes/demo.details
+++ b/samples/stock/xaxis/plotlines-acrosspanes/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Paweł Fus
+ js_wrap: b
+...

--- a/samples/stock/xaxis/plotlines-acrosspanes/demo.html
+++ b/samples/stock/xaxis/plotlines-acrosspanes/demo.html
@@ -1,0 +1,3 @@
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+
+<div id="container" style="height: 400px"></div>

--- a/samples/stock/xaxis/plotlines-acrosspanes/demo.js
+++ b/samples/stock/xaxis/plotlines-acrosspanes/demo.js
@@ -1,0 +1,51 @@
+Highcharts.stockChart('container', {
+    series: [{
+        data: [1, 2, 3, 4]
+    }, {
+        data: [1, 2, 3, 4],
+        yAxis: 1,
+        xAxis: 1
+    }],
+    yAxis: [{
+        height: '50%'
+    }, {
+        height: '50%',
+        top: '50%'
+    }],
+    xAxis: [{
+        tickLength: 0,
+        lineWidth: 1,
+        labels: {
+            enabled: false
+        },
+        plotLines: [{
+            value: 0.75,
+            width: 1,
+            color: '#000000',
+            acrossPanes: false,
+            label: {
+                text: 'Top pane'
+            }
+        }, {
+            value: 1.5,
+            width: 1,
+            color: '#000000',
+            label: {
+                text: 'Both panes'
+            }
+        }],
+        height: '50%'
+    }, {
+        top: '50%',
+        height: '50%',
+        plotLines: [{
+            value: 2.25,
+            width: 1,
+            color: '#000000',
+            acrossPanes: false,
+            label: {
+                text: 'Bottom pane'
+            }
+        }]
+    }]
+});

--- a/samples/unit-tests/axis/gridlines/demo.js
+++ b/samples/unit-tests/axis/gridlines/demo.js
@@ -32,7 +32,7 @@ QUnit.test('Guard too dense minor grid lines', function (assert) {
 QUnit.test('Animation of grid lines and tick marks', function (assert) {
 
     var clock = TestUtilities.lolexInstall();
-    var chart = Highcharts.chart('container', {
+    var chart = Highcharts.stockChart('container', {
         chart: {
             animation: {
                 duration: 500,


### PR DESCRIPTION
Added new options `plotBands.acrossPanes` and `plotLines.acrossPanes` to control rendering lines across all panes. See #6644.
___
Note: I decided to refactor a bit `Axis.getPlotLinePath()` method instead of adding n-th argument. Let me know if this is fine. Alternatively we can just add another param to `getPlotLinePath()`.

@bre1470 - could you check `AxisPlotLinePathOptionsObject` interface?