### PR TITLE
Tools: Changed size of compared tests to 600x400

### DIFF
--- a/test/karma-imagecapture-reporter.js
+++ b/test/karma-imagecapture-reporter.js
@@ -44,12 +44,16 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
      *         The file name
      * @param  {Array}  frames
      *         The image data of the GIF frames
+     * @param {number} width
+     *          Width of the created gif
+     * @param {number} height
+     *          Height of the created gif
      * @return {void}
      */
-    function createAnimatedGif(filename, frames) {
+    function createAnimatedGif(filename, frames, width, height) {
         var GIFEncoder = require('gifencoder');
 
-        var encoder = new GIFEncoder(300, 200);
+        var encoder = new GIFEncoder(width, height);
         encoder.start();
         // 0 for repeat, -1 for no-repeat
         encoder.setRepeat(0);
@@ -140,7 +144,9 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
                 fs.writeFileSync(filename, Buffer.from(data, 'base64'));
 
             } else if (/\.gif$/.test(filename)) {
-                createAnimatedGif(filename, info.frames);
+                const canvasWidth = info.canvasWidth || 600;
+                const canvasHeight = info.canvasHeight || 400;
+                createAnimatedGif(filename, info.frames, canvasWidth, canvasHeight);
             }
         } catch (err) {
             LOG.error(`Failed to write file ${filename}\n\n${err}`);

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -8,6 +8,9 @@
 
 var VERBOSE = false;
 
+var CANVAS_WIDTH = 600;
+var CANVAS_HEIGHT = 400;
+
 var div;
 if (!document.getElementById('container')) {
     div = document.createElement('div');
@@ -24,8 +27,8 @@ demoHTML.setAttribute('id', 'demo-html');
 document.body.appendChild(demoHTML);
 
 var canvas = document.createElement('canvas');
-canvas.setAttribute('width', 300);
-canvas.setAttribute('height', 200);
+canvas.setAttribute('width', CANVAS_WIDTH);
+canvas.setAttribute('height', CANVAS_HEIGHT);
 var ctx = canvas.getContext && canvas.getContext('2d');
 
 var currentTests = [];
@@ -145,7 +148,7 @@ if (window.$) {
 function resetDefaultOptions(testName) {
 
     var defaultOptionsRaw = JSON.parse(Highcharts.defaultOptionsRaw);
-    
+
     // Before running setOptions, delete properties that are undefined by
     // default. For example, in `highcharts/members/setoptions`, properties like
     // chart.borderWidth and chart.plotBorderWidth are set. The default options
@@ -162,7 +165,7 @@ function resetDefaultOptions(testName) {
                 deleteAddedProperties(copy[key], original[key]);
             } else if (
                 // functions are not saved in defaultOptionsRaw
-                typeof value !== 'function' &&    
+                typeof value !== 'function' &&
                 !(key in original)
             ) {
                 delete copy[key];
@@ -508,9 +511,9 @@ function compareToReference(chart, path) { // eslint-disable-line no-unused-vars
                     blob = new Blob([svg], { type: 'image/svg+xml' }),
                     url = DOMURL.createObjectURL(blob);
                 img.onload = function () {
-                    ctx.clearRect(0, 0, 300, 200);
-                    ctx.drawImage(img, 0, 0, 300, 200);
-                    callback(ctx.getImageData(0, 0, 300, 200).data);
+                    ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+                    ctx.drawImage(img, 0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+                    callback(ctx.getImageData(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT).data);
                 };
                 img.onerror = function () {
                     // console.log(svg)
@@ -531,6 +534,8 @@ function compareToReference(chart, path) { // eslint-disable-line no-unused-vars
                 if (diff !== 0) {
                     __karma__.info({
                         filename: './samples/' + path + '/diff.gif',
+                        canvasWidth: CANVAS_WIDTH,
+                        canvasHeight: CANVAS_HEIGHT,
                         frames: [
                             referenceData,
                             candidateData


### PR DESCRIPTION
Increased the size of the compared visual test samples from 300x200 to 600x400.

I'm not entirely sure how this will play out with the nightly diff, but as the SVGs stored in S3 already are the same size it should be ok. If not we should delete all "latest" references on S3 so that new ones will be generated.