### PR TITLE
bugfix/scrollable-area-settitle

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -828,6 +828,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             this.titleOffset.join(',') !== titleOffset.join(','));
         // Used in getMargins
         this.titleOffset = titleOffset;
+        fireEvent(this, 'afterLayOutTitles');
         if (!this.isDirtyBox && requiresDirtyBox) {
             this.isDirtyBox = this.isDirtyLegend = requiresDirtyBox;
             // Redraw if necessary (#2719, #2744)

--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -777,6 +777,8 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      * @param {boolean} [redraw=true]
      *
      * @return {void}
+     *
+     * @fires Highcharts.Chart#event:afterLayOutTitles
      */
     layOutTitles: function (redraw) {
         var titleOffset = [0, 0, 0], requiresDirtyBox, renderer = this.renderer, spacingBox = this.spacingBox;

--- a/js/parts/ScrollablePlotArea.js
+++ b/js/parts/ScrollablePlotArea.js
@@ -260,6 +260,7 @@ Chart.prototype.applyFixed = function () {
             .add();
         this.moveFixedElements();
         addEvent(this, 'afterShowResetZoom', this.moveFixedElements);
+        addEvent(this, 'afterLayOutTitles', this.moveFixedElements);
     }
     else {
         // Set the size of the fixed renderer to the visible width

--- a/samples/unit-tests/scrollable-plotarea/dynamics/demo.details
+++ b/samples/unit-tests/scrollable-plotarea/dynamics/demo.details
@@ -1,0 +1,5 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+...

--- a/samples/unit-tests/scrollable-plotarea/dynamics/demo.html
+++ b/samples/unit-tests/scrollable-plotarea/dynamics/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/scrollable-plotarea/dynamics/demo.js
+++ b/samples/unit-tests/scrollable-plotarea/dynamics/demo.js
@@ -1,0 +1,20 @@
+QUnit.test('Test dynamic behaviour of Scrollable PlotArea', function (assert) {
+
+    var chart = new Highcharts.Chart({
+        chart: {
+            renderTo: 'container',
+            scrollablePlotArea: {
+                minWidth: 2000,
+                scrollPositionX: 1
+            }
+        }
+    });
+
+    chart.setTitle({ text: 'New title' });
+
+    assert.equal(
+        chart.title.element.parentNode.parentNode.classList.contains('highcharts-fixed'),
+        true,
+        'Title should be outside the scrollable plot area (#11966)'
+    );
+});

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -1205,6 +1205,8 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      * @param {boolean} [redraw=true]
      *
      * @return {void}
+     *
+     * @fires Highcharts.Chart#event:afterLayOutTitles
      */
     layOutTitles: function (
         this: Highcharts.Chart,

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -1288,6 +1288,8 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         // Used in getMargins
         this.titleOffset = titleOffset;
 
+        fireEvent(this, 'afterLayOutTitles');
+
         if (!this.isDirtyBox && requiresDirtyBox) {
             this.isDirtyBox = this.isDirtyLegend = requiresDirtyBox;
             // Redraw if necessary (#2719, #2744)

--- a/ts/parts/ScrollablePlotArea.ts
+++ b/ts/parts/ScrollablePlotArea.ts
@@ -374,6 +374,7 @@ Chart.prototype.applyFixed = function (this: Highcharts.Chart): void {
         this.moveFixedElements();
 
         addEvent(this, 'afterShowResetZoom', this.moveFixedElements);
+        addEvent(this, 'afterLayOutTitles', this.moveFixedElements);
 
     } else {
 


### PR DESCRIPTION
Fixed #11966, using `chart.setTitle()` on a chart with `scrollablePlotArea` misplaced the title.