### PR TITLE
bugfix/12182-dtl-format-timezone-tooltip

### DIFF
--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -1028,7 +1028,7 @@ H.Tooltip.prototype = {
      *         The optimal date format for a point.
      */
     getDateFormat: function (range, date, startOfWeek, dateTimeLabelFormats) {
-        var time = this.chart.time, dateStr = time.dateFormat('%m-%d %H:%M:%S.%L', date), format, n, blank = '01-01 00:00:00.000', strpos = {
+        var time = this.chart.time, dateStr = time.dateFormat('%m-%d %H:%M:%S.%L', date + time.getTimezoneOffset(date)), format, n, blank = '01-01 00:00:00.000', strpos = {
             millisecond: 15,
             second: 12,
             minute: 9,

--- a/samples/unit-tests/tooltip/header-format/demo.js
+++ b/samples/unit-tests/tooltip/header-format/demo.js
@@ -42,3 +42,37 @@ QUnit.test('Formats in tooltip header (#3238)', function (assert) {
     );
 
 });
+
+QUnit.test('Tooltip dateTime formats and timezone', function (assert) {
+    var chart = Highcharts.chart('container', {
+            time: {
+                timezone: 'Europe/Oslo'
+            },
+            xAxis: {
+                type: 'datetime'
+            },
+            tooltip: {
+                dateTimeLabelFormats: {
+                    day: '<span class="test">%e %b \'%y</span>'
+                }
+            },
+            series: [{
+                data: [
+                    [Date.UTC(2016, 9, 22), 10],
+                    [Date.UTC(2016, 9, 23), 20]
+                ]
+            }]
+        }),
+        controller = new TestController(chart);
+
+    controller.mouseMove(
+        chart.series[0].points[0].plotX + chart.plotLeft,
+        chart.series[0].points[0].plotY + chart.plotTop
+    );
+
+    assert.strictEqual(
+        chart.container.querySelectorAll('.test')[0].innerHTML,
+        '22 Oct \'16',
+        'DateTimeLabelFormat in tooltip should be `%e %b \'%y` (#12182)'
+    );
+});

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -1505,7 +1505,10 @@ H.Tooltip.prototype = {
         dateTimeLabelFormats: Highcharts.Dictionary<string>
     ): string {
         var time = this.chart.time,
-            dateStr = time.dateFormat('%m-%d %H:%M:%S.%L', date),
+            dateStr = time.dateFormat(
+                '%m-%d %H:%M:%S.%L',
+                date + time.getTimezoneOffset(date)
+            ),
             format,
             n,
             blank = '01-01 00:00:00.000',


### PR DESCRIPTION
Fixed #12182, wrong Tooltip's `dateTimeLabelFormat` was picked when timezones were used.