### PR TITLE
Tools: Adjusted Browserstack parallellity.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,8 +375,9 @@ workflows:
           browsers: "Win.IE8 --oldie"
       - test_browsers:
           name: "test-Mac.Safari"
+          browsercount: 2
           requires:
-            - "test-Win.IE8"
+            - install_dependencies
           browsers: "Mac.Safari"
       - test_browsers:
           name: "test-Mac.Firefox"
@@ -388,7 +389,7 @@ workflows:
           name: "test-Win.Chrome"
           browsercount: 2
           requires:
-            - "test-Mac.Firefox"
+            - "test-Win.IE8"
           browsers: "Win.Chrome"
 
   nightly:

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -612,7 +612,7 @@ module.exports = function (config) {
         options.logLevel = config.LOG_INFO;
 
         // to avoid DISCONNECTED messages when connecting to BrowserStack
-        options.concurrency = 1;
+        options.concurrency = 2;
         options.browserDisconnectTimeout = 30000; // default 2000
         options.browserDisconnectTolerance = 1; // default 0
         options.browserNoActivityTimeout = 4 * 60 * 1000; // default 10000


### PR DESCRIPTION
For now we have available 5 parallell tests. This will allow our CI to build faster.