### PR TITLE
Feature/subtitle bottom

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -762,7 +762,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                 // Skip the cache for HTML (#3481)
                 height = title.getBBox(titleOptions.useHTML).height;
                 title.align(extend({
-                    y: bottomAlign ? 0 : offset + titleSize,
+                    y: bottomAlign ? titleSize : offset + titleSize,
                     height: height
                 }, titleOptions), false, 'spacingBox');
                 if (!titleOptions.floating && !titleOptions.verticalAlign) {
@@ -1033,8 +1033,9 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         if (titleOffset && !defined(margin[0])) {
             this.plotTop = Math.max(this.plotTop, titleOffset + this.options.title.margin + spacing[0]);
         }
-        if (titleOffsetBottom && !margin[2]) {
-            this.marginBottom += titleOffsetBottom;
+        if (titleOffsetBottom && !defined(margin[2])) {
+            this.marginBottom = Math.max(this.marginBottom, titleOffsetBottom + this.options.title.margin +
+                spacing[2]);
         }
         // Adjust for legend
         if (this.legend && this.legend.display) {

--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -742,12 +742,12 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      * @return {void}
      */
     layOutTitles: function (redraw) {
-        var titleOffset = 0, titleOffsetBottom = 0, requiresDirtyBox, renderer = this.renderer, spacingBox = this.spacingBox;
+        var titleOffset = [0, 0, 0], requiresDirtyBox, renderer = this.renderer, spacingBox = this.spacingBox;
         // Lay out the title and the subtitle respectively
         ['title', 'subtitle'].forEach(function (key) {
             var title = this[key], titleOptions = this.options[key], offset = key === 'title' ? -3 :
                 // Floating subtitle (#6574)
-                titleOptions.verticalAlign ? 0 : titleOffset + 2, bottomAlign = (key === 'subtitle' &&
+                titleOptions.verticalAlign ? 0 : titleOffset[0] + 2, bottomAlign = (key === 'subtitle' &&
                 titleOptions.verticalAlign === 'bottom'), titleSize, height;
             if (title) {
                 if (!this.styledMode) {
@@ -766,20 +766,19 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                     height: height
                 }, titleOptions), false, 'spacingBox');
                 if (!titleOptions.floating && !titleOptions.verticalAlign) {
-                    titleOffset = Math.ceil(titleOffset +
+                    titleOffset[0] = Math.ceil(titleOffset[0] +
                         height);
                 }
                 if (key === 'subtitle' &&
                     titleOptions.verticalAlign === 'bottom') {
-                    titleOffsetBottom = height;
+                    titleOffset[2] = height;
                 }
             }
         }, this);
-        requiresDirtyBox = (this.titleOffset !== titleOffset ||
-            this.titleOffsetBottom !== titleOffsetBottom);
+        requiresDirtyBox = (!this.titleOffset ||
+            this.titleOffset.join(',') !== titleOffset.join(','));
         // Used in getMargins
         this.titleOffset = titleOffset;
-        this.titleOffsetBottom = titleOffsetBottom;
         if (!this.isDirtyBox && requiresDirtyBox) {
             this.isDirtyBox = this.isDirtyLegend = requiresDirtyBox;
             // Redraw if necessary (#2719, #2744)
@@ -1027,15 +1026,14 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      * @fires Highcharts.Chart#event:getMargins
      */
     getMargins: function (skipAxes) {
-        var _a = this, spacing = _a.spacing, margin = _a.margin, titleOffset = _a.titleOffset, titleOffsetBottom = _a.titleOffsetBottom;
+        var _a = this, spacing = _a.spacing, margin = _a.margin, titleOffset = _a.titleOffset;
         this.resetMargins();
         // Adjust for title and subtitle
-        if (titleOffset && !defined(margin[0])) {
-            this.plotTop = Math.max(this.plotTop, titleOffset + this.options.title.margin + spacing[0]);
+        if (titleOffset[0] && !defined(margin[0])) {
+            this.plotTop = Math.max(this.plotTop, titleOffset[0] + this.options.title.margin + spacing[0]);
         }
-        if (titleOffsetBottom && !defined(margin[2])) {
-            this.marginBottom = Math.max(this.marginBottom, titleOffsetBottom + this.options.title.margin +
-                spacing[2]);
+        if (titleOffset[2] && !defined(margin[2])) {
+            this.marginBottom = Math.max(this.marginBottom, titleOffset[2] + this.options.title.margin + spacing[2]);
         }
         // Adjust for legend
         if (this.legend && this.legend.display) {

--- a/js/parts/Legend.js
+++ b/js/parts/Legend.js
@@ -640,9 +640,10 @@ Highcharts.Legend.prototype = {
      * @return {void}
      */
     adjustMargins: function (margin, spacing) {
-        var chart = this.chart, options = this.options, alignment = this.getAlignment(), titleMargin = chart.options.title.margin !== undefined ?
-            chart.titleOffset +
-                chart.options.title.margin :
+        var chart = this.chart, options = this.options, alignment = this.getAlignment(), titleMarginOption = chart.options.title.margin, titleMargin = titleMarginOption !== undefined ?
+            chart.titleOffset + titleMarginOption :
+            0, titleMarginBottom = titleMarginOption !== undefined ?
+            chart.titleOffsetBottom + titleMarginOption :
             0;
         if (alignment) {
             ([
@@ -659,8 +660,11 @@ Highcharts.Legend.prototype = {
                         pick(options.margin, 12) +
                         spacing[side] +
                         (side === 0 &&
-                            (chart.titleOffset === 0 ? 0 : titleMargin)) // #7428, #7894
-                    ));
+                            (chart.titleOffset === 0 ?
+                                0 : titleMargin)) + // #7428, #7894
+                        (side === 2 &&
+                            (chart.titleOffsetBottom === 0 ?
+                                0 : titleMarginBottom))));
                 }
             });
         }
@@ -716,7 +720,7 @@ Highcharts.Legend.prototype = {
      * @return {void}
      */
     render: function () {
-        var legend = this, chart = legend.chart, renderer = chart.renderer, legendGroup = legend.group, allItems, display, legendWidth, legendHeight, box = legend.box, options = legend.options, padding = legend.padding, alignTo, allowedWidth, y;
+        var legend = this, chart = legend.chart, renderer = chart.renderer, legendGroup = legend.group, allItems, display, legendWidth, legendHeight, box = legend.box, options = legend.options, padding = legend.padding, allowedWidth;
         legend.itemX = padding;
         legend.itemY = legend.initialItemY;
         legend.offsetWidth = 0;
@@ -830,13 +834,18 @@ Highcharts.Legend.prototype = {
         if (display) {
             // If aligning to the top and the layout is horizontal, adjust for
             // the title (#7428)
-            alignTo = chart.spacingBox;
-            if (/(lth|ct|rth)/.test(legend.getAlignment())) {
-                y = alignTo.y + chart.titleOffset;
-                alignTo = merge(alignTo, {
-                    y: chart.titleOffset > 0 ?
-                        y += chart.options.title.margin : y
-                });
+            var margin = chart.options.title.margin;
+            var vAlign = legend.getAlignment().charAt(1);
+            var alignTo = chart.spacingBox;
+            var y = alignTo.y;
+            if (vAlign === 't' && chart.titleOffset > 0) {
+                y += chart.titleOffset + margin;
+            }
+            else if (vAlign === 'b' && chart.titleOffsetBottom > 0) {
+                y -= chart.titleOffsetBottom + margin;
+            }
+            if (y !== alignTo.y) {
+                alignTo = merge(alignTo, { y: y });
             }
             legendGroup.align(merge(options, {
                 width: legendWidth,

--- a/js/parts/Legend.js
+++ b/js/parts/Legend.js
@@ -641,9 +641,9 @@ Highcharts.Legend.prototype = {
      */
     adjustMargins: function (margin, spacing) {
         var chart = this.chart, options = this.options, alignment = this.getAlignment(), titleMarginOption = chart.options.title.margin, titleMargin = titleMarginOption !== undefined ?
-            chart.titleOffset + titleMarginOption :
+            chart.titleOffset[0] + titleMarginOption :
             0, titleMarginBottom = titleMarginOption !== undefined ?
-            chart.titleOffsetBottom + titleMarginOption :
+            chart.titleOffset[2] + titleMarginOption :
             0;
         if (alignment) {
             ([
@@ -660,10 +660,10 @@ Highcharts.Legend.prototype = {
                         pick(options.margin, 12) +
                         spacing[side] +
                         (side === 0 &&
-                            (chart.titleOffset === 0 ?
+                            (chart.titleOffset[0] === 0 ?
                                 0 : titleMargin)) + // #7428, #7894
                         (side === 2 &&
-                            (chart.titleOffsetBottom === 0 ?
+                            (chart.titleOffset[2] === 0 ?
                                 0 : titleMarginBottom))));
                 }
             });
@@ -838,11 +838,11 @@ Highcharts.Legend.prototype = {
             var vAlign = legend.getAlignment().charAt(1);
             var alignTo = chart.spacingBox;
             var y = alignTo.y;
-            if (vAlign === 't' && chart.titleOffset > 0) {
-                y += chart.titleOffset + margin;
+            if (vAlign === 't' && chart.titleOffset[0] > 0) {
+                y += chart.titleOffset[0] + margin;
             }
-            else if (vAlign === 'b' && chart.titleOffsetBottom > 0) {
-                y -= chart.titleOffsetBottom + margin;
+            else if (vAlign === 'b' && chart.titleOffset[2] > 0) {
+                y -= chart.titleOffset[2] + margin;
             }
             if (y !== alignTo.y) {
                 alignTo = merge(alignTo, { y: y });

--- a/js/parts/RangeSelector.js
+++ b/js/parts/RangeSelector.js
@@ -1278,9 +1278,9 @@ RangeSelector.prototype = {
             if (floating) {
                 translateY = 0;
             }
-            if (chart.titleOffset) {
+            if (chart.titleOffset && chart.titleOffset[0]) {
                 translateY =
-                    chart.titleOffset + chart.options.title.margin;
+                    chart.titleOffset[0] + chart.options.title.margin;
             }
             translateY += ((chart.margin[0] - chart.spacing[0]) || 0);
         }

--- a/samples/highcharts/subtitle/verticalalign/demo.css
+++ b/samples/highcharts/subtitle/verticalalign/demo.css
@@ -1,0 +1,6 @@
+#container {
+    height: 450px;
+    min-width: 300px;
+    max-width: 800px;
+    margin: 0 auto;
+}

--- a/samples/highcharts/subtitle/verticalalign/demo.html
+++ b/samples/highcharts/subtitle/verticalalign/demo.html
@@ -1,3 +1,4 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
 
-<div id="container" style="height: 400px"></div>
+<div id="container"></div>

--- a/samples/highcharts/subtitle/verticalalign/demo.js
+++ b/samples/highcharts/subtitle/verticalalign/demo.js
@@ -1,19 +1,18 @@
 Highcharts.chart('container', {
-    chart: {
-        marginBottom: 70
+    title: {
+        text: 'Subtitle in the bottom'
     },
     xAxis: {
-        categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-    },
-    subtitle: {
-        text: '* Footnote is using verticalAlign: bottom',
-        floating: true,
-        align: 'right',
-        x: -10,
-        verticalAlign: 'bottom',
-        y: -75
+        categories: ['Apples', 'Pears', 'Bananas', 'Oranges']
     },
     series: [{
-        data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]
-    }]
+        data: [1, 4, 3, 5],
+        type: 'column',
+        name: 'Fruits'
+    }],
+    subtitle: {
+        text: '<b>The subtitle may be used as a chart description, then it will be part of exported charts.</b><br><em>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</em>',
+        verticalAlign: 'bottom',
+        align: 'left'
+    }
 });

--- a/samples/unit-tests/rangeselector/floating/demo.js
+++ b/samples/unit-tests/rangeselector/floating/demo.js
@@ -15,12 +15,14 @@ QUnit.test('Floating enabled.', function (assert) {
         }]
     });
 
-    assert.strictEqual(
-        (chart.rangeSelector.group.translateX === 10) &&
-        (chart.rangeSelector.group.translateY === 100) &&
-        (chart.extraTopMargin === undefined) &&
-        (chart.plotTop === 10),
-        true,
-        'floating'
+    assert.deepEqual(
+        [
+            chart.rangeSelector.group.translateX,
+            chart.rangeSelector.group.translateY,
+            chart.extraTopMargin,
+            chart.plotTop
+        ],
+        [10, 100, undefined, 10],
+        'The range selector should be floating'
     );
 });

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -1171,7 +1171,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
 
             if (title) {
 
-                if (!(this as any).styledMode) {
+                if (!this.styledMode) {
                     titleSize = titleOptions.style.fontSize;
                 }
                 titleSize = renderer.fontMetrics(titleSize, title).b;
@@ -1185,7 +1185,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                 height = title.getBBox(titleOptions.useHTML).height;
 
                 title.align(extend({
-                    y: bottomAlign ? 0 : offset + titleSize,
+                    y: bottomAlign ? titleSize : offset + titleSize,
                     height
                 }, titleOptions), false, 'spacingBox');
 
@@ -1546,8 +1546,12 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             );
         }
 
-        if (titleOffsetBottom && !margin[2]) {
-            this.marginBottom += titleOffsetBottom;
+        if (titleOffsetBottom && !defined(margin[2])) {
+            this.marginBottom = Math.max(
+                this.marginBottom,
+                titleOffsetBottom + (this.options.title as any).margin +
+                    spacing[2]
+            );
         }
 
         // Adjust for legend

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -90,8 +90,7 @@ declare global {
             public symbolCounter: number;
             public time: Time;
             public title?: SVGElement;
-            public titleOffset: number;
-            public titleOffsetBottom: number;
+            public titleOffset: Array<number>;
             public unbindReflow?: Function;
             public userOptions: Options;
             public xAxis: Array<Axis>;
@@ -1146,8 +1145,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         this: Highcharts.Chart,
         redraw?: boolean
     ): void {
-        var titleOffset = 0,
-            titleOffsetBottom = 0,
+        var titleOffset = [0, 0, 0],
             requiresDirtyBox,
             renderer = this.renderer,
             spacingBox = this.spacingBox as Highcharts.BBoxObject;
@@ -1161,7 +1159,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                 titleOptions = (this as any).options[key],
                 offset = key === 'title' ? -3 :
                     // Floating subtitle (#6574)
-                    titleOptions.verticalAlign ? 0 : titleOffset + 2,
+                    titleOptions.verticalAlign ? 0 : titleOffset[0] + 2,
                 bottomAlign = (
                     key === 'subtitle' &&
                     titleOptions.verticalAlign === 'bottom'
@@ -1190,8 +1188,8 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                 }, titleOptions), false, 'spacingBox');
 
                 if (!titleOptions.floating && !titleOptions.verticalAlign) {
-                    titleOffset = Math.ceil(
-                        titleOffset +
+                    titleOffset[0] = Math.ceil(
+                        titleOffset[0] +
                         height
                     );
                 }
@@ -1199,19 +1197,18 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                     key === 'subtitle' &&
                     titleOptions.verticalAlign === 'bottom'
                 ) {
-                    titleOffsetBottom = height;
+                    titleOffset[2] = height;
                 }
             }
         }, this);
 
         requiresDirtyBox = (
-            this.titleOffset !== titleOffset ||
-            this.titleOffsetBottom !== titleOffsetBottom
+            !this.titleOffset ||
+            this.titleOffset.join(',') !== titleOffset.join(',')
         );
 
         // Used in getMargins
         this.titleOffset = titleOffset;
-        this.titleOffsetBottom = titleOffsetBottom;
 
         if (!this.isDirtyBox && requiresDirtyBox) {
             this.isDirtyBox = this.isDirtyLegend = requiresDirtyBox;
@@ -1534,23 +1531,22 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      * @fires Highcharts.Chart#event:getMargins
      */
     getMargins: function (this: Highcharts.Chart, skipAxes?: boolean): void {
-        const { spacing, margin, titleOffset, titleOffsetBottom } = this;
+        const { spacing, margin, titleOffset } = this;
 
         this.resetMargins();
 
         // Adjust for title and subtitle
-        if (titleOffset && !defined(margin[0])) {
+        if (titleOffset[0] && !defined(margin[0])) {
             this.plotTop = Math.max(
                 this.plotTop,
-                titleOffset + (this.options.title as any).margin + spacing[0]
+                titleOffset[0] + (this.options.title as any).margin + spacing[0]
             );
         }
 
-        if (titleOffsetBottom && !defined(margin[2])) {
+        if (titleOffset[2] && !defined(margin[2])) {
             this.marginBottom = Math.max(
                 this.marginBottom,
-                titleOffsetBottom + (this.options.title as any).margin +
-                    spacing[2]
+                titleOffset[2] + (this.options.title as any).margin + spacing[2]
             );
         }
 

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -91,6 +91,7 @@ declare global {
             public time: Time;
             public title?: SVGElement;
             public titleOffset: number;
+            public titleOffsetBottom: number;
             public unbindReflow?: Function;
             public userOptions: Options;
             public xAxis: Array<Axis>;
@@ -1146,6 +1147,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         redraw?: boolean
     ): void {
         var titleOffset = 0,
+            titleOffsetBottom = 0,
             requiresDirtyBox,
             renderer = this.renderer,
             spacingBox = this.spacingBox as Highcharts.BBoxObject;
@@ -1160,7 +1162,12 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                 offset = key === 'title' ? -3 :
                     // Floating subtitle (#6574)
                     titleOptions.verticalAlign ? 0 : titleOffset + 2,
-                titleSize;
+                bottomAlign = (
+                    key === 'subtitle' &&
+                    titleOptions.verticalAlign === 'bottom'
+                ),
+                titleSize,
+                height;
 
             if (title) {
 
@@ -1172,23 +1179,39 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                     .css({
                         width: (titleOptions.width ||
                             spacingBox.width + titleOptions.widthAdjust) + 'px'
-                    })
-                    .align(extend({
-                        y: offset + titleSize
-                    }, titleOptions), false, 'spacingBox');
+                    });
+
+                // Skip the cache for HTML (#3481)
+                height = title.getBBox(titleOptions.useHTML).height;
+
+                title.align(extend({
+                    y: bottomAlign ? 0 : offset + titleSize,
+                    height
+                }, titleOptions), false, 'spacingBox');
 
                 if (!titleOptions.floating && !titleOptions.verticalAlign) {
                     titleOffset = Math.ceil(
                         titleOffset +
-                        // Skip the cache for HTML (#3481)
-                        title.getBBox(titleOptions.useHTML).height
+                        height
                     );
+                }
+                if (
+                    key === 'subtitle' &&
+                    titleOptions.verticalAlign === 'bottom'
+                ) {
+                    titleOffsetBottom = height;
                 }
             }
         }, this);
 
-        requiresDirtyBox = this.titleOffset !== titleOffset;
-        this.titleOffset = titleOffset; // used in getMargins
+        requiresDirtyBox = (
+            this.titleOffset !== titleOffset ||
+            this.titleOffsetBottom !== titleOffsetBottom
+        );
+
+        // Used in getMargins
+        this.titleOffset = titleOffset;
+        this.titleOffsetBottom = titleOffsetBottom;
 
         if (!this.isDirtyBox && requiresDirtyBox) {
             this.isDirtyBox = this.isDirtyLegend = requiresDirtyBox;
@@ -1511,24 +1534,25 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      * @fires Highcharts.Chart#event:getMargins
      */
     getMargins: function (this: Highcharts.Chart, skipAxes?: boolean): void {
-        var chart = this,
-            spacing = chart.spacing,
-            margin = chart.margin,
-            titleOffset = chart.titleOffset;
+        const { spacing, margin, titleOffset, titleOffsetBottom } = this;
 
-        chart.resetMargins();
+        this.resetMargins();
 
         // Adjust for title and subtitle
         if (titleOffset && !defined(margin[0])) {
-            chart.plotTop = Math.max(
-                chart.plotTop,
-                titleOffset + (chart.options.title as any).margin + spacing[0]
+            this.plotTop = Math.max(
+                this.plotTop,
+                titleOffset + (this.options.title as any).margin + spacing[0]
             );
         }
 
+        if (titleOffsetBottom && !margin[2]) {
+            this.marginBottom += titleOffsetBottom;
+        }
+
         // Adjust for legend
-        if (chart.legend && chart.legend.display) {
-            chart.legend.adjustMargins(margin, spacing);
+        if (this.legend && this.legend.display) {
+            this.legend.adjustMargins(margin, spacing);
         }
 
         fireEvent(this, 'getMargins');

--- a/ts/parts/Legend.ts
+++ b/ts/parts/Legend.ts
@@ -1032,10 +1032,10 @@ Highcharts.Legend.prototype = {
             alignment = this.getAlignment(),
             titleMarginOption: number = (chart.options.title as any).margin,
             titleMargin: number = titleMarginOption !== undefined ?
-                chart.titleOffset + titleMarginOption :
+                chart.titleOffset[0] + titleMarginOption :
                 0,
             titleMarginBottom: number = titleMarginOption !== undefined ?
-                chart.titleOffsetBottom + titleMarginOption :
+                chart.titleOffset[2] + titleMarginOption :
                 0;
 
         if (alignment) {
@@ -1063,12 +1063,12 @@ Highcharts.Legend.prototype = {
                             spacing[side] +
                             (
                                 side === 0 &&
-                                (chart.titleOffset === 0 ?
+                                (chart.titleOffset[0] === 0 ?
                                     0 : titleMargin)
                             ) + // #7428, #7894
                             (
                                 side === 2 &&
-                                (chart.titleOffsetBottom === 0 ?
+                                (chart.titleOffset[2] === 0 ?
                                     0 : titleMarginBottom)
                             )
                         )
@@ -1301,11 +1301,11 @@ Highcharts.Legend.prototype = {
             let alignTo = chart.spacingBox;
             let y = alignTo.y;
 
-            if (vAlign === 't' && chart.titleOffset > 0) {
-                y += chart.titleOffset + margin;
+            if (vAlign === 't' && chart.titleOffset[0] > 0) {
+                y += chart.titleOffset[0] + margin;
 
-            } else if (vAlign === 'b' && chart.titleOffsetBottom > 0) {
-                y -= chart.titleOffsetBottom + margin;
+            } else if (vAlign === 'b' && chart.titleOffset[2] > 0) {
+                y -= chart.titleOffset[2] + margin;
             }
 
             if (y !== alignTo.y) {

--- a/ts/parts/Legend.ts
+++ b/ts/parts/Legend.ts
@@ -1030,9 +1030,12 @@ Highcharts.Legend.prototype = {
         var chart = this.chart,
             options = this.options,
             alignment = this.getAlignment(),
-            titleMargin = (chart.options.title as any).margin !== undefined ?
-                (chart.titleOffset as any) +
-                (chart.options.title as any).margin :
+            titleMarginOption: number = (chart.options.title as any).margin,
+            titleMargin: number = titleMarginOption !== undefined ?
+                chart.titleOffset + titleMarginOption :
+                0,
+            titleMarginBottom: number = titleMarginOption !== undefined ?
+                chart.titleOffsetBottom + titleMarginOption :
                 0;
 
         if (alignment) {
@@ -1060,8 +1063,14 @@ Highcharts.Legend.prototype = {
                             spacing[side] +
                             (
                                 side === 0 &&
-                                (chart.titleOffset === 0 ? 0 : titleMargin)
-                            ) // #7428, #7894
+                                (chart.titleOffset === 0 ?
+                                    0 : titleMargin)
+                            ) + // #7428, #7894
+                            (
+                                side === 2 &&
+                                (chart.titleOffsetBottom === 0 ?
+                                    0 : titleMarginBottom)
+                            )
                         )
                     );
                 }
@@ -1148,9 +1157,7 @@ Highcharts.Legend.prototype = {
             box = legend.box,
             options = legend.options,
             padding = legend.padding,
-            alignTo,
-            allowedWidth: number,
-            y;
+            allowedWidth: number;
 
         legend.itemX = padding;
         legend.itemY = legend.initialItemY;
@@ -1289,15 +1296,20 @@ Highcharts.Legend.prototype = {
         if (display) {
             // If aligning to the top and the layout is horizontal, adjust for
             // the title (#7428)
-            alignTo = chart.spacingBox;
-            if (/(lth|ct|rth)/.test(legend.getAlignment())) {
+            const margin: number = (chart.options.title as any).margin;
+            const vAlign = legend.getAlignment().charAt(1);
+            let alignTo = chart.spacingBox;
+            let y = alignTo.y;
 
-                y = alignTo.y + chart.titleOffset;
+            if (vAlign === 't' && chart.titleOffset > 0) {
+                y += chart.titleOffset + margin;
 
-                alignTo = merge(alignTo, {
-                    y: chart.titleOffset > 0 ?
-                        y += (chart.options.title as any).margin : y
-                });
+            } else if (vAlign === 'b' && chart.titleOffsetBottom > 0) {
+                y -= chart.titleOffsetBottom + margin;
+            }
+
+            if (y !== alignTo.y) {
+                alignTo = merge(alignTo, { y });
             }
 
             legendGroup.align(merge(options, {

--- a/ts/parts/RangeSelector.ts
+++ b/ts/parts/RangeSelector.ts
@@ -1845,9 +1845,9 @@ RangeSelector.prototype = {
                 translateY = 0;
             }
 
-            if (chart.titleOffset) {
+            if (chart.titleOffset && chart.titleOffset[0]) {
                 translateY =
-                    chart.titleOffset + (chart.options.title as any).margin;
+                    chart.titleOffset[0] + (chart.options.title as any).margin;
             }
 
             translateY += ((chart.margin[0] - chart.spacing[0]) || 0);


### PR DESCRIPTION
Currently the chart doesn't reserve space for the subtitle if it is bottom aligned. If this is allowed, it can be used for general chart descriptions/captions/narratives.

Corresponding Cloud issue https://github.com/highcharts/highcharts-cloud/issues/485

#### Work in progress
http://jsfiddle.net/highcharts/0qkudhow/

#### To do
 - [x] Align the legend above the subtitle.
 - [x] Adjust the vertical alignment of the subtitle, it looks like it is one line-height too high. Probably currently aligned to the first text baseline.
 - [x] Investigate possible refactoring of `chart.titleOffset` and `chart.titleOffsetBottom` into `chart.titleOffset = [number, undefined, number]`, so that we can reference it by `axis.side`.