### PR TITLE
bugfix/8608-bubble-zparam-hidden

### DIFF
--- a/js/parts-more/BubbleSeries.js
+++ b/js/parts-more/BubbleSeries.js
@@ -316,6 +316,7 @@ seriesType('bubble', 'scatter', {
         var len,
             i,
             zData = this.zData,
+            yData = this.yData,
             minSize = series.minPxSize,
             maxSize = series.maxPxSize,
             radii = [],
@@ -325,13 +326,22 @@ seriesType('bubble', 'scatter', {
         for (i = 0, len = zData.length; i < len; i++) {
             value = zData[i];
             // Separate method to get individual radius for bubbleLegend
-            radii.push(this.getRadius(zMin, zMax, minSize, maxSize, value));
+            radii.push(
+                this.getRadius(
+                    zMin,
+                    zMax,
+                    minSize,
+                    maxSize,
+                    value,
+                    yData[i]
+                )
+            );
         }
         this.radii = radii;
     },
 
     // Get the individual radius for one point.
-    getRadius: function (zMin, zMax, minSize, maxSize, value) {
+    getRadius: function (zMin, zMax, minSize, maxSize, value, yValue) {
         var options = this.options,
             sizeByArea = options.sizeBy !== 'width',
             zThreshold = options.zThreshold,
@@ -350,8 +360,8 @@ seriesType('bubble', 'scatter', {
             zMin = 0;
         }
 
-        if (value === null) {
-        //if (!isNumber(value)) {
+        // #8608 - bubble should be visible when z is undefined
+        if (yValue === null || value === null) {
             radius = null;
         // Issue #4419 - if value is less than zMin, push a radius that's
         // always smaller than the minimum size

--- a/js/parts-more/BubbleSeries.js
+++ b/js/parts-more/BubbleSeries.js
@@ -350,7 +350,8 @@ seriesType('bubble', 'scatter', {
             zMin = 0;
         }
 
-        if (!isNumber(value)) {
+        if (value === null) {
+        //if (!isNumber(value)) {
             radius = null;
         // Issue #4419 - if value is less than zMin, push a radius that's
         // always smaller than the minimum size

--- a/samples/unit-tests/series-bubble/marker/demo.js
+++ b/samples/unit-tests/series-bubble/marker/demo.js
@@ -87,3 +87,27 @@ QUnit.test('Clicking marker (#6705)', function (assert) {
         'Click event fired'
     );
 });
+
+QUnit.test('Bubble data points without z-param.(#8608)', function (assert) {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            type: 'bubble',
+        },
+        series: [{
+            data: [{
+                x: 95,
+                y: 95
+            },
+            {
+                x: 86.5,
+                y: 102.9
+            }]
+        }]
+    });
+
+    assert.strictEqual(
+        typeof chart.series[0].points[0].graphic,
+        'object',
+        'Has marker'
+    );
+});


### PR DESCRIPTION
Fixed #8608, bubble markers were hidden when z param missing.