### PR TITLE
Tools: Added CI testing of stock and maps samples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,18 +155,26 @@ jobs:
       - run:
           # run tests in sequence due to all writing to the same file
           name: "Highcharts visual tests"
-          command: "npx gulp test --tests highcharts/*/* --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite"
+          command: >
+            npx karma start test/karma-conf.js --tests highcharts/*/* --single-run
+            --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite
       - run:
           name: "Highmaps visual tests"
-          command: "npx gulp test --tests maps/*/* --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite"
+          command: >
+            npx karma start test/karma-conf.js --tests maps/*/* --single-run
+            --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite
           when: always
       - run:
           name: "Highstock visual tests"
-          command: "npx gulp test --tests stock/*/* --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite"
+          command: >
+            npx karma start test/karma-conf.js --tests stock/*/* --single-run
+            --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite
           when: always
       - run:
           name: "Gant visual tests"
-          command: "npx gulp test --tests gantt/*/* --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite"
+          command: >
+            npx karma start test/karma-conf.js --tests gantt/*/* --single-run
+            --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite
           when: always
       - run: "sudo apt-get install -y librsvg2-bin"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
       - <<: *load_workspace
       - run:
           name: Generate visual references
-          command: npx gulp test --tests highcharts/*/*,maps/*/*,stock/*/*,gantt/*/* --reference --browsercount 1 --no-fail-on-empty-test-suite
+          command: npx karma start test/karma-conf.js --tests highcharts/*/*,maps/*/*,stock/*/*,gantt/*/* --reference --browsercount 1 --no-fail-on-empty-test-suite
       - run: "mkdir -p /home/circleci/repo/tmp/latest/"
       - aws-s3/sync:
           from: "/home/circleci/repo/tmp/latest/"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,7 +292,7 @@ workflows:
           context: highcharts-staging
       - test_browsers:
           name: "verify-samples-Chrome"
-          browsers: "ChromeHeadless --tests highcharts/*/*,maps/*/*,stock/*/*/*"
+          browsers: "ChromeHeadless --tests highcharts/*/*,maps/*/*,stock/*/*/*,gantt/*/*"
           browsercount: 2
           requires:
             - install_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,17 +146,22 @@ jobs:
         description: "Which browser to test?"
         type: string
         default: "ChromeHeadless"
-      tests:
-        description: "The path to the visual tests to run"
-        type: string
-        default: "highcharts/demo/*"
     steps:
       - early_return_for_forked_pull_requests # to avoid secrets being passed on to forked PR builds we don't run browser tests for forked PRs
       - <<: *load_workspace
       - aws-s3/sync: # fetch reference images
           from: "s3://${HIGHCHARTS_S3_BUCKET}/test/visualtests/reference/latest/"
-          to: 'samples/'
-      - run: "npx gulp test --tests << parameters.tests >> --splitbrowsers << parameters.browsers >> --browsercount 1 --difflog"
+          to: "samples/"
+      - run:
+          # run tests in sequence due to all writing to the same file
+          name: "Highcharts visual tests"
+          command: "npx gulp test --tests highcharts/demo/* --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog"
+      - run:
+          name: "Highmaps visual tests"
+          command: "npx gulp test --tests maps/demo/* --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog"
+      - run:
+          name: "Highstock visual tests"
+          command: "npx gulp test --tests stock/demo/* --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog"
       - run: "sudo apt-get install -y librsvg2-bin"
       - run:
           name: "Generate PNGs and diff"
@@ -286,6 +291,12 @@ workflows:
               only: /^v\d+(?:\.\d+)+?$/
           context: highcharts-staging
       - test_browsers:
+          name: "verify-samples-Chrome"
+          browsers: "ChromeHeadless --tests highcharts/*/*,maps/*/*,stock/*/*/*"
+          browsercount: 2
+          requires:
+            - install_dependencies
+      - test_browsers:
           name: "test-Win.IE8"
           requires:
             - install_dependencies
@@ -313,7 +324,7 @@ workflows:
           filters:
             branches:
               only:
-                - feature/ci-visual-tests
+                - tools/vis-test-samples
                 - master
     jobs:
       - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,6 @@ workflows:
       - test_browsers:
           name: "verify-samples-Chrome"
           browsers: "ChromeHeadless --tests highcharts/*/*,maps/*/*,stock/*/*/*,gantt/*/*"
-          browsercount: 2
           requires:
             - install_dependencies
       - test_browsers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
       - <<: *load_workspace
       - run:
           name: Generate visual references
-          command: npx gulp test --tests highcharts/demo/* --reference --browsercount 1
+          command: npx gulp test --tests highcharts/*/*,maps/*/*,stock/*/*,gantt/*/* --reference --browsercount 1 --no-fail-on-empty-test-suite
       - run: "mkdir -p /home/circleci/repo/tmp/latest/"
       - aws-s3/sync:
           from: "/home/circleci/repo/tmp/latest/"
@@ -155,13 +155,19 @@ jobs:
       - run:
           # run tests in sequence due to all writing to the same file
           name: "Highcharts visual tests"
-          command: "npx gulp test --tests highcharts/demo/* --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog"
+          command: "npx gulp test --tests highcharts/*/* --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite"
       - run:
           name: "Highmaps visual tests"
-          command: "npx gulp test --tests maps/demo/* --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog"
+          command: "npx gulp test --tests maps/*/* --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite"
+          when: always
       - run:
           name: "Highstock visual tests"
-          command: "npx gulp test --tests stock/demo/* --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog"
+          command: "npx gulp test --tests stock/*/* --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite"
+          when: always
+      - run:
+          name: "Gant visual tests"
+          command: "npx gulp test --tests gantt/*/* --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite"
+          when: always
       - run: "sudo apt-get install -y librsvg2-bin"
       - run:
           name: "Generate PNGs and diff"
@@ -292,7 +298,7 @@ workflows:
           context: highcharts-staging
       - test_browsers:
           name: "verify-samples-Chrome"
-          browsers: "ChromeHeadless --tests highcharts/*/*,maps/*/*,stock/*/*/*,gantt/*/*"
+          browsers: "ChromeHeadless --tests highcharts/*/*,maps/*/*,stock/*/*,gantt/*/*"
           requires:
             - install_dependencies
       - test_browsers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,7 +324,7 @@ workflows:
           filters:
             branches:
               only:
-                - tools/vis-test-samples
+                - tools/visual-test-samples
                 - master
     jobs:
       - checkout_code

--- a/js/modules/networkgraph/layouts.js
+++ b/js/modules/networkgraph/layouts.js
@@ -11,8 +11,8 @@
 import H from '../../parts/Globals.js';
 import U from '../../parts/Utilities.js';
 var defined = U.defined;
-import 'integrations.js';
-import 'QuadTree.js';
+import './integrations.js';
+import './QuadTree.js';
 var pick = H.pick, addEvent = H.addEvent, Chart = H.Chart;
 /* eslint-disable no-invalid-this, valid-jsdoc */
 H.layouts = {

--- a/js/parts-more/PackedBubbleSeries.js
+++ b/js/parts-more/PackedBubbleSeries.js
@@ -701,7 +701,6 @@ seriesType('packedbubble', 'bubble',
         if (!series.parentNode.graphic) {
             series.graph = series.parentNode.graphic =
                 chart.renderer.symbol(parentOptions.symbol)
-                    .attr(parentAttribs)
                     .add(series.parentNodesGroup);
         }
         series.parentNode.graphic.attr(parentAttribs);

--- a/js/parts-more/PackedBubbleSeries.js
+++ b/js/parts-more/PackedBubbleSeries.js
@@ -698,15 +698,13 @@ seriesType('packedbubble', 'bubble',
             width: series.parentNodeRadius * 2,
             height: series.parentNodeRadius * 2
         }, parentOptions);
-        if (!series.graph) {
+        if (!series.parentNode.graphic) {
             series.graph = series.parentNode.graphic =
                 chart.renderer.symbol(parentOptions.symbol)
                     .attr(parentAttribs)
                     .add(series.parentNodesGroup);
         }
-        else {
-            series.graph.attr(parentAttribs);
-        }
+        series.parentNode.graphic.attr(parentAttribs);
     },
     /**
      * Creating parent nodes for split series, in which all the bubbles

--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -1129,7 +1129,12 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         var chart = this;
         if (reflow !== false && !this.unbindReflow) {
             this.unbindReflow = addEvent(win, 'resize', function (e) {
-                chart.reflow(e);
+                // a removed event listener still runs in Edge and IE if the
+                // listener was removed while the event runs, so check if the
+                // chart is not destroyed (#11609)
+                if (chart.options) {
+                    chart.reflow(e);
+                }
             });
             addEvent(this, 'destroy', this.unbindReflow);
         }

--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -772,7 +772,10 @@ extend(Point.prototype, /** @lends Highcharts.Point.prototype */ {
         haloOptions = stateOptions.halo;
         var markerGraphic = (point.graphic || stateMarkerGraphic);
         var markerVisibility = (markerGraphic && markerGraphic.visibility || 'inherit');
-        if (haloOptions && haloOptions.size && markerVisibility !== 'hidden') {
+        if (haloOptions &&
+            haloOptions.size &&
+            markerGraphic &&
+            markerVisibility !== 'hidden') {
             if (!halo) {
                 series.halo = halo = chart.renderer.path()
                     // #5818, #5903, #6705

--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -596,7 +596,7 @@ extend(Point.prototype, /** @lends Highcharts.Point.prototype */ {
      *
      * @function Highcharts.Point#onMouseOver
      *
-     * @param {Highcharts.PointerEventObject} e
+     * @param {Highcharts.PointerEventObject} [e]
      *        The event arguments.
      *
      * @return {void}

--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -364,7 +364,7 @@ Highcharts.Pointer.prototype = {
      * @param {boolean|undefined} shared
      *        Whether it is a shared tooltip or not.
      *
-     * @param {Highcharts.PointerEventObject} e
+     * @param {Highcharts.PointerEventObject} [e]
      *        The triggering event, containing chart coordinates of the pointer.
      *
      * @return {object}
@@ -386,7 +386,7 @@ Highcharts.Pointer.prototype = {
                 return filter(s) && s.stickyTracking;
             });
         // Use existing hovered point or find the one closest to coordinates.
-        hoverPoint = useExisting ?
+        hoverPoint = useExisting || !e ?
             existingHoverPoint :
             this.findNearestKDPoint(searchSeries, shared, e);
         // Assign hover series
@@ -448,7 +448,7 @@ Highcharts.Pointer.prototype = {
             tooltip.shared :
             false), hoverPoint = p || chart.hoverPoint, hoverSeries = hoverPoint && hoverPoint.series || chart.hoverSeries, 
         // onMouseOver or already hovering a series with directTouch
-        isDirectTouch = e.type !== 'touchmove' && (!!p || ((hoverSeries && hoverSeries.directTouch) &&
+        isDirectTouch = (!e || e.type !== 'touchmove') && (!!p || ((hoverSeries && hoverSeries.directTouch) &&
             pointer.isDirectTouch)), hoverData = this.getHoverData(hoverPoint, hoverSeries, series, isDirectTouch, shared, e), useSharedTooltip, followPointer, anchor, points;
         // Update variables from hoverData.
         hoverPoint = hoverData.hoverPoint;

--- a/samples/highcharts/css/bullet-graph/demo.js
+++ b/samples/highcharts/css/bullet-graph/demo.js
@@ -1,4 +1,4 @@
-Highcharts.setOptions({
+var commonBulletOptions = {
     chart: {
         inverted: true,
         marginLeft: 135,
@@ -29,12 +29,11 @@ Highcharts.setOptions({
     exporting: {
         enabled: false
     }
-});
+};
 
-Highcharts.chart('container1', {
+Highcharts.chart('container1', Highcharts.merge(commonBulletOptions, {
     chart: {
-        marginTop: 40,
-        styledMode: true
+        marginTop: 40
     },
     title: {
         text: '2017 YTD'
@@ -67,12 +66,9 @@ Highcharts.chart('container1', {
     tooltip: {
         pointFormat: '<b>{point.y}</b> (with target at {point.target})'
     }
-});
+}));
 
-Highcharts.chart('container2', {
-    chart: {
-        styledMode: true
-    },
+Highcharts.chart('container2', Highcharts.merge(commonBulletOptions, {
     xAxis: {
         categories: ['<span class="hc-cat-title">Profit</span><br/>%']
     },
@@ -104,13 +100,10 @@ Highcharts.chart('container2', {
     tooltip: {
         pointFormat: '<b>{point.y}</b> (with target at {point.target})'
     }
-});
+}));
 
 
-Highcharts.chart('container3', {
-    chart: {
-        styledMode: true
-    },
+Highcharts.chart('container3', Highcharts.merge(commonBulletOptions, {
     xAxis: {
         categories: ['<span class="hc-cat-title">New Customers</span><br/>Count']
     },
@@ -145,4 +138,4 @@ Highcharts.chart('container3', {
     credits: {
         enabled: true
     }
-});
+}));

--- a/samples/highcharts/demo/annotations/demo.details
+++ b/samples/highcharts/demo/annotations/demo.details
@@ -3,4 +3,5 @@
  authors:
    - Torstein Hønsi
  js_wrap: b
+ alt_text: Highcharts basic line chart with annotations JavaScript example displays annotated shaded graph plot of Tour France.
 ...

--- a/samples/highcharts/demo/area-basic/demo.details
+++ b/samples/highcharts/demo/area-basic/demo.details
@@ -3,4 +3,5 @@
  authors:
    - Torstein Hønsi
  js_wrap: b
+ alt_text: Highcharts basic area chart JavaScript example graph compares cold war nuclear weapon stockpile peaks over time.
 ...

--- a/samples/highcharts/demo/area-stacked/demo.details
+++ b/samples/highcharts/demo/area-stacked/demo.details
@@ -3,4 +3,5 @@
  authors:
    - Torstein Hønsi
  js_wrap: b
+ alt_text: Highcharts percentage area chart JavaScript example graph compares and estimates global continental population growth over time.
 ...

--- a/samples/highcharts/demo/bar-stacked/demo.details
+++ b/samples/highcharts/demo/bar-stacked/demo.details
@@ -3,4 +3,5 @@
  authors:
    - Torstein Hønsi
  js_wrap: b
+ alt_text: Highcharts horizontal stacked bar chart JavaScript example graph compares human fruit consumption of apple pear grape.
 ...

--- a/samples/highcharts/demo/bubble-3d/demo.details
+++ b/samples/highcharts/demo/bubble-3d/demo.details
@@ -3,4 +3,5 @@
  authors:
    - Torstein Hønsi
  js_wrap: b
+ alt_text: Highcharts 3D Bubbles chart JavaScript example graph compares series values as radial gradient fill bubble diagram.
 ...

--- a/samples/highcharts/demo/column-basic/demo.details
+++ b/samples/highcharts/demo/column-basic/demo.details
@@ -3,4 +3,5 @@
  authors:
    - Torstein Hønsi
  js_wrap: b
+ alt_text: Highcharts vertical basic column chart JavaScript example graph compares monthly average rainfall in major cities clusters.
 ...

--- a/samples/highcharts/demo/cylinder/demo.details
+++ b/samples/highcharts/demo/cylinder/demo.details
@@ -4,4 +4,5 @@
    - Torstein Hønsi
    - Kacper Madej
  js_wrap: b
+ alt_text: Highcharts 3D cylinder chart JavaScript example graph compares variables as three dimensional vertical color bar chart.
 ...

--- a/samples/highcharts/demo/funnel3d/demo.details
+++ b/samples/highcharts/demo/funnel3d/demo.details
@@ -4,4 +4,5 @@
    - Kacper Madej
  js_wrap: b
  isNew: true
+ alt_text: Highcharts 3D funnel chart JavaScript example graph visualizes pipeline conversion of website visits to customers downloads.
 ...

--- a/samples/highcharts/demo/honeycomb-usa/demo.details
+++ b/samples/highcharts/demo/honeycomb-usa/demo.details
@@ -3,4 +3,5 @@
  authors:
    - Mustapha Mekhatria
  js_wrap: b
+ alt_text: Highcharts honeycomb tile map JavaScript example graph visualizes US population geographically by state with color chart.
 ...

--- a/samples/highcharts/demo/line-basic/demo.details
+++ b/samples/highcharts/demo/line-basic/demo.details
@@ -3,4 +3,5 @@
  authors:
    - Torstein Hønsi
  js_wrap: b
+ alt_text: Highcharts basic line chart JavaScript example displays graph plot of solar employment growth areas over time.
 ...

--- a/samples/highcharts/demo/pareto/demo.details
+++ b/samples/highcharts/demo/pareto/demo.details
@@ -3,4 +3,5 @@
  authors:
    - Sebastian Bochan
  js_wrap: b
+ alt_text: Highcharts pareto chart JavaScript example visualizes percentage restaurant complaints by combining line and vertical bar graphs.
 ...

--- a/samples/highcharts/demo/parliament-chart/demo.details
+++ b/samples/highcharts/demo/parliament-chart/demo.details
@@ -4,4 +4,5 @@
    - Torstein Hønsi
  js_wrap: b
  isNew: true
+ alt_text: Highcharts parliament item chart JavaScript example visualizes German political party breakdown by color and percentage proportion.
 ...

--- a/samples/highcharts/demo/pie-basic/demo.details
+++ b/samples/highcharts/demo/pie-basic/demo.details
@@ -3,4 +3,5 @@
  authors:
    - Torstein Hønsi
  js_wrap: b
+ alt_text: Highcharts basic pie chart JavaScript example compares Chrome Firefox Safari browser market share as proportional segments.
 ...

--- a/samples/highcharts/demo/polar-wind-rose/demo.details
+++ b/samples/highcharts/demo/polar-wind-rose/demo.details
@@ -3,4 +3,5 @@
  authors:
    - Torstein Hønsi
  js_wrap: b
+ alt_text: Highcharts wind rose chart JavaScript example visualizes weather frequency conditions by compass direction using polar graph.
 ...

--- a/samples/highcharts/demo/scatter/demo.details
+++ b/samples/highcharts/demo/scatter/demo.details
@@ -3,4 +3,5 @@
  authors:
    - Torstein Hønsi
  js_wrap: b
+ alt_text: Highcharts basic scatter plot JavaScript example graph compares male female gender type height and weight variables.
 ...

--- a/samples/highcharts/demo/timeline/demo.details
+++ b/samples/highcharts/demo/timeline/demo.details
@@ -4,4 +4,5 @@
    - Daniel Studencki
  js_wrap: b
  isNew: true
+ alt_text: Highcharts timeline diagram JavaScript example visualizes space exploration over time with Sputnik to Apollo story chart.
 ...

--- a/samples/highcharts/tooltip/formatter-split/demo.js
+++ b/samples/highcharts/tooltip/formatter-split/demo.js
@@ -17,9 +17,10 @@ Highcharts.chart('container', {
             // The first returned item is the header, subsequent items are the
             // points
             return ['<b>' + this.x + '</b>'].concat(
-                this.points.map(function (point) {
-                    return point.series.name + ': ' + point.y + 'm';
-                })
+                this.points ?
+                    this.points.map(function (point) {
+                        return point.series.name + ': ' + point.y + 'm';
+                    }) : []
             );
         },
         split: true

--- a/samples/maps/chart/transform-on-chart/demo.js
+++ b/samples/maps/chart/transform-on-chart/demo.js
@@ -3,8 +3,6 @@ var transforms = {
     custom: Highcharts.maps['countries/gb/gb-all']['hc-transform']['gb-all-shetland']
 };
 
-delete Highcharts.maps['countries/gb/gb-all']['hc-transform']; // Remove transform from map
-
 // Initiate the chart
 Highcharts.mapChart('container', {
     chart: {

--- a/samples/unit-tests/series-packedbubble/update/demo.details
+++ b/samples/unit-tests/series-packedbubble/update/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series-packedbubble/update/demo.html
+++ b/samples/unit-tests/series-packedbubble/update/demo.html
@@ -1,0 +1,8 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 400px; margin: 0 auto"></div>

--- a/samples/unit-tests/series-packedbubble/update/demo.js
+++ b/samples/unit-tests/series-packedbubble/update/demo.js
@@ -1,0 +1,30 @@
+QUnit.test('Series update', function (assert) {
+    var series,
+        chart = Highcharts.chart('container', {
+            chart: {
+                type: 'packedbubble',
+                width: 500,
+                height: 500,
+                marginTop: 46,
+                marginBottom: 53
+            },
+            series: [{
+                layoutAlgorithm: {
+                    splitSeries: true,
+                    parentNodeLimit: true
+                },
+                data: [50, 80, 50]
+            }]
+        });
+    chart.update({
+        series: [{
+            data: [2, 3, 4, 5, 6, 7]
+        }]
+    });
+    series = chart.series[0];
+    assert.strictEqual(
+        !series.parentNode.graphic,
+        false,
+        'parentNode is visible after series.update'
+    );
+});

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -712,10 +712,15 @@ function createVisualTestTemplate(argv, path, js, assertion) {
         `;
     }
 
+    var useFakeTime = path.startsWith('gantt/');
+    var startOfMockedTime = Date.UTC(2019, 7, 1);
+
     return `
         QUnit.test('${path}', function (assert) {
             // Apply demo.html
             document.getElementById('demo-html').innerHTML = \`${html}\`;
+            
+            ${useFakeTime ? `var clock = TestUtilities.lolexInstall({ now: ${startOfMockedTime} });` : ''}
             
             /*
              * we expect 2 callbacks if --visualcompare argument is supplied,
@@ -748,6 +753,8 @@ function createVisualTestTemplate(argv, path, js, assertion) {
                 }
             }
             assertIfChartExists();
+            
+            ${useFakeTime ? 'TestUtilities.lolexUninstall(clock);' : ''}
         });
     `;
 }

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -398,23 +398,6 @@ module.exports = function (config) {
             'samples/highcharts/demo/pareto/demo.js',
             'samples/highcharts/demo/pyramid3d/demo.js',
             'samples/highcharts/demo/synchronized-charts/demo.js',
-            // various samples failing standard chart creation test
-            'samples/highcharts/series/data-array-of-name-value/demo.js',
-            'samples/highcharts/plotoptions/series-dashstyle-all/demo.js',
-            'samples/highcharts/series/data-array-of-name-value/demo.js',
-            'samples/highcharts/studies/direction-arrows/demo.js',
-            'samples/highcharts/studies/distribution-algorithm/demo.js',
-            'samples/highcharts/members/renderer-arc/demo.js',
-            'samples/highcharts/members/renderer-basic/demo.js',
-            'samples/highcharts/members/renderer-callout/demo.js',
-            'samples/highcharts/members/renderer-circle/demo.js',
-            'samples/highcharts/members/renderer-g/demo.js',
-            'samples/highcharts/members/renderer-path/demo.js',
-            'samples/highcharts/members/renderer-rect/demo.js',
-            'samples/maps/coloraxis/dataclasses-name/demo.js',
-            'samples/maps/coloraxis/dataclasses-labelformatter/demo.js',
-            'samples/maps/series/latlon-transform/demo.js',
-
         ],
         reporters: ['imagecapture', 'progress', 'json-log'],
         port: 9876,  // karma web server port
@@ -736,7 +719,7 @@ function createVisualTestTemplate(argv, path, js, assertion) {
                     Highcharts.charts.length - 1
                 ];
 
-                if (chart && document.getElementsByTagName('svg').length) {
+                if (chart || document.getElementsByTagName('svg').length) {
                     ${assertion}
                     done();
                     ${reset}

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -228,18 +228,8 @@ function getSVG(chart) {
         if (chart.styledMode) {
             svg = svg.replace(
                 '</style>',
-                `
-                * {
-                    fill: rgba(0, 0, 0, 0.1);
-                    stroke: black;
-                    stroke-width: 1px;
-                }
-                text, tspan {
-                    fill: blue;
-                    stroke: none;
-                }
-                </style>
-                `
+                '* { fill: rgba(0, 0, 0, 0.1); stroke: black; stroke-width: 1px; } '
+                + 'text, tspan { fill: blue; stroke: none; } </style>'
             );
         }
 

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -225,6 +225,24 @@ function getSVG(chart) {
         Highcharts.prepareShot(chart);
         svg = container.querySelector('svg').outerHTML;
 
+        if (chart.styledMode) {
+            svg = svg.replace(
+                '</style>',
+                `
+                * {
+                    fill: rgba(0, 0, 0, 0.1);
+                    stroke: black;
+                    stroke-width: 1px;
+                }
+                text, tspan {
+                    fill: blue;
+                    stroke: none;
+                }
+                </style>
+                `
+            );
+        }
+
     // Renderer samples
     } else {
         if (document.getElementsByTagName('svg').length) {

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -349,7 +349,7 @@ function compareToReference(chart, path) { // eslint-disable-line no-unused-vars
             reject(new Error('No candidate SVG found'));
         }
 
-        var remotelocation = __karma__.config.cliArgs.remotelocation;
+        var remotelocation = __karma__.config.cliArgs && __karma__.config.cliArgs.remotelocation;
         // Handle reference, load SVG from bucket or file
         var url = 'base/samples/' + path + '/reference.svg';
         if (remotelocation) {

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -200,7 +200,7 @@ Highcharts.prepareShot = function (chart) {
             chart.series[0].nodes[0] &&
             typeof chart.series[0].nodes[0].onMouseOver === 'function'
         ) {
-            chart.series[0].nodes[0].onMouseOver({});
+            chart.series[0].nodes[0].onMouseOver();
         
         // Others
         } else if (
@@ -208,7 +208,7 @@ Highcharts.prepareShot = function (chart) {
             chart.series[0].points[0] &&
             typeof chart.series[0].points[0].onMouseOver === 'function'
         ) {
-            chart.series[0].points[0].onMouseOver({});
+            chart.series[0].points[0].onMouseOver();
         }
     }
 };

--- a/test/test-utilities.js
+++ b/test/test-utilities.js
@@ -38,8 +38,11 @@ var TestUtilities = /** @class */ (function () {
     /**
      * Convenient wrapper for installing lolex and bypassing
      * requestAnimationFrame. Returns a clock object.
+     *
+     * @param lolexConfig
+     *        Config supplied to lolex.install
      */
-    TestUtilities.lolexInstall = function () {
+    TestUtilities.lolexInstall = function (lolexConfig) {
         if (!lolex) {
             return;
         }
@@ -48,7 +51,7 @@ var TestUtilities = /** @class */ (function () {
         win.requestAnimationFrame = null;
         // Abort running animations, otherwise they will take over
         Highcharts.timers.length = 0;
-        return lolex.install();
+        return lolex.install(lolexConfig);
     };
     /**
      * Convenient wrapper for uninstalling lolex.

--- a/test/test-utilities.ts
+++ b/test/test-utilities.ts
@@ -98,9 +98,11 @@ class TestUtilities {
     /**
      * Convenient wrapper for installing lolex and bypassing
      * requestAnimationFrame. Returns a clock object.
+     *
+     * @param lolexConfig
+     *        Config supplied to lolex.install
      */
-    private static lolexInstall (): (LolexClock|undefined) {
-
+    private static lolexInstall (lolexConfig?: any): (LolexClock|undefined) {
         if (!lolex) {
             return;
         }
@@ -113,7 +115,7 @@ class TestUtilities {
         // Abort running animations, otherwise they will take over
         (Highcharts as any).timers.length = 0;
 
-        return lolex.install();
+        return lolex.install(lolexConfig);
     }
 
     /**

--- a/test/tsglobal.d.ts
+++ b/test/tsglobal.d.ts
@@ -1,7 +1,7 @@
 /// <reference path="../code/highcharts.d.ts" />
 
 declare interface Lolex {
-    install: () => (LolexClock|undefined);
+    install: (lolexConfig? : any) => (LolexClock|undefined);
 }
 
 declare interface LolexClock {

--- a/tools/gulptasks/test.js
+++ b/tools/gulptasks/test.js
@@ -296,9 +296,14 @@ Available arguments for 'gulp test':
     Example: 'gulp test --tests unit-tests/chart/*' runs all tests in the chart
     directory.
 
---difflog
+--visualcompare
+    Performs a visual comparison of the output and creates a reference.svg and candidate.svg
+    when doing so.
+
+--difflog 
     Produces a JSON file containing the number of different pixels for visual tests.
-    Use --remotelocation to specify remote location of reference.svg files to compare with.
+    Use --remotelocation to specify remote location of reference.svg files to compare with,
+    or local file will be expected to exist.
 
 --ts
     Compile TypeScript-based tests.

--- a/ts/modules/networkgraph/layouts.ts
+++ b/ts/modules/networkgraph/layouts.ts
@@ -143,8 +143,8 @@ import U from '../../parts/Utilities.js';
 var defined = U.defined;
 
 
-import 'integrations.js';
-import 'QuadTree.js';
+import './integrations.js';
+import './QuadTree.js';
 
 var pick = H.pick,
     addEvent = H.addEvent,

--- a/ts/parts-more/PackedBubbleSeries.ts
+++ b/ts/parts-more/PackedBubbleSeries.ts
@@ -1113,14 +1113,13 @@ seriesType<Highcharts.PackedBubbleSeriesOptions>(
                 width: (series.parentNodeRadius as any) * 2,
                 height: (series.parentNodeRadius as any) * 2
             }, parentOptions);
-            if (!series.graph) {
+            if (!(series.parentNode as any).graphic) {
                 series.graph = (series.parentNode as any).graphic =
                     chart.renderer.symbol(parentOptions.symbol)
                         .attr(parentAttribs)
                         .add(series.parentNodesGroup);
-            } else {
-                series.graph.attr(parentAttribs);
             }
+            (series.parentNode as any).graphic.attr(parentAttribs);
         },
         /**
          * Creating parent nodes for split series, in which all the bubbles

--- a/ts/parts-more/PackedBubbleSeries.ts
+++ b/ts/parts-more/PackedBubbleSeries.ts
@@ -1116,7 +1116,6 @@ seriesType<Highcharts.PackedBubbleSeriesOptions>(
             if (!(series.parentNode as any).graphic) {
                 series.graph = (series.parentNode as any).graphic =
                     chart.renderer.symbol(parentOptions.symbol)
-                        .attr(parentAttribs)
                         .add(series.parentNodesGroup);
             }
             (series.parentNode as any).graphic.attr(parentAttribs);

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -1696,7 +1696,12 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             this.unbindReflow = addEvent(win, 'resize', function (
                 e: Event
             ): void {
-                chart.reflow(e);
+                // a removed event listener still runs in Edge and IE if the
+                // listener was removed while the event runs, so check if the
+                // chart is not destroyed (#11609)
+                if (chart.options) {
+                    chart.reflow(e);
+                }
             });
             addEvent(this, 'destroy', this.unbindReflow);
 

--- a/ts/parts/Interaction.ts
+++ b/ts/parts/Interaction.ts
@@ -1250,11 +1250,14 @@ extend(Point.prototype, /** @lends Highcharts.Point.prototype */ {
             markerGraphic && markerGraphic.visibility || 'inherit'
         );
 
-        if (haloOptions && haloOptions.size && markerVisibility !== 'hidden') {
+        if (haloOptions &&
+            haloOptions.size &&
+            markerGraphic &&
+            markerVisibility !== 'hidden') {
             if (!halo) {
                 series.halo = halo = chart.renderer.path()
                     // #5818, #5903, #6705
-                    .add((markerGraphic as any).parentGroup);
+                    .add(markerGraphic.parentGroup);
             }
             halo.show()[move ? 'animate' : 'attr']({
                 d: point.haloPath(haloOptions.size) as any

--- a/ts/parts/Interaction.ts
+++ b/ts/parts/Interaction.ts
@@ -43,7 +43,7 @@ declare global {
             haloPath(size: number): SVGElement;
             importEvents(): void;
             onMouseOut(): void;
-            onMouseOver(e: PointerEventObject): void;
+            onMouseOver(e?: PointerEventObject): void;
             select(selected?: boolean, accumulate?: boolean): void;
             setState(
                 state?: string,
@@ -963,14 +963,14 @@ extend(Point.prototype, /** @lends Highcharts.Point.prototype */ {
      *
      * @function Highcharts.Point#onMouseOver
      *
-     * @param {Highcharts.PointerEventObject} e
+     * @param {Highcharts.PointerEventObject} [e]
      *        The event arguments.
      *
      * @return {void}
      */
     onMouseOver: function (
         this: Highcharts.Point,
-        e: Highcharts.PointerEventObject
+        e?: Highcharts.PointerEventObject
     ): void {
         var point = this,
             series = point.series,

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -92,7 +92,7 @@ declare global {
                 series: Array<Series>,
                 isDirectTouch: boolean,
                 shared: (boolean|undefined),
-                e: PointerEventObject
+                e?: PointerEventObject
             ): PointerHoverDataObject;
             public getPointFromEvent(e: Event): (Point|undefined)
             public inClass(
@@ -112,7 +112,7 @@ declare global {
             public onDocumentMouseUp(e: PointerEventObject): void;
             public onTrackerMouseOut(e: PointerEventObject): void;
             public reset(allowMove?: boolean, delay?: number): void;
-            public runPointActions(e: PointerEventObject, p?: Point): void;
+            public runPointActions(e?: PointerEventObject, p?: Point): void;
             public scaleGroups(
                 attribs?: SeriesPlotBoxObject,
                 clip?: boolean
@@ -594,7 +594,7 @@ Highcharts.Pointer.prototype = {
      * @param {boolean|undefined} shared
      *        Whether it is a shared tooltip or not.
      *
-     * @param {Highcharts.PointerEventObject} e
+     * @param {Highcharts.PointerEventObject} [e]
      *        The triggering event, containing chart coordinates of the pointer.
      *
      * @return {object}
@@ -608,7 +608,7 @@ Highcharts.Pointer.prototype = {
         series: Array<Highcharts.Series>,
         isDirectTouch: boolean,
         shared: (boolean|undefined),
-        e: Highcharts.PointerEventObject
+        e?: Highcharts.PointerEventObject
     ): Highcharts.PointerHoverDataObject {
         var hoverPoint: Highcharts.Point,
             hoverPoints = [] as Array<Highcharts.Point>,
@@ -632,7 +632,7 @@ Highcharts.Pointer.prototype = {
                 });
 
         // Use existing hovered point or find the one closest to coordinates.
-        hoverPoint = useExisting ?
+        hoverPoint = useExisting || !e ?
             existingHoverPoint :
             this.findNearestKDPoint(searchSeries, shared, e) as any;
 
@@ -699,7 +699,7 @@ Highcharts.Pointer.prototype = {
      */
     runPointActions: function (
         this: Highcharts.Pointer,
-        e: Highcharts.PointerEventObject,
+        e?: Highcharts.PointerEventObject,
         p?: Highcharts.Point
     ): void {
         var pointer = this,
@@ -718,7 +718,7 @@ Highcharts.Pointer.prototype = {
             hoverPoint = p || chart.hoverPoint,
             hoverSeries = hoverPoint && hoverPoint.series || chart.hoverSeries,
             // onMouseOver or already hovering a series with directTouch
-            isDirectTouch = e.type !== 'touchmove' && (
+            isDirectTouch = (!e || e.type !== 'touchmove') && (
                 !!p || (
                     (hoverSeries && hoverSeries.directTouch) &&
                     pointer.isDirectTouch


### PR DESCRIPTION
.. and fixed test verification of additional samples.

Extracted karma js template for the visual test samples into separate function. 

Now an assert for checking if the chart exists is always run for all visual tests. I'm a bit divided with regards to splitting it up or not. I.e. sample verification could instead be done only when explicitly asking for it through an argument
E.g `karma start test/karma-conf.js  --browsercount 1 --tests highcharts/*/* --verify-only`

Also it is not apparent that the above will not run unit tests, but rather wrap demo files as QUnit tests. Should we make that more explicit or is it ok as it is?