### PR TITLE
bugfix/10896-series-labels-color-stylemode

### DIFF
--- a/js/modules/series-label.src.js
+++ b/js/modules/series-label.src.js
@@ -712,7 +712,11 @@ Chart.prototype.drawSeriesLabels = function () {
             maxFontSize = labelOptions.maxFontSize,
             dataExtremes,
             areaMin,
-            areaMax;
+            areaMax,
+            colorClass = 'highcharts-color-' + pick(
+                series.colorIndex,
+                'none'
+            );
 
         // Stay within the area data bounds (#10038)
         if (onArea && !inverted) {
@@ -753,13 +757,17 @@ Chart.prototype.drawSeriesLabels = function () {
                     .addClass(
                         'highcharts-series-label ' +
                         'highcharts-series-label-' + series.index + ' ' +
-                        (series.options.className || '')
-                    )
-                    .css(extend({
+                        (series.options.className || '') +
+                        colorClass
+                    );
+
+                if (!chart.renderer.styledMode) {
+                    label.css(extend({
                         color: onArea ?
                             chart.renderer.getContrast(series.color) :
                             series.color
                     }, series.options.label.style));
+                }
 
                 // Adapt label sizes to the sum of the data
                 if (minFontSize && maxFontSize) {


### PR DESCRIPTION
Fixed #10896, class name of series label was missing in styled mode.