### PR TITLE
Tools: Updated karma captureTimeout as per comment from Browserstack.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ workflows:
       - test_browsers:
           name: "test-Mac.Safari"
           requires:
-            - lint
+            - "test-Win.IE8"
           browsers: "Mac.Safari"
       - test_browsers:
           name: "test-Mac.Firefox"
@@ -389,7 +389,7 @@ workflows:
           name: "test-Win.Chrome"
           browsercount: 2
           requires:
-            - "test-Win.IE8"
+            - "test-Mac.Firefox"
           browsers: "Win.Chrome"
 
   nightly:

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -617,6 +617,7 @@ module.exports = function (config) {
         options.browserDisconnectTolerance = 1; // default 0
         options.browserNoActivityTimeout = 4 * 60 * 1000; // default 10000
         options.browserSocketTimeout = 20000;
+        options.captureTimeout = 100000;
 
         options.plugins = [
             'karma-browserstack-launcher',


### PR DESCRIPTION
This should hopefully prevent startup timeout failures for Win.Chrome.
Also changed back CI test job dependencies as we now are back to 1 instance on Browserstack.