### PR TITLE
Bugfix/10960 windows zoom

### DIFF
--- a/js/parts/Globals.js
+++ b/js/parts/Globals.js
@@ -32,7 +32,7 @@ var H = {
     deg2rad: Math.PI * 2 / 360,
     doc: doc,
     hasBidiBug: hasBidiBug,
-    hasTouch: doc && typeof doc.documentElement.ontouchstart !== 'undefined',
+    hasTouch: !!win.TouchEvent,
     isMS: isMS,
     isWebKit: userAgent.indexOf('AppleWebKit') !== -1,
     isFirefox: isFirefox,

--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -1087,12 +1087,12 @@ Highcharts.Pointer.prototype = {
             H.unbindDocumentMouseUp = addEvent(ownerDoc, 'mouseup', pointer.onDocumentMouseUp);
         }
         if (H.hasTouch) {
-            container.ontouchstart = function (e) {
+            addEvent(container, 'touchstart', function (e) {
                 pointer.onContainerTouchStart(e);
-            };
-            container.ontouchmove = function (e) {
+            });
+            addEvent(container, 'touchmove', function (e) {
                 pointer.onContainerTouchMove(e);
-            };
+            });
             if (!H.unbindDocumentTouchEnd) {
                 H.unbindDocumentTouchEnd = addEvent(ownerDoc, 'touchend', pointer.onDocumentTouchEnd);
             }

--- a/samples/unit-tests/stock-tools/popup/demo.js
+++ b/samples/unit-tests/stock-tools/popup/demo.js
@@ -56,8 +56,13 @@ QUnit.test('Touch event test on popup', function (assert) {
         inputGroup = rangeSelector.inputGroup;
 
     // click on the first button
-    testController.triggerEvent('touchstart', inputGroup.translateX +
-            rangeSelector.minDateBox.x + 80, chart.plotTop + inputGroup.translateY, {}, true);
+    testController.touchStart(
+        inputGroup.translateX + rangeSelector.minDateBox.x + 80,
+        chart.plotTop + inputGroup.translateY,
+        undefined,
+        undefined,
+        true
+    );
 
     assert.strictEqual(
         chart.navigationBindings.popup.container.className.indexOf('highcharts-annotation-toolbar'),

--- a/ts/parts/Globals.ts
+++ b/ts/parts/Globals.ts
@@ -24,6 +24,7 @@ declare global {
     interface Window {
         Image: typeof Image;
         opera?: any;
+        TouchEvent?: typeof TouchEvent;
     }
     const win: Window; // @todo: UMD variable
     function parseFloat (value: (number|string)): number;
@@ -229,7 +230,7 @@ var H: GlobalHighcharts = {
     deg2rad: Math.PI * 2 / 360,
     doc: doc,
     hasBidiBug: hasBidiBug,
-    hasTouch: doc && typeof doc.documentElement.ontouchstart !== 'undefined',
+    hasTouch: !!win.TouchEvent,
     isMS: isMS,
     isWebKit: userAgent.indexOf('AppleWebKit') !== -1,
     isFirefox: isFirefox,

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -1629,12 +1629,20 @@ Highcharts.Pointer.prototype = {
             );
         }
         if (H.hasTouch) {
-            container.ontouchstart = function (e: TouchEvent): void {
-                pointer.onContainerTouchStart(e as any);
-            };
-            container.ontouchmove = function (e: TouchEvent): void {
-                pointer.onContainerTouchMove(e as any);
-            };
+            addEvent(
+                container,
+                'touchstart',
+                function (e: TouchEvent): void {
+                    pointer.onContainerTouchStart(e as any);
+                }
+            );
+            addEvent(
+                container,
+                'touchmove',
+                function (e: TouchEvent): void {
+                    pointer.onContainerTouchMove(e as any);
+                }
+            );
             if (!H.unbindDocumentTouchEnd) {
                 H.unbindDocumentTouchEnd = addEvent(
                     ownerDoc,


### PR DESCRIPTION
Fixed #10960, improved touch support on Windows devices.

---
# Description
Switched to test for and register handlers for [TouchEvent](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent) which has better support than [GlobalEventHandlers.ontouchstart](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ontouchstart) and the similar event handlers.

## Manual Testing
Tested using the demo [samples/highcharts/chart/events-selection](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/chart/events-selection)
Tried touch gestures as touch, pinch-zoom, and panning.
Tried mouse interactions click, drag, and hover.

### Devices and Browsers
Samsung Galaxy 10+ with Android 9
- Chrome 75.0.3770.101
- Edge 42.0.2.3773
- Firefox 67.0.3
- Opera 52.4.2517.140781

Microsoft Surface Book 2 with Windows 10
- Chrome 75.0.3770.100
- Microsoft Edge 44.18362.1.0 Microsoft EdgeHTML 18.18362
- Firefox 64.0
- Opera 62.0.3331.18
- Internet Explorer 11.175.18362.0 (No touch support)

BrowserStack with Windows XP
- Internet Explorer 8 (No touch support)

# Related issue(s)
- Closes #10960 