### PR TITLE
feature/10648-annotations-remove-integer

### DIFF
--- a/js/annotations/annotations.src.js
+++ b/js/annotations/annotations.src.js
@@ -12,7 +12,6 @@ import H from '../parts/Globals.js';
 
 import U from '../parts/Utilities.js';
 var defined = U.defined,
-    isString = U.isString,
     splat = U.splat;
 
 import '../parts/Chart.js';
@@ -211,7 +210,7 @@ merge(
              * annotation in [Chart#removeAnnotation(id)](
              * /class-reference/Highcharts.Chart#removeAnnotation) method.
              *
-             * @type      {string}
+             * @type      {string|number}
              * @apioption annotations.id
              */
 
@@ -1237,17 +1236,19 @@ H.extend(chartProto, /** @lends Highcharts.Chart# */ {
     /**
      * Remove an annotation from the chart.
      *
-     * @param {String|Annotation} idOrAnnotation - The annotation's id or
+     * @param {String|Number|Annotation} idOrAnnotation - The annotation's id or
      *      direct annotation object.
      */
     removeAnnotation: function (idOrAnnotation) {
         var annotations = this.annotations,
-            annotation = isString(idOrAnnotation) ? find(
-                annotations,
-                function (annotation) {
-                    return annotation.options.id === idOrAnnotation;
-                }
-            ) : idOrAnnotation;
+            annotation = idOrAnnotation.coll === 'annotations' ?
+                idOrAnnotation :
+                find(
+                    annotations,
+                    function (annotation) {
+                        return annotation.options.id === idOrAnnotation;
+                    }
+                );
 
         if (annotation) {
             fireEvent(annotation, 'remove');

--- a/samples/unit-tests/annotations/annotations-dynamic/demo.js
+++ b/samples/unit-tests/annotations/annotations-dynamic/demo.js
@@ -56,7 +56,7 @@ QUnit.test('Annotation\'s dynamic methods', function (assert) {
     );
 
     var secondAnnotationOptions = {
-        id: '2',
+        id: 2,
         labels: [{
             point: {
                 x: 3,
@@ -138,6 +138,14 @@ QUnit.test('Annotation\'s dynamic methods', function (assert) {
         annotation.shapes[0].graphic.attr('r'),
         25,
         'Correct annotation size after update (annotations.shapes)'
+    );
+
+    chart.removeAnnotation(2);
+
+    assert.strictEqual(
+        chart.annotations.length,
+        2,
+        'Annotation with id=number, should be removed without errors (#10648)'
     );
 });
 


### PR DESCRIPTION
Added support for number type in `annotation.id`, see #10648.