### PR TITLE
bugfix/11386-exporting-missing-css-filters

### DIFF
--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -1058,7 +1058,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             .replace(/zIndex="[^"]+"/g, '')
             .replace(/symbolName="[^"]+"/g, '')
             .replace(/jQuery[0-9]+="[^"]+"/g, '')
-            .replace(/url\(("|&quot;)(\S+)("|&quot;)\)/g, 'url($2)')
+            .replace(/url\(("|&quot;)(.*?)("|&quot;)\;?\)/g, 'url($2)')
             .replace(/url\([^#]+#/g, 'url(#')
             .replace(
                 /<svg /,

--- a/samples/unit-tests/exporting/styled-mode/demo.css
+++ b/samples/unit-tests/exporting/styled-mode/demo.css
@@ -1,0 +1,7 @@
+@import 'https://code.highcharts.com/css/highcharts.css';
+
+.highcharts-yaxis-labels {
+    filter: url(#glow);
+    fill: red;
+    stroke-width: 1px;
+}

--- a/samples/unit-tests/exporting/styled-mode/demo.details
+++ b/samples/unit-tests/exporting/styled-mode/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/exporting/styled-mode/demo.html
+++ b/samples/unit-tests/exporting/styled-mode/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 400px; height: 400px; margin: 0 auto;"></div>

--- a/samples/unit-tests/exporting/styled-mode/demo.js
+++ b/samples/unit-tests/exporting/styled-mode/demo.js
@@ -1,0 +1,36 @@
+QUnit.test("General exporting module tests with Styled Mode enabled.", function (assert) {
+
+    var chart = Highcharts.chart('container', {
+        chart: {
+            styledMode: true
+        },
+
+        defs: {
+            glow: {
+                tagName: 'filter',
+                id: 'glow',
+                children: [{
+                    tagName: 'feGaussianBlur',
+                    result: 'coloredBlur',
+                    stdDeviation: 1
+                }]
+            }
+        },
+
+        series: [{
+            data: [1, 2, 3]
+        }]
+    });
+
+    var svg = chart.getSVG(),
+        urls = svg.match(/url\(.*?\;?\)/g),
+        matched = urls.filter(function (url) {
+            return url.match(/\&quot;/);
+        });
+
+    assert.strictEqual(
+        matched.length,
+        0,
+        "Exported chart CSS 'url' values does not have any unnecessary '&quot;' strings.",
+    );
+});


### PR DESCRIPTION
Fixed #11386, CSS filters were missing when Styled Mode enabled.