### PR TITLE
 bugfix/10932-minpadding-datagrouping

### DIFF
--- a/js/parts/DataGrouping.js
+++ b/js/parts/DataGrouping.js
@@ -809,7 +809,7 @@ seriesProto.processData = function () {
             // But only for visible series (#5493, #6393)
             if (
                 defined(groupedXData[0]) &&
-                groupedXData[0] < xAxis.dataMin &&
+                groupedXData[0] < xAxis.min &&
                 visible
             ) {
                 if (

--- a/samples/unit-tests/series/datagrouping/demo.js
+++ b/samples/unit-tests/series/datagrouping/demo.js
@@ -365,6 +365,33 @@ QUnit.test('Data groupind and extremes change', function (assert) {
         min,
         'User defined minimum is applied on a chart (#8335).'
     );
+
+    chart.xAxis[0].update({
+        min: null,
+        minPadding: 0.1
+    });
+
+    chart.series[0].setData([
+        [
+            26179200000,
+            0
+        ], [
+            28771200000,
+            1
+        ], [
+            1285804800000,
+            479
+        ], [
+            1288483200000,
+            480
+        ]
+    ]);
+
+    assert.strictEqual(
+        chart.xAxis[0].getExtremes().min < chart.series[0].points[0].x,
+        true,
+        'minPadding should decrease xAxis.min even when points are grouped (#10932).'
+    );
 });
 
 QUnit.test('Data groupind, keys and turboThreshold', function (assert) {


### PR DESCRIPTION
Fixed #10932, `xAxis.minPadding` didn't work when `series.dataGrouping` was enabled.