### PR TITLE
bugfix/11301-inactive-hidden-series

### DIFF
--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -898,8 +898,6 @@ extend(Series.prototype, /** @lends Highcharts.Series.prototype */ {
         // slower to un-hover
         stateAnimation = pick((stateOptions[state || 'normal'] &&
             stateOptions[state || 'normal'].animation), series.chart.options.chart.animation), attribs, i = 0;
-        console.log(state, stateAnimation, (stateOptions[state || 'normal'] &&
-            stateOptions[state || 'normal'].animation), series.chart.options.chart.animation);
         state = state || '';
         if (series.state !== state) {
             // Toggle class names

--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -267,11 +267,13 @@ extend(Legend.prototype, {
         // itself (#1249)
         (useHTML ? legendItem : item.legendGroup)
             .on('mouseover', function () {
-            legend.allItems.forEach(function (inactiveItem) {
-                if (item !== inactiveItem) {
-                    inactiveItem.setState('inactive', !isPoint);
-                }
-            });
+            if (item.visible) {
+                legend.allItems.forEach(function (inactiveItem) {
+                    if (item !== inactiveItem) {
+                        inactiveItem.setState('inactive', !isPoint);
+                    }
+                });
+            }
             item.setState('hover');
             // A CSS class to dim or hide other than the hovered series.
             // Works only if hovered series is visible (#10071).
@@ -302,6 +304,12 @@ extend(Legend.prototype, {
                 if (item.setVisible) {
                     item.setVisible();
                 }
+                // Reset inactive state
+                legend.allItems.forEach(function (inactiveItem) {
+                    if (item !== inactiveItem) {
+                        inactiveItem.setState(item.visible ? 'inactive' : '', !isPoint);
+                    }
+                });
             };
             // A CSS class to dim or hide other than the hovered series.
             // Event handling in iOS causes the activeClass to be added
@@ -890,6 +898,8 @@ extend(Series.prototype, /** @lends Highcharts.Series.prototype */ {
         // slower to un-hover
         stateAnimation = pick((stateOptions[state || 'normal'] &&
             stateOptions[state || 'normal'].animation), series.chart.options.chart.animation), attribs, i = 0;
+        console.log(state, stateAnimation, (stateOptions[state || 'normal'] &&
+            stateOptions[state || 'normal'].animation), series.chart.options.chart.animation);
         state = state || '';
         if (series.state !== state) {
             // Toggle class names

--- a/samples/unit-tests/interaction/setstate/demo.js
+++ b/samples/unit-tests/interaction/setstate/demo.js
@@ -34,3 +34,57 @@ QUnit.test('stateMarkerGraphic', function (assert) {
         'stateMarkerGraphic should have fill: "blue" when hovering second point.'
     );
 });
+
+QUnit.test('Inactive state and legend', function (assert) {
+    var chart = Highcharts.chart('container', {
+            series: [{
+                visible: false,
+                name: 'John',
+                data: [5, 3, 4, 7, 2]
+            }, {
+                name: 'Jane',
+                data: [2, -2, -3, 2, 1]
+            }]
+        }),
+        series = chart.series,
+        legend = chart.legend,
+        legendItemBox = legend.allItems[0].legendItem.getBBox(),
+        controller = new TestController(chart),
+        xPosition = legend.group.translateX + legendItemBox.x +
+            legendItemBox.width / 2,
+        yPosition = legend.group.translateY + legendItemBox.y +
+            legendItemBox.height / 2;
+
+    controller.mouseMove(
+        xPosition,
+        yPosition
+    );
+
+    assert.strictEqual(
+        series[1].group.attr('opacity'),
+        1,
+        'Hovering hidden series should not inactive other series (#11301)'
+    );
+
+    controller.click(
+        xPosition,
+        yPosition
+    );
+
+    assert.strictEqual(
+        series[1].group.attr('opacity'),
+        0.2,
+        'Showing hidden series should inactivate other series (#11301)'
+    );
+
+    controller.click(
+        xPosition,
+        yPosition
+    );
+
+    assert.strictEqual(
+        series[1].group.attr('opacity'),
+        1,
+        'Disabling visible series should not inactivate other series (#11301)'
+    );
+});

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -41,6 +41,20 @@ Highcharts.setOptions({
             kdNow: true,
             dataLabels: {
                 defer: false
+            },
+            states: {
+                hover: {
+                    animation: false
+                },
+                select: {
+                    animation: false
+                },
+                inactive: {
+                    animation: false
+                },
+                normal: {
+                    animation: false
+                }
             }
         },
         // We cannot use it in plotOptions.series because treemap

--- a/ts/parts/Interaction.ts
+++ b/ts/parts/Interaction.ts
@@ -445,13 +445,15 @@ extend(Legend.prototype, {
         (useHTML ? legendItem : (item.legendGroup as any))
             .on('mouseover', function (): void {
 
-                legend.allItems.forEach(function (
-                    inactiveItem: (Highcharts.Point|Highcharts.Series)
-                ): void {
-                    if (item !== inactiveItem) {
-                        inactiveItem.setState('inactive', !isPoint);
-                    }
-                });
+                if (item.visible) {
+                    legend.allItems.forEach(function (
+                        inactiveItem: (Highcharts.Point|Highcharts.Series)
+                    ): void {
+                        if (item !== inactiveItem) {
+                            inactiveItem.setState('inactive', !isPoint);
+                        }
+                    });
+                }
 
                 item.setState('hover');
 
@@ -497,6 +499,17 @@ extend(Legend.prototype, {
                         if ((item as any).setVisible) {
                             (item as any).setVisible();
                         }
+                        // Reset inactive state
+                        legend.allItems.forEach(function (
+                            inactiveItem: (Highcharts.Point|Highcharts.Series)
+                        ): void {
+                            if (item !== inactiveItem) {
+                                inactiveItem.setState(
+                                    item.visible ? 'inactive' : '',
+                                    !isPoint
+                                );
+                            }
+                        });
                     };
 
                 // A CSS class to dim or hide other than the hovered series.


### PR DESCRIPTION
Fixed #11301, hovering legend item for a hidden series caused other series to get inactive state. 
___
I had some problems with animation for states in karma - disabled all of those since karma should run without default animations.