### PR TITLE
bugfix/4024-stacking-xaxis

### DIFF
--- a/js/parts/Stacking.js
+++ b/js/parts/Stacking.js
@@ -255,10 +255,13 @@ Chart.prototype.getStacks = function () {
         }
     });
     chart.series.forEach(function (series) {
+        var xAxis = series.xAxis;
         if (series.options.stacking &&
             (series.visible === true ||
                 chart.options.chart.ignoreHiddenSeries === false)) {
-            series.stackKey = series.type + pick(series.options.stack, '');
+            series.stackKey = series.type +
+                pick(series.options.stack, '') + ',' +
+                xAxis.options.left + ',' + xAxis.options.width;
         }
     });
 };

--- a/js/parts/Stacking.js
+++ b/js/parts/Stacking.js
@@ -247,7 +247,7 @@ H.StackItem.prototype = {
  * @return {void}
  */
 Chart.prototype.getStacks = function () {
-    var chart = this;
+    var chart = this, inverted = chart.inverted;
     // reset stacks for each yAxis
     chart.yAxis.forEach(function (axis) {
         if (axis.stacks && axis.hasVisibleSeries) {
@@ -259,9 +259,12 @@ Chart.prototype.getStacks = function () {
         if (series.options.stacking &&
             (series.visible === true ||
                 chart.options.chart.ignoreHiddenSeries === false)) {
-            series.stackKey = series.type +
-                pick(series.options.stack, '') + ',' +
-                xAxis.options.left + ',' + xAxis.options.width;
+            series.stackKey = [
+                series.type,
+                pick(series.options.stack, ''),
+                inverted ? xAxis.options.top : xAxis.options.left,
+                inverted ? xAxis.options.height : xAxis.options.width
+            ].join(',');
         }
     });
 };

--- a/samples/unit-tests/3d/column-stacked-labels/demo.js
+++ b/samples/unit-tests/3d/column-stacked-labels/demo.js
@@ -31,8 +31,9 @@ QUnit.test('3D columns stackLabels render', function (assert) {
         }]
     });
 
-    var dataLabel = chart.series[0].data[0].dataLabel,
-        stackLabel = chart.yAxis[0].stacks.columnfemale[0].label;
+    var series = chart.series[0],
+        dataLabel = series.data[0].dataLabel,
+        stackLabel = chart.yAxis[0].stacks[series.stackKey][0].label;
 
     dataLabel.x = dataLabel.translateX + dataLabel.element.getBBox().x;
     dataLabel.y = dataLabel.translateY + dataLabel.element.getBBox().y;

--- a/samples/unit-tests/axis/waterfall-stacklabels/demo.js
+++ b/samples/unit-tests/axis/waterfall-stacklabels/demo.js
@@ -31,11 +31,14 @@ QUnit.test('#3165 - Stack labels in waterfall series', function (assert) {
         }]
     });
 
+    var series = chart.series,
+        yAxis = chart.yAxis[0];
+
     assert.strictEqual(
-        chart.series[1].points[3].plotY >
-            chart.yAxis[0].waterfallStacks.waterfall[3].label.alignAttr.y,
+        series[1].points[3].plotY >
+            yAxis.waterfallStacks[series[0].stackKey][3].label.alignAttr.y,
         true,
-        'Stack label is positioned above the stack.'
+        'Stack label should be positioned above the stack.'
     );
 
     chart.update({
@@ -48,10 +51,10 @@ QUnit.test('#3165 - Stack labels in waterfall series', function (assert) {
     });
 
     assert.strictEqual(
-        chart.series[1].points[3].plotY <
-            chart.yAxis[0].waterfallStacks.waterfall[3].label.alignAttr.y,
+        series[1].points[3].plotY <
+            yAxis.waterfallStacks[series[0].stackKey][3].label.alignAttr.y,
         true,
-        'Stack label is positioned below the stack.'
+        'Stack label should be positioned below the stack.'
     );
 
     chart.update({

--- a/samples/unit-tests/series/stacking/demo.js
+++ b/samples/unit-tests/series/stacking/demo.js
@@ -194,7 +194,7 @@ QUnit.test('Date objects as X values, column', function (assert) {
         }).highcharts();
 
         assert.strictEqual(
-            sizeof(chart.yAxis[0].stacks.area),
+            sizeof(chart.yAxis[0].stacks[chart.series[0].stackKey]),
             5,
             'Stack is 5'
         );
@@ -210,7 +210,7 @@ QUnit.test('Date objects as X values, column', function (assert) {
         // Note: the size of the stacks is now 10, while we would ideally have 5.
         // It seems like the initial 5 are not removed at all.
         assert.strictEqual(
-            sizeof(chart.yAxis[0].stacks.area) < 11,
+            sizeof(chart.yAxis[0].stacks[chart.series[0].stackKey]) < 11,
             true,
             'Stacks have been removed'
         );
@@ -522,7 +522,10 @@ QUnit.test('Date objects as X values, column', function (assert) {
         });
 
         assert.strictEqual(
-            chart.yAxis[0].stacks.column[0].label.alignAttr.y <
+            chart
+                .yAxis[0]
+                .stacks[chart.series[1].stackKey][0]
+                .label.alignAttr.y <
             chart.series[1].points[0].plotY,
             true,
             'Stack labels should be above the stack'
@@ -553,12 +556,77 @@ QUnit.test('Date objects as X values, column', function (assert) {
             }]
         });
 
-        var labelPos = chart.yAxis[0].stacks.bar[0].label;
+        var labelPos = chart
+            .yAxis[0]
+            .stacks[chart.series[0].stackKey][0]
+            .label;
+
         assert.close(
             chart.xAxis[0].toPixels(0, true),
             labelPos.alignAttr.y + (labelPos.getBBox().height / 2),
             1,
             'Stack labels should be properly positioned'
+        );
+    });
+
+
+    QUnit.test("Stack positions with multiple axes", function (assert) {
+        var chart = Highcharts.chart('container', {
+                chart: {
+                    type: 'column'
+                },
+                plotOptions: {
+                    series: {
+                        stacking: 'normal',
+                        grouping: false
+                    }
+                },
+                xAxis: [{
+                    width: '50%'
+                }, {
+                    width: '50%',
+                    opposite: true
+                }, {
+                    width: '50%',
+                    left: '50%',
+                    offset: 0
+                }, {
+                    width: '50%',
+                    left: '50%',
+                    offset: 0,
+                    opposite: true
+                }],
+                series: [{
+                    data: [1]
+                }, {
+                    data: [1],
+                    xAxis: 1
+                }, {
+                    data: [1],
+                    xAxis: 2
+                }, {
+                    data: [1],
+                    xAxis: 3
+                }]
+            }),
+            yAxis = chart.yAxis[0],
+            series = chart.series;
+
+        // Use assert.close() because of criping logic
+        assert.close(
+            series[0].points[0].shapeArgs.y +
+                series[0].points[0].shapeArgs.height,
+            yAxis.toPixels(1, true),
+            2,
+            'Series 1 - point should start from value=1 (#4024)'
+        );
+
+        assert.close(
+            series[2].points[0].shapeArgs.y +
+                series[2].points[0].shapeArgs.height,
+            yAxis.toPixels(1, true),
+            2,
+            'Series 3 - Point should start from value=1 (#4024)'
         );
     });
 }());

--- a/samples/unit-tests/series/threshold/demo.js
+++ b/samples/unit-tests/series/threshold/demo.js
@@ -38,7 +38,7 @@ QUnit.test(
         });
 
         assert.strictEqual(
-            chart.yAxis[0].stacks.bar[0].cumulative,
+            chart.yAxis[0].stacks[chart.series[0].stackKey][0].cumulative,
             90,
             'Threshold is applied'
         );

--- a/ts/parts/Stacking.ts
+++ b/ts/parts/Stacking.ts
@@ -499,11 +499,15 @@ Chart.prototype.getStacks = function (this: Highcharts.Chart): void {
     });
 
     chart.series.forEach(function (series: Highcharts.Series): void {
+        var xAxis = series.xAxis;
+
         if (series.options.stacking &&
             (series.visible === true ||
             (chart.options.chart as any).ignoreHiddenSeries === false)
         ) {
-            series.stackKey = series.type + pick(series.options.stack, '');
+            series.stackKey = series.type +
+                pick(series.options.stack, '') + ',' +
+                xAxis.options.left + ',' + xAxis.options.width;
         }
     });
 };

--- a/ts/parts/Stacking.ts
+++ b/ts/parts/Stacking.ts
@@ -489,7 +489,8 @@ H.StackItem.prototype = {
  * @return {void}
  */
 Chart.prototype.getStacks = function (this: Highcharts.Chart): void {
-    var chart = this;
+    var chart = this,
+        inverted = chart.inverted;
 
     // reset stacks for each yAxis
     chart.yAxis.forEach(function (axis: Highcharts.Axis): void {
@@ -505,9 +506,12 @@ Chart.prototype.getStacks = function (this: Highcharts.Chart): void {
             (series.visible === true ||
             (chart.options.chart as any).ignoreHiddenSeries === false)
         ) {
-            series.stackKey = series.type +
-                pick(series.options.stack, '') + ',' +
-                xAxis.options.left + ',' + xAxis.options.width;
+            series.stackKey = [
+                series.type,
+                pick(series.options.stack, ''),
+                inverted ? xAxis.options.top : xAxis.options.left,
+                inverted ? xAxis.options.height : xAxis.options.width
+            ].join(',');
         }
     });
 };


### PR DESCRIPTION
Fixed #4024, stacking columns on different xAxis translated columns as in stacking on the same xAxis.
___
Note: We can not use `series.options.xAxis` option for generating key, because two axes with the same position (e.g. duplicated xAxis on top) should apply stacking naturally.

Additionally replaced hardcoded stack keys names in tests with dynamic values, generated in core.