### PR TITLE
bugfix/11801-annotation-drag-zoom

### DIFF
--- a/js/annotations/annotations.src.js
+++ b/js/annotations/annotations.src.js
@@ -1301,3 +1301,13 @@ chartProto.callbacks.push(function (chart) {
         chart.controlPointsGroup.destroy();
     });
 });
+
+H.wrap(
+    H.Pointer.prototype,
+    'onContainerMouseDown',
+    function (proceed) {
+        if (!this.chart.hasDraggedAnnotation) {
+            proceed.apply(this, Array.prototype.slice.call(arguments, 1));
+        }
+    }
+);

--- a/js/annotations/eventEmitterMixin.js
+++ b/js/annotations/eventEmitterMixin.js
@@ -22,14 +22,6 @@ var eventEmitterMixin = {
     addEvents: function () {
         var emitter = this;
 
-        H.addEvent(
-            emitter.graphic.element,
-            'mousedown',
-            function (e) {
-                emitter.onMouseDown(e);
-            }
-        );
-
         objectEach(emitter.options.events, function (event, type) {
             var eventHandler = function (e) {
                 if (type !== 'click' || !emitter.cancelClick) {
@@ -49,6 +41,14 @@ var eventEmitterMixin = {
         });
 
         if (emitter.options.draggable) {
+            H.addEvent(
+                emitter.graphic.element,
+                'mousedown',
+                function (e) {
+                    emitter.onMouseDown(e);
+                }
+            );
+
             H.addEvent(emitter, 'drag', emitter.onDrag);
 
             if (!emitter.graphic.renderer.styledMode) {
@@ -105,6 +105,7 @@ var eventEmitterMixin = {
         prevChartY = e.chartY;
 
         emitter.cancelClick = false;
+        emitter.chart.hasDraggedAnnotation = true;
 
         emitter.removeDrag = H.addEvent(
             H.doc,
@@ -129,6 +130,7 @@ var eventEmitterMixin = {
             function (e) {
                 emitter.cancelClick = emitter.hasDragged;
                 emitter.hasDragged = false;
+                emitter.chart.hasDraggedAnnotation = false;
                 // ControlPoints vs Annotation:
                 fireEvent(H.pick(emitter.target, emitter), 'afterUpdate');
                 emitter.onMouseUp(e);

--- a/samples/unit-tests/annotations/annotations-draggable/demo.js
+++ b/samples/unit-tests/annotations/annotations-draggable/demo.js
@@ -1,5 +1,14 @@
 QUnit.test('Draggable annotation - exporting', function (assert) {
     var chart = Highcharts.chart('container', {
+            chart: {
+                zoomType: 'xy'
+            },
+            xAxis: {
+                minRange: 0.1
+            },
+            yAxis: {
+                minRange: 0.1
+            },
             series: [{
                 data: [3, 6]
             }],
@@ -31,6 +40,10 @@ QUnit.test('Draggable annotation - exporting', function (assert) {
             }]
         }),
         annoattionOptions = chart.options.annotations,
+        oldExtremes = [
+            chart.xAxis[0].getExtremes(),
+            chart.yAxis[0].getExtremes()
+        ],
         controller = new TestController(chart);
 
     // Label tests:
@@ -58,7 +71,7 @@ QUnit.test('Draggable annotation - exporting', function (assert) {
         chart.yAxis[0].toPixels(5)
     );
     controller.mouseMove(
-        chart.xAxis[0].toPixels(0.75) - 5,
+        chart.xAxis[0].toPixels(0.75),
         chart.yAxis[0].toPixels(3)
     );
     controller.mouseUp();
@@ -68,5 +81,20 @@ QUnit.test('Draggable annotation - exporting', function (assert) {
         3,
         0.5,
         'Correctly updated options for annotation\'s shape (#10605).'
+    );
+
+    [chart.xAxis[0], chart.yAxis[0]].forEach(
+        (axis, i) => {
+            assert.strictEqual(
+                axis.min,
+                oldExtremes[i].min,
+                axis.coll + '.min unchanged after drag&drop (#11801)'
+            );
+            assert.strictEqual(
+                axis.max,
+                oldExtremes[i].max,
+                axis.coll + '.max unchanged after drag&drop (#11801)'
+            );
+        }
     );
 });


### PR DESCRIPTION
Fixed #11801, dragging annotations did not prevent zooming in.