### PR TITLE
 bugfix/11608-boost-points-objects-extremes

### DIFF
--- a/js/modules/boost/boost-init.js
+++ b/js/modules/boost/boost-init.js
@@ -193,8 +193,8 @@ function init() {
 
                 if (!chartDestroyed) {
                     if (useRaw) {
-                        x = d[0];
-                        y = d[1];
+                        x = H.pick(d[0], d.x);
+                        y = H.pick(d[1], d.y);
                     } else {
                         x = d;
                         y = yData[i];

--- a/samples/unit-tests/boost/tooltip/demo.js
+++ b/samples/unit-tests/boost/tooltip/demo.js
@@ -1,4 +1,4 @@
-QUnit.test('Tooltip on a boosted chart with categories', function (assert) {
+QUnit.test('Tooltip on a boosted chart', function (assert) {
     var chart = Highcharts.chart('container', {
             xAxis: {
                 categories: ['categoryName', 'B', 'C']
@@ -16,4 +16,20 @@ QUnit.test('Tooltip on a boosted chart with categories', function (assert) {
         document.getElementsByClassName('highcharts-tooltip')[0].textContent.match('categoryName') !== null,
         '`categoryName` found in the tooltip (#10432).'
     );
+
+    chart.yAxis[0].setExtremes(0, 1, false);
+
+    chart.series[0].setData([
+        { x: 0, y: 0.5 },
+        { x: 1, y: 10 }
+    ]);
+
+    controller.moveTo(chart.plotLeft + 5, chart.plotTop + 5);
+
+    assert.strictEqual(
+        chart.container.querySelectorAll('.highcharts-tooltip')[0].style.visibility,
+        '',
+        'Tooltip should be visible after hover and {x, y} data format (#11608)'
+    );
+
 });


### PR DESCRIPTION
Fixed #11608, tooltip was not displayed in boosted mode when yAxis extremes were set and points were configured as objects (`{ x, y }`).