### PR TITLE
bugfix/11212-networkgraph-selected-state

### DIFF
--- a/js/mixins/nodes.js
+++ b/js/mixins/nodes.js
@@ -165,31 +165,33 @@ H.NodesMixin = {
 
     // When hovering node, highlight all connected links. When hovering a link,
     // highlight all connected nodes.
-    setNodeState: function () {
+    setNodeState: function (state) {
         var args = arguments,
             others = this.isNode ? this.linksTo.concat(this.linksFrom) :
                 [this.fromNode, this.toNode];
 
-        others.forEach(function (linkOrNode) {
-            if (linkOrNode.series) {
-                Point.prototype.setState.apply(linkOrNode, args);
+        if (state !== 'select') {
+            others.forEach(function (linkOrNode) {
+                if (linkOrNode.series) {
+                    Point.prototype.setState.apply(linkOrNode, args);
 
-                if (!linkOrNode.isNode) {
-                    if (linkOrNode.fromNode.graphic) {
-                        Point.prototype.setState.apply(
-                            linkOrNode.fromNode,
-                            args
-                        );
-                    }
-                    if (linkOrNode.toNode.graphic) {
-                        Point.prototype.setState.apply(
-                            linkOrNode.toNode,
-                            args
-                        );
+                    if (!linkOrNode.isNode) {
+                        if (linkOrNode.fromNode.graphic) {
+                            Point.prototype.setState.apply(
+                                linkOrNode.fromNode,
+                                args
+                            );
+                        }
+                        if (linkOrNode.toNode.graphic) {
+                            Point.prototype.setState.apply(
+                                linkOrNode.toNode,
+                                args
+                            );
+                        }
                     }
                 }
-            }
-        });
+            });
+        }
 
         Point.prototype.setState.apply(this, args);
     }

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.js
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.js
@@ -2,6 +2,17 @@ QUnit.test('Network Graph', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {
             type: 'networkgraph'
+        },
+        plotOptions: {
+            series: {
+                marker: {
+                    states: {
+                        select: {
+                            fillColor: 'orange'
+                        }
+                    }
+                }
+            }
         }
     });
     var point;
@@ -86,6 +97,16 @@ QUnit.test('Network Graph', function (assert) {
         point.graphic.element.getAttribute('stroke-dasharray').replace(/[ px]/g, ''),
         '2,6',
         'Custom series.data.dashStyle (#9798)'
+    );
+
+    chart.series[0].nodes[0].setState('select');
+
+    assert.strictEqual(
+        chart.series[0].nodes.filter(
+            node => node.graphic.element.getAttribute('fill') === 'orange'
+        ).length,
+        1,
+        'Only one node has selected attributes (#11212)'
     );
 
     chart.series[1].setData([['XX', 'XY']]);


### PR DESCRIPTION
Fixed #11212, selected state for a node in network graph was applied to all connected nodes.
___
It's a temporary solution, but makes presentational attributes of a node consistent with `point.selected` flag. If more requests like will show up, we should go back to the discussion about neighbourhood for a points/nodes/cells in series and states (ref heatmap: https://jsfiddle.net/BlackLabel/x71wvh39/show )