### PR TITLE
Fixed #12374, sankey nodes rearranged after redraw when specifying level

### DIFF
--- a/js/mixins/nodes.js
+++ b/js/mixins/nodes.js
@@ -102,7 +102,7 @@ H.NodesMixin = {
         this.nodes.forEach(function (node) {
             node.linksFrom.length = 0;
             node.linksTo.length = 0;
-            node.level = void 0;
+            node.level = node.options.level;
         });
         // Create the node list and set up links
         this.points.forEach(function (point) {

--- a/samples/unit-tests/series-sankey/sankey/demo.js
+++ b/samples/unit-tests/series-sankey/sankey/demo.js
@@ -539,3 +539,72 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test(
+    'Sankey and node.level option',
+    assert => {
+        const chart = Highcharts.chart('container', {
+
+            title: {
+                text: 'Highcharts Sankey Diagram'
+            },
+            series: [{
+                keys: ['from', 'to', 'weight', 'color'],
+                data: [
+                    ["Primary Oil", "Oil Refineries", 34762592],
+                    ["Oil Refineries", "Oil: Supplied", 34549489],
+                    ["Coal", "Coal: Supplied", 13741144]
+                ],
+                type: 'sankey',
+                nodes: [{
+                    id: 'Oil: Supplied',
+                    level: 2,
+                    color: '#121212'
+                },
+                {
+                    id: 'Coal: Supplied',
+                    level: 2,
+                    color: '#E59400'
+                },
+                {
+                    id: 'Oil Refineries',
+                    level: 1,
+                    color: '#121212'
+                },
+                {
+                    id: 'Primary Oil',
+                    level: 0,
+                    color: '#121212'
+                }],
+                name: 'Sankey demo series'
+            }]
+        });
+
+        assert.deepEqual(
+            chart.series[0].nodes.map(n => n.name),
+            [
+                "Primary Oil",
+                "Coal",
+                "Oil Refineries",
+                "Oil: Supplied",
+                "Coal: Supplied"
+            ],
+            'The level option should apply initially'
+        );
+
+        // Trigger redraw
+        chart.setSize(undefined, 401);
+
+        assert.deepEqual(
+            chart.series[0].nodes.map(n => n.name),
+            [
+                "Primary Oil",
+                "Coal",
+                "Oil Refineries",
+                "Oil: Supplied",
+                "Coal: Supplied"
+            ],
+            'The level option should apply after redraw (#12374)'
+        );
+    }
+);

--- a/ts/mixins/nodes.ts
+++ b/ts/mixins/nodes.ts
@@ -33,6 +33,7 @@ declare global {
         }
         interface NodesPointOptions extends PointOptionsObject {
             id?: string;
+            level?: number;
             mass?: number;
             outgoing?: boolean;
             weight?: (number|null);
@@ -220,7 +221,7 @@ H.NodesMixin = {
         this.nodes.forEach(function (node: Highcharts.NodesPoint): void {
             node.linksFrom.length = 0;
             node.linksTo.length = 0;
-            node.level = void 0;
+            node.level = node.options.level;
         });
 
         // Create the node list and set up links


### PR DESCRIPTION
Fixed #12374, sankey nodes were rearranged after redraw where the `nodes.level` option was used.