### PR TITLE
Tools: Changes to reflect migration of visual test data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,11 +147,11 @@ jobs:
       - run: "mkdir -p /home/circleci/repo/tmp/latest/"
       - aws-s3/sync:
           from: "/home/circleci/repo/tmp/latest/"
-          to: 's3://${HIGHCHARTS_S3_BUCKET}/test/visualtests/reference/latest/' # delete existing latest references in S3 location
+          to: 's3://${HIGHCHARTS_VISUAL_TESTS_BUCKET}/visualtests/reference/latest/' # delete existing latest references in S3 location
           overwrite: true
       - run:
           name: "Upload test results"
-          command: "npx gulp dist-testresults --tag ${CIRCLE_TAG} --bucket ${HIGHCHARTS_S3_BUCKET}"
+          command: "npx gulp dist-testresults --tag ${CIRCLE_TAG} --bucket ${HIGHCHARTS_VISUAL_TESTS_BUCKET}"
           when: always
       - <<: *persist_workspace
 
@@ -194,7 +194,7 @@ jobs:
       - run: npx karma start test/karma-conf.js --tests maps/*/* --single-run --browsercount 2 --visualcompare || true
       - run: npx karma start test/karma-conf.js --tests gantt/*/* --single-run --browsercount 2 --visualcompare || true
       - run:
-          name: Comment on PR
+          name: Comment on PR and upload visual test images if any produced
           command: echo ${CIRCLE_PULL_REQUEST##*/} | xargs -I{} npx gulp update-pr-testresults --fail-silently --user circleci-mu --pr {}
           when: always
       - run:
@@ -223,14 +223,14 @@ jobs:
           command: echo "export HIGHCHARTS_VERSION=$(node -p "require('./package.json').version")" >> $BASH_ENV
       - generate_references_command
       - aws-s3/sync: # overwrite with remote reference images before uploading any new ones
-          from: "s3://${HIGHCHARTS_S3_BUCKET}/test/visualtests/reference/latest/"
+          from: "s3://${HIGHCHARTS_VISUAL_TESTS_BUCKET}/visualtests/reference/latest/"
           to: "samples/"
           arguments: |
             --exclude "*" \
             --include "*/reference.svg"
       - run:
           name: "Upload old and any new reference images"
-          command: "npx gulp dist-testresults --tag ${HIGHCHARTS_VERSION} --bucket ${HIGHCHARTS_S3_BUCKET}"
+          command: "npx gulp dist-testresults --tag ${HIGHCHARTS_VERSION} --bucket ${HIGHCHARTS_VISUAL_TESTS_BUCKET}"
       - run:
           # run tests in sequence due to all writing to the same file
           name: "Highcharts visual tests"
@@ -264,7 +264,7 @@ jobs:
             find . -name reference.png -print -execdir npx pixelmatch candidate.png reference.png diff.png 0 \;
       - run:
           name: "Upload visual test candidates and diff assets"
-          command: "npx gulp dist-testresults --bucket ${HIGHCHARTS_S3_BUCKET}"
+          command: "npx gulp dist-testresults --bucket ${HIGHCHARTS_VISUAL_TESTS_BUCKET}"
           when: always
 
   build_dist:

--- a/samples/highcharts/3d/bar/demo.js
+++ b/samples/highcharts/3d/bar/demo.js
@@ -24,7 +24,7 @@ Highcharts.chart('container', {
     },
     series: [{
         data: [
-            ['Birchh', 34],
+            ['Birch', 34],
             ['Oak', 20],
             ['Pine', 44],
             ['Elm', 12],

--- a/samples/highcharts/3d/bar/demo.js
+++ b/samples/highcharts/3d/bar/demo.js
@@ -24,7 +24,7 @@ Highcharts.chart('container', {
     },
     series: [{
         data: [
-            ['Birch', 34],
+            ['Birchh', 34],
             ['Oak', 20],
             ['Pine', 44],
             ['Elm', 12],

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -565,7 +565,7 @@ function compareToReference(chart, path) { // eslint-disable-line no-unused-vars
         // Handle reference, load SVG from bucket or file
         var url = 'base/samples/' + path + '/reference.svg';
         if (remotelocation) {
-            url = 'http://' + remotelocation + '.s3.eu-central-1.amazonaws.com/test/visualtests/reference/latest/' + path + '/reference.svg';
+            url = 'http://' + remotelocation + '.s3.eu-central-1.amazonaws.com/visualtests/reference/latest/' + path + '/reference.svg';
         }
         xhrLoad(url, function onXHRDone(xhr) {
             if (xhr.status == 200) {

--- a/tools/gulptasks/dist-testresults.js
+++ b/tools/gulptasks/dist-testresults.js
@@ -10,7 +10,8 @@ const SAMPLES_SRC_DIR = 'samples/**';
 const DESTINATION_DIR = 'test/visualtests';
 
 /**
- * Upload visual test results and assets to S3.
+ * Upload baseline/reference images and
+ * visual test results and assets to S3.
  *
  * @return {Promise<*> | Promise | Promise} Promise to keep
  */
@@ -27,13 +28,14 @@ function uploadVisualTestResults() {
     }
 
     if (argv.tag || argv.saveresetdate) {
+        // upload of baseline a.k.a reference images
         const latestReferenceImages = glob.sync(`${SAMPLES_SRC_DIR}/reference.svg`).map(file => ({
             from: file,
             to: `${DESTINATION_DIR}/reference/latest/${[...file.split('/')].slice(1).join('/')}`
         }));
 
         if (!argv.saveresetdate) {
-            // upload reference images to folder named after tag
+            // upload baseline reference images to folder named after tag
             const referenceImages = glob.sync(`${SAMPLES_SRC_DIR}/reference.svg`).map(file => ({
                 from: file,
                 to: `${DESTINATION_DIR}/reference/${argv.tag}/${[...file.split('/')].slice(1).join('/')}`
@@ -53,7 +55,7 @@ function uploadVisualTestResults() {
         const latestReferences = Object.assign({}, defaultParams, { files: [...latestReferenceImages], name: 'Reference SVGs' });
         promises.push(uploadFiles(latestReferences));
     } else {
-        // upload to latest/ folder + date folder
+        // upload of nightly snapshots a.k.a candidates to latest/ folder + date folder
         const resultsJson = glob.sync('test/visual-test-results.json').map(file => ({
             from: file,
             to: `${DESTINATION_DIR}/diffs/latest/${[...file.split('/')].pop()}`

--- a/tools/gulptasks/dist-testresults.js
+++ b/tools/gulptasks/dist-testresults.js
@@ -7,7 +7,8 @@ const glob = require('glob');
 const { uploadFiles } = require('./lib/uploadS3');
 
 const SAMPLES_SRC_DIR = 'samples/**';
-const DESTINATION_DIR = 'test/visualtests';
+const DESTINATION_DIR = 'visualtests';
+const NIGHTLY_DIFF_DEST_DIR = `${DESTINATION_DIR}/diffs/nightly`;
 
 /**
  * Upload baseline/reference images and
@@ -58,22 +59,22 @@ function uploadVisualTestResults() {
         // upload of nightly snapshots a.k.a candidates to latest/ folder + date folder
         const resultsJson = glob.sync('test/visual-test-results.json').map(file => ({
             from: file,
-            to: `${DESTINATION_DIR}/diffs/latest/${[...file.split('/')].pop()}`
+            to: `${NIGHTLY_DIFF_DEST_DIR}/latest/${[...file.split('/')].pop()}`
         }));
 
         const resultImageFilesLatest = glob.sync(`${SAMPLES_SRC_DIR}/*+(candidate.svg|diff.png)`).map(file => ({
             from: file,
-            to: `${DESTINATION_DIR}/diffs/latest/${[...file.split('/')].slice(1).join('/')}`
+            to: `${NIGHTLY_DIFF_DEST_DIR}/latest/${[...file.split('/')].slice(1).join('/')}`
         }));
 
         const resultsJsonVersionedDestination = glob.sync('test/visual-test-results.json').map(file => ({
             from: file,
-            to: `${DESTINATION_DIR}/diffs/${dateString}/${[...file.split('/')].pop()}`
+            to: `${NIGHTLY_DIFF_DEST_DIR}/${dateString}/${[...file.split('/')].pop()}`
         }));
 
         const resultImageFiles = glob.sync(`${SAMPLES_SRC_DIR}/*+(candidate.svg|diff.png)`).map(file => ({
             from: file,
-            to: `${DESTINATION_DIR}/diffs/${dateString}/${[...file.split('/')].slice(1).join('/')}`
+            to: `${NIGHTLY_DIFF_DEST_DIR}/${dateString}/${[...file.split('/')].slice(1).join('/')}`
         }));
 
         const resultsUploadConfig = Object.assign({}, defaultParams, { files: [...resultsJson, ...resultsJsonVersionedDestination], name: 'visual-test-results.json' });

--- a/tools/gulptasks/update-pr-testresults.js
+++ b/tools/gulptasks/update-pr-testresults.js
@@ -10,6 +10,7 @@ const argv = require('yargs').argv;
 const { getFilesChanged } = require('./lib/git');
 const { uploadFiles } = require('./lib/uploadS3');
 
+const DEFAULT_PR_ASSET_S3_BASEPATH = 'visualtests/diffs/pullrequests';
 const DEFAULT_COMMENT_MATCH = '## Visual test results';
 const DEFAULT_OPTIONS = {
     method: 'GET',
@@ -197,7 +198,7 @@ function createTemplateForChangeSamples() {
 
 /* eslint-disable require-jsdoc */
 function buildImgS3Path(filename, sample, pr) {
-    return `highcharts/pr-diffs/${pr}/${sample}/${filename}`;
+    return `${DEFAULT_PR_ASSET_S3_BASEPATH}/${pr}/${sample}/${filename}`;
 }
 
 function buildImgURL(filename, sample, pr) {
@@ -211,8 +212,8 @@ function buildImgMarkdownLinks(sample, pr) {
 /* eslint-enable require-jsdoc */
 
 /**
- * Using a list of diffing samples (visual test differences) this
- * function uploads the reference/candidate/diff images that are produced
+ * Based on a list of diffing samples (that contain visual test differences compared to a baseline/reference)
+ * this function uploads the reference/candidate/diff images + JSON report that are produced
  * from a visual test run to S3 in order to make them easily available.
  * @param {Array} diffingSamples list
  * @param {string} pr number to upload for
@@ -235,6 +236,11 @@ function uploadVisualTestDiffImages(diffingSamples = [], pr) {
             });
             return resultingFiles;
         }, []);
+
+        files.push({
+            from: 'test/visual-test-results.json',
+            to: `${DEFAULT_PR_ASSET_S3_BASEPATH}/${pr}/visual-test-results.json`
+        });
 
         uploadFiles({ files, bucket: PR_IMAGEDIFF_BUCKET, name: `image diff on PR #${pr}` })
             .catch(err => logLib.warn('Failed to upload PR diff images. Reason ' + err));

--- a/tools/gulptasks/update-pr-testresults.js
+++ b/tools/gulptasks/update-pr-testresults.js
@@ -22,7 +22,7 @@ const DEFAULT_OPTIONS = {
     }
 };
 
-const PR_IMAGEDIFF_BUCKET = process.env.HIGHCHARTS_PR_IMAGEDIFF_BUCKET || 'staging-vis-dev.highcharts.com';
+const VISUAL_TESTS_BUCKET = process.env.HIGHCHARTS_VISUAL_TESTS_BUCKET || 'staging-vis-dev.highcharts.com';
 
 /**
  * Executes a request with the specified options
@@ -202,7 +202,7 @@ function buildImgS3Path(filename, sample, pr) {
 }
 
 function buildImgURL(filename, sample, pr) {
-    return `http://${PR_IMAGEDIFF_BUCKET}.s3.eu-central-1.amazonaws.com/${buildImgS3Path(filename, sample, pr)}`;
+    return `http://${VISUAL_TESTS_BUCKET}.s3.eu-central-1.amazonaws.com/${buildImgS3Path(filename, sample, pr)}`;
 }
 
 function buildImgMarkdownLinks(sample, pr) {
@@ -242,7 +242,7 @@ function uploadVisualTestDiffImages(diffingSamples = [], pr) {
             to: `${DEFAULT_PR_ASSET_S3_BASEPATH}/${pr}/visual-test-results.json`
         });
 
-        uploadFiles({ files, bucket: PR_IMAGEDIFF_BUCKET, name: `image diff on PR #${pr}` })
+        uploadFiles({ files, bucket: VISUAL_TESTS_BUCKET, name: `image diff on PR #${pr}` })
             .catch(err => logLib.warn('Failed to upload PR diff images. Reason ' + err));
     }
 }
@@ -315,7 +315,7 @@ commentOnPR.description = 'Comments any diff from test/visual-test-results.json'
 commentOnPR.flags = {
     '--pr': 'Pull request number',
     '--user': 'Github user',
-    '--token': 'Github token (can also be specified with GITHUB_TOKEN env var.',
+    '--token': 'Github token (can also be specified with GITHUB_TOKEN env var)',
     '--contains-text': 'Filter text used to find PR comment to overwrite',
     '--always-add': 'If present any old test results comment won\'t be deleted',
     '--fail-silently': 'Will always return exitCode 0 (success)'


### PR DESCRIPTION
Changed paths when storing visual test results and references to align them better with the PR diff data.

This is done in order to simplify the way the visual test data is stored to that it can be more easily used from the review tool.

Closes #12402, #12407 

