### PR TITLE
bugfix/11650-highcharts-tooltip-header-class

### DIFF
--- a/docs/chart-design-and-style/style-by-css.md
+++ b/docs/chart-design-and-style/style-by-css.md
@@ -443,6 +443,7 @@ Text styles for the title. Replaces [title.style](https://api.highcharts.com/hi
     .highcharts-tooltip  
     .highcharts-tooltip-box  
     .highcharts-tooltip text
+    .highcharts-tooltip-header
 
 Styles for the tooltip. The tooltip box is the shape or path where the background and border can be set. Text styles should be applied to the text element.
 

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -855,7 +855,10 @@ H.Tooltip.prototype = {
                         .label(null, null, null, (point.isHeader ?
                         options.headerShape :
                         options.shape) || 'callout', null, null, options.useHTML)
-                        .addClass('highcharts-tooltip-box ' + colorClass)
+                        .addClass(point.isHeader ?
+                        'highcharts-tooltip-header ' : '' +
+                        'highcharts-tooltip-box ' +
+                        colorClass)
                         .attr(attribs)
                         .add(tooltipLabel);
                 }

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -1255,7 +1255,12 @@ H.Tooltip.prototype = {
                             null as any,
                             options.useHTML
                         )
-                        .addClass('highcharts-tooltip-box ' + colorClass)
+                        .addClass(
+                            (point as any).isHeader ?
+                                'highcharts-tooltip-header ' : '' +
+                            'highcharts-tooltip-box ' +
+                            colorClass
+                        )
                         .attr(attribs)
                         .add(tooltipLabel);
                 }


### PR DESCRIPTION
Fixed #11650, added missing `highcharts-tooltip-header` classname to the tooltip's header.
___
Additionally we can:

- remove `highcharts-header` class: https://github.com/highcharts/highcharts/blob/5e5553521eb50408d1fb4674d71cc5328c85ae7a/ts/parts/Tooltip.ts#L1716-L1719
- and move CSS under `highcharts-tooltip-header`: https://github.com/highcharts/highcharts/blob/5e5553521eb50408d1fb4674d71cc5328c85ae7a/css/highcharts.scss#L205-L207