### PR TITLE
bugfix/11211-networkgraph-node-update

### DIFF
--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -527,6 +527,20 @@ seriesType(
             this.data.forEach(function (link) {
                 link.formatPrefix = 'link';
             });
+
+            this.indexateNodes();
+        },
+
+        /**
+         * Set index for each node. Required for proper `node.update()`.
+         * Note that links are indexated out of the box in `generatePoints()`.
+         *
+         * @private
+         */
+        indexateNodes: function () {
+            this.nodes.forEach(function (node, index) {
+                node.index = index;
+            });
         },
 
         /**

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.js
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.js
@@ -49,6 +49,17 @@ QUnit.test('Network Graph', function (assert) {
         'No-data label should NOT display when there is data (#9801)'
     );
 
+    chart.series[0].nodes[0].update({
+        marker: {
+            fillColor: 'red'
+        }
+    });
+
+    assert.ok(
+        true,
+        'No errors on node.update() (#11211)'
+    );
+
     chart.addSeries({
         keys: ['from', 'to', 'width', 'color', 'dashStyle'],
         data: [


### PR DESCRIPTION
Fixed #11211, calling `node.update()` in networkgraph series caused errors in console.