### PR TITLE
Bugfix/11753 venn label regression

### DIFF
--- a/js/mixins/geometry-circles.js
+++ b/js/mixins/geometry-circles.js
@@ -182,6 +182,22 @@ function isPointOutsideAllCircles(point, circles) {
     });
 }
 /**
+ * Calculates the points for the polygon of the intersection area between a set
+ * of circles.
+ *
+ * @private
+ * @param {Array<Highcharts.CircleObject>} circles
+ *        List of circles to calculate polygon of.
+ * @return {Array<Highcharts.GeometryObject>} Return list of points in the
+ * intersection polygon.
+ */
+function getCirclesIntersectionPolygon(circles) {
+    return getCirclesIntersectionPoints(circles)
+        .filter(function (p) {
+        return isPointInsideAllCircles(p, circles);
+    });
+}
+/**
  * Calculate the path for the area of overlap between a set of circles.
  * @todo handle cases with only 1 or 0 arcs.
  * @private
@@ -192,10 +208,7 @@ function isPointOutsideAllCircles(point, circles) {
  *         there are no intersection between all the circles.
  */
 function getAreaOfIntersectionBetweenCircles(circles) {
-    var intersectionPoints = (getCirclesIntersectionPoints(circles)
-        .filter(function (p) {
-        return isPointInsideAllCircles(p, circles);
-    })), result;
+    var intersectionPoints = getCirclesIntersectionPolygon(circles), result;
     if (intersectionPoints.length > 1) {
         // Calculate the center of the intersection points.
         var center_1 = getCenterOfPoints(intersectionPoints);
@@ -281,6 +294,7 @@ var geometryCircles = {
     getAreaOfIntersectionBetweenCircles: getAreaOfIntersectionBetweenCircles,
     getCircleCircleIntersection: getCircleCircleIntersection,
     getCirclesIntersectionPoints: getCirclesIntersectionPoints,
+    getCirclesIntersectionPolygon: getCirclesIntersectionPolygon,
     getCircularSegmentArea: getCircularSegmentArea,
     getOverlapBetweenCircles: getOverlapBetweenCircles,
     isPointInsideCircle: isPointInsideCircle,

--- a/js/mixins/geometry-circles.js
+++ b/js/mixins/geometry-circles.js
@@ -14,10 +14,10 @@ var getAngleBetweenPoints = geometry.getAngleBetweenPoints, getCenterOfPoints = 
  * @return {number}
  *         Rounded number
  */
-var round = function round(x, decimals) {
+function round(x, decimals) {
     var a = Math.pow(10, decimals);
     return Math.round(x * a) / a;
-};
+}
 /**
  * Calculates the area of a circle based on its radius.
  * @private
@@ -26,12 +26,12 @@ var round = function round(x, decimals) {
  * @return {number}
  *         Returns the area of the circle.
  */
-var getAreaOfCircle = function (r) {
+function getAreaOfCircle(r) {
     if (r <= 0) {
         throw new Error('radius of circle must be a positive number.');
     }
     return Math.PI * r * r;
-};
+}
 /**
  * Calculates the area of a circular segment based on the radius of the circle
  * and the height of the segment.
@@ -44,9 +44,9 @@ var getAreaOfCircle = function (r) {
  * @return {number}
  *         Returns the area of the circular segment.
  */
-var getCircularSegmentArea = function getCircularSegmentArea(r, h) {
+function getCircularSegmentArea(r, h) {
     return r * r * Math.acos(1 - h / r) - (r - h) * Math.sqrt(h * (2 * r - h));
-};
+}
 /**
  * Calculates the area of overlap between two circles based on their radiuses
  * and the distance between them.
@@ -61,7 +61,7 @@ var getCircularSegmentArea = function getCircularSegmentArea(r, h) {
  * @return {number}
  *         Returns the area of overlap between the two circles.
  */
-var getOverlapBetweenCircles = function getOverlapBetweenCircles(r1, r2, d) {
+function getOverlapBetweenCircles(r1, r2, d) {
     var overlap = 0;
     // If the distance is larger than the sum of the radiuses then the circles
     // does not overlap.
@@ -83,7 +83,7 @@ var getOverlapBetweenCircles = function getOverlapBetweenCircles(r1, r2, d) {
         overlap = round(overlap, 14);
     }
     return overlap;
-};
+}
 /**
  * Calculates the intersection points of two circles.
  *
@@ -96,8 +96,9 @@ var getOverlapBetweenCircles = function getOverlapBetweenCircles(r1, r2, d) {
  * @return {Array<Highcharts.PositionObject>}
  *         Returns the resulting intersection points.
  */
-var getCircleCircleIntersection = function getCircleCircleIntersection(c1, c2) {
-    var d = getDistanceBetweenPoints(c1, c2), r1 = c1.r, r2 = c2.r, points = [];
+function getCircleCircleIntersection(c1, c2) {
+    var d = getDistanceBetweenPoints(c1, c2), r1 = c1.r, r2 = c2.r;
+    var points = [];
     if (d < r1 + r2 && d > Math.abs(r1 - r2)) {
         // If the circles are overlapping, but not completely overlapping, then
         // it exists intersecting points.
@@ -112,7 +113,7 @@ var getCircleCircleIntersection = function getCircleCircleIntersection(c1, c2) {
         ];
     }
     return points;
-};
+}
 /**
  * Calculates all the intersection points for between a list of circles.
  * @private
@@ -121,7 +122,7 @@ var getCircleCircleIntersection = function getCircleCircleIntersection(c1, c2) {
  * @return {Array<Highcharts.GeometryObject>}
  *         Returns a list of intersection points.
  */
-var getCirclesIntersectionPoints = function getIntersectionPoints(circles) {
+function getCirclesIntersectionPoints(circles) {
     return circles.reduce(function (points, c1, i, arr) {
         var additional = arr.slice(i + 1)
             .reduce(function (points, c2, j) {
@@ -134,7 +135,7 @@ var getCirclesIntersectionPoints = function getIntersectionPoints(circles) {
         }, []);
         return points.concat(additional);
     }, []);
-};
+}
 /**
  * Tests wether a point lies within a given circle.
  * @private
@@ -145,9 +146,9 @@ var getCirclesIntersectionPoints = function getIntersectionPoints(circles) {
  * @return {boolean}
  *         Returns true if the point is inside, false if outside.
  */
-var isPointInsideCircle = function isPointInsideCircle(point, circle) {
+function isPointInsideCircle(point, circle) {
     return getDistanceBetweenPoints(point, circle) <= circle.r + 1e-10;
-};
+}
 /**
  * Tests wether a point lies within a set of circles.
  * @private
@@ -158,11 +159,11 @@ var isPointInsideCircle = function isPointInsideCircle(point, circle) {
  * @return {boolean}
  *         Returns true if the point is inside all the circles, false if not.
  */
-var isPointInsideAllCircles = function isPointInsideAllCircles(point, circles) {
+function isPointInsideAllCircles(point, circles) {
     return !circles.some(function (circle) {
         return !isPointInsideCircle(point, circle);
     });
-};
+}
 /**
  * Tests wether a point lies outside a set of circles.
  *
@@ -175,11 +176,11 @@ var isPointInsideAllCircles = function isPointInsideAllCircles(point, circles) {
  * @return {boolean}
  *         Returns true if the point is outside all the circles, false if not.
  */
-var isPointOutsideAllCircles = function isPointOutsideAllCircles(point, circles) {
+function isPointOutsideAllCircles(point, circles) {
     return !circles.some(function (circle) {
         return isPointInsideCircle(point, circle);
     });
-};
+}
 /**
  * Calculate the path for the area of overlap between a set of circles.
  * @todo handle cases with only 1 or 0 arcs.
@@ -190,18 +191,18 @@ var isPointOutsideAllCircles = function isPointOutsideAllCircles(point, circles)
  *         Returns the path for the area of overlap. Returns an empty string if
  *         there are no intersection between all the circles.
  */
-var getAreaOfIntersectionBetweenCircles = function getAreaOfIntersectionBetweenCircles(circles) {
+function getAreaOfIntersectionBetweenCircles(circles) {
     var intersectionPoints = (getCirclesIntersectionPoints(circles)
         .filter(function (p) {
         return isPointInsideAllCircles(p, circles);
     })), result;
     if (intersectionPoints.length > 1) {
         // Calculate the center of the intersection points.
-        var center = getCenterOfPoints(intersectionPoints);
+        var center_1 = getCenterOfPoints(intersectionPoints);
         intersectionPoints = intersectionPoints
             // Calculate the angle between the center and the points.
             .map(function (p) {
-            p.angle = getAngleBetweenPoints(center, p);
+            p.angle = getAngleBetweenPoints(center_1, p);
             return p;
         })
             // Sort the points by the angle to the center.
@@ -224,10 +225,12 @@ var getAreaOfIntersectionBetweenCircles = function getAreaOfIntersectionBetweenC
                 // calculate arcs.
                 .reduce(function (arc, index) {
                 var circle = circles[index], angle1 = getAngleBetweenPoints(circle, p1), angle2 = getAngleBetweenPoints(circle, startPoint), angleDiff = angle2 - angle1 +
-                    (angle2 < angle1 ? 2 * Math.PI : 0), angle = angle2 - angleDiff / 2, width = getDistanceBetweenPoints(midPoint, {
+                    (angle2 < angle1 ? 2 * Math.PI : 0), angle = angle2 - angleDiff / 2;
+                var width = getDistanceBetweenPoints(midPoint, {
                     x: circle.x + circle.r * Math.sin(angle),
                     y: circle.y + circle.r * Math.cos(angle)
-                }), r = circle.r;
+                });
+                var r = circle.r;
                 // Width can sometimes become to large due to floating
                 // point errors
                 if (width > r * 2) {
@@ -266,13 +269,13 @@ var getAreaOfIntersectionBetweenCircles = function getAreaOfIntersectionBetweenC
         else {
             arcs.unshift(['M', startPoint.x, startPoint.y]);
             result = {
-                center: center,
+                center: center_1,
                 d: arcs
             };
         }
     }
     return result;
-};
+}
 var geometryCircles = {
     getAreaOfCircle: getAreaOfCircle,
     getAreaOfIntersectionBetweenCircles: getAreaOfIntersectionBetweenCircles,

--- a/js/modules/venn.src.js
+++ b/js/modules/venn.src.js
@@ -37,6 +37,8 @@ var addEvent = H.addEvent,
     getAreaOfCircle = geometryCircles.getAreaOfCircle,
     getAreaOfIntersectionBetweenCircles =
         geometryCircles.getAreaOfIntersectionBetweenCircles,
+    getCirclesIntersectionPolygon =
+        geometryCircles.getCirclesIntersectionPolygon,
     getCircleCircleIntersection = geometryCircles.getCircleCircleIntersection,
     getCenterOfPoints = geometry.getCenterOfPoints,
     getDistanceBetweenPoints = geometry.getDistanceBetweenPoints,
@@ -299,7 +301,16 @@ var getLabelPosition = function getLabelPosition(internal, external) {
     )) {
         // If point was either outside one of the internal, or inside one of the
         // external, then it was invalid and should use a fallback.
-        best = getCenterOfPoints(internal);
+        if (internal.length > 1) {
+            best = getCenterOfPoints(
+                getCirclesIntersectionPolygon(internal)
+            );
+        } else {
+            best = {
+                x: internal[0].x,
+                y: internal[0].y
+            };
+        }
     }
 
     // Return the best point.

--- a/samples/unit-tests/series-venn/members/demo.js
+++ b/samples/unit-tests/series-venn/members/demo.js
@@ -79,85 +79,6 @@ QUnit.test('addOverlapToRelations', function (assert) {
     );
 });
 
-QUnit.test('getAreaOfCircle', assert => {
-    const { prototype: vennPrototype } = Highcharts.seriesTypes.venn;
-    const { getAreaOfCircle } = vennPrototype.utils.geometryCircles;
-
-    assert.strictEqual(
-        getAreaOfCircle(1),
-        3.141592653589793,
-        'should have area equal 3.141592653589793 when r = 1.'
-    );
-
-    assert.strictEqual(
-        getAreaOfCircle(3),
-        Math.PI * 3 * 3,
-        'should have area equal 28.274333882308138 when r = 3.'
-    );
-
-    assert.throws(
-        () => getAreaOfCircle(0),
-        new Error('radius of circle must be a positive number.'),
-        'should throw an error when r is zero.'
-    );
-
-    assert.throws(
-        () => getAreaOfCircle(-1),
-        new Error('radius of circle must be a positive number.'),
-        'should throw an error when r is negative.'
-    );
-});
-
-QUnit.test('getAreaOfIntersectionBetweenCircles', function (assert) {
-    var vennPrototype = Highcharts.seriesTypes.venn.prototype,
-        getAreaOfIntersectionBetweenCircles =
-            vennPrototype.utils.geometryCircles
-                .getAreaOfIntersectionBetweenCircles;
-
-    assert.deepEqual(
-        getAreaOfIntersectionBetweenCircles([
-            { x: 0, y: 0, r: 3 },
-            { x: 5, y: 0, r: 3 }
-        ]).d,
-        [
-            ['M', 2.5, 1.6583123951777],
-            ['A', 3, 3, 0, 0, 1, 2.5, -1.6583123951777],
-            ['A', 3, 3, 0, 0, 1, 2.5, 1.6583123951777]
-        ],
-        'should return a path representing the area of overlap between the two circles.'
-    );
-
-    assert.deepEqual(
-        getAreaOfIntersectionBetweenCircles([
-            { x: 5.75, y: 0, r: 2.763953195770684 },
-            { x: 3.24, y: 0, r: 1.9544100476116797 }
-        ]).d,
-        [
-            ['M', 3.73409987366425, 1.89092145501881],
-            ['A', 2.763953195770684, 2.763953195770684, 0, 0, 1, 3.73409987366425, -1.89092145501881],
-            ['A', 1.9544100476116797, 1.9544100476116797, 0, 0, 1, 3.73409987366425, 1.89092145501881]
-        ],
-        'should return a path representing the area of overlap between the two circles.'
-    );
-});
-
-QUnit.test('getCenterOfPoints', function (assert) {
-    var vennPrototype = Highcharts.seriesTypes.venn.prototype,
-        getCenterOfPoints =
-            vennPrototype.utils.geometry.getCenterOfPoints;
-
-    assert.deepEqual(
-        getCenterOfPoints([
-            { x: -2, y: 1 },
-            { x: -2, y: 3 },
-            { x: 0, y: 3 },
-            { x: 0, y: 1 }
-        ]),
-        { x: -1, y: 2 },
-        'should return center (-1, 2) when points are [(-2, 1), (-2, 3), (0, 3), (0, 1).'
-    );
-});
-
 QUnit.test('getLabelWidth', assert => {
     const { getLabelWidth } = Highcharts.seriesTypes.venn.prototype.utils;
 
@@ -198,41 +119,6 @@ QUnit.test('getLabelWidth', assert => {
     );
 });
 
-QUnit.test('getOverlapBetweenCircles', assert => {
-    var { prototype: vennPrototype } = Highcharts.seriesTypes.venn,
-        { getOverlapBetweenCircles } = vennPrototype.utils.geometryCircles;
-
-    assert.strictEqual(
-        getOverlapBetweenCircles(3, 4, 5),
-        6.64167470270706,
-        'should return 6.64167470270706 when r1=3, r2=4 and d=5.'
-    );
-
-    assert.strictEqual(
-        getOverlapBetweenCircles(8, 6, 1),
-        113.09733552923257,
-        'should return 113.09733552923257 when r1=8, r2=6 and d=1. The circles completely overlaps.'
-    );
-
-    assert.strictEqual(
-        getOverlapBetweenCircles(2.5231325220201604, 3.0901936161855166, 0.7011044346618891),
-        19.68884261304518,
-        'should return 19.68884261304518 when r1=2.5231325220201604, r2=3.0901936161855166 and d=0.7011044346618891.'
-    );
-
-    assert.strictEqual(
-        getOverlapBetweenCircles(2, 3, 6),
-        0,
-        'should return 0 when r1=2, r2=3 and d=6. The circles does not overlap.'
-    );
-
-    assert.strictEqual(
-        getOverlapBetweenCircles(1.9544100476116797, 1.9544100476116797, 0),
-        12,
-        'should return the area of one of the circles when they have equal position and radius.'
-    );
-});
-
 QUnit.test('getDistanceBetweenCirclesByOverlap', assert => {
     var { prototype: vennPrototype } = Highcharts.seriesTypes.venn,
         { getDistanceBetweenCirclesByOverlap } = vennPrototype.utils;
@@ -262,127 +148,6 @@ QUnit.test('getDistanceBetweenCirclesByOverlap', assert => {
         getDistanceBetweenCirclesByOverlap(3, 4, 30),
         0,
         'should return a distance of 0 when r1=3, r2=4, and overlap=30. Complete overlap.'
-    );
-});
-
-QUnit.test('getDistanceBetweenPoints', function (assert) {
-    var vennPrototype = Highcharts.seriesTypes.venn.prototype,
-        getDistanceBetweenPoints = vennPrototype.utils.geometry
-            .getDistanceBetweenPoints;
-
-    assert.strictEqual(
-        getDistanceBetweenPoints({ x: 0, y: 0 }, { x: 2, y: 0 }),
-        2,
-        'should return 2 when points have the coordinates (0,0) and (2, 0).'
-    );
-
-    assert.strictEqual(
-        getDistanceBetweenPoints({ x: -1, y: 1 }, { x: 3, y: 4 }),
-        5,
-        'should return 2 when points have the coordinates (-1,1) and (3, 4).'
-    );
-});
-
-QUnit.test('getCircleCircleIntersection', function (assert) {
-    var vennPrototype = Highcharts.seriesTypes.venn.prototype,
-        getCircleCircleIntersection =
-            vennPrototype.utils.geometryCircles.getCircleCircleIntersection;
-    var a = { x: 0, y: 0, r: 3 };
-    var b = { x: 1, y: 0, r: 1 };
-    var c = { x: 5, y: 0, r: 3 };
-
-    assert.deepEqual(
-        getCircleCircleIntersection(b, c),
-        [],
-        'should return empty array if no overlap.'
-    );
-
-    assert.deepEqual(
-        getCircleCircleIntersection(a, b),
-        [],
-        'should return empty array if circles completely overlap.'
-    );
-
-    assert.deepEqual(
-        getCircleCircleIntersection(a, c),
-        [{ x: 2.5, y: 1.6583123951777 }, { x: 2.5, y: -1.6583123951777 }],
-        'should return (2.5, 1.6583123951777) and (2.5, -1.6583123951777) when c1(0, 0, 3) and c2(5, 0, 3).'
-    );
-});
-
-QUnit.test('getCirclesIntersectionPoints', function (assert) {
-    var vennPrototype = Highcharts.seriesTypes.venn.prototype,
-        getCirclesIntersectionPoints =
-            vennPrototype.utils.geometryCircles.getCirclesIntersectionPoints,
-        circles = [
-            { x: 0, y: 0, r: 3 },
-            { x: 5, y: 0, r: 3 },
-            { x: -3, y: 3, r: 3 }
-        ];
-
-    assert.deepEqual(
-        getCirclesIntersectionPoints(circles),
-        [
-            { x: 2.5, y: 1.6583123951777, indexes: [0, 1] },
-            { x: 2.5, y: -1.6583123951777, indexes: [0, 1] },
-            { x: -3, y: 0, indexes: [0, 2] },
-            { x: 0, y: 3, indexes: [0, 2] }
-        ],
-        'should return a list of all the intersection points between the circles.'
-    );
-});
-
-QUnit.test('getCircularSegmentArea', assert => {
-    var { prototype: vennPrototype } = Highcharts.seriesTypes.venn,
-        { getCircularSegmentArea } = vennPrototype.utils.geometryCircles;
-
-    assert.strictEqual(
-        getCircularSegmentArea(1, 1),
-        Math.PI / 2,
-        'should return PI/2 when r=1 and h=1 and circle area is equal to PI.'
-    );
-
-    assert.strictEqual(
-        getCircularSegmentArea(1, 2),
-        Math.PI,
-        'should return PI when r=1 and h=2 and circle area is equal to PI.'
-    );
-});
-
-QUnit.test('isPointInsideCircle', function (assert) {
-    var vennPrototype = Highcharts.seriesTypes.venn.prototype,
-        isPointInsideCircle =
-            vennPrototype.utils.geometryCircles.isPointInsideCircle;
-
-    assert.strictEqual(
-        isPointInsideCircle({ x: 1, y: 1 }, { x: 0, y: 0, r: 3 }),
-        true,
-        'should return true for P(1, 1) and C(0, 0, 3).'
-    );
-
-    assert.strictEqual(
-        isPointInsideCircle({ x: 4, y: 1 }, { x: 0, y: 0, r: 3 }),
-        false,
-        'should return true for P(4, 1) and C(0, 0, 3).'
-    );
-});
-
-QUnit.test('isPointInsideAllCircles', function (assert) {
-    var vennPrototype = Highcharts.seriesTypes.venn.prototype,
-        isPointInsideAllCircles =
-            vennPrototype.utils.geometryCircles.isPointInsideAllCircles,
-        circles = [{ x: 0, y: 0, r: 3 }, { x: 4, y: 0, r: 3 }];
-
-    assert.strictEqual(
-        isPointInsideAllCircles({ x: 2, y: 0 }, circles),
-        true,
-        'should return true for P(2, 0) and [(0, 0, 3), (4, 0, 3)].'
-    );
-
-    assert.strictEqual(
-        isPointInsideAllCircles({ x: -1, y: 0 }, circles),
-        false,
-        'should return true for P(-1, 0) and [(0, 0, 3), (4, 0, 3)].'
     );
 });
 
@@ -745,8 +510,146 @@ QUnit.module('nelder-mead', () => {
     });
 });
 
+QUnit.module('geometry', () => {
+    const { geometry } = Highcharts.seriesTypes.venn.prototype.utils;
+
+    QUnit.test('getCenterOfPoints', function (assert) {
+        const { getCenterOfPoints } = geometry;
+
+        assert.deepEqual(
+            getCenterOfPoints([
+                { x: -2, y: 1 },
+                { x: -2, y: 3 },
+                { x: 0, y: 3 },
+                { x: 0, y: 1 }
+            ]),
+            { x: -1, y: 2 },
+            'should return center (-1, 2) when points are [(-2, 1), (-2, 3), (0, 3), (0, 1).'
+        );
+    });
+
+    QUnit.test('getDistanceBetweenPoints', function (assert) {
+        const { getDistanceBetweenPoints } = geometry;
+
+        assert.strictEqual(
+            getDistanceBetweenPoints({ x: 0, y: 0 }, { x: 2, y: 0 }),
+            2,
+            'should return 2 when points have the coordinates (0,0) and (2, 0).'
+        );
+
+        assert.strictEqual(
+            getDistanceBetweenPoints({ x: -1, y: 1 }, { x: 3, y: 4 }),
+            5,
+            'should return 2 when points have the coordinates (-1,1) and (3, 4).'
+        );
+    });
+});
+
 QUnit.module('geometry-circles', () => {
     const { geometryCircles } = Highcharts.seriesTypes.venn.prototype.utils;
+
+    QUnit.test('getAreaOfCircle', assert => {
+        const { getAreaOfCircle } = geometryCircles;
+
+        assert.strictEqual(
+            getAreaOfCircle(1),
+            3.141592653589793,
+            'should have area equal 3.141592653589793 when r = 1.'
+        );
+
+        assert.strictEqual(
+            getAreaOfCircle(3),
+            Math.PI * 3 * 3,
+            'should have area equal 28.274333882308138 when r = 3.'
+        );
+
+        assert.throws(
+            () => getAreaOfCircle(0),
+            new Error('radius of circle must be a positive number.'),
+            'should throw an error when r is zero.'
+        );
+
+        assert.throws(
+            () => getAreaOfCircle(-1),
+            new Error('radius of circle must be a positive number.'),
+            'should throw an error when r is negative.'
+        );
+    });
+    QUnit.test('getAreaOfIntersectionBetweenCircles', function (assert) {
+        const { getAreaOfIntersectionBetweenCircles } = geometryCircles;
+
+        assert.deepEqual(
+            getAreaOfIntersectionBetweenCircles([
+                { x: 0, y: 0, r: 3 },
+                { x: 5, y: 0, r: 3 }
+            ]).d,
+            [
+                ['M', 2.5, 1.6583123951777],
+                ['A', 3, 3, 0, 0, 1, 2.5, -1.6583123951777],
+                ['A', 3, 3, 0, 0, 1, 2.5, 1.6583123951777]
+            ],
+            'should return a path representing the area of overlap between the two circles.'
+        );
+
+        assert.deepEqual(
+            getAreaOfIntersectionBetweenCircles([
+                { x: 5.75, y: 0, r: 2.763953195770684 },
+                { x: 3.24, y: 0, r: 1.9544100476116797 }
+            ]).d,
+            [
+                ['M', 3.73409987366425, 1.89092145501881],
+                ['A', 2.763953195770684, 2.763953195770684, 0, 0, 1, 3.73409987366425, -1.89092145501881],
+                ['A', 1.9544100476116797, 1.9544100476116797, 0, 0, 1, 3.73409987366425, 1.89092145501881]
+            ],
+            'should return a path representing the area of overlap between the two circles.'
+        );
+    });
+
+    QUnit.test('getCircleCircleIntersection', function (assert) {
+        const { getCircleCircleIntersection } = geometryCircles;
+        const a = { x: 0, y: 0, r: 3 };
+        const b = { x: 1, y: 0, r: 1 };
+        const c = { x: 5, y: 0, r: 3 };
+
+        assert.deepEqual(
+            getCircleCircleIntersection(b, c),
+            [],
+            'should return empty array if no overlap.'
+        );
+
+        assert.deepEqual(
+            getCircleCircleIntersection(a, b),
+            [],
+            'should return empty array if circles completely overlap.'
+        );
+
+        assert.deepEqual(
+            getCircleCircleIntersection(a, c),
+            [{ x: 2.5, y: 1.6583123951777 }, { x: 2.5, y: -1.6583123951777 }],
+            'should return (2.5, 1.6583123951777) and (2.5, -1.6583123951777) when c1(0, 0, 3) and c2(5, 0, 3).'
+        );
+    });
+
+    QUnit.test('getCirclesIntersectionPoints', function (assert) {
+        const { getCirclesIntersectionPoints } = geometryCircles;
+        const circles = [
+            { x: 0, y: 0, r: 3 },
+            { x: 5, y: 0, r: 3 },
+            { x: -3, y: 3, r: 3 }
+        ];
+
+        assert.deepEqual(
+            getCirclesIntersectionPoints(circles),
+            [
+                { x: 2.5, y: 1.6583123951777, indexes: [0, 1] },
+                { x: 2.5, y: -1.6583123951777, indexes: [0, 1] },
+                { x: -3, y: 0, indexes: [0, 2] },
+                { x: 0, y: 3, indexes: [0, 2] }
+            ],
+            'should return a list of all the intersection points between the circles.'
+        );
+    });
+
     QUnit.test('getCirclesIntersectionPolygon', assert => {
         const { getCirclesIntersectionPolygon } = geometryCircles;
 
@@ -773,6 +676,89 @@ QUnit.module('geometry-circles', () => {
                 { indexes: [1, 2], x: 1.64575131106459, y: -1.64575131106459 }
             ],
             'Should have an intersection polygon consisting of 3 points when 3 circles are overlapping'
+        );
+    });
+
+    QUnit.test('getCircularSegmentArea', assert => {
+        const { getCircularSegmentArea } = geometryCircles;
+
+        assert.strictEqual(
+            getCircularSegmentArea(1, 1),
+            Math.PI / 2,
+            'should return PI/2 when r=1 and h=1 and circle area is equal to PI.'
+        );
+
+        assert.strictEqual(
+            getCircularSegmentArea(1, 2),
+            Math.PI,
+            'should return PI when r=1 and h=2 and circle area is equal to PI.'
+        );
+    });
+
+    QUnit.test('getOverlapBetweenCircles', assert => {
+        const { getOverlapBetweenCircles } = geometryCircles;
+
+        assert.strictEqual(
+            getOverlapBetweenCircles(3, 4, 5),
+            6.64167470270706,
+            'should return 6.64167470270706 when r1=3, r2=4 and d=5.'
+        );
+
+        assert.strictEqual(
+            getOverlapBetweenCircles(8, 6, 1),
+            113.09733552923257,
+            'should return 113.09733552923257 when r1=8, r2=6 and d=1. The circles completely overlaps.'
+        );
+
+        assert.strictEqual(
+            getOverlapBetweenCircles(2.5231325220201604, 3.0901936161855166, 0.7011044346618891),
+            19.68884261304518,
+            'should return 19.68884261304518 when r1=2.5231325220201604, r2=3.0901936161855166 and d=0.7011044346618891.'
+        );
+
+        assert.strictEqual(
+            getOverlapBetweenCircles(2, 3, 6),
+            0,
+            'should return 0 when r1=2, r2=3 and d=6. The circles does not overlap.'
+        );
+
+        assert.strictEqual(
+            getOverlapBetweenCircles(1.9544100476116797, 1.9544100476116797, 0),
+            12,
+            'should return the area of one of the circles when they have equal position and radius.'
+        );
+    });
+
+    QUnit.test('isPointInsideAllCircles', function (assert) {
+        const { isPointInsideAllCircles } = geometryCircles;
+        const circles = [{ x: 0, y: 0, r: 3 }, { x: 4, y: 0, r: 3 }];
+
+        assert.strictEqual(
+            isPointInsideAllCircles({ x: 2, y: 0 }, circles),
+            true,
+            'should return true for P(2, 0) and [(0, 0, 3), (4, 0, 3)].'
+        );
+
+        assert.strictEqual(
+            isPointInsideAllCircles({ x: -1, y: 0 }, circles),
+            false,
+            'should return true for P(-1, 0) and [(0, 0, 3), (4, 0, 3)].'
+        );
+    });
+
+    QUnit.test('isPointInsideCircle', function (assert) {
+        const { isPointInsideCircle } = geometryCircles;
+
+        assert.strictEqual(
+            isPointInsideCircle({ x: 1, y: 1 }, { x: 0, y: 0, r: 3 }),
+            true,
+            'should return true for P(1, 1) and C(0, 0, 3).'
+        );
+
+        assert.strictEqual(
+            isPointInsideCircle({ x: 4, y: 1 }, { x: 0, y: 0, r: 3 }),
+            false,
+            'should return true for P(4, 1) and C(0, 0, 3).'
         );
     });
 });

--- a/samples/unit-tests/series-venn/members/demo.js
+++ b/samples/unit-tests/series-venn/members/demo.js
@@ -744,3 +744,35 @@ QUnit.module('nelder-mead', () => {
         );
     });
 });
+
+QUnit.module('geometry-circles', () => {
+    const { geometryCircles } = Highcharts.seriesTypes.venn.prototype.utils;
+    QUnit.test('getCirclesIntersectionPolygon', assert => {
+        const { getCirclesIntersectionPolygon } = geometryCircles;
+
+        const circlesNotOverlapping = [
+            { r: 1, x: -1, y: 0 },
+            { r: 1, x: 1, y: 0 }
+        ];
+        assert.deepEqual(
+            getCirclesIntersectionPolygon(circlesNotOverlapping),
+            [],
+            'Should not have an intersection polygon when there is no overlap'
+        );
+
+        const circlesOverlapping = [
+            { r: 4, x: 2, y: 0 },
+            { r: 4, x: -2, y: 0 },
+            { r: 4, x: 0, y: 2 }
+        ];
+        assert.deepEqual(
+            getCirclesIntersectionPolygon(circlesOverlapping),
+            [
+                { indexes: [0, 1], x: 0, y: 3.46410161513775 },
+                { indexes: [0, 2], x: -1.64575131106459, y: -1.64575131106459 },
+                { indexes: [1, 2], x: 1.64575131106459, y: -1.64575131106459 }
+            ],
+            'Should have an intersection polygon consisting of 3 points when 3 circles are overlapping'
+        );
+    });
+});

--- a/ts/mixins/geometry-circles.ts
+++ b/ts/mixins/geometry-circles.ts
@@ -54,10 +54,11 @@ declare global {
 }
 
 import geometry from './geometry.js';
-
-var getAngleBetweenPoints = geometry.getAngleBetweenPoints,
-    getCenterOfPoints = geometry.getCenterOfPoints,
-    getDistanceBetweenPoints = geometry.getDistanceBetweenPoints;
+const {
+    getAngleBetweenPoints,
+    getCenterOfPoints,
+    getDistanceBetweenPoints
+} = geometry;
 
 /**
  * @private
@@ -68,11 +69,11 @@ var getAngleBetweenPoints = geometry.getAngleBetweenPoints,
  * @return {number}
  *         Rounded number
  */
-var round = function round(x: number, decimals: number): number {
-    var a = Math.pow(10, decimals);
+function round(x: number, decimals: number): number {
+    const a = Math.pow(10, decimals);
 
     return Math.round(x * a) / a;
-};
+}
 
 /**
  * Calculates the area of a circle based on its radius.
@@ -82,12 +83,12 @@ var round = function round(x: number, decimals: number): number {
  * @return {number}
  *         Returns the area of the circle.
  */
-var getAreaOfCircle = function (r: number): number {
+function getAreaOfCircle(r: number): number {
     if (r <= 0) {
         throw new Error('radius of circle must be a positive number.');
     }
     return Math.PI * r * r;
-};
+}
 
 /**
  * Calculates the area of a circular segment based on the radius of the circle
@@ -101,10 +102,9 @@ var getAreaOfCircle = function (r: number): number {
  * @return {number}
  *         Returns the area of the circular segment.
  */
-var getCircularSegmentArea =
 function getCircularSegmentArea(r: number, h: number): number {
     return r * r * Math.acos(1 - h / r) - (r - h) * Math.sqrt(h * (2 * r - h));
-};
+}
 
 /**
  * Calculates the area of overlap between two circles based on their radiuses
@@ -120,9 +120,8 @@ function getCircularSegmentArea(r: number, h: number): number {
  * @return {number}
  *         Returns the area of overlap between the two circles.
  */
-var getOverlapBetweenCircles =
 function getOverlapBetweenCircles(r1: number, r2: number, d: number): number {
-    var overlap = 0;
+    let overlap = 0;
 
     // If the distance is larger than the sum of the radiuses then the circles
     // does not overlap.
@@ -133,7 +132,7 @@ function getOverlapBetweenCircles(r1: number, r2: number, d: number): number {
             overlap = getAreaOfCircle(r1 < r2 ? r1 : r2);
         } else {
             // Height of first triangle segment.
-            var d1 = (r1 * r1 - r2 * r2 + d * d) / (2 * d),
+            const d1 = (r1 * r1 - r2 * r2 + d * d) / (2 * d),
                 // Height of second triangle segment.
                 d2 = d - d1;
 
@@ -146,7 +145,7 @@ function getOverlapBetweenCircles(r1: number, r2: number, d: number): number {
         overlap = round(overlap, 14);
     }
     return overlap;
-};
+}
 
 /**
  * Calculates the intersection points of two circles.
@@ -160,20 +159,19 @@ function getOverlapBetweenCircles(r1: number, r2: number, d: number): number {
  * @return {Array<Highcharts.PositionObject>}
  *         Returns the resulting intersection points.
  */
-var getCircleCircleIntersection =
 function getCircleCircleIntersection(
     c1: Highcharts.CircleObject,
     c2: Highcharts.CircleObject
 ): Array<Highcharts.PositionObject> {
-    var d = getDistanceBetweenPoints(c1, c2),
+    const d = getDistanceBetweenPoints(c1, c2),
         r1 = c1.r,
-        r2 = c2.r,
-        points = [] as Array<Highcharts.PositionObject>;
+        r2 = c2.r;
+    let points = [] as Array<Highcharts.PositionObject>;
 
     if (d < r1 + r2 && d > Math.abs(r1 - r2)) {
         // If the circles are overlapping, but not completely overlapping, then
         // it exists intersecting points.
-        var r1Square = r1 * r1,
+        const r1Square = r1 * r1,
             r2Square = r2 * r2,
             // d^2 - r^2 + R^2 / 2d
             x = (r1Square - r2Square + d * d) / (2 * d),
@@ -194,7 +192,7 @@ function getCircleCircleIntersection(
         ];
     }
     return points;
-};
+}
 
 /**
  * Calculates all the intersection points for between a list of circles.
@@ -204,8 +202,7 @@ function getCircleCircleIntersection(
  * @return {Array<Highcharts.GeometryObject>}
  *         Returns a list of intersection points.
  */
-var getCirclesIntersectionPoints =
-function getIntersectionPoints(
+function getCirclesIntersectionPoints(
     circles: Array<Highcharts.CircleObject>
 ): Array<Highcharts.GeometryObject> {
     return circles.reduce(function (
@@ -214,13 +211,13 @@ function getIntersectionPoints(
         i: number,
         arr: Array<Highcharts.CircleObject>
     ): Array<Highcharts.GeometryObject> {
-        var additional = arr.slice(i + 1)
+        const additional = arr.slice(i + 1)
             .reduce(function (
                 points: Array<Highcharts.GeometryObject>,
                 c2: Highcharts.CircleObject,
                 j: number
             ): Array<Highcharts.GeometryObject> {
-                var indexes: [number, number] = [i, j + i + 1];
+                const indexes: [number, number] = [i, j + i + 1];
 
                 return points.concat(
                     getCircleCircleIntersection(c1, c2)
@@ -235,7 +232,7 @@ function getIntersectionPoints(
 
         return points.concat(additional);
     }, []);
-};
+}
 
 /**
  * Tests wether a point lies within a given circle.
@@ -247,12 +244,12 @@ function getIntersectionPoints(
  * @return {boolean}
  *         Returns true if the point is inside, false if outside.
  */
-var isPointInsideCircle = function isPointInsideCircle(
+function isPointInsideCircle(
     point: Highcharts.PositionObject,
     circle: Highcharts.CircleObject
 ): boolean {
     return getDistanceBetweenPoints(point, circle) <= circle.r + 1e-10;
-};
+}
 
 /**
  * Tests wether a point lies within a set of circles.
@@ -264,14 +261,14 @@ var isPointInsideCircle = function isPointInsideCircle(
  * @return {boolean}
  *         Returns true if the point is inside all the circles, false if not.
  */
-var isPointInsideAllCircles = function isPointInsideAllCircles(
+function isPointInsideAllCircles(
     point: Highcharts.PositionObject,
     circles: Array<Highcharts.CircleObject>
 ): boolean {
     return !circles.some(function (circle: Highcharts.CircleObject): boolean {
         return !isPointInsideCircle(point, circle);
     });
-};
+}
 
 /**
  * Tests wether a point lies outside a set of circles.
@@ -285,7 +282,6 @@ var isPointInsideAllCircles = function isPointInsideAllCircles(
  * @return {boolean}
  *         Returns true if the point is outside all the circles, false if not.
  */
-var isPointOutsideAllCircles =
 function isPointOutsideAllCircles(
     point: Highcharts.PositionObject,
     circles: Array<Highcharts.CircleObject>
@@ -293,7 +289,7 @@ function isPointOutsideAllCircles(
     return !circles.some(function (circle: Highcharts.CircleObject): boolean {
         return isPointInsideCircle(point, circle);
     });
-};
+}
 
 /**
  * Calculate the path for the area of overlap between a set of circles.
@@ -305,11 +301,10 @@ function isPointOutsideAllCircles(
  *         Returns the path for the area of overlap. Returns an empty string if
  *         there are no intersection between all the circles.
  */
-var getAreaOfIntersectionBetweenCircles =
 function getAreaOfIntersectionBetweenCircles(
     circles: Array<Highcharts.CircleObject>
 ): (Highcharts.GeometryIntersectionObject|undefined) {
-    var intersectionPoints = (
+    let intersectionPoints = (
             getCirclesIntersectionPoints(circles)
                 .filter(function (p: Highcharts.PositionObject): boolean {
                     return isPointInsideAllCircles(p, circles);
@@ -319,7 +314,7 @@ function getAreaOfIntersectionBetweenCircles(
 
     if (intersectionPoints.length > 1) {
         // Calculate the center of the intersection points.
-        var center = getCenterOfPoints(intersectionPoints);
+        const center = getCenterOfPoints(intersectionPoints);
 
         intersectionPoints = intersectionPoints
             // Calculate the angle between the center and the points.
@@ -337,18 +332,18 @@ function getAreaOfIntersectionBetweenCircles(
                 return (b.angle as any) - (a.angle as any);
             });
 
-        var startPoint = intersectionPoints[intersectionPoints.length - 1];
-        var arcs: Array<Highcharts.SVGPathArray> = intersectionPoints
+        const startPoint = intersectionPoints[intersectionPoints.length - 1];
+        const arcs: Array<Highcharts.SVGPathArray> = intersectionPoints
             .reduce(function (
                 data,
                 p1: Highcharts.GeometryObject
             ): any {
-                var startPoint = data.startPoint,
+                const { startPoint } = data,
                     midPoint = getCenterOfPoints([startPoint, p1]);
 
                 // Calculate the arc from the intersection points and their
                 // circles.
-                var arc = (p1.indexes as any)
+                const arc = (p1.indexes as any)
                     // Filter out circles that are not included in both
                     // intersection points.
                     .filter(function (index: number): boolean {
@@ -357,20 +352,20 @@ function getAreaOfIntersectionBetweenCircles(
                     // Iterate the circles of the intersection points and
                     // calculate arcs.
                     .reduce(function (arc: any, index: number): any {
-                        var circle = circles[index],
+                        const circle = circles[index],
                             angle1 = getAngleBetweenPoints(circle, p1),
                             angle2 = getAngleBetweenPoints(circle, startPoint),
                             angleDiff = angle2 - angle1 +
                                 (angle2 < angle1 ? 2 * Math.PI : 0),
-                            angle = angle2 - angleDiff / 2,
-                            width = getDistanceBetweenPoints(
-                                midPoint,
-                                {
-                                    x: circle.x + circle.r * Math.sin(angle),
-                                    y: circle.y + circle.r * Math.cos(angle)
-                                }
-                            ),
-                            r = circle.r;
+                            angle = angle2 - angleDiff / 2;
+                        let width = getDistanceBetweenPoints(
+                            midPoint,
+                            {
+                                x: circle.x + circle.r * Math.sin(angle),
+                                y: circle.y + circle.r * Math.cos(angle)
+                            }
+                        );
+                        const { r } = circle;
 
                         // Width can sometimes become to large due to floating
                         // point errors
@@ -380,9 +375,9 @@ function getAreaOfIntersectionBetweenCircles(
                         // Get the arc with the smallest width.
                         if (!arc || arc.width > width) {
                             arc = {
-                                r: r,
+                                r,
                                 largeArc: width > r ? 1 : 0,
-                                width: width,
+                                width,
                                 x: p1.x,
                                 y: p1.y
                             };
@@ -394,7 +389,7 @@ function getAreaOfIntersectionBetweenCircles(
 
                 // If we find an arc then add it to the list and update p2.
                 if (arc) {
-                    var r = arc.r;
+                    const { r } = arc;
 
                     data.arcs.push(
                         ['A', r, r, 0, arc.largeArc, 1, arc.x, arc.y]
@@ -414,26 +409,26 @@ function getAreaOfIntersectionBetweenCircles(
         } else {
             arcs.unshift(['M', startPoint.x, startPoint.y]);
             result = {
-                center: center,
+                center,
                 d: arcs
             };
         }
     }
 
     return result;
-};
+}
 
-var geometryCircles: Highcharts.GeometryCircleMixin = {
-    getAreaOfCircle: getAreaOfCircle,
-    getAreaOfIntersectionBetweenCircles: getAreaOfIntersectionBetweenCircles,
-    getCircleCircleIntersection: getCircleCircleIntersection,
-    getCirclesIntersectionPoints: getCirclesIntersectionPoints,
-    getCircularSegmentArea: getCircularSegmentArea,
-    getOverlapBetweenCircles: getOverlapBetweenCircles,
-    isPointInsideCircle: isPointInsideCircle,
-    isPointInsideAllCircles: isPointInsideAllCircles,
-    isPointOutsideAllCircles: isPointOutsideAllCircles,
-    round: round
+const geometryCircles: Highcharts.GeometryCircleMixin = {
+    getAreaOfCircle,
+    getAreaOfIntersectionBetweenCircles,
+    getCircleCircleIntersection,
+    getCirclesIntersectionPoints,
+    getCircularSegmentArea,
+    getOverlapBetweenCircles,
+    isPointInsideCircle,
+    isPointInsideAllCircles,
+    isPointOutsideAllCircles,
+    round
 };
 
 export default geometryCircles;

--- a/ts/mixins/geometry-circles.ts
+++ b/ts/mixins/geometry-circles.ts
@@ -25,6 +25,9 @@ declare global {
             getCirclesIntersectionPoints(
                 circles: Array<CircleObject>
             ): Array<PositionObject>;
+            getCirclesIntersectionPolygon(
+                circles: Array<CircleObject>
+            ): Array<GeometryObject>;
             getCircularSegmentArea(r: number, h: number): number;
             getOverlapBetweenCircles(r1: number, r2: number, d: number): number;
             isPointInsideAllCircles(
@@ -292,6 +295,25 @@ function isPointOutsideAllCircles(
 }
 
 /**
+ * Calculates the points for the polygon of the intersection area between a set
+ * of circles.
+ *
+ * @private
+ * @param {Array<Highcharts.CircleObject>} circles
+ *        List of circles to calculate polygon of.
+ * @return {Array<Highcharts.GeometryObject>} Return list of points in the
+ * intersection polygon.
+ */
+function getCirclesIntersectionPolygon(
+    circles: Array<Highcharts.CircleObject>
+): Array<Highcharts.GeometryObject> {
+    return getCirclesIntersectionPoints(circles)
+        .filter(function (p: Highcharts.PositionObject): boolean {
+            return isPointInsideAllCircles(p, circles);
+        });
+}
+
+/**
  * Calculate the path for the area of overlap between a set of circles.
  * @todo handle cases with only 1 or 0 arcs.
  * @private
@@ -304,12 +326,7 @@ function isPointOutsideAllCircles(
 function getAreaOfIntersectionBetweenCircles(
     circles: Array<Highcharts.CircleObject>
 ): (Highcharts.GeometryIntersectionObject|undefined) {
-    let intersectionPoints = (
-            getCirclesIntersectionPoints(circles)
-                .filter(function (p: Highcharts.PositionObject): boolean {
-                    return isPointInsideAllCircles(p, circles);
-                })
-        ),
+    let intersectionPoints = getCirclesIntersectionPolygon(circles),
         result: (Highcharts.GeometryIntersectionObject|undefined);
 
     if (intersectionPoints.length > 1) {
@@ -423,6 +440,7 @@ const geometryCircles: Highcharts.GeometryCircleMixin = {
     getAreaOfIntersectionBetweenCircles,
     getCircleCircleIntersection,
     getCirclesIntersectionPoints,
+    getCirclesIntersectionPolygon,
     getCircularSegmentArea,
     getOverlapBetweenCircles,
     isPointInsideCircle,


### PR DESCRIPTION
Fixed #11753, invalid label placement broke venn diagrams in certain scenarios.

---
# Description
The fallback label position in `getLabelPosition` could sometimes be invalid and outside the intersection area of the circles. Modified the fallback to use the circles intersection polygon to be certain the position is inside all circles and valid.

I have made some refactoring that disturbs the diff, but the real changes can be viewed in the commit b201bc4.

# Example(s)
- [Demo of issue](https://jsfiddle.net/rua6x7k8/)
- [Demo of issue with fix applied](https://jsfiddle.net/jon_a_nygaard/kwsc3d9b/)

# Related issue(s)
- Closes #11753 