### PR TITLE
bugfix/10491-colorAxis-update-ignored-responsive

### DIFF
--- a/js/parts-map/ColorAxis.js
+++ b/js/parts-map/ColorAxis.js
@@ -591,7 +591,10 @@ extend(ColorAxis.prototype, {
      * Build options to keep layout params on init and update.
      *
      * @private
-     * @function Highcharts.ColorAxis#setTickPositions
+     * 
+     * @param {Object} options
+     * @param {Object} userOptions
+     *
      */
     buildOptions: function (options, userOptions) {
         var legend = this.options.legend,

--- a/js/parts-map/ColorAxis.js
+++ b/js/parts-map/ColorAxis.js
@@ -491,15 +491,11 @@ extend(ColorAxis.prototype, {
         this.coll = 'colorAxis';
 
         // Build the options
-        options = merge(this.defaultColorAxisOptions, {
-            side: horiz ? 2 : 1,
-            reversed: !horiz
-        }, userOptions, {
-            opposite: !horiz,
-            showEmpty: false,
-            title: null,
-            visible: chart.options.legend.enabled
-        });
+        options = this.buildOptions.call(
+            chart,
+            this.defaultColorAxisOptions,
+            userOptions
+        );
 
         Axis.prototype.init.call(this, chart, options);
 
@@ -591,7 +587,26 @@ extend(ColorAxis.prototype, {
             stop.color = color(stop[1]);
         });
     },
+    /**
+     * Build options to keep layout params on init and update.
+     *
+     * @private
+     * @function Highcharts.ColorAxis#setTickPositions
+     */
+    buildOptions: function (options, userOptions) {
+        var legend = this.options.legend,
+            horiz = legend.layout !== 'vertical';
 
+        return merge(options, {
+            side: horiz ? 2 : 1,
+            reversed: !horiz
+        }, userOptions, {
+            opposite: !horiz,
+            showEmpty: false,
+            title: null,
+            visible: legend.enabled
+        });
+    },
     /**
      * Extend the setOptions method to process extreme colors and color
      * stops.
@@ -916,7 +931,8 @@ extend(ColorAxis.prototype, {
 
     update: function (newOptions, redraw) {
         var chart = this.chart,
-            legend = chart.legend;
+            legend = chart.legend,
+            updatedOptions = this.buildOptions.call(chart, {}, newOptions);
 
         this.series.forEach(function (series) {
             // Needed for Axis.update when choropleth colors change
@@ -936,9 +952,9 @@ extend(ColorAxis.prototype, {
 
         // Keep the options structure updated for export. Unlike xAxis and
         // yAxis, the colorAxis is not an array. (#3207)
-        chart.options[this.coll] = merge(this.userOptions, newOptions);
+        chart.options[this.coll] = merge(this.userOptions, updatedOptions);
 
-        Axis.prototype.update.call(this, newOptions, redraw);
+        Axis.prototype.update.call(this, updatedOptions, redraw);
         if (this.legendItem) {
             this.setLegendColor();
             legend.colorizeItem(this, true);

--- a/samples/unit-tests/coloraxis/coloraxis-update/demo.js
+++ b/samples/unit-tests/coloraxis/coloraxis-update/demo.js
@@ -59,3 +59,60 @@ QUnit.test('Color axis updates', function (assert) {
         'No extra undefined properties after update'
     );
 });
+
+QUnit.test('Color axis update with responsive rules', function (assert) {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            type: 'heatmap',
+            width: 600,
+            height: 400
+        },
+        colorAxis: {
+            min: 0
+        },
+        legend: {
+            align: 'right',
+            layout: 'vertical',
+            margin: 0,
+            verticalAlign: 'top',
+            y: 25,
+            symbolHeight: 280
+        },
+        series: [{
+            data: [
+                [0, 0, 10],
+                [0, 1, 19],
+                [0, 2, 8],
+                [0, 3, 24],
+                [0, 4, 67],
+                [1, 0, 92],
+                [1, 1, 58],
+                [1, 2, 78],
+                [1, 3, 117],
+                [1, 4, 48]
+            ]
+        }],
+        responsive: {
+            rules: [{
+                condition: { maxWidth: 500 },
+                chartOptions: {
+                    legend: {
+                        align: 'center',
+                        verticalAlign: 'bottom',
+                        layout: 'horizontal',
+                        symbolHeight: 10,
+                        y: 15
+                    }
+                }
+            }]
+        }
+    });
+
+    chart.setSize(500, 400);
+
+    assert.strictEqual(
+        chart.colorAxis[0].labelAlign,
+        'center',
+        'Labels are not misaligned'
+    );
+});


### PR DESCRIPTION
Fixed #10491, responsive rules were ignored when \`colorAxis\` updated.