### PR TITLE
bugfix/11448-bubble-legend-gridlines 

### DIFF
--- a/js/parts-more/BubbleLegend.js
+++ b/js/parts-more/BubbleLegend.js
@@ -852,7 +852,9 @@ wrap(Chart.prototype, 'drawChartBox', function (proceed, options, callback) {
         legend.render();
         chart.getMargins();
         chart.axes.forEach(function (axis) {
-            axis.render();
+            if (axis.visible) { // #11448
+                axis.render();
+            }
             if (!bubbleLegendOptions.placed) {
                 axis.setScale();
                 axis.updateNames();

--- a/samples/unit-tests/bubble-legend/layout/demo.html
+++ b/samples/unit-tests/bubble-legend/layout/demo.html
@@ -1,6 +1,7 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 <script src="https://code.highcharts.com/maps/modules/map.js"></script>
+<script src="https://code.highcharts.com/mapdata/countries/bn/bn-all.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/bubble-legend/layout/demo.js
+++ b/samples/unit-tests/bubble-legend/layout/demo.js
@@ -104,3 +104,30 @@ QUnit.test('Negative values (#9678)', function (assert) {
 
     });
 });
+
+
+QUnit.test('Bubble legend with maps', function (assert) {
+    var chart = Highcharts.mapChart('container', {
+        legend: {
+            bubbleLegend: {
+                enabled: true
+            }
+        },
+        series: [{
+            mapData: Highcharts.maps['countries/bn/bn-all']
+        }, {
+            joinBy: ['code', 'iso-a2'],
+            type: 'mapbubble',
+            data: [
+                ['tu', 10],
+                ['be', 20]
+            ]
+        }]
+    });
+
+    assert.strictEqual(
+        Object.keys(chart.yAxis[0].ticks).length,
+        0,
+        'Grid lines and ticks should not be rendered (#11448).'
+    );
+});

--- a/ts/parts-more/BubbleLegend.ts
+++ b/ts/parts-more/BubbleLegend.ts
@@ -1343,7 +1343,9 @@ wrap(Chart.prototype, 'drawChartBox', function (
         chart.getMargins();
 
         chart.axes.forEach(function (axis: Highcharts.Axis): void {
-            axis.render();
+            if (axis.visible) { // #11448
+                axis.render();
+            }
 
             if (!bubbleLegendOptions.placed) {
                 axis.setScale();


### PR DESCRIPTION
Fixed #11448, bubble legend in Highmaps caused unexpected grid lines.