### PR TITLE
bugfix/7911-linked-axis-reversed

### DIFF
--- a/js/parts/Tick.js
+++ b/js/parts/Tick.js
@@ -280,7 +280,10 @@ H.Tick.prototype = {
      * @return {Highcharts.PositionObject}
      */
     getLabelPosition: function (x, y, label, horiz, labelOptions, tickmarkOffset, index, step) {
-        var axis = this.axis, transA = axis.transA, reversed = axis.reversed, staggerLines = axis.staggerLines, rotCorr = axis.tickRotCorr || { x: 0, y: 0 }, yOffset = labelOptions.y, 
+        var axis = this.axis, transA = axis.transA, reversed = ( // #7911
+        axis.isLinked && axis.linkedParent ?
+            axis.linkedParent.reversed :
+            axis.reversed), staggerLines = axis.staggerLines, rotCorr = axis.tickRotCorr || { x: 0, y: 0 }, yOffset = labelOptions.y, 
         // Adjust for label alignment if we use reserveSpace: true (#5286)
         labelOffsetCorrection = (!horiz && !axis.reserveSpaceDefault ?
             -axis.labelOffset * (axis.labelAlign === 'center' ? 0.5 : 1) :

--- a/samples/unit-tests/axis/labels/demo.js
+++ b/samples/unit-tests/axis/labels/demo.js
@@ -1,3 +1,34 @@
+QUnit.test('Respect reversed-flag of linked axis (#7911)', function (assert) {
+
+    TestTemplate.test('highcharts/bar', {
+        chart: {
+            type: 'bar'
+        },
+        xAxis: [{
+            categories: ['c1', 'c2', 'c3'],
+            reversed: false
+        }, {
+            categories: ['c1', 'c2', 'c3'],
+            linkedTo: 0
+        }],
+        series: [{
+            data: [1, 2, 3]
+        }, {
+            data: [1, 2, 3]
+        }]
+    }, function (template) {
+        var chart = template.chart,
+            axis1 = chart.axes[0],
+            axis2 = chart.axes[1];
+
+        assert.equal(
+            axis1.ticks[0].label.xy.y,
+            axis2.ticks[0].label.xy.y,
+            'Axes should share the same reversed y offset (#7911)'
+        );
+    });
+
+});
 QUnit.test('Show last label hiding interrupted by animation (#5332)', function (assert) {
 
     var done = assert.async();

--- a/test/templates/highcharts/bar.js
+++ b/test/templates/highcharts/bar.js
@@ -1,0 +1,16 @@
+TestTemplate.register('highcharts/bar', Highcharts.chart, {
+
+    chart: {
+        type: 'bar'
+    },
+
+    title: {
+        text: 'template/highcharts/bar'
+    },
+
+    series: [{
+        type: 'bar',
+        data: [1, 3, 2]
+    }]
+
+});

--- a/ts/parts/Tick.ts
+++ b/ts/parts/Tick.ts
@@ -552,7 +552,11 @@ H.Tick.prototype = {
 
         var axis = this.axis,
             transA = axis.transA,
-            reversed = axis.reversed,
+            reversed = ( // #7911
+                axis.isLinked && axis.linkedParent ?
+                    axis.linkedParent.reversed :
+                    axis.reversed
+            ),
             staggerLines = axis.staggerLines,
             rotCorr = axis.tickRotCorr || { x: 0, y: 0 },
             yOffset = labelOptions.y,
@@ -821,7 +825,6 @@ H.Tick.prototype = {
                 index,
                 step
             );
-
             // Apply show first and show last. If the tick is both first and
             // last, it is a single centered tick, in which case we show the
             // label anyway (#2100).


### PR DESCRIPTION
Fixed #7911, `axis.reversed` should not take effect on a linked axis if the parent axis had a different setting.