### PR TITLE
Tools: Fixed issue with disconnected Edge when testing on BrowserStack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,11 +185,6 @@ workflows:
           requires:
             - build_dependencies
           browsers: "Mac.Firefox"
-      - test_browsers:
-          name: "test-Win.Edge"
-          requires:
-            - build_dependencies
-          browsers: "Win.Edge --split 2"
       - hold_for_approval:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - early_return_for_forked_pull_requests # to avoid secrets being passed on to forked PR builds we don't run browser tests for forked PRs
       - << : *load_workspace
       - run: npm run gulp scripts
-      - run: "npx cross-env NODE_OPTIONS=--max_old_space_size=3072 karma start test/karma-conf.js --single-run --browsers << parameters.browsers >>"
+      - run: "npx cross-env NODE_OPTIONS=--max_old_space_size=3072 gulp test --single-run --browsers << parameters.browsers >> --force"
       - run: mkdir ../test-results
       - run:
           name: Save test results
@@ -189,7 +189,7 @@ workflows:
           name: "test-Win.Edge"
           requires:
             - build_dependencies
-          browsers: "Win.Edge"
+          browsers: "Win.Edge --sharding 2"
       - hold_for_approval:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,11 @@ workflows:
           requires:
             - build_dependencies
           browsers: "Mac.Firefox"
+      - test_browsers:
+          name: "test-Win.Edge"
+          requires:
+            - build_dependencies
+          browsers: "Win.Edge"
       - hold_for_approval:
           type: approval
           filters:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "npx gulp test --force --speak",
     "testall": "npx gulp test --browsers all --force --speak",
     "preci-test": "npm run ts-compile:test",
-    "ci-test": "npx gulp scripts && cross-env NODE_OPTIONS=--max_old_space_size=3072 karma start test/karma-conf.js --single-run --browsers Mac.Safari,Mac.Firefox,Win.Edge",
+    "ci-test": "npx gulp scripts && cross-env NODE_OPTIONS=--max_old_space_size=3072 karma start test/karma-conf.js --single-run --browsers Mac.Safari,Mac.Firefox",
     "prebuild": "rimraf build/ code/",
     "build": "npx gulp dist",
     "jsdoc": "npx gulp jsdoc --watch",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "npx gulp test --force --speak",
     "testall": "npx gulp test --browsers all --force --speak",
     "preci-test": "npm run ts-compile:test",
-    "ci-test": "npx gulp scripts && cross-env NODE_OPTIONS=--max_old_space_size=3072 karma start test/karma-conf.js --single-run --browsers Mac.Safari,Mac.Firefox",
+    "ci-test": "npx gulp scripts && cross-env NODE_OPTIONS=--max_old_space_size=3072 karma start test/karma-conf.js --single-run --browsers Mac.Safari,Mac.Firefox,Win.Edge",
     "prebuild": "rimraf build/ code/",
     "build": "npx gulp dist",
     "jsdoc": "npx gulp jsdoc --watch",

--- a/samples/unit-tests/boost/tooltip/demo.js
+++ b/samples/unit-tests/boost/tooltip/demo.js
@@ -13,7 +13,7 @@ QUnit.test('Tooltip on a boosted chart with categories', function (assert) {
     controller.moveTo(chart.plotLeft + 5, chart.plotTop + 5);
 
     assert.ok(
-        document.getElementsByClassName('highcharts-tooltip')[0].innerHTML.match('categoryName') !== null,
+        document.getElementsByClassName('highcharts-tooltip')[0].textContent.match('categoryName') !== null,
         '`categoryName` found in the tooltip (#10432).'
     );
 });

--- a/samples/unit-tests/series-venn/members/demo.js
+++ b/samples/unit-tests/series-venn/members/demo.js
@@ -21,7 +21,7 @@ QUnit.test('addOverlapToRelations', function (assert) {
 
     addOverlapToSets(data);
 
-    set = data.find(isSetWithId('A'));
+    set = Highcharts.find(data, isSetWithId('A'));
     assert.strictEqual(
         set.totalOverlap,
         3,
@@ -36,7 +36,7 @@ QUnit.test('addOverlapToRelations', function (assert) {
         'should set the property overlapping on set A to include a map from id of overlapping set to the amount of overlap.'
     );
 
-    set = data.find(isSetWithId('B'));
+    set = Highcharts.find(data, isSetWithId('B'));
     assert.strictEqual(
         set.totalOverlap,
         4,
@@ -51,7 +51,7 @@ QUnit.test('addOverlapToRelations', function (assert) {
         'should set the property overlapping on set B to include a map from id of overlapping set to the amount of overlap.'
     );
 
-    set = data.find(isSetWithId('C'));
+    set = Highcharts.find(data, isSetWithId('C'));
     assert.strictEqual(
         set.totalOverlap,
         5,

--- a/samples/unit-tests/sonification/timeline/demo.js
+++ b/samples/unit-tests/sonification/timeline/demo.js
@@ -1,4 +1,10 @@
 QUnit.test('Instrument.play/onEnd is being called correctly', function (assert) {
+
+    if (navigator.userAgent.indexOf('Trident') !== -1) {
+        assert.ok(true, 'IE not supported');
+        return;
+    }
+
     var done = assert.async(),
         clock = TestUtilities.lolexInstall();
 
@@ -126,6 +132,7 @@ QUnit.test('Instrument.play/onEnd is being called correctly', function (assert) 
 
         TestUtilities.lolexRunAndUninstall(clock);
     } finally {
+        done();
         TestUtilities.lolexUninstall(clock);
     }
 });

--- a/samples/unit-tests/sonification/timeline/demo.js
+++ b/samples/unit-tests/sonification/timeline/demo.js
@@ -132,7 +132,6 @@ QUnit.test('Instrument.play/onEnd is being called correctly', function (assert) 
 
         TestUtilities.lolexRunAndUninstall(clock);
     } finally {
-        done();
         TestUtilities.lolexUninstall(clock);
     }
 });

--- a/samples/unit-tests/svgrenderer/text/demo.js
+++ b/samples/unit-tests/svgrenderer/text/demo.js
@@ -77,7 +77,10 @@ QUnit.test('Text word wrap with markup', function (assert) {
 
     // For some reason Edge gets the BBox width wrong, but the text looks
     // correct
-    if (navigator.userAgent.indexOf('Edge') === -1) {
+    if (
+        navigator.userAgent.indexOf('Edge') === -1 &&
+        navigator.userAgent.indexOf('Trident') === -1
+    ) {
         assert.ok(
             text.getBBox().width <= 100,
             'The text node width should be less than 100'

--- a/test/test-controller.d.ts
+++ b/test/test-controller.d.ts
@@ -19,6 +19,10 @@ interface TestControllerTouchPositions extends Array<TestControllerTouchPosition
     [index: number]: TestControllerTouchPosition;
     item?: (index: number) => TestControllerTouchPosition;
 }
+interface ClipPaths {
+    elements: Array<HighchartsElement>;
+    values: Array<string>;
+}
 /**
  * The test controller makes it easy to emulate mouse and touch stuff on the
  * chart.
@@ -64,6 +68,19 @@ declare class TestController {
     private positionY;
     private relatedTarget;
     /**
+     * Edge and IE are unable to get elementFromPoint when the group has a
+     * clip path. It reports the first underlying element with no clip path.
+     */
+    private setUpMSWorkaround;
+    /**
+     * Undo the workaround
+     *
+     * @param clipPaths
+     *        The clip paths that were returned from the `setUpMSWorkaround`
+     *        function
+     */
+    private tearDownMSWorkaround;
+    /**
      * Simulates a mouse click.
      *
      * @param chartX
@@ -90,7 +107,7 @@ declare class TestController {
      * @param chartY
      *        Y relative to the chart.
      */
-    elementFromPoint(chartX?: number, chartY?: number): (HighchartsElement | null);
+    elementFromPoint(chartX?: number, chartY?: number, useMSWorkaround?: boolean): (HighchartsElement | null);
     /**
      * Get the current position of the cursor.
      */

--- a/test/test-controller.js
+++ b/test/test-controller.js
@@ -96,6 +96,41 @@ var TestController = /** @class */ (function () {
         }
         return points;
     };
+    /**
+     * Edge and IE are unable to get elementFromPoint when the group has a
+     * clip path. It reports the first underlying element with no clip path.
+     */
+    TestController.prototype.setUpMSWorkaround = function () {
+        var clipPaths = {
+            elements: [],
+            values: []
+        };
+        if (/(Trident|Edge)/.test(window.navigator.userAgent)) {
+            [].slice
+                .call(document.querySelectorAll('[clip-path],[CLIP-PATH]'))
+                .forEach(function (elemCP) {
+                clipPaths.elements.push(elemCP);
+                clipPaths.values.push(elemCP.getAttribute('clip-path'));
+                elemCP.removeAttribute('clip-path');
+            });
+        }
+        return clipPaths;
+    };
+    /**
+     * Undo the workaround
+     *
+     * @param clipPaths
+     *        The clip paths that were returned from the `setUpMSWorkaround`
+     *        function
+     */
+    TestController.prototype.tearDownMSWorkaround = function (clipPaths) {
+        // Reset clip paths for Edge and IE
+        if (clipPaths) {
+            clipPaths.elements.forEach(function (elemCP, i) {
+                elemCP.setAttribute('clip-path', clipPaths.values[i]);
+            });
+        }
+    };
     /* *
      *
      *  Functions
@@ -126,32 +161,6 @@ var TestController = /** @class */ (function () {
         this.mouseDown(chartX, chartY, extra, debug);
         this.mouseUp(chartX, chartY, extra, debug);
         this.triggerEvent('click', chartX, chartY, extra, debug);
-    };
-    TestController.prototype.setUpMSWorkaround = function () {
-        var clipPaths = {
-            elements: [],
-            values: []
-        };
-        // Edge and IE are unable to get elementFromPoint when the group has a
-        // clip path. It reports the first underlying element with no clip path.
-        if (/(Trident|Edge)/.test(window.navigator.userAgent)) {
-            [].slice
-                .call(document.querySelectorAll('[clip-path],[CLIP-PATH]'))
-                .forEach(function (elemCP) {
-                clipPaths.elements.push(elemCP);
-                clipPaths.values.push(elemCP.getAttribute('clip-path'));
-                elemCP.removeAttribute('clip-path');
-            });
-        }
-        return clipPaths;
-    };
-    TestController.prototype.tearDownMSWorkaround = function (clipPaths) {
-        // Reset clip paths for Edge and IE
-        if (clipPaths) {
-            clipPaths.elements.forEach(function (elemCP, i) {
-                elemCP.setAttribute('clip-path', clipPaths.values[i]);
-            });
-        }
     };
     /**
      * Get the element from a point on the chart.

--- a/test/test-controller.ts
+++ b/test/test-controller.ts
@@ -10,6 +10,9 @@
  *
  * */
 
+/**
+ * DOM elements
+ */
 type HighchartsElement = (
     Highcharts.HTMLDOMElement |
     Highcharts.SVGDOMElement
@@ -26,25 +29,37 @@ type TestControllerPoint = [number, number];
  *
  * */
 
+/**
+ * SVG clip paths
+ */
+interface ClipPaths {
+    elements: Array<HighchartsElement>;
+    values: Array<string>;
+}
+
+/**
+ * Chart position of a controller instance
+ */
 interface TestControllerPosition extends Highcharts.PositionObject {
     relatedTarget: (HighchartsElement | null);
 }
 
+/**
+ * Page coordinates of a controller instance
+ */
 interface TestControllerTouchPosition {
     pageX: number;
     pageY: number;
 }
 
+/**
+ * Touch coordinates
+ */
 interface TestControllerTouchPositions
     extends Array<TestControllerTouchPosition>
 {
     [index: number]: TestControllerTouchPosition;
     item?: (index: number) => TestControllerTouchPosition;
-}
-
-interface ClipPaths {
-    elements: Array<HighchartsElement>;
-    values: Array<string>;
 }
 
 /* *
@@ -183,50 +198,6 @@ class TestController {
 
     private relatedTarget: (HighchartsElement | null);
 
-    /**
-     * Edge and IE are unable to get elementFromPoint when the group has a
-     * clip path. It reports the first underlying element with no clip path.
-     */
-    private setUpMSWorkaround () {
-        const clipPaths: ClipPaths = {
-            elements: [],
-            values: []
-        };
-
-        if (/(Trident|Edge)/.test(window.navigator.userAgent)) {
-            [].slice
-                .call(document.querySelectorAll('[clip-path],[CLIP-PATH]'))
-                .forEach(
-                    function (elemCP: HighchartsElement) {
-                        clipPaths.elements.push(elemCP);
-                        clipPaths.values.push(
-                            elemCP.getAttribute('clip-path')!
-                        );
-                        elemCP.removeAttribute('clip-path');
-                    }
-                );
-        }
-        return clipPaths;
-        
-    }
-
-    /**
-     * Undo the workaround
-     * 
-     * @param clipPaths
-     *        The clip paths that were returned from the `setUpMSWorkaround`
-     *        function
-     */
-    private tearDownMSWorkaround (
-        clipPaths: ClipPaths
-    ) {
-        // Reset clip paths for Edge and IE
-        if (clipPaths) {
-            clipPaths.elements.forEach(function (elemCP, i) {
-                elemCP.setAttribute('clip-path', clipPaths.values[i]);
-            });
-        }
-    }
     /* *
      *
      *  Functions
@@ -654,6 +625,33 @@ class TestController {
     }
 
     /**
+     * Edge and IE are unable to get elementFromPoint when the group has a
+     * clip path. It reports the first underlying element with no clip path.
+     */
+    private setUpMSWorkaround () {
+        const clipPaths: ClipPaths = {
+            elements: [],
+            values: []
+        };
+
+        if (/(Trident|Edge)/.test(window.navigator.userAgent)) {
+            [].slice
+                .call(document.querySelectorAll('[clip-path],[CLIP-PATH]'))
+                .forEach(
+                    function (elemCP: HighchartsElement) {
+                        clipPaths.elements.push(elemCP);
+                        clipPaths.values.push(
+                            elemCP.getAttribute('clip-path')!
+                        );
+                        elemCP.removeAttribute('clip-path');
+                    }
+                );
+        }
+        return clipPaths;
+        
+    }
+
+    /**
      * Move the cursor position to a new position, without firing events.
      *
      * @param chartX
@@ -745,6 +743,24 @@ class TestController {
     ) {
         this.touchStart(chartX, chartY, twoFingers, undefined, debug);
         this.touchEnd(chartX, chartY, twoFingers, undefined, debug);
+    }
+
+    /**
+     * Undo the workaround for Edge and IE.
+     * 
+     * @param clipPaths
+     *        The clip paths that were returned from the `setUpMSWorkaround`
+     *        function
+     */
+    private tearDownMSWorkaround (
+        clipPaths: ClipPaths
+    ) {
+        // Reset clip paths for Edge and IE
+        if (clipPaths) {
+            clipPaths.elements.forEach(function (elemCP, i) {
+                elemCP.setAttribute('clip-path', clipPaths.values[i]);
+            });
+        }
     }
 
     /**

--- a/test/test-controller.ts
+++ b/test/test-controller.ts
@@ -183,6 +183,50 @@ class TestController {
 
     private relatedTarget: (HighchartsElement | null);
 
+    /**
+     * Edge and IE are unable to get elementFromPoint when the group has a
+     * clip path. It reports the first underlying element with no clip path.
+     */
+    private setUpMSWorkaround () {
+        const clipPaths: ClipPaths = {
+            elements: [],
+            values: []
+        };
+
+        if (/(Trident|Edge)/.test(window.navigator.userAgent)) {
+            [].slice
+                .call(document.querySelectorAll('[clip-path],[CLIP-PATH]'))
+                .forEach(
+                    function (elemCP: HighchartsElement) {
+                        clipPaths.elements.push(elemCP);
+                        clipPaths.values.push(
+                            elemCP.getAttribute('clip-path')!
+                        );
+                        elemCP.removeAttribute('clip-path');
+                    }
+                );
+        }
+        return clipPaths;
+        
+    }
+
+    /**
+     * Undo the workaround
+     * 
+     * @param clipPaths
+     *        The clip paths that were returned from the `setUpMSWorkaround`
+     *        function
+     */
+    private tearDownMSWorkaround (
+        clipPaths: ClipPaths
+    ) {
+        // Reset clip paths for Edge and IE
+        if (clipPaths) {
+            clipPaths.elements.forEach(function (elemCP, i) {
+                elemCP.setAttribute('clip-path', clipPaths.values[i]);
+            });
+        }
+    }
     /* *
      *
      *  Functions
@@ -215,42 +259,6 @@ class TestController {
         this.mouseDown(chartX, chartY, extra, debug);
         this.mouseUp(chartX, chartY, extra, debug);
         this.triggerEvent('click', chartX, chartY, extra, debug);
-    }
-
-    public setUpMSWorkaround () {
-        const clipPaths: ClipPaths = {
-            elements: [],
-            values: []
-        };
-
-        // Edge and IE are unable to get elementFromPoint when the group has a
-        // clip path. It reports the first underlying element with no clip path.
-        if (/(Trident|Edge)/.test(window.navigator.userAgent)) {
-            [].slice
-                .call(document.querySelectorAll('[clip-path],[CLIP-PATH]'))
-                .forEach(
-                    function (elemCP: HighchartsElement) {
-                        clipPaths.elements.push(elemCP);
-                        clipPaths.values.push(
-                            elemCP.getAttribute('clip-path')!
-                        );
-                        elemCP.removeAttribute('clip-path');
-                    }
-                );
-        }
-        return clipPaths;
-        
-    }
-
-    public tearDownMSWorkaround (
-        clipPaths: ClipPaths
-    ) {
-        // Reset clip paths for Edge and IE
-        if (clipPaths) {
-            clipPaths.elements.forEach(function (elemCP, i) {
-                elemCP.setAttribute('clip-path', clipPaths.values[i]);
-            });
-        }
     }
 
     /**


### PR DESCRIPTION
A loop was running over numerous DOM nodes for each step of `TestController.moveTo`.