### PR TITLE
bugfix/10570-10580-gantt-setdata-on-render

### DIFF
--- a/js/parts-gantt/TreeGrid.js
+++ b/js/parts-gantt/TreeGrid.js
@@ -485,18 +485,19 @@ var onBeforeRender = function (e) {
                 removeFoundExtremesEvent,
                 uniqueNames = options.uniqueNames,
                 numberOfSeries = 0,
-                isDirtyData,
+                isDirty,
                 data,
                 treeGrid;
             // Check whether any of series is rendering for the first time,
-            // or its data is dirty, and only then update. #10570, #10580
-            axis.series.forEach(function (series) {
-                isDirtyData = isDirtyData ||
-                    !series.hasRendered ||
-                    series.isDirtyData;
+            // visibility has changed, or its data is dirty,
+            // and only then update. #10570, #10580
+            isDirty = axis.series.some(function (series) {
+                return !series.hasRendered ||
+                    series.isDirtyData ||
+                    series.isDirty;
             });
 
-            if (isDirtyData) {
+            if (isDirty) {
                 // Concatenate data from all series assigned to this axis.
                 data = axis.series.reduce(function (arr, s) {
                     if (s.visible) {

--- a/samples/unit-tests/gantt/treegrid/demo.js
+++ b/samples/unit-tests/gantt/treegrid/demo.js
@@ -256,7 +256,7 @@ QUnit.test('Series.setVisible', assert => {
     );
     assert.strictEqual(
         series3.points[0].y,
-        1,
+        2,
         'should have "Point 3" y-value equal 1  when "Series 2" is hidden.'
     );
     assert.strictEqual(
@@ -266,7 +266,7 @@ QUnit.test('Series.setVisible', assert => {
     );
     assert.deepEqual(
         [axis.min, axis.max],
-        [0, 1],
+        [0, 2],
         'should have axis [min, max] equal [0, 1]  when "Series 2" is hidden.'
     );
 

--- a/samples/unit-tests/gantt/treegrid/demo.js
+++ b/samples/unit-tests/gantt/treegrid/demo.js
@@ -256,7 +256,7 @@ QUnit.test('Series.setVisible', assert => {
     );
     assert.strictEqual(
         series3.points[0].y,
-        2,
+        1,
         'should have "Point 3" y-value equal 1  when "Series 2" is hidden.'
     );
     assert.strictEqual(
@@ -266,7 +266,7 @@ QUnit.test('Series.setVisible', assert => {
     );
     assert.deepEqual(
         [axis.min, axis.max],
-        [0, 2],
+        [0, 1],
         'should have axis [min, max] equal [0, 1]  when "Series 2" is hidden.'
     );
 


### PR DESCRIPTION
Fixed #10570 and #10580, `setData` was triggered on every render, causing treegrid failure when collapsing and problems with the navigator.