### PR TITLE
Tools: Added --splitbrowsers as argument when running karma

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ workflows:
           requires:
             - build_dependencies
           browsers: "Win.Edge"
-          browsercount: 2
+          browsercount: 3
       - hold_for_approval:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ workflows:
           requires:
             - build_dependencies
           browsers: "Win.Edge"
-          browsercount: 3
+          browsercount: 2
       - hold_for_approval:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,11 +116,15 @@ jobs:
         description: "Which browser to test?"
         type: string
         default: "Mac.Safari"
+      browsercount:
+        description: "Number of browser instances"
+        type: integer
+        default: 1
     steps:
       - early_return_for_forked_pull_requests # to avoid secrets being passed on to forked PR builds we don't run browser tests for forked PRs
       - << : *load_workspace
       - run: npm run gulp scripts
-      - run: "npx cross-env NODE_OPTIONS=--max_old_space_size=3072 karma start test/karma-conf.js --single-run --browsers << parameters.browsers >>"
+      - run: "npx cross-env NODE_OPTIONS=--max_old_space_size=3072 karma start test/karma-conf.js --single-run --splitbrowsers << parameters.browsers >> --browsercount << parameters.browsercount >>"
       - run: mkdir ../test-results
       - run:
           name: Save test results
@@ -185,6 +189,12 @@ workflows:
           requires:
             - build_dependencies
           browsers: "Mac.Firefox"
+      - test_browsers:
+          name: "test-Win.Edge"
+          requires:
+            - build_dependencies
+          browsers: "Win.Edge"
+          browsercount: 2
       - hold_for_approval:
           type: approval
           filters:

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -603,6 +603,20 @@ module.exports = function (config) {
         options.browserNoActivityTimeout = 4 * 60 * 1000; // default 10000
         options.browserSocketTimeout = 20000;
 
+        options.plugins = [
+            'karma-browserstack-launcher',
+            'karma-qunit',
+            'karma-sharding',
+            'karma-generic-preprocessor'
+        ];
+
+        options.reporters = ['progress'];
+
+        if (browsers.some(browser => /(Edge)/.test(browser))) {
+            // fallback to polling for Edge browsers as websockets disconnects a lot.
+            options.transports = ['polling'];
+        }
+
         console.log(
             'BrowserStack initialized. Please wait while tests are uploaded and VMs prepared. ' +
             `Any other test runs must complete before this test run will start. Current Browserstack concurrency rate is ${options.concurrency}..`

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -339,7 +339,10 @@ module.exports = function (config) {
             'samples/highcharts/data/google-spreadsheet/demo.js', // advanced demo
             'samples/highcharts/css/exporting/demo.js', // advanced demo
             'samples/highcharts/css/map-dataclasses/demo.js', // Google Spreadsheets
-            'samples/highcharts/css/pattern/demo.js' // styled mode, setOptions
+            'samples/highcharts/css/pattern/demo.js', // styled mode, setOptions
+
+            // Failing on Edge only
+            'samples/unit-tests/pointer/members/demo.js'
         ],
         reporters: ['imagecapture', 'progress'],
         port: 9876,  // karma web server port

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -166,7 +166,6 @@ const browserStackBrowsers = {
         browser_version: 'insider preview',
         os: 'Windows',
         os_version: '10',
-        'browserstack.selenium_version' : '3.14.0'
     },
     'Win.Firefox': {
         base: 'BrowserStack',

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -614,6 +614,11 @@ module.exports = function (config) {
 
         options.reporters = ['progress'];
 
+        if (browsers.some(browser => /(Edge)/.test(browser))) {
+            // fallback to polling for Edge browsers as websockets disconnects a lot.
+            options.transports = ['polling'];
+        }
+
         console.log(
             'BrowserStack initialized. Please wait while tests are uploaded and VMs prepared. ' +
             `Any other test runs must complete before this test run will start. Current Browserstack concurrency rate is ${options.concurrency}..`

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -591,6 +591,9 @@ module.exports = function (config) {
             name: `circle-ci-karma-highcharts-${randomString}`,
             localIdentifier: randomString, // to avoid instances interfering with each other.
             video: false,
+            retryLimit: 1,
+            timeout: 5 * 60,
+            captureTimeout: 4 * 60 // default 60
         };
         options.customLaunchers = browserStackBrowsers;
         options.logLevel = config.LOG_INFO;
@@ -601,7 +604,6 @@ module.exports = function (config) {
         options.browserDisconnectTimeout = 20000; // default 2000
         options.browserDisconnectTolerance = 1; // default 0
         options.browserNoActivityTimeout = 4 * 60 * 1000; // default 10000
-        options.captureTimeout = 4 * 60 * 1000; // default 60000
 
         console.log(
             'BrowserStack initialized. Please wait while tests are uploaded and VMs prepared. ' +

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -165,7 +165,8 @@ const browserStackBrowsers = {
         browser: 'edge',
         browser_version: '43.0',
         os: 'Windows',
-        os_version: '10'
+        os_version: '10',
+        'browserstack.selenium_version' : '3.14.0'
     },
     'Win.Firefox': {
         base: 'BrowserStack',
@@ -592,8 +593,6 @@ module.exports = function (config) {
             localIdentifier: randomString, // to avoid instances interfering with each other.
             video: false,
             retryLimit: 1,
-            timeout: 5 * 60,
-            captureTimeout: 4 * 60 // default 60
         };
         options.customLaunchers = browserStackBrowsers;
         options.logLevel = config.LOG_INFO;
@@ -601,9 +600,19 @@ module.exports = function (config) {
 
         // to avoid DISCONNECTED messages when connecting to BrowserStack
         options.concurrency = 1;
-        options.browserDisconnectTimeout = 20000; // default 2000
+        options.browserDisconnectTimeout = 30000; // default 2000
         options.browserDisconnectTolerance = 1; // default 0
         options.browserNoActivityTimeout = 4 * 60 * 1000; // default 10000
+        options.browserSocketTimeout = 20000;
+
+        options.plugins = [
+            'karma-browserstack-launcher',
+            'karma-qunit',
+            'karma-sharding',
+            'karma-generic-preprocessor'
+        ];
+
+        options.reporters = ['progress'];
 
         console.log(
             'BrowserStack initialized. Please wait while tests are uploaded and VMs prepared. ' +

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -163,7 +163,7 @@ const browserStackBrowsers = {
     'Win.Edge': {
         base: 'BrowserStack',
         browser: 'edge',
-        browser_version: '43.0',
+        browser_version: 'insider preview',
         os: 'Windows',
         os_version: '10',
         'browserstack.selenium_version' : '3.14.0'
@@ -597,27 +597,12 @@ module.exports = function (config) {
         options.customLaunchers = browserStackBrowsers;
         options.logLevel = config.LOG_INFO;
 
-
         // to avoid DISCONNECTED messages when connecting to BrowserStack
         options.concurrency = 1;
         options.browserDisconnectTimeout = 30000; // default 2000
         options.browserDisconnectTolerance = 1; // default 0
         options.browserNoActivityTimeout = 4 * 60 * 1000; // default 10000
         options.browserSocketTimeout = 20000;
-
-        options.plugins = [
-            'karma-browserstack-launcher',
-            'karma-qunit',
-            'karma-sharding',
-            'karma-generic-preprocessor'
-        ];
-
-        options.reporters = ['progress'];
-
-        if (browsers.some(browser => /(Edge)/.test(browser))) {
-            // fallback to polling for Edge browsers as websockets disconnects a lot.
-            options.transports = ['polling'];
-        }
 
         console.log(
             'BrowserStack initialized. Please wait while tests are uploaded and VMs prepared. ' +

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -220,13 +220,16 @@ module.exports = function (config) {
         browsers = Object.keys(browserStackBrowsers);
     }
 
-    if (argv.split) {
+    if (argv.splitbrowsers) {
         // Sharding / splitting tests across multiple browser instances
-        const numberOfInstances = !isNaN(argv.split) ? argv.split : 2;
+        if (argv.browsers) {
+            console.log(`Note: --browsers has been added as a cli argument and will override karma-sharding browser config.`)
+        }
+        const browserCount = !isNaN(argv.browsercount) ? argv.browsercount : 2;
         frameworks = [...frameworks, 'sharding'];
         // create a duplicate of the added browsers ${numberOfInstances} times.
-        browsers = browsers.reduce((browserInstances, current) => {
-            for (let i = 0; i < numberOfInstances; i++) {
+        browsers = argv.splitbrowsers.split(',').reduce((browserInstances, current) => {
+            for (let i = 0; i < browserCount; i++) {
                 browserInstances.push(current);
             }
             return browserInstances;


### PR DESCRIPTION
in split/sharded mode. Using --browsers as cli argument will otherwise override the config.

Rename --split argument to --browsercount.
Enabled Win.Edge on CI again.