### PR TITLE
bugfix/12266-zones-with-no-data

### DIFF
--- a/js/indicators/macd.src.js
+++ b/js/indicators/macd.src.js
@@ -255,7 +255,7 @@ seriesType('macd', 'sma',
         this.zones = this.signalZones.zones;
         SMA.prototype.applyZones.call(this);
         // applyZones hides only main series.graph, hide macd line manually
-        if (this.options.macdLine.zones.length) {
+        if (this.graphmacd && this.options.macdLine.zones.length) {
             this.graphmacd.hide();
         }
         this.zones = histogramZones;

--- a/samples/unit-tests/indicator-macd/recalculations/demo.js
+++ b/samples/unit-tests/indicator-macd/recalculations/demo.js
@@ -1,3 +1,41 @@
+QUnit.test('Zones on macd with no data.', function (assert) {
+
+    Highcharts.stockChart('container', {
+        yAxis: [{
+            height: '50%'
+        }, {
+            top: '60%',
+            height: '40%'
+        }],
+        series: [{
+            id: 'main',
+            data: []
+        }, {
+            yAxis: 1,
+            type: 'macd',
+            linkedTo: 'main',
+            params: {
+                shortPeriod: 12,
+                longPeriod: 26,
+                signalPeriod: 9,
+                period: 26
+            },
+            macdLine: {
+                zones: [{
+                    value: 0,
+                    color: 'green'
+                }, {
+                    color: 'red'
+                }]
+            }
+        }]
+    });
+
+    // We expect no JS error when applying zones on macd and chart has no data.
+    assert.expect(0);
+
+});
+
 QUnit.test('Test algorithm on data updates.', function (assert) {
 
     var chart = Highcharts.stockChart('container', {

--- a/ts/indicators/macd.src.ts
+++ b/ts/indicators/macd.src.ts
@@ -416,7 +416,7 @@ seriesType<Highcharts.MACDIndicator>(
             SMA.prototype.applyZones.call(this);
 
             // applyZones hides only main series.graph, hide macd line manually
-            if ((this.options.macdLine as any).zones.length) {
+            if (this.graphmacd && (this.options.macdLine as any).zones.length) {
                 (this.graphmacd as any).hide();
             }
 


### PR DESCRIPTION
Fixed #12266, applying zones on macd when the main series had no data produced an error.