### PR TITLE
Added high contrast themes.

### DIFF
--- a/js/masters/themes/high-contrast-dark.src.js
+++ b/js/masters/themes/high-contrast-dark.src.js
@@ -1,0 +1,11 @@
+/**
+ * @license Highcharts JS v@product.version@ (@product.date@)
+ * @module highcharts/themes/high-contrast-dark
+ * @requires highcharts
+ *
+ * (c) 2009-2019 Highsoft AS
+ *
+ * License: www.highcharts.com/license
+ */
+'use strict';
+import '../../themes/high-contrast-dark.js';

--- a/js/masters/themes/high-contrast-light.src.js
+++ b/js/masters/themes/high-contrast-light.src.js
@@ -1,0 +1,11 @@
+/**
+ * @license Highcharts JS v@product.version@ (@product.date@)
+ * @module highcharts/themes/high-contrast-light
+ * @requires highcharts
+ *
+ * (c) 2009-2019 Highsoft AS
+ *
+ * License: www.highcharts.com/license
+ */
+'use strict';
+import '../../themes/high-contrast-light.js';

--- a/js/themes/high-contrast-dark.js
+++ b/js/themes/high-contrast-dark.js
@@ -1,0 +1,227 @@
+/* *
+ *
+ *  (c) 2010-2019 Highsoft AS
+ *
+ *  Author: Øystein Moseng
+ *
+ *  License: www.highcharts.com/license
+ *
+ *  Accessible high-contrast dark theme for Highcharts. Specifically tailored
+ *  towards 3:1 contrast against black/off-black backgrounds. Neighboring
+ *  colors are tested for color blindness.
+ * */
+
+'use strict';
+
+import Highcharts from '../parts/Globals.js';
+
+var textBright = '#F0F0F3';
+
+Highcharts.theme = {
+    colors: [
+        '#a6f0ff',
+        '#70d49e',
+        '#e898a5',
+        '#007faa',
+        '#f9db72',
+        '#f45b5b',
+        '#1e824c',
+        '#e7934c',
+        '#dadfe1',
+        '#a0618b'
+    ],
+
+    chart: {
+        backgroundColor: '#1f1f20',
+        plotBorderColor: '#606063'
+    },
+
+    title: {
+        style: {
+            color: textBright
+        }
+    },
+
+    subtitle: {
+        style: {
+            color: textBright
+        }
+    },
+
+    xAxis: {
+        gridLineColor: '#707073',
+        labels: {
+            style: {
+                color: textBright
+            }
+        },
+        lineColor: '#707073',
+        minorGridLineColor: '#505053',
+        tickColor: '#707073',
+        title: {
+            style: {
+                color: textBright
+
+            }
+        }
+    },
+
+    yAxis: {
+        gridLineColor: '#707073',
+        labels: {
+            style: {
+                color: textBright
+            }
+        },
+        lineColor: '#707073',
+        minorGridLineColor: '#505053',
+        tickColor: '#707073',
+        title: {
+            style: {
+                color: textBright
+            }
+        }
+    },
+
+    tooltip: {
+        backgroundColor: 'rgba(0, 0, 0, 0.85)',
+        style: {
+            color: textBright
+        }
+    },
+
+    plotOptions: {
+        series: {
+            dataLabels: {
+                color: textBright
+            },
+            marker: {
+                lineColor: '#333'
+            }
+        },
+        boxplot: {
+            fillColor: '#505053'
+        },
+        candlestick: {
+            lineColor: 'white'
+        },
+        errorbar: {
+            color: 'white'
+        },
+        map: {
+            nullColor: '#353535'
+        }
+    },
+
+    legend: {
+        backgroundColor: 'transparent',
+        itemStyle: {
+            color: textBright
+        },
+        itemHoverStyle: {
+            color: '#FFF'
+        },
+        itemHiddenStyle: {
+            color: '#606063'
+        },
+        title: {
+            style: {
+                color: '#D0D0D0'
+            }
+        }
+    },
+
+    credits: {
+        style: {
+            color: textBright
+        }
+    },
+
+    labels: {
+        style: {
+            color: '#707073'
+        }
+    },
+
+    drilldown: {
+        activeAxisLabelStyle: {
+            color: textBright
+        },
+        activeDataLabelStyle: {
+            color: textBright
+        }
+    },
+
+    navigation: {
+        buttonOptions: {
+            symbolStroke: '#DDDDDD',
+            theme: {
+                fill: '#505053'
+            }
+        }
+    },
+
+    rangeSelector: {
+        buttonTheme: {
+            fill: '#505053',
+            stroke: '#000000',
+            style: {
+                color: '#eee'
+            },
+            states: {
+                hover: {
+                    fill: '#707073',
+                    stroke: '#000000',
+                    style: {
+                        color: textBright
+                    }
+                },
+                select: {
+                    fill: '#303030',
+                    stroke: '#101010',
+                    style: {
+                        color: textBright
+                    }
+                }
+            }
+        },
+        inputBoxBorderColor: '#505053',
+        inputStyle: {
+            backgroundColor: '#333',
+            color: textBright
+        },
+        labelStyle: {
+            color: textBright
+        }
+    },
+
+    navigator: {
+        handles: {
+            backgroundColor: '#666',
+            borderColor: '#AAA'
+        },
+        outlineColor: '#CCC',
+        maskFill: 'rgba(180,180,255,0.2)',
+        series: {
+            color: '#7798BF',
+            lineColor: '#A6C7ED'
+        },
+        xAxis: {
+            gridLineColor: '#505053'
+        }
+    },
+
+    scrollbar: {
+        barBackgroundColor: '#808083',
+        barBorderColor: '#808083',
+        buttonArrowColor: '#CCC',
+        buttonBackgroundColor: '#606063',
+        buttonBorderColor: '#606063',
+        rifleColor: '#FFF',
+        trackBackgroundColor: '#404043',
+        trackBorderColor: '#404043'
+    }
+};
+
+// Apply the theme
+Highcharts.setOptions(Highcharts.theme);

--- a/js/themes/high-contrast-light.js
+++ b/js/themes/high-contrast-light.js
@@ -1,0 +1,41 @@
+/* *
+ *
+ *  (c) 2010-2019 Highsoft AS
+ *
+ *  Author: Øystein Moseng
+ *
+ *  License: www.highcharts.com/license
+ *
+ *  Accessible high-contrast theme for Highcharts. Specifically tailored
+ *  towards 3:1 contrast against white/off-white backgrounds. Neighboring
+ *  colors are tested for color blindness.
+ * */
+
+'use strict';
+
+import Highcharts from '../parts/Globals.js';
+
+Highcharts.theme = {
+    colors: [
+        '#5f98cf',
+        '#434348',
+        '#49a65e',
+        '#f45b5b',
+        '#708090',
+        '#b68c51',
+        '#397550',
+        '#c0493d',
+        '#4f4a7a',
+        '#b381b3'
+    ],
+
+    navigator: {
+        series: {
+            color: '#5f98cf',
+            lineColor: '#5f98cf'
+        }
+    }
+};
+
+// Apply the theme
+Highcharts.setOptions(Highcharts.theme);

--- a/samples/highcharts/accessibility/high-contrast-theme-dark/demo.css
+++ b/samples/highcharts/accessibility/high-contrast-theme-dark/demo.css
@@ -1,0 +1,10 @@
+body {
+	background-color: #1f1f20;
+}
+
+.container {
+    width: 50%;
+	height: 400px;
+	margin-bottom: 15px;
+	float: left;
+}

--- a/samples/highcharts/accessibility/high-contrast-theme-dark/demo.details
+++ b/samples/highcharts/accessibility/high-contrast-theme-dark/demo.details
@@ -1,0 +1,7 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Oystein Moseng
+ js_wrap: b
+ skipTest: true
+...

--- a/samples/highcharts/accessibility/high-contrast-theme-dark/demo.html
+++ b/samples/highcharts/accessibility/high-contrast-theme-dark/demo.html
@@ -1,0 +1,9 @@
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+<script src="https://code.highcharts.com/maps/modules/map.js"></script>
+<script src="https://code.highcharts.com/mapdata/custom/europe.js"></script>
+<script src="https://code.highcharts.com/themes/high-contrast-dark.js"></script>
+<div id="container-column" class="container"></div>
+<div id="container-spline" class="container"></div>
+<div id="container-scatter" class="container"></div>
+<div id="container-map" class="container"></div>
+<div id="container-pie" class="container"></div>

--- a/samples/highcharts/accessibility/high-contrast-theme-dark/demo.js
+++ b/samples/highcharts/accessibility/high-contrast-theme-dark/demo.js
@@ -1,0 +1,48 @@
+function makeArray(length, populate) {
+    return [...new Array(length)].map(populate);
+}
+
+function makeChart(constructor, type, series) {
+    const capitalizeString = s => s.charAt(0).toUpperCase() + s.slice(1);
+    return Highcharts[constructor](`container-${type}`, Highcharts.merge({
+        chart: {
+            type: type
+        },
+        title: {
+            text: `${capitalizeString(type)} chart`
+        },
+        series: series
+    }));
+}
+
+// Loop over the regular charts and create them
+[
+    ['column', [{
+        data: [1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1]
+    }, {
+        colorByPoint: true,
+        data: [1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1]
+    }]],
+
+    ['scatter', makeArray(10, (_, i) => ({
+        data: makeArray(100, () => i / 2 + Math.random())
+    }))],
+
+    ['pie', [{
+        dataLabels: {
+            enabled: false
+        },
+        data: makeArray(10, () => 1)
+    }]]
+].forEach(c => makeChart('chart', c[0], c[1]));
+
+// Create map and stock charts
+makeChart('stockChart', 'spline', makeArray(10, (_, i) => ({
+    data: makeArray(100, () => i + Math.random())
+})));
+makeChart('mapChart', 'map', [{
+    joinBy: null,
+    mapData: Highcharts.maps['custom/europe'],
+    colorByPoint: true,
+    data: makeArray(30, () => 1)
+}]);

--- a/samples/highcharts/accessibility/high-contrast-theme-light/demo.css
+++ b/samples/highcharts/accessibility/high-contrast-theme-light/demo.css
@@ -1,0 +1,6 @@
+.container {
+	width: 50%;
+	height: 400px;
+	margin-bottom: 15px;
+	float: left;
+}

--- a/samples/highcharts/accessibility/high-contrast-theme-light/demo.details
+++ b/samples/highcharts/accessibility/high-contrast-theme-light/demo.details
@@ -1,0 +1,7 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Oystein Moseng
+ js_wrap: b
+ skipTest: true
+...

--- a/samples/highcharts/accessibility/high-contrast-theme-light/demo.html
+++ b/samples/highcharts/accessibility/high-contrast-theme-light/demo.html
@@ -1,0 +1,9 @@
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+<script src="https://code.highcharts.com/maps/modules/map.js"></script>
+<script src="https://code.highcharts.com/mapdata/custom/europe.js"></script>
+<script src="https://code.highcharts.com/themes/high-contrast-light.js"></script>
+<div id="container-column" class="container"></div>
+<div id="container-spline" class="container"></div>
+<div id="container-scatter" class="container"></div>
+<div id="container-map" class="container"></div>
+<div id="container-pie" class="container"></div>

--- a/samples/highcharts/accessibility/high-contrast-theme-light/demo.js
+++ b/samples/highcharts/accessibility/high-contrast-theme-light/demo.js
@@ -1,0 +1,48 @@
+function makeArray(length, populate) {
+    return [...new Array(length)].map(populate);
+}
+
+function makeChart(constructor, type, series) {
+    const capitalizeString = s => s.charAt(0).toUpperCase() + s.slice(1);
+    return Highcharts[constructor](`container-${type}`, Highcharts.merge({
+        chart: {
+            type: type
+        },
+        title: {
+            text: `${capitalizeString(type)} chart`
+        },
+        series: series
+    }));
+}
+
+// Loop over the regular charts and create them
+[
+    ['column', [{
+        data: [1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1]
+    }, {
+        colorByPoint: true,
+        data: [1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1]
+    }]],
+
+    ['scatter', makeArray(10, (_, i) => ({
+        data: makeArray(100, () => i / 2 + Math.random())
+    }))],
+
+    ['pie', [{
+        dataLabels: {
+            enabled: false
+        },
+        data: makeArray(10, () => 1)
+    }]]
+].forEach(c => makeChart('chart', c[0], c[1]));
+
+// Create map and stock charts
+makeChart('stockChart', 'spline', makeArray(10, (_, i) => ({
+    data: makeArray(100, () => i + Math.random())
+})));
+makeChart('mapChart', 'map', [{
+    joinBy: null,
+    mapData: Highcharts.maps['custom/europe'],
+    colorByPoint: true,
+    data: makeArray(30, () => 1)
+}]);


### PR DESCRIPTION
Added `high-contrast-light` and `high-contrast-dark` themes with 3:1 contrast against background.
___
Also added skipTest demos of both for use in docs. Themes have 10 series colors that all comply with the WCAG requirement of 3:1 contrast against background for graphical elements. Neighboring colors are tested for color blindness.

Tweaks appreciated as it is hard to find 10 colors that play well together within these constraints.

Looks like this:

![Screenshot 2019-08-14 at 19 31 35](https://user-images.githubusercontent.com/5276642/63042425-444bcb80-beca-11e9-98d2-2c2bdc3f2fbd.png)
![Screenshot 2019-08-14 at 19 31 44](https://user-images.githubusercontent.com/5276642/63042427-444bcb80-beca-11e9-96e4-7509e142c556.png)