### PR TITLE
Bugfix/11486 treegrid point update

### DIFF
--- a/js/modules/broken-axis.src.js
+++ b/js/modules/broken-axis.src.js
@@ -10,7 +10,7 @@
 'use strict';
 import H from '../parts/Globals.js';
 import U from '../parts/Utilities.js';
-var extend = U.extend, isArray = U.isArray, pick = U.pick;
+var extend = U.extend, isArray = U.isArray, isNumber = U.isNumber, pick = U.pick;
 import '../parts/Axis.js';
 import '../parts/Series.js';
 var addEvent = H.addEvent, find = H.find, fireEvent = H.fireEvent, Axis = H.Axis, Series = H.Series;
@@ -276,17 +276,19 @@ Axis.prototype.setBreaks = function (breaks, redraw) {
     }
 };
 addEvent(Series, 'afterGeneratePoints', function () {
-    var series = this, xAxis = series.xAxis, yAxis = series.yAxis, points = series.points, point, i = points.length, connectNulls = series.options.connectNulls, nullGap;
+    var _a = this, xAxis = _a.xAxis, yAxis = _a.yAxis, points = _a.points, connectNulls = _a.options.connectNulls;
     if (xAxis && yAxis && (xAxis.options.breaks || yAxis.options.breaks)) {
+        var i = points.length;
         while (i--) {
-            point = points[i];
+            var point = points[i];
             // Respect nulls inside the break (#4275)
-            nullGap = point.y === null && connectNulls === false;
-            if (!nullGap &&
+            var nullGap = point.y === null && connectNulls === false;
+            var isPointInBreak = (!nullGap &&
                 (xAxis.isInAnyBreak(point.x, true) ||
-                    yAxis.isInAnyBreak(point.y, true))) {
-                point.isNull = true;
-            }
+                    yAxis.isInAnyBreak(point.y, true)));
+            // Set point.isNull if in any break.
+            // If not in break, reset isNull to original value.
+            point.isNull = isPointInBreak || pick(point.isValid && !point.isValid(), point.x === null || !isNumber(point.y));
         }
     }
 });

--- a/js/modules/broken-axis.src.js
+++ b/js/modules/broken-axis.src.js
@@ -10,7 +10,7 @@
 'use strict';
 import H from '../parts/Globals.js';
 import U from '../parts/Utilities.js';
-var extend = U.extend, isArray = U.isArray, isNumber = U.isNumber, pick = U.pick;
+var extend = U.extend, isArray = U.isArray, pick = U.pick;
 import '../parts/Axis.js';
 import '../parts/Series.js';
 var addEvent = H.addEvent, find = H.find, fireEvent = H.fireEvent, Axis = H.Axis, Series = H.Series;
@@ -276,19 +276,23 @@ Axis.prototype.setBreaks = function (breaks, redraw) {
     }
 };
 addEvent(Series, 'afterGeneratePoints', function () {
-    var _a = this, xAxis = _a.xAxis, yAxis = _a.yAxis, points = _a.points, connectNulls = _a.options.connectNulls;
-    if (xAxis && yAxis && (xAxis.options.breaks || yAxis.options.breaks)) {
+    var _a = this, isDirty = _a.isDirty, connectNulls = _a.options.connectNulls, points = _a.points, xAxis = _a.xAxis, yAxis = _a.yAxis;
+    /* Set, or reset visibility of the points. Axis.setBreaks marks the series
+    as isDirty */
+    if (isDirty) {
         var i = points.length;
         while (i--) {
             var point = points[i];
             // Respect nulls inside the break (#4275)
             var nullGap = point.y === null && connectNulls === false;
             var isPointInBreak = (!nullGap &&
-                (xAxis.isInAnyBreak(point.x, true) ||
-                    yAxis.isInAnyBreak(point.y, true)));
-            // Set point.isNull if in any break.
-            // If not in break, reset isNull to original value.
-            point.isNull = isPointInBreak || pick(point.isValid && !point.isValid(), point.x === null || !isNumber(point.y));
+                (xAxis && xAxis.isInAnyBreak(point.x, true) ||
+                    yAxis && yAxis.isInAnyBreak(point.y, true)));
+            // Set point.visible if in any break.
+            // If not in break, reset visible to original value.
+            point.visible = isPointInBreak ?
+                false :
+                point.options.visible !== false;
         }
     }
 });
@@ -344,7 +348,7 @@ H.Series.prototype.drawBreaks = function (axis, keys) {
  *         Gapped path
  */
 H.Series.prototype.gappedPath = function () {
-    var currentDataGrouping = this.currentDataGrouping, groupingSize = currentDataGrouping && currentDataGrouping.gapSize, gapSize = this.options.gapSize, points = this.points.slice(), i = points.length - 1, yAxis = this.yAxis, xRange, stack;
+    var currentDataGrouping = this.currentDataGrouping, groupingSize = currentDataGrouping && currentDataGrouping.gapSize, gapSize = this.options.gapSize, points = this.points.slice(), i = points.length - 1, yAxis = this.yAxis, stack;
     /**
      * Defines when to display a gap in the graph, together with the
      * [gapUnit](plotOptions.series.gapUnit) option.
@@ -409,9 +413,19 @@ H.Series.prototype.gappedPath = function () {
             gapSize = groupingSize;
         }
         // extension for ordinal breaks
+        var current = void 0, next = void 0;
         while (i--) {
-            if (points[i + 1].x - points[i].x > gapSize) {
-                xRange = (points[i].x + points[i + 1].x) / 2;
+            // Reassign next if it is not visible
+            if (!(next && next.visible !== false)) {
+                next = points[i + 1];
+            }
+            current = points[i];
+            // Skip iteration if one of the points is not visible
+            if (next.visible === false || current.visible === false) {
+                continue;
+            }
+            if (next.x - current.x > gapSize) {
+                var xRange = (current.x + next.x) / 2;
                 points.splice(// insert after this one
                 i + 1, 0, {
                     isNull: true,
@@ -425,6 +439,8 @@ H.Series.prototype.gappedPath = function () {
                     stack.total = 0;
                 }
             }
+            // Assign current to next for the upcoming iteration
+            next = current;
         }
     }
     // Call base method

--- a/js/modules/broken-axis.src.js
+++ b/js/modules/broken-axis.src.js
@@ -151,6 +151,10 @@ Axis.prototype.setBreaks = function (breaks, redraw) {
     axis.isBroken = isBroken;
     axis.options.breaks = axis.userOptions.breaks = breaks;
     axis.forceRedraw = true; // Force recalculation in setScale
+    // Recalculate series related to the axis.
+    axis.series.forEach(function (series) {
+        series.isDirty = true;
+    });
     if (!isBroken && axis.val2lin === breakVal2Lin) {
         // Revert to prototype functions
         delete axis.val2lin;
@@ -281,11 +285,7 @@ addEvent(Series, 'afterGeneratePoints', function () {
             if (!nullGap &&
                 (xAxis.isInAnyBreak(point.x, true) ||
                     yAxis.isInAnyBreak(point.y, true))) {
-                points.splice(i, 1);
-                if (this.data[i]) {
-                    // Removes the graphics for this point if they exist
-                    this.data[i].destroyElements();
-                }
+                point.isNull = true;
             }
         }
     }

--- a/js/modules/xrange.src.js
+++ b/js/modules/xrange.src.js
@@ -21,7 +21,7 @@ import H from '../parts/Globals.js';
 */
 import U from '../parts/Utilities.js';
 var clamp = U.clamp, correctFloat = U.correctFloat, defined = U.defined, isNumber = U.isNumber, isObject = U.isObject, pick = U.pick;
-var addEvent = H.addEvent, color = H.color, columnType = H.seriesTypes.column, merge = H.merge, seriesType = H.seriesType, seriesTypes = H.seriesTypes, Axis = H.Axis, Point = H.Point, Series = H.Series;
+var addEvent = H.addEvent, color = H.color, columnType = H.seriesTypes.column, find = H.find, merge = H.merge, seriesType = H.seriesType, seriesTypes = H.seriesTypes, Axis = H.Axis, Point = H.Point, Series = H.Series;
 /**
  * Return color of a point based on its category.
  *
@@ -203,29 +203,29 @@ seriesType('xrange', 'column'
      * returns undefined if no match is found.
      */
     findPointIndex: function (options) {
-        var series = this, 
-        // Search in data, since broken-axis can remove points inside a
-        // break.
-        points = series.data, oldData = series.points, id = options.id, point, pointIndex;
+        var _a = this, cropped = _a.cropped, cropStart = _a.cropStart, points = _a.points;
+        var id = options.id;
+        var pointIndex;
         if (id) {
-            point = H.find(points, function (point) {
+            var point = find(points, function (point) {
                 return point.id === id;
             });
             pointIndex = point ? point.index : void 0;
         }
         if (typeof pointIndex === 'undefined') {
-            point = H.find(points, function (point) {
+            var point = find(points, function (point) {
                 return (point.x === options.x &&
                     point.x2 === options.x2 &&
-                    !(oldData[pointIndex] &&
-                        oldData[pointIndex].touched));
+                    !point.touched);
             });
             pointIndex = point ? point.index : void 0;
         }
         // Reduce pointIndex if data is cropped
-        if (series.cropped &&
-            pointIndex >= series.cropStart) {
-            pointIndex -= series.cropStart;
+        if (cropped &&
+            isNumber(pointIndex) &&
+            isNumber(cropStart) &&
+            pointIndex >= cropStart) {
+            pointIndex -= cropStart;
         }
         return pointIndex;
     },

--- a/js/parts-map/ColorSeriesMixin.js
+++ b/js/parts-map/ColorSeriesMixin.js
@@ -26,7 +26,7 @@ H.colorPointMixin = {
      */
     setVisible: function (vis) {
         var point = this, method = vis ? 'show' : 'hide';
-        point.visible = Boolean(vis);
+        point.visible = point.options.visible = Boolean(vis);
         // Show and hide associated elements
         ['graphic', 'dataLabel'].forEach(function (key) {
             if (point[key]) {

--- a/samples/unit-tests/broken-axis/integration/demo.details
+++ b/samples/unit-tests/broken-axis/integration/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/broken-axis/integration/demo.html
+++ b/samples/unit-tests/broken-axis/integration/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/broken-axis.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/broken-axis/integration/demo.js
+++ b/samples/unit-tests/broken-axis/integration/demo.js
@@ -1,14 +1,16 @@
 QUnit.test('Axis.setBreaks', assert => {
     const {
+        series: [series],
         series: [{ points }],
         xAxis: [axis]
     } = Highcharts.chart('container', {
         series: [{
-            data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            connectNulls: true,
+            data: [1, 2, 3, 4, null, 6, 7, 8, 9, 10]
         }]
     });
-    const getXValuesOfNullPoints = points => points
-        .filter(point => point.isNull)
+    const getXValuesOfInvisiblePoints = points => points
+        .filter(point => !point.visible)
         .map(point => point.x);
 
     axis.setBreaks([{
@@ -17,15 +19,24 @@ QUnit.test('Axis.setBreaks', assert => {
     }]);
 
     assert.deepEqual(
-        getXValuesOfNullPoints(points),
+        getXValuesOfInvisiblePoints(points),
         [4, 5],
-        'Should set points with x-values above 3 and below 6 as null points.'
+        'Should set point.visible to false for points with x-values above 3 and below 6.'
+    );
+
+    series.update({
+        connectNulls: false
+    });
+    assert.deepEqual(
+        getXValuesOfInvisiblePoints(points),
+        [5],
+        'Should set point.visible to false for points with x-values above 3 and below 6, except for null points when series connectNulls is false.'
     );
 
     axis.setBreaks([]);
     assert.deepEqual(
-        getXValuesOfNullPoints(points),
+        getXValuesOfInvisiblePoints(points),
         [],
-        'Should have no null points after unsetting breaks. #11642'
+        'Should all points should have point.visible equals true after unsetting breaks. #11642'
     );
 });

--- a/samples/unit-tests/broken-axis/integration/demo.js
+++ b/samples/unit-tests/broken-axis/integration/demo.js
@@ -1,0 +1,31 @@
+QUnit.test('Axis.setBreaks', assert => {
+    const {
+        series: [{ points }],
+        xAxis: [axis]
+    } = Highcharts.chart('container', {
+        series: [{
+            data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        }]
+    });
+    const getXValuesOfNullPoints = points => points
+        .filter(point => point.isNull)
+        .map(point => point.x);
+
+    axis.setBreaks([{
+        from: 3,
+        to: 6
+    }]);
+
+    assert.deepEqual(
+        getXValuesOfNullPoints(points),
+        [4, 5],
+        'Should set points with x-values above 3 and below 6 as null points.'
+    );
+
+    axis.setBreaks([]);
+    assert.deepEqual(
+        getXValuesOfNullPoints(points),
+        [],
+        'Should have no null points after unsetting breaks. #11642'
+    );
+});

--- a/samples/unit-tests/gantt/gantt/demo.js
+++ b/samples/unit-tests/gantt/gantt/demo.js
@@ -309,4 +309,63 @@
             'Ticks are mainated when collapsing two series'
         );
     });
+
+    QUnit.test('Point.update', assert => {
+        const today = +new Date();
+        const day = 24 * 60 * 60 * 1000;
+        const {
+            series: [{
+                points,
+                points: [point]
+            }]
+        } = Highcharts.ganttChart('container', {
+            series: [{
+                data: [{
+                    name: 'Planning',
+                    start: today,
+                    end: today + day
+                }, {
+                    name: 'Moving',
+                    id: 'moving',
+                    collapsed: true
+                }, {
+                    name: 'Packing',
+                    parent: 'moving',
+                    start: today + 2 * day,
+                    end: today + 4 * day
+                }, {
+                    name: 'Wash down',
+                    parent: 'moving',
+                    start: today + 4 * day,
+                    end: today + 5 * day
+                }]
+            }]
+        });
+        const updateValues = {
+            start: today + day,
+            end: today + 2 * day
+        };
+
+        // Run Point.update
+        point.update(updateValues);
+
+        // Test that point values are as expected.
+        assert.strictEqual(
+            point.start,
+            updateValues.start,
+            'Should have point.start equal the updated value'
+        );
+        assert.strictEqual(
+            point.end,
+            updateValues.end,
+            'Should have point.end equal the updated value'
+        );
+
+        // Test that number of points has not changed
+        assert.strictEqual(
+            points.length,
+            4,
+            'Should not change the number of points after update. #11231, #11486'
+        );
+    });
 }());

--- a/samples/unit-tests/series/getvalidpoints/demo.js
+++ b/samples/unit-tests/series/getvalidpoints/demo.js
@@ -1,4 +1,4 @@
-(function () {
+QUnit.module('Series.getValidPoints', () => {
 
     function getData() {
         var arr = [];
@@ -14,8 +14,11 @@
         return arr;
     }
     function test(inverted) {
-        QUnit.test('Get valid points', function (assert) {
-            var chart = Highcharts.chart('container', {
+        QUnit.test(`chart.inverted: ${inverted}`, assert => {
+            const {
+                series: [series],
+                series: [{ points }]
+            } = Highcharts.chart('container', {
                 chart: {
                     type: 'scatter',
                     inverted: inverted,
@@ -37,17 +40,23 @@
                 }]
             });
 
-            var series = chart.series[0];
             assert.strictEqual(
-                series.getValidPoints(series.points).length,
+                series.getValidPoints(points).length,
                 99,
                 'All valid points'
             );
 
             assert.strictEqual(
-                series.getValidPoints(series.points, true).length,
+                series.getValidPoints(points, true).length,
                 63,
                 'Valid points inside plot area'
+            );
+
+            points[0].visible = false;
+            assert.strictEqual(
+                series.getValidPoints(points).length,
+                98,
+                'Should filter out points with visible equal to false'
             );
         });
     }
@@ -55,4 +64,4 @@
     test(false);
     test(true);
 
-}());
+});

--- a/ts/modules/broken-axis.src.ts
+++ b/ts/modules/broken-axis.src.ts
@@ -269,6 +269,11 @@ Axis.prototype.setBreaks = function (
     axis.options.breaks = axis.userOptions.breaks = breaks;
     axis.forceRedraw = true; // Force recalculation in setScale
 
+    // Recalculate series related to the axis.
+    axis.series.forEach(function (series): void {
+        series.isDirty = true;
+    });
+
     if (!isBroken && axis.val2lin === breakVal2Lin) {
         // Revert to prototype functions
         delete axis.val2lin;
@@ -470,11 +475,7 @@ addEvent(Series, 'afterGeneratePoints', function (): void {
                     yAxis.isInAnyBreak(point.y, true)
                 )
             ) {
-                points.splice(i, 1);
-                if (this.data[i]) {
-                    // Removes the graphics for this point if they exist
-                    this.data[i].destroyElements();
-                }
+                point.isNull = true;
             }
         }
     }

--- a/ts/parts-map/ColorSeriesMixin.ts
+++ b/ts/parts-map/ColorSeriesMixin.ts
@@ -63,7 +63,7 @@ H.colorPointMixin = {
         var point = this,
             method = vis ? 'show' : 'hide';
 
-        point.visible = Boolean(vis);
+        point.visible = point.options.visible = Boolean(vis);
 
         // Show and hide associated elements
         ['graphic', 'dataLabel'].forEach(function (key: string): void {

--- a/ts/parts/Point.ts
+++ b/ts/parts/Point.ts
@@ -123,6 +123,7 @@ declare global {
             name?: string;
             selected?: boolean;
             states?: PointStatesOptionsObject;
+            visible?: boolean;
             x?: number;
             y?: (null|number);
         }


### PR DESCRIPTION
Fixed #11231 and #11486, gantt update failed when there was collapsed tasks.

---
# Description
Broken axis removed points from the `Series.points` array which caused issues with finding the correct point index to update in `xRangeSeries.findPointIndex`, which in terms cause `Point.update` to go crazy.

Also fixed an issue with `getListOfParents` breaking when trying to hoist parent to root, because it accessed the wrong variable. 

# Example(s)
- [Demo of #11231 issue](https://jsfiddle.net/513ovfut/1/) - Collapse "Design", then click "update" to see that several points disappear.
- [Demo of #11231 issue with fix applied](https://jsfiddle.net/jon_a_nygaard/4x3Lrbtz/)
- [Demo of #11486 issue](https://jsfiddle.net/fav2Lwkb/) - Collapse any task, then try to drag the "Start Prototype"
- [Demo of #11486 issue with fix applied](https://jsfiddle.net/jon_a_nygaard/nep14mkh/2/)

# Related issue(s)
- Closes #11231 
- Closes #11486