### PR TITLE
Update jsdoc to v3.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "highcharts-documentation-generators": "github:highcharts/highcharts-documentation-generators#v0.4.2",
     "husky": "^1.3.1",
     "js-yaml": "^3.13.0",
-    "jsdoc": "^3.5.5",
+    "jsdoc": "^3.6.2",
     "karma": "^4.1.0",
     "karma-browserstack-launcher": "1.4.0",
     "karma-chrome-launcher": "^2.2.0",


### PR DESCRIPTION
Solves Node v12 compatibility issue.