### PR TITLE
bugfix/10961-annotations-mousedown-block

### DIFF
--- a/js/annotations/eventEmitterMixin.js
+++ b/js/annotations/eventEmitterMixin.js
@@ -99,8 +99,6 @@ var eventEmitterMixin = {
             return;
         }
 
-        e.stopPropagation();
-
         e = pointer.normalize(e);
         prevChartX = e.chartX;
         prevChartY = e.chartY;

--- a/samples/unit-tests/annotations/annotations-events/demo.js
+++ b/samples/unit-tests/annotations/annotations-events/demo.js
@@ -58,10 +58,28 @@ QUnit.test('Annotations events - general', function (assert) {
             '`annotation.update()`.'
     );
 
+    var mouseDown = false,
+        unbindMouseDownEvent = Highcharts.addEvent(
+            document.getElementById('container'),
+            'mousedown',
+            function () {
+                mouseDown = true;
+            }
+        );
+
     controller.mouseDown(
         chart.plotLeft + point.plotX,
         chart.plotTop + point.plotY - 20
     );
+
+    assert.strictEqual(
+        mouseDown,
+        true,
+        'Default mouseDown event called (#10961).'
+    );
+
+    unbindMouseDownEvent();
+
     controller.mouseMove(
         chart.plotLeft + point.plotX + 50,
         chart.plotTop + point.plotY - 20


### PR DESCRIPTION
Fixed #10961, annotations used to block `mouseDown` event.