### PR TITLE
bugfix/11405-plotlines-bottom-chart-edge

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -3484,8 +3484,9 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
             }
             return x;
         };
-        // #11405
-        if (!this.horiz && value === this.min) {
+        // Move the line inside the chart (#11405)
+        if ((!this.reversed && value === this.min) ||
+            (this.reversed && value === this.max)) {
             lineWidth = defined(lineWidth) ? lineWidth * -1 : -1;
         }
         evt = {

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -3484,6 +3484,10 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
             }
             return x;
         };
+        // #11405
+        if (!this.horiz && value === this.min) {
+            lineWidth = defined(lineWidth) ? lineWidth * -1 : -1;
+        }
         evt = {
             value: value,
             lineWidth: lineWidth,

--- a/samples/unit-tests/plotbandslines/plotbandslines/demo.js
+++ b/samples/unit-tests/plotbandslines/plotbandslines/demo.js
@@ -199,37 +199,89 @@ QUnit.test('PlotLines on a chart edges (#11405)', function (assert) {
             chart: {
                 spacing: 0
             },
+            credits: {
+                enabled: false
+            },
+            exporting: {
+                enabled: false
+            },
+            series: [{
+                data: [1, 2, 3]
+            }],
             title: {
                 text: ''
             },
-            series: [{
-                data: [0, 1, 2]
-            }],
             xAxis: {
-                visible: false
+                visible: false,
+                min: 0,
+                max: 2
             },
             yAxis: {
-                gridLineWidth: 0,
+                title: '',
+                labels: '',
+                min: 1,
+                max: 3,
                 plotLines: [{
-                    value: 0,
-                    color: '#FF0000'
+                    value: 1,
+                    color: '#FF0000',
+                    width: 1,
+                    zIndex: 2
+                }, {
+                    value: 3,
+                    color: '#0000FF',
+                    width: 1,
+                    zIndex: 2
                 }]
             }
         }),
-        plotLineY = chart.yAxis[0].plotLinesAndBands[0].svgElem.getBBox().y;
+        yAxes = chart.yAxis,
+        plotLines = yAxes[0].plotLinesAndBands;
 
     assert.strictEqual(
-        plotLineY < chart.chartHeight,
+        plotLines[0].svgElem.getBBox().y < chart.chartHeight &&
+        plotLines[1].svgElem.getBBox().y > 0,
         true,
-        'The plot line should be placed on the chart.'
+        'The plot lines should be placed on the chart.'
     );
 
-    chart.series[0].setData([0, -1, -2]);
-    plotLineY = chart.yAxis[0].plotLinesAndBands[0].svgElem.getBBox().y;
+    yAxes[0].update({
+        reversed: true
+    });
+
+    plotLines = yAxes[0].plotLinesAndBands;
 
     assert.strictEqual(
-        plotLineY > 0,
+        plotLines[0].svgElem.getBBox().y > 0 &&
+        plotLines[1].svgElem.getBBox().y < chart.chartHeight,
         true,
-        'The plot line should be placed on the chart.'
+        'The plot lines should be placed on the chart with reversed yAxis.'
+    );
+
+    chart.update({
+        chart: {
+            inverted: true
+        }
+    });
+
+    plotLines = yAxes[0].plotLinesAndBands;
+
+    assert.strictEqual(
+        plotLines[0].svgElem.getBBox().x < chart.chartWidth &&
+        plotLines[1].svgElem.getBBox().x > 0,
+        true,
+        'The plot lines should be placed on the inverted chart with reversed yAxis.'
+    );
+
+    yAxes[0].update({
+        reversed: false
+    });
+
+    plotLines = yAxes[0].plotLinesAndBands;
+
+    assert.strictEqual(
+        plotLines[0].svgElem.getBBox().x > 0 &&
+        plotLines[1].svgElem.getBBox().x < chart.chartWidth,
+        true,
+        'The plot lines should be placed on the inverted chart.'
     );
 });

--- a/samples/unit-tests/plotbandslines/plotbandslines/demo.js
+++ b/samples/unit-tests/plotbandslines/plotbandslines/demo.js
@@ -190,3 +190,46 @@ QUnit.test('Events should be bound to all plotBands (#6166) and plotLines (#1030
         'Click event fired on plot line'
     );
 });
+
+QUnit.test('PlotLines on a chart edges (#11405)', function (assert) {
+    var chart = Highcharts.chart('container', {
+            legend: {
+                enabled: false
+            },
+            chart: {
+                spacing: 0
+            },
+            title: {
+                text: ''
+            },
+            series: [{
+                data: [0, 1, 2]
+            }],
+            xAxis: {
+                visible: false
+            },
+            yAxis: {
+                gridLineWidth: 0,
+                plotLines: [{
+                    value: 0,
+                    color: '#FF0000'
+                }]
+            }
+        }),
+        plotLineY = chart.yAxis[0].plotLinesAndBands[0].svgElem.getBBox().y;
+
+    assert.strictEqual(
+        plotLineY < chart.chartHeight,
+        true,
+        'The plot line should be placed on the chart.'
+    );
+
+    chart.series[0].setData([0, -1, -2]);
+    plotLineY = chart.yAxis[0].plotLinesAndBands[0].svgElem.getBBox().y;
+
+    assert.strictEqual(
+        plotLineY > 0,
+        true,
+        'The plot line should be placed on the chart.'
+    );
+});

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -4384,8 +4384,11 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
                 return x;
             };
 
-        // #11405
-        if (!this.horiz && value === this.min) {
+        // Move the line inside the chart (#11405)
+        if (
+            (!this.reversed && value === this.min) ||
+            (this.reversed && value === this.max)
+        ) {
             lineWidth = defined(lineWidth) ? lineWidth * -1 : -1;
         }
 

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -4384,6 +4384,11 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
                 return x;
             };
 
+        // #11405
+        if (!this.horiz && value === this.min) {
+            lineWidth = defined(lineWidth) ? lineWidth * -1 : -1;
+        }
+
         evt = {
             value: value,
             lineWidth: lineWidth,
@@ -4392,8 +4397,8 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
             acrossPanes: options.acrossPanes,
             translatedValue: translatedValue
         } as any;
-        fireEvent(this, 'getPlotLinePath', evt, function (e: Event): void {
 
+        fireEvent(this, 'getPlotLinePath', evt, function (e: Event): void {
             translatedValue = pick(
                 translatedValue,
                 axis.translate(value as any, null, null, old)


### PR DESCRIPTION
Fixed #11405, plotLines were rendered outside the bottom and left chart edge if the value was the same as the axis extreme.