### PR TITLE
bugfix/11546-parentNodes-missing-after-update

### DIFF
--- a/js/parts-more/PackedBubbleSeries.js
+++ b/js/parts-more/PackedBubbleSeries.js
@@ -701,7 +701,6 @@ seriesType('packedbubble', 'bubble',
         if (!series.parentNode.graphic) {
             series.graph = series.parentNode.graphic =
                 chart.renderer.symbol(parentOptions.symbol)
-                    .attr(parentAttribs)
                     .add(series.parentNodesGroup);
         }
         series.parentNode.graphic.attr(parentAttribs);

--- a/js/parts-more/PackedBubbleSeries.js
+++ b/js/parts-more/PackedBubbleSeries.js
@@ -698,15 +698,13 @@ seriesType('packedbubble', 'bubble',
             width: series.parentNodeRadius * 2,
             height: series.parentNodeRadius * 2
         }, parentOptions);
-        if (!series.graph) {
+        if (!series.parentNode.graphic) {
             series.graph = series.parentNode.graphic =
                 chart.renderer.symbol(parentOptions.symbol)
                     .attr(parentAttribs)
                     .add(series.parentNodesGroup);
         }
-        else {
-            series.graph.attr(parentAttribs);
-        }
+        series.parentNode.graphic.attr(parentAttribs);
     },
     /**
      * Creating parent nodes for split series, in which all the bubbles

--- a/samples/unit-tests/series-packedbubble/update/demo.details
+++ b/samples/unit-tests/series-packedbubble/update/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series-packedbubble/update/demo.html
+++ b/samples/unit-tests/series-packedbubble/update/demo.html
@@ -1,0 +1,8 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 400px; margin: 0 auto"></div>

--- a/samples/unit-tests/series-packedbubble/update/demo.js
+++ b/samples/unit-tests/series-packedbubble/update/demo.js
@@ -1,0 +1,30 @@
+QUnit.test('Series update', function (assert) {
+    var series,
+        chart = Highcharts.chart('container', {
+            chart: {
+                type: 'packedbubble',
+                width: 500,
+                height: 500,
+                marginTop: 46,
+                marginBottom: 53
+            },
+            series: [{
+                layoutAlgorithm: {
+                    splitSeries: true,
+                    parentNodeLimit: true
+                },
+                data: [50, 80, 50]
+            }]
+        });
+    chart.update({
+        series: [{
+            data: [2, 3, 4, 5, 6, 7]
+        }]
+    });
+    series = chart.series[0];
+    assert.strictEqual(
+        !series.parentNode.graphic,
+        false,
+        'parentNode is visible after series.update'
+    );
+});

--- a/ts/parts-more/PackedBubbleSeries.ts
+++ b/ts/parts-more/PackedBubbleSeries.ts
@@ -1113,14 +1113,13 @@ seriesType<Highcharts.PackedBubbleSeriesOptions>(
                 width: (series.parentNodeRadius as any) * 2,
                 height: (series.parentNodeRadius as any) * 2
             }, parentOptions);
-            if (!series.graph) {
+            if (!(series.parentNode as any).graphic) {
                 series.graph = (series.parentNode as any).graphic =
                     chart.renderer.symbol(parentOptions.symbol)
                         .attr(parentAttribs)
                         .add(series.parentNodesGroup);
-            } else {
-                series.graph.attr(parentAttribs);
             }
+            (series.parentNode as any).graphic.attr(parentAttribs);
         },
         /**
          * Creating parent nodes for split series, in which all the bubbles

--- a/ts/parts-more/PackedBubbleSeries.ts
+++ b/ts/parts-more/PackedBubbleSeries.ts
@@ -1116,7 +1116,6 @@ seriesType<Highcharts.PackedBubbleSeriesOptions>(
             if (!(series.parentNode as any).graphic) {
                 series.graph = (series.parentNode as any).graphic =
                     chart.renderer.symbol(parentOptions.symbol)
-                        .attr(parentAttribs)
                         .add(series.parentNodesGroup);
             }
             (series.parentNode as any).graphic.attr(parentAttribs);


### PR DESCRIPTION
Fixed #11546, in packed bubble series parentNodes were missing after chart and series update.