### PR TITLE
bugfix/10741-networkgraph-disappearing-points

### DIFF
--- a/js/modules/networkgraph/layouts.js
+++ b/js/modules/networkgraph/layouts.js
@@ -454,16 +454,20 @@ H.extend(
                         ) {
                             distanceXY = layout.getDistXY(node, repNode);
                             distanceR = layout.vectorLength(distanceXY);
+                            if (distanceR !== 0) {
+                                force = layout.repulsiveForce(
+                                    distanceR,
+                                    layout.k
+                                );
 
-                            force = layout.repulsiveForce(distanceR, layout.k);
-
-                            layout.force(
-                                'repulsive',
-                                node,
-                                force * repNode.mass,
-                                distanceXY,
-                                distanceR
-                            );
+                                layout.force(
+                                    'repulsive',
+                                    node,
+                                    force * repNode.mass,
+                                    distanceXY,
+                                    distanceR
+                                );
+                            }
                         }
                     });
                 });

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.js
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.js
@@ -146,4 +146,11 @@ QUnit.test('Network Graph', function (assert) {
         'Node survived `setData()` (#10625)'
     );
 
+    // Addition for bug #10741
+    chart.setSize(30, 90);
+    assert.strictEqual(
+        rSeries.data[0].plotX / rSeries.data[0].plotX,
+        1,
+        'points are visible on small resolutions'
+    );
 });


### PR DESCRIPTION
Fixed #10741, overlapping networkgraph points were dissapearing.
