### PR TITLE
Fixed #10909, subpixel precision caused unwanted space in area

### DIFF
--- a/js/parts/AreaSeries.js
+++ b/js/parts/AreaSeries.js
@@ -333,7 +333,9 @@ seriesType(
                 plotX,
                 stacks = yAxis.stacks[this.stackKey],
                 threshold = options.threshold,
-                translatedThreshold = yAxis.getThreshold(options.threshold),
+                translatedThreshold = Math.round( // #10909
+                    yAxis.getThreshold(options.threshold)
+                ),
                 isNull,
                 yBottom,
                 connectNulls = H.pick( // #10574


### PR DESCRIPTION
Fixed #10909, subpixel precision caused unwanted space between the area series' area and baseline grid lines.