### PR TITLE
Tools: Run ci browsertests in series.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ workflows:
       - test_browsers:
           name: "test-Mac.Firefox"
           requires:
-            - build_dependencies
+            - "test-Mac.Safari"
           browsers: "Mac.Firefox"
       - hold_for_approval:
           type: approval


### PR DESCRIPTION
To fail fast and avoid bs rate limiting with current plan.