### PR TITLE
Remove duplicate theme files

### DIFF
--- a/js/masters/themes/avocado.js
+++ b/js/masters/themes/avocado.js
@@ -1,9 +1,0 @@
-/**
- * @license Highcharts JS v@product.version@ (@product.date@)
- *
- * (c) 2009-2019 Highsoft AS
- *
- * License: www.highcharts.com/license
- */
-'use strict';
-import '../../themes/avocado.js';

--- a/js/masters/themes/sunset.js
+++ b/js/masters/themes/sunset.js
@@ -1,9 +1,0 @@
-/**
- * @license Highcharts JS v@product.version@ (@product.date@)
- *
- * (c) 2009-2019 Highsoft AS
- *
- * License: www.highcharts.com/license
- */
-'use strict';
-import '../../themes/sunset.js';


### PR DESCRIPTION
Removed duplicate theme files `avocado.js` and `sunset.js` that has likely overwritten what should be the [minified theme files in highcharts-dist](https://github.com/highcharts/highcharts-dist/blob/06ffc9a3b8d5072deefd663898aab114f27f0287/themes/avocado.js)