### PR TITLE
bugfix/6657-contrast-column-datalabels

### DIFF
--- a/js/modules/overlapping-datalabels.src.js
+++ b/js/modules/overlapping-datalabels.src.js
@@ -17,7 +17,7 @@ var Chart = H.Chart,
     isArray = H.isArray,
     objectEach = H.objectEach,
     pick = H.pick,
-    intersectRect = H.intersectRect,
+    isIntersectRect = H.isIntersectRect,
     addEvent = H.addEvent,
     fireEvent = H.fireEvent;
 
@@ -100,7 +100,6 @@ Chart.prototype.hideOverlappingLabels = function (labels) {
         j,
         label1,
         label2,
-        isIntersecting,
         box1,
         box2,
 
@@ -181,19 +180,8 @@ Chart.prototype.hideOverlappingLabels = function (labels) {
                 label1.newOpacity !== 0 &&
                 label2.newOpacity !== 0
             ) {
-                isIntersecting = intersectRect(
-                    box1.x,
-                    box1.y,
-                    box1.width,
-                    box1.height,
-                    box2.x,
-                    box2.y,
-                    box2.width,
-                    box2.height
-                );
 
-
-                if (isIntersecting) {
+                if (isIntersectRect(box1, box2)) {
                     (label1.labelrank < label2.labelrank ? label1 : label2)
                         .newOpacity = 0;
                 }

--- a/js/modules/overlapping-datalabels.src.js
+++ b/js/modules/overlapping-datalabels.src.js
@@ -17,6 +17,7 @@ var Chart = H.Chart,
     isArray = H.isArray,
     objectEach = H.objectEach,
     pick = H.pick,
+    intersectRect = H.intersectRect,
     addEvent = H.addEvent,
     fireEvent = H.fireEvent;
 
@@ -102,14 +103,6 @@ Chart.prototype.hideOverlappingLabels = function (labels) {
         isIntersecting,
         box1,
         box2,
-        intersectRect = function (x1, y1, w1, h1, x2, y2, w2, h2) {
-            return !(
-                x2 > x1 + w1 ||
-                x2 + w2 < x1 ||
-                y2 > y1 + h1 ||
-                y2 + h2 < y1
-            );
-        },
 
         // Get the box with its position inside the chart, as opposed to getBBox
         // that only reports the position relative to the parent.

--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -496,7 +496,7 @@ import H from './Globals.js';
 */
 import './Utilities.js';
 import './Series.js';
-var arrayMax = H.arrayMax, defined = H.defined, extend = H.extend, format = H.format, merge = H.merge, noop = H.noop, pick = H.pick, relativeLength = H.relativeLength, Series = H.Series, seriesTypes = H.seriesTypes, stableSort = H.stableSort, isArray = H.isArray, splat = H.splat;
+var arrayMax = H.arrayMax, defined = H.defined, extend = H.extend, format = H.format, merge = H.merge, noop = H.noop, pick = H.pick, intersectRect = H.intersectRect, relativeLength = H.relativeLength, Series = H.Series, seriesTypes = H.seriesTypes, stableSort = H.stableSort, isArray = H.isArray, splat = H.splat;
 /* eslint-disable valid-jsdoc */
 /**
  * General distribution algorithm for distributing labels of differing size
@@ -1509,7 +1509,9 @@ if (seriesTypes.column) {
         // Call the parent method
         Series.prototype.alignDataLabel.call(this, point, dataLabel, options, alignTo, isNew);
         // If label was justified and we have contrast, set it:
-        if (point.isLabelJustified && point.contrastColor) {
+        if (point.contrastColor &&
+            point.shapeArgs &&
+            intersectRect(dataLabel.x, dataLabel.y, dataLabel.width - dataLabel.padding, dataLabel.height - dataLabel.padding, point.shapeArgs.x, point.shapeArgs.y, point.shapeArgs.width, point.shapeArgs.height)) {
             dataLabel.css({
                 color: point.contrastColor
             });

--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -496,7 +496,7 @@ import H from './Globals.js';
 */
 import './Utilities.js';
 import './Series.js';
-var arrayMax = H.arrayMax, defined = H.defined, extend = H.extend, format = H.format, merge = H.merge, noop = H.noop, pick = H.pick, intersectRect = H.intersectRect, relativeLength = H.relativeLength, Series = H.Series, seriesTypes = H.seriesTypes, stableSort = H.stableSort, isArray = H.isArray, splat = H.splat;
+var arrayMax = H.arrayMax, defined = H.defined, extend = H.extend, format = H.format, merge = H.merge, noop = H.noop, pick = H.pick, isIntersectRect = H.isIntersectRect, relativeLength = H.relativeLength, Series = H.Series, seriesTypes = H.seriesTypes, stableSort = H.stableSort, isArray = H.isArray, splat = H.splat;
 /* eslint-disable valid-jsdoc */
 /**
  * General distribution algorithm for distributing labels of differing size
@@ -1511,7 +1511,12 @@ if (seriesTypes.column) {
         // If label was justified and we have contrast, set it:
         if (point.contrastColor &&
             point.shapeArgs &&
-            intersectRect(dataLabel.x, dataLabel.y, dataLabel.width - dataLabel.padding, dataLabel.height - dataLabel.padding, point.shapeArgs.x, point.shapeArgs.y, point.shapeArgs.width, point.shapeArgs.height)) {
+            isIntersectRect({
+                x: dataLabel.x,
+                y: dataLabel.y,
+                width: dataLabel.width - dataLabel.padding,
+                height: dataLabel.height - dataLabel.padding
+            }, point.shapeArgs)) {
             dataLabel.css({
                 color: point.contrastColor
             });

--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -1355,6 +1355,37 @@ H.getMagnitude = function (num) {
     return Math.pow(10, Math.floor(Math.log(num) / Math.LN10));
 };
 /**
+ * Get the magnitude of a number.
+ *
+ * @function Highcharts.intersectRect
+ *
+ * @param {number} x1
+ *        x-position of the first box
+ * @param {number} y1
+ *        y-position of the first box
+ * @param {number} w1
+ *        width of the first box
+ * @param {number} h1
+ *        height of the first box
+ * @param {number} x2
+ *        x-position of the second box
+ * @param {number} y2
+ *        y-position of the second box
+ * @param {number} w2
+ *        width of the second box
+ * @param {number} h2
+ *        height of the second box
+ *
+ * @return {boolean}
+ *         Boolean wheater rects are intersecting.
+ */
+H.intersectRect = function (x1, y1, w1, h1, x2, y2, w2, h2) {
+    return !(x2 > x1 + w1 ||
+        x2 + w2 < x1 ||
+        y2 > y1 + h1 ||
+        y2 + h2 < y1);
+};
+/**
  * Take an interval and normalize it to multiples of round numbers.
  *
  * @deprecated

--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -1355,35 +1355,23 @@ H.getMagnitude = function (num) {
     return Math.pow(10, Math.floor(Math.log(num) / Math.LN10));
 };
 /**
- * Get the magnitude of a number.
+ * Check if two boxes are intersecting.
  *
- * @function Highcharts.intersectRect
+ * @function Highcharts.isIntersectRect
  *
- * @param {number} x1
- *        x-position of the first box
- * @param {number} y1
- *        y-position of the first box
- * @param {number} w1
- *        width of the first box
- * @param {number} h1
- *        height of the first box
- * @param {number} x2
- *        x-position of the second box
- * @param {number} y2
- *        y-position of the second box
- * @param {number} w2
- *        width of the second box
- * @param {number} h2
- *        height of the second box
+ * @param {Highcharts.BBoxObject} box1
+ *        First box
+ * @param {Highcharts.BBoxObject} box2
+ *        Second box
  *
  * @return {boolean}
- *         Boolean wheater rects are intersecting.
+ *         Boolean whether rects overlap.
  */
-H.intersectRect = function (x1, y1, w1, h1, x2, y2, w2, h2) {
-    return !(x2 > x1 + w1 ||
-        x2 + w2 < x1 ||
-        y2 > y1 + h1 ||
-        y2 + h2 < y1);
+H.isIntersectRect = function (box1, box2) {
+    return !(box2.x > box1.x + box1.width ||
+        box2.x + box2.width < box1.x ||
+        box2.y > box1.y + box1.height ||
+        box2.y + box2.height < box1.y);
 };
 /**
  * Take an interval and normalize it to multiples of round numbers.

--- a/samples/unit-tests/datalabels/contrast/demo.js
+++ b/samples/unit-tests/datalabels/contrast/demo.js
@@ -2,19 +2,23 @@ QUnit.test('#6487: Column\'s data label with contrast after justification.', fun
     var chart = Highcharts.chart('container', {
             chart: {
                 width: 600,
-                height: 400
+                height: 400,
+                type: 'column'
             },
-            series: [{
-                data: [15, 14.5, 14, 12, 11, 10, 9, 8, 7, 6, 5, 4],
-                type: 'column',
-                colorByPoint: true,
-                dataLabels: {
-                    enabled: true,
-                    inside: false,
-                    style: {
-                        textOutline: null
+            plotOptions: {
+                column: {
+                    colorByPoint: true,
+                    dataLabels: {
+                        enabled: true,
+                        inside: false,
+                        style: {
+                            textOutline: null
+                        }
                     }
                 }
+            },
+            series: [{
+                data: [15, 14.5, 14, 12, 11, 10, 9, 8, 7, 6, 5, 4]
             }],
             yAxis: {
                 endOnTick: false,
@@ -30,6 +34,20 @@ QUnit.test('#6487: Column\'s data label with contrast after justification.', fun
         Highcharts.Color(
             chart.renderer.getContrast(point.color)
         ).get(),
-        'Correct color for justified label on a column.'
+        'Contrast color should be used for a justified label on a column.'
+    );
+
+    chart.yAxis[0].setExtremes(null, 20000000, false, false);
+    chart.addSeries({
+        data: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 10000000]
+    });
+
+    assert.strictEqual(
+        Highcharts.Color(
+            point.dataLabel.element.childNodes[0].style.color
+        ).get(),
+        'rgb(0,0,0)',
+        `Contrast color should not be used when dataLabel does not collide  
+            with column (#6657).`
     );
 });

--- a/ts/parts/DataLabels.ts
+++ b/ts/parts/DataLabels.ts
@@ -651,7 +651,7 @@ var arrayMax = H.arrayMax,
     merge = H.merge,
     noop = H.noop,
     pick = H.pick,
-    intersectRect = H.intersectRect,
+    isIntersectRect = H.isIntersectRect,
     relativeLength = H.relativeLength,
     Series = H.Series,
     seriesTypes = H.seriesTypes,
@@ -2184,15 +2184,14 @@ if (seriesTypes.column) {
         if (
             point.contrastColor &&
             point.shapeArgs &&
-            intersectRect(
-                dataLabel.x,
-                dataLabel.y,
-                dataLabel.width - dataLabel.padding,
-                dataLabel.height - dataLabel.padding,
-                point.shapeArgs.x,
-                point.shapeArgs.y,
-                point.shapeArgs.width,
-                point.shapeArgs.height
+            isIntersectRect(
+                {
+                    x: dataLabel.x,
+                    y: dataLabel.y,
+                    width: dataLabel.width - dataLabel.padding,
+                    height: dataLabel.height - dataLabel.padding
+                },
+                point.shapeArgs
             )
         ) {
             dataLabel.css({

--- a/ts/parts/DataLabels.ts
+++ b/ts/parts/DataLabels.ts
@@ -651,6 +651,7 @@ var arrayMax = H.arrayMax,
     merge = H.merge,
     noop = H.noop,
     pick = H.pick,
+    intersectRect = H.intersectRect,
     relativeLength = H.relativeLength,
     Series = H.Series,
     seriesTypes = H.seriesTypes,
@@ -2180,7 +2181,20 @@ if (seriesTypes.column) {
         );
 
         // If label was justified and we have contrast, set it:
-        if (point.isLabelJustified && point.contrastColor) {
+        if (
+            point.contrastColor &&
+            point.shapeArgs &&
+            intersectRect(
+                dataLabel.x,
+                dataLabel.y,
+                dataLabel.width - dataLabel.padding,
+                dataLabel.height - dataLabel.padding,
+                point.shapeArgs.x,
+                point.shapeArgs.y,
+                point.shapeArgs.width,
+                point.shapeArgs.height
+            )
+        ) {
             dataLabel.css({
                 color: point.contrastColor
             });

--- a/ts/parts/Utilities.ts
+++ b/ts/parts/Utilities.ts
@@ -170,15 +170,9 @@ declare global {
         function format(str: string, ctx: any, time: Time): string;
         function formatSingle(format: string, val: any, time: Time): string;
         function getMagnitude(num: number): number;
-        function intersectRect(
-            x1: number,
-            y1: number,
-            w1: number,
-            h1: number,
-            x2: number,
-            y2: number,
-            w2: number,
-            h2: number
+        function isIntersectRect(
+            box1: BBoxObject,
+            box2: BBoxObject
         ): boolean;
         function getStyle(
             el: HTMLDOMElement,
@@ -1886,45 +1880,27 @@ H.getMagnitude = function (num: number): number {
 };
 
 /**
- * Get the magnitude of a number.
+ * Check if two boxes are intersecting.
  *
- * @function Highcharts.intersectRect
+ * @function Highcharts.isIntersectRect
  *
- * @param {number} x1
- *        x-position of the first box
- * @param {number} y1
- *        y-position of the first box
- * @param {number} w1
- *        width of the first box
- * @param {number} h1
- *        height of the first box
- * @param {number} x2
- *        x-position of the second box
- * @param {number} y2
- *        y-position of the second box
- * @param {number} w2
- *        width of the second box
- * @param {number} h2
- *        height of the second box
+ * @param {Highcharts.BBoxObject} box1
+ *        First box
+ * @param {Highcharts.BBoxObject} box2
+ *        Second box
  *
  * @return {boolean}
- *         Boolean wheater rects are intersecting.
+ *         Boolean whether rects overlap.
  */
-H.intersectRect = function (
-    x1: number,
-    y1: number,
-    w1: number,
-    h1: number,
-    x2: number,
-    y2: number,
-    w2: number,
-    h2: number
+H.isIntersectRect = function (
+    box1: Highcharts.BBoxObject,
+    box2: Highcharts.BBoxObject
 ): boolean {
     return !(
-        x2 > x1 + w1 ||
-        x2 + w2 < x1 ||
-        y2 > y1 + h1 ||
-        y2 + h2 < y1
+        box2.x > box1.x + box1.width ||
+        box2.x + box2.width < box1.x ||
+        box2.y > box1.y + box1.height ||
+        box2.y + box2.height < box1.y
     );
 };
 

--- a/ts/parts/Utilities.ts
+++ b/ts/parts/Utilities.ts
@@ -170,6 +170,16 @@ declare global {
         function format(str: string, ctx: any, time: Time): string;
         function formatSingle(format: string, val: any, time: Time): string;
         function getMagnitude(num: number): number;
+        function intersectRect(
+            x1: number,
+            y1: number,
+            w1: number,
+            h1: number,
+            x2: number,
+            y2: number,
+            w2: number,
+            h2: number
+        ): boolean;
         function getStyle(
             el: HTMLDOMElement,
             prop: string,
@@ -1873,6 +1883,49 @@ H.format = function (str: string, ctx: any, time: Highcharts.Time): string {
  */
 H.getMagnitude = function (num: number): number {
     return Math.pow(10, Math.floor(Math.log(num) / Math.LN10));
+};
+
+/**
+ * Get the magnitude of a number.
+ *
+ * @function Highcharts.intersectRect
+ *
+ * @param {number} x1
+ *        x-position of the first box
+ * @param {number} y1
+ *        y-position of the first box
+ * @param {number} w1
+ *        width of the first box
+ * @param {number} h1
+ *        height of the first box
+ * @param {number} x2
+ *        x-position of the second box
+ * @param {number} y2
+ *        y-position of the second box
+ * @param {number} w2
+ *        width of the second box
+ * @param {number} h2
+ *        height of the second box
+ *
+ * @return {boolean}
+ *         Boolean wheater rects are intersecting.
+ */
+H.intersectRect = function (
+    x1: number,
+    y1: number,
+    w1: number,
+    h1: number,
+    x2: number,
+    y2: number,
+    w2: number,
+    h2: number
+): boolean {
+    return !(
+        x2 > x1 + w1 ||
+        x2 + w2 < x1 ||
+        y2 > y1 + h1 ||
+        y2 + h2 < y1
+    );
 };
 
 /**


### PR DESCRIPTION
Fixed #6657, inappropriate contrast color for first and last dataLabel in column/bar series.
___
Simply moved `intersectRect` to Utils, I think this function is quite handy.
Let me know if TS definitions should look different (personally, I think it's more readable this way).