### PR TITLE
 bugfix/update-points-without-ids

### DIFF
--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -2667,6 +2667,12 @@ null,
         pointsToAdd.forEach(function (point) {
             this.addPoint(point, false, null, null, false);
         }, this);
+        if (this.xIncrement === null &&
+            this.xData &&
+            this.xData.length) {
+            this.xIncrement = arrayMax(this.xData);
+            this.autoIncrement();
+        }
         return true;
     },
     /**

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -2623,6 +2623,10 @@ null,
                     hasUpdatedByKey = true;
                 }
             }
+            else {
+                // Gather all points that are not matched
+                pointsToAdd.push(pointOptions);
+            }
         }, this);
         // Remove points that don't exist in the updated data set
         if (hasUpdatedByKey) {
@@ -2644,6 +2648,8 @@ null,
                     oldData[i].update(point, false, null, false);
                 }
             });
+            // Don't add new points since those configs are used above
+            pointsToAdd.length = 0;
             // Did not succeed in updating data
         }
         else {

--- a/samples/unit-tests/series/setdata/demo.js
+++ b/samples/unit-tests/series/setdata/demo.js
@@ -376,6 +376,35 @@ QUnit.test('Series.setData with updatePoints', function (assert) {
         'Two points should be rendered (#12333).'
     );
 
+    // Auto incremented X should match current max X after update
+    chart.series[0].setData(
+        [{
+            id: 'one',
+            y: 10
+        }, {
+            id: 'two',
+            y: 10
+        }, {
+            y: 20
+        }]
+    );
+
+    chart.series[0].setData(
+        [{
+            id: 'one',
+            y: 20
+        }]
+    );
+    chart.series[0].addPoint({
+        y: 100
+    });
+
+    assert.strictEqual(
+        chart.series[0].points[1].x,
+        1,
+        'Auto incremented X should not overlap first point.'
+    );
+
 });
 
 QUnit.test('Boosted series with updatePoints', function (assert) {

--- a/samples/unit-tests/series/setdata/demo.js
+++ b/samples/unit-tests/series/setdata/demo.js
@@ -346,6 +346,36 @@ QUnit.test('Series.setData with updatePoints', function (assert) {
         [4, 5, 5],
         'Data is set correctly when oldData has null values and the same length (#10187)'
     );
+
+    // #12333
+    // Some points with ID's, others without
+    chart.series[0].setData([
+        {
+            y: 10,
+            id: 'main1'
+        }, {
+            y: 20,
+            id: 'main2'
+        }, {
+            y: 10
+        }
+    ]);
+
+    chart.series[0].setData([
+        {
+            y: 20,
+            id: 'main1'
+        }, {
+            y: 20
+        }
+    ]);
+
+    assert.strictEqual(
+        chart.series[0].points.length,
+        2,
+        'Two points should be rendered (#12333).'
+    );
+
 });
 
 QUnit.test('Boosted series with updatePoints', function (assert) {

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -3468,6 +3468,9 @@ H.Series = H.seriesType<Highcharts.LineSeries>(
                     ) {
                         hasUpdatedByKey = true;
                     }
+                } else {
+                    // Gather all points that are not matched
+                    pointsToAdd.push(pointOptions);
                 }
             }, this);
 
@@ -3494,6 +3497,8 @@ H.Series = H.seriesType<Highcharts.LineSeries>(
                         oldData[i].update(point, false, null as any, false);
                     }
                 });
+                // Don't add new points since those configs are used above
+                pointsToAdd.length = 0;
 
             // Did not succeed in updating data
             } else {

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -3520,6 +3520,15 @@ H.Series = H.seriesType<Highcharts.LineSeries>(
                 this.addPoint(point, false, null as any, null as any, false);
             }, this);
 
+            if (
+                this.xIncrement === null &&
+                this.xData &&
+                this.xData.length
+            ) {
+                this.xIncrement = arrayMax(this.xData);
+                this.autoIncrement();
+            }
+
             return true;
         },
 


### PR DESCRIPTION
Fixed #12333, setting data in treemap series with points with the same ID's did not render new points.
___
As described in #12333, PR fixes two issues:

a) not adding new points, when at least one matching ID was found: https://jsfiddle.net/BlackLabel/sqx61yvk/ 
b) wrong auto-calculated `point.x` when x's are not set: https://jsfiddle.net/BlackLabel/sqx61yvk/3/

Now it works this way:
https://jsfiddle.net/BlackLabel/sqx61yvk/19/ - point added and placed at correct x-position

PS: Sorry for missing ticket number in branch name.