### PR TITLE
Docs/escaped code fix

### DIFF
--- a/docs/accessibility/accessibility-module.md
+++ b/docs/accessibility/accessibility-module.md
@@ -26,8 +26,8 @@ Highcharts.chart(‘container’, {
     // …
     
     accessibility: {
-        description: ‘Shows how apples have been more popular than oranges for the past 10 years. \\  
-Oranges are gaining in popularity over the past 3 years, but are still far from as popular as apples.’
+        description: 'Shows how apples have been more popular than oranges for the past 10 years \
+        Oranges are gaining in popularity over the past 3 years, but are still far from as popular as apples.'
     }
 
     // ....

--- a/docs/accessibility/sonification.md
+++ b/docs/accessibility/sonification.md
@@ -262,7 +262,7 @@ In this example we will take a look at Earcons and how to use them in a chart.
 
 <iframe style="width: 100%; height: 470px; border: none;" src=https://www.highcharts.com/samples/embed/highcharts/sonification/series-earcon allow="fullscreen"></iframe>
 
-In the above example we use the same approach as with [Series.sonify](https://api.highcharts.com/class-reference/Highcharts.Series#sonify) above, calling \`Series.sonify\` when a series is clicked. In addition, we define an [Earcon](https://api.highcharts.com/class-reference/Highcharts.Earcon#Earcon).
+In the above example we use the same approach as with [Series.sonify](https://api.highcharts.com/class-reference/Highcharts.Series#sonify) above, calling `Series.sonify` when a series is clicked. In addition, we define an [Earcon](https://api.highcharts.com/class-reference/Highcharts.Earcon#Earcon).
 
 An Earcon is mainly defined by providing a list of instruments and specifying how they should be played. Since an Earcon is a predefined sound, there is no mapping from data properties here. In the example above, we use two instruments. Both of the instruments are predefined, and referenced by name. The parameters for playing them are fixed for duration and panning, but for frequency we utilize a callback function. This callback function receives the relative time as a parameter, with the start of the Earcon playback being `0` and the end of the playback being `1`. We use this parameter to create a frequency ramp.
 

--- a/docs/chart-and-series-types/timeline-series.md
+++ b/docs/chart-and-series-types/timeline-series.md
@@ -28,7 +28,7 @@ The Timeline series data is structured differently for the above alternatives fo
 
 ### Data series for a Timeline chart with time periods
 
-The data series has no \`x\`property set.
+The data series has no `x`property set.
 
     
      data: [{
@@ -43,7 +43,7 @@ The data series has no \`x\`property set.
 
 ### Events tied to a datetime axis
 
-Set for each data point the n \`x\` property with a timestamp in milliseconds since 1970.
+Set for each data point the n `x` property with a timestamp in milliseconds since 1970.
 
 Examples of data series:
 

--- a/docs/chart-concepts/series.md
+++ b/docs/chart-concepts/series.md
@@ -1,22 +1,6 @@
 Series
 ======
 
-Below is a list of the main topics regarding series.
-
-*   [What is series?](#series)
-*   [The data in a series](#1)
-*   [Point and marker](#point)
-*   [Series options](#2):
-    *   [Animation](#3)
-    *   [Color](#4)
-    *   [Point selection](#6)
-    *   [Line width](#7)
-    *   [Stacking](#9)
-    *   [Cursor](#10)
-    *   [Data labels](#11)
-    *   [Dash style](#12)
-    *   [Zones](#zones)
-
 What is a series?
 -----------------
 
@@ -92,8 +76,7 @@ Here is an example showing how to alter the color and size of a marker on a spec
     }]
     
 
-Series options
-==============
+## Series options
 
 The series options can be defined in two places within the Highchars options structure.
 
@@ -102,18 +85,15 @@ The series options can be defined in two places within the Highchars options str
 
 Here is an overview over the most common options that can be applied to a data series:
 
-Animation
----------
+### Animation
 
 Allows disabling or altering the characteristics of the initial animation of a series. Animation is enabled by default.
 
-Color
------
+### Color
 
 Allows changing the color of a series.
 
-Point selection
----------------
+### Point selection
 
 Allows the selection and highlighting of a single point. Can be used to remove, edit or display information about a point.
 
@@ -137,8 +117,7 @@ Code to get the selected points:
     var selectedPoints = chart.getSelectedPoints();
     
 
-Line width
-----------
+### Line width
 
 Allows altering the width of a line.
 
@@ -153,18 +132,15 @@ Code to alter line width:
         data: [216.4, 194.1, 95.6],
         lineWidth: 5}],
 
-Stacking
---------
+### Stacking
 
 Stacking allows series to be placed on top of each other without overlapping. See [Stacking charts](docs/advanced-chart-features/stacking-charts) for more information.
 
-Cursor
-------
+### Cursor
 
 Allows the cursor to change appearence to indicate that points and series are clickable.
 
-Data labels
------------
+### Data labels
 
 Allows data labels to be displayed for each point of data in a series on the chart.
 
@@ -188,8 +164,7 @@ Note: You may wish to disable mouse tracking, which highlights the series and po
 
 The text displayed on datalabels may also be be customized by using the formatter option. See [API reference](https://api.highcharts.com/highcharts/plotOptions.series.dataLabels) for more options.
 
-Dash style
-----------
+### Dash style
 
 Allows to use dashed lines instead of solid, there are several different dash options available.
 
@@ -205,8 +180,7 @@ Code to set dashed lines for a individual series (the dashStyle can also be set 
         dashStyle: 'longdash'
     }]
 
-Zones
------
+### Zones
 
 In some cases, you would want to display certain sections of the graph different, a common example is to use different colors when data falls in a certain range.  This effect can be achieved by using `zones`.  By default zoning is done on the yAxis, but this can be easily changed by setting the `zoneAxis` variable on the series.  For the zoning itself, you have to define an array called `zones` where each entry corresponds to a zone, delimited by a parameter `value`, which is the point up to which the zones goes.  The settings that can be overwritten for each zone are color, fillColor and dashStyle.
 

--- a/docs/chart-concepts/series.md
+++ b/docs/chart-concepts/series.md
@@ -5,12 +5,12 @@ What is a series?
 -----------------
 
 A series is a set of data, for example a line graph or one set of columns. All data plotted on a chart comes from the series object. The series object has the structure:
-
-    
-    series: [{
-        name: ''
-        data: []
-    }]
+```js
+series: [{
+    name: ''
+    data: []
+}]
+```
 
 Note: The series object is an array, meaning it can contain several series.
 
@@ -23,30 +23,33 @@ The actual data is represented as an array, by the data attribute, and can be pr
 
 1.  A list of numerical values. In this case, the numerical values will be interpreted as y values and the x values will be automatically calculated, either starting at 0 and incrementing by 1, or from the pointStart and pointInterval options. If the axis is has categories, these will be used. Example:
 
-    
-    data: [0, 5, 3, 5]
+```js
+data: [0, 5, 3, 5]
+```
 
 [Online example](https://jsfiddle.net/gh/get/jquery/1.7.1/highslide-software/highcharts.com/tree/master/samples/highcharts/chart/reflow-true/)
 
 2.  A list of arrays with two or more values. In this case, the first value is the x value and the second is the y value. If the first value is a string, it is applied as the name of the point, and the x value is incremented following the above rules. Some series, [like arearange](https://api.highcharts.com/highcharts/series.arearange.data), accept more than two values. See API documentation for each series type. Example:
 
-    
-    data: [[5, 2], [6, 3], [8, 2]]
+```js  
+data: [[5, 2], [6, 3], [8, 2]]
+```
 
 [Online example](https://jsfiddle.net/gh/get/jquery/1.7.1/highslide-software/highcharts.com/tree/master/samples/highcharts/series/data-array-of-arrays/)
 
 3.  A list of object with named values. In this case the objects are point configuration objects as seen under options.point. The full list of available properties can be seen from the API, for [example for line series](https://api.highcharts.com/highcharts/series.line.data). Note that for this option to work in Highstock, the total number of points must not exceed the [turboThreshold](https://api.highcharts.com/highstock/series.line.turboThreshold), or the _turboThreshold_ setting must be increased. Example:
 
-    
-    data: [{
-        name: 'Point 1',
-        color: '#00FF00',
-        y: 0
-    }, {
-        name: 'Point 2',
-        color: '#FF00FF',
-        y: 5
-    }]
+```js   
+data: [{
+    name: 'Point 1',
+    color: '#00FF00',
+    y: 0
+}, {
+    name: 'Point 2',
+    color: '#FF00FF',
+    y: 5
+}]
+```
     
 
 [Online example](https://jsfiddle.net/gh/get/jquery/1.7.1/highslide-software/highcharts.com/tree/master/samples/highcharts/series/data-array-of-objects/)
@@ -58,22 +61,24 @@ For cartesian charts, a point represents a (x, y) pair on the chart. Points can 
 
 The point option can be applied to all charts. Here is an example showing how to edit the color of a specific point:
 
-    
-    series: [{
-        data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5,
-              { y: 216.4, color: '#BF0B23'}, 194.1, 95.6, 54.4]
-    }]
+```js
+series: [{
+    data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5,
+            { y: 216.4, color: '#BF0B23'}, 194.1, 95.6, 54.4]
+}]
+```
     
 
 Line, spline, area and areaspline charts have the option to display point markers, these are slightly different from the point option because they enable altering the style and shape of the point marker.
 
 Here is an example showing how to alter the color and size of a marker on a specific point.
 
-    
-    series: [{
-        data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5,
-        {y: 216.4, marker: { fillColor: '#BF0B23', radius: 10 } }, 194.1, 95.6, 54.4]
-    }]
+```js
+series: [{
+    data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5,
+    {y: 216.4, marker: { fillColor: '#BF0B23', radius: 10 } }, 194.1, 95.6, 54.4]
+}]
+```
     
 
 ## Series options
@@ -103,18 +108,20 @@ Allows the selection and highlighting of a single point. Can be used to remove, 
 
 Code to enable point selection:
 
-    
-    plotOptions: {
-        series: {
-            allowPointSelect: true
-        }
+```js
+plotOptions: {
+    series: {
+        allowPointSelect: true
     }
+}
+```
     
 
 Code to get the selected points:
 
-    
-    var selectedPoints = chart.getSelectedPoints();
+```js
+var selectedPoints = chart.getSelectedPoints();
+```
     
 
 ### Line width
@@ -127,10 +134,11 @@ Allows altering the width of a line.
 
 Code to alter line width:
 
-    
-    series: [{
-        data: [216.4, 194.1, 95.6],
-        lineWidth: 5}],
+```js
+series: [{
+    data: [216.4, 194.1, 95.6],
+    lineWidth: 5}],
+```
 
 ### Stacking
 
@@ -150,14 +158,15 @@ Allows data labels to be displayed for each point of data in a series on the cha
 
 Code example showing how to enable datalabels:
 
-    
-    plotOptions: {
-        line: {
-            dataLabels: {
-                enabled: true
-            }
+```js
+plotOptions: {
+    line: {
+        dataLabels: {
+            enabled: true
         }
-    },
+    }
+},
+```
     
 
 Note: You may wish to disable mouse tracking, which highlights the series and points the mouse hovers over (tooltips will not show if mouse tracking is disabled).
@@ -174,11 +183,12 @@ Allows to use dashed lines instead of solid, there are several different dash op
 
 Code to set dashed lines for a individual series (the dashStyle can also be set in plotOptions):
 
-    
-    series: [{
-        data: [1, 3, 2, 4, 5, 4, 6, 2, 3, 5, 6],
-        dashStyle: 'longdash'
-    }]
+```js
+series: [{
+    data: [1, 3, 2, 4, 5, 4, 6, 2, 3, 5, 6],
+    dashStyle: 'longdash'
+}]
+```
 
 ### Zones
 
@@ -188,16 +198,17 @@ In some cases, you would want to display certain sections of the graph different
 
 Code used for the zoning:
 
-    
-    zones: [{  
-       value: 0,  
-       color: '#f7a35c'  
-    }, {  
-       value: 10,  
-       color: '#7cb5ec'  
-    }, {  
-       color: '#90ed7d'  
-    }]
+```js
+zones: [{  
+    value: 0,  
+    color: '#f7a35c'  
+}, {  
+    value: 10,  
+    color: '#7cb5ec'  
+}, {  
+    color: '#90ed7d'  
+}]
+```
 
 Another common use of this is to style future, estimated data points differently.
 
@@ -205,12 +216,13 @@ Another common use of this is to style future, estimated data points differently
 
 Code used for the zoning:
 
-    
-    zoneAxis: 'x',
-    zones: [{
-        value: 8
-    }, {
-        dashStyle: 'dot'
-    }]
+```js
+zoneAxis: 'x',
+zones: [{
+    value: 8
+}, {
+    dashStyle: 'dot'
+}]
+```
 
 See the [API](https://api.highcharts.com/highcharts/plotOptions.series.zones) for more information.

--- a/docs/chart-concepts/series.md
+++ b/docs/chart-concepts/series.md
@@ -208,7 +208,7 @@ Code to set dashed lines for a individual series (the dashStyle can also be set 
 Zones
 -----
 
-In some cases, you would want to display certain sections of the graph different, a common example is to use different colors when data falls in a certain range.  This effect can be achieved by using \`zones\`.  By default zoning is done on the yAxis, but this can be easily changed by setting the \`zoneAxis\` variable on the series.  For the zoning itself, you have to define an array called \`zones\` where each entry corresponds to a zone, delimited by a parameter \`value\`, which is the point up to which the zones goes.  The settings that can be overwritten for each zone are color, fillColor and dashStyle.
+In some cases, you would want to display certain sections of the graph different, a common example is to use different colors when data falls in a certain range.  This effect can be achieved by using `zones`.  By default zoning is done on the yAxis, but this can be easily changed by setting the `zoneAxis` variable on the series.  For the zoning itself, you have to define an array called `zones` where each entry corresponds to a zone, delimited by a parameter `value`, which is the point up to which the zones goes.  The settings that can be overwritten for each zone are color, fillColor and dashStyle.
 
 <iframe style="width: 100%; height: 475px;" src=https://www.highcharts.com/samples/embed/highcharts/series/color-zones-simple allow="fullscreen"></iframe>
 

--- a/docs/chart-concepts/tooltip.md
+++ b/docs/chart-concepts/tooltip.md
@@ -5,12 +5,6 @@ The tooltip appears when hovering over a point in a series. By default the toolt
 
 ![tooltip.png](tooltip.png)
 
-Some basic concepts:
-
-*   [Appearance](#app)
-*   [Tooltip formatter](#formatter)
-*   [Crosshairs](#cross)
-
 Appearance
 ----------
 

--- a/docs/chart-concepts/tooltip.md
+++ b/docs/chart-concepts/tooltip.md
@@ -10,14 +10,14 @@ Appearance
 
  The following code example shows the most common appearance options for tooltip:
 
-    
-    tooltip: {
-        backgroundColor: '#FCFFC5',
-        borderColor: 'black',
-        borderRadius: 10,
-        borderWidth: 3
-    }
-    
+```js
+tooltip: {
+    backgroundColor: '#FCFFC5',
+    borderColor: 'black',
+    borderRadius: 10,
+    borderWidth: 3
+}
+```
 
 The background color can also be set to a gradient, see [an example](http://jsfiddle.net/gh/get/jquery/1.7.1/highslide-software/highcharts.com/tree/master/samples/highcharts/tooltip/backgroundcolor-gradient/). Text properties can be set using the style option.
 
@@ -33,12 +33,13 @@ The tooltip's content is rendered from a subset of HTML that can be altered in a
 
 By default the tooltip only allows a subset of HTML because the HTML is parsed and rendered using SVG. By setting the [useHTML](http://api.highcharts.com/highcharts/tooltip.useHTML) option to true, the renderer switches to full HTML, which allows for instance table layouts or images inside the tooltip.
 
-    
-    tooltip: {
-        formatter: function() {
-            return 'The value for <b>' + this.x + '</b> is <b>' + this.y + '</b>, in series '+ this.series.name;
-        }
+```js
+tooltip: {
+    formatter: function() {
+        return 'The value for <b>' + this.x + '</b> is <b>' + this.y + '</b>, in series '+ this.series.name;
     }
+}
+```
 
 Crosshairs
 ----------
@@ -49,18 +50,19 @@ Crosshairs display a line connecting the points with their corresponding axis. 
 
 Crosshairs can be enabled for the x-axis, y-axis or both:
 
-    
-    // Enable for x-axis only
-    tooltip: {
-        crosshairs: [true]
-    }
-    
-    // Enable for y-axis only
-    tooltip: {
-        crosshairs: [false, true]
-    }
-    
-    // Enable for both axes
-    tooltip: {
-        crosshairs: [true,true]
-    }
+```js
+// Enable for x-axis only
+tooltip: {
+    crosshairs: [true]
+}
+
+// Enable for y-axis only
+tooltip: {
+    crosshairs: [false, true]
+}
+
+// Enable for both axes
+tooltip: {
+    crosshairs: [true,true]
+}
+```

--- a/docs/export-module/legacy-export-servers.md
+++ b/docs/export-module/legacy-export-servers.md
@@ -102,7 +102,7 @@ Upload/copy this to the application server. You're done with setting up the high
 
 By default WebLogic registers its own `URLStreamHandler to handle http` URLs. This results in that the Connection silently returns and empty files being returned from the server. The solution is to get in a reference to Java's default `URLStreamHandler` instead of the one from WebLogic. Follow these steps
 
-1. Alter this file: highcharts-export\\highcharts-export-convert/src/main/java/com/highcharts/export/server.Server.java
+1. Alter this file: `highcharts-export\highcharts-export-convert/src/main/java/com/highcharts/export/server.Server.java`
 
 Change line 94,95 from
 

--- a/docs/export-module/render-charts-serverside.md
+++ b/docs/export-module/render-charts-serverside.md
@@ -70,12 +70,13 @@ Filename containing a callback JavaScript. The callback is a function which will
 
 Stringified JSON which can contain three properties js, css and files. See below here for an example
 
-    
-    { 
-    "files": "highstock.js,highcharts-more.js,data.js,drilldown.js,funnel.js,heatmap.js,treemap.js,highcharts-3d.js,no-data-to-display.js,map.js,solid-gauge.js,broken-axis.js", 
-    "css": "g.highcharts-series path {stroke-width:2;stroke: pink}", 
-    "js": "document.body.style.webkitTransform = \\"rotate(-10deg)\\";" 
-    }
+```json
+{ 
+"files": "highstock.js,highcharts-more.js,data.js,drilldown.js,funnel.js,heatmap.js,treemap.js,highcharts-3d.js,no-data-to-display.js,map.js,solid-gauge.js,broken-axis.js", 
+"css": "g.highcharts-series path {stroke-width:2;stroke: pink}", 
+"js": "document.body.style.webkitTransform = 'rotate(-10deg)';" 
+}
+```
 
 *   `files`: A comma separated string of filenames that need to be injected to the page for rendering a chart. Only files with the extensions `.css` and `.js` are injected, the rest is ignored.
 *   `css`: css inserted in the body of the page
@@ -104,23 +105,27 @@ This is how you start a web server in PhantomJS with the highcharts-convert.js s
 
 Note that the web server listens only to POST requests. Use the same parameters as for command line usage, but wrap them in a JSON structure. See this example for the content of a POST request. Note these parameters are defined: 'infile', 'callback' and 'constr';
 
-    
-    {"infile":"{xAxis: {categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']},series: [{data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]}]};","callback":"function(chart) {chart.renderer.arc(200, 150, 100, 50, -Math.PI, 0).attr({fill : '#FCFFC5',stroke : 'black','stroke-width' : 1}).add();}","constr":"Chart"}
+```json
+{"infile":"{xAxis: {categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']},series: [{data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]}]};","callback":"function(chart) {chart.renderer.arc(200, 150, 100, 50, -Math.PI, 0).attr({fill : '#FCFFC5',stroke : 'black','stroke-width' : 1}).add();}","constr":"Chart"}
+```
 
 This is how you can send a POST from the command line with Curl (MAC & Ubuntu);
 
-    
-    curl -H "Content-Type: application/json" -X POST -d '{"infile":"{xAxis: {categories: [\\"Jan\\", \\"Feb\\", \\"Mar\\"]},series: [{data: [29.9, 71.5, 106.4]}]}"}' 127.0.0.1:3005
+```sh
+curl -H "Content-Type: application/json" -X POST -d '{"infile":"{xAxis: {categories: [\"Jan\", \"Feb\", \"Mar\"]},series: [{data: [29.9, 71.5, 106.4]}]}"}' 127.0.0.1:3005
+```
 
 Example of sending the contents of a file
 
-    
-    curl http://127.0.0.1:3005 -H "Content-Type: application/json" -X POST --data-binary "@/Users/yourname/yourfolder/chart-config.json"
+```sh
+curl http://127.0.0.1:3005 -H "Content-Type: application/json" -X POST --data-binary "@/Users/yourname/yourfolder/chart-config.json"
+```
 
 This is how you can send a POST from the commandline with Curl (Windows);
 
-    
-    curl -H "Content-Type: application/json" -X POST -d "{\\"infile\\":\\"{series:[{data:[29.9,71.5,106.4]}]}\\"}" 127.0.0.1:3005
+```sh
+curl -H "Content-Type: application/json" -X POST -d "{\"infile\":\"{series:[{data:[29.9,71.5,106.4]}]}\"}" 127.0.0.1:3005
+```
 
 ### Setting it up
 

--- a/docs/export-module/setting-up-the-server-old.md
+++ b/docs/export-module/setting-up-the-server-old.md
@@ -131,7 +131,7 @@ Upload/copy this to the application server. You're done with setting up the hig
 
 By default WebLogic registers its own `URLStreamHandler to handle http `URLs. This results in that the Connection silently returns and empty files being returned from the server.  The solution is to get in a reference to Java's default `URLStreamHandler` instead of the one from WebLogic. Follow these steps
 
-1. Alter this file: highcharts-export\\highcharts-export-convert/src/main/java/com/highcharts/export/server.Server.java
+1. Alter this file: `highcharts-export\highcharts-export-convert/src/main/java/com/highcharts/export/server.Server.java`
 
 Change line 94,95 from 
 

--- a/docs/getting-started/system-requirements.md
+++ b/docs/getting-started/system-requirements.md
@@ -28,7 +28,7 @@ We test our software on many browsers using the latest versions. Knowing that In
 Supporting IE 6-8
 -----------------
 
-For supporting IE 6-8, some polyfills are needed. The first file, \`oldie-polyfills.js\` includes some common array functions. This file extends array and object prototypes, and can be omitted if you have other polyfill libraries, or prefer to use your own. The second file, \`oldie.js\`, includes the VML renderer since old IE doesn't support SVG rendering. The polyfills must be inluded before the Highcharts main file. With conditional comments, it looks like this:
+For supporting IE 6-8, some polyfills are needed. The first file, `oldie-polyfills.js` includes some common array functions. This file extends array and object prototypes, and can be omitted if you have other polyfill libraries, or prefer to use your own. The second file, `oldie.js`, includes the VML renderer since old IE doesn't support SVG rendering. The polyfills must be inluded before the Highcharts main file. With conditional comments, it looks like this:
 
     
     <!--[if lt IE 9]>

--- a/docs/working-with-data/custom-preprocessing.md
+++ b/docs/working-with-data/custom-preprocessing.md
@@ -16,80 +16,83 @@ This example shows how to set up the basic chart options first, then do an ajax 
 
 1.  **Create an external CSV file** containing only the data. In this example, the file looks like below. The first line lists the categories with a dummy name in the first position. The subsequent lines list the data series name in the first position and values in the subsequent positions. In real life, you will often create the contents of this file using PHP or other server side programming languages. Or you may choose to use other markup formats like XML or JSON. In those cases, jQuery can also parse the data for you natively.
 
-    
-    Categories,Apples,Pears,Oranges,Bananas
-    John,8,4,6,5
-    Jane,3,4,2,3
-    Joe,86,76,79,77
-    Janet,3,16,13,15
+```csv
+Categories,Apples,Pears,Oranges,Bananas
+John,8,4,6,5
+Jane,3,4,2,3
+Joe,86,76,79,77
+Janet,3,16,13,15
+```
     
 
 2.  **Define the initial, basic options.** Note that we create empty arrays for the categories and series objects, so that we can just push values to them later.
 
-    
-    var options = {
-        chart: {
-            defaultSeriesType: 'column'
-        },
+```js
+var options = {
+    chart: {
+        defaultSeriesType: 'column'
+    },
+    title: {
+        text: 'Fruit Consumption'
+    },
+    xAxis: {
+        categories: []
+    },
+    yAxis: {
         title: {
-            text: 'Fruit Consumption'
-        },
-        xAxis: {
-            categories: []
-        },
-        yAxis: {
-            title: {
-                text: 'Units'
-            }
-        },
-        series: []
-    };
+            text: 'Units'
+        }
+    },
+    series: []
+};
+```
     
 
 3.  **Put it all together.** We use the Highcharts.ajax method to get the contents of the data.csv file. In the success callback function, we parse the returned string, add the results to the categories and series members of the options object, and create the chart. Note that we can't create the chart outside the Ajax callback, as we have to wait for the data to be returned from the server.
 
+```js
+Highcharts.ajax({  
+    url: 'data.csv',  
+    dataType: 'text',  
+    success: function(data) {  
+        // Split the lines  
+        var lines = data.split('\n');  
+        lines.forEach(function(line, lineNo) {  
+            var items = line.split(',');  
+              
+            // header line containes categories  
+            if (lineNo == 0) {  
+                items.forEach(function(item, itemNo) {  
+                    if (itemNo > 0) options.xAxis.categories.push(item);  
+                });  
+            }  
+              
+            // the rest of the lines contain data with their name in the first position  
+            else {  
+                var series = {   
+                    data: []  
+                };  
+                items.forEach(function(item, itemNo) {  
+                    if (itemNo == 0) {  
+                        series.name = item;  
+                    } else {  
+                        series.data.push(parseFloat(item));  
+                    }  
+                });  
+                  
+                options.series.push(series);  
     
-    Highcharts.ajax({  
-        url: 'data.csv',  
-        dataType: 'text',  
-        success: function(data) {  
-            // Split the lines  
-            var lines = data.split('\\n');  
-            lines.forEach(function(line, lineNo) {  
-                var items = line.split(',');  
-                  
-                // header line containes categories  
-                if (lineNo == 0) {  
-                    items.forEach(function(item, itemNo) {  
-                        if (itemNo > 0) options.xAxis.categories.push(item);  
-                    });  
-                }  
-                  
-                // the rest of the lines contain data with their name in the first position  
-                else {  
-                    var series = {   
-                        data: []  
-                    };  
-                    items.forEach(function(item, itemNo) {  
-                        if (itemNo == 0) {  
-                            series.name = item;  
-                        } else {  
-                            series.data.push(parseFloat(item));  
-                        }  
-                    });  
-                      
-                    options.series.push(series);  
-      
-                }  
-                  
-            });  
-              
-            Highcharts.chart('container', options);  
-        },  
-        error: function (e, t) {  
-            console.error(e, t);  
-        }  
-    });  
+            }  
+              
+        });  
+          
+        Highcharts.chart('container', options);  
+    },  
+    error: function (e, t) {  
+        console.error(e, t);  
+    }  
+});
+```
     
 
 Preprocess data using JSON
@@ -101,42 +104,44 @@ Here is a basic example with a JSON file containing the data shown and using the
 
 *   The JSON file
 
-    
-    [
-    [1,12],
-    [2,5],
-    [3,18],
-    [4,13],
-    [5,7],
-    [6,4],
-    [7,9],
-    [8,10],
-    [9,15],
-    [10,22]
-    ]
+```json
+[
+[1,12],
+[2,5],
+[3,18],
+[4,13],
+[5,7],
+[6,4],
+[7,9],
+[8,10],
+[9,15],
+[10,22]
+]
+```
     
 
 *   Using getJSON to preprocess the options and then create the chart.
 
-    
-    document.addEventListener('DOMContentLoaded', function () {
-    
-        var options = {
-            chart: {
-                type: 'spline'
-            },
-            series: [{}]
-        };
-    
-        Highcharts.ajax({  
-            url: 'data.json',  
-            success: function(data) {
-                options.series[0].data = data;
-                Highcharts.Chart('container', options);
-            }  
-        });
-    
+```js
+document.addEventListener('DOMContentLoaded', function () {
+
+    var options = {
+        chart: {
+            type: 'spline'
+        },
+        series: [{}]
+    };
+
+    Highcharts.ajax({  
+        url: 'data.json',  
+        success: function(data) {
+            options.series[0].data = data;
+            Highcharts.Chart('container', options);
+        }  
     });
+
+});
+```
     
 
 There are two things to note here:
@@ -149,36 +154,37 @@ Preprocess data using XML
 
 Loading data from an XML file is similar to the CSV approach. Since Highcharts does not come with a predefined XML data syntax, it is entirely up to you to write the XML and to define a parsing function for it. The downside of using XML over CSV is that it adds some markup to the data, leaving a larger footprint. How large the extra footprint is depends on how you mark up your data. For example, if you wrap each point with a `<point>` tag and load 1000 points, it will add some weight. If however you add a comma separated list of point values, it doesn't. The upside to using XML, at least for small data sets, is that you don't have to manually parse the incoming data. You can utilize jQuery's existing DOM parsing abilities to access the XML tree. We set up a live example for this at [data-from-xml.htm](http://highcharts.com/studies/data-from-xml.htm). The data can be viewed at [data.xml](http://highcharts.com/studies/data.xml). Below is the function used to parse the XML data and adding it to the options object.
 
+```js
+// Load the data from the XML file 
+$.get('data.xml', function(xml) {
     
-    // Load the data from the XML file 
-    $.get('data.xml', function(xml) {
-        
-        // Split the lines
-        var $xml = $(xml);
-    
-        // push categories
-        $xml.find('categories item').each(function(i, category) {
-            options.xAxis.categories.push($(category).text());
-        });
-    
-        // push series
-        $xml.find('series').each(function(i, series) {
-    
-            var seriesOptions = {
-                name: $(series).find('name').text(),
-                data: []
-            };
-    
-            // push data points
-            $(series).find('data point').each(function(i, point) {
-                seriesOptions.data.push(
-                    parseInt($(point).text())
-                );
-            });
-    
-            // add it to the options
-            options.series.push(seriesOptions);
-        });
-    
-        var chart = new Highcharts.Chart(options);
+    // Split the lines
+    var $xml = $(xml);
+
+    // push categories
+    $xml.find('categories item').each(function(i, category) {
+        options.xAxis.categories.push($(category).text());
     });
+
+    // push series
+    $xml.find('series').each(function(i, series) {
+
+        var seriesOptions = {
+            name: $(series).find('name').text(),
+            data: []
+        };
+
+        // push data points
+        $(series).find('data point').each(function(i, point) {
+            seriesOptions.data.push(
+                parseInt($(point).text())
+            );
+        });
+
+        // add it to the options
+        options.series.push(seriesOptions);
+    });
+
+    var chart = new Highcharts.Chart(options);
+});
+```


### PR DESCRIPTION
- Replaces instances of `\\`with `\`
- Removes two in-document ToCs, which were not correct (or needed anymore as they are auto-generated)
- Adds code and code block tags in some documents
