### PR TITLE
Tools: Run tests with more cores

### DIFF
--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const yaml = require('js-yaml');
 const path = require('path');
+const os = require('os');
 
 // Internal reference
 const hasJSONSources = {};
@@ -79,7 +80,7 @@ function resolveJSON(js) {
     if (match) {
         let src = match[2];
 
-            
+
         let innerMatch = src.match(
             /^(https:\/\/cdn.jsdelivr.net\/gh\/highcharts\/highcharts@[a-z0-9\.]+|https:\/\/www.highcharts.com)\/samples\/data\/([a-z0-9\-\.]+$)/
         );
@@ -99,7 +100,7 @@ function resolveJSON(js) {
             );
 
             if (data) {
-    
+
                 if (/json$/.test(filename)) {
                     return `
                     window.JSONSources['${src}'] = ${data};
@@ -239,8 +240,7 @@ module.exports = function (config) {
         browsers = Object.keys(browserStackBrowsers);
     }
 
-    const browserCount = argv.browsercount || 2;
-
+    const browserCount = argv.browsercount || (os.cpus().length - 1);
     if (!argv.browsers && browserCount && !isNaN(browserCount)  && browserCount > 1) {
         // Sharding / splitting tests across multiple browser instances
         frameworks = [...frameworks, 'sharding'];
@@ -385,7 +385,7 @@ module.exports = function (config) {
             'samples/highcharts/css/map-dataclasses/demo.js', // Google Spreadsheets
             'samples/highcharts/css/pattern/demo.js', // styled mode, setOptions
             'samples/highcharts/studies/logistics/demo.js', // overriding
-            
+
             // Failing on Edge only
             'samples/unit-tests/pointer/members/demo.js',
 


### PR DESCRIPTION
..when not explicitly specified in order to speed up test runs.

This is just a small improvement in order to make the tests run even faster by default in cases where the developer have more than 2 cores available (cpuCount - 1).

On my machine I have 6 cores available (12 with hyperthreading). With this change the tests are split across 11 cores and runs in less than half the time compared to 2 cores which was the old default.