### PR TITLE
Tools:  Run visual samples comparison with master on all PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,8 +346,7 @@ workflows:
             - install_dependencies
           filters:
             branches:
-              only: tools/visual-test-compare
-              # later change to ignore: master
+              ignore: master
           context: highcharts-staging
       - generate_release_reference_images:
           requires:

--- a/samples/unit-tests/series-area/update/demo.js
+++ b/samples/unit-tests/series-area/update/demo.js
@@ -2,7 +2,8 @@ QUnit.test('Updating series stacked property', assert => {
     const chart = Highcharts.chart('container', {
         chart: {
             type: 'area',
-            width: 600
+            width: 600,
+            height: 350
         },
         xAxis: {
             categories: ['Apples', 'Pears', 'Oranges', 'Bananas', 'Grapes', 'Plums', 'Strawberries', 'Raspberries']


### PR DESCRIPTION
Changes branch filtering rules to run visual sample comparison tests on all branches but master (as master is the source for comparison).

NOTE: Also changed chart.height in test `unit-tests/series-area/update` to 350px in order to make the test pass on Linux.