### PR TITLE
bugfix/11415-annotation-popup-overflow

### DIFF
--- a/css/annotations/popup.scss
+++ b/css/annotations/popup.scss
@@ -9,6 +9,7 @@ $button-hover-color: #e6ebf5;
   right: 10%;
   left: auto;
   height: 40px;
+  overflow: hidden;
   padding-right: 40px;
   width: auto;
   min-width: 0;


### PR DESCRIPTION
Fixed #11415, vertical scrollbar was visible in annotation popup.