### PR TITLE
Fixed #12161, legend textDecoration not working on IE11 with a11y.

### DIFF
--- a/js/modules/accessibility/AccessibilityComponent.js
+++ b/js/modules/accessibility/AccessibilityComponent.js
@@ -352,7 +352,7 @@ AccessibilityComponent.prototype = {
             if (evt.initMouseEvent) {
                 evt.initMouseEvent(
                     e.type,
-                    e.type === 'click' || e.canBubble, // #10561
+                    e.bubbles, // #10561, #12161
                     e.cancelable,
                     e.view,
                     e.detail,


### PR DESCRIPTION
Fixed #12161, legend `textDecoration` hidden style not working on IE11 with accessibility module enabled.