### PR TITLE
Fixed #10712, solid gauge data labels default y position

### DIFF
--- a/js/modules/solid-gauge.src.js
+++ b/js/modules/solid-gauge.src.js
@@ -250,7 +250,11 @@ var solidGaugeOptions = {
     /**
      * Whether to give each point an individual color.
      */
-    colorByPoint: true
+    colorByPoint: true,
+
+    dataLabels: {
+        y: 0
+    }
 
 };
 


### PR DESCRIPTION
Fixed #10712, solid gauge data labels rendered below center by default. They are now vertically centered. Changed `dataLabels.y` default to 0.