### PR TITLE
bugfix/10984-networkgraph-data-module

### DIFF
--- a/js/modules/data.src.js
+++ b/js/modules/data.src.js
@@ -91,6 +91,7 @@ var addEvent = Highcharts.addEvent,
     Chart = Highcharts.Chart,
     win = Highcharts.win,
     doc = win.document,
+    defined = Highcharts.defined,
     objectEach = Highcharts.objectEach,
     pick = Highcharts.pick,
     isNumber = Highcharts.isNumber,
@@ -677,12 +678,24 @@ Highcharts.extend(Data.prototype, {
                     getValueCount(globalType),
                 seriesArr = (chartOptions && chartOptions.series) || [],
                 series = seriesArr[seriesIndex] || {},
-                pointArrayMap = getPointArrayMap(series.type || globalType) ||
-                    ['y'];
+                defaultPointArrayMap = getPointArrayMap(
+                    series.type || globalType
+                ),
+                pointArrayMap = defaultPointArrayMap || ['y'];
 
-            // Add an x reader from the x property or from an undefined column
-            // if the property is not set. It will then be auto populated later.
-            builder.addColumnReader(mapping.x, 'x');
+            if (
+                // User-defined x.mapping
+                defined(mapping.x) ||
+                // All non cartesian don't need 'x'
+                series.isCartesian ||
+                // Except pie series:
+                !defaultPointArrayMap
+            ) {
+                // Add an x reader from the x property or from an undefined
+                // column if the property is not set. It will then be auto
+                // populated later.
+                builder.addColumnReader(mapping.x, 'x');
+            }
 
             // Add all column mappings
             objectEach(mapping, function (val, name) {

--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -454,6 +454,7 @@ seriesType(
         requireSorting: false,
         directTouch: true,
         noSharedTooltip: true,
+        pointArrayMap: ['from', 'to'],
         trackerGroups: ['group', 'markerGroup', 'dataLabelsGroup'],
         drawTracker: H.TrackerMixin.drawTrackerPoint,
         // Animation is run in `series.simulation`.

--- a/js/modules/sankey.src.js
+++ b/js/modules/sankey.src.js
@@ -382,6 +382,7 @@ seriesType('sankey', 'column',
         invertable: true,
         forceDL: true,
         orderNodes: true,
+        pointArrayMap: ['from', 'to'],
         // Create a single node that holds information on incoming and outgoing
         // links.
         createNode: H.NodesMixin.createNode,

--- a/samples/unit-tests/data/general/demo.html
+++ b/samples/unit-tests/data/general/demo.html
@@ -1,5 +1,7 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
+<script src="https://code.highcharts.com/modules/sankey.js"></script>
+<script src="https://code.highcharts.com/modules/networkgraph.js"></script>
 <script src="https://code.highcharts.com/modules/data.js"></script>
 <script src="https://code.highcharts.com/modules/exporting.js"></script>
 

--- a/samples/unit-tests/data/general/demo.js
+++ b/samples/unit-tests/data/general/demo.js
@@ -59,4 +59,36 @@ QUnit.test('Combination charts and column mapping', function (assert) {
         ['column', 'errorbar', 'line', 'errorbar'],
         'Alternating series types should eat different numbers of columns (#8438)'
     );
+
+    chart = Highcharts.chart('container', {
+        data: {
+            csv: [
+                'From,To,Weight,From,To',
+                'A,B,1,A,B',
+                'A,C,1,A,C',
+                'A,D,1,B,C'
+            ].join('\n'),
+            seriesMapping: [{
+                from: 0,
+                to: 1,
+                weight: 2
+            }, {
+                from: 3,
+                to: 4
+            }]
+        },
+        series: [{
+            type: 'sankey'
+        }, {
+            type: 'networkgraph'
+        }]
+    });
+
+    assert.deepEqual(
+        chart.series.map(function (s) {
+            return s.data.length;
+        }),
+        [3, 3],
+        'Non-cartesian series should pick columns without X-column (#10984)'
+    );
 });


### PR DESCRIPTION
Fixed #10984, networkgraph series did not render when loading data from CSV.
___
Actually this is a general issue for series that don't define `x` value at all. PR includes also fixes for sankey and dependency wheel series. Not only `pointArrayMap` is required for series, but also we shouldn't add `x` mapping - if we do that, then number of columns won't match mappings and series will not be rendered at all.

I'm not sure about a fix for venn diagrams (another non-cartesian series) - can we somehow define this `sets` in CSV? See:
```js
        data: [{
            sets: ['Good'],
            value: 2
        }, {
            sets: ['Fast'],
            value: 2
        }, {
            sets: ['Cheap'],
            value: 2
        }, {
            sets: ['Fast', 'Cheap', 'Good'],
            value: 1,
            name: 'They\'re dreaming'
        }]
``` 
I couldn't find an example, so I did not test it.