### PR TITLE
Fixed issue with Point.onMouseOver

### DIFF
--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -596,7 +596,7 @@ extend(Point.prototype, /** @lends Highcharts.Point.prototype */ {
      *
      * @function Highcharts.Point#onMouseOver
      *
-     * @param {Highcharts.PointerEventObject} e
+     * @param {Highcharts.PointerEventObject} [e]
      *        The event arguments.
      *
      * @return {void}

--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -364,7 +364,7 @@ Highcharts.Pointer.prototype = {
      * @param {boolean|undefined} shared
      *        Whether it is a shared tooltip or not.
      *
-     * @param {Highcharts.PointerEventObject} e
+     * @param {Highcharts.PointerEventObject} [e]
      *        The triggering event, containing chart coordinates of the pointer.
      *
      * @return {object}
@@ -386,7 +386,7 @@ Highcharts.Pointer.prototype = {
                 return filter(s) && s.stickyTracking;
             });
         // Use existing hovered point or find the one closest to coordinates.
-        hoverPoint = useExisting ?
+        hoverPoint = useExisting || !e ?
             existingHoverPoint :
             this.findNearestKDPoint(searchSeries, shared, e);
         // Assign hover series
@@ -448,7 +448,7 @@ Highcharts.Pointer.prototype = {
             tooltip.shared :
             false), hoverPoint = p || chart.hoverPoint, hoverSeries = hoverPoint && hoverPoint.series || chart.hoverSeries, 
         // onMouseOver or already hovering a series with directTouch
-        isDirectTouch = e.type !== 'touchmove' && (!!p || ((hoverSeries && hoverSeries.directTouch) &&
+        isDirectTouch = (!e || e.type !== 'touchmove') && (!!p || ((hoverSeries && hoverSeries.directTouch) &&
             pointer.isDirectTouch)), hoverData = this.getHoverData(hoverPoint, hoverSeries, series, isDirectTouch, shared, e), useSharedTooltip, followPointer, anchor, points;
         // Update variables from hoverData.
         hoverPoint = hoverData.hoverPoint;

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -200,7 +200,7 @@ Highcharts.prepareShot = function (chart) {
             chart.series[0].nodes[0] &&
             typeof chart.series[0].nodes[0].onMouseOver === 'function'
         ) {
-            chart.series[0].nodes[0].onMouseOver({});
+            chart.series[0].nodes[0].onMouseOver();
         
         // Others
         } else if (
@@ -208,7 +208,7 @@ Highcharts.prepareShot = function (chart) {
             chart.series[0].points[0] &&
             typeof chart.series[0].points[0].onMouseOver === 'function'
         ) {
-            chart.series[0].points[0].onMouseOver({});
+            chart.series[0].points[0].onMouseOver();
         }
     }
 };

--- a/ts/parts/Interaction.ts
+++ b/ts/parts/Interaction.ts
@@ -43,7 +43,7 @@ declare global {
             haloPath(size: number): SVGElement;
             importEvents(): void;
             onMouseOut(): void;
-            onMouseOver(e: PointerEventObject): void;
+            onMouseOver(e?: PointerEventObject): void;
             select(selected?: boolean, accumulate?: boolean): void;
             setState(
                 state?: string,
@@ -963,14 +963,14 @@ extend(Point.prototype, /** @lends Highcharts.Point.prototype */ {
      *
      * @function Highcharts.Point#onMouseOver
      *
-     * @param {Highcharts.PointerEventObject} e
+     * @param {Highcharts.PointerEventObject} [e]
      *        The event arguments.
      *
      * @return {void}
      */
     onMouseOver: function (
         this: Highcharts.Point,
-        e: Highcharts.PointerEventObject
+        e?: Highcharts.PointerEventObject
     ): void {
         var point = this,
             series = point.series,

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -92,7 +92,7 @@ declare global {
                 series: Array<Series>,
                 isDirectTouch: boolean,
                 shared: (boolean|undefined),
-                e: PointerEventObject
+                e?: PointerEventObject
             ): PointerHoverDataObject;
             public getPointFromEvent(e: Event): (Point|undefined)
             public inClass(
@@ -112,7 +112,7 @@ declare global {
             public onDocumentMouseUp(e: PointerEventObject): void;
             public onTrackerMouseOut(e: PointerEventObject): void;
             public reset(allowMove?: boolean, delay?: number): void;
-            public runPointActions(e: PointerEventObject, p?: Point): void;
+            public runPointActions(e?: PointerEventObject, p?: Point): void;
             public scaleGroups(
                 attribs?: SeriesPlotBoxObject,
                 clip?: boolean
@@ -594,7 +594,7 @@ Highcharts.Pointer.prototype = {
      * @param {boolean|undefined} shared
      *        Whether it is a shared tooltip or not.
      *
-     * @param {Highcharts.PointerEventObject} e
+     * @param {Highcharts.PointerEventObject} [e]
      *        The triggering event, containing chart coordinates of the pointer.
      *
      * @return {object}
@@ -608,7 +608,7 @@ Highcharts.Pointer.prototype = {
         series: Array<Highcharts.Series>,
         isDirectTouch: boolean,
         shared: (boolean|undefined),
-        e: Highcharts.PointerEventObject
+        e?: Highcharts.PointerEventObject
     ): Highcharts.PointerHoverDataObject {
         var hoverPoint: Highcharts.Point,
             hoverPoints = [] as Array<Highcharts.Point>,
@@ -632,7 +632,7 @@ Highcharts.Pointer.prototype = {
                 });
 
         // Use existing hovered point or find the one closest to coordinates.
-        hoverPoint = useExisting ?
+        hoverPoint = useExisting || !e ?
             existingHoverPoint :
             this.findNearestKDPoint(searchSeries, shared, e) as any;
 
@@ -699,7 +699,7 @@ Highcharts.Pointer.prototype = {
      */
     runPointActions: function (
         this: Highcharts.Pointer,
-        e: Highcharts.PointerEventObject,
+        e?: Highcharts.PointerEventObject,
         p?: Highcharts.Point
     ): void {
         var pointer = this,
@@ -718,7 +718,7 @@ Highcharts.Pointer.prototype = {
             hoverPoint = p || chart.hoverPoint,
             hoverSeries = hoverPoint && hoverPoint.series || chart.hoverSeries,
             // onMouseOver or already hovering a series with directTouch
-            isDirectTouch = e.type !== 'touchmove' && (
+            isDirectTouch = (!e || e.type !== 'touchmove') && (
                 !!p || (
                     (hoverSeries && hoverSeries.directTouch) &&
                     pointer.isDirectTouch


### PR DESCRIPTION
It failed for some series types (funnel, packed bubble etc)  when calling without arguments.