### PR TITLE
bugfix/10874-tooltip-for-points-that-were-null

### DIFF
--- a/js/parts/Point.js
+++ b/js/parts/Point.js
@@ -201,9 +201,7 @@ Highcharts.Point.prototype = {
             point.y = point[pointValKey];
         }
         point.isNull = pick(point.isValid && !point.isValid(), point.x === null || !isNumber(point.y, true)); // #3571, check for NaN
-        if (point.isNull) { // #9233
-            point.formatPrefix = 'null';
-        }
+        point.formatPrefix = point.isNull ? 'null' : 'point'; // #9233, #10874
         // The point is initially selected by options (#5777)
         if (point.selected) {
             point.state = 'select';

--- a/samples/unit-tests/tooltip/nullformat/demo.js
+++ b/samples/unit-tests/tooltip/nullformat/demo.js
@@ -21,3 +21,25 @@ QUnit.test('#9233: Support for visible null points formatting in tooltip.',
             '#9233: Toolip for null point contains the given formatting.'
         );
     });
+
+
+QUnit.test('#10874: update null point with non-null values.',
+    function (assert) {
+        var pointFormat = 'Value is available.',
+            chart = Highcharts.chart('container', {
+                series: [{
+                    data: [null],
+                    tooltip: {
+                        pointFormat: pointFormat
+                    }
+                }]
+            });
+
+        chart.series[0].points[0].update(1);
+        chart.tooltip.refresh(chart.series[0].points[0]);
+
+        assert.ok(
+            chart.tooltip.label.text.textStr.indexOf(pointFormat) > -1,
+            '#10874: Toolip for updated null point has correct formatting.'
+        );
+    });

--- a/ts/parts/Point.ts
+++ b/ts/parts/Point.ts
@@ -309,9 +309,7 @@ Highcharts.Point.prototype = {
             point.x === null || !(isNumber as any)(point.y, true)
         ); // #3571, check for NaN
 
-        if (point.isNull) { // #9233
-            point.formatPrefix = 'null';
-        }
+        point.formatPrefix = point.isNull ? 'null' : 'point'; // #9233, #10874
 
         // The point is initially selected by options (#5777)
         if (point.selected) {


### PR DESCRIPTION
Fixed #10874: tooltip wasn't formatted correctly for updated null points.