### PR TITLE
Fixed #12058, compare with one data value failed

### DIFF
--- a/js/parts/StockChart.js
+++ b/js/parts/StockChart.js
@@ -603,6 +603,7 @@ seriesProto.setCompare = function (compare) {
                 }
                 return value;
             }
+            return 0;
         } :
         null;
     // Survive to export, #5485

--- a/samples/unit-tests/series/compare/demo.js
+++ b/samples/unit-tests/series/compare/demo.js
@@ -157,3 +157,24 @@ QUnit.test('Compare to the proper series (#7773)', function (assert) {
         'First change value is correct'
     );
 });
+
+QUnit.test('Compare with one single value', assert => {
+    const chart = Highcharts.chart('container', {
+
+        plotOptions: {
+            series: {
+                compare: 'value'
+            }
+        },
+
+        series: [{
+            data: [1]
+        }]
+    });
+
+    assert.deepEqual(
+        chart.yAxis[0].tickPositions,
+        [0],
+        'The Y axis should have one tick at 0 (#12058)'
+    );
+});

--- a/ts/parts/StockChart.ts
+++ b/ts/parts/StockChart.ts
@@ -873,6 +873,7 @@ seriesProto.setCompare = function (
 
                 return value;
             }
+            return 0;
         } :
         null as any;
 


### PR DESCRIPTION
Fixed #12058, compare with one single data value failed. It now behaves like when comparing to data points of the same value - it renders on the 0 line.