### PR TITLE
bugfix/11176-networkgraph-clear-data

### DIFF
--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -1053,9 +1053,13 @@ seriesType(
          */
         destroy: function () {
             if (this.isNode) {
-                this.linksFrom.forEach(
-                    function (linkFrom) {
-                        linkFrom.destroyElements();
+                this.linksFrom.concat(this.linksTo).forEach(
+                    function (link) {
+                        // Removing multiple nodes at the same time
+                        // will try to remove link between nodes twice
+                        if (link.destroyElements) {
+                            link.destroyElements();
+                        }
                     }
                 );
                 this.series.layout.removeNode(this);

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.js
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.js
@@ -153,4 +153,14 @@ QUnit.test('Network Graph', function (assert) {
         1,
         'points are visible on small resolutions'
     );
+
+    rSeries.update({
+        data: [],
+        nodes: []
+    });
+
+    assert.ok(
+        true,
+        'Clearing nodes and links in `series.update()` should not throw errors (#11176)'
+    );
 });


### PR DESCRIPTION
Fixed #11176, removing all nodes and links in networkgraph used to throw errors with circular data.