### PR TITLE
bugfix/11174-annotation-measure-size-fullscreen

### DIFF
--- a/js/annotations/types/Measure.js
+++ b/js/annotations/types/Measure.js
@@ -357,6 +357,11 @@ H.extendAnnotation(Measure, null,
                 this.calculations.updateStartPoints.call(this, true, false);
             }
 
+            // #11174 - clipBox was not recalculate during resize / redraw
+            if (this.clipRect) {
+                this.clipRect.animate(this.getClipBox());
+            }
+
             this.addValues(resize);
             this.addCrosshairs();
             this.redrawItems(this.shapes, animation);


### PR DESCRIPTION
Fixed #11174, size of measure annotation was not recalculated in redraw.