### PR TITLE
Tests: Fixed warning caused by topojson file.

### DIFF
--- a/test/karma-files.json
+++ b/test/karma-files.json
@@ -3,7 +3,7 @@
 	"vendor/moment-2.18.1.js",
 	"vendor/moment-timezone-0.5.13-with-data-2012-2022.js",
 	"vendor/proj4-2.3.6.js",
-	"https://unpkg.com/topojson-client@3",
+	"https://unpkg.com/topojson-client@3.0.0/dist/topojson-client.js",
 	"node_modules/lolex/lolex.js",
 
 	"code/highcharts.src.js",


### PR DESCRIPTION
Changed the file ending in `karma-files.json` to the full url ending with .js.

Fixes #11809