### PR TITLE
Bugfix/12296 plotbackgroundimage update

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -1464,6 +1464,9 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                     chart.plotBGImage = renderer.image(plotBackgroundImage, plotLeft, plotTop, plotWidth, plotHeight).add();
                 }
                 else {
+                    if (plotBackgroundImage !== plotBGImage.attr('href')) {
+                        plotBGImage.attr('href', plotBackgroundImage);
+                    }
                     plotBGImage.animate(plotBox);
                 }
             }

--- a/samples/unit-tests/chart/chart-update-chart-2/demo.js
+++ b/samples/unit-tests/chart/chart-update-chart-2/demo.js
@@ -56,6 +56,19 @@ QUnit.test('Option chart plot border and background update', function (assert) {
         testimage,
         'Image attempted loaded'
     );
+
+    // Change plot background image
+    testimage = `${testimage}?updated`;
+    chart.update({
+        chart: {
+            plotBackgroundImage: testimage
+        }
+    });
+    assert.strictEqual(
+        chart.plotBGImage.element.getAttribute('href'),
+        testimage,
+        'Plot background image should change (#12296)'
+    );
 });
 
 QUnit.test('Option chart.ignoreHiddenSeries update', function (assert) {

--- a/samples/unit-tests/chart/panning/demo.js
+++ b/samples/unit-tests/chart/panning/demo.js
@@ -185,6 +185,7 @@ QUnit.test('Zoom and pan key', function (assert) {
     );
 
     // Pan
+    delete chart.pointer.chartPosition; // delete cache, QUnit header is moving chart
     controller.mouseDown(100, 200, { shiftKey: true });
     for (var x = 110; x < 400; x += 10) {
         controller.mouseMove(x, 100, { shiftKey: true });

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -2164,6 +2164,10 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                         plotHeight
                     ).add();
                 } else {
+                    if (plotBackgroundImage !== plotBGImage.attr('href')) {
+                        plotBGImage.attr('href', plotBackgroundImage);
+                    }
+
                     plotBGImage.animate(plotBox as Highcharts.SVGAttributes);
                 }
             }


### PR DESCRIPTION
Fixed #12296, unable to update `chart.plotBackgroundImage` when an image existed from before.