### PR TITLE
tools/fix-single-test

### DIFF
--- a/tools/gulptasks/test.js
+++ b/tools/gulptasks/test.js
@@ -301,7 +301,7 @@ Available arguments for 'gulp test':
         checkSamplesConsistency();
         checkJSWrap();
 
-        const forceRun = (argv.force || argv.length > 2);
+        const forceRun = !!(argv.browsers || argv.force || argv.tests);
 
         if (forceRun || shouldRun()) {
 


### PR DESCRIPTION
Restored forced testing when single tests explicit given.