### PR TITLE
bugfix/12248-waterfall-overlap-stacking 

### DIFF
--- a/js/parts-more/WaterfallSeries.js
+++ b/js/parts-more/WaterfallSeries.js
@@ -33,6 +33,10 @@ addEvent(Axis, 'afterInit', function () {
         };
     }
 });
+addEvent(Axis, 'afterBuildStacks', function () {
+    this.waterfallStacks.changed = false;
+    delete this.waterfallStacks.alreadyChanged;
+});
 addEvent(Chart, 'beforeRedraw', function () {
     var axes = this.axes, series = this.series, i = series.length;
     while (i--) {
@@ -475,7 +479,7 @@ seriesType('waterfall', 'column', {
     },
     // Waterfall has stacking along the x-values too.
     setStackedPoints: function () {
-        var series = this, options = series.options, waterfallStacks = series.yAxis.waterfallStacks, seriesThreshold = options.threshold, stackThreshold = seriesThreshold || 0, interSum = stackThreshold, stackKey = series.stackKey, xData = series.xData, xLength = xData.length, actualStack, actualStackX, totalYVal, actualSum, prevSum, statesLen, posTotal, negTotal, xPoint, yVal, x;
+        var series = this, options = series.options, waterfallStacks = series.yAxis.waterfallStacks, seriesThreshold = options.threshold, stackThreshold = seriesThreshold || 0, interSum = stackThreshold, stackKey = series.stackKey, xData = series.xData, xLength = xData.length, actualStack, actualStackX, totalYVal, actualSum, prevSum, statesLen, posTotal, negTotal, xPoint, yVal, x, alreadyChanged, changed;
         // function responsible for calculating correct values for stackState
         // array of each stack item. The arguments are: firstS - the value for
         // the first state, nextS - the difference between the previous and the
@@ -500,13 +504,22 @@ seriesType('waterfall', 'column', {
         // code responsible for creating stacks for waterfall series
         if (series.visible ||
             !series.chart.options.chart.ignoreHiddenSeries) {
+            changed = waterfallStacks.changed;
+            alreadyChanged = waterfallStacks.alreadyChanged;
+            // in case of a redraw, stack for each x value must be
+            // emptied (only for the first series in a specific stack)
+            // and recalculated once more
+            if (alreadyChanged &&
+                alreadyChanged.indexOf(stackKey) < 0) {
+                changed = true;
+            }
             if (!waterfallStacks[stackKey]) {
                 waterfallStacks[stackKey] = {};
             }
             actualStack = waterfallStacks[stackKey];
             for (var i = 0; i < xLength; i++) {
                 x = xData[i];
-                if (!actualStack[x] || waterfallStacks.changed) {
+                if (!actualStack[x] || changed) {
                     actualStack[x] = {
                         negTotal: 0,
                         posTotal: 0,
@@ -514,7 +527,7 @@ seriesType('waterfall', 'column', {
                         threshold: 0,
                         stateIndex: 0,
                         stackState: [],
-                        label: ((waterfallStacks.changed &&
+                        label: ((changed &&
                             actualStack[x]) ?
                             actualStack[x].label :
                             undefined)
@@ -561,6 +574,10 @@ seriesType('waterfall', 'column', {
                 stackThreshold += actualStackX.stackTotal;
             }
             waterfallStacks.changed = false;
+            if (!waterfallStacks.alreadyChanged) {
+                waterfallStacks.alreadyChanged = [];
+            }
+            waterfallStacks.alreadyChanged.push(stackKey);
         }
     },
     // Extremes for a non-stacked series are recorded in processData.

--- a/js/parts/Stacking.js
+++ b/js/parts/Stacking.js
@@ -295,6 +295,7 @@ Axis.prototype.buildStacks = function () {
         for (i = 0; i < len; i++) {
             axisSeries[i].modifyStacks();
         }
+        H.fireEvent(this, 'afterBuildStacks');
     }
 };
 /**

--- a/samples/unit-tests/series-waterfall/overlap-stacking/demo.details
+++ b/samples/unit-tests/series-waterfall/overlap-stacking/demo.details
@@ -1,0 +1,5 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+...

--- a/samples/unit-tests/series-waterfall/overlap-stacking/demo.html
+++ b/samples/unit-tests/series-waterfall/overlap-stacking/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 500px; margin: 0 auto"></div>

--- a/samples/unit-tests/series-waterfall/overlap-stacking/demo.js
+++ b/samples/unit-tests/series-waterfall/overlap-stacking/demo.js
@@ -1,0 +1,52 @@
+QUnit.test('#12248 - Correct visible range for points.', function (assert) {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            type: 'waterfall'
+        },
+        yAxis: {
+            stackLabels: {
+                enabled: true
+            }
+        },
+        plotOptions: {
+            series: {
+                stacking: 'overlap'
+            }
+        },
+        series: [{
+            stack: 'a',
+            data: [-10],
+            zIndex: 1
+        }, {
+            stack: 'a',
+            data: [30]
+        }, {
+            stack: 'b',
+            data: [-10],
+            zIndex: 1
+        }, {
+            stack: 'b',
+            data: [20]
+        }]
+    });
+
+    var firstSeries = chart.series[0],
+        yAxis = chart.yAxis[0],
+        yMax = yAxis.max,
+        stackState = [0, 30, 20];
+
+    firstSeries.setVisible(false);
+    firstSeries.setVisible(true);
+
+    assert.strictEqual(
+        yMax,
+        yAxis.max,
+        'The initial yAxis.max should be unchanged.'
+    );
+
+    assert.strictEqual(
+        stackState.length,
+        yAxis.waterfallStacks[firstSeries.stackKey][0].stackState.length,
+        'The number of the first stack\'s states should be unchanged.'
+    );
+});

--- a/ts/parts/Stacking.ts
+++ b/ts/parts/Stacking.ts
@@ -548,6 +548,7 @@ Axis.prototype.buildStacks = function (this: Highcharts.Axis): void {
         for (i = 0; i < len; i++) {
             axisSeries[i].modifyStacks();
         }
+        H.fireEvent(this, 'afterBuildStacks');
     }
 };
 


### PR DESCRIPTION
Fixed #12248, the Y axis' range was disturbed on stacked (overlapping) waterfall chart.