### PR TITLE
Bugfix/10247 venn label placement

### DIFF
--- a/js/mixins/nelder-mead.js
+++ b/js/mixins/nelder-mead.js
@@ -1,0 +1,143 @@
+/**
+ * Finds an optimal position for a given point.
+ * @private
+ * @todo add unit tests.
+ * @todo add constraints to optimize the algorithm.
+ * @param {Function} fn The function to test a point.
+ * @param {Array<*>} initial The initial point to optimize.
+ * @return {Array<*>} Returns the opimized position of a point.
+ */
+var nelderMead = function nelderMead(fn, initial) {
+    var maxIterations = 100,
+        sortByFx = function (a, b) {
+            return a.fx - b.fx;
+        },
+        pRef = 1, // Reflection parameter
+        pExp = 2, // Expansion parameter
+        pCon = -0.5, // Contraction parameter
+        pOCon = pCon * pRef, // Outwards contraction parameter
+        pShrink = 0.5; // Shrink parameter
+
+    var weightedSum = function weightedSum(weight1, v1, weight2, v2) {
+        return v1.map(function (x, i) {
+            return weight1 * x + weight2 * v2[i];
+        });
+    };
+
+    var getSimplex = function getSimplex(initial) {
+        var n = initial.length,
+            simplex = new Array(n + 1);
+
+        // Initial point to the simplex.
+        simplex[0] = initial;
+        simplex[0].fx = fn(initial);
+
+        // Create a set of extra points based on the initial.
+        for (var i = 0; i < n; ++i) {
+            var point = initial.slice();
+
+            point[i] = point[i] ? point[i] * 1.05 : 0.001;
+            point.fx = fn(point);
+            simplex[i + 1] = point;
+        }
+        return simplex;
+    };
+
+    var updateSimplex = function (simplex, point) {
+        point.fx = fn(point);
+        simplex[simplex.length - 1] = point;
+        return simplex;
+    };
+
+    var shrinkSimplex = function (simplex) {
+        var best = simplex[0];
+
+        return simplex.map(function (point) {
+            var p = weightedSum(1 - pShrink, best, pShrink, point);
+
+            p.fx = fn(p);
+            return p;
+        });
+    };
+
+    var getCentroid = function (simplex) {
+        var arr = simplex.slice(0, -1),
+            length = arr.length,
+            result = [],
+            sum = function (data, point) {
+                data.sum += point[data.i];
+                return data;
+            };
+
+        for (var i = 0; i < length; i++) {
+            result[i] = simplex.reduce(sum, { sum: 0, i: i }).sum / length;
+        }
+        return result;
+    };
+
+    var getPoint = function (centroid, worst, a, b) {
+        var point = weightedSum(a, centroid, b, worst);
+
+        point.fx = fn(point);
+        return point;
+    };
+
+    // Create a simplex
+    var simplex = getSimplex(initial);
+
+    // Iterate from 0 to max iterations
+    for (var i = 0; i < maxIterations; i++) {
+        // Sort the simplex
+        simplex.sort(sortByFx);
+
+        // Create a centroid from the simplex
+        var worst = simplex[simplex.length - 1];
+        var centroid = getCentroid(simplex);
+
+        // Calculate the reflected point.
+        var reflected = getPoint(centroid, worst, 1 + pRef, -pRef);
+
+        if (reflected.fx < simplex[0].fx) {
+            // If reflected point is the best, then possibly expand.
+            var expanded = getPoint(centroid, worst, 1 + pExp, -pExp);
+
+            simplex = updateSimplex(
+                simplex,
+                (expanded.fx < reflected.fx) ? expanded : reflected
+            );
+        } else if (reflected.fx >= simplex[simplex.length - 2].fx) {
+            // If the reflected point is worse than the second worse, then
+            // contract.
+            var contracted;
+
+            if (reflected.fx > worst.fx) {
+                // If the reflected is worse than the worst point, do a
+                // contraction
+                contracted = getPoint(centroid, worst, 1 + pCon, -pCon);
+                if (contracted.fx < worst.fx) {
+                    simplex = updateSimplex(simplex, contracted);
+                } else {
+                    simplex = shrinkSimplex(simplex);
+                }
+            } else {
+                // Otherwise do an outwards contraction
+                contracted = getPoint(centroid, worst, 1 - pOCon, pOCon);
+                if (contracted.fx < reflected.fx) {
+                    simplex = updateSimplex(simplex, contracted);
+                } else {
+                    simplex = shrinkSimplex(simplex);
+                }
+            }
+        } else {
+            simplex = updateSimplex(simplex, reflected);
+        }
+    }
+
+    return simplex[0];
+};
+
+var content = {
+    nelderMead: nelderMead
+};
+
+export default content;

--- a/js/mixins/nelder-mead.js
+++ b/js/mixins/nelder-mead.js
@@ -1,3 +1,18 @@
+var getCentroid = function (simplex) {
+    var arr = simplex.slice(0, -1),
+        length = arr.length,
+        result = [],
+        sum = function (data, point) {
+            data.sum += point[data.i];
+            return data;
+        };
+
+    for (var i = 0; i < length; i++) {
+        result[i] = arr.reduce(sum, { sum: 0, i: i }).sum / length;
+    }
+    return result;
+};
+
 /**
  * Finds an optimal position for a given point.
  * @private
@@ -58,21 +73,6 @@ var nelderMead = function nelderMead(fn, initial) {
             p.fx = fn(p);
             return p;
         });
-    };
-
-    var getCentroid = function (simplex) {
-        var arr = simplex.slice(0, -1),
-            length = arr.length,
-            result = [],
-            sum = function (data, point) {
-                data.sum += point[data.i];
-                return data;
-            };
-
-        for (var i = 0; i < length; i++) {
-            result[i] = simplex.reduce(sum, { sum: 0, i: i }).sum / length;
-        }
-        return result;
     };
 
     var getPoint = function (centroid, worst, a, b) {
@@ -137,6 +137,7 @@ var nelderMead = function nelderMead(fn, initial) {
 };
 
 var content = {
+    getCentroid: getCentroid,
     nelderMead: nelderMead
 };
 

--- a/js/modules/venn.src.js
+++ b/js/modules/venn.src.js
@@ -307,7 +307,6 @@ var getLabelPosition = function getLabelPosition(internal, external) {
  * outside all external circles.
  *
  * @private
- * @todo Add unit tests
  * @param {object} pos The x and y coordinate of the label.
  * @param {Array<object>} internal Internal circles.
  * @param {Array<object>} external External circles.
@@ -340,7 +339,9 @@ var getLabelWidth = function getLabelWidth(pos, internal, external) {
     };
 
     // Find the smallest distance of left and right.
-    return Math.min(findDistance(radius, -1), findDistance(radius, 1)) * 2;
+    return Math.round(
+        Math.min(findDistance(radius, -1), findDistance(radius, 1)) * 2
+    );
 };
 
 /**
@@ -1037,6 +1038,7 @@ var vennSeries = {
         addOverlapToSets: addOverlapToSets,
         geometry: geometry,
         geometryCircles: geometryCircles,
+        getLabelWidth: getLabelWidth,
         getMarginFromCircles: getMarginFromCircles,
         getDistanceBetweenCirclesByOverlap: getDistanceBetweenCirclesByOverlap,
         layoutGreedyVenn: layoutGreedyVenn,

--- a/js/modules/venn.src.js
+++ b/js/modules/venn.src.js
@@ -16,6 +16,11 @@
 import draw from '../mixins/draw-point.js';
 import geometry from '../mixins/geometry.js';
 import geometryCircles from '../mixins/geometry-circles.js';
+
+import NelderMeadModule from '../mixins/nelder-mead.js';
+// TODO: replace with individual imports
+var nelderMead = NelderMeadModule.nelderMead;
+
 import H from '../parts/Globals.js';
 import '../parts/Series.js';
 
@@ -195,144 +200,6 @@ function getDistanceBetweenCirclesByOverlap(r1, r2, overlap) {
 
 var isSet = function (x) {
     return isArray(x.sets) && x.sets.length === 1;
-};
-
-/**
- * Finds an optimal position for a given point.
- * @private
- * @todo add unit tests.
- * @todo add constraints to optimize the algorithm.
- * @param {Function} fn The function to test a point.
- * @param {Array<*>} initial The initial point to optimize.
- * @return {Array<*>} Returns the opimized position of a point.
- */
-var nelderMead = function nelderMead(fn, initial) {
-    var maxIterations = 100,
-        sortByFx = function (a, b) {
-            return a.fx - b.fx;
-        },
-        pRef = 1, // Reflection parameter
-        pExp = 2, // Expansion parameter
-        pCon = -0.5, // Contraction parameter
-        pOCon = pCon * pRef, // Outwards contraction parameter
-        pShrink = 0.5; // Shrink parameter
-
-    var weightedSum = function weightedSum(weight1, v1, weight2, v2) {
-        return v1.map(function (x, i) {
-            return weight1 * x + weight2 * v2[i];
-        });
-    };
-
-    var getSimplex = function getSimplex(initial) {
-        var n = initial.length,
-            simplex = new Array(n + 1);
-
-        // Initial point to the simplex.
-        simplex[0] = initial;
-        simplex[0].fx = fn(initial);
-
-        // Create a set of extra points based on the initial.
-        for (var i = 0; i < n; ++i) {
-            var point = initial.slice();
-
-            point[i] = point[i] ? point[i] * 1.05 : 0.001;
-            point.fx = fn(point);
-            simplex[i + 1] = point;
-        }
-        return simplex;
-    };
-
-    var updateSimplex = function (simplex, point) {
-        point.fx = fn(point);
-        simplex[simplex.length - 1] = point;
-        return simplex;
-    };
-
-    var shrinkSimplex = function (simplex) {
-        var best = simplex[0];
-
-        return simplex.map(function (point) {
-            var p = weightedSum(1 - pShrink, best, pShrink, point);
-
-            p.fx = fn(p);
-            return p;
-        });
-    };
-
-    var getCentroid = function (simplex) {
-        var arr = simplex.slice(0, -1),
-            length = arr.length,
-            result = [],
-            sum = function (data, point) {
-                data.sum += point[data.i];
-                return data;
-            };
-
-        for (var i = 0; i < length; i++) {
-            result[i] = simplex.reduce(sum, { sum: 0, i: i }).sum / length;
-        }
-        return result;
-    };
-
-    var getPoint = function (centroid, worst, a, b) {
-        var point = weightedSum(a, centroid, b, worst);
-
-        point.fx = fn(point);
-        return point;
-    };
-
-    // Create a simplex
-    var simplex = getSimplex(initial);
-
-    // Iterate from 0 to max iterations
-    for (var i = 0; i < maxIterations; i++) {
-        // Sort the simplex
-        simplex.sort(sortByFx);
-
-        // Create a centroid from the simplex
-        var worst = simplex[simplex.length - 1];
-        var centroid = getCentroid(simplex);
-
-        // Calculate the reflected point.
-        var reflected = getPoint(centroid, worst, 1 + pRef, -pRef);
-
-        if (reflected.fx < simplex[0].fx) {
-            // If reflected point is the best, then possibly expand.
-            var expanded = getPoint(centroid, worst, 1 + pExp, -pExp);
-
-            simplex = updateSimplex(
-                simplex,
-                (expanded.fx < reflected.fx) ? expanded : reflected
-            );
-        } else if (reflected.fx >= simplex[simplex.length - 2].fx) {
-            // If the reflected point is worse than the second worse, then
-            // contract.
-            var contracted;
-
-            if (reflected.fx > worst.fx) {
-                // If the reflected is worse than the worst point, do a
-                // contraction
-                contracted = getPoint(centroid, worst, 1 + pCon, -pCon);
-                if (contracted.fx < worst.fx) {
-                    simplex = updateSimplex(simplex, contracted);
-                } else {
-                    simplex = shrinkSimplex(simplex);
-                }
-            } else {
-                // Otherwise do an outwards contraction
-                contracted = getPoint(centroid, worst, 1 - pOCon, pOCon);
-                if (contracted.fx < reflected.fx) {
-                    simplex = updateSimplex(simplex, contracted);
-                } else {
-                    simplex = shrinkSimplex(simplex);
-                }
-            }
-        } else {
-            simplex = updateSimplex(simplex, reflected);
-        }
-    }
-
-    return simplex[0];
 };
 
 /**

--- a/js/modules/venn.src.js
+++ b/js/modules/venn.src.js
@@ -788,6 +788,8 @@ var vennOptions = {
         /** @ignore-option */
         enabled: true,
         /** @ignore-option */
+        verticalAlign: 'middle',
+        /** @ignore-option */
         formatter: function () {
             return this.point.name;
         }

--- a/js/modules/venn.src.js
+++ b/js/modules/venn.src.js
@@ -971,9 +971,11 @@ var vennSeries = {
         addOverlapToSets: addOverlapToSets,
         geometry: geometry,
         geometryCircles: geometryCircles,
+        getMarginFromCircles: getMarginFromCircles,
         getDistanceBetweenCirclesByOverlap: getDistanceBetweenCirclesByOverlap,
         layoutGreedyVenn: layoutGreedyVenn,
         loss: loss,
+        nelderMead: NelderMeadModule,
         processVennData: processVennData,
         sortByTotalOverlap: sortByTotalOverlap
     }

--- a/samples/unit-tests/series-venn/members/demo.js
+++ b/samples/unit-tests/series-venn/members/demo.js
@@ -158,6 +158,46 @@ QUnit.test('getCenterOfPoints', function (assert) {
     );
 });
 
+QUnit.test('getLabelWidth', assert => {
+    const { getLabelWidth } = Highcharts.seriesTypes.venn.prototype.utils;
+
+    // Start with an internal circle, and no external circles.
+    const internal = [{ x: 0, y: 0, r: 100 }];
+    const external = [];
+
+    assert.strictEqual(
+        getLabelWidth({ x: 0, y: 0 }, internal, external),
+        200,
+        'Should return width of 200 when distance to closest internal circle border is 100.'
+    );
+
+    // Add another internal circle that is completely overlapped by the other
+    // internal circle.
+    internal.push({ x: 0, y: 0, r: 50 });
+
+    assert.strictEqual(
+        getLabelWidth({ x: 0, y: 0 }, internal, external),
+        100,
+        'Should return width of 100 when distance to closest internal circle border is 50.'
+    );
+
+    // Add an external circle that overlaps on the right side of the smallest
+    // internal circle
+    external.push({ x: 60, y: 0, r: 20 });
+
+    assert.strictEqual(
+        getLabelWidth({ x: -10, y: 0 }, internal, external),
+        80,
+        'Should return width of 80 when distance to closest internal circle border is 40.'
+    );
+
+    assert.strictEqual(
+        getLabelWidth({ x: 10, y: 0 }, internal, external),
+        60,
+        'Should return width of 60 when distance to closest external circle border is 30.'
+    );
+});
+
 QUnit.test('getOverlapBetweenCircles', assert => {
     var { prototype: vennPrototype } = Highcharts.seriesTypes.venn,
         { getOverlapBetweenCircles } = vennPrototype.utils.geometryCircles;

--- a/samples/unit-tests/series-venn/members/demo.js
+++ b/samples/unit-tests/series-venn/members/demo.js
@@ -668,3 +668,39 @@ QUnit.test('sortByTotalOverlap', function (assert) {
         'should return 0 when a is equal to b.'
     );
 });
+
+QUnit.module('nelder-mead', () => {
+    const vennUtils = Highcharts.seriesTypes.venn.prototype.utils;
+    const NelderMeadModule = vennUtils.nelderMead;
+
+    QUnit.test('getCentroid', assert => {
+        const { getCentroid } = NelderMeadModule;
+        assert.deepEqual(
+            getCentroid([
+                [184.16021264966827, 99.75],
+                [184.16021264966827, 95],
+                [193.3682232821517, 95]
+            ]),
+            [184.16021264966827, 97.375],
+            'should calculate the center point between all the coordinates, except the last'
+        );
+    });
+
+    QUnit.test('nelderMead', assert => {
+        const { nelderMead } = NelderMeadModule;
+        const { getMarginFromCircles } = vennUtils;
+        const internal = [{ r: 160, x: 184.16021264966827, y: 175 }];
+        const external = [{ r: 160, x: 415.8397873503318, y: 175 }];
+        const fn = ([x, y]) => -(
+            getMarginFromCircles({ x, y }, internal, external)
+        );
+        assert.deepEqual(
+            nelderMead(
+                fn,
+                [184.16021264966827, 95]
+            ),
+            [140.0000000000064, 174.99997672224276],
+            'should something'
+        );
+    });
+});

--- a/samples/unit-tests/series-venn/members/demo.js
+++ b/samples/unit-tests/series-venn/members/demo.js
@@ -682,7 +682,7 @@ QUnit.module('nelder-mead', () => {
                 [193.3682232821517, 95]
             ]),
             [184.16021264966827, 97.375],
-            'should calculate the center point between all the coordinates, except the last'
+            'Should calculate the center point between all the coordinates, except the last'
         );
     });
 
@@ -700,7 +700,7 @@ QUnit.module('nelder-mead', () => {
                 [184.16021264966827, 95]
             ),
             [140.0000000000064, 174.99997672224276],
-            'should something'
+            'Should optimize position into the one with the best margin.'
         );
     });
 });


### PR DESCRIPTION
Fixed #10247, improved data label positions in venn series.

---
# Description
Fixes scope issue with optimization algorithm causing label position to be worse than the initial position.
Also vertically aligns the label in the middle, and adds width so the label breaks when it overflows the shape. 

# Example(s)
- [Demo of issue](https://highcharts.github.io/highcharts-utils/samples/#gh/master/sample/highcharts/demo/venn-diagram). Especially visible with the label "More Expensive".
- [Demo with fix applied](https://highcharts.github.io/highcharts-utils/samples/#gh/bugfix/10247-venn-label-placement/sample/highcharts/demo/venn-diagram) The label "Will take time to deliver" shows the best benefit of having applied width.

# Related issue(s)
- Closes #10247 