### PR TITLE
bugfix/11510-variwide-minimum-point-width

### DIFF
--- a/js/modules/variwide.src.js
+++ b/js/modules/variwide.src.js
@@ -179,7 +179,7 @@ seriesType('variwide', 'column'
                 }
 
                 point.shapeArgs.x = left;
-                point.shapeArgs.width = right - left;
+                point.shapeArgs.width = Math.max(right - left, 1);
 
                 // Crosshair position (#8083)
                 point.plotX = (left + right) / 2;

--- a/samples/unit-tests/series-variwide/variwide/demo.js
+++ b/samples/unit-tests/series-variwide/variwide/demo.js
@@ -95,6 +95,25 @@ QUnit.test('variwide', function (assert) {
         'Correct number of points after zoom and redraw (#9525)'
     );
 
+    chart.xAxis[0].setExtremes(0, 10000, true, false);
+
+    chart.update({
+        series: [{
+            data: [
+                [0, 2, 1],
+                [1, 1, 400]
+            ]
+        }],
+        xAxis: {
+            type: 'linear'
+        }
+    }, true, true, false);
+
+    assert.strictEqual(
+        chart.series[0].points[0].graphic.getBBox().width >= 1,
+        true,
+        'The width of the first point should not be less than 1px (#11510)'
+    );
 });
 
 QUnit.test('variwide null points', function (assert) {


### PR DESCRIPTION
Fixed #11510, points with a relatively very small `z` value were not displayed in a variwide chart.