### PR TITLE
Fixed #3881, plotOptions.series trumped plotOptions[type]

### DIFF
--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -430,6 +430,8 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
 
         options = H.cleanRecursively(options, chart.options);
 
+        merge(true, chart.userOptions, options);
+
         // If the top-level chart option is present, some special updates are
         // required
         optionsChart = options.chart;

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -2707,14 +2707,12 @@ H.Series = H.seriesType(
             // use copy to prevent undetected changes (#9762)
             this.userOptions = seriesUserOptions;
 
-            // General series options take precedence over type options because
-            // otherwise, default type options like column.animation would be
-            // overwritten by the general option. But issues have been raised
-            // here (#3881), and the solution may be to distinguish between
-            // default option and userOptions like in the tooltip below.
             options = merge(
                 typeOptions,
                 plotOptions.series,
+                // #3881, chart instance plotOptions[type] should trump
+                // plotOptions.series
+                userOptions.plotOptions && userOptions.plotOptions[this.type],
                 seriesUserOptions
             );
 

--- a/samples/unit-tests/plotoptions/general/demo.js
+++ b/samples/unit-tests/plotoptions/general/demo.js
@@ -1,3 +1,53 @@
+QUnit.test('Plot options and series options priority (#3881)', assert => {
+
+    const options = {
+        series: [{
+            type: 'column'
+        }]
+    };
+
+    let chart;
+
+    chart = Highcharts.chart('container', options);
+
+    assert.strictEqual(
+        chart.series[0].options.cropThreshold,
+        50,
+        'Pri 4: Default plotOptions.column value should be respected'
+    );
+
+    options.plotOptions = {
+        series: {
+            cropThreshold: 100
+        }
+    };
+    chart = Highcharts.chart('container', options);
+    assert.strictEqual(
+        chart.series[0].options.cropThreshold,
+        100,
+        'Pri 3: When an option is set in the chart config plotOptions.series, it should override type default'
+    );
+
+    options.plotOptions.column = {
+        cropThreshold: 150
+    };
+    chart = Highcharts.chart('container', options);
+    assert.strictEqual(
+        chart.series[0].options.cropThreshold,
+        150,
+        'Pri 2: When an option is set in the chart config plotOptions[type], it should override plotOptions.series'
+    );
+
+    options.series[0].cropThreshold = 200;
+    chart = Highcharts.chart('container', options);
+    assert.strictEqual(
+        chart.series[0].options.cropThreshold,
+        200,
+        'Pri 1: When an option is set in the item, it trumps all'
+    );
+});
+
+
 QUnit.test('Random properties in plot options', assert => {
 
     Highcharts.chart('container', {


### PR DESCRIPTION
Fixed #3881, `plotOptions.series` trumped `plotOptions[type]` in chart instance options.