### PR TITLE
bugfix/11717-layout-es6-module

### DIFF
--- a/js/modules/networkgraph/layouts.js
+++ b/js/modules/networkgraph/layouts.js
@@ -11,8 +11,8 @@
 import H from '../../parts/Globals.js';
 import U from '../../parts/Utilities.js';
 var defined = U.defined;
-import 'integrations.js';
-import 'QuadTree.js';
+import './integrations.js';
+import './QuadTree.js';
 var pick = H.pick, addEvent = H.addEvent, Chart = H.Chart;
 /* eslint-disable no-invalid-this, valid-jsdoc */
 H.layouts = {

--- a/ts/modules/networkgraph/layouts.ts
+++ b/ts/modules/networkgraph/layouts.ts
@@ -143,8 +143,8 @@ import U from '../../parts/Utilities.js';
 var defined = U.defined;
 
 
-import 'integrations.js';
-import 'QuadTree.js';
+import './integrations.js';
+import './QuadTree.js';
 
 var pick = H.pick,
     addEvent = H.addEvent,


### PR DESCRIPTION
Fixed #11717, loading networkgraph as ES6 module used to throw errors.