### PR TITLE
Feature/a11y event hooks

### DIFF
--- a/js/modules/accessibility/accessibility.js
+++ b/js/modules/accessibility/accessibility.js
@@ -60,7 +60,8 @@ import '../../modules/accessibility/a11y-i18n.js';
 
 var addEvent = H.addEvent,
     doc = H.win.document,
-    merge = H.merge;
+    merge = H.merge,
+    fireEvent = H.fireEvent;
 
 
 // Add default options
@@ -295,12 +296,19 @@ Accessibility.prototype = {
             chart = this.chart,
             a11yOptions = chart.options.accessibility;
 
+        fireEvent(chart, 'beforeA11yUpdate');
+
         // Update the chart type list as this is used by multiple modules
         chart.types = this.getChartTypes();
 
         // Update markup
         Object.keys(components).forEach(function (componentName) {
             components[componentName].onChartUpdate();
+
+            fireEvent(chart, 'afterA11yComponentUpdate', {
+                name: componentName,
+                component: components[componentName]
+            });
         });
 
         // Update keyboard navigation
@@ -315,6 +323,8 @@ Accessibility.prototype = {
         ) {
             whcm.setHighContrastTheme(chart);
         }
+
+        fireEvent(chart, 'afterA11yUpdate');
     },
 
 

--- a/js/modules/accessibility/components/LegendComponent.js
+++ b/js/modules/accessibility/components/LegendComponent.js
@@ -20,6 +20,23 @@ import A11yUtilities from '../utilities.js';
 
 var stripHTMLTags = A11yUtilities.stripHTMLTagsFromString;
 
+function scrollLegendToItem(legend, itemIx) {
+    var itemPage = legend.allItems[itemIx].pageIx,
+        curPage = legend.currentPage;
+
+    if (itemPage !== undefined && itemPage + 1 !== curPage) {
+        legend.scroll(1 + itemPage - curPage);
+    }
+}
+
+function shouldDoLegendA11y(chart) {
+    var items = chart.legend && chart.legend.allItems,
+        legendA11yOptions = chart.options.legend.accessibility || {};
+
+    return items && items.length &&
+        !(chart.colorAxis && chart.colorAxis.length) &&
+        legendA11yOptions.enabled !== false;
+}
 
 /**
  * Highlight legend item by index.
@@ -37,20 +54,15 @@ H.Chart.prototype.highlightLegendItem = function (ix) {
 
     if (items[ix]) {
         if (items[oldIx]) {
-            H.fireEvent(
-                items[oldIx].legendGroup.element,
-                'mouseout'
-            );
+            H.fireEvent(items[oldIx].legendGroup.element, 'mouseout');
         }
-        // Scroll if we have to
-        if (items[ix].pageIx !== undefined &&
-            items[ix].pageIx + 1 !== this.legend.currentPage) {
-            this.legend.scroll(1 + items[ix].pageIx - this.legend.currentPage);
-        }
-        // Focus
+
+        scrollLegendToItem(this.legend, ix);
+
         this.setFocusToElement(
             items[ix].legendItem, items[ix].a11yProxyElement
         );
+
         H.fireEvent(items[ix].legendGroup.element, 'mouseover');
         return true;
     }
@@ -62,6 +74,7 @@ H.addEvent(H.Legend, 'afterColorizeItem', function (e) {
     var chart = this.chart,
         a11yOptions = chart.options.accessibility,
         legendItem = e.item;
+
     if (a11yOptions.enabled && legendItem && legendItem.a11yProxyElement) {
         legendItem.a11yProxyElement.setAttribute(
             'aria-pressed', e.visible ? 'false' : 'true'
@@ -86,14 +99,11 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
      * of the proxy overlays.
      */
     onChartRender: function () {
-        var chart = this.chart,
-            a11yOptions = chart.options.accessibility,
-            items = chart.legend && chart.legend.allItems,
-            component = this;
+        var component = this;
 
         // Ignore render after proxy clicked. No need to destroy it, and
         // destroying also kills focus.
-        if (component.legendProxyButtonClicked) {
+        if (this.legendProxyButtonClicked) {
             delete component.legendProxyButtonClicked;
             return;
         }
@@ -101,52 +111,79 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
         // Always Remove group if exists
         this.removeElement(this.legendProxyGroup);
 
-        // Skip everything if we do not have legend items, or if we have a
-        // color axis
-        if (
-            !items || !items.length ||
-            chart.colorAxis && chart.colorAxis.length ||
-            !chart.options.legend.accessibility.enabled
-        ) {
-            return;
+        if (shouldDoLegendA11y(this.chart)) {
+            this.addLegendProxyGroup();
+            this.proxyLegendItems();
         }
+    },
 
-        // Add proxy group
-        this.legendProxyGroup = this.addProxyGroup({
-            'aria-label': chart.langFormat(
+
+    /**
+     * @private
+     */
+    addLegendProxyGroup: function () {
+        var a11yOptions = this.chart.options.accessibility,
+            groupLabel = this.chart.langFormat(
                 'accessibility.legend.legendLabel'
             ),
-            'role': a11yOptions.landmarkVerbosity === 'all' ?
-                'region' : null
-        });
+            groupRole = a11yOptions.landmarkVerbosity === 'all' ?
+                'region' : null;
 
-        // Proxy the legend items
+        this.legendProxyGroup = this.addProxyGroup({
+            'aria-label': groupLabel,
+            'role': groupRole
+        });
+    },
+
+
+    /**
+     * @private
+     */
+    proxyLegendItems: function () {
+        var component = this,
+            items = this.chart.legend && this.chart.legend.allItems;
+
         items.forEach(function (item) {
             if (item.legendItem && item.legendItem.element) {
-                item.a11yProxyElement = component.createProxyButton(
-                    item.legendItem,
-                    component.legendProxyGroup,
-                    {
-                        tabindex: -1,
-                        'aria-pressed': !item.visible,
-                        'aria-label': chart.langFormat(
-                            'accessibility.legend.legendItem',
-                            {
-                                chart: chart,
-                                itemName: stripHTMLTags(item.name)
-                            }
-                        )
-                    },
-                    // Consider useHTML
-                    item.legendGroup.div ? item.legendItem : item.legendGroup,
-                    // Additional click event (fires first)
-                    function () {
-                        // Keep track of when we should ignore next render
-                        component.legendProxyButtonClicked = true;
-                    }
-                );
+                component.proxyLegendItem(item);
             }
         });
+    },
+
+
+    /**
+     * @private
+     * @param {Highcharts.BubbleLegend|Highcharts.Point|Highcharts.Series} item
+     */
+    proxyLegendItem: function (item) {
+        var component = this,
+            itemLabel = this.chart.langFormat(
+                'accessibility.legend.legendItem',
+                {
+                    chart: this.chart,
+                    itemName: stripHTMLTags(item.name)
+                }
+            ),
+            attribs = {
+                tabindex: -1,
+                'aria-pressed': !item.visible,
+                'aria-label': itemLabel
+            },
+            // Keep track of when we should ignore next render
+            preClickEvent = function () {
+                component.legendProxyButtonClicked = true;
+            },
+            // Considers useHTML
+            proxyPositioningElement = item.legendGroup.div ?
+                item.legendItem : item.legendGroup;
+
+        item.a11yProxyElement = this.createProxyButton(
+            item.legendItem,
+            this.legendProxyGroup,
+            attribs,
+            proxyPositioningElement,
+            preClickEvent
+        );
     },
 
 
@@ -157,78 +194,113 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
     getKeyboardNavigation: function () {
         var keys = this.keyCodes,
             component = this,
-            chart = this.chart,
-            a11yOptions = chart.options.accessibility;
+            chart = this.chart;
+
         return new KeyboardNavigationHandler(chart, {
             keyCodeMap: [
-                // Arrow key handling
-                [[
-                    keys.left, keys.right, keys.up, keys.down
-                ], function (keyCode) {
-                    var direction = (
-                        keyCode === keys.left || keyCode === keys.up
-                    ) ? -1 : 1;
+                [[keys.left, keys.right, keys.up, keys.down],
+                    function (keyCode) {
+                        return component.onKbdArrowKey(this, keyCode);
+                    }],
 
-                    // Try to highlight next/prev legend item
-                    var res = chart.highlightLegendItem(
-                        component.highlightedLegendItemIx + direction
-                    );
-                    if (res) {
-                        component.highlightedLegendItemIx += direction;
-                        return this.response.success;
-                    }
-
-                    // Failed, can we wrap around?
-                    if (
-                        chart.legend.allItems.length > 1 &&
-                        a11yOptions.keyboardNavigation.wrapAround
-                    ) {
-                        // Wrap around if we failed and have more than 1 item
-                        this.init(direction);
-                        return this.response.success;
-                    }
-
-                    // No wrap, move
-                    return this.response[direction > 0 ? 'next' : 'prev'];
-                }],
-
-                // Click item
-                [[
-                    keys.enter, keys.space
-                ], function () {
-                    var legendItem = chart.legend.allItems[
-                        component.highlightedLegendItemIx
-                    ];
-                    if (legendItem && legendItem.a11yProxyElement) {
-                        H.fireEvent(legendItem.a11yProxyElement, 'click');
-                    }
-                    return this.response.success;
-                }]
+                [[keys.enter, keys.space],
+                    function () {
+                        return component.onKbdClick(this);
+                    }]
             ],
 
-            // Only run this module if we have at least one legend - wait for
-            // it - item. Don't run if the legend is populated by a colorAxis.
-            // Don't run if legend navigation is disabled.
             validate: function () {
-                var legendOptions = chart.options.legend;
-                return chart.legend && chart.legend.allItems &&
-                    chart.legend.display &&
-                    !(chart.colorAxis && chart.colorAxis.length) &&
-                    legendOptions &&
-                    legendOptions.accessibility &&
-                    legendOptions.accessibility.enabled &&
-                    legendOptions.accessibility.keyboardNavigation &&
-                    legendOptions.accessibility.keyboardNavigation.enabled;
+                return component.shouldHaveLegendNavigation();
             },
 
-
-            // Focus first/last item
             init: function (direction) {
-                var ix = direction > 0 ? 0 : chart.legend.allItems.length - 1;
-                chart.highlightLegendItem(ix);
-                component.highlightedLegendItemIx = ix;
+                return component.onKbdNavigationInit(direction);
             }
         });
+    },
+
+
+    /**
+     * @private
+     * @param {Highcharts.KeyboardNavigationHandler} keyboardNavigationHandler
+     * @param {number} keyCode
+     * @return {number} Response code
+     */
+    onKbdArrowKey: function (keyboardNavigationHandler, keyCode) {
+        var keys = this.keyCodes,
+            response = keyboardNavigationHandler.response,
+            chart = this.chart,
+            a11yOptions = chart.options.accessibility,
+            numItems = chart.legend.allItems.length,
+            direction = (keyCode === keys.left || keyCode === keys.up) ? -1 : 1;
+
+        var res = chart.highlightLegendItem(
+            this.highlightedLegendItemIx + direction
+        );
+        if (res) {
+            this.highlightedLegendItemIx += direction;
+            return response.success;
+        }
+
+        if (numItems > 1 && a11yOptions.keyboardNavigation.wrapAround) {
+            keyboardNavigationHandler.init(direction);
+            return response.success;
+        }
+
+        // No wrap, move
+        return response[direction > 0 ? 'next' : 'prev'];
+    },
+
+
+    /**
+     * @private
+     * @param {Highcharts.KeyboardNavigationHandler} keyboardNavigationHandler
+     * @return {number} Response code
+     */
+    onKbdClick: function (keyboardNavigationHandler) {
+        var legendItem = this.chart.legend.allItems[
+            this.highlightedLegendItemIx
+        ];
+
+        if (legendItem && legendItem.a11yProxyElement) {
+            H.fireEvent(legendItem.a11yProxyElement, 'click');
+        }
+
+        return keyboardNavigationHandler.response.success;
+    },
+
+
+    /**
+     * @private
+     * @return {boolean}
+     */
+    shouldHaveLegendNavigation: function () {
+        var chart = this.chart,
+            legendOptions = chart.options.legend || {},
+            hasLegend = chart.legend && chart.legend.allItems,
+            hasColorAxis = chart.colorAxis && chart.colorAxis.length,
+            legendA11yOptions = legendOptions.accessibility || {};
+
+        return hasLegend &&
+            chart.legend.display &&
+            !hasColorAxis &&
+            legendA11yOptions.enabled &&
+            legendA11yOptions.keyboardNavigation &&
+            legendA11yOptions.keyboardNavigation.enabled;
+    },
+
+
+    /**
+     * @private
+     * @param {number} direction
+     */
+    onKbdNavigationInit: function (direction) {
+        var chart = this.chart,
+            lastIx = chart.legend.allItems.length - 1,
+            ixToHighlight = direction > 0 ? 0 : lastIx;
+
+        chart.highlightLegendItem(ixToHighlight);
+        this.highlightedLegendItemIx = ixToHighlight;
     }
 
 });

--- a/js/modules/accessibility/components/RangeSelectorComponent.js
+++ b/js/modules/accessibility/components/RangeSelectorComponent.js
@@ -16,6 +16,25 @@ var extend = U.extend;
 
 import AccessibilityComponent from '../AccessibilityComponent.js';
 import KeyboardNavigationHandler from '../KeyboardNavigationHandler.js';
+import A11yUtilities from '../utilities.js';
+var setElAttrs = A11yUtilities.setElAttrs;
+
+
+function shouldRunInputNavigation(chart) {
+    var inputVisible = (
+        chart.rangeSelector &&
+        chart.rangeSelector.inputGroup &&
+        chart.rangeSelector.inputGroup.element
+            .getAttribute('visibility') !== 'hidden'
+    );
+
+    return (
+        inputVisible &&
+        chart.options.rangeSelector.inputEnabled !== false &&
+        chart.rangeSelector.minInput &&
+        chart.rangeSelector.maxInput
+    );
+}
 
 
 /**
@@ -72,45 +91,63 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
             return;
         }
 
-        // Make sure buttons are accessible and focusable
         if (rangeSelector.buttons && rangeSelector.buttons.length) {
             rangeSelector.buttons.forEach(function (button) {
                 component.unhideElementFromScreenReaders(button.element);
-                button.element.setAttribute('tabindex', '-1');
-                button.element.setAttribute('role', 'button');
-                button.element.setAttribute(
-                    'aria-label',
-                    chart.langFormat(
-                        'accessibility.rangeSelector.buttonText',
-                        {
-                            chart: chart,
-                            buttonText: button.text && button.text.textStr
-                        }
-                    )
-                );
+                component.setRangeButtonAttrs(button);
             });
         }
 
         // Make sure input boxes are accessible and focusable
         if (rangeSelector.maxInput && rangeSelector.minInput) {
             ['minInput', 'maxInput'].forEach(function (key, i) {
-                if (rangeSelector[key]) {
-                    component.unhideElementFromScreenReaders(
-                        rangeSelector[key]
-                    );
-                    rangeSelector[key].setAttribute('tabindex', '-1');
-                    rangeSelector[key].setAttribute('role', 'textbox');
-                    rangeSelector[key].setAttribute(
-                        'aria-label',
-                        chart.langFormat(
-                            'accessibility.rangeSelector.' +
-                                (i ? 'max' : 'min') + 'InputLabel',
-                            { chart: chart }
-                        )
+                var input = rangeSelector[key];
+                if (input) {
+                    component.unhideElementFromScreenReaders(input);
+                    component.setRangeInputAttrs(
+                        input,
+                        'accessibility.rangeSelector.' + (i ? 'max' : 'min') +
+                            'InputLabel'
                     );
                 }
             });
         }
+    },
+
+
+    /**
+     * @private
+     * @param {Highcharts.SVGElement} button
+     */
+    setRangeButtonAttrs: function (button) {
+        var chart = this.chart,
+            label = chart.langFormat(
+                'accessibility.rangeSelector.buttonText',
+                {
+                    chart: chart,
+                    buttonText: button.text && button.text.textStr
+                }
+            );
+
+        setElAttrs(button.element, {
+            tabindex: -1,
+            role: 'button',
+            'aria-label': label
+        });
+    },
+
+
+    /**
+     * @private
+     */
+    setRangeInputAttrs: function (input, langKey) {
+        var chart = this.chart;
+
+        setElAttrs(input, {
+            tabindex: -1,
+            role: 'textbox',
+            'aria-label': chart.langFormat(langKey, { chart: chart })
+        });
     },
 
 
@@ -122,62 +159,85 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
     getRangeSelectorButtonNavigation: function () {
         var chart = this.chart,
             keys = this.keyCodes,
-            a11yOptions = chart.options.accessibility,
             component = this;
 
         return new KeyboardNavigationHandler(chart, {
             keyCodeMap: [
-                // Left/Right/Up/Down
-                [[
-                    keys.left, keys.right, keys.up, keys.down
-                ], function (keyCode) {
-                    var direction = (
-                        keyCode === keys.left || keyCode === keys.up
-                    ) ? -1 : 1;
+                [[keys.left, keys.right, keys.up, keys.down],
+                    function (keyCode) {
+                        return component.onButtonNavKbdArrowKey(this, keyCode);
+                    }],
 
-                    // Try to highlight next/prev button
-                    if (
-                        !chart.highlightRangeSelectorButton(
-                            chart.highlightedRangeSelectorItemIx + direction
-                        )
-                    ) {
-                        // If we failed, handle wrap around/move
-                        if (a11yOptions.keyboardNavigation.wrapAround) {
-                            this.init(direction);
-                            return this.response.success;
-                        }
-                        return this.response[direction > 0 ? 'next' : 'prev'];
-                    }
-                }],
-
-                // Enter/Spacebar
-                [[
-                    keys.enter, keys.space
-                ], function () {
-                    // Don't allow click if button used to be disabled
-                    if (chart.oldRangeSelectorItemState !== 3) {
-                        component.fakeClickEvent(
-                            chart.rangeSelector.buttons[
-                                chart.highlightedRangeSelectorItemIx
-                            ].element
-                        );
-                    }
-                }]
+                [[keys.enter, keys.space],
+                    function () {
+                        return component.onButtonNavKbdClick(this);
+                    }]
             ],
 
-            // Only run this module if we have range selector
             validate: function () {
-                return chart.rangeSelector && chart.rangeSelector.buttons &&
+                var hasRangeSelector = chart.rangeSelector &&
+                    chart.rangeSelector.buttons &&
                     chart.rangeSelector.buttons.length;
+                return hasRangeSelector;
             },
 
-            // Focus first/last button
             init: function (direction) {
+                var lastButtonIx = chart.rangeSelector.buttons.length - 1;
                 chart.highlightRangeSelectorButton(
-                    direction > 0 ? 0 : chart.rangeSelector.buttons.length - 1
+                    direction > 0 ? 0 : lastButtonIx
                 );
             }
         });
+    },
+
+
+    /**
+     * @private
+     * @param {Highcharts.KeyboardNavigationHandler} keyboardNavigationHandler
+     * @param {number} keyCode
+     * @return {number} Response code
+     */
+    onButtonNavKbdArrowKey: function (keyboardNavigationHandler, keyCode) {
+        var response = keyboardNavigationHandler.response,
+            keys = this.keyCodes,
+            chart = this.chart,
+            wrapAround = chart.options.accessibility.keyboardNavigation
+                .wrapAround,
+            direction = (
+                keyCode === keys.left || keyCode === keys.up
+            ) ? -1 : 1,
+            didHighlight = chart.highlightRangeSelectorButton(
+                chart.highlightedRangeSelectorItemIx + direction
+            );
+
+        if (!didHighlight) {
+            if (wrapAround) {
+                keyboardNavigationHandler.init(direction);
+                return response.success;
+            }
+            return response[direction > 0 ? 'next' : 'prev'];
+        }
+
+        return response.success;
+    },
+
+
+    /**
+     * @private
+     * @param {Highcharts.KeyboardNavigationHandler} keyboardNavigationHandler
+     * @param {number} keyCode
+     */
+    onButtonNavKbdClick: function () {
+        var chart = this.chart,
+            wasDisabled = chart.oldRangeSelectorItemState === 3;
+
+        if (!wasDisabled) {
+            this.fakeClickEvent(
+                chart.rangeSelector.buttons[
+                    chart.highlightedRangeSelectorItemIx
+                ].element
+            );
+        }
     },
 
 
@@ -189,67 +249,87 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
      */
     getRangeSelectorInputNavigation: function () {
         var chart = this.chart,
-            keys = this.keyCodes;
+            keys = this.keyCodes,
+            component = this;
 
         return new KeyboardNavigationHandler(chart, {
             keyCodeMap: [
-                // Tab/Up/Down
                 [[
                     keys.tab, keys.up, keys.down
                 ], function (keyCode, e) {
                     var direction = (
-                            keyCode === keys.tab && e.shiftKey ||
-                            keyCode === keys.up
-                        ) ? -1 : 1,
+                        keyCode === keys.tab && e.shiftKey ||
+                        keyCode === keys.up
+                    ) ? -1 : 1;
 
-                        newIx = chart.highlightedInputRangeIx =
-                            chart.highlightedInputRangeIx + direction;
-
-                    // Try to highlight next/prev item in list.
-                    if (newIx > 1 || newIx < 0) { // Out of range
-                        return this.response[direction > 0 ? 'next' : 'prev'];
-                    }
-                    chart.rangeSelector[
-                        newIx ? 'maxInput' : 'minInput'
-                    ].focus();
-                    return this.response.success;
+                    return component.onInputKbdMove(this, direction);
                 }]
             ],
 
-            // Only run if we have range selector with input boxes
             validate: function () {
-                var inputVisible = (
-                    chart.rangeSelector &&
-                    chart.rangeSelector.inputGroup &&
-                    chart.rangeSelector.inputGroup.element
-                        .getAttribute('visibility') !== 'hidden'
-                );
-
-                return (
-                    inputVisible &&
-                    chart.options.rangeSelector.inputEnabled !== false &&
-                    chart.rangeSelector.minInput &&
-                    chart.rangeSelector.maxInput
-                );
+                return shouldRunInputNavigation(chart);
             },
 
-            // Highlight first/last input box
             init: function (direction) {
-                chart.highlightedInputRangeIx = direction > 0 ? 0 : 1;
-                chart.rangeSelector[
-                    chart.highlightedInputRangeIx ? 'maxInput' : 'minInput'
-                ].focus();
+                component.onInputNavInit(direction);
             },
 
-            // Hide HTML element when leaving boxes
             terminate: function () {
-                var rangeSel = chart.rangeSelector;
-                if (rangeSel && rangeSel.maxInput && rangeSel.minInput) {
-                    rangeSel.hideInput('max');
-                    rangeSel.hideInput('min');
-                }
+                component.onInputNavTerminate();
             }
         });
+    },
+
+
+    /**
+     * @private
+     * @param {Highcharts.KeyboardNavigationHandler} keyboardNavigationHandler
+     * @param {number} direction
+     * @return {number} Response code
+     */
+    onInputKbdMove: function (keyboardNavigationHandler, direction) {
+        var chart = this.chart,
+            response = keyboardNavigationHandler.response,
+            newIx = chart.highlightedInputRangeIx =
+                chart.highlightedInputRangeIx + direction,
+            newIxOutOfRange = newIx > 1 || newIx < 0;
+
+        if (newIxOutOfRange) {
+            return response[direction > 0 ? 'next' : 'prev'];
+        }
+
+        chart.rangeSelector[newIx ? 'maxInput' : 'minInput'].focus();
+        return response.success;
+    },
+
+
+    /**
+     * @private
+     * @param {number} direction
+     */
+    onInputNavInit: function (direction) {
+        var chart = this.chart,
+            buttonIxToHighlight = direction > 0 ? 0 : 1;
+
+        chart.highlightedInputRangeIx = buttonIxToHighlight;
+        chart.rangeSelector[
+            buttonIxToHighlight ? 'maxInput' : 'minInput'
+        ].focus();
+    },
+
+
+    /**
+     * @private
+     */
+    onInputNavTerminate: function () {
+        var rangeSel = this.chart.rangeSelector || {};
+
+        if (rangeSel.maxInput) {
+            rangeSel.hideInput('max');
+        }
+        if (rangeSel.minInput) {
+            rangeSel.hideInput('min');
+        }
     },
 
 

--- a/js/modules/accessibility/components/ZoomComponent.js
+++ b/js/modules/accessibility/components/ZoomComponent.js
@@ -208,7 +208,7 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
                     }],
 
                 [[keys.space, keys.enter], function () {
-                    return component.onMapKbdClick();
+                    return component.onMapKbdClick(this);
                 }]
             ],
 

--- a/js/modules/accessibility/components/ZoomComponent.js
+++ b/js/modules/accessibility/components/ZoomComponent.js
@@ -16,6 +16,14 @@ var extend = U.extend;
 
 import AccessibilityComponent from '../AccessibilityComponent.js';
 import KeyboardNavigationHandler from '../KeyboardNavigationHandler.js';
+import A11yUtilities from '../utilities.js';
+var setElAttrs = A11yUtilities.setElAttrs;
+
+function chartHasMapZoom(chart) {
+    return chart.mapZoom &&
+        chart.mapNavButtons &&
+        chart.mapNavButtons.length;
+}
 
 
 /**
@@ -85,17 +93,32 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
         if (chart.mapNavButtons) {
             chart.mapNavButtons.forEach(function (button, i) {
                 component.unhideElementFromScreenReaders(button.element);
-                button.element.setAttribute('tabindex', -1);
-                button.element.setAttribute('role', 'button');
-                button.element.setAttribute(
-                    'aria-label',
-                    chart.langFormat(
-                        'accessibility.zoom.mapZoom' + (i ? 'Out' : 'In'),
-                        { chart: chart }
-                    )
+                component.setMapNavButtonAttrs(
+                    button.element,
+                    'accessibility.zoom.mapZoom' + (i ? 'Out' : 'In')
                 );
             });
         }
+    },
+
+
+    /**
+     * @private
+     * @param {Highcharts.HTMLDOMElement|Highcharts.SVGDOMElement} button
+     * @param {string} labelFormatKey
+     */
+    setMapNavButtonAttrs: function (button, labelFormatKey) {
+        var chart = this.chart,
+            label = chart.langFormat(
+                labelFormatKey,
+                { chart: chart }
+            );
+
+        setElAttrs(button, {
+            tabindex: -1,
+            role: 'button',
+            'aria-label': label
+        });
     },
 
 
@@ -112,27 +135,14 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
      * Update proxy overlays, recreating the buttons.
      */
     updateProxyOverlays: function () {
-        var component = this,
-            chart = this.chart,
-            proxyButton = function (buttonEl, buttonProp, groupProp, label) {
-                component.removeElement(component[groupProp]);
-                component[groupProp] = component.addProxyGroup();
-                component[buttonProp] = component.createProxyButton(
-                    buttonEl,
-                    component[groupProp],
-                    {
-                        'aria-label': label,
-                        tabindex: -1
-                    }
-                );
-            };
+        var chart = this.chart;
 
         // Always start with a clean slate
-        component.removeElement(component.drillUpProxyGroup);
-        component.removeElement(component.resetZoomProxyGroup);
+        this.removeElement(this.drillUpProxyGroup);
+        this.removeElement(this.resetZoomProxyGroup);
 
         if (chart.resetZoomButton) {
-            proxyButton(
+            this.recreateProxyButtonAndGroup(
                 chart.resetZoomButton, 'resetZoomProxyButton',
                 'resetZoomProxyGroup', chart.langFormat(
                     'accessibility.zoom.resetZoomButton',
@@ -142,7 +152,7 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
         }
 
         if (chart.drillUpButton) {
-            proxyButton(
+            this.recreateProxyButtonAndGroup(
                 chart.drillUpButton, 'drillUpProxyButton',
                 'drillUpProxyGroup', chart.langFormat(
                     'accessibility.drillUpButton',
@@ -153,6 +163,25 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
                 )
             );
         }
+    },
+
+
+    /**
+     * @private
+     * @param {Highcharts.HTMLDOMElement|Highcharts.SVGDOMElement} buttonEl
+     * @param {string} buttonProp
+     * @param {string} groupProp
+     * @param {string} label
+     */
+    recreateProxyButtonAndGroup: function (
+        buttonEl, buttonProp, groupProp, label
+    ) {
+        this.removeElement(this[groupProp]);
+        this[groupProp] = this.addProxyGroup();
+        this[buttonProp] = this.createProxyButton(
+            buttonEl,
+            this[groupProp], { 'aria-label': label, tabindex: -1 }
+        );
     },
 
 
@@ -168,85 +197,110 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
 
         return new KeyboardNavigationHandler(chart, {
             keyCodeMap: [
-                // Arrow keys
-                [[
-                    keys.up, keys.down, keys.left, keys.right
-                ], function (keyCode) {
-                    chart[
-                        keyCode === keys.up || keyCode === keys.down ?
-                            'yAxis' : 'xAxis'
-                    ][0].panStep(
-                        keyCode === keys.left || keyCode === keys.up ? -1 : 1
-                    );
-                    return this.response.success;
-                }],
+                [[keys.up, keys.down, keys.left, keys.right],
+                    function (keyCode) {
+                        return component.onMapKbdArrow(this, keyCode);
+                    }],
 
-                // Tabs
-                [[
-                    keys.tab
-                ], function (keyCode, e) {
-                    var button;
+                [[keys.tab],
+                    function (keyCode, e) {
+                        return component.onMapKbdTab(this, e);
+                    }],
 
-                    // Deselect old
-                    chart.mapNavButtons[
-                        component.focusedMapNavButtonIx
-                    ].setState(0);
-
-                    // Trying to go somewhere we can't?
-                    if (
-                        e.shiftKey && !component.focusedMapNavButtonIx ||
-                        !e.shiftKey && component.focusedMapNavButtonIx
-                    ) {
-                        chart.mapZoom(); // Reset zoom
-                        // Nowhere to go, go to prev/next module
-                        return this.response[e.shiftKey ? 'prev' : 'next'];
-                    }
-
-                    // Select other button
-                    component.focusedMapNavButtonIx += e.shiftKey ? -1 : 1;
-                    button = chart.mapNavButtons[
-                        component.focusedMapNavButtonIx
-                    ];
-                    chart.setFocusToElement(button.box, button.element);
-                    button.setState(2);
-
-                    return this.response.success;
-                }],
-
-                // Press button
-                [[
-                    keys.space, keys.enter
-                ], function () {
-                    component.fakeClickEvent(
-                        chart.mapNavButtons[
-                            component.focusedMapNavButtonIx
-                        ].element
-                    );
-                    return this.response.success;
+                [[keys.space, keys.enter], function () {
+                    return component.onMapKbdClick();
                 }]
             ],
 
-            // Only run this module if we have map zoom on the chart
             validate: function () {
-                return (
-                    chart.mapZoom &&
-                    chart.mapNavButtons &&
-                    chart.mapNavButtons.length === 2
-                );
+                return chartHasMapZoom(chart);
             },
 
-            // Make zoom buttons do their magic
             init: function (direction) {
-                var zoomIn = chart.mapNavButtons[0],
-                    zoomOut = chart.mapNavButtons[1],
-                    initialButton = direction > 0 ? zoomIn : zoomOut;
-                chart.setFocusToElement(
-                    initialButton.box, initialButton.element
-                );
-                initialButton.setState(2);
-                component.focusedMapNavButtonIx = direction > 0 ? 0 : 1;
+                return component.onMapNavInit(direction);
             }
         });
+    },
+
+
+    /**
+     * @private
+     * @param {Highcharts.KeyboardNavigationHandler} keyboardNavigationHandler
+     * @param {number} keyCode
+     * @return {number} Response code
+     */
+    onMapKbdArrow: function (keyboardNavigationHandler, keyCode) {
+        var keys = this.keyCodes,
+            panAxis = keyCode === keys.up || keyCode === keys.down ?
+                'yAxis' : 'xAxis',
+            stepDirection = keyCode === keys.left || keyCode === keys.up ?
+                -1 : 1;
+
+        this.chart[panAxis][0].panStep(stepDirection);
+
+        return keyboardNavigationHandler.response.success;
+    },
+
+
+    /**
+     * @private
+     * @param {Highcharts.KeyboardNavigationHandler} keyboardNavigationHandler
+     * @param {global.Event} event
+     * @return {number} Response code
+     */
+    onMapKbdTab: function (keyboardNavigationHandler, event) {
+        var button,
+            chart = this.chart,
+            response = keyboardNavigationHandler.response,
+            isBackwards = event.shiftKey,
+            isMoveOutOfRange = isBackwards && !this.focusedMapNavButtonIx ||
+                !isBackwards && this.focusedMapNavButtonIx;
+
+        // Deselect old
+        chart.mapNavButtons[this.focusedMapNavButtonIx].setState(0);
+
+        if (isMoveOutOfRange) {
+            chart.mapZoom(); // Reset zoom
+            return response[isBackwards ? 'prev' : 'next'];
+        }
+
+        // Select other button
+        this.focusedMapNavButtonIx += isBackwards ? -1 : 1;
+        button = chart.mapNavButtons[this.focusedMapNavButtonIx];
+        chart.setFocusToElement(button.box, button.element);
+        button.setState(2);
+
+        return response.success;
+    },
+
+
+    /**
+     * @private
+     * @param {Highcharts.KeyboardNavigationHandler} keyboardNavigationHandler
+     * @return {number} Response code
+     */
+    onMapKbdClick: function (keyboardNavigationHandler) {
+        this.fakeClickEvent(
+            this.chart.mapNavButtons[this.focusedMapNavButtonIx].element
+        );
+        return keyboardNavigationHandler.response.success;
+    },
+
+
+    /**
+     * @private
+     * @param {number} direction
+     */
+    onMapNavInit: function (direction) {
+        var chart = this.chart,
+            zoomIn = chart.mapNavButtons[0],
+            zoomOut = chart.mapNavButtons[1],
+            initialButton = direction > 0 ? zoomIn : zoomOut;
+
+        chart.setFocusToElement(initialButton.box, initialButton.element);
+        initialButton.setState(2);
+
+        this.focusedMapNavButtonIx = direction > 0 ? 0 : 1;
     },
 
 
@@ -265,33 +319,28 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
 
         return new KeyboardNavigationHandler(chart, {
             keyCodeMap: [
-                // Arrow/tab just move
-                [[
-                    keys.tab, keys.up, keys.down, keys.left, keys.right
-                ], function (keyCode, e) {
-                    return this.response[
-                        keyCode === this.tab && e.shiftKey ||
-                        keyCode === keys.left || keyCode === keys.up ?
-                            'prev' : 'next'
-                    ];
-                }],
+                [[keys.tab, keys.up, keys.down, keys.left, keys.right],
+                    function (keyCode, e) {
+                        var isBackwards = keyCode === this.tab && e.shiftKey ||
+                        keyCode === keys.left || keyCode === keys.up;
 
-                // Select to click
-                [[
-                    keys.space, keys.enter
-                ], function () {
-                    onClick(chart);
-                    return this.response.success;
-                }]
+                        // Arrow/tab => just move
+                        return this.response[isBackwards ? 'prev' : 'next'];
+                    }],
+
+                [[keys.space, keys.enter],
+                    function () {
+                        onClick(chart);
+                        return this.response.success;
+                    }]
             ],
 
-            // Only run if we have the button
             validate: function () {
-                return chart[buttonProp] && chart[buttonProp].box &&
+                var hasButton = chart[buttonProp] && chart[buttonProp].box &&
                     component[proxyProp];
+                return hasButton;
             },
 
-            // Focus button initially
             init: function () {
                 chart.setFocusToElement(
                     chart[buttonProp].box, component[proxyProp]

--- a/js/modules/accessibility/components/ZoomComponent.js
+++ b/js/modules/accessibility/components/ZoomComponent.js
@@ -321,8 +321,8 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
             keyCodeMap: [
                 [[keys.tab, keys.up, keys.down, keys.left, keys.right],
                     function (keyCode, e) {
-                        var isBackwards = keyCode === this.tab && e.shiftKey ||
-                        keyCode === keys.left || keyCode === keys.up;
+                        var isBackwards = keyCode === keys.tab && e.shiftKey ||
+                            keyCode === keys.left || keyCode === keys.up;
 
                         // Arrow/tab => just move
                         return this.response[isBackwards ? 'prev' : 'next'];


### PR DESCRIPTION
Fixed minor bugs with keyboard navigation.
___
Added event hooks for a11y (for internal/workaround use only, for now).
    * `chart.beforeA11yUpdate`
    * `chart.afterA11yUpdate`
    * `chart.afterA11yComponentUpdate`

Minor cleanup of components with minor bugfixes (tagged to go into changelog now, but debatable since they are not on GitHub).

No changes to non-a11y files.