### PR TITLE
Fixed #12222, empty pie series showing `lineWidth` after hover

### DIFF
--- a/js/parts/PieSeries.js
+++ b/js/parts/PieSeries.js
@@ -544,6 +544,8 @@ seriesType('pie', 'line',
      * @private
      */
     borderWidth: 1,
+    /** @ignore-options */
+    lineWidth: undefined,
     states: {
         /**
          * @extends   plotOptions.series.states.hover

--- a/ts/parts/PieSeries.ts
+++ b/ts/parts/PieSeries.ts
@@ -706,6 +706,8 @@ seriesType<Highcharts.PieSeries>(
          */
         borderWidth: 1,
 
+        /** @ignore-options */
+        lineWidth: undefined, // #12222
         states: {
 
             /**


### PR DESCRIPTION
Fixed #12222, empty pie series showing `lineWidth` after hover