### PR TITLE
tools/ci-browserstack-patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "husky": "^3.0.2",
     "js-yaml": "^3.13.1",
     "karma": "^4.2.0",
-    "karma-browserstack-launcher": "1.4.0",
+    "karma-browserstack-launcher": "github:bre1470/karma-browserstack-launcher#v1.3.1",
     "karma-chrome-launcher": "^3.0.0",
     "karma-edge-launcher": "^0.4.2",
     "karma-firefox-launcher": "^1.1.0",


### PR DESCRIPTION
I looked into the issue tracker of the `karma-browserstack-launcher` and learned that there was an architectural switch to a different library, `browserstack-local` instead of `browserstack`.
Therefore I created a repository with the older version that was known to be stable and updated the browserstack dependencies there so security and API are up-to-date.
I do not know, if we can use this one for CircleCI, but we could give it a try, because it is actually also faster in the `Win.Chrome` test.