### PR TITLE
Tools: Optionally remove fileextensions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
           command: npx gulp jsdoc
       - run:
           name: Upload api docs to S3
-          command: npx gulp upload-api --silent
+          command: npx gulp upload-api --silent --noextensions
       - run: echo -e "API docs deployed to https://s3.eu-central-1.amazonaws.com/${HIGHCHARTS_APIDOCS_BUCKET}/highcharts/index.html"
 
   deploy_changelog:

--- a/tools/gulptasks/unsorted/upload-api.js
+++ b/tools/gulptasks/unsorted/upload-api.js
@@ -53,7 +53,7 @@ const uploadAPIDocs = () => {
             onError
         };
         const getMapOfFromTo = fileName => {
-            let to = fileName;
+            let to = argv.noextensions ? fileName.split('.').slice(0, -1).join('.') : fileName;
             if (tag !== 'current') {
                 const parts = to.split('/');
                 parts.splice(1, 0, tag);


### PR DESCRIPTION
..when uploading api docs.

To support links without fileextensions in staging api docs where we have no web server in front.