### PR TITLE
Bugfix/9590 split tooltip outside

### DIFF
--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -722,7 +722,7 @@ H.Tooltip.prototype = {
      * @return {void}
      */
     refresh: function (pointOrPoints, mouseEvent) {
-        var tooltip = this, chart = this.chart, label, options = tooltip.options, x, y, point = pointOrPoints, anchor, textConfig = {}, text, pointConfig = [], formatter = options.formatter || tooltip.defaultFormatter, shared = tooltip.shared, currentSeries, styledMode = chart.styledMode;
+        var tooltip = this, chart = this.chart, options = tooltip.options, x, y, point = pointOrPoints, anchor, textConfig = {}, text, pointConfig = [], formatter = options.formatter || tooltip.defaultFormatter, shared = tooltip.shared, currentSeries, styledMode = chart.styledMode;
         if (!options.enabled) {
             return;
         }
@@ -764,18 +764,12 @@ H.Tooltip.prototype = {
             this.hide();
         }
         else {
-            label = tooltip.getLabel();
-            // show it
-            if (tooltip.isHidden) {
-                label.attr({
-                    opacity: 1
-                }).show();
-            }
             // update text
             if (tooltip.split) {
                 this.renderSplit(text, splat(pointOrPoints));
             }
             else {
+                var label = tooltip.getLabel();
                 // Prevent the tooltip from flowing over the chart box (#6659)
                 if (!options.style.width || styledMode) {
                     label.css({
@@ -807,7 +801,13 @@ H.Tooltip.prototype = {
                     h: anchor[2] || 0
                 });
             }
-            this.isHidden = false;
+            // show it
+            if (tooltip.isHidden && tooltip.label) {
+                tooltip.label.attr({
+                    opacity: 1
+                }).show();
+            }
+            tooltip.isHidden = false;
         }
         H.fireEvent(this, 'refresh');
     },

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -1049,7 +1049,6 @@ H.Tooltip.prototype = {
     ): void {
         var tooltip = this,
             chart = this.chart,
-            label,
             options = tooltip.options,
             x,
             y,
@@ -1111,20 +1110,11 @@ H.Tooltip.prototype = {
         if (text === false) {
             this.hide();
         } else {
-
-            label = tooltip.getLabel();
-
-            // show it
-            if (tooltip.isHidden) {
-                label.attr({
-                    opacity: 1
-                }).show();
-            }
-
             // update text
             if (tooltip.split) {
                 this.renderSplit(text as any, splat(pointOrPoints));
             } else {
+                const label = tooltip.getLabel();
 
                 // Prevent the tooltip from flowing over the chart box (#6659)
                 if (!(options.style as any).width || styledMode) {
@@ -1169,7 +1159,13 @@ H.Tooltip.prototype = {
                 } as any);
             }
 
-            this.isHidden = false;
+            // show it
+            if (tooltip.isHidden && tooltip.label) {
+                tooltip.label.attr({
+                    opacity: 1
+                }).show();
+            }
+            tooltip.isHidden = false;
         }
 
         H.fireEvent(this, 'refresh');


### PR DESCRIPTION
Fixed #9590, added support for split tooltip with `tooltip.outside=true`

---
# Description
Add support for using split tooltip with outside container.

There is potential to simplify and use the `updateTooltipContainer` function on "non-split" tooltips, but I ran into issues with calculating label positions and width across different types.

**NB!:** The solution does not include support for the edge cases of transform and translate, similar to what is described in #11329.


# Example(s)
- [Demo of issue](http://jsfiddle.net/qa7hvb2o/) - hover one of the charts to see the tooltip is inside
- [Demo of issue with fix applied](http://jsfiddle.net/jon_a_nygaard/8w6km0Lu/) - hover one of the charts to see the tooltip is outside

# Related issue(s)
- Closes #9590 
