### PR TITLE
Revert "bugfix/11982/stacklabels-overlapping"

### DIFF
--- a/js/modules/overlapping-datalabels.src.js
+++ b/js/modules/overlapping-datalabels.src.js
@@ -13,7 +13,7 @@
 'use strict';
 import H from '../parts/Globals.js';
 import U from '../parts/Utilities.js';
-var isArray = U.isArray, objectEach = U.objectEach, pick = U.pick;
+var isArray = U.isArray, objectEach = U.objectEach, pick = U.pick, isNumber = U.isNumber;
 import '../parts/Chart.js';
 var Chart = H.Chart, addEvent = H.addEvent, fireEvent = H.fireEvent;
 /* eslint-disable no-invalid-this */
@@ -84,10 +84,11 @@ Chart.prototype.hideOverlappingLabels = function (labels) {
         padding = label.box ? 0 : (label.padding || 0), lineHeightCorrection = 0;
         if (label &&
             (!label.alignAttr || label.placed)) {
-            var x = label.attr('x');
-            var y = label.attr('y');
-            if (typeof x === 'number' && typeof y === 'number') {
-                pos = { x: x, y: y };
+            if (isNumber(+label.attr('x')) && isNumber(+label.attr('y'))) {
+                pos = {
+                    x: +label.attr('x'),
+                    y: +label.attr('y')
+                };
             }
             else {
                 pos = label.alignAttr;

--- a/js/modules/overlapping-datalabels.src.js
+++ b/js/modules/overlapping-datalabels.src.js
@@ -13,7 +13,7 @@
 'use strict';
 import H from '../parts/Globals.js';
 import U from '../parts/Utilities.js';
-var isArray = U.isArray, objectEach = U.objectEach, pick = U.pick, isNumber = U.isNumber;
+var isArray = U.isArray, objectEach = U.objectEach, pick = U.pick;
 import '../parts/Chart.js';
 var Chart = H.Chart, addEvent = H.addEvent, fireEvent = H.fireEvent;
 /* eslint-disable no-invalid-this */
@@ -84,15 +84,10 @@ Chart.prototype.hideOverlappingLabels = function (labels) {
         padding = label.box ? 0 : (label.padding || 0), lineHeightCorrection = 0;
         if (label &&
             (!label.alignAttr || label.placed)) {
-            if (isNumber(+label.attr('x')) && isNumber(+label.attr('y'))) {
-                pos = {
-                    x: +label.attr('x'),
-                    y: +label.attr('y')
-                };
-            }
-            else {
-                pos = label.alignAttr;
-            }
+            pos = label.alignAttr || {
+                x: label.attr('x'),
+                y: label.attr('y')
+            };
             parent = label.parentGroup;
             // Get width and height if pure text nodes (stack labels)
             if (!label.width) {

--- a/samples/unit-tests/axis/stacklabels/demo.js
+++ b/samples/unit-tests/axis/stacklabels/demo.js
@@ -211,30 +211,3 @@ QUnit.test('Stack labels crop and overflow features #8912', function (assert) {
         'Stack label should be inside plot area right'
     );
 });
-
-QUnit.test('Stack labels overlapping issue #11982', function (assert) {
-
-    var chart = Highcharts.chart('container', {
-        chart: {
-            type: 'column',
-            width: 200
-        },
-
-        yAxis: {
-            stackLabels: {
-                enabled: true
-            }
-        },
-        series: [{
-            stacking: 'normal',
-            data: [25.2, 24, 25, 26, 25, 25, 23, 27, 25, 25, 25, 25, 25, 25]
-        }]
-    });
-
-
-    assert.strictEqual(
-        chart.yAxis[0].stacks['column,,,'][2].label.y,
-        -9999,
-        'This stack-label should be hidden'
-    );
-});

--- a/ts/modules/overlapping-datalabels.src.ts
+++ b/ts/modules/overlapping-datalabels.src.ts
@@ -18,7 +18,8 @@ import U from '../parts/Utilities.js';
 const {
     isArray,
     objectEach,
-    pick
+    pick,
+    isNumber
 } = U;
 
 import '../parts/Chart.js';
@@ -152,10 +153,11 @@ Chart.prototype.hideOverlappingLabels = function (
                 label &&
                 (!label.alignAttr || label.placed)
             ) {
-                const x = label.attr('x');
-                const y = label.attr('y');
-                if (typeof x === 'number' && typeof y === 'number') {
-                    pos = { x, y };
+                if (isNumber(+label.attr('x')) && isNumber(+label.attr('y'))) {
+                    pos = {
+                        x: +label.attr('x'),
+                        y: +label.attr('y')
+                    };
                 } else {
                     pos = label.alignAttr;
                 }

--- a/ts/modules/overlapping-datalabels.src.ts
+++ b/ts/modules/overlapping-datalabels.src.ts
@@ -152,14 +152,14 @@ Chart.prototype.hideOverlappingLabels = function (
             if (
                 label &&
                 (!label.alignAttr || label.placed)
-            ) {
-                if (isNumber(+label.attr('x')) && isNumber(+label.attr('y'))) {
+            ) { 
+                if(isNumber(+label.attr('x')) && isNumber(+label.attr('y'))){
                     pos = {
                         x: +label.attr('x'),
                         y: +label.attr('y')
-                    };
+                    }
                 } else {
-                    pos = label.alignAttr;
+                    pos = label.alignAttr
                 }
                 parent = label.parentGroup as any;
 

--- a/ts/modules/overlapping-datalabels.src.ts
+++ b/ts/modules/overlapping-datalabels.src.ts
@@ -18,8 +18,7 @@ import U from '../parts/Utilities.js';
 const {
     isArray,
     objectEach,
-    pick,
-    isNumber
+    pick
 } = U;
 
 import '../parts/Chart.js';
@@ -152,15 +151,11 @@ Chart.prototype.hideOverlappingLabels = function (
             if (
                 label &&
                 (!label.alignAttr || label.placed)
-            ) { 
-                if(isNumber(+label.attr('x')) && isNumber(+label.attr('y'))){
-                    pos = {
-                        x: +label.attr('x'),
-                        y: +label.attr('y')
-                    }
-                } else {
-                    pos = label.alignAttr
-                }
+            ) {
+                pos = label.alignAttr || {
+                    x: label.attr('x'),
+                    y: label.attr('y')
+                };
                 parent = label.parentGroup as any;
 
                 // Get width and height if pure text nodes (stack labels)


### PR DESCRIPTION
Fixed #12390, not overlapping dataLabels after zoom in and zoom out were hidden.
___
Reverts highcharts/highcharts#12135

`labelAttr` should have higher priority than current attributes in DOM. Otherwise, when animation starts, we compare wrong bboxes between dataLabels, e.g. existing dataLabel animation's start position vs new label with position already in place (we should compare animation's end position instead).

Issue is more visible in Highmaps when zooming in/out is more popular.

**Some debugging thoughts:**
It seems to be a general problem with `textAlign` and `align` options. In dataLabels we support only `align`, while `stackLabels` has also `textAlign` support. The problem with `textAlign` is how it's applied:
https://github.com/highcharts/highcharts/blob/cbb7f0a14653cc33afb03bd026edbc70578b4a75/ts/parts/SvgRenderer.ts#L6034-L6055

It does not update `alignAttr` (like `align` in dataLabels does), so we have #11982 bug: https://github.com/highcharts/highcharts/blob/cbb7f0a14653cc33afb03bd026edbc70578b4a75/ts/parts/DataLabels.ts#L920-L928