### PR TITLE
bugfix/10993-points-visible-outside-of-extremes

### DIFF
--- a/js/modules/timeline.src.js
+++ b/js/modules/timeline.src.js
@@ -194,10 +194,10 @@ seriesType('timeline', 'line',
                     closestPointRangePx = Number.MAX_VALUE;
 
                 series.points.forEach(function (point) {
-                    // Set the isInside parameter basing on the real point
+                    // Set the isInside parameter basing also on the real point
                     // visibility, in order to avoid showing hidden points
                     // in drawPoints method.
-                    point.isInside = point.visible;
+                    point.isInside = point.isInside && point.visible;
 
                     // New way of calculating closestPointRangePx value, which
                     // respects the real point visibility is needed.

--- a/samples/unit-tests/series-timeline/datetime-axis/demo.js
+++ b/samples/unit-tests/series-timeline/datetime-axis/demo.js
@@ -202,4 +202,17 @@ QUnit.test('Timeline: General tests.', function (assert) {
         connector.opacity,
         "Connector is visible together with data label, after setting extremes."
     );
+
+    chart.update({
+        chart: {
+            marginLeft: 100
+        }
+    });
+
+    chart.xAxis[0].setExtremes(Date.UTC(1959, 3, 1), Date.UTC(1961, 0, 4));
+    assert.strictEqual(
+        timeline.points[2].isInside,
+        false,
+        "The third point is hidden, when it's outside of plot area."
+    );
 });


### PR DESCRIPTION
Fixed #10993, Timeline: points were visible outside the axis extremes.