### PR TITLE
Fixed #10861, a regression with series events and update

### DIFF
--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -960,6 +960,7 @@ extend(Series.prototype, /** @lends Series.prototype */ {
             'dataLabelsGroup',
             'transformGroup'
         ], preserve = [
+            'eventOptions',
             'navigatorSeries',
             'baseSeries'
         ], 

--- a/samples/unit-tests/chart/chart-update-series/demo.js
+++ b/samples/unit-tests/chart/chart-update-series/demo.js
@@ -154,3 +154,83 @@ QUnit.test('Updating series with indexes', function (assert) {
         'The updated chart should have three series (#9226)'
     );
 });
+
+QUnit.test('Chart.update and series events (#11088)', assert => {
+    const counters = {
+        initial: 0,
+        updated: 0,
+        updated2: 0
+    };
+    const chart =  Highcharts.chart('container', {
+        chart: {
+            width: 400,
+            height: 300
+        },
+        series: [{
+            type: 'column',
+            data: [3, 2, 1]
+        }],
+        plotOptions: {
+            series: {
+                events: {
+                    click: () => counters.initial++
+                }
+            }
+        }
+    });
+    let controller = new TestController(chart);
+    controller.moveTo(100, 120);
+    controller.click(100, 120, undefined, true);
+
+    assert.strictEqual(
+        counters.initial,
+        1,
+        'Initial click handler should fire'
+    );
+
+    chart.update({
+        plotOptions: {
+            series: {
+                events: {
+                    click: () => counters.updated++
+                }
+            }
+        }
+    });
+
+    controller = new TestController(chart);
+    controller.moveTo(100, 130);
+    controller.click(100, 130, undefined, true);
+
+    assert.strictEqual(
+        counters.initial,
+        1,
+        'Initial click handler should not fire'
+    );
+    assert.strictEqual(
+        counters.updated,
+        1,
+        'Updated click handler should fire'
+    );
+
+    chart.series[0].update({
+        pointStart: 2019,
+        events: {
+            click: () => counters.updated2++
+        }
+    });
+
+    controller.moveTo(100, 140);
+    controller.click(100, 140, undefined, true);
+    assert.strictEqual(
+        counters.updated,
+        1,
+        'With new points, updated click handler should not fire'
+    );
+    assert.strictEqual(
+        counters.updated2,
+        1,
+        'With new points, updated click handler should fire'
+    );
+
+});

--- a/samples/unit-tests/series/update/demo.js
+++ b/samples/unit-tests/series/update/demo.js
@@ -320,6 +320,7 @@ QUnit.test('Series.update and mouse interaction', function (assert) {
 QUnit.test('Series.update and events', assert => {
     const clicks = {
         option: 0,
+        updatedOption: 0,
         added: 0
     };
     let updated = false;
@@ -387,6 +388,29 @@ QUnit.test('Series.update and events', assert => {
     assert.ok(
         updated,
         'The afterUpdate handler has run'
+    );
+
+
+    chart.series[0].update({
+        events: {
+            click: () => clicks.updatedOption++
+        }
+    });
+
+    // Bug in test-controller? The second click won't fire
+    const controller2 = new TestController(chart);
+    controller2.moveTo(100, 130);
+    controller2.click(100, 130, undefined, true);
+
+    assert.strictEqual(
+        clicks.option,
+        2,
+        'The old click event option should be inactive'
+    );
+    assert.strictEqual(
+        clicks.updatedOption,
+        1,
+        'The new click event option should take over'
     );
 });
 

--- a/ts/parts/Dynamics.ts
+++ b/ts/parts/Dynamics.ts
@@ -1345,6 +1345,7 @@ extend(Series.prototype, /** @lends Series.prototype */ {
                 'transformGroup'
             ],
             preserve = [
+                'eventOptions',
                 'navigatorSeries',
                 'baseSeries'
             ],


### PR DESCRIPTION
Fixed #10861, a regression causing event handlers to pile up when running `Chart.update` or `Series.update` with new `events` options.