### PR TITLE
Bugfix/addevent order

### DIFF
--- a/js/annotations/navigationBindings.js
+++ b/js/annotations/navigationBindings.js
@@ -220,13 +220,15 @@ extend(H.NavigationBindings.prototype, {
         });
 
         objectEach(options.events || {}, function (callback, eventName) {
-            navigation.eventsToUnbind.push(
-                addEvent(
-                    navigation,
-                    eventName,
-                    callback
-                )
-            );
+            if (H.isFunction(callback)) {
+                navigation.eventsToUnbind.push(
+                    addEvent(
+                        navigation,
+                        eventName,
+                        callback
+                    )
+                );
+            }
         });
 
         navigation.eventsToUnbind.push(

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -3387,7 +3387,9 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
 
         // register event listeners
         objectEach(events, function (event, eventType) {
-            addEvent(axis, eventType, event);
+            if (H.isFunction(event)) {
+                addEvent(axis, eventType, event);
+            }
         });
 
         // extend logarithmic axis

--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -340,7 +340,9 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             // Chart event handlers
             if (chartEvents) {
                 objectEach(chartEvents, function (event, eventType) {
-                    addEvent(chart, eventType, event);
+                    if (H.isFunction(event)) {
+                        addEvent(chart, eventType, event);
+                    }
                 });
             }
 

--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -799,7 +799,9 @@ extend(Point.prototype, /** @lends Highcharts.Point.prototype */ {
             point.events = events;
 
             H.objectEach(events, function (event, eventType) {
-                addEvent(point, eventType, event);
+                if (H.isFunction(event)) {
+                    addEvent(point, eventType, event);
+                }
             });
             this.hasImportedEvents = true;
 

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -2393,11 +2393,14 @@ H.Series = H.seriesType(
 
             objectEach(events, function (event, eventType) {
                 if (
-                    // In case we're doing Series.update(), first check if the
-                    // event already exists.
-                    !series.hcEvents ||
-                    !series.hcEvents[eventType] ||
-                    series.hcEvents[eventType].indexOf(event) === -1
+                    H.isFunction(event) &&
+                    (
+                        // In case we're doing Series.update(), first check if
+                        // the event already exists.
+                        !series.hcEvents ||
+                        !series.hcEvents[eventType] ||
+                        series.hcEvents[eventType].indexOf(event) === -1
+                    )
                 ) {
                     addEvent(series, eventType, event);
                 }

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -2399,7 +2399,9 @@ H.Series = H.seriesType(
                         // the event already exists.
                         !series.hcEvents ||
                         !series.hcEvents[eventType] ||
-                        series.hcEvents[eventType].indexOf(event) === -1
+                        !series.hcEvents[eventType].some(function (obj) {
+                            return obj.fn === event;
+                        })
                     )
                 ) {
                     addEvent(series, eventType, event);

--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -178,7 +178,7 @@ import H from './Globals.js';
  * The function callback to execute when the event is fired. The `this` context
  * contains the instance, that fired the event.
  *
- * @callback Function
+ * @callback Highcharts.EventCallbackFunction<T>
  *
  * @param {T} this
  *
@@ -2035,7 +2035,7 @@ H.objectEach({
  * @param {string} type
  *        The event type.
  *
- * @param {Function} fn
+ * @param {Highcharts.EventCallbackFunction<T>} fn
  *        The function callback to execute when the event is fired.
  *
  * @param {Highcharts.EventOptionsObject} [options]
@@ -2099,7 +2099,7 @@ H.addEvent = function (el, type, fn, options) {
  *        The type of events to remove. If undefined, all events are removed
  *        from the element.
  *
- * @param {Highcharts.EventObject} [fn]
+ * @param {Highcharts.EventCallbackFunction<T>} [fn]
  *        The specific callback to remove. If undefined, all events that match
  *        the element and optionally the type are removed.
  *
@@ -2111,7 +2111,7 @@ H.removeEvent = function (el, type, fn) {
     /**
      * @private
      * @param {string} type - event type
-     * @param {Function} fn - callback
+     * @param {Highcharts.EventCallbackFunction<T>} fn - callback
      * @return {void}
      */
     function removeOneEvent(type, fn) {

--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -2073,12 +2073,12 @@ H.addEvent = function (el, type, fn, options) {
     }
     events[type].push(fn);
     // Order the calls
-    if (options && H.isNumber(options.order)) {
-        fn.order = options.order;
-        events[type].sort(function (a, b) {
-            return a.order - b.order;
-        });
-    }
+    fn.order = options && H.isNumber(options.order) ?
+        options.order :
+        Number.MAX_VALUE;
+    events[type].sort(function (a, b) {
+        return a.order - b.order;
+    });
     // Return a function that can be called to remove this event.
     return function () {
         H.removeEvent(el, type, fn);

--- a/samples/unit-tests/utilities/events/demo.js
+++ b/samples/unit-tests/utilities/events/demo.js
@@ -514,24 +514,27 @@
 
     });
 
-    QUnit.test('Event order', function (assert) {
+    QUnit.test('Event order', assert => {
         var obj = {},
             calls = [];
 
-        addEvent(obj, 'hit', function () {
-            calls.push('klakk');
-        }, { order: 2 });
-
-        addEvent(obj, 'hit', function () {
-            calls.push('klikk');
-        }, { order: 1 });
+        [
+            undefined,
+            { order: 2 },
+            undefined,
+            { order: 1 }
+        ].forEach(options => {
+            addEvent(obj, 'hit', () => {
+                calls.push(options ? options.order : undefined);
+            }, options);
+        });
 
         fireEvent(obj, 'hit');
 
         assert.deepEqual(
             calls,
-            ['klikk', 'klakk'],
-            'Events should be fired in order'
+            [1, 2, undefined, undefined],
+            'Events should be fired in ascending order'
         );
 
     });

--- a/ts/parts/Utilities.ts
+++ b/ts/parts/Utilities.ts
@@ -2733,15 +2733,16 @@ H.addEvent = function<T> (
     events[type].push(fn);
 
     // Order the calls
-    if (options && H.isNumber(options.order)) {
-        fn.order = options.order;
-        events[type].sort(function (
-            a: Highcharts.EventCallbackFunction<T>,
-            b: Highcharts.EventCallbackFunction<T>
-        ): number {
-            return (a.order as any) - (b.order as any);
-        });
-    }
+    fn.order = options && H.isNumber(options.order) ?
+        options.order as number :
+        Number.MAX_VALUE;
+
+    events[type].sort(function (
+        a: Highcharts.EventCallbackFunction<T>,
+        b: Highcharts.EventCallbackFunction<T>
+    ): number {
+        return (a.order as number) - (b.order as number);
+    });
 
     // Return a function that can be called to remove this event.
     return function (): void {

--- a/ts/parts/Utilities.ts
+++ b/ts/parts/Utilities.ts
@@ -22,7 +22,7 @@ declare global {
     }
     interface EventObject<T> {
         fn: Highcharts.EventCallbackFunction<T>;
-        order: number
+        order: number;
     }
     namespace Highcharts {
         type CursorValue = (


### PR DESCRIPTION
Fixed issue with sorting of events when `addEvent` was called with parameter `options.order` value of `undefined`.

---
# Description
Sorting of event orders went wrong when either options or options.order was undefined.

A remake of the #10710