### PR TITLE
 docs/10983-networgraph-weight

### DIFF
--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -1141,14 +1141,6 @@ seriesType(
  */
 
 /**
- * The weight of the link.
- *
- * @type      {number}
- * @product   highcharts
- * @apioption series.networkgraph.data.weight
- */
-
-/**
  * A collection of options for the individual nodes. The nodes in a
  * networkgraph diagram are auto-generated instances of `Highcharts.Point`,
  * but options can be applied here and linked by the `id`.


### PR DESCRIPTION
Fixed #10983, removed networkgraph weight docs. There's no such option for a link in networkgraph. 