### PR TITLE
Tools: Increase pollingtimeout for Browserstack

### DIFF
--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -624,6 +624,7 @@ module.exports = function (config) {
             localIdentifier: randomString, // to avoid instances interfering with each other.
             video: false,
             retryLimit: 1,
+            pollingTimeout: 5000 // to avoid rate limit errors with browserstack.
         };
         options.customLaunchers = argv.oldie ?
             {


### PR DESCRIPTION
..(browserstack-karma-launcher) to avoid rate limit errors when multiple builds are waiting simultaneously.