### PR TITLE
bugfix/11483-incorrect-lastvisibleprice-datagrouping

### DIFF
--- a/js/modules/price-indicator.src.js
+++ b/js/modules/price-indicator.src.js
@@ -74,6 +74,7 @@ var addEvent = H.addEvent,
 addEvent(H.Series, 'afterRender', function () {
     var serie = this,
         seriesOptions = serie.options,
+        pointRange = seriesOptions.pointRange,
         lastVisiblePrice = seriesOptions.lastVisiblePrice,
         lastPrice = seriesOptions.lastPrice;
 
@@ -86,8 +87,10 @@ addEvent(H.Series, 'afterRender', function () {
             origGraphic = yAxis.cross,
             origLabel = yAxis.crossLabel,
             points = serie.points,
+            yLength = serie.yData.length,
+            pLength = points.length,
             x = serie.xData[serie.xData.length - 1],
-            y = serie.yData[serie.yData.length - 1],
+            y = serie.yData[yLength - 1],
             lastPoint,
             yValue,
             crop;
@@ -115,17 +118,17 @@ addEvent(H.Series, 'afterRender', function () {
 
         if (lastVisiblePrice &&
             lastVisiblePrice.enabled &&
-            points.length > 0
+            pLength > 0
         ) {
 
-            crop = points[points.length - 1].x === x ? 1 : 2;
+            crop = (points[pLength - 1].x === x) || pointRange === null ? 1 : 2;
 
             yAxis.crosshair = yAxis.options.crosshair = merge({
                 color: 'transparent'
             }, seriesOptions.lastVisiblePrice);
 
             yAxis.cross = serie.lastVisiblePrice;
-            lastPoint = points[points.length - crop];
+            lastPoint = points[pLength - crop];
             // Save price
             yAxis.drawCrosshair(null, lastPoint);
 

--- a/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
+++ b/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
@@ -1,3 +1,21 @@
+var correctFloat = Highcharts.correctFloat,
+    getData = function () {
+        var data = [],
+            i;
+
+        for (i = 0; i < 1000; i++) {
+            data.push([
+                (+new Date()) + i * 3600,
+                153 + correctFloat(Math.random(0, 1), 2),
+                153 + correctFloat(Math.random(0, 1), 2),
+                153 + correctFloat(Math.random(0, 1), 2),
+                153 + correctFloat(Math.random(0, 1), 2)
+            ]);
+        }
+
+        return data;
+    };
+
 QUnit.test('Price indicator.', function (assert) {
 
     var chart = Highcharts.stockChart('container', {
@@ -30,5 +48,49 @@ QUnit.test('Price indicator.', function (assert) {
         series.points.length === 0 && series.lastPrice === undefined,
         true,
         'No errors when points are missing.'
+    );
+});
+
+QUnit.test('Datagrouping and setExtremes.', function (assert) {
+
+    var chart = Highcharts.stockChart('container', {
+            rangeSelector: {
+                selected: 5
+            },
+            series: [{
+                type: 'candlestick',
+                dataGrouping: {
+                    enabled: true
+                },
+                lastVisiblePrice: {
+                    enabled: true,
+                    label: {
+                        enabled: true
+                    }
+                },
+                lastPrice: {
+                    enabled: true,
+                    color: 'red'
+                },
+                data: getData()
+            }]
+        }),
+        series = chart.series[0];
+
+    assert.strictEqual(
+        series.points[series.points.length - 1].y === series.lastVisiblePrice.y,
+        true,
+        'Correct value when datagrouping enabled.'
+    );
+
+    var min = chart.xAxis[0].min,
+        max = min + 100 * 3600;
+
+    chart.xAxis[0].setExtremes(min, max);
+
+    assert.strictEqual(
+        series.points[series.points.length - 1].y === series.lastVisiblePrice.y,
+        true,
+        'Correct value when setExtremes and disabled datagrouping.'
     );
 });

--- a/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
+++ b/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
@@ -77,7 +77,7 @@ QUnit.test('Datagrouping and setExtremes.', function (assert) {
         }),
         series = chart.series[0];
 
-    assert.ok(
+    assert.strictEqual(
         series.points[series.points.length - 1].y,
         series.lastVisiblePrice.y,
         'Indicator should show the close value of the last grouped point.'
@@ -88,7 +88,7 @@ QUnit.test('Datagrouping and setExtremes.', function (assert) {
 
     chart.xAxis[0].setExtremes(min, max);
 
-    assert.ok(
+    assert.strictEqual(
         series.points[series.points.length - 1].y,
         series.lastVisiblePrice.y,
         'Indicator should show the close value of the last non-grouped point.'

--- a/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
+++ b/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
@@ -77,9 +77,9 @@ QUnit.test('Datagrouping and setExtremes.', function (assert) {
         }),
         series = chart.series[0];
 
-    assert.strictEqual(
-        series.points[series.points.length - 1].y === series.lastVisiblePrice.y,
-        true,
+    assert.ok(
+        series.points[series.points.length - 1].y,
+        series.lastVisiblePrice.y,
         'Indicator should show the close value of the last grouped point.'
     );
 
@@ -88,9 +88,9 @@ QUnit.test('Datagrouping and setExtremes.', function (assert) {
 
     chart.xAxis[0].setExtremes(min, max);
 
-    assert.strictEqual(
-        series.points[series.points.length - 1].y === series.lastVisiblePrice.y,
-        true,
+    assert.ok(
+        series.points[series.points.length - 1].y,
+        series.lastVisiblePrice.y,
         'Indicator should show the close value of the last non-grouped point.'
     );
 });

--- a/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
+++ b/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
@@ -80,7 +80,7 @@ QUnit.test('Datagrouping and setExtremes.', function (assert) {
     assert.strictEqual(
         series.points[series.points.length - 1].y === series.lastVisiblePrice.y,
         true,
-        'Correct value when datagrouping enabled.'
+        'Indicator should show the close value of the last grouped point.'
     );
 
     var min = chart.xAxis[0].min,
@@ -91,6 +91,6 @@ QUnit.test('Datagrouping and setExtremes.', function (assert) {
     assert.strictEqual(
         series.points[series.points.length - 1].y === series.lastVisiblePrice.y,
         true,
-        'Correct value when setExtremes and disabled datagrouping.'
+        'Indicator should show the close value of the last non-grouped point.'
     );
 });


### PR DESCRIPTION
Fixed #11483, lastPrice indicator was incorrect with dataGrouping.