### PR TITLE
Fixed #10518, single orientation in Wordcloud crash render

### DIFF
--- a/js/modules/wordcloud.src.js
+++ b/js/modules/wordcloud.src.js
@@ -380,12 +380,12 @@ function getRotation(orientations, index, from, to) {
         isNumber(index) &&
         isNumber(from) &&
         isNumber(to) &&
-        orientations > -1 &&
+        orientations > 0 &&
         index > -1 &&
         to > from
     ) {
         range = to - from;
-        intervals = range / (orientations - 1);
+        intervals = range / (orientations - 1 || 1);
         orientation = index % orientations;
         result = from + (orientation * intervals);
     }
@@ -667,7 +667,7 @@ var wordCloudOptions = {
         from: 0,
         /**
          * The number of possible orientations for a word, within the range of
-         * `rotation.from` and `rotation.to`.
+         * `rotation.from` and `rotation.to`. Must be a number larger than 0.
          */
         orientations: 2,
         /**

--- a/samples/unit-tests/series-wordcloud/members/demo.js
+++ b/samples/unit-tests/series-wordcloud/members/demo.js
@@ -105,7 +105,7 @@ QUnit.test('getRotation', function (assert) {
     assert.strictEqual(
         getRotation(-1, 2, -60, 60),
         false,
-        'should return false if orientations is negative.'
+        'should return false if orientations is zero or negative.'
     );
     assert.strictEqual(
         getRotation(3, undefined, -60, 60),
@@ -146,6 +146,11 @@ QUnit.test('getRotation', function (assert) {
         getRotation(3, 2, -60, 60),
         60,
         'should return 60 which is the 3rd of 3 orientations between -60 to 60.'
+    );
+    assert.strictEqual(
+        getRotation(1, 0, 0, 90),
+        0,
+        'should return from when orientations equal 1. #10518'
     );
 });
 


### PR DESCRIPTION
Fixed #10518, `rotation.orientations = 1` in wordcloud series resulted in rotation `NaN`, which made the SVG rendering of the word crash.

---
# Example(s)
- [Demo of issue](https://jsfiddle.net/kzoon/6vjrcn4k/)
- [Demo with fix applied](https://jsfiddle.net/jon_a_nygaard/gu2rtq91/)

# Related issue(s)
- Closes #10518 