### PR TITLE
Fixed #10788, wrong docs for stock tools.

### DIFF
--- a/docs/stock/stock-tools.md
+++ b/docs/stock/stock-tools.md
@@ -1,0 +1,203 @@
+# Stock Tools
+
+Stock Tools is a Highstock module for building a GUI that enables user interaction with the chart, such as adding annotations, technical indicators or just for zooming in or out. The module is released with Highstock 7 and won't work with previous versions.
+
+Building the GUI is facilitated by the Stock Tools module, where your HTML elements for user interaction are automatically bound to predefined events in this module. Full list of the available bindings can be found in the API [navigation.bindings](https://api.highcharts.com/highstock/navigation.bindings).
+
+## QUICK START
+To get started quickly it's recommended to use the default toolbar of the Stock Tools module. We need to load the JavaScript files in the following order.
+
+1. First load Highstock and the bundle with all the technical indicators for convenience.
+```
+<script src="http://code.highcharts.com/indicators/indicators-all.js"></script>
+```
+See the example below when you only need some specific indicators for your project. Load first the `indicator.js` base module and specific indicators successively. Technical indicators require the [indicators/indicators.js](https://code.highcharts.com/stock/indicators/indicators.js) base module. The base module includes SMA (Simple Moving Average). Find here a list of [available technical indicators](https://www.highcharts.com/docs/stock/technical-indicator-series).
+
+_See example below for loading specific indicators._
+```
+<script src="http://code.highcharts.com/indicators/indicators.js"></script>
+<script src="http://code.highcharts.com/indicators/rsi.js"></script>
+<script src="http://code.highcharts.com/indicators/ema.js"></script> 
+<script src="http://code.highcharts.com/indicators/macd.js"></script> 
+<script src="/ .... other technical indicators ...  "
+```
+
+2. Load also the other modules needed by the default toolbar: _Resizable panes, Annotations, Full screen, and Current Price_.
+```
+<script src="https://code.highcharts.com/modules/drag-panes.js"></script>
+<script src="https://code.highcharts.com/modules/annotations-advanced.js"></script>
+<script src="https://code.highcharts.com/modules/price-indicator.js"></script>
+<script src="https://code.highcharts.com/modules/full-screen.js"></script>
+```
+3. It is necessary to load the Stock Tools module last, so it will pick up on all available plugins above:
+```
+<script src="https://code.highcharts.com/modules/stock-tools.js">
+```
+4. The build-in toolbar, needs the following CSS files:
+```
+<link rel="stylesheet" type="text/css" href="https://code.highcharts.com/css/stocktools/gui.css">
+<link rel="stylesheet" type="text/css" href="https://code.highcharts.com/css/annotations/popup.css">
+```
+5. Now you have loaded all required files, create a stock chart as you normally would, see the below example.
+```
+Highcharts.stockChart('container', {
+    series: [{
+        type: 'ohlc',
+            data: [ ... ]
+        }]
+    });
+```
+And Stock Tools toolbar will show up on the left side of the chart, see the demo below.
+
+[iframe: stock/demo/stock-tools-gui]
+
+**Note:** The buttons graphics of the Stock Toolbar buttons are by default loaded from the Highcharts CDN. If you want to load Stock Tools from your local package, you might also want to set the symbol properties for each of the [`stockTools.gui.definitions`](https://api.highcharts.com/highstock/stockTools.gui.definitions). The icons are available in the Highcharts NPM [package](https://www.npmjs.com/package/highcharts) or clone the highcharts-dist [GitHub repository](https://github.com/highcharts/highcharts-dist).
+
+Find the icons in the `/gfx/stocktools` folder of this package.
+
+## BUILD A CUSTOM GUI
+The built-in Stock Toolbar will cover most use cases and get you quickly started. The API of this module supports additionally building a custom defined user interface. Automatic binding and built-in actions for your custom HTML elements come out of the box and require minimal programming.
+
+### BINDING AN EVENT TO A HTML ELEMENT
+HTML elements are bound to stock tools events through reverse lookup of HTML elements with a classname in the form of: `highcharts-BINDINGNAME`. For example a HTML button with `highcharts-circle-annotation` will bind the [`navigation.bindings.circleAnnotation`](https://api.highcharts.com/highstock/navigation.bindings.circleAnnotation) events. Class name can be changed by setting `navigation.bindings.circleAnnotation.className`. The actual binding takes place on chart initialization, but only for HTML elements that are wrapped within another HTML element with the classname correlating the chart configuration for [`navigation.bindingsClassName`](https://api.highcharts.com/highstock/navigation.bindingsClassName). The wrapping classname defaults to `highcharts-bindings-wrapper`. Wrapping the GUI elements is made required for specifying which GUI elements need to be bound and events are delegated to the correct chart.
+
+_The code snippet below demonstrates how to disable the default toolbar, and triggers lookup of a custom GUI with the `navigation.bindingsClassName`._
+
+```
+Highcharts.stockChart('container', {
+    navigation: {
+        bindingsClassName: ‘tools-container’ // informs Stock Tools where to look for HTML elements for adding technical indicators, annotations etc. 
+    },
+    stockTools: {
+        gui: {
+            enabled: false // disable the built-in toolbar
+        }
+    },
+    series: [{
+        ....
+    }]
+});
+```
+
+_The button below is now bound to the `circleAnnotation` events, after it's found through the above specified classname `tools-container`._
+
+```
+<div class="tools-container">
+  <button class="highcharts-circle-annotation">Add Circle</button>
+</div>
+```
+
+_See this demo for binding a button to the [`circleAnnotation`](https://api.highcharts.com/highstock/navigation.bindings.circleAnnotation)._
+
+[iframe: samples/stock-tools/basic-gui]
+
+### DIALOGUE WINDOWS
+
+In applications with more advanced user interaction, additional dialogue windows are likely needed. Support for building custom dialogue windows is facilitated by hooking up functions to the [`navigation.bindings`](https://api.highcharts.com/highstock/navigation.bindings).
+
+How to implement a custom dialogue window, is best explained with an example where we change the background color of a circle annotation.
+
+1. First we define a dialogue window in HTML. Notice the classname `highcharts-popup-annotations` of the outer `div` element. We need this classname in the [`navigation.events.showPopup`](https://api.highcharts.com/highstock/navigation.events.showPopup) event later on.
+
+_Example of an dialogue window with an color input field_
+
+```
+<div class="highcharts-popup highcharts-popup-annotations">
+    <div class="highcharts-popup-wrapper">
+        <label for="stroke">Color</label>
+        <input type="color" name="stroke" value="rgba(0, 0, 0, 0.75)"/>
+    </div>
+    <button class="button">Save</button>
+</div>
+```
+
+2. Hook up the functions for the events for [`navigation.bindings`](https://api.highcharts.com/highstock/navigation.bindings).
+
+```
+navigation: {
+    // Informs Stock Tools where to look for HTML elements for adding
+    // technical indicators, annotations etc.
+    bindingsClassName: 'tools-container',
+    events: {
+        // On selecting the annotation the showPopup event is fired
+        showPopup: function(event) {
+            var chart = this.chart;
+
+            if (!chart.annotationsPopupContainer) {
+                // Get and store the popup annotations container
+                chart.annotationsPopupContainer = document
+                  .getElementsByClassName('highcharts-popup-annotations')[0];
+            }
+
+            // Show the popup container, but not when we add the annotation.
+            if (
+                event.formType === 'annotation-toolbar' &&
+                !chart.activeButton
+            ) {
+                chart.currentAnnotation = event.annotation;
+                chart.annotationsPopupContainer.style.display = 'block';
+            }
+        },
+        
+        closePopup: function() {
+            // Hide the popup container, and reset currentAnnotation
+            this.chart.annotationsPopupContainer.style.display = 'none';
+            this.chart.currentAnnotation = null;
+        },
+        
+        selectButton: function(event) {
+            // Select button
+            event.button.classList.add('active');
+            // Register this is current button to indicate we're adding
+            // an annotation.
+            this.chart.activeButton = event.button;
+        },
+            
+        deselectButton: function(event) {
+            // Unselect the button
+            event.button.classList.remove('active');
+            // Remove info about active button:
+            this.chart.activeButton = null;
+        }
+    }
+},
+```
+
+3. Add an event listener to the "Save" button of the dialogue window for saving the color to the `fill` of the circle annotation.
+
+```
+Highcharts.stockChart('container', {
+    chart: {
+        events: {
+            load: function() {
+                // Function which saves the new background color.
+                var chart = this;
+                // Select the save button of the popup and assign a click event
+                document.querySelectorAll('.highcharts-popup-annotations button')[0].addEventListener(
+                    'click',
+                    function() {
+                        var color = document.querySelectorAll(
+                            '.highcharts-popup-annotations input[name="stroke"]'
+                        )[0].value;
+
+                        // Update the circle
+                        chart.currentAnnotation.update({
+                            shapes: [{
+                                fill: color
+                            }]
+                        });
+
+                        // Close the container
+                        chart.annotationsPopupContainer.style.display = 'none';
+                    }
+                )
+            }
+        }
+    },
+    navigation: { ... },
+    ...
+});
+```
+
+_The above code is put together in the below demo_
+[iframe: samples/stock-tools/custom-popup]

--- a/samples/stock/stocktools/basic-gui/demo.details
+++ b/samples/stock/stocktools/basic-gui/demo.details
@@ -1,0 +1,7 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Pawel Fus
+ requiresManualTesting: true
+ js_wrap: b
+...

--- a/samples/stock/stocktools/basic-gui/demo.html
+++ b/samples/stock/stocktools/basic-gui/demo.html
@@ -1,0 +1,13 @@
+<script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+
+<script src="https://code.highcharts.com/modules/annotations-advanced.js"></script>
+
+<script src="https://code.highcharts.com/modules/stock-tools.js"></script>
+
+<div class="tools-container">
+  <button class="highcharts-circle-annotation">Add Circle</button>
+</div>
+
+<div id="container" style="height: 400px; min-width: 310px"></div>
+

--- a/samples/stock/stocktools/basic-gui/demo.js
+++ b/samples/stock/stocktools/basic-gui/demo.js
@@ -1,0 +1,23 @@
+$.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+    // Create the chart
+    Highcharts.stockChart('container', {
+        navigation: {
+            bindingsClassName: 'tools-container' // informs Stock Tools where to look for HTML elements for adding technical indicators, annotations etc.
+        },
+
+        stockTools: {
+            gui: {
+                enabled: false // disable the built-in toolbar
+            }
+        },
+
+        series: [{
+            id: 'aapl',
+            name: 'AAPL',
+            data: data,
+            tooltip: {
+                valueDecimals: 2
+            }
+        }]
+    });
+});

--- a/samples/stock/stocktools/basic-gui/test-notes.md
+++ b/samples/stock/stocktools/basic-gui/test-notes.md
@@ -1,0 +1,1 @@
+Click "Add Circle" then add an annotation on the chart. Expected is a circle annotation on the chart.

--- a/samples/stock/stocktools/custom-popup/demo.css
+++ b/samples/stock/stocktools/custom-popup/demo.css
@@ -1,0 +1,29 @@
+.highcharts-popup-annotations {
+    display: none;
+    position: absolute;
+    left: calc(50% - 50px);
+    width: 100px;
+    background-color: white;
+    border: 2px grey solid;
+    padding: 10px;
+    top: 150px;
+}
+
+.button {
+    border: none;
+    color: white;
+    padding: 5px 15px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+    margin: 10px;
+    background-color: #4CAF50;
+    color: white;
+    border: 2px solid #4CAF50;
+}
+
+.button:hover, button.active {
+    background-color: white;
+    color: black;
+}

--- a/samples/stock/stocktools/custom-popup/demo.details
+++ b/samples/stock/stocktools/custom-popup/demo.details
@@ -1,0 +1,7 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Pawel Fus
+ requiresManualTesting: true
+ js_wrap: b
+...

--- a/samples/stock/stocktools/custom-popup/demo.html
+++ b/samples/stock/stocktools/custom-popup/demo.html
@@ -1,0 +1,20 @@
+<script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+
+<script src="https://code.highcharts.com/modules/annotations-advanced.js"></script>
+
+<script src="https://code.highcharts.com/modules/stock-tools.js"></script>
+
+<div class="tools-container">
+    <button class="highcharts-circle-annotation button">Add Circle</button>
+</div>
+
+<div id="container" style="height: 400px; min-width: 310px"></div>
+
+<div class="highcharts-popup highcharts-popup-annotations">
+    <div class="highcharts-popup-wrapper">
+        <label for="stroke">Color</label>
+        <input type="color" name="stroke" value="rgba(0, 0, 0, 0.75)"/>
+    </div>
+    <button class="button">Save</button>
+</div>

--- a/samples/stock/stocktools/custom-popup/demo.js
+++ b/samples/stock/stocktools/custom-popup/demo.js
@@ -1,0 +1,96 @@
+$.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+    // Create the chart
+    Highcharts.stockChart('container', {
+        chart: {
+            events: {
+                load: function () {
+                    var chart = this;
+
+                    // Select the save button of the popup and assign a click event
+                    document
+                        .querySelectorAll('.highcharts-popup-annotations button')[0]
+                        .addEventListener(
+                            'click',
+                            // Function which saves the new background color.
+                            function () {
+                                var color = document.querySelectorAll(
+                                    '.highcharts-popup-annotations input[name="stroke"]'
+                                )[0].value;
+
+                                // Update the circle
+                                chart.currentAnnotation.update({
+                                    shapes: [{
+                                        fill: color
+                                    }]
+                                });
+
+                                // Close the popup
+                                chart.annotationsPopupContainer.style.display = 'none';
+                            }
+                        );
+                }
+            }
+        },
+        navigation: {
+            // Informs Stock Tools where to look for HTML elements for adding
+            // technical indicators, annotations etc.
+            bindingsClassName: 'tools-container',
+            events: {
+                // On selecting the annotation the showPopup event is fired
+                showPopup: function (event) {
+                    var chart = this.chart;
+
+                    if (!chart.annotationsPopupContainer) {
+                        // Get and store the popup annotations container
+                        chart.annotationsPopupContainer = document
+                            .getElementsByClassName('highcharts-popup-annotations')[0];
+                    }
+
+                    // Show the popup container, but not when we add the annotation.
+                    if (
+                        event.formType === 'annotation-toolbar' &&
+                        !chart.activeButton
+                    ) {
+                        chart.currentAnnotation = event.annotation;
+                        chart.annotationsPopupContainer.style.display = 'block';
+                    }
+                },
+
+                closePopup: function () {
+                    // Hide the popup container, and reset currentAnnotation
+                    this.chart.annotationsPopupContainer.style.display = 'none';
+                    this.chart.currentAnnotation = null;
+                },
+
+                selectButton: function (event) {
+                    // Select button
+                    event.button.classList.add('active');
+                    // Register this is current button to indicate we're adding
+                    // an annotation.
+                    this.chart.activeButton = event.button;
+                },
+
+                deselectButton: function (event) {
+                    // Unselect the button
+                    event.button.classList.remove('active');
+                    // Remove info about active button:
+                    this.chart.activeButton = null;
+                }
+            }
+        },
+        stockTools: {
+            gui: {
+                enabled: false // disable the built-in toolbar
+            }
+        },
+
+        series: [{
+            id: 'aapl',
+            name: 'AAPL',
+            data: data,
+            tooltip: {
+                valueDecimals: 2
+            }
+        }]
+    });
+});

--- a/samples/stock/stocktools/custom-popup/test-notes.md
+++ b/samples/stock/stocktools/custom-popup/test-notes.md
@@ -1,0 +1,1 @@
+Click "Add Circle" then add an annotation on the chart. Expected is a circle annotation on the chart. Then click on annotation - custom popup should show up with a possibility to update an annotation.


### PR DESCRIPTION
Fixed #10788, samples in stock-tools documentation had minor bugs.
___

In general, a few minor fixes:
- reviewed docs, fixed minor things there too
- moved demos from Gert's jsfiddle account to official samples + added description for manual testing
- added docs file for stock tools. Created `stock/` dir for that. I'm not sure about convention here (e.g. all series are placed in the main dir), but I guess something similar will be implemented anyway

Let me know if something else is needed too. It's my first PR for website docs.

