### PR TITLE
bugfix/11609-reflow-destroy

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -1129,7 +1129,12 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         var chart = this;
         if (reflow !== false && !this.unbindReflow) {
             this.unbindReflow = addEvent(win, 'resize', function (e) {
-                chart.reflow(e);
+                // a removed event listener still runs in Edge and IE if the
+                // listener was removed while the event runs, so check if the
+                // chart is not destroyed (#11609)
+                if (chart.options) {
+                    chart.reflow(e);
+                }
             });
             addEvent(this, 'destroy', this.unbindReflow);
         }

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -1696,7 +1696,12 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             this.unbindReflow = addEvent(win, 'resize', function (
                 e: Event
             ): void {
-                chart.reflow(e);
+                // a removed event listener still runs in Edge and IE if the
+                // listener was removed while the event runs, so check if the
+                // chart is not destroyed (#11609)
+                if (chart.options) {
+                    chart.reflow(e);
+                }
             });
             addEvent(this, 'destroy', this.unbindReflow);
 


### PR DESCRIPTION
Fixed #11609, prevented reflow of destroyed charts.