### PR TITLE
bugfix/11100-3d-column-animation

### DIFF
--- a/js/modules/cylinder.src.js
+++ b/js/modules/cylinder.src.js
@@ -49,7 +49,11 @@ seriesType('cylinder', 'column',
 {}, {}, 
 /** @lends Highcharts.seriesTypes.cylinder#pointClass# */
 {
-    shapeType: 'cylinder'
+    shapeType: 'cylinder',
+    hasNewShapeType: H
+        .seriesTypes.column.prototype
+        .pointClass.prototype
+        .hasNewShapeType
 });
 /**
  * A `cylinder` series. If the [type](#series.cylinder.type) option is not

--- a/js/modules/funnel3d.src.js
+++ b/js/modules/funnel3d.src.js
@@ -303,7 +303,11 @@ seriesType('funnel3d', 'column',
         seriesTypes.column.prototype.alignDataLabel.apply(series, arguments);
     }
 }, /** @lends seriesTypes.funnel3d.prototype.pointClass.prototype */ {
-    shapeType: 'funnel3d'
+    shapeType: 'funnel3d',
+    hasNewShapeType: H
+        .seriesTypes.column.prototype
+        .pointClass.prototype
+        .hasNewShapeType
 });
 /**
  * A `funnel3d` series. If the [type](#series.funnel3d.type) option is

--- a/js/parts-3d/Column.js
+++ b/js/parts-3d/Column.js
@@ -290,11 +290,29 @@ function setState(proceed, state, inherit) {
         this.options.inactiveOtherPoints = false;
     }
 }
+// eslint-disable-next-line valid-jsdoc
+/**
+ * In 3D mode, simple checking for a new shape to animate is not enough.
+ * Additionally check if graphic is a group of elements
+ *
+ * @private
+ */
+function hasNewShapeType(proceed) {
+    var args = [];
+    for (var _i = 1; _i < arguments.length; _i++) {
+        args[_i - 1] = arguments[_i];
+    }
+    return this.series.chart.is3d() ?
+        this.graphic && this.graphic.element.nodeName !== 'g' :
+        proceed.apply(this, args);
+}
 wrap(seriesTypes.column.prototype, 'pointAttribs', pointAttribs);
 wrap(seriesTypes.column.prototype, 'setState', setState);
+wrap(seriesTypes.column.prototype.pointClass.prototype, 'hasNewShapeType', hasNewShapeType);
 if (seriesTypes.columnrange) {
     wrap(seriesTypes.columnrange.prototype, 'pointAttribs', pointAttribs);
     wrap(seriesTypes.columnrange.prototype, 'setState', setState);
+    wrap(seriesTypes.columnrange.prototype.pointClass.prototype, 'hasNewShapeType', hasNewShapeType);
     seriesTypes.columnrange.prototype.plotGroup =
         seriesTypes.column.prototype.plotGroup;
     seriesTypes.columnrange.prototype.setVisible =

--- a/js/parts/ColumnSeries.js
+++ b/js/parts/ColumnSeries.js
@@ -761,8 +761,7 @@ seriesType('column', 'line',
                 shapeArgs = point.shapeArgs;
                 // When updating a series between 2d and 3d or cartesian and
                 // polar, the shape type changes.
-                if (graphic &&
-                    graphic.element.nodeName !== point.shapeType) {
+                if (graphic && point.hasNewShapeType()) {
                     graphic = graphic.destroy();
                 }
                 if (graphic) { // update

--- a/js/parts/Point.js
+++ b/js/parts/Point.js
@@ -749,6 +749,16 @@ Highcharts.Point.prototype = {
         return zone;
     },
     /**
+     * Utility to check if point has new shape type. Used in column series and
+     * all others that are based on column series.
+     *
+     * @return boolean|undefined
+     */
+    hasNewShapeType: function () {
+        return this.graphic &&
+            this.graphic.element.nodeName !== this.shapeType;
+    },
+    /**
      * Destroy a point to clear memory. Its reference still stays in
      * `series.data`.
      *

--- a/samples/unit-tests/3d/column-animation/demo.css
+++ b/samples/unit-tests/3d/column-animation/demo.css
@@ -1,0 +1,4 @@
+#container {
+	height: 400px;
+	width: 800px;
+}

--- a/samples/unit-tests/3d/column-animation/demo.details
+++ b/samples/unit-tests/3d/column-animation/demo.details
@@ -1,0 +1,5 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+...

--- a/samples/unit-tests/3d/column-animation/demo.html
+++ b/samples/unit-tests/3d/column-animation/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+<script src="https://code.highcharts.com/stock/highcharts-3d.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/3d/column-animation/demo.js
+++ b/samples/unit-tests/3d/column-animation/demo.js
@@ -1,0 +1,96 @@
+/* eslint func-style:0 */
+
+QUnit.test('Point animation', function (assert) {
+
+    var clock = null;
+
+    function getPhysicalHeight(point) {
+        return Math.round(point.graphic.front.getBBox(true).height);
+    }
+
+    function getCalculatedHeight(point) {
+        return Math.round(
+            point.series.yAxis.toPixels(0) -
+            point.series.yAxis.toPixels(point.y)
+        );
+    }
+
+    try {
+
+        clock = TestUtilities.lolexInstall();
+
+        var chart = Highcharts
+                .chart('container', {
+                    chart: {
+                        type: 'column',
+                        animation: {
+                            duration: 1000
+                        },
+                        options3d: {
+                            enabled: true,
+                            alpha: 0,
+                            beta: 0,
+                            viewDistance: 25,
+                            depth: 0
+                        }
+                    },
+                    plotOptions: {
+                        column: {
+                            depth: 0
+                        }
+                    },
+                    series: [{
+                        data: [25, 25, 250]
+                    }]
+                }),
+            point = chart.series[0].points[1],
+            initialPos = getCalculatedHeight(point),
+            realPos,
+            done = assert.async();
+
+        point.update(200);
+
+        realPos = getPhysicalHeight(point);
+        assert.strictEqual(
+            realPos,
+            initialPos,
+            'Time 0 - point has not started moving'
+        );
+
+        setTimeout(function () {
+            assert.strictEqual(
+                getPhysicalHeight(point) > realPos,
+                true,
+                'Time 400 - point has continued'
+            );
+            realPos = getPhysicalHeight(point);
+        }, 400);
+
+        setTimeout(function () {
+            assert.strictEqual(
+                getPhysicalHeight(point) > realPos,
+                true,
+                'Time 800 - point has continued'
+            );
+
+        }, 800);
+
+        setTimeout(function () {
+            assert.strictEqual(
+                getPhysicalHeight(point),
+                getCalculatedHeight(point),
+                'Time 1200 - point has landed'
+            );
+
+            done();
+        }, 1200);
+
+        TestUtilities.lolexRunAndUninstall(clock);
+
+    } finally {
+
+        TestUtilities.lolexUninstall(clock);
+
+    }
+
+});

--- a/ts/modules/cylinder.src.ts
+++ b/ts/modules/cylinder.src.ts
@@ -126,7 +126,11 @@ seriesType<Highcharts.CylinderSeries>(
     {},
     /** @lends Highcharts.seriesTypes.cylinder#pointClass# */
     {
-        shapeType: 'cylinder'
+        shapeType: 'cylinder',
+        hasNewShapeType: H
+            .seriesTypes.column.prototype
+            .pointClass.prototype
+            .hasNewShapeType
     }
 );
 

--- a/ts/modules/funnel3d.src.ts
+++ b/ts/modules/funnel3d.src.ts
@@ -473,7 +473,11 @@ seriesType<Highcharts.Funnel3dSeries>('funnel3d', 'column',
             );
         }
     }, /** @lends seriesTypes.funnel3d.prototype.pointClass.prototype */ {
-        shapeType: 'funnel3d'
+        shapeType: 'funnel3d',
+        hasNewShapeType: H
+            .seriesTypes.column.prototype
+            .pointClass.prototype
+            .hasNewShapeType
     }
 );
 

--- a/ts/parts-3d/Column.ts
+++ b/ts/parts-3d/Column.ts
@@ -450,11 +450,39 @@ function setState(
     }
 }
 
+// eslint-disable-next-line valid-jsdoc
+/**
+ * In 3D mode, simple checking for a new shape to animate is not enough.
+ * Additionally check if graphic is a group of elements
+ *
+ * @private
+ */
+function hasNewShapeType(
+    this: Highcharts.ColumnPoint,
+    proceed: Highcharts.ColumnPoint['hasNewShapeType'],
+    ...args: []
+): boolean|undefined {
+    return this.series.chart.is3d() ?
+        this.graphic && this.graphic.element.nodeName !== 'g' :
+        proceed.apply(this, args);
+}
+
 wrap(seriesTypes.column.prototype, 'pointAttribs', pointAttribs);
 wrap(seriesTypes.column.prototype, 'setState', setState);
+wrap(
+    seriesTypes.column.prototype.pointClass.prototype,
+    'hasNewShapeType',
+    hasNewShapeType
+);
+
 if (seriesTypes.columnrange) {
     wrap(seriesTypes.columnrange.prototype, 'pointAttribs', pointAttribs);
     wrap(seriesTypes.columnrange.prototype, 'setState', setState);
+    wrap(
+        seriesTypes.columnrange.prototype.pointClass.prototype,
+        'hasNewShapeType',
+        hasNewShapeType
+    );
     seriesTypes.columnrange.prototype.plotGroup =
         seriesTypes.column.prototype.plotGroup;
     seriesTypes.columnrange.prototype.setVisible =

--- a/ts/parts/ColumnSeries.ts
+++ b/ts/parts/ColumnSeries.ts
@@ -1066,10 +1066,7 @@ seriesType<Highcharts.ColumnSeries>(
 
                     // When updating a series between 2d and 3d or cartesian and
                     // polar, the shape type changes.
-                    if (
-                        graphic &&
-                        graphic.element.nodeName !== point.shapeType
-                    ) {
+                    if (graphic && point.hasNewShapeType()) {
                         graphic = graphic.destroy();
                     }
 

--- a/ts/parts/Point.ts
+++ b/ts/parts/Point.ts
@@ -169,6 +169,7 @@ declare global {
             ): void;
             public getLabelConfig(): PointLabelObject;
             public getZone(): PlotSeriesZonesOptions;
+            public hasNewShapeType (this: Point): boolean|undefined;
             public init(
                 series: Series,
                 options: PointOptionsType,
@@ -1036,6 +1037,19 @@ Highcharts.Point.prototype = {
         }
 
         return zone;
+    },
+
+    /**
+     * Utility to check if point has new shape type. Used in column series and
+     * all others that are based on column series.
+     *
+     * @return boolean|undefined
+     */
+    hasNewShapeType: function (
+        this: Highcharts.Point
+    ): boolean|undefined {
+        return this.graphic &&
+            this.graphic.element.nodeName !== this.shapeType;
     },
 
     /**


### PR DESCRIPTION
Fixed #11100, 3D columns were not animated on data update.
___
Two minor things to mention:

1.
There's one small problem with this solution: `hasNewShapeType` is added to `Point` class, not to `ColumnPoint`. This is caused by behaviour of `seriesType(..args, /* pointClass */)` - which does not use parent's series `pointClass`, but original `Point` class when adding some new props to new `pointClass`. For example (demo: http://jsfiddle.net/BlackLabel/tp82b4rh/)

```js
Highcharts.seriesType(
  'newColumnOK', 'column', {}, {},
  { something: true }
);

Highcharts.seriesType(
  'newColumnBAD', 'newColumnOK', {}, {},
  { }
);

console.log(
  typeof Highcharts
    .seriesTypes.newColumnOK.prototype
    .pointClass.prototype
    .something
); // boolean

console.log(
  typeof Highcharts
    .seriesTypes.newColumnBAD.prototype
    .pointClass.prototype
    .something
); // undefined
```

I'm not sure if this is expected? 

2. 
Is `...args` really fine in TS? Probably `for`-loop is faster than `Array.prototype.splice.call(arguments, 1)`.