### PR TITLE
Use clamp where possible

### DIFF
--- a/js/modules/boost/wgl-shader.js
+++ b/js/modules/boost/wgl-shader.js
@@ -11,6 +11,8 @@
  * */
 'use strict';
 import H from '../../parts/Globals.js';
+import U from '../../parts/Utilities.js';
+var clamp = U.clamp;
 var pick = H.pick;
 /* eslint-disable valid-jsdoc */
 /**
@@ -373,8 +375,8 @@ function GLShader(gl) {
     function setBubbleUniforms(series, zCalcMin, zCalcMax) {
         var seriesOptions = series.options, zMin = Number.MAX_VALUE, zMax = -Number.MAX_VALUE;
         if (gl && shaderProgram && series.type === 'bubble') {
-            zMin = pick(seriesOptions.zMin, Math.min(zMin, Math.max(zCalcMin, seriesOptions.displayNegative === false ?
-                seriesOptions.zThreshold : -Number.MAX_VALUE)));
+            zMin = pick(seriesOptions.zMin, clamp(zCalcMin, seriesOptions.displayNegative === false ?
+                seriesOptions.zThreshold : -Number.MAX_VALUE, zMin));
             zMax = pick(seriesOptions.zMax, Math.max(zMax, zCalcMax));
             gl.uniform1i(isBubbleUniform, 1);
             gl.uniform1i(isCircleUniform, 1);

--- a/js/modules/drag-panes.src.js
+++ b/js/modules/drag-panes.src.js
@@ -14,7 +14,7 @@
 'use strict';
 import H from '../parts/Globals.js';
 import U from '../parts/Utilities.js';
-var isNumber = U.isNumber, objectEach = U.objectEach;
+var clamp = U.clamp, isNumber = U.isNumber, objectEach = U.objectEach;
 import '../parts/Axis.js';
 import '../parts/Pointer.js';
 var hasTouch = H.hasTouch, merge = H.merge, wrap = H.wrap, addEvent = H.addEvent, relativeLength = H.relativeLength, Axis = H.Axis, Pointer = H.Pointer, 
@@ -210,7 +210,7 @@ H.AxisResizer.prototype = {
     render: function () {
         var resizer = this, axis = resizer.axis, chart = axis.chart, options = resizer.options, x = options.x, y = options.y, 
         // Normalize control line position according to the plot area
-        pos = Math.min(Math.max(axis.top + axis.height + y, chart.plotTop), chart.plotTop + chart.plotHeight), attr = {}, lineWidth;
+        pos = clamp(axis.top + axis.height + y, chart.plotTop, chart.plotTop + chart.plotHeight), attr = {}, lineWidth;
         if (!chart.styledMode) {
             attr = {
                 cursor: options.cursor,
@@ -332,10 +332,10 @@ H.AxisResizer.prototype = {
         axesConfigs = [], stopDrag = false, plotTop = chart.plotTop, plotHeight = chart.plotHeight, plotBottom = plotTop + plotHeight, yDelta, calculatePercent = function (value) {
             return value * 100 / plotHeight + '%';
         }, normalize = function (val, min, max) {
-            return Math.round(Math.min(Math.max(val, min), max));
+            return Math.round(clamp(val, min, max));
         };
         // Normalize chartY to plot area limits
-        chartY = Math.max(Math.min(chartY, plotBottom), plotTop);
+        chartY = clamp(chartY, plotTop, plotBottom);
         yDelta = chartY - resizer.lastPos;
         // Update on changes of at least 1 pixel in the desired direction
         if (yDelta * yDelta < 1) {

--- a/js/modules/draggable-points.src.js
+++ b/js/modules/draggable-points.src.js
@@ -196,7 +196,7 @@ import H from '../parts/Globals.js';
 * @type {"drop"}
 */
 import U from '../parts/Utilities.js';
-var objectEach = U.objectEach, pick = U.pick;
+var clamp = U.clamp, objectEach = U.objectEach, pick = U.pick;
 var addEvent = H.addEvent, merge = H.merge, seriesTypes = H.seriesTypes;
 /**
  * Flip a side property, used with resizeRect. If input side is "left", return
@@ -1774,7 +1774,7 @@ H.Point.prototype.getDropValues = function (origin, newPos, updateProps) {
         if (precision) {
             res = Math.round(res / precision) * precision;
         }
-        return Math.max(min, Math.min(max, res));
+        return clamp(res, min, max);
     };
     // Assign new value to property. Adds dX/YValue to the old value, limiting
     // it within min/max ranges.

--- a/js/modules/networkgraph/layouts.js
+++ b/js/modules/networkgraph/layouts.js
@@ -12,7 +12,7 @@
 'use strict';
 import H from '../../parts/Globals.js';
 import U from '../../parts/Utilities.js';
-var defined = U.defined, extend = U.extend, pick = U.pick, setAnimation = U.setAnimation;
+var clamp = U.clamp, defined = U.defined, extend = U.extend, pick = U.pick, setAnimation = U.setAnimation;
 import './integrations.js';
 import './QuadTree.js';
 var addEvent = H.addEvent, Chart = H.Chart;
@@ -395,9 +395,9 @@ H.layouts['reingold-fruchterman'].prototype, {
 
         */
         // Limit X-coordinates:
-        node.plotX = Math.max(Math.min(node.plotX, box.width - radius), box.left + radius);
+        node.plotX = clamp(node.plotX, box.left + radius, box.width - radius);
         // Limit Y-coordinates:
-        node.plotY = Math.max(Math.min(node.plotY, box.height - radius), box.top + radius);
+        node.plotY = clamp(node.plotY, box.top + radius, box.height - radius);
     },
     /**
      * From "A comparison of simulated annealing cooling strategies" by

--- a/js/modules/solid-gauge.src.js
+++ b/js/modules/solid-gauge.src.js
@@ -21,7 +21,7 @@ import H from '../parts/Globals.js';
 * @type {boolean|undefined}
 */
 import U from '../parts/Utilities.js';
-var extend = U.extend, isNumber = U.isNumber, pick = U.pick, pInt = U.pInt;
+var clamp = U.clamp, extend = U.extend, isNumber = U.isNumber, pick = U.pick, pInt = U.pInt;
 import '../parts/Options.js';
 import '../parts-more/GaugeSeries.js';
 var wrap = H.wrap, Renderer = H.Renderer, colorAxisMethods;
@@ -268,10 +268,10 @@ H.seriesType('solidgauge', 'gauge', solidGaugeOptions, {
                     point.color = toColor;
                 }
                 // Handle overshoot and clipping to axis max/min
-                rotation = Math.max(axisMinAngle - overshootVal, Math.min(axisMaxAngle + overshootVal, rotation));
+                rotation = clamp(rotation, axisMinAngle - overshootVal, axisMaxAngle + overshootVal);
                 // Handle the wrap option
                 if (options.wrap === false) {
-                    rotation = Math.max(axisMinAngle, Math.min(axisMaxAngle, rotation));
+                    rotation = clamp(rotation, axisMinAngle, axisMaxAngle);
                 }
                 minAngle = Math.min(rotation, series.thresholdAngleRad);
                 maxAngle = Math.max(rotation, series.thresholdAngleRad);

--- a/js/modules/sonification/utilities.js
+++ b/js/modules/sonification/utilities.js
@@ -11,6 +11,8 @@
  * */
 'use strict';
 import musicalFrequencies from './musicalFrequencies.js';
+import U from '../../parts/Utilities.js';
+var clamp = U.clamp;
 /* eslint-disable no-invalid-this, valid-jsdoc */
 /**
  * The SignalHandler class. Stores signal callbacks (event handlers), and
@@ -156,7 +158,7 @@ var utilities = {
         var lenValueAxis = dataExtremes.max - dataExtremes.min, lenVirtualAxis = limits.max - limits.min, virtualAxisValue = limits.min +
             lenVirtualAxis * (value - dataExtremes.min) / lenValueAxis;
         return lenValueAxis > 0 ?
-            Math.max(Math.min(virtualAxisValue, limits.max), limits.min) :
+            clamp(virtualAxisValue, limits.min, limits.max) :
             limits.min;
     }
 };

--- a/js/modules/tilemap.src.js
+++ b/js/modules/tilemap.src.js
@@ -13,16 +13,12 @@
 'use strict';
 import H from '../parts/Globals.js';
 import U from '../parts/Utilities.js';
-var extend = U.extend, pick = U.pick;
+var clamp = U.clamp, extend = U.extend, pick = U.pick;
 /**
  * @typedef {"circle"|"diamond"|"hexagon"|"square"} Highcharts.TilemapShapeValue
  */
 import '../parts-map/HeatmapSeries.js';
 var seriesType = H.seriesType, 
-// Utility func to get the middle number of 3
-between = function (x, a, b) {
-    return Math.min(Math.max(a, x), b);
-}, 
 // Utility func to get padding definition from tile size division
 tilePaddingFromTileSize = function (series, xDiv, yDiv) {
     var options = series.options;
@@ -58,11 +54,11 @@ H.tileShapeTypes = {
             var series = this, options = series.options, xAxis = series.xAxis, yAxis = series.yAxis, seriesPointPadding = options.pointPadding || 0, xPad = (options.colsize || 1) / 3, yPad = (options.rowsize || 1) / 2, yShift;
             series.generatePoints();
             series.points.forEach(function (point) {
-                var x1 = between(Math.floor(xAxis.len -
-                    xAxis.translate(point.x - xPad * 2, 0, 1, 0, 1)), -xAxis.len, 2 * xAxis.len), x2 = between(Math.floor(xAxis.len -
-                    xAxis.translate(point.x - xPad, 0, 1, 0, 1)), -xAxis.len, 2 * xAxis.len), x3 = between(Math.floor(xAxis.len -
-                    xAxis.translate(point.x + xPad, 0, 1, 0, 1)), -xAxis.len, 2 * xAxis.len), x4 = between(Math.floor(xAxis.len -
-                    xAxis.translate(point.x + xPad * 2, 0, 1, 0, 1)), -xAxis.len, 2 * xAxis.len), y1 = between(Math.floor(yAxis.translate(point.y - yPad, 0, 1, 0, 1)), -yAxis.len, 2 * yAxis.len), y2 = between(Math.floor(yAxis.translate(point.y, 0, 1, 0, 1)), -yAxis.len, 2 * yAxis.len), y3 = between(Math.floor(yAxis.translate(point.y + yPad, 0, 1, 0, 1)), -yAxis.len, 2 * yAxis.len), pointPadding = pick(point.pointPadding, seriesPointPadding), 
+                var x1 = clamp(Math.floor(xAxis.len -
+                    xAxis.translate(point.x - xPad * 2, 0, 1, 0, 1)), -xAxis.len, 2 * xAxis.len), x2 = clamp(Math.floor(xAxis.len -
+                    xAxis.translate(point.x - xPad, 0, 1, 0, 1)), -xAxis.len, 2 * xAxis.len), x3 = clamp(Math.floor(xAxis.len -
+                    xAxis.translate(point.x + xPad, 0, 1, 0, 1)), -xAxis.len, 2 * xAxis.len), x4 = clamp(Math.floor(xAxis.len -
+                    xAxis.translate(point.x + xPad * 2, 0, 1, 0, 1)), -xAxis.len, 2 * xAxis.len), y1 = clamp(Math.floor(yAxis.translate(point.y - yPad, 0, 1, 0, 1)), -yAxis.len, 2 * yAxis.len), y2 = clamp(Math.floor(yAxis.translate(point.y, 0, 1, 0, 1)), -yAxis.len, 2 * yAxis.len), y3 = clamp(Math.floor(yAxis.translate(point.y + yPad, 0, 1, 0, 1)), -yAxis.len, 2 * yAxis.len), pointPadding = pick(point.pointPadding, seriesPointPadding), 
                 // We calculate the point padding of the midpoints to
                 // preserve the angles of the shape.
                 midPointPadding = pointPadding *
@@ -133,10 +129,10 @@ H.tileShapeTypes = {
             var series = this, options = series.options, xAxis = series.xAxis, yAxis = series.yAxis, seriesPointPadding = options.pointPadding || 0, xPad = (options.colsize || 1), yPad = (options.rowsize || 1) / 2, yShift;
             series.generatePoints();
             series.points.forEach(function (point) {
-                var x1 = between(Math.round(xAxis.len -
-                    xAxis.translate(point.x - xPad, 0, 1, 0, 0)), -xAxis.len, 2 * xAxis.len), x2 = between(Math.round(xAxis.len -
-                    xAxis.translate(point.x, 0, 1, 0, 0)), -xAxis.len, 2 * xAxis.len), x3 = between(Math.round(xAxis.len -
-                    xAxis.translate(point.x + xPad, 0, 1, 0, 0)), -xAxis.len, 2 * xAxis.len), y1 = between(Math.round(yAxis.translate(point.y - yPad, 0, 1, 0, 0)), -yAxis.len, 2 * yAxis.len), y2 = between(Math.round(yAxis.translate(point.y, 0, 1, 0, 0)), -yAxis.len, 2 * yAxis.len), y3 = between(Math.round(yAxis.translate(point.y + yPad, 0, 1, 0, 0)), -yAxis.len, 2 * yAxis.len), pointPadding = pick(point.pointPadding, seriesPointPadding), 
+                var x1 = clamp(Math.round(xAxis.len -
+                    xAxis.translate(point.x - xPad, 0, 1, 0, 0)), -xAxis.len, 2 * xAxis.len), x2 = clamp(Math.round(xAxis.len -
+                    xAxis.translate(point.x, 0, 1, 0, 0)), -xAxis.len, 2 * xAxis.len), x3 = clamp(Math.round(xAxis.len -
+                    xAxis.translate(point.x + xPad, 0, 1, 0, 0)), -xAxis.len, 2 * xAxis.len), y1 = clamp(Math.round(yAxis.translate(point.y - yPad, 0, 1, 0, 0)), -yAxis.len, 2 * yAxis.len), y2 = clamp(Math.round(yAxis.translate(point.y, 0, 1, 0, 0)), -yAxis.len, 2 * yAxis.len), y3 = clamp(Math.round(yAxis.translate(point.y + yPad, 0, 1, 0, 0)), -yAxis.len, 2 * yAxis.len), pointPadding = pick(point.pointPadding, seriesPointPadding), 
                 // We calculate the point padding of the midpoints to
                 // preserve the angles of the shape.
                 midPointPadding = pointPadding *
@@ -192,8 +188,8 @@ H.tileShapeTypes = {
             var series = this, options = series.options, xAxis = series.xAxis, yAxis = series.yAxis, seriesPointPadding = options.pointPadding || 0, yRadius = (options.rowsize || 1) / 2, colsize = (options.colsize || 1), colsizePx, yRadiusPx, xRadiusPx, radius, forceNextRadiusCompute = false;
             series.generatePoints();
             series.points.forEach(function (point) {
-                var x = between(Math.round(xAxis.len -
-                    xAxis.translate(point.x, 0, 1, 0, 0)), -xAxis.len, 2 * xAxis.len), y = between(Math.round(yAxis.translate(point.y, 0, 1, 0, 0)), -yAxis.len, 2 * yAxis.len), pointPadding = seriesPointPadding, hasPerPointPadding = false;
+                var x = clamp(Math.round(xAxis.len -
+                    xAxis.translate(point.x, 0, 1, 0, 0)), -xAxis.len, 2 * xAxis.len), y = clamp(Math.round(yAxis.translate(point.y, 0, 1, 0, 0)), -yAxis.len, 2 * yAxis.len), pointPadding = seriesPointPadding, hasPerPointPadding = false;
                 // If there is point padding defined on a single point, add it
                 if (typeof point.pointPadding !== 'undefined') {
                     pointPadding = point.pointPadding;
@@ -219,9 +215,9 @@ H.tileShapeTypes = {
                     instead (yRadiusPx).
                 */
                 if (!radius || forceNextRadiusCompute) {
-                    colsizePx = Math.abs(between(Math.floor(xAxis.len -
+                    colsizePx = Math.abs(clamp(Math.floor(xAxis.len -
                         xAxis.translate(point.x + colsize, 0, 1, 0, 0)), -xAxis.len, 2 * xAxis.len) - x);
-                    yRadiusPx = Math.abs(between(Math.floor(yAxis.translate(point.y + yRadius, 0, 1, 0, 0)), -yAxis.len, 2 * yAxis.len) - y);
+                    yRadiusPx = Math.abs(clamp(Math.floor(yAxis.translate(point.y + yRadius, 0, 1, 0, 0)), -yAxis.len, 2 * yAxis.len) - y);
                     xRadiusPx = Math.floor(Math.sqrt((colsizePx * colsizePx + yRadiusPx * yRadiusPx)) / 2);
                     radius = Math.min(colsizePx, xRadiusPx, yRadiusPx) - pointPadding;
                     // If we have per point padding we need to always compute

--- a/js/modules/variable-pie.src.js
+++ b/js/modules/variable-pie.src.js
@@ -15,7 +15,7 @@ import H from '../parts/Globals.js';
  * @typedef {"area"|"radius"} Highcharts.VariablePieSizeByValue
  */
 import U from '../parts/Utilities.js';
-var arrayMax = U.arrayMax, arrayMin = U.arrayMin, pick = U.pick;
+var arrayMax = U.arrayMax, arrayMin = U.arrayMin, clamp = U.clamp, pick = U.pick;
 import '../parts/Options.js';
 var fireEvent = H.fireEvent, seriesType = H.seriesType, pieProto = H.seriesTypes.pie.prototype;
 /**
@@ -146,7 +146,7 @@ seriesType('variablepie', 'pie',
                 length * 2; // Because it should be radius, not diameter.
         });
         series.minPxSize = positions[3] + extremes.minPointSize;
-        series.maxPxSize = Math.max(Math.min(positions[2], extremes.maxPointSize), positions[3] + extremes.minPointSize);
+        series.maxPxSize = clamp(positions[2], positions[3] + extremes.minPointSize, extremes.maxPointSize);
         if (zData.length) {
             zMin = pick(seriesOptions.zMin, arrayMin(zData.filter(series.zValEval)));
             zMax = pick(seriesOptions.zMax, arrayMax(zData.filter(series.zValEval)));

--- a/js/modules/xrange.src.js
+++ b/js/modules/xrange.src.js
@@ -20,7 +20,7 @@ import H from '../parts/Globals.js';
 * @requires modules/xrange
 */
 import U from '../parts/Utilities.js';
-var correctFloat = U.correctFloat, defined = U.defined, isNumber = U.isNumber, isObject = U.isObject, pick = U.pick;
+var clamp = U.clamp, correctFloat = U.correctFloat, defined = U.defined, isNumber = U.isNumber, isObject = U.isObject, pick = U.pick;
 var addEvent = H.addEvent, color = H.color, columnType = H.seriesTypes.column, merge = H.merge, seriesType = H.seriesType, seriesTypes = H.seriesTypes, Axis = H.Axis, Point = H.Point, Series = H.Series;
 /**
  * Return color of a point based on its category.
@@ -246,7 +246,7 @@ seriesType('xrange', 'column'
             plotX2 += widthDifference / 2;
         }
         plotX = Math.max(plotX, -10);
-        plotX2 = Math.min(Math.max(plotX2, -10), xAxis.len + 10);
+        plotX2 = clamp(plotX2, -10, xAxis.len + 10);
         // Handle individual pointWidth
         if (defined(point.options.pointWidth)) {
             yOffset -= ((Math.ceil(point.options.pointWidth) - pointHeight) / 2);
@@ -269,8 +269,8 @@ seriesType('xrange', 'column'
         dlLeft = point.shapeArgs.x;
         dlRight = dlLeft + point.shapeArgs.width;
         if (dlLeft < 0 || dlRight > xAxis.len) {
-            dlLeft = Math.min(xAxis.len, Math.max(0, dlLeft));
-            dlRight = Math.max(0, Math.min(dlRight, xAxis.len));
+            dlLeft = clamp(dlLeft, 0, xAxis.len);
+            dlRight = clamp(dlRight, 0, xAxis.len);
             dlWidth = dlRight - dlLeft;
             point.dlBox = merge(point.shapeArgs, {
                 x: dlLeft,
@@ -282,22 +282,13 @@ seriesType('xrange', 'column'
             point.dlBox = null;
         }
         // Tooltip position
-        if (!inverted) {
-            point.tooltipPos[0] +=
-                length / 2 * (xAxis.reversed ? -1 : 1);
-            point.tooltipPos[1] -= metrics.width / 2;
-            // Limit position by the correct axis size (#9727)
-            point.tooltipPos[0] = Math.max(Math.min(point.tooltipPos[0], xAxis.len - 1), 0);
-            point.tooltipPos[1] = Math.max(Math.min(point.tooltipPos[1], yAxis.len - 1), 0);
-        }
-        else {
-            point.tooltipPos[1] +=
-                length / 2 * (xAxis.reversed ? 1 : -1);
-            point.tooltipPos[0] += metrics.width / 2;
-            // Limit position by the correct axis size (#9727)
-            point.tooltipPos[1] = Math.max(Math.min(point.tooltipPos[1], xAxis.len - 1), 0);
-            point.tooltipPos[0] = Math.max(Math.min(point.tooltipPos[0], yAxis.len - 1), 0);
-        }
+        var tooltipPos = point.tooltipPos;
+        var xIndex = !inverted ? 0 : 1;
+        var yIndex = !inverted ? 1 : 0;
+        // Limit position by the correct axis size (#9727)
+        tooltipPos[xIndex] = clamp(tooltipPos[xIndex] + ((!inverted ? 1 : -1) * (xAxis.reversed ? -1 : 1) *
+            (length / 2)), 0, xAxis.len - 1);
+        tooltipPos[yIndex] = clamp(tooltipPos[yIndex] + ((!inverted ? -1 : 1) * (metrics.width / 2)), 0, yAxis.len - 1);
         // Add a partShapeArgs to the point, based on the shapeArgs property
         partialFill = point.partialFill;
         if (partialFill) {

--- a/js/parts-map/HeatmapSeries.js
+++ b/js/parts-map/HeatmapSeries.js
@@ -22,7 +22,7 @@ import H from '../parts/Globals.js';
 * @type {number|null|undefined}
 */
 import U from '../parts/Utilities.js';
-var extend = U.extend, pick = U.pick;
+var clamp = U.clamp, extend = U.extend, pick = U.pick;
 import '../parts/Options.js';
 import '../parts/Point.js';
 import '../parts/Series.js';
@@ -186,14 +186,12 @@ seriesType('heatmap', 'scatter',
      * @return {void}
      */
     translate: function () {
-        var series = this, options = series.options, xAxis = series.xAxis, yAxis = series.yAxis, seriesPointPadding = options.pointPadding || 0, between = function (x, a, b) {
-            return Math.min(Math.max(a, x), b);
-        }, pointPlacement = series.pointPlacementToXValue(); // #7860
+        var series = this, options = series.options, xAxis = series.xAxis, yAxis = series.yAxis, seriesPointPadding = options.pointPadding || 0, pointPlacement = series.pointPlacementToXValue(); // #7860
         series.generatePoints();
         series.points.forEach(function (point) {
-            var xPad = (options.colsize || 1) / 2, yPad = (options.rowsize || 1) / 2, x1 = between(Math.round(xAxis.len -
-                xAxis.translate(point.x - xPad, 0, 1, 0, 1, -pointPlacement)), -xAxis.len, 2 * xAxis.len), x2 = between(Math.round(xAxis.len -
-                xAxis.translate(point.x + xPad, 0, 1, 0, 1, -pointPlacement)), -xAxis.len, 2 * xAxis.len), y1 = between(Math.round(yAxis.translate(point.y - yPad, 0, 1, 0, 1)), -yAxis.len, 2 * yAxis.len), y2 = between(Math.round(yAxis.translate(point.y + yPad, 0, 1, 0, 1)), -yAxis.len, 2 * yAxis.len), pointPadding = pick(point.pointPadding, seriesPointPadding);
+            var xPad = (options.colsize || 1) / 2, yPad = (options.rowsize || 1) / 2, x1 = clamp(Math.round(xAxis.len -
+                xAxis.translate(point.x - xPad, 0, 1, 0, 1, -pointPlacement)), -xAxis.len, 2 * xAxis.len), x2 = clamp(Math.round(xAxis.len -
+                xAxis.translate(point.x + xPad, 0, 1, 0, 1, -pointPlacement)), -xAxis.len, 2 * xAxis.len), y1 = clamp(Math.round(yAxis.translate(point.y - yPad, 0, 1, 0, 1)), -yAxis.len, 2 * yAxis.len), y2 = clamp(Math.round(yAxis.translate(point.y + yPad, 0, 1, 0, 1)), -yAxis.len, 2 * yAxis.len), pointPadding = pick(point.pointPadding, seriesPointPadding);
             // Set plotX and plotY for use in K-D-Tree and more
             point.plotX = point.clientX = (x1 + x2) / 2;
             point.plotY = (y1 + y2) / 2;

--- a/js/parts-more/BubbleSeries.js
+++ b/js/parts-more/BubbleSeries.js
@@ -13,7 +13,7 @@ import H from '../parts/Globals.js';
  * @typedef {"area"|"width"} Highcharts.BubbleSizeByValue
  */
 import U from '../parts/Utilities.js';
-var arrayMax = U.arrayMax, arrayMin = U.arrayMin, extend = U.extend, isNumber = U.isNumber, pick = U.pick, pInt = U.pInt;
+var arrayMax = U.arrayMax, arrayMin = U.arrayMin, clamp = U.clamp, extend = U.extend, isNumber = U.isNumber, pick = U.pick, pInt = U.pInt;
 import '../parts/Axis.js';
 import '../parts/Color.js';
 import '../parts/Point.js';
@@ -439,9 +439,9 @@ Axis.prototype.beforePadding = function () {
                 // Find the min and max Z
                 zData = series.zData.filter(isNumber);
                 if (zData.length) { // #1735
-                    zMin = pick(seriesOptions.zMin, Math.min(zMin, Math.max(arrayMin(zData), seriesOptions.displayNegative === false ?
+                    zMin = pick(seriesOptions.zMin, clamp(arrayMin(zData), seriesOptions.displayNegative === false ?
                         seriesOptions.zThreshold :
-                        -Number.MAX_VALUE)));
+                        -Number.MAX_VALUE, zMin));
                     zMax = pick(seriesOptions.zMax, Math.max(zMax, arrayMax(zData)));
                 }
             }

--- a/js/parts-more/ColumnPyramidSeries.js
+++ b/js/parts-more/ColumnPyramidSeries.js
@@ -10,7 +10,7 @@
 'use strict';
 import H from '../parts/Globals.js';
 import U from '../parts/Utilities.js';
-var pick = U.pick;
+var clamp = U.clamp, pick = U.pick;
 var seriesType = H.seriesType, seriesTypes = H.seriesTypes;
 var colProto = seriesTypes.column.prototype;
 /**
@@ -74,7 +74,7 @@ seriesType('columnpyramid', 'column',
         colProto.translate.apply(series);
         // Record the new values
         series.points.forEach(function (point) {
-            var yBottom = pick(point.yBottom, translatedThreshold), safeDistance = 999 + Math.abs(yBottom), plotY = Math.min(Math.max(-safeDistance, point.plotY), yAxis.len + safeDistance), 
+            var yBottom = pick(point.yBottom, translatedThreshold), safeDistance = 999 + Math.abs(yBottom), plotY = clamp(point.plotY, -safeDistance, yAxis.len + safeDistance), 
             // Don't draw too far outside plot area
             // (#1303, #2241, #4264)
             barX = point.plotX + pointXOffset, barW = seriesBarW / 2, barY = Math.min(plotY, yBottom), barH = Math.max(plotY, yBottom) - barY, stackTotal, stackHeight, topPointY, topXwidth, bottomXwidth, invBarPos, x1, x2, x3, x4, y1, y2;

--- a/js/parts-more/ColumnRangeSeries.js
+++ b/js/parts-more/ColumnRangeSeries.js
@@ -10,7 +10,7 @@
 'use strict';
 import H from '../parts/Globals.js';
 import U from '../parts/Utilities.js';
-var pick = U.pick;
+var clamp = U.clamp, pick = U.pick;
 var defaultPlotOptions = H.defaultPlotOptions, merge = H.merge, noop = H.noop, seriesType = H.seriesType, seriesTypes = H.seriesTypes;
 var colProto = seriesTypes.column.prototype;
 /**
@@ -74,7 +74,7 @@ seriesType('columnrange', 'arearange', merge(defaultPlotOptions.column, defaultP
          * @private
          */
         function safeBounds(pixelPos) {
-            return Math.min(Math.max(-safeDistance, pixelPos), safeDistance);
+            return clamp(pixelPos, -safeDistance, safeDistance);
         }
         colProto.translate.apply(series);
         // Set plotLow and plotHigh

--- a/js/parts-more/GaugeSeries.js
+++ b/js/parts-more/GaugeSeries.js
@@ -10,7 +10,7 @@
 'use strict';
 import H from '../parts/Globals.js';
 import U from '../parts/Utilities.js';
-var isNumber = U.isNumber, pick = U.pick, pInt = U.pInt;
+var clamp = U.clamp, isNumber = U.isNumber, pick = U.pick, pInt = U.pInt;
 import '../parts/Options.js';
 import '../parts/Point.js';
 import '../parts/Series.js';
@@ -194,7 +194,6 @@ seriesType('gauge', 'line', {
      *         Allow 5 degrees overshoot
      *
      * @type      {number}
-     * @default   0
      * @since     3.0.10
      * @product   highcharts
      * @apioption plotOptions.gauge.overshoot
@@ -299,12 +298,10 @@ seriesType('gauge', 'line', {
                 100), rearLength = ((pInt(pick(dialOptions.rearLength, '10%')) * radius) /
                 100), baseWidth = dialOptions.baseWidth || 3, topWidth = dialOptions.topWidth || 1, overshoot = options.overshoot, rotation = yAxis.startAngleRad + yAxis.translate(point.y, null, null, null, true);
             // Handle the wrap and overshoot options
-            if (isNumber(overshoot)) {
-                overshoot = overshoot / 180 * Math.PI;
-                rotation = Math.max(yAxis.startAngleRad - overshoot, Math.min(yAxis.endAngleRad + overshoot, rotation));
-            }
-            else if (options.wrap === false) {
-                rotation = Math.max(yAxis.startAngleRad, Math.min(yAxis.endAngleRad, rotation));
+            if (isNumber(overshoot) || options.wrap === false) {
+                overshoot = isNumber(overshoot) ?
+                    (overshoot / 180 * Math.PI) : 0;
+                rotation = clamp(rotation, yAxis.startAngleRad - overshoot, yAxis.endAngleRad + overshoot);
             }
             rotation = rotation * 180 / Math.PI;
             point.shapeType = 'path';

--- a/js/parts-more/PackedBubbleSeries.js
+++ b/js/parts-more/PackedBubbleSeries.js
@@ -45,7 +45,7 @@ import H from '../parts/Globals.js';
 * @since 7.0.0
 */
 import U from '../parts/Utilities.js';
-var defined = U.defined, extend = U.extend, isArray = U.isArray, isNumber = U.isNumber, pick = U.pick;
+var clamp = U.clamp, defined = U.defined, extend = U.extend, isArray = U.isArray, isNumber = U.isNumber, pick = U.pick;
 import '../parts/Axis.js';
 import '../parts/Color.js';
 import '../parts/Point.js';
@@ -659,11 +659,10 @@ seriesType('packedbubble', 'bubble',
     calculateParentRadius: function () {
         var series = this, bBox, parentPadding = 20, minParentRadius = 20;
         bBox = series.seriesBox();
-        series.parentNodeRadius =
-            Math.min(Math.max(Math.sqrt(2 * series.parentNodeMass / Math.PI) + parentPadding, minParentRadius), bBox ?
-                Math.max(Math.sqrt(Math.pow(bBox.width, 2) +
-                    Math.pow(bBox.height, 2)) / 2 + parentPadding, minParentRadius) :
-                Math.sqrt(2 * series.parentNodeMass / Math.PI) + parentPadding);
+        series.parentNodeRadius = clamp(Math.sqrt(2 * series.parentNodeMass / Math.PI) + parentPadding, minParentRadius, bBox ?
+            Math.max(Math.sqrt(Math.pow(bBox.width, 2) +
+                Math.pow(bBox.height, 2)) / 2 + parentPadding, minParentRadius) :
+            Math.sqrt(2 * series.parentNodeMass / Math.PI) + parentPadding);
         if (series.parentNode) {
             series.parentNode.marker.radius =
                 series.parentNode.radius = series.parentNodeRadius;
@@ -1107,7 +1106,7 @@ seriesType('packedbubble', 'bubble',
             [minSize, maxSize];
         (allDataPoints || []).forEach(function (point, i) {
             value = useSimulation ?
-                Math.max(Math.min(point[2], zExtremes[1]), zExtremes[0]) :
+                clamp(point[2], zExtremes[0], zExtremes[1]) :
                 point[2];
             radius = series.getRadius(zExtremes[0], zExtremes[1], minSize, maxSize, value);
             if (radius === 0) {

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -205,7 +205,7 @@ import H from './Globals.js';
  * @return {string}
  */
 import U from './Utilities.js';
-var animObject = U.animObject, arrayMax = U.arrayMax, arrayMin = U.arrayMin, correctFloat = U.correctFloat, defined = U.defined, destroyObjectProperties = U.destroyObjectProperties, extend = U.extend, isArray = U.isArray, isNumber = U.isNumber, isString = U.isString, objectEach = U.objectEach, pick = U.pick, splat = U.splat, syncTimeout = U.syncTimeout;
+var animObject = U.animObject, arrayMax = U.arrayMax, arrayMin = U.arrayMin, clamp = U.clamp, correctFloat = U.correctFloat, defined = U.defined, destroyObjectProperties = U.destroyObjectProperties, extend = U.extend, isArray = U.isArray, isNumber = U.isNumber, isString = U.isString, objectEach = U.objectEach, pick = U.pick, splat = U.splat, syncTimeout = U.syncTimeout;
 import './Color.js';
 import './Options.js';
 import './Tick.js';
@@ -3491,7 +3491,7 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
         between = function (x, a, b) {
             if (force !== 'pass' && x < a || x > b) {
                 if (force) {
-                    x = Math.min(Math.max(a, x), b);
+                    x = clamp(x, a, b);
                 }
                 else {
                     skip = true;
@@ -3511,7 +3511,7 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
             translatedValue = pick(translatedValue, axis.translate(value, null, null, old));
             // Keep the translated value within sane bounds, and avoid Infinity
             // to fail the isNumber test (#7709).
-            translatedValue = Math.min(Math.max(-1e5, translatedValue), 1e5);
+            translatedValue = clamp(translatedValue, -1e5, 1e5);
             x1 = x2 = Math.round(translatedValue + transB);
             y1 = y2 = Math.round(cHeight - translatedValue - transB);
             if (!isNumber(translatedValue)) { // no min or max
@@ -3996,21 +3996,21 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
             }
         }
         // Handle options for floor, ceiling, softMin and softMax (#6359)
-        if (isNumber(options.softMin) &&
-            !isNumber(axis.userMin) &&
-            options.softMin < axis.min) {
-            axis.min = hardMin = options.softMin; // #6894
+        if (!isNumber(axis.userMin)) {
+            if (isNumber(options.softMin) && options.softMin < axis.min) {
+                axis.min = hardMin = options.softMin; // #6894
+            }
+            if (isNumber(options.floor)) {
+                axis.min = Math.max(axis.min, options.floor);
+            }
         }
-        if (isNumber(options.softMax) &&
-            !isNumber(axis.userMax) &&
-            options.softMax > axis.max) {
-            axis.max = hardMax = options.softMax; // #6894
-        }
-        if (isNumber(options.floor)) {
-            axis.min = Math.min(Math.max(axis.min, options.floor), Number.MAX_VALUE);
-        }
-        if (isNumber(options.ceiling)) {
-            axis.max = Math.max(Math.min(axis.max, options.ceiling), pick(axis.userMax, -Number.MAX_VALUE));
+        if (!isNumber(axis.userMax)) {
+            if (isNumber(options.softMax) && options.softMax > axis.max) {
+                axis.max = hardMax = options.softMax; // #6894
+            }
+            if (isNumber(options.ceiling)) {
+                axis.max = Math.min(axis.max, options.ceiling);
+            }
         }
         // When the threshold is soft, adjust the extreme value only if the data
         // extreme and the padded extreme land on either side of the threshold.

--- a/js/parts/ColumnSeries.js
+++ b/js/parts/ColumnSeries.js
@@ -39,7 +39,7 @@ import H from './Globals.js';
 * @type {number|undefined}
 */
 import U from './Utilities.js';
-var animObject = U.animObject, defined = U.defined, extend = U.extend, isNumber = U.isNumber, pick = U.pick;
+var animObject = U.animObject, clamp = U.clamp, defined = U.defined, extend = U.extend, isNumber = U.isNumber, pick = U.pick;
 import './Color.js';
 import './Legend.js';
 import './Series.js';
@@ -593,7 +593,7 @@ seriesType('column', 'line',
             var yBottom = pick(point.yBottom, translatedThreshold), safeDistance = 999 + Math.abs(yBottom), pointWidth = seriesPointWidth, 
             // Don't draw too far outside plot area (#1303, #2241,
             // #4264)
-            plotY = Math.min(Math.max(-safeDistance, point.plotY), yAxis.len + safeDistance), barX = point.plotX + seriesXOffset, barW = seriesBarW, barY = Math.min(plotY, yBottom), up, barH = Math.max(plotY, yBottom) - barY;
+            plotY = clamp(point.plotY, -safeDistance, yAxis.len + safeDistance), barX = point.plotX + seriesXOffset, barW = seriesBarW, barY = Math.min(plotY, yBottom), up, barH = Math.max(plotY, yBottom) - barY;
             // Handle options.minPointLength
             if (minPointLength && Math.abs(barH) < minPointLength) {
                 barH = minPointLength;
@@ -798,7 +798,7 @@ seriesType('column', 'line',
         if (svg) { // VML is too slow anyway
             if (init) {
                 attr.scaleY = 0.001;
-                translatedThreshold = Math.min(yAxis.pos + yAxis.len, Math.max(yAxis.pos, yAxis.toPixels(options.threshold)));
+                translatedThreshold = clamp(yAxis.toPixels(options.threshold), yAxis.pos, yAxis.pos + yAxis.len);
                 if (inverted) {
                     attr.translateX = translatedThreshold - yAxis.len;
                 }

--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -70,7 +70,7 @@ import H from './Globals.js';
 * @type {number|undefined}
 */
 import U from './Utilities.js';
-var animObject = U.animObject, arrayMax = U.arrayMax, defined = U.defined, extend = U.extend, isArray = U.isArray, objectEach = U.objectEach, pick = U.pick, splat = U.splat;
+var animObject = U.animObject, arrayMax = U.arrayMax, clamp = U.clamp, defined = U.defined, extend = U.extend, isArray = U.isArray, objectEach = U.objectEach, pick = U.pick, splat = U.splat;
 import './Series.js';
 var format = H.format, merge = H.merge, noop = H.noop, relativeLength = H.relativeLength, Series = H.Series, seriesTypes = H.seriesTypes, stableSort = H.stableSort;
 /* eslint-disable valid-jsdoc */
@@ -136,7 +136,7 @@ H.distribute = function (boxes, len, maxDistance) {
             // Composite box, average of targets
             target = (Math.min.apply(0, box.targets) +
                 Math.max.apply(0, box.targets)) / 2;
-            box.pos = Math.min(Math.max(0, target - box.size * box.align), len - box.size);
+            box.pos = clamp(target - box.size * box.align, 0, len - box.size);
         }
         // Detect overlap and join boxes
         i = boxes.length;
@@ -1010,13 +1010,12 @@ if (seriesTypes.pie) {
             }
             // Handle vertical size and center
             if (centerOption[1] !== null) { // Fixed center
-                newSize = Math.max(Math.min(newSize, center[2] -
-                    Math.max(overflow[0], overflow[2])), minSize);
+                newSize = clamp(newSize, minSize, center[2] - Math.max(overflow[0], overflow[2]));
             }
             else { // Auto center
-                newSize = Math.max(Math.min(newSize, 
+                newSize = clamp(newSize, minSize, 
                 // vertical overflow
-                center[2] - overflow[0] - overflow[2]), minSize);
+                center[2] - overflow[0] - overflow[2]);
                 // vertical center
                 center[1] += (overflow[0] - overflow[2]) / 2;
             }

--- a/js/parts/Navigator.js
+++ b/js/parts/Navigator.js
@@ -10,7 +10,7 @@
 'use strict';
 import H from './Globals.js';
 import U from './Utilities.js';
-var correctFloat = U.correctFloat, defined = U.defined, destroyObjectProperties = U.destroyObjectProperties, erase = U.erase, extend = U.extend, isArray = U.isArray, isNumber = U.isNumber, pick = U.pick, splat = U.splat;
+var clamp = U.clamp, correctFloat = U.correctFloat, defined = U.defined, destroyObjectProperties = U.destroyObjectProperties, erase = U.erase, extend = U.extend, isArray = U.isArray, isNumber = U.isNumber, pick = U.pick, splat = U.splat;
 import './Color.js';
 import './Axis.js';
 import './Chart.js';
@@ -915,10 +915,10 @@ Navigator.prototype = {
             }
         }
         // Handles are allowed to cross, but never exceed the plot area
-        navigator.zoomedMax = Math.min(Math.max(pxMin, pxMax, 0), zoomedMax);
-        navigator.zoomedMin = Math.min(Math.max(navigator.fixedWidth ?
+        navigator.zoomedMax = clamp(Math.max(pxMin, pxMax), 0, zoomedMax);
+        navigator.zoomedMin = clamp(navigator.fixedWidth ?
             navigator.zoomedMax - navigator.fixedWidth :
-            Math.min(pxMin, pxMax), 0), zoomedMax);
+            Math.min(pxMin, pxMax), 0, zoomedMax);
         navigator.range = navigator.zoomedMax - navigator.zoomedMin;
         zoomedMax = Math.round(navigator.zoomedMax);
         zoomedMin = Math.round(navigator.zoomedMin);

--- a/js/parts/PieSeries.js
+++ b/js/parts/PieSeries.js
@@ -17,7 +17,7 @@ import H from './Globals.js';
 * @type {boolean|undefined}
 */
 import U from './Utilities.js';
-var defined = U.defined, isNumber = U.isNumber, pick = U.pick, setAnimation = U.setAnimation;
+var clamp = U.clamp, defined = U.defined, isNumber = U.isNumber, pick = U.pick, setAnimation = U.setAnimation;
 import './ColumnSeries.js';
 import '../mixins/centered-series.js';
 import './Legend.js';
@@ -651,8 +651,7 @@ seriesType('pie', 'line',
         radius = this.radii ?
             this.radii[point.index] :
             center[2] / 2, angle, x;
-        angle = Math.asin(Math.max(Math.min(((y - center[1]) /
-            (radius + point.labelDistance)), 1), -1));
+        angle = Math.asin(clamp((y - center[1]) / (radius + point.labelDistance), -1, 1));
         x = center[0] +
             (left ? -1 : 1) *
                 (Math.cos(angle) * (radius + point.labelDistance)) +

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -208,7 +208,7 @@ import H from './Globals.js';
  * @typedef {"hover"|"inactive"|"normal"|"select"} Highcharts.SeriesStateValue
  */
 import U from './Utilities.js';
-var animObject = U.animObject, arrayMax = U.arrayMax, arrayMin = U.arrayMin, correctFloat = U.correctFloat, defined = U.defined, erase = U.erase, extend = U.extend, isArray = U.isArray, isNumber = U.isNumber, isString = U.isString, objectEach = U.objectEach, pick = U.pick, splat = U.splat, syncTimeout = U.syncTimeout;
+var animObject = U.animObject, arrayMax = U.arrayMax, arrayMin = U.arrayMin, clamp = U.clamp, correctFloat = U.correctFloat, defined = U.defined, erase = U.erase, extend = U.extend, isArray = U.isArray, isNumber = U.isNumber, isString = U.isString, objectEach = U.objectEach, pick = U.pick, splat = U.splat, syncTimeout = U.syncTimeout;
 import './Options.js';
 import './Legend.js';
 import './Point.js';
@@ -3642,7 +3642,7 @@ null,
          * @private
          */
         function limitedRange(val) {
-            return Math.min(Math.max(-1e5, val), 1e5);
+            return clamp(val, -1e5, 1e5);
         }
         // Translate each point
         for (i = 0; i < dataLength; i++) {
@@ -4429,8 +4429,8 @@ null,
                 translatedFrom = reversed ?
                     (horiz ? chart.plotWidth : 0) :
                     (horiz ? 0 : (axis.toPixels(extremes.min) || 0));
-                translatedFrom = Math.min(Math.max(pick(translatedTo, translatedFrom), 0), chartSizeMax);
-                translatedTo = Math.min(Math.max(Math.round(axis.toPixels(pick(threshold.value, extremes.max), true) || 0), 0), chartSizeMax);
+                translatedFrom = clamp(pick(translatedTo, translatedFrom), 0, chartSizeMax);
+                translatedTo = clamp(Math.round(axis.toPixels(pick(threshold.value, extremes.max), true) || 0), 0, chartSizeMax);
                 if (ignoreZones) {
                     translatedFrom = translatedTo =
                         axis.toPixels(extremes.max);

--- a/js/parts/StockChart.js
+++ b/js/parts/StockChart.js
@@ -10,7 +10,7 @@
 'use strict';
 import H from './Globals.js';
 import U from './Utilities.js';
-var arrayMax = U.arrayMax, arrayMin = U.arrayMin, defined = U.defined, extend = U.extend, isNumber = U.isNumber, isString = U.isString, pick = U.pick, splat = U.splat;
+var arrayMax = U.arrayMax, arrayMin = U.arrayMin, clamp = U.clamp, defined = U.defined, extend = U.extend, isNumber = U.isNumber, isString = U.isString, pick = U.pick, splat = U.splat;
 import './Chart.js';
 import './Axis.js';
 import './Point.js';
@@ -342,7 +342,7 @@ addEvent(Axis, 'getPlotLinePath', function (e) {
                     if (force !== 'pass' &&
                         (x1 < axisLeft || x1 > axisLeft + axis.width)) {
                         if (force) {
-                            x1 = x2 = Math.min(Math.max(axisLeft, x1), axisLeft + axis.width);
+                            x1 = x2 = clamp(x1, axisLeft, axisLeft + axis.width);
                         }
                         else {
                             skip = true;
@@ -363,7 +363,7 @@ addEvent(Axis, 'getPlotLinePath', function (e) {
                     if (force !== 'pass' &&
                         (y1 < axisTop || y1 > axisTop + axis.height)) {
                         if (force) {
-                            y1 = y2 = Math.min(Math.max(axisTop, y1), axis.top + axis.height);
+                            y1 = y2 = clamp(y1, axisTop, axisTop + axis.height);
                         }
                         else {
                             skip = true;

--- a/js/parts/Tick.js
+++ b/js/parts/Tick.js
@@ -26,7 +26,7 @@ import H from './Globals.js';
 * @type {number|undefined}
 */
 import U from './Utilities.js';
-var correctFloat = U.correctFloat, defined = U.defined, destroyObjectProperties = U.destroyObjectProperties, extend = U.extend, isNumber = U.isNumber, pick = U.pick;
+var clamp = U.clamp, correctFloat = U.correctFloat, defined = U.defined, destroyObjectProperties = U.destroyObjectProperties, extend = U.extend, isNumber = U.isNumber, pick = U.pick;
 var fireEvent = H.fireEvent, merge = H.merge, deg2rad = H.deg2rad;
 /* eslint-disable no-invalid-this, valid-jsdoc */
 /**
@@ -317,7 +317,7 @@ H.Tick.prototype = {
                     axis.transB)
         };
         // Chrome workaround for #10516
-        pos.y = Math.max(Math.min(pos.y, 1e5), -1e5);
+        pos.y = clamp(pos.y, -1e5, 1e5);
         fireEvent(this, 'afterGetPosition', { pos: pos });
         return pos;
     },

--- a/ts/modules/boost/wgl-shader.ts
+++ b/ts/modules/boost/wgl-shader.ts
@@ -12,6 +12,10 @@
 
 'use strict';
 import H from '../../parts/Globals.js';
+import U from '../../parts/Utilities.js';
+const {
+    clamp
+} = U;
 
 /**
  * Internal types
@@ -483,13 +487,11 @@ function GLShader(gl: WebGLRenderingContext): (false|Highcharts.BoostGLShader) {
             zMax = -Number.MAX_VALUE;
 
         if (gl && shaderProgram && series.type === 'bubble') {
-            zMin = pick(seriesOptions.zMin, Math.min(
-                zMin,
-                Math.max(
-                    zCalcMin,
-                    seriesOptions.displayNegative === false ?
-                        (seriesOptions.zThreshold as any) : -Number.MAX_VALUE
-                )
+            zMin = pick(seriesOptions.zMin, clamp(
+                zCalcMin,
+                seriesOptions.displayNegative === false ?
+                    (seriesOptions.zThreshold as any) : -Number.MAX_VALUE,
+                zMin
             ));
 
             zMax = pick(seriesOptions.zMax, Math.max(zMax, zCalcMax));

--- a/ts/modules/drag-panes.src.ts
+++ b/ts/modules/drag-panes.src.ts
@@ -72,8 +72,11 @@ declare global {
 }
 
 import U from '../parts/Utilities.js';
-var isNumber = U.isNumber,
-    objectEach = U.objectEach;
+const {
+    clamp,
+    isNumber,
+    objectEach
+} = U;
 
 import '../parts/Axis.js';
 import '../parts/Pointer.js';
@@ -309,11 +312,9 @@ H.AxisResizer.prototype = {
             x = options.x,
             y = options.y,
             // Normalize control line position according to the plot area
-            pos = Math.min(
-                Math.max(
-                    axis.top + axis.height + (y as any),
-                    chart.plotTop
-                ),
+            pos = clamp(
+                axis.top + axis.height + (y as any),
+                chart.plotTop,
                 chart.plotTop + chart.plotHeight
             ),
             attr: Highcharts.SVGAttributes = {},
@@ -509,11 +510,11 @@ H.AxisResizer.prototype = {
                 min: number,
                 max: number
             ): number {
-                return Math.round(Math.min(Math.max(val, min), max));
+                return Math.round(clamp(val, min, max));
             };
 
         // Normalize chartY to plot area limits
-        chartY = Math.max(Math.min(chartY, plotBottom), plotTop);
+        chartY = clamp(chartY, plotTop, plotBottom);
 
         yDelta = chartY - resizer.lastPos;
 

--- a/ts/modules/draggable-points.src.ts
+++ b/ts/modules/draggable-points.src.ts
@@ -386,6 +386,7 @@ declare global {
 
 import U from '../parts/Utilities.js';
 const {
+    clamp,
     objectEach,
     pick
 } = U;
@@ -2366,7 +2367,7 @@ H.Point.prototype.getDropValues = function (
         if (precision) {
             res = Math.round(res / precision) * precision;
         }
-        return Math.max(min, Math.min(max, res));
+        return clamp(res, min, max);
     };
 
     // Assign new value to property. Adds dX/YValue to the old value, limiting

--- a/ts/modules/networkgraph/layouts.ts
+++ b/ts/modules/networkgraph/layouts.ts
@@ -143,6 +143,7 @@ declare global {
 
 import U from '../../parts/Utilities.js';
 const {
+    clamp,
     defined,
     extend,
     pick,
@@ -756,21 +757,13 @@ extend(
 
             */
             // Limit X-coordinates:
-            node.plotX = Math.max(
-                Math.min(
-                    node.plotX as any,
-                    box.width - radius
-                ),
-                box.left + radius
+            node.plotX = clamp(
+                node.plotX as any, box.left + radius, box.width - radius
             );
 
             // Limit Y-coordinates:
-            node.plotY = Math.max(
-                Math.min(
-                    node.plotY as any,
-                    box.height - radius
-                ),
-                box.top + radius
+            node.plotY = clamp(
+                node.plotY as any, box.top + radius, box.height - radius
             );
         },
         /**

--- a/ts/modules/solid-gauge.src.ts
+++ b/ts/modules/solid-gauge.src.ts
@@ -89,6 +89,7 @@ declare global {
 
 import U from '../parts/Utilities.js';
 const {
+    clamp,
     extend,
     isNumber,
     pick,
@@ -489,17 +490,15 @@ H.seriesType<Highcharts.SolidGaugeSeries>(
                     }
 
                     // Handle overshoot and clipping to axis max/min
-                    rotation = Math.max(
+                    rotation = clamp(
+                        rotation,
                         axisMinAngle - overshootVal,
-                        Math.min(axisMaxAngle + overshootVal, rotation)
+                        axisMaxAngle + overshootVal
                     );
 
                     // Handle the wrap option
                     if (options.wrap === false) {
-                        rotation = Math.max(
-                            axisMinAngle,
-                            Math.min(axisMaxAngle, rotation)
-                        );
+                        rotation = clamp(rotation, axisMinAngle, axisMaxAngle);
                     }
 
                     minAngle = Math.min(rotation, series.thresholdAngleRad);

--- a/ts/modules/sonification/utilities.ts
+++ b/ts/modules/sonification/utilities.ts
@@ -12,6 +12,8 @@
 
 'use strict';
 import musicalFrequencies from './musicalFrequencies.js';
+import U from '../../parts/Utilities.js';
+const { clamp } = U;
 
 /**
  * Internal types.
@@ -248,7 +250,7 @@ var utilities: Highcharts.SonificationUtilitiesObject = {
                 lenVirtualAxis * (value - dataExtremes.min) / lenValueAxis;
 
         return lenValueAxis > 0 ?
-            Math.max(Math.min(virtualAxisValue, limits.max), limits.min) :
+            clamp(virtualAxisValue, limits.min, limits.max) :
             limits.min;
     }
 };

--- a/ts/modules/tilemap.src.ts
+++ b/ts/modules/tilemap.src.ts
@@ -16,6 +16,7 @@ import H from '../parts/Globals.js';
 
 import U from '../parts/Utilities.js';
 const {
+    clamp,
     extend,
     pick
 } = U;
@@ -97,10 +98,6 @@ declare global {
 import '../parts-map/HeatmapSeries.js';
 
 var seriesType = H.seriesType,
-    // Utility func to get the middle number of 3
-    between = function (x: number, a: number, b: number): number {
-        return Math.min(Math.max(a, x), b);
-    },
     // Utility func to get padding definition from tile size division
     tilePaddingFromTileSize = function (
         series: Highcharts.TilemapSeries,
@@ -160,7 +157,7 @@ H.tileShapeTypes = {
             series.points.forEach(function (
                 point: Highcharts.TilemapPoint
             ): void {
-                var x1 = between(
+                var x1 = clamp(
                         Math.floor(
                             xAxis.len -
                             (xAxis.translate(
@@ -172,7 +169,7 @@ H.tileShapeTypes = {
                             ) as any)
                         ), -xAxis.len, 2 * xAxis.len
                     ),
-                    x2 = between(
+                    x2 = clamp(
                         Math.floor(
                             xAxis.len -
                             (xAxis.translate(
@@ -184,7 +181,7 @@ H.tileShapeTypes = {
                             ) as any)
                         ), -xAxis.len, 2 * xAxis.len
                     ),
-                    x3 = between(
+                    x3 = clamp(
                         Math.floor(
                             xAxis.len -
                             (xAxis.translate(
@@ -196,7 +193,7 @@ H.tileShapeTypes = {
                             ) as any)
                         ), -xAxis.len, 2 * xAxis.len
                     ),
-                    x4 = between(
+                    x4 = clamp(
                         Math.floor(
                             xAxis.len -
                             (xAxis.translate(
@@ -208,7 +205,7 @@ H.tileShapeTypes = {
                             ) as any)
                         ), -xAxis.len, 2 * xAxis.len
                     ),
-                    y1 = between(
+                    y1 = clamp(
                         Math.floor(yAxis.translate(
                             point.y - yPad,
                             0 as any,
@@ -219,7 +216,7 @@ H.tileShapeTypes = {
                         -yAxis.len,
                         2 * yAxis.len
                     ),
-                    y2 = between(
+                    y2 = clamp(
                         Math.floor(yAxis.translate(
                             point.y,
                             0 as any,
@@ -230,7 +227,7 @@ H.tileShapeTypes = {
                         -yAxis.len,
                         2 * yAxis.len
                     ),
-                    y3 = between(
+                    y3 = clamp(
                         Math.floor(yAxis.translate(
                             point.y + yPad,
                             0 as any,
@@ -340,7 +337,7 @@ H.tileShapeTypes = {
             series.points.forEach(function (
                 point: Highcharts.TilemapPoint
             ): void {
-                var x1 = between(
+                var x1 = clamp(
                         Math.round(
                             xAxis.len -
                             (xAxis.translate(
@@ -352,7 +349,7 @@ H.tileShapeTypes = {
                             ) as any)
                         ), -xAxis.len, 2 * xAxis.len
                     ),
-                    x2 = between(
+                    x2 = clamp(
                         Math.round(
                             xAxis.len -
                             (xAxis.translate(
@@ -364,7 +361,7 @@ H.tileShapeTypes = {
                             ) as any)
                         ), -xAxis.len, 2 * xAxis.len
                     ),
-                    x3 = between(
+                    x3 = clamp(
                         Math.round(
                             xAxis.len -
                             (xAxis.translate(
@@ -376,7 +373,7 @@ H.tileShapeTypes = {
                             ) as any)
                         ), -xAxis.len, 2 * xAxis.len
                     ),
-                    y1 = between(
+                    y1 = clamp(
                         Math.round(yAxis.translate(
                             point.y - yPad,
                             0 as any,
@@ -387,7 +384,7 @@ H.tileShapeTypes = {
                         -yAxis.len,
                         2 * yAxis.len
                     ),
-                    y2 = between(
+                    y2 = clamp(
                         Math.round(yAxis.translate(
                             point.y,
                             0 as any,
@@ -398,7 +395,7 @@ H.tileShapeTypes = {
                         -yAxis.len,
                         2 * yAxis.len
                     ),
-                    y3 = between(
+                    y3 = clamp(
                         Math.round(yAxis.translate(
                             point.y + yPad,
                             0 as any,
@@ -502,7 +499,7 @@ H.tileShapeTypes = {
             series.points.forEach(function (
                 point: Highcharts.TilemapPoint
             ): void {
-                var x = between(
+                var x = clamp(
                         Math.round(
                             xAxis.len -
                             (xAxis.translate(
@@ -514,7 +511,7 @@ H.tileShapeTypes = {
                             ) as any)
                         ), -xAxis.len, 2 * xAxis.len
                     ),
-                    y = between(
+                    y = clamp(
                         Math.round(yAxis.translate(
                             point.y,
                             0 as any,
@@ -555,7 +552,7 @@ H.tileShapeTypes = {
                 */
                 if (!radius || forceNextRadiusCompute) {
                     colsizePx = Math.abs(
-                        between(
+                        clamp(
                             Math.floor(
                                 xAxis.len -
                                 (xAxis.translate(
@@ -569,7 +566,7 @@ H.tileShapeTypes = {
                         ) - x
                     );
                     yRadiusPx = Math.abs(
-                        between(
+                        clamp(
                             Math.floor(
                                 yAxis.translate(
                                     point.y + yRadius,

--- a/ts/modules/variable-pie.src.ts
+++ b/ts/modules/variable-pie.src.ts
@@ -67,6 +67,7 @@ import U from '../parts/Utilities.js';
 const {
     arrayMax,
     arrayMin,
+    clamp,
     pick
 } = U;
 
@@ -228,9 +229,10 @@ seriesType<Highcharts.VariablePieSeries>(
             });
 
             series.minPxSize = positions[3] + extremes.minPointSize;
-            series.maxPxSize = Math.max(
-                Math.min(positions[2], extremes.maxPointSize),
-                positions[3] + extremes.minPointSize
+            series.maxPxSize = clamp(
+                positions[2],
+                positions[3] + extremes.minPointSize,
+                extremes.maxPointSize
             );
 
             if (zData.length) {

--- a/ts/parts-map/HeatmapSeries.ts
+++ b/ts/parts-map/HeatmapSeries.ts
@@ -96,6 +96,7 @@ declare global {
 
 import U from '../parts/Utilities.js';
 const {
+    clamp,
     extend,
     pick
 } = U;
@@ -305,9 +306,6 @@ seriesType<Highcharts.HeatmapSeries>(
                 xAxis = series.xAxis,
                 yAxis = series.yAxis,
                 seriesPointPadding = options.pointPadding || 0,
-                between = function (x: number, a: number, b: number): number {
-                    return Math.min(Math.max(a, x), b);
-                },
                 pointPlacement = series.pointPlacementToXValue(); // #7860
 
             series.generatePoints();
@@ -317,7 +315,7 @@ seriesType<Highcharts.HeatmapSeries>(
             ): void {
                 var xPad = (options.colsize || 1) / 2,
                     yPad = (options.rowsize || 1) / 2,
-                    x1 = between(
+                    x1 = clamp(
                         Math.round(
                             xAxis.len -
                             (xAxis.translate(
@@ -331,7 +329,7 @@ seriesType<Highcharts.HeatmapSeries>(
                         ),
                         -xAxis.len, 2 * xAxis.len
                     ),
-                    x2 = between(
+                    x2 = clamp(
                         Math.round(
                             xAxis.len -
                             (xAxis.translate(point.x + xPad,
@@ -344,7 +342,7 @@ seriesType<Highcharts.HeatmapSeries>(
                         ),
                         -xAxis.len, 2 * xAxis.len
                     ),
-                    y1 = between(
+                    y1 = clamp(
                         Math.round(yAxis.translate(
                             point.y - yPad,
                             0 as any,
@@ -354,7 +352,7 @@ seriesType<Highcharts.HeatmapSeries>(
                         ) as any),
                         -yAxis.len, 2 * yAxis.len
                     ),
-                    y2 = between(
+                    y2 = clamp(
                         Math.round(yAxis.translate(
                             point.y + yPad,
                             0 as any,

--- a/ts/parts-more/BubbleSeries.ts
+++ b/ts/parts-more/BubbleSeries.ts
@@ -103,6 +103,7 @@ import U from '../parts/Utilities.js';
 const {
     arrayMax,
     arrayMin,
+    clamp,
     extend,
     isNumber,
     pick,
@@ -677,14 +678,12 @@ Axis.prototype.beforePadding = function (this: Highcharts.Axis): void {
                 // Find the min and max Z
                 zData = (series.zData as any).filter(isNumber);
                 if (zData.length) { // #1735
-                    zMin = pick(seriesOptions.zMin, Math.min(
-                        zMin,
-                        Math.max(
-                            arrayMin(zData),
-                            seriesOptions.displayNegative === false ?
-                                (seriesOptions.zThreshold as any) :
-                                -Number.MAX_VALUE
-                        )
+                    zMin = pick(seriesOptions.zMin, clamp(
+                        arrayMin(zData),
+                        seriesOptions.displayNegative === false ?
+                            (seriesOptions.zThreshold as any) :
+                            -Number.MAX_VALUE,
+                        zMin
                     ));
                     zMax = pick(
                         seriesOptions.zMax,

--- a/ts/parts-more/ColumnPyramidSeries.ts
+++ b/ts/parts-more/ColumnPyramidSeries.ts
@@ -42,6 +42,7 @@ declare global {
 
 import U from '../parts/Utilities.js';
 const {
+    clamp,
     pick
 } = U;
 
@@ -139,8 +140,9 @@ seriesType<Highcharts.ColumnPyramidSeries>(
                         point.yBottom, translatedThreshold as any
                     ),
                     safeDistance = 999 + Math.abs(yBottom),
-                    plotY = Math.min(
-                        Math.max(-safeDistance, point.plotY as any),
+                    plotY = clamp(
+                        point.plotY as any,
+                        -safeDistance,
                         yAxis.len + safeDistance
                     ),
                     // Don't draw too far outside plot area

--- a/ts/parts-more/ColumnRangeSeries.ts
+++ b/ts/parts-more/ColumnRangeSeries.ts
@@ -54,6 +54,7 @@ declare global {
 
 import U from '../parts/Utilities.js';
 const {
+    clamp,
     pick
 } = U;
 
@@ -145,10 +146,7 @@ seriesType<Highcharts.ColumnRangeSeries>('columnrange', 'arearange', merge(
          * @private
          */
         function safeBounds(pixelPos: number): number {
-            return Math.min(Math.max(
-                -safeDistance,
-                pixelPos
-            ), safeDistance);
+            return clamp(pixelPos, -safeDistance, safeDistance);
         }
 
 

--- a/ts/parts-more/GaugeSeries.ts
+++ b/ts/parts-more/GaugeSeries.ts
@@ -87,6 +87,7 @@ declare global {
 
 import U from '../parts/Utilities.js';
 const {
+    clamp,
     isNumber,
     pick,
     pInt
@@ -293,7 +294,6 @@ seriesType<Highcharts.GaugeSeries>('gauge', 'line', {
      *         Allow 5 degrees overshoot
      *
      * @type      {number}
-     * @default   0
      * @since     3.0.10
      * @product   highcharts
      * @apioption plotOptions.gauge.overshoot
@@ -432,17 +432,13 @@ seriesType<Highcharts.GaugeSeries>('gauge', 'line', {
                 ) as any);
 
             // Handle the wrap and overshoot options
-            if (isNumber(overshoot)) {
-                overshoot = overshoot / 180 * Math.PI;
-                rotation = Math.max(
+            if (isNumber(overshoot) || options.wrap === false) {
+                overshoot = isNumber(overshoot) ?
+                    (overshoot / 180 * Math.PI) : 0;
+                rotation = clamp(
+                    rotation,
                     yAxis.startAngleRad - overshoot,
-                    Math.min(yAxis.endAngleRad + overshoot, rotation)
-                );
-
-            } else if (options.wrap === false) {
-                rotation = Math.max(
-                    yAxis.startAngleRad,
-                    Math.min(yAxis.endAngleRad, rotation)
+                    yAxis.endAngleRad + overshoot
                 );
             }
 

--- a/ts/parts-more/PackedBubbleSeries.ts
+++ b/ts/parts-more/PackedBubbleSeries.ts
@@ -241,6 +241,7 @@ declare global {
 
 import U from '../parts/Utilities.js';
 const {
+    clamp,
     defined,
     extend,
     isArray,
@@ -1057,26 +1058,23 @@ seriesType<Highcharts.PackedBubbleSeries>(
                 minParentRadius = 20;
 
             bBox = series.seriesBox();
-            series.parentNodeRadius =
-                Math.min(
+            series.parentNodeRadius = clamp(
+                Math.sqrt(
+                    2 * (series.parentNodeMass as any) / Math.PI
+                ) + parentPadding,
+                minParentRadius,
+                bBox ?
                     Math.max(
                         Math.sqrt(
-                            2 * (series.parentNodeMass as any) / Math.PI
-                        ) + parentPadding,
+                            Math.pow((bBox as any).width, 2) +
+                            Math.pow((bBox as any).height, 2)
+                        ) / 2 + parentPadding,
                         minParentRadius
-                    ),
-                    bBox ?
-                        Math.max(
-                            Math.sqrt(
-                                Math.pow((bBox as any).width, 2) +
-                                Math.pow((bBox as any).height, 2)
-                            ) / 2 + parentPadding,
-                            minParentRadius
-                        ) :
-                        Math.sqrt(
-                            2 * (series.parentNodeMass as any) / Math.PI
-                        ) + parentPadding
-                );
+                    ) :
+                    Math.sqrt(
+                        2 * (series.parentNodeMass as any) / Math.PI
+                    ) + parentPadding
+            );
 
             if (series.parentNode) {
                 (series.parentNode as any).marker.radius =
@@ -1750,9 +1748,10 @@ seriesType<Highcharts.PackedBubbleSeries>(
             ): void {
 
                 value = useSimulation ?
-                    Math.max(
-                        Math.min((point[2] as any), zExtremes[1]),
-                        zExtremes[0]
+                    clamp(
+                        point[2] as any,
+                        zExtremes[0],
+                        zExtremes[1]
                     ) :
                     (point[2] as any);
 

--- a/ts/parts/ColumnSeries.ts
+++ b/ts/parts/ColumnSeries.ts
@@ -127,6 +127,7 @@ declare global {
 import U from './Utilities.js';
 const {
     animObject,
+    clamp,
     defined,
     extend,
     isNumber,
@@ -821,8 +822,9 @@ seriesType<Highcharts.ColumnSeries>(
                     pointWidth = seriesPointWidth,
                     // Don't draw too far outside plot area (#1303, #2241,
                     // #4264)
-                    plotY = Math.min(
-                        Math.max(-safeDistance, point.plotY as any),
+                    plotY = clamp(
+                        point.plotY as any,
+                        -safeDistance,
                         yAxis.len + safeDistance
                     ),
                     barX = (point.plotX as any) + seriesXOffset,
@@ -1124,12 +1126,10 @@ seriesType<Highcharts.ColumnSeries>(
             if (svg) { // VML is too slow anyway
                 if (init) {
                     attr.scaleY = 0.001;
-                    translatedThreshold = Math.min(
-                        (yAxis.pos as any) + yAxis.len,
-                        Math.max(
-                            yAxis.pos as any,
-                            yAxis.toPixels(options.threshold as any)
-                        )
+                    translatedThreshold = clamp(
+                        yAxis.toPixels(options.threshold as any),
+                        yAxis.pos,
+                        yAxis.pos + yAxis.len
                     );
                     if (inverted) {
                         attr.translateX = translatedThreshold - yAxis.len;

--- a/ts/parts/DataLabels.ts
+++ b/ts/parts/DataLabels.ts
@@ -231,6 +231,7 @@ import U from './Utilities.js';
 const {
     animObject,
     arrayMax,
+    clamp,
     defined,
     extend,
     isArray,
@@ -341,9 +342,8 @@ H.distribute = function (
                 Math.min.apply(0, box.targets as any) +
                 Math.max.apply(0, box.targets as any)
             ) / 2;
-            box.pos = Math.min(
-                Math.max(0, target - box.size * (box.align as any)),
-                len - box.size
+            box.pos = clamp(
+                target - box.size * (box.align as any), 0, len - box.size
             );
         }
 
@@ -1662,17 +1662,17 @@ if (seriesTypes.pie) {
 
             // Handle vertical size and center
             if ((centerOption as any)[1] !== null) { // Fixed center
-                newSize = Math.max(Math.min(newSize, center[2] -
-                    Math.max(overflow[0], overflow[2])), minSize as any);
-
+                newSize = clamp(
+                    newSize,
+                    minSize as any,
+                    center[2] - Math.max(overflow[0], overflow[2])
+                );
             } else { // Auto center
-                newSize = Math.max(
-                    Math.min(
-                        newSize,
-                        // vertical overflow
-                        center[2] - overflow[0] - overflow[2]
-                    ),
-                    minSize as any
+                newSize = clamp(
+                    newSize,
+                    minSize as any,
+                    // vertical overflow
+                    center[2] - overflow[0] - overflow[2]
                 );
                 // vertical center
                 center[1] += (overflow[0] - overflow[2]) / 2;

--- a/ts/parts/Navigator.ts
+++ b/ts/parts/Navigator.ts
@@ -188,6 +188,7 @@ declare global {
 
 import U from './Utilities.js';
 const {
+    clamp,
     correctFloat,
     defined,
     destroyObjectProperties,
@@ -1345,17 +1346,16 @@ Navigator.prototype = {
         }
 
         // Handles are allowed to cross, but never exceed the plot area
-        navigator.zoomedMax = Math.min(
-            Math.max(pxMin as any, pxMax as any, 0),
+        navigator.zoomedMax = clamp(
+            Math.max(pxMin, pxMax as any),
+            0,
             zoomedMax
         );
-        navigator.zoomedMin = Math.min(
-            Math.max(
-                navigator.fixedWidth ?
-                    navigator.zoomedMax - navigator.fixedWidth :
-                    Math.min(pxMin as any, pxMax as any),
-                0
-            ),
+        navigator.zoomedMin = clamp(
+            navigator.fixedWidth ?
+                navigator.zoomedMax - navigator.fixedWidth :
+                Math.min(pxMin, pxMax as any),
+            0,
             zoomedMax
         );
 

--- a/ts/parts/PieSeries.ts
+++ b/ts/parts/PieSeries.ts
@@ -130,6 +130,7 @@ declare global {
 
 import U from './Utilities.js';
 const {
+    clamp,
     defined,
     isNumber,
     pick,
@@ -863,16 +864,7 @@ seriesType<Highcharts.PieSeries>(
                 x;
 
             angle = Math.asin(
-                Math.max(
-                    Math.min(
-                        (
-                            (y - center[1]) /
-                        (radius + point.labelDistance)
-                        ),
-                        1
-                    ),
-                    -1
-                )
+                clamp((y - center[1]) / (radius + point.labelDistance), -1, 1)
             );
             x = center[0] +
             (left ? -1 : 1) *

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -655,6 +655,7 @@ const {
     animObject,
     arrayMax,
     arrayMin,
+    clamp,
     correctFloat,
     defined,
     erase,
@@ -4754,7 +4755,7 @@ H.Series = H.seriesType<Highcharts.LineSeries>(
              * @private
              */
             function limitedRange(val: number): number {
-                return Math.min(Math.max(-1e5, val), 1e5);
+                return clamp(val, -1e5, 1e5);
             }
 
             // Translate each point
@@ -5947,22 +5948,19 @@ H.Series = H.seriesType<Highcharts.LineSeries>(
                         (horiz ? chart.plotWidth : 0) :
                         (horiz ? 0 : (axis.toPixels(extremes.min) || 0));
 
-                    translatedFrom = Math.min(
-                        Math.max(
-                            pick(translatedTo, translatedFrom), 0
-                        ),
+                    translatedFrom = clamp(
+                        pick(translatedTo, translatedFrom),
+                        0,
                         chartSizeMax
                     );
-                    translatedTo = Math.min(
-                        Math.max(
-                            Math.round(
-                                axis.toPixels(
-                                    pick(threshold.value, extremes.max),
-                                    true
-                                ) || 0
-                            ),
-                            0
+                    translatedTo = clamp(
+                        Math.round(
+                            axis.toPixels(
+                                pick(threshold.value, extremes.max),
+                                true
+                            ) || 0
                         ),
+                        0,
                         chartSizeMax
                     );
 

--- a/ts/parts/StockChart.ts
+++ b/ts/parts/StockChart.ts
@@ -58,6 +58,7 @@ import U from './Utilities.js';
 const {
     arrayMax,
     arrayMin,
+    clamp,
     defined,
     extend,
     isNumber,
@@ -537,8 +538,9 @@ addEvent(Axis, 'getPlotLinePath', function (
                         (x1 < axisLeft || x1 > axisLeft + axis.width)
                     ) {
                         if (force) {
-                            x1 = x2 = Math.min(
-                                Math.max(axisLeft, x1),
+                            x1 = x2 = clamp(
+                                x1,
+                                axisLeft,
                                 axisLeft + axis.width
                             );
                         } else {
@@ -563,9 +565,10 @@ addEvent(Axis, 'getPlotLinePath', function (
                         (y1 < axisTop || y1 > axisTop + axis.height)
                     ) {
                         if (force) {
-                            y1 = y2 = Math.min(
-                                Math.max(axisTop, y1),
-                                axis.top + axis.height
+                            y1 = y2 = clamp(
+                                y1,
+                                axisTop,
+                                axisTop + axis.height
                             );
                         } else {
                             skip = true;

--- a/ts/parts/Tick.ts
+++ b/ts/parts/Tick.ts
@@ -123,6 +123,7 @@ declare global {
 
 import U from './Utilities.js';
 const {
+    clamp,
     correctFloat,
     defined,
     destroyObjectProperties,
@@ -573,7 +574,7 @@ H.Tick.prototype = {
         };
 
         // Chrome workaround for #10516
-        pos.y = Math.max(Math.min(pos.y, 1e5), -1e5);
+        pos.y = clamp(pos.y, -1e5, 1e5);
 
         fireEvent(this, 'afterGetPosition', { pos: pos });
 


### PR DESCRIPTION
Follow up to #12324

> Use clamp in other parts of the code where appropriate.

Looked for use of `Math.min(...Math.max(...))` patterns and replaced these.


*Highlighted changes:*
- [Corrected `gaugeseries.overshoot` default]( https://github.com/highcharts/highcharts/pull/12371/files#diff-bd49f49cdcd5914e9964af171150ab9dL296)
- [Merged tooltipPos `!inverted` with `inverted` logic](https://github.com/highcharts/highcharts/pull/12371/files#diff-0b96b3577df835c8a55f8c9e5ff9fed5R501-R519)
- [Merged `!gauge.wrap` and `gauge.overshoot` logic](https://github.com/highcharts/highcharts/pull/12371/files#diff-bd49f49cdcd5914e9964af171150ab9dR435-R441)
- [Merged `Axis.ceiling` and `Axis.floor` with `Axis.softMax` and `Axis.softMin` logic](https://github.com/highcharts/highcharts/pull/12371/files#diff-8186e6de9bdccd41d6fe758e63bc95adR5137-R5155)