### PR TITLE
bugfix/12215-vwap-stocktools

### DIFF
--- a/js/modules/stock-tools-bindings.js
+++ b/js/modules/stock-tools-bindings.js
@@ -183,7 +183,6 @@ bindingsUtils.manageIndicators = function (data) {
             'mfi',
             'roc',
             'rsi',
-            'vwap',
             'ao',
             'aroon',
             'aroonoscillator',


### PR DESCRIPTION
Fixed #12215, VWAP technical indicator added via StockTools was added to the wrong pane.