### PR TITLE
Fixed #11783, issue with `tooltip.outside` and `chart.styledMode`

### DIFF
--- a/js/parts/Html.js
+++ b/js/parts/Html.js
@@ -267,7 +267,7 @@ extend(SVGRenderer.prototype, /** @lends SVGRenderer.prototype */ {
                 };
             });
             gWrapper.addedSetters = true;
-        }, chart = H.charts[renderer.chartIndex], styledMode = chart && chart.styledMode;
+        };
         // Text setter
         wrapper.textSetter = function (value) {
             if (value !== element.innerHTML) {
@@ -314,7 +314,7 @@ extend(SVGRenderer.prototype, /** @lends SVGRenderer.prototype */ {
             .css({
             position: 'absolute'
         });
-        if (!styledMode) {
+        if (!renderer.styledMode) {
             wrapper.css({
                 fontFamily: this.style.fontFamily,
                 fontSize: this.style.fontSize

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -326,7 +326,7 @@ H.Tooltip.prototype = {
                  * @name Highcharts.Tooltip#renderer
                  * @type {Highcharts.SVGRenderer|undefined}
                  */
-                this.renderer = renderer = new H.Renderer(container, 0, 0);
+                this.renderer = renderer = new H.Renderer(container, 0, 0, {}, undefined, undefined, renderer.styledMode);
             }
             // Create the label
             if (this.split) {

--- a/samples/unit-tests/tooltip/outside/demo.details
+++ b/samples/unit-tests/tooltip/outside/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/tooltip/outside/demo.html
+++ b/samples/unit-tests/tooltip/outside/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/data.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/tooltip/outside/demo.js
+++ b/samples/unit-tests/tooltip/outside/demo.js
@@ -1,0 +1,31 @@
+QUnit.test('Outside tooltip and styledMode (#11783)', function (assert) {
+
+    var chart = Highcharts.chart('container', {
+        chart: {
+            styledMode: true,
+            width: 200,
+            height: 200
+        },
+
+        tooltip: {
+            outside: true
+        },
+
+        series: [{
+            data: [1, 3, 2, 4]
+        }]
+    });
+
+    var point = chart.series[0].points[0];
+
+    // Set hoverPoint
+    point.onMouseOver();
+
+    assert.strictEqual(
+        chart.tooltip.renderer.box
+            .querySelector('.highcharts-tooltip-box').nodeName,
+        'path',
+        'A label box should be generated'
+    );
+
+});

--- a/ts/parts/Html.ts
+++ b/ts/parts/Html.ts
@@ -434,9 +434,7 @@ extend(SVGRenderer.prototype, /** @lends SVGRenderer.prototype */ {
                     };
                 });
                 gWrapper.addedSetters = true;
-            },
-            chart = H.charts[renderer.chartIndex],
-            styledMode = chart && chart.styledMode;
+            };
 
         // Text setter
         wrapper.textSetter = function (value: string): void {
@@ -492,7 +490,7 @@ extend(SVGRenderer.prototype, /** @lends SVGRenderer.prototype */ {
                 position: 'absolute'
             });
 
-        if (!styledMode) {
+        if (!renderer.styledMode) {
             wrapper.css({
                 fontFamily: this.style.fontFamily,
                 fontSize: this.style.fontSize

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -511,7 +511,15 @@ H.Tooltip.prototype = {
                  * @name Highcharts.Tooltip#renderer
                  * @type {Highcharts.SVGRenderer|undefined}
                  */
-                this.renderer = renderer = new H.Renderer(container, 0, 0);
+                this.renderer = renderer = new H.Renderer(
+                    container,
+                    0,
+                    0,
+                    {},
+                    undefined,
+                    undefined,
+                    renderer.styledMode
+                );
             }
 
 


### PR DESCRIPTION
Fixed #11783, tooltip border and background disappeared when combining `tooltip.outside` and `chart.styledMode`.