### PR TITLE
Tests: POC tests fail when run in random order.

### DIFF
--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -107,6 +107,8 @@ var origWrap = Highcharts.wrap;
 var wrappedFunctions = [];
 
 if (window.QUnit) {
+    QUnit.config.seed = 'randomWord';
+
     /*
      * Compare numbers taking in account an error.
      * http://bumbu.me/comparing-numbers-approximately-in-qunitjs/


### PR DESCRIPTION
Just a small proof-of-concept that we have tests that fails when being run in "random" order (other than default). 

This indicates that some tests are not resetting some global parameters or are leaking data into the global scope. 