### PR TITLE
refactor/chart-update-collections

### DIFF
--- a/js/annotations/annotations.src.js
+++ b/js/annotations/annotations.src.js
@@ -31,7 +31,8 @@ var merge = H.merge,
     pick = H.pick,
     reduce = H.reduce,
     splat = H.splat,
-    destroyObjectProperties = H.destroyObjectProperties;
+    destroyObjectProperties = H.destroyObjectProperties,
+    chartProto = H.Chart.prototype;
 
 /* *********************************************************************
  *
@@ -989,6 +990,7 @@ merge(
          * See {@link Highcharts.Chart#removeAnnotation}.
          */
         remove: function () {
+            // Let chart.update() remove annoations on demand
             return this.chart.removeAnnotation(this);
         },
 
@@ -1194,10 +1196,7 @@ H.extendAnnotation = function (
  *
  ******************************************************************** */
 
-// Let chart.update() work with annotations
-H.Chart.prototype.collectionsWithUpdate.push('annotations');
-
-H.extend(H.Chart.prototype, /** @lends Highcharts.Chart# */ {
+H.extend(chartProto, /** @lends Highcharts.Chart# */ {
     initAnnotation: function (userOptions) {
         var Constructor =
             Annotation.types[userOptions.type] || Annotation,
@@ -1265,8 +1264,13 @@ H.extend(H.Chart.prototype, /** @lends Highcharts.Chart# */ {
     }
 });
 
+// Let chart.update() update annotations
+chartProto.collectionsWithUpdate.push('annotations');
 
-H.Chart.prototype.callbacks.push(function (chart) {
+// Let chart.update() create annoations on demand
+chartProto.collectionsWithInit.annotations = [chartProto.addAnnotation];
+
+chartProto.callbacks.push(function (chart) {
     chart.annotations = [];
 
     if (!chart.options.annotations) {

--- a/js/parts/Responsive.js
+++ b/js/parts/Responsive.js
@@ -253,7 +253,8 @@ Chart.prototype.matchResponsiveRule = function (rule, matches) {
  */
 Chart.prototype.currentOptions = function (options) {
 
-    var ret = {};
+    var chart = this,
+        ret = {};
 
     /**
      * Recurse over a set of options and its current values,
@@ -265,7 +266,7 @@ Chart.prototype.currentOptions = function (options) {
         H.objectEach(options, function (val, key) {
             if (
                 !depth &&
-                ['series', 'xAxis', 'yAxis', 'annotations'].indexOf(key) > -1
+                chart.collectionsWithUpdate.indexOf(key) > -1
             ) {
                 val = splat(val);
 


### PR DESCRIPTION
Refactored collections adders in `chart.update()`.

I decided to go with:
```
Chart.prototype.collectionsWithInit = {
    // collectionName: [ initializingMethod, [extraArguments] ]
    xAxis: [Chart.prototype.addAxis, [true]],
    yAxis: [Chart.prototype.addAxis, [false]],
    series: [Chart.prototype.addSeries]
};
```
So we define a direct reference to the init method instead of just it's name (e.g. `"addAxis"`). At this moment, it seems all methods are linked to the `Chart` class, but in future that may be change. It's just more flexible.

**Heads up**

We need to define a method before linking in `collectionsWithInit`:

*Correct order:*
```
Axis.proto.addSomething = function () { ... };
Chart.prototype.collectionsWithInit.something = [ Axis.proto.addSomething ];
```

*Wrong order:*
```
Chart.prototype.collectionsWithInit.something = [ Axis.proto.addSomething ];
Axis.proto.addSomething = function () { ... };
```

