### PR TITLE
bugfix/11388-histogram-error-nodata

### DIFF
--- a/js/modules/histogram.src.js
+++ b/js/modules/histogram.src.js
@@ -125,8 +125,14 @@ seriesType(
     },
     merge(derivedSeriesMixin, {
         setDerivedData: function () {
+            var yData = this.baseSeries.yData;
+
+            if (!yData.length) {
+                return;
+            }
+
             var data = this.derivedData(
-                this.baseSeries.yData,
+                yData,
                 this.binsNumber(),
                 this.options.binWidth
             );

--- a/samples/unit-tests/series-histogram/members/demo.details
+++ b/samples/unit-tests/series-histogram/members/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series-histogram/members/demo.html
+++ b/samples/unit-tests/series-histogram/members/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/histogram-bellcurve.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/series-histogram/members/demo.js
+++ b/samples/unit-tests/series-histogram/members/demo.js
@@ -1,0 +1,17 @@
+QUnit.test('setDerivedData', assert => {
+    const { setDerivedData } = Highcharts.seriesTypes.histogram.prototype;
+    const ctx = {
+        baseSeries: {
+            yData: []
+        }
+    };
+
+    /**
+     * setDerivedData should work properly with an empty yData. #11388.
+     */
+    setDerivedData.call(ctx);
+    assert.ok(
+        true,
+        'Should not error when called with empty yData.'
+    );
+});


### PR DESCRIPTION
Fixed #11388, error was return when empty histogram data.