### PR TITLE
Added functionality for showing previous price in Stockchart tooltip

### DIFF
--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -412,22 +412,7 @@ Highcharts.Pointer.prototype = {
                 searchSeries = series.filter(function (s) {
                     return filter(s) && !s.noSharedTooltip;
                 });
-                // Get all points with the same x value as the hoverPoint
-                searchSeries.forEach(function (s) {
-                    var point = find(s.points, function (p) {
-                        return p.x === hoverPoint.x && !p.isNull;
-                    });
-                    if (isObject(point)) {
-                        /*
-                        * Boost returns a minimal point. Convert it to a usable
-                        * point for tooltip and states.
-                        */
-                        if (s.chart.isBoosting) {
-                            point = s.getPoint(point);
-                        }
-                        hoverPoints.push(point);
-                    }
-                });
+                hoverPoints = this.getSharedHoverPoints(searchSeries, hoverPoint);
             }
             else {
                 hoverPoints.push(hoverPoint);
@@ -438,6 +423,42 @@ Highcharts.Pointer.prototype = {
             hoverSeries: hoverSeries,
             hoverPoints: hoverPoints
         };
+    },
+
+    /**
+     * Calculates what is the current hovered point/points for shared tooltip.
+     *
+     * @private
+     * @function Highcharts.Pointer#getSharedHoverPoints
+     *
+     *
+     * @param {Array<Highcharts.Series>} searchSeries
+     *        All the series in the chart with sticky tracking.
+     *
+     * @param {Highcharts.Point|undefined} hoverPoint
+     *        The point currrently beeing hovered.
+     *
+     * @return {Array<Highcharts.Point|undefined>}
+     *         Array containing the hover points
+     */
+    getSharedHoverPoints(searchSeries, hoverPoint){
+        var hoverPoints = [];
+        searchSeries.forEach(function (s) {
+            var point = find(s.points, function (p) {
+                return p.x === hoverPoint.x && !p.isNull;
+            });
+            if (isObject(point)) {
+                /*
+                * Boost returns a minimal point. Convert it to a usable
+                * point for tooltip and states.
+                */
+                if (s.chart.isBoosting) {
+                    point = s.getPoint(point);
+                }
+                hoverPoints.push(point);
+            }
+        });
+        return hoverPoints
     },
     /**
      * With line type charts with a single tracker, get the point closest to the

--- a/js/parts/StockChart.js
+++ b/js/parts/StockChart.js
@@ -26,7 +26,7 @@ import './Scrollbar.js';
 // Has a dependency on RangeSelector due to the use of
 // defaultOptions.rangeSelector
 import './RangeSelector.js';
-var addEvent = H.addEvent, Axis = H.Axis, Chart = H.Chart, format = H.format, merge = H.merge, Point = H.Point, Renderer = H.Renderer, Series = H.Series, SVGRenderer = H.SVGRenderer, VMLRenderer = H.VMLRenderer, seriesProto = Series.prototype, seriesInit = seriesProto.init, seriesProcessData = seriesProto.processData, pointTooltipFormatter = Point.prototype.tooltipFormatter;
+var addEvent = H.addEvent, Axis = H.Axis, Chart = H.Chart, format = H.format, merge = H.merge, Point = H.Point, Pointer = H.Pointer, Renderer = H.Renderer, Series = H.Series, SVGRenderer = H.SVGRenderer, VMLRenderer = H.VMLRenderer, seriesProto = Series.prototype, seriesInit = seriesProto.init, seriesProcessData = seriesProto.processData, pointTooltipFormatter = Point.prototype.tooltipFormatter;
 /**
  * Compare the values of the series against the first non-null, non-
  * zero value in the visible range. The y axis will show percentage
@@ -784,20 +784,20 @@ addEvent(Chart, 'update', function (e) {
  * @return {Array<Highcharts.Point|undefined>}
  *         Array containing the hover points
  */
-Pointer.prototype.getSharedHoverPoints() = function(searchSeries, hoverPoint){
+Pointer.prototype.getSharedHoverPoints = function(searchSeries, hoverPoint){
     var hoverPoints = [];
 
     searchSeries.forEach(function (s) {
         var point = searchSeries.length === 1 ?
             // When just showing one series get the point with the same x value as the hoverPoint 
-            find(s.points, function (p) {
+            H.find(s.points, function (p) {
                 return p.x === hoverPoint.x && !p.isNull;
             }) :
             // When showing multiple series get the point with the same or lower x value as the hoverPoint from all series 
-            findLast(s.points, function (p) {
+            H.findLast(s.points, function (p) {
                 return p.x <= hoverPoint.x && !p.isNull;
             });
-        if (isObject(point)) {
+        if (H.isObject(point)) {
             /*
             * Boost returns a minimal point. Convert it to a usable
             * point for tooltip and states.

--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -1893,6 +1893,35 @@ H.find = Array.prototype.find ?
         }
     };
 /**
+ * Return the value of the last element in the array that satisfies the
+ * provided testing function.
+* @function Highcharts.findLast<T>
+*
+* @param {Array<T>} arr
+*        The array to test.
+*
+* @param {Function} callback
+*        The callback function. The function receives the item as the first
+*        argument. Return `true` if this item satisfies the condition.
+*
+* @return {T|undefined}
+*         The value of the element.
+*/
+H.findLast = Array.prototype.findLast ?
+    /* eslint-enable valid-jsdoc */
+    function (arr, callback) {
+        return arr.findLast(callback);
+    } :
+    // Legacy implementation. PhantomJS, IE <= 11 etc. #7223.
+    function (arr, callback) {
+        var i, length = arr.length;
+        for (i = length -1; i < 0; i--) {
+            if (callback(arr[i], i)) { // eslint-disable-line callback-return
+                return arr[i];
+            }
+        }
+    };
+/**
  * Returns an array of a given object's own properties.
  *
  * @function Highcharts.keys

--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -1915,7 +1915,7 @@ H.findLast = Array.prototype.findLast ?
     // Legacy implementation. PhantomJS, IE <= 11 etc. #7223.
     function (arr, callback) {
         var i, length = arr.length;
-        for (i = length -1; i < 0; i--) {
+        for (i = length -1; i >= 0; i--) {
             if (callback(arr[i], i)) { // eslint-disable-line callback-return
                 return arr[i];
             }

--- a/samples/stock/demo/compare/demo.html
+++ b/samples/stock/demo/compare/demo.html
@@ -1,6 +1,6 @@
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/stock/modules/exporting.js"></script>
 <script src="https://code.highcharts.com/stock/modules/export-data.js"></script>
-
+<script src="demo.js"></script>
 
 <div id="container" style="height: 400px; min-width: 310px"></div>

--- a/samples/stock/demo/compare/demo.js
+++ b/samples/stock/demo/compare/demo.js
@@ -37,7 +37,8 @@ function createChart() {
         tooltip: {
             pointFormat: '<span style="color:{series.color}">{series.name}</span>: <b>{point.y}</b> ({point.change}%)<br/>',
             valueDecimals: 2,
-            split: true
+            split: true,
+            shared: true
         },
 
         series: seriesOptions
@@ -47,6 +48,10 @@ function createChart() {
 function success(data) {
     var name = this.url.match(/(msft|aapl|goog)/)[0].toUpperCase();
     var i = names.indexOf(name);
+    if(name == "MSFT"){
+        var quarter = data.length / 4;
+        data.splice(quarter, quarter);
+    }
     seriesOptions[i] = {
         name: name,
         data: data

--- a/samples/stock/demo/sharedtooltip/demo.details
+++ b/samples/stock/demo/sharedtooltip/demo.details
@@ -1,0 +1,7 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Torstein Hønsi
+   - Eirik L. Djuve
+ js_wrap: b
+...

--- a/samples/stock/demo/sharedtooltip/demo.html
+++ b/samples/stock/demo/sharedtooltip/demo.html
@@ -1,0 +1,6 @@
+<script src="../../../../code/highstock.src.js"></script>
+<script src="https://code.highcharts.com/stock/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/stock/modules/export-data.js"></script>
+<script src="demo.js"></script>
+
+<div id="container" style="height: 400px; min-width: 310px"></div>

--- a/samples/stock/demo/sharedtooltip/demo.js
+++ b/samples/stock/demo/sharedtooltip/demo.js
@@ -1,0 +1,81 @@
+var seriesOptions = [],
+    seriesCounter = 0,
+    names = ['MSFT', 'AAPL', 'GOOG'];
+
+/**
+ * Create the chart when all data is loaded
+ * @returns {undefined}
+ */
+function createChart() {
+
+
+    Highcharts.stockChart('container', {
+
+        rangeSelector: {
+            selected: 4
+        },
+
+        yAxis: {
+            labels: {
+                formatter: function () {
+                    return (this.value > 0 ? ' + ' : '') + this.value + '%';
+                }
+            },
+            plotLines: [{
+                value: 0,
+                width: 2,
+                color: 'silver'
+            }]
+        },
+
+        plotOptions: {
+            series: {
+                compare: 'percent',
+                showInNavigator: true
+            }
+        },
+
+        tooltip: {
+            pointFormat: '<span style="color:{series.color}">{series.name}</span>: <b>{point.y}</b> ({point.change}%)<br/>',
+            valueDecimals: 2,
+            split: true,
+            shared: true
+        },
+
+        series: seriesOptions
+    });
+}
+
+function success(data) {
+    var name = this.url.match(/(msft|aapl|goog)/)[0].toUpperCase();
+    var i = names.indexOf(name);
+    if(name == "AAPL"){
+        var quarter = data.length / 4;
+        data.splice(quarter, quarter);
+    }
+    seriesOptions[i] = {
+        name: name,
+        data: data
+    };
+
+    // As we're loading the data asynchronously, we don't know what order it
+    // will arrive. So we keep a counter and create the chart when all the data is loaded.
+    seriesCounter += 1;
+
+    if (seriesCounter === names.length) {
+        createChart();
+    }
+}
+
+Highcharts.getJSON(
+    'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/msft-c.json',
+    success
+);
+Highcharts.getJSON(
+    'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/aapl-c.json',
+    success
+);
+Highcharts.getJSON(
+    'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/goog-c.json',
+    success
+);

--- a/samples/stock/demo/sharedtooltip/readme.md
+++ b/samples/stock/demo/sharedtooltip/readme.md
@@ -1,0 +1,6 @@
+# Compare multiple series
+This demo fetches and visualizes the stock prices of MSFT (Microsoft Corporation), GOOG (Google) and AAPL (Apple). All the series start at the same point, then changes in percentage are plotted on the same Y axis regardless of the actual data values.
+
+
+#### Tip
+Since the data series are fetched asynchronously, they need to be sorted before the rendering process.


### PR DESCRIPTION
I did something like this using wrap on one of my implementations, and really liked the effect.

Basically when showing compares on stockcharts I want to always show a valid tick for all series that has data/ticks before the hover point. I have customers that have been thinking it is a bug when the shared tooltip falls out mid chart when there are gaps in the data for a less volatile symbol, but this would make it very clear.

Not been able to compile and test(have to set env variable for python and stuff) but hopefully it compiles. Data manipulation in demo to show data with gaps.