### PR TITLE
bugfix/11193-showtable-exporting

### DIFF
--- a/js/modules/export-data.src.js
+++ b/js/modules/export-data.src.js
@@ -241,7 +241,8 @@ Highcharts.addEvent(Highcharts.Chart, 'render', function () {
     if (
         this.options &&
         this.options.exporting &&
-        this.options.exporting.showTable
+        this.options.exporting.showTable &&
+        !this.options.chart.forExport
     ) {
         this.viewData();
     }


### PR DESCRIPTION
Fixed #11193, downloading the chart as image used to duplicate table created by `exporting.showTable` option.
___
PS: I don't see any particular difference between `rendered.forExport` and `chart.options.chart.forExport`. I assume those are equivalents. 