### PR TITLE
bugfix/11261-highcharts-more-module-path

### DIFF
--- a/js/modules/networkgraph/layouts.js
+++ b/js/modules/networkgraph/layouts.js
@@ -8,8 +8,8 @@
 
 'use strict';
 import H from '../../parts/Globals.js';
-import 'integrations.js';
-import 'QuadTree.js';
+import './integrations.js';
+import './QuadTree.js';
 
 var pick = H.pick,
     defined = H.defined,


### PR DESCRIPTION
Fixed #11261 - use relative path instead of the module name only. 