### PR TITLE
Tools: Reducing to 1 instance for Mac.Safari.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,6 @@ workflows:
           browsers: "Win.IE8 --oldie"
       - test_browsers:
           name: "test-Mac.Safari"
-          browsercount: 2
           requires:
             - install_dependencies
           browsers: "Mac.Safari"


### PR DESCRIPTION
This is due to karma/browserstack not splitting the tests properly.
Both instances are running all the tests, or one of them fails
while doing so.