### PR TITLE
Fixed #10708, remove use of findIndex

### DIFF
--- a/js/modules/sankey.src.js
+++ b/js/modules/sankey.src.js
@@ -469,11 +469,17 @@ seriesType('sankey', 'column',
                         // Hanging layout for organization chart
                         if (fromNode.options.layout === 'hanging') {
                             node.hangsFrom = fromNode;
-                            node.column += fromNode.linksFrom.findIndex(
-                                function (link) {
-                                    return link.toNode === node;
+                            i = -1; // Reuse existing variable i
+                            fromNode.linksFrom.find(
+                                function (link, index) {
+                                    var found = link.toNode === node;
+                                    if (found) {
+                                        i = index;
+                                    }
+                                    return found;
                                 }
                             );
+                            node.column += i;
                         }
                     }
                 }

--- a/js/modules/sankey.src.js
+++ b/js/modules/sankey.src.js
@@ -114,6 +114,7 @@ var getLevelOptions = mixinTreeSeries.getLevelOptions;
 
 
 var defined = H.defined,
+    find = H.find,
     isObject = H.isObject,
     merge = H.merge,
     seriesType = H.seriesType,
@@ -470,7 +471,8 @@ seriesType('sankey', 'column',
                         if (fromNode.options.layout === 'hanging') {
                             node.hangsFrom = fromNode;
                             i = -1; // Reuse existing variable i
-                            fromNode.linksFrom.find(
+                            find(
+                                fromNode.linksFrom,
                                 function (link, index) {
                                     var found = link.toNode === node;
                                     if (found) {


### PR DESCRIPTION
Fixed #10708, removed use of `Array.prototype.findIndex` which would cause Sankey series to break in IE.

---
# Description
Unfortunately this replacement does not look pretty code-wise, but I am unable to see an elegant solution for this issue.

# Related issue(s)
- Closes #10708 