### PR TITLE
Fixed #10884, removed `axis.labels.levels` demo.

### DIFF
--- a/js/parts-gantt/TreeGrid.js
+++ b/js/parts-gantt/TreeGrid.js
@@ -612,8 +612,6 @@ override(GridAxis.prototype, {
                         * Specify the level which the options within this object
                         * applies to.
                         *
-                        * @sample {gantt} gantt/treegrid-axis/labels-levels
-                        *
                         * @type      {number}
                         * @product   gantt
                         * @apioption yAxis.labels.levels.level


### PR DESCRIPTION
Simply removed sample's reference. The same demo is defined in the parent:

![Screen Shot 2019-06-05 at 16 15 27](https://user-images.githubusercontent.com/1453926/58963285-2d437b80-87ad-11e9-852e-ddf2719f5d48.png)
