### PR TITLE
bugfix/10827-tema-name-collision

### DIFF
--- a/js/indicators/dema.src.js
+++ b/js/indicators/dema.src.js
@@ -28,7 +28,7 @@ H.seriesType(
     'dema',
     'ema',
     /**
-     * Normalized average true range indicator (NATR). This series requires
+     * Double exponential moving average (DEMA) indicator. This series requires
      * `linkedTo` option to be set and should be loaded after the
      * `stock/indicators/indicators.js` and `stock/indicators/ema.js`.
      *

--- a/js/indicators/tema.src.js
+++ b/js/indicators/tema.src.js
@@ -28,7 +28,7 @@ H.seriesType(
     'tema',
     'ema',
     /**
-     * Normalized average true range indicator (NATR). This series requires
+     * Triple exponential moving average (TEMA) indicator. This series requires
      * `linkedTo` option to be set and should be loaded after the
      * `stock/indicators/indicators.js` and `stock/indicators/ema.js`.
      *
@@ -82,7 +82,7 @@ H.seriesType(
                 SMA
             );
         },
-        getPoint: function (
+        getTemaPoint: function (
             xVal,
             tripledPeriod,
             EMAlevels,
@@ -207,7 +207,7 @@ H.seriesType(
                             EMAlevels.prevLevel3,
                             SMA
                         )[1];
-                        TEMAPoint = this.getPoint(
+                        TEMAPoint = this.getTemaPoint(
                             xVal,
                             tripledPeriod,
                             EMAlevels,

--- a/js/indicators/trix.src.js
+++ b/js/indicators/trix.src.js
@@ -26,7 +26,7 @@ H.seriesType(
     'trix',
     'tema',
     /**
-     * Normalized average true range indicator (NATR). This series requires
+     * Triple exponential average (TRIX) oscillator. This series requires
      * `linkedTo` option to be set.
      *
      * Requires https://code.highcharts.com/stock/indicators/ema.js
@@ -62,7 +62,8 @@ H.seriesType(
                 }
             );
         },
-        getPoint: function (
+        // TRIX is calculated using TEMA so we just extend getTemaPoint method.
+        getTemaPoint: function (
             xVal,
             tripledPeriod,
             EMAlevels,


### PR DESCRIPTION
Fixed #10827, issues with the TEMA indicator's tooltip and boost module. Caused by a method name collision.