### PR TITLE
Added sensible defaults to plot lines and bands

### DIFF
--- a/js/parts/PlotLineOrBand.js
+++ b/js/parts/PlotLineOrBand.js
@@ -74,18 +74,17 @@ H.PlotLineOrBand.prototype = {
         // Set the presentational attributes
         if (!axis.chart.styledMode) {
             if (isLine) {
-                attribs.stroke = color;
+                attribs.stroke = color || '${palette.neutralColor40}';
                 attribs['stroke-width'] =
-                    options.width;
+                    options.width ||
+                        1;
                 if (options.dashStyle) {
                     attribs.dashstyle =
                         options.dashStyle;
                 }
             }
             else if (isBand) { // plot band
-                if (color) {
-                    attribs.fill = color;
-                }
+                attribs.fill = color || '${palette.highlightColor10}';
                 if (options.borderWidth) {
                     attribs.stroke = options.borderColor;
                     attribs['stroke-width'] = options.borderWidth;
@@ -298,6 +297,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      *         Plot band on Y axis
      *
      * @type      {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
+     * @default   ${palette.highlightColor10}
      * @apioption xAxis.plotBands.color
      */
     /**
@@ -541,6 +541,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      *         Plot line on Y axis
      *
      * @type      {Highcharts.ColorString}
+     * @default   ${palette.neutralColor40}
      * @apioption xAxis.plotLines.color
      */
     /**
@@ -620,6 +621,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      *         Plot line on Y axis
      *
      * @type      {number}
+     * @default   2
      * @apioption xAxis.plotLines.width
      */
     /**

--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
@@ -1,3 +1,53 @@
+QUnit.test('Defaults', assert => {
+    const chart = Highcharts.chart('container', {
+
+        title: {
+            text: 'Sensible defaults'
+        },
+
+        xAxis: {
+            categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+
+            plotLines: [{
+                value: 5.5
+            }]
+        },
+
+        yAxis: {
+            plotBands: [{
+                from: 100,
+                to: 120
+            }]
+        },
+
+        series: [{
+            data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]
+        }]
+    });
+
+    assert.strictEqual(
+        chart.xAxis[0].plotLinesAndBands[0].svgElem.element
+            .getAttribute('stroke-width'),
+        '1',
+        'A default stroke width should be applied to the plot line'
+    );
+    assert.ok(
+        /^#[0-9a-f]{6}$/.test(
+            chart.xAxis[0].plotLinesAndBands[0].svgElem.element
+                .getAttribute('stroke')
+        ),
+        'A default stroke color should be applied to the plot line'
+    );
+
+    assert.ok(
+        /^#[0-9a-f]{6}$/.test(
+            chart.yAxis[0].plotLinesAndBands[0].svgElem.element
+                .getAttribute('fill')
+        ),
+        'A default fill color should be applied to the plot band'
+    );
+});
+
 QUnit.test('General tests', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {

--- a/ts/parts/PlotLineOrBand.ts
+++ b/ts/parts/PlotLineOrBand.ts
@@ -82,7 +82,7 @@ declare global {
             events?: any;
             id?: string;
             label?: AxisPlotLinesLabelOptions;
-            value?: number;
+            value: number;
             width?: number;
             zIndex?: number;
         }
@@ -229,18 +229,17 @@ H.PlotLineOrBand.prototype = {
         // Set the presentational attributes
         if (!axis.chart.styledMode) {
             if (isLine) {
-                attribs.stroke = color as any;
+                attribs.stroke = (color as any) || '${palette.neutralColor40}';
                 attribs['stroke-width'] =
-                    (options as Highcharts.AxisPlotLinesOptions).width;
+                    (options as Highcharts.AxisPlotLinesOptions).width ||
+                    1;
                 if ((options as Highcharts.AxisPlotLinesOptions).dashStyle) {
                     attribs.dashstyle =
                         (options as Highcharts.AxisPlotLinesOptions).dashStyle;
                 }
 
             } else if (isBand) { // plot band
-                if (color) {
-                    attribs.fill = color as any;
-                }
+                attribs.fill = (color as any) || '${palette.highlightColor10}';
                 if ((options as Highcharts.AxisPlotBandsOptions).borderWidth) {
                     attribs.stroke = (
                         options as Highcharts.AxisPlotBandsOptions
@@ -505,6 +504,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      *         Plot band on Y axis
      *
      * @type      {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
+     * @default   ${palette.highlightColor10}
      * @apioption xAxis.plotBands.color
      */
 
@@ -771,6 +771,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      *         Plot line on Y axis
      *
      * @type      {Highcharts.ColorString}
+     * @default   ${palette.neutralColor40}
      * @apioption xAxis.plotLines.color
      */
 
@@ -859,6 +860,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      *         Plot line on Y axis
      *
      * @type      {number}
+     * @default   2
      * @apioption xAxis.plotLines.width
      */
 


### PR DESCRIPTION
Added sensible defaults to plot lines and bands. A plot band can now be initialized with only a `value`, and a plot band with either `from`, `to`, or both.