### PR TITLE
Expose the ESM entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "7.1.2-modified",
   "description": "JavaScript charting framework",
   "main": "lib/highcharts",
+  "module": "es-modules/masters/highcharts.src.js",
   "author": "Highsoft AS <support@highcharts.com> (http://www.highcharts.com/about)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Exposes the standard `module` entry point for ESM-aware bundlers, utilities like @pika/web, and helper sites like unpkg.com and bundle.run