### PR TITLE
 bugfix/10245-datalabels-disappear-low-columns 

### DIFF
--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -1041,6 +1041,7 @@ Series.prototype.alignDataLabel = function (
         rotCorr, // rotation correction
         // Math.round for rounding errors (#2683), alignTo to allow column
         // labels (#2700)
+        crop = pick(options.crop, true),
         visible =
             this.visible &&
             (
@@ -1079,6 +1080,13 @@ Series.prototype.alignDataLabel = function (
             width: bBox.width,
             height: bBox.height
         });
+
+        // #10245 - datalabels were hidden when small columns
+        if (visible && !crop && H.defined(point.y)) {
+            alignTo.height = point.y > 0 ?
+                Math.abs(alignTo.height) :
+                -alignTo.height;
+        }
 
         // Allow a hook for changing alignment in the last moment, then do the
         // alignment
@@ -1132,7 +1140,7 @@ Series.prototype.alignDataLabel = function (
             );
 
         // Now check that the data label is within the plot area
-        } else if (pick(options.crop, true)) {
+        } else if (crop) {
             visible =
                 chart.isInsidePlot(
                     alignAttr.x,

--- a/samples/unit-tests/datalabels/crop/demo.details
+++ b/samples/unit-tests/datalabels/crop/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/datalabels/crop/demo.html
+++ b/samples/unit-tests/datalabels/crop/demo.html
@@ -1,0 +1,6 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/datalabels/crop/demo.js
+++ b/samples/unit-tests/datalabels/crop/demo.js
@@ -1,0 +1,28 @@
+QUnit.test(
+    'Cropped datalabels are visible when small columns.',
+    function (assert) {
+        var chart = Highcharts.chart('container', {
+            chart: {
+                type: 'column'
+            },
+            plotOptions: {
+                series: {
+                    dataLabels: {
+                        crop: false,
+                        enabled: true,
+                        inside: true
+                    }
+                }
+            },
+            series: [{
+                data: [1121, 523, 5, 256, 2, 843, 726, 590, 1, 434, 312, 432]
+            }]
+        });
+
+        assert.strictEqual(
+            chart.series[0].points[4].dataLabel.options.y !== null,
+            true,
+            'Cropped datalabel is show (#10245).'
+        );
+    }
+);


### PR DESCRIPTION
Fixed #10245, data labels were hidden when columns were small and `crop` was enabled.