### PR TITLE
Fixed 12289, sonification timeline issues with multiple charts.

### DIFF
--- a/js/modules/sonification/sonification.js
+++ b/js/modules/sonification/sonification.js
@@ -11,6 +11,8 @@
 'use strict';
 
 import H from '../../parts/Globals.js';
+var addEvent = H.addEvent;
+
 import U from '../../parts/Utilities.js';
 var extend = U.extend;
 
@@ -105,6 +107,10 @@ extend(H.Chart.prototype, {
     getCurrentSonifyPoints: chartSonifyFunctions.getCurrentPoints,
     setSonifyCursor: chartSonifyFunctions.setCursor,
     resetSonifyCursor: chartSonifyFunctions.resetCursor,
-    resetSonifyCursorEnd: chartSonifyFunctions.resetCursorEnd,
-    sonification: {}
+    resetSonifyCursorEnd: chartSonifyFunctions.resetCursorEnd
+});
+
+// Prepare charts for sonification on init
+addEvent(H.Chart, 'init', function () {
+    this.sonification = {};
 });

--- a/samples/highcharts/sonification/multiple-charts/demo.details
+++ b/samples/highcharts/sonification/multiple-charts/demo.details
@@ -1,0 +1,7 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Øystein Moseng
+ requiresManualTesting: true
+ js_wrap: b
+...

--- a/samples/highcharts/sonification/multiple-charts/demo.html
+++ b/samples/highcharts/sonification/multiple-charts/demo.html
@@ -1,0 +1,5 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/sonification.js"></script>
+
+<div id="containerA" style="width:400px; float:left"></div>
+<div id="containerB" style="width:400px;"></div>

--- a/samples/highcharts/sonification/multiple-charts/demo.js
+++ b/samples/highcharts/sonification/multiple-charts/demo.js
@@ -1,0 +1,66 @@
+var data = [1, 2, 4, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 26, 30, 35];
+
+var opts = function (pan) {
+    return {
+        yAxis: {
+            gridLineWidth: 0,
+            visible: false
+        },
+        legend: {
+            enabled: false
+        },
+        plotOptions: {
+            series: {
+                events: {
+                    click: function () {
+                        var chart = this.chart;
+                        chart.isSonifying = !chart.isSonifying;
+                        if (chart.isSonifying) {
+                            if (chart.sonification.timeline) {
+                                chart.resumeSonify();
+                            } else {
+                                chart.sonify({
+                                    duration: 2000,
+                                    order: 'sequential',
+                                    pointPlayTime: 'x',
+                                    onEnd: function () {
+                                        chart.resetSonifyCursor();
+                                        chart.isSonifying = false;
+                                    },
+                                    instruments: [{
+                                        instrument: 'triangleMajor',
+                                        instrumentMapping: {
+                                            duration: 250,
+                                            pan: pan,
+                                            frequency: 'y'
+                                        }
+                                    }]
+                                });
+                            }
+                        } else {
+                            chart.pauseSonify();
+                        }
+                    }
+                }
+            }
+        }
+    };
+};
+
+Highcharts.chart('containerA', Highcharts.merge(opts(-1), {
+    title: {
+        text: 'A'
+    },
+    series: [{
+        data: data
+    }]
+}));
+
+Highcharts.chart('containerB', Highcharts.merge(opts(1), {
+    title: {
+        text: 'B'
+    },
+    series: [{
+        data: data.reverse()
+    }]
+}));

--- a/samples/highcharts/sonification/multiple-charts/test-notes.md
+++ b/samples/highcharts/sonification/multiple-charts/test-notes.md
@@ -1,0 +1,3 @@
+1. Clicking the series in each chart should sonify the series. It should be possible to play the series at the same time.
+
+2. Clicking again should pause the series. Clicking a third time should start the same series again.


### PR DESCRIPTION
Fixed #12289, sonification timeline issues with multiple charts.
___
`Chart.sonification` object was set on prototype, while each chart needs to have a separate copy.