### PR TITLE
bugfix/12287-packedbubble-shared-tooltip-error

### DIFF
--- a/js/parts-more/PackedBubbleSeries.js
+++ b/js/parts-more/PackedBubbleSeries.js
@@ -511,8 +511,11 @@ seriesType('packedbubble', 'bubble',
     pointArrayMap: ['value'],
     pointValKey: 'value',
     isCartesian: false,
+    requireSorting: false,
+    directTouch: true,
     axisTypes: [],
     noSharedTooltip: true,
+    searchPoint: H.noop,
     /* eslint-disable no-invalid-this, valid-jsdoc */
     /**
      * Create a single array of all points from all series

--- a/js/parts-more/PackedBubbleSeries.js
+++ b/js/parts-more/PackedBubbleSeries.js
@@ -515,6 +515,7 @@ seriesType('packedbubble', 'bubble',
     directTouch: true,
     axisTypes: [],
     noSharedTooltip: true,
+    // solving #12287
     searchPoint: H.noop,
     /* eslint-disable no-invalid-this, valid-jsdoc */
     /**

--- a/samples/unit-tests/series-packedbubble/tooltip/demo.details
+++ b/samples/unit-tests/series-packedbubble/tooltip/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series-packedbubble/tooltip/demo.html
+++ b/samples/unit-tests/series-packedbubble/tooltip/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 400px; margin: 0 auto"></div>

--- a/samples/unit-tests/series-packedbubble/tooltip/demo.js
+++ b/samples/unit-tests/series-packedbubble/tooltip/demo.js
@@ -1,0 +1,63 @@
+QUnit.test('Packed Bubble Tooltip options', function (assert) {
+    try {
+        const chart = Highcharts.chart('container', {
+                chart: {
+                    type: 'packedbubble',
+                    height: '100%'
+                },
+                title: false,
+                plotOptions: {
+                    packedbubble: {
+                        layoutAlgorithm: {
+                            enableSimulation: false,
+                            splitSeries: true
+                        },
+                        dataLabels: {
+                            enabled: false
+                        }
+                    }
+                },
+                tooltip: {
+                    shared: true
+                },
+                series: [{
+                    data: [{
+                        value: 20
+                    }, {
+                        value: 20
+                    }]
+                }, {
+                    data: [{
+                        value: 20
+                    }, {
+                        value: 20
+                    }]
+                }, {
+                    data: [{
+                        value: 20
+                    }]
+                }]
+            }),
+            offset = $('#container').offset(),
+            left = offset.left + chart.plotLeft,
+            top = offset.top + chart.plotTop,
+            points = chart.series[0].points;
+
+        chart.pointer.onContainerMouseMove({
+            type: 'mousemove',
+            pageX: left + points[0].plotX,
+            pageY: top + points[0].plotY,
+            target: points[0].series.group.element
+        });
+
+        assert.ok(
+            true,
+            'PackedBubble series works correctly with shared tooltip.'
+        );
+    } catch (error) {
+        assert.ok(
+            false,
+            'PackedBubble series with shared tooltip throws error.'
+        );
+    }
+});

--- a/ts/parts-more/PackedBubbleSeries.ts
+++ b/ts/parts-more/PackedBubbleSeries.ts
@@ -850,6 +850,7 @@ seriesType<Highcharts.PackedBubbleSeries>(
         directTouch: true,
         axisTypes: [],
         noSharedTooltip: true,
+        // solving #12287
         searchPoint: H.noop as any,
 
         /* eslint-disable no-invalid-this, valid-jsdoc */

--- a/ts/parts-more/PackedBubbleSeries.ts
+++ b/ts/parts-more/PackedBubbleSeries.ts
@@ -846,8 +846,11 @@ seriesType<Highcharts.PackedBubbleSeries>(
         pointArrayMap: ['value'],
         pointValKey: 'value',
         isCartesian: false,
+        requireSorting: false,
+        directTouch: true,
         axisTypes: [],
         noSharedTooltip: true,
+        searchPoint: H.noop as any,
 
         /* eslint-disable no-invalid-this, valid-jsdoc */
 


### PR DESCRIPTION
Fixed #12287, using PackedBubble series with shared tooltip caused error in console on mouseover.
