### PR TITLE
Fix regression with axis.grid.cellHeight

### DIFF
--- a/js/parts-gantt/GridAxis.js
+++ b/js/parts-gantt/GridAxis.js
@@ -19,11 +19,7 @@ var addEvent = H.addEvent, argsToArray = function (args) {
     return U.isObject(x, true);
 }, merge = H.merge, wrap = H.wrap, Chart = H.Chart, Axis = H.Axis, Tick = H.Tick;
 var applyGridOptions = function applyGridOptions(axis) {
-    var options = axis.options, gridOptions = options && isObject(options.grid) ? options.grid : {}, 
-    // TODO: Consider using cell margins defined in % of font size?
-    // 25 is optimal height for default fontSize (11px)
-    // 25 / 11 ≈ 2.28
-    fontSizeToCellHeightRatio = 25 / 11, fontSize = options.labels.style.fontSize, fontMetrics = axis.chart.renderer.fontMetrics(fontSize);
+    var options = axis.options;
     // Center-align by default
     if (!options.labels) {
         options.labels = {};
@@ -37,12 +33,6 @@ var applyGridOptions = function applyGridOptions(axis) {
        an "extra" label would appear. */
     if (!axis.categories) {
         options.showLastLabel = false;
-    }
-    // Make tick marks taller, creating cell walls of a grid. Use cellHeight
-    // axis option if set
-    if (axis.horiz) {
-        options.tickLength = gridOptions.cellHeight ||
-            fontMetrics.h * fontSizeToCellHeightRatio;
     }
     // Prevents rotation of labels when squished, as rotating them would not
     // help.
@@ -91,8 +81,10 @@ var applyGridOptions = function applyGridOptions(axis) {
  */
 /**
  * Set cell height for grid axis labels. By default this is calculated from font
- * size.
+ * size. This option only applies to horizontal axes.
  *
+ * @sample gantt/grid-axis/cellheight
+ *         Gant chart with custom cell height
  * @type      {number}
  * @apioption xAxis.grid.cellHeight
  */
@@ -274,13 +266,13 @@ function (e) {
 // Draw vertical axis ticks extra long to create cell floors and roofs.
 // Overrides the tickLength for vertical axes.
 addEvent(Axis, 'afterTickSize', function (e) {
-    var axis = this, dimensions = axis.maxLabelDimensions, options = axis.options, gridOptions = (options && isObject(options.grid)) ? options.grid : {}, labelPadding, distance;
-    if (gridOptions.enabled === true) {
-        labelPadding =
-            (Math.abs(axis.defaultLeftAxisOptions.labels.x) * 2);
-        distance = labelPadding + (axis.horiz ?
-            dimensions.height :
-            dimensions.width);
+    var _a = this, defaultLeftAxisOptions = _a.defaultLeftAxisOptions, horiz = _a.horiz, _b = _a.options.grid, gridOptions = _b === void 0 ? {} : _b;
+    var dimensions = this.maxLabelDimensions;
+    if (gridOptions.enabled) {
+        var labelPadding = (Math.abs(defaultLeftAxisOptions.labels.x) * 2);
+        var distance = horiz ?
+            gridOptions.cellHeight || labelPadding + dimensions.height :
+            labelPadding + dimensions.width;
         if (isArray(e.tickSize)) {
             e.tickSize[0] = distance;
         }

--- a/samples/gantt/grid-axis/cellheight/demo.css
+++ b/samples/gantt/grid-axis/cellheight/demo.css
@@ -1,0 +1,4 @@
+#container {
+    max-width: 800px;
+    margin: 1em auto;
+}

--- a/samples/gantt/grid-axis/cellheight/demo.details
+++ b/samples/gantt/grid-axis/cellheight/demo.details
@@ -1,0 +1,8 @@
+---
+name: Gantt Chart with custom cell height
+js_wrap: b
+authors:
+  - Jon Arild Nygård
+tags: []
+categories: []
+...

--- a/samples/gantt/grid-axis/cellheight/demo.html
+++ b/samples/gantt/grid-axis/cellheight/demo.html
@@ -1,0 +1,3 @@
+<script src="https://code.highcharts.com/gantt/highcharts-gantt.js"></script>
+
+<div id="container"></div>

--- a/samples/gantt/grid-axis/cellheight/demo.js
+++ b/samples/gantt/grid-axis/cellheight/demo.js
@@ -1,0 +1,44 @@
+Highcharts.ganttChart('container', {
+    title: {
+        text: 'Gantt chart with custom cell height'
+    },
+    xAxis: [{
+        min: Date.UTC(2014, 10, 17),
+        max: Date.UTC(2014, 10, 30),
+        // Set the first axis to have a height of 30px
+        grid: {
+            cellHeight: 30
+        }
+    }, {
+        // Set the second axis to have a height of 60px
+        grid: {
+            cellHeight: 60
+        }
+    }],
+
+    series: [{
+        name: 'Project 1',
+        data: [{
+            name: 'Start prototype',
+            start: Date.UTC(2014, 10, 18),
+            end: Date.UTC(2014, 10, 25),
+            completed: 0.25
+        }, {
+            name: 'Test prototype',
+            start: Date.UTC(2014, 10, 27),
+            end: Date.UTC(2014, 10, 29)
+        }, {
+            name: 'Develop',
+            start: Date.UTC(2014, 10, 20),
+            end: Date.UTC(2014, 10, 25),
+            completed: {
+                amount: 0.12,
+                fill: '#fa0'
+            }
+        }, {
+            name: 'Run acceptance tests',
+            start: Date.UTC(2014, 10, 23),
+            end: Date.UTC(2014, 10, 26)
+        }]
+    }]
+});

--- a/ts/parts-gantt/GridAxis.ts
+++ b/ts/parts-gantt/GridAxis.ts
@@ -53,7 +53,7 @@ var addEvent = H.addEvent,
         return Array.prototype.slice.call(args, 1);
     },
     dateFormat = H.dateFormat,
-    isObject = function (x: unknown): boolean {
+    isObject = function (x: unknown): x is object {
         // Always use strict mode
         return U.isObject(x, true);
     },
@@ -64,14 +64,7 @@ var addEvent = H.addEvent,
     Tick = H.Tick;
 
 var applyGridOptions = function applyGridOptions(axis: Highcharts.Axis): void {
-    var options = axis.options,
-        gridOptions = options && isObject(options.grid) ? options.grid : {},
-        // TODO: Consider using cell margins defined in % of font size?
-        // 25 is optimal height for default fontSize (11px)
-        // 25 / 11 ≈ 2.28
-        fontSizeToCellHeightRatio = 25 / 11,
-        fontSize = (options.labels as any).style.fontSize,
-        fontMetrics = axis.chart.renderer.fontMetrics(fontSize);
+    var options = axis.options;
 
     // Center-align by default
     if (!options.labels) {
@@ -88,13 +81,6 @@ var applyGridOptions = function applyGridOptions(axis: Highcharts.Axis): void {
        an "extra" label would appear. */
     if (!axis.categories) {
         options.showLastLabel = false;
-    }
-
-    // Make tick marks taller, creating cell walls of a grid. Use cellHeight
-    // axis option if set
-    if (axis.horiz) {
-        options.tickLength = (gridOptions as any).cellHeight ||
-                fontMetrics.h * fontSizeToCellHeightRatio;
     }
 
     // Prevents rotation of labels when squished, as rotating them would not
@@ -150,8 +136,10 @@ var applyGridOptions = function applyGridOptions(axis: Highcharts.Axis): void {
 
 /**
  * Set cell height for grid axis labels. By default this is calculated from font
- * size.
+ * size. This option only applies to horizontal axes.
  *
+ * @sample gantt/grid-axis/cellheight
+ *         Gant chart with custom cell height
  * @type      {number}
  * @apioption xAxis.grid.cellHeight
  */
@@ -426,23 +414,21 @@ addEvent(Axis, 'afterTickSize', function (
         tickSize?: Array<number>;
     }
 ): void {
-    var axis = this,
-        dimensions = axis.maxLabelDimensions,
-        options = axis.options,
-        gridOptions: Highcharts.XAxisGridOptions =
-            (options && isObject(options.grid)) ? (options.grid as any) : {},
-        labelPadding,
-        distance;
+    const {
+        defaultLeftAxisOptions,
+        horiz,
+        options: {
+            grid: gridOptions = {}
+        }
+    } = this;
+    const dimensions: Highcharts.SizeObject = this.maxLabelDimensions as any;
 
-    if (gridOptions.enabled === true) {
-        labelPadding =
-            (Math.abs((axis.defaultLeftAxisOptions.labels as any).x) * 2);
-        distance = labelPadding + (
-            axis.horiz ?
-                (dimensions as any).height :
-                (dimensions as any).width
-        );
-
+    if (gridOptions.enabled) {
+        const labelPadding =
+            (Math.abs((defaultLeftAxisOptions.labels as any).x) * 2);
+        const distance = horiz ?
+            gridOptions.cellHeight || labelPadding + dimensions.height :
+            labelPadding + dimensions.width;
         if (isArray(e.tickSize)) {
             e.tickSize[0] = distance;
         } else {


### PR DESCRIPTION
Fixed #10324, regression with `xAxis.grid.cellHeight`.

---
# Description
- Added logic to use `grid.cellHeight` as `tickLength`, if defined.
- Added sample `gantt/grid-axis/cellheight` to use in API
- Modified the API description of `grid.cellHeight`
- Mentioned sample will also serve as visual test to avoid new regressions

# Example(s)
- [Demo of issue](https://jsfiddle.net/BlackLabel/vxj4Lshe/)
- [Demo of issue with fix applied](https://jsfiddle.net/jon_a_nygaard/3vk2qzmc/)

# Related issue(s)
- Closes #10324 