### PR TITLE
Fixed issue with the data module failing on CORS resources

### DIFF
--- a/js/mixins/ajax.js
+++ b/js/mixins/ajax.js
@@ -66,6 +66,7 @@ H.ajax = function (attr) {
             headers: {}
         }, attr),
         headers = {
+            json: 'application/json',
             xml: 'application/xml',
             text: 'text/plain',
             octet: 'application/octet-stream'
@@ -85,10 +86,10 @@ H.ajax = function (attr) {
     }
 
     r.open(options.type.toUpperCase(), options.url, true);
-    if (headers[options.dataType]) {
+    if (!options.headers['Content-Type']) {
         r.setRequestHeader(
             'Content-Type',
-            headers[options.dataType]
+            headers[options.dataType] || headers.text
         );
     }
 
@@ -124,8 +125,7 @@ H.ajax = function (attr) {
 };
 
 /**
- * Get a JSON resource over XHR, a shorthand for `Highcharts.ajax` with
- * `dataType: 'json'`.
+ * Get a JSON resource over XHR, also supporting CORS without preflight.
  *
  * @function Highcharts.getJSON
  *
@@ -138,6 +138,12 @@ H.ajax = function (attr) {
 H.getJSON = function (url, success) {
     H.ajax({
         url: url,
-        success: success
+        success: success,
+        dataType: 'json',
+        headers: {
+            // Override the Content-Type to avoid preflight problems with CORS
+            // in the Highcharts demos
+            'Content-Type': 'text/plain'
+        }
     });
 };

--- a/js/mixins/ajax.js
+++ b/js/mixins/ajax.js
@@ -66,7 +66,6 @@ H.ajax = function (attr) {
             headers: {}
         }, attr),
         headers = {
-            json: 'application/json',
             xml: 'application/xml',
             text: 'text/plain',
             octet: 'application/octet-stream'
@@ -86,10 +85,12 @@ H.ajax = function (attr) {
     }
 
     r.open(options.type.toUpperCase(), options.url, true);
-    r.setRequestHeader(
-        'Content-Type',
-        headers[options.dataType] || headers.text
-    );
+    if (headers[options.dataType]) {
+        r.setRequestHeader(
+            'Content-Type',
+            headers[options.dataType]
+        );
+    }
 
     H.objectEach(options.headers, function (val, key) {
         r.setRequestHeader(key, val);
@@ -120,4 +121,23 @@ H.ajax = function (attr) {
     } catch (e) {}
 
     r.send(options.data || true);
+};
+
+/**
+ * Get a JSON resource over XHR, a shorthand for `Highcharts.ajax` with
+ * `dataType: 'json'`.
+ *
+ * @function Highcharts.getJSON
+ *
+ * @param {string} url
+ *        The URL to load.
+ * @param {function} success
+ *        The success callback. For error handling, use the `Highcharts.ajax`
+ *        function instead.
+ */
+H.getJSON = function (url, success) {
+    H.ajax({
+        url: url,
+        success: success
+    });
 };

--- a/samples/highcharts/demo/treemap-large-dataset/demo.html
+++ b/samples/highcharts/demo/treemap-large-dataset/demo.html
@@ -1,5 +1,5 @@
-<script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/data.js"></script>
 <script src="https://code.highcharts.com/modules/heatmap.js"></script>
 <script src="https://code.highcharts.com/modules/treemap.js"></script>
 <div id="container"></div>

--- a/samples/highcharts/demo/treemap-large-dataset/demo.js
+++ b/samples/highcharts/demo/treemap-large-dataset/demo.js
@@ -1,4 +1,4 @@
-$.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/world-mortality.json', function (data) {
+Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/world-mortality.json', function (data) {
 
     var points = [],
         regionP,


### PR DESCRIPTION
Fixed issue with the data module failing on CORS resources.

The Content-Type `application/json` triggered a preflight response from the server, disallowing CORS in our demo cases. The proposed solution is to send the request with no Content-Type, as jQuery does, thus allowing a [simple request](https://dev.to/effingkay/cors-preflighted-requests--options-method-3024) with no preflight response.

In the next turn, we can start removing jQuery from those samples that only rely on `$.getJSON`.

