### PR TITLE
Fixed #10524, skip tspan when nowrap

### DIFF
--- a/js/modules/wordcloud.src.js
+++ b/js/modules/wordcloud.src.js
@@ -696,7 +696,9 @@ var wordCloudOptions = {
         /** @ignore-option */
         fontFamily: 'sans-serif',
         /** @ignore-option */
-        fontWeight: '900'
+        fontWeight: '900',
+        /** @ignore-option */
+        whiteSpace: 'nowrap'
     },
     tooltip: {
         followPointer: true,

--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -2828,6 +2828,7 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
                 }
             }
         };
+        var regexMatchBreaks = /<br.*?>/g;
         // The buildText code is quite heavy, so if we're not changing something
         // that affects the text, skip it (#6113).
         textCache = [
@@ -2853,7 +2854,8 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
             !textOutline &&
             !ellipsis &&
             !width &&
-            textStr.indexOf(' ') === -1) {
+            (textStr.indexOf(' ') === -1 ||
+                (noWrap && !regexMatchBreaks.test(textStr)))) {
             textNode.appendChild(doc.createTextNode(unescapeEntities(textStr)));
             // Complex strings, add more logic
         }
@@ -2871,7 +2873,7 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
                 lines = lines
                     .replace(/<a/g, '<span')
                     .replace(/<\/(b|strong|i|em|a)>/g, '</span>')
-                    .split(/<br.*?>/g);
+                    .split(regexMatchBreaks);
             }
             else {
                 lines = [textStr];

--- a/samples/unit-tests/svgrenderer/text/demo.js
+++ b/samples/unit-tests/svgrenderer/text/demo.js
@@ -89,6 +89,46 @@ QUnit.test('Text word wrap with markup', function (assert) {
 
 });
 
+QUnit.module('whiteSpace: "nowrap"', hooks => {
+    const { Renderer } = Highcharts;
+    const renderer = new Renderer(
+        document.getElementById('container'),
+        400,
+        300
+    );
+    const text = renderer.text('test', 100, 40)
+        .css({
+            whiteSpace: 'nowrap'
+        })
+        .add();
+
+    // Cleanup
+    hooks.after(() => {
+        renderer.destroy();
+        text.destroy();
+    });
+
+
+    QUnit.test('Skip tspans', assert => {
+        text.attr({ text: 'single_word' });
+        assert.strictEqual(
+            text.element.innerHTML,
+            'single_word',
+            'should not use tspan when whiteSpace equals "nowrap", and text equals "single_word".'
+        );
+
+        text.attr({ text: 'two words' });
+        assert.strictEqual(
+            text.element.innerHTML,
+            'two words',
+            'should not use tspan when whiteSpace equals "nowrap", and text equals "two words".'
+        );
+
+    });
+
+    // TODO: move rest of nowrap tests into this module.
+});
+
 QUnit.test('Text word wrap with nowrap and break (#5689)', function (assert) {
 
     var renderer = new Highcharts

--- a/ts/parts/SvgRenderer.ts
+++ b/ts/parts/SvgRenderer.ts
@@ -4093,6 +4093,7 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
                     }
                 }
             };
+        const regexMatchBreaks = /<br.*?>/g;
 
         // The buildText code is quite heavy, so if we're not changing something
         // that affects the text, skip it (#6113).
@@ -4122,7 +4123,10 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
             !textOutline &&
             !ellipsis &&
             !width &&
-            textStr.indexOf(' ') === -1
+            (
+                textStr.indexOf(' ') === -1 ||
+                (noWrap && !regexMatchBreaks.test(textStr))
+            )
         ) {
             textNode.appendChild(doc.createTextNode(unescapeEntities(textStr)));
 
@@ -4160,7 +4164,7 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
                 lines = (lines as any)
                     .replace(/<a/g, '<span')
                     .replace(/<\/(b|strong|i|em|a)>/g, '</span>')
-                    .split(/<br.*?>/g);
+                    .split(regexMatchBreaks);
 
             } else {
                 lines = [textStr];


### PR DESCRIPTION
Fixed #10524, Wordcloud text with multiple words had different alignment than text with a single word.

---
# Example(s)
- [Demo of issue](https://jsfiddle.net/kzoon/b7ofwjat)
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/dg529c46/)

# Related issue(s)
- Closes #10524 