### PR TITLE
Bugfix/11493 split tooltip

### DIFF
--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -401,7 +401,9 @@ Highcharts.Pointer.prototype = {
                 // Get all points with the same x value as the hoverPoint
                 searchSeries.forEach(function (s) {
                     var point = find(s.points, function (p) {
-                        return p.x === hoverPoint.x && !p.isNull;
+                        return (p.x === hoverPoint.x &&
+                            !p.isNull &&
+                            p.isInside !== false);
                     });
                     if (isObject(point)) {
                         /*

--- a/samples/unit-tests/pointer/members/demo.js
+++ b/samples/unit-tests/pointer/members/demo.js
@@ -864,3 +864,42 @@ QUnit.test('Pointer.getHoverData', function (assert) {
         'Combination chart: Only one point hovered when hovered series has noSharedTooltip'
     );
 });
+
+QUnit.test('Hover points', assert => {
+    const chart = Highcharts.chart('container', {
+        yAxis: {
+            min: 2,
+            max: 5
+        },
+        series: [{
+            data: [1, 2, 3, 4]
+        }, {
+            data: [3, 2, 1, 4]
+        }],
+        tooltip: {
+            shared: true
+        }
+    });
+    const { series: [series1] } = chart;
+    const getSeriesNameAndPointIndex = point => `${point.series.name}.${point.index}`;
+
+    assert.strictEqual(
+        chart.hoverPoints,
+        undefined,
+        'Should have no hover points before any interaction'
+    );
+
+    series1.points[3].onMouseOver();
+    assert.deepEqual(
+        chart.hoverPoints.map(getSeriesNameAndPointIndex),
+        ['Series 1.3', 'Series 2.3'],
+        'Should include all series in hover points'
+    );
+
+    series1.points[2].onMouseOver();
+    assert.deepEqual(
+        chart.hoverPoints.map(getSeriesNameAndPointIndex),
+        ['Series 1.2'],
+        'Should not include points outside plot area in hover points. #7650'
+    );
+});

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -656,7 +656,11 @@ Highcharts.Pointer.prototype = {
                     var point = find(s.points, function (
                         p: Highcharts.Point
                     ): boolean {
-                        return p.x === hoverPoint.x && !p.isNull;
+                        return (
+                            p.x === hoverPoint.x &&
+                            !p.isNull &&
+                            p.isInside !== false
+                        );
                     });
 
                     if (isObject(point)) {


### PR DESCRIPTION
Fixed #7650 and #11493, points outside plot area were included as hover points, and were displayed in shared and split tooltip.

---
# Description
- Filter `hoverPoints` by `point.isInside` in `getHoverData` 

# Example(s)
- [Demo of issue #7650](https://jsfiddle.net/jon_a_nygaard/z0o94uwm/)
- [Demo of issue #7650 with fix applied](https://jsfiddle.net/jon_a_nygaard/nv6tq2kh/)
- [Demo of issue #11493](https://jsfiddle.net/jon_a_nygaard/nhudqsfa/)
- [Demo of issue #11493 with fix applied](https://jsfiddle.net/jon_a_nygaard/L68gt5pu/)

# Related issue(s)
- Closes #7650
- Closes #11493 
- Possibly related to #7711