### PR TITLE
Fixed #10942, gantt progress is not redrawn after toggle

### DIFF
--- a/js/modules/xrange.src.js
+++ b/js/modules/xrange.src.js
@@ -464,13 +464,13 @@ seriesType('xrange', 'column'
 
                 // Original graphic
                 if (graphic) { // update
-                    point.graphicOriginal[verb](shapeArgs);
+                    graphic.rect[verb](shapeArgs);
                 } else {
                     point.graphic = graphic = renderer.g('point')
                         .addClass(point.getClassName())
                         .add(point.group || series.group);
 
-                    point.graphicOriginal = renderer[type](merge(shapeArgs))
+                    graphic.rect = renderer[type](merge(shapeArgs))
                         .addClass(point.getClassName())
                         .addClass('highcharts-partfill-original')
                         .add(graphic);
@@ -478,35 +478,35 @@ seriesType('xrange', 'column'
 
                 // Partial fill graphic
                 if (partShapeArgs) {
-                    if (point.graphicOverlay) {
-                        point.graphicOverlay[verb](
+                    if (graphic.partRect) {
+                        graphic.partRect[verb](
                             merge(partShapeArgs)
                         );
-                        point.clipRect[verb](
+                        graphic.partialClipRect[verb](
                             merge(clipRectArgs)
                         );
 
                     } else {
 
-                        point.clipRect = renderer.clipRect(
+                        graphic.partialClipRect = renderer.clipRect(
                             clipRectArgs.x,
                             clipRectArgs.y,
                             clipRectArgs.width,
                             clipRectArgs.height
                         );
 
-                        point.graphicOverlay = renderer[type](partShapeArgs)
+                        graphic.partRect = renderer[type](partShapeArgs)
                             .addClass('highcharts-partfill-overlay')
                             .add(graphic)
-                            .clip(point.clipRect);
+                            .clip(graphic.partialClipRect);
                     }
                 }
 
 
                 // Presentational
                 if (!series.chart.styledMode) {
-                    point
-                        .graphicOriginal[verb](
+                    graphic
+                        .rect[verb](
                             pointAttr,
                             animation
                         )
@@ -531,8 +531,8 @@ seriesType('xrange', 'column'
                         );
 
                         pointAttr.fill = fill;
-                        point
-                            .graphicOverlay[pointStateVerb](
+                        graphic
+                            .partRect[pointStateVerb](
                                 pointAttr,
                                 animation
                             )

--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -1722,6 +1722,13 @@ extend(SVGElement.prototype, /** @lends Highcharts.SVGElement.prototype */ {
             erase(renderer.alignedObjects, wrapper);
         }
         objectEach(wrapper, function (val, key) {
+            // Destroy child elements of a group
+            if (wrapper[key] &&
+                wrapper[key].parentGroup === wrapper &&
+                wrapper[key].destroy) {
+                wrapper[key].destroy();
+            }
+            // Delete all properties
             delete wrapper[key];
         });
     },

--- a/samples/unit-tests/series-xrange/xrange/demo.js
+++ b/samples/unit-tests/series-xrange/xrange/demo.js
@@ -105,13 +105,13 @@ QUnit.test('X-Range', function (assert) {
     series.points[5].setState('hover');
 
     assert.strictEqual(
-        series.points[5].graphicOriginal.attr('fill'),
+        series.points[5].graphic.rect.attr('fill'),
         '#ff0000',
         'Hover color of graphicOriginal is correct (#9880).'
     );
 
     assert.strictEqual(
-        series.points[5].graphicOverlay.attr('fill').replace(/ /g, ''),
+        series.points[5].graphic.partRect.attr('fill').replace(/ /g, ''),
         'rgb(179,0,0)',
         'Hover color of graphicOverlay (#9880).'
     );
@@ -143,7 +143,7 @@ QUnit.test('X-Range', function (assert) {
     chart.xAxis[0].setExtremes(2, null);
 
     var point = chart.series[0].points[0],
-        clipRect = point.clipRect;
+        clipRect = point.graphic.partialClipRect;
     assert.strictEqual(
         Math.floor(
             chart.xAxis[0].toValue(
@@ -156,7 +156,7 @@ QUnit.test('X-Range', function (assert) {
 
     point.select();
     assert.strictEqual(
-        point.graphicOriginal.attr('fill'),
+        point.graphic.rect.attr('fill'),
         point.series.options.states.select.color,
         'Correct fill for a point upon point selection (#8104).'
     );
@@ -197,7 +197,7 @@ QUnit.test('X-Range', function (assert) {
 
     point = chart.series[0].points[1];
     assert.close(
-        point.graphicOriginal.attr('y') + point.graphicOriginal.getBBox().height / 2,
+        point.graphic.rect.attr('y') + point.graphic.rect.getBBox().height / 2,
         chart.plotHeight,
         1,
         'The point should now be on the center of the plot area'

--- a/ts/parts/SvgRenderer.ts
+++ b/ts/parts/SvgRenderer.ts
@@ -2633,6 +2633,17 @@ extend((
         }
 
         objectEach(wrapper, function (val: unknown, key: string): void {
+
+            // Destroy child elements of a group
+            if (
+                wrapper[key] &&
+                wrapper[key].parentGroup === wrapper &&
+                wrapper[key].destroy
+            ) {
+                wrapper[key].destroy();
+            }
+
+            // Delete all properties
             delete wrapper[key];
         });
     },


### PR DESCRIPTION
Fixed #10942, progress indicator was not redrawn after collapsing and expanding nodes.