### PR TITLE
Tools: Split up nightly reference creation per product.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,8 +153,17 @@ jobs:
           name: "Set application version env var"
           command: echo "export HIGHCHARTS_VERSION=$(node -p "require('./package.json').version")" >> $BASH_ENV
       - run:
-          name: Generate any new references images
-          command: npx karma start test/karma-conf.js --tests highcharts/*/*,maps/*/*,stock/*/*,gantt/*/* --reference --browsercount 1 --no-fail-on-empty-test-suite
+          name: Generate Highcharts new references images
+          command: npx karma start test/karma-conf.js --tests highcharts/*/* --reference --browsercount 1 --no-fail-on-empty-test-suite
+      - run:
+          name: Generate Highmaps new references images
+          command: npx karma start test/karma-conf.js --tests maps/*/* --reference --browsercount 1 --no-fail-on-empty-test-suite
+      - run:
+          name: Generate Highstock new references images
+          command: npx karma start test/karma-conf.js --tests stock/*/* --reference --browsercount 1 --no-fail-on-empty-test-suite
+      - run:
+          name: Generate Gantt new references images
+          command: npx karma start test/karma-conf.js --tests gantt/*/* --reference --browsercount 1 --no-fail-on-empty-test-suite
       - aws-s3/sync: # overwrite with remote reference images before uploading any new ones
           from: "s3://${HIGHCHARTS_S3_BUCKET}/test/visualtests/reference/latest/"
           to: "samples/"


### PR DESCRIPTION
This is due to not finding an obvious solution as to why karma seems a bit random with regards to which tests it includes and runs (number of test varies from run to run with the same command). 