### PR TITLE
ts/plot-options-reflections

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -210,9 +210,8 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             // in chart.options.plotOptions (#6218)
             objectEach(options.plotOptions, function (typeOptions, type) {
                 if (isObject(typeOptions)) { // #8766
-                    typeOptions.tooltip = (userPlotOptions[type] &&
-                        merge(userPlotOptions[type].tooltip) // override by copy
-                    ) || undefined; // or clear
+                    typeOptions.tooltip = (userPlotOptions[type] && // override by copy:
+                        merge(userPlotOptions[type].tooltip)) || undefined; // or clear
                 }
             });
             // User options have higher priority than default options

--- a/js/parts/DataGrouping.js
+++ b/js/parts/DataGrouping.js
@@ -585,8 +585,8 @@ addEvent(Series, 'afterSetOptions', function (e) {
             defaultOptions = merge(commonOptions, specificOptions[type]);
         }
         options.dataGrouping = merge(baseOptions, defaultOptions, plotOptions.series && plotOptions.series.dataGrouping, // #1228
-        plotOptions[type].dataGrouping, // Set by the StockChart constructor
-        this.userOptions.dataGrouping);
+        // Set by the StockChart constructor:
+        plotOptions[type].dataGrouping, this.userOptions.dataGrouping);
     }
 });
 // When resetting the scale reset the hasProccessed flag to avoid taking

--- a/ts/mixins/centered-series.ts
+++ b/ts/mixins/centered-series.ts
@@ -18,6 +18,9 @@ import H from '../parts/Globals.js';
  */
 declare global {
     namespace Highcharts {
+        interface CenteredSeries extends Series {
+            options: CenteredSeriesOptions;
+        }
         interface CenteredSeriesMixin {
             getCenter(this: Series): Array<number>;
             getStartAndEndRadians(
@@ -25,12 +28,15 @@ declare global {
                 end?: number
             ): RadianAngles;
         }
+        interface CenteredSeriesOptions extends SeriesOptions {
+            center?: Array<(number|string|null)>;
+            innerSize?: (number|string);
+            size?: (number|string);
+            slicedOffset?: number;
+        }
         interface RadianAngles {
             end: number;
             start: number;
-        }
-        interface SeriesOptions {
-            slicedOffset?: number;
         }
         let CenteredSeriesMixin: CenteredSeriesMixin;
     }
@@ -73,7 +79,7 @@ H.CenteredSeriesMixin = {
      *
      * @return {Array<number>}
      */
-    getCenter: function (this: Highcharts.Series): Array<number> {
+    getCenter: function (this: Highcharts.CenteredSeries): Array<number> {
 
         var options = this.options,
             chart = this.chart,
@@ -81,20 +87,20 @@ H.CenteredSeriesMixin = {
             handleSlicingRoom,
             plotWidth = chart.plotWidth - 2 * slicingRoom,
             plotHeight = chart.plotHeight - 2 * slicingRoom,
-            centerOption = options.center,
-            positions = [
-                pick((centerOption as any)[0], '50%'),
-                pick((centerOption as any)[1], '50%'),
-                options.size || '100%',
+            centerOption: Array<(number|string|null)> = options.center as any,
+            positions: Array<number> = [
+                pick<number>(centerOption[0] as any, '50%' as any),
+                pick<number>(centerOption[1] as any, '50%' as any),
+                options.size || '100%' as any,
                 options.innerSize || 0
             ],
             smallestSize = Math.min(plotWidth, plotHeight),
-            i,
-            value;
+            i: number,
+            value: number;
 
         for (i = 0; i < 4; ++i) {
             value = positions[i];
-            handleSlicingRoom = i < 2 || (i === 2 && /%$/.test(value));
+            handleSlicingRoom = i < 2 || (i === 2 && /%$/.test(value as any));
 
             // i == 0: centerX, relative to width
             // i == 1: centerY, relative to height

--- a/ts/modules/broken-axis.src.ts
+++ b/ts/modules/broken-axis.src.ts
@@ -47,13 +47,13 @@ declare global {
             len: number;
             to: number;
         }
-        interface PlotSeriesOptions {
-            gapSize?: number;
-            gapUnit?: string;
-        }
         interface Series {
             /** @requires modules/broken-axis */
             drawBreaks(axis: Axis, keys: Array<string>): void;
+        }
+        interface SeriesOptions {
+            gapSize?: number;
+            gapUnit?: string;
         }
         interface XAxisBreaksOptions {
             inclusive?: boolean;

--- a/ts/modules/dependency-wheel.src.ts
+++ b/ts/modules/dependency-wheel.src.ts
@@ -24,6 +24,7 @@ declare global {
         interface DependencyWheelPointOptions extends SankeyPointOptions {
         }
         interface DependencyWheelSeriesOptions extends SankeySeriesOptions {
+            center?: Array<(number|string|null)>;
             startAngle?: number;
             states?: SeriesStatesOptionsObject<DependencyWheelSeries>;
         }

--- a/ts/modules/draggable-points.src.ts
+++ b/ts/modules/draggable-points.src.ts
@@ -149,9 +149,6 @@ declare global {
             target: Point;
             type: 'drop';
         }
-        interface PlotSeriesOptions {
-            dragDrop?: DragDropOptionsObject;
-        }
         interface PointOptionsObject {
             dragDrop?: DragDropOptionsObject;
         }
@@ -185,6 +182,9 @@ declare global {
         }
         interface SeriesDragDropPropsResizeSideFunction {
             (...args: Array<any>): string;
+        }
+        interface SeriesOptions {
+            dragDrop?: DragDropOptionsObject;
         }
     }
 }

--- a/ts/modules/funnel3d.src.ts
+++ b/ts/modules/funnel3d.src.ts
@@ -45,6 +45,7 @@ declare global {
             y?: number;
         }
         interface Funnel3dSeriesOptions extends ColumnSeriesOptions {
+            center?: Array<(number|string|null)>;
             data?: Array<(Funnel3dPointOptions|PointOptionsType)>;
             gradientForSides?: boolean;
             height?: (number|string);

--- a/ts/modules/networkgraph/networkgraph.src.ts
+++ b/ts/modules/networkgraph/networkgraph.src.ts
@@ -77,6 +77,7 @@ declare global {
         {
             dataLabels?: NetworkgraphDataLabelsOptionsObject;
             draggable?: boolean;
+            inactiveOtherPoints?: boolean;
             layoutAlgorithm?: NetworkgraphLayoutAlgorithmOptions;
             link?: SVGAttributes;
             marker?: NetworkgraphPointMarkerOptionsObject;

--- a/ts/modules/price-indicator.src.ts
+++ b/ts/modules/price-indicator.src.ts
@@ -13,17 +13,6 @@ import H from '../parts/Globals.js';
 
 declare global {
     namespace Highcharts {
-        interface Series {
-            lastPrice?: SVGElement;
-            lastVisiblePrice?: SVGElement;
-            crossLabel?: SVGElement;
-        }
-
-        interface PlotSeriesOptions {
-            lastPrice?: LastPriceOptions;
-            lastVisiblePrice?: LastVisiblePriceOptions;
-        }
-
         interface LastPriceOptions extends XAxisCrosshairOptions {
             enabled?: boolean;
         }
@@ -33,6 +22,15 @@ declare global {
         }
         interface LastVisiblePriceLabelOptions {
             enabled: true;
+        }
+        interface Series {
+            lastPrice?: SVGElement;
+            lastVisiblePrice?: SVGElement;
+            crossLabel?: SVGElement;
+        }
+        interface SeriesOptions {
+            lastPrice?: LastPriceOptions;
+            lastVisiblePrice?: LastVisiblePriceOptions;
         }
     }
 }

--- a/ts/modules/sankey.src.ts
+++ b/ts/modules/sankey.src.ts
@@ -146,6 +146,7 @@ declare global {
             curveFactor?: number;
             dataLabels?: SankeyDataLabelsOptionsObject;
             height?: number;
+            inactiveOtherPoints?: boolean;
             levels?: Array<SankeySeriesLevelsOptions>;
             linkOpacity?: number;
             mass?: undefined;

--- a/ts/modules/series-label.src.ts
+++ b/ts/modules/series-label.src.ts
@@ -34,9 +34,6 @@ declare global {
             right: number;
             top: number;
         }
-        interface PlotSeriesOptions {
-            label?: SeriesLabelOptionsObject;
-        }
         interface Point {
             chartCenterY?: number;
             chartX?: number;
@@ -65,6 +62,9 @@ declare global {
             minFontSize?: (number|null);
             onArea?: (boolean|null);
             style?: CSSObject;
+        }
+        interface SeriesOptions {
+            label?: SeriesLabelOptionsObject;
         }
     }
 }

--- a/ts/modules/sunburst.src.ts
+++ b/ts/modules/sunburst.src.ts
@@ -136,6 +136,7 @@ declare global {
             value?: number;
         }
         interface SunburstSeriesOptions extends TreemapSeriesOptions {
+            center?: Array<(number|string|null)>;
             dataLabels?: (
                 SunburstDataLabelsOptionsObject|
                 Array<SunburstDataLabelsOptionsObject>
@@ -145,6 +146,7 @@ declare global {
             levelSize?: SunburstSeriesLevelSizeOptions;
             mapIdToNode?: SunburstSeries['nodeMap'];
             rootId?: string;
+            slicedOffset?: number;
             startAngle?: number;
             states?: SeriesStatesOptionsObject<SunburstSeries>;
         }

--- a/ts/modules/timeline.src.ts
+++ b/ts/modules/timeline.src.ts
@@ -107,6 +107,7 @@ declare global {
         interface TimelineSeriesOptions extends LineSeriesOptions {
             data?: Array<TimelinePointOptions>;
             dataLabels?: TimelineDataLabelsOptionsObject;
+            ignoreHiddenPoint?: boolean;
             radius?: number;
             radiusPlus?: number;
             states?: SeriesStatesOptionsObject<TimelineSeries>;

--- a/ts/modules/treemap.src.ts
+++ b/ts/modules/treemap.src.ts
@@ -239,6 +239,7 @@ declare global {
             cropThreshold?: number;
             data?: Array<TreemapPointOptions>;
             drillUpButton?: TreemapSeriesUpButtonOptions;
+            ignoreHiddenPoint?: boolean;
             interactByLeaf?: boolean;
             layoutAlgorithm?: TreemapSeriesLayoutAlgorithmValue;
             layoutStartingDirection?: TreemapSeriesLayoutStartingDirectionValue;

--- a/ts/parts-3d/Column.ts
+++ b/ts/parts-3d/Column.ts
@@ -39,6 +39,7 @@ declare global {
             edgeColor?: ColorString;
             edgeWidth?: number;
             groupZPadding?: number;
+            inactiveOtherPoints?: boolean;
         }
         interface Series {
             translate3dShapes(): void;

--- a/ts/parts-map/ColorAxis.ts
+++ b/ts/parts-map/ColorAxis.ts
@@ -68,7 +68,7 @@ declare global {
             stops?: GradientColorObject['stops'];
         }
         interface Options {
-            colorAxis?: Array<ColorAxisOptions>;
+            colorAxis?: (ColorAxisOptions|Array<ColorAxisOptions>);
         }
         interface Point {
             dataClass?: number;

--- a/ts/parts-map/MapSeries.ts
+++ b/ts/parts-map/MapSeries.ts
@@ -98,7 +98,7 @@ declare global {
             _minY?: number;
         }
         interface MapPointOptions extends ScatterPointOptions {
-            color?: (ColorString|GradientColorObject|PatternObject);
+            color?: ColorType;
             dataLabels?: DataLabelsOptionsObject;
             drilldown?: string;
             id?: string;
@@ -113,7 +113,7 @@ declare global {
             extends ColorSeriesOptions, ScatterSeriesOptions
         {
             data?: Array<MapPointOptions|PointOptionsType>;
-            nullColor?: (ColorString|GradientColorObject|PatternObject);
+            nullColor?: ColorType;
             nullInteraction?: boolean;
             states?: SeriesStatesOptionsObject<MapSeries>;
         }

--- a/ts/parts-more/BubbleSeries.ts
+++ b/ts/parts-more/BubbleSeries.ts
@@ -73,6 +73,7 @@ declare global {
         interface BubbleSeriesOptions extends ScatterSeriesOptions {
             displayNegative?: boolean;
             marker?: BubblePointMarkerOptions;
+            minSize?: (number|string);
             maxSize?: (number|string);
             sizeBy?: BubbleSizeByValue;
             sizeByAbsoluteValue?: boolean;

--- a/ts/parts-more/PackedBubbleSeries.ts
+++ b/ts/parts-more/PackedBubbleSeries.ts
@@ -18,14 +18,83 @@ import H from '../parts/Globals.js';
  */
 declare global {
     namespace Highcharts {
-        type PackedBubbleData = [
-            (number|null),
-            (number|null),
-            (number|null),
-            number,
-            number,
-            PackedBubblePointOptions
-        ];
+        class PackedBubblePoint extends BubblePoint implements DragNodesPoint {
+            public collisionNmb?: number;
+            public dataLabelOnNull?: boolean;
+            public degree: number;
+            public dispX?: number;
+            public dispY?: number;
+            public fixedPosition: DragNodesPoint['fixedPosition'];
+            public isParentNode?: boolean;
+            public mass: number;
+            public neighbours?: number;
+            public options: PackedBubblePointOptions;
+            public prevX?: number;
+            public prevY?: number;
+            public radius: number;
+            public removed?: any; // @todo
+            public series: PackedBubbleSeries;
+            public seriesIndex?: number;
+            public value: (number|null);
+        }
+        class PackedBubbleSeries extends BubbleSeries
+            implements DragNodesSeries {
+            public chart: PackedBubbleChart;
+            public data: Array<PackedBubblePoint>;
+            public forces: Array<string>;
+            public hasDraggableNodes: boolean;
+            public hoverPoint: PackedBubblePoint;
+            public index: number;
+            public isCartesian: boolean;
+            public layout: PackedBubbleLayout;
+            public noSharedTooltip: boolean;
+            public onMouseDown: DragNodesMixin['onMouseDown'];
+            public onMouseMove: DragNodesMixin['onMouseMove'];
+            public options: PackedBubbleSeriesOptions;
+            public parentNode?: PackedBubblePoint;
+            public parentNodesGroup?: SVGElement;
+            public parentNodeLayout: PackedBubbleLayout;
+            public parentNodeMass?: number;
+            public parentNodeRadius?: number;
+            public pointArrayMap: Array<string>;
+            public pointClass: typeof PackedBubblePoint;
+            public points: Array<PackedBubblePoint>;
+            public pointValKey: string;
+            public redrawHalo: DragNodesMixin['redrawHalo'];
+            public xData: Array<number>;
+            public checkOverlap(
+                bubble1: Array<number>,
+                bubble2: Array<number>
+            ): boolean;
+            public accumulateAllPoints(
+                series: PackedBubbleSeries
+            ): Array<PackedBubbleData>;
+            public addLayout(): void;
+            public addSeriesLayout(): void;
+            public calculateParentRadius(): void;
+            public calculateZExtremes(): Array<number>;
+            public createParentNodes(): void;
+            public deferLayout(): void;
+            public destroy(): void;
+            public drawDataLabels(): void;
+            public drawGraph(): void;
+            public getPointRadius(): void;
+            public init(): PackedBubbleSeries;
+            public onMouseUp(point: DragNodesPoint): void;
+            public placeBubbles(
+                allDataPoints: Array<PackedBubbleData>
+            ): Array<PackedBubbleData>;
+            public positionBubble(
+                lastBubble: Array<number>,
+                newOrigin: Array<number>,
+                nextBubble: Array<number>
+            ): Array<number>;
+            public render(): void;
+            public resizeRadius(): void;
+            public seriesBox(): (Array<number>|null);
+            public setVisible(): void;
+            public translate(): void;
+        }
         interface NetworkgraphLayout {
             beforeStep?(): void;
         }
@@ -113,6 +182,7 @@ declare global {
             dataLabels?: PackedBubbleDataLabelsOptionsObject;
             draggable?: boolean;
             layoutAlgorithm?: PackedBubbleLayoutAlgorithmOptions;
+            minSize?: (number|string);
             useSimulation?: boolean;
         }
         interface Point {
@@ -121,83 +191,14 @@ declare global {
         interface SeriesTypesDictionary {
             packedbubble: typeof PackedBubbleSeries;
         }
-        class PackedBubblePoint extends BubblePoint implements DragNodesPoint {
-            public collisionNmb?: number;
-            public dataLabelOnNull?: boolean;
-            public degree: number;
-            public dispX?: number;
-            public dispY?: number;
-            public fixedPosition: DragNodesPoint['fixedPosition'];
-            public isParentNode?: boolean;
-            public mass: number;
-            public neighbours?: number;
-            public options: PackedBubblePointOptions;
-            public prevX?: number;
-            public prevY?: number;
-            public radius: number;
-            public removed?: any; // @todo
-            public series: PackedBubbleSeries;
-            public seriesIndex?: number;
-            public value: (number|null);
-        }
-        class PackedBubbleSeries extends BubbleSeries
-            implements DragNodesSeries {
-            public chart: PackedBubbleChart;
-            public data: Array<PackedBubblePoint>;
-            public forces: Array<string>;
-            public hasDraggableNodes: boolean;
-            public hoverPoint: PackedBubblePoint;
-            public index: number;
-            public isCartesian: boolean;
-            public layout: PackedBubbleLayout;
-            public noSharedTooltip: boolean;
-            public onMouseDown: DragNodesMixin['onMouseDown'];
-            public onMouseMove: DragNodesMixin['onMouseMove'];
-            public options: PackedBubbleSeriesOptions;
-            public parentNode?: PackedBubblePoint;
-            public parentNodesGroup?: SVGElement;
-            public parentNodeLayout: PackedBubbleLayout;
-            public parentNodeMass?: number;
-            public parentNodeRadius?: number;
-            public pointArrayMap: Array<string>;
-            public pointClass: typeof PackedBubblePoint;
-            public points: Array<PackedBubblePoint>;
-            public pointValKey: string;
-            public redrawHalo: DragNodesMixin['redrawHalo'];
-            public xData: Array<number>;
-            public checkOverlap(
-                bubble1: Array<number>,
-                bubble2: Array<number>
-            ): boolean;
-            public accumulateAllPoints(
-                series: PackedBubbleSeries
-            ): Array<PackedBubbleData>;
-            public addLayout(): void;
-            public addSeriesLayout(): void;
-            public calculateParentRadius(): void;
-            public calculateZExtremes(): Array<number>;
-            public createParentNodes(): void;
-            public deferLayout(): void;
-            public destroy(): void;
-            public drawDataLabels(): void;
-            public drawGraph(): void;
-            public getPointRadius(): void;
-            public init(): PackedBubbleSeries;
-            public onMouseUp(point: DragNodesPoint): void;
-            public placeBubbles(
-                allDataPoints: Array<PackedBubbleData>
-            ): Array<PackedBubbleData>;
-            public positionBubble(
-                lastBubble: Array<number>,
-                newOrigin: Array<number>,
-                nextBubble: Array<number>
-            ): Array<number>;
-            public render(): void;
-            public resizeRadius(): void;
-            public seriesBox(): (Array<number>|null);
-            public setVisible(): void;
-            public translate(): void;
-        }
+        type PackedBubbleData = [
+            (number|null),
+            (number|null),
+            (number|null),
+            number,
+            number,
+            PackedBubblePointOptions
+        ];
     }
 }
 

--- a/ts/parts-more/Polar.ts
+++ b/ts/parts-more/Polar.ts
@@ -24,9 +24,6 @@ declare global {
         interface ColumnSeries {
             polarArc: PolarSeries['polarArc'];
         }
-        interface PlotSeriesOptions {
-            connectEnds?: boolean;
-        }
         interface Point {
             rectPlotX?: PolarPoint['rectPlotX'];
             ttBelow?: boolean;
@@ -79,6 +76,9 @@ declare global {
             searchPointByAngle(e: PointerEventObject): (Point|undefined);
             translate(): void;
             toXY(point: Point): void;
+        }
+        interface SeriesOptions {
+            connectEnds?: boolean;
         }
         interface SVGRenderer {
             clipCircle(x: number, y: number, r: number): SVGElement;

--- a/ts/parts/AreaSeries.ts
+++ b/ts/parts/AreaSeries.ts
@@ -18,23 +18,6 @@ import H from './Globals.js';
  */
 declare global {
     namespace Highcharts {
-        interface AreaPathObject extends SVGPathArray {
-            xMap?: number;
-        }
-        interface AreaPointOptions extends LinePointOptions {
-        }
-        interface AreaSeriesOptions extends LineSeriesOptions {
-            fillColor?: (ColorString|GradientColorObject|PatternObject);
-            fillOpacity?: number;
-            negativeFillColor?: (ColorString|GradientColorObject|PatternObject);
-            states?: SeriesStatesOptionsObject<AreaSeries>;
-        }
-        interface PlotSeriesOptions {
-            negativeFillColor?: AreaSeriesOptions['negativeFillColor'];
-        }
-        interface SeriesTypesDictionary {
-            area: typeof AreaSeries;
-        }
         class AreaPoint extends LinePoint {
             public isCliff?: boolean;
             public leftNull?: boolean;
@@ -49,6 +32,20 @@ declare global {
             public pointClass: typeof AreaPoint;
             public points: Array<AreaPoint>;
             public getStackPoints(points: Array<AreaPoint>): Array<AreaPoint>;
+        }
+        interface AreaPathObject extends SVGPathArray {
+            xMap?: number;
+        }
+        interface AreaPointOptions extends LinePointOptions {
+        }
+        interface AreaSeriesOptions extends LineSeriesOptions {
+            fillColor?: ColorType;
+            fillOpacity?: number;
+            negativeFillColor?: ColorType;
+            states?: SeriesStatesOptionsObject<AreaSeries>;
+        }
+        interface SeriesTypesDictionary {
+            area: typeof AreaSeries;
         }
     }
 }
@@ -556,7 +553,7 @@ seriesType<Highcharts.AreaSeries>(
                 ]]; // area name, main color, fill color
 
             zones.forEach(function (
-                zone: Highcharts.PlotSeriesZonesOptions,
+                zone: Highcharts.SeriesZonesOptions,
                 i: number
             ): void {
                 props.push([

--- a/ts/parts/AreaSplineSeries.ts
+++ b/ts/parts/AreaSplineSeries.ts
@@ -78,7 +78,7 @@ seriesType<Highcharts.AreaSplineSeries>(
      * @product   highcharts highstock
      * @apioption plotOptions.areaspline
      */
-    defaultPlotOptions.area,
+    defaultPlotOptions.area as any,
     {
         getStackPoints: areaProto.getStackPoints,
         getGraphPath: areaProto.getGraphPath,

--- a/ts/parts/CandlestickSeries.ts
+++ b/ts/parts/CandlestickSeries.ts
@@ -18,18 +18,6 @@ import H from './Globals.js';
  */
 declare global {
     namespace Highcharts {
-        interface CandlestickPointOptions extends OHLCPointOptions {
-            lineColor?: (ColorString|GradientColorObject|PatternObject);
-            upLineColor?: (ColorString|GradientColorObject|PatternObject);
-        }
-        interface CandlestickSeriesOptions extends OHLCSeriesOptions {
-            lineColor?: (ColorString|GradientColorObject|PatternObject);
-            states?: SeriesStatesOptionsObject<CandlestickSeries>;
-            upLineColor?: (ColorString|GradientColorObject|PatternObject);
-        }
-        interface SeriesTypesDictionary {
-            candlestick: typeof CandlestickSeries;
-        }
         class CandlestickPoint extends OHLCPoint {
             public close: number;
             public open: number;
@@ -41,6 +29,18 @@ declare global {
             public options: CandlestickSeriesOptions;
             public pointClass: typeof CandlestickPoint;
             public points: Array<CandlestickPoint>;
+        }
+        interface CandlestickPointOptions extends OHLCPointOptions {
+            lineColor?: (ColorString|GradientColorObject|PatternObject);
+            upLineColor?: (ColorString|GradientColorObject|PatternObject);
+        }
+        interface CandlestickSeriesOptions extends OHLCSeriesOptions {
+            lineColor?: (ColorString|GradientColorObject|PatternObject);
+            states?: SeriesStatesOptionsObject<CandlestickSeries>;
+            upLineColor?: (ColorString|GradientColorObject|PatternObject);
+        }
+        interface SeriesTypesDictionary {
+            candlestick: typeof CandlestickSeries;
         }
     }
 }
@@ -106,7 +106,7 @@ var candlestickOptions = {
     /**
      * @extends plotOptions.ohlc.tooltip
      */
-    tooltip: defaultPlotOptions.ohlc.tooltip,
+    tooltip: (defaultPlotOptions.ohlc as any).tooltip,
 
     /**
      * @type    {number|null}

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -457,8 +457,8 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             ): void {
                 if (isObject(typeOptions)) { // #8766
                     typeOptions.tooltip = (
-                        userPlotOptions[type] &&
-                        merge(userPlotOptions[type].tooltip) // override by copy
+                        userPlotOptions[type] && // override by copy:
+                        merge((userPlotOptions[type] as any).tooltip)
                     ) || undefined; // or clear
                 }
             });

--- a/ts/parts/ColumnSeries.ts
+++ b/ts/parts/ColumnSeries.ts
@@ -22,11 +22,6 @@ declare global {
             offset: number;
             width: number;
         }
-        interface PlotSeriesZonesOptions {
-            borderColor?: (ColorString|GradientColorObject|PatternObject);
-            borderWidth?: number;
-            color?: (ColorString|GradientColorObject|PatternObject);
-        }
         interface ColumnPointOptions extends LinePointOptions {
             dashStyle?: DashStyleValue;
             pointWidth?: number;
@@ -40,11 +35,7 @@ declare global {
             minPointLength?: number;
             pointPadding?: number;
             pointWidth?: number;
-            startFromThreshold?: boolean;
             states?: SeriesStatesOptionsObject<ColumnSeries>;
-        }
-        interface PlotSeriesOptions {
-            startFromThreshold?: ColumnSeriesOptions['startFromThreshold'];
         }
         interface Point {
             allowShadow?: ColumnPoint['allowShadow'];
@@ -61,6 +52,11 @@ declare global {
         }
         interface SeriesTypesDictionary {
             column: typeof ColumnSeries;
+        }
+        interface SeriesZonesOptions {
+            borderColor?: (ColorString|GradientColorObject|PatternObject);
+            borderWidth?: number;
+            color?: (ColorString|GradientColorObject|PatternObject);
         }
         class ColumnPoint extends LinePoint {
             public allowShadow?: boolean;

--- a/ts/parts/DataGrouping.ts
+++ b/ts/parts/DataGrouping.ts
@@ -950,13 +950,13 @@ addEvent(Series, 'destroy', seriesProto.destroyGroupedData);
 // some series types are defined after this.
 addEvent(Series, 'afterSetOptions', function (
     this: Highcharts.Series,
-    e: { options: Highcharts.PlotSeriesOptions }
+    e: { options: Highcharts.SeriesOptions }
 ): void {
 
     var options = e.options,
         type = this.type,
         plotOptions = this.chart.options.plotOptions as Highcharts.PlotOptions,
-        defaultOptions = defaultPlotOptions[type].dataGrouping,
+        defaultOptions = (defaultPlotOptions[type] as any).dataGrouping,
         // External series, for example technical indicators should also
         // inherit commonOptions which are not available outside this module
         baseOptions = this.useCommonDataGrouping && commonOptions;
@@ -970,7 +970,8 @@ addEvent(Series, 'afterSetOptions', function (
             baseOptions,
             defaultOptions,
             plotOptions.series && plotOptions.series.dataGrouping, // #1228
-            plotOptions[type].dataGrouping, // Set by the StockChart constructor
+            // Set by the StockChart constructor:
+            (plotOptions[type] as any).dataGrouping,
             this.userOptions.dataGrouping
         );
     }

--- a/ts/parts/Globals.ts
+++ b/ts/parts/Globals.ts
@@ -36,12 +36,12 @@ declare global {
         interface ChartOptions {
             forExport?: any; // @todo
         }
-        interface PlotSeriesOptions {
-            accessibility?: any; // @todo
-        }
         interface Point {
             startR?: any; // @todo solid-gauge
             tooltipDateKeys?: any; // @todo xrange
+        }
+        interface Options {
+            toolbar?: any; // @todo stock-tools
         }
         interface Series {
             fillGraph?: any; // @todo ichimoku indicator
@@ -50,6 +50,9 @@ declare global {
             resetZones?: any; // @todo macd indicator
             useCommonDataGrouping?: any; // @todo indicators
             getPoint: Function; // @todo boost module
+        }
+        interface SeriesOptions {
+            accessibility?: any; // @todo
         }
         interface SeriesTypesDictionary {
             [key: string]: typeof Series;
@@ -78,6 +81,7 @@ declare global {
         const seriesTypes: SeriesTypesDictionary;
         const svg: boolean;
         const version: string;
+        let theme: (Options|undefined);
     }
     type GlobalWindow = typeof window;
     type GlobalHTMLElement = HTMLElement;

--- a/ts/parts/Interaction.ts
+++ b/ts/parts/Interaction.ts
@@ -82,6 +82,9 @@ declare global {
             setVisible(visible?: boolean, redraw?: boolean): void;
             show(): void;
         }
+        interface SeriesOptions {
+            inactiveOtherPoints?: boolean;
+        }
         interface TrackerMixin {
             drawTrackerGraph(this: Highcharts.Series): void;
             drawTrackerPoint(this: Series): void;

--- a/ts/parts/Legend.ts
+++ b/ts/parts/Legend.ts
@@ -44,12 +44,12 @@ declare global {
             drawLineMarker(legend: Legend): void;
             drawRectangle(legend: Legend, item: (Point|Series)): void;
         }
-        interface PlotSeriesOptions {
-            legendType?: ('point'|'series');
-        }
         interface Point extends LegendItemObject {
         }
         interface Series extends LegendItemObject {
+        }
+        interface SeriesOptions {
+            legendType?: ('point'|'series');
         }
         class Legend {
             public constructor(chart: Chart, options: LegendOptions);

--- a/ts/parts/PieSeries.ts
+++ b/ts/parts/PieSeries.ts
@@ -18,73 +18,6 @@ import H from './Globals.js';
  */
 declare global {
     namespace Highcharts {
-        interface PlotSeriesOptions {
-            fillColor?: (ColorString|GradientColorObject|PatternObject);
-            ignoreHiddenPoint?: boolean;
-        }
-        interface PiePointConnectorShapeFunction {
-            (...args: Array<any>): SVGPathArray;
-        }
-        interface PiePointLabelConnectorPositionObject {
-            breakAt: PositionObject;
-            touchingSliceAt: PositionObject;
-        }
-        interface PiePointLabelPositionObject {
-            alignment: AlignValue;
-            connectorPosition: PiePointLabelConnectorPositionObject;
-            'final': Dictionary<undefined>;
-            natural: PositionObject;
-        }
-        interface PiePointOptions extends LinePointOptions {
-            dataLabels?: PieSeriesDataLabelsOptionsObject;
-            sliced?: boolean;
-            visible?: boolean;
-        }
-        interface PiePositionObject extends PositionObject {
-            alignment: AlignValue;
-        }
-        interface PieSeriesDataLabelsOptionsObject
-            extends DataLabelsOptionsObject
-        {
-            alignTo?: string;
-            connectorColor?: (ColorString|GradientColorObject|PatternObject);
-            connectorPadding?: number;
-            connectorShape?: (string|Function);
-            connectorWidth?: number;
-            crookDistance?: string;
-            distance?: number;
-            softConnector?: boolean;
-        }
-        interface PieSeriesOptions extends LineSeriesOptions {
-            endAngle?: number;
-            center?: [(number|string|null), (number|string|null)];
-            colorByPoint?: boolean;
-            dataLabels?: PieSeriesDataLabelsOptionsObject;
-            ignoreHiddenPoint?: boolean;
-            inactiveOtherPoints?: boolean;
-            innerSize?: (number|string);
-            minSize?: (number|string);
-            size?: (number|string|null);
-            startAngle?: number;
-            states?: SeriesStatesOptionsObject<PieSeries>;
-        }
-        interface PieSeriesPositionObject extends PositionObject {
-            alignment: AlignValue;
-        }
-        interface SeriesStatesHoverOptionsObject {
-            brightness?: number;
-        }
-        interface PlotSeriesOptions {
-            center?: PieSeriesOptions['center'];
-            colorByPoint?: PieSeriesOptions['colorByPoint'];
-            inactiveOtherPoints?: PieSeriesOptions['inactiveOtherPoints'];
-            innerSize?: PieSeriesOptions['innerSize'];
-            minSize?: PieSeriesOptions['minSize'];
-            size?: PieSeriesOptions['size'];
-        }
-        interface SeriesTypesDictionary {
-            pie: typeof PieSeries;
-        }
         class PiePoint extends LinePoint {
             public angle?: number;
             public connectorShapes?: Dictionary<PiePointConnectorShapeFunction>;
@@ -126,6 +59,63 @@ declare global {
             public sortByAngle(points: Array<PiePoint>, sign: number): void;
             public translate(positions?: Array<number>): void;
             public updateTotals(): void;
+        }
+        interface PiePointConnectorShapeFunction {
+            (...args: Array<any>): SVGPathArray;
+        }
+        interface PiePointLabelConnectorPositionObject {
+            breakAt: PositionObject;
+            touchingSliceAt: PositionObject;
+        }
+        interface PiePointLabelPositionObject {
+            alignment: AlignValue;
+            connectorPosition: PiePointLabelConnectorPositionObject;
+            'final': Dictionary<undefined>;
+            natural: PositionObject;
+        }
+        interface PiePointOptions extends LinePointOptions {
+            dataLabels?: PieSeriesDataLabelsOptionsObject;
+            sliced?: boolean;
+            visible?: boolean;
+        }
+        interface PiePositionObject extends PositionObject {
+            alignment: AlignValue;
+        }
+        interface PieSeriesDataLabelsOptionsObject
+            extends DataLabelsOptionsObject
+        {
+            alignTo?: string;
+            connectorColor?: (ColorString|GradientColorObject|PatternObject);
+            connectorPadding?: number;
+            connectorShape?: (string|Function);
+            connectorWidth?: number;
+            crookDistance?: string;
+            distance?: number;
+            softConnector?: boolean;
+        }
+        interface PieSeriesOptions extends LineSeriesOptions {
+            endAngle?: number;
+            center?: [(number|string|null), (number|string|null)];
+            colorByPoint?: boolean;
+            dataLabels?: PieSeriesDataLabelsOptionsObject;
+            fillColor?: (ColorString|GradientColorObject|PatternObject);
+            ignoreHiddenPoint?: boolean;
+            inactiveOtherPoints?: boolean;
+            innerSize?: (number|string);
+            minSize?: (number|string);
+            size?: (number|string|null);
+            slicedOffset?: number;
+            startAngle?: number;
+            states?: SeriesStatesOptionsObject<PieSeries>;
+        }
+        interface PieSeriesPositionObject extends PositionObject {
+            alignment: AlignValue;
+        }
+        interface SeriesStatesHoverOptionsObject {
+            brightness?: number;
+        }
+        interface SeriesTypesDictionary {
+            pie: typeof PieSeries;
         }
     }
 }

--- a/ts/parts/Point.ts
+++ b/ts/parts/Point.ts
@@ -18,12 +18,49 @@ import Highcharts from './Globals.js';
  */
 declare global {
     namespace Highcharts {
-        type PointOptionsType = (
-            number|string|Array<(number|string)>|PointOptionsObject|null
-        );
-        interface PlotSeriesOptions {
-            marker?: PointMarkerOptionsObject;
-            point?: PlotSeriesPointOptions;
+        class Point {
+            public constructor();
+            public color?: ColorType;
+            public colorIndex: number;
+            public formatPrefix: string;
+            public id: string;
+            public isNull: boolean;
+            public marker?: PointMarkerOptionsObject;
+            public nonZonedColor?: (
+                ColorString|GradientColorObject|PatternObject
+            );
+            public options: PointOptionsObject;
+            public percentage?: number;
+            public series: Series;
+            public shapeArgs?: SVGAttributes;
+            public shapeType?: string;
+            public state?: string;
+            public total?: number;
+            public visible: boolean;
+            public x: (number|null);
+            public y?: (number|null);
+            public applyOptions(options: PointOptionsType, x?: number): Point;
+            public destroy(): void;
+            public destroyElements(kinds?: Dictionary<number>): void;
+            public getClassName(): string;
+            public firePointEvent(
+                eventType: string,
+                eventArgs?: (Dictionary<any>|Event),
+                defaultFunction?: (EventCallbackFunction<Point>|Function)
+            ): void;
+            public getLabelConfig(): PointLabelObject;
+            public getZone(): SeriesZonesOptions;
+            public hasNewShapeType (this: Point): boolean|undefined;
+            public init(
+                series: Series,
+                options: PointOptionsType,
+                x?: number
+            ): Point;
+            public isValid?(): boolean;
+            public optionsToObject(options: PointOptionsType): Dictionary<any>;
+            public resolveColor(): void;
+            public setNestedProperty<T>(object: T, value: any, key: string): T;
+            public tooltipFormatter(pointFormat: string): string;
         }
         interface PlotSeriesPointOptions {
             events?: PointEventsOptionsObject;
@@ -133,54 +170,15 @@ declare global {
         }
         interface SeriesOptions {
             data?: Array<PointOptionsType>;
+            marker?: PointMarkerOptionsObject;
+            point?: PlotSeriesPointOptions;
         }
         interface SeriesPointOptions {
             events?: PointEventsOptionsObject;
         }
-        class Point {
-            public constructor();
-            public color?: ColorType;
-            public colorIndex: number;
-            public formatPrefix: string;
-            public id: string;
-            public isNull: boolean;
-            public marker?: PointMarkerOptionsObject;
-            public nonZonedColor?: (
-                ColorString|GradientColorObject|PatternObject
-            );
-            public options: PointOptionsObject;
-            public percentage?: number;
-            public series: Series;
-            public shapeArgs?: SVGAttributes;
-            public shapeType?: string;
-            public state?: string;
-            public total?: number;
-            public visible: boolean;
-            public x: (number|null);
-            public y?: (number|null);
-            public applyOptions(options: PointOptionsType, x?: number): Point;
-            public destroy(): void;
-            public destroyElements(kinds?: Dictionary<number>): void;
-            public getClassName(): string;
-            public firePointEvent(
-                eventType: string,
-                eventArgs?: (Dictionary<any>|Event),
-                defaultFunction?: (EventCallbackFunction<Point>|Function)
-            ): void;
-            public getLabelConfig(): PointLabelObject;
-            public getZone(): PlotSeriesZonesOptions;
-            public hasNewShapeType (this: Point): boolean|undefined;
-            public init(
-                series: Series,
-                options: PointOptionsType,
-                x?: number
-            ): Point;
-            public isValid?(): boolean;
-            public optionsToObject(options: PointOptionsType): Dictionary<any>;
-            public resolveColor(): void;
-            public setNestedProperty<T>(object: T, value: any, key: string): T;
-            public tooltipFormatter(pointFormat: string): string;
-        }
+        type PointOptionsType = (
+            number|string|Array<(number|string)>|PointOptionsObject|null
+        );
     }
 }
 
@@ -1013,7 +1011,7 @@ Highcharts.Point.prototype = {
      */
     getZone: function (
         this: Highcharts.Point
-    ): Highcharts.PlotSeriesZonesOptions {
+    ): Highcharts.SeriesZonesOptions {
         var series = this.series,
             zones = series.zones,
             zoneAxis = series.zoneAxis || 'y',

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -102,7 +102,7 @@ declare global {
                 Array<Array<(number|null|undefined)>>
             );
             public zoneAxis?: string;
-            public zones: Array<PlotSeriesZonesOptions>;
+            public zones: Array<SeriesZonesOptions>;
             public afterAnimate(): void;
             public animate(init?: boolean): void;
             public applyZones(): void;
@@ -219,83 +219,6 @@ declare global {
         interface LineSeriesOptions extends SeriesOptions {
             states?: SeriesStatesOptionsObject<LineSeries>;
         }
-        interface PlotOptions {
-            [key: string]: PlotSeriesOptions;
-        }
-        interface PlotSeriesOptions {
-            allAreas?: boolean;
-            allowPointSelect?: boolean;
-            animation?: (boolean|AnimationOptionsObject);
-            animationLimit?: number;
-            boostBlending?: SeriesBlendingValue;
-            boostThreshold?: number;
-            borderColor?: (ColorString|GradientColorObject|PatternObject);
-            borderWidth?: number;
-            className?: string;
-            clip?: boolean;
-            color?: (ColorString|GradientColorObject|PatternObject);
-            colorAxis?: boolean;
-            colorIndex?: number;
-            colors?: Array<(ColorString|GradientColorObject|PatternObject)>;
-            connectEnds?: boolean;
-            connectNulls?: boolean;
-            cropThreshold?: number;
-            cursor?: (string|CursorValue);
-            dashStyle?: DashStyleValue;
-            dataGrouping?: PlotSeriesDataGroupingOptions;
-            dataLabels?: (
-                DataLabelsOptionsObject|Array<DataLabelsOptionsObject>
-            );
-            description?: string;
-            enableMouseTracking?: boolean;
-            events?: SeriesEventsOptions;
-            findNearestPointBy?: SeriesFindNearestPointByValue;
-            getExtremesFromAll?: boolean;
-            includeInDataExport?: boolean;
-            isInternal?: boolean;
-            joinBy?: (string|Array<string>);
-            keys?: Array<string>;
-            linecap?: SeriesLinecapValue;
-            lineWidth?: number;
-            linkedTo?: string;
-            marker?: PointMarkerOptionsObject;
-            navigatorOptions?: SeriesOptions;
-            negativeColor?: (ColorString|GradientColorObject|PatternObject);
-            opacity?: number;
-            point?: PlotSeriesPointOptions;
-            pointDescriptionFormatter?: Function;
-            pointInterval?: number;
-            pointIntervalUnit?: SeriesPointIntervalUnitValue;
-            pointPlacement?: (number|string);
-            pointRange?: (number|null);
-            pointStart?: number;
-            pointValKey?: string;
-            selected?: boolean;
-            shadow?: (boolean|ShadowOptionsObject);
-            showCheckbox?: boolean;
-            showInLegend?: boolean;
-            showInNavigator?: boolean;
-            skipKeyboardNavigation?: boolean;
-            softThreshold?: boolean;
-            stacking?: OptionsStackingValue;
-            states?: SeriesStatesOptionsObject<Series>;
-            step?: SeriesStepValue;
-            stickyTracking?: boolean;
-            supportingColor?: (ColorString|GradientColorObject|PatternObject);
-            threshold?: number;
-            turboThreshold?: number;
-            visible?: boolean;
-            zIndex?: number;
-            zoneAxis?: string;
-            zones?: Array<PlotSeriesZonesOptions>;
-        }
-        interface PlotSeriesZonesOptions {
-            className?: string;
-            color?: (ColorString|GradientColorObject|PatternObject);
-            dashStyle?: DashStyleValue;
-            fillColor?: (ColorString|GradientColorObject|PatternObject);
-            value?: number;
-        }
         interface Point {
             category?: string;
             clientX?: number;
@@ -313,7 +236,7 @@ declare global {
             stackTotal?: number;
             stackY?: (number|null);
             yBottom?: number;
-            zone?: PlotSeriesZonesOptions;
+            zone?: SeriesZonesOptions;
         }
         interface SeriesAfterAnimateCallbackFunction {
             (this: Series, event: SeriesAfterAnimateEventObject): void;
@@ -371,22 +294,87 @@ declare global {
         interface SeriesMouseOverCallbackFunction {
             (this: Series, event: PointerEvent): void;
         }
-        interface SeriesOptions extends PlotSeriesOptions {
+        interface SeriesOptions {
+            allAreas?: boolean;
+            allowPointSelect?: boolean;
+            animation?: (boolean|AnimationOptionsObject);
+            animationLimit?: number;
+            boostBlending?: SeriesBlendingValue;
+            boostThreshold?: number;
+            borderColor?: ColorType;
+            borderWidth?: number;
+            className?: string;
+            clip?: boolean;
+            color?: ColorType;
+            colorAxis?: boolean;
+            colorByPoint?: boolean;
+            colorIndex?: number;
+            colors?: Array<ColorType>;
+            connectEnds?: boolean;
+            connectNulls?: boolean;
+            cropThreshold?: number;
+            cursor?: (string|CursorValue);
+            dashStyle?: DashStyleValue;
             data?: Array<PointOptionsType>;
+            dataGrouping?: PlotSeriesDataGroupingOptions;
+            dataLabels?: (
+                DataLabelsOptionsObject|Array<DataLabelsOptionsObject>
+            );
+            description?: string;
+            enableMouseTracking?: boolean;
+            events?: SeriesEventsOptions;
+            findNearestPointBy?: SeriesFindNearestPointByValue;
+            getExtremesFromAll?: boolean;
             grouping?: boolean;
             id?: string;
             index?: number;
+            includeInDataExport?: boolean;
+            isInternal?: boolean;
+            joinBy?: (string|Array<string>);
             kdNow?: boolean;
+            keys?: Array<string>;
             legendIndex?: number;
-            lineColor?: (ColorString|GradientColorObject|PatternObject);
+            linecap?: SeriesLinecapValue;
+            lineColor?: ColorType;
+            lineWidth?: number;
+            linkedTo?: string;
+            marker?: PointMarkerOptionsObject;
             name?: string;
+            navigatorOptions?: SeriesOptions;
+            negativeColor?: ColorType;
+            negativeFillColor?: ColorType;
+            opacity?: number;
+            point?: PlotSeriesPointOptions;
+            pointDescriptionFormatter?: Function;
+            pointInterval?: number;
+            pointIntervalUnit?: SeriesPointIntervalUnitValue;
+            pointPlacement?: (number|string);
+            pointRange?: (number|null);
+            pointStart?: number;
+            pointValKey?: string;
             selected?: boolean;
+            shadow?: (boolean|ShadowOptionsObject);
+            showCheckbox?: boolean;
+            showInLegend?: boolean;
+            showInNavigator?: boolean;
+            skipKeyboardNavigation?: boolean;
+            softThreshold?: boolean;
             stack?: (number|string);
+            stacking?: OptionsStackingValue;
+            startFromThreshold?: boolean;
+            states?: SeriesStatesOptionsObject<Series>;
+            step?: SeriesStepValue;
+            stickyTracking?: boolean;
+            supportingColor?: ColorType;
+            threshold?: number;
+            turboThreshold?: number;
             type?: string;
             visible?: boolean;
             xAxis?: (number|string);
             yAxis?: (number|string);
             zIndex?: number;
+            zoneAxis?: string;
+            zones?: Array<SeriesZonesOptions>;
         }
         interface SeriesPlotBoxObject {
             scaleX?: number;
@@ -430,6 +418,22 @@ declare global {
         interface SeriesTypesDictionary {
             line: typeof LineSeries;
         }
+        interface SeriesZonesOptions {
+            className?: string;
+            color?: (ColorString|GradientColorObject|PatternObject);
+            dashStyle?: DashStyleValue;
+            fillColor?: (ColorString|GradientColorObject|PatternObject);
+            value?: number;
+        }
+        type PlotOptions = {
+            [TSeriesType in keyof SeriesTypesDictionary]?: (
+                Omit<SeriesTypesDictionary[TSeriesType]['prototype']['options'],
+                (
+                    'data'|'id'|'index'|'legendIndex'|'mapData'|'name'|'stack'|
+                    'treemap'|'type'|'xAxis'|'yAxis'|'zIndex'
+                )>
+            )
+        };
         type SeriesBlendingValue = ('add'|'darken'|'multiply');
         type SeriesLinecapValue = ('butt'|'round'|'square'|string);
         type SeriesFindNearestPointByValue = ('x'|'xy');
@@ -3171,7 +3175,7 @@ H.Series = H.seriesType<Highcharts.LineSeries>(
                         options.threshold ||
                         0,
                     className: 'highcharts-negative'
-                } as Highcharts.PlotSeriesZonesOptions;
+                } as Highcharts.SeriesZonesOptions;
                 if (!styledMode) {
                     zone.color = options.negativeColor;
                     zone.fillColor = options.negativeFillColor;
@@ -5363,7 +5367,7 @@ H.Series = H.seriesType<Highcharts.LineSeries>(
         ): Array<Array<string>> {
             // Add the zone properties if any
             this.zones.forEach(function (
-                zone: Highcharts.PlotSeriesZonesOptions,
+                zone: Highcharts.SeriesZonesOptions,
                 i: number
             ): void {
                 var propset = [
@@ -5436,7 +5440,7 @@ H.Series = H.seriesType<Highcharts.LineSeries>(
                 // Create the clips
                 extremes = axis.getExtremes();
                 zones.forEach(function (
-                    threshold: Highcharts.PlotSeriesZonesOptions,
+                    threshold: Highcharts.SeriesZonesOptions,
                     i: number
                 ): void {
 

--- a/ts/parts/StockChart.ts
+++ b/ts/parts/StockChart.ts
@@ -25,11 +25,6 @@ declare global {
         interface Chart {
             _labelPanes?: Dictionary<Axis>;
         }
-        interface PlotSeriesOptions {
-            compare?: string;
-            compareBase?: (0|100);
-            compareStart?: boolean;
-        }
         interface Options {
             isStock?: boolean;
         }
@@ -41,6 +36,11 @@ declare global {
             compareValue?: number;
             modifyValue?(value?: number, point?: Point): (number|undefined);
             setCompare(compare?: string): void;
+        }
+        interface SeriesOptions {
+            compare?: string;
+            compareBase?: (0|100);
+            compareStart?: boolean;
         }
         interface SVGRenderer {
             crispPolyLine(points: SVGPathArray, width: number): SVGPathArray;

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -28,51 +28,6 @@ const {
  */
 declare global {
     namespace Highcharts {
-        type TooltipShapeValue = ('callout'|'circle'|'square');
-        interface PlotSeriesOptions {
-            tooltip?: TooltipOptions;
-        }
-        interface Point {
-            tooltipPos?: Array<number>;
-        }
-        interface Series {
-            noSharedTooltip?: boolean;
-            tt?: SVGElement;
-        }
-        interface TooltipFormatterCallbackFunction {
-            (
-                this: TooltipFormatterContextObject,
-                tooltip: Tooltip
-            ): (false|string|Array<string>);
-        }
-        interface TooltipFormatterContextObject {
-            color: (ColorString|GradientColorObject|PatternObject);
-            colorIndex?: number;
-            key: number;
-            percentage?: number;
-            point: Point;
-            points?: Array<Highcharts.TooltipFormatterContextObject>;
-            series: Series;
-            total?: number;
-            x: number;
-            y: number;
-        }
-        interface TooltipOptions {
-            distance?: number;
-        }
-        interface TooltipPositionerCallbackFunction {
-            (
-                labelWidth: number,
-                labelHeight: number,
-                point: TooltipPositionerPointObject
-            ): PositionObject;
-        }
-        interface TooltipPositionerPointObject {
-            isHeader: boolean;
-            negative: boolean;
-            plotX: number;
-            plotY: number;
-        }
         class Tooltip {
             public constructor(chart: Chart, options: TooltipOptions);
             public chart: Chart;
@@ -145,6 +100,51 @@ declare global {
             public update(options: TooltipOptions): void;
             public updatePosition(point: Point): void;
         }
+        interface Point {
+            tooltipPos?: Array<number>;
+        }
+        interface Series {
+            noSharedTooltip?: boolean;
+            tt?: SVGElement;
+        }
+        interface SeriesOptions {
+            tooltip?: TooltipOptions;
+        }
+        interface TooltipFormatterCallbackFunction {
+            (
+                this: TooltipFormatterContextObject,
+                tooltip: Tooltip
+            ): (false|string|Array<string>);
+        }
+        interface TooltipFormatterContextObject {
+            color: (ColorString|GradientColorObject|PatternObject);
+            colorIndex?: number;
+            key: number;
+            percentage?: number;
+            point: Point;
+            points?: Array<Highcharts.TooltipFormatterContextObject>;
+            series: Series;
+            total?: number;
+            x: number;
+            y: number;
+        }
+        interface TooltipOptions {
+            distance?: number;
+        }
+        interface TooltipPositionerCallbackFunction {
+            (
+                labelWidth: number,
+                labelHeight: number,
+                point: TooltipPositionerPointObject
+            ): PositionObject;
+        }
+        interface TooltipPositionerPointObject {
+            isHeader: boolean;
+            negative: boolean;
+            plotX: number;
+            plotY: number;
+        }
+        type TooltipShapeValue = ('callout'|'circle'|'square');
     }
 }
 


### PR DESCRIPTION
Made internal plot options reflecting from series types. The interesting part is in `parts/Series.ts`. The rest are adjustments to more explicit typing as a result.

```ts
        type PlotOptions = {
            [TSeriesType in keyof SeriesTypesDictionary]?: (
                Omit<SeriesTypesDictionary[TSeriesType]['prototype']['options'],
                (
                    'data'|'id'|'index'|'legendIndex'|'mapData'|'name'|'stack'|
                    'treemap'|'type'|'xAxis'|'yAxis'|'zIndex'
                )>
            )
        };
```