### PR TITLE
bugfix/1172-column-navigator

### DIFF
--- a/js/parts/Navigator.js
+++ b/js/parts/Navigator.js
@@ -280,6 +280,15 @@ extend(defaultOptions, {
              * The type of the navigator series. Defaults to `areaspline` if
              * defined, otherwise `line`.
              *
+             * Heads up:
+             * When using `column` type navigator, don't forget to change
+             * [pointRange](#navigator.series.pointRange) to `null`.
+             * In column-type navigator, zooming is limited to at least one
+             * point with it's `pointRange`.
+             *
+             * @sample {highstock} stock/navigator/column/
+             *         Column type navigator
+             *
              * @type    {string}
              * @default areaspline
              */

--- a/js/parts/Navigator.js
+++ b/js/parts/Navigator.js
@@ -281,10 +281,8 @@ extend(defaultOptions, {
              * defined, otherwise `line`.
              *
              * Heads up:
-             * When using `column` type navigator, don't forget to change
-             * [pointRange](#navigator.series.pointRange) to `null`.
              * In column-type navigator, zooming is limited to at least one
-             * point with it's `pointRange`.
+             * point with its `pointRange`.
              *
              * @sample {highstock} stock/navigator/column/
              *         Column type navigator
@@ -365,7 +363,17 @@ extend(defaultOptions, {
             marker: {
                 enabled: false
             },
-            pointRange: 0,
+            /**
+             * Since Highstock v8, default value is the same as default
+             * `pointRange` defined for a specific type (e.g. `null` for
+             * column type).
+             *
+             * In Highstock version < 8, defaults to 0.
+             *
+             * @extends plotOptions.series.pointRange
+             * @type {number|null}
+             * @apioption navigator.series.pointRange
+             */
             /**
              * The threshold option. Setting it to 0 will make the default
              * navigator area series draw its area from the 0 value and up.
@@ -1522,6 +1530,12 @@ Navigator.prototype = {
                 baseOptions = base.options || {};
                 baseNavigatorOptions = baseOptions.navigatorOptions || {};
                 mergedNavSeriesOptions = merge(baseOptions, navSeriesMixin, userNavOptions, baseNavigatorOptions);
+                // Once nav series type is resolved, pick correct pointRange
+                mergedNavSeriesOptions.pointRange = pick(
+                // Stricte set pointRange in options
+                userNavOptions.pointRange, baseNavigatorOptions.pointRange, 
+                // Fallback to default values, e.g. `null` for column
+                defaultOptions.plotOptions[mergedNavSeriesOptions.type || 'line'].pointRange);
                 // Merge data separately. Do a slice to avoid mutating the
                 // navigator options from base series (#4923).
                 var navigatorSeriesData = baseNavigatorOptions.data || userNavOptions.data;

--- a/samples/stock/navigator/column/demo.details
+++ b/samples/stock/navigator/column/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+...

--- a/samples/stock/navigator/column/demo.html
+++ b/samples/stock/navigator/column/demo.html
@@ -1,0 +1,8 @@
+
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+<script src="https://code.highcharts.com/stock/modules/data.js"></script>
+<script src="https://code.highcharts.com/stock/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/stock/modules/export-data.js"></script>
+
+
+<div id="container" style="height: 400px"></div>

--- a/samples/stock/navigator/column/demo.js
+++ b/samples/stock/navigator/column/demo.js
@@ -1,0 +1,29 @@
+Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-v.json', function (data) {
+
+    Highcharts.stockChart('container', {
+
+        rangeSelector: {
+            selected: 4
+        },
+
+        navigator: {
+            series: {
+                type: 'column',
+                pointRange: null,
+                dataGrouping: {
+                    groupPixelWidth: 10
+                }
+            }
+        },
+
+        title: {
+            text: 'AAPL Stock Volume'
+        },
+
+        series: [{
+            type: 'column',
+            name: 'AAPL Stock Volume',
+            data: data
+        }]
+    });
+});

--- a/samples/stock/navigator/column/readme.md
+++ b/samples/stock/navigator/column/readme.md
@@ -1,0 +1,4 @@
+# Column
+[Column stock chart](https://api.highcharts.com/highstock/series.column) is often used to visualize the volume of how much of financial asset has been traded in a specific period of time.
+#### Tip
+Set the type to column under the series to get the volume chart.

--- a/samples/unit-tests/navigator/series-type/demo.details
+++ b/samples/unit-tests/navigator/series-type/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/navigator/series-type/demo.html
+++ b/samples/unit-tests/navigator/series-type/demo.html
@@ -1,0 +1,6 @@
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/navigator/series-type/demo.js
+++ b/samples/unit-tests/navigator/series-type/demo.js
@@ -1,0 +1,58 @@
+QUnit.test('Column type navigator', function (assert) {
+    var chart = Highcharts.stockChart('container', {
+            navigator: {
+                series: {
+                    type: 'column',
+                    pointRange: null
+                }
+            },
+            series: [{
+                type: 'column',
+                data: [10, 20, 30, 10, 20, 30, 10, 20, 30]
+            }]
+        }),
+        nav = chart.navigator,
+        navGroupBox = nav.navigatorGroup.getBBox(),
+        controller = new TestController(chart),
+        xAxis = chart.xAxis[0];
+
+    assert.strictEqual(
+        nav.handles[0].attr('translateX'),
+        nav.left,
+        'LEFT handle should be rendered at the most LEFT position'
+    );
+
+    assert.strictEqual(
+        nav.handles[1].attr('translateX'),
+        nav.left + nav.size,
+        'RIGHT handle should be rendered at the most RIGHT position'
+    );
+
+    controller.mouseDown(
+        nav.handles[0].attr('translateX'),
+        navGroupBox.y + nav.height / 2
+    );
+
+    controller.mouseMove(
+        nav.handles[1].attr('translateX'),
+        navGroupBox.y + nav.height / 2
+    );
+
+    controller.mouseUp(
+        nav.handles[1].attr('translateX'),
+        navGroupBox.y + nav.height / 2
+    );
+
+    assert.strictEqual(
+        xAxis.max - xAxis.min,
+        xAxis.minRange,
+        'It should not be possible to zoom below minRange'
+    );
+
+    assert.close(
+        nav.handles[0].attr('translateX') + nav.scrollbarHeight / 2,
+        chart.xAxis[1].toPixels(xAxis.min, true),
+        1,
+        'Left handle should be rendered between points: x=2 and x=3'
+    );
+});

--- a/ts/parts/Navigator.ts
+++ b/ts/parts/Navigator.ts
@@ -505,6 +505,15 @@ extend(defaultOptions, {
              * The type of the navigator series. Defaults to `areaspline` if
              * defined, otherwise `line`.
              *
+             * Heads up:
+             * When using `column` type navigator, don't forget to change
+             * [pointRange](#navigator.series.pointRange) to `null`.
+             * In column-type navigator, zooming is limited to at least one
+             * point with it's `pointRange`.
+             *
+             * @sample {highstock} stock/navigator/column/
+             *         Column type navigator
+             *
              * @type    {string}
              * @default areaspline
              */

--- a/ts/parts/Navigator.ts
+++ b/ts/parts/Navigator.ts
@@ -797,6 +797,7 @@ Axis.prototype.toFixedRange = function (
     fixedMax?: number
 ): Highcharts.RangeObject {
     var fixedRange = this.chart && this.chart.fixedRange,
+        halfPointRange = (this.pointRange || 0) / 2,
         newMin = pick<number|undefined, number>(
             fixedMin, this.translate(pxMin as any, true, !this.horiz) as any
         ),
@@ -804,6 +805,14 @@ Axis.prototype.toFixedRange = function (
             fixedMax, this.translate(pxMax as any, true, !this.horiz) as any
         ),
         changeRatio = fixedRange && (newMax - newMin) / fixedRange;
+
+    // Add/remove half point range to/from the extremes (#1172)
+    if (!defined(fixedMin)) {
+        newMin = H.correctFloat(newMin + halfPointRange);
+    }
+    if (!defined(fixedMax)) {
+        newMax = H.correctFloat(newMax - halfPointRange);
+    }
 
     // If the difference between the fixed range and the actual requested range
     // is too great, the user is dragging across an ordinal gap, and we need to
@@ -1223,6 +1232,7 @@ Navigator.prototype = {
             scrollbarHeight = navigator.scrollbarHeight,
             navigatorSize,
             xAxis = navigator.xAxis,
+            pointRange = xAxis.pointRange || 0,
             scrollbarXAxis = xAxis.fake ? chart.xAxis[0] : xAxis,
             navigatorEnabled = navigator.navigatorEnabled,
             zoomedMin,
@@ -1240,6 +1250,9 @@ Navigator.prototype = {
         if (this.hasDragged && !defined(pxMin)) {
             return;
         }
+
+        min = H.correctFloat(min - pointRange / 2);
+        max = H.correctFloat(max + pointRange / 2);
 
         // Don't render the navigator until we have data (#486, #4202, #5172).
         if (!isNumber(min) || !isNumber(max)) {
@@ -1285,18 +1298,37 @@ Navigator.prototype = {
         // Are we below the minRange? (#2618, #6191)
         newMin = xAxis.toValue(pxMin as any, true);
         newMax = xAxis.toValue(pxMax as any, true);
+
         currentRange = Math.abs(H.correctFloat(newMax - newMin));
-        if (currentRange < (minRange as any)) {
+
+        if (
+            H.correctFloat(currentRange - pointRange) < (minRange as any)
+        ) {
             if (this.grabbedLeft) {
-                pxMin = xAxis.toPixels(newMax - (minRange as any), true);
+                pxMin = xAxis.toPixels(
+                    newMax - (minRange as any) - pointRange,
+                    true
+                );
             } else if (this.grabbedRight) {
-                pxMax = xAxis.toPixels(newMin + (minRange as any), true);
+                pxMax = xAxis.toPixels(
+                    newMin + (minRange as any) + pointRange,
+                    true
+                );
             }
-        } else if (defined(maxRange) && currentRange > (maxRange as any)) {
+        } else if (
+            defined(maxRange) &&
+            H.correctFloat(currentRange - pointRange) > (maxRange as any)
+        ) {
             if (this.grabbedLeft) {
-                pxMin = xAxis.toPixels(newMax - (maxRange as any), true);
+                pxMin = xAxis.toPixels(
+                    newMax - (maxRange as any) - pointRange,
+                    true
+                );
             } else if (this.grabbedRight) {
-                pxMax = xAxis.toPixels(newMin + (maxRange as any), true);
+                pxMax = xAxis.toPixels(
+                    newMin + (maxRange as any) + pointRange,
+                    true
+                );
             }
         }
 

--- a/ts/parts/Navigator.ts
+++ b/ts/parts/Navigator.ts
@@ -506,10 +506,8 @@ extend(defaultOptions, {
              * defined, otherwise `line`.
              *
              * Heads up:
-             * When using `column` type navigator, don't forget to change
-             * [pointRange](#navigator.series.pointRange) to `null`.
              * In column-type navigator, zooming is limited to at least one
-             * point with it's `pointRange`.
+             * point with its `pointRange`.
              *
              * @sample {highstock} stock/navigator/column/
              *         Column type navigator
@@ -602,7 +600,17 @@ extend(defaultOptions, {
                 enabled: false
             },
 
-            pointRange: 0,
+            /**
+             * Since Highstock v8, default value is the same as default
+             * `pointRange` defined for a specific type (e.g. `null` for
+             * column type).
+             *
+             * In Highstock version < 8, defaults to 0.
+             *
+             * @extends plotOptions.series.pointRange
+             * @type {number|null}
+             * @apioption navigator.series.pointRange
+             */
 
             /**
              * The threshold option. Setting it to 0 will make the default
@@ -2273,6 +2281,17 @@ Navigator.prototype = {
                     navSeriesMixin,
                     userNavOptions,
                     baseNavigatorOptions
+                );
+
+                // Once nav series type is resolved, pick correct pointRange
+                mergedNavSeriesOptions.pointRange = pick(
+                    // Stricte set pointRange in options
+                    userNavOptions.pointRange,
+                    baseNavigatorOptions.pointRange,
+                    // Fallback to default values, e.g. `null` for column
+                    (defaultOptions.plotOptions as any)[
+                        mergedNavSeriesOptions.type || 'line'
+                    ].pointRange
                 );
 
                 // Merge data separately. Do a slice to avoid mutating the


### PR DESCRIPTION
Fixed #1172, handles positions and `xAxis` extremes were incorrect when using column type series in navigator.
___
Note: This does not fix #3136 - it would be nice to have an official API option to change `cropShoulder`. Otherwise most left/right columns are hidden even when xAxis labels (due to extra space created by columns) are rendered. 

Fixed demos from #1171:

- http://jsfiddle.net/BlackLabel/6rzqoasu/1/
- http://jsfiddle.net/BlackLabel/Lmhqngu5/
- http://jsfiddle.net/BlackLabel/yncevr5j/1/