### PR TITLE
Fix outer line position in Grid Axis

### DIFF
--- a/js/parts-gantt/GridAxis.js
+++ b/js/parts-gantt/GridAxis.js
@@ -546,20 +546,14 @@ addEvent(Axis, 'afterRender',
  *        the original function
  */
 function () {
-    var axis = this, options = axis.options, gridOptions = ((options && isObject(options.grid)) ? options.grid : {}), labelPadding, distance, lineWidth, linePath, yStartIndex, yEndIndex, xStartIndex, xEndIndex, renderer = axis.chart.renderer, horiz = axis.horiz, axisGroupBox;
+    var axis = this, options = axis.options, gridOptions = ((options && isObject(options.grid)) ? options.grid : {}), yStartIndex, yEndIndex, xStartIndex, xEndIndex, renderer = axis.chart.renderer;
     if (gridOptions.enabled === true) {
         // @todo acutual label padding (top, bottom, left, right)
-        // Label padding is needed to figure out where to draw the outer
-        // line.
-        labelPadding = (Math.abs(axis.defaultLeftAxisOptions.labels.x) * 2);
         axis.maxLabelDimensions = axis.getMaxLabelDimensions(axis.ticks, axis.tickPositions);
-        distance = axis.maxLabelDimensions.width + labelPadding;
-        lineWidth = options.lineWidth;
         // Remove right wall before rendering if updating
         if (axis.rightWall) {
             axis.rightWall.destroy();
         }
-        axisGroupBox = axis.axisGroup.getBBox();
         /*
            Draw an extra axis line on outer axes
                        >
@@ -569,23 +563,19 @@ function () {
            Into this:    |______|______|______|__|
                                                    */
         if (axis.isOuterAxis() && axis.axisLine) {
-            if (horiz) {
-                // -1 to avoid adding distance each time the chart updates
-                distance = axisGroupBox.height - 1;
-            }
+            var lineWidth = options.lineWidth;
             if (lineWidth) {
-                linePath = axis.getLinePath(lineWidth);
+                var linePath = axis.getLinePath(lineWidth);
                 xStartIndex = linePath.indexOf('M') + 1;
                 xEndIndex = linePath.indexOf('L') + 1;
                 yStartIndex = linePath.indexOf('M') + 2;
                 yEndIndex = linePath.indexOf('L') + 2;
                 // Negate distance if top or left axis
-                if (axis.side === axisSide.top ||
-                    axis.side === axisSide.left) {
-                    distance = -distance;
-                }
+                // Subtract 1px to draw the line at the end of the tick
+                var distance = (axis.tickSize('tick')[0] - 1) * ((axis.side === axisSide.top ||
+                    axis.side === axisSide.left) ? -1 : 1);
                 // If axis is horizontal, reposition line path vertically
-                if (horiz) {
+                if (axis.horiz) {
                     linePath[yStartIndex] =
                         linePath[yStartIndex] + distance;
                     linePath[yEndIndex] =

--- a/ts/parts-gantt/GridAxis.ts
+++ b/ts/parts-gantt/GridAxis.ts
@@ -862,40 +862,24 @@ addEvent(
             gridOptions: Highcharts.XAxisGridOptions = ((
                 options && isObject(options.grid)) ? (options.grid as any) : {}
             ),
-            labelPadding,
-            distance,
-            lineWidth,
-            linePath,
             yStartIndex,
             yEndIndex,
             xStartIndex,
             xEndIndex,
-            renderer = axis.chart.renderer,
-            horiz = axis.horiz,
-            axisGroupBox;
+            renderer = axis.chart.renderer;
 
         if (gridOptions.enabled === true) {
 
             // @todo acutual label padding (top, bottom, left, right)
-
-            // Label padding is needed to figure out where to draw the outer
-            // line.
-            labelPadding = (
-                Math.abs((axis.defaultLeftAxisOptions.labels as any).x) * 2
-            );
             axis.maxLabelDimensions = axis.getMaxLabelDimensions(
                 axis.ticks,
                 axis.tickPositions
             );
-            distance = axis.maxLabelDimensions.width + labelPadding;
-            lineWidth = options.lineWidth;
 
             // Remove right wall before rendering if updating
             if (axis.rightWall) {
                 axis.rightWall.destroy();
             }
-
-            axisGroupBox = (axis.axisGroup as any).getBBox();
 
             /*
                Draw an extra axis line on outer axes
@@ -906,27 +890,24 @@ addEvent(
                Into this:    |______|______|______|__|
                                                        */
             if (axis.isOuterAxis() && axis.axisLine) {
-                if (horiz) {
-                    // -1 to avoid adding distance each time the chart updates
-                    distance = axisGroupBox.height - 1;
-                }
 
+                const lineWidth = options.lineWidth;
                 if (lineWidth) {
-                    linePath = axis.getLinePath(lineWidth);
+                    const linePath = axis.getLinePath(lineWidth);
                     xStartIndex = linePath.indexOf('M') + 1;
                     xEndIndex = linePath.indexOf('L') + 1;
                     yStartIndex = linePath.indexOf('M') + 2;
                     yEndIndex = linePath.indexOf('L') + 2;
 
                     // Negate distance if top or left axis
-                    if (axis.side === axisSide.top ||
+                    // Subtract 1px to draw the line at the end of the tick
+                    const distance = (axis.tickSize('tick')[0] - 1) * ((
+                        axis.side === axisSide.top ||
                         axis.side === axisSide.left
-                    ) {
-                        distance = -distance;
-                    }
+                    ) ? -1 : 1);
 
                     // If axis is horizontal, reposition line path vertically
-                    if (horiz) {
+                    if (axis.horiz) {
                         linePath[yStartIndex] =
                             (linePath[yStartIndex] as any) + distance;
                         linePath[yEndIndex] =


### PR DESCRIPTION
Fixed #11895, corrected alignment of the outer line in grid axis.

---
# Description
The grid axis used the bounding box to calculate its size on the outer xAxis, which would include the old position of itself and give an incorrect size.
Switched to using `Axis.tickSize` to find tick length, the same way as in `Tick.renderMark`. This also allowed to simplify as the solution works across both the y- and x-axis.

This change will impact the visual tests of at least the `samples/gantt/grid-axis/demo`, but I found that it actually corrects a small misalignment on yAxis.

# Example(s)
- [Demo of issue](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/gantt/demo/with-navigation/) - Resize the container until the navigator drops down, then the outer line will be misaligned.
- [Demo of issue with fix applied](https://jsfiddle.net/jon_a_nygaard/snfh1r90/)

# Related issue(s)
- Closes #11895 