### PR TITLE
Fixed #7292, blurred tooltip text in styled mode

### DIFF
--- a/css/highcharts.scss
+++ b/css/highcharts.scss
@@ -214,6 +214,9 @@ $indicator-negative-line: #F21313;
     fill: $tooltip-background;
     fill-opacity: 0.85;
 }
+div.highcharts-tooltip {
+    filter: none;
+}
 
 .highcharts-selection-marker {
     fill: $highlight-color-80;


### PR DESCRIPTION
Fixed #7292, blurred tooltip text in styled mode when setting `tooltip.useHTML`.
___
The drop-shadow of the outer tooltip box was inherited by the HTML content.
