### PR TITLE
Use removeEvent in drilldown module

### DIFF
--- a/js/modules/drilldown.src.js
+++ b/js/modules/drilldown.src.js
@@ -131,7 +131,7 @@ import '../parts/Chart.js';
 import '../parts/Series.js';
 import '../parts/ColumnSeries.js';
 import '../parts/Tick.js';
-var noop = H.noop, color = H.color, defaultOptions = H.defaultOptions, format = H.format, Chart = H.Chart, seriesTypes = H.seriesTypes, PieSeries = seriesTypes.pie, ColumnSeries = seriesTypes.column, Tick = H.Tick, fireEvent = H.fireEvent, ddSeriesId = 1;
+var addEvent = H.addEvent, noop = H.noop, color = H.color, defaultOptions = H.defaultOptions, format = H.format, Chart = H.Chart, seriesTypes = H.seriesTypes, PieSeries = seriesTypes.pie, ColumnSeries = seriesTypes.column, Tick = H.Tick, fireEvent = H.fireEvent, ddSeriesId = 1;
 // Add language
 extend(defaultOptions.lang, 
 /**
@@ -704,12 +704,12 @@ Chart.prototype.callbacks.push(function () {
     };
 });
 // Don't show the reset button if we already are displaying the drillUp button.
-H.addEvent(Chart, 'beforeShowResetZoom', function () {
+addEvent(Chart, 'beforeShowResetZoom', function () {
     if (this.drillUpButton) {
         return false;
     }
 });
-H.addEvent(Chart, 'render', function () {
+addEvent(Chart, 'render', function () {
     (this.xAxis || []).forEach(function (axis) {
         axis.ddPoints = {};
         axis.series.forEach(function (series) {
@@ -977,32 +977,31 @@ Tick.prototype.drillable = function () {
             if (!label.basicStyles && !styledMode) {
                 label.basicStyles = H.merge(label.styles);
             }
-            label
-                .addClass('highcharts-drilldown-axis-label')
-                .on('click', function (e) {
+            label.addClass('highcharts-drilldown-axis-label');
+            label.removeOnDrillableClick = addEvent(label.element, 'click', function (e) {
                 axis.drilldownCategory(pos, e);
             });
             if (!styledMode) {
                 label.css(axis.chart.options.drilldown.activeAxisLabelStyle);
             }
         }
-        else if (label && label.drillable) {
+        else if (label && label.removeOnDrillableClick) {
             if (!styledMode) {
                 label.styles = {}; // reset for full overwrite of styles
                 label.css(label.basicStyles);
             }
-            label.on('click', null); // #3806
+            label.removeOnDrillableClick(); // #3806
             label.removeClass('highcharts-drilldown-axis-label');
         }
     }
 };
 // On initialization of each point, identify its label and make it clickable.
 // Also, provide a list of points associated to that label.
-H.addEvent(H.Point, 'afterInit', function () {
+addEvent(H.Point, 'afterInit', function () {
     var point = this, series = point.series;
     if (point.drilldown) {
         // Add the click event to the point
-        H.addEvent(point, 'click', function (e) {
+        addEvent(point, 'click', function (e) {
             if (series.xAxis &&
                 series.chart.options.drilldown.allowPointDrilldown ===
                     false) {
@@ -1016,7 +1015,7 @@ H.addEvent(H.Point, 'afterInit', function () {
     }
     return point;
 });
-H.addEvent(H.Series, 'afterDrawDataLabels', function () {
+addEvent(H.Series, 'afterDrawDataLabels', function () {
     var css = this.chart.options.drilldown.activeDataLabelStyle, renderer = this.chart.renderer, styledMode = this.chart.styledMode;
     this.points.forEach(function (point) {
         var dataLabelsOptions = point.options.dataLabels, pointCSS = pick(point.dlOptions, dataLabelsOptions && dataLabelsOptions.style, {});
@@ -1044,7 +1043,7 @@ var applyCursorCSS = function (element, cursor, addClass, styledMode) {
     }
 };
 // Mark the trackers with a pointer
-H.addEvent(H.Series, 'afterDrawTracker', function () {
+addEvent(H.Series, 'afterDrawTracker', function () {
     var styledMode = this.chart.styledMode;
     this.points.forEach(function (point) {
         if (point.drilldown && point.graphic) {
@@ -1052,7 +1051,7 @@ H.addEvent(H.Series, 'afterDrawTracker', function () {
         }
     });
 });
-H.addEvent(H.Point, 'afterSetState', function () {
+addEvent(H.Point, 'afterSetState', function () {
     var styledMode = this.series.chart.styledMode;
     if (this.drilldown && this.series.halo && this.state === 'hover') {
         applyCursorCSS(this.series.halo, 'pointer', true, styledMode);

--- a/samples/unit-tests/drilldown/multi-series/demo.js
+++ b/samples/unit-tests/drilldown/multi-series/demo.js
@@ -1,5 +1,5 @@
 QUnit.test('Drill down on points and categories', function (assert) {
-
+    const { fireEvent } = Highcharts;
     var chart = Highcharts
         .chart('container', {
             chart: {
@@ -121,7 +121,7 @@ QUnit.test('Drill down on points and categories', function (assert) {
     );
 
     // Click first point
-    Highcharts.fireEvent(chart.series[0].points[0], 'click');
+    fireEvent(chart.series[0].points[0], 'click');
     assert.equal(
         chart.series.length,
         1,
@@ -142,7 +142,7 @@ QUnit.test('Drill down on points and categories', function (assert) {
     );
 
     // Click the category
-    chart.xAxis[0].ticks[0].label.element.onclick();
+    fireEvent(chart.xAxis[0].ticks[0].label.element, 'click');
     assert.equal(
         chart.series.length,
         2,

--- a/ts/modules/drilldown.src.ts
+++ b/ts/modules/drilldown.src.ts
@@ -307,7 +307,8 @@ import '../parts/Series.js';
 import '../parts/ColumnSeries.js';
 import '../parts/Tick.js';
 
-var noop = H.noop,
+var addEvent = H.addEvent,
+    noop = H.noop,
     color = H.color,
     defaultOptions = H.defaultOptions,
     format = H.format,
@@ -1024,12 +1025,12 @@ Chart.prototype.callbacks.push(function (): void {
 });
 
 // Don't show the reset button if we already are displaying the drillUp button.
-H.addEvent(Chart, 'beforeShowResetZoom', function (): (boolean|undefined) {
+addEvent(Chart, 'beforeShowResetZoom', function (): (boolean|undefined) {
     if (this.drillUpButton) {
         return false;
     }
 });
-H.addEvent(Chart, 'render', function (): void {
+addEvent(Chart, 'render', function (): void {
     (this.xAxis || []).forEach(function (axis: Highcharts.Axis): void {
         axis.ddPoints = {};
         axis.series.forEach(function (series: Highcharts.Series): void {
@@ -1432,11 +1433,14 @@ Tick.prototype.drillable = function (): void {
                 label.basicStyles = H.merge(label.styles);
             }
 
-            label
-                .addClass('highcharts-drilldown-axis-label')
-                .on('click', function (e: MouseEvent): void {
+            label.addClass('highcharts-drilldown-axis-label');
+            label.removeOnDrillableClick = addEvent(
+                label.element,
+                'click',
+                function (e: MouseEvent): void {
                     axis.drilldownCategory(pos, e);
-                });
+                }
+            );
 
             if (!styledMode) {
                 label.css(
@@ -1444,14 +1448,13 @@ Tick.prototype.drillable = function (): void {
                 );
             }
 
-        } else if (label && label.drillable) {
+        } else if (label && label.removeOnDrillableClick) {
 
             if (!styledMode) {
                 label.styles = {}; // reset for full overwrite of styles
                 label.css(label.basicStyles);
             }
-
-            label.on('click', null as any); // #3806
+            label.removeOnDrillableClick(); // #3806
             label.removeClass('highcharts-drilldown-axis-label');
         }
     }
@@ -1460,14 +1463,14 @@ Tick.prototype.drillable = function (): void {
 
 // On initialization of each point, identify its label and make it clickable.
 // Also, provide a list of points associated to that label.
-H.addEvent(H.Point, 'afterInit', function (): Highcharts.Point {
+addEvent(H.Point, 'afterInit', function (): Highcharts.Point {
     var point = this,
         series = point.series;
 
     if (point.drilldown) {
 
         // Add the click event to the point
-        H.addEvent(point, 'click', function (
+        addEvent(point, 'click', function (
             e: Highcharts.PointerEventObject
         ): void {
             if (
@@ -1487,7 +1490,7 @@ H.addEvent(H.Point, 'afterInit', function (): Highcharts.Point {
     return point;
 });
 
-H.addEvent(H.Series, 'afterDrawDataLabels', function (): void {
+addEvent(H.Series, 'afterDrawDataLabels', function (): void {
     var css = (this.chart.options.drilldown as any).activeDataLabelStyle,
         renderer = this.chart.renderer,
         styledMode = this.chart.styledMode;
@@ -1540,7 +1543,7 @@ var applyCursorCSS = function (
 };
 
 // Mark the trackers with a pointer
-H.addEvent(H.Series, 'afterDrawTracker', function (): void {
+addEvent(H.Series, 'afterDrawTracker', function (): void {
     var styledMode = this.chart.styledMode;
 
     this.points.forEach(function (point: Highcharts.Point): void {
@@ -1551,7 +1554,7 @@ H.addEvent(H.Series, 'afterDrawTracker', function (): void {
 });
 
 
-H.addEvent(H.Point, 'afterSetState', function (): void {
+addEvent(H.Point, 'afterSetState', function (): void {
     var styledMode = this.series.chart.styledMode;
 
     if (this.drilldown && this.series.halo && this.state === 'hover') {


### PR DESCRIPTION
Fixed #12295, `null` was used as event listener in drilldown module, which caused a JavaScript error when called.

---
# Description
Removed the use of `null` as event handler. Also replaced `label.on('click', ...)` with `addEvent`, because I found the returned `removeEvent` handler to be useful.

Had to make a small change afterwards in the unit test `samples/unit-tests/drilldown/multi-series` on how the click event was fired.
# Example(s)
- [Demo of issue](https://jsfiddle.net/BlackLabel/1vuts8qk/) - Click on tick label "Animals", then on "Cats", see JS error in console.
- [Demo of issue with fix applied](https://jsfiddle.net/jon_a_nygaard/g3zfkb57/)

# Related issue(s)
- Closes #12295 