### PR TITLE
Tools: Added possibility to always generate reference.svg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ jobs:
            else
             git clone -b ${CIRCLE_BRANCH} --single-branch ${CIRCLE_REPOSITORY_URL} --depth=1 /home/circleci/repo/highcharts
            fi
+     - run: aws s3 --version #testing presences of cli tool
      - <<: *persist_workspace
 
   install_dependencies:
@@ -152,31 +153,35 @@ jobs:
       - run:
           name: "Set application version env var"
           command: echo "export HIGHCHARTS_VERSION=$(node -p "require('./package.json').version")" >> $BASH_ENV
+      - run:
+          name: Generate any new references images
+          command: npx karma start test/karma-conf.js --tests highcharts/*/*,maps/*/*,stock/*/*,gantt/*/* --reference --browsercount 1 --no-fail-on-empty-test-suite
       - aws-s3/sync: # fetch reference images
           from: "s3://${HIGHCHARTS_S3_BUCKET}/test/visualtests/reference/latest/"
           to: "samples/"
+          overwrite: true
       - run:
           # run tests in sequence due to all writing to the same file
           name: "Highcharts visual tests"
           command: >
-            npx karma start test/karma-conf.js --tests highcharts/*/* --single-run --create-missing-references
+            npx karma start test/karma-conf.js --tests highcharts/*/* --single-run
             --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite
       - run:
           name: "Highmaps visual tests"
           command: >
-            npx karma start test/karma-conf.js --tests maps/*/* --single-run --create-missing-references
+            npx karma start test/karma-conf.js --tests maps/*/* --single-run
             --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite
           when: always
       - run:
           name: "Highstock visual tests"
           command: >
-            npx karma start test/karma-conf.js --tests stock/*/* --single-run --create-missing-references
+            npx karma start test/karma-conf.js --tests stock/*/* --single-run
             --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite
           when: always
       - run:
           name: "Gant visual tests"
           command: >
-            npx karma start test/karma-conf.js --tests gantt/*/* --single-run --create-missing-references
+            npx karma start test/karma-conf.js --tests gantt/*/* --single-run
             --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite
           when: always
       - run: "sudo apt-get install -y librsvg2-bin"
@@ -192,7 +197,7 @@ jobs:
           to: 's3://${HIGHCHARTS_S3_BUCKET}/test/visualtests/diffs/latest/'
           overwrite: true
       - run:
-          name: "Upload visual tests assets"
+          name: "Upload visual test candidates and diff assets"
           command: "npx gulp dist-testresults --bucket ${HIGHCHARTS_S3_BUCKET}"
           when: always
       - aws-s3/sync: # upload any missing or new reference images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,6 @@ jobs:
            else
             git clone -b ${CIRCLE_BRANCH} --single-branch ${CIRCLE_REPOSITORY_URL} --depth=1 /home/circleci/repo/highcharts
            fi
-     - run: aws s3 --version #testing presences of cli tool
      - <<: *persist_workspace
 
   install_dependencies:
@@ -156,10 +155,22 @@ jobs:
       - run:
           name: Generate any new references images
           command: npx karma start test/karma-conf.js --tests highcharts/*/*,maps/*/*,stock/*/*,gantt/*/* --reference --browsercount 1 --no-fail-on-empty-test-suite
-      - aws-s3/sync: # fetch reference images
+      - aws-s3/sync: # fetch remote reference images
           from: "s3://${HIGHCHARTS_S3_BUCKET}/test/visualtests/reference/latest/"
           to: "samples/"
           overwrite: true
+      - aws-s3/sync: # upload any missing or new reference images (won't overwrite existing references)
+          from: "samples/"
+          to: "s3://${HIGHCHARTS_S3_BUCKET}/test/visualtests/reference/latest/"
+          arguments: |
+            --exclude "*" \
+            --include "*/reference.svg"
+      - aws-s3/sync: # upload any missing or new reference images to versioned location (won't overwrite existing references)
+          from: "samples/"
+          to: "s3://${HIGHCHARTS_S3_BUCKET}/test/visualtests/reference/${HIGHCHARTS_VERSION}/"
+          arguments: |
+            --exclude "*" \
+            --include "*/reference.svg"
       - run:
           # run tests in sequence due to all writing to the same file
           name: "Highcharts visual tests"
@@ -200,19 +211,6 @@ jobs:
           name: "Upload visual test candidates and diff assets"
           command: "npx gulp dist-testresults --bucket ${HIGHCHARTS_S3_BUCKET}"
           when: always
-      - aws-s3/sync: # upload any missing or new reference images
-          from: "samples/"
-          to: "s3://${HIGHCHARTS_S3_BUCKET}/test/visualtests/reference/latest/"
-          arguments: |
-            --exclude "*" \
-            --include "*/reference.svg"
-      - aws-s3/sync: # upload any missing or new reference images to versioned location
-          from: "samples/"
-          to: "s3://${HIGHCHARTS_S3_BUCKET}/test/visualtests/reference/${HIGHCHARTS_VERSION}/"
-          arguments: |
-            --exclude "*" \
-            --include "*/reference.svg"
-
 
   build_dist:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,9 @@ jobs:
     steps:
       - early_return_for_forked_pull_requests # to avoid secrets being passed on to forked PR builds we don't run browser tests for forked PRs
       - <<: *load_workspace
+      - run:
+          name: "Set application version env var"
+          command: echo "export HIGHCHARTS_VERSION=$(node -p "require('./package.json').version")" >> $BASH_ENV
       - aws-s3/sync: # fetch reference images
           from: "s3://${HIGHCHARTS_S3_BUCKET}/test/visualtests/reference/latest/"
           to: "samples/"
@@ -156,24 +159,24 @@ jobs:
           # run tests in sequence due to all writing to the same file
           name: "Highcharts visual tests"
           command: >
-            npx karma start test/karma-conf.js --tests highcharts/*/* --single-run
+            npx karma start test/karma-conf.js --tests highcharts/*/* --single-run --create-missing-references
             --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite
       - run:
           name: "Highmaps visual tests"
           command: >
-            npx karma start test/karma-conf.js --tests maps/*/* --single-run
+            npx karma start test/karma-conf.js --tests maps/*/* --single-run --create-missing-references
             --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite
           when: always
       - run:
           name: "Highstock visual tests"
           command: >
-            npx karma start test/karma-conf.js --tests stock/*/* --single-run
+            npx karma start test/karma-conf.js --tests stock/*/* --single-run --create-missing-references
             --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite
           when: always
       - run:
           name: "Gant visual tests"
           command: >
-            npx karma start test/karma-conf.js --tests gantt/*/* --single-run
+            npx karma start test/karma-conf.js --tests gantt/*/* --single-run --create-missing-references
             --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --difflog --no-fail-on-empty-test-suite
           when: always
       - run: "sudo apt-get install -y librsvg2-bin"
@@ -192,6 +195,19 @@ jobs:
           name: "Upload visual tests assets"
           command: "npx gulp dist-testresults --bucket ${HIGHCHARTS_S3_BUCKET}"
           when: always
+      - aws-s3/sync: # upload any missing or new reference images
+          from: "samples/"
+          to: "s3://${HIGHCHARTS_S3_BUCKET}/test/visualtests/reference/latest/"
+          arguments: |
+            --exclude "*" \
+            --include "*/reference.svg"
+      - aws-s3/sync: # upload any missing or new reference images to versioned location
+          from: "samples/"
+          to: "s3://${HIGHCHARTS_S3_BUCKET}/test/visualtests/reference/${HIGHCHARTS_VERSION}/"
+          arguments: |
+            --exclude "*" \
+            --include "*/reference.svg"
+
 
   build_dist:
     <<: *defaults
@@ -337,7 +353,7 @@ workflows:
           filters:
             branches:
               only:
-                - tools/visual-test-samples
+                - tools/visual-tests-generate-missing-refs
                 - master
     jobs:
       - checkout_code

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -541,9 +541,9 @@ module.exports = function (config) {
                         `;
 
                     } else if (argv.visualcompare) {
-                        if (!argv.remotelocation && !fs.existsSync(
-                            `./samples/${path}/reference.svg`
-                        )) {
+                        var referenceSVGExists = fs.existsSync(`./samples/${path}/reference.svg`);
+                        if (!argv['create-missing-references'] &&
+                            !argv.remotelocation && !referenceSVGExists) {
                             console.log(
                                 'Reference file doesn\'t exist: '.yellow +
                                 ` ./samples/${path}/reference.svg`
@@ -555,6 +555,14 @@ module.exports = function (config) {
                         }
 
                         assertion = `
+                        if (${!referenceSVGExists} && ${argv['create-missing-references']}) {
+                            console.log('Reference.svg not found. Forcing creation before comparing..');
+                            __karma__.info({
+                                filename: \`./samples/${path}/reference.svg\`,
+                                data: getSVG(chart)
+                            });
+                        }
+
                         compareToReference(chart, '${path}')
                             .then(actual => {
                                 if (${argv.difflog}) {

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -541,9 +541,9 @@ module.exports = function (config) {
                         `;
 
                     } else if (argv.visualcompare) {
-                        var referenceSVGExists = fs.existsSync(`./samples/${path}/reference.svg`);
-                        if (!argv['create-missing-references'] &&
-                            !argv.remotelocation && !referenceSVGExists) {
+                        if (!argv.remotelocation && !fs.existsSync(
+                            `./samples/${path}/reference.svg`
+                        )) {
                             console.log(
                                 'Reference file doesn\'t exist: '.yellow +
                                 ` ./samples/${path}/reference.svg`
@@ -555,14 +555,6 @@ module.exports = function (config) {
                         }
 
                         assertion = `
-                        if (${!referenceSVGExists} && ${argv['create-missing-references']}) {
-                            console.log('Reference.svg not found. Forcing creation before comparing..');
-                            __karma__.info({
-                                filename: \`./samples/${path}/reference.svg\`,
-                                data: getSVG(chart)
-                            });
-                        }
-
                         compareToReference(chart, '${path}')
                             .then(actual => {
                                 if (${argv.difflog}) {


### PR DESCRIPTION
.. for the visual tests and made sure CI runs the nightly with that option on.
This is needed in order to be able to upload reference images for new tests even before new versions are released.

The approach is as follows:
1. Create reference images
2. Overwrite with latest from S3 (any new reference.svg from step 1 will naturally not be overwritten)
3. Upload any new reference images to 'latest' folder
4. Upload any new reference images to '<package.json.version>' folder
5. Run comparison
6. Upload tests results (+candidates)