### PR TITLE
 bugfix/11716-annotations-basic-popup

### DIFF
--- a/js/annotations/annotations.src.js
+++ b/js/annotations/annotations.src.js
@@ -65,9 +65,9 @@ var merge = H.merge,
  * @name Highcharts.Annotation
  *
  * @param {Highcharts.Chart} chart a chart instance
- * @param {Highcharts.AnnotationsOptions} options the options object
+ * @param {Highcharts.AnnotationsOptions} userOptions the options object
  */
-var Annotation = H.Annotation = function (chart, options) {
+var Annotation = H.Annotation = function (chart, userOptions) {
     var labelsAndShapes;
 
     /**
@@ -112,24 +112,23 @@ var Annotation = H.Annotation = function (chart, options) {
      *
      * @type {Highcharts.AnnotationsOptions}
      */
-    // this.options = merge(this.defaultOptions, userOptions);
-    this.options = options;
+    this.options = merge(this.defaultOptions, userOptions);
 
     /**
      * The user options for the annotations.
      *
      * @type {Highcharts.AnnotationsOptions}
      */
-    this.userOptions = merge(true, {}, options);
+    this.userOptions = userOptions;
 
     // Handle labels and shapes - those are arrays
     // Merging does not work with arrays (stores reference)
     labelsAndShapes = this.getLabelsAndShapesOptions(
-        this.userOptions,
-        options
+        this.options,
+        userOptions
     );
-    this.userOptions.labels = labelsAndShapes.labels;
-    this.userOptions.shapes = labelsAndShapes.shapes;
+    this.options.labels = labelsAndShapes.labels;
+    this.options.shapes = labelsAndShapes.shapes;
 
     /**
      * The callback that reports to the overlapping-labels module which
@@ -164,7 +163,7 @@ var Annotation = H.Annotation = function (chart, options) {
      * @type {Highcharts.SVGElement}
      */
 
-    this.init(chart, options);
+    this.init(chart, this.options);
 };
 
 
@@ -768,17 +767,19 @@ merge(
         },
 
         addShapes: function () {
-            (this.options.shapes || []).forEach(
-                this.initShape,
-                this
-            );
+            (this.options.shapes || []).forEach(function (shapeOptions, i) {
+                var shape = this.initShape(shapeOptions, i);
+
+                merge(true, this.options.shapes[i], shape.options);
+            }, this);
         },
 
         addLabels: function () {
-            (this.options.labels || []).forEach(
-                this.initLabel,
-                this
-            );
+            (this.options.labels || []).forEach(function (labelsOptions, i) {
+                var labels = this.initLabel(labelsOptions, i);
+
+                merge(true, this.options.labels[i], labels.options);
+            }, this);
         },
 
         addClipPaths: function () {
@@ -1202,11 +1203,7 @@ extend(chartProto, /** @lends Highcharts.Chart# */ {
     initAnnotation: function (userOptions) {
         var Constructor =
             Annotation.types[userOptions.type] || Annotation,
-            options = H.merge(
-                Constructor.prototype.defaultOptions,
-                userOptions
-            ),
-            annotation = new Constructor(this, options);
+            annotation = new Constructor(this, userOptions);
 
         this.annotations.push(annotation);
 

--- a/samples/unit-tests/annotations/annotations-events/demo.js
+++ b/samples/unit-tests/annotations/annotations-events/demo.js
@@ -2,6 +2,7 @@ QUnit.test('Annotations events - general', function (assert) {
     var addEventCalled = 0,
         afterUpdateEventCalled = 0,
         removeEventCalled = 0,
+        popupOptions,
         getShapes = function () {
             return [{
                 strokeWidth: 3,
@@ -34,7 +35,25 @@ QUnit.test('Annotations events - general', function (assert) {
                         removeEventCalled++;
                     }
                 }
+            }, {
+                shapes: [{
+                    type: 'circle',
+                    point: {
+                        xAxis: 0,
+                        yAxis: 0,
+                        x: 5,
+                        y: 20
+                    },
+                    r: 10
+                }]
             }],
+            navigation: {
+                events: {
+                    showPopup: function (event) {
+                        popupOptions = event.options;
+                    }
+                }
+            },
             series: [{
                 data: [7.0, 6.9, 9.5, 14.5, 18.2, 21.5, 25.2, 23.3, 18.3, 13.9, 9.6]
             }]
@@ -118,5 +137,24 @@ QUnit.test('Annotations events - general', function (assert) {
     assert.ok(
         true,
         'No errors after removing selected annotation and selecting a new one (#11015)'
+    );
+
+    controller.click(
+        chart.xAxis[0].toPixels(5),
+        chart.yAxis[0].toPixels(20)
+    );
+
+    assert.deepEqual(
+        popupOptions,
+        {
+            langKey: undefined,
+            shapes: [{
+                fill: ['rgba(0, 0, 0, 0.75)', 'text'],
+                stroke: ['rgba(0, 0, 0, 0.75)', 'text'],
+                strokeWidth: [1, 'number']
+            }],
+            type: 'circle'
+        },
+        'Annotations\' popup should get correct config for fields (#11716)'
     );
 });


### PR DESCRIPTION
Fixed #11716, basic annotations (rect, circle and label) were missing options in StockTools' popup.