### PR TITLE
Added getLevelFromAndTo in sunburst

### DIFF
--- a/js/modules/sunburst.src.js
+++ b/js/modules/sunburst.src.js
@@ -282,6 +282,13 @@ var getDrillId = function getDrillId(point, idRoot, mapIdToNode) {
     }
     return drillId;
 };
+var getLevelFromAndTo = function getLevelFromAndTo(_a) {
+    var level = _a.level, height = _a.height;
+    //  Never displays level below 1
+    var from = level > 0 ? level : 1;
+    var to = level + height;
+    return { from: from, to: to };
+};
 var cbSetTreeValuesBefore = function before(node, options) {
     var mapIdToNode = options.mapIdToNode, nodeParent = mapIdToNode[node.parent], series = options.series, chart = series.chart, points = series.points, point = points[node.i], colors = (series.options.colors || chart && chart.options.colors), colorInfo = getColor(node, {
         colors: colors,
@@ -678,10 +685,11 @@ var sunburstSeries = {
         nodeRoot = mapIdToNode[rootId];
         idTop = isString(nodeRoot.parent) ? nodeRoot.parent : '';
         nodeTop = mapIdToNode[idTop];
+        var _a = getLevelFromAndTo(nodeRoot), from = _a.from, to = _a.to;
         mapOptionsToLevel = getLevelOptions({
-            from: nodeRoot.level > 0 ? nodeRoot.level : 1,
+            from: from,
             levels: series.options.levels,
-            to: tree.height,
+            to: to,
             defaults: {
                 colorByPoint: options.colorByPoint,
                 dataLabels: options.dataLabels,
@@ -694,8 +702,8 @@ var sunburstSeries = {
         // getLevelOptions
         mapOptionsToLevel = calculateLevelSizes(mapOptionsToLevel, {
             diffRadius: diffRadius,
-            from: nodeRoot.level > 0 ? nodeRoot.level : 1,
-            to: tree.height
+            from: from,
+            to: to
         });
         // TODO Try to combine setTreeValues & setColorRecursive to avoid
         //  unnecessary looping.
@@ -766,6 +774,7 @@ var sunburstSeries = {
     },
     utils: {
         calculateLevelSizes: calculateLevelSizes,
+        getLevelFromAndTo: getLevelFromAndTo,
         range: range
     }
 };

--- a/samples/unit-tests/series-sunburst/members/demo.js
+++ b/samples/unit-tests/series-sunburst/members/demo.js
@@ -107,6 +107,27 @@ QUnit.test('utils.calculateLevelSizes', function (assert) {
     );
 });
 
+QUnit.test('utils.getLevelFromAndTo', function (assert) {
+    const {
+        getLevelFromAndTo
+    } = Highcharts.seriesTypes.sunburst.prototype.utils;
+    assert.deepEqual(
+        getLevelFromAndTo({ level: 0, height: 3 }),
+        { from: 1, to: 3 },
+        'should display levels from 1 to 3 when node is on level 0 and has the height of 3. Should never display level 0'
+    );
+    assert.deepEqual(
+        getLevelFromAndTo({ level: 1, height: 2 }),
+        { from: 1, to: 3 },
+        'should display levels from 1 to 3 when node is on level 1 and has the height of 2'
+    );
+    assert.deepEqual(
+        getLevelFromAndTo({ level: 4, height: 10 }),
+        { from: 4, to: 14 },
+        'should display levels from 4 to 14 when node is on level 4 and has the height of 10'
+    );
+});
+
 QUnit.test('utils.range', function (assert) {
     var sunburstPrototype = Highcharts.seriesTypes.sunburst.prototype,
         range = sunburstPrototype.utils.range;

--- a/ts/modules/sunburst.src.ts
+++ b/ts/modules/sunburst.src.ts
@@ -566,6 +566,15 @@ var getDrillId = function getDrillId(
     return drillId;
 };
 
+const getLevelFromAndTo = function getLevelFromAndTo(
+    { level, height }: Highcharts.SunburstNodeObject
+): { from: number; to: number } {
+    //  Never displays level below 1
+    const from = level > 0 ? level : 1;
+    const to = level + height;
+    return { from, to };
+};
+
 var cbSetTreeValuesBefore = function before(
     node: Highcharts.SunburstNodeObject,
     options: Highcharts.SunburstNodeValuesObject
@@ -1101,10 +1110,11 @@ var sunburstSeries = {
         nodeRoot = mapIdToNode[rootId];
         idTop = isString(nodeRoot.parent) ? nodeRoot.parent : '';
         nodeTop = mapIdToNode[idTop];
+        const { from, to } = getLevelFromAndTo(nodeRoot);
         mapOptionsToLevel = getLevelOptions<Highcharts.SunburstSeries>({
-            from: nodeRoot.level > 0 ? nodeRoot.level : 1,
+            from,
             levels: series.options.levels,
-            to: tree.height,
+            to,
             defaults: {
                 colorByPoint: options.colorByPoint,
                 dataLabels: options.dataLabels,
@@ -1116,9 +1126,9 @@ var sunburstSeries = {
         // NOTE consider doing calculateLevelSizes in a callback to
         // getLevelOptions
         mapOptionsToLevel = calculateLevelSizes(mapOptionsToLevel, {
-            diffRadius: diffRadius,
-            from: nodeRoot.level > 0 ? nodeRoot.level : 1,
-            to: tree.height
+            diffRadius,
+            from,
+            to
         }) as any;
         // TODO Try to combine setTreeValues & setColorRecursive to avoid
         //  unnecessary looping.
@@ -1200,8 +1210,9 @@ var sunburstSeries = {
         }
     },
     utils: {
-        calculateLevelSizes: calculateLevelSizes,
-        range: range
+        calculateLevelSizes,
+        getLevelFromAndTo,
+        range
     } as any
 };
 


### PR DESCRIPTION
Fixed #12262, Sunburst did not use 100% of the plot area.

---
- Added a function getLevelFromAndTo, to calculate correct display levels.
- Added a unit test for the same function.
- Closes #12262 