### PR TITLE
Improve grid axis isOuterAxis

### DIFF
--- a/js/parts-gantt/GridAxis.js
+++ b/js/parts-gantt/GridAxis.js
@@ -136,19 +136,6 @@ var axisSide = {
 };
 
 /**
- * Checks if an axis is a navigator axis.
- *
- * @private
- * @function Highcharts.Axis#isNavigatorAxis
- *
- * @return {boolean}
- *         true if axis is found in axis.chart.navigator
- */
-Axis.prototype.isNavigatorAxis = function () {
-    return /highcharts-navigator-[xy]axis/.test(this.options.className);
-};
-
-/**
  * Checks if an axis is the outer axis in its dimension. Since
  * axes are placed outwards in order, the axis with the highest
  * index is the outermost axis.
@@ -166,34 +153,27 @@ Axis.prototype.isNavigatorAxis = function () {
 Axis.prototype.isOuterAxis = function () {
     var axis = this,
         chart = axis.chart,
+        columnIndex = axis.columnIndex,
+        columns = axis.linkedParent && axis.linkedParent.columns ||
+            axis.columns,
+        parentAxis = columnIndex ? axis.linkedParent : axis,
         thisIndex = -1,
-        isOuter = true;
+        lastIndex = 0;
 
-    chart.axes.forEach(function (otherAxis, index) {
-        if (otherAxis.side === axis.side && !otherAxis.isNavigatorAxis()) {
-            if (otherAxis === axis) {
+    chart[axis.coll].forEach(function (otherAxis, index) {
+        if (otherAxis.side === axis.side && !otherAxis.isInteral) {
+            lastIndex = index;
+            if (otherAxis === parentAxis) {
                 // Get the index of the axis in question
                 thisIndex = index;
-
-                // Check thisIndex >= 0 in case thisIndex has
-                // not been found yet
-            } else if (thisIndex >= 0 && index > thisIndex) {
-                // There was an axis on the same side with a
-                // higher index.
-                isOuter = false;
             }
         }
     });
 
-    if (isOuter && isNumber(axis.columnIndex)) {
-        var columns = axis.linkedParent && axis.linkedParent.columns ||
-            axis.columns;
-        isOuter = columns.length === axis.columnIndex;
-    }
-
-    // There were either no other axes on the same side,
-    // or the other axes were not farther from the chart
-    return isOuter;
+    return (
+        lastIndex === thisIndex &&
+        (isNumber(columnIndex) ? columns.length === columnIndex : true)
+    );
 };
 
 /**

--- a/js/parts-gantt/GridAxis.js
+++ b/js/parts-gantt/GridAxis.js
@@ -161,7 +161,7 @@ Axis.prototype.isOuterAxis = function () {
         lastIndex = 0;
 
     chart[axis.coll].forEach(function (otherAxis, index) {
-        if (otherAxis.side === axis.side && !otherAxis.isInteral) {
+        if (otherAxis.side === axis.side && !otherAxis.options.isInternal) {
             lastIndex = index;
             if (otherAxis === parentAxis) {
                 // Get the index of the axis in question

--- a/samples/unit-tests/gantt/grid-axis-stock/demo.js
+++ b/samples/unit-tests/gantt/grid-axis-stock/demo.js
@@ -1,28 +1,4 @@
 /**
- * Tests the isNavigatorAxis() function
- */
-QUnit.test('isNavigatorAxis()', function (assert) {
-    var chart = Highcharts.stockChart('container', {
-        chart: {
-            type: 'bar'
-        },
-        series: [{
-            data: [129.9, 271.5, 306.4, -29.2, 544.0, 376.0, 435.6, 348.5]
-        }]
-    });
-
-    assert.notOk(
-        chart.xAxis[0].isNavigatorAxis(),
-        'xAxis[0] is not a navigator axis'
-    );
-
-    assert.ok(
-        chart.xAxis[1].isNavigatorAxis(),
-        'xAxis[1] is a navigator axis'
-    );
-});
-
-/**
  * Tests the isOuterAxis() function
  */
 QUnit.test('isOuterAxis()', function (assert) {
@@ -65,6 +41,11 @@ QUnit.test('isOuterAxis()', function (assert) {
             xAxis: 3
         }]
     });
+
+    assert.notOk(
+        chart.xAxis[0].isOuterAxis(),
+        'Rightmost left x-axis is not outerAxis'
+    );
 
     assert.ok(
         chart.xAxis[1].isOuterAxis(),
@@ -824,7 +805,7 @@ QUnit.test('Horizontal axis tick labels centered', function (assert) {
     });
 
     axes = Highcharts.grep(chart.xAxis, function (axis) {
-        return !axis.isNavigatorAxis();
+        return !axis.options.isInternal;
     });
 
     Highcharts.each(axes, function (axis) {

--- a/samples/unit-tests/gantt/grid-axis/demo.js
+++ b/samples/unit-tests/gantt/grid-axis/demo.js
@@ -739,7 +739,7 @@ QUnit.test('Horizontal axis tick labels centered', function (assert) {
     });
 
     axes = Highcharts.grep(chart.xAxis, function (axis) {
-        return !axis.isNavigatorAxis();
+        return !axis.options.isInternal;
     });
 
     Highcharts.each(axes, function (axis) {


### PR DESCRIPTION
Some additional enhancements to utility function `isOuterAxis` in grid axis.
Solves a potential bug with multiple "extra grid lines" when using multiple axis on the same side of the chart.