### PR TITLE
bugfix/10930-datalabels-visibility-toggle

### DIFF
--- a/js/modules/overlapping-datalabels.src.js
+++ b/js/modules/overlapping-datalabels.src.js
@@ -226,6 +226,7 @@ Chart.prototype.hideOverlappingLabels = function (labels) {
                     } else {
                         complete = function () {
                             label.hide(true);
+                            label.placed = false; // avoid animation from top
                         };
                     }
 

--- a/js/modules/overlapping-datalabels.src.js
+++ b/js/modules/overlapping-datalabels.src.js
@@ -225,7 +225,7 @@ Chart.prototype.hideOverlappingLabels = function (labels) {
                         label.show(true);
                     } else {
                         complete = function () {
-                            label.hide();
+                            label.hide(true);
                         };
                     }
 

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -4828,7 +4828,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
             });
         }
         // hide or show the title depending on whether showEmpty is set
-        axis.axisTitle[display ? 'show' : 'hide'](true);
+        axis.axisTitle[display ? 'show' : 'hide'](display);
     },
     /**
      * Generates a tick for initial positioning.
@@ -5230,7 +5230,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
             });
             axisLine.isPlaced = true;
             // Show or hide the line depending on options.showEmpty
-            axisLine[showAxis ? 'show' : 'hide'](true);
+            axisLine[showAxis ? 'show' : 'hide'](showAxis);
         }
         if (axisTitle && showAxis) {
             var titleXy = axis.getTitlePosition();

--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -937,7 +937,7 @@ Series.prototype.alignDataLabel = function (point, dataLabel, options, alignTo, 
     }
     // Show or hide based on the final aligned position
     if (!visible) {
-        dataLabel.attr({ y: -9999 });
+        dataLabel.hide(true);
         dataLabel.placed = false; // don't animate back in
     }
 };

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -4255,7 +4255,7 @@ H.Series = H.seriesType(
                         if (graphic) { // update
                             // Since the marker group isn't clipped, each
                             // individual marker must be toggled
-                            graphic[isInside ? 'show' : 'hide'](true)
+                            graphic[isInside ? 'show' : 'hide'](isInside)
                                 .animate(markerAttribs);
 
                         } else if (

--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -1571,16 +1571,26 @@ extend(SVGElement.prototype, /** @lends Highcharts.SVGElement.prototype */ {
         return this.attr({ visibility: inherit ? 'inherit' : 'visible' });
     },
     /**
-     * Hide the element, equivalent to setting the `visibility` attribute to
+     * Hide the element, similar to setting the `visibility` attribute to
      * `hidden`.
      *
      * @function Highcharts.SVGElement#hide
      *
+     * @param {boolean} [hideByTranslation=false]
+     *        The flag to determine if element should be hidden by moving out
+     *        of the viewport. Used for example for dataLabels.
+     *
      * @return {Highcharts.SVGElement}
      *         Returns the SVGElement for chaining.
      */
-    hide: function () {
-        return this.attr({ visibility: 'hidden' });
+    hide: function (hideByTranslation) {
+        if (hideByTranslation) {
+            this.attr({ y: -9999 });
+        }
+        else {
+            this.attr({ visibility: 'hidden' });
+        }
+        return this;
     },
     /**
      * Fade out an element by animating its opacity down to 0, and hide it on

--- a/samples/unit-tests/3d/column-stacked-labels/demo.js
+++ b/samples/unit-tests/3d/column-stacked-labels/demo.js
@@ -19,6 +19,7 @@ QUnit.test('3D columns stackLabels render', function (assert) {
                 animation: false,
                 stacking: 'normal',
                 dataLabels: {
+                    allowOverlap: true,
                     enabled: true,
                     inside: false
                 }

--- a/samples/unit-tests/datalabels/overlapping/demo.js
+++ b/samples/unit-tests/datalabels/overlapping/demo.js
@@ -128,8 +128,8 @@ QUnit.test(
         });
 
         assert.strictEqual(
-            chart.series[0].points[0].dataLabel.visibility,
-            'hidden',
+            chart.series[0].points[0].dataLabel.attr('y') < 0,
+            true,
             'Overlapping dataLabel is hidden (#9119).'
         );
     }

--- a/samples/unit-tests/series-columnrange/datalabel/demo.js
+++ b/samples/unit-tests/series-columnrange/datalabel/demo.js
@@ -11,6 +11,7 @@ QUnit.test('Columnrange align datalabels (#3017)', function (assert) {
             dataLabels: {
                 enabled: true,
                 inside: true,
+                allowOverlap: true,
                 align: 'center'
             }
         }]

--- a/samples/unit-tests/series/datalabels/demo.js
+++ b/samples/unit-tests/series/datalabels/demo.js
@@ -233,20 +233,20 @@ QUnit.test(
         });
 
         assert.strictEqual(
-            chart.series[1].dataLabelsGroup.element.querySelectorAll(
-                'g.highcharts-label[visibility="hidden"]'
-            ).length,
-            6,
+            chart.series[1].points.every(
+                point => point.dataLabel.attr('translateY') < 0
+            ),
+            true,
             'All six labels of the second series should be hidden.'
         );
 
         chart.series[0].hide();
 
         assert.strictEqual(
-            chart.series[1].dataLabelsGroup.element.querySelectorAll(
-                'g.highcharts-label[visibility="hidden"]'
-            ).length,
-            0,
+            chart.series[1].points.every(
+                point => point.dataLabel.attr('translateY') >= 0
+            ),
+            true,
             'All six labels of the second series should be visible.'
         );
 

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -6425,7 +6425,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
         }
 
         // hide or show the title depending on whether showEmpty is set
-        axis.axisTitle[display ? 'show' : 'hide'](true);
+        axis.axisTitle[display ? 'show' : 'hide'](display);
     },
 
     /**
@@ -7027,7 +7027,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
             axisLine.isPlaced = true;
 
             // Show or hide the line depending on options.showEmpty
-            axisLine[showAxis ? 'show' : 'hide'](true);
+            axisLine[showAxis ? 'show' : 'hide'](showAxis);
         }
 
         if (axisTitle && showAxis) {

--- a/ts/parts/DataLabels.ts
+++ b/ts/parts/DataLabels.ts
@@ -1353,7 +1353,7 @@ Series.prototype.alignDataLabel = function (
 
     // Show or hide based on the final aligned position
     if (!visible) {
-        dataLabel.attr({ y: -9999 });
+        dataLabel.hide(true);
         dataLabel.placed = false; // don't animate back in
     }
 

--- a/ts/parts/SvgRenderer.ts
+++ b/ts/parts/SvgRenderer.ts
@@ -200,7 +200,7 @@ declare global {
             public getBBox(reload?: boolean, rot?: number): BBoxObject;
             public getStyle(prop: string): string;
             public hasClass(className: string): boolean;
-            public hide(): SVGElement;
+            public hide(hideByTranslation?: boolean): SVGElement;
             public init(renderer: SVGRenderer, nodeName: string): void;
             public invert(inverted: boolean): SVGElement
             public matrixSetter(value: any, key: string): void;

--- a/ts/parts/SvgRenderer.ts
+++ b/ts/parts/SvgRenderer.ts
@@ -2435,16 +2435,30 @@ extend((
     },
 
     /**
-     * Hide the element, equivalent to setting the `visibility` attribute to
+     * Hide the element, similar to setting the `visibility` attribute to
      * `hidden`.
      *
      * @function Highcharts.SVGElement#hide
      *
+     * @param {boolean} [hideByTranslation=false]
+     *        The flag to determine if element should be hidden by moving out
+     *        of the viewport. Used for example for dataLabels.
+     *
      * @return {Highcharts.SVGElement}
      *         Returns the SVGElement for chaining.
      */
-    hide: function (this: Highcharts.SVGElement): Highcharts.SVGElement {
-        return this.attr({ visibility: 'hidden' }) as any;
+    hide: function (
+        this: Highcharts.SVGElement,
+        hideByTranslation?: boolean
+    ): Highcharts.SVGElement {
+
+        if (hideByTranslation) {
+            this.attr({ y: -9999 });
+        } else {
+            this.attr({ visibility: 'hidden' });
+        }
+
+        return this as any;
     },
 
     /**


### PR DESCRIPTION
Fixed #10930, sometimes data labels were not visible after zooming.
___

TS note (@bre):
I might be missing something, I have this error:

> ts/parts/DataLabels.ts(1356,24): error TS2554: Expected 0 arguments, but got 1.

But I have added this: https://github.com/highcharts/highcharts/compare/bugfix/10930-datalabels-visibility-toggle?expand=1#diff-eaca87a6f0fc86b8d82591529cab6728R2452

Should I run some other task, not only `npx gulp scripts-ts` ? Did I make some silly mistake perhaps? :)


@TorsteinHonsi 
One of the issues that can be resolved in many ways. Alternative solutions (and why I decided to choose this one):

- overwrite `dataLabels.hide = function () { ... };` instead of polluting `hide(..args)`, but that would require creating function for every label (prototyped function vs assigned function) - performance issue (I don't think we want to decrease performance for dataLabels any bit more). Additionally this may cause issues with extending library/workarounding issues (no way to use `wrap()` on SVGElement, as later it will be overwritten).

- replace `label.hide()`/`label.show()` in overlapping's algorithm with `attr({ y: -9999 })`, again no polluting `hide(..args)` but it's easy to forget that `dataLabel.show()`/`dataLabel.hide()` shouldn't be used - maintenance issue.

Pros of the PR'ed solution - I have fixed some minor issues with `hide(true)` that were called with an argument indirectly, e.g. `axisLine[showAxis ? 'show' : 'hide'](true);` - `hide(true)` used to make no sense. Note that TS didn't comply about extra arg in this particular case.