### PR TITLE
bugfix/11476-inverted-variwide-labels-error

### DIFF
--- a/js/modules/variwide.src.js
+++ b/js/modules/variwide.src.js
@@ -264,14 +264,18 @@ addEvent(H.Axis, 'afterDrawCrosshair', function (e) {
 addEvent(H.Axis, 'afterRender', function () {
     var axis = this;
 
-    if (!this.horiz && this.variwide && this.options.labels.enabled) {
+    if (!this.horiz && this.variwide) {
         this.chart.labelCollectors.push(function () {
-            return axis.tickPositions.map(function (pos, i) {
-                var label = axis.ticks[pos].label;
+            return axis.tickPositions
+                .filter(function (pos) {
+                    return axis.ticks[pos].label;
+                })
+                .map(function (pos, i) {
+                    var label = axis.ticks[pos].label;
 
-                label.labelrank = axis.zData[i];
-                return label;
-            });
+                    label.labelrank = axis.zData[i];
+                    return label;
+                });
         });
     }
 });

--- a/js/modules/variwide.src.js
+++ b/js/modules/variwide.src.js
@@ -264,7 +264,7 @@ addEvent(H.Axis, 'afterDrawCrosshair', function (e) {
 addEvent(H.Axis, 'afterRender', function () {
     var axis = this;
 
-    if (!this.horiz && this.variwide) {
+    if (!this.horiz && this.variwide && this.options.labels.enabled) {
         this.chart.labelCollectors.push(function () {
             return axis.tickPositions.map(function (pos, i) {
                 var label = axis.ticks[pos].label;

--- a/samples/unit-tests/series-variwide/variwide/demo.js
+++ b/samples/unit-tests/series-variwide/variwide/demo.js
@@ -95,6 +95,21 @@ QUnit.test('variwide', function (assert) {
         'Correct number of points after zoom and redraw (#9525)'
     );
 
+    chart.update({
+        chart: {
+            inverted: true
+        },
+        xAxis: {
+            labels: {
+                enabled: false
+            }
+        }
+    });
+
+    assert.ok(
+        true,
+        'No errors with disabled xAxis labels (#11476)'
+    );
 });
 
 QUnit.test('variwide null points', function (assert) {


### PR DESCRIPTION
Fixed #11476, inverted variwide chart with disabled X axis labels threw an error.