### PR TITLE
bugfix/11426-datagrouping-arearange

### DIFF
--- a/js/parts/DataGrouping.js
+++ b/js/parts/DataGrouping.js
@@ -312,6 +312,7 @@ commonOptions = {
     spline: {},
     area: {},
     areaspline: {},
+    arearange: {},
     column: {
         groupPixelWidth: 10
     },

--- a/ts/parts/DataGrouping.ts
+++ b/ts/parts/DataGrouping.ts
@@ -554,6 +554,7 @@ var seriesProto = Series.prototype,
         spline: {},
         area: {},
         areaspline: {},
+        arearange: {},
         column: {
             groupPixelWidth: 10
         },


### PR DESCRIPTION
Fixed #11426, arearange series had disabled `dataGrouping` by default.