### PR TITLE
hotfix-ci-regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "husky": "^3.0.2",
     "js-yaml": "^3.13.1",
     "karma": "^4.2.0",
-    "karma-browserstack-launcher": "^1.5.1",
+    "karma-browserstack-launcher": "1.4.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-edge-launcher": "^0.4.2",
     "karma-firefox-launcher": "^1.1.0",

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -135,28 +135,28 @@ const browserStackBrowsers = {
     'Mac.Chrome': {
         base: 'BrowserStack',
         browser: 'chrome',
-        browser_version: '72.0',
+        browser_version: '76.0',
         os: 'OS X',
         os_version: 'Mojave'
     },
     'Mac.Firefox': {
         base: 'BrowserStack',
         browser: 'firefox',
-        browser_version: '65.0',
+        browser_version: '68.0',
         os: 'OS X',
         os_version: 'Mojave'
     },
     'Mac.Safari': {
         base: 'BrowserStack',
         browser: 'safari',
-        browser_version: '12.0',
+        browser_version: '12.1',
         os: 'OS X',
         os_version: 'Mojave'
     },
     'Win.Chrome': {
         base: 'BrowserStack',
         browser: 'chrome',
-        browser_version: '72.0',
+        browser_version: '76.0',
         os: 'Windows',
         os_version: '10'
     },
@@ -170,7 +170,7 @@ const browserStackBrowsers = {
     'Win.Firefox': {
         base: 'BrowserStack',
         browser: 'firefox',
-        browser_version: '65.0',
+        browser_version: '68.0',
         os: 'Windows',
         os_version: '10'
     },

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -641,7 +641,7 @@ module.exports = function (config) {
 
         // to avoid DISCONNECTED messages when connecting to BrowserStack
         options.concurrency = 1;
-        options.browserDisconnectTimeout = 30000; // default 2000
+        options.browserDisconnectTimeout = 33000; // default 2000
         options.browserDisconnectTolerance = 1; // default 0
         options.browserNoActivityTimeout = 4 * 60 * 1000; // default 10000
         options.browserSocketTimeout = 20000;
@@ -664,7 +664,7 @@ module.exports = function (config) {
 
         console.log(
             'BrowserStack initialized. Please wait while tests are uploaded and VMs prepared. ' +
-            `Any other test runs must complete before this test run will start. Current Browserstack concurrency rate is ${options.concurrency}..`
+            `Any other test runs must complete before this test run will start. Current Browserstack concurrency rate is ${options.concurrency}.`
         );
 
     }


### PR DESCRIPTION
Switched back to working `karma-browserstack-launcher`. v1.5.1 did not fixed CI problem. See https://github.com/highcharts/highcharts/commit/1138f60de44e3c11740e2f45ffb8188575533f52