### PR TITLE
Bugfix/forced a11y markers

### DIFF
--- a/js/modules/accessibility/options.js
+++ b/js/modules/accessibility/options.js
@@ -63,7 +63,7 @@ var options = {
          * @type  {boolean|number}
          * @since 5.0.0
          */
-        pointDescriptionThreshold: 500, // set to false to disable
+        pointDescriptionThreshold: 200, // set to false to disable
 
         /**
          * Whether or not to add a shortcut button in the screen reader

--- a/js/parts/Point.js
+++ b/js/parts/Point.js
@@ -308,11 +308,11 @@ Highcharts.Point.prototype = {
     },
 
     /**
-     * Transform number or array configs into objects. Used internally to unify
-     * the different configuration formats for points. For example, a simple
-     * number `10` in a line series will be transformed to `{ y: 10 }`, and an
-     * array config like `[1, 10]` in a scatter series will be transformed to
-     * `{ x: 1, y: 10 }`.
+     * Transform number or array configs into objects. Also called for object
+     * configs. Used internally to unify the different configuration formats for
+     * points. For example, a simple number `10` in a line series will be
+     * transformed to `{ y: 10 }`, and an array config like `[1, 10]` in a
+     * scatter series will be transformed to `{ x: 1, y: 10 }`.
      *
      * @function Highcharts.Point#optionsToObject
      *

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -4377,8 +4377,8 @@ H.Series = H.seriesType(
          *        The point instance to inspect.
          *
          * @param {string} [state]
-         *        The point state, can be either `hover`, `select` or undefined
-         *        for normal state.
+         *        The point state, can be either `hover`, `select` or 'normal'.
+         *        If undefined, normal state is assumed.
          *
          * @return {Highcharts.SVGAttributes}
          *         The presentational attributes to be set on the point.
@@ -4422,6 +4422,7 @@ H.Series = H.seriesType(
             );
 
             // Handle hover and select states
+            state = state || 'normal';
             if (state) {
                 seriesStateOptions = seriesMarkerOptions.states[state];
                 pointStateOptions = (

--- a/samples/unit-tests/accessibility/accessible-highstock/demo.js
+++ b/samples/unit-tests/accessibility/accessible-highstock/demo.js
@@ -1,5 +1,8 @@
 QUnit.test('Basic stock chart', function (assert) {
     var chart = Highcharts.stockChart('container', {
+        accessibility: {
+            pointDescriptionThreshold: 1
+        },
         series: [{
             data: [1, 2, 3, 4, 5, 6]
         }]
@@ -17,13 +20,10 @@ QUnit.test('Basic stock chart', function (assert) {
     );
 });
 
-QUnit.test('Stock chart with markers', function (assert) {
+QUnit.test('Stock chart with forced markers', function (assert) {
     var chart = Highcharts.stockChart('container', {
             series: [{
-                data: [1, 2, 3, 4, 5, 6],
-                marker: {
-                    enabled: true
-                }
+                data: [1, 2, 3, 4, 5, 6]
             }]
         }),
         point = chart.series[0].points[0];

--- a/samples/unit-tests/accessibility/forced-markers/demo.details
+++ b/samples/unit-tests/accessibility/forced-markers/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/accessibility/forced-markers/demo.html
+++ b/samples/unit-tests/accessibility/forced-markers/demo.html
@@ -1,0 +1,8 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+<script src="https://code.highcharts.com/modules/accessibility.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/accessibility/forced-markers/demo.js
+++ b/samples/unit-tests/accessibility/forced-markers/demo.js
@@ -1,0 +1,189 @@
+// Marker testing functions
+function hasMarker(point) {
+    return !!point.graphic;
+}
+function hasVisibleMarker(point) {
+    return hasMarker(point) && point.graphic.opacity !== 0;
+}
+
+QUnit.test('No series markers', function (assert) {
+    const chart = Highcharts.chart('container', {
+            plotOptions: {
+                series: {
+                    marker: {
+                        enabled: false
+                    }
+                }
+            },
+            series: [{
+                data: [1, 2, 3, 4]
+            }]
+        }),
+        point = chart.series[0].points[1];
+
+    // Markers should exist and not be visible
+    assert.strictEqual(hasMarker(point), true, 'Marker exists');
+    assert.strictEqual(hasVisibleMarker(point), false, 'Marker hidden');
+});
+
+QUnit.test('Too many points for markers', function (assert) {
+    const chart = Highcharts.chart('container', {
+            series: [{
+                data: [1, 2, 3, 4],
+                marker: {
+                    enabledThreshold: 100
+                }
+            }]
+        }),
+        point = chart.series[0].points[1];
+
+    // Markers should not exist
+    assert.strictEqual(hasMarker(point), false, 'No markers');
+});
+
+QUnit.test('Too many points for a11y', function (assert) {
+    const chart = Highcharts.chart('container', {
+            accessibility: {
+                pointDescriptionThreshold: 1
+            },
+            series: [{
+                marker: {
+                    enabled: false
+                },
+                data: [1, 2, 3, 4]
+            }]
+        }),
+        point = chart.series[0].points[1];
+
+    // Markers should not exist
+    assert.strictEqual(hasMarker(point), false, 'No markers');
+});
+
+QUnit.test('Markers enabled', function (assert) {
+    const chart = Highcharts.chart('container', {
+            plotOptions: {
+                series: {
+                    marker: {
+                        enabled: true
+                    }
+                }
+            },
+            series: [{
+                data: [1, 2, 3, 4]
+            }]
+        }),
+        point = chart.series[0].points[1];
+
+    // Markers should exist and be visible
+    assert.strictEqual(hasMarker(point), true, 'Marker exists');
+    assert.strictEqual(hasVisibleMarker(point), true, 'Marker visible');
+});
+
+QUnit.test('Markers enabled, point marker off', function (assert) {
+    const chart = Highcharts.chart('container', {
+            series: [{
+                data: [1, 2, {
+                    y: 3,
+                    marker: {
+                        enabled: false
+                    }
+                }, 4]
+            }]
+        }),
+        pointA = chart.series[0].points[1],
+        pointB = chart.series[0].points[2];
+
+    // Markers should exist and be visible, point marker should not be visible
+    assert.strictEqual(hasMarker(pointA), true, 'Series marker exists');
+    assert.strictEqual(hasVisibleMarker(pointA), true, 'Series marker visible');
+    assert.strictEqual(hasMarker(pointB), true, 'Point marker exists');
+    assert.strictEqual(hasVisibleMarker(pointB), false, 'Point marker hidden');
+});
+
+QUnit.test('Markers disabled, point marker off', function (assert) {
+    const chart = Highcharts.chart('container', {
+            series: [{
+                marker: {
+                    enabled: false
+                },
+                data: [1, 2, {
+                    y: 3,
+                    marker: {
+                        enabled: false
+                    }
+                }, 4]
+            }]
+        }),
+        pointA = chart.series[0].points[1],
+        pointB = chart.series[0].points[2];
+
+    // Markers should exist and not be visible
+    assert.strictEqual(hasMarker(pointA), true, 'Series marker exists');
+    assert.strictEqual(hasVisibleMarker(pointA), false, 'Series marker hidden');
+    assert.strictEqual(hasMarker(pointB), true, 'Point marker exists');
+    assert.strictEqual(hasVisibleMarker(pointB), false, 'Point marker hidden');
+});
+
+QUnit.test('Markers disabled, point marker on', function (assert) {
+    const chart = Highcharts.chart('container', {
+            series: [{
+                marker: {
+                    enabled: false
+                },
+                data: [1, 2, {
+                    y: 3,
+                    marker: {
+                        enabled: true
+                    }
+                }, 4]
+            }]
+        }),
+        pointA = chart.series[0].points[1],
+        pointB = chart.series[0].points[2];
+
+    // Markers should exist and not be visible, point marker should be visible
+    assert.strictEqual(hasMarker(pointA), true, 'Series marker exists');
+    assert.strictEqual(hasVisibleMarker(pointA), false, 'Series marker hidden');
+    assert.strictEqual(hasMarker(pointB), true, 'Point marker exists');
+    assert.strictEqual(hasVisibleMarker(pointB), true, 'Point marker visible');
+});
+
+QUnit.test('Dynamic markers on update', function (assert) {
+    const chart = Highcharts.chart('container', {
+            series: [{
+                type: 'arearange',
+                marker: {
+                    enabled: false
+                },
+                data: [[1, 2], [2, 3], {
+                    low: 3,
+                    high: 4,
+                    marker: {
+                        enabled: true
+                    }
+                }, [4, 5]]
+            }]
+        }),
+        series = chart.series[0];
+
+    series.update({
+        marker: {
+            enabled: true
+        }
+    });
+
+    series.points[2].update({
+        marker: {
+            enabled: false
+        }
+    });
+
+    const pointA = series.points[1],
+        pointB = series.points[2];
+
+    // Markers should exist and be visible, point marker should not be visible
+    assert.strictEqual(hasMarker(pointA), true, 'Series marker exists');
+    assert.strictEqual(hasVisibleMarker(pointA), true, 'Series marker visible');
+    assert.strictEqual(hasMarker(pointB), true, 'Point marker exists');
+    assert.strictEqual(hasVisibleMarker(pointB), false, 'Point marker hidden');
+});

--- a/samples/unit-tests/point/point-update/demo.js
+++ b/samples/unit-tests/point/point-update/demo.js
@@ -76,7 +76,9 @@ QUnit.test(
     'Preserve point config initial array type in options.data',
     function (assert) {
         var chart = $('#container').highcharts({
-
+            accessibility: {
+                enabled: false // Forces markers
+            },
             series: [{
                 data: [[0, 1], [1, 2], [2, 3]],
                 turboThreshold: 2
@@ -132,6 +134,9 @@ QUnit.test(
     'Preserve data values when updating from array to object config (#4916)',
     function (assert) {
         var chart = Highcharts.chart('container', {
+            accessibility: {
+                enabled: false // Forces markers
+            },
             xAxis: {
                 type: 'datetime'
             },
@@ -174,6 +179,9 @@ QUnit.test(
     'marker.symbol=null should be accepted in point.update() (#6792)',
     function (assert) {
         var chart = Highcharts.chart('container', {
+                accessibility: {
+                    enabled: false // Forces markers
+                },
                 series: [{
                     data: [{
                         y: 10,

--- a/samples/unit-tests/series/marker/demo.js
+++ b/samples/unit-tests/series/marker/demo.js
@@ -3,6 +3,9 @@ QUnit.test('Marker size and position', function (assert) {
         chart: {
             animation: false
         },
+        accessibility: {
+            enabled: false // A11y forces markers
+        },
         series: [{
             data: [1, 2, 3],
             animation: false,

--- a/samples/unit-tests/series/update-highstock/demo.js
+++ b/samples/unit-tests/series/update-highstock/demo.js
@@ -126,6 +126,9 @@ QUnit.test('Series.update', function (assert) {
 
     // create the chart
     Highcharts.stockChart('container', {
+        accessibility: {
+            enabled: false // A11y forces markers
+        },
         rangeSelector: {
             selected: 1
         },

--- a/samples/unit-tests/series/update/demo.js
+++ b/samples/unit-tests/series/update/demo.js
@@ -1,6 +1,9 @@
 QUnit.test('Series.update', function (assert) {
 
     var chart = Highcharts.chart('container', {
+        accessibility: {
+            enabled: false // A11y forces markers
+        },
         xAxis: {
             categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
             showEmpty: false
@@ -820,6 +823,9 @@ QUnit.test('series.update using altered original chart options', function (asser
 
 QUnit.test('Series.update with individual markers and data labels (#10649)', assert => {
     const chart = Highcharts.chart('container', {
+        accessibility: {
+            enabled: false // A11y forces markers
+        },
         title: {
             text: 'Individual marker and dataLabel'
         },


### PR DESCRIPTION
Fixed issue with accessibility features not working for series without markers.
___

Added support for normal state in markers, e.g. `series.marker.state.normal`.

Added forcing of markers so that markers disabled now means markers enabled, but invisible.

Markers are forced on render (because data grouping/zoom/container size can affect marker enabled/disabled). They are forced by overriding the normal marker state, either on series or point level (for point markers).

Markers are not forced if the number of points exceeds the `accessibility.pointDescriptionThreshold` option value. This defaults to 200. They are also not forced unless accessibility is enabled for the chart.