### PR TITLE
bugfix/11140-datalabels-pie-inside

### DIFF
--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -727,7 +727,7 @@ Series.prototype.drawDataLabels = function () {
                     (!point.isNull || point.dataLabelOnNull) &&
                     applyFilter(point, labelOptions)), labelConfig, formatString, labelText, style, rotation, attr, dataLabel = point.dataLabels ? point.dataLabels[i] :
                     point.dataLabel, connector = point.connectors ? point.connectors[i] :
-                    point.connector, isNew = !dataLabel;
+                    point.connector, labelDistance = pick(labelOptions.distance, point.labelDistance), isNew = !dataLabel;
                 if (labelEnabled) {
                     // Create individual options structure that can be extended
                     // without affecting others
@@ -745,8 +745,9 @@ Series.prototype.drawDataLabels = function () {
                         // Get automated contrast color
                         if (style.color === 'contrast') {
                             point.contrastColor = renderer.getContrast(point.color || series.color);
-                            style.color = labelOptions.inside ||
-                                pick(labelOptions.distance, point.labelDistance) < 0 ||
+                            style.color = (!defined(labelDistance) &&
+                                labelOptions.inside) ||
+                                labelDistance < 0 ||
                                 !!seriesOptions.stacking ?
                                 point.contrastColor :
                                 '${palette.neutralColor100}';

--- a/samples/unit-tests/datalabels/contrast/demo.js
+++ b/samples/unit-tests/datalabels/contrast/demo.js
@@ -33,3 +33,31 @@ QUnit.test('#6487: Column\'s data label with contrast after justification.', fun
         'Correct color for justified label on a column.'
     );
 });
+
+QUnit.test('Pie dataLabels and contrast', function (assert) {
+    var chart = Highcharts.chart('container', {
+            plotOptions: {
+                series: {
+                    dataLabels: {
+                        inside: true,
+                        enabled: true
+                    }
+                }
+            },
+            series: [{
+                type: 'pie',
+                data: [86, 5]
+            }]
+        }),
+        points = chart.series[0].points;
+
+    assert.strictEqual(
+        Highcharts.Color(
+            points[1].dataLabel.element.childNodes[0].style.color
+        ).get(),
+        Highcharts.Color(
+            points[0].dataLabel.element.childNodes[0].style.color
+        ).get(),
+        'DataLabels outside the pie chart should not get contrast color (#11140).'
+    );
+});

--- a/ts/parts/DataLabels.ts
+++ b/ts/parts/DataLabels.ts
@@ -1033,6 +1033,10 @@ Series.prototype.drawDataLabels = function (this: Highcharts.Series): void {
                         point.dataLabel,
                     connector = point.connectors ? point.connectors[i] :
                         point.connector,
+                    labelDistance = pick(
+                        (labelOptions as any).distance,
+                        point.labelDistance
+                    ),
                     isNew = !dataLabel;
 
                 if (labelEnabled) {
@@ -1070,11 +1074,11 @@ Series.prototype.drawDataLabels = function (this: Highcharts.Series): void {
                             point.contrastColor = renderer.getContrast(
                                 point.color || series.color
                             );
-                            (style as any).color = labelOptions.inside ||
-                                pick(
-                                    (labelOptions as any).distance,
-                                    point.labelDistance
-                                ) < 0 ||
+                            (style as any).color = (
+                                !defined(labelDistance) &&
+                                    labelOptions.inside
+                            ) ||
+                                labelDistance < 0 ||
                                 !!seriesOptions.stacking ?
                                 point.contrastColor :
                                 '${palette.neutralColor100}';


### PR DESCRIPTION
Fixed #11140, setting `series.dataLabels.inside` to `true` forced pie dataLabels to render as in contrast.
___
PS: If you have better idea for the changelog description, feel free to change it :)