### PR TITLE
Fixed #10887, treegrid update regression

### DIFF
--- a/js/parts-gantt/TreeGrid.js
+++ b/js/parts-gantt/TreeGrid.js
@@ -491,11 +491,15 @@ var onBeforeRender = function (e) {
             // Check whether any of series is rendering for the first time,
             // visibility has changed, or its data is dirty,
             // and only then update. #10570, #10580
-            isDirty = axis.series.some(function (series) {
-                return !series.hasRendered ||
-                    series.isDirtyData ||
-                    series.isDirty;
-            });
+            // Also check if mapOfPosToGridNode exists. #10887
+            isDirty = (
+                !axis.mapOfPosToGridNode ||
+                axis.series.some(function (series) {
+                    return !series.hasRendered ||
+                        series.isDirtyData ||
+                        series.isDirty;
+                })
+            );
 
             if (isDirty) {
                 // Concatenate data from all series assigned to this axis.

--- a/samples/unit-tests/gantt/treegrid/demo.js
+++ b/samples/unit-tests/gantt/treegrid/demo.js
@@ -156,6 +156,64 @@ QUnit.test('Tree.getNode', function (assert) {
     );
 });
 
+QUnit.test('Axis.update', assert => {
+    const { getStyle } = Highcharts;
+    const { yAxis: [axis] } = Highcharts.chart('container', {
+        series: [{
+            data: [{
+                name: 'Point 1',
+                y: 1
+            }]
+        }],
+        yAxis: {
+            type: 'treegrid',
+            labels: {
+                style: {
+                    color: '#000000'
+                }
+            }
+        }
+    });
+    let { ticks: { 0: { label: { element } } } } = axis;
+
+
+    assert.deepEqual(
+        axis.tickPositions,
+        [0],
+        'Should have tickPositions equal [0] after render.'
+    );
+    assert.strictEqual(
+        getStyle(element, 'color', false),
+        'rgb(0, 0, 0)',
+        'Should have color equal rgb(0, 0, 0) after render.'
+    );
+
+
+    // Update the axis
+    axis.update({
+        labels: {
+            style: {
+                color: '#ff0000'
+            }
+        }
+    });
+
+    // Update reference to label element
+    ({ ticks: { 0: { label: { element } } } } = axis);
+
+
+    assert.deepEqual(
+        axis.tickPositions,
+        [0],
+        'Should still have tickPositions equal [0] after update.'
+    );
+    assert.strictEqual(
+        getStyle(element, 'color', false),
+        'rgb(255, 0, 0)',
+        'Should have color equal rgb(255, 0, 0) after update.'
+    );
+});
+
 QUnit.test('Chart.addSeries', assert => {
     const chart = Highcharts.chart('container', {
         yAxis: [{


### PR DESCRIPTION
Fixed #10887, regression with `Axis.update()` in Treegrid axis.

---

# Description
Regression since #10846.
The update improved performance considerably, unfortunately `isDirty` do not catch when `Axis.update` is performed and calls `Axis.destroy`, which removes all properties on the treegrid axis.

Solved by checking if `mapOfPosToGridNode` exists on the axis. Considered checking for `axis.isDirty` instead, but I found that it would likely always be `true` at this stage.

# Example(s)
- [Demo of issue](https://jsfiddle.net/BlackLabel/7q2w0m35/)
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/k7mw3vqe/)

# Related issue(s)
- Closes #10887 