### PR TITLE
bugfix/11469-networkgraph-packedbubble-layouts

### DIFF
--- a/js/modules/networkgraph/layouts.js
+++ b/js/modules/networkgraph/layouts.js
@@ -131,37 +131,6 @@ H.layouts['reingold-fruchterman'].prototype, {
             collection.splice(index, 1);
         }
     },
-    addNodes: function (nodes) {
-        nodes.forEach(function (node) {
-            if (this.nodes.indexOf(node) === -1) {
-                this.nodes.push(node);
-            }
-        }, this);
-    },
-    removeNode: function (node) {
-        var index = this.nodes.indexOf(node);
-        if (index !== -1) {
-            this.nodes.splice(index, 1);
-        }
-    },
-    removeLink: function (link) {
-        var index = this.links.indexOf(link);
-        if (index !== -1) {
-            this.links.splice(index, 1);
-        }
-    },
-    addLinks: function (links) {
-        links.forEach(function (link) {
-            if (this.links.indexOf(link) === -1) {
-                this.links.push(link);
-            }
-        }, this);
-    },
-    addSeries: function (series) {
-        if (this.series.indexOf(series) === -1) {
-            this.series.push(series);
-        }
-    },
     clear: function () {
         this.nodes.length = 0;
         this.links.length = 0;

--- a/js/modules/networkgraph/layouts.js
+++ b/js/modules/networkgraph/layouts.js
@@ -118,6 +118,19 @@ H.layouts['reingold-fruchterman'].prototype, {
         // available space around the node:
         this.k = this.options.linkLength || this.integration.getK(this);
     },
+    addElementsToCollection: function (elements, collection) {
+        elements.forEach(function (elem) {
+            if (collection.indexOf(elem) === -1) {
+                collection.push(elem);
+            }
+        });
+    },
+    removeElementFromCollection: function (element, collection) {
+        var index = collection.indexOf(element);
+        if (index !== -1) {
+            collection.splice(index, 1);
+        }
+    },
     addNodes: function (nodes) {
         nodes.forEach(function (node) {
             if (this.nodes.indexOf(node) === -1) {

--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -576,9 +576,9 @@ seriesType('networkgraph', 'line',
         }
         this.layout = layout;
         layout.setArea(0, 0, this.chart.plotWidth, this.chart.plotHeight);
-        layout.addSeries(this);
-        layout.addNodes(this.nodes);
-        layout.addLinks(this.points);
+        layout.addElementsToCollection([this], layout.series);
+        layout.addElementsToCollection(this.nodes, layout.nodes);
+        layout.addElementsToCollection(this.points, layout.links);
     },
     /**
      * Extend the render function to also render this.nodes together with
@@ -922,11 +922,8 @@ seriesType('networkgraph', 'line',
                     link.destroyElements();
                 }
             });
-            this.series.layout.removeNode(this);
         }
-        else {
-            this.series.layout.removeLink(this);
-        }
+        this.series.layout.removeElementFromCollection(this, this.series.layout[this.isNode ? 'nodes' : 'links']);
         return Point.prototype.destroy.apply(this, arguments);
     }
 });

--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -448,7 +448,10 @@ seriesType('networkgraph', 'line',
      * @private
      */
     createNode: H.NodesMixin.createNode,
-    destroy: H.NodesMixin.destroy,
+    destroy: function () {
+        this.layout.removeElementFromCollection(this, this.layout.series);
+        H.NodesMixin.destroy.call(this);
+    },
     /* eslint-disable no-invalid-this, valid-jsdoc */
     /**
      * Extend init with base event, which should stop simulation during

--- a/js/parts-more/PackedBubbleSeries.js
+++ b/js/parts-more/PackedBubbleSeries.js
@@ -1172,6 +1172,12 @@ seriesType('packedbubble', 'bubble',
         }
     },
     destroy: function () {
+        // Remove the series from all layouts series collections #11469
+        if (this.chart.graphLayoutsLookup) {
+            this.chart.graphLayoutsLookup.forEach(function (layout) {
+                layout.removeElementFromCollection(this, layout.series);
+            }, this);
+        }
         if (this.parentNode) {
             this.parentNodeLayout.removeElementFromCollection(this.parentNode, this.parentNodeLayout.nodes);
             if (this.parentNode.dataLabel) {

--- a/js/parts-more/PackedBubbleSeries.js
+++ b/js/parts-more/PackedBubbleSeries.js
@@ -586,7 +586,7 @@ seriesType('packedbubble', 'bubble',
             else {
                 series.graph.hide();
                 series.parentNodeLayout
-                    .removeNode(series.parentNode);
+                    .removeElementFromCollection(series.parentNode, series.parentNodeLayout.nodes);
                 if (series.parentNode.dataLabel) {
                     series.parentNode.dataLabel.hide();
                 }
@@ -594,11 +594,11 @@ seriesType('packedbubble', 'bubble',
         }
         else if (series.layout) {
             if (series.visible) {
-                series.layout.addNodes(series.points);
+                series.layout.addElementsToCollection(series.points, series.layout.nodes);
             }
             else {
                 series.points.forEach(function (node) {
-                    series.layout.removeNode(node);
+                    series.layout.removeElementFromCollection(node, series.layout.nodes);
                 });
             }
         }
@@ -748,8 +748,8 @@ seriesType('packedbubble', 'bubble',
                 parentNode.plotY = series.parentNode.plotY;
             }
             series.parentNode = parentNode;
-            parentNodeLayout.addSeries(series);
-            parentNodeLayout.addNodes([parentNode]);
+            parentNodeLayout.addElementsToCollection([series], parentNodeLayout.series);
+            parentNodeLayout.addElementsToCollection([parentNode], parentNodeLayout.nodes);
         }
     },
     /**
@@ -799,8 +799,8 @@ seriesType('packedbubble', 'bubble',
             node.collisionNmb = 1;
         });
         layout.setArea(0, 0, series.chart.plotWidth, series.chart.plotHeight);
-        layout.addSeries(series);
-        layout.addNodes(series.points);
+        layout.addElementsToCollection([series], layout.series);
+        layout.addElementsToCollection(series.points, layout.nodes);
     },
     /**
      * Function responsible for adding all the layouts to the chart.
@@ -1162,7 +1162,7 @@ seriesType('packedbubble', 'bubble',
                                 plotX: point.plotX,
                                 plotY: point.plotY
                             }), false);
-                            layout.removeNode(point);
+                            layout.removeElementFromCollection(point, layout.nodes);
                             point.remove();
                         }
                     }
@@ -1173,7 +1173,7 @@ seriesType('packedbubble', 'bubble',
     },
     destroy: function () {
         if (this.parentNode) {
-            this.parentNodeLayout.removeNode(this.parentNode);
+            this.parentNodeLayout.removeElementFromCollection(this.parentNode, this.parentNodeLayout.nodes);
             if (this.parentNode.dataLabel) {
                 this.parentNode.dataLabel =
                     this.parentNode.dataLabel.destroy();
@@ -1191,7 +1191,7 @@ seriesType('packedbubble', 'bubble',
      */
     destroy: function () {
         if (this.series.layout) {
-            this.series.layout.removeNode(this);
+            this.series.layout.removeElementFromCollection(this, this.series.layout.nodes);
         }
         return Point.prototype.destroy.apply(this, arguments);
     }

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.js
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.js
@@ -251,3 +251,42 @@ QUnit.test('Markers', function (assert) {
         );
     });
 });
+
+QUnit.test('Layout operations', function (assert) {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'networkgraph'
+        },
+        series: [{
+            marker: {
+                radius: 35
+            },
+            data: [{
+                from: 'n1',
+                to: 'n2'
+            }, {
+                from: 'n2',
+                to: 'n3'
+            }]
+        }, {
+            marker: {
+                radius: 35
+            },
+            data: [{
+                from: 'n1',
+                to: 'n2'
+            }, {
+                from: 'n2',
+                to: 'n3'
+            }]
+        }]
+    });
+
+    chart.series[1].remove();
+
+    assert.strictEqual(
+        chart.series[0].layout.series.length,
+        chart.series.length,
+        'Series is removed from layout.series collection.'
+    );
+});

--- a/samples/unit-tests/series-packedbubble/packedbubble/demo.details
+++ b/samples/unit-tests/series-packedbubble/packedbubble/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series-packedbubble/packedbubble/demo.html
+++ b/samples/unit-tests/series-packedbubble/packedbubble/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 400px; margin: 0 auto"></div>

--- a/samples/unit-tests/series-packedbubble/packedbubble/demo.js
+++ b/samples/unit-tests/series-packedbubble/packedbubble/demo.js
@@ -1,0 +1,58 @@
+QUnit.test('Packed Bubble layouts operations', function (assert) {
+
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'packedbubble',
+            height: '100%'
+        },
+        title: false,
+        plotOptions: {
+            packedbubble: {
+                layoutAlgorithm: {
+                    enableSimulation: false,
+                    splitSeries: true
+                },
+                dataLabels: {
+                    enabled: false
+                }
+            }
+        },
+        series: [{
+            data: [{
+                value: 20
+            }, {
+                value: 20
+            }]
+        }, {
+            data: [{
+                value: 20
+            }, {
+                value: 20
+            }]
+        }, {
+            data: [{
+                value: 20
+            }]
+        }]
+    });
+
+    chart.series[2].remove();
+
+    function compareCollections(collections, collection) {
+        var equal = true;
+
+        collections.forEach(function (c) {
+            if (equal) {
+                equal = c.series.length === collection.length;
+            }
+        });
+
+        return equal;
+    }
+
+    assert.strictEqual(
+        compareCollections(chart.graphLayoutsLookup, chart.series),
+        true,
+        'Series is removed from layout.series collection.'
+    );
+});

--- a/ts/modules/networkgraph/layouts.ts
+++ b/ts/modules/networkgraph/layouts.ts
@@ -83,9 +83,10 @@ declare global {
             public startTemperature?: number;
             public systemTemperature?: number;
             public temperature?: number;
-            public addLinks(links: Array<NetworkgraphPoint>): void;
-            public addNodes(nodes: Array<Point>): void;
-            public addSeries(series: Series): void;
+            public addElementsToCollection<T, C extends T>(
+                elements: Array<C>,
+                collection: Array<T>
+            ): void;
             public applyLimitBox(node: Point, box: Dictionary<number>): void;
             public applyLimits(): void;
             public attractiveForces(): void;
@@ -115,8 +116,9 @@ declare global {
             public init(options: NetworkgraphLayoutAlgorithmOptions): void;
             public initPositions(): void;
             public isStable(): boolean;
-            public removeLink(link: Point): void;
-            public removeNode(node: Point): void;
+            public removeElementFromCollection<T>(
+                element: T, collection: Array<T>
+            ): void
             public repulsiveForces(): void;
             public resetSimulation(): void;
             public setArea(x: number, y: number, w: number, h: number): void;
@@ -298,6 +300,28 @@ H.extend(
             // Optimal distance between nodes,
             // available space around the node:
             this.k = this.options.linkLength || this.integration.getK(this);
+        },
+        addElementsToCollection: function<T, C extends T> (
+            this: Highcharts.NetworkgraphLayout,
+            elements: Array<C>,
+            collection: Array<T>
+        ): void {
+            elements.forEach(function (elem): void {
+                if (collection.indexOf(elem) === -1) {
+                    collection.push(elem);
+                }
+            });
+        },
+        removeElementFromCollection: function<T> (
+            this: Highcharts.NetworkgraphLayout,
+            element: T,
+            collection: Array<T>
+        ): void {
+            var index = collection.indexOf(element);
+
+            if (index !== -1) {
+                collection.splice(index, 1);
+            }
         },
         addNodes: function (
             this: Highcharts.NetworkgraphLayout,

--- a/ts/modules/networkgraph/layouts.ts
+++ b/ts/modules/networkgraph/layouts.ts
@@ -323,54 +323,6 @@ H.extend(
                 collection.splice(index, 1);
             }
         },
-        addNodes: function (
-            this: Highcharts.NetworkgraphLayout,
-            nodes: Array<Highcharts.Point>
-        ): void {
-            nodes.forEach(function (node: Highcharts.Point): void {
-                if (this.nodes.indexOf(node) === -1) {
-                    this.nodes.push(node);
-                }
-            }, this);
-        },
-        removeNode: function (
-            this: Highcharts.NetworkgraphLayout,
-            node: Highcharts.Point
-        ): void {
-            var index = this.nodes.indexOf(node);
-
-            if (index !== -1) {
-                this.nodes.splice(index, 1);
-            }
-        },
-        removeLink: function (
-            this: Highcharts.NetworkgraphLayout,
-            link: Highcharts.Point
-        ): void {
-            var index = this.links.indexOf(link);
-
-            if (index !== -1) {
-                this.links.splice(index, 1);
-            }
-        },
-        addLinks: function (
-            this: Highcharts.NetworkgraphLayout,
-            links: Array<Highcharts.NetworkgraphPoint>
-        ): void {
-            links.forEach(function (link: Highcharts.NetworkgraphPoint): void {
-                if (this.links.indexOf(link) === -1) {
-                    this.links.push(link);
-                }
-            }, this);
-        },
-        addSeries: function (
-            this: Highcharts.NetworkgraphLayout,
-            series: Highcharts.Series
-        ): void {
-            if (this.series.indexOf(series) === -1) {
-                this.series.push(series);
-            }
-        },
         clear: function (this: Highcharts.NetworkgraphLayout): void {
             this.nodes.length = 0;
             this.links.length = 0;

--- a/ts/modules/networkgraph/networkgraph.src.ts
+++ b/ts/modules/networkgraph/networkgraph.src.ts
@@ -137,7 +137,7 @@ declare global {
             public chart: NetworkgraphChart;
             public createNode: NodesMixin['createNode'];
             public data: Array<NetworkgraphPoint>;
-            public destroy: NodesMixin['destroy'];
+            public destroy(): void;
             public directTouch: boolean;
             public drawTracker: TrackerMixin['drawTrackerPoint'];
             public forces: Array<string>;
@@ -656,7 +656,10 @@ seriesType<Highcharts.NetworkgraphSeriesOptions>(
          * @private
          */
         createNode: H.NodesMixin.createNode,
-        destroy: H.NodesMixin.destroy,
+        destroy: function (this: Highcharts.NetworkgraphSeries): void {
+            this.layout.removeElementFromCollection(this, this.layout.series);
+            H.NodesMixin.destroy.call(this);
+        },
 
         /* eslint-disable no-invalid-this, valid-jsdoc */
 

--- a/ts/modules/networkgraph/networkgraph.src.ts
+++ b/ts/modules/networkgraph/networkgraph.src.ts
@@ -849,9 +849,9 @@ seriesType<Highcharts.NetworkgraphSeriesOptions>(
             this.layout = layout;
 
             layout.setArea(0, 0, this.chart.plotWidth, this.chart.plotHeight);
-            layout.addSeries(this);
-            layout.addNodes(this.nodes);
-            layout.addLinks(this.points);
+            layout.addElementsToCollection([this], layout.series);
+            layout.addElementsToCollection(this.nodes, layout.nodes);
+            layout.addElementsToCollection(this.points, layout.links);
         },
 
         /**
@@ -1327,10 +1327,11 @@ seriesType<Highcharts.NetworkgraphSeriesOptions>(
                         }
                     }
                 );
-                this.series.layout.removeNode(this);
-            } else {
-                this.series.layout.removeLink(this);
             }
+
+            this.series.layout.removeElementFromCollection(
+                this, this.series.layout[this.isNode ? 'nodes' : 'links']
+            );
 
             return Point.prototype.destroy.apply(this, arguments as any);
         }

--- a/ts/parts-more/PackedBubbleSeries.ts
+++ b/ts/parts-more/PackedBubbleSeries.ts
@@ -940,19 +940,25 @@ seriesType<Highcharts.PackedBubbleSeriesOptions>(
                 } else {
                     series.graph.hide();
                     series.parentNodeLayout
-                        .removeNode(series.parentNode as any);
+                        .removeElementFromCollection(
+                            series.parentNode, series.parentNodeLayout.nodes
+                        );
                     if ((series.parentNode as any).dataLabel) {
                         (series.parentNode as any).dataLabel.hide();
                     }
                 }
             } else if (series.layout) {
                 if (series.visible) {
-                    series.layout.addNodes(series.points);
+                    series.layout.addElementsToCollection(
+                        series.points, series.layout.nodes
+                    );
                 } else {
                     series.points.forEach(function (
                         node: Highcharts.PackedBubblePoint
                     ): void {
-                        series.layout.removeNode(node);
+                        series.layout.removeElementFromCollection(
+                            node, series.layout.nodes
+                        );
                     });
                 }
             }
@@ -1169,8 +1175,12 @@ seriesType<Highcharts.PackedBubbleSeriesOptions>(
                     (parentNode as any).plotY = series.parentNode.plotY;
                 }
                 series.parentNode = parentNode;
-                parentNodeLayout.addSeries(series);
-                parentNodeLayout.addNodes([parentNode as any]);
+                parentNodeLayout.addElementsToCollection(
+                    [series], parentNodeLayout.series
+                );
+                parentNodeLayout.addElementsToCollection(
+                    [parentNode as any], parentNodeLayout.nodes
+                );
             }
         },
         /**
@@ -1256,8 +1266,8 @@ seriesType<Highcharts.PackedBubbleSeriesOptions>(
             layout.setArea(
                 0, 0, series.chart.plotWidth, series.chart.plotHeight
             );
-            layout.addSeries(series);
-            layout.addNodes(series.points);
+            layout.addElementsToCollection([series], layout.series);
+            layout.addElementsToCollection(series.points, layout.nodes);
         },
         /**
          * Function responsible for adding all the layouts to the chart.
@@ -1798,7 +1808,9 @@ seriesType<Highcharts.PackedBubbleSeriesOptions>(
                                     plotX: point.plotX,
                                     plotY: point.plotY
                                 }), false);
-                                layout.removeNode(point);
+                                layout.removeElementFromCollection(
+                                    point, layout.nodes
+                                );
                                 point.remove();
                             }
                         }
@@ -1809,7 +1821,8 @@ seriesType<Highcharts.PackedBubbleSeriesOptions>(
         },
         destroy: function (this: Highcharts.PackedBubbleSeries): void {
             if (this.parentNode) {
-                this.parentNodeLayout.removeNode(this.parentNode);
+                this.parentNodeLayout.removeElementFromCollection(
+                    this.parentNode, this.parentNodeLayout.nodes);
                 if (this.parentNode.dataLabel) {
                     this.parentNode.dataLabel =
                         this.parentNode.dataLabel.destroy();
@@ -1827,7 +1840,9 @@ seriesType<Highcharts.PackedBubbleSeriesOptions>(
          */
         destroy: function (this: Highcharts.PackedBubblePoint): void {
             if (this.series.layout) {
-                this.series.layout.removeNode(this);
+                this.series.layout.removeElementFromCollection(
+                    this, this.series.layout.nodes
+                );
             }
             return Point.prototype.destroy.apply(this, arguments as any);
         }

--- a/ts/parts-more/PackedBubbleSeries.ts
+++ b/ts/parts-more/PackedBubbleSeries.ts
@@ -1820,9 +1820,17 @@ seriesType<Highcharts.PackedBubbleSeriesOptions>(
             }
         },
         destroy: function (this: Highcharts.PackedBubbleSeries): void {
+            // Remove the series from all layouts series collections #11469
+            if (this.chart.graphLayoutsLookup) {
+                this.chart.graphLayoutsLookup.forEach(function (layout): void {
+                    layout.removeElementFromCollection(this, layout.series);
+                }, this);
+            }
+
             if (this.parentNode) {
                 this.parentNodeLayout.removeElementFromCollection(
-                    this.parentNode, this.parentNodeLayout.nodes);
+                    this.parentNode, this.parentNodeLayout.nodes
+                );
                 if (this.parentNode.dataLabel) {
                     this.parentNode.dataLabel =
                         this.parentNode.dataLabel.destroy();


### PR DESCRIPTION
Fixed #11469, `Series.remove()` function didn't work properly with _networkgraph_ and _packedbubble_ series.