### PR TITLE
bugfix/10696-animating-left-2-right

### DIFF
--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -643,6 +643,12 @@ H.Fx.prototype = {
                     shift = i;
                     reverse = true;
                     break;
+                    // Fixed from the right side, "scaling" left
+                }
+                else if (startX[startX.length - 1] ===
+                    endX[endX.length - startX.length + i]) {
+                    shift = startX.length - i;
+                    break;
                 }
             }
             if (typeof shift === 'undefined') {

--- a/samples/unit-tests/svgrenderer/animate/demo.js
+++ b/samples/unit-tests/svgrenderer/animate/demo.js
@@ -100,8 +100,32 @@ QUnit.test('Path animation', function (assert) {
                 'M 300 30 L 300 400',
                 'First animation aborted by shorter second animation'
             );
-            document.body.removeChild(div);
         }, 1500);
+
+
+        setTimeout(function () {
+            path.startX = [1800, 3600];
+            path.attr({
+                d: ['M', 400, 120, 'L', 700, 120]
+            });
+            path.endX = [2349, 3600];
+
+            path.animate({
+                d: ['M', 200, 120, 'L', 700, 120]
+            }, {
+                duration: 300
+            });
+        }, 1700);
+
+        setTimeout(function () {
+            console.log('M 200 120 L 700 120', path.attr('d'));
+            assert.notEqual(
+                path.attr('d'),
+                'M 200 120 L 700 120',
+                'Path is animating, not changing immediately (#10696).'
+            );
+            document.body.removeChild(div);
+        }, 1900);
 
         // Reset animation
         TestUtilities.lolexRunAndUninstall(clock);

--- a/ts/parts/Utilities.ts
+++ b/ts/parts/Utilities.ts
@@ -1021,6 +1021,13 @@ H.Fx.prototype = {
                     shift = i;
                     reverse = true;
                     break;
+                // Fixed from the right side, "scaling" left
+                } else if (
+                    startX[startX.length - 1] ===
+                        endX[endX.length - startX.length + i]
+                ) {
+                    shift = startX.length - i;
+                    break;
                 }
             }
             if (typeof shift === 'undefined') {


### PR DESCRIPTION
Fixed #10696, sometimes series animation was missing when updating points via `Series.setData()`.
___
**Disclaimer:**
I might be missing something important in the current algorithm and my solution could break many unexpected things. During review, paper and pencil are recommended.

What used to work:
a) [100, **200**, 300] => [**200**, 300, 400] (comparing left array against first item in right array) 
b) [**100**, 200, 300] => [-100, 0, **100**]  (comparing right array against first item in left array)

Now we also support animation for:
c) [100, 200, **300**] => [50, 150, **300**] (comparing right array against last item in left array)

Probably opposite animation may be required some day (comparing left array against last item in right array: [100, 200, **300**] => [50, 150, **300**]) but for now added `else-if` should resolve both cases.

PS: Building sources from TS takes up to 25seconds. Can we speed this up?