### PR TITLE
Fixed #10826, add missing jquery

### DIFF
--- a/samples/highcharts/demo/treemap-large-dataset/demo.html
+++ b/samples/highcharts/demo/treemap-large-dataset/demo.html
@@ -1,3 +1,4 @@
+<script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/heatmap.js"></script>
 <script src="https://code.highcharts.com/modules/treemap.js"></script>


### PR DESCRIPTION
Fixed #10826, jQuery missing in Highcharts demo treemap-large-dataset.

---
The `treemap-large-dataset` example [crashes in JSFiddle](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/demo/treemap-large-dataset/) and CodePen due to missing jQuery.

# Related issue(s)
- Closes #10826 