### PR TITLE
bugfix/9198-negative-color-ignored-setData

### DIFF
--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -4928,15 +4928,19 @@ H.Series = H.seriesType(
                         clips[i].animate(clipAttr);
                     } else {
                         clips[i] = renderer.clipRect(clipAttr);
-
-                        if (graph) {
-                            series['zone-graph-' + i].clip(clips[i]);
-                        }
-
-                        if (area) {
-                            series['zone-area-' + i].clip(clips[i]);
-                        }
                     }
+
+                    // when no data, graph zone is not applied and after setData
+                    // clip was ignored. As a result, it should be applied each
+                    // time.
+                    if (graph) {
+                        series['zone-graph-' + i].clip(clips[i]);
+                    }
+
+                    if (area) {
+                        series['zone-area-' + i].clip(clips[i]);
+                    }
+
                     // if this zone extends out of the axis, ignore the others
                     ignoreZones = threshold.value > extremes.max;
 

--- a/samples/unit-tests/series/zones/demo.js
+++ b/samples/unit-tests/series/zones/demo.js
@@ -179,3 +179,29 @@ QUnit.test('Adding and removing zones', function (assert) {
         'Series line is hidden after adding zones back (#10569).'
     );
 });
+
+QUnit.test('#9198 setData and zones', function (assert) {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            height: 500,
+            width: 800
+        },
+        yAxis: {
+            min: -3,
+            max: 3
+        },
+        series: [{
+            type: 'area',
+            negativeColor: 'green',
+            data: []
+        }]
+    });
+
+    chart.series[0].setData([4, 3, 4, -3, -3, 10]);
+
+    assert.strictEqual(
+        chart.series[0]['zone-graph-1'].attr('clip-path') !== 0,
+        true,
+        'Negative color is applied on the line and area.'
+    );
+});


### PR DESCRIPTION
Fixed #9198, zones and negative color were not applied after `series.setData`.