### PR TITLE
Fixed #10804, ignore internal series in pathfinder

### DIFF
--- a/js/parts-gantt/Pathfinder.js
+++ b/js/parts-gantt/Pathfinder.js
@@ -865,7 +865,7 @@ Pathfinder.prototype = {
         // Rebuild pathfinder connections from options
         pathfinder.connections = [];
         chart.series.forEach(function (series) {
-            if (series.visible) {
+            if (series.visible && !series.options.isInternal) {
                 series.points.forEach(function (point) {
                     var to,
                         connects = (
@@ -1006,7 +1006,7 @@ Pathfinder.prototype = {
             calculatedMargin;
 
         for (var i = 0, sLen = series.length; i < sLen; ++i) {
-            if (series[i].visible) {
+            if (series[i].visible && !series[i].options.isInternal) {
                 for (
                     var j = 0, pLen = series[i].points.length, bb, point;
                     j < pLen;


### PR DESCRIPTION
Fixed #10804, navigator affected the positions of the gantt dependencies negatively.

---
# Example(s)
- [Demo of issue](https://jsfiddle.net/BlackLabel/xcsyab72)
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/1r6aowL0/)

# Related issue(s)
- Closes #10804 