### PR TITLE
Tools: Compare visual tests with point of diverge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,10 @@ jobs:
           fi
       - <<: *load_workspace
       - run: sudo apt-get install -y rsync
-      - run: git checkout master && git fetch origin master && git reset --hard origin/master && git log --oneline -5 && npm i && npx gulp scripts
+      - run: > # checkout master at diverge point of current branch and install
+          git checkout master && git fetch origin master && git reset --hard origin/master &&
+          git checkout $(git merge-base master ${CIRCLE_BRANCH}) && git log --oneline -5 &&
+          npm i && npx gulp scripts
       - generate_references_command:
           browsercount: 2
       - run: git checkout ${CIRCLE_BRANCH}  && git log --oneline -5 && npm i && npx gulp scripts


### PR DESCRIPTION
..from master branch.

Currently the comparison is done against the newest version of master. This has the drawback that the comparison will include newer (already merged) changes on master branch. A result of this is that reported differences on the current PR also will report changes that is not "caused by" the current PR.

This fix will remove any such pollution when comparing PR visual results by finding the commit on master that the PR branch diverged from and use that as the base for the comparison.