### PR TITLE
Bugfix/8607 tooltip masked when scrollable

### DIFF
--- a/js/parts/Options.js
+++ b/js/parts/Options.js
@@ -2845,11 +2845,14 @@ H.defaultOptions = {
          * overlaid on the page, allowing the tooltip to be aligned inside the
          * page itself.
          *
+         * Defaults to `true` if `chart.scrollablePlotArea` is activated,
+         * otherwise `false`.
+         *
          * @sample highcharts/tooltip/outside
          *         Small charts with tooltips outside
          *
-         * @type      {boolean}
-         * @default   false
+         * @type      {boolean|undefined}
+         * @default   undefined
          * @since     6.1.1
          * @apioption tooltip.outside
          */

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -229,10 +229,12 @@ H.Tooltip.prototype = {
          * not be too complicated to implement.
          */
         this.outside = (
-            options.outside ||
-            chart.scrollablePixelsX ||
-            chart.scrollablePixelsY
-        ) && !this.split;
+            pick(
+                options.outside,
+                Boolean(chart.scrollablePixelsX || chart.scrollablePixelsY)
+            ) &&
+            !this.split
+        );
     },
 
     /**

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -228,8 +228,11 @@ H.Tooltip.prototype = {
          * Split tooltip does not support outside in the first iteration. Should
          * not be too complicated to implement.
          */
-        this.outside = options.outside && !this.split;
-
+        this.outside = (
+            options.outside ||
+            chart.scrollablePixelsX ||
+            chart.scrollablePixelsY
+        ) && !this.split;
     },
 
     /**
@@ -331,7 +334,8 @@ H.Tooltip.prototype = {
                 H.css(container, {
                     position: 'absolute',
                     top: '1px',
-                    pointerEvents: options.style && options.style.pointerEvents
+                    pointerEvents: options.style && options.style.pointerEvents,
+                    zIndex: 3
                 });
                 H.doc.body.appendChild(container);
 

--- a/ts/parts/Options.ts
+++ b/ts/parts/Options.ts
@@ -3368,11 +3368,14 @@ H.defaultOptions = {
          * overlaid on the page, allowing the tooltip to be aligned inside the
          * page itself.
          *
+         * Defaults to `true` if `chart.scrollablePlotArea` is activated,
+         * otherwise `false`.
+         *
          * @sample highcharts/tooltip/outside
          *         Small charts with tooltips outside
          *
-         * @type      {boolean}
-         * @default   false
+         * @type      {boolean|undefined}
+         * @default   undefined
          * @since     6.1.1
          * @apioption tooltip.outside
          */


### PR DESCRIPTION
Fixed #8607, tooltip was masked at the edges of the chart when `chart.scrollablePlotArea` was active. Changed the `tooltip.outside` option to default to true when using scrollable plot area.