### PR TITLE
docs/fix-series-typescript-comment

### DIFF
--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -344,8 +344,6 @@ H.Series = H.seriesType('line',
  * chart is a combination of series types, there is no need to set it on the
  * series level.
  *
- * In TypeScript instead the `type` option must always be set.
- *
  * @sample {highcharts} highcharts/series/type/
  *         Line and column in the same chart
  * @sample highcharts/series/type-dynamic/
@@ -4383,8 +4381,6 @@ null,
 /**
  * A `line` series. If the [type](#series.line.type) option is not
  * specified, it is inherited from [chart.type](#chart.type).
- *
- * In TypeScript instead the `type` option must always be set.
  *
  * @extends   series,plotOptions.line
  * @excluding dataParser,dataURL

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -815,8 +815,6 @@ H.Series = H.seriesType<Highcharts.SeriesOptions>(
      * chart is a combination of series types, there is no need to set it on the
      * series level.
      *
-     * In TypeScript instead the `type` option must always be set.
-     *
      * @sample {highcharts} highcharts/series/type/
      *         Line and column in the same chart
      * @sample highcharts/series/type-dynamic/
@@ -6070,8 +6068,6 @@ H.Series = H.seriesType<Highcharts.SeriesOptions>(
 /**
  * A `line` series. If the [type](#series.line.type) option is not
  * specified, it is inherited from [chart.type](#chart.type).
- *
- * In TypeScript instead the `type` option must always be set.
  *
  * @extends   series,plotOptions.line
  * @excluding dataParser,dataURL


### PR DESCRIPTION
Fixed #11772, Removed doubled TypeScript comments.