### PR TITLE
tools/update-documentation-generators

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "gzip-size": "^5.0.0",
     "highcharts-assembler": "github:highcharts/highcharts-assembler#v1.3.4",
     "highcharts-declarations-generator": "github:highcharts/highcharts-declarations-generator#v1.1.10",
-    "highcharts-documentation-generators": "github:highcharts/highcharts-documentation-generators#v0.4.2",
+    "highcharts-documentation-generators": "github:highcharts/highcharts-documentation-generators#v0.4.3",
     "husky": "^1.3.1",
     "js-yaml": "^3.13.0",
     "jsdoc": "^3.6.2",


### PR DESCRIPTION
Updated documentation generator dependency to get complex types in the 'see also' lists.