### PR TITLE
Add gulp task dist-api

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,6 +27,7 @@ Gulp.registry(new GulpForwardReference());
     'common-webpack',
     'dist',
     'dist-ant',
+    'dist-api',
     'dist-upload',
     'dist-testresults',
     'dist-clean',

--- a/tools/gulptasks/dist-api.js
+++ b/tools/gulptasks/dist-api.js
@@ -1,45 +1,92 @@
 // Libraries sorted by require path
-const { existsSync } = require('fs');
+const fs = require('fs');
 const gulp = require('gulp');
 const zip = require('gulp-zip');
+const { promisify } = require('util');
 const build = require('./lib/build');
 const log = require('./lib/log');
 
+/* Promisify utility functions. NOTE: When configured Node.js version is
+>=11.14.0, switch to require().promises. */
+const copyFile = promisify(fs.copyFile);
+const { existsSync } = fs;
+
+// Constants
+const DIST_BUILD = 'build';
 const DIST_DIR = 'build/dist';
-const API_DIR = 'build/api';
+const DIR_API = 'build/api';
+const DIR_LIB = 'tools/gulptasks/lib/api';
 
 /**
- * Creates zip file for the api.
+ * Copy lib files to api directory.
  *
- * @return {Promise<*> | Promise | Promise} Promise to keep
+ * @return {Promise<void>} Returns a promise that resolves when the copy is
+ * completed.
  */
-function apiZip() {
-    const properties = build.getBuildProperties();
-    const DIR_CLASS_REFERENCE = `${API_DIR}/class-reference`;
+function copyLibFiles() {
+    const promises = ['server.js', 'README.md'].map(
+        filename => copyFile(`${DIR_LIB}/${filename}`, `${DIR_API}/${filename}`)
+    );
+    return Promise.all(promises);
+}
+
+/**
+ * Creates a zip archive for a single product API.
+ *
+ * @param {string} product The product folder name.
+ * @return {Promise<void>} Returns a Promise that resolves when the zip archive
+ * is built.
+ */
+function zipProductAPI(product) {
+    const DIR_CLASS_REFERENCE = `${DIR_API}/class-reference`;
+
+    const DIR_PRODUCT = `${DIR_API}/${product}`;
+    if (!existsSync(DIR_PRODUCT)) {
+        return Promise.reject(new Error(`Missing folder: ${DIR_PRODUCT}. Has the other dist tasks been run in advance?`));
+    }
+
+    const zipFileName = `${product}/api.zip`;
+    log.message(`Zipping file ${zipFileName}`);
+
+    return new Promise((resolve, reject) => {
+        gulp.src([
+            `${DIR_PRODUCT}/**`,
+            `${DIR_CLASS_REFERENCE}/**`,
+            `${DIR_API}/server.js`,
+            `${DIR_API}/README.md`
+        ], { base: DIST_BUILD })
+            .pipe(zip(zipFileName))
+            .pipe(gulp.dest(DIST_DIR))
+            .on('error', reject)
+            .on('end', resolve);
+    });
+}
+
+/**
+ * Creates zip archives for all the product API's.
+ *
+ * @return {Promise<void>} Returns a Promise that resolves when all the zip
+ * archives is built.
+ */
+function createProductsAPIArchives() {
+
+    // Check if the class references exists
+    const DIR_CLASS_REFERENCE = `${DIR_API}/class-reference`;
     if (!existsSync(DIR_CLASS_REFERENCE)) {
         return Promise.reject(new Error(`Missing folder: ${DIR_CLASS_REFERENCE}. Has the other dist tasks been run in advance?`));
     }
-    const zipTasks = Object.keys(properties).map(key => {
-        const DIR_PRODUCT = `${API_DIR}/${key}`;
-        if (!existsSync(DIR_PRODUCT)) {
-            return Promise.reject(new Error(`Missing folder: ${DIR_PRODUCT}. Has the other dist tasks been run in advance?`));
-        }
 
-        const zipFileName = `${key}/api.zip`;
-        log.message(`Zipping file ${zipFileName}`);
-
-        return new Promise((resolve, reject) => {
-            gulp.src([`${DIR_PRODUCT}/**`, `${DIR_CLASS_REFERENCE}/**`], {
-                base: API_DIR
-            })
-                .pipe(zip(zipFileName))
-                .pipe(gulp.dest(DIST_DIR))
-                .on('error', reject)
-                .on('end', resolve);
-        });
+    // Copy lib files, then zip all product api archives
+    return copyLibFiles().then(() => {
+        const properties = build.getBuildProperties();
+        const zipTasks = Object.keys(properties).map(zipProductAPI);
+        return Promise.all(zipTasks);
     });
-    return Promise.all(zipTasks);
 }
 
 
-gulp.task('dist-api', apiZip);
+require('./jsdoc');
+gulp.task('dist-api', gulp.series(
+    'jsdoc',
+    createProductsAPIArchives
+));

--- a/tools/gulptasks/dist-api.js
+++ b/tools/gulptasks/dist-api.js
@@ -1,0 +1,45 @@
+// Libraries sorted by require path
+const { existsSync } = require('fs');
+const gulp = require('gulp');
+const zip = require('gulp-zip');
+const build = require('./lib/build');
+const log = require('./lib/log');
+
+const DIST_DIR = 'build/dist';
+const API_DIR = 'build/api';
+
+/**
+ * Creates zip file for the api.
+ *
+ * @return {Promise<*> | Promise | Promise} Promise to keep
+ */
+function apiZip() {
+    const properties = build.getBuildProperties();
+    const DIR_CLASS_REFERENCE = `${API_DIR}/class-reference`;
+    if (!existsSync(DIR_CLASS_REFERENCE)) {
+        return Promise.reject(new Error(`Missing folder: ${DIR_CLASS_REFERENCE}. Has the other dist tasks been run in advance?`));
+    }
+    const zipTasks = Object.keys(properties).map(key => {
+        const DIR_PRODUCT = `${API_DIR}/${key}`;
+        if (!existsSync(DIR_PRODUCT)) {
+            return Promise.reject(new Error(`Missing folder: ${DIR_PRODUCT}. Has the other dist tasks been run in advance?`));
+        }
+
+        const zipFileName = `${key}/api.zip`;
+        log.message(`Zipping file ${zipFileName}`);
+
+        return new Promise((resolve, reject) => {
+            gulp.src([`${DIR_PRODUCT}/**`, `${DIR_CLASS_REFERENCE}/**`], {
+                base: API_DIR
+            })
+                .pipe(zip(zipFileName))
+                .pipe(gulp.dest(DIST_DIR))
+                .on('error', reject)
+                .on('end', resolve);
+        });
+    });
+    return Promise.all(zipTasks);
+}
+
+
+gulp.task('dist-api', apiZip);

--- a/tools/gulptasks/dist.js
+++ b/tools/gulptasks/dist.js
@@ -37,6 +37,7 @@ Gulp.task(
         'dist-copy',
         'dist-examples',
         'dist-productsjs',
+        'dist-api',
         'jsdoc-dts',
         'lint-dts',
         'dist-compress'

--- a/tools/gulptasks/lib/api/README.md
+++ b/tools/gulptasks/lib/api/README.md
@@ -1,0 +1,17 @@
+# How to view the API
+The Highcharts API requires a static file server to be able to perform optimal. 
+You can use your own static file server if you have one available, but we have also provided a simple Node.js server to get you started quickly.
+
+## Install Node.js
+The provided server requires Node.js to be installed, which can be done by downloading and executing their installer provided at the [Node.js Website](https://nodejs.org/en/).
+
+## Start the server
+Once Node.js is installed you can start the server by opening a terminal in this folder, and execute the command `node server.js`. After this the API should be available at http://localhost:8080.
+
+### Usage
+```
+Usage: node server.js {OPTIONS}
+
+Options:
+    --port  Specify a port for the server. Defaults to 8080.
+```

--- a/tools/gulptasks/lib/api/server.js
+++ b/tools/gulptasks/lib/api/server.js
@@ -1,0 +1,110 @@
+/* eslint-disable require-jsdoc */
+
+// Dependencies sorted by require path
+const fs = require('fs');
+const http = require('http');
+const { parse, resolve } = require('path');
+const { promisify } = require('util');
+
+/* Create promise versions of utility functions
+ * Note: Consider e.g require('fs').promises, if limiting support to NodeJS v10
+ * and above. */
+const stat = promisify(fs.stat);
+const readFile = promisify(fs.readFile);
+
+// Constants
+const { argv } = process;
+const PORT = Number(argv[(argv.indexOf('--port') + 1)]) || 8080;
+const BASE = `http://localhost:${PORT}`;
+const PRODUCT = ['highcharts', 'highstock', 'highmaps', 'gantt'].find(
+    product => {
+        try {
+            fs.statSync(resolve(__dirname, product));
+            return true;
+        } catch {
+            return false;
+        }
+    }
+);
+const MIME_TYPE = {
+    '.css': 'text/css',
+    '.html': 'text/html',
+    '.js': 'text/javascript',
+    '.json': 'application/json',
+    '.png': 'image/png',
+    '.svg': 'image/svg+xml'
+};
+
+function log(str) {
+    console.log(str); // eslint-disable-line no-console
+}
+
+function fileExists(path) {
+    return stat(path)
+        .then(stats => (stats.isFile() ?
+            path :
+            Promise.reject(new Error(`no such file ${path}`))
+        ));
+}
+
+function get404Handler(response) {
+    return e => {
+        response.writeHead(404, {});
+        response.end(`404: ${e.message}`, 'utf-8');
+    };
+}
+
+function get200Handler(response) {
+    return path => readFile(path)
+        .then(data => {
+            const { ext } = parse(path);
+            response.writeHead(200, {
+                'Content-type': MIME_TYPE[ext] || 'text/plain'
+            });
+            response.end(data, 'utf-8');
+        });
+}
+
+function getRewriteHandler(response) {
+    const rewrites = {
+        '': `/${PRODUCT}/`,
+        '/': `/${PRODUCT}/`,
+        '/gantt': '/gantt/',
+        '/highcharts': '/highcharts/',
+        '/highstock': '/highstock/',
+        '/maps': '/maps/'
+    };
+    return url => {
+        const rewrite = rewrites[url];
+        if (rewrite) {
+            response.writeHead(301, {
+                Location: rewrite
+            });
+            response.end();
+            return false;
+        }
+        return true;
+    };
+}
+
+http.createServer((request, response) => {
+    const handle404 = get404Handler(response);
+    const handle200 = get200Handler(response);
+    const handleRewrites = getRewriteHandler(response);
+    const url = new URL(request.url, BASE).pathname;
+    if (handleRewrites(url)) {
+        const { ext } = parse(url);
+        const isDirectory = url.endsWith('/');
+        const filepath = resolve(
+            __dirname,
+            `.${url}${!isDirectory && !MIME_TYPE[ext] ? '.html' : ''}`,
+            (isDirectory ? 'index.html' : '')
+        );
+        return fileExists(filepath)
+            .then(handle200)
+            .catch(handle404);
+    }
+    return Promise.resolve();
+}).listen(PORT);
+
+log(`API available at ${BASE}/${PRODUCT}/`);

--- a/tools/gulptasks/lib/build.js
+++ b/tools/gulptasks/lib/build.js
@@ -3,6 +3,7 @@
  */
 
 const fs = require('fs-extra');
+const { EOL } = require('os');
 
 /**
  * Convert a properties file line to a nested object.
@@ -41,7 +42,7 @@ function getBuildProperties() {
         const lines = fs.readFileSync(
             './build.properties', 'utf8'
         );
-        lines.split('\n').forEach(function (line) {
+        lines.split(EOL).forEach(function (line) {
             if (!line.startsWith('#')) {
                 const splitLine = line.split('=');
                 if (splitLine[0]) {


### PR DESCRIPTION
# Description
- [x] Provide a static file server for easy serve of the API
- [x] Zip offline API and add zip to distribution archives
- [x] Add task as a part of the gulp task named `dist`

# Example(s)
Run `npx gulp dist-api` locally too see result in `build/dist/{product}`

# Related issue(s)
- Touch #8533 