### PR TITLE
bugfix/11955-inverted-chart-incorrect-point-positions

### DIFF
--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -4416,14 +4416,14 @@ null,
      * @return {number}
      */
     pointPlacementToXValue: function () {
-        var series = this, pointPlacement = series.options.pointPlacement;
+        var series = this, axis = series.xAxis, pointPlacement = series.options.pointPlacement;
         // Point placement is relative to each series pointRange (#5889)
         if (pointPlacement === 'between') {
-            pointPlacement = 0.5;
+            pointPlacement = axis.reversed ? -0.5 : 0.5; // #11955
         }
         if (isNumber(pointPlacement)) {
             pointPlacement *=
-                pick(series.options.pointRange || series.xAxis.pointRange);
+                pick(series.options.pointRange || axis.pointRange);
         }
         return pointPlacement;
     }

--- a/samples/unit-tests/axis/pointplacement/demo.js
+++ b/samples/unit-tests/axis/pointplacement/demo.js
@@ -26,4 +26,29 @@ QUnit.test('Axis pointPlacement', assert => {
         'No padded ticks'
     );
 
+    chart = Highcharts.chart('container', {
+        chart: {
+            inverted: true
+        },
+        series: [{
+            data: [1, 4, 3, 5],
+            type: 'column',
+            pointPlacement: 'between',
+            pointPadding: 0,
+            groupPadding: 0
+        }]
+    });
+
+    var isInsidePlot = true;
+
+    chart.series[0].points.forEach(p => {
+        if (isInsidePlot) {
+            isInsidePlot = chart.isInsidePlot(p.plotX, p.plotY, true);
+        }
+    });
+
+    assert.ok(
+        isInsidePlot,
+        'All points are between appropriate ticks when the chart is inverted.'
+    );
 });

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -6119,15 +6119,16 @@ H.Series = H.seriesType<Highcharts.LineSeries>(
         pointPlacementToXValue: function (this: Highcharts.Series): number {
 
             var series = this,
+                axis = series.xAxis,
                 pointPlacement = series.options.pointPlacement;
 
             // Point placement is relative to each series pointRange (#5889)
             if (pointPlacement === 'between') {
-                pointPlacement = 0.5;
+                pointPlacement = axis.reversed ? -0.5 : 0.5; // #11955
             }
             if (isNumber(pointPlacement)) {
                 (pointPlacement as any) *=
-                    pick(series.options.pointRange || series.xAxis.pointRange);
+                    pick(series.options.pointRange || axis.pointRange);
             }
 
             return pointPlacement as any;


### PR DESCRIPTION
Fixed #11955, incorrect point positions on inverted chart, when `series.pointPlacement` was set to `between`.