### PR TITLE
bugfix/11644-tilemap-coloraxis-extremes

### DIFF
--- a/js/modules/tilemap.src.js
+++ b/js/modules/tilemap.src.js
@@ -268,7 +268,7 @@ H.tileShapeTypes = {
 // series and adds the largest padding required. If no series has this function
 // defined, we add nothing.
 H.addEvent(H.Axis, 'afterSetAxisTranslation', function () {
-    if (this.recomputingForTilemap) {
+    if (this.recomputingForTilemap || this.coll === 'colorAxis') {
         return;
     }
     var axis = this, 

--- a/samples/unit-tests/series-tilemap/coloraxis/demo.details
+++ b/samples/unit-tests/series-tilemap/coloraxis/demo.details
@@ -1,0 +1,8 @@
+---
+ name: Highcharts Demo
+ resources:
+    - https://code.jquery.com/qunit/qunit-2.0.1.js
+    - https://code.jquery.com/qunit/qunit-2.0.1.css
+ authors:
+   - Paweł Fus
+...

--- a/samples/unit-tests/series-tilemap/coloraxis/demo.html
+++ b/samples/unit-tests/series-tilemap/coloraxis/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/maps/highmaps.js"></script>
+<script src="https://code.highcharts.com/maps/modules/tilemap.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/series-tilemap/coloraxis/demo.js
+++ b/samples/unit-tests/series-tilemap/coloraxis/demo.js
@@ -1,0 +1,33 @@
+QUnit.test('Tilemap and ColorAxis', function (assert) {
+    var chart = Highcharts.chart('container', {
+            chart: {
+                type: 'tilemap'
+            },
+            colorAxis: {},
+            series: [{
+                data: [{
+                    x: 0,
+                    y: 0,
+                    value: 0.02
+                }, {
+                    x: 25,
+                    y: 15,
+                    value: 0.06
+                }]
+            }]
+        }),
+        extremes = chart.colorAxis[0].getExtremes();
+
+    assert.strictEqual(
+        extremes.min,
+        0.02,
+        'ColorAxis.min should be the same as min value in points (#11644)'
+    );
+
+    assert.strictEqual(
+        extremes.max,
+        0.06,
+        'ColorAxis.max should be the same as max value in points (#11644)'
+    );
+
+});

--- a/ts/modules/tilemap.src.ts
+++ b/ts/modules/tilemap.src.ts
@@ -645,7 +645,7 @@ H.tileShapeTypes = {
 // defined, we add nothing.
 H.addEvent(H.Axis, 'afterSetAxisTranslation', function (): void {
 
-    if (this.recomputingForTilemap) {
+    if (this.recomputingForTilemap || this.coll === 'colorAxis') {
         return;
     }
 


### PR DESCRIPTION
Fixed #11644, extremes in color axis were incorrect when using tilemap series with very small values.