### PR TITLE
Fixed #10699, enable inactiveOtherPoints in venn

### DIFF
--- a/js/modules/venn.src.js
+++ b/js/modules/venn.src.js
@@ -798,6 +798,11 @@ var vennOptions = {
             return this.point.name;
         }
     },
+    /**
+     * @ignore-option
+     * @private
+     */
+    inactiveOtherPoints: true,
     marker: false,
     opacity: 0.75,
     showInLegend: false,


### PR DESCRIPTION
Fixed #10699, inactive state was configured wrongly in venn series, causing bad opacity.

---
# Example(s)
- [Demo of issue](https://jsfiddle.net/jgex9rc1/1/), hover shapes, move cursor out of chart, the opacity is applied to the whole series.
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/kxor5eb0/1/)

# Related issue(s)
- Closes #10699 