### PR TITLE
Added accessibility.pointNavigationThreshold. Also closes #10876.

### DIFF
--- a/js/modules/accessibility/components/SeriesComponent.js
+++ b/js/modules/accessibility/components/SeriesComponent.js
@@ -50,7 +50,9 @@ H.addEvent(H.Series, 'render', function () {
             ) !== false &&
             (
                 dataLength < a11yOptions.pointDescriptionThreshold ||
-                a11yOptions.pointDescriptionThreshold === false
+                a11yOptions.pointDescriptionThreshold === false ||
+                dataLength < a11yOptions.pointNavigationThreshold ||
+                a11yOptions.pointNavigationThreshold === false
             );
 
     if (forceMarkers) {
@@ -186,10 +188,10 @@ function isSkipSeries(series) {
         seriesA11yOptions.enabled === false ||
         series.options.enableMouseTracking === false || // #8440
         !series.visible ||
-        // Skip all points in a series where pointDescriptionThreshold is
+        // Skip all points in a series where pointNavigationThreshold is
         // reached
-        (a11yOptions.pointDescriptionThreshold &&
-        a11yOptions.pointDescriptionThreshold <= series.points.length);
+        (a11yOptions.pointNavigationThreshold &&
+        a11yOptions.pointNavigationThreshold <= series.points.length);
 }
 
 
@@ -1069,12 +1071,19 @@ H.extend(SeriesComponent.prototype, /** @lends Highcharts.SeriesComponent */ {
             a11yOptions = chart.options.accessibility,
             seriesA11yOptions = series.options.accessibility || {},
             firstPointEl = component.getSeriesFirstPointElement(series),
-            seriesEl = component.getSeriesElement(series);
+            seriesEl = component.getSeriesElement(series),
+            setScreenReaderProps = series.points && (
+                series.points.length <
+                    a11yOptions.pointDescriptionThreshold ||
+                    a11yOptions.pointDescriptionThreshold === false
+            ) && !seriesA11yOptions.exposeAsGroupOnly,
+            setKeyboardProps = series.points && (
+                series.points.length <
+                    a11yOptions.pointNavigationThreshold ||
+                    a11yOptions.pointNavigationThreshold === false
+            );
 
         if (seriesEl) {
-            // Unhide series
-            this.unhideElementFromScreenReaders(seriesEl);
-
             // For some series types the order of elements do not match the
             // order of points in series. In that case we have to reverse them
             // in order for AT to read them out in an understandable order
@@ -1082,32 +1091,36 @@ H.extend(SeriesComponent.prototype, /** @lends Highcharts.SeriesComponent */ {
                 component.reverseChildNodes(seriesEl);
             }
 
-            // Make individual point elements accessible if possible. Note: If
-            // markers are disabled there might not be any elements there to
-            // make accessible.
-            if (
-                series.points && (
-                    series.points.length <
-                        a11yOptions.pointDescriptionThreshold ||
-                    a11yOptions.pointDescriptionThreshold === false
-                ) &&
-                !seriesA11yOptions.exposeAsGroupOnly
-            ) {
+            // Unhide series element
+            component.unhideElementFromScreenReaders(seriesEl);
+
+            // Make individual point elements accessible if possible
+            if (setScreenReaderProps || setKeyboardProps) {
                 series.points.forEach(function (point) {
                     var pointEl = point.graphic && point.graphic.element;
                     if (pointEl) {
-                        pointEl.setAttribute('role', 'img');
+                        // We always set tabindex, as long as we are setting
+                        // props.
                         pointEl.setAttribute('tabindex', '-1');
-                        pointEl.setAttribute('aria-label',
-                            component.stripTags(
-                                seriesA11yOptions.pointDescriptionFormatter &&
-                                seriesA11yOptions
-                                    .pointDescriptionFormatter(point) ||
-                                a11yOptions.pointDescriptionFormatter &&
-                                a11yOptions.pointDescriptionFormatter(point) ||
-                                component
-                                    .defaultPointDescriptionFormatter(point)
-                            ));
+
+                        if (setScreenReaderProps) {
+                            // Set screen reader specific props
+                            pointEl.setAttribute('role', 'img');
+                            pointEl.setAttribute('aria-label',
+                                component.stripTags(
+                                    seriesA11yOptions
+                                        .pointDescriptionFormatter &&
+                                    seriesA11yOptions
+                                        .pointDescriptionFormatter(point) ||
+                                    a11yOptions.pointDescriptionFormatter &&
+                                    a11yOptions
+                                        .pointDescriptionFormatter(point) ||
+                                    component
+                                        .defaultPointDescriptionFormatter(point)
+                                ));
+                        } else {
+                            pointEl.setAttribute('aria-hidden', true);
+                        }
                     }
                 });
             }
@@ -1130,6 +1143,8 @@ H.extend(SeriesComponent.prototype, /** @lends Highcharts.SeriesComponent */ {
                         component.defaultSeriesDescriptionFormatter(series)
                     )
                 );
+            } else {
+                seriesEl.setAttribute('aria-label', '');
             }
         }
     },

--- a/js/modules/accessibility/options.js
+++ b/js/modules/accessibility/options.js
@@ -63,7 +63,18 @@ var options = {
          * @type  {boolean|number}
          * @since 5.0.0
          */
-        pointDescriptionThreshold: 200, // set to false to disable
+        pointDescriptionThreshold: 200,
+
+        /**
+         * When a series contains more points than this, we no longer allow
+         * keyboard navigation for it.
+         *
+         * Set to `false` to disable.
+         *
+         * @type  {boolean|number}
+         * @since next
+         */
+        pointNavigationThreshold: false,
 
         /**
          * Whether or not to add a shortcut button in the screen reader

--- a/samples/unit-tests/accessibility/accessibility-options/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-options/demo.js
@@ -60,7 +60,8 @@ QUnit.test('No data', function (assert) {
 QUnit.test('pointDescriptionThreshold', function (assert) {
     var chart = Highcharts.chart('container', {
             accessibility: {
-                pointDescriptionThreshold: 7
+                pointDescriptionThreshold: 7,
+                describeSingleSeries: true
             },
             series: [{
                 data: [1, 2, 3, 4, 5, 6]
@@ -72,12 +73,59 @@ QUnit.test('pointDescriptionThreshold', function (assert) {
         point.graphic.element.getAttribute('aria-label'),
         'There be ARIA on point'
     );
+    assert.ok(
+        chart.series[0].markerGroup.element.getAttribute('aria-label'),
+        'There be ARIA on series'
+    );
 
     point.series.addPoint(4);
 
     assert.notOk(
         point.series.points[6].graphic.element.getAttribute('aria-label'),
         'There be no ARIA on point'
+    );
+    assert.ok(
+        chart.series[0].markerGroup.element.getAttribute('aria-label'),
+        'There be ARIA on series'
+    );
+});
+
+QUnit.test('pointNavigationThreshold', function (assert) {
+    var chart = Highcharts.chart('container', {
+            accessibility: {
+                pointNavigationThreshold: 7
+            },
+            series: [{
+                data: [1, 2, 3, 4, 5, 6]
+            }]
+        }),
+        point = chart.series[0].points[0];
+
+    assert.ok(
+        point.graphic.element.getAttribute('aria-label'),
+        'There be ARIA on point'
+    );
+    assert.strictEqual(
+        point.graphic.element.getAttribute('tabindex'),
+        '-1',
+        'There be tabindex on point'
+    );
+    assert.strictEqual(
+        chart.series[0].markerGroup.element.getAttribute('aria-label'),
+        '',
+        'There be empty ARIA on series'
+    );
+
+    point.series.addPoint(4);
+
+    assert.ok(
+        point.series.points[6].graphic.element.getAttribute('aria-label'),
+        'There still be ARIA on point'
+    );
+    assert.strictEqual(
+        chart.series[0].markerGroup.element.getAttribute('aria-label'),
+        '',
+        'There still be ARIA on series'
     );
 });
 

--- a/samples/unit-tests/accessibility/accessible-highstock/demo.js
+++ b/samples/unit-tests/accessibility/accessible-highstock/demo.js
@@ -9,7 +9,7 @@ QUnit.test('Basic stock chart', function (assert) {
     });
 
     assert.ok(
-        chart.series[0].graph.element.getAttribute('aria-label'),
+        chart.series[0].markerGroup.element.getAttribute('aria-label'),
         'There be ARIA on series'
     );
 

--- a/samples/unit-tests/accessibility/forced-markers/demo.js
+++ b/samples/unit-tests/accessibility/forced-markers/demo.js
@@ -44,7 +44,8 @@ QUnit.test('Too many points for markers', function (assert) {
 QUnit.test('Too many points for a11y', function (assert) {
     const chart = Highcharts.chart('container', {
             accessibility: {
-                pointDescriptionThreshold: 1
+                pointDescriptionThreshold: 1,
+                pointNavigationThreshold: 1
             },
             series: [{
                 marker: {


### PR DESCRIPTION
Added new option `accessibility.pointNavigationThreshold`.
___
Allows separately setting the threshold for keyboard navigation and screen reader descriptions for points.