### PR TITLE
bugfix/11812-color-axis-chart-update

### DIFF
--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -178,7 +178,9 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         chartOptions[type] = splat(chartOptions[type] || {});
         chartOptions[type].push(userOptions);
         if (isColorAxis) {
-            this.isDirtyLegend = true;
+            this.series.forEach(function (series) {
+                series.update({}, false);
+            });
         }
         if (pick(redraw, true)) {
             this.redraw(animation);
@@ -338,8 +340,8 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         'xAxis',
         'yAxis',
         'zAxis',
-        'series',
         'colorAxis',
+        'series',
         'pane'
     ],
     /**

--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -178,8 +178,9 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         chartOptions[type] = splat(chartOptions[type] || {});
         chartOptions[type].push(userOptions);
         if (isColorAxis) {
+            this.isDirtyLegend = true;
             this.series.forEach(function (series) {
-                series.update({}, false);
+                series.bindAxes();
             });
         }
         if (pick(redraw, true)) {

--- a/samples/unit-tests/coloraxis/coloraxis-update/demo.js
+++ b/samples/unit-tests/coloraxis/coloraxis-update/demo.js
@@ -116,3 +116,38 @@ QUnit.test('Color axis update with responsive rules', function (assert) {
         'Labels are not misaligned'
     );
 });
+
+QUnit.test('Adding color axis', function (assert) {
+    var chart = Highcharts.chart('container', {
+        series: [{
+            data: [1, 2, 3]
+        }, {
+            data: [3, 2, 1],
+            colorAxis: 1
+        }]
+    });
+
+    chart.update({
+        colorAxis: {}
+    }, true, true);
+
+    assert.notEqual(
+        chart.series[0].points[0].color,
+        chart.series[0].points[1].color,
+        'Colors should be different for the first series after colorAxis has been added.'
+    );
+
+    assert.strictEqual(
+        chart.series[1].points[0].color,
+        chart.series[1].points[1].color,
+        'Colors should be the same for the second series.'
+    );
+
+    chart.addColorAxis({});
+
+    assert.notEqual(
+        chart.series[1].points[0].color,
+        chart.series[1].points[2].color,
+        'Colors should be different for the second series after the second colorAxis has been added.'
+    );
+});

--- a/ts/parts/Dynamics.ts
+++ b/ts/parts/Dynamics.ts
@@ -376,7 +376,9 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         (chartOptions as any)[type].push(userOptions);
 
         if (isColorAxis) {
-            this.isDirtyLegend = true;
+            this.series.forEach(function (series: Highcharts.Series): void {
+                series.update({}, false);
+            });
         }
 
         if (pick(redraw, true)) {
@@ -565,8 +567,8 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         'xAxis',
         'yAxis',
         'zAxis',
-        'series',
         'colorAxis',
+        'series',
         'pane'
     ],
 

--- a/ts/parts/Dynamics.ts
+++ b/ts/parts/Dynamics.ts
@@ -376,8 +376,9 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         (chartOptions as any)[type].push(userOptions);
 
         if (isColorAxis) {
+            this.isDirtyLegend = true;
             this.series.forEach(function (series: Highcharts.Series): void {
-                series.update({}, false);
+                series.bindAxes();
             });
         }
 


### PR DESCRIPTION
Fixed #11812, point colors were not changed if `colorAxis` was added in update.