### PR TITLE
Fix scripts-watch windows compatibility

### DIFF
--- a/tools/gulptasks/scripts-watch.js
+++ b/tools/gulptasks/scripts-watch.js
@@ -11,9 +11,9 @@ const gulp = require('gulp');
  * */
 
 const WATCH_GLOBS = [
-    'js/!(adapters|builds)/**/*.js',
+    'js/**/*.js',
     'ts/**/*.json',
-    'ts/!(adapters|builds)/**/*.ts'
+    'ts/**/*.ts'
 ];
 
 /* *


### PR DESCRIPTION
The globs patterns in `gulp scripts-watch` did not work for me, and it seems to be due to the `!(adapters|builds)` section.
I do not believe it is necessary to filter out adapters and builds, as these do not exists anymore, and removing this part seems to work.