### PR TITLE
bugfix/10980-stocktools-single-item

### DIFF
--- a/js/modules/stock-tools-gui.js
+++ b/js/modules/stock-tools-gui.js
@@ -1082,7 +1082,7 @@ H.Toolbar.prototype = {
 
 
         // submenu
-        if (items && items.length > 1) {
+        if (items && items.length) {
 
             // arrow is a hook to show / hide submenu
             submenuArrow = createElement(SPAN, {

--- a/samples/unit-tests/stock-tools/gui/demo.details
+++ b/samples/unit-tests/stock-tools/gui/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/stock-tools/gui/demo.html
+++ b/samples/unit-tests/stock-tools/gui/demo.html
@@ -1,0 +1,11 @@
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+
+<script src="https://code.highcharts.com/stock/indicators/indicators.js"></script>
+<script src="https://code.highcharts.com/stock/modules/annotations-advanced.js"></script>
+
+<script src="https://code.highcharts.com/stock/modules/stock-tools.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/stock-tools/gui/demo.js
+++ b/samples/unit-tests/stock-tools/gui/demo.js
@@ -1,0 +1,22 @@
+QUnit.test('Touch event test on popup', function (assert) {
+
+    Highcharts.stockChart('container', {
+        stockTools: {
+            gui: {
+                definitions: {
+                    measure: {
+                        items: ['measureX']
+                    }
+                }
+            }
+        },
+        series: [{
+            data: [1, 2, 3]
+        }]
+    });
+
+    assert.ok(
+        1,
+        'No errors should be thrown after setting just one item (#10980)'
+    );
+});


### PR DESCRIPTION
Fixed #10980, defining just one item in `stockTools.gui.definitions[name]` threw errors.
___
I went the simpler route - I let render just one submenu button so errors are not thrown. Alternative approach is to replace button+submenu with that item (of course when exactly one item is set). What do you think @sebastianbochan ?