### PR TITLE
bugfix/sankey-multiple-a-points-b-and-b-points-a

### DIFF
--- a/js/modules/sankey.src.js
+++ b/js/modules/sankey.src.js
@@ -464,7 +464,7 @@ seriesType('sankey', 'column',
                 }
                 else {
                     for (i = 0; i < node.linksTo.length; i++) {
-                        point = node.linksTo[0];
+                        point = node.linksTo[i];
                         if (point.fromNode.column > fromColumn) {
                             fromNode = point.fromNode;
                             fromColumn = fromNode.column;

--- a/ts/modules/sankey.src.ts
+++ b/ts/modules/sankey.src.ts
@@ -732,7 +732,7 @@ seriesType<Highcharts.SankeySeriesOptions>(
                     // highest order column that links to this one.
                     } else {
                         for (i = 0; i < node.linksTo.length; i++) {
-                            point = node.linksTo[0];
+                            point = node.linksTo[i];
                             if ((point.fromNode.column as any) > fromColumn) {
                                 fromNode = point.fromNode;
                                 fromColumn = (fromNode.column as any);


### PR DESCRIPTION
Issue occur when i have multiple circular dependencies - this is based on the observation on 20 cases 4 that have larger dataset was not rendering at all I've received:

```
TypeError: fromNode is undefined sankey.src.js:865
    createNodeColumns sankey.src.js:865
    forEach self-hosted:266
    createNodeColumns sankey.src.js:846
    translate sankey.src.js:1102
   ...
```

Sample chart that did render after patch was applied:

<img width="1098" alt="case chart didnt render without patch" src="https://user-images.githubusercontent.com/120829/63550949-14d53880-c534-11e9-90cf-7960be068b5c.png">

After applying those small changes, i haven't found any case when it didn't worked.


It might be related with #11712 and #9679 and #8218 - and this only assumption based on reading those tickets, haven't tested those cases. 

I do not now highcharts source code - this the first time i've look inside - still the loop looks broken from general perspective. 

