### PR TITLE
Fixed menu navigation compatibility issues.

### DIFF
--- a/js/modules/accessibility/components/MenuComponent.js
+++ b/js/modules/accessibility/components/MenuComponent.js
@@ -33,7 +33,6 @@ var removeElement = HTMLUtilities.removeElement;
 H.Chart.prototype.showExportMenu = function () {
     if (this.exportSVGElements && this.exportSVGElements[0]) {
         this.exportSVGElements[0].element.onclick();
-        this.highlightExportItem(0);
     }
 };
 
@@ -81,7 +80,7 @@ H.Chart.prototype.highlightExportItem = function (ix) {
 
     if (
         listItem &&
-        listItem.tagName === 'DIV' &&
+        listItem.tagName === 'LI' &&
         !(listItem.children && listItem.children.length)
     ) {
         // Test if we have focus support for SVG elements
@@ -194,7 +193,6 @@ extend(MenuComponent.prototype, /** @lends Highcharts.MenuComponent */ {
         if (menu) {
             this.addAccessibleContextMenuAttribs();
             unhideChartElementFromAT(chart, menu);
-            chart.highlightExportItem(0);
         }
 
         this.setExportButtonExpandedState('true');
@@ -265,10 +263,9 @@ extend(MenuComponent.prototype, /** @lends Highcharts.MenuComponent */ {
             // Set tabindex on the menu items to allow focusing by script
             // Set role to give screen readers a chance to pick up the contents
             exportList.forEach(function (item) {
-                if (item.tagName === 'DIV' &&
+                if (item.tagName === 'LI' &&
                     !(item.children && item.children.length)) {
-                    item.setAttribute('role', 'listitem');
-                    item.setAttribute('tabindex', 0);
+                    item.setAttribute('tabindex', -1);
                 } else {
                     item.setAttribute('aria-hidden', 'true');
                 }
@@ -276,7 +273,6 @@ extend(MenuComponent.prototype, /** @lends Highcharts.MenuComponent */ {
 
             // Set accessibility properties on parent div
             var parentDiv = exportList[0].parentNode;
-            parentDiv.setAttribute('role', 'list');
             parentDiv.removeAttribute('aria-hidden');
             parentDiv.setAttribute(
                 'aria-label',
@@ -332,10 +328,10 @@ extend(MenuComponent.prototype, /** @lends Highcharts.MenuComponent */ {
             init: function (direction) {
                 chart.showExportMenu();
 
-                // If coming back to export menu from other module, try to
-                // highlight last item in menu
                 if (direction < 0) {
                     chart.highlightLastExportItem();
+                } else {
+                    chart.highlightExportItem(0);
                 }
             },
 

--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -1293,7 +1293,11 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                     padding: menuPadding + 'px',
                     pointerEvents: 'auto'
                 }, chart.fixedDiv || chart.container);
-            innerMenu = createElement('div', { className: 'highcharts-menu' }, null, menu);
+            innerMenu = createElement('ul', { className: 'highcharts-menu' }, {
+                listStyle: 'none',
+                margin: 0,
+                padding: 0
+            }, menu);
             // Presentational CSS
             if (!chart.styledMode) {
                 css(innerMenu, extend({
@@ -1342,7 +1346,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                         element = createElement('hr', null, null, innerMenu);
                     }
                     else {
-                        element = createElement('div', {
+                        element = createElement('li', {
                             className: 'highcharts-menu-item',
                             onclick: function (e) {
                                 if (e) { // IE7

--- a/ts/modules/exporting.src.ts
+++ b/ts/modules/exporting.src.ts
@@ -1754,9 +1754,13 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                 ) as Highcharts.ExportingDivElement;
 
             innerMenu = createElement(
-                'div',
+                'ul',
                 { className: 'highcharts-menu' },
-                null as any,
+                {
+                    listStyle: 'none',
+                    margin: 0,
+                    padding: 0
+                },
                 menu
             );
 
@@ -1827,7 +1831,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                         );
 
                     } else {
-                        element = createElement('div', {
+                        element = createElement('li', {
                             className: 'highcharts-menu-item',
                             onclick: function (e: PointerEvent): void {
                                 if (e) { // IE7


### PR DESCRIPTION
Fixed compatibility issues with menu navigation for screen readers.
___
Note: Changes HTML markup of exporting menu in the exporting module.

While the menu and the individual items have traditionally been divs, this has been causing issues for screen readers. This PR changes the exporting module to use `ul` with `li` for the menu items. This leads to a more consistent experience across different screen readers and browsers, and also somewhat simplifies the a11y code.

Ideally the internal `exportDivElements` prop should be renamed to `exportMenuItemElements` or something, but I did not change it in fear of breaking backwards compatibility for 3rd party plugins and custom code (e.g. in cloud). Thoughts @TorsteinHonsi?