### PR TITLE
bugfix/12043-liveredraw-mobile

### DIFF
--- a/js/parts/Navigator.js
+++ b/js/parts/Navigator.js
@@ -1195,7 +1195,8 @@ Navigator.prototype = {
                 });
             }
         }
-        if (e.DOMType !== 'mousemove') {
+        if (e.DOMType !== 'mousemove' &&
+            e.DOMType !== 'touchmove') {
             navigator.grabbedLeft = navigator.grabbedRight =
                 navigator.grabbedCenter = navigator.fixedWidth =
                     navigator.fixedExtreme = navigator.otherHandlePos =

--- a/ts/parts/Navigator.ts
+++ b/ts/parts/Navigator.ts
@@ -1766,7 +1766,10 @@ Navigator.prototype = {
             }
         }
 
-        if ((e as any).DOMType !== 'mousemove') {
+        if (
+            (e as any).DOMType !== 'mousemove' &&
+            (e as any).DOMType !== 'touchmove'
+        ) {
             navigator.grabbedLeft = navigator.grabbedRight =
                 navigator.grabbedCenter = navigator.fixedWidth =
                 navigator.fixedExtreme = navigator.otherHandlePos =


### PR DESCRIPTION
Fixed #12043, `scrollbar.liveRedraw` was not respected in mobile devices for navigator.