### PR TITLE
Tools: Force checkout branch for visual comparison

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,8 +182,8 @@ jobs:
       - <<: *load_workspace
       - run: sudo apt-get install -y rsync
       - run: > # checkout master at diverge point of current branch and install
-          git checkout master && git fetch origin master && git reset --hard origin/master &&
-          git checkout $(git merge-base master ${CIRCLE_BRANCH}) && git log --oneline -5 &&
+          git checkout -f master && git fetch origin master && git reset --hard origin/master &&
+          git checkout -f $(git merge-base master ${CIRCLE_BRANCH}) && git log --oneline -5 &&
           npm i && npx gulp scripts
       - generate_references_command:
           browsercount: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
           npm i && npx gulp scripts
       - generate_references_command:
           browsercount: 2
-      - run: git checkout ${CIRCLE_BRANCH}  && git log --oneline -5 && npm i && npx gulp scripts
+      - run: git checkout -f ${CIRCLE_BRANCH}  && git log --oneline -5 && npm i && npx gulp scripts
       # we are forcing success on the below test runs to avoid failing the PR build
       - run: npx karma start test/karma-conf.js --tests highcharts/*/* --single-run --browsercount 2 --visualcompare || true
       - run: npx karma start test/karma-conf.js --tests stock/*/* --single-run --browsercount 2 --visualcompare || true


### PR DESCRIPTION
To make sure visual test comparison runs even if checking someone has forgot to check in something  (with reference to ts compiled js files)

@TorsteinHonsi  Merging this could potentially make the CI not uncover these non-commited files unless their inner workings has changed someway that it would be caught by a test instead. So if you don't want to merge this it is totally fine, but ideally we should write a different test/pre-commit check in a more sensible place that would uncover such errors. 

We could also implement a check on CI in the initial step that exits with an error code if there are found any uncommited js files after running `gulp scripts`.