### PR TITLE
Tools: Intial work on resetting references.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   aws-s3: circleci/aws-s3@1.0.11
 parameters:
-  reset_tests_workflow:
+  run_reset_tests:
     type: boolean
     default: false
   reset_tests:
@@ -165,7 +165,7 @@ jobs:
         default: ""
     steps:
       - <<: *load_workspace
-      - run: "npx gulp reset-visual-references << parameters.reset_tests >> --reference --browsercount 2 --bucket ${HIGHCHARTS_STAGING_CODE_BUCKET}"
+      - run: "npx gulp reset-visual-references --tests << parameters.reset_tests >> --reference --browsercount 2 --bucket ${HIGHCHARTS_STAGING_CODE_BUCKET}"
 
   visual_comparison_with_master:
     <<: *defaults
@@ -340,7 +340,7 @@ jobs:
 workflows:
   version: 2
   build_and_test:
-    unless: << pipeline.parameters.reset_tests_workflow >>
+    unless: << pipeline.parameters.run_reset_tests >>
     jobs:
       - checkout_and_install:
           filters:
@@ -447,7 +447,7 @@ workflows:
           context: highcharts-staging
 
   reset_visual_test_references:
-    when: << pipeline.parameters.reset_tests_workflow >>
+    when: << pipeline.parameters.run_reset_tests >>
     jobs:
       - checkout_and_install:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,13 @@
 version: 2.1
 orbs:
   aws-s3: circleci/aws-s3@1.0.11
+parameters:
+  reset_tests_workflow:
+    type: boolean
+    default: false
+  reset_tests:
+    type: string
+    default: ""
 ######### Anchors ####################
 defaults: &defaults
   executor: node_image
@@ -123,16 +130,6 @@ jobs:
       - run:
           command: "npx cross-env NODE_OPTIONS=--max_old_space_size=3072 karma start test/karma-conf.js --single-run --splitbrowsers << parameters.browsers >> --browsercount << parameters.browsercount >>"
           no_output_timeout: 20m
-      - run: mkdir ../test-results
-      - run:
-          name: Save test results
-          command: |
-            find . -type f -regex ".*TESTS.*xml" -exec cp {} ../test-results/ \;
-          when: always
-      - store_test_results:
-          path: ../test-results
-      - store_artifacts:
-          path: ../test-results
 
   check_for_docs_changes_and_deploy:
     <<: *defaults
@@ -157,6 +154,18 @@ jobs:
           command: "npx gulp dist-testresults --tag ${CIRCLE_TAG} --bucket ${HIGHCHARTS_S3_BUCKET}"
           when: always
       - <<: *persist_workspace
+
+  reset_visual_references_job:
+    <<: *defaults
+    description: Reset reference images stored on S3 based on
+    parameters:
+      reset_tests:
+        description: "Which tests to run?"
+        type: string
+        default: ""
+    steps:
+      - <<: *load_workspace
+      - run: "npx gulp reset-visual-references << parameters.reset_tests >> --reference --browsercount 2 --bucket ${HIGHCHARTS_STAGING_CODE_BUCKET}"
 
   visual_comparison_with_master:
     <<: *defaults
@@ -331,6 +340,7 @@ jobs:
 workflows:
   version: 2
   build_and_test:
+    unless: << pipeline.parameters.reset_tests_workflow >>
     jobs:
       - checkout_and_install:
           filters:
@@ -387,7 +397,8 @@ workflows:
           requires: ["test-Mac.Firefox", "test-Win.Chrome"]
           filters:
             branches:
-              only: [master, tools/trigger-docs-deploy]
+              only: [master]
+          context: highcharts-staging
 
   nightly:
     triggers:
@@ -434,3 +445,14 @@ workflows:
       - deploy_to_highcharts_dist:
           requires: [build_dist]
           context: highcharts-staging
+
+  reset_visual_test_references:
+    when: << pipeline.parameters.reset_tests_workflow >>
+    jobs:
+      - checkout_and_install:
+          filters:
+            branches:
+              only: [master, tools/reset-visual-test]
+      - reset_visual_references_job:
+          requires: [checkout_and_install]
+          reset_tests: << pipeline.parameters.reset_tests >>

--- a/.circleci/scripts/check_and_trigger_docs_deploy.sh
+++ b/.circleci/scripts/check_and_trigger_docs_deploy.sh
@@ -39,6 +39,9 @@ if [ $DOCS_COMMIT = $LATEST_COMMIT ]; then
     # Circle API v2
     curl -X POST -H 'Content-Type: application/json' -d '{ "branch":"master", "parameters": { "run_deploy": true, "target_bucket": "${BUCKET}" }}' \
     https://circleci.com/api/v2/project/github/highcharts/doc-builder/pipeline?circle-token=${TOKEN}&branch=master
+
+    ret_code=$?
+    exit $ret_code
 else
      echo "No change in docs/ folder found."
      exit 0;

--- a/.circleci/scripts/check_and_trigger_docs_deploy.sh
+++ b/.circleci/scripts/check_and_trigger_docs_deploy.sh
@@ -37,11 +37,11 @@ DOCS_COMMIT=$(git log -1 --format=format:%H --full-diff docs/)
 if [ $DOCS_COMMIT = $LATEST_COMMIT ]; then
     echo "Files in docs/ has changed, triggering deploy of docs via doc-builder to bucket ${BUCKET}"
     # Circle API v2
-    curl -X POST -H 'Content-Type: application/json' -d '{ "branch":"master", "parameters": { "run_deploy": true, "target_bucket": "${BUCKET}" }}' \
-    https://circleci.com/api/v2/project/github/highcharts/doc-builder/pipeline?circle-token=${TOKEN}&branch=master
-
-    ret_code=$?
-    exit $ret_code
+    httpUrl="https://circleci.com/api/v2/project/github/highcharts/doc-builder/pipeline?circle-token=${TOKEN}&branch=master"
+    rep=$(curl -f -X POST -H 'Content-Type: application/json' -d '{ "branch":"master", "parameters": { "run_deploy": true, "target_bucket": "${BUCKET}" }}' "$httpUrl")
+    status="$?"
+    echo "$rep"
+    exit "$status"
 else
      echo "No change in docs/ folder found."
      exit 0;

--- a/.circleci/scripts/reset_visual_tests.sh
+++ b/.circleci/scripts/reset_visual_tests.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -e
+
+TESTS=""
+TOKEN=""
+BRANCH="master"
+
+for i in "$@"
+do
+case $i in
+    -t=*|--tests=*)
+    TESTS="${i#*=}"
+    ;;
+    -b=*|--branch=*)
+    BRANCH="${i#*=}"
+    ;;
+      -t=*|--token=*)
+    TOKEN="${i#*=}"
+    ;;
+    *)
+     # unknown option
+    ;;
+esac
+done
+
+if [[ -z $TESTS ]]; then
+  echo "Please specify test path(s) to reset to using --tests=<your.testpath.a,your.testpath.b> argument."
+  exit 1;
+fi
+
+if [[ -z $TOKEN ]]; then
+  echo "Please specify CirleCI API token to trigger the CI job as using --token=<token> argument."
+  exit 1;
+fi
+
+echo "Triggering reset visual tests job on CircleCI using branch ${BRANCH}.."
+# Circle API v2
+
+httpUrl="https://circleci.com/api/v2/project/github/highcharts/highcharts/pipeline?circle-token=${TOKEN}&branch=${BRANCH}"
+rep=$(curl -f -X POST -H 'Content-Type: application/json' -d '{ "branch":"${BRANCH}", "parameters": { "run_reset_tests": true, "reset_tests": "${TESTS}" }}' "$httpUrl")
+status="$?"
+echo "$rep"
+exit "$status"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,6 +57,7 @@ Gulp.registry(new GulpForwardReference());
     'scripts-vendor',
     'scripts-watch',
     'test',
+    'reset-visual-references',
     'tsdoc',
     'tsdoc-watch',
     'update',

--- a/tools/gulptasks/dist-testresults.js
+++ b/tools/gulptasks/dist-testresults.js
@@ -26,21 +26,34 @@ function uploadVisualTestResults() {
         return Promise.reject(new Error('Please specify argument --bucket to upload to.'));
     }
 
-    if (argv.tag) {
-        const referenceImages = glob.sync(`${SAMPLES_SRC_DIR}/reference.svg`).map(file => ({
-            from: file,
-            to: `${DESTINATION_DIR}/reference/${argv.tag}/${[...file.split('/')].slice(1).join('/')}`
-        }));
-
+    if (argv.tag || argv.saveresetdate) {
         const latestReferenceImages = glob.sync(`${SAMPLES_SRC_DIR}/reference.svg`).map(file => ({
             from: file,
             to: `${DESTINATION_DIR}/reference/latest/${[...file.split('/')].slice(1).join('/')}`
         }));
 
-        const uploadConfig = Object.assign({}, defaultParams, { files: [...referenceImages, ...latestReferenceImages], name: 'Reference SVGs' });
-        promises.push(uploadFiles(uploadConfig));
+        if (!argv.saveresetdate) {
+            // upload reference images to folder named after tag
+            const referenceImages = glob.sync(`${SAMPLES_SRC_DIR}/reference.svg`).map(file => ({
+                from: file,
+                to: `${DESTINATION_DIR}/reference/${argv.tag}/${[...file.split('/')].slice(1).join('/')}`
+            }));
+            const versionedReferences = Object.assign({}, defaultParams, { files: [...referenceImages], name: 'Reference SVGs' });
+            promises.push(uploadFiles(versionedReferences));
+        } else {
+            const resetReferenceImages = glob.sync(`${SAMPLES_SRC_DIR}/reference.svg`).map(file => ({
+                from: file,
+                to: `${DESTINATION_DIR}/reference/resets/${dateString}/${[...file.split('/')].slice(1).join('/')}`
+            }));
 
+            const resetReferences = Object.assign({}, defaultParams, { files: [...resetReferenceImages], name: 'Reset reference SVGs' });
+            promises.push(uploadFiles(resetReferences));
+        }
+
+        const latestReferences = Object.assign({}, defaultParams, { files: [...latestReferenceImages], name: 'Reference SVGs' });
+        promises.push(uploadFiles(latestReferences));
     } else {
+        // upload to latest/ folder + date folder
         const resultsJson = glob.sync('test/visual-test-results.json').map(file => ({
             from: file,
             to: `${DESTINATION_DIR}/diffs/latest/${[...file.split('/')].pop()}`
@@ -72,7 +85,9 @@ function uploadVisualTestResults() {
 uploadVisualTestResults.description = 'Uploads images/assets from visual test runs. E.g candidate.svg, diff.gif and visual-test-results.json';
 uploadVisualTestResults.flags = {
     '--tag': 'Will look for reference.svg files and upload them to a S3 path with the specified tag.',
-    '--bucket': 'The S3 bucket to upload to.'
+    '--bucket': 'The S3 bucket to upload to.',
+    '--saveresetdate': 'If present, it will also upload the references to a separate folder in order to identify when' +
+        ' the references was reset.'
 };
 
 gulp.task('dist-testresults', uploadVisualTestResults);

--- a/tools/gulptasks/reset-visual-references.js
+++ b/tools/gulptasks/reset-visual-references.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) Highsoft AS
+ */
+
+const fs = require('./lib/fs');
+const gulp = require('gulp');
+const glob = require('glob');
+const log = require('./lib/log');
+const yargs = require('yargs');
+
+const SAMPLES_SRC_DIR = 'samples/**';
+
+/**
+ * Sets the correct config before creating the references
+ * and uploading them to S3. Deletes any existing reference.svgs.
+ * @return {Promise} task result.
+ */
+function configureVisualTestRun() {
+    log.starting('Setting config for creating and uploading reference images..');
+
+    return new Promise((resolve, reject) => {
+        const { tests } = yargs.argv;
+
+        if (!tests) {
+            const errMsg = 'Please provide --tests using a comma separated list of path(s) or' +
+                ' glob style like highcharts/3d/*.';
+            log.failure(errMsg);
+            reject(errMsg);
+        }
+        const forcedArgs = [
+            '--reference', 'true',
+            '--saveresetdate', 'true'
+        ];
+
+        yargs.parse([...process.argv, ...forcedArgs]);
+
+        const existingReferenceImages = glob.sync(`${SAMPLES_SRC_DIR}/reference.svg`);
+        log.message('Deleting existing reference.svgs:\n' + existingReferenceImages.join('\n'));
+        existingReferenceImages.forEach(fs.deleteFile);
+        log.starting('Initiate creation of new references..');
+        resolve();
+    });
+
+}
+// gulp.task('pre-visual-tests', resetVisualTestReferences());
+gulp.task('reset-visual-references',
+    gulp.series(
+        configureVisualTestRun,
+        'test',
+        'dist-testresults'
+    ));


### PR DESCRIPTION
This simple initial version enables a separate CI workflow that can be triggered from the HTTP API of CircleCI. It takes tests to reset as input and overwrites the references of these tests which are stored as `latest/` in the "visual test bucket". 

This means that by invoking the supplied script it will trigger a job in CircleCI that for the specified tests will recreate and upload/overwrite reference.svg(s) that are used as base in the nightly comparison. 



