### PR TITLE
ts/mixins-centeredseries

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+js/mixins/centered-series.js
 js/modules/oldie.src.js
 js/modules/oldie-polyfills.src.js
 js/parts/Axis.js

--- a/js/mixins/centered-series.js
+++ b/js/mixins/centered-series.js
@@ -1,34 +1,32 @@
 /* *
- * (c) 2010-2019 Torstein Honsi
  *
- * License: www.highcharts.com/license
- */
-
+ *  (c) 2010-2019 Torstein Honsi
+ *
+ *  License: www.highcharts.com/license
+ *
+ *  !!!!!!! SOURCE GETS TRANSPILED BY TYPESCRIPT. EDIT TS FILE ONLY. !!!!!!!
+ *
+ * */
+'use strict';
+import H from '../parts/Globals.js';
 /**
  * @private
- * @typedef Highcharts.RadianAngles
- *
- * @property {number} start
- *
- * @property {number} end
- */
-
-'use strict';
-
-import H from '../parts/Globals.js';
+ * @interface Highcharts.RadianAngles
+ */ /**
+* @name Highcharts.RadianAngles#end
+* @type {number}
+*/ /**
+* @name Highcharts.RadianAngles#start
+* @type {number}
+*/
 import '../parts/Utilities.js';
-
-var deg2rad = H.deg2rad,
-    isNumber = H.isNumber,
-    pick = H.pick,
-    relativeLength = H.relativeLength;
-
+var deg2rad = H.deg2rad, isNumber = H.isNumber, pick = H.pick, relativeLength = H.relativeLength;
+/* eslint-disable valid-jsdoc */
 /**
  * @private
  * @mixin Highcharts.CenteredSeriesMixin
  */
 H.CenteredSeriesMixin = {
-
     /**
      * Get the center of the pie based on the size and center options relative
      * to the plot area. Borrowed by the polar and gauge series types.
@@ -39,37 +37,20 @@ H.CenteredSeriesMixin = {
      * @return {Array<number>}
      */
     getCenter: function () {
-
-        var options = this.options,
-            chart = this.chart,
-            slicingRoom = 2 * (options.slicedOffset || 0),
-            handleSlicingRoom,
-            plotWidth = chart.plotWidth - 2 * slicingRoom,
-            plotHeight = chart.plotHeight - 2 * slicingRoom,
-            centerOption = options.center,
-            positions = [
-                pick(centerOption[0], '50%'),
-                pick(centerOption[1], '50%'),
-                options.size || '100%',
-                options.innerSize || 0
-            ],
-            smallestSize = Math.min(plotWidth, plotHeight),
-            i,
-            value;
-
+        var options = this.options, chart = this.chart, slicingRoom = 2 * (options.slicedOffset || 0), handleSlicingRoom, plotWidth = chart.plotWidth - 2 * slicingRoom, plotHeight = chart.plotHeight - 2 * slicingRoom, centerOption = options.center, positions = [
+            pick(centerOption[0], '50%'),
+            pick(centerOption[1], '50%'),
+            options.size || '100%',
+            options.innerSize || 0
+        ], smallestSize = Math.min(plotWidth, plotHeight), i, value;
         for (i = 0; i < 4; ++i) {
             value = positions[i];
             handleSlicingRoom = i < 2 || (i === 2 && /%$/.test(value));
-
             // i == 0: centerX, relative to width
             // i == 1: centerY, relative to height
             // i == 2: size, relative to smallestSize
             // i == 3: innerSize, relative to size
-            positions[i] = relativeLength(
-                value,
-                [plotWidth, plotHeight, smallestSize, positions[2]][i]
-            ) + (handleSlicingRoom ? slicingRoom : 0);
-
+            positions[i] = relativeLength(value, [plotWidth, plotHeight, smallestSize, positions[2]][i]) + (handleSlicingRoom ? slicingRoom : 0);
         }
         // innerSize cannot be larger than size (#3632)
         if (positions[3] > positions[2]) {
@@ -77,7 +58,6 @@ H.CenteredSeriesMixin = {
         }
         return positions;
     },
-
     /**
      * getStartAndEndRadians - Calculates start and end angles in radians.
      * Used in series types such as pie and sunburst.
@@ -94,20 +74,14 @@ H.CenteredSeriesMixin = {
      * @return {Highcharts.RadianAngles}
      *         Returns an object containing start and end angles as radians.
      */
-    getStartAndEndRadians: function getStartAndEndRadians(start, end) {
+    getStartAndEndRadians: function (start, end) {
         var startAngle = isNumber(start) ? start : 0, // must be a number
-            endAngle = (
-                (
-                    isNumber(end) && // must be a number
-                    end > startAngle && // must be larger than the start angle
-                    // difference must be less than 360 degrees
-                    (end - startAngle) < 360
-                ) ?
-                    end :
-                    startAngle + 360
-            ),
-            correction = -90;
-
+        endAngle = ((isNumber(end) && // must be a number
+            end > startAngle && // must be larger than the start angle
+            // difference must be less than 360 degrees
+            (end - startAngle) < 360) ?
+            end :
+            startAngle + 360), correction = -90;
         return {
             start: deg2rad * (startAngle + correction),
             end: deg2rad * (endAngle + correction)

--- a/ts/mixins/centered-series.ts
+++ b/ts/mixins/centered-series.ts
@@ -1,0 +1,154 @@
+/* *
+ *
+ *  (c) 2010-2019 Torstein Honsi
+ *
+ *  License: www.highcharts.com/license
+ *
+ *  !!!!!!! SOURCE GETS TRANSPILED BY TYPESCRIPT. EDIT TS FILE ONLY. !!!!!!!
+ *
+ * */
+
+'use strict';
+
+import H from '../parts/Globals.js';
+
+/**
+ * Internal types
+ * @private
+ */
+declare global {
+    namespace Highcharts {
+        interface CenteredSeriesMixin {
+            getCenter(this: Series): Array<number>;
+            getStartAndEndRadians(
+                this: Series,
+                start: number,
+                end: number
+            ): RadianAngles;
+        }
+        interface RadianAngles {
+            end: number;
+            start: number;
+        }
+        interface SeriesOptions {
+            slicedOffset?: number;
+        }
+        let CenteredSeriesMixin: CenteredSeriesMixin;
+    }
+}
+
+/**
+ * @private
+ * @interface Highcharts.RadianAngles
+ *//**
+ * @name Highcharts.RadianAngles#end
+ * @type {number}
+ *//**
+ * @name Highcharts.RadianAngles#start
+ * @type {number}
+ */
+
+import '../parts/Utilities.js';
+
+var deg2rad = H.deg2rad,
+    isNumber = H.isNumber,
+    pick = H.pick,
+    relativeLength = H.relativeLength;
+
+/* eslint-disable valid-jsdoc */
+
+/**
+ * @private
+ * @mixin Highcharts.CenteredSeriesMixin
+ */
+H.CenteredSeriesMixin = {
+
+    /**
+     * Get the center of the pie based on the size and center options relative
+     * to the plot area. Borrowed by the polar and gauge series types.
+     *
+     * @private
+     * @function Highcharts.CenteredSeriesMixin.getCenter
+     *
+     * @return {Array<number>}
+     */
+    getCenter: function (this: Highcharts.Series): Array<number> {
+
+        var options = this.options,
+            chart = this.chart,
+            slicingRoom = 2 * (options.slicedOffset || 0),
+            handleSlicingRoom,
+            plotWidth = chart.plotWidth - 2 * slicingRoom,
+            plotHeight = chart.plotHeight - 2 * slicingRoom,
+            centerOption = options.center,
+            positions = [
+                pick(centerOption[0], '50%'),
+                pick(centerOption[1], '50%'),
+                options.size || '100%',
+                options.innerSize || 0
+            ],
+            smallestSize = Math.min(plotWidth, plotHeight),
+            i,
+            value;
+
+        for (i = 0; i < 4; ++i) {
+            value = positions[i];
+            handleSlicingRoom = i < 2 || (i === 2 && /%$/.test(value));
+
+            // i == 0: centerX, relative to width
+            // i == 1: centerY, relative to height
+            // i == 2: size, relative to smallestSize
+            // i == 3: innerSize, relative to size
+            positions[i] = relativeLength(
+                value,
+                [plotWidth, plotHeight, smallestSize, positions[2]][i]
+            ) + (handleSlicingRoom ? slicingRoom : 0);
+
+        }
+        // innerSize cannot be larger than size (#3632)
+        if (positions[3] > positions[2]) {
+            positions[3] = positions[2];
+        }
+        return positions;
+    },
+
+    /**
+     * getStartAndEndRadians - Calculates start and end angles in radians.
+     * Used in series types such as pie and sunburst.
+     *
+     * @private
+     * @function Highcharts.CenteredSeriesMixin.getStartAndEndRadians
+     *
+     * @param {number} start
+     *        Start angle in degrees.
+     *
+     * @param {number} end
+     *        Start angle in degrees.
+     *
+     * @return {Highcharts.RadianAngles}
+     *         Returns an object containing start and end angles as radians.
+     */
+    getStartAndEndRadians: function (
+        this: Highcharts.Series,
+        start: number,
+        end: number
+    ): Highcharts.RadianAngles {
+        var startAngle = isNumber(start) ? start : 0, // must be a number
+            endAngle = (
+                (
+                    isNumber(end) && // must be a number
+                    end > startAngle && // must be larger than the start angle
+                    // difference must be less than 360 degrees
+                    (end - startAngle) < 360
+                ) ?
+                    end :
+                    startAngle + 360
+            ),
+            correction = -90;
+
+        return {
+            start: deg2rad * (startAngle + correction),
+            end: deg2rad * (endAngle + correction)
+        };
+    }
+};

--- a/ts/parts/Globals.ts
+++ b/ts/parts/Globals.ts
@@ -171,7 +171,7 @@ declare global {
         }
         interface SeriesStatesHoverOptions {
             dashStyle?: unknown; // @todo
-            opacity?: unknown; // @todo
+            opacity?: any; // @todo
         }
         interface SVGRenderer {
             invertChild: Function; // @todo


### PR DESCRIPTION
Fixed #11228 - Migrated CenteredSeriesMixins to TypeScript.
Fixed `pick` error in ColumnSeries.