### PR TITLE
`inactive.except`: implemented PoC for heatmap.

### DIFF
--- a/js/modules/boost/boost-overrides.js
+++ b/js/modules/boost/boost-overrides.js
@@ -331,6 +331,21 @@ wrap(Series.prototype, 'processData', function (proceed) {
     }
 });
 
+
+// In heatmap, inactive state tries to modify opacity for other points.
+// Disable this for canvas (where opacity is disabled) to improve performance.
+if (seriesTypes.heatmap) {
+    wrap(
+        seriesTypes.heatmap.prototype.pointClass.prototype,
+        'setState',
+        function (proceed) {
+            if (!this.series.isSeriesBoosting) {
+                proceed.apply(this, Array.prototype.slice.call(arguments, 1));
+            }
+        }
+    );
+}
+
 addEvent(Series, 'hide', function () {
     if (this.canvas && this.renderTarget) {
         if (this.ogl) {

--- a/js/modules/dependency-wheel.src.js
+++ b/js/modules/dependency-wheel.src.js
@@ -57,6 +57,7 @@ H.seriesType(
     }, {
         orderNodes: false,
         getCenter: H.seriesTypes.pie.prototype.getCenter,
+        inactiveFilters: H.NodesMixin.inactiveFilters,
 
         // Dependency wheel has only one column, it runs along the perimeter
         createNodeColumns: function () {
@@ -269,7 +270,6 @@ H.seriesType(
 
     // Point class
     {
-        setState: H.NodesMixin.setNodeState,
         // Return a text path that the data label uses
         getDataLabelPath: function (label) {
             var renderer = this.series.chart.renderer,

--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -161,6 +161,7 @@ seriesType('networkgraph', 'line',
          * to all links that are not comming from the hovered node.
          */
         inactive: {
+            except: 'from-to',
             /**
              * Opacity of inactive links.
              */
@@ -449,6 +450,7 @@ seriesType('networkgraph', 'line',
      */
     createNode: H.NodesMixin.createNode,
     destroy: H.NodesMixin.destroy,
+    inactiveFilters: H.NodesMixin.inactiveFilters,
     /* eslint-disable no-invalid-this, valid-jsdoc */
     /**
      * Extend init with base event, which should stop simulation during
@@ -689,9 +691,14 @@ seriesType('networkgraph', 'line',
         if (!this.layout.simulation && !state) {
             this.render();
         }
+    },
+    setAllPointsToState: function (state) {
+        var points = this.points;
+        this.points = this.data.concat(this.nodes);
+        Series.prototype.setAllPointsToState.call(this, state);
+        this.points = points;
     }
 }, {
-    setState: H.NodesMixin.setNodeState,
     /**
      * Basic `point.init()` and additional styles applied when
      * `series.draggable` is enabled.

--- a/js/modules/sankey.src.js
+++ b/js/modules/sankey.src.js
@@ -342,6 +342,7 @@ seriesType('sankey', 'column',
              * The opposite state of a hover for a single point node/link.
              */
             inactive: {
+                except: 'from-to',
                 /**
                  * Opacity for the links between nodes in the sankey diagram in
                  * inactive mode.
@@ -404,6 +405,7 @@ seriesType('sankey', 'column',
         createNode: H.NodesMixin.createNode,
         setData: H.NodesMixin.setData,
         destroy: H.NodesMixin.destroy,
+        inactiveFilters: H.NodesMixin.inactiveFilters,
 
         // Overridable function to get node padding, overridden in dependency
         // wheel series type
@@ -895,7 +897,6 @@ seriesType('sankey', 'column',
             }
             return this;
         },
-        setState: H.NodesMixin.setNodeState,
         getClassName: function () {
             return (this.isNode ? 'highcharts-node ' : 'highcharts-link ') +
             Point.prototype.getClassName.call(this);

--- a/js/parts-map/HeatmapSeries.js
+++ b/js/parts-map/HeatmapSeries.js
@@ -307,8 +307,7 @@ seriesType('heatmap', 'scatter',
             return activePoint.y === otherPoint.y;
         },
         self: function (activePoint, otherPoint) {
-            return activePoint.x === otherPoint.x &&
-                activePoint.y === otherPoint.y;
+            return false;
         }
     }
     /* eslint-enable valid-jsdoc */

--- a/js/parts-map/HeatmapSeries.js
+++ b/js/parts-map/HeatmapSeries.js
@@ -136,6 +136,8 @@ seriesType('heatmap', 'scatter',
         padding: 0 // #3837
     },
     /** @ignore-option */
+    inactiveOtherPoints: true,
+    /** @ignore-option */
     marker: null,
     /** @ignore-option */
     pointRange: null,
@@ -311,7 +313,7 @@ seriesType('heatmap', 'scatter',
         }
     }
     /* eslint-enable valid-jsdoc */
-}), merge({
+}), H.extend({
     /**
      * Heatmap series only. Padding between the points in the heatmap.
      * @name Highcharts.Point#pointPadding
@@ -350,29 +352,7 @@ seriesType('heatmap', 'scatter',
         ];
     }
     /* eslint-enable valid-jsdoc */
-}, colorPointMixin, {
-    setState: function (state) {
-        var point = this, series = this.series, points = series.points, inactiveException = series.options.states &&
-            series.options.states.inactive &&
-            series.options.states.inactive.except, filterFunction, i = 0;
-        if (inactiveException) {
-            filterFunction = series.inactiveFilters[inactiveException];
-            series.options.inactiveOtherPoints = true;
-            for (; i < points.length; i++) {
-                // Check if points are not being destroyed
-                if (points[i] && points[i].series) {
-                    colorPointMixin.setState.call(points[i], state !== 'hover' ||
-                        (state === 'hover' &&
-                            filterFunction(point, points[i])) ?
-                        '' : 'inactive');
-                }
-            }
-            series.options.inactiveOtherPoints = true;
-        }
-        // Apply default state for current point:
-        colorPointMixin.setState.apply(this, arguments);
-    }
-}));
+}, colorPointMixin));
 /**
  * A `heatmap` series. If the [type](#series.heatmap.type) option is
  * not specified, it is inherited from [chart.type](#chart.type).

--- a/js/parts-map/HeatmapSeries.js
+++ b/js/parts-map/HeatmapSeries.js
@@ -174,7 +174,7 @@ seriesType('heatmap', 'scatter',
              * @sample         highcharts/series-heatmap/inactive-except/
              *                 Compare different `except` options
              *
-             * @validvalue     ["all", column", "row", "column-row", "self"]
+             * @validvalue     ["all", "column", "row", "column-row", "self"]
              * @since          7.1.4
              * @product        highcharts highmaps
              */
@@ -353,9 +353,11 @@ seriesType('heatmap', 'scatter',
     /* eslint-enable valid-jsdoc */
 }, colorPointMixin, {
     setState: function (state) {
-        var point = this, series = this.series, points = series.points, inactiveException = series.options.states
-            .inactive.except, filterFunction = series.inactiveFilters[inactiveException], i = 0;
-        if (filterFunction) {
+        var point = this, series = this.series, points = series.points, inactiveException = series.options.states &&
+            series.options.states.inactive &&
+            series.options.states.inactive.except, filterFunction, i = 0;
+        if (inactiveException) {
+            filterFunction = series.inactiveFilters[inactiveException];
             series.options.inactiveOtherPoints = true;
             for (; i < points.length; i++) {
                 // Check if points are not being destroyed

--- a/js/parts-map/HeatmapSeries.js
+++ b/js/parts-map/HeatmapSeries.js
@@ -306,7 +306,7 @@ seriesType('heatmap', 'scatter',
         row: function (activePoint, otherPoint) {
             return activePoint.y === otherPoint.y;
         },
-        self: function (activePoint, otherPoint) {
+        self: function () {
             return false;
         }
     }

--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -472,11 +472,6 @@ Highcharts.Pointer.prototype = {
             if (chart.hoverSeries !== hoverSeries) {
                 hoverSeries.onMouseOver();
             }
-            pointer.applyInactiveState(points);
-            // Do mouseover on all points (#3919, #3985, #4410, #5622)
-            (points || []).forEach(function (p) {
-                p.setState('hover');
-            });
             // If tracking is on series in stead of on each point,
             // fire mouseOver on hover point. // #4448
             if (chart.hoverPoint) {
@@ -505,6 +500,12 @@ Highcharts.Pointer.prototype = {
             if (tooltip) {
                 tooltip.refresh(useSharedTooltip ? points : hoverPoint, e);
             }
+            // Once `hoverPoints` is set, apply inactive state:
+            pointer.applyInactiveState(points);
+            // Do mouseover on all points (#3919, #3985, #4410, #5622)
+            (points || []).forEach(function (p) {
+                p.setState('hover');
+            });
             // Update positions (regardless of kdpoint or hoverPoint)
         }
         else if (followPointer && tooltip && !tooltip.isHidden) {

--- a/samples/highcharts/series-heatmap/inactive-except/demo.details
+++ b/samples/highcharts/series-heatmap/inactive-except/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Pawel Fus
+ js_wrap: b
+...

--- a/samples/highcharts/series-heatmap/inactive-except/demo.html
+++ b/samples/highcharts/series-heatmap/inactive-except/demo.html
@@ -1,0 +1,23 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+<script src="https://code.highcharts.com/modules/heatmap.js"></script>
+<script src="https://code.highcharts.com/modules/data.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
+
+<div>
+  <input type="radio" id="all" name="inactive-except" value="all">
+  <label for="all">All (disabled)</label>
+
+  <input type="radio" id="column" name="inactive-except" value="column">
+  <label for="column">Column</label>
+
+  <input type="radio" id="column-row" name="inactive-except" value="column-row" checked>
+  <label for="column-row">Column-row</label>
+
+  <input type="radio" id="row" name="inactive-except" value="row">
+  <label for="row">Row</label>
+
+  <input type="radio" id="self" name="inactive-except" value="self">
+  <label for="self">Self</label>
+</div>
+<div id="container"></div>

--- a/samples/highcharts/series-heatmap/inactive-except/demo.js
+++ b/samples/highcharts/series-heatmap/inactive-except/demo.js
@@ -16,11 +16,12 @@ Highcharts.chart('container', {
                     });
                 }
 
-                document
-                    .querySelectorAll('input[name="inactive-except"]')
-                    .forEach(function (radio) {
+                Array.prototype.forEach.call(
+                    document.querySelectorAll('input[name="inactive-except"]'),
+                    function (radio) {
                         Highcharts.addEvent(radio, 'change', change);
-                    });
+                    }
+                );
             }
         }
     },

--- a/samples/highcharts/series-heatmap/inactive-except/demo.js
+++ b/samples/highcharts/series-heatmap/inactive-except/demo.js
@@ -1,0 +1,102 @@
+Highcharts.chart('container', {
+
+    chart: {
+        type: 'heatmap',
+        animation: false,
+        events: {
+            load: function () {
+                var chart = this;
+                function change() {
+                    chart.series[0].update({
+                        states: {
+                            inactive: {
+                                except: this.value
+                            }
+                        }
+                    });
+                }
+
+                document
+                    .querySelectorAll('input[name="inactive-except"]')
+                    .forEach(function (radio) {
+                        Highcharts.addEvent(radio, 'change', change);
+                    });
+            }
+        }
+    },
+
+    title: {
+        text: 'Change inactive.except option above and hover any cell to compare'
+    },
+
+    colorAxis: {
+        min: 0,
+        minColor: '#FFFFFF',
+        maxColor: Highcharts.getOptions().colors[0]
+    },
+
+    yAxis: {
+        gridLineWidth: 0
+    },
+
+    series: [{
+        borderWidth: 1,
+        data: [
+            [0, 0, 10],
+            [0, 1, 19],
+            [0, 2, 8],
+            [0, 3, 24],
+            [0, 4, 67],
+            [1, 0, 92],
+            [1, 1, 58],
+            [1, 2, 78],
+            [1, 3, 117],
+            [1, 4, 48],
+            [2, 0, 35],
+            [2, 1, 15],
+            [2, 2, 123],
+            [2, 3, 64],
+            [2, 4, 52],
+            [3, 0, 72],
+            [3, 1, 132],
+            [3, 2, 114],
+            [3, 3, 19],
+            [3, 4, 16],
+            [4, 0, 38],
+            [4, 1, 5],
+            [4, 2, 8],
+            [4, 3, 117],
+            [4, 4, 115],
+            [5, 0, 88],
+            [5, 1, 32],
+            [5, 2, 12],
+            [5, 3, 6],
+            [5, 4, 120],
+            [6, 0, 13],
+            [6, 1, 44],
+            [6, 2, 88],
+            [6, 3, 98],
+            [6, 4, 96],
+            [7, 0, 31],
+            [7, 1, 1],
+            [7, 2, 82],
+            [7, 3, 32],
+            [7, 4, 30],
+            [8, 0, 85],
+            [8, 1, 97],
+            [8, 2, 123],
+            [8, 3, 64],
+            [8, 4, 84],
+            [9, 0, 47],
+            [9, 1, 114],
+            [9, 2, 31],
+            [9, 3, 48],
+            [9, 4, 91]
+        ],
+        dataLabels: {
+            enabled: true,
+            color: '#000000'
+        }
+    }]
+
+});

--- a/samples/unit-tests/point/point/demo.js
+++ b/samples/unit-tests/point/point/demo.js
@@ -335,15 +335,6 @@ QUnit.test(
 
         assert.strictEqual(
             Highcharts.attr(
-                chart.series[0].points[0].graphic.element,
-                'opacity'
-            ),
-            '0.3',
-            'Legend hover: correct inactive series point opacity'
-        );
-
-        assert.strictEqual(
-            Highcharts.attr(
                 chart.series[1].points[0].graphic.element,
                 'opacity'
             ),

--- a/samples/unit-tests/series-heatmap/members/demo.js
+++ b/samples/unit-tests/series-heatmap/members/demo.js
@@ -200,7 +200,8 @@ QUnit.test('seriesTypes.heatmap.pointClass.setState', function (assert) {
                 options: {
                     states: {
                         hover: {},
-                        select: {}
+                        select: {},
+                        inactive: {}
                     }
                 },
                 pointAttribs: pointAttribs,
@@ -211,7 +212,8 @@ QUnit.test('seriesTypes.heatmap.pointClass.setState', function (assert) {
                             animation: false
                         }
                     }
-                }
+                },
+                inactiveFilters: {}
             },
             options: {}
         };

--- a/samples/unit-tests/styled-mode/series-states/demo.js
+++ b/samples/unit-tests/styled-mode/series-states/demo.js
@@ -29,7 +29,7 @@ QUnit.test('Inactive state and styledMode', function (assert) {
 
     assert.strictEqual(
         inactivePoints.length,
-        2,
+        1,
         'Exactly one point should have inactive state.'
     );
 

--- a/ts/modules/networkgraph/networkgraph.src.ts
+++ b/ts/modules/networkgraph/networkgraph.src.ts
@@ -88,6 +88,7 @@ declare global {
         {
             animation?: (boolean|AnimationOptionsObject);
             linkOpacity?: number;
+            except?: string;
         }
         interface NetworkgraphSeriesStatesOptions
             extends LineSeriesStatesOptions
@@ -112,7 +113,6 @@ declare global {
             public offset: NodesPoint['offset'];
             public options: NetworkgraphPointOptions;
             public series: NetworkgraphSeries;
-            public setNodeState: NodesMixin['setNodeState'];
             public to: NodesPoint['to'];
             public toNode: NetworkgraphPoint;
             public destroy(): void;
@@ -172,7 +172,6 @@ declare global {
                 state?: string
             ): SVGAttributes;
             public render(): void;
-            public setState(state: string, inherit?: boolean): void;
             public translate(): void;
         }
     }
@@ -347,6 +346,7 @@ seriesType<Highcharts.NetworkgraphSeriesOptions>(
              * to all links that are not comming from the hovered node.
              */
             inactive: {
+                except: 'from-to',
                 /**
                  * Opacity of inactive links.
                  */
@@ -656,6 +656,7 @@ seriesType<Highcharts.NetworkgraphSeriesOptions>(
          */
         createNode: H.NodesMixin.createNode,
         destroy: H.NodesMixin.destroy,
+        inactiveFilters: H.NodesMixin.inactiveFilters,
 
         /* eslint-disable no-invalid-this, valid-jsdoc */
 
@@ -996,9 +997,20 @@ seriesType<Highcharts.NetworkgraphSeriesOptions>(
             if (!this.layout.simulation && !state) {
                 this.render();
             }
+        },
+        setAllPointsToState: function (
+            this: Highcharts.NetworkgraphSeries,
+            state?: string
+        ): void {
+            var points = this.points;
+
+            this.points = this.data.concat(this.nodes);
+
+            Series.prototype.setAllPointsToState.call(this, state);
+
+            this.points = points;
         }
     }, {
-        setState: H.NodesMixin.setNodeState,
         /**
          * Basic `point.init()` and additional styles applied when
          * `series.draggable` is enabled.

--- a/ts/parts-map/HeatmapSeries.ts
+++ b/ts/parts-map/HeatmapSeries.ts
@@ -22,10 +22,9 @@ declare global {
             'row'|'column'|'column-row'|'self'|'all'
         );
 
-        type HeatmapInactiveFilterFunction = (
-            activePoint: HeatmapPoint,
-            otherPoint: HeatmapPoint
-        ) => boolean;
+        interface HeatmapInactiveFilterFunction {
+            (activePoint: HeatmapPoint, otherPoint: HeatmapPoint): boolean;
+        }
 
         interface HeatmapPointOptions extends ScatterPointOptions {
             pointPadding?: HeatmapPoint['pointPadding'];
@@ -536,10 +535,7 @@ seriesType<Highcharts.HeatmapSeriesOptions>(
             ): boolean {
                 return activePoint.y === otherPoint.y;
             },
-            self: function (
-                activePoint: Highcharts.HeatmapPoint,
-                otherPoint: Highcharts.HeatmapPoint
-            ): boolean {
+            self: function (): boolean {
                 return false;
             }
         }

--- a/ts/parts-map/HeatmapSeries.ts
+++ b/ts/parts-map/HeatmapSeries.ts
@@ -22,6 +22,11 @@ declare global {
             'row'|'column'|'column-row'|'self'|'all'
         );
 
+        type HeatmapInactiveFilterFunction = (
+            activePoint: HeatmapPoint,
+            otherPoint: HeatmapPoint
+        ) => boolean;
+
         interface HeatmapPointOptions extends ScatterPointOptions {
             pointPadding?: HeatmapPoint['pointPadding'];
             value?: HeatmapPoint['value'];
@@ -52,26 +57,11 @@ declare global {
             except?: HeatmapSeriesStatesInactiveExceptValue;
         }
         interface HeatmapInactiveFiltersObject {
-            all(
-                activePoint: HeatmapPoint,
-                otherPoint: HeatmapPoint
-            ): boolean;
-            column(
-                activePoint: HeatmapPoint,
-                otherPoint: HeatmapPoint
-            ): boolean;
-            'column-row'(
-                activePoint: HeatmapPoint,
-                otherPoint: HeatmapPoint
-            ): boolean;
-            row(
-                activePoint: HeatmapPoint,
-                otherPoint: HeatmapPoint
-            ): boolean;
-            self(
-                activePoint: HeatmapPoint,
-                otherPoint: HeatmapPoint
-            ): boolean;
+            all: HeatmapInactiveFilterFunction;
+            column: HeatmapInactiveFilterFunction;
+            'column-row': HeatmapInactiveFilterFunction;
+            row: HeatmapInactiveFilterFunction;
+            self: HeatmapInactiveFilterFunction;
         }
         interface Series {
             valueMax?: number;
@@ -550,8 +540,7 @@ seriesType<Highcharts.HeatmapSeriesOptions>(
                 activePoint: Highcharts.HeatmapPoint,
                 otherPoint: Highcharts.HeatmapPoint
             ): boolean {
-                return activePoint.x === otherPoint.x &&
-                    activePoint.y === otherPoint.y;
+                return false;
             }
         }
 

--- a/ts/parts-map/HeatmapSeries.ts
+++ b/ts/parts-map/HeatmapSeries.ts
@@ -313,7 +313,7 @@ seriesType<Highcharts.HeatmapSeriesOptions>(
                  * @sample         highcharts/series-heatmap/inactive-except/
                  *                 Compare different `except` options
                  *
-                 * @validvalue     ["all", column", "row", "column-row", "self"]
+                 * @validvalue     ["all", "column", "row", "column-row", "self"]
                  * @since          7.1.4
                  * @product        highcharts highmaps
                  */
@@ -616,13 +616,15 @@ seriesType<Highcharts.HeatmapSeriesOptions>(
             var point = this,
                 series = this.series,
                 points = series.points,
-                inactiveException = (series.options.states as any)
-                    .inactive.except as Highcharts
-                    .HeatmapSeriesStatesInactiveExceptValue,
-                filterFunction = series.inactiveFilters[inactiveException],
+                inactiveException = series.options.states &&
+                        series.options.states.inactive &&
+                        series.options.states.inactive.except,
+                filterFunction,
                 i = 0;
 
-            if (filterFunction) {
+            if (inactiveException) {
+                filterFunction = series.inactiveFilters[inactiveException];
+
                 series.options.inactiveOtherPoints = true;
 
                 for (; i < points.length; i++) {

--- a/ts/parts/Interaction.ts
+++ b/ts/parts/Interaction.ts
@@ -1547,11 +1547,55 @@ extend(Series.prototype, /** @lends Highcharts.Series.prototype */ {
         this: Highcharts.Series,
         state?: string
     ): void {
-        this.points.forEach(function (point: Highcharts.Point): void {
-            if (point.setState) {
-                point.setState(state);
+
+        var series = this,
+            points = series.points,
+            inactiveException = series.options.states &&
+                    series.options.states.inactive &&
+                    series.options.states.inactive.except,
+            // Get hovered points for this series:
+            activePoints = (series.chart.hoverPoints || [])
+                .filter(function (p): boolean {
+                    return p.series === series;
+                }),
+            i = 0;
+
+        if (
+            series.inactiveFilters &&
+            inactiveException &&
+            state === 'inactive'
+        ) {
+
+            if (activePoints && activePoints[0]) {
+                for (; i < points.length; i++) {
+                    // Check if points are not being destroyed
+                    if (points[i]) {
+                        points[i].setState(
+                            series.inactiveFilters[inactiveException](
+                                activePoints[0],
+                                points[i]
+                            ) ?
+                                // Set normal state in case we have switch
+                                // from 'inactive' state to 'normal'
+                                '' : state
+                        );
+                    }
+                }
+
+                activePoints[0].setState('hover');
             }
-        });
+        } else {
+            // For example reset all points from inactive to normal state
+            // after mouseOut event or when filters don't exist:
+            this.points.forEach(function (point: Highcharts.Point): void {
+                if (
+                    point.setState &&
+                    activePoints.indexOf(point) === -1
+                ) {
+                    point.setState(state);
+                }
+            });
+        }
     },
 
     /**

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -768,13 +768,6 @@ Highcharts.Pointer.prototype = {
                 hoverSeries.onMouseOver();
             }
 
-            pointer.applyInactiveState(points);
-
-            // Do mouseover on all points (#3919, #3985, #4410, #5622)
-            (points || []).forEach(function (p: Highcharts.Point): void {
-                p.setState('hover');
-            });
-
             // If tracking is on series in stead of on each point,
             // fire mouseOver on hover point. // #4448
             if (chart.hoverPoint) {
@@ -808,6 +801,15 @@ Highcharts.Pointer.prototype = {
             if (tooltip) {
                 tooltip.refresh(useSharedTooltip ? points : hoverPoint, e);
             }
+
+            // Once `hoverPoints` is set, apply inactive state:
+            pointer.applyInactiveState(points);
+
+            // Do mouseover on all points (#3919, #3985, #4410, #5622)
+            (points || []).forEach(function (p: Highcharts.Point): void {
+                p.setState('hover');
+            });
+
         // Update positions (regardless of kdpoint or hoverPoint)
         } else if (followPointer && tooltip && !tooltip.isHidden) {
             anchor = tooltip.getAnchor([{} as any], e);

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -246,8 +246,16 @@ declare global {
             opacity?: SeriesOptions['opacity'];
         }
         interface SeriesStatesInactiveOptions {
+            except?: string;
             opacity?: number;
         }
+        interface SeriesStatesInactiveFilterFunction {
+            (activePoint: Point, otherPoint: Point | NodesPoint): boolean;
+        }
+        interface SeriesStatesInactiveFilterDictionary
+            extends Dictionary<SeriesStatesInactiveFilterFunction> {
+        }
+
         interface SeriesStatesNormalOptions {
             animation?: (boolean|AnimationOptionsObject);
         }
@@ -306,6 +314,7 @@ declare global {
             public isCartesian: boolean;
             public isDirty: boolean;
             public isDirtyData: boolean;
+            public inactiveFilters?: SeriesStatesInactiveFilterDictionary;
             public kdAxisArray: Array<string>;
             public kdTree?: KDNode;
             public linkedSeries: Array<Series>;


### PR DESCRIPTION
Added `series.state.inactive.except` option to the heatmap series.
___
### Demos:
- ~[Demo](https://highcharts.github.io/highcharts-utils/samples/#gh/4b3df845ee/sample/highcharts/series-heatmap/inactive-except) for API~ <- broken, [another demo](https://jsfiddle.net/BlackLabel/amx6sdtj/2/)

### API proposal:
I don't see a perfect name for this option. I suggest to use `inactive.except: string`:

> When hovering over a cell, decide which **other** cells
> should not apply an inactive state.
> For example `'column-row'` will apply inactive state to all
> other cells except cells within the same row or column.
>
> Possible options:
> - `'all'`- all cells (aka disabled)
> - `'column'` - all cells within the same row
> - `'row'` - all cells within the same column
> - `'column-row'` - all cells within the same row or column
> - `'self'` - only current cell
> Point padding for a single point.

```
/**
 * @sample         highcharts/series-heatmap/inactive-except/
 *                 Compare different `except` options
 *
 * @validvalue     ["all", "column", "column-row", "row",  "self"]
 * @since          7.1.4
 * @product        highcharts highmaps
 */
```

Why not simply `filter`? While logic in heatmap looks exactly like filters, but for node-based series (networkgraph, sankey, dependency wheel, organization) it's not: in tree-structure, we don't loop over all points (performance), but only from the currently hovered point we change state for it's `from`/`to`/`siblings`/`parents`/`children`. So in this case, options for other series could be:

1. Dependencywheel/Sankey/Networkgraph/:
`@validvalue     ["all", "from", "from-to", "to", "self"]` - currently "from-to" (highlights all incoming/outgoing links with nodes) - we are good here, no need to implement "from" and "to" now. We could consider implementing simple "all"/"self" options, just to improve performance (instead of setting `inactive.opacity = 1` which still loops over all points, `all` could be simply be a switch on/off). Unless we would prefer "all" to be replaced with `inactive.enabled: boolean`.

2. Organization chart:
`@validvalue     ["all", "ancestors", "descendants-ancestors",  "descendants",  "self"]` - quite similar to the above. PoC:
- ["ancestors"](https://jsfiddle.net/BlackLabel/trb8y6fm/)
- ["descendants-ancestors"](https://jsfiddle.net/BlackLabel/rs41uk2a/)
- ["descendants"](https://jsfiddle.net/BlackLabel/k9nz0L8w/)


### Discussion points/issues:
- disabled in boosted mode - it seems that opacity is not supported and iterating over all cells takes too much time (see changes in `boost-overrides.js` file). I have a dilemma here: add a  wrapper (see PR) or add a condition in heatmap.js (`this.series.isSeriesBoosting`) to prevent inactive state.
- disabled animation - when animation is enabled ([demo](https://jsfiddle.net/BlackLabel/amx6sdtj/)) - the experience is.. no the best, feels like performance is poor

### To do:
- unit-tests