### PR TITLE
bugfix/10987-pareto-didnt-refresh-after-update

### DIFF
--- a/js/modules/pareto.src.js
+++ b/js/modules/pareto.src.js
@@ -64,16 +64,14 @@ seriesType('pareto', 'line'
          *         Returns array of points [x,y]
          */
         setDerivedData: function () {
-            if (this.baseSeries.yData.length > 1) {
-                var xValues = this.baseSeries.xData,
-                    yValues = this.baseSeries.yData,
-                    sum = this.sumPointsPercents(yValues, xValues, null, true);
+            var xValues = this.baseSeries.xData,
+                yValues = this.baseSeries.yData,
+                sum = this.sumPointsPercents(yValues, xValues, null, true);
 
-                this.setData(
-                    this.sumPointsPercents(yValues, xValues, sum, false),
-                    false
-                );
-            }
+            this.setData(
+                this.sumPointsPercents(yValues, xValues, sum, false),
+                false
+            );
         },
         /**
          * Calculate y sum and each percent point.

--- a/samples/unit-tests/series-pareto/pareto/demo.js
+++ b/samples/unit-tests/series-pareto/pareto/demo.js
@@ -110,3 +110,26 @@ QUnit.test('Pareto wasnt working with baseSeries set to 0 - #10471', function (a
         'Number of points in pareto series should be equal amount of point in assigned series'
     );
 });
+
+QUnit.test('Pareto was not refreshing the data, when baseSeries data was updated with less than two points.', function (assert) {
+    var chart = Highcharts.chart('container', {
+        series: [{
+            type: "pareto",
+            baseSeries: 'col'
+        },
+        {
+            type: "column",
+            id: 'col',
+            data: [1, 2, 3]
+        }
+        ]
+    });
+
+    chart.series[1].setData([1]);
+
+    assert.strictEqual(
+        chart.series[0].points.length,
+        chart.series[1].points.length,
+        "Pareto have the same amount of points like its baseSeries after update."
+    );
+});

--- a/samples/unit-tests/series-pareto/pareto/demo.js
+++ b/samples/unit-tests/series-pareto/pareto/demo.js
@@ -111,7 +111,7 @@ QUnit.test('Pareto wasnt working with baseSeries set to 0 - #10471', function (a
     );
 });
 
-QUnit.test('Pareto was not refreshing the data, when baseSeries data was updated with less than two points.', function (assert) {
+QUnit.test('Pareto did not refreshing the data, when baseSeries data was updated with less than two points.', function (assert) {
     var chart = Highcharts.chart('container', {
         series: [{
             type: "pareto",


### PR DESCRIPTION
Fixed #10987, pareto series didn't refresh after updating `baseSeries` data with less than two points.