### PR TITLE
Tools: Changed CI deploy context to highcharts-prod.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ workflows:
       - deploy:
           requires:
             - build_dist
-          context: core-developers
+          context: highcharts-prod
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
The highcharts-prod context still points to a staging-bucket, so it yet remains to actually configure/enable CI deploy to production.