### PR TITLE
enhancement/plot-lines-radialAxis-3

### DIFF
--- a/js/parts-more/RadialAxis.js
+++ b/js/parts-more/RadialAxis.js
@@ -320,16 +320,25 @@ radialAxisMixin = {
      * Find the path for plot lines perpendicular to the radial axis.
      */
     getPlotLinePath: function (options) {
-        var axis = this, center = axis.center, chart = axis.chart, value = options.value, reverse = options.reverse, end = axis.getPosition(value), xAxis, xy, tickPositions, ret;
+        var axis = this, center = axis.center, chart = axis.chart, value = options.value, reverse = options.reverse, end = axis.getPosition(value), background = axis.pane.options.background ?
+            (axis.pane.options.background[0] ||
+                axis.pane.options.background) :
+            {}, innerRadius = background.innerRadius || '0%', outerRadius = background.outerRadius || '100%', x1 = center[0] + chart.plotLeft, y1 = center[1] + chart.plotTop, x2 = end.x, y2 = end.y, a, b, xAxis, xy, tickPositions, ret;
         // Spokes
         if (axis.isCircular) {
+            a = (typeof innerRadius === 'string') ?
+                H.relativeLength(innerRadius, 1) : (innerRadius /
+                Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2)));
+            b = (typeof outerRadius === 'string') ?
+                H.relativeLength(outerRadius, 1) : (outerRadius /
+                Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2)));
             ret = [
                 'M',
-                center[0] + chart.plotLeft,
-                center[1] + chart.plotTop,
+                x1 + a * (x2 - x1),
+                y1 - a * (y1 - y2),
                 'L',
-                end.x,
-                end.y
+                x2 - (1 - b) * (x2 - x1),
+                y2 + (1 - b) * (y1 - y2)
             ];
             // Concentric circles
         }

--- a/js/parts/PlotLineOrBand.js
+++ b/js/parts/PlotLineOrBand.js
@@ -829,6 +829,10 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      * An array of objects representing plot lines on the X axis
      *
      * @type      {Array<*>}
+     * @sample {highcharts} highcharts/xaxis/plotlines-color/
+     *      Basic plot line
+     * @sample {highcharts} highcharts/series-solidgauge/labels-auto-aligned/
+     *      Solid gauge plot line
      * @extends   xAxis.plotLines
      * @apioption yAxis.plotLines
      */

--- a/samples/highcharts/series-solidgauge/labels-auto-aligned/demo.js
+++ b/samples/highcharts/series-solidgauge/labels-auto-aligned/demo.js
@@ -27,7 +27,13 @@ Highcharts.chart('container', {
             style: {
                 fontSize: "20px"
             }
-        }
+        },
+        plotLines: [{
+            value: 35,
+            zIndex: 5,
+            width: 2,
+            color: '#ff0000'
+        }]
     },
     series: [{
         innerRadius: '50%',

--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.html
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.html
@@ -1,5 +1,6 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
-
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+<script src="https://code.highcharts.com/modules/solid-gauge.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
@@ -93,6 +93,82 @@ QUnit.test('General tests', function (assert) {
         'z',
         'Border should be rendered around the shape (#5909)'
     );
+
+    // Radial Axes plot lines
+    var plotLineValue = 27,
+        innerRadiusPx = 50,
+        axis, plotLine, bBox, center, end, start, plotLineLength;
+
+    chart = Highcharts.chart('container', {
+        chart: {
+            type: 'solidgauge'
+        },
+        title: null,
+        pane: {
+            center: ['50%', '50%'],
+            size: '100%',
+            startAngle: -90,
+            endAngle: 90,
+            background: {
+                innerRadius: '43%',
+                outerRadius: '100%',
+                shape: 'arc'
+            }
+        },
+        yAxis: {
+            min: 0,
+            max: 200,
+            lineWidth: 0,
+            minorTickInterval: null,
+            plotLines: [{
+                color: '#268FDD',
+                width: 2,
+                value: plotLineValue,
+                zIndex: 5
+            }]
+        },
+        series: [{
+            innerRadius: '43%',
+            data: [80]
+        }]
+    });
+
+    axis = chart.yAxis[0];
+    plotLine = axis.plotLinesAndBands[0];
+    bBox = plotLine.svgElem.getBBox();
+    center = chart.pane[0].center;
+    end = axis.getPosition(plotLineValue);
+    start = {
+        x: center[0] + chart.plotLeft,
+        y: center[1] + chart.plotTop
+    };
+    plotLineLength =
+        Math.sqrt(Math.pow(bBox.width, 2) + Math.pow(bBox.height, 2));
+
+    assert.equal(
+        (0.57 * Math.sqrt(Math.pow(end.x - start.x, 2) + Math.pow(end.y - start.y, 2))).toFixed(3),
+        plotLineLength.toFixed(3),
+        'RadialAxis plotLine should be plotted from inner to outer radius (percentage radius).'
+    );
+
+    chart.update({
+        pane: {
+            background: {
+                innerRadius: innerRadiusPx
+            }
+        }
+    });
+
+    plotLine = chart.yAxis[0].plotLinesAndBands[0];
+    bBox = plotLine.svgElem.getBBox();
+    plotLineLength =
+            Math.sqrt(Math.pow(bBox.width, 2) + Math.pow(bBox.height, 2));
+
+    assert.equal(
+        (Math.sqrt(Math.pow(end.x - start.x, 2) + Math.pow(end.y - start.y, 2)) - innerRadiusPx).toFixed(3),
+        plotLineLength.toFixed(3),
+        'RadialAxis plotLine should be plotted from inner to outer radius (pixel radius).'
+    );
 });
 
 QUnit.test('#6433 - axis.update leaves empty plotbands\' groups', function (assert) {

--- a/ts/parts-more/RadialAxis.ts
+++ b/ts/parts-more/RadialAxis.ts
@@ -590,6 +590,18 @@ radialAxisMixin = {
             value = options.value,
             reverse = options.reverse,
             end = axis.getPosition(value as any),
+            background = axis.pane.options.background ?
+                (axis.pane.options.background[0] ||
+                    axis.pane.options.background) :
+                {},
+            innerRadius = background.innerRadius || '0%',
+            outerRadius = background.outerRadius || '100%',
+            x1 = center[0] + chart.plotLeft,
+            y1 = center[1] + chart.plotTop,
+            x2 = end.x,
+            y2 = end.y,
+            a,
+            b,
             xAxis: (Highcharts.RadialAxis|undefined),
             xy,
             tickPositions,
@@ -597,13 +609,25 @@ radialAxisMixin = {
 
         // Spokes
         if (axis.isCircular) {
+            a = (typeof innerRadius === 'string') ?
+                H.relativeLength(innerRadius, 1) : (
+                    innerRadius /
+                    Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2))
+                );
+
+            b = (typeof outerRadius === 'string') ?
+                H.relativeLength(outerRadius, 1) : (
+                    outerRadius /
+                    Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2))
+                );
+
             ret = [
                 'M',
-                center[0] + chart.plotLeft,
-                center[1] + chart.plotTop,
+                x1 + a * (x2 - x1),
+                y1 - a * (y1 - y2),
                 'L',
-                end.x,
-                end.y
+                x2 - (1 - b) * (x2 - x1),
+                y2 + (1 - b) * (y1 - y2)
             ];
 
         // Concentric circles

--- a/ts/parts/PlotLineOrBand.ts
+++ b/ts/parts/PlotLineOrBand.ts
@@ -1111,6 +1111,10 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      * An array of objects representing plot lines on the X axis
      *
      * @type      {Array<*>}
+     * @sample {highcharts} highcharts/xaxis/plotlines-color/
+     *      Basic plot line
+     * @sample {highcharts} highcharts/series-solidgauge/labels-auto-aligned/
+     *      Solid gauge plot line
      * @extends   xAxis.plotLines
      * @apioption yAxis.plotLines
      */


### PR DESCRIPTION
Added feature to draw plot lines on radial axes from the inner to the outer radius of the main pane.
___

- Added a new PR because of the circleCi test which failed unexpectedly, see: https://github.com/highcharts/highcharts/pull/10906.

- Added a new PR because some of the changed files have been already exported to TypeScript, see: https://github.com/highcharts/highcharts/pull/11322