### PR TITLE
bugfix/11727-log-axis-precission

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -3948,8 +3948,8 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
             // The correctFloat cures #934, float errors on full tens. But it
             // was too aggressive for #4360 because of conversion back to lin,
             // therefore use precision 15.
-            axis.min = correctFloat(axis.log2lin(axis.min), 15);
-            axis.max = correctFloat(axis.log2lin(axis.max), 15);
+            axis.min = correctFloat(axis.log2lin(axis.min), 16);
+            axis.max = correctFloat(axis.log2lin(axis.max), 16);
         }
         // handle zoomed range
         if (axis.range && defined(axis.max)) {

--- a/samples/unit-tests/axis/extremes/demo.js
+++ b/samples/unit-tests/axis/extremes/demo.js
@@ -52,7 +52,7 @@ QUnit.test("Zooming too tight on left category should show full category (#4536)
     );
 });
 
-QUnit.test('Log axis extremes and precision', function (assert) {
+QUnit.test('Log axis extremes, issue #934', function (assert) {
     var chart = new Highcharts.Chart({
         chart: {
             renderTo: 'container',
@@ -81,35 +81,18 @@ QUnit.test('Log axis extremes and precision', function (assert) {
     assert.strictEqual(
         ext.min,
         1000,
-        'Min is 1000 (#934)'
+        'Min is 1000'
     );
 
     assert.strictEqual(
         ext.max,
         1000000000,
-        'Max is 1000000000 (#934)'
+        'Max is 1000000000'
     );
 
-    chart.update({
-        yAxis: {
-            min: null,
-            max: null
-        },
-        series: [{
-            data: [650]
-        }]
-    }, true, true);
-
-    assert.strictEqual(
-        chart.yAxis[0].ticks[chart.yAxis[0].tickPositions[0]].label.textStr,
-        '650',
-        'Single value logarithmic yAxis should show the same ' +
-        'tick label as the points value (#11727)'
-    );
 });
 
-
-QUnit.test('Log axis extremes, issue #4360', function (assert) {
+QUnit.test('Log axis extremes and precision', function (assert) {
     var chart = new Highcharts.Chart({
         chart: {
             renderTo: 'container',
@@ -141,7 +124,20 @@ QUnit.test('Log axis extremes, issue #4360', function (assert) {
     assert.strictEqual(
         chart.yAxis[0].ticks[chart.yAxis[0].tickPositions[0]].label.textStr,
         '30',
-        'Label is 30'
+        'Label should be exactly 30 (#4360)'
+    );
+
+    chart.update({
+        series: [{
+            data: [650]
+        }]
+    }, true, true);
+
+    assert.strictEqual(
+        chart.yAxis[0].ticks[chart.yAxis[0].tickPositions[0]].label.textStr,
+        '650',
+        'Single value logarithmic yAxis should show the same ' +
+        'tick label as the points value (#11727)'
     );
 });
 

--- a/samples/unit-tests/axis/extremes/demo.js
+++ b/samples/unit-tests/axis/extremes/demo.js
@@ -52,7 +52,7 @@ QUnit.test("Zooming too tight on left category should show full category (#4536)
     );
 });
 
-QUnit.test('Log axis extremes, issue #934', function (assert) {
+QUnit.test('Log axis extremes and precision', function (assert) {
     var chart = new Highcharts.Chart({
         chart: {
             renderTo: 'container',
@@ -67,11 +67,13 @@ QUnit.test('Log axis extremes, issue #934', function (assert) {
         series: [{
             data: [
                 10000,
-                8900]
+                8900
+            ]
         }, {
             data: [
                 8600,
-                7700]
+                7700
+            ]
         }]
     });
 
@@ -79,15 +81,31 @@ QUnit.test('Log axis extremes, issue #934', function (assert) {
     assert.strictEqual(
         ext.min,
         1000,
-        'Min is 1000'
+        'Min is 1000 (#934)'
     );
 
     assert.strictEqual(
         ext.max,
         1000000000,
-        'Max is 1000000000'
+        'Max is 1000000000 (#934)'
     );
 
+    chart.update({
+        yAxis: {
+            min: null,
+            max: null
+        },
+        series: [{
+            data: [650]
+        }]
+    }, true, true);
+
+    assert.strictEqual(
+        chart.yAxis[0].ticks[chart.yAxis[0].tickPositions[0]].label.textStr,
+        '650',
+        'Single value logarithmic yAxis should show the same ' +
+        'tick label as the points value (#11727)'
+    );
 });
 
 

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -5072,8 +5072,8 @@ H.extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */{
             // The correctFloat cures #934, float errors on full tens. But it
             // was too aggressive for #4360 because of conversion back to lin,
             // therefore use precision 15.
-            axis.min = correctFloat(axis.log2lin(axis.min as any), 15);
-            axis.max = correctFloat(axis.log2lin(axis.max as any), 15);
+            axis.min = correctFloat(axis.log2lin(axis.min as any), 16);
+            axis.max = correctFloat(axis.log2lin(axis.max as any), 16);
         }
 
         // handle zoomed range


### PR DESCRIPTION
Fixed #11727, logarithmic yAxis with just one label sometimes was rendered with numerical errors.
___
Just a small doubt: I'm not sure if this is a way to go (what if there are other values that will require value higher than browsers' supported precision?), I was simply inspired by other commit that resolved #4360