### PR TITLE
bugfix/10941-stacking-null-x

### DIFF
--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -3832,7 +3832,6 @@ H.Series = H.seriesType(
                 if (
                     stacking &&
                     series.visible &&
-                    !point.isNull &&
                     stack &&
                     stack[xValue]
                 ) {
@@ -3841,8 +3840,11 @@ H.Series = H.seriesType(
                         xValue,
                         series.index
                     );
-                    pointStack = stack[xValue];
-                    stackValues = pointStack.points[stackIndicator.key];
+
+                    if (!point.isNull) {
+                        pointStack = stack[xValue];
+                        stackValues = pointStack.points[stackIndicator.key];
+                    }
                 }
 
                 if (isArray(stackValues)) {

--- a/samples/unit-tests/series/stacking/demo.js
+++ b/samples/unit-tests/series/stacking/demo.js
@@ -252,6 +252,19 @@ QUnit.test('Updating to null value (#7493)', function (assert) {
 
     assert.ok(true, 'Stacking the same column series with null values (#10160)');
 
+    chart.series[1].setData([
+        [0, null],
+        [0, 1],
+        [0, 1]
+    ]);
+
+    assert.strictEqual(
+        chart.series[1].points[1].shapeArgs.y,
+        chart.series[1].points[2].shapeArgs.y +
+            chart.series[1].points[2].shapeArgs.height,
+        'Stacking the same points starting from null value' +
+            'should not overlap other points (#10941)'
+    );
 });
 
 QUnit.test("StackLabels position with multiple yAxis (#7798)", function (assert) {


### PR DESCRIPTION
Fixed #10941, null points with the same x-value in stacking were causing wrong offset for other points.
___
Note: That was a general issue, not only for column series.