### PR TITLE
bugfix/10323-hidden-connectors-after-zoom

### DIFF
--- a/js/modules/timeline.src.js
+++ b/js/modules/timeline.src.js
@@ -257,6 +257,17 @@ seriesType('timeline', 'line',
                     }
                 });
             });
+            addEvent(series.chart, 'afterHideOverlappingLabels', function () {
+                series.points.forEach(function (p) {
+                    if (
+                        p.connector &&
+                        p.dataLabel &&
+                        p.dataLabel.oldOpacity !== p.dataLabel.newOpacity
+                    ) {
+                        p.alignConnector();
+                    }
+                });
+            });
         },
         alignDataLabel: function (point, dataLabel) {
             var series = this,
@@ -615,7 +626,9 @@ seriesType('timeline', 'line',
                 connector.attr({
                     stroke: dlOptions.connectorColor || point.color,
                     'stroke-width': dlOptions.connectorWidth,
-                    opacity: point.dataLabel.opacity
+                    opacity: dl[
+                        defined(dl.newOpacity) ? 'newOpacity' : 'opacity'
+                    ]
                 });
             }
         }

--- a/samples/unit-tests/series-timeline/datetime-axis/demo.js
+++ b/samples/unit-tests/series-timeline/datetime-axis/demo.js
@@ -169,4 +169,37 @@ QUnit.test('Timeline: General tests.', function (assert) {
         connector['stroke-width'] === undefined,
         "Connector is hidden when the data label is not visible on init."
     );
+
+    chart.update({
+        series: [{
+            dataLabels: {
+                allowOverlap: false
+            },
+            data: [{
+                x: Date.UTC(1951, 5, 22),
+                label: 'First long data label with some description'
+            }, {
+                x: Date.UTC(1957, 9, 4),
+                label: 'Second long data label with some description'
+            }, {
+                x: Date.UTC(1959, 0, 4),
+                label: 'Third long data label with some description'
+            }, {
+                x: Date.UTC(1961, 0, 4),
+                label: 'Fourth long data label with some description'
+            }]
+        }]
+    });
+
+    chart.xAxis[0].setExtremes(Date.UTC(1958, 11, 31), Date.UTC(1961, 0, 4));
+
+    point = timeline.points[3];
+    dataLabel = point.dataLabel;
+    connector = point.connector;
+
+    assert.strictEqual(
+        dataLabel.opacity,
+        connector.opacity,
+        "Connector is visible together with data label, after setting extremes."
+    );
 });


### PR DESCRIPTION
Fixed #10323, dataLabel's connector was hidden after setting extremes.