### PR TITLE
Bugfix/12055 overlapping legend items

### DIFF
--- a/js/parts/Legend.js
+++ b/js/parts/Legend.js
@@ -670,7 +670,7 @@ Highcharts.Legend.prototype = {
                     item.points.slice(0).reverse(), function (item) {
                     return isNumber(item.plotY);
                 });
-                height = item.legendGroup.getBBox().height;
+                height = item.legendItem.getBBox().height;
                 top = item.yAxis.top - chart.plotTop;
                 if (item.visible) {
                     target = lastPoint ?

--- a/js/parts/Legend.js
+++ b/js/parts/Legend.js
@@ -169,6 +169,7 @@ Highcharts.Legend.prototype = {
             this.itemHiddenStyle = merge(this.itemStyle, options.itemHiddenStyle);
         }
         this.itemMarginTop = options.itemMarginTop || 0;
+        this.itemMarginBottom = options.itemMarginBottom || 0;
         this.padding = padding;
         this.initialItemY = padding - 5; // 5 is pixels above the text
         this.symbolWidth = pick(options.symbolWidth, 16);
@@ -535,7 +536,7 @@ Highcharts.Legend.prototype = {
      * @return {void}
      */
     layoutItem: function (item) {
-        var options = this.options, padding = this.padding, horizontal = options.layout === 'horizontal', itemHeight = item.itemHeight, itemMarginBottom = options.itemMarginBottom || 0, itemMarginTop = this.itemMarginTop, itemDistance = horizontal ? pick(options.itemDistance, 20) : 0, maxLegendWidth = this.maxLegendWidth, itemWidth = (options.alignColumns &&
+        var options = this.options, padding = this.padding, horizontal = options.layout === 'horizontal', itemHeight = item.itemHeight, itemMarginBottom = this.itemMarginBottom, itemMarginTop = this.itemMarginTop, itemDistance = horizontal ? pick(options.itemDistance, 20) : 0, maxLegendWidth = this.maxLegendWidth, itemWidth = (options.alignColumns &&
             this.totalItemWidth > maxLegendWidth) ?
             this.maxItemWidth :
             item.itemWidth;
@@ -670,7 +671,9 @@ Highcharts.Legend.prototype = {
                     item.points.slice(0).reverse(), function (item) {
                     return isNumber(item.plotY);
                 });
-                height = item.legendItem.getBBox().height;
+                height = this.itemMarginTop +
+                    item.legendItem.getBBox().height +
+                    this.itemMarginBottom;
                 top = item.yAxis.top - chart.plotTop;
                 if (item.visible) {
                     target = lastPoint ?

--- a/js/parts/Options.js
+++ b/js/parts/Options.js
@@ -2135,9 +2135,9 @@ H.defaultOptions = {
         },
         /**
          * Line height for the legend items. Deprecated as of 2.1\. Instead,
-         * the line height for each item can be set using itemStyle.lineHeight,
-         * and the padding between items using `itemMarginTop` and
-         * `itemMarginBottom`.
+         * the line height for each item can be set using
+         * `itemStyle.lineHeight`, and the padding between items using
+         * `itemMarginTop` and `itemMarginBottom`.
          *
          * @sample {highcharts} highcharts/legend/lineheight/
          *         Setting padding

--- a/samples/unit-tests/legend/layout/demo.js
+++ b/samples/unit-tests/legend/layout/demo.js
@@ -40,5 +40,29 @@ QUnit.test(
                 'Label should be next to last point'
             );
         });
+
+        chart.series[1].setData(
+            [1, 1, 1]
+        );
+        assert.ok(
+            Math.abs(
+                chart.series[0].legendGroup.translateY -
+                chart.series[1].legendGroup.translateY
+            ) > 12,
+            'The overlapping items should have sufficient distance'
+        );
+
+
+        chart.legend.update({
+            useHTML: true
+        });
+
+        assert.ok(
+            Math.abs(
+                chart.series[0].legendGroup.translateY -
+                chart.series[1].legendGroup.translateY
+            ) > 12,
+            'The overlapping items should have sufficient distance with useHTML (#12055)'
+        );
     }
 );

--- a/samples/unit-tests/legend/layout/demo.js
+++ b/samples/unit-tests/legend/layout/demo.js
@@ -64,5 +64,19 @@ QUnit.test(
             ) > 12,
             'The overlapping items should have sufficient distance with useHTML (#12055)'
         );
+
+        chart.legend.update({
+            itemMarginTop: 10,
+            itemMarginBottom: 10,
+            useHTML: false
+        });
+
+        assert.ok(
+            Math.abs(
+                chart.series[0].legendGroup.translateY -
+                chart.series[1].legendGroup.translateY
+            ) > 30,
+            'The overlapping items should have sufficient distance when an item margin is applied'
+        );
     }
 );

--- a/ts/parts/Legend.ts
+++ b/ts/parts/Legend.ts
@@ -1097,7 +1097,7 @@ Highcharts.Legend.prototype = {
                         return isNumber(item.plotY);
                     }
                 );
-                height = (item.legendGroup as any).getBBox().height;
+                height = (item.legendItem as any).getBBox().height;
 
                 top = (item as any).yAxis.top - chart.plotTop;
                 if (item.visible) {

--- a/ts/parts/Legend.ts
+++ b/ts/parts/Legend.ts
@@ -70,6 +70,7 @@ declare global {
             public initialItemY: number;
             public itemHeight: number;
             public itemHiddenStyle?: CSSObject;
+            public itemMarginBottom: number;
             public itemMarginTop: number;
             public itemStyle?: CSSObject;
             public itemX: number;
@@ -347,6 +348,7 @@ Highcharts.Legend.prototype = {
         }
 
         this.itemMarginTop = options.itemMarginTop || 0;
+        this.itemMarginBottom = options.itemMarginBottom || 0;
         this.padding = padding;
         this.initialItemY = padding - 5; // 5 is pixels above the text
         this.symbolWidth = pick(options.symbolWidth, 16);
@@ -882,7 +884,7 @@ Highcharts.Legend.prototype = {
             padding = this.padding,
             horizontal = options.layout === 'horizontal',
             itemHeight = item.itemHeight,
-            itemMarginBottom = options.itemMarginBottom || 0,
+            itemMarginBottom = this.itemMarginBottom,
             itemMarginTop = this.itemMarginTop,
             itemDistance = horizontal ? pick(options.itemDistance, 20) : 0,
             maxLegendWidth = this.maxLegendWidth,
@@ -1079,7 +1081,7 @@ Highcharts.Legend.prototype = {
             item: (Highcharts.BubbleLegend|Highcharts.Point|Highcharts.Series)
         ): void {
             var lastPoint: (Highcharts.Point|undefined),
-                height,
+                height: number,
                 useFirstPoint = alignLeft,
                 target,
                 top;
@@ -1097,7 +1099,10 @@ Highcharts.Legend.prototype = {
                         return isNumber(item.plotY);
                     }
                 );
-                height = (item.legendItem as any).getBBox().height;
+
+                height = this.itemMarginTop +
+                    (item.legendItem as any).getBBox().height +
+                    this.itemMarginBottom;
 
                 top = (item as any).yAxis.top - chart.plotTop;
                 if (item.visible) {

--- a/ts/parts/Options.ts
+++ b/ts/parts/Options.ts
@@ -2649,9 +2649,9 @@ H.defaultOptions = {
 
         /**
          * Line height for the legend items. Deprecated as of 2.1\. Instead,
-         * the line height for each item can be set using itemStyle.lineHeight,
-         * and the padding between items using `itemMarginTop` and
-         * `itemMarginBottom`.
+         * the line height for each item can be set using
+         * `itemStyle.lineHeight`, and the padding between items using
+         * `itemMarginTop` and `itemMarginBottom`.
          *
          * @sample {highcharts} highcharts/legend/lineheight/
          *         Setting padding


### PR DESCRIPTION
Fixed #12055, overlapping legend items when combining `layout: 'proximate'` and `useHTML: true`.