### PR TITLE
Tools: Fixes for visual tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,18 +154,18 @@ jobs:
       - <<: *load_workspace
       - <<: *add_gh_keys
       - <<: *add_to_ssh_config
+      - run: sudo apt-get install -y rsync
       - run: git fetch origin master:master && git checkout master && npm i && npx gulp scripts
       - run: "npx karma start test/karma-conf.js --tests highcharts/*/* --reference --browsercount 2 --no-fail-on-empty-test-suite"
       - run: "npx karma start test/karma-conf.js --tests maps/*/* --reference --browsercount 2 --no-fail-on-empty-test-suite"
       - run: "npx karma start test/karma-conf.js --tests stock/*/* --reference --browsercount 2 --no-fail-on-empty-test-suite"
       - run: "npx karma start test/karma-conf.js --tests gantt/*/* --reference --browsercount 2 --no-fail-on-empty-test-suite"
       - run: git checkout ${CIRCLE_BRANCH} && npm i && npx gulp scripts
-      - run: npx karma start test/karma-conf.js --tests highcharts/*/* --single-run --browsercount 2 --visualcompare --no-fail-on-failing-test-suite
-      - run: npx karma start test/karma-conf.js --tests stock/*/* --single-run --browsercount 2 --visualcompare --no-fail-on-failing-test-suite
-      - run: npx karma start test/karma-conf.js --tests maps/*/* --single-run --browsercount 2 --visualcompare --no-fail-on-failing-test-suite
-      - run: npx karma start test/karma-conf.js --tests gantt/*/* --single-run --browsercount 2 --visualcompare --no-fail-on-failing-test-suite
+      - run: npx karma start test/karma-conf.js --tests highcharts/*/* --single-run --browsercount 2 --visualcompare || true
+      - run: npx karma start test/karma-conf.js --tests stock/*/* --single-run --browsercount 2 --visualcompare || true
+      - run: npx karma start test/karma-conf.js --tests maps/*/* --single-run --browsercount 2 --visualcompare || true
+      - run: npx karma start test/karma-conf.js --tests gantt/*/* --single-run --browsercount 2 --visualcompare || true
       - run: echo ${CIRCLE_PULL_REQUEST##*/} | xargs -I{} npx gulp update-pr-testresults --fail-silently --user circleci-mu --pr {}
-      - run: sudo apt-get install -y rsync
       - run:
           name: Save test results where both an reference.svg and candidate.svg exists
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,12 +165,12 @@ jobs:
       - run: npx karma start test/karma-conf.js --tests maps/*/* --single-run --browsercount 2 --visualcompare --no-fail-on-failing-test-suite
       - run: npx karma start test/karma-conf.js --tests gantt/*/* --single-run --browsercount 2 --visualcompare --no-fail-on-failing-test-suite
       - run: echo ${CIRCLE_PULL_REQUEST##*/} | xargs -I{} npx gulp update-pr-testresults --fail-silently --user circleci-mu --pr {}
-      - run: mkdir ../visual-test-results
+      - run: sudo apt-get install -y rsync
       - run:
           name: Save test results where both an reference.svg and candidate.svg exists
           command: |
             mkdir ../visual-test-results &&
-            find samples -type d  -exec test -f '{}'/reference.svg -a -f '{}'/candidate.svg \; -print | xargs -I{} cp -r --parents {} ../visual-test-results
+            find samples -type d  -exec test -f '{}'/reference.svg -a -f '{}'/candidate.svg \; -print | xargs -I{} rsync -Rrv --include="*.svg" --include="*.gif" --exclude="*" {} ../visual-test-results
           when: always
       - store_test_results:
           path: ../visual-test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,10 @@ jobs:
       - run: npx karma start test/karma-conf.js --tests stock/*/* --single-run --browsercount 2 --visualcompare || true
       - run: npx karma start test/karma-conf.js --tests maps/*/* --single-run --browsercount 2 --visualcompare || true
       - run: npx karma start test/karma-conf.js --tests gantt/*/* --single-run --browsercount 2 --visualcompare || true
-      - run: echo ${CIRCLE_PULL_REQUEST##*/} | xargs -I{} npx gulp update-pr-testresults --fail-silently --user circleci-mu --pr {}
+      - run:
+          name: Comment on PR
+          command: echo ${CIRCLE_PULL_REQUEST##*/} | xargs -I{} npx gulp update-pr-testresults --fail-silently --user circleci-mu --pr {}
+          when: always
       - run:
           name: Save test results where both an reference.svg and candidate.svg exists
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,7 @@ jobs:
       - run:
           name: Save test results where both an reference.svg and candidate.svg exists
           command: |
+            mkdir ../visual-test-results &&
             find samples -type d  -exec test -f '{}'/reference.svg -a -f '{}'/candidate.svg \; -print | xargs -I{} cp -r --parents {} ../visual-test-results
           when: always
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,7 @@ jobs:
       - run: "npx karma start test/karma-conf.js --tests stock/*/* --reference --browsercount 2 --no-fail-on-empty-test-suite"
       - run: "npx karma start test/karma-conf.js --tests gantt/*/* --reference --browsercount 2 --no-fail-on-empty-test-suite"
       - run: git checkout ${CIRCLE_BRANCH} && npm i && npx gulp scripts
+      # we are forcing success on the below test runs to avoid failing the PR build
       - run: npx karma start test/karma-conf.js --tests highcharts/*/* --single-run --browsercount 2 --visualcompare || true
       - run: npx karma start test/karma-conf.js --tests stock/*/* --single-run --browsercount 2 --visualcompare || true
       - run: npx karma start test/karma-conf.js --tests maps/*/* --single-run --browsercount 2 --visualcompare || true
@@ -173,7 +174,7 @@ jobs:
           name: Save test results where both an reference.svg and candidate.svg exists
           command: |
             mkdir ../visual-test-results &&
-            find samples -type d  -exec test -f '{}'/reference.svg -a -f '{}'/candidate.svg \; -print | xargs -I{} rsync -Rrv --include="*.svg" --include="*.gif" --exclude="*" {} ../visual-test-results
+            find samples -type d  -exec test -f '{}'/reference.svg -a -f '{}'/candidate.svg \; -print | xargs -I{} rsync -Rri --include="*/" --include="*.svg" --include="*.gif" --exclude="*" {} ../visual-test-results
           when: always
       - store_test_results:
           path: ../visual-test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,12 +154,12 @@ jobs:
       - <<: *load_workspace
       - <<: *add_gh_keys
       - <<: *add_to_ssh_config
-      - run: git fetch origin master:master && git checkout master && npm i
+      - run: git fetch origin master:master && git checkout master && npm i && npx gulp scripts
       - run: "npx karma start test/karma-conf.js --tests highcharts/*/* --reference --browsercount 2 --no-fail-on-empty-test-suite"
       - run: "npx karma start test/karma-conf.js --tests maps/*/* --reference --browsercount 2 --no-fail-on-empty-test-suite"
       - run: "npx karma start test/karma-conf.js --tests stock/*/* --reference --browsercount 2 --no-fail-on-empty-test-suite"
       - run: "npx karma start test/karma-conf.js --tests gantt/*/* --reference --browsercount 2 --no-fail-on-empty-test-suite"
-      - run: git checkout ${CIRCLE_BRANCH} && npm i
+      - run: git checkout ${CIRCLE_BRANCH} && npm i && npx gulp scripts
       - run: npx karma start test/karma-conf.js --tests highcharts/*/* --single-run --browsercount 2 --visualcompare --no-fail-on-failing-test-suite
       - run: npx karma start test/karma-conf.js --tests stock/*/* --single-run --browsercount 2 --visualcompare --no-fail-on-failing-test-suite
       - run: npx karma start test/karma-conf.js --tests maps/*/* --single-run --browsercount 2 --visualcompare --no-fail-on-failing-test-suite

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -580,6 +580,7 @@ module.exports = function (config) {
             resultsOutputPath: 'test/visual-test-results.json',
         };
         options.browserDisconnectTolerance = 1; // default 0
+        options.browserDisconnectTimeout = 30000; // default 2000
     }
 
     if (browsers.some(browser => /^(Mac|Win)\./.test(browser)) || argv.oldie) {

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -579,6 +579,7 @@ module.exports = function (config) {
         options.imageCapture = {
             resultsOutputPath: 'test/visual-test-results.json',
         };
+        options.browserDisconnectTolerance = 1; // default 0
     }
 
     if (browsers.some(browser => /^(Mac|Win)\./.test(browser)) || argv.oldie) {

--- a/test/karma-imagecapture-reporter.js
+++ b/test/karma-imagecapture-reporter.js
@@ -131,16 +131,21 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
     emitter.on('browser_info', (browser, info) => {
         let data = info.data;
         const filename = info.filename;
-        if (/\.svg$/.test(filename)) {
-            fs.writeFileSync(filename, prettyXML(data));
+        try {
+            if (/\.svg$/.test(filename)) {
+                fs.writeFileSync(filename, prettyXML(data));
 
-        } else if (/\.png$/.test(filename)) {
-            data = data.replace(/^data:image\/\w+;base64,/, '');
-            fs.writeFileSync(filename, Buffer.from(data, 'base64'));
+            } else if (/\.png$/.test(filename)) {
+                data = data.replace(/^data:image\/\w+;base64,/, '');
+                fs.writeFileSync(filename, Buffer.from(data, 'base64'));
 
-        } else if (/\.gif$/.test(filename)) {
-            createAnimatedGif(filename, info.frames);
+            } else if (/\.gif$/.test(filename)) {
+                createAnimatedGif(filename, info.frames);
+            }
+        } catch (err) {
+            LOG.error(`Failed to write file ${filename}\n\n${err}`);
         }
+
     });
 
 }


### PR DESCRIPTION
This PR contains fixes that has been tested via #12098

Main reason for failure was not running `gulp scripts` when switching branches.
Made visual comparison with master more bulletproof, forced success on CI even when failures occur and fixed issue with test artifact upload.