### PR TITLE
ts/api-internals

### DIFF
--- a/js/mixins/nelder-mead.js
+++ b/js/mixins/nelder-mead.js
@@ -19,11 +19,11 @@ var getCentroid = function (simplex) {
  * @todo add unit tests.
  * @todo add constraints to optimize the algorithm.
  * @private
- * @param {Highcharts.NelderMearTestFunction} fn
+ * @param {Highcharts.NelderMeadTestFunction} fn
  *        The function to test a point.
- * @param {Highcharts.NelderMearPointArray} initial
+ * @param {Highcharts.NelderMeadPointArray} initial
  *        The initial point to optimize.
- * @return {Highcharts.NelderMearPointArray}
+ * @return {Highcharts.NelderMeadPointArray}
  *         Returns the opimized position of a point.
  */
 var nelderMead = function nelderMead(fn, initial) {

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -3750,7 +3750,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
         var axis = this, names = this.names, i = names.length;
         if (i > 0) {
             Object.keys(names.keys).forEach(function (key) {
-                delete names.keys[key];
+                delete (names.keys)[key];
             });
             names.length = 0;
             this.minRange = this.userMinRange; // Reset

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "gzip-size": "^5.0.0",
     "highcharts-assembler": "github:highcharts/highcharts-assembler#v1.3.5",
     "highcharts-declarations-generator": "github:highcharts/highcharts-declarations-generator#v1.1.13",
-    "highcharts-documentation-generators": "github:highcharts/highcharts-documentation-generators#v0.4.8",
+    "highcharts-documentation-generators": "github:highcharts/highcharts-documentation-generators#v0.5.0",
     "highcharts-utils": "github:highcharts/highcharts-utils",
     "husky": "^1.3.1",
     "js-yaml": "^3.13.0",

--- a/tools/gulptasks/tsdoc.js
+++ b/tools/gulptasks/tsdoc.js
@@ -11,15 +11,11 @@ const path = require('path');
  *
  * */
 
-const SOURCE_CONFIGS = [
-    'tsconfig-bullet.json'
-].map(
-    fileName => path.join('ts', 'masters-not-in-use-yet', fileName)
-);
+// const SOURCE_CONFIG = path.join('ts', 'tsconfig.json');
 
-const TARGET_JSON = 'tree-typescript.json';
+const TARGET_DIRECTORY = path.join('build', 'api-internals');
 
-const TARGET_DIRECTORY = path.join('build', 'api');
+// const TARGET_JSON = path.join(TARGET_DIRECTORY, 'tree-typescript.json');
 
 /* *
  *
@@ -33,6 +29,10 @@ const TARGET_DIRECTORY = path.join('build', 'api');
  */
 function task() {
 
+    const processLib = require('./lib/process');
+
+    return processLib.exec('cd ts && npx typedoc --out ../' + TARGET_DIRECTORY);
+    /*
     const generators = require('highcharts-documentation-generators');
     const log = require('./lib/log');
 
@@ -41,10 +41,11 @@ function task() {
         log.message('Generating', TARGET_DIRECTORY + '...');
 
         generators.TypeDoc
-            .task(SOURCE_CONFIGS[0], TARGET_DIRECTORY, TARGET_JSON)
+            .task(SOURCE_CONFIG, TARGET_DIRECTORY, TARGET_JSON)
             .then(() => log.success('Created', TARGET_DIRECTORY))
             .then(resolve);
     });
+    */
 }
 
 gulp.task('tsdoc', gulp.series('clean-api', task));

--- a/ts/mixins/nelder-mead.ts
+++ b/ts/mixins/nelder-mead.ts
@@ -10,18 +10,18 @@
  */
 declare global {
     namespace Highcharts {
-        interface NelderMearMixin {
-            getCentroid(simplex: Array<NelderMearPointArray>): Array<number>;
+        interface NelderMeadMixin {
+            getCentroid(simplex: Array<NelderMeadPointArray>): Array<number>;
             nelderMead(
-                fn: NelderMearTestFunction,
-                initial: NelderMearPointArray
-            ): NelderMearPointArray;
+                fn: NelderMeadTestFunction,
+                initial: NelderMeadPointArray
+            ): NelderMeadPointArray;
         }
-        interface NelderMearPointArray extends Array<number> {
+        interface NelderMeadPointArray extends Array<number> {
             fx: number;
         }
-        interface NelderMearTestFunction {
-            (point: NelderMearPointArray): number;
+        interface NelderMeadTestFunction {
+            (point: NelderMeadPointArray): number;
         }
     }
 }
@@ -34,7 +34,7 @@ declare interface NelderMearCentroidObject {
 /* eslint-disable valid-jsdoc */
 
 var getCentroid = function (
-    simplex: Array<Highcharts.NelderMearPointArray>
+    simplex: Array<Highcharts.NelderMeadPointArray>
 ): Array<number> {
     var arr = simplex.slice(0, -1),
         length = arr.length,
@@ -58,21 +58,21 @@ var getCentroid = function (
  * @todo add unit tests.
  * @todo add constraints to optimize the algorithm.
  * @private
- * @param {Highcharts.NelderMearTestFunction} fn
+ * @param {Highcharts.NelderMeadTestFunction} fn
  *        The function to test a point.
- * @param {Highcharts.NelderMearPointArray} initial
+ * @param {Highcharts.NelderMeadPointArray} initial
  *        The initial point to optimize.
- * @return {Highcharts.NelderMearPointArray}
+ * @return {Highcharts.NelderMeadPointArray}
  *         Returns the opimized position of a point.
  */
 var nelderMead = function nelderMead(
-    fn: Highcharts.NelderMearTestFunction,
-    initial: Highcharts.NelderMearPointArray
-): Highcharts.NelderMearPointArray {
+    fn: Highcharts.NelderMeadTestFunction,
+    initial: Highcharts.NelderMeadPointArray
+): Highcharts.NelderMeadPointArray {
     var maxIterations = 100,
         sortByFx = function (
-            a: Highcharts.NelderMearPointArray,
-            b: Highcharts.NelderMearPointArray
+            a: Highcharts.NelderMeadPointArray,
+            b: Highcharts.NelderMeadPointArray
         ): number {
             return a.fx - b.fx;
         },
@@ -100,10 +100,10 @@ var nelderMead = function nelderMead(
      * @private
      */
     var getSimplex = function getSimplex(
-        initial: Highcharts.NelderMearPointArray
-    ): Array<Highcharts.NelderMearPointArray> {
+        initial: Highcharts.NelderMeadPointArray
+    ): Array<Highcharts.NelderMeadPointArray> {
         var n = initial.length,
-            simplex: Array<Highcharts.NelderMearPointArray> =
+            simplex: Array<Highcharts.NelderMeadPointArray> =
                 new Array(n + 1);
 
         // Initial point to the simplex.
@@ -112,7 +112,7 @@ var nelderMead = function nelderMead(
 
         // Create a set of extra points based on the initial.
         for (var i = 0; i < n; ++i) {
-            var point = initial.slice() as Highcharts.NelderMearPointArray;
+            var point = initial.slice() as Highcharts.NelderMeadPointArray;
 
             point[i] = point[i] ? point[i] * 1.05 : 0.001;
             point.fx = fn(point);
@@ -122,24 +122,24 @@ var nelderMead = function nelderMead(
     };
 
     var updateSimplex = function (
-        simplex: Array<Highcharts.NelderMearPointArray>,
-        point: Highcharts.NelderMearPointArray
-    ): Array<Highcharts.NelderMearPointArray> {
+        simplex: Array<Highcharts.NelderMeadPointArray>,
+        point: Highcharts.NelderMeadPointArray
+    ): Array<Highcharts.NelderMeadPointArray> {
         point.fx = fn(point);
         simplex[simplex.length - 1] = point;
         return simplex;
     };
 
     var shrinkSimplex = function (
-        simplex: Array<Highcharts.NelderMearPointArray>
-    ): Array<Highcharts.NelderMearPointArray> {
+        simplex: Array<Highcharts.NelderMeadPointArray>
+    ): Array<Highcharts.NelderMeadPointArray> {
         var best = simplex[0];
 
         return simplex.map(function (
-            point: Highcharts.NelderMearPointArray
-        ): Highcharts.NelderMearPointArray {
+            point: Highcharts.NelderMeadPointArray
+        ): Highcharts.NelderMeadPointArray {
             var p = weightedSum(1 - pShrink, best, pShrink, point) as (
-                Highcharts.NelderMearPointArray
+                Highcharts.NelderMeadPointArray
             );
 
             p.fx = fn(p);
@@ -152,9 +152,9 @@ var nelderMead = function nelderMead(
         worst: Array<number>,
         a: number,
         b: number
-    ): Highcharts.NelderMearPointArray {
+    ): Highcharts.NelderMeadPointArray {
         var point = weightedSum(a, centroid, b, worst) as (
-            Highcharts.NelderMearPointArray
+            Highcharts.NelderMeadPointArray
         );
 
         point.fx = fn(point);
@@ -215,7 +215,7 @@ var nelderMead = function nelderMead(
     return simplex[0];
 };
 
-var content: Highcharts.NelderMearMixin = {
+var content: Highcharts.NelderMeadMixin = {
     getCentroid: getCentroid,
     nelderMead: nelderMead
 };

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -3830,7 +3830,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
         axis.categories = (options.categories as any) || axis.hasNames;
         if (!axis.names) { // Preserve on update (#3830)
             axis.names = [];
-            axis.names.keys = {} as any;
+            (axis.names as any).keys = {};
         }
 
 
@@ -4773,7 +4773,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
         if (x !== undefined) {
             this.names[x] = point.name as any;
             // Backwards mapping is much faster than array searching (#7725)
-            (this.names.keys as any)[point.name as any] = x;
+            (this.names as any).keys[point.name as any] = x;
         }
 
         return x;
@@ -4789,8 +4789,10 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
             i = names.length;
 
         if (i > 0) {
-            Object.keys(names.keys).forEach(function (key: string): void {
-                delete (names.keys as any)[key];
+            Object.keys((names as any).keys).forEach(function (
+                key: string
+            ): void {
+                delete ((names as any).keys)[key];
             });
             names.length = 0;
 

--- a/ts/parts/Utilities.ts
+++ b/ts/parts/Utilities.ts
@@ -1329,12 +1329,12 @@ function isDOMElement(obj: unknown): obj is HTMLElement {
  *         True if the argument is a class.
  */
 function isClass(obj: (object|undefined)): boolean {
-    var c = obj && obj.constructor;
+    var c: (Function|undefined) = obj && obj.constructor;
 
     return !!(
         isObject(obj, true) &&
         !isDOMElement(obj) &&
-        (c && c.name && c.name !== 'Object')
+        (c && (c as any).name && (c as any).name !== 'Object')
     );
 }
 
@@ -2509,10 +2509,10 @@ H.inArray = function (item: any, arr: Array<any>, fromIndex?: number): number {
  * @return {T|undefined}
  *         The value of the element.
  */
-H.find = Array.prototype.find ?
+H.find = (Array.prototype as any).find ?
     /* eslint-enable valid-jsdoc */
     function<T> (arr: Array<T>, callback: Function): (T|undefined) {
-        return arr.find(callback as any);
+        return (arr as any).find(callback as any);
     } :
     // Legacy implementation. PhantomJS, IE <= 11 etc. #7223.
     function<T> (arr: Array<T>, callback: Function): (T|undefined) {

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -1,74 +1,21 @@
 {
   "compilerOptions": {
-    /* Basic Options */
-    // "target": "es5",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "target": "es5",
-    // "module": "commonjs",                  /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "module": "es6",
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
     "allowJs": true,
-    // "checkJs": true,                       /* Report errors in .js files. */
     "checkJs": false,
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     "declaration": false,
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./",                        /* Redirect output structure to the directory. */
     "outDir": "../js",
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    "rootDir": "./",
-    // "composite": true,                     /* Enable project compilation */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "noEmitOnError": true,                 /* Do not emit outputs on error. */
+    "rootDir": ".",
     "noEmitOnError": true,
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
-    /* Strict Type-Checking Options */
-    // "strict": true,                        /* Enable all strict type-checking options. */
     "strict": true,
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     "noImplicitThis": true,                   /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
     "noUnusedLocals": true,
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     "noFallthroughCasesInSwitch": true,       /* Report errors for fallthrough cases in switch statement. */
-
-    /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "allowSyntheticDefaultImports": true,
-    // "esModuleInterop": true                /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     "esModuleInterop": true
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-    // "suppressImplicitAnyIndexErrors": true
-  }
+  },
+  "include": [
+      "**/*.ts"
+  ]
 }

--- a/ts/typedoc.json
+++ b/ts/typedoc.json
@@ -1,0 +1,12 @@
+{
+    "excludeExternals": true,
+    "excludeNotExported": false,
+    "excludePrivate": true,
+    "excludeProtected": true,
+    "ignoreCompilerErrors": false,
+    "includeDeclarations": false,
+    "gitRevision": "master",
+    "mode": "file",
+    "name": "Highcharts Internals",
+    "plugin": "none"
+}


### PR DESCRIPTION
- Added temporary config for internal documentation.
- `npm i` recommend afterwards.
- `npx gulp tsdoc` creates a `build/api-internals` documentation with all migrated classes and types.
- Some type fixes included.