### PR TITLE
Fixed #10791, disable halo in venn

### DIFF
--- a/js/modules/venn.src.js
+++ b/js/modules/venn.src.js
@@ -24,7 +24,8 @@ var nelderMead = NelderMeadModule.nelderMead;
 import H from '../parts/Globals.js';
 import '../parts/Series.js';
 
-var color = H.Color,
+var addEvent = H.addEvent,
+    color = H.Color,
     extend = H.extend,
     getAreaOfCircle = geometryCircles.getAreaOfCircle,
     getAreaOfIntersectionBetweenCircles =
@@ -42,7 +43,8 @@ var color = H.Color,
     isPointOutsideAllCircles = geometryCircles.isPointOutsideAllCircles,
     isString = H.isString,
     merge = H.merge,
-    seriesType = H.seriesType;
+    seriesType = H.seriesType,
+    seriesTypes = H.seriesTypes;
 
 var objectValues = function objectValues(obj) {
     return Object.keys(obj).map(function (x) {
@@ -802,11 +804,16 @@ var vennOptions = {
     opacity: 0.75,
     showInLegend: false,
     states: {
+        /**
+         * @excluding halo
+         */
         hover: {
             opacity: 1,
-            halo: false,
             borderColor: '${palette.neutralColor80}'
         },
+        /**
+         * @excluding halo
+         */
         select: {
             color: '${palette.neutralColor20}',
             borderColor: '${palette.neutralColor100}',
@@ -1132,6 +1139,16 @@ var vennPoint = {
  */
 
 /**
+ * @excluding halo
+ * @apioption series.venn.states.hover
+ */
+
+/**
+ * @excluding halo
+ * @apioption series.venn.states.select
+ */
+
+/**
  * @private
  * @class
  * @name Highcharts.seriesTypes.venn
@@ -1139,3 +1156,16 @@ var vennPoint = {
  * @augments Highcharts.Series
  */
 seriesType('venn', 'scatter', vennOptions, vennSeries, vennPoint);
+
+// Modify final series options.
+addEvent(seriesTypes.venn, 'afterSetOptions', function (e) {
+    var options = e.options,
+        states = options.states;
+
+    if (this instanceof seriesTypes.venn) {
+        // Explicitly disable all halo options.
+        Object.keys(states).forEach(function (state) {
+            states[state].halo = false;
+        });
+    }
+});

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -2122,7 +2122,6 @@ H.Series = H.seriesType(
              *
              * @extends   plotOptions.series.states.hover
              * @excluding brightness
-             * @product   highmaps
              */
             select: {
                 animation: {

--- a/samples/unit-tests/series-venn/integration/demo.js
+++ b/samples/unit-tests/series-venn/integration/demo.js
@@ -48,3 +48,53 @@ QUnit.test('zIndex. #10490', assert => {
         'should order the point graphics by its number of sets in the relation'
     );
 });
+
+QUnit.module('Options', () => {
+    QUnit.test('states[<state>].halo', assert => {
+        const chart = Highcharts.chart('container', {
+            series: [{
+                type: 'venn'
+            }]
+        });
+        const { series: [series] } = chart;
+        const states = ['hover', 'inactive', 'normal', 'select'];
+        let { userOptions, options } = series;
+
+        // Test default behaviour
+        states.forEach(state => {
+            assert.strictEqual(
+                options.states[state].halo,
+                false,
+                `Should have states.${state}.halo equal false by default.`
+            );
+        });
+
+
+        // Update the series options
+        const halo = { size: 20 };
+        const statesOptions = states.reduce(
+            (obj, key) => {
+                obj[key] = { halo };
+                return obj;
+            },
+            {}
+        );
+        series.update({ states: statesOptions });
+        ({ userOptions, options } = series);
+
+        states.forEach(state => {
+            assert.strictEqual(
+                typeof userOptions.states[state].halo,
+                'object',
+                `Should have userOptions.states.${state}.halo type of "object".`
+            );
+        });
+        states.forEach(state => {
+            assert.strictEqual(
+                options.states[state].halo,
+                false,
+                `Should have options.states.${state}.halo ignore userOptions and equal false.`
+            );
+        });
+    });
+});


### PR DESCRIPTION
Fixed #10791, disabled halo feature in Venn series. The docs said it was supported, though it didn't work well.

---
# Description
Also removed the `product` tag for `plotOptions.series.states.select` to make it appear in the API.

# Example(s)
- [Demo of issue](https://jsfiddle.net/BlackLabel/o9z5xwfa/), hover a shape to see the appearing halo
- ~~Demo with fix applied~~ Could not provide demo ATM, github.highcharts.com did not find the branch.

# Related issue(s)
- Closes #10791 