### PR TITLE
Fixed #9099, getSelectedPoints with series select event

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -616,7 +616,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             // points outside the visible range (#6445). For grouped data,
             // inspect the generated series.points.
             points = points.concat((serie[serie.hasGroupedData ? 'points' : 'data'] || []).filter(function (point) {
-                return point.selected;
+                return pick(point.selectedStaging, point.selected);
             }));
         });
         return points;

--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -689,6 +689,8 @@ extend(Point.prototype, /** @lends Highcharts.Point.prototype */ {
 
         selected = pick(selected, !point.selected);
 
+        this.selectedStaging = selected;
+
         // fire the event with the default handler
         point.firePointEvent(
             selected ? 'select' : 'unselect',
@@ -736,6 +738,8 @@ extend(Point.prototype, /** @lends Highcharts.Point.prototype */ {
                 }
             }
         );
+
+        delete this.selectedStaging;
     },
 
     /**

--- a/samples/unit-tests/point/point-select/demo.details
+++ b/samples/unit-tests/point/point-select/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/point/point-select/demo.html
+++ b/samples/unit-tests/point/point-select/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/point/point-select/demo.js
+++ b/samples/unit-tests/point/point-select/demo.js
@@ -1,0 +1,73 @@
+QUnit.test('Point select and staging', assert => {
+    let selectedPoints = [];
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'column'
+        },
+        xAxis: {
+            type: 'category'
+        },
+        series: [{
+            data: [
+                ['Ein', 1],
+                ['To', 2],
+                ['Tre', 3],
+                ['Fire', 4]
+            ],
+            point: {
+                events: {
+                    select: () => {
+                        selectedPoints = chart.getSelectedPoints()
+                            .map(p => p.name);
+                    },
+                    unselect: () => {
+                        selectedPoints = chart.getSelectedPoints()
+                            .map(p => p.name);
+                    }
+                }
+            }
+        }]
+    });
+
+    assert.deepEqual(
+        selectedPoints,
+        [],
+        'Initially we should have an empty array'
+    );
+
+    chart.series[0].points[0].select();
+    assert.deepEqual(
+        selectedPoints,
+        ['Ein'],
+        'We should have one selected point'
+    );
+
+    chart.series[0].points[1].select();
+    assert.deepEqual(
+        selectedPoints,
+        ['To'],
+        'After selecting the second point, the first should be unselected'
+    );
+
+    chart.series[0].points[2].select(true, true);
+    assert.deepEqual(
+        selectedPoints,
+        ['To', 'Tre'],
+        'After accumulating the third point, there should be two points selected'
+    );
+
+    chart.series[0].points[1].select(false, true);
+    assert.deepEqual(
+        selectedPoints,
+        ['Tre'],
+        'After unselecting/accumulating the second point, there should be one point selected'
+    );
+
+    chart.series[0].points[2].select(false);
+    assert.deepEqual(
+        selectedPoints,
+        [],
+        'After unselecting the final point, there should be no point selected'
+    );
+
+});

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -960,7 +960,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             points = points.concat(
                 (serie[serie.hasGroupedData ? 'points' : 'data'] || []).filter(
                     function (point: Highcharts.Point): boolean {
-                        return point.selected;
+                        return pick(point.selectedStaging, point.selected);
                     }
                 )
             );


### PR DESCRIPTION
Fixed #9099, `getSelectedPoints` did not include the currently selected or unselected point when called from inside `series.point.events.select`.