### PR TITLE
bugfix/11956-pointplacement-single-axis

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -3869,7 +3869,7 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
                 pointRangePadding = pointRangePadding * ordinalCorrection;
             // pointRange means the width reserved for each point, like in a
             // column chart
-            axis.pointRange = Math.min(pointRange, range);
+            axis.pointRange = Math.min(pointRange, axis.single && hasCategories ? 1 : range);
             // closestPointRange means the closest distance between points. In
             // columns it is mostly equal to pointRange, but in lines pointRange
             // is 0 while closestPointRange is some other value

--- a/samples/unit-tests/axis/members/demo.js
+++ b/samples/unit-tests/axis/members/demo.js
@@ -24,8 +24,8 @@ QUnit.test('setAxisTranslation', assert => {
     );
     assert.strictEqual(
         axis.pointRange,
-        0,
-        'should have pointRange equal 0 when min and max is 0.'
+        1,
+        'should have pointRange equal 1 when min and max is 0 but axis has categories'
     );
     assert.strictEqual(
         axis.minPixelPadding,

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -4948,7 +4948,10 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
 
             // pointRange means the width reserved for each point, like in a
             // column chart
-            axis.pointRange = Math.min(pointRange, range);
+            axis.pointRange = Math.min(
+                pointRange,
+                axis.single && hasCategories ? 1 : range
+            );
 
             // closestPointRange means the closest distance between points. In
             // columns it is mostly equal to pointRange, but in lines pointRange


### PR DESCRIPTION
Fixed #11956, `pointPlacement` did not work for columns with just one category.
___
I think it's safe (famous last words) to assume that singular categorized axis has range=1.