### PR TITLE
bugfix/12298-crosshair-after-update

### DIFF
--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -646,7 +646,8 @@ Highcharts.Pointer.prototype = {
                 else if (hoverPoint) { // #2500
                     hoverPoint.setState(hoverPoint.state, true);
                     chart.axes.forEach(function (axis) {
-                        if (axis.crosshair) {
+                        if (axis.crosshair &&
+                            hoverPoint.series[axis.coll] === axis) {
                             axis.drawCrosshair(null, hoverPoint);
                         }
                     });

--- a/samples/unit-tests/axis/crosshairs/demo.js
+++ b/samples/unit-tests/axis/crosshairs/demo.js
@@ -193,7 +193,7 @@ QUnit.test('snap', function (assert) {
     // TODO Test positioning of crosshairs.
 });
 
-QUnit.test('Show only one crosshair at the same time (#6420, #7219).', function (assert) {
+QUnit.test('Show only one crosshair at the same time', function (assert) {
     var chart = Highcharts.chart('container', {
             xAxis: [{
                 crosshair: true
@@ -278,6 +278,51 @@ QUnit.test('Show only one crosshair at the same time (#6420, #7219).', function 
         series2.yAxis.crossLabel.attr('visibility'),
         'hidden',
         'Hover Series 1 back: crosshair label on yAxis of Series 2 is hidden (#7219)'
+    );
+
+    chart.update({
+        yAxis: [{
+            crosshair: {
+                snap: true,
+                label: {
+                    enabled: false
+                }
+            }
+        }, {
+            crosshair: {
+                snap: true,
+                label: {
+                    enabled: false
+                }
+            }
+        }]
+    });
+
+    chart.update({
+        yAxis: [{
+            crosshair: {
+                label: {
+                    enabled: true
+                }
+            }
+        }, {
+            crosshair: {
+                label: {
+                    enabled: true
+                }
+            }
+        }]
+    });
+
+    assert.strictEqual(
+        series1.yAxis.crossLabel.attr('visibility'),
+        'visible',
+        'Crosshair should be visible for the first series (#12298)'
+    );
+    assert.strictEqual(
+        typeof series2.yAxis.crossLabel,
+        'undefined',
+        'Crosshair should not be visible for the second series  (#12298)'
     );
 });
 

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -1002,7 +1002,10 @@ Highcharts.Pointer.prototype = {
                 } else if (hoverPoint) { // #2500
                     hoverPoint.setState(hoverPoint.state, true);
                     chart.axes.forEach(function (axis: Highcharts.Axis): void {
-                        if (axis.crosshair) {
+                        if (
+                            axis.crosshair &&
+                            (hoverPoint as any).series[axis.coll] === axis
+                        ) {
                             axis.drawCrosshair(null as any, hoverPoint);
                         }
                     });


### PR DESCRIPTION
Fixed #12298, enabling crosshair label while a point is hovered rendered crosshair labels for all axes.