### PR TITLE
Tools: Setting karma to version 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "highcharts-utils": "github:highcharts/highcharts-utils",
     "husky": "^3.0.2",
     "js-yaml": "^3.13.1",
-    "karma": "^4.3.0",
+    "karma": "4.3.0",
     "karma-browserstack-launcher": "1.4.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-edge-launcher": "^0.4.2",


### PR DESCRIPTION
This is due to issues with browserstack and starting certain browsers.
Also the exit code from the tests differs so that the nightly visual
tests now are reported as failure even though we have config to behave
differently.

Downgrade from karma v.4.4.0