### PR TITLE
bugfix/12223-animate-arc-flags

### DIFF
--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -411,12 +411,17 @@ H.Fx.prototype = {
         else if (i === end.length && now < 1) {
             while (i--) {
                 startVal = parseFloat(start[i]);
-                ret[i] =
-                    isNaN(startVal) ? // a letter instruction like M or L
-                        end[i] :
-                        (now *
-                            parseFloat('' + (end[i] - startVal)) +
-                            startVal);
+                ret[i] = (
+                // A letter instruction like M or L
+                isNaN(startVal) ||
+                    // Arc boolean flags:
+                    end[i - 4] === 'A' || // large-arc-flag
+                    end[i - 5] === 'A' // sweep-flag
+                ) ?
+                    end[i] :
+                    (now *
+                        parseFloat('' + (end[i] - startVal)) +
+                        startVal);
             }
             // If animation is finished or length not matching, land on right value
         }

--- a/samples/unit-tests/svgrenderer/animate/demo.js
+++ b/samples/unit-tests/svgrenderer/animate/demo.js
@@ -110,17 +110,39 @@ QUnit.test('Path animation', function (assert) {
         document.body.appendChild(div);
 
         var ren = new Highcharts.Renderer(
-            div,
-            600,
-            400
-        );
-
-        var path = ren.path(['M', 10, 30, 'L', 10, 100])
-            .attr({
+                div,
+                600,
+                400
+            ),
+            attrs = {
                 'stroke-width': 2,
                 stroke: 'blue'
-            })
+            };
+
+        var path = ren.path(['M', 10, 30, 'L', 10, 100])
+            .attr(attrs)
             .add();
+
+        var arc = ren
+            .path([
+                'M', 144, 5,
+                'A', 145, 145, 0, 1, 1, 144, 5,
+                'M', 144, 16,
+                'A', 134, 134, 0, 1, 0, 144, 16,
+                'Z'
+            ])
+            .attr(attrs)
+            .add();
+
+        arc.animate({
+            d: [
+                'M', 30, 79,
+                'A', 135, 135, 0, 0, 1, 144, 15,
+                'L', 144, 16,
+                'A', 134, 134, 0, 0, 0, 31, 79,
+                'Z'
+            ]
+        });
 
         path.animate({
             d: ['M', 300, 330, 'L', 300, 400]
@@ -166,6 +188,12 @@ QUnit.test('Path animation', function (assert) {
                 'M 200 120 L 700 120',
                 'Path is animating, not changing immediately (#10696).'
             );
+
+            assert.ok(
+                true,
+                'No errors when animatin arc (#12223)'
+            );
+
             document.body.removeChild(div);
         }, 1900);
 

--- a/ts/parts/Utilities.ts
+++ b/ts/parts/Utilities.ts
@@ -792,14 +792,19 @@ H.Fx.prototype = {
         } else if (i === end.length && now < 1) {
             while (i--) {
                 startVal = parseFloat(start[i]);
-                ret[i] =
-                    isNaN(startVal) ? // a letter instruction like M or L
-                        end[i] :
-                        (
-                            now *
-                            parseFloat('' + (end[i] - startVal)) +
-                            startVal
-                        );
+                ret[i] = (
+                    // A letter instruction like M or L
+                    isNaN(startVal) ||
+                    // Arc boolean flags:
+                    end[i - 4] === 'A' || // large-arc-flag
+                    end[i - 5] === 'A' // sweep-flag
+                ) ?
+                    end[i] :
+                    (
+                        now *
+                        parseFloat('' + (end[i] - startVal)) +
+                        startVal
+                    );
 
             }
         // If animation is finished or length not matching, land on right value


### PR DESCRIPTION
Fixed #12223, animating halo for a slice in pie series used to throw errors.
___
I don't know how sweep/clockwise could be animated so it's simply moving to the end position instead.