### PR TITLE
Fixed #11513, arearange failed when started with NaN

### DIFF
--- a/js/parts-more/AreaRangeSeries.js
+++ b/js/parts-more/AreaRangeSeries.js
@@ -77,7 +77,7 @@ import H from '../parts/Globals.js';
 * @product highcharts highstock
 */
 import U from '../parts/Utilities.js';
-var defined = U.defined, isArray = U.isArray;
+var defined = U.defined, isArray = U.isArray, isNumber = U.isNumber;
 import '../parts/Options.js';
 import '../parts/Series.js';
 var noop = H.noop, pick = H.pick, extend = H.extend, Series = H.Series, seriesType = H.seriesType, seriesTypes = H.seriesTypes, seriesProto = Series.prototype, pointProto = H.Point.prototype;
@@ -183,9 +183,8 @@ seriesType('arearange', 'area', {
         seriesTypes.area.prototype.translate.apply(series);
         // Set plotLow and plotHigh
         series.points.forEach(function (point) {
-            var low = point.low, high = point.high, plotY = point.plotY;
-            if (high === null || low === null) {
-                point.isNull = true;
+            var high = point.high, plotY = point.plotY;
+            if (point.isNull) {
                 point.plotY = null;
             }
             else {
@@ -564,6 +563,9 @@ seriesType('arearange', 'area', {
         // Clear graphic for states, removed in the above each:
         this.graphic = null;
         return pointProto.destroyElements.apply(this, arguments);
+    },
+    isValid: function () {
+        return isNumber(this.low) && isNumber(this.high);
     }
     /* eslint-enable valid-jsdoc */
 });

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -3074,7 +3074,7 @@ null,
                 j = y.length;
                 if (j) { // array, like ohlc or range data
                     while (j--) {
-                        if (typeof y[j] === 'number') { // #7380
+                        if (isNumber(y[j])) { // #7380, #11513
                             activeYData[activeCounter++] = y[j];
                         }
                     }

--- a/samples/unit-tests/series-arearange/arearange/demo.js
+++ b/samples/unit-tests/series-arearange/arearange/demo.js
@@ -37,7 +37,7 @@ QUnit.test('Range series data labels(#4421)', function (assert) {
 
 });
 
-QUnit.test('Area range with compare (#4922)', function (assert) {
+QUnit.test('Area range with compare (#4922) and NaN (#11513)', function (assert) {
     var chart = Highcharts.stockChart('container', {
 
         chart: {
@@ -52,12 +52,19 @@ QUnit.test('Area range with compare (#4922)', function (assert) {
 
         series: [{
             data: [
+                [0, NaN, NaN], // #11513
                 [0, 3, 4],
                 [1, 4, 6],
                 [2, 2, 3]
             ]
         }]
     });
+
+    assert.strictEqual(
+        typeof chart.yAxis[0].min,
+        'number',
+        'The Y axis extremes should be valid (#11513)'
+    );
 
     assert.ok(
         typeof chart.series[0].graph.element.getAttribute('d'),

--- a/ts/parts-more/AreaRangeSeries.ts
+++ b/ts/parts-more/AreaRangeSeries.ts
@@ -151,8 +151,11 @@ declare global {
 
 
 import U from '../parts/Utilities.js';
-var defined = U.defined,
-    isArray = U.isArray;
+const {
+    defined,
+    isArray,
+    isNumber
+} = U;
 
 import '../parts/Options.js';
 import '../parts/Series.js';
@@ -294,12 +297,10 @@ seriesType<Highcharts.AreaRangeSeriesOptions>('arearange', 'area', {
             point: Highcharts.AreaRangePoint
         ): void {
 
-            var low = point.low,
-                high = point.high,
+            var high = point.high,
                 plotY = point.plotY;
 
-            if (high === null || low === null) {
-                point.isNull = true;
+            if (point.isNull) {
                 point.plotY = null as any;
             } else {
                 point.plotLow = plotY as any;
@@ -790,6 +791,9 @@ seriesType<Highcharts.AreaRangeSeriesOptions>('arearange', 'area', {
         this.graphic = null as any;
 
         return pointProto.destroyElements.apply(this, arguments as any);
+    },
+    isValid: function (this: Highcharts.AreaRangePoint): boolean {
+        return isNumber(this.low) && isNumber(this.high);
     }
 
     /* eslint-enable valid-jsdoc */

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -4107,7 +4107,7 @@ H.Series = H.seriesType<Highcharts.SeriesOptions>(
                     j = (y as any).length;
                     if (j) { // array, like ohlc or range data
                         while (j--) {
-                            if (typeof (y as any)[j] === 'number') { // #7380
+                            if (isNumber((y as any)[j])) { // #7380, #11513
                                 activeYData[activeCounter++] = (y as any)[j];
                             }
                         }


### PR DESCRIPTION
Fixed #11513, arearange failed to render when the data started with NaN.