### PR TITLE
Fixed #10498, wrong chart width if parent had transform style

### DIFF
--- a/samples/unit-tests/chart/container-size/demo.js
+++ b/samples/unit-tests/chart/container-size/demo.js
@@ -70,13 +70,18 @@ QUnit.test('10px height (#6217)', function (assert) {
     }
 });
 
-QUnit.test('Transform (#9871)', assert => {
-    const container = document.createElement('div');
-    container.style.transform = 'scale(0.7)';
-    container.style.width = '400px';
-    document.getElementById('container').appendChild(container);
+QUnit.test('Transformed container parents', assert => {
+    const container1 = document.createElement('div');
+    container1.style.transform = 'scale(0.7)';
+    container1.style.width = '400px';
+    document.getElementById('container').appendChild(container1);
 
-    const chart = Highcharts.chart(container, {
+    const container2 = document.createElement('div');
+    container2.style.transform = 'scale(0.7)';
+    container2.style.width = '400px';
+    container1.appendChild(container2);
+
+    const chart = Highcharts.chart(container2, {
         series: [{
             data: [1, 3, 2, 4]
         }]
@@ -86,10 +91,11 @@ QUnit.test('Transform (#9871)', assert => {
         assert.strictEqual(
             chart.chartWidth,
             400,
-            "Transforms shouln't confuse the chart sizing"
+            "Transforms shouln't confuse the chart sizing (#9871, #10498)"
         );
     } finally {
         chart.destroy();
-        container.parentNode.removeChild(container);
+        container2.parentNode.removeChild(container2);
+        container1.parentNode.removeChild(container1);
     }
 });

--- a/ts/parts/Utilities.ts
+++ b/ts/parts/Utilities.ts
@@ -2366,21 +2366,27 @@ H.getStyle = function (
 
     // For width and height, return the actual inner pixel size (#4913)
     if (prop === 'width') {
+
+        let offsetWidth = Math.min(el.offsetWidth, el.scrollWidth);
+
+        // In flex boxes, we need to use getBoundingClientRect and floor it,
+        // because scrollWidth doesn't support subpixel precision (#6427) ...
+        const boundingClientRectWidth = el.getBoundingClientRect &&
+            el.getBoundingClientRect().width;
+        // ...unless if the containing div or its parents are transform-scaled
+        // down, in which case the boundingClientRect can't be used as it is
+        // also scaled down (#9871, #10498).
+        if (
+            boundingClientRectWidth < offsetWidth &&
+            boundingClientRectWidth >= offsetWidth - 1
+        ) {
+            offsetWidth = Math.floor(boundingClientRectWidth);
+        }
+
         return Math.max(
             0, // #8377
             (
-                Math.min(
-                    el.offsetWidth,
-                    el.scrollWidth,
-                    (
-                        el.getBoundingClientRect &&
-                        // #9871, getBoundingClientRect doesn't handle
-                        // transforms, so avoid that
-                        H.getStyle(el, 'transform', false) as any === 'none'
-                    ) ?
-                        Math.floor(el.getBoundingClientRect().width) : // #6427
-                        Infinity
-                ) -
+                offsetWidth -
                 (H as any).getStyle(el, 'padding-left') -
                 (H as any).getStyle(el, 'padding-right')
             )


### PR DESCRIPTION
Fixed #10498, a regression causing wrong chart width if a parent had transform style.