### PR TITLE
bugfix/11146-ts-TooltipFormatterCallbackFunction

### DIFF
--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -21,6 +21,9 @@ import H from './Globals.js';
  *
  * @param {Highcharts.TooltipFormatterContextObject} this
  *        Context to format
+
+ * @param {Highcharts.Tooltip} tooltip
+ *        The tooltip instance
  *
  * @return {false|string|Array<string>}
  *         Formatted text or false
@@ -171,6 +174,7 @@ H.Tooltip.prototype = {
         /**
          * Tooltips are initially hidden.
          *
+         * @private
          * @readonly
          * @name Highcharts.Tooltip#isHidden
          * @type {boolean}
@@ -295,6 +299,14 @@ H.Tooltip.prototype = {
             (defined(options.className) ? ' ' + options.className : ''), container, set;
         if (!this.label) {
             if (this.outside) {
+                /**
+                 * Reference to the tooltip's container, when
+                 * [Highcharts.Tooltip#outside] is set to true, otherwise
+                 * it's undefined.
+                 *
+                 * @name Highcharts.Tooltip#container
+                 * @type {Highcharts.HTMLDOMElement|undefined}
+                 */
                 this.container = container = H.doc.createElement('div');
                 container.className = 'highcharts-tooltip-container';
                 H.css(container, {
@@ -304,6 +316,14 @@ H.Tooltip.prototype = {
                     zIndex: 3
                 });
                 H.doc.body.appendChild(container);
+                /**
+                 * Reference to the tooltip's renderer, when
+                 * [Highcharts.Tooltip#outside] is set to true, otherwise
+                 * it's undefined.
+                 *
+                 * @name Highcharts.Tooltip#renderer
+                 * @type {Highcharts.SVGRenderer|undefined}
+                 */
                 this.renderer = renderer = new H.Renderer(container, 0, 0);
             }
             // Create the label
@@ -396,6 +416,7 @@ H.Tooltip.prototype = {
     /**
      * Moves the tooltip with a soft animation to a new position.
      *
+     * @private
      * @function Highcharts.Tooltip#move
      *
      * @param {number} x
@@ -653,7 +674,6 @@ H.Tooltip.prototype = {
      * In case no user defined formatter is given, this will be used. Note that
      * the context here is an object holding point, series, x, y etc.
      *
-     * @private
      * @function Highcharts.Tooltip#defaultFormatter
      *
      * @param {Highcharts.Tooltip} tooltip

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -143,6 +143,9 @@ declare global {
  *
  * @param {Highcharts.TooltipFormatterContextObject} this
  *        Context to format
+
+ * @param {Highcharts.Tooltip} tooltip
+ *        The tooltip instance
  *
  * @return {false|string|Array<string>}
  *         Formatted text or false

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -1383,7 +1383,7 @@ H.Tooltip.prototype = {
         // Set the renderer size dynamically to prevent document size to change
         if (this.outside) {
             pad = (this.options.borderWidth || 0) + 2 * this.distance;
-            this.renderer.setSize(
+            (this.renderer as any).setSize(
                 label.width + pad,
                 label.height + pad,
                 false

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -25,7 +25,7 @@ declare global {
         interface TooltipFormatterCallbackFunction {
             (
                 this: TooltipFormatterContextObject,
-                tooltip?: Tooltip
+                tooltip: Tooltip
             ): (false|string|Array<string>);
         }
         interface TooltipFormatterContextObject {
@@ -70,7 +70,7 @@ declare global {
             public now: Dictionary<number>;
             public options: TooltipOptions;
             public outside: (boolean|undefined);
-            public renderer: Renderer;
+            public renderer?: Renderer;
             public shared: (boolean|undefined);
             public split: (boolean|undefined);
             public tooltipTimeout?: number;
@@ -324,6 +324,7 @@ H.Tooltip.prototype = {
         /**
          * Tooltips are initially hidden.
          *
+         * @private
          * @readonly
          * @name Highcharts.Tooltip#isHidden
          * @type {boolean}
@@ -471,7 +472,16 @@ H.Tooltip.prototype = {
         if (!this.label) {
 
             if (this.outside) {
+                /**
+                 * Reference to the tooltip's container, when
+                 * [Highcharts.Tooltip#outside] is set to true, otherwise
+                 * it's undefined.
+                 *
+                 * @name Highcharts.Tooltip#container
+                 * @type {Highcharts.HTMLDOMElement|undefined}
+                 */
                 this.container = container = H.doc.createElement('div');
+
                 container.className = 'highcharts-tooltip-container';
                 H.css(container, {
                     position: 'absolute',
@@ -481,6 +491,14 @@ H.Tooltip.prototype = {
                 });
                 H.doc.body.appendChild(container);
 
+                /**
+                 * Reference to the tooltip's renderer, when
+                 * [Highcharts.Tooltip#outside] is set to true, otherwise
+                 * it's undefined.
+                 *
+                 * @name Highcharts.Tooltip#renderer
+                 * @type {Highcharts.SVGRenderer|undefined}
+                 */
                 this.renderer = renderer = new H.Renderer(container, 0, 0);
             }
 
@@ -600,6 +618,7 @@ H.Tooltip.prototype = {
     /**
      * Moves the tooltip with a soft animation to a new position.
      *
+     * @private
      * @function Highcharts.Tooltip#move
      *
      * @param {number} x
@@ -943,7 +962,6 @@ H.Tooltip.prototype = {
      * In case no user defined formatter is given, this will be used. Note that
      * the context here is an object holding point, series, x, y etc.
      *
-     * @private
      * @function Highcharts.Tooltip#defaultFormatter
      *
      * @param {Highcharts.Tooltip} tooltip

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -23,7 +23,10 @@ declare global {
             tt?: SVGElement;
         }
         interface TooltipFormatterCallbackFunction {
-            (this: TooltipFormatterContextObject): (false|string|Array<string>);
+            (
+                this: TooltipFormatterContextObject,
+                tooltip?: Tooltip
+            ): (false|string|Array<string>);
         }
         interface TooltipFormatterContextObject {
             color: ColorString;


### PR DESCRIPTION
Fixed #11146, added Tooltip argument to TooltipFormatterCallbackFunction interface.

PS: Let me know if this should be somehow labeled (added just product: TS). Should this be placed in changelog too? 