### PR TITLE
bugfix/11156/boost-draggable-group-points

### DIFF
--- a/js/modules/draggable-points.src.js
+++ b/js/modules/draggable-points.src.js
@@ -1529,11 +1529,27 @@ function getPositionSnapshot(e, points, guideBox) {
  */
 function getGroupedPoints(point) {
     var series = point.series,
+        points = [],
         groupKey = series.options.dragDrop.groupBy;
+
+    if (series.isSeriesBoosting) { // #11156
+        series.options.data.forEach(function (pointOptions, i) {
+            points.push(
+                (new series.pointClass()).init( // eslint-disable-line new-cap
+                    series,
+                    pointOptions
+                )
+            );
+            points[points.length - 1].index = i;
+        });
+
+    } else {
+        points = series.points;
+    }
 
     return point.options[groupKey] ?
         // If we have a grouping option, filter the points by that
-        series.points.filter(function (comparePoint) {
+        points.filter(function (comparePoint) {
             return comparePoint.options[groupKey] === point.options[groupKey];
         }) :
         // Otherwise return the point by itself only

--- a/samples/unit-tests/dragdrop/dynamic/demo.html
+++ b/samples/unit-tests/dragdrop/dynamic/demo.html
@@ -1,5 +1,6 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/draggable-points.js"></script>
+<script src="https://code.highcharts.com/modules/boost.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/dragdrop/dynamic/demo.js
+++ b/samples/unit-tests/dragdrop/dynamic/demo.js
@@ -105,3 +105,42 @@ QUnit.test('Dragdrop and logarithmic axes', function (assert) {
         'Correct y-value after vertical drag&drop (#10285)'
     );
 });
+
+QUnit.test('Dragdrop with boost', function (assert) {
+    var chart = Highcharts.chart('container', {
+            boost: {
+                seriesThreshold: 1
+            },
+            series: [{
+                data: [
+                    [0, 4, 'line1'],
+                    [10, 7, 'line1'],
+                    [10.001, 3, 'line1'],
+                    [10.002, 5, 'line1'],
+                    [20, 10, 'line1']
+                ],
+                keys: ['x', 'y', 'groupId'],
+                dragDrop: {
+                    liveRedraw: false,
+                    draggableX: true,
+                    draggableY: true,
+                    groupBy: 'groupId'
+                }
+            }]
+        }),
+        controller = new TestController(chart),
+        point = chart.series[0].points[0],
+        x = point.plotX + chart.plotLeft,
+        y = point.plotY + chart.plotTop;
+
+    controller.mouseMove(x, y);
+    controller.mouseDown(x, y);
+    controller.mouseMove(x + 100, y + 100);
+    controller.mouseUp(x + 100, y + 100);
+
+    assert.notEqual(
+        point.x,
+        chart.series[0].points[0].x,
+        'Dragdrop should work with boost (#11156).'
+    );
+});


### PR DESCRIPTION
Fixed #11156, draggable did not work with group points and boost module.