### PR TITLE
bugfix/11244-setdata-update-series-type

### DIFF
--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -997,6 +997,11 @@ extend(Series.prototype, /** @lends Series.prototype */ {
             // when updating after addPoint
             series.xData[0])
         }, (!keepPoints && { data: series.options.data }), options);
+        // Merge does not merge arrays, but replaces them. Since points were
+        // updated, `series.options.data` has correct merged options, use it:
+        if (keepPoints && options.data) {
+            options.data = series.options.data;
+        }
         // Make sure preserved properties are not destroyed (#3094)
         preserve = groups.concat(preserve);
         preserve.forEach(function (prop) {

--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -828,7 +828,6 @@ function isArray(obj) {
     var str = Object.prototype.toString.call(obj);
     return str === '[object Array]' || str === '[object Array Iterator]';
 }
-;
 /**
  * Utility function to check if an item is of type object.
  *

--- a/samples/unit-tests/series/update/demo.js
+++ b/samples/unit-tests/series/update/demo.js
@@ -454,6 +454,25 @@ QUnit.test('Series.update and setData', function (assert) {
         'Graph is continuous (#7326)'
     );
 
+    chart.series[0].setData([{
+        x: 0,
+        y: 10,
+        customProp: true
+    }]);
+
+    chart.update({
+        series: [{
+            data: [{
+                y: 100
+            }]
+        }]
+    });
+
+    assert.strictEqual(
+        chart.series[0].options.data[0].customProp,
+        true,
+        'Custom property should be available in options after update (#11244)'
+    );
 });
 
 QUnit.test('Series.update color index, class name should change', function (assert) {

--- a/ts/parts/Dynamics.ts
+++ b/ts/parts/Dynamics.ts
@@ -1408,6 +1408,12 @@ extend(Series.prototype, /** @lends Series.prototype */ {
             )
         }, (!keepPoints && { data: series.options.data }) as any, options);
 
+        // Merge does not merge arrays, but replaces them. Since points were
+        // updated, `series.options.data` has correct merged options, use it:
+        if (keepPoints && options.data) {
+            options.data = series.options.data;
+        }
+
         // Make sure preserved properties are not destroyed (#3094)
         preserve = groups.concat(preserve);
         preserve.forEach(function (prop: string): void {


### PR DESCRIPTION
Fixed #11244, `series.update({ data })` did not preserve old options if `data` was passed as an array of objects.
___
This is a case when
```
merge(
  { a: [ {x1}, {y1}, {z1} ] },
  { a: [ {x2}, {y2}, {z2} ] }
)
```
replaces `x1` with `x2`, instead of merging.

For this case, workaround is safe because internally, we use `point.update()` which collects updated props in `series.options.data`