### PR TITLE
bugfix/8897-3D-columns-not-visible-on init

### DIFF
--- a/js/parts-3d/Column.js
+++ b/js/parts-3d/Column.js
@@ -249,6 +249,10 @@ wrap(
             this[prop] = this.chart.columnGroup;
             this.chart.columnGroup.attr(this.getPlotBox());
             this[prop].survive = true;
+            if (prop === 'group' || prop === 'markerGroup') {
+                arguments[3] = 'visible';
+                // For 3D column group and markerGroup should be visible
+            }
         }
         return proceed.apply(this, Array.prototype.slice.call(arguments, 1));
     }
@@ -266,7 +270,8 @@ wrap(
         if (series.chart.is3d()) {
             series.data.forEach(function (point) {
                 point.visible = point.options.visible = vis =
-                    vis === undefined ? !point.visible : vis;
+                    vis === undefined ?
+                        !pick(series.visible, point.visible) : vis;
                 pointVis = vis ? 'visible' : 'hidden';
                 series.options.data[series.data.indexOf(point)] =
                     point.options;

--- a/samples/unit-tests/3d/column-initial-visibility/demo.css
+++ b/samples/unit-tests/3d/column-initial-visibility/demo.css
@@ -1,0 +1,4 @@
+#container {
+	height: 400px;
+	width: 800px;
+}

--- a/samples/unit-tests/3d/column-initial-visibility/demo.details
+++ b/samples/unit-tests/3d/column-initial-visibility/demo.details
@@ -1,0 +1,5 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+...

--- a/samples/unit-tests/3d/column-initial-visibility/demo.html
+++ b/samples/unit-tests/3d/column-initial-visibility/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-3d.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/3d/column-initial-visibility/demo.js
+++ b/samples/unit-tests/3d/column-initial-visibility/demo.js
@@ -1,0 +1,47 @@
+QUnit.test('3D columns with initial visibility', function (assert) {
+    var chart = new Highcharts.Chart({
+        chart: {
+            renderTo: 'container',
+            type: 'column',
+            animation: false,
+            options3d: {
+                enabled: true,
+                alpha: 10,
+                beta: 0,
+                depth: 300,
+                viewDistance: 5
+            }
+        },
+        series: [{
+            visible: false,
+            data: [{
+                x: 1,
+                y: 4
+            }, {
+                x: 2,
+                y: 9
+            }, {
+                x: 3,
+                y: 9
+            }]
+        }, {
+            data: [{
+                x: 1,
+                y: 5
+            }, {
+                x: 2,
+                y: 10
+            }, {
+                x: 3,
+                y: 10
+            }]
+        }]
+    });
+
+    assert.strictEqual(
+        chart.series[1].data[0].series.group.visibility,
+        'visible',
+        'Second series is visible'
+    );
+
+});


### PR DESCRIPTION
Fixed #8897, 3D columns were not visible when first series was initially hidden.
