### PR TITLE
 bugfix/11351-gapsize-datagrouping

### DIFF
--- a/js/modules/broken-axis.src.js
+++ b/js/modules/broken-axis.src.js
@@ -499,11 +499,17 @@ H.Series.prototype.gappedPath = function () {
 
         // Gap unit is relative
         if (this.options.gapUnit !== 'value') {
-            gapSize *= this.closestPointRange;
+            gapSize *= this.basePointRange;
         }
 
         // Setting a new gapSize in case dataGrouping is enabled (#7686)
-        if (groupingSize && groupingSize > gapSize) {
+        if (
+            groupingSize &&
+            groupingSize > gapSize &&
+            // Except when DG is forced (e.g. from other series)
+            // and has lower granularity than actual points (#11351)
+            groupingSize >= this.basePointRange
+        ) {
             gapSize = groupingSize;
         }
 

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -2866,7 +2866,8 @@ null,
         series.cropStart = cropStart;
         series.processedXData = processedXData;
         series.processedYData = processedYData;
-        series.closestPointRange = closestPointRange;
+        series.closestPointRange =
+            series.basePointRange = closestPointRange;
     },
     /**
      * Iterate over xData and crop values between min and max. Returns

--- a/samples/unit-tests/series/datagrouping-with-gapsize/demo.js
+++ b/samples/unit-tests/series/datagrouping-with-gapsize/demo.js
@@ -136,4 +136,34 @@ QUnit.test('dataGrouping with gapSize (#7686)', function (assert) {
         33,
         'Graph should be continuous when dataGrouping is months (#10000)'
     );
+
+    chart.addSeries({
+        dataGrouping: {
+            forced: true,
+            units: [
+                [
+                    'month', [1]
+                ]
+            ]
+        },
+        gapSize: 2,
+        data: [
+            [Date.UTC(2019, 0, 1), 1],
+            [Date.UTC(2019, 3, 1), 2],
+            [Date.UTC(2019, 6, 1), 3],
+            [Date.UTC(2019, 9, 1), 4]
+        ]
+    }, false);
+    chart.series[0].update({
+        dataGrouping: {
+            forced: true
+        },
+        gapSize: 2
+    });
+
+    assert.strictEqual(
+        chart.series[1].graph.attr('d').split(' ').lastIndexOf('L'),
+        9,
+        'Series with higher granularity should be continous (#11351)'
+    );
 });

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -268,6 +268,7 @@ declare global {
             public animationTimeout?: number;
             public area?: SVGElement;
             public axisTypes: ['xAxis', 'yAxis'];
+            public basePointRange?: number;
             public buildingKdTree?: boolean;
             public chart: Chart;
             public clips?: Array<SVGElement>;
@@ -3814,7 +3815,8 @@ H.Series = H.seriesType<Highcharts.SeriesOptions>(
             series.processedXData = processedXData;
             series.processedYData = processedYData;
 
-            series.closestPointRange = closestPointRange;
+            series.closestPointRange =
+                series.basePointRange = closestPointRange;
 
         },
 


### PR DESCRIPTION
Fixed #11351, `gapSize` and multiple `dataGrouping`s sometimes hide series line with lower granularity.
___
Added an extra prop: `series.basePointRange` - in comparison to `series.closestPointRange`, it's unaffected by dataGrouping. I'm open for suggestions for a better name (`baseClosestPointRange` seems a bit too long ;) ). 