### PR TITLE
Tools: Nightly visual comparisons shouldn't fail on diffs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,24 +208,24 @@ jobs:
           name: "Highcharts visual tests"
           command: >
             npx karma start test/karma-conf.js --tests highcharts/*/* --single-run
-            --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --no-fail-on-empty-test-suite
+            --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --no-fail-on-empty-test-suite --no-fail-on-failing-test-suite
       - run:
           name: "Highmaps visual tests"
           command: >
             npx karma start test/karma-conf.js --tests maps/*/* --single-run
-            --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --no-fail-on-empty-test-suite
+            --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --no-fail-on-empty-test-suite --no-fail-on-failing-test-suite
           when: always
       - run:
           name: "Highstock visual tests"
           command: >
             npx karma start test/karma-conf.js --tests stock/*/* --single-run
-            --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --no-fail-on-empty-test-suite
+            --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --no-fail-on-empty-test-suite --no-fail-on-failing-test-suite
           when: always
       - run:
           name: "Gant visual tests"
           command: >
             npx karma start test/karma-conf.js --tests gantt/*/* --single-run
-            --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --no-fail-on-empty-test-suite
+            --splitbrowsers << parameters.browsers >> --browsercount 1 --visualcompare --no-fail-on-empty-test-suite --no-fail-on-failing-test-suite
           when: always
       - run: "sudo apt-get install -y librsvg2-bin"
       - run:


### PR DESCRIPTION
Although it completed all the jobs, the nightly build reported failure due to changes made for the comparison with master. This fixes the issue to make sure that nightly visual comparisons doesn't fail the CI job when differences are found in samples and is on par with how it worked before yesterdays changes.