### PR TITLE
tools/scripts-process

### DIFF
--- a/tools/gulptasks/lib/process.js
+++ b/tools/gulptasks/lib/process.js
@@ -104,8 +104,10 @@ function isRunning(name, runningFlag, keepOnExit) {
             writeConfig(config);
         }
     } else {
-        config.isRunning[key] = true;
-        writeConfig(config);
+        if (!Object.keys(config.isRunning).includes(key)) {
+            config.isRunning[key] = true;
+            writeConfig(config);
+        }
         if (!keepOnExit) {
             [
                 'exit', 'uncaughtException',
@@ -117,7 +119,6 @@ function isRunning(name, runningFlag, keepOnExit) {
                 })
             );
         }
-        writeConfig(config);
     }
 
     return (config.isRunning[key] === true);

--- a/tools/gulptasks/lib/process.js
+++ b/tools/gulptasks/lib/process.js
@@ -99,8 +99,10 @@ function isRunning(name, runningFlag, keepOnExit) {
     }
 
     if (!runningFlag) {
-        delete config.isRunning[key];
-        writeConfig(config);
+        if (Object.keys(config.isRunning).includes(key)) {
+            delete config.isRunning[key];
+            writeConfig(config);
+        }
     } else {
         config.isRunning[key] = true;
         writeConfig(config);
@@ -111,7 +113,7 @@ function isRunning(name, runningFlag, keepOnExit) {
             ].forEach(
                 evt => process.on(evt, code => {
                     isRunning(key, false, true);
-                    process.exit(code); // eslint-disable-line
+                    process.exit(code); // eslint-disable-line no-process-exit
                 })
             );
         }
@@ -132,6 +134,7 @@ function readConfig() {
     const FS = require('fs');
 
     let config = {
+        isProcessing: {},
         isRunning: {}
     };
 

--- a/tools/gulptasks/scripts-js.js
+++ b/tools/gulptasks/scripts-js.js
@@ -29,6 +29,7 @@ function task() {
     const argv = require('yargs').argv;
     const buildTool = require('../build');
     const logLib = require('./lib/log');
+    const processLib = require('./lib/process');
 
     return new Promise((resolve, reject) => {
 
@@ -44,11 +45,19 @@ function task() {
 
         logLib.message('Generating code...');
 
+        processLib.isRunning('scripts-js', true);
+
         BuildScripts
             .fnFirstBuild()
             .then(() => logLib.success('Created code'))
-            .then(resolve)
-            .catch(reject);
+            .then(function (output) {
+                processLib.isRunning('scripts-js', false);
+                resolve(output);
+            })
+            .catch(function (error) {
+                processLib.isRunning('scripts-js', false);
+                reject(error);
+            });
     });
 }
 

--- a/tools/gulptasks/scripts-ts.js
+++ b/tools/gulptasks/scripts-ts.js
@@ -20,10 +20,18 @@ function task() {
 
     return new Promise((resolve, reject) => {
 
+        processLib.isRunning('scripts-ts', true);
+
         processLib
             .exec('npx tsc --project ts')
-            .then(resolve)
-            .catch(reject);
+            .then(function (output) {
+                processLib.isRunning('scripts-ts', true);
+                resolve(output);
+            })
+            .catch(function (error) {
+                processLib.isRunning('scripts-ts', true);
+                reject(error);
+            });
     });
 }
 


### PR DESCRIPTION
- Reduced amount of JSON changes
- Added building details for utils. When `scripts-js` is running `node_modules/_gulptasks_lib_process.json` will contain at least:
  ```json
  {
    "isRunning": {
      "scripts-js": true
    }
  }
  ```