### PR TITLE
Fixed #11329, tooltip transform/scaling issues.

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -1643,6 +1643,8 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         if (chart.setResponsive) {
             chart.setResponsive();
         }
+        // Handle scaling
+        chart.updateContainerScaling();
         // Set flag
         chart.hasRendered = true;
     },
@@ -1693,6 +1695,30 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                 chart.credits = chart.credits.destroy();
                 chart.addCredits(options);
             };
+        }
+    },
+    /**
+     * Handle scaling, #11329 - when there is scaling/transform on the container
+     * or on a parent element, we need to take this into account. We calculate
+     * the scaling once here and it is picked up where we need to use it
+     * (Pointer, Tooltip).
+     *
+     * @private
+     * @function Highcharts.Chart#updateContainerScaling
+     * @return {void}
+     */
+    updateContainerScaling: function () {
+        var container = this.container;
+        if (container.offsetWidth &&
+            container.offsetHeight &&
+            container.getBoundingClientRect) {
+            var bb = container.getBoundingClientRect(), scaleX = bb.width / container.offsetWidth, scaleY = bb.height / container.offsetHeight;
+            if (scaleX !== 1 || scaleY !== 1) {
+                this.containerScaling = { scaleX: scaleX, scaleY: scaleY };
+            }
+            else {
+                delete this.containerScaling;
+            }
         }
     },
     /**

--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -207,9 +207,17 @@ Highcharts.Pointer.prototype = {
         if (!chartPosition) {
             this.chartPosition = chartPosition = offset(this.chart.container);
         }
+        var chartX = ePos.pageX - chartPosition.left, chartY = ePos.pageY - chartPosition.top;
+        // #11329 - when there is scaling on a parent element, we need to take
+        // this into account
+        var containerScaling = this.chart.containerScaling;
+        if (containerScaling) {
+            chartX /= containerScaling.scaleX;
+            chartY /= containerScaling.scaleY;
+        }
         return extend(e, {
-            chartX: Math.round(ePos.pageX - chartPosition.left),
-            chartY: Math.round(ePos.pageY - chartPosition.top)
+            chartX: Math.round(chartX),
+            chartY: Math.round(chartY)
         });
     },
     /**

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -565,43 +565,35 @@ H.Tooltip.prototype = {
             doc.documentElement.clientWidth - 2 * distance :
             chart.chartWidth, outerHeight = outside ?
             Math.max(doc.body.scrollHeight, doc.documentElement.scrollHeight, doc.body.offsetHeight, doc.documentElement.offsetHeight, doc.documentElement.clientHeight) :
-            chart.chartHeight, chartPosition = chart.pointer.chartPosition, containerScaling = chart.containerScaling, scaleX = function (val) {
-            return containerScaling ? val * containerScaling.scaleX : val;
-        }, scaleY = function (val) {
-            return containerScaling ? val * containerScaling.scaleY : val;
-        }, 
+            chart.chartHeight, chartPosition = chart.pointer.chartPosition, containerScaling = chart.containerScaling, scaleX = function (val) { return ( // eslint-disable-line no-confusing-arrow
+        containerScaling ? val * containerScaling.scaleX : val); }, scaleY = function (val) { return ( // eslint-disable-line no-confusing-arrow
+        containerScaling ? val * containerScaling.scaleY : val); }, 
         // Build parameter arrays for firstDimension()/secondDimension()
         buildDimensionArray = function (dim) {
             var isX = dim === 'x';
             return [
                 dim,
-                isX ? outerWidth
-                    : outerHeight,
-                isX ? boxWidth
-                    : boxHeight
+                isX ? outerWidth : outerHeight,
+                isX ? boxWidth : boxHeight
             ].concat(outside ? [
                 // If we are using tooltip.outside, we need to scale the
                 // position to match scaling of the container in case there
                 // is a transform/zoom on the container. #11329
-                isX ? scaleX(boxWidth)
-                    : scaleY(boxHeight),
+                isX ? scaleX(boxWidth) : scaleY(boxHeight),
                 isX ? chartPosition.left - distance +
-                    scaleX(point.plotX + chart.plotLeft)
-                    : chartPosition.top - distance +
+                    scaleX(point.plotX + chart.plotLeft) :
+                    chartPosition.top - distance +
                         scaleY(point.plotY + chart.plotTop),
                 0,
-                isX ? outerWidth
-                    : outerHeight
+                isX ? outerWidth : outerHeight
             ] : [
                 // Not outside, no scaling is needed
-                isX ? boxWidth
-                    : boxHeight,
-                isX ? point.plotX + chart.plotLeft
-                    : point.plotY + chart.plotTop,
-                isX ? chart.plotLeft
-                    : chart.plotTop,
-                isX ? chart.plotLeft + chart.plotWidth
-                    : chart.plotTop + chart.plotHeight
+                isX ? boxWidth : boxHeight,
+                isX ? point.plotX + chart.plotLeft :
+                    point.plotY + chart.plotTop,
+                isX ? chart.plotLeft : chart.plotTop,
+                isX ? chart.plotLeft + chart.plotWidth :
+                    chart.plotTop + chart.plotHeight
             ]);
         }, first = buildDimensionArray('y'), second = buildDimensionArray('x'), 
         // The far side is right or bottom

--- a/samples/highcharts/tooltip/scale/demo.details
+++ b/samples/highcharts/tooltip/scale/demo.details
@@ -1,0 +1,7 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Øystein Moseng
+ js_wrap: b
+ requiresManualTesting: true
+...

--- a/samples/highcharts/tooltip/scale/demo.html
+++ b/samples/highcharts/tooltip/scale/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div style="margin-right:95px; margin-top:170px; margin-bottom: 80px">
+    <div style="transform: scale(0.6, 1.2); ">
+      <div id="container" style="height: 400px; max-width: 700px"></div>
+    </div>
+</div>

--- a/samples/highcharts/tooltip/scale/demo.js
+++ b/samples/highcharts/tooltip/scale/demo.js
@@ -1,0 +1,13 @@
+Highcharts.chart('container', {
+    tooltip: {
+        outside: true,
+        useHTML: true
+    },
+    series: [{
+        data: [1, 4, 3, 5, 6, 7, 4, 3, 5, 2, 3, 4, 6, 5, 4],
+        type: 'line'
+    }, {
+        data: [1, 2, 2, 1, 2, 1, 2, 1, 2, 2, 1, 2, 2, 1, 2],
+        type: 'spline'
+    }]
+});

--- a/samples/highcharts/tooltip/scale/test-notes.md
+++ b/samples/highcharts/tooltip/scale/test-notes.md
@@ -1,0 +1,1 @@
+Verify that tooltips display correctly with scaling/transform matching the chart, and that tooltip follows the mouse hovering action as on a normal chart.

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -72,7 +72,7 @@ declare global {
             public colorCounter: number;
             public container: HTMLDOMElement;
             public containerHeight?: string;
-            public containerScaling?: { scaleX: number, scaleY: number };
+            public containerScaling?: { scaleX: number; scaleY: number };
             public containerWidth?: string;
             public credits?: SVGElement;
             public hasCartesianSeries?: boolean;

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -72,6 +72,7 @@ declare global {
             public colorCounter: number;
             public container: HTMLDOMElement;
             public containerHeight?: string;
+            public containerScaling?: { scaleX: number, scaleY: number };
             public containerWidth?: string;
             public credits?: SVGElement;
             public hasCartesianSeries?: boolean;
@@ -165,6 +166,7 @@ declare global {
                 redraw?: boolean
             ): void;
             public temporaryDisplay(revert?: boolean): void;
+            public updateContainerScaling(): void;
         }
         function chart(
             options: Options,
@@ -2408,6 +2410,9 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             chart.setResponsive();
         }
 
+        // Handle scaling
+        chart.updateContainerScaling();
+
         // Set flag
         chart.hasRendered = true;
 
@@ -2477,6 +2482,34 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                 chart.credits = (chart.credits as any).destroy() as any;
                 chart.addCredits(options);
             };
+        }
+    },
+
+    /**
+     * Handle scaling, #11329 - when there is scaling/transform on the container
+     * or on a parent element, we need to take this into account. We calculate
+     * the scaling once here and it is picked up where we need to use it
+     * (Pointer, Tooltip).
+     *
+     * @private
+     * @function Highcharts.Chart#updateContainerScaling
+     * @return {void}
+     */
+    updateContainerScaling: function (this: Highcharts.Chart): void {
+        const container = this.container;
+        if (
+            container.offsetWidth &&
+            container.offsetHeight &&
+            container.getBoundingClientRect
+        ) {
+            const bb = container.getBoundingClientRect(),
+                scaleX = bb.width / container.offsetWidth,
+                scaleY = bb.height / container.offsetHeight;
+            if (scaleX !== 1 || scaleY !== 1) {
+                this.containerScaling = { scaleX, scaleY };
+            } else {
+                delete this.containerScaling;
+            }
         }
     },
 

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -386,10 +386,21 @@ Highcharts.Pointer.prototype = {
             this.chartPosition = chartPosition = offset(this.chart.container);
         }
 
+        let chartX = ePos.pageX - chartPosition.left,
+            chartY = ePos.pageY - chartPosition.top;
+
+        // #11329 - when there is scaling on a parent element, we need to take
+        // this into account
+        const containerScaling = this.chart.containerScaling;
+        if (containerScaling) {
+            chartX /= containerScaling.scaleX;
+            chartY /= containerScaling.scaleY;
+        }
+
         return extend(e, {
-            chartX: Math.round(ePos.pageX - chartPosition.left),
-            chartY: Math.round(ePos.pageY - chartPosition.top)
-        }) as any;
+            chartX: Math.round(chartX),
+            chartY: Math.round(chartY)
+        }) as any;    
     },
 
     /**

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -400,7 +400,7 @@ Highcharts.Pointer.prototype = {
         return extend(e, {
             chartX: Math.round(chartX),
             chartY: Math.round(chartY)
-        }) as any;    
+        }) as any;
     },
 
     /**

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -835,42 +835,38 @@ H.Tooltip.prototype = {
                 chart.chartHeight,
             chartPosition = chart.pointer.chartPosition,
             containerScaling = chart.containerScaling,
-            scaleX = (val: number): number =>
-                    containerScaling ? val * containerScaling.scaleX : val,
-            scaleY = (val: number): number =>
-                    containerScaling ? val * containerScaling.scaleY : val,
+            scaleX = (val: number): number => ( // eslint-disable-line no-confusing-arrow
+                containerScaling ? val * containerScaling.scaleX : val
+            ),
+            scaleY = (val: number): number => ( // eslint-disable-line no-confusing-arrow
+                containerScaling ? val * containerScaling.scaleY : val
+            ),
             // Build parameter arrays for firstDimension()/secondDimension()
-            buildDimensionArray = (dim: 'x' | 'y') => {
+            buildDimensionArray = (dim: 'x' | 'y'): Array<number|string> => {
                 const isX = dim === 'x';
                 return [
                     dim, // Dimension - x or y
-                    isX ? outerWidth
-                        : outerHeight,
-                    isX ? boxWidth
-                        : boxHeight
+                    isX ? outerWidth : outerHeight,
+                    isX ? boxWidth : boxHeight
                 ].concat(outside ? [
                     // If we are using tooltip.outside, we need to scale the
                     // position to match scaling of the container in case there
                     // is a transform/zoom on the container. #11329
-                    isX ? scaleX(boxWidth)
-                        : scaleY(boxHeight),
+                    isX ? scaleX(boxWidth) : scaleY(boxHeight),
                     isX ? chartPosition.left - distance +
-                            scaleX(point.plotX! + chart.plotLeft)
-                        : chartPosition.top - distance +
-                            scaleY(point.plotY! + chart.plotTop),
+                            scaleX((point.plotX as any) + chart.plotLeft) :
+                        chartPosition.top - distance +
+                            scaleY((point.plotY as any) + chart.plotTop),
                     0,
-                    isX ? outerWidth
-                        : outerHeight
+                    isX ? outerWidth : outerHeight
                 ] : [
                     // Not outside, no scaling is needed
-                    isX ? boxWidth
-                        : boxHeight,
-                    isX ? point.plotX! + chart.plotLeft
-                        : point.plotY! + chart.plotTop,
-                    isX ? chart.plotLeft
-                        : chart.plotTop,
-                    isX ? chart.plotLeft + chart.plotWidth
-                        : chart.plotTop + chart.plotHeight
+                    isX ? boxWidth : boxHeight,
+                    isX ? (point.plotX as any) + chart.plotLeft :
+                        (point.plotY as any) + chart.plotTop,
+                    isX ? chart.plotLeft : chart.plotTop,
+                    isX ? chart.plotLeft + chart.plotWidth :
+                        chart.plotTop + chart.plotHeight
                 ]);
             },
             first = buildDimensionArray('y'),
@@ -1413,8 +1409,8 @@ H.Tooltip.prototype = {
                 label.height,
                 point
             ),
-            anchorX = point.plotX! + chart.plotLeft,
-            anchorY = point.plotY! + chart.plotTop,
+            anchorX = (point.plotX as any) + chart.plotLeft,
+            anchorY = (point.plotY as any) + chart.plotTop,
             pad;
 
         // Set the renderer size dynamically to prevent document size to change

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -834,24 +834,47 @@ H.Tooltip.prototype = {
                 ) :
                 chart.chartHeight,
             chartPosition = chart.pointer.chartPosition,
-            first = [
-                'y',
-                outerHeight,
-                boxHeight,
-                (outside ? chartPosition.top - distance : 0) +
-                    (point.plotY as any) + chart.plotTop,
-                outside ? 0 : chart.plotTop,
-                outside ? outerHeight : chart.plotTop + chart.plotHeight
-            ],
-            second = [
-                'x',
-                outerWidth,
-                boxWidth,
-                (outside ? chartPosition.left - distance : 0) +
-                    (point.plotX as any) + chart.plotLeft,
-                outside ? 0 : chart.plotLeft,
-                outside ? outerWidth : chart.plotLeft + chart.plotWidth
-            ],
+            containerScaling = chart.containerScaling,
+            scaleX = (val: number): number =>
+                    containerScaling ? val * containerScaling.scaleX : val,
+            scaleY = (val: number): number =>
+                    containerScaling ? val * containerScaling.scaleY : val,
+            // Build parameter arrays for firstDimension()/secondDimension()
+            buildDimensionArray = (dim: 'x' | 'y') => {
+                const isX = dim === 'x';
+                return [
+                    dim, // Dimension - x or y
+                    isX ? outerWidth
+                        : outerHeight,
+                    isX ? boxWidth
+                        : boxHeight
+                ].concat(outside ? [
+                    // If we are using tooltip.outside, we need to scale the
+                    // position to match scaling of the container in case there
+                    // is a transform/zoom on the container. #11329
+                    isX ? scaleX(boxWidth)
+                        : scaleY(boxHeight),
+                    isX ? chartPosition.left - distance +
+                            scaleX(point.plotX! + chart.plotLeft)
+                        : chartPosition.top - distance +
+                            scaleY(point.plotY! + chart.plotTop),
+                    0,
+                    isX ? outerWidth
+                        : outerHeight
+                ] : [
+                    // Not outside, no scaling is needed
+                    isX ? boxWidth
+                        : boxHeight,
+                    isX ? point.plotX! + chart.plotLeft
+                        : point.plotY! + chart.plotTop,
+                    isX ? chart.plotLeft
+                        : chart.plotTop,
+                    isX ? chart.plotLeft + chart.plotWidth
+                        : chart.plotTop + chart.plotHeight
+                ]);
+            },
+            first = buildDimensionArray('y'),
+            second = buildDimensionArray('x'),
             // The far side is right or bottom
             preferFarSide = !this.followPointer && pick(
                 point.ttBelow,
@@ -869,14 +892,18 @@ H.Tooltip.prototype = {
                 dim: string,
                 outerSize: number,
                 innerSize: number,
+                scaledInnerSize: number, // #11329
                 point: number,
                 min: number,
                 max: number
             ): (boolean|undefined) {
-                var roomLeft = innerSize < point - distance,
-                    roomRight = point + distance + innerSize < outerSize,
-                    alignedLeft = point - distance - innerSize,
-                    alignedRight = point + distance;
+                const scaledDist = dim === 'y' ?
+                        scaleY(distance) : scaleX(distance),
+                    scaleDiff = (innerSize - scaledInnerSize) / 2,
+                    roomLeft = scaledInnerSize < point - distance,
+                    roomRight = point + distance + scaledInnerSize < outerSize,
+                    alignedLeft = point - scaledDist - innerSize + scaleDiff,
+                    alignedRight = point + scaledDist - scaleDiff;
 
                 if (preferFarSide && roomRight) {
                     ret[dim] = alignedRight;
@@ -884,7 +911,7 @@ H.Tooltip.prototype = {
                     ret[dim] = alignedLeft;
                 } else if (roomLeft) {
                     ret[dim] = Math.min(
-                        max - innerSize,
+                        max - scaledInnerSize,
                         alignedLeft - h < 0 ? alignedLeft : alignedLeft - h
                     );
                 } else if (roomRight) {
@@ -911,10 +938,10 @@ H.Tooltip.prototype = {
                 dim: number,
                 outerSize: number,
                 innerSize: number,
+                scaledInnerSize: number, // #11329
                 point: number
             ): (boolean|undefined) {
                 var retVal;
-
                 // Too close to the edge, return false and swap dimensions
                 if (point < distance || point > outerSize - distance) {
                     retVal = false;
@@ -922,8 +949,8 @@ H.Tooltip.prototype = {
                 } else if (point < innerSize / 2) {
                     ret[dim] = 1;
                 // Align right/bottom
-                } else if (point > outerSize - innerSize / 2) {
-                    ret[dim] = outerSize - innerSize - 2;
+                } else if (point > outerSize - scaledInnerSize / 2) {
+                    ret[dim] = outerSize - scaledInnerSize - 2;
                 // Align center
                 } else {
                     ret[dim] = point - innerSize / 2;
@@ -1386,8 +1413,8 @@ H.Tooltip.prototype = {
                 label.height,
                 point
             ),
-            anchorX = (point.plotX as any) + chart.plotLeft,
-            anchorY = (point.plotY as any) + chart.plotTop,
+            anchorX = point.plotX! + chart.plotLeft,
+            anchorY = point.plotY! + chart.plotTop,
             pad;
 
         // Set the renderer size dynamically to prevent document size to change
@@ -1398,6 +1425,22 @@ H.Tooltip.prototype = {
                 label.height + pad,
                 false
             );
+
+            // Anchor and tooltip container need scaling if chart container has
+            // scale transform/css zoom. #11329.
+            const containerScaling = chart.containerScaling;
+            if (containerScaling) {
+                H.css(this.container as Highcharts.HTMLDOMElement, {
+                    transform: `scale(${
+                        containerScaling.scaleX
+                    }, ${
+                        containerScaling.scaleY
+                    })`
+                });
+                anchorX *= containerScaling.scaleX;
+                anchorY *= containerScaling.scaleY;
+            }
+
             anchorX += chart.pointer.chartPosition.left - pos.x;
             anchorY += chart.pointer.chartPosition.top - pos.y;
         }


### PR DESCRIPTION
Fixed #11329, tooltip transform/scaling issues.
___
When `transform: scale(...)` is added to a parent container of the chart, pointer positioning is wrong. In addition, when using `tooltip.outside`, the tooltip positioning/sizing is off, since it renders a new container for the tooltip outside of the chart container.

This is solved in the PR by adding a new prop `chart.containerScaling` that is set by `render` when we detect a mismatch between the clientRect width/height and offsetWidth/height. The prop is an object that contains the scaling factor for the X and Y dimensions.

This scaling factor is then applied in `Pointer.normalize` if it exists, which handles most of the issues.

It is also applied to the Tooltip whenever we are using `tooltip.outside`. The tooltip container is scaled to match, and its positioning algorithm is adjusted accordingly. Some refactoring was necessary to avoid repeating too much code here.

Storing the prop on render should avoid any noticeable performance hits that would incur by checking the clientRect on every pointer event and tooltip draw, and we are now only appying a scale factor here (and only if the scale factor exists).

@bre1470 Do we need a full-on interface for the `containerScaling` prop on chart (see Chart.ts), or can we get away with the shorter way, as in the current code?