### PR TITLE
tools/10358-ie-localed-number

### DIFF
--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -182,6 +182,21 @@ var origAddEvent = Highcharts.addEvent;
 var addedEvents = [];
 
 if (window.QUnit) {
+    // Fix the number localization in IE
+    if (
+        /msie/.test(navigator.userAgent) &&
+        !Number.prototype._toString
+    ) {
+        Number.prototype._toString = Number.prototype.toString;
+        Number.prototype.toString = function(radix) {
+            if (radix) {
+                return Number.prototype._toString.apply(this, arguments);
+            } else {
+                return this.toLocaleString('en', { useGrouping: false, maximumFractionDigits: 20 });
+            }
+        }
+    }
+
     //QUnit.config.seed = 'vaolebrok';
     /*
      * Compare numbers taking in account an error.
@@ -193,6 +208,15 @@ if (window.QUnit) {
      * @param  {String} message  Optional
      */
     QUnit.assert.close = function (number, expected, error, message) {
+        // Remove fix of number localization in IE
+        if (
+            /msie/.test(navigator.userAgent) &&
+            Number.prototype._toString
+        ) {
+            Number.prototype.toString = Number.prototype._toString;
+            delete Number.prototype._toString;
+        }
+
         if (error === void 0 || error === null) {
             error = 0.00001; // default error
         }


### PR DESCRIPTION
Fixed #10358, localed number strings in IE @ BrowserStack.