### PR TITLE
bugfix/12073-annotations-draggable-points

### DIFF
--- a/js/modules/draggable-points.src.js
+++ b/js/modules/draggable-points.src.js
@@ -2186,6 +2186,10 @@ function mouseDown(e, chart) {
         mouseUp(e, chart);
         return;
     }
+    // Ignore if dragging an annotation
+    if (chart.hasDraggedAnnotation) {
+        return;
+    }
     // If this point is movable, start dragging it
     if (dragPoint && isPointMovable(dragPoint)) {
         chart.mouseIsDown = false; // Prevent zooming

--- a/js/modules/draggable-points.src.js
+++ b/js/modules/draggable-points.src.js
@@ -2173,21 +2173,19 @@ function mouseDown(e, chart) {
     var dragPoint = chart.hoverPoint, dragDropOptions = H.merge(dragPoint && dragPoint.series.options.dragDrop, dragPoint && dragPoint.options.dragDrop), draggableX = dragDropOptions.draggableX || false, draggableY = dragDropOptions.draggableY || false;
     // Reset cancel click
     chart.cancelClick = false;
-    // Ignore if option is disable for the point
-    if (!(draggableX || draggableY)) {
-        return;
-    }
-    // Ignore if zoom/pan key is pressed
-    if (chart.zoomOrPanKeyPressed(e)) {
+    // Ignore if:
+    if (
+    // Option is disabled for the point
+    !(draggableX || draggableY) ||
+        // Zoom/pan key is pressed
+        chart.zoomOrPanKeyPressed(e) ||
+        // Dragging an annotation
+        chart.hasDraggedAnnotation) {
         return;
     }
     // If we somehow get a mousedown event while we are dragging, cancel
     if (chart.dragDropData && chart.dragDropData.isDragging) {
         mouseUp(e, chart);
-        return;
-    }
-    // Ignore if dragging an annotation
-    if (chart.hasDraggedAnnotation) {
         return;
     }
     // If this point is movable, start dragging it

--- a/samples/unit-tests/annotations/annotations-draggable/demo.html
+++ b/samples/unit-tests/annotations/annotations-draggable/demo.html
@@ -1,5 +1,6 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/annotations.js"></script>
+<script src="https://code.highcharts.com/modules/draggable-points.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/annotations/annotations-draggable/demo.js
+++ b/samples/unit-tests/annotations/annotations-draggable/demo.js
@@ -9,6 +9,13 @@ QUnit.test('Draggable annotation - exporting', function (assert) {
             chart: {
                 zoomType: 'xy'
             },
+            plotOptions: {
+                series: {
+                    dragDrop: {
+                        draggableY: true
+                    }
+                }
+            },
             xAxis: {
                 minRange: 0.1
             },
@@ -129,5 +136,17 @@ QUnit.test('Draggable annotation - exporting', function (assert) {
                 eventName + ' should be fired (#11970)'
             );
         }
+    );
+
+    assert.strictEqual(
+        chart.series[0].points[0].y,
+        3,
+        'Dragging an annotation should not drag point too (#12073)'
+    );
+
+    assert.strictEqual(
+        chart.series[0].points[1].y,
+        6,
+        'Dragging an annotation should not drag point too (#12073)'
     );
 });

--- a/ts/modules/draggable-points.src.ts
+++ b/ts/modules/draggable-points.src.ts
@@ -29,6 +29,8 @@ declare global {
             dragGuideBox?: SVGElement;
             /** @requires modules/draggable-points */
             hasAddedDragDropEvents?: boolean;
+            /** @requires modules/annotations */
+            hasDraggedAnnotation?: boolean;
             /** @requires modules/draggable-points */
             isDragDropAnimating?: boolean;
             /** @requires modules/draggable-points */
@@ -2946,24 +2948,21 @@ function mouseDown(
     // Reset cancel click
     chart.cancelClick = false;
 
-    // Ignore if option is disable for the point
-    if (!(draggableX || draggableY)) {
-        return;
-    }
-
-    // Ignore if zoom/pan key is pressed
-    if (chart.zoomOrPanKeyPressed(e)) {
+    // Ignore if:
+    if (
+        // Option is disabled for the point
+        !(draggableX || draggableY) ||
+        // Zoom/pan key is pressed
+        chart.zoomOrPanKeyPressed(e) ||
+        // Dragging an annotation
+        chart.hasDraggedAnnotation
+    ) {
         return;
     }
 
     // If we somehow get a mousedown event while we are dragging, cancel
     if (chart.dragDropData && chart.dragDropData.isDragging) {
         mouseUp(e, chart);
-        return;
-    }
-
-    // Ignore if dragging an annotation
-    if ((chart as any).hasDraggedAnnotation) {
         return;
     }
 

--- a/ts/modules/draggable-points.src.ts
+++ b/ts/modules/draggable-points.src.ts
@@ -2962,6 +2962,11 @@ function mouseDown(
         return;
     }
 
+    // Ignore if dragging an annotation
+    if ((chart as any).hasDraggedAnnotation) {
+        return;
+    }
+
     // If this point is movable, start dragging it
     if (dragPoint && isPointMovable(dragPoint)) {
         chart.mouseIsDown = false; // Prevent zooming


### PR DESCRIPTION
Fixed #12073, dragging an annotation used to change points' values too.
___

@oysteinmoseng - do you think it's okay to add this `if` in draggable-points module? Maybe you have a better idea? I would rather keep annotations logic in annotations plugin..

@bre1470 - annotations are not TS-ready, so I'm not sure if this is fine: `(chart as any).hasDraggedAnnotation`