### PR TITLE
samples/wrong-accrosspanes-demo-path

### DIFF
--- a/js/parts/PlotLineOrBand.js
+++ b/js/parts/PlotLineOrBand.js
@@ -583,7 +583,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
     /**
      * Flag to decide if plotLine should be rendered across all panes.
      *
-     * @sample {highstock} highcharts/xaxis/plotlines-acrosspane/
+     * @sample {highstock} stock/xaxis/plotlines-acrosspane/
      *         Plot lines on different panes
      *
      * @since     7.1.2


### PR DESCRIPTION
Docs: Fixed wrong path for plotlines-acrosspane demo.