### PR TITLE
Bugfix/11617 scrollable split tooltip

### DIFF
--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -190,8 +190,10 @@ Highcharts.Pointer.prototype = {
      *         The offset of the chart container within the page
      */
     getChartPosition: function () {
+        var chart = this.chart;
+        var container = chart.scrollingContainer || chart.container;
         return (this.chartPosition ||
-            (this.chartPosition = offset(this.chart.container)));
+            (this.chartPosition = offset(container)));
     },
     /**
      * Takes a browser event object and extends it with custom Highcharts

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -846,8 +846,6 @@ H.Tooltip.prototype = {
         var clamp = function (value, min, max) {
             return value > min ? value < max ? value : max : min;
         };
-        var clampToHorizontalPlotArea = function (value) { return clamp(value, plotLeft, plotLeft + plotWidth - scrollablePixelsX); };
-        var clampToVerticalPlotArea = function (value) { return clamp(value, plotTop, plotTop + plotHeight - scrollablePixelsY); };
         var boundaries = {
             left: scrollablePixelsX ? plotLeft : 0,
             right: scrollablePixelsX ?
@@ -952,8 +950,8 @@ H.Tooltip.prototype = {
                         - scrollTop;
                 }
                 // Limit values to plot area
-                anchorX = clampToHorizontalPlotArea(anchorX);
-                anchorY = clampToVerticalPlotArea(anchorY);
+                anchorX = clamp(anchorX, boundaries.left, boundaries.right);
+                anchorY = clamp(anchorY, boundaries.top, boundaries.bottom);
                 if (isHeader) {
                     x = clamp(x, boundaries.left, boundaries.right - boxWidth);
                 }

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -1044,13 +1044,13 @@ H.Tooltip.prototype = {
          */
         var container = tooltip.container, outside = tooltip.outside, renderer = tooltip.renderer;
         if (outside && container && renderer) {
+            // Set container size to fit the tooltip
+            var _h = tooltipLabel.getBBox(), width = _h.width, height = _h.height, x = _h.x, y = _h.y;
+            renderer.setSize(width + x, height + y, false);
             // Position the tooltip container to the chart container
             var chartPosition = pointer.getChartPosition();
             container.style.left = chartPosition.left + 'px';
             container.style.top = chartPosition.top + 'px';
-            // Set container size to fit the tooltip
-            var _h = tooltipLabel.getBBox(), width = _h.width, height = _h.height, x = _h.x, y = _h.y;
-            renderer.setSize(width + x, height + y, false);
         }
     },
     /**

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -856,13 +856,8 @@ H.Tooltip.prototype = {
         };
         var tooltipLabel = tooltip.getLabel();
         var headerTop = Boolean(opposite);
-        var boxes = [];
         var distributionBoxTop = plotTop;
         var headerHeight = 0;
-        // Graceful degradation for legacy formatters
-        if (isString(labels)) {
-            labels = [false, labels];
-        }
         // Calculate the x and y position for the anchor
         function getAnchor(point) {
             var isHeader = point.isHeader, _a = point.plotX, plotX = _a === void 0 ? 0 : _a, _b = point.plotY, plotY = _b === void 0 ? 0 : _b, series = point.series;
@@ -950,15 +945,20 @@ H.Tooltip.prototype = {
             }
             return tt;
         }
+        // Graceful degradation for legacy formatters
+        if (isString(labels)) {
+            labels = [false, labels];
+        }
         // Create the individual labels for header and points, ignore footer
-        labels.slice(0, points.length + 1).forEach(function (str, i) {
+        var boxes = labels.slice(0, points.length + 1).reduce(function (boxes, str, i) {
             if (str !== false && str !== '') {
                 var point = points[i - 1] || {
                     // Item 0 is the header. Instead of this, we could also
                     // use the crosshair label
                     isHeader: true,
                     plotX: points[0].plotX,
-                    plotY: plotHeight
+                    plotY: plotHeight,
+                    series: {}
                 };
                 var isHeader = point.isHeader;
                 // Store the tooltip referance on the series
@@ -990,7 +990,8 @@ H.Tooltip.prototype = {
                     x: boxPosition.x
                 });
             }
-        });
+            return boxes;
+        }, []);
         // Clean previous run (for missing points)
         tooltip.cleanSplit();
         // Distribute and put in place

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -901,7 +901,6 @@ H.Tooltip.prototype = {
                 var series = point.series || {};
                 var owner = point.series || tooltip;
                 var colorClass = 'highcharts-color-' + pick(point.colorIndex, series.colorIndex, 'none');
-                var _a = point.plotY, plotY = _a === void 0 ? 0 : _a;
                 var isHeader = point.isHeader;
                 // Store the tooltip referance on the series
                 var tt = owner.tt;
@@ -950,7 +949,7 @@ H.Tooltip.prototype = {
                 }
                 // Prepare for distribution
                 var target = void 0;
-                var _b = __read(getAnchor(point), 2), anchorX = _b[0], anchorY = _b[1];
+                var _a = __read(getAnchor(point), 2), anchorX = _a[0], anchorY = _a[1];
                 if (isHeader) {
                     target = headerTop ?
                         -headerHeight :
@@ -958,8 +957,7 @@ H.Tooltip.prototype = {
                     x = anchorX - (boxWidth / 2);
                 }
                 else {
-                    var yAxis = series.yAxis;
-                    target = yAxis.pos - distributionBoxTop + Math.max(0, Math.min(plotY, yAxis.len)); // Limit target position to within yAxis
+                    target = anchorY - distributionBoxTop;
                     x = anchorX - distance - boxWidth;
                 }
                 if (isHeader) {

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -893,18 +893,15 @@ H.Tooltip.prototype = {
          * @param {number} anchorX The tooltip anchor x position
          * @param {number} anchorY The tooltip anchor y position
          * @param {boolean} isHeader Wether the tooltip is a header
-         * @param {Highcharts.BBoxObject} bBox The bounding box of the tooltip
+         * @param {number} boxWidth Width of the tooltip
          * @return {Highcharts.PositionObject} Returns the tooltip x and y
          * position
          */
-        function defaultPositioner(anchorX, anchorY, isHeader, bBox) {
-            var boxWidth = bBox.width;
+        function defaultPositioner(anchorX, anchorY, isHeader, boxWidth) {
             var y;
             var x;
             if (isHeader) {
-                y = headerTop ?
-                    -headerHeight :
-                    plotHeight + headerHeight;
+                y = headerTop ? 0 : plotHeight - scrollablePixelsY;
                 x = clamp(anchorX - (boxWidth / 2), boundaries.left, boundaries.right - boxWidth);
             }
             else {
@@ -919,6 +916,7 @@ H.Tooltip.prototype = {
                     x = boundaries.right - boxWidth;
                 }
             }
+            // NOTE: y is relative to distributionBoxTop
             return { x: x, y: y };
         }
         /**
@@ -1001,10 +999,10 @@ H.Tooltip.prototype = {
                 }
                 var _a = __read(getAnchor(point), 2), anchorX = _a[0], anchorY = _a[1];
                 var size = bBox.height + 1;
-                var boxPosition = positioner ? positioner.call(tooltip, boxWidth, size, point) : defaultPositioner(anchorX, anchorY, isHeader, bBox);
+                var boxPosition = positioner ? positioner.call(tooltip, boxWidth, size, point) : defaultPositioner(anchorX, anchorY, isHeader, boxWidth);
                 boxes.push({
                     // 0-align to the top, 1-align to the bottom
-                    align: positioner ? 0 : void 0,
+                    align: positioner || isHeader ? 0 : void 0,
                     anchorX: anchorX,
                     anchorY: anchorY,
                     point: point,

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -842,7 +842,7 @@ H.Tooltip.prototype = {
      */
     renderSplit: function (labels, points) {
         var tooltip = this;
-        var _a = tooltip.chart, chartWidth = _a.chartWidth, _b = _a.marginRight, marginRight = _b === void 0 ? 0 : _b, plotHeight = _a.plotHeight, plotLeft = _a.plotLeft, plotTop = _a.plotTop, pointer = _a.pointer, ren = _a.renderer, _c = _a.scrollablePixelsX, scrollablePixelsX = _c === void 0 ? 0 : _c, styledMode = _a.styledMode, _d = __read(_a.xAxis, 1), opposite = _d[0].opposite, distance = tooltip.distance, options = tooltip.options, positioner = tooltip.options.positioner;
+        var _a = tooltip.chart, chartWidth = _a.chartWidth, _b = _a.marginRight, marginRight = _b === void 0 ? 0 : _b, plotHeight = _a.plotHeight, plotLeft = _a.plotLeft, plotTop = _a.plotTop, pointer = _a.pointer, ren = _a.renderer, _c = _a.scrollablePixelsX, scrollablePixelsX = _c === void 0 ? 0 : _c, _d = _a.scrollablePixelsY, scrollablePixelsY = _d === void 0 ? 0 : _d, styledMode = _a.styledMode, _e = __read(_a.xAxis, 1), opposite = _e[0].opposite, distance = tooltip.distance, options = tooltip.options, positioner = tooltip.options.positioner;
         var tooltipLabel = tooltip.getLabel();
         var headerTop = Boolean(opposite);
         var boxes = [];
@@ -939,15 +939,17 @@ H.Tooltip.prototype = {
                         -headerHeight :
                         plotHeight + headerHeight;
                     anchorX = plotX + plotLeft;
-                    anchorY = plotTop + plotHeight / 2;
+                    // Set anchorY to center of visible plot area.
+                    anchorY = plotTop + (plotHeight - scrollablePixelsY) / 2;
                 }
                 else {
                     var yAxis = series.yAxis;
                     var xAxis = series.xAxis;
                     target = yAxis.pos - distributionBoxTop + Math.max(0, Math.min(plotY, yAxis.len)); // Limit target position to within yAxis
                     anchorX = plotX + xAxis.pos;
-                    anchorY = yAxis.pos +
-                        Math.max(0, Math.min(plotY, yAxis.len));
+                    // Set anchorY to plotY. Limit to within visible plot area,
+                    // and within yAxis.
+                    anchorY = Math.max(plotTop, yAxis.pos, Math.min(plotTop + plotHeight - scrollablePixelsY, yAxis.pos + yAxis.len, yAxis.pos + plotY));
                 }
                 var box = {
                     target: target,
@@ -981,7 +983,8 @@ H.Tooltip.prototype = {
                 x: x,
                 /* NOTE: y should equal pos to be consistent with !split
                  * tooltip, but is currently relative to plotTop. Is left as is
-                 * to avoid breaking change.
+                 * to avoid breaking change. Remove distributionBoxTop to make
+                 * it consistent.
                  */
                 y: pos + distributionBoxTop,
                 anchorX: anchorX,
@@ -1000,7 +1003,7 @@ H.Tooltip.prototype = {
             container.style.left = chartPosition.left + 'px';
             container.style.top = chartPosition.top + 'px';
             // Set container size to fit the tooltip
-            var _e = tooltipLabel.getBBox(), width = _e.width, height = _e.height, x = _e.x, y = _e.y;
+            var _f = tooltipLabel.getBBox(), width = _f.width, height = _f.height, x = _f.x, y = _f.y;
             renderer.setSize(width + x, height + y, false);
         }
     },

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -26,7 +26,7 @@ var __read = (this && this.__read) || function (o, n) {
 };
 import H from './Globals.js';
 import U from './Utilities.js';
-var defined = U.defined, discardElement = U.discardElement, extend = U.extend, isNumber = U.isNumber, isString = U.isString, pick = U.pick, splat = U.splat, syncTimeout = U.syncTimeout;
+var clamp = U.clamp, defined = U.defined, discardElement = U.discardElement, extend = U.extend, isNumber = U.isNumber, isString = U.isString, pick = U.pick, splat = U.splat, syncTimeout = U.syncTimeout;
 /**
  * Callback function to format the text of the tooltip from scratch.
  *
@@ -843,9 +843,6 @@ H.Tooltip.prototype = {
     renderSplit: function (labels, points) {
         var tooltip = this;
         var _a = tooltip.chart, chartWidth = _a.chartWidth, chartHeight = _a.chartHeight, plotHeight = _a.plotHeight, plotLeft = _a.plotLeft, plotTop = _a.plotTop, plotWidth = _a.plotWidth, pointer = _a.pointer, ren = _a.renderer, _b = _a.scrollablePixelsX, scrollablePixelsX = _b === void 0 ? 0 : _b, _c = _a.scrollablePixelsY, scrollablePixelsY = _c === void 0 ? 0 : _c, _d = _a.scrollingContainer, _e = _d === void 0 ? { scrollLeft: 0, scrollTop: 0 } : _d, scrollLeft = _e.scrollLeft, scrollTop = _e.scrollTop, styledMode = _a.styledMode, _f = __read(_a.xAxis, 1), opposite = _f[0].opposite, _g = tooltip.distance, distance = _g === void 0 ? 16 : _g, options = tooltip.options, positioner = tooltip.options.positioner;
-        var clamp = function (value, min, max) {
-            return value > min ? value < max ? value : max : min;
-        };
         var boundaries = {
             left: scrollablePixelsX ? plotLeft : 0,
             right: scrollablePixelsX ?
@@ -858,7 +855,15 @@ H.Tooltip.prototype = {
         var headerTop = Boolean(opposite);
         var distributionBoxTop = plotTop;
         var headerHeight = 0;
-        // Calculate the x and y position for the anchor
+        /**
+         * Calculates the anchor position for the tooltip
+         *
+         * @private
+         * Calculate the x and y position for the anchor
+         * @param {Highcharts.Point & { isHeader?: boolean }} point
+         *  The point related to the tooltip
+         * @return {[number, number]} Returns the anchor's x and y position
+         */
         function getAnchor(point) {
             var isHeader = point.isHeader, _a = point.plotX, plotX = _a === void 0 ? 0 : _a, _b = point.plotY, plotY = _b === void 0 ? 0 : _b, series = point.series;
             var anchorX;
@@ -872,17 +877,26 @@ H.Tooltip.prototype = {
             else {
                 var xAxis = series.xAxis, yAxis = series.yAxis;
                 // Set anchorX to plotX. Limit to within xAxis.
-                anchorX = xAxis.pos + clamp(plotX, 0, xAxis.len)
-                    - scrollLeft;
+                anchorX = xAxis.pos + clamp(plotX, 0, xAxis.len) - scrollLeft;
                 // Set anchorY to plotY. Limit to within yAxis.
-                anchorY = yAxis.pos + clamp(plotY, 0, yAxis.len)
-                    - scrollTop;
+                anchorY = yAxis.pos + clamp(plotY, 0, yAxis.len) - scrollTop;
             }
             // Limit values to plot area
             anchorX = clamp(anchorX, boundaries.left, boundaries.right);
             anchorY = clamp(anchorY, boundaries.top, boundaries.bottom);
             return [anchorX, anchorY];
         }
+        /**
+         * Calculates the position of the tooltip
+         *
+         * @private
+         * @param {number} anchorX The tooltip anchor x position
+         * @param {number} anchorY The tooltip anchor y position
+         * @param {boolean} isHeader Wether the tooltip is a header
+         * @param {Highcharts.BBoxObject} bBox The bounding box of the tooltip
+         * @return {Highcharts.PositionObject} Returns the tooltip x and y
+         * position
+         */
         function defaultPositioner(anchorX, anchorY, isHeader, bBox) {
             var boxWidth = bBox.width;
             var y;
@@ -907,6 +921,17 @@ H.Tooltip.prototype = {
             }
             return { x: x, y: y };
         }
+        /**
+         * Updates the attributes and styling of the tooltip. Creates a new
+         * tooltip if it does not exists.
+         *
+         * @private
+         * @param {Highcharts.Tooltip|undefined} tooltip The tooltip to update
+         * @param {Highcharts.Point & { isHeader?: boolean }} point
+         *  The point related to the tooltip
+         * @param {boolean|string} str The label for the tooltip
+         * @return {Highcharts.SVGElement} Returns the updated tooltip
+         */
         function updateTooltip(tooltip, point, str) {
             var tt = tooltip;
             var isHeader = point.isHeader, series = point.series;

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -842,12 +842,20 @@ H.Tooltip.prototype = {
      */
     renderSplit: function (labels, points) {
         var tooltip = this;
-        var _a = tooltip.chart, chartWidth = _a.chartWidth, _b = _a.marginRight, marginRight = _b === void 0 ? 0 : _b, plotHeight = _a.plotHeight, plotLeft = _a.plotLeft, plotTop = _a.plotTop, plotWidth = _a.plotWidth, pointer = _a.pointer, ren = _a.renderer, _c = _a.scrollablePixelsX, scrollablePixelsX = _c === void 0 ? 0 : _c, _d = _a.scrollablePixelsY, scrollablePixelsY = _d === void 0 ? 0 : _d, _e = _a.scrollingContainer, _f = _e === void 0 ? { scrollLeft: 0, scrollTop: 0 } : _e, scrollLeft = _f.scrollLeft, scrollTop = _f.scrollTop, styledMode = _a.styledMode, _g = __read(_a.xAxis, 1), opposite = _g[0].opposite, distance = tooltip.distance, options = tooltip.options, positioner = tooltip.options.positioner;
+        var _a = tooltip.chart, chartWidth = _a.chartWidth, chartHeight = _a.chartHeight, plotHeight = _a.plotHeight, plotLeft = _a.plotLeft, plotTop = _a.plotTop, plotWidth = _a.plotWidth, pointer = _a.pointer, ren = _a.renderer, _b = _a.scrollablePixelsX, scrollablePixelsX = _b === void 0 ? 0 : _b, _c = _a.scrollablePixelsY, scrollablePixelsY = _c === void 0 ? 0 : _c, _d = _a.scrollingContainer, _e = _d === void 0 ? { scrollLeft: 0, scrollTop: 0 } : _d, scrollLeft = _e.scrollLeft, scrollTop = _e.scrollTop, styledMode = _a.styledMode, _f = __read(_a.xAxis, 1), opposite = _f[0].opposite, _g = tooltip.distance, distance = _g === void 0 ? 16 : _g, options = tooltip.options, positioner = tooltip.options.positioner;
         var clamp = function (value, min, max) {
             return value > min ? value < max ? value : max : min;
         };
         var clampToHorizontalPlotArea = function (value) { return clamp(value, plotLeft, plotLeft + plotWidth - scrollablePixelsX); };
         var clampToVerticalPlotArea = function (value) { return clamp(value, plotTop, plotTop + plotHeight - scrollablePixelsY); };
+        var boundaries = {
+            left: scrollablePixelsX ? plotLeft : 0,
+            right: scrollablePixelsX ?
+                plotLeft + plotWidth - scrollablePixelsX : chartWidth,
+            top: scrollablePixelsY ? plotTop : 0,
+            bottom: scrollablePixelsY ?
+                plotTop + plotHeight - scrollablePixelsY : chartHeight
+        };
         var tooltipLabel = tooltip.getLabel();
         var headerTop = Boolean(opposite);
         var boxes = [];
@@ -916,24 +924,6 @@ H.Tooltip.prototype = {
                     if (headerTop) {
                         distributionBoxTop -= headerHeight;
                     }
-                    x = Math.max(0, // No left overflow
-                    Math.min(plotX + plotLeft - boxWidth / 2, 
-                    // No right overflow (#5794)
-                    chartWidth +
-                        (
-                        // Scrollable plot area
-                        scrollablePixelsX ?
-                            scrollablePixelsX - marginRight :
-                            0) -
-                        boxWidth));
-                }
-                else {
-                    x = plotX + plotLeft - pick(options.distance, 16) -
-                        boxWidth;
-                }
-                // If overflow left, set a new x position
-                if (x < 0) {
-                    x = plotX + plotLeft + distance;
                 }
                 // Prepare for distribution
                 var target = void 0;
@@ -945,6 +935,7 @@ H.Tooltip.prototype = {
                         plotHeight + headerHeight;
                     // Set anchorX to plotX
                     anchorX = plotLeft + plotX - scrollLeft;
+                    x = anchorX - (boxWidth / 2);
                     // Set anchorY to center of visible plot area.
                     anchorY = plotTop + (plotHeight - scrollablePixelsY) / 2;
                 }
@@ -955,6 +946,7 @@ H.Tooltip.prototype = {
                     // Set anchorX to plotX. Limit to within xAxis.
                     anchorX = xAxis.pos + clamp(plotX, 0, xAxis.len)
                         - scrollLeft;
+                    x = anchorX - distance - boxWidth;
                     // Set anchorY to plotY. Limit to within yAxis.
                     anchorY = yAxis.pos + clamp(plotY, 0, yAxis.len)
                         - scrollTop;
@@ -962,6 +954,17 @@ H.Tooltip.prototype = {
                 // Limit values to plot area
                 anchorX = clampToHorizontalPlotArea(anchorX);
                 anchorY = clampToVerticalPlotArea(anchorY);
+                if (isHeader) {
+                    x = clamp(x, boundaries.left, boundaries.right - boxWidth);
+                }
+                else if (x < boundaries.left) {
+                    // Align label to the right side if overflow left.
+                    x = anchorX + distance;
+                }
+                else if (boundaries.right < x + boxWidth) {
+                    // Limit label to plot area.
+                    x = boundaries.right - boxWidth;
+                }
                 var box = {
                     target: target,
                     rank: isHeader ? 1 : 0,

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -912,6 +912,44 @@ H.Tooltip.prototype = {
             }
             return { x: x, y: y };
         }
+        function updateTooltip(tooltip, point, str) {
+            var tt = tooltip;
+            var isHeader = point.isHeader, series = point.series;
+            var colorClass = 'highcharts-color-' + pick(point.colorIndex, series.colorIndex, 'none');
+            if (!tt) {
+                var attribs = {
+                    padding: options.padding,
+                    r: options.borderRadius
+                };
+                if (!styledMode) {
+                    attribs.fill = options.backgroundColor;
+                    attribs['stroke-width'] = options.borderWidth;
+                }
+                tt = ren
+                    .label(null, null, null, (options[isHeader ? 'headerShape' : 'shape']) ||
+                    'callout', null, null, options.useHTML)
+                    .addClass(isHeader ? 'highcharts-tooltip-header ' : '' +
+                    'highcharts-tooltip-box ' +
+                    colorClass)
+                    .attr(attribs)
+                    .add(tooltipLabel);
+            }
+            tt.isActive = true;
+            tt.attr({
+                text: str
+            });
+            if (!styledMode) {
+                tt.css(options.style)
+                    .shadow(options.shadow)
+                    .attr({
+                    stroke: (options.borderColor ||
+                        point.color ||
+                        series.color ||
+                        '${palette.neutralColor80}')
+                });
+            }
+            return tt;
+        }
         // Create the individual labels for header and points, ignore footer
         labels.slice(0, points.length + 1).forEach(function (str, i) {
             if (str !== false && str !== '') {
@@ -922,44 +960,10 @@ H.Tooltip.prototype = {
                     plotX: points[0].plotX,
                     plotY: plotHeight
                 };
-                var series = point.series || {};
-                var owner = point.series || tooltip;
-                var colorClass = 'highcharts-color-' + pick(point.colorIndex, series.colorIndex, 'none');
                 var isHeader = point.isHeader;
                 // Store the tooltip referance on the series
-                var tt = owner.tt;
-                if (!tt) {
-                    var attribs = {
-                        padding: options.padding,
-                        r: options.borderRadius
-                    };
-                    if (!styledMode) {
-                        attribs.fill = options.backgroundColor;
-                        attribs['stroke-width'] = options.borderWidth;
-                    }
-                    owner.tt = tt = ren
-                        .label(null, null, null, (options[isHeader ? 'headerShape' : 'shape']) ||
-                        'callout', null, null, options.useHTML)
-                        .addClass(isHeader ? 'highcharts-tooltip-header ' : '' +
-                        'highcharts-tooltip-box ' +
-                        colorClass)
-                        .attr(attribs)
-                        .add(tooltipLabel);
-                }
-                tt.isActive = true;
-                tt.attr({
-                    text: str
-                });
-                if (!styledMode) {
-                    tt.css(options.style)
-                        .shadow(options.shadow)
-                        .attr({
-                        stroke: (options.borderColor ||
-                            point.color ||
-                            series.color ||
-                            '${palette.neutralColor80}')
-                    });
-                }
+                var owner = isHeader ? tooltip : point.series;
+                var tt = owner.tt = updateTooltip(owner.tt, point, str);
                 // Get X position now, so we can move all to the other side in
                 // case of overflow
                 var bBox = tt.getBBox();

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -863,6 +863,31 @@ H.Tooltip.prototype = {
         if (isString(labels)) {
             labels = [false, labels];
         }
+        // Calculate the x and y position for the anchor
+        function getAnchor(point) {
+            var isHeader = point.isHeader, _a = point.plotX, plotX = _a === void 0 ? 0 : _a, _b = point.plotY, plotY = _b === void 0 ? 0 : _b, series = point.series;
+            var anchorX;
+            var anchorY;
+            if (isHeader) {
+                // Set anchorX to plotX
+                anchorX = plotLeft + plotX - scrollLeft;
+                // Set anchorY to center of visible plot area.
+                anchorY = plotTop + (plotHeight - scrollablePixelsY) / 2;
+            }
+            else {
+                var xAxis = series.xAxis, yAxis = series.yAxis;
+                // Set anchorX to plotX. Limit to within xAxis.
+                anchorX = xAxis.pos + clamp(plotX, 0, xAxis.len)
+                    - scrollLeft;
+                // Set anchorY to plotY. Limit to within yAxis.
+                anchorY = yAxis.pos + clamp(plotY, 0, yAxis.len)
+                    - scrollTop;
+            }
+            // Limit values to plot area
+            anchorX = clamp(anchorX, boundaries.left, boundaries.right);
+            anchorY = clamp(anchorY, boundaries.top, boundaries.bottom);
+            return [anchorX, anchorY];
+        }
         // Create the individual labels for header and points, ignore footer
         labels.slice(0, points.length + 1).forEach(function (str, i) {
             if (str !== false && str !== '') {
@@ -876,7 +901,7 @@ H.Tooltip.prototype = {
                 var series = point.series || {};
                 var owner = point.series || tooltip;
                 var colorClass = 'highcharts-color-' + pick(point.colorIndex, series.colorIndex, 'none');
-                var _a = point.plotX, plotX = _a === void 0 ? 0 : _a, _b = point.plotY, plotY = _b === void 0 ? 0 : _b;
+                var _a = point.plotY, plotY = _a === void 0 ? 0 : _a;
                 var isHeader = point.isHeader;
                 // Store the tooltip referance on the series
                 var tt = owner.tt;
@@ -925,33 +950,18 @@ H.Tooltip.prototype = {
                 }
                 // Prepare for distribution
                 var target = void 0;
-                var anchorX = void 0;
-                var anchorY = void 0;
+                var _b = __read(getAnchor(point), 2), anchorX = _b[0], anchorY = _b[1];
                 if (isHeader) {
                     target = headerTop ?
                         -headerHeight :
                         plotHeight + headerHeight;
-                    // Set anchorX to plotX
-                    anchorX = plotLeft + plotX - scrollLeft;
                     x = anchorX - (boxWidth / 2);
-                    // Set anchorY to center of visible plot area.
-                    anchorY = plotTop + (plotHeight - scrollablePixelsY) / 2;
                 }
                 else {
                     var yAxis = series.yAxis;
-                    var xAxis = series.xAxis;
                     target = yAxis.pos - distributionBoxTop + Math.max(0, Math.min(plotY, yAxis.len)); // Limit target position to within yAxis
-                    // Set anchorX to plotX. Limit to within xAxis.
-                    anchorX = xAxis.pos + clamp(plotX, 0, xAxis.len)
-                        - scrollLeft;
                     x = anchorX - distance - boxWidth;
-                    // Set anchorY to plotY. Limit to within yAxis.
-                    anchorY = yAxis.pos + clamp(plotY, 0, yAxis.len)
-                        - scrollTop;
                 }
-                // Limit values to plot area
-                anchorX = clamp(anchorX, boundaries.left, boundaries.right);
-                anchorY = clamp(anchorY, boundaries.top, boundaries.bottom);
                 if (isHeader) {
                     x = clamp(x, boundaries.left, boundaries.right - boxWidth);
                 }

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -966,7 +966,7 @@ H.Tooltip.prototype = {
                 var box = {
                     target: target,
                     rank: isHeader ? 1 : 0,
-                    size: tt.getBBox().height + 1,
+                    size: bBox.height + 1,
                     point: point,
                     x: x,
                     tt: tt,
@@ -974,7 +974,7 @@ H.Tooltip.prototype = {
                     anchorY: anchorY
                 };
                 if (positioner) {
-                    var boxPosition = positioner.call(tooltip, box.tt.getBBox().width, box.size, box.point);
+                    var boxPosition = positioner.call(tooltip, boxWidth, box.size, box.point);
                     box.x = boxPosition.x;
                     box.align = 0; // 0-align to the top, 1-align to the bottom
                     box.target = boxPosition.y;

--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -815,6 +815,18 @@ H.merge = function () {
     return ret;
 };
 /**
+ * Constrain a value to within a lower and upper threshold.
+ *
+ * @private
+ * @param {number} value The initial value
+ * @param {number} min The lower threshold
+ * @param {number} max The upper threshold
+ * @return {number} Returns a number value within min and max.
+ */
+function clamp(value, min, max) {
+    return value > min ? value < max ? value : max : min;
+}
+/**
  * Shortcut for parseInt
  *
  * @private
@@ -2508,6 +2520,7 @@ var utils = {
     arrayMax: arrayMax,
     arrayMin: arrayMin,
     attr: attr,
+    clamp: clamp,
     correctFloat: correctFloat,
     defined: defined,
     destroyObjectProperties: destroyObjectProperties,

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -371,9 +371,11 @@ Highcharts.Pointer.prototype = {
     getChartPosition: function (
         this: Highcharts.Pointer
     ): Highcharts.OffsetObject {
+        const { chart } = this;
+        const container = chart.scrollingContainer || chart.container;
         return (
             this.chartPosition ||
-            (this.chartPosition = offset(this.chart.container))
+            (this.chartPosition = offset(container))
         );
     },
 

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -1216,16 +1216,6 @@ H.Tooltip.prototype = {
         } = tooltip;
         const clamp = (value: number, min: number, max: number) =>
             value > min ? value < max ? value : max : min;
-        const clampToHorizontalPlotArea = (value: number) => clamp(
-            value,
-            plotLeft,
-            plotLeft + plotWidth - scrollablePixelsX
-        );
-        const clampToVerticalPlotArea = (value: number) => clamp(
-            value,
-            plotTop,
-            plotTop + plotHeight - scrollablePixelsY
-        );
 
         const boundaries = {
             left: scrollablePixelsX ? plotLeft : 0,
@@ -1364,8 +1354,8 @@ H.Tooltip.prototype = {
                 }
 
                 // Limit values to plot area
-                anchorX = clampToHorizontalPlotArea(anchorX);
-                anchorY = clampToVerticalPlotArea(anchorY);
+                anchorX = clamp(anchorX, boundaries.left, boundaries.right);
+                anchorY = clamp(anchorY, boundaries.top, boundaries.bottom);
 
                 if (isHeader) {
                     x = clamp(x, boundaries.left, boundaries.right - boxWidth);

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -1370,7 +1370,7 @@ H.Tooltip.prototype = {
                 const box: Highcharts.Dictionary<any> = {
                     target,
                     rank: isHeader ? 1 : 0,
-                    size: tt.getBBox().height + 1,
+                    size: bBox.height + 1,
                     point: point as any,
                     x,
                     tt,
@@ -1381,7 +1381,7 @@ H.Tooltip.prototype = {
                 if (positioner) {
                     const boxPosition = positioner.call(
                         tooltip,
-                        box.tt.getBBox().width,
+                        boxWidth,
                         box.size,
                         box.point
                     );

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -1286,7 +1286,6 @@ H.Tooltip.prototype = {
                 const colorClass = 'highcharts-color-' + pick(
                     point.colorIndex, series.colorIndex, 'none'
                 );
-                const { plotY = 0 } = point;
                 const isHeader: boolean = (point as any).isHeader;
 
                 // Store the tooltip referance on the series
@@ -1363,10 +1362,7 @@ H.Tooltip.prototype = {
 
                     x = anchorX - (boxWidth / 2);
                 } else {
-                    const yAxis = series.yAxis;
-                    target = yAxis.pos - distributionBoxTop + Math.max(
-                        0, Math.min(plotY, yAxis.len)
-                    ); // Limit target position to within yAxis
+                    target = anchorY - distributionBoxTop;
                     x = anchorX - distance - boxWidth;
                 }
 

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -1199,6 +1199,7 @@ H.Tooltip.prototype = {
                 pointer,
                 renderer: ren,
                 scrollablePixelsX = 0,
+                scrollablePixelsY = 0,
                 styledMode,
                 xAxis: [{ opposite }]
             },
@@ -1336,7 +1337,8 @@ H.Tooltip.prototype = {
                         -headerHeight :
                         plotHeight + headerHeight;
                     anchorX = plotX + plotLeft;
-                    anchorY = plotTop + plotHeight / 2;
+                    // Set anchorY to center of visible plot area.
+                    anchorY = plotTop + (plotHeight - scrollablePixelsY) / 2;
                 } else {
                     const yAxis = series.yAxis;
                     const xAxis = series.xAxis;
@@ -1344,8 +1346,17 @@ H.Tooltip.prototype = {
                         0, Math.min(plotY, yAxis.len)
                     ); // Limit target position to within yAxis
                     anchorX = plotX + xAxis.pos;
-                    anchorY = yAxis.pos +
-                        Math.max(0, Math.min(plotY, yAxis.len));
+                    // Set anchorY to plotY. Limit to within visible plot area,
+                    // and within yAxis.
+                    anchorY = Math.max(
+                        plotTop,
+                        yAxis.pos,
+                        Math.min(
+                            plotTop + plotHeight - scrollablePixelsY,
+                            yAxis.pos + yAxis.len,
+                            yAxis.pos + plotY
+                        )
+                    );
                 }
                 const box: Highcharts.Dictionary<any> = {
                     target,
@@ -1388,7 +1399,8 @@ H.Tooltip.prototype = {
                 x,
                 /* NOTE: y should equal pos to be consistent with !split
                  * tooltip, but is currently relative to plotTop. Is left as is
-                 * to avoid breaking change.
+                 * to avoid breaking change. Remove distributionBoxTop to make
+                 * it consistent.
                  */
                 y: pos + distributionBoxTop,
                 anchorX,

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -1273,7 +1273,7 @@ H.Tooltip.prototype = {
          * @param {number} anchorX The tooltip anchor x position
          * @param {number} anchorY The tooltip anchor y position
          * @param {boolean} isHeader Wether the tooltip is a header
-         * @param {Highcharts.BBoxObject} bBox The bounding box of the tooltip
+         * @param {number} boxWidth Width of the tooltip
          * @return {Highcharts.PositionObject} Returns the tooltip x and y
          * position
          */
@@ -1281,17 +1281,13 @@ H.Tooltip.prototype = {
             anchorX: number,
             anchorY: number,
             isHeader: boolean,
-            bBox: Highcharts.BBoxObject
+            boxWidth: number
         ): Highcharts.PositionObject {
-            const boxWidth = bBox.width;
 
             let y;
             let x;
             if (isHeader) {
-                y = headerTop ?
-                    -headerHeight :
-                    plotHeight + headerHeight;
-
+                y = headerTop ? 0 : plotHeight - scrollablePixelsY;
                 x = clamp(
                     anchorX - (boxWidth / 2),
                     boundaries.left,
@@ -1308,6 +1304,8 @@ H.Tooltip.prototype = {
                     x = boundaries.right - boxWidth;
                 }
             }
+
+            // NOTE: y is relative to distributionBoxTop
             return { x, y };
         }
 
@@ -1430,12 +1428,12 @@ H.Tooltip.prototype = {
                     anchorX,
                     anchorY,
                     isHeader,
-                    bBox
+                    boxWidth
                 );
 
                 boxes.push({
                     // 0-align to the top, 1-align to the bottom
-                    align: positioner ? 0 : void 0,
+                    align: positioner || isHeader ? 0 : void 0,
                     anchorX,
                     anchorY,
                     point: point as any,

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -1228,15 +1228,9 @@ H.Tooltip.prototype = {
 
         const tooltipLabel = tooltip.getLabel();
         const headerTop = Boolean(opposite);
-        const boxes: Array<Highcharts.Dictionary<any>> = [];
 
         let distributionBoxTop = plotTop;
         let headerHeight = 0;
-
-        // Graceful degradation for legacy formatters
-        if (isString(labels)) {
-            labels = [false, labels];
-        }
 
         // Calculate the x and y position for the anchor
         function getAnchor(
@@ -1363,18 +1357,24 @@ H.Tooltip.prototype = {
             return tt;
         }
 
+        // Graceful degradation for legacy formatters
+        if (isString(labels)) {
+            labels = [false, labels];
+        }
         // Create the individual labels for header and points, ignore footer
-        labels.slice(0, points.length + 1).forEach(function (
+        const boxes = labels.slice(0, points.length + 1).reduce(function (
+            boxes: Array<Highcharts.Dictionary<any>>,
             str: (boolean|string),
             i: number
-        ): void {
+        ): Array<Highcharts.Dictionary<any>> {
             if (str !== false && str !== '') {
                 const point = points[i - 1] || {
                     // Item 0 is the header. Instead of this, we could also
                     // use the crosshair label
                     isHeader: true,
                     plotX: points[0].plotX,
-                    plotY: plotHeight
+                    plotY: plotHeight,
+                    series: {}
                 };
                 const isHeader: boolean = (point as any).isHeader;
 
@@ -1420,7 +1420,8 @@ H.Tooltip.prototype = {
                     x: boxPosition.x
                 });
             }
-        });
+            return boxes;
+        }, []);
 
         // Clean previous run (for missing points)
         tooltip.cleanSplit();

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -1482,11 +1482,6 @@ H.Tooltip.prototype = {
             renderer
         } = tooltip;
         if (outside && container && renderer) {
-            // Position the tooltip container to the chart container
-            const chartPosition = pointer.getChartPosition();
-            container.style.left = chartPosition.left + 'px';
-            container.style.top = chartPosition.top + 'px';
-
             // Set container size to fit the tooltip
             const { width, height, x, y } = tooltipLabel.getBBox();
             renderer.setSize(
@@ -1494,6 +1489,11 @@ H.Tooltip.prototype = {
                 height + y,
                 false
             );
+
+            // Position the tooltip container to the chart container
+            const chartPosition = pointer.getChartPosition();
+            container.style.left = chartPosition.left + 'px';
+            container.style.top = chartPosition.top + 'px';
         }
     },
 

--- a/ts/parts/Utilities.ts
+++ b/ts/parts/Utilities.ts
@@ -1315,6 +1315,19 @@ H.merge = function<T> (): T {
 };
 
 /**
+ * Constrain a value to within a lower and upper threshold.
+ *
+ * @private
+ * @param {number} value The initial value
+ * @param {number} min The lower threshold
+ * @param {number} max The upper threshold
+ * @return {number} Returns a number value within min and max.
+ */
+function clamp(value: number, min: number, max: number): number {
+    return value > min ? value < max ? value : max : min;
+}
+
+/**
  * Shortcut for parseInt
  *
  * @private
@@ -3391,6 +3404,7 @@ const utils = {
     arrayMax,
     arrayMin,
     attr,
+    clamp,
     correctFloat,
     defined,
     destroyObjectProperties,


### PR DESCRIPTION
Fixed #11617, support `tooltip.split` with `chart.scrollablePlotArea`.

---
# Description
Added support for split tooltip with scrollable plot area.

- Limit the tooltip to render within the plot area when `scrollablePlotArea` is enabled.
- Updated `getChartPosition` to use `scrollingContainer` when it exists, to position tooltip correctly when `container` is moved during scrolling. [See #diff-31a7e6aaf7bdf7daa73993cea91fd9efR375]( https://github.com/highcharts/highcharts/compare/bugfix/11617-scrollable-split-tooltip?expand=1#diff-31a7e6aaf7bdf7daa73993cea91fd9efR375)
- Added utility function `clamp`
- Refactored to `renderSplit` to gather logic in smaller sections, added scoped functions `getAnchor`, `defaultPositioner`, and `updateTooltip`. 
- Removed `any` casts in `renderSplit` where possible.

# Example(s)
- [Demo of issue](https://jsfiddle.net/BlackLabel/jbk9qpnx/)
- [Demo of issue with fix applied](https://jsfiddle.net/jon_a_nygaard/q5dhzv2y/)
- [Demo of #11493 with current changes](https://jsfiddle.net/jon_a_nygaard/w3cq1Lt5/) - Manually tested against regressions.
- [Demo of #9590 with current changes](http://jsfiddle.net/jon_a_nygaard/w4L7brqs/) - Manually tested against regressions.

# Related issue(s)
- Closes #11617
