### PR TITLE
bugfix/10285-dragdrop-logarithmic

### DIFF
--- a/samples/unit-tests/dragdrop/dynamic/demo.js
+++ b/samples/unit-tests/dragdrop/dynamic/demo.js
@@ -49,11 +49,12 @@ QUnit.test('Dragdrop and logarithmic axes', function (assert) {
             },
 
             series: [{
+                type: 'scatter',
                 data: [
-                    [1.5, 70],
+                    [1.5, 70], // drag this point
                     [2, 45],
                     [3.5, 20],
-                    [5, 15], // drag this point
+                    [5, 15],
                     [7.5, 8],
                     [16, 3]
                 ]

--- a/samples/unit-tests/dragdrop/dynamic/demo.js
+++ b/samples/unit-tests/dragdrop/dynamic/demo.js
@@ -36,3 +36,71 @@ QUnit.test('Dragdrop enabled in dynamic chart', function (assert) {
     assert.ok(chart.unbindDragDropMouseUp, 'Has mouse up event');
     assert.ok(chart.hasAddedDragDropEvents, 'Has events added flag');
 });
+
+QUnit.test('Dragdrop and logarithmic axes', function (assert) {
+    var chart = Highcharts.chart('container', {
+            xAxis: {
+                type: 'logarithmic',
+                min: 1
+            },
+
+            yAxis: {
+                type: 'logarithmic'
+            },
+
+            series: [{
+                data: [
+                    [1.5, 70],
+                    [2, 45],
+                    [3.5, 20],
+                    [5, 15], // drag this point
+                    [7.5, 8],
+                    [16, 3]
+                ]
+            }],
+
+            plotOptions: {
+                series: {
+                    dragDrop: {
+                        draggableY: true,
+                        draggableX: true
+                    }
+                }
+            }
+        }),
+        controller = new TestController(chart),
+        xAxis = chart.xAxis[0],
+        yAxis = chart.yAxis[0],
+        point = chart.series[0].points[0],
+        x = point.plotX + chart.plotLeft,
+        y = point.plotY + chart.plotTop,
+        pxTranslationX = xAxis.len / 2,
+        pxTranslationY = yAxis.len / 2;
+
+    // Hover draggable point, so k-d tree builds and
+    // `chart.hoverPoint` will be available for drag&drop module:
+    controller.mouseMove(x, y);
+
+    // Drag point:
+    controller.mouseDown(x, y);
+
+    // Move point:
+    controller.mouseMove(x + pxTranslationX, y + pxTranslationY);
+
+    // And mic drop:
+    controller.mouseUp(x + pxTranslationX, y + pxTranslationY);
+
+    assert.close(
+        point.x,
+        xAxis.toValue(x + pxTranslationX),
+        0.1,
+        'Correct x-value after horizontal drag&drop (#10285)'
+    );
+
+    assert.close(
+        point.y,
+        yAxis.toValue(y + pxTranslationY),
+        0.1,
+        'Correct y-value after vertical drag&drop (#10285)'
+    );
+});


### PR DESCRIPTION
Fixed #10285, drag and drop module did not work with logarithmic axes.
___
Refactored logic a bit. Instead of translating things back and forth (`toValue(toPixels() - sth1) -sth2)`), distance between mouse pointer and point's value is stored in the snapshot. Later, when calculating new value we simply use `e.chartX/e.chartY` position of the cursor + offset from the snapshot. 

I'm not saying this is the only solution, maybe something with `dX`/`dY`/`oldX`/`oldY`/`dxValue`/`dyValue` is wrong, but this way it's simpler (readable) and faster (only one translation for values in snapshot, instead of calculating `toPixels()` in every step).

Tested manually with grouped points, xrange, line series, gantt and inverted charts.