### PR TITLE
bugfix/10713-respo-annotations-init

### DIFF
--- a/js/annotations/annotations.src.js
+++ b/js/annotations/annotations.src.js
@@ -986,10 +986,10 @@ merge(
         },
 
         /**
-         * See {@link Highcharts.Annotation#destroy}.
+         * See {@link Highcharts.Chart#removeAnnotation}.
          */
         remove: function () {
-            return this.destroy();
+            return this.chart.removeAnnotation(this);
         },
 
         update: function (userOptions) {

--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -386,16 +386,16 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      *        Whether to redraw the chart.
      *
      * @param {boolean} [oneToOne=false]
-     *        When `true`, the `series`, `xAxis` and `yAxis` collections will
-     *        be updated one to one, and items will be either added or removed
-     *        to match the new updated options. For example, if the chart has
-     *        two series and we call `chart.update` with a configuration
-     *        containing three series, one will be added. If we call
-     *        `chart.update` with one series, one will be removed. Setting an
-     *        empty `series` array will remove all series, but leaving out the
-     *        `series` property will leave all series untouched. If the series
-     *        have id's, the new series options will be matched by id, and the
-     *        remaining ones removed.
+     *        When `true`, the `series`, `xAxis`, `yAxis` and `annotations`
+     *        collections will be updated one to one, and items will be either
+     *        added or removed to match the new updated options. For example,
+     *        if the chart has two series and we call `chart.update` with a
+     *        configuration containing three series, one will be added. If we
+     *        call `chart.update` with one series, one will be removed. Setting
+     *        an empty `series` array will remove all series, but leaving out
+     *        the`series` property will leave all series untouched. If the
+     *        series have id's, the new series options will be matched by id,
+     *        and the remaining ones removed.
      *
      * @param {boolean|Highcharts.AnimationOptionsObject} [animation=true]
      *        Whether to apply animation, and optionally animation
@@ -572,6 +572,9 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                                 .touched = true;
                         } else if (coll === 'xAxis' || coll === 'yAxis') {
                             chart.addAxis(newOptions, coll === 'xAxis', false)
+                                .touched = true;
+                        } else if (coll === 'annotations') {
+                            chart.addAnnotation(newOptions, false)
                                 .touched = true;
                         }
                     }

--- a/js/parts/Responsive.js
+++ b/js/parts/Responsive.js
@@ -190,7 +190,7 @@ Chart.prototype.setResponsive = function (redraw, reset) {
         // Undo previous rules. Before we apply a new set of rules, we need to
         // roll back completely to base options (#6291).
         if (currentResponsive) {
-            this.update(currentResponsive.undoOptions, redraw);
+            this.update(currentResponsive.undoOptions, redraw, true);
         }
 
         if (ruleIds) {
@@ -203,7 +203,7 @@ Chart.prototype.setResponsive = function (redraw, reset) {
                 undoOptions: undoOptions
             };
 
-            this.update(mergedOptions, redraw);
+            this.update(mergedOptions, redraw, true);
 
         } else {
             this.currentResponsive = undefined;
@@ -263,7 +263,10 @@ Chart.prototype.currentOptions = function (options) {
         var i;
 
         H.objectEach(options, function (val, key) {
-            if (!depth && ['series', 'xAxis', 'yAxis'].indexOf(key) > -1) {
+            if (
+                !depth &&
+                ['series', 'xAxis', 'yAxis', 'annotations'].indexOf(key) > -1
+            ) {
                 val = splat(val);
 
                 ret[key] = [];

--- a/samples/unit-tests/responsive/responsive/demo.js
+++ b/samples/unit-tests/responsive/responsive/demo.js
@@ -241,6 +241,16 @@ QUnit.test(
                         }],
                         annotations: [{
                             visible: false
+                        }, {
+                            labels: [{
+                                point: {
+                                    xAxis: 0,
+                                    yAxis: 0,
+                                    x: 1,
+                                    y: 1
+                                },
+                                text: 'Label v2'
+                            }]
                         }]
                     }
                 }]
@@ -280,7 +290,19 @@ QUnit.test(
             'hidden',
             'Initial annotation hidden'
         );
+        assert.strictEqual(
+            chart.annotations.length,
+            2,
+            'New annotation added (#10713)'
+        );
 
+        chart.setSize(600);
+
+        assert.strictEqual(
+            chart.annotations.length,
+            1,
+            'Old annotation removed (#10713)'
+        );
     }
 );
 


### PR DESCRIPTION
Fixed #10713, initializing annotations in responsive rules didn't work.
___
It is a general issue, where responsive rules don't set `oneToOne` argument in `chart.update()`.

A few things to consider:

- `['series', 'xAxis', 'yAxis', 'annotations'].indexOf(key) > -1` - we may want to replace this array with `chart.collectionsWithUpdate`. In theory, we don't have logic for adding/removing `zAxis`, `colorAxis` and `pane` but one day we may want to add this.

- Maybe this if-else tree 
https://github.com/highcharts/highcharts/blob/f3f7a6e42b1614d19f7b56ec5c4704f8c8b563f5/js/parts/Dynamics.js#L569-L580
could be replaced with (a): 
```
Chart.prototype.initWith = {
  // collectionName: [ 'initializer', [extraArgs]]
  xAxis: ['addAxis', [true]],
  yAxis: [ 'addAxis', [false]],
  series: ['addSeries', []]
}
```
Or (b):
```
Chart.prototype.initWith = {
  // collectionName: [ 'initializer', [extraArgs]]
  xAxis: [Chart.prototype.addAxis, [true]],
  yAxis: [Chart.prototype.addAxis, [false]],
  series: [Chart.prototype.addSeries, []]
}
```
So it will be easily extendable and we could avoid polluting Highcharts core with modules definitions here. We would get simple (for a)):
```
chart[chart.initWith[coll][0]](newOptions, ...chart.initWith[coll][1], false)
```
(I know, rest param syntax can't be used here, but it's just an idea).