### PR TITLE
Addition #11637, corrected wrong order of tooltips regression

### DIFF
--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -912,8 +912,7 @@ H.Tooltip.prototype = {
                 }
                 else {
                     var yAxis = series.yAxis;
-                    var tooltipHeight = tt.getBBox().height;
-                    target = yAxis.pos - distributionBoxTop + Math.max((tooltipHeight / 2), Math.min((point.plotY || 0), yAxis.len - (tooltipHeight / 2))); // Limit target position to within yAxis
+                    target = yAxis.pos - distributionBoxTop + Math.max(0, Math.min((point.plotY || 0), yAxis.len)); // Limit target position to within yAxis
                 }
                 boxes.push({
                     target: target,

--- a/samples/unit-tests/tooltip/split/demo.js
+++ b/samples/unit-tests/tooltip/split/demo.js
@@ -315,9 +315,8 @@ QUnit.test('positioning', assert => {
         },
         series: [{ data: data, yAxis: 0 }, { data: data, yAxis: 1 }]
     });
-    const isInsideAxis = ({ pos, len }, { y, height }) => (
-        (pos <= y) &&
-        ((y + height) <= (pos + len))
+    const isInsideAxis = ({ pos, len }, { anchorY }) => (
+        (pos <= anchorY) && (anchorY <= (pos + len))
     );
 
     // Set extremes to 85-90 for yAxis2.
@@ -332,20 +331,20 @@ QUnit.test('positioning', assert => {
     // Test tooltip position when point is inside plot area
     assert.ok(
         isInsideAxis(yAxis2, tooltip),
-        'Should have Series 2 tooltip aligned within yAxis when point is inside plot area'
+        'Should have Series 2 tooltip anchorY aligned within yAxis when point is inside plot area'
     );
 
     // Test tooltip position when point is below plot area
     series1.points[2].onMouseOver();
     assert.ok(
         isInsideAxis(yAxis2, tooltip),
-        'Should have Series 2 tooltip aligned within yAxis when point is below plot area'
+        'Should have Series 2 tooltip anchorY aligned within yAxis when point is below plot area'
     );
 
     // Test tooltip position when point is above plot area
     series1.points[4].onMouseOver();
     assert.ok(
         isInsideAxis(yAxis2, tooltip),
-        'Should have Series 2 tooltip aligned within yAxis when point is above plot area'
+        'Should have Series 2 tooltip anchorY aligned within yAxis when point is above plot area'
     );
 });

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -1320,13 +1320,9 @@ H.Tooltip.prototype = {
                         chart.plotHeight + headerHeight;
                 } else {
                     const yAxis = (series.yAxis as any);
-                    const tooltipHeight = tt.getBBox().height;
                     target = yAxis.pos - distributionBoxTop + Math.max(
-                        (tooltipHeight / 2),
-                        Math.min(
-                            (point.plotY || 0),
-                            yAxis.len - (tooltipHeight / 2)
-                        )
+                        0,
+                        Math.min((point.plotY || 0), yAxis.len)
                     ); // Limit target position to within yAxis
                 }
                 boxes.push({


### PR DESCRIPTION
Corrected regression visible in sample `/samples/stock/demo/sma-volume-by-price`