### PR TITLE
bugfix/10962-misaligned-stack-labels

### DIFF
--- a/js/modules/variwide.src.js
+++ b/js/modules/variwide.src.js
@@ -59,6 +59,7 @@ seriesType('variwide', 'column'
          */
         groupPadding: 0
     }, {
+        irregularWidths: true,
         pointArrayMap: ['y', 'z'],
         parallelArrays: ['x', 'y', 'z'],
         processData: function (force) {
@@ -192,6 +193,42 @@ seriesType('variwide', 'column'
                     xAxis.len - point.shapeArgs.x - point.shapeArgs.width / 2;
                 }
             }, this);
+
+            if (this.options.stacking) {
+                this.correctStackLabels();
+            }
+        },
+
+        // Function that corrects stack labels positions
+        correctStackLabels: function () {
+            var series = this,
+                options = series.options,
+                yAxis = series.yAxis,
+                pointStack,
+                pointWidth,
+                stack,
+                xValue;
+
+            series.points.forEach(function (point) {
+                xValue = point.x;
+                pointWidth = point.shapeArgs.width;
+                stack = yAxis.stacks[(series.negStacks &&
+                    point.y <
+                        (options.startFromThreshold ? 0 : options.threshold) ?
+                    '-' :
+                    '') + series.stackKey];
+                pointStack = stack[xValue];
+
+                if (stack && pointStack && !point.isNull) {
+                    pointStack.setOffset(
+                        -(pointWidth / 2) || 0,
+                        pointWidth || 0,
+                        undefined,
+                        undefined,
+                        point.plotX
+                    );
+                }
+            });
         }
 
         // Point functions

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -3152,7 +3152,14 @@ null,
                         (point.y / pointStack.total * 100);
                 point.stackY = yValue;
                 // Place the stack label
-                pointStack.setOffset(series.pointXOffset || 0, series.barW || 0);
+                // in case of variwide series (where widths of points are
+                // different in most cases), stack labels are positioned
+                // wrongly, so the call of the setOffset is omited here and
+                // labels are correctly positioned later, at the end of the
+                // variwide's translate function (#10962)
+                if (!series.irregularWidths) {
+                    pointStack.setOffset(series.pointXOffset || 0, series.barW || 0);
+                }
             }
             // Set translated yBottom or remove it
             point.yBottom = defined(yBottom) ?

--- a/js/parts/Stacking.js
+++ b/js/parts/Stacking.js
@@ -159,9 +159,10 @@ H.StackItem.prototype = {
      * @param {number} xWidth
      * @param {number} [boxBottom]
      * @param {number} [boxTop]
+     * @param {number} [defaultX]
      * @return {void}
      */
-    setOffset: function (xOffset, xWidth, boxBottom, boxTop) {
+    setOffset: function (xOffset, xWidth, boxBottom, boxTop, defaultX) {
         var stackItem = this, axis = stackItem.axis, chart = axis.chart, 
         // stack value translated mapped to chart coordinates
         y = axis.translate(axis.usePercentage ?
@@ -172,7 +173,8 @@ H.StackItem.prototype = {
         // stack height:
         h = defined(y) && Math.abs(y - yZero), 
         // x position:
-        x = chart.xAxis[0].translate(stackItem.x) + xOffset, stackBox = defined(y) && stackItem.getStackBox(chart, stackItem, x, y, xWidth, h, axis), label = stackItem.label, isNegative = stackItem.isNegative, isJustify = pick(stackItem.options.overflow, 'justify') === 'justify', visible, alignAttr;
+        x = pick(defaultX, chart.xAxis[0].translate(stackItem.x)) +
+            xOffset, stackBox = defined(y) && stackItem.getStackBox(chart, stackItem, x, y, xWidth, h, axis), label = stackItem.label, isNegative = stackItem.isNegative, isJustify = pick(stackItem.options.overflow, 'justify') === 'justify', visible, alignAttr;
         if (label && stackBox) {
             var bBox = label.getBBox(), boxOffsetX = chart.inverted ?
                 (isNegative ? bBox.width : 0) : bBox.width / 2, boxOffsetY = chart.inverted ?

--- a/samples/highcharts/yaxis/stacklabels-enabled-variwide/demo.details
+++ b/samples/highcharts/yaxis/stacklabels-enabled-variwide/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Pawel Dalek
+ js_wrap: b
+...

--- a/samples/highcharts/yaxis/stacklabels-enabled-variwide/demo.html
+++ b/samples/highcharts/yaxis/stacklabels-enabled-variwide/demo.html
@@ -1,0 +1,3 @@
+<div id="container" style="height: 400px"></div>
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/variwide.js"></script>

--- a/samples/highcharts/yaxis/stacklabels-enabled-variwide/demo.js
+++ b/samples/highcharts/yaxis/stacklabels-enabled-variwide/demo.js
@@ -1,0 +1,40 @@
+Highcharts.chart('container', {
+    chart: {
+        type: 'variwide'
+    },
+    title: {
+        text: 'Stack labels in variwide chart'
+    },
+    xAxis: {
+        type: 'category'
+    },
+    yAxis: {
+        stackLabels: {
+            enabled: true
+        }
+    },
+    plotOptions: {
+        series: {
+            stacking: 'normal'
+        }
+    },
+    series: [{
+        data: [
+            [0, 50, 135504],
+            [1, 42, 277339],
+            [2, 32, 421611],
+            [3, 38, 462057],
+            [4, 35, 902885],
+            [5, 34, 1702641]
+        ]
+    }, {
+        data: [
+            [0, 47, 135504],
+            [1, 61, 277339],
+            [2, 92, 421611],
+            [3, 76, 462057],
+            [4, 99, 902885],
+            [5, 82, 1702641]
+        ]
+    }]
+});

--- a/samples/unit-tests/axis/variwide-stacklabels/demo.details
+++ b/samples/unit-tests/axis/variwide-stacklabels/demo.details
@@ -1,0 +1,5 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+...

--- a/samples/unit-tests/axis/variwide-stacklabels/demo.html
+++ b/samples/unit-tests/axis/variwide-stacklabels/demo.html
@@ -1,0 +1,8 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/variwide.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/axis/variwide-stacklabels/demo.js
+++ b/samples/unit-tests/axis/variwide-stacklabels/demo.js
@@ -1,0 +1,88 @@
+QUnit.test('#10962 - Stack labels in variwide series', function (assert) {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            type: 'variwide'
+        },
+        title: {
+            text: 'Stack labels in variwide chart'
+        },
+        xAxis: {
+            type: 'category'
+        },
+        yAxis: {
+            stackLabels: {
+                enabled: true
+            }
+        },
+        plotOptions: {
+            series: {
+                stacking: 'normal'
+            }
+        },
+        series: [{
+            data: [
+                [0, 50, 135504],
+                [1, 42, 277339],
+                [2, 32, 421611],
+                [3, 38, 462057],
+                [4, 35, 902885],
+                [5, 34, 1702641]
+            ]
+        }, {
+            data: [
+                [0, 47, 135504],
+                [1, 61, 277339],
+                [2, 92, 421611],
+                [3, 76, 462057],
+                [4, 99, 902885],
+                [5, 82, 1702641]
+            ]
+        }]
+    });
+
+    var series = chart.series,
+        yAxis = chart.yAxis[0];
+
+    chart.update({
+        yAxis: {
+            stackLabels: {
+                align: 'left'
+            }
+        }
+    });
+
+    assert.strictEqual(
+        series[0].points[4].plotX >
+            yAxis.stacks[series[0].stackKey][4].label.alignAttr.x,
+        true,
+        'The stack label should be positioned before the 4th point\'s center.'
+    );
+
+    chart.update({
+        yAxis: {
+            stackLabels: {
+                align: 'right'
+            }
+        }
+    });
+
+    assert.strictEqual(
+        series[0].points[4].plotX <
+            yAxis.stacks[series[0].stackKey][4].label.alignAttr.x,
+        true,
+        'The stack label should be positioned after the 4th point\'s center.'
+    );
+
+    chart.update({
+        xAxis: {
+            min: 6
+        }
+    });
+
+    assert.strictEqual(
+        chart.container.querySelector('.highcharts-label.highcharts-stack-labels')
+            .getAttribute('visibility'),
+        'hidden',
+        'Stack label is hidden.'
+    );
+});

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -4245,10 +4245,18 @@ H.Series = H.seriesType<Highcharts.SeriesOptions>(
                     point.stackY = yValue;
 
                     // Place the stack label
-                    (pointStack as any).setOffset(
-                        series.pointXOffset || 0,
-                        series.barW || 0
-                    );
+
+                    // in case of variwide series (where widths of points are
+                    // different in most cases), stack labels are positioned
+                    // wrongly, so the call of the setOffset is omited here and
+                    // labels are correctly positioned later, at the end of the
+                    // variwide's translate function (#10962)
+                    if (!(series as any).irregularWidths) {
+                        (pointStack as any).setOffset(
+                            series.pointXOffset || 0,
+                            series.barW || 0
+                        );
+                    }
 
                 }
 

--- a/ts/parts/Stacking.ts
+++ b/ts/parts/Stacking.ts
@@ -132,7 +132,8 @@ declare global {
                 xOffset: number,
                 xWidth: number,
                 boxBottom?: number,
-                boxTop?: number
+                boxTop?: number,
+                defaultX?: number
             ): void;
         }
     }
@@ -342,6 +343,7 @@ H.StackItem.prototype = {
      * @param {number} xWidth
      * @param {number} [boxBottom]
      * @param {number} [boxTop]
+     * @param {number} [defaultX]
      * @return {void}
      */
     setOffset: function (
@@ -349,7 +351,8 @@ H.StackItem.prototype = {
         xOffset: number,
         xWidth: number,
         boxBottom?: number,
-        boxTop?: number
+        boxTop?: number,
+        defaultX?: number
     ): void {
         var stackItem = this,
             axis = stackItem.axis,
@@ -370,7 +373,8 @@ H.StackItem.prototype = {
             // stack height:
             h = defined(y) && Math.abs((y as any) - (yZero as any)),
             // x position:
-            x = (chart.xAxis[0].translate(stackItem.x) as any) + xOffset,
+            x = pick(defaultX, (chart.xAxis[0].translate(stackItem.x) as any)) +
+                xOffset,
             stackBox = defined(y) && stackItem.getStackBox(
                 chart,
                 stackItem,


### PR DESCRIPTION
Fixed #10962, stack labels were misaligned in variwide series.