### PR TITLE
Fixed #12090, a11y module breaks legend navigation.

### DIFF
--- a/js/modules/accessibility/components/LegendComponent.js
+++ b/js/modules/accessibility/components/LegendComponent.js
@@ -95,6 +95,41 @@ LegendComponent.prototype = new AccessibilityComponent();
 extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
 
     /**
+     * Init the component
+     * @private
+     */
+    init: function () {
+        var component = this;
+
+        this.addEvent(H.Legend, 'afterScroll', function () {
+            if (this.chart === component.chart) {
+                component.updateProxies();
+            }
+        });
+    },
+
+
+    /**
+     * @private
+     */
+    updateLegendItemProxyVisibility: function () {
+        var legend = this.chart.legend,
+            items = legend.allItems || [],
+            curPage = legend.currentPage || 1;
+
+        items.forEach(function (item) {
+            var itemPage = item.pageIx || 0,
+                hide = itemPage !== curPage - 1;
+
+            if (item.a11yProxyElement) {
+                item.a11yProxyElement.style.visibility = hide ?
+                    'hidden' : 'visible';
+            }
+        });
+    },
+
+
+    /**
      * The legend needs updates on every render, in order to update positioning
      * of the proxy overlays.
      */
@@ -108,12 +143,20 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
             return;
         }
 
-        // Always Remove group if exists
+        this.updateProxies();
+    },
+
+
+    /**
+     * @private
+     */
+    updateProxies: function () {
         this.removeElement(this.legendProxyGroup);
 
         if (shouldDoLegendA11y(this.chart)) {
             this.addLegendProxyGroup();
             this.proxyLegendItems();
+            this.updateLegendItemProxyVisibility();
         }
     },
 

--- a/js/parts/Legend.js
+++ b/js/parts/Legend.js
@@ -990,14 +990,15 @@ Highcharts.Legend.prototype = {
      * @return {void}
      */
     scroll: function (scrollBy, animation) {
-        var pages = this.pages, pageCount = pages.length, currentPage = this.currentPage + scrollBy, clipHeight = this.clipHeight, navOptions = this.options.navigation, pager = this.pager, padding = this.padding;
+        var _this = this;
+        var chart = this.chart, pages = this.pages, pageCount = pages.length, currentPage = this.currentPage + scrollBy, clipHeight = this.clipHeight, navOptions = this.options.navigation, pager = this.pager, padding = this.padding;
         // When resizing while looking at the last page
         if (currentPage > pageCount) {
             currentPage = pageCount;
         }
         if (currentPage > 0) {
             if (animation !== undefined) {
-                setAnimation(animation, this.chart);
+                setAnimation(animation, chart);
             }
             this.nav.attr({
                 translateX: padding,
@@ -1023,7 +1024,7 @@ Highcharts.Legend.prototype = {
                         'highcharts-legend-nav-active'
                 });
             }, this);
-            if (!this.chart.styledMode) {
+            if (!chart.styledMode) {
                 this.up
                     .attr({
                     fill: currentPage === 1 ?
@@ -1053,6 +1054,11 @@ Highcharts.Legend.prototype = {
             });
             this.currentPage = currentPage;
             this.positionCheckboxes();
+            // Fire event after scroll animation is complete
+            var animOptions = H.animObject(pick(animation, chart.renderer.globalAnimation, true));
+            setTimeout(function () {
+                fireEvent(_this, 'afterScroll', { currentPage: currentPage });
+            }, animOptions.duration);
         }
     }
 };

--- a/ts/parts/Legend.ts
+++ b/ts/parts/Legend.ts
@@ -1542,7 +1542,8 @@ Highcharts.Legend.prototype = {
         scrollBy: number,
         animation?: (boolean|Highcharts.AnimationOptionsObject)
     ): void {
-        var pages = this.pages,
+        var chart = this.chart,
+            pages = this.pages,
             pageCount = pages.length,
             currentPage = (this.currentPage as any) + scrollBy,
             clipHeight = this.clipHeight,
@@ -1558,7 +1559,7 @@ Highcharts.Legend.prototype = {
         if (currentPage > 0) {
 
             if (animation !== undefined) {
-                setAnimation(animation, this.chart);
+                setAnimation(animation, chart);
             }
 
             (this.nav as any).attr({
@@ -1589,7 +1590,7 @@ Highcharts.Legend.prototype = {
                 });
             }, this);
 
-            if (!this.chart.styledMode) {
+            if (!chart.styledMode) {
                 (this.up as any)
                     .attr({
                         fill: currentPage === 1 ?
@@ -1622,8 +1623,15 @@ Highcharts.Legend.prototype = {
 
             this.currentPage = currentPage;
             this.positionCheckboxes();
-        }
 
+            // Fire event after scroll animation is complete
+            const animOptions = H.animObject(
+                pick(animation, chart.renderer.globalAnimation, true)
+            );
+            setTimeout((): void => {
+                fireEvent(this, 'afterScroll', { currentPage });
+            }, animOptions.duration);
+        }
     }
 
 } as any;


### PR DESCRIPTION
Fixed #12090, a11y module breaks legend navigation.
___
A11y legend proxy buttons were overlaying navigation arrows. These are now hidden unless the corresponding legend item is on the current page.

Added a `legend.afterScroll` event that fires after legend scroll animation is complete in order to update proxies.

No other changes to non-a11y files.