### PR TITLE
bugfix/10737-data-export-equal-names

### DIFF
--- a/js/modules/export-data.src.js
+++ b/js/modules/export-data.src.js
@@ -422,13 +422,6 @@ Highcharts.Chart.prototype.getDataRows = function (multiLevelHeaders) {
                 key = point.x;
                 name = series.data[pIdx] && series.data[pIdx].name;
 
-                if (xTaken) {
-                    if (xTaken[key]) {
-                        key += '|' + pIdx;
-                    }
-                    xTaken[key] = true;
-                }
-
                 j = 0;
 
                 // Pies, funnels, geo maps etc. use point name in X row
@@ -436,6 +429,12 @@ Highcharts.Chart.prototype.getDataRows = function (multiLevelHeaders) {
                     key = name;
                 }
 
+                if (xTaken) {
+                    if (xTaken[key]) {
+                        key += '|' + pIdx;
+                    }
+                    xTaken[key] = true;
+                }
 
                 if (!rows[key]) {
                     // Generate the row

--- a/samples/unit-tests/export-data/basics/demo.js
+++ b/samples/unit-tests/export-data/basics/demo.js
@@ -198,7 +198,7 @@ QUnit.test("Numeric", function (assert) {
 
 
 QUnit.test("Pie chart", function (assert) {
-    $('#container').highcharts({
+    var chart = Highcharts.chart('container', {
         series: [{
             data: [
                 ['', 1], // #7404, missing name
@@ -215,11 +215,24 @@ QUnit.test("Pie chart", function (assert) {
         '"Oranges",3';
 
     assert.equal(
-        $('#container').highcharts().getCSV(),
+        chart.getCSV(),
         csv,
         "Pie chart"
     );
-    $('#container').highcharts().destroy();
+
+    chart.series[0].setData([['p1', 1], ['p1', 2]]);
+
+    csv = '"Category","Series 1"\n' +
+        '"p1",1\n' +
+        '"p1",2';
+
+    assert.equal(
+        chart.getCSV(),
+        csv,
+        "Pie chart/sunburst with the same names (#10737)."
+    );
+
+    chart.destroy();
 });
 
 


### PR DESCRIPTION
Fixed #10737, exporting sunburst's data to CSV did not include points with the same name.