### PR TITLE
Tools: Testing to increase Win.Chrome+ Mac.Firefox browsercount

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,6 +338,7 @@ workflows:
           browsers: "Mac.Firefox"
       - test_browsers:
           name: "test-Win.Chrome"
+          browsercount: 2
           requires:
             - "test-Mac.Firefox"
           browsers: "Win.Chrome"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,6 +333,7 @@ workflows:
           browsers: "Mac.Safari"
       - test_browsers:
           name: "test-Mac.Firefox"
+          browsercount: 2
           requires:
             - "test-Mac.Safari"
           browsers: "Mac.Firefox"
@@ -374,6 +375,7 @@ workflows:
             - "test-Mac.Safari"
       - test_browsers:
           name: "test-Mac.Firefox"
+          browsercount: 2
           requires:
             - "test-Win.Chrome"
           browsers: "Mac.Firefox"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,6 +368,7 @@ workflows:
           browsers: "Mac.Safari"
       - test_browsers:
           name: "test-Win.Chrome"
+          browsercount: 2
           requires:
             - "test-Mac.Safari"
       - test_browsers:


### PR DESCRIPTION
Testing to split tests across two instances when running Win.Chrome and Mac.Firefox in order to migate the disconnect issue.