### PR TITLE
ts/11438-quad-node-clean

### DIFF
--- a/js/modules/networkgraph/QuadTree.js
+++ b/js/modules/networkgraph/QuadTree.js
@@ -83,6 +83,7 @@ H.extend(QuadTreeNode.prototype,
      *        Max depth of the QuadTree
      */
     insert: function (point, depth) {
+        var newQuadTreeNode;
         if (this.isInternal) {
             // Internal node:
             this.nodes[this.getBoxPosition(point)].insert(point, depth - 1);
@@ -110,7 +111,24 @@ H.extend(QuadTreeNode.prototype,
                         .insert(point, depth - 1);
                 }
                 else {
-                    this.nodes.push(point);
+                    // We are below max allowed depth. That means either:
+                    // - really huge number of points
+                    // - falling two points into exactly the same position
+                    // In this case, create another node in the QuadTree.
+                    //
+                    // Alternatively we could add some noise to the
+                    // position, but that could result in different
+                    // rendered chart in exporting.
+                    newQuadTreeNode = new QuadTreeNode({
+                        top: point.plotX,
+                        left: point.plotY,
+                        // Width/height below 1px
+                        width: 0.1,
+                        height: 0.1
+                    });
+                    newQuadTreeNode.body = point;
+                    newQuadTreeNode.isInternal = false;
+                    this.nodes.push(newQuadTreeNode);
                 }
             }
         }
@@ -301,9 +319,6 @@ H.extend(QuadTree.prototype,
             return;
         }
         node.nodes.forEach(function (qtNode) {
-            if (chart) {
-                // this.renderBox(qtNode, chart, clear);
-            }
             if (qtNode.isInternal) {
                 if (beforeCallback) {
                     goFurther = beforeCallback(qtNode);
@@ -333,43 +348,5 @@ H.extend(QuadTree.prototype,
         this.visitNodeRecursive(null, null, function (node) {
             node.updateMassAndCenter();
         });
-    },
-    render: function (chart, clear) {
-        this.visitNodeRecursive(this.root, null, null, chart, clear);
-    },
-    clear: function (chart) {
-        this.render(chart, true);
-    },
-    renderBox: function (qtNode, chart, clear) {
-        if (!qtNode.graphic && !clear) {
-            qtNode.graphic = chart.renderer
-                .rect(qtNode.box.left + chart.plotLeft, qtNode.box.top + chart.plotTop, qtNode.box.width, qtNode.box.height)
-                .attr({
-                stroke: 'rgba(100, 100, 100, 0.5)',
-                'stroke-width': 2
-            })
-                .add();
-            if (!isNaN(qtNode.plotX)) {
-                qtNode.graphic2 = chart.renderer
-                    .circle(qtNode.plotX, qtNode.plotY, qtNode.mass / 10)
-                    .attr({
-                    fill: 'red',
-                    translateY: chart.plotTop,
-                    translateX: chart.plotLeft
-                })
-                    .add();
-            }
-        }
-        else if (clear) {
-            if (qtNode.graphic) {
-                qtNode.graphic = qtNode.graphic.destroy();
-            }
-            if (qtNode.graphic2) {
-                qtNode.graphic2 = qtNode.graphic2.destroy();
-            }
-            if (qtNode.label) {
-                qtNode.label = qtNode.label.destroy();
-            }
-        }
     }
 });

--- a/js/modules/networkgraph/QuadTree.js
+++ b/js/modules/networkgraph/QuadTree.js
@@ -307,7 +307,7 @@ H.extend(QuadTree.prototype,
      * @param {Function} afterCallback function to be called after
      *                      visiting children nodes
      */
-    visitNodeRecursive: function (node, beforeCallback, afterCallback, chart, clear) {
+    visitNodeRecursive: function (node, beforeCallback, afterCallback) {
         var goFurther;
         if (!node) {
             node = this.root;
@@ -326,7 +326,7 @@ H.extend(QuadTree.prototype,
                 if (goFurther === false) {
                     return;
                 }
-                this.visitNodeRecursive(qtNode, beforeCallback, afterCallback, chart, clear);
+                this.visitNodeRecursive(qtNode, beforeCallback, afterCallback);
             }
             else if (qtNode.body) {
                 if (beforeCallback) {

--- a/ts/modules/networkgraph/QuadTree.ts
+++ b/ts/modules/networkgraph/QuadTree.ts
@@ -29,9 +29,7 @@ declare global {
             public visitNodeRecursive(
                 node: (QuadTreeNode|null),
                 beforeCallback: (Function|null),
-                afterCallback: (Function|null),
-                chart?: Chart,
-                clear?: boolean
+                afterCallback: (Function|null)
             ): void;
         }
         class QuadTreeNode {
@@ -398,9 +396,7 @@ H.extend(
             this: Highcharts.QuadTree,
             node: (Highcharts.QuadTreeNode|null),
             beforeCallback: (Function|null),
-            afterCallback: (Function|null),
-            chart?: Highcharts.Chart,
-            clear?: boolean
+            afterCallback: (Function|null)
         ): void {
             var goFurther: (boolean|undefined);
 
@@ -431,9 +427,7 @@ H.extend(
                         this.visitNodeRecursive(
                             qtNode,
                             beforeCallback,
-                            afterCallback,
-                            chart,
-                            clear
+                            afterCallback
                         );
                     } else if (qtNode.body) {
                         if (beforeCallback) {


### PR DESCRIPTION
Fixed #11438 - wrong types in QuadTree nodes. Additionally cleaned up the QuadNode - there was post dev code that was not necessary anymore.

Just for future reference, it helps debugging BH-approx: https://jsfiddle.net/BlackLabel/m3tr104z/