### PR TITLE
ts/modules-exporting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,6 +11,7 @@ js/modules/dotplot.src.js
 js/modules/drag-panes.src.js
 js/modules/drilldown.src.js
 js/modules/export-data.src.js
+js/modules/exporting.src.js
 js/modules/full-screen.src.js
 js/modules/oldie.src.js
 js/modules/oldie-polyfills.src.js

--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -3270,7 +3270,7 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
         if (isArray(path)) {
             attribs.d = path;
         }
-        else if (isObject(path)) { // attributes
+        else if (isObject(path, true)) { // attributes
             extend(attribs, path);
         }
         return this.createElement('path').attr(attribs);
@@ -3306,7 +3306,7 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
     *         The generated wrapper element.
     */
     circle: function (x, y, r) {
-        var attribs = (isObject(x) ?
+        var attribs = (isObject(x, true) ?
             x :
             x === undefined ? {} : { x: x, y: y, r: r }), wrapper = this.createElement('circle');
         // Setting x or y translates to cx and cy
@@ -3358,7 +3358,7 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
     */
     arc: function (x, y, r, innerR, start, end) {
         var arc, options;
-        if (isObject(x)) {
+        if (isObject(x, true)) {
             options = x;
             y = options.y;
             r = options.r;
@@ -3422,8 +3422,8 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
     *         The generated wrapper element.
     */
     rect: function (x, y, width, height, r, strokeWidth) {
-        r = isObject(x) ? x.r : r;
-        var wrapper = this.createElement('rect'), attribs = isObject(x) ?
+        r = isObject(x, true) ? x.r : r;
+        var wrapper = this.createElement('rect'), attribs = isObject(x, true) ?
             x :
             x === undefined ?
                 {} :

--- a/js/parts/Time.js
+++ b/js/parts/Time.js
@@ -526,7 +526,7 @@ Highcharts.Time.prototype = {
      * @return {Highcharts.Dictionary<T>} - The object definition
      */
     resolveDTLFormat: function (f) {
-        if (!isObject(f, true)) { // check for string or array
+        if (!isObject(f)) { // check for string or array
             f = splat(f);
             return {
                 main: f[0],

--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -856,9 +856,7 @@ function isArray(obj) {
  *         True if the argument is an object.
  */
 function isObject(obj, strict) {
-    return (!!obj &&
-        typeof obj === 'object' &&
-        (!strict || !isArray(obj))); // eslint-disable-line @typescript-eslint/no-explicit-any
+    return (!!obj && typeof obj === 'object' && (!strict || !isArray(obj)));
 }
 /**
  * Utility function to check if an Object is a HTML Element.
@@ -1633,7 +1631,7 @@ H.setAnimation = function (animation, chart) {
  *         An object with at least a duration property.
  */
 H.animObject = function (animation) {
-    return isObject(animation) ?
+    return isObject(animation, true) ?
         H.merge(animation) :
         { duration: animation ? 500 : 0 };
 };

--- a/ts/modules/export-data.src.ts
+++ b/ts/modules/export-data.src.ts
@@ -45,31 +45,6 @@ declare global {
             /** @requires modules/export-data */
             viewData(): void;
         }
-        interface ExportingButtonOptionsObject {
-            className?: string;
-            enabled?: boolean;
-            menuClassName?: string;
-            menuItems?: Array<string>;
-            onclick?: Function;
-            symbol?: ('menu'|'menuball'|'exportIcon'|string|SymbolKeyValue);
-            symbolFill?: ColorString;
-            symbolStroke?: ColorString;
-            symbolStrokeWidth?: number;
-            text?: string;
-            theme?: ExportingButtonThemeOptionsObject;
-            titleKey?: string;
-            x?: number;
-            y?: number;
-        }
-        interface ExportingButtonsOptions {
-            [key: string]: ExportingButtonOptionsObject;
-            contextButton: ExportingButtonOptionsObject;
-        }
-        interface ExportingButtonThemeOptionsObject {
-            fill?: ColorType;
-            padding?: number;
-            stroke?: ColorString;
-        }
         interface ExportingCsvOptions {
             columnHeaderFormatter?: (Function|null);
             dateFormat?: string;
@@ -77,35 +52,13 @@ declare global {
             itemDelimiter?: (string|null);
             lineDelimiter?: string;
         }
-        interface ExportingMenuObject {
-            onclick?: EventCallbackFunction<Chart>;
-            separator?: boolean;
-            text?: string;
-            textKey?: string;
-        }
         interface ExportingOptions {
-            allowHTML?: boolean;
-            buttons?: ExportingButtonsOptions;
-            chartOptions?: Options;
             csv?: ExportingCsvOptions;
-            enabled?: boolean;
-            error?: ExportingErrorCallbackFunction;
-            fallbackToExportServer?: boolean;
-            filename?: string;
-            formAttributes?: any;
-            libURL?: string;
             menuItemDefinitions?: Dictionary<ExportingMenuObject>;
-            printMaxWidth?: number;
-            scale?: number;
             showTable?: boolean;
-            sourceHeight?: number;
-            sourceWidth?: number;
             tableCaption?: (boolean|string);
-            type?: string;
-            url?: string;
             useMultiLevelHeaders?: boolean;
             useRowspanHeaders?: boolean;
-            width?: number;
         }
         interface ExportingPoint extends PointOptionsObject {
             series: ExportingSeries;

--- a/ts/modules/exporting.src.ts
+++ b/ts/modules/exporting.src.ts
@@ -9,8 +9,188 @@
  *  !!!!!!! SOURCE GETS TRANSPILED BY TYPESCRIPT. EDIT TS FILE ONLY. !!!!!!!
  *
  * */
+
 'use strict';
+
 import H from '../parts/Globals.js';
+
+/**
+ * Internal types
+ * @private
+ */
+declare global {
+    namespace Highcharts {
+        interface Chart {
+            btnCount?: number;
+            buttonOffset?: number;
+            exportContextMenu?: ExportingDivElement;
+            exportDivElements?: Array<ExportingDivElement>;
+            exportEvents?: Array<Function>;
+            exporting?: ChartExportingObject;
+            exportingGroup?: SVGElement;
+            exportMenuHeight?: number;
+            exportMenuWidth?: number;
+            exportSVGElements?: Array<SVGElement>;
+            fullscreen?: FullScreen;
+            isDirtyExporting?: boolean;
+            isPrinting?: boolean;
+            openMenu?: boolean;
+            /** @requires modules/exporting */
+            addButton(options: ExportingButtonOptions): void;
+            /** @requires modules/exporting */
+            contextMenu(
+                className: string,
+                items: Array<(string|ExportingMenuObject)>,
+                x: number,
+                y: number,
+                width: number,
+                height: number,
+                button: SVGElement
+            ): void;
+            /** @requires modules/exporting */
+            destroyExport(e?: Event): void;
+            /** @requires modules/exporting */
+            exportChart(
+                exportingOptions?: ExportingOptions,
+                chartOptions?: Options
+            ): void;
+            /** @requires modules/exporting */
+            getChartHTML(): string;
+            /** @requires modules/exporting */
+            getFilename(): string;
+            /** @requires modules/exporting */
+            getSVG(chartOptions?: Options): string;
+            /** @requires modules/exporting */
+            getSVGForExport(
+                options: ExportingOptions,
+                chartOptions: Options
+            ): string;
+            /** @requires modules/exporting */
+            inlineStyles(): void;
+            /** @requires modules/exporting */
+            print(): void;
+            /** @requires modules/exporting */
+            renderExporting(): void;
+            /** @requires modules/exporting */
+            sanitizeSVG(svg: string, options: Options): string;
+        }
+        interface ChartEventsOptions {
+            afterPrint?: ExportingAfterPrintCallbackFunction;
+            beforePrint?: ExportingBeforePrintCallbackFunction;
+        }
+        interface ChartExportingObject {
+            update(options: ExportingOptions, redraw?: boolean): void;
+        }
+        interface ExportingAfterPrintCallbackFunction {
+            (chart: Chart, event: Event): void;
+        }
+        interface ExportingBeforePrintCallbackFunction {
+            (chart: Chart, event: Event): void;
+        }
+        interface ExportingButtonOptions {
+            _titleKey?: string;
+            align?: AlignValue;
+            buttonSpacing?: number;
+            className?: string;
+            enabled?: boolean;
+            height?: number;
+            menuClassName?: string;
+            menuItems?: Array<string>;
+            onclick?: Function;
+            symbol?: ('menu'|'menuball'|'exportIcon'|string|SymbolKeyValue);
+            symbolFill?: ColorString;
+            symbolSize?: number;
+            symbolStroke?: ColorString;
+            symbolStrokeWidth?: number;
+            symbolX?: number;
+            symbolY?: number;
+            text?: string;
+            theme?: SVGAttributes;
+            titleKey?: string;
+            verticalAlign?: VerticalAlignValue;
+            width?: number;
+            x?: number;
+            y?: number;
+        }
+        interface ExportingButtonsOptions {
+            [key: string]: ExportingButtonOptions;
+            contextButton: ExportingButtonOptions;
+        }
+        interface ExportingErrorCallbackFunction {
+            (options: ExportingOptions, err: Error): void;
+        }
+        interface ExportingDivElement extends HTMLDOMElement {
+            hideTimer?: number;
+            hideMenu(): void;
+        }
+        interface ExportingMenuObject {
+            onclick?: EventCallbackFunction<Chart>;
+            separator?: boolean;
+            text?: string;
+            textKey?: string;
+        }
+        interface ExportingOptions {
+            allowHTML?: boolean;
+            buttons?: ExportingButtonsOptions;
+            chartOptions?: Options;
+            enabled?: boolean;
+            error?: ExportingErrorCallbackFunction;
+            fallbackToExportServer?: boolean;
+            filename?: string;
+            formAttributes?: HTMLAttributes;
+            libURL?: string;
+            menuItemDefinitions?: Dictionary<ExportingMenuObject>;
+            printMaxWidth?: number;
+            scale?: number;
+            sourceHeight?: number;
+            sourceWidth?: number;
+            type?: string;
+            url?: string;
+            useMultiLevelHeaders?: boolean;
+            useRowspanHeaders?: boolean;
+            width?: number;
+        }
+        interface NavigationOptions {
+            bindingsClassName?: string;
+            buttonOptions?: ExportingButtonOptions;
+            menuItemHoverStyle?: CSSObject;
+            menuItemStyle?: CSSObject;
+            menuStyle?: CSSObject;
+        }
+        interface LangOptions {
+            contextButtonTitle?: string;
+            downloadJPEG?: string;
+            downloadPDF?: string;
+            downloadPNG?: string;
+            downloadSVG?: string;
+            printChart?: string;
+            viewFullscreen?: string;
+        }
+        interface Options {
+            exporting?: ExportingOptions;
+            navigation?: NavigationOptions;
+        }
+        interface SVGRenderer {
+            inlineBlacklist?: Array<RegExp>;
+            inlineToAttributes?: Array<string>;
+            unstyledElements?: Array<string>;
+        }
+        interface SymbolDictionary {
+            /** @requires modules/exporting */
+            menuball: SymbolFunction<Array<SVGElement>>;
+        }
+        interface XAxisOptions {
+            internalKey?: string;
+        }
+        /** @requires modules/exporting */
+        function post(
+            url: string,
+            data: object,
+            formAttributes?: Dictionary<string>
+        ): void;
+    }
+}
+
 /**
  * Gets fired after a chart is printed through the context menu item or the
  * Chart.print method.
@@ -23,6 +203,7 @@ import H from '../parts/Globals.js';
  * @param {global.Event} event
  *        The event that occured.
  */
+
 /**
  * Gets fired before a chart is printed through the context menu item or the
  * Chart.print method.
@@ -35,6 +216,7 @@ import H from '../parts/Globals.js';
  * @param {global.Event} event
  *        The event that occured.
  */
+
 /**
  * Function to call if the offline-exporting module fails to export a chart on
  * the client side.
@@ -47,107 +229,142 @@ import H from '../parts/Globals.js';
  * @param {global.Error} err
  *        The error from the module.
  */
+
 /**
  * Definition for a menu item in the context menu.
  *
  * @interface Highcharts.ExportingMenuObject
- */ /**
-* The text for the menu item.
-*
-* @name Highcharts.ExportingMenuObject#text
-* @type {string|undefined}
-*/ /**
-* If internationalization is required, the key to a language string.
-*
-* @name Highcharts.ExportingMenuObject#textKey
-* @type {string|undefined}
-*/ /**
-* The click handler for the menu item.
-*
-* @name Highcharts.ExportingMenuObject#onclick
-* @type {Highcharts.EventCallbackFunction<Highcharts.Chart>|undefined}
-*/ /**
-* Indicates a separator line instead of an item.
-*
-* @name Highcharts.ExportingMenuObject#separator
-* @type {boolean|undefined}
-*/
+ *//**
+ * The text for the menu item.
+ *
+ * @name Highcharts.ExportingMenuObject#text
+ * @type {string|undefined}
+ *//**
+ * If internationalization is required, the key to a language string.
+ *
+ * @name Highcharts.ExportingMenuObject#textKey
+ * @type {string|undefined}
+ *//**
+ * The click handler for the menu item.
+ *
+ * @name Highcharts.ExportingMenuObject#onclick
+ * @type {Highcharts.EventCallbackFunction<Highcharts.Chart>|undefined}
+ *//**
+ * Indicates a separator line instead of an item.
+ *
+ * @name Highcharts.ExportingMenuObject#separator
+ * @type {boolean|undefined}
+ */
+
 /**
  * Possible MIME types for exporting.
  *
  * @typedef {"image/png"|"image/jpeg"|"application/pdf"|"image/svg+xml"} Highcharts.ExportingMimeTypeValue
  */
+
 import U from '../parts/Utilities.js';
-var isObject = U.isObject, objectEach = U.objectEach;
+var isObject = U.isObject,
+    objectEach = U.objectEach;
+
 import '../parts/Options.js';
 import '../parts/Chart.js';
 import chartNavigationMixin from '../mixins/navigation.js';
+
 // create shortcuts
-var defaultOptions = H.defaultOptions, doc = H.doc, Chart = H.Chart, addEvent = H.addEvent, removeEvent = H.removeEvent, fireEvent = H.fireEvent, createElement = H.createElement, discardElement = H.discardElement, css = H.css, merge = H.merge, pick = H.pick, extend = H.extend, isTouchDevice = H.isTouchDevice, win = H.win, userAgent = win.navigator.userAgent, SVGRenderer = H.SVGRenderer, symbols = H.Renderer.prototype.symbols, isMSBrowser = /Edge\/|Trident\/|MSIE /.test(userAgent), isFirefoxBrowser = /firefox/i.test(userAgent);
+var defaultOptions = H.defaultOptions,
+    doc = H.doc,
+    Chart = H.Chart,
+    addEvent = H.addEvent,
+    removeEvent = H.removeEvent,
+    fireEvent = H.fireEvent,
+    createElement = H.createElement,
+    discardElement = H.discardElement,
+    css = H.css,
+    merge = H.merge,
+    pick = H.pick,
+    extend = H.extend,
+    isTouchDevice = H.isTouchDevice,
+    win = H.win,
+    userAgent = win.navigator.userAgent,
+    SVGRenderer = H.SVGRenderer,
+    symbols = H.Renderer.prototype.symbols,
+    isMSBrowser = /Edge\/|Trident\/|MSIE /.test(userAgent),
+    isFirefoxBrowser = /firefox/i.test(userAgent);
+
 // Add language
 extend(defaultOptions.lang
-/**
- * @optionparent lang
- */
-, {
     /**
-     * Exporting module only. View the chart in full screen.
-     *
-     * @since 7.1.0
-     *
-     * @private
+     * @optionparent lang
      */
-    viewFullscreen: 'View in full screen',
-    /**
-     * Exporting module only. The text for the menu item to print the chart.
-     *
-     * @since 3.0.1
-     *
-     * @private
-     */
-    printChart: 'Print chart',
-    /**
-     * Exporting module only. The text for the PNG download menu item.
-     *
-     * @since 2.0
-     *
-     * @private
-     */
-    downloadPNG: 'Download PNG image',
-    /**
-     * Exporting module only. The text for the JPEG download menu item.
-     *
-     * @since 2.0
-     *
-     * @private
-     */
-    downloadJPEG: 'Download JPEG image',
-    /**
-     * Exporting module only. The text for the PDF download menu item.
-     *
-     * @since 2.0
-     *
-     * @private
-     */
-    downloadPDF: 'Download PDF document',
-    /**
-     * Exporting module only. The text for the SVG download menu item.
-     *
-     * @since 2.0
-     *
-     * @private
-     */
-    downloadSVG: 'Download SVG vector image',
-    /**
-     * Exporting module menu. The tooltip title for the context menu holding
-     * print and export menu items.
-     *
-     * @since 3.0
-     *
-     * @private
-     */
-    contextButtonTitle: 'Chart context menu'
-});
+    , {
+
+        /**
+         * Exporting module only. View the chart in full screen.
+         *
+         * @since 7.1.0
+         *
+         * @private
+         */
+        viewFullscreen: 'View in full screen',
+
+
+        /**
+         * Exporting module only. The text for the menu item to print the chart.
+         *
+         * @since 3.0.1
+         *
+         * @private
+         */
+        printChart: 'Print chart',
+
+        /**
+         * Exporting module only. The text for the PNG download menu item.
+         *
+         * @since 2.0
+         *
+         * @private
+         */
+        downloadPNG: 'Download PNG image',
+
+        /**
+         * Exporting module only. The text for the JPEG download menu item.
+         *
+         * @since 2.0
+         *
+         * @private
+         */
+        downloadJPEG: 'Download JPEG image',
+
+        /**
+         * Exporting module only. The text for the PDF download menu item.
+         *
+         * @since 2.0
+         *
+         * @private
+         */
+        downloadPDF: 'Download PDF document',
+
+        /**
+         * Exporting module only. The text for the SVG download menu item.
+         *
+         * @since 2.0
+         *
+         * @private
+         */
+        downloadSVG: 'Download SVG vector image',
+
+        /**
+         * Exporting module menu. The tooltip title for the context menu holding
+         * print and export menu items.
+         *
+         * @since 3.0
+         *
+         * @private
+         */
+        contextButtonTitle: 'Chart context menu'
+
+    });
+
 if (!defaultOptions.navigation) {
     // Buttons and menus are collected in a separate config option set called
     // 'navigation'. This can be extended later to add control buttons like
@@ -161,8 +378,11 @@ if (!defaultOptions.navigation) {
     defaultOptions.navigation = {};
 }
 merge(true, defaultOptions.navigation, {
+
     buttonOptions: {
+
         theme: {},
+
         /**
          * Whether to enable buttons.
          *
@@ -174,6 +394,7 @@ merge(true, defaultOptions.navigation, {
          * @since     2.0
          * @apioption navigation.buttonOptions.enabled
          */
+
         /**
          * The pixel size of the symbol on the button.
          *
@@ -183,6 +404,7 @@ merge(true, defaultOptions.navigation, {
          * @since 2.0
          */
         symbolSize: 14,
+
         /**
          * The x position of the center of the symbol inside the button.
          *
@@ -192,6 +414,7 @@ merge(true, defaultOptions.navigation, {
          * @since 2.0
          */
         symbolX: 12.5,
+
         /**
          * The y position of the center of the symbol inside the button.
          *
@@ -201,6 +424,7 @@ merge(true, defaultOptions.navigation, {
          * @since 2.0
          */
         symbolY: 10.5,
+
         /**
          * Alignment for the buttons.
          *
@@ -211,12 +435,14 @@ merge(true, defaultOptions.navigation, {
          * @since 2.0
          */
         align: 'right',
+
         /**
          * The pixel spacing between buttons.
          *
          * @since 2.0
          */
         buttonSpacing: 3,
+
         /**
          * Pixel height of the buttons.
          *
@@ -226,6 +452,7 @@ merge(true, defaultOptions.navigation, {
          * @since 2.0
          */
         height: 22,
+
         /**
          * A text string to add to the individual button.
          *
@@ -239,6 +466,7 @@ merge(true, defaultOptions.navigation, {
          * @since     3.0
          * @apioption navigation.buttonOptions.text
          */
+
         /**
          * The vertical offset of the button's position relative to its
          * `verticalAlign`.
@@ -251,6 +479,7 @@ merge(true, defaultOptions.navigation, {
          * @since     2.0
          * @apioption navigation.buttonOptions.y
          */
+
         /**
          * The vertical alignment of the buttons. Can be one of `"top"`,
          * `"middle"` or `"bottom"`.
@@ -262,6 +491,7 @@ merge(true, defaultOptions.navigation, {
          * @since 2.0
          */
         verticalAlign: 'top',
+
         /**
          * The pixel width of the button.
          *
@@ -271,166 +501,186 @@ merge(true, defaultOptions.navigation, {
          * @since 2.0
          */
         width: 24
+
     }
+
 });
+
 // Presentational attributes
 merge(true, defaultOptions.navigation
-/**
- * A collection of options for buttons and menus appearing in the exporting
- * module.
- *
- * @optionparent navigation
- */
-, {
     /**
-     * CSS styles for the popup menu appearing by default when the export
-     * icon is clicked. This menu is rendered in HTML.
-     *
-     * @see In styled mode, the menu is styled with the `.highcharts-menu`
-     *      class.
-     *
-     * @sample highcharts/navigation/menustyle/
-     *         Light gray menu background
-     *
-     * @type    {Highcharts.CSSObject}
-     * @default {"border": "1px solid #999999", "background": "#ffffff", "padding": "5px 0"}
-     * @since   2.0
-     *
-     * @private
-     */
-    menuStyle: {
-        /** @ignore-option */
-        border: '1px solid ${palette.neutralColor40}',
-        /** @ignore-option */
-        background: '${palette.backgroundColor}',
-        /** @ignore-option */
-        padding: '5px 0'
-    },
-    /**
-     * CSS styles for the individual items within the popup menu appearing
-     * by default when the export icon is clicked. The menu items are
-     * rendered in HTML. Font size defaults to `11px` on desktop and `14px`
-     * on touch devices.
-     *
-     * @see In styled mode, the menu items are styled with the
-     *      `.highcharts-menu-item` class.
-     *
-     * @sample {highcharts} highcharts/navigation/menuitemstyle/
-     *         Add a grey stripe to the left
-     *
-     * @type    {Highcharts.CSSObject}
-     * @default {"padding": "0.5em 1em", "color": "#333333", "background": "none", "fontSize": "11px/14px", "transition": "background 250ms, color 250ms"}
-     * @since   2.0
-     *
-     * @private
-     */
-    menuItemStyle: {
-        /** @ignore-option */
-        padding: '0.5em 1em',
-        /** @ignore-option */
-        color: '${palette.neutralColor80}',
-        /** @ignore-option */
-        background: 'none',
-        /** @ignore-option */
-        fontSize: isTouchDevice ? '14px' : '11px',
-        /** @ignore-option */
-        transition: 'background 250ms, color 250ms'
-    },
-    /**
-     * CSS styles for the hover state of the individual items within the
-     * popup menu appearing by default when the export icon is clicked. The
-     * menu items are rendered in HTML.
-     *
-     * @see In styled mode, the menu items are styled with the
-     *      `.highcharts-menu-item` class.
-     *
-     * @sample highcharts/navigation/menuitemhoverstyle/
-     *         Bold text on hover
-     *
-     * @type    {Highcharts.CSSObject}
-     * @default {"background": "#335cad", "color": "#ffffff"}
-     * @since   2.0
-     *
-     * @private
-     */
-    menuItemHoverStyle: {
-        /** @ignore-option */
-        background: '${palette.highlightColor80}',
-        /** @ignore-option */
-        color: '${palette.backgroundColor}'
-    },
-    /**
-     * A collection of options for buttons appearing in the exporting
+     * A collection of options for buttons and menus appearing in the exporting
      * module.
      *
-     * In styled mode, the buttons are styled with the
-     * `.highcharts-contextbutton` and `.highcharts-button-symbol` classes.
-     *
-     * @private
+     * @optionparent navigation
      */
-    buttonOptions: {
+    , {
+
         /**
-         * Fill color for the symbol within the button.
+         * CSS styles for the popup menu appearing by default when the export
+         * icon is clicked. This menu is rendered in HTML.
          *
-         * @sample highcharts/navigation/buttonoptions-symbolfill/
-         *         Blue symbol stroke for one of the buttons
+         * @see In styled mode, the menu is styled with the `.highcharts-menu`
+         *      class.
          *
-         * @type  {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
-         * @since 2.0
+         * @sample highcharts/navigation/menustyle/
+         *         Light gray menu background
+         *
+         * @type    {Highcharts.CSSObject}
+         * @default {"border": "1px solid #999999", "background": "#ffffff", "padding": "5px 0"}
+         * @since   2.0
+         *
+         * @private
          */
-        symbolFill: '${palette.neutralColor60}',
+        menuStyle: {
+            /** @ignore-option */
+            border: '1px solid ${palette.neutralColor40}',
+            /** @ignore-option */
+            background: '${palette.backgroundColor}',
+            /** @ignore-option */
+            padding: '5px 0'
+        },
+
         /**
-         * The color of the symbol's stroke or line.
+         * CSS styles for the individual items within the popup menu appearing
+         * by default when the export icon is clicked. The menu items are
+         * rendered in HTML. Font size defaults to `11px` on desktop and `14px`
+         * on touch devices.
          *
-         * @sample highcharts/navigation/buttonoptions-symbolstroke/
-         *         Blue symbol stroke
+         * @see In styled mode, the menu items are styled with the
+         *      `.highcharts-menu-item` class.
          *
-         * @type  {Highcharts.ColorString}
-         * @since 2.0
+         * @sample {highcharts} highcharts/navigation/menuitemstyle/
+         *         Add a grey stripe to the left
+         *
+         * @type    {Highcharts.CSSObject}
+         * @default {"padding": "0.5em 1em", "color": "#333333", "background": "none", "fontSize": "11px/14px", "transition": "background 250ms, color 250ms"}
+         * @since   2.0
+         *
+         * @private
          */
-        symbolStroke: '${palette.neutralColor60}',
+        menuItemStyle: {
+            /** @ignore-option */
+            padding: '0.5em 1em',
+            /** @ignore-option */
+            color: '${palette.neutralColor80}',
+            /** @ignore-option */
+            background: 'none',
+            /** @ignore-option */
+            fontSize: isTouchDevice ? '14px' : '11px',
+            /** @ignore-option */
+            transition: 'background 250ms, color 250ms'
+        },
+
         /**
-         * The pixel stroke width of the symbol on the button.
+         * CSS styles for the hover state of the individual items within the
+         * popup menu appearing by default when the export icon is clicked. The
+         * menu items are rendered in HTML.
          *
-         * @sample highcharts/navigation/buttonoptions-height/
-         *         Bigger buttons
+         * @see In styled mode, the menu items are styled with the
+         *      `.highcharts-menu-item` class.
          *
-         * @since 2.0
+         * @sample highcharts/navigation/menuitemhoverstyle/
+         *         Bold text on hover
+         *
+         * @type    {Highcharts.CSSObject}
+         * @default {"background": "#335cad", "color": "#ffffff"}
+         * @since   2.0
+         *
+         * @private
          */
-        symbolStrokeWidth: 3,
+        menuItemHoverStyle: {
+            /** @ignore-option */
+            background: '${palette.highlightColor80}',
+            /** @ignore-option */
+            color: '${palette.backgroundColor}'
+        },
+
         /**
-         * A configuration object for the button theme. The object accepts
-         * SVG properties like `stroke-width`, `stroke` and `fill`.
-         * Tri-state button styles are supported by the `states.hover` and
-         * `states.select` objects.
+         * A collection of options for buttons appearing in the exporting
+         * module.
          *
-         * @sample highcharts/navigation/buttonoptions-theme/
-         *         Theming the buttons
+         * In styled mode, the buttons are styled with the
+         * `.highcharts-contextbutton` and `.highcharts-button-symbol` classes.
          *
-         * @since 3.0
+         * @private
          */
-        theme: {
+        buttonOptions: {
+
             /**
-             * The default fill exists only to capture hover events.
+             * Fill color for the symbol within the button.
              *
-             * @type      {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
-             * @default   ${palette.backgroundColor}
-             * @apioption navigation.buttonOptions.theme.fill
+             * @sample highcharts/navigation/buttonoptions-symbolfill/
+             *         Blue symbol stroke for one of the buttons
+             *
+             * @type  {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
+             * @since 2.0
              */
+            symbolFill: '${palette.neutralColor60}',
+
             /**
-             * Default stroke for the buttons.
-             * @type      {Highcharts.ColorString}
-             * @default   none
-             * @apioption navigation.buttonOptions.theme.stroke
+             * The color of the symbol's stroke or line.
+             *
+             * @sample highcharts/navigation/buttonoptions-symbolstroke/
+             *         Blue symbol stroke
+             *
+             * @type  {Highcharts.ColorString}
+             * @since 2.0
              */
+            symbolStroke: '${palette.neutralColor60}',
+
             /**
-             * Padding for the button.
+             * The pixel stroke width of the symbol on the button.
+             *
+             * @sample highcharts/navigation/buttonoptions-height/
+             *         Bigger buttons
+             *
+             * @since 2.0
              */
-            padding: 5
+            symbolStrokeWidth: 3,
+
+            /**
+             * A configuration object for the button theme. The object accepts
+             * SVG properties like `stroke-width`, `stroke` and `fill`.
+             * Tri-state button styles are supported by the `states.hover` and
+             * `states.select` objects.
+             *
+             * @sample highcharts/navigation/buttonoptions-theme/
+             *         Theming the buttons
+             *
+             * @since 3.0
+             */
+            theme: {
+
+                /**
+                 * The default fill exists only to capture hover events.
+                 *
+                 * @type      {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
+                 * @default   ${palette.backgroundColor}
+                 * @apioption navigation.buttonOptions.theme.fill
+                 */
+
+                /**
+                 * Default stroke for the buttons.
+                 * @type      {Highcharts.ColorString}
+                 * @default   none
+                 * @apioption navigation.buttonOptions.theme.stroke
+                 */
+
+                /**
+                 * Padding for the button.
+                 */
+                padding: 5
+
+            }
+
         }
-    }
-});
+
+    });
+
+
 // Add the export related options
+
 /**
  * Options for the exporting module. For an overview on the matter, see
  * [the docs](https://www.highcharts.com/docs/export-module/export-module-overview).
@@ -438,6 +688,7 @@ merge(true, defaultOptions.navigation
  * @optionparent exporting
  */
 defaultOptions.exporting = {
+
     /**
      * Experimental setting to allow HTML inside the chart (added through
      * the `useHTML` options), directly in the exported image. This allows
@@ -455,6 +706,7 @@ defaultOptions.exporting = {
      * @since     4.1.8
      * @apioption exporting.allowHTML
      */
+
     /**
      * Additional chart options to be merged into the chart before exporting to
      * an image format. This does not apply to printing the chart via the export
@@ -472,6 +724,7 @@ defaultOptions.exporting = {
      * @type      {Highcharts.Options}
      * @apioption exporting.chartOptions
      */
+
     /**
      * Whether to enable the exporting module. Disabling the module will
      * hide the context button, but API methods will still be available.
@@ -486,6 +739,7 @@ defaultOptions.exporting = {
      * @since     2.0
      * @apioption exporting.enabled
      */
+
     /**
      * Function to call if the offline-exporting module fails to export
      * a chart on the client side, and [fallbackToExportServer](
@@ -499,6 +753,7 @@ defaultOptions.exporting = {
      * @since     5.0.0
      * @apioption exporting.error
      */
+
     /**
      * Whether or not to fall back to the export server if the offline-exporting
      * module is unable to export the chart on the client side. This happens for
@@ -515,6 +770,7 @@ defaultOptions.exporting = {
      * @since     4.1.8
      * @apioption exporting.fallbackToExportServer
      */
+
     /**
      * The filename, without extension, to use for the exported chart.
      *
@@ -528,6 +784,7 @@ defaultOptions.exporting = {
      * @since     2.0
      * @apioption exporting.filename
      */
+
     /**
      * An object containing additional key value data for the POST form that
      * sends the SVG to the export server. For example, a `target` can be set to
@@ -538,6 +795,7 @@ defaultOptions.exporting = {
      * @since     3.0.8
      * @apioption exporting.formAttributes
      */
+
     /**
      * Path where Highcharts will look for export module dependencies to
      * load on demand if they don't already exist on `window`. Should currently
@@ -552,6 +810,7 @@ defaultOptions.exporting = {
      * @since     5.0.0
      * @apioption exporting.libURL
      */
+
     /**
      * Analogous to [sourceWidth](#exporting.sourceWidth).
      *
@@ -559,6 +818,7 @@ defaultOptions.exporting = {
      * @since     3.0
      * @apioption exporting.sourceHeight
      */
+
     /**
      * The width of the original chart when exported, unless an explicit
      * [chart.width](#chart.width) is set, or a pixel width is set on the
@@ -576,6 +836,7 @@ defaultOptions.exporting = {
      * @since     3.0
      * @apioption exporting.sourceWidth
      */
+
     /**
      * The pixel width of charts exported to PNG or JPG. As of Highcharts
      * 3.0, the default pixel width is a function of the [chart.width](
@@ -591,6 +852,7 @@ defaultOptions.exporting = {
      * @since     2.0
      * @apioption exporting.width
      */
+
     /**
      * Default MIME type for exporting if `chart.exportChart()` is called
      * without specifying a `type` option. Possible values are `image/png`,
@@ -600,6 +862,7 @@ defaultOptions.exporting = {
      * @since 2.0
      */
     type: 'image/png',
+
     /**
      * The URL for the server module converting the SVG string to an image
      * format. By default this points to Highchart's free web service.
@@ -607,6 +870,7 @@ defaultOptions.exporting = {
      * @since 2.0
      */
     url: 'https://export.highcharts.com/',
+
     /**
      * When printing the chart from the menu item in the burger menu, if
      * the on-screen chart exceeds this width, it is resized. After printing
@@ -617,6 +881,7 @@ defaultOptions.exporting = {
      * @since 4.2.5
      */
     printMaxWidth: 780,
+
     /**
      * Defines the scale or zoom factor for the exported image compared
      * to the on-screen display. While for instance a 600px wide chart
@@ -636,6 +901,7 @@ defaultOptions.exporting = {
      * @since 3.0
      */
     scale: 2,
+
     /**
      * Options for the export related buttons, print and export. In addition
      * to the default buttons listed here, custom buttons can be added.
@@ -645,6 +911,7 @@ defaultOptions.exporting = {
      * @type {Highcharts.Dictionary<Highcharts.ExportingButtonsContextButtonOptions>}
      */
     buttons: {
+
         /**
          * Options for the export button.
          *
@@ -654,6 +921,7 @@ defaultOptions.exporting = {
          * @extends navigation.buttonOptions
          */
         contextButton: {
+
             /**
              * A click handler callback to use on the button directly instead of
              * the popup menu.
@@ -665,6 +933,7 @@ defaultOptions.exporting = {
              * @since     2.0
              * @apioption exporting.buttons.contextButton.onclick
              */
+
             /**
              * See [navigation.buttonOptions.symbolFill](
              * #navigation.buttonOptions.symbolFill).
@@ -674,6 +943,7 @@ defaultOptions.exporting = {
              * @since     2.0
              * @apioption exporting.buttons.contextButton.symbolFill
              */
+
             /**
              * The horizontal position of the button relative to the `align`
              * option.
@@ -683,14 +953,17 @@ defaultOptions.exporting = {
              * @since     2.0
              * @apioption exporting.buttons.contextButton.x
              */
+
             /**
              * The class name of the context button.
              */
             className: 'highcharts-contextbutton',
+
             /**
              * The class name of the menu appearing from the button.
              */
             menuClassName: 'highcharts-contextmenu',
+
             /**
              * The symbol for the button. Points to a definition function in
              * the `Highcharts.Renderer.symbols` collection. The default
@@ -707,6 +980,7 @@ defaultOptions.exporting = {
              * @since 2.0
              */
             symbol: 'menu',
+
             /**
              * The key to a [lang](#lang) option setting that is used for the
              * button's title tooltip. When the key is `contextButtonTitle`, it
@@ -716,6 +990,7 @@ defaultOptions.exporting = {
              * @since 6.1.4
              */
             titleKey: 'contextButtonTitle',
+
             /**
              * This option is deprecated, use
              * [titleKey](#exporting.buttons.contextButton.titleKey) instead.
@@ -724,6 +999,7 @@ defaultOptions.exporting = {
              * @type      {string}
              * @apioption exporting.buttons.contextButton._titleKey
              */
+
             /**
              * A collection of strings pointing to config options for the menu
              * items. The config options are defined in the
@@ -752,7 +1028,9 @@ defaultOptions.exporting = {
                 'downloadPDF',
                 'downloadSVG'
             ]
+
         }
+
     },
     /**
      * An object consisting of definitions for the menu items in the context
@@ -779,74 +1057,84 @@ defaultOptions.exporting = {
      * @since   5.0.13
      */
     menuItemDefinitions: {
+
         /**
          * @ignore
          */
         viewFullscreen: {
             textKey: 'viewFullscreen',
-            onclick: function () {
+            onclick: function (): void {
                 this.fullscreen = new H.FullScreen(this.container);
             }
         },
+
         /**
          * @ignore
          */
         printChart: {
             textKey: 'printChart',
-            onclick: function () {
+            onclick: function (): void {
                 this.print();
             }
         },
+
         /**
          * @ignore
          */
         separator: {
             separator: true
         },
+
         /**
          * @ignore
          */
         downloadPNG: {
             textKey: 'downloadPNG',
-            onclick: function () {
+            onclick: function (): void {
                 this.exportChart();
             }
         },
+
         /**
          * @ignore
          */
         downloadJPEG: {
             textKey: 'downloadJPEG',
-            onclick: function () {
+            onclick: function (): void {
                 this.exportChart({
                     type: 'image/jpeg'
                 });
             }
         },
+
         /**
          * @ignore
          */
         downloadPDF: {
             textKey: 'downloadPDF',
-            onclick: function () {
+            onclick: function (): void {
                 this.exportChart({
                     type: 'application/pdf'
                 });
             }
         },
+
         /**
          * @ignore
          */
         downloadSVG: {
             textKey: 'downloadSVG',
-            onclick: function () {
+            onclick: function (): void {
                 this.exportChart({
                     type: 'image/svg+xml'
                 });
             }
         }
+
     }
+
 };
+
 /**
  * Fires after a chart is printed through the context menu item or the
  * `Chart.print` method. Requires the exporting module.
@@ -859,6 +1147,7 @@ defaultOptions.exporting = {
  * @context   Highcharts.Chart
  * @apioption chart.events.afterPrint
  */
+
 /**
  * Fires before a chart is printed through the context menu item or
  * the `Chart.print` method. Requires the exporting module.
@@ -871,6 +1160,7 @@ defaultOptions.exporting = {
  * @context   Highcharts.Chart
  * @apioption chart.events.beforePrint
  */
+
 /**
  * The post utility
  *
@@ -884,30 +1174,40 @@ defaultOptions.exporting = {
  *        Additional attributes for the post request
  * @return {void}
  */
-H.post = function (url, data, formAttributes) {
+H.post = function (
+    url: string,
+    data: object,
+    formAttributes?: Highcharts.HTMLAttributes
+): void {
     // create the form
-    var form = createElement('form', merge({
+    var form: HTMLFormElement = createElement('form', merge({
         method: 'post',
         action: url,
         enctype: 'multipart/form-data'
     }, formAttributes), {
         display: 'none'
-    }, doc.body);
+    }, doc.body) as unknown as HTMLFormElement;
+
     // add the data
-    objectEach(data, function (val, name) {
+    objectEach(data, function (val: string, name: string): void {
         createElement('input', {
             type: 'hidden',
             name: name,
             value: val
-        }, null, form);
+        }, null as any, form);
     });
+
     // submit
     form.submit();
+
     // clean up
     discardElement(form);
 };
+
 extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
+
     /* eslint-disable no-invalid-this, valid-jsdoc */
+
     /**
      * Exporting module only. A collection of fixes on the produced SVG to
      * account for expando properties, browser bugs, VML problems and other.
@@ -922,44 +1222,63 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      * @return {string}
      *         Sanitized SVG code
      */
-    sanitizeSVG: function (svg, options) {
-        var split = svg.indexOf('</svg>') + 6, html = svg.substr(split);
+    sanitizeSVG: function (
+        this: Highcharts.Chart,
+        svg: string,
+        options: Highcharts.Options
+    ): string {
+
+        var split = svg.indexOf('</svg>') + 6,
+            html = svg.substr(split);
+
         // Remove any HTML added to the container after the SVG (#894, #9087)
         svg = svg.substr(0, split);
+
         // Move HTML into a foreignObject
         if (options && options.exporting && options.exporting.allowHTML) {
             if (html) {
                 html = '<foreignObject x="0" y="0" ' +
-                    'width="' + options.chart.width + '" ' +
-                    'height="' + options.chart.height + '">' +
+                            'width="' + (options.chart as any).width + '" ' +
+                            'height="' + (options.chart as any).height + '">' +
                     '<body xmlns="http://www.w3.org/1999/xhtml">' +
                     html +
                     '</body>' +
                     '</foreignObject>';
                 svg = svg.replace('</svg>', html + '</svg>');
             }
+
         }
+
         svg = svg
             .replace(/zIndex="[^"]+"/g, '')
             .replace(/symbolName="[^"]+"/g, '')
             .replace(/jQuery[0-9]+="[^"]+"/g, '')
             .replace(/url\(("|&quot;)(.*?)("|&quot;)\;?\)/g, 'url($2)')
             .replace(/url\([^#]+#/g, 'url(#')
-            .replace(/<svg /, '<svg xmlns:xlink="http://www.w3.org/1999/xlink" ')
+            .replace(
+                /<svg /,
+                '<svg xmlns:xlink="http://www.w3.org/1999/xlink" '
+            )
             .replace(/ (|NS[0-9]+\:)href=/g, ' xlink:href=') // #3567
             .replace(/\n/, ' ')
             // Batik doesn't support rgba fills and strokes (#3095)
-            .replace(/(fill|stroke)="rgba\(([ 0-9]+,[ 0-9]+,[ 0-9]+),([ 0-9\.]+)\)"/g, // eslint-disable-line max-len
-        '$1="rgb($2)" $1-opacity="$3"')
+            .replace(
+                /(fill|stroke)="rgba\(([ 0-9]+,[ 0-9]+,[ 0-9]+),([ 0-9\.]+)\)"/g, // eslint-disable-line max-len
+                '$1="rgb($2)" $1-opacity="$3"'
+            )
+
             // Replace HTML entities, issue #347
             .replace(/&nbsp;/g, '\u00A0') // no-break space
             .replace(/&shy;/g, '\u00AD'); // soft hyphen
+
         // Further sanitize for oldIE
         if (this.ieSanitizeSVG) {
             svg = this.ieSanitizeSVG(svg);
         }
+
         return svg;
     },
+
     /**
      * Return the unfiltered innerHTML of the chart container. Used as hook for
      * plugins. In styled mode, it also takes care of inlining CSS style rules.
@@ -971,12 +1290,14 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      * @returns {string}
      *          The unfiltered SVG of the chart.
      */
-    getChartHTML: function () {
+    getChartHTML: function (this: Highcharts.Chart): string {
         if (this.styledMode) {
             this.inlineStyles();
         }
+
         return this.container.innerHTML;
     },
+
     /**
      * Return an SVG representation of the chart.
      *
@@ -996,30 +1317,48 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      *
      * @fires Highcharts.Chart#event:getSVG
      */
-    getSVG: function (chartOptions) {
-        var chart = this, chartCopy, sandbox, svg, seriesOptions, sourceWidth, sourceHeight, cssWidth, cssHeight, 
-        // Copy the options and add extra options
-        options = merge(chart.options, chartOptions);
+    getSVG: function (
+        this: Highcharts.Chart,
+        chartOptions?: Highcharts.Options
+    ): string {
+        var chart = this,
+            chartCopy: Highcharts.Chart,
+            sandbox,
+            svg,
+            seriesOptions: Highcharts.SeriesOptions,
+            sourceWidth: number,
+            sourceHeight: number,
+            cssWidth: string,
+            cssHeight: string,
+            // Copy the options and add extra options
+            options = merge(chart.options, chartOptions);
+
         // Use userOptions to make the options chain in series right (#3881)
-        options.plotOptions = merge(chart.userOptions.plotOptions, chartOptions && chartOptions.plotOptions);
+        options.plotOptions = merge(
+            chart.userOptions.plotOptions,
+            chartOptions && chartOptions.plotOptions
+        );
+
         // create a sandbox where a new chart will be generated
-        sandbox = createElement('div', null, {
+        sandbox = createElement('div', null as any, {
             position: 'absolute',
             top: '-9999em',
             width: chart.chartWidth + 'px',
             height: chart.chartHeight + 'px'
         }, doc.body);
+
         // get the source size
-        cssWidth = chart.renderTo.style.width;
-        cssHeight = chart.renderTo.style.height;
-        sourceWidth = options.exporting.sourceWidth ||
-            options.chart.width ||
+        cssWidth = chart.renderTo.style.width as any;
+        cssHeight = chart.renderTo.style.height as any;
+        sourceWidth = (options.exporting as any).sourceWidth ||
+            (options.chart as any).width ||
             (/px$/.test(cssWidth) && parseInt(cssWidth, 10)) ||
             (options.isGantt ? 800 : 600);
-        sourceHeight = options.exporting.sourceHeight ||
-            options.chart.height ||
+        sourceHeight = (options.exporting as any).sourceHeight ||
+            (options.chart as any).height ||
             (/px$/.test(cssHeight) && parseInt(cssHeight, 10)) ||
             400;
+
         // override some options
         extend(options.chart, {
             animation: false,
@@ -1029,62 +1368,84 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             width: sourceWidth,
             height: sourceHeight
         });
-        options.exporting.enabled = false; // hide buttons in print
+        (options.exporting as any).enabled = false; // hide buttons in print
         delete options.data; // #3004
+
         // prepare for replicating the chart
         options.series = [];
-        chart.series.forEach(function (serie) {
-            seriesOptions = merge(serie.userOptions, {
-                animation: false,
+        chart.series.forEach(function (serie: Highcharts.Series): void {
+            seriesOptions = merge(serie.userOptions, { // #4912
+                animation: false, // turn off animation
                 enableMouseTracking: false,
                 showCheckbox: false,
                 visible: serie.visible
             });
+
             // Used for the navigator series that has its own option set
             if (!seriesOptions.isInternal) {
-                options.series.push(seriesOptions);
+                (options.series as any).push(seriesOptions);
             }
         });
+
         // Assign an internal key to ensure a one-to-one mapping (#5924)
-        chart.axes.forEach(function (axis) {
+        chart.axes.forEach(function (axis: Highcharts.Axis): void {
             if (!axis.userOptions.internalKey) { // #6444
                 axis.userOptions.internalKey = H.uniqueKey();
             }
         });
+
         // generate the chart copy
         chartCopy = new H.Chart(options, chart.callback);
+
         // Axis options and series options  (#2022, #3900, #5982)
         if (chartOptions) {
-            ['xAxis', 'yAxis', 'series'].forEach(function (coll) {
-                var collOptions = {};
-                if (chartOptions[coll]) {
-                    collOptions[coll] = chartOptions[coll];
+            ['xAxis', 'yAxis', 'series'].forEach(function (coll: string): void {
+                var collOptions: Highcharts.Options = {};
+
+                if ((chartOptions as any)[coll]) {
+                    (collOptions as any)[coll] = (chartOptions as any)[coll];
                     chartCopy.update(collOptions);
                 }
             });
         }
+
         // Reflect axis extremes in the export (#5924)
-        chart.axes.forEach(function (axis) {
-            var axisCopy = H.find(chartCopy.axes, function (copy) {
-                return copy.options.internalKey ===
-                    axis.userOptions.internalKey;
-            }), extremes = axis.getExtremes(), userMin = extremes.userMin, userMax = extremes.userMax;
-            if (axisCopy &&
-                ((userMin !== undefined && userMin !== axisCopy.min) ||
-                    (userMax !== undefined && userMax !== axisCopy.max))) {
+        chart.axes.forEach(function (axis: Highcharts.Axis): void {
+            var axisCopy = H.find(chartCopy.axes, function (
+                    copy: Highcharts.Axis
+                ): boolean {
+                    return copy.options.internalKey ===
+                        axis.userOptions.internalKey;
+                }),
+                extremes = axis.getExtremes(),
+                userMin = extremes.userMin,
+                userMax = extremes.userMax;
+
+            if (
+                axisCopy &&
+                (
+                    (userMin !== undefined && userMin !== axisCopy.min) ||
+                    (userMax !== undefined && userMax !== axisCopy.max)
+                )
+            ) {
                 axisCopy.setExtremes(userMin, userMax, true, false);
             }
         });
+
         // Get the SVG from the container's innerHTML
         svg = chartCopy.getChartHTML();
         fireEvent(this, 'getSVG', { chartCopy: chartCopy });
+
         svg = chart.sanitizeSVG(svg, options);
+
         // free up memory
-        options = null;
+        options = null as any;
         chartCopy.destroy();
         discardElement(sandbox);
+
         return svg;
     },
+
     /**
      * @private
      * @function Highcharts.Chart#getSVGForExport
@@ -1095,17 +1456,33 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      *
      * @return {string}
      */
-    getSVGForExport: function (options, chartOptions) {
-        var chartExportingOptions = this.options.exporting;
-        return this.getSVG(merge({ chart: { borderRadius: 0 } }, chartExportingOptions.chartOptions, chartOptions, {
-            exporting: {
-                sourceWidth: ((options && options.sourceWidth) ||
-                    chartExportingOptions.sourceWidth),
-                sourceHeight: ((options && options.sourceHeight) ||
-                    chartExportingOptions.sourceHeight)
+    getSVGForExport: function (
+        this: Highcharts.Chart,
+        options: Highcharts.ExportingOptions,
+        chartOptions: Highcharts.Options
+    ): string {
+        var chartExportingOptions: Highcharts.ExportingOptions =
+            this.options.exporting as any;
+
+        return this.getSVG(merge(
+            { chart: { borderRadius: 0 } },
+            chartExportingOptions.chartOptions,
+            chartOptions,
+            {
+                exporting: {
+                    sourceWidth: (
+                        (options && options.sourceWidth) ||
+                        chartExportingOptions.sourceWidth
+                    ),
+                    sourceHeight: (
+                        (options && options.sourceHeight) ||
+                        chartExportingOptions.sourceHeight
+                    )
+                }
             }
-        }));
+        ));
     },
+
     /**
      * Get the default file name used for exported charts. By default it creates
      * a file name based on the chart title.
@@ -1114,11 +1491,14 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      *
      * @return {string} A file name without extension.
      */
-    getFilename: function () {
-        var s = this.userOptions.title && this.userOptions.title.text, filename = this.options.exporting.filename;
+    getFilename: function (this: Highcharts.Chart): string {
+        var s = this.userOptions.title && this.userOptions.title.text,
+            filename: string = (this.options.exporting as any).filename;
+
         if (filename) {
             return filename;
         }
+
         if (typeof s === 'string') {
             filename = s
                 .toLowerCase()
@@ -1130,11 +1510,14 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                 .substr(0, 24)
                 .replace(/[\-]+$/g, ''); // dashes in the end;
         }
+
         if (!filename || filename.length < 5) {
             filename = 'chart';
         }
+
         return filename;
     },
+
     /**
      * Exporting module required. Submit an SVG version of the chart to a server
      * along with some parameters for conversion.
@@ -1161,20 +1544,28 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      *
      * @return {void}
      */
-    exportChart: function (exportingOptions, chartOptions) {
+    exportChart: function (
+        this: Highcharts.Chart,
+        exportingOptions: Highcharts.ExportingOptions,
+        chartOptions: Highcharts.Options
+    ): void {
+
         var svg = this.getSVGForExport(exportingOptions, chartOptions);
+
         // merge the options
         exportingOptions = merge(this.options.exporting, exportingOptions);
+
         // do the post
-        H.post(exportingOptions.url, {
+        H.post(exportingOptions.url as any, {
             filename: exportingOptions.filename || this.getFilename(),
             type: exportingOptions.type,
             // IE8 fails to post undefined correctly, so use 0
             width: exportingOptions.width || 0,
             scale: exportingOptions.scale,
             svg: svg
-        }, exportingOptions.formAttributes);
+        }, exportingOptions.formAttributes as any);
     },
+
     /**
      * Exporting module required. Clears away other elements in the page and
      * prints the chart as it is displayed. By default, when the exporting
@@ -1191,8 +1582,21 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      * @fires Highcharts.Chart#event:beforePrint
      * @fires Highcharts.Chart#event:afterPrint
      */
-    print: function () {
-        var chart = this, origDisplay = [], body = doc.body, childNodes = body.childNodes, printMaxWidth = chart.options.exporting.printMaxWidth, resetParams, handleMaxWidth;
+    print: function (this: Highcharts.Chart): void {
+
+        var chart = this,
+            origDisplay: Array<(string|null)> = [],
+            body = doc.body,
+            childNodes = body.childNodes,
+            printMaxWidth: number =
+                (chart.options.exporting as any).printMaxWidth,
+            resetParams: [
+                (number|null)?,
+                (number|null)?,
+                (boolean|Highcharts.AnimationOptionsObject)?
+            ],
+            handleMaxWidth: (boolean|number);
+
         /**
          * Move the chart container(s) to another div.
          * @private
@@ -1200,62 +1604,88 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
          *        Move target
          * @return {void}
          */
-        function moveContainers(moveTo) {
-            (chart.fixedDiv ? // When scrollablePlotArea is active (#9533)
-                [chart.fixedDiv, chart.scrollingContainer] :
-                [chart.container]).forEach(function (div) {
+        function moveContainers(moveTo: Highcharts.HTMLDOMElement): void {
+            (
+                chart.fixedDiv ? // When scrollablePlotArea is active (#9533)
+                    [chart.fixedDiv, chart.scrollingContainer as any] :
+                    [chart.container]
+
+            ).forEach(function (div: Highcharts.HTMLDOMElement): void {
                 moveTo.appendChild(div);
             });
         }
+
         if (chart.isPrinting) { // block the button while in printing mode
             return;
         }
+
         chart.isPrinting = true;
-        chart.pointer.reset(null, 0);
+        chart.pointer.reset(null as any, 0);
+
         fireEvent(chart, 'beforePrint');
+
         // Handle printMaxWidth
         handleMaxWidth = printMaxWidth && chart.chartWidth > printMaxWidth;
         if (handleMaxWidth) {
             resetParams = [
-                chart.options.chart.width,
+                (chart.options.chart as any).width,
                 undefined,
                 false
             ];
             chart.setSize(printMaxWidth, undefined, false);
         }
+
         // hide all body content
-        [].forEach.call(childNodes, function (node, i) {
+        [].forEach.call(childNodes, function (
+            node: Highcharts.HTMLDOMElement,
+            i: number
+        ): void {
             if (node.nodeType === 1) {
                 origDisplay[i] = node.style.display;
                 node.style.display = 'none';
             }
         });
+
         // pull out the chart
         moveContainers(body);
+
         // Give the browser time to draw WebGL content, an issue that randomly
         // appears (at least) in Chrome ~67 on the Mac (#8708).
-        setTimeout(function () {
+        setTimeout(function (): void {
+
             win.focus(); // #1510
             win.print();
+
             // allow the browser to prepare before reverting
-            setTimeout(function () {
+            setTimeout(function (): void {
+
                 // put the chart back in
                 moveContainers(chart.renderTo);
+
                 // restore all body content
-                [].forEach.call(childNodes, function (node, i) {
+                [].forEach.call(childNodes, function (
+                    node: Highcharts.HTMLDOMElement,
+                    i: number
+                ): void {
                     if (node.nodeType === 1) {
                         node.style.display = origDisplay[i];
                     }
                 });
+
                 chart.isPrinting = false;
+
                 // Reset printMaxWidth
                 if (handleMaxWidth) {
                     chart.setSize.apply(chart, resetParams);
                 }
+
                 fireEvent(chart, 'afterPrint');
+
             }, 1000);
         }, 1);
+
     },
+
     /**
      * Display a popup menu for choosing the export type.
      *
@@ -1275,127 +1705,190 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      *        The height of the opener button
      * @return {void}
      */
-    contextMenu: function (className, items, x, y, width, height, button) {
-        var chart = this, navOptions = chart.options.navigation, chartWidth = chart.chartWidth, chartHeight = chart.chartHeight, cacheName = 'cache-' + className, menu = chart[cacheName], menuPadding = Math.max(width, height), // for mouse leave detection
-        innerMenu, menuStyle;
+    contextMenu: function (
+        this: Highcharts.Chart,
+        className: string,
+        items: Array<(string|Highcharts.ExportingMenuObject)>,
+        x: number,
+        y: number,
+        width: number,
+        height: number,
+        button: Highcharts.SVGElement
+    ): void {
+        var chart = this,
+            navOptions: Highcharts.NavigationOptions =
+                chart.options.navigation as any,
+            chartWidth = chart.chartWidth,
+            chartHeight = chart.chartHeight,
+            cacheName = 'cache-' + className,
+            menu: Highcharts.ExportingDivElement = (chart as any)[cacheName],
+            menuPadding = Math.max(width, height), // for mouse leave detection
+            innerMenu: Highcharts.HTMLDOMElement,
+            menuStyle: Highcharts.CSSObject;
+
         // create the menu only the first time
         if (!menu) {
+
             // create a HTML element above the SVG
-            chart.exportContextMenu = chart[cacheName] = menu =
-                createElement('div', {
-                    className: className
-                }, {
-                    position: 'absolute',
-                    zIndex: 1000,
-                    padding: menuPadding + 'px',
-                    pointerEvents: 'auto'
-                }, chart.fixedDiv || chart.container);
-            innerMenu = createElement('div', { className: 'highcharts-menu' }, null, menu);
+            chart.exportContextMenu = (chart as any)[cacheName] = menu =
+                createElement(
+                    'div', {
+                        className: className
+                    },
+                    {
+                        position: 'absolute',
+                        zIndex: 1000,
+                        padding: menuPadding + 'px',
+                        pointerEvents: 'auto'
+                    },
+                    chart.fixedDiv || chart.container
+                ) as Highcharts.ExportingDivElement;
+
+            innerMenu = createElement(
+                'div',
+                { className: 'highcharts-menu' },
+                null as any,
+                menu
+            );
+
             // Presentational CSS
             if (!chart.styledMode) {
-                css(innerMenu, extend({
+                css(innerMenu, extend<Highcharts.CSSObject>({
                     MozBoxShadow: '3px 3px 10px #888',
                     WebkitBoxShadow: '3px 3px 10px #888',
                     boxShadow: '3px 3px 10px #888'
-                }, navOptions.menuStyle));
+                }, navOptions.menuStyle as any));
             }
+
             // hide on mouse out
-            menu.hideMenu = function () {
+            menu.hideMenu = function (): void {
                 css(menu, { display: 'none' });
                 if (button) {
                     button.setState(0);
                 }
                 chart.openMenu = false;
                 css(chart.renderTo, { overflow: 'hidden' }); // #10361
-                H.clearTimeout(menu.hideTimer);
+                H.clearTimeout(menu.hideTimer as any);
                 fireEvent(chart, 'exportMenuHidden');
             };
+
             // Hide the menu some time after mouse leave (#1357)
-            chart.exportEvents.push(addEvent(menu, 'mouseleave', function () {
-                menu.hideTimer = win.setTimeout(menu.hideMenu, 500);
-            }), addEvent(menu, 'mouseenter', function () {
-                H.clearTimeout(menu.hideTimer);
-            }), 
-            // Hide it on clicking or touching outside the menu (#2258,
-            // #2335, #2407)
-            addEvent(doc, 'mouseup', function (e) {
-                if (!chart.pointer.inClass(e.target, className)) {
-                    menu.hideMenu();
-                }
-            }), addEvent(menu, 'click', function () {
-                if (chart.openMenu) {
-                    menu.hideMenu();
-                }
-            }));
+            (chart.exportEvents as any).push(
+                addEvent(menu, 'mouseleave', function (): void {
+                    menu.hideTimer = win.setTimeout(menu.hideMenu, 500);
+                }),
+                addEvent(menu, 'mouseenter', function (): void {
+                    H.clearTimeout(menu.hideTimer as any);
+                }),
+
+                // Hide it on clicking or touching outside the menu (#2258,
+                // #2335, #2407)
+                addEvent(doc, 'mouseup', function (e: PointerEvent): void {
+                    if (!chart.pointer.inClass(e.target as any, className)) {
+                        menu.hideMenu();
+                    }
+                }),
+
+                addEvent(menu, 'click', function (): void {
+                    if (chart.openMenu) {
+                        menu.hideMenu();
+                    }
+                })
+            );
+
             // create the items
-            items.forEach(function (item) {
+            items.forEach(function (
+                item: (string|Highcharts.ExportingMenuObject)
+            ): void {
+
                 if (typeof item === 'string') {
-                    item = chart.options.exporting
+                    item = (chart.options.exporting as any)
                         .menuItemDefinitions[item];
                 }
+
                 if (isObject(item, true)) {
                     var element;
+
                     if (item.separator) {
-                        element = createElement('hr', null, null, innerMenu);
-                    }
-                    else {
+                        element = createElement(
+                            'hr',
+                            null as any,
+                            null as any,
+                            innerMenu
+                        );
+
+                    } else {
                         element = createElement('div', {
                             className: 'highcharts-menu-item',
-                            onclick: function (e) {
+                            onclick: function (e: PointerEvent): void {
                                 if (e) { // IE7
                                     e.stopPropagation();
                                 }
-                                menu.hideMenu();
-                                if (item.onclick) {
-                                    item.onclick
+                                (menu as any).hideMenu();
+                                if ((item as any).onclick) {
+                                    (item as any).onclick
                                         .apply(chart, arguments);
                                 }
                             },
-                            innerHTML: (item.text ||
-                                chart.options.lang[item.textKey])
-                        }, null, innerMenu);
+                            innerHTML: (
+                                item.text ||
+                                (chart.options.lang as any)[item.textKey as any]
+                            )
+                        }, null as any, innerMenu);
+
                         if (!chart.styledMode) {
-                            element.onmouseover = function () {
-                                css(this, navOptions.menuItemHoverStyle);
-                            };
-                            element.onmouseout = function () {
-                                css(this, navOptions.menuItemStyle);
-                            };
+                            element.onmouseover = function (
+                                this: Highcharts.HTMLDOMElement
+                            ): void {
+                                css(this, navOptions.menuItemHoverStyle as any);
+                            } as any;
+                            element.onmouseout = function (
+                                this: Highcharts.HTMLDOMElement
+                            ): void {
+                                css(this, navOptions.menuItemStyle as any);
+                            } as any;
                             css(element, extend({
                                 cursor: 'pointer'
-                            }, navOptions.menuItemStyle));
+                            }, navOptions.menuItemStyle as any));
                         }
                     }
+
                     // Keep references to menu divs to be able to destroy them
-                    chart.exportDivElements.push(element);
+                    (chart.exportDivElements as any).push(element);
                 }
             });
+
             // Keep references to menu and innerMenu div to be able to destroy
             // them
-            chart.exportDivElements.push(innerMenu, menu);
+            (chart.exportDivElements as any).push(innerMenu, menu);
+
             chart.exportMenuWidth = menu.offsetWidth;
             chart.exportMenuHeight = menu.offsetHeight;
         }
+
         menuStyle = { display: 'block' };
+
         // if outside right, right align it
-        if (x + chart.exportMenuWidth > chartWidth) {
+        if (x + (chart.exportMenuWidth as any) > chartWidth) {
             menuStyle.right = (chartWidth - x - width - menuPadding) + 'px';
-        }
-        else {
+        } else {
             menuStyle.left = (x - menuPadding) + 'px';
         }
         // if outside bottom, bottom align it
-        if (y + height + chart.exportMenuHeight > chartHeight &&
-            button.alignOptions.verticalAlign !== 'top') {
+        if (
+            y + height + (chart.exportMenuHeight as any) > chartHeight &&
+            button.alignOptions.verticalAlign !== 'top'
+        ) {
             menuStyle.bottom = (chartHeight - y - menuPadding) + 'px';
-        }
-        else {
+        } else {
             menuStyle.top = (y + height - menuPadding) + 'px';
         }
+
         css(menu, menuStyle);
         css(chart.renderTo, { overflow: '' }); // #10361
         chart.openMenu = true;
     },
+
     /**
      * Add the export button to the chart, with options.
      *
@@ -1404,79 +1897,147 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      * @param {Highcharts.NavigationButtonOptions} options
      * @return {void}
      */
-    addButton: function (options) {
-        var chart = this, renderer = chart.renderer, btnOptions = merge(chart.options.navigation.buttonOptions, options), onclick = btnOptions.onclick, menuItems = btnOptions.menuItems, symbol, button, symbolSize = btnOptions.symbolSize || 12;
+    addButton: function (
+        this: Highcharts.Chart,
+        options: Highcharts.ExportingButtonOptions
+    ): void {
+        var chart = this,
+            renderer = chart.renderer,
+            btnOptions = merge<Highcharts.ExportingButtonOptions>(
+                (chart.options.navigation as any).buttonOptions,
+                options
+            ),
+            onclick = btnOptions.onclick,
+            menuItems = btnOptions.menuItems,
+            symbol,
+            button: Highcharts.SVGElement,
+            symbolSize = btnOptions.symbolSize || 12;
+
         if (!chart.btnCount) {
             chart.btnCount = 0;
         }
+
         // Keeps references to the button elements
         if (!chart.exportDivElements) {
             chart.exportDivElements = [];
             chart.exportSVGElements = [];
         }
+
         if (btnOptions.enabled === false) {
             return;
         }
-        var attr = btnOptions.theme, states = attr.states, hover = states && states.hover, select = states && states.select, callback;
+
+
+        var attr: Highcharts.SVGAttributes = btnOptions.theme as any,
+            states = attr.states,
+            hover = states && states.hover,
+            select = states && states.select,
+            callback: (
+                Highcharts.EventCallbackFunction<Highcharts.SVGElement>|
+                undefined
+            );
+
         if (!chart.styledMode) {
             attr.fill = pick(attr.fill, '${palette.backgroundColor}');
             attr.stroke = pick(attr.stroke, 'none');
         }
+
         delete attr.states;
+
         if (onclick) {
-            callback = function (e) {
+            callback = function (
+                this: Highcharts.SVGElement,
+                e: (Event|Highcharts.Dictionary<any>)
+            ): void {
                 if (e) {
                     e.stopPropagation();
                 }
-                onclick.call(chart, e);
+                (onclick as any).call(chart, e);
             };
-        }
-        else if (menuItems) {
-            callback = function (e) {
+
+        } else if (menuItems) {
+            callback = function (
+                this: Highcharts.SVGElement,
+                e: (Event|Highcharts.Dictionary<any>)
+            ): void {
                 // consistent with onclick call (#3495)
                 if (e) {
                     e.stopPropagation();
                 }
-                chart.contextMenu(button.menuClassName, menuItems, button.translateX, button.translateY, button.width, button.height, button);
+                chart.contextMenu(
+                    button.menuClassName,
+                    menuItems as any,
+                    button.translateX,
+                    button.translateY,
+                    button.width,
+                    button.height,
+                    button
+                );
                 button.setState(2);
             };
         }
+
+
         if (btnOptions.text && btnOptions.symbol) {
             attr.paddingLeft = pick(attr.paddingLeft, 25);
-        }
-        else if (!btnOptions.text) {
+
+        } else if (!btnOptions.text) {
             extend(attr, {
                 width: btnOptions.width,
                 height: btnOptions.height,
                 padding: 0
             });
         }
+
+
         if (!chart.styledMode) {
             attr['stroke-linecap'] = 'round';
             attr.fill = pick(attr.fill, '${palette.backgroundColor}');
             attr.stroke = pick(attr.stroke, 'none');
         }
+
         button = renderer
-            .button(btnOptions.text, 0, 0, callback, attr, hover, select)
-            .addClass(options.className)
+            .button(
+                btnOptions.text as any,
+                0,
+                0,
+                callback as any,
+                attr,
+                hover,
+                select
+            )
+            .addClass(options.className as any)
             .attr({
-            title: pick(chart.options.lang[btnOptions._titleKey || btnOptions.titleKey], '')
-        });
-        button.menuClassName = (options.menuClassName ||
-            'highcharts-menu-' + chart.btnCount++);
+                title: pick((chart.options.lang as any)[
+                    btnOptions._titleKey || (btnOptions.titleKey as any)
+                ], '')
+            });
+
+        button.menuClassName = (
+            options.menuClassName ||
+            'highcharts-menu-' + chart.btnCount++
+        );
+
         if (btnOptions.symbol) {
             symbol = renderer
-                .symbol(btnOptions.symbol, btnOptions.symbolX - (symbolSize / 2), btnOptions.symbolY - (symbolSize / 2), symbolSize, symbolSize
-            // If symbol is an image, scale it (#7957)
-            , {
-                width: symbolSize,
-                height: symbolSize
-            })
+                .symbol(
+                    btnOptions.symbol,
+                    (btnOptions.symbolX as any) - (symbolSize / 2),
+                    (btnOptions.symbolY as any) - (symbolSize / 2),
+                    symbolSize,
+                    symbolSize
+                    // If symbol is an image, scale it (#7957)
+                    , {
+                        width: symbolSize,
+                        height: symbolSize
+                    }
+                )
                 .addClass('highcharts-button-symbol')
                 .attr({
-                zIndex: 1
-            })
+                    zIndex: 1
+                })
                 .add(button);
+
             if (!chart.styledMode) {
                 symbol.attr({
                     stroke: btnOptions.symbolStroke,
@@ -1485,16 +2046,23 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                 });
             }
         }
+
         button
             .add(chart.exportingGroup)
             .align(extend(btnOptions, {
-            width: button.width,
-            x: pick(btnOptions.x, chart.buttonOffset) // #1654
-        }), true, 'spacingBox');
-        chart.buttonOffset += ((button.width + btnOptions.buttonSpacing) *
-            (btnOptions.align === 'right' ? -1 : 1));
-        chart.exportSVGElements.push(button, symbol);
+                width: button.width,
+                x: pick(btnOptions.x, chart.buttonOffset) // #1654
+            }), true, 'spacingBox');
+
+        (chart.buttonOffset as any) += (
+            (button.width + btnOptions.buttonSpacing) *
+            (btnOptions.align === 'right' ? -1 : 1)
+        );
+
+        (chart.exportSVGElements as any).push(button, symbol as any);
+
     },
+
     /**
      * Destroy the export buttons.
      *
@@ -1503,54 +2071,80 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      *
      * @param {global.Event} [e]
      */
-    destroyExport: function (e) {
-        var chart = e ? e.target : this, exportSVGElements = chart.exportSVGElements, exportDivElements = chart.exportDivElements, exportEvents = chart.exportEvents, cacheName;
+    destroyExport: function (
+        this: Highcharts.Chart,
+        e?: Event
+    ): void {
+        var chart: Highcharts.Chart = e ? (e.target as any) : this,
+            exportSVGElements = chart.exportSVGElements,
+            exportDivElements = chart.exportDivElements,
+            exportEvents = chart.exportEvents,
+            cacheName;
+
         // Destroy the extra buttons added
         if (exportSVGElements) {
-            exportSVGElements.forEach(function (elem, i) {
+            exportSVGElements.forEach(function (
+                elem: Highcharts.SVGElement,
+                i: number
+            ): void {
+
                 // Destroy and null the svg elements
                 if (elem) { // #1822
                     elem.onclick = elem.ontouchstart = null;
                     cacheName = 'cache-' + elem.menuClassName;
-                    if (chart[cacheName]) {
-                        delete chart[cacheName];
+
+                    if ((chart as any)[cacheName]) {
+                        delete (chart as any)[cacheName];
                     }
-                    chart.exportSVGElements[i] = elem.destroy();
+
+                    (chart.exportSVGElements as any)[i] = elem.destroy();
                 }
             });
             exportSVGElements.length = 0;
         }
+
         // Destroy the exporting group
         if (chart.exportingGroup) {
             chart.exportingGroup.destroy();
             delete chart.exportingGroup;
         }
+
         // Destroy the divs for the menu
         if (exportDivElements) {
-            exportDivElements.forEach(function (elem, i) {
+            exportDivElements.forEach(function (
+                elem: Highcharts.ExportingDivElement,
+                i: number
+            ): void {
+
                 // Remove the event handler
-                H.clearTimeout(elem.hideTimer); // #5427
+                H.clearTimeout(elem.hideTimer as any); // #5427
                 removeEvent(elem, 'mouseleave');
+
                 // Remove inline events
-                chart.exportDivElements[i] =
+                (chart.exportDivElements as any)[i] =
                     elem.onmouseout =
-                        elem.onmouseover =
-                            elem.ontouchstart =
-                                elem.onclick = null;
+                    elem.onmouseover =
+                    elem.ontouchstart =
+                    elem.onclick = null;
+
                 // Destroy the div by moving to garbage bin
                 discardElement(elem);
             });
             exportDivElements.length = 0;
         }
+
         if (exportEvents) {
-            exportEvents.forEach(function (unbind) {
+            exportEvents.forEach(function (unbind: Function): void {
                 unbind();
             });
             exportEvents.length = 0;
         }
     }
+
     /* eslint-enable no-invalid-this, valid-jsdoc */
+
 });
+
 // These ones are translated to attributes rather than styles
 SVGRenderer.prototype.inlineToAttributes = [
     'fill',
@@ -1562,11 +2156,12 @@ SVGRenderer.prototype.inlineToAttributes = [
     'x',
     'y'
 ];
+
 // These CSS properties are not inlined. Remember camelCase.
 SVGRenderer.prototype.inlineBlacklist = [
-    /-/,
-    /^(clipPath|cssText|d|height|width)$/,
-    /^font$/,
+    /-/, // In Firefox, both hyphened and camelCased names are listed
+    /^(clipPath|cssText|d|height|width)$/, // Full words
+    /^font$/, // more specific props are set
     /[lL]ogical(Width|Height)$/,
     /perspective/,
     /TapHighlightColor/,
@@ -1574,11 +2169,13 @@ SVGRenderer.prototype.inlineBlacklist = [
     /^length$/ // #7700
     // /^text (border|color|cursor|height|webkitBorder)/
 ];
+
 SVGRenderer.prototype.unstyledElements = [
     'clipPath',
     'defs',
     'desc'
 ];
+
 /**
  * Analyze inherited styles from stylesheets and add them inline
  *
@@ -1590,9 +2187,17 @@ SVGRenderer.prototype.unstyledElements = [
  * of properties.
  * @todo: Make it work with IE9 and IE10.
  */
-Chart.prototype.inlineStyles = function () {
-    var renderer = this.renderer, inlineToAttributes = renderer.inlineToAttributes, blacklist = renderer.inlineBlacklist, whitelist = renderer.inlineWhitelist, // For IE
-    unstyledElements = renderer.unstyledElements, defaultStyles = {}, dummySVG, iframe, iframeDoc;
+Chart.prototype.inlineStyles = function (): void {
+    var renderer = this.renderer,
+        inlineToAttributes = renderer.inlineToAttributes,
+        blacklist = renderer.inlineBlacklist,
+        whitelist = renderer.inlineWhitelist, // For IE
+        unstyledElements = renderer.unstyledElements,
+        defaultStyles: Highcharts.Dictionary<Highcharts.CSSObject> = {},
+        dummySVG: Element,
+        iframe: HTMLIFrameElement,
+        iframeDoc: Document;
+
     // Create an iframe where we read default styles without pollution from this
     // body
     iframe = doc.createElement('iframe');
@@ -1602,10 +2207,12 @@ Chart.prototype.inlineStyles = function () {
         visibility: 'hidden'
     });
     doc.body.appendChild(iframe);
-    iframeDoc = iframe.contentWindow.document;
+    iframeDoc = (iframe.contentWindow as any).document;
     iframeDoc.open();
     iframeDoc.write('<svg xmlns="http://www.w3.org/2000/svg"></svg>');
     iframeDoc.close();
+
+
     /**
      * Make hyphenated property names out of camelCase
      * @private
@@ -1614,11 +2221,15 @@ Chart.prototype.inlineStyles = function () {
      * @return {string}
      *         Hyphenated property name
      */
-    function hyphenate(prop) {
-        return prop.replace(/([A-Z])/g, function (a, b) {
-            return '-' + b.toLowerCase();
-        });
+    function hyphenate(prop: string): string {
+        return prop.replace(
+            /([A-Z])/g,
+            function (a: string, b: string): string {
+                return '-' + b.toLowerCase();
+            }
+        );
     }
+
     /**
      * Call this on all elements and recurse to children
      * @private
@@ -1626,8 +2237,16 @@ Chart.prototype.inlineStyles = function () {
      *        Element child
      * @return {void}
      */
-    function recurse(node) {
-        var styles, parentStyles, cssText = '', dummy, styleAttr, blacklisted, whitelisted, i;
+    function recurse(node: Highcharts.HTMLDOMElement): void {
+        var styles: Highcharts.CSSObject,
+            parentStyles: (Highcharts.CSSObject|Highcharts.SVGAttributes),
+            cssText = '',
+            dummy: Element,
+            styleAttr,
+            blacklisted: (boolean|undefined),
+            whitelisted: (boolean|undefined),
+            i: number;
+
         /**
          * Check computed styles and whether they are in the white/blacklist for
          * styles or atttributes.
@@ -1638,7 +2257,8 @@ Chart.prototype.inlineStyles = function () {
          *        Style property name
          * @return {void}
          */
-        function filterStyles(val, prop) {
+        function filterStyles(val: string, prop: string): void {
+
             // Check against whitelist & blacklist
             blacklisted = whitelisted = false;
             if (whitelist) {
@@ -1650,38 +2270,48 @@ Chart.prototype.inlineStyles = function () {
                 }
                 blacklisted = !whitelisted;
             }
+
             // Explicitly remove empty transforms
             if (prop === 'transform' && val === 'none') {
                 blacklisted = true;
             }
-            i = blacklist.length;
+
+            i = (blacklist as any).length;
             while (i-- && !blacklisted) {
-                blacklisted = (blacklist[i].test(prop) ||
-                    typeof val === 'function');
+                blacklisted = (
+                    (blacklist as any)[i].test(prop) ||
+                    typeof val === 'function'
+                );
             }
+
             if (!blacklisted) {
                 // If parent node has the same style, it gets inherited, no need
                 // to inline it. Top-level props should be diffed against parent
                 // (#7687).
-                if ((parentStyles[prop] !== val || node.nodeName === 'svg') &&
-                    defaultStyles[node.nodeName][prop] !== val) {
+                if (
+                    (parentStyles[prop] !== val || node.nodeName === 'svg') &&
+                    defaultStyles[node.nodeName][prop] !== val
+                ) {
                     // Attributes
-                    if (inlineToAttributes.indexOf(prop) !== -1) {
+                    if ((inlineToAttributes as any).indexOf(prop) !== -1) {
                         node.setAttribute(hyphenate(prop), val);
-                        // Styles
-                    }
-                    else {
+                    // Styles
+                    } else {
                         cssText += hyphenate(prop) + ':' + val + ';';
                     }
                 }
             }
         }
-        if (node.nodeType === 1 &&
-            unstyledElements.indexOf(node.nodeName) === -1) {
-            styles = win.getComputedStyle(node, null);
+
+        if (
+            node.nodeType === 1 &&
+            (unstyledElements as any).indexOf(node.nodeName) === -1
+        ) {
+            styles = win.getComputedStyle(node, null) as any;
             parentStyles = node.nodeName === 'svg' ?
                 {} :
-                win.getComputedStyle(node.parentNode, null);
+                win.getComputedStyle(node.parentNode as any, null) as any;
+
             // Get default styles from the browser so that we don't have to add
             // these
             if (!defaultStyles[node.nodeName]) {
@@ -1693,55 +2323,77 @@ Chart.prototype.inlineStyles = function () {
                 }
                 */
                 dummySVG = iframeDoc.getElementsByTagName('svg')[0];
-                dummy = iframeDoc.createElementNS(node.namespaceURI, node.nodeName);
+                dummy = iframeDoc.createElementNS(
+                    node.namespaceURI,
+                    node.nodeName
+                );
                 dummySVG.appendChild(dummy);
                 // Copy, so we can remove the node
-                defaultStyles[node.nodeName] = merge(win.getComputedStyle(dummy, null));
+                defaultStyles[node.nodeName] = merge(
+                    win.getComputedStyle(dummy, null) as any
+                );
                 // Remove default fill, otherwise text disappears when exported
                 if (node.nodeName === 'text') {
                     delete defaultStyles.text.fill;
                 }
                 dummySVG.removeChild(dummy);
             }
+
             // Loop through all styles and add them inline if they are ok
             if (isFirefoxBrowser || isMSBrowser) {
                 // Some browsers put lots of styles on the prototype
                 for (var p in styles) { // eslint-disable-line guard-for-in
-                    filterStyles(styles[p], p);
+                    filterStyles(styles[p] as any, p);
                 }
-            }
-            else {
+            } else {
                 objectEach(styles, filterStyles);
             }
+
             // Apply styles
             if (cssText) {
                 styleAttr = node.getAttribute('style');
-                node.setAttribute('style', (styleAttr ? styleAttr + ';' : '') + cssText);
+                node.setAttribute(
+                    'style',
+                    (styleAttr ? styleAttr + ';' : '') + cssText
+                );
             }
+
             // Set default stroke width (needed at least for IE)
             if (node.nodeName === 'svg') {
                 node.setAttribute('stroke-width', '1px');
             }
+
             if (node.nodeName === 'text') {
                 return;
             }
+
             // Recurse
             [].forEach.call(node.children || node.childNodes, recurse);
         }
     }
+
     /**
      * Remove the dummy objects used to get defaults
      * @private
      * @return {void}
      */
-    function tearDown() {
-        dummySVG.parentNode.removeChild(dummySVG);
+    function tearDown(): void {
+        (dummySVG.parentNode as any).removeChild(dummySVG);
     }
-    recurse(this.container.querySelector('svg'));
+
+    recurse(this.container.querySelector('svg') as any);
     tearDown();
+
 };
-symbols.menu = function (x, y, width, height) {
-    var arr = [
+
+
+symbols.menu = function (
+    x: number,
+    y: number,
+    width: number,
+    height: number
+): Highcharts.SVGPathArray {
+    var arr: Highcharts.SVGPathArray = [
         'M', x, y + 2.5,
         'L', x + width, y + 2.5,
         'M', x, y + height / 2 + 0.5,
@@ -1749,13 +2401,27 @@ symbols.menu = function (x, y, width, height) {
         'M', x, y + height - 1.5,
         'L', x + width, y + height - 1.5
     ];
+
     return arr;
 };
-symbols.menuball = function (x, y, width, height) {
-    var path = [], h = (height / 3) - 2;
-    path = path.concat(this.circle(width - h, y, h, h), this.circle(width - h, y + h + 4, h, h), this.circle(width - h, y + 2 * (h + 4), h, h));
+
+symbols.menuball = function (
+    x: number,
+    y: number,
+    width: number,
+    height: number
+): Array<Highcharts.SVGElement> {
+    var path: Array<Highcharts.SVGElement> = [],
+        h = (height / 3) - 2;
+
+    path = path.concat(
+        this.circle(width - h, y, h, h),
+        this.circle(width - h, y + h + 4, h, h),
+        this.circle(width - h, y + 2 * (h + 4), h, h)
+    );
     return path;
 };
+
 /**
  * Add the buttons on chart load
  *
@@ -1763,33 +2429,48 @@ symbols.menuball = function (x, y, width, height) {
  * @function Highcharts.Chart#renderExporting
  * @return {void}
  */
-Chart.prototype.renderExporting = function () {
-    var chart = this, exportingOptions = chart.options.exporting, buttons = exportingOptions.buttons, isDirty = chart.isDirtyExporting || !chart.exportSVGElements;
+Chart.prototype.renderExporting = function (): void {
+    var chart = this,
+        exportingOptions: Highcharts.ExportingOptions =
+            chart.options.exporting as any,
+        buttons = exportingOptions.buttons,
+        isDirty = chart.isDirtyExporting || !chart.exportSVGElements;
+
     chart.buttonOffset = 0;
     if (chart.isDirtyExporting) {
         chart.destroyExport();
     }
-    if (isDirty && exportingOptions.enabled !== false) {
+
+    if (isDirty && (exportingOptions as any).enabled !== false) {
         chart.exportEvents = [];
+
         chart.exportingGroup = chart.exportingGroup ||
             chart.renderer.g('exporting-group').attr({
                 zIndex: 3 // #4955, // #8392
             }).add();
-        objectEach(buttons, function (button) {
+
+        objectEach(buttons, function (
+            button: Highcharts.ExportingButtonOptions
+        ): void {
             chart.addButton(button);
         });
+
         chart.isDirtyExporting = false;
     }
+
     // Destroy the export elements at chart destroy
     addEvent(chart, 'destroy', chart.destroyExport);
 };
+
 /* eslint-disable no-invalid-this */
+
 // Add update methods to handle chart.update and chart.exporting.update and
 // chart.navigation.update. These must be added to the chart instance rather
 // than the Chart prototype in order to use the chart instance inside the update
 // function.
-addEvent(Chart, 'init', function () {
+addEvent(Chart, 'init', function (): void {
     var chart = this;
+
     /**
      * @private
      * @param {"exporting"|"navigation"} prop
@@ -1800,29 +2481,50 @@ addEvent(Chart, 'init', function () {
      *        Whether to redraw
      * @return {void}
      */
-    function update(prop, options, redraw) {
+    function update(
+        prop: 'exporting'|'navigation',
+        options: (Highcharts.ExportingOptions|Highcharts.NavigationOptions),
+        redraw?: boolean
+    ): void {
         chart.isDirtyExporting = true;
-        merge(true, chart.options[prop], options);
+        merge(true, (chart.options as any)[prop], options);
         if (pick(redraw, true)) {
             chart.redraw();
         }
     }
+
     chart.exporting = {
-        update: function (options, redraw) {
+        update: function (
+            options: Highcharts.ExportingOptions,
+            redraw?: boolean
+        ): void {
             update('exporting', options, redraw);
         }
     };
+
     // Register update() method for navigation. Can not be set the same way as
     // for exporting, because navigation options are shared with bindings which
     // has separate update() logic.
-    chartNavigationMixin.addUpdate(function (options, redraw) {
-        update('navigation', options, redraw);
-    }, chart);
+    chartNavigationMixin.addUpdate(
+        function (
+            options: Highcharts.NavigationOptions,
+            redraw?: boolean
+        ): void {
+            update('navigation', options, redraw);
+        },
+        chart
+    );
 });
+
 /* eslint-enable no-invalid-this */
-Chart.prototype.callbacks.push(function (chart) {
+
+Chart.prototype.callbacks.push(function (chart: Highcharts.Chart): void {
+
     chart.renderExporting();
+
     addEvent(chart, 'redraw', chart.renderExporting);
+
+
     // Uncomment this to see a button directly below the chart, for quick
     // testing of export
     /*

--- a/ts/modules/oldie.src.ts
+++ b/ts/modules/oldie.src.ts
@@ -2076,7 +2076,7 @@ if (!svg) {
     H.VMLRenderer = VMLRenderer = function (
         this: Highcharts.VMLRenderer
     ): void {
-        this.init.apply(this, arguments as any);
+        this.init.apply(this, arguments);
     } as any;
     VMLRenderer.prototype = merge(SVGRenderer.prototype, VMLRendererExtension);
 

--- a/ts/parts-3d/SVGRenderer.ts
+++ b/ts/parts-3d/SVGRenderer.ts
@@ -279,7 +279,7 @@ SVGRenderer.prototype.face3d = function (
             hash.d = path;
             hash.visibility = visibility;
         }
-        return SVGElement.prototype.attr.apply(this, arguments as any);
+        return SVGElement.prototype.attr.apply(this, arguments);
     } as any;
 
     ret.animate = function (
@@ -318,7 +318,7 @@ SVGRenderer.prototype.face3d = function (
             this.attr('visibility', visibility);
         }
 
-        return SVGElement.prototype.animate.apply(this, arguments as any);
+        return SVGElement.prototype.animate.apply(this, arguments);
     };
 
     return ret.attr(args);
@@ -378,7 +378,7 @@ SVGRenderer.prototype.polyhedron = function (
             }
             delete hash.faces;
         }
-        return SVGElement.prototype.attr.apply(this, arguments as any);
+        return SVGElement.prototype.attr.apply(this, arguments);
     } as any;
 
     result.animate = function (
@@ -399,7 +399,7 @@ SVGRenderer.prototype.polyhedron = function (
             }
             delete params.faces;
         }
-        return SVGElement.prototype.animate.apply(this, arguments as any);
+        return SVGElement.prototype.animate.apply(this, arguments);
     };
 
     return result.attr(args);
@@ -960,7 +960,7 @@ H.SVGRenderer.prototype.arc3d = function (
                 wrapper.setPaths(wrapper.attribs as any);
             }
         }
-        return SVGElement.prototype.attr.apply(wrapper, arguments as any);
+        return SVGElement.prototype.attr.apply(wrapper, arguments);
     } as any;
 
     // Override the animate function by sucking out custom parameters related to

--- a/ts/parts-gantt/GanttChart.ts
+++ b/ts/parts-gantt/GanttChart.ts
@@ -25,6 +25,9 @@ declare global {
             options: Options,
             callback?: ChartCallbackFunction
         ): Chart;
+        interface Options {
+            isGantt?: boolean;
+        }
     }
 }
 

--- a/ts/parts/Globals.ts
+++ b/ts/parts/Globals.ts
@@ -16,8 +16,6 @@
  */
 declare global {
     namespace Highcharts {
-        type ExportingErrorCallbackFunction = any; // @todo offline exporting
-        type NavigationOptions = any; // @todo exporting module
         type OrganizationSeries = any; // @todo organization module
         type OrganizationSeriesOptions = any // @todo organization module
         type PatternObject = object; // @todo pattern module
@@ -31,17 +29,11 @@ declare global {
             frameShapes?: any; // @todo highcharts 3d
             hasParallelCoordinates?: any; // @todo parallel module
             isBoosting?: any; // @todo boost module
-            isPrinting?: any; // @todo exporting module
-            openMenu?: any; // @todo exporting module
             redrawTrigger?: any; // @todo static-scale module
-            getFilename: Function; // @todo exporting module
             hideOverlappingLabels: Function; // @todo overlapping module
         }
         interface ChartOptions {
             forExport?: any; // @todo
-        }
-        interface Options {
-            navigation?: any; // @todo exporting module
         }
         interface PlotSeriesOptions {
             accessibility?: any; // @todo
@@ -58,6 +50,9 @@ declare global {
             resetZones?: any; // @todo macd indicator
             useCommonDataGrouping?: any; // @todo indicators
             getPoint: Function; // @todo boost module
+        }
+        interface SVGRenderer {
+            inlineWhitelist?: any; // @todo offline exporting module
         }
         interface Tick {
             slotWidth?: any; // @todo
@@ -85,6 +80,13 @@ declare global {
     type GlobalHighcharts = typeof Highcharts;
     type GlobalHTMLElement = HTMLElement;
     type GlobalSVGElement = SVGElement;
+    interface CallableFunction {
+        apply<TScope, TArguments extends any[], TReturn>(
+            this: (this: TScope, ...args: TArguments) => TReturn,
+            thisArg: TScope,
+            args?: (TArguments|IArguments)
+        ): TReturn;
+    }
     interface Document {
         msHidden: boolean;
         webkitHidden: boolean;

--- a/ts/parts/Html.ts
+++ b/ts/parts/Html.ts
@@ -619,7 +619,7 @@ extend(SVGRenderer.prototype, /** @lends SVGRenderer.prototype */ {
                                     if (parents[0].div) { // #6418
                                         wrapper.on.apply(
                                             { element: parents[0].div },
-                                            arguments as any
+                                            arguments
                                         );
                                     }
                                     return parentGroup;

--- a/ts/parts/RangeSelector.ts
+++ b/ts/parts/RangeSelector.ts
@@ -1698,7 +1698,7 @@ RangeSelector.prototype = {
             ((buttonPosition as any).y +
                 buttonGroup.getBBox().height - 12) <
             ((navButtonOptions.y || 0) +
-                navButtonOptions.height))
+                (navButtonOptions.height as any)))
         ) {
             exportingX = -40;
         }
@@ -1737,7 +1737,7 @@ RangeSelector.prototype = {
                 ((inputPosition as any).y -
                     inputGroup.getBBox().height - 12) <
                 ((navButtonOptions.y || 0) +
-                    navButtonOptions.height +
+                    (navButtonOptions.height as any) +
                     chart.spacing[0]))
             ) {
                 exportingX = -40;

--- a/ts/parts/SvgRenderer.ts
+++ b/ts/parts/SvgRenderer.ts
@@ -92,7 +92,9 @@ declare global {
             textContent?: string;
         }
         interface SymbolDictionary {
-            [key: string]: SymbolFunction<(SVGElement|SVGPathArray)>;
+            [key: string]: SymbolFunction<(
+                SVGElement|SVGPathArray|Array<SVGElement>
+            )>;
             arc: SymbolFunction<SVGPathArray>;
             callout: SymbolFunction<SVGPathArray>;
             circle: SymbolFunction<SVGElement>;
@@ -3459,7 +3461,7 @@ SVGElement.prototype.strokeSetter = function (
 SVGRenderer = H.SVGRenderer = function (
     this: Highcharts.SVGRenderer
 ): any {
-    this.init.apply(this, arguments as any);
+    this.init.apply(this, arguments);
 } as any;
 extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
     /**
@@ -4737,8 +4739,8 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
 
         if (isArray(path)) {
             attribs.d = path as any;
-        } else if (isObject(path)) { // attributes
-            extend(attribs, path as any);
+        } else if (isObject(path, true)) { // attributes
+            extend(attribs, path);
         }
         return this.createElement('path').attr(attribs) as any;
     },
@@ -4780,8 +4782,8 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
         r?: number
     ): Highcharts.SVGElement {
         var attribs = (
-                isObject(x) ?
-                    x as Highcharts.SVGAttributes :
+                isObject(x, true) ?
+                    x :
                     x === undefined ? {} : { x: x, y: y, r: r }
             ),
             wrapper = this.createElement('circle');
@@ -4851,8 +4853,8 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
         var arc: Highcharts.SVGElement,
             options: Highcharts.SVGAttributes;
 
-        if (isObject(x)) {
-            options = x as Highcharts.SVGAttributes;
+        if (isObject(x, true)) {
+            options = x;
             y = options.y;
             r = options.r;
             innerR = options.innerR;
@@ -4932,11 +4934,11 @@ extend(SVGRenderer.prototype, /** @lends Highcharts.SVGRenderer.prototype */ {
         strokeWidth?: number
     ): Highcharts.SVGElement {
 
-        r = isObject(x) ? (x as any).r : r;
+        r = isObject(x, true) ? x.r : r;
 
         var wrapper = this.createElement('rect'),
-            attribs: Highcharts.SVGAttributes = isObject(x) ?
-                (x as any) :
+            attribs: Highcharts.SVGAttributes = isObject(x, true) ?
+                x :
                 x === undefined ?
                     {} :
                     {

--- a/ts/parts/Time.ts
+++ b/ts/parts/Time.ts
@@ -516,7 +516,7 @@ Highcharts.Time.prototype = {
         var d, offset, newOffset;
 
         if (this.useUTC) {
-            d = this.Date.UTC.apply(0, arguments as any);
+            d = this.Date.UTC.apply(0, arguments);
             offset = this.getTimezoneOffset(d);
             d += offset;
             newOffset = this.getTimezoneOffset(d);
@@ -744,7 +744,7 @@ Highcharts.Time.prototype = {
         this: Highcharts.Time,
         f: (string|Array<T>|Highcharts.Dictionary<T>)
     ): Highcharts.Dictionary<T> {
-        if (!isObject(f, true)) { // check for string or array
+        if (!isObject(f)) { // check for string or array
             f = splat(f);
             return {
                 main: f[0],

--- a/ts/parts/Utilities.ts
+++ b/ts/parts/Utilities.ts
@@ -13,15 +13,12 @@
 import H from './Globals.js';
 
 /** @private */
-type IsObjectConditionalType<TObject, TStrict> = (
+type IsObjectConditionalType<TObject> = (
     TObject extends object ?
         (TObject extends null ?
             false :
-            (TStrict extends true ?
-                (TObject extends Array<any> ?
-                    false :
-                    true
-                ) :
+            (TObject extends Array<any> ?
+                false :
                 true
             )
         ) :
@@ -226,10 +223,11 @@ declare global {
         function isDOMElement(obj: unknown): obj is HTMLElement;
         function isFunction(obj: unknown): obj is Function;
         function isNumber(n: unknown): n is number;
-        function isObject<T1, T2 extends boolean = false>(
-            obj: T1,
-            strict?: T2
-        ): IsObjectConditionalType<T1, T2>;
+        function isObject(obj: unknown, strict: true): obj is object;
+        function isObject<T>(
+            obj: T,
+            strict?: false
+        ): IsObjectConditionalType<T>;
         function isString(s: unknown): s is string;
         /** @deprecated */
         function keys(obj: any): Array<string>;
@@ -1162,7 +1160,7 @@ H.Fx.prototype = {
      * @return {void}
      */
     fillSetter: function (): void {
-        H.Fx.prototype.strokeSetter.apply(this, arguments as any);
+        H.Fx.prototype.strokeSetter.apply(this, arguments);
     },
 
     /**
@@ -1320,6 +1318,8 @@ function isArray(obj: unknown): obj is Array<unknown> {
     return str === '[object Array]' || str === '[object Array Iterator]';
 }
 
+function isObject<T>(obj: T, strict?: false): IsObjectConditionalType<T>;
+function isObject(obj: unknown, strict: true): obj is object;
 /**
  * Utility function to check if an item is of type object.
  *
@@ -1334,15 +1334,11 @@ function isArray(obj: unknown): obj is Array<unknown> {
  * @return {boolean}
  *         True if the argument is an object.
  */
-function isObject<T1, T2 extends boolean = false>(
-    obj: T1,
-    strict?: T2
-): IsObjectConditionalType<T1, T2> {
-    return (
-        !!obj &&
-        typeof obj === 'object' &&
-        (!strict || !isArray(obj))
-    ) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+function isObject<T>(
+    obj: T,
+    strict?: boolean
+): boolean {
+    return (!!obj && typeof obj === 'object' && (!strict || !isArray(obj)));
 }
 
 /**
@@ -1377,7 +1373,7 @@ function isClass(obj: (object|undefined)): boolean {
     return !!(
         isObject(obj, true) &&
         !isDOMElement(obj) &&
-        (c && (c as any).name && (c as any).name !== 'Object')
+        (c && c.name && c.name !== 'Object')
     );
 }
 
@@ -2293,8 +2289,8 @@ H.setAnimation = function (
 H.animObject = function (
     animation?: (boolean|Highcharts.AnimationOptionsObject)
 ): Highcharts.AnimationOptionsObject {
-    return isObject(animation) ?
-        H.merge(animation as Highcharts.AnimationOptionsObject) as any :
+    return isObject(animation, true) ?
+        H.merge<Highcharts.AnimationOptionsObject>(animation) :
         { duration: animation as boolean ? 500 : 0 };
 };
 
@@ -3123,7 +3119,7 @@ H.animate = function (
         unit = '',
         end,
         fx,
-        args;
+        args: IArguments;
 
     if (!isObject(opt)) { // Number or undefined/null
         args = arguments;


### PR DESCRIPTION
- Fixed #11575, Migrated exporting module to TypeScript.
- Improved typing to avoid `arguments as any` and `any` after `isObject(o, true)`.