### PR TITLE
Fixed issue with fill property on pattern fills

### DIFF
--- a/js/modules/pattern-fill.src.js
+++ b/js/modules/pattern-fill.src.js
@@ -17,6 +17,10 @@ import H from '../parts/Globals.js';
  *
  * @interface Highcharts.PatternOptionsObject
  */ /**
+* Background color for the pattern if a `path` is set (not images).
+* @name Highcharts.PatternOptionsObject#backgroundColor
+* @type {Highcharts.ColorString}
+*/ /**
 * URL to an image to use as the pattern.
 * @name Highcharts.PatternOptionsObject#image
 * @type {string}
@@ -233,9 +237,7 @@ H.Point.prototype.calculatePatternDimensions = function (pattern) {
 H.SVGRenderer.prototype.addPattern = function (options, animation) {
     var pattern, animate = pick(animation, true), animationOptions = H.animObject(animate), path, defaultSize = 32, width = options.width || options._width || defaultSize, height = (options.height || options._height || defaultSize), color = options.color || '#343434', id = options.id, ren = this, rect = function (fill) {
         ren.rect(0, 0, width, height)
-            .attr({
-            fill: fill
-        })
+            .attr({ fill: fill })
             .add(pattern);
     }, attribs;
     if (!id) {
@@ -255,6 +257,7 @@ H.SVGRenderer.prototype.addPattern = function (options, animation) {
     pattern = this.createElement('pattern').attr({
         id: id,
         patternUnits: 'userSpaceOnUse',
+        patternContentUnits: options.patternContentUnits || 'userSpaceOnUse',
         width: width,
         height: height,
         x: options._x || options.x || 0,
@@ -266,8 +269,8 @@ H.SVGRenderer.prototype.addPattern = function (options, animation) {
     if (options.path) {
         path = options.path;
         // The background
-        if (path.fill) {
-            rect(path.fill);
+        if (options.backgroundColor) {
+            rect(options.backgroundColor);
         }
         // The pattern
         attribs = {
@@ -275,7 +278,11 @@ H.SVGRenderer.prototype.addPattern = function (options, animation) {
         };
         if (!this.styledMode) {
             attribs.stroke = path.stroke || color;
-            attribs['stroke-width'] = path.strokeWidth || 2;
+            attribs['stroke-width'] = pick(path.strokeWidth, 2);
+            attribs.fill = path.fill || 'none';
+        }
+        if (path.transform) {
+            attribs.transform = path.transform;
         }
         this.createElement('path').attr(attribs).add(pattern);
         pattern.color = color;

--- a/samples/unit-tests/color/pattern-fill/demo.js
+++ b/samples/unit-tests/color/pattern-fill/demo.js
@@ -18,7 +18,8 @@ QUnit.test('SVGRenderer used directly', function (assert) {
                     width: 12,
                     height: 12,
                     color: '#ff0000',
-                    opacity: 0.5
+                    opacity: 0.5,
+                    backgroundColor: '#00ffff'
                 }
             },
             x: 40,
@@ -36,13 +37,18 @@ QUnit.test('SVGRenderer used directly', function (assert) {
     assert.strictEqual(
         pattern.getElementsByTagName('path')[0].getAttribute('stroke'),
         '#ff0000',
-        'Pattern has path with correct color'
+        'Pattern has path with correct stroke'
+    );
+    assert.strictEqual(
+        pattern.getElementsByTagName('path')[0].getAttribute('fill'),
+        '#00ff00',
+        'Pattern has path with correct fill'
     );
 
     assert.strictEqual(
         pattern.getElementsByTagName('rect')[0].getAttribute('fill'),
-        '#00ff00',
-        'Pattern has rect with correct color'
+        '#00ffff',
+        'Pattern has background rect with correct fill'
     );
 
     assert.strictEqual(
@@ -62,13 +68,13 @@ QUnit.test('Pattern fill set on series', function (assert) {
                     pattern: {
                         id: 'custom-id',
                         path: {
-                            d: 'M 3 3 L 8 3 L 8 8 Z',
-                            fill: '#000000'
+                            d: 'M 3 3 L 8 3 L 8 8 Z'
                         },
                         width: 12,
                         height: 12,
                         color: '#ff0000',
-                        opacity: 0.5
+                        opacity: 0.5,
+                        backgroundColor: '#000000'
                     }
                 },
                 data: [


### PR DESCRIPTION
Fixed  #12243, fill property on pattern fills was applied to the wrong element. Introduced new option, `pattern.backgroundColor`.
___
The `path.fill` option didn't apply to the path itself, instead it was
applied to a rectangle that serves as a backdrop, and the path itself
was always filled with black.

