### PR TITLE
Added Windows High Contrast Mode capabilities. Closes #7424.

### DIFF
--- a/js/modules/accessibility/accessibility.js
+++ b/js/modules/accessibility/accessibility.js
@@ -47,6 +47,8 @@ import ZoomComponent from './components/ZoomComponent.js';
 import RangeSelectorComponent from './components/RangeSelectorComponent.js';
 import InfoRegionComponent from './components/InfoRegionComponent.js';
 import ContainerComponent from './components/ContainerComponent.js';
+import whcm from './high-contrast-mode.js';
+import highContrastTheme from './high-contrast-theme.js';
 import defaultOptions from './options.js';
 import '../../modules/accessibility/a11y-i18n.js';
 
@@ -59,7 +61,11 @@ var addEvent = H.addEvent,
 
 
 // Add default options
-merge(true, H.defaultOptions, defaultOptions);
+merge(true, H.defaultOptions, defaultOptions, {
+    accessibility: {
+        highContrastTheme: highContrastTheme
+    }
+});
 
 // Expose classes on Highcharts namespace
 H.KeyboardNavigationHandler = KeyboardNavigationHandler;
@@ -264,10 +270,11 @@ Accessibility.prototype = {
      */
     update: function () {
         var components = this.components,
-            a11yOptions = this.chart.options.accessibility;
+            chart = this.chart,
+            a11yOptions = chart.options.accessibility;
 
         // Update the chart type list as this is used by multiple modules
-        this.chart.types = this.getChartTypes();
+        chart.types = this.getChartTypes();
 
         // Update markup
         Object.keys(components).forEach(function (componentName) {
@@ -278,6 +285,14 @@ Accessibility.prototype = {
         this.keyboardNavigation.update(
             a11yOptions.keyboardNavigation.order
         );
+
+        // Handle high contrast mode
+        if (
+            !chart.highContrastModeActive && // Only do this once
+            whcm.isHighContrastModeActive(chart)
+        ) {
+            whcm.setHighContrastTheme(chart);
+        }
     },
 
 

--- a/js/modules/accessibility/high-contrast-mode.js
+++ b/js/modules/accessibility/high-contrast-mode.js
@@ -1,0 +1,98 @@
+/* *
+ *
+ *  (c) 2009-2019 Øystein Moseng
+ *
+ *  Handling for Windows High Contrast Mode.
+ *
+ *  License: www.highcharts.com/license
+ *
+ * */
+
+'use strict';
+
+import H from '../../parts/Globals.js';
+
+var isMS = H.isMS,
+    win = H.win,
+    doc = win.document;
+
+var whcm = {
+
+    /**
+     * Detect WHCM in the browser.
+     *
+     * @function Highcharts#isHighContrastModeActive
+     * @private
+     * @return {boolean} Returns true if the browser is in High Contrast mode.
+     */
+    isHighContrastModeActive: function () {
+        if (
+            win.matchMedia &&
+            isMS &&
+            /Edge\/\d./i.test(win.navigator.userAgent)
+        ) {
+            // Use media query for Edge
+            return win.matchMedia('(-ms-high-contrast: active)').matches;
+        }
+        if (isMS && win.getComputedStyle) {
+            // Test BG image for IE
+            var testDiv = doc.createElement('div');
+            testDiv.style.backgroundImage = 'url(#)';
+            doc.body.appendChild(testDiv);
+            var bi = (
+                testDiv.currentStyle || win.getComputedStyle(testDiv)
+            ).backgroundImage;
+            doc.body.removeChild(testDiv);
+            return bi === 'none';
+        }
+        // Not used for other browsers
+        return false;
+    },
+
+    /**
+     * Force high contrast theme for the chart. The default theme is defined in
+     * a separate file.
+     *
+     * @function Highcharts#setHighContrastTheme
+     * @private
+     * @param {Highcharts.Chart} chart The chart to set the theme of.
+     */
+    setHighContrastTheme: function (chart) {
+        // We might want to add additional functionality here in the future for
+        // storing the old state so that we can reset the theme if HC mode is
+        // disabled. For now, the user will have to reload the page.
+
+        chart.highContrastModeActive = true;
+
+        // Apply theme to chart
+        var theme = chart.options.accessibility.highContrastTheme;
+        chart.update(theme, false);
+
+        // Force series colors (plotOptions is not enough)
+        chart.series.forEach(function (s) {
+            var plotOpts = theme.plotOptions[s.type] || {};
+            s.update({
+                color: plotOpts.color || 'windowText',
+                colors: [plotOpts.color || 'windowText'],
+                borderColor: plotOpts.borderColor || 'window'
+            });
+
+            // Force point colors if existing
+            s.points.forEach(function (p) {
+                if (p.options && p.options.color) {
+                    p.update({
+                        color: plotOpts.color || 'windowText',
+                        borderColor: plotOpts.borderColor || 'window'
+                    }, false);
+                }
+            });
+        });
+
+        // The redraw for each series and after is required for 3D pie
+        // (workaround)
+        chart.redraw();
+    }
+
+};
+
+export default whcm;

--- a/js/modules/accessibility/high-contrast-theme.js
+++ b/js/modules/accessibility/high-contrast-theme.js
@@ -1,0 +1,212 @@
+/* *
+ *
+ *  (c) 2009-2019 Øystein Moseng
+ *
+ *  Default theme for Windows High Contrast Mode.
+ *
+ *  License: www.highcharts.com/license
+ *
+ * */
+
+'use strict';
+
+var theme = {
+    chart: {
+        backgroundColor: 'window'
+    },
+    title: {
+        style: {
+            color: 'windowText'
+        }
+    },
+    subtitle: {
+        style: {
+            color: 'windowText'
+        }
+    },
+    colorAxis: {
+        minColor: 'windowText',
+        maxColor: 'windowText',
+        stops: null
+    },
+    colors: ['windowText'],
+    xAxis: {
+        gridLineColor: 'windowText',
+        labels: {
+            style: {
+                color: 'windowText'
+            }
+        },
+        lineColor: 'windowText',
+        minorGridLineColor: 'windowText',
+        tickColor: 'windowText',
+        title: {
+            style: {
+                color: 'windowText'
+            }
+        }
+    },
+    yAxis: {
+        gridLineColor: 'windowText',
+        labels: {
+            style: {
+                color: 'windowText'
+            }
+        },
+        lineColor: 'windowText',
+        minorGridLineColor: 'windowText',
+        tickColor: 'windowText',
+        title: {
+            style: {
+                color: 'windowText'
+            }
+        }
+    },
+    tooltip: {
+        backgroundColor: 'window',
+        borderColor: 'windowText',
+        style: {
+            color: 'windowText'
+        }
+    },
+    plotOptions: {
+        series: {
+            lineColor: 'windowText',
+            fillColor: 'window',
+            borderColor: 'windowText',
+            edgeColor: 'windowText',
+            borderWidth: 1,
+            dataLabels: {
+                connectorColor: 'windowText',
+                color: 'windowText',
+                style: {
+                    color: 'windowText',
+                    textOutline: 'none'
+                }
+            },
+            marker: {
+                lineColor: 'windowText',
+                fillColor: 'windowText'
+            }
+        },
+        pie: {
+            color: 'window',
+            colors: ['window'],
+            borderColor: 'windowText',
+            borderWidth: 1
+        },
+        boxplot: {
+            fillColor: 'window'
+        },
+        candlestick: {
+            lineColor: 'windowText',
+            fillColor: 'window'
+        },
+        errorbar: {
+            fillColor: 'window'
+        }
+    },
+    legend: {
+        backgroundColor: 'window',
+        itemStyle: {
+            color: 'windowText'
+        },
+        itemHoverStyle: {
+            color: 'windowText'
+        },
+        itemHiddenStyle: {
+            color: '#555'
+        },
+        title: {
+            style: {
+                color: 'windowText'
+            }
+        }
+    },
+    credits: {
+        style: {
+            color: 'windowText'
+        }
+    },
+    labels: {
+        style: {
+            color: 'windowText'
+        }
+    },
+    drilldown: {
+        activeAxisLabelStyle: {
+            color: 'windowText'
+        },
+        activeDataLabelStyle: {
+            color: 'windowText'
+        }
+    },
+    navigation: {
+        buttonOptions: {
+            symbolStroke: 'windowText',
+            theme: {
+                fill: 'window'
+            }
+        }
+    },
+    rangeSelector: {
+        buttonTheme: {
+            fill: 'window',
+            stroke: 'windowText',
+            style: {
+                color: 'windowText'
+            },
+            states: {
+                hover: {
+                    fill: 'window',
+                    stroke: 'windowText',
+                    style: {
+                        color: 'windowText'
+                    }
+                },
+                select: {
+                    fill: '#444',
+                    stroke: 'windowText',
+                    style: {
+                        color: 'windowText'
+                    }
+                }
+            }
+        },
+        inputBoxBorderColor: 'windowText',
+        inputStyle: {
+            backgroundColor: 'window',
+            color: 'windowText'
+        },
+        labelStyle: {
+            color: 'windowText'
+        }
+    },
+    navigator: {
+        handles: {
+            backgroundColor: 'window',
+            borderColor: 'windowText'
+        },
+        outlineColor: 'windowText',
+        maskFill: 'transparent',
+        series: {
+            color: 'windowText',
+            lineColor: 'windowText'
+        },
+        xAxis: {
+            gridLineColor: 'windowText'
+        }
+    },
+    scrollbar: {
+        barBackgroundColor: '#444',
+        barBorderColor: 'windowText',
+        buttonArrowColor: 'windowText',
+        buttonBackgroundColor: 'window',
+        buttonBorderColor: 'windowText',
+        rifleColor: 'windowText',
+        trackBackgroundColor: 'window',
+        trackBorderColor: 'windowText'
+    }
+};
+
+export default theme;

--- a/js/modules/accessibility/options.js
+++ b/js/modules/accessibility/options.js
@@ -122,6 +122,15 @@ var options = {
          */
 
         /**
+         * Theme to apply to the chart when Windows High Contrast Mode is
+         * detected.
+         *
+         * @since next
+         * @type {object}
+         * @apioption accessibility.highContrastTheme
+         */
+
+        /**
          * A text description of the chart.
          *
          * If the Accessibility module is loaded, this is included by default


### PR DESCRIPTION
Added support for Windows High Contrast Mode.
___
A set of styling options are automatically set using chart/series/point update when WHCM is detected. The options automatically match the OS theme, but can be overridden with the new `accessibility.highContrastTheme` option.