### PR TITLE
bugfix/11079-annotations-inverted

### DIFF
--- a/js/annotations/controllable/ControllableLabel.js
+++ b/js/annotations/controllable/ControllableLabel.js
@@ -236,7 +236,14 @@ H.merge(
                 // Chart.options.annotations
                 annotationIndex = chart.annotations.indexOf(this.annotation),
                 chartAnnotations = chart.options.annotations,
-                chartOptions = chartAnnotations[annotationIndex];
+                chartOptions = chartAnnotations[annotationIndex],
+                temp;
+
+            if (chart.inverted) {
+                temp = dx;
+                dx = dy;
+                dy = temp;
+            }
 
             // Local options:
             this.options.x += dx;

--- a/js/annotations/eventEmitterMixin.js
+++ b/js/annotations/eventEmitterMixin.js
@@ -166,6 +166,13 @@ var eventEmitterMixin = {
         ) {
             var translation = this.mouseMoveToTranslation(e);
 
+            if (this.chart.inverted) {
+                translation = {
+                    x: translation.y,
+                    y: translation.x
+                };
+            }
+
             if (this.options.draggable === 'x') {
                 translation.y = 0;
             }

--- a/js/annotations/eventEmitterMixin.js
+++ b/js/annotations/eventEmitterMixin.js
@@ -166,13 +166,6 @@ var eventEmitterMixin = {
         ) {
             var translation = this.mouseMoveToTranslation(e);
 
-            if (this.chart.inverted) {
-                translation = {
-                    x: translation.y,
-                    y: translation.x
-                };
-            }
-
             if (this.options.draggable === 'x') {
                 translation.y = 0;
             }
@@ -184,6 +177,12 @@ var eventEmitterMixin = {
             if (this.points.length) {
                 this.translate(translation.x, translation.y);
             } else {
+                if (this.chart.inverted) {
+                    translation = {
+                        x: translation.y,
+                        y: translation.x
+                    };
+                }
                 this.shapes.forEach(function (shape) {
                     shape.translate(translation.x, translation.y);
                 });

--- a/js/annotations/eventEmitterMixin.js
+++ b/js/annotations/eventEmitterMixin.js
@@ -177,12 +177,6 @@ var eventEmitterMixin = {
             if (this.points.length) {
                 this.translate(translation.x, translation.y);
             } else {
-                if (this.chart.inverted) {
-                    translation = {
-                        x: translation.y,
-                        y: translation.x
-                    };
-                }
                 this.shapes.forEach(function (shape) {
                     shape.translate(translation.x, translation.y);
                 });

--- a/js/annotations/navigationBindings.js
+++ b/js/annotations/navigationBindings.js
@@ -997,8 +997,7 @@ H.setOptions({
                 className: 'highcharts-circle-annotation',
                 /** @ignore */
                 start: function (e) {
-                    var x = this.chart.xAxis[0].toValue(e.chartX),
-                        y = this.chart.yAxis[0].toValue(e.chartY),
+                    var coords = this.chart.pointer.getCoordinates(e),
                         type = 'circle',
                         navigation = this.chart.options.navigation,
                         bindings = navigation && navigation.bindings,
@@ -1011,8 +1010,8 @@ H.setOptions({
                             point: {
                                 xAxis: 0,
                                 yAxis: 0,
-                                x: x,
-                                y: y
+                                x: coords.xAxis[0].value,
+                                y: coords.yAxis[0].value
                             },
                             r: 5,
                             controlPoints: [{
@@ -1068,10 +1067,17 @@ H.setOptions({
                         var point = annotation.options.shapes[0].point,
                             x = this.chart.xAxis[0].toPixels(point.x),
                             y = this.chart.yAxis[0].toPixels(point.y),
+                            inverted = this.chart.inverted,
                             distance = Math.max(
                                 Math.sqrt(
-                                    Math.pow(x - e.chartX, 2) +
-                                    Math.pow(y - e.chartY, 2)
+                                    Math.pow(
+                                        inverted ? y - e.chartX : x - e.chartX,
+                                        2
+                                    ) +
+                                    Math.pow(
+                                        inverted ? x - e.chartY : y - e.chartY,
+                                        2
+                                    )
                                 ),
                                 5
                             );
@@ -1096,8 +1102,7 @@ H.setOptions({
                 className: 'highcharts-rectangle-annotation',
                 /** @ignore */
                 start: function (e) {
-                    var x = this.chart.xAxis[0].toValue(e.chartX),
-                        y = this.chart.yAxis[0].toValue(e.chartY),
+                    var coords = this.chart.pointer.getCoordinates(e),
                         type = 'rect',
                         navigation = this.chart.options.navigation,
                         bindings = navigation && navigation.bindings;
@@ -1107,10 +1112,10 @@ H.setOptions({
                         shapes: [{
                             type: type,
                             point: {
-                                x: x,
-                                y: y,
                                 xAxis: 0,
-                                yAxis: 0
+                                yAxis: 0,
+                                x: coords.xAxis[0].value,
+                                y: coords.yAxis[0].value
                             },
                             width: 5,
                             height: 5,
@@ -1130,15 +1135,18 @@ H.setOptions({
                                 events: {
                                     drag: function (e, target) {
                                         var annotation = target.annotation,
+                                            inverted = this.chart.inverted,
                                             xy = this
                                                 .mouseMoveToTranslation(e);
 
                                         target.options.width = Math.max(
-                                            target.options.width + xy.x,
+                                            target.options.width +
+                                                (inverted ? xy.y : xy.x),
                                             5
                                         );
                                         target.options.height = Math.max(
-                                            target.options.height + xy.y,
+                                            target.options.height +
+                                                (inverted ? xy.x : xy.y),
                                             5
                                         );
 
@@ -1161,11 +1169,18 @@ H.setOptions({
                     function (e, annotation) {
                         var xAxis = this.chart.xAxis[0],
                             yAxis = this.chart.yAxis[0],
+                            inverted = this.chart.inverted,
                             point = annotation.options.shapes[0].point,
                             x = xAxis.toPixels(point.x),
                             y = yAxis.toPixels(point.y),
-                            width = Math.max(e.chartX - x, 5),
-                            height = Math.max(e.chartY - y, 5);
+                            width = Math.max(
+                                inverted ? e.chartX - y : e.chartX - x,
+                                5
+                            ),
+                            height = Math.max(
+                                inverted ? e.chartY - x : e.chartY - y,
+                                5
+                            );
 
                         annotation.update({
                             shapes: [{
@@ -1191,8 +1206,7 @@ H.setOptions({
                 className: 'highcharts-label-annotation',
                 /** @ignore */
                 start: function (e) {
-                    var x = this.chart.xAxis[0].toValue(e.chartX),
-                        y = this.chart.yAxis[0].toValue(e.chartY),
+                    var coords = this.chart.pointer.getCoordinates(e),
                         type = 'label',
                         navigation = this.chart.options.navigation,
                         bindings = navigation && navigation.bindings;
@@ -1204,10 +1218,10 @@ H.setOptions({
                         },
                         labels: [{
                             point: {
-                                x: x,
-                                y: y,
                                 xAxis: 0,
-                                yAxis: 0
+                                yAxis: 0,
+                                x: coords.xAxis[0].value,
+                                y: coords.yAxis[0].value
                             },
                             controlPoints: [{
                                 symbol: 'triangle-down',
@@ -1265,9 +1279,13 @@ H.setOptions({
                                 // ANCHOR
                                 events: {
                                     drag: function (e, target) {
-                                        var xy = this.mouseMoveToTranslation(e);
+                                        var xy = this.mouseMoveToTranslation(e),
+                                            inverted = this.chart.inverted;
 
-                                        target.translate(xy.x, xy.y);
+                                        target.translate(
+                                            inverted ? xy.y : xy.x,
+                                            inverted ? xy.x : xy.y
+                                        );
 
                                         target.annotation.labels[0].options =
                                             target.options;

--- a/js/annotations/navigationBindings.js
+++ b/js/annotations/navigationBindings.js
@@ -1279,13 +1279,9 @@ H.setOptions({
                                 // ANCHOR
                                 events: {
                                     drag: function (e, target) {
-                                        var xy = this.mouseMoveToTranslation(e),
-                                            inverted = this.chart.inverted;
+                                        var xy = this.mouseMoveToTranslation(e);
 
-                                        target.translate(
-                                            inverted ? xy.y : xy.x,
-                                            inverted ? xy.x : xy.y
-                                        );
+                                        target.translate(xy.x, xy.y);
 
                                         target.annotation.labels[0].options =
                                             target.options;

--- a/js/annotations/navigationBindings.js
+++ b/js/annotations/navigationBindings.js
@@ -65,17 +65,17 @@ var bindingsUtils = {
      *        Annotation to be updated
      */
     updateRectSize: function (event, annotation) {
-        var options = annotation.options.typeOptions,
-            x = this.chart.xAxis[0].toValue(event.chartX),
-            y = this.chart.yAxis[0].toValue(event.chartY),
-            width = x - options.point.x,
-            height = options.point.y - y;
+        var chart = annotation.chart,
+            options = annotation.options.typeOptions,
+            coords = chart.pointer.getCoordinates(event),
+            width = coords.xAxis[0].value - options.point.x,
+            height = options.point.y - coords.yAxis[0].value;
 
         annotation.update({
             typeOptions: {
                 background: {
-                    width: width,
-                    height: height
+                    width: chart.inverted ? height : width,
+                    height: chart.inverted ? width : height
                 }
             }
         });

--- a/js/annotations/types/Measure.js
+++ b/js/annotations/types/Measure.js
@@ -124,18 +124,13 @@ H.extendAnnotation(Measure, null,
          * @param {boolean} resize - the flag for resize shape
          */
         addValues: function (resize) {
-            var options = this.options.typeOptions,
-                formatter = options.label.formatter,
-                typeOptions = this.options.typeOptions,
-                chart = this.chart,
-                inverted = chart.options.chart.inverted,
-                xAxis = chart.xAxis[typeOptions.xAxis],
-                yAxis = chart.yAxis[typeOptions.yAxis];
+            var typeOptions = this.options.typeOptions,
+                formatter = typeOptions.label.formatter;
 
             // set xAxisMin, xAxisMax, yAxisMin, yAxisMax
             this.calculations.recalculate.call(this, resize);
 
-            if (!options.label.enabled) {
+            if (!typeOptions.label.enabled) {
                 return;
             }
 
@@ -156,6 +151,10 @@ H.extendAnnotation(Measure, null,
                     crop: true,
                     point: function (target) {
                         var annotation = target.annotation,
+                            chart = annotation.chart,
+                            inverted = chart.inverted,
+                            xAxis = chart.xAxis[typeOptions.xAxis],
+                            yAxis = chart.yAxis[typeOptions.yAxis],
                             top = chart.plotTop,
                             left = chart.plotLeft;
 
@@ -168,7 +167,7 @@ H.extendAnnotation(Measure, null,
                     },
                     text: (formatter && formatter.call(this)) ||
                         this.calculations.defaultFormatter.call(this)
-                }, options.label));
+                }, typeOptions.label));
             }
         },
         /**
@@ -204,7 +203,7 @@ H.extendAnnotation(Measure, null,
                 point = this.options.typeOptions.point,
                 xAxis = chart.xAxis[options.xAxis],
                 yAxis = chart.yAxis[options.yAxis],
-                inverted = chart.options.chart.inverted,
+                inverted = chart.inverted,
                 xAxisMin = xAxis.toPixels(this.xAxisMin),
                 xAxisMax = xAxis.toPixels(this.xAxisMax),
                 yAxisMin = yAxis.toPixels(this.yAxisMin),
@@ -215,13 +214,18 @@ H.extendAnnotation(Measure, null,
                 },
                 pathH = [],
                 pathV = [],
-                crosshairOptionsX, crosshairOptionsY;
+                crosshairOptionsX,
+                crosshairOptionsY,
+                temp;
 
             if (inverted) {
-                xAxisMin = yAxis.toPixels(this.yAxisMin);
-                xAxisMax = yAxis.toPixels(this.yAxisMax);
-                yAxisMin = xAxis.toPixels(this.xAxisMin);
-                yAxisMax = xAxis.toPixels(this.xAxisMax);
+                temp = xAxisMin;
+                xAxisMin = yAxisMin;
+                yAxisMin = temp;
+
+                temp = xAxisMax;
+                xAxisMax = yAxisMax;
+                yAxisMax = temp;
             }
             // horizontal line
             if (options.crosshairX.enabled) {
@@ -379,15 +383,15 @@ H.extendAnnotation(Measure, null,
                 var options = this.options.typeOptions,
                     chart = this.chart,
                     getPointPos = this.calculations.getPointPos,
-                    inverted = chart.options.chart.inverted,
+                    inverted = chart.inverted,
                     xAxis = chart.xAxis[options.xAxis],
                     yAxis = chart.yAxis[options.yAxis],
                     bck = options.background,
                     width = inverted ? bck.height : bck.width,
                     height = inverted ? bck.width : bck.height,
                     selectType = options.selectType,
-                    top = chart.plotTop,
-                    left = chart.plotLeft;
+                    top = inverted ? chart.plotLeft : chart.plotTop,
+                    left = inverted ? chart.plotTop : chart.plotLeft;
 
                 this.startXMin = options.point.x;
                 this.startYMin = options.point.y;
@@ -415,10 +419,10 @@ H.extendAnnotation(Measure, null,
                 // x / y selection type
                 if (selectType === 'x') {
                     this.startYMin = yAxis.toValue(top);
-                    this.startYMax = yAxis.toValue(top + chart.plotHeight);
+                    this.startYMax = yAxis.toValue(top + yAxis.len);
                 } else if (selectType === 'y') {
                     this.startXMin = xAxis.toValue(left);
-                    this.startXMax = xAxis.toValue(left + chart.plotWidth);
+                    this.startXMax = xAxis.toValue(left + xAxis.len);
                 }
 
             },
@@ -855,7 +859,7 @@ H.extendAnnotation(Measure, null,
                     typeOptions = options.typeOptions,
                     selectType = typeOptions.selectType,
                     controlPointOptions = options.controlPointOptions,
-                    inverted = chart.options.chart.inverted,
+                    inverted = chart.inverted,
                     xAxis = chart.xAxis[typeOptions.xAxis],
                     yAxis = chart.yAxis[typeOptions.yAxis],
                     targetX = target.xAxisMax,

--- a/js/modules/stock-tools-bindings.js
+++ b/js/modules/stock-tools-bindings.js
@@ -289,7 +289,7 @@ bindingsUtils.manageIndicators = function (data) {
 bindingsUtils.updateHeight = function (e, annotation) {
     annotation.update({
         typeOptions: {
-            height: this.chart.yAxis[0].toValue(e.chartY) -
+            height: this.chart.pointer.getCoordinates(e).yAxis[0].value -
                 annotation.options.typeOptions.points[1].y
         }
     });
@@ -298,8 +298,9 @@ bindingsUtils.updateHeight = function (e, annotation) {
 // @todo
 // Consider using getHoverData(), but always kdTree (columns?)
 bindingsUtils.attractToPoint = function (e, chart) {
-    var x = chart.xAxis[0].toValue(e.chartX),
-        y = chart.yAxis[0].toValue(e.chartY),
+    var coords = chart.pointer.getCoordinates(e),
+        x = coords.xAxis[0].value,
+        y = coords.yAxis[0].value,
         distX = Number.MAX_VALUE,
         closestPoint;
 
@@ -356,8 +357,9 @@ bindingsUtils.isNotNavigatorYAxis = function (axis) {
 bindingsUtils.updateNthPoint = function (startIndex) {
     return function (e, annotation) {
         var options = annotation.options.typeOptions,
-            x = this.chart.xAxis[0].toValue(e.chartX),
-            y = this.chart.yAxis[0].toValue(e.chartY);
+            coords = this.chart.pointer.getCoordinates(e),
+            x = coords.xAxis[0].value,
+            y = coords.yAxis[0].value;
 
         options.points.forEach(function (point, index) {
             if (index >= startIndex) {
@@ -644,8 +646,7 @@ var stockToolsBindings = {
         className: 'highcharts-segment',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'crookedLine',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -654,11 +655,11 @@ var stockToolsBindings = {
                     type: type,
                     typeOptions: {
                         points: [{
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }]
                     }
                 },
@@ -685,8 +686,7 @@ var stockToolsBindings = {
         className: 'highcharts-arrow-segment',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'crookedLine',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -698,11 +698,11 @@ var stockToolsBindings = {
                             markerEnd: 'arrow'
                         },
                         points: [{
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }]
                     }
                 },
@@ -729,8 +729,7 @@ var stockToolsBindings = {
         className: 'highcharts-ray',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'crookedLine',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -740,11 +739,11 @@ var stockToolsBindings = {
                     typeOptions: {
                         type: 'ray',
                         points: [{
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }]
                     }
                 },
@@ -771,8 +770,7 @@ var stockToolsBindings = {
         className: 'highcharts-arrow-ray',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'infinityLine',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -785,11 +783,11 @@ var stockToolsBindings = {
                             markerEnd: 'arrow'
                         },
                         points: [{
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }]
                     }
                 },
@@ -815,8 +813,7 @@ var stockToolsBindings = {
         className: 'highcharts-infinity-line',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'infinityLine',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -826,11 +823,11 @@ var stockToolsBindings = {
                     typeOptions: {
                         type: 'line',
                         points: [{
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }]
                     }
                 },
@@ -857,8 +854,7 @@ var stockToolsBindings = {
         className: 'highcharts-arrow-infinity-line',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'infinityLine',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -871,11 +867,11 @@ var stockToolsBindings = {
                             markerEnd: 'arrow'
                         },
                         points: [{
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }]
                     }
                 },
@@ -901,8 +897,7 @@ var stockToolsBindings = {
         className: 'highcharts-horizontal-line',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'infinityLine',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -912,8 +907,8 @@ var stockToolsBindings = {
                     typeOptions: {
                         type: 'horizontalLine',
                         points: [{
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }]
                     }
                 },
@@ -935,8 +930,7 @@ var stockToolsBindings = {
         className: 'highcharts-vertical-line',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'infinityLine',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -946,8 +940,8 @@ var stockToolsBindings = {
                     typeOptions: {
                         type: 'verticalLine',
                         points: [{
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }]
                     }
                 },
@@ -971,8 +965,7 @@ var stockToolsBindings = {
         className: 'highcharts-crooked3',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'crookedLine',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -981,14 +974,14 @@ var stockToolsBindings = {
                     type: type,
                     typeOptions: {
                         points: [{
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }]
                     }
                 },
@@ -1016,8 +1009,7 @@ var stockToolsBindings = {
         className: 'highcharts-crooked5',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'crookedLine',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -1026,20 +1018,20 @@ var stockToolsBindings = {
                     type: type,
                     typeOptions: {
                         points: [{
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }]
                     }
                 },
@@ -1069,8 +1061,7 @@ var stockToolsBindings = {
         className: 'highcharts-elliott3',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'elliottWave',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -1079,17 +1070,17 @@ var stockToolsBindings = {
                     type: type,
                     typeOptions: {
                         points: [{
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }]
                     },
                     labelOptions: {
@@ -1123,8 +1114,7 @@ var stockToolsBindings = {
         className: 'highcharts-elliott5',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'elliottWave',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -1133,23 +1123,23 @@ var stockToolsBindings = {
                     type: type,
                     typeOptions: {
                         points: [{
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }]
                     },
                     labelOptions: {
@@ -1185,8 +1175,7 @@ var stockToolsBindings = {
         className: 'highcharts-measure-x',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'measure',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -1196,8 +1185,8 @@ var stockToolsBindings = {
                     typeOptions: {
                         selectType: 'x',
                         point: {
-                            x: x,
-                            y: y,
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value,
                             xAxis: 0,
                             yAxis: 0
                         },
@@ -1247,8 +1236,7 @@ var stockToolsBindings = {
         className: 'highcharts-measure-y',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'measure',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -1258,8 +1246,8 @@ var stockToolsBindings = {
                     typeOptions: {
                         selectType: 'y',
                         point: {
-                            x: x,
-                            y: y,
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value,
                             xAxis: 0,
                             yAxis: 0
                         },
@@ -1308,8 +1296,7 @@ var stockToolsBindings = {
         className: 'highcharts-measure-xy',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'measure',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -1319,8 +1306,8 @@ var stockToolsBindings = {
                     typeOptions: {
                         selectType: 'xy',
                         point: {
-                            x: x,
-                            y: y,
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value,
                             xAxis: 0,
                             yAxis: 0
                         },
@@ -1368,8 +1355,7 @@ var stockToolsBindings = {
         className: 'highcharts-fibonacci',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'fibonacci',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -1378,11 +1364,11 @@ var stockToolsBindings = {
                     type: type,
                     typeOptions: {
                         points: [{
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }]
                     },
                     labelOptions: {
@@ -1415,8 +1401,7 @@ var stockToolsBindings = {
         className: 'highcharts-parallel-channel',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'tunnel',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -1425,11 +1410,11 @@ var stockToolsBindings = {
                     type: type,
                     typeOptions: {
                         points: [{
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }]
                     }
                 },
@@ -1457,8 +1442,7 @@ var stockToolsBindings = {
         className: 'highcharts-pitchfork',
         /** @ignore */
         start: function (e) {
-            var x = this.chart.xAxis[0].toValue(e.chartX),
-                y = this.chart.yAxis[0].toValue(e.chartY),
+            var coords = this.chart.pointer.getCoordinates(e),
                 type = 'pitchfork',
                 navigation = this.chart.options.navigation,
                 bindings = navigation && navigation.bindings,
@@ -1467,19 +1451,19 @@ var stockToolsBindings = {
                     type: type,
                     typeOptions: {
                         points: [{
-                            x: x,
-                            y: y,
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value,
                             controlPoint: {
                                 style: {
                                     fill: 'red'
                                 }
                             }
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }, {
-                            x: x,
-                            y: y
+                            x: coords.xAxis[0].value,
+                            y: coords.yAxis[0].value
                         }],
                         innerBackground: {
                             fill: 'rgba(100, 170, 255, 0.8)'

--- a/js/modules/stock-tools-bindings.js
+++ b/js/modules/stock-tools-bindings.js
@@ -1203,8 +1203,7 @@ var stockToolsBindings = {
                             width: 0,
                             height: 0,
                             strokeWidth: 0,
-                            stroke: '#ffffff',
-                            fill: 'red'
+                            stroke: '#ffffff'
                         }
                     },
                     labelOptions: {


### PR DESCRIPTION
Fixed #11079, stock-tools were not working correctly in inverted charts.
___
I have reused `pointer.getCoordinates` to calculate inverted positions. I hope it's safe.
Honestly, `inverted` + `reversed` options cause a lot of work. Maybe somehow we could improve/refactor this? Just sharing my thoughts.

Edit: Required for Cloud, so bindings will work with inverted charts.