### PR TITLE
bugfix/10404-rangeselector-input-overlapped-exportingmenu

### DIFF
--- a/js/parts/RangeSelector.js
+++ b/js/parts/RangeSelector.js
@@ -1232,13 +1232,15 @@ RangeSelector.prototype = {
         };
         // Hide away the input box
         input.onblur = function () {
+            // update extermes only when inputs are active
             if (input === H.doc.activeElement) { // Only when focused
                 // Update also when no `change` event is triggered, like when
                 // clicking inside the SVG (#4710)
                 updateExtremes();
-                rangeSelector.hideInput(name);
-                input.blur(); // #4606
             }
+            // #10404 - move hide and blur outside focus
+            rangeSelector.hideInput(name);
+            input.blur(); // #4606
         };
 
         // handle changes in the input boxes

--- a/samples/unit-tests/rangeselector/input-range/demo.js
+++ b/samples/unit-tests/rangeselector/input-range/demo.js
@@ -278,3 +278,58 @@ QUnit.test('Check input format', function (assert) {
     );
 
 });
+
+QUnit.test('Set extremes on inputs blur (#4710)', function (assert) {
+    var chart = new Highcharts.StockChart('container', {
+            chart: {
+                width: 650
+            },
+            title: false,
+            xAxis: {
+                min: Date.UTC(2007, 8, 5),
+                max: Date.UTC(2007, 8, 25)
+            },
+            series: [{
+                data: [
+                    [Date.UTC(2007, 8, 3), 0.7342],
+                    [Date.UTC(2007, 8, 4), 0.7349],
+                    [Date.UTC(2007, 8, 5), 0.7326],
+                    [Date.UTC(2007, 8, 6), 0.7306],
+                    [Date.UTC(2007, 8, 7), 0.7263],
+                    [Date.UTC(2007, 8, 10), 0.7247],
+                    [Date.UTC(2007, 8, 11), 0.7227],
+                    [Date.UTC(2007, 8, 12), 0.7191],
+                    [Date.UTC(2007, 8, 13), 0.7209],
+                    [Date.UTC(2007, 8, 14), 0.7207],
+                    [Date.UTC(2007, 8, 17), 0.7211],
+                    [Date.UTC(2007, 8, 18), 0.7153],
+                    [Date.UTC(2007, 8, 19), 0.7165],
+                    [Date.UTC(2007, 8, 20), 0.7107],
+                    [Date.UTC(2007, 8, 21), 0.7097],
+                    [Date.UTC(2007, 8, 24), 0.7098],
+                    [Date.UTC(2007, 8, 25), 0.7069],
+                    [Date.UTC(2007, 8, 26), 0.7078],
+                    [Date.UTC(2007, 8, 27), 0.7066],
+                    [Date.UTC(2007, 8, 28), 0.7006]
+                ]
+            }]
+        }),
+        min = chart.xAxis[0].min,
+        newMin,
+        test = new TestController(chart);
+
+    test.triggerEvent('click', 400, 20, {}, true);
+
+    document.activeElement.value = "2007-09-13";
+
+    test.mouseDown(400, 120);
+    test.mouseUp();
+
+    newMin = chart.xAxis[0].min;
+
+    assert.strictEqual(
+        min === newMin,
+        false,
+        'Extremes are updated.'
+    );
+});


### PR DESCRIPTION
Fixed #10404, range selector inputs overlapped exporting menu.