### PR TITLE
bugfix/12267-getCrispPath-error

### DIFF
--- a/js/parts-more/WaterfallSeries.js
+++ b/js/parts-more/WaterfallSeries.js
@@ -455,7 +455,7 @@ seriesType('waterfall', 'column', {
                     yPos
                 ];
             }
-            if (!stacking &&
+            if (!stacking && d &&
                 (prevPoint.y < 0 && !reversedYAxis) ||
                 (prevPoint.y > 0 && reversedYAxis)) {
                 d[2] += prevArgs.height;

--- a/ts/parts-more/WaterfallSeries.ts
+++ b/ts/parts-more/WaterfallSeries.ts
@@ -825,7 +825,7 @@ seriesType<Highcharts.WaterfallSeries>('waterfall', 'column', {
             }
 
             if (
-                !stacking &&
+                !stacking && d &&
                 (prevPoint.y < 0 && !reversedYAxis) ||
                 (prevPoint.y > 0 && reversedYAxis)
             ) {


### PR DESCRIPTION
Fixed #12267, error in waterfall chart when the series was invisible and the first value was below 0