### PR TITLE
bugfix/12231-coloraxis-highcharts-not-defined

### DIFF
--- a/js/parts-map/ColorAxis.js
+++ b/js/parts-map/ColorAxis.js
@@ -811,7 +811,7 @@ extend(ColorAxis.prototype, {
                     Math.max(this.dataMax, cSeries.maxColorValue);
             }
             if (!calculatedExtremes) {
-                Highcharts.Series.prototype.getExtremes.call(cSeries);
+                Series.prototype.getExtremes.call(cSeries);
             }
         }
     },

--- a/ts/parts-map/ColorAxis.ts
+++ b/ts/parts-map/ColorAxis.ts
@@ -1173,7 +1173,7 @@ extend(ColorAxis.prototype, {
             }
 
             if (!calculatedExtremes) {
-                Highcharts.Series.prototype.getExtremes.call(cSeries);
+                Series.prototype.getExtremes.call(cSeries);
             }
         }
     },


### PR DESCRIPTION
Fixed #12231, loading Highmaps as a module and using color axis thrown a reference error.