### PR TITLE
 bugfix/8417-3D-stacked-column-zIndex

### DIFF
--- a/js/parts-3d/Column.js
+++ b/js/parts-3d/Column.js
@@ -241,17 +241,22 @@ wrap(
     seriesTypes.column.prototype,
     'plotGroup',
     function (proceed, prop, name, visibility, zIndex, parent) {
-        if (this.chart.is3d() && parent && !this[prop]) {
-            if (!this.chart.columnGroup) {
-                this.chart.columnGroup =
-                    this.chart.renderer.g('columnGroup').add(parent);
+        if (this.chart.is3d()) {
+            if (this[prop]) {
+                delete this[prop];
             }
-            this[prop] = this.chart.columnGroup;
-            this.chart.columnGroup.attr(this.getPlotBox());
-            this[prop].survive = true;
-            if (prop === 'group' || prop === 'markerGroup') {
-                arguments[3] = 'visible';
-                // For 3D column group and markerGroup should be visible
+            if (parent) {
+                if (!this.chart.columnGroup) {
+                    this.chart.columnGroup =
+                        this.chart.renderer.g('columnGroup').add(parent);
+                }
+                this[prop] = this.chart.columnGroup;
+                this.chart.columnGroup.attr(this.getPlotBox());
+                this[prop].survive = true;
+                if (prop === 'group' || prop === 'markerGroup') {
+                    arguments[3] = 'visible';
+                    // For 3D column group and markerGroup should be visible
+                }
             }
         }
         return proceed.apply(this, Array.prototype.slice.call(arguments, 1));

--- a/samples/unit-tests/3d/column-stacked-3d-update/demo.css
+++ b/samples/unit-tests/3d/column-stacked-3d-update/demo.css
@@ -1,0 +1,4 @@
+#container {
+	height: 400px;
+	width: 800px;
+}

--- a/samples/unit-tests/3d/column-stacked-3d-update/demo.details
+++ b/samples/unit-tests/3d/column-stacked-3d-update/demo.details
@@ -1,0 +1,5 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+...

--- a/samples/unit-tests/3d/column-stacked-3d-update/demo.html
+++ b/samples/unit-tests/3d/column-stacked-3d-update/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-3d.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/3d/column-stacked-3d-update/demo.js
+++ b/samples/unit-tests/3d/column-stacked-3d-update/demo.js
@@ -1,0 +1,52 @@
+QUnit.test('Update from 2D to 3D stacked columns', function (assert) {
+    var chart = new Highcharts.Chart({
+        chart: {
+            renderTo: 'container',
+            type: 'column'
+        },
+        plotOptions: {
+            series: {
+                stacking: 'normal'
+            }
+        },
+        series: [{
+            data: [{
+                x: 1,
+                y: 4
+            }, {
+                x: 2,
+                y: 9
+            }, {
+                x: 3,
+                y: 9
+            }]
+        }, {
+            data: [{
+                x: 1,
+                y: 5
+            }, {
+                x: 2,
+                y: 10
+            }, {
+                x: 3,
+                y: 10
+            }]
+        }]
+    }, function (chart) {
+        chart.update({
+            chart: {
+                options3d: {
+                    enabled: true,
+                    beta: 20,
+                    alpha: 30
+                }
+            }
+        });
+    });
+    assert.strictEqual(
+        chart.series[1].group.element.children.length,
+        6,
+        'Both series are in the same group'
+    );
+
+});


### PR DESCRIPTION
Fixed #8417, stacked columns were overlapping after update to 3D.
