### PR TITLE
Tools: Fixed issue with samples table

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,9 @@ jobs:
         default: 1
     steps:
       - << : *load_workspace
-      - run: "npx cross-env NODE_OPTIONS=--max_old_space_size=3072 karma start test/karma-conf.js --single-run --splitbrowsers << parameters.browsers >> --browsercount << parameters.browsercount >>"
+      - run:
+          command: "npx cross-env NODE_OPTIONS=--max_old_space_size=3072 karma start test/karma-conf.js --single-run --splitbrowsers << parameters.browsers >> --browsercount << parameters.browsercount >>"
+          no_output_timeout: 20m
       - run: mkdir ../test-results
       - run:
           name: Save test results

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -617,7 +617,7 @@ module.exports = function (config) {
         options.browserDisconnectTolerance = 1; // default 0
         options.browserNoActivityTimeout = 4 * 60 * 1000; // default 10000
         options.browserSocketTimeout = 20000;
-        options.captureTimeout = 100000;
+        options.captureTimeout = 120000;
 
         options.plugins = [
             'karma-browserstack-launcher',

--- a/tools/gulptasks/update-pr-testresults.js
+++ b/tools/gulptasks/update-pr-testresults.js
@@ -173,13 +173,12 @@ function resolveGitFileStatus(changeCharacter) {
 /**
  * Retrieves changes from samples/ folder and returns a markdown
  * template that lists the changed files (compared with master).
- * @param {string} folder to look for changes in.
  * @return {string} markdown template with the changed files.
  */
-function createChangedDirFilesTemplate(folder) {
+function createTemplateForChangeSamples() {
     let gitChangedFiles = getFilesChanged();
-    logLib.message(`Changed files:\n ${gitChangedFiles}`);
-    gitChangedFiles = gitChangedFiles.split('\n').filter(line => line && line.includes(folder));
+    logLib.message(`Changed files:\n${gitChangedFiles}`);
+    gitChangedFiles = gitChangedFiles.split('\n').filter(line => line && /samples\/(highcharts|maps|stock|gantt).*demo.js$/.test(line));
     let samplesChangedTemplate = '';
     if (gitChangedFiles && gitChangedFiles.length > 0) {
         samplesChangedTemplate = '<details>\n<summary>Samples changed</summary><p>\n\n| Change type | Sample |\n| --- | --- |\n' +
@@ -231,7 +230,7 @@ async function commentOnPR() {
         `${DEFAULT_COMMENT_MATCH} - diffs found\n| Test name | Pixels diff |\n| --- | --- |\n${diffs.map(diff => '| `' + diff[0] + '` | ' + diff[1] + ' |').join('\n')}
             ${process.env.CIRCLE_BUILD_URL ? `\n\nCompared SVGs can be found under the [CI job artifacts](${process.env.CIRCLE_BUILD_URL}#artifacts).` : ''}`;
 
-    const changedSamplesTemplate = createChangedDirFilesTemplate('samples/');
+    const changedSamplesTemplate = createTemplateForChangeSamples();
     commentTemplate += `\n\n${changedSamplesTemplate}`;
 
     const { containsText = DEFAULT_COMMENT_MATCH } = argv;


### PR DESCRIPTION
Now only samples in the product folders are listed as changed in the PR.

Also increased timeout of CI test jobs for browserstack to allow 20 minutes with no output as we only have 1 instance on Browserstack. When many builds run at the same time it would otherwise cause the CI to fail the job when no output has been recorded for 10minutes (old value/default)