### PR TITLE
Fixed #10671, responsive spacing caused crash

### DIFF
--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -349,12 +349,12 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             credits: 'addCredits',
             title: 'setTitle',
             subtitle: 'setSubtitle'
-        }, optionsChart, updateAllAxes, updateAllSeries, newWidth, newHeight, runSetSize, itemsForRemoval = [];
+        }, optionsChart, updateAllAxes, updateAllSeries, newWidth, newHeight, runSetSize, isResponsiveOptions = options.isResponsiveOptions, itemsForRemoval = [];
         fireEvent(chart, 'update', { options: options });
         // If there are responsive rules in action, undo the responsive rules
         // before we apply the updated options and replay the responsive rules
         // on top from the chart.redraw function (#9617).
-        if (!options.isResponsiveOptions) {
+        if (!isResponsiveOptions) {
             chart.setResponsive(false, true);
         }
         options = H.cleanRecursively(options, chart.options);
@@ -392,7 +392,8 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                     chart.isDirtyBox = true;
                 }
                 // Chart setSize
-                if (chart.propsRequireReflow.indexOf(key) !== -1) {
+                if (!isResponsiveOptions &&
+                    chart.propsRequireReflow.indexOf(key) !== -1) {
                     runSetSize = true;
                 }
             });

--- a/samples/unit-tests/responsive/responsive/demo.js
+++ b/samples/unit-tests/responsive/responsive/demo.js
@@ -645,3 +645,56 @@ QUnit.test('Falsy default', assert => {
         'Legend items should be removed as per default showInLegend'
     );
 });
+
+QUnit.test('Responsive spacing options', assert => {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'pie',
+            borderWidth: 1,
+            plotBorderWidth: 1,
+            width: 600
+        },
+        series: [{
+            data: [
+                ['Apples', 40],
+                ['Oranges', 60]
+            ]
+        }],
+        responsive: {
+            rules: [{
+                condition: {
+                    minWidth: 321
+                },
+                chartOptions: {
+                    chart: {
+                        spacing: [10, 10, 25, 10]
+                    }
+                }
+            },
+            {
+                condition: {
+                    maxWidth: 320
+                },
+                chartOptions: {
+                    chart: {
+                        spacing: [18, 0, 0, 0]
+                    }
+                }
+            }]
+        }
+    });
+
+    assert.deepEqual(
+        chart.spacing,
+        [10, 10, 25, 10],
+        'The initial spacing should correpond to responsive option'
+    );
+
+    chart.setSize(300);
+
+    assert.deepEqual(
+        chart.spacing,
+        [18, 0, 0, 0],
+        'The updated spacing should correpond to responsive option'
+    );
+});

--- a/ts/parts/Dynamics.ts
+++ b/ts/parts/Dynamics.ts
@@ -547,6 +547,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             newWidth,
             newHeight,
             runSetSize,
+            isResponsiveOptions = options.isResponsiveOptions,
             itemsForRemoval = [] as Array<string>;
 
         fireEvent(chart, 'update', { options: options });
@@ -554,7 +555,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         // If there are responsive rules in action, undo the responsive rules
         // before we apply the updated options and replay the responsive rules
         // on top from the chart.redraw function (#9617).
-        if (!options.isResponsiveOptions) {
+        if (!isResponsiveOptions) {
             chart.setResponsive(false, true);
         }
 
@@ -606,7 +607,10 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                     chart.isDirtyBox = true;
                 }
                 // Chart setSize
-                if (chart.propsRequireReflow.indexOf(key) !== -1) {
+                if (
+                    !isResponsiveOptions &&
+                    chart.propsRequireReflow.indexOf(key) !== -1
+                ) {
                     runSetSize = true;
                 }
             });


### PR DESCRIPTION
Fixed #10671, a regression causing crash with responsive `chart.spacing` settings.