### PR TITLE
enhancement/11308-center-column-nulls

### DIFF
--- a/docs/advanced-chart-features/center-columns-with-empty-points.md
+++ b/docs/advanced-chart-features/center-columns-with-empty-points.md
@@ -1,0 +1,14 @@
+Center columns with empty points
+===============
+
+By default, all the columns from the same series are positioned in the same place per category. If user does not provide data for some points, then empty spaces are created between the columns.
+Now, we are providing the feature that centers columns when there are no values between them.
+
+The options responsible for that are:
+*   **false** `series.ignoreNulls: false` - old behavior.
+*   **normal** `series.ignoreNulls: "normal"` - align columns close to the center of category.
+*   **evenlySpaced** `series.ignoreNulls: "evenlySpaced"` - distribute the columns evenly.
+*   **fillSpace** `series.ignoreNulls: "fillSpace"` - center the columns and let them fill the whole space in category.
+
+Here is a live demo showing the difference between these four options:
+<iframe width="100%" height="400" style="null" src=https://www.highcharts.com/samples/embed/highcharts/plotoptions/column-ignorenulls allow="fullscreen"></iframe>

--- a/js/indicators/ao.src.js
+++ b/js/indicators/ao.src.js
@@ -79,6 +79,7 @@ H.seriesType('ao', 'sma',
     nameComponents: false,
     // Columns support:
     markerAttribs: noop,
+    getColumnCount: H.seriesTypes.column.prototype.getColumnCount,
     getColumnMetrics: H.seriesTypes.column.prototype.getColumnMetrics,
     crispCol: H.seriesTypes.column.prototype.crispCol,
     translate: H.seriesTypes.column.prototype.translate,

--- a/js/indicators/macd.src.js
+++ b/js/indicators/macd.src.js
@@ -142,6 +142,7 @@ seriesType(
         pointValKey: 'y',
         // Columns support:
         markerAttribs: noop,
+        getColumnCount: H.seriesTypes.column.prototype.getColumnCount,
         getColumnMetrics: H.seriesTypes.column.prototype.getColumnMetrics,
         crispCol: H.seriesTypes.column.prototype.crispCol,
         // Colors and lines:

--- a/js/indicators/volume-by-price.src.js
+++ b/js/indicators/volume-by-price.src.js
@@ -174,6 +174,8 @@ seriesType(
         calculateOn: 'render',
         markerAttribs: noop,
         drawGraph: noop,
+        // Below methods always fire the currect method from column
+        // prototype even when we change/wrap them in column prototype.
         getColumnCount: function () {
             return columnPrototype.getColumnCount.apply(this, arguments);
         },

--- a/js/indicators/volume-by-price.src.js
+++ b/js/indicators/volume-by-price.src.js
@@ -174,8 +174,15 @@ seriesType(
         calculateOn: 'render',
         markerAttribs: noop,
         drawGraph: noop,
-        getColumnMetrics: columnPrototype.getColumnMetrics,
-        crispCol: columnPrototype.crispCol,
+        getColumnCount: function () {
+            return columnPrototype.getColumnCount.apply(this, arguments);
+        },
+        getColumnMetrics: function () {
+            return columnPrototype.getColumnMetrics.apply(this, arguments);
+        },
+        crispCol: function () {
+            return columnPrototype.crispCol.apply(this, arguments);
+        },
         init: function (chart) {
             var indicator = this,
                 params,

--- a/js/parts-more/ColumnRangeSeries.js
+++ b/js/parts-more/ColumnRangeSeries.js
@@ -126,6 +126,9 @@ seriesType('columnrange', 'arearange', merge(defaultPlotOptions.column, defaultP
     drawGraph: noop,
     getSymbol: noop,
     // Overrides from modules that may be loaded after this module
+    addPoint: function () {
+        return colProto.addPoint.apply(this, arguments);
+    },
     crispCol: function () {
         return colProto.crispCol.apply(this, arguments);
     },
@@ -135,14 +138,17 @@ seriesType('columnrange', 'arearange', merge(defaultPlotOptions.column, defaultP
     drawTracker: function () {
         return colProto.drawTracker.apply(this, arguments);
     },
-    hasPointInX: function (point, otherSeries) {
-        return colProto.hasPointInX.apply(this, arguments);
+    findMinColumnWidth: function () {
+        return colProto.findMinColumnWidth.apply(this, arguments);
     },
     getColumnCount: function (point) {
         return colProto.getColumnCount.apply(this, arguments);
     },
     getColumnMetrics: function () {
         return colProto.getColumnMetrics.apply(this, arguments);
+    },
+    hasPointInX: function (point, otherSeries) {
+        return colProto.hasPointInX.apply(this, arguments);
     },
     pointAttribs: function () {
         return colProto.pointAttribs.apply(this, arguments);

--- a/js/parts-more/ColumnRangeSeries.js
+++ b/js/parts-more/ColumnRangeSeries.js
@@ -135,6 +135,12 @@ seriesType('columnrange', 'arearange', merge(defaultPlotOptions.column, defaultP
     drawTracker: function () {
         return colProto.drawTracker.apply(this, arguments);
     },
+    hasPointInX: function (point, otherSeries) {
+        return colProto.hasPointInX.apply(this, arguments);
+    },
+    getColumnCount: function (point) {
+        return colProto.getColumnCount.apply(this, arguments);
+    },
     getColumnMetrics: function () {
         return colProto.getColumnMetrics.apply(this, arguments);
     },
@@ -154,7 +160,9 @@ seriesType('columnrange', 'arearange', merge(defaultPlotOptions.column, defaultP
         return colProto.translate3dShapes.apply(this, arguments);
     }
 }, {
-    setState: colProto.pointClass.prototype.setState
+    setState: colProto.pointClass.prototype.setState,
+    remove: colProto.pointClass.prototype.remove,
+    update: colProto.pointClass.prototype.update
 });
 /**
  * A `columnrange` series. If the [type](#series.columnrange.type)

--- a/js/parts-more/ColumnRangeSeries.js
+++ b/js/parts-more/ColumnRangeSeries.js
@@ -138,8 +138,11 @@ seriesType('columnrange', 'arearange', merge(defaultPlotOptions.column, defaultP
     drawTracker: function () {
         return colProto.drawTracker.apply(this, arguments);
     },
-    findMinColumnWidth: function () {
-        return colProto.findMinColumnWidth.apply(this, arguments);
+    getMaxColumnCount: function () {
+        return colProto.getMaxColumnCount.apply(this, arguments);
+    },
+    getMinColumnWidth: function () {
+        return colProto.getMinColumnWidth.apply(this, arguments);
     },
     getColumnCount: function (point) {
         return colProto.getColumnCount.apply(this, arguments);
@@ -147,8 +150,8 @@ seriesType('columnrange', 'arearange', merge(defaultPlotOptions.column, defaultP
     getColumnMetrics: function () {
         return colProto.getColumnMetrics.apply(this, arguments);
     },
-    hasPointInX: function (point, otherSeries) {
-        return colProto.hasPointInX.apply(this, arguments);
+    hasValueInX: function (point, otherSeries) {
+        return colProto.hasValueInX.apply(this, arguments);
     },
     pointAttribs: function () {
         return colProto.pointAttribs.apply(this, arguments);

--- a/js/parts-more/ColumnRangeSeries.js
+++ b/js/parts-more/ColumnRangeSeries.js
@@ -125,7 +125,9 @@ seriesType('columnrange', 'arearange', merge(defaultPlotOptions.column, defaultP
     trackerGroups: ['group', 'dataLabelsGroup'],
     drawGraph: noop,
     getSymbol: noop,
-    // Overrides from modules that may be loaded after this module
+    // Overrides from modules that may be loaded after this module.
+    // All below methods always fire the currect method from colProto
+    // even when we change/wrap them in colProto.
     addPoint: function () {
         return colProto.addPoint.apply(this, arguments);
     },

--- a/js/parts-more/ColumnRangeSeries.js
+++ b/js/parts-more/ColumnRangeSeries.js
@@ -131,6 +131,9 @@ seriesType('columnrange', 'arearange', merge(defaultPlotOptions.column, defaultP
     addPoint: function () {
         return colProto.addPoint.apply(this, arguments);
     },
+    correctStackLabels: function (point) {
+        return colProto.correctStackLabels.apply(this, arguments);
+    },
     crispCol: function () {
         return colProto.crispCol.apply(this, arguments);
     },

--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -525,11 +525,27 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         if (chart.minColumnWidth) {
             delete chart.minColumnWidth;
         }
+        if (chart.maxColumnCount) {
+            delete chart.maxColumnCount;
+        }
         chart.series.forEach(function (series) {
             var ignoreNulls = series.options.ignoreNulls;
-            if (series instanceof H.seriesTypes.column &&
-                ignoreNulls === 'evenlySpaced') {
+            if ((series.type === 'column' ||
+                series.type === 'columnrange' ||
+                series.type === 'bar') &&
+                (ignoreNulls === 'evenlySpaced' || ignoreNulls === 'centered')) {
                 series.findMinColumnWidth();
+                if (ignoreNulls === 'centered') {
+                    series.points.forEach(function (point) {
+                        if (!chart.maxColumnCount ||
+                            series
+                                .getColumnCount(point) > chart.maxColumnCount) {
+                            chart.maxColumnCount =
+                                series
+                                    .getColumnCount(point);
+                        }
+                    });
+                }
             }
         });
         // redraw affected series
@@ -1601,11 +1617,25 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      * @return {void}
      */
     renderSeries: function () {
-        this.series.forEach(function (series) {
+        var chart = this;
+        chart.series.forEach(function (series) {
             var ignoreNulls = series.options.ignoreNulls;
-            if (series instanceof H.seriesTypes.column &&
-                ignoreNulls === 'evenlySpaced') {
+            if ((series.type === 'column' ||
+                series.type === 'columnrange' ||
+                series.type === 'bar') &&
+                (ignoreNulls === 'evenlySpaced' || ignoreNulls === 'centered')) {
                 series.findMinColumnWidth();
+                if (ignoreNulls === 'centered') {
+                    series.points.forEach(function (point) {
+                        if (!chart.maxColumnCount ||
+                            series
+                                .getColumnCount(point) > chart.maxColumnCount) {
+                            chart.maxColumnCount =
+                                series
+                                    .getColumnCount(point);
+                        }
+                    });
+                }
             }
         });
         this.series.forEach(function (series) {

--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -422,7 +422,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      */
     redraw: function (animation) {
         fireEvent(this, 'beforeRedraw');
-        var chart = this, axes = chart.axes, series = chart.series, pointer = chart.pointer, legend = chart.legend, legendUserOptions = chart.userOptions.legend, redrawLegend = chart.isDirtyLegend, hasStackedSeries, hasDirtyStacks, hasCartesianSeries = chart.hasCartesianSeries, isDirtyBox = chart.isDirtyBox, i, serie, renderer = chart.renderer, isHiddenChart = renderer.isHidden(), afterRedraw = [];
+        var chart = this, axes = chart.axes, series = chart.series, pointer = chart.pointer, legend = chart.legend, legendUserOptions = chart.userOptions.legend, redrawLegend = chart.isDirtyLegend, hasStackedSeries, hasCartesianSeries = chart.hasCartesianSeries, isDirtyBox = chart.isDirtyBox, i, serie, renderer = chart.renderer, isHiddenChart = renderer.isHidden(), afterRedraw = [];
         // Handle responsive rules, not only on resize (#6130)
         if (chart.setResponsive) {
             chart.setResponsive(false);
@@ -433,27 +433,6 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         }
         // Adjust title layout (reflow multiline text)
         chart.layOutTitles();
-        // link stacked series
-        i = series.length;
-        while (i--) {
-            serie = series[i];
-            if (serie.options.stacking) {
-                hasStackedSeries = true;
-                if (serie.isDirty) {
-                    hasDirtyStacks = true;
-                    break;
-                }
-            }
-        }
-        if (hasDirtyStacks) { // mark others as dirty
-            i = series.length;
-            while (i--) {
-                serie = series[i];
-                if (serie.options.stacking) {
-                    serie.isDirty = true;
-                }
-            }
-        }
         // Handle updated data in the series
         series.forEach(function (serie) {
             if (serie.isDirty) {
@@ -480,8 +459,13 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             chart.isDirtyLegend = false;
         }
         // reset stacks
-        if (hasStackedSeries) {
-            chart.getStacks();
+        i = series.length;
+        while (i--) {
+            serie = series[i];
+            if (serie.options.stacking) {
+                chart.getStacks();
+                break;
+            }
         }
         if (hasCartesianSeries) {
             // set axes scales

--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -522,32 +522,9 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         // Fire an event before redrawing series, used by the boost module to
         // clear previous series renderings.
         fireEvent(chart, 'predraw');
-        if (chart.minColumnWidth) {
-            delete chart.minColumnWidth;
-        }
-        if (chart.maxColumnCount) {
-            delete chart.maxColumnCount;
-        }
-        chart.series.forEach(function (series) {
-            var ignoreNulls = series.options.ignoreNulls;
-            if ((series.type === 'column' ||
-                series.type === 'columnrange' ||
-                series.type === 'bar') &&
-                (ignoreNulls === 'evenlySpaced' || ignoreNulls === 'centered')) {
-                series.findMinColumnWidth();
-                if (ignoreNulls === 'centered') {
-                    series.points.forEach(function (point) {
-                        if (!chart.maxColumnCount ||
-                            series
-                                .getColumnCount(point) > chart.maxColumnCount) {
-                            chart.maxColumnCount =
-                                series
-                                    .getColumnCount(point);
-                        }
-                    });
-                }
-            }
-        });
+        // Clear previous and calculate new column props before series
+        // renderings.
+        fireEvent(chart, 'getColumnProps');
         // redraw affected series
         series.forEach(function (serie) {
             if ((isDirtyBox || serie.isDirty) && serie.visible) {
@@ -1618,27 +1595,10 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      */
     renderSeries: function () {
         var chart = this;
+        // Clear previous and calculate new column props before series
+        // renderings.
+        fireEvent(chart, 'getColumnProps');
         chart.series.forEach(function (series) {
-            var ignoreNulls = series.options.ignoreNulls;
-            if ((series.type === 'column' ||
-                series.type === 'columnrange' ||
-                series.type === 'bar') &&
-                (ignoreNulls === 'evenlySpaced' || ignoreNulls === 'centered')) {
-                series.findMinColumnWidth();
-                if (ignoreNulls === 'centered') {
-                    series.points.forEach(function (point) {
-                        if (!chart.maxColumnCount ||
-                            series
-                                .getColumnCount(point) > chart.maxColumnCount) {
-                            chart.maxColumnCount =
-                                series
-                                    .getColumnCount(point);
-                        }
-                    });
-                }
-            }
-        });
-        this.series.forEach(function (series) {
             series.translate();
             series.render();
         });

--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -522,6 +522,16 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         // Fire an event before redrawing series, used by the boost module to
         // clear previous series renderings.
         fireEvent(chart, 'predraw');
+        if (chart.minColumnWidth) {
+            delete chart.minColumnWidth;
+        }
+        chart.series.forEach(function (series) {
+            var ignoreNulls = series.options.ignoreNulls;
+            if (series instanceof H.seriesTypes.column &&
+                ignoreNulls === 'evenlySpaced') {
+                series.findMinColumnWidth();
+            }
+        });
         // redraw affected series
         series.forEach(function (serie) {
             if ((isDirtyBox || serie.isDirty) && serie.visible) {
@@ -1591,9 +1601,16 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      * @return {void}
      */
     renderSeries: function () {
-        this.series.forEach(function (serie) {
-            serie.translate();
-            serie.render();
+        this.series.forEach(function (series) {
+            var ignoreNulls = series.options.ignoreNulls;
+            if (series instanceof H.seriesTypes.column &&
+                ignoreNulls === 'evenlySpaced') {
+                series.findMinColumnWidth();
+            }
+        });
+        this.series.forEach(function (series) {
+            series.translate();
+            series.render();
         });
     },
     /**

--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -422,7 +422,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      */
     redraw: function (animation) {
         fireEvent(this, 'beforeRedraw');
-        var chart = this, axes = chart.axes, series = chart.series, pointer = chart.pointer, legend = chart.legend, legendUserOptions = chart.userOptions.legend, redrawLegend = chart.isDirtyLegend, hasStackedSeries, hasCartesianSeries = chart.hasCartesianSeries, isDirtyBox = chart.isDirtyBox, i, serie, renderer = chart.renderer, isHiddenChart = renderer.isHidden(), afterRedraw = [];
+        var chart = this, axes = chart.axes, series = chart.series, pointer = chart.pointer, legend = chart.legend, legendUserOptions = chart.userOptions.legend, redrawLegend = chart.isDirtyLegend, hasStackedSeries, hasCartesianSeries = chart.hasCartesianSeries, isDirtyBox = chart.isDirtyBox, i, serie, hasDirtyStacks, renderer = chart.renderer, isHiddenChart = renderer.isHidden(), afterRedraw = [];
         // Handle responsive rules, not only on resize (#6130)
         if (chart.setResponsive) {
             chart.setResponsive(false);
@@ -433,6 +433,29 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         }
         // Adjust title layout (reflow multiline text)
         chart.layOutTitles();
+        // link stacked series
+        i = series.length;
+        while (i--) {
+            serie = series[i];
+            if (serie.options.stacking) {
+                hasStackedSeries = true;
+                if (serie.isDirty) {
+                    hasDirtyStacks = true;
+                    break;
+                }
+            }
+        }
+        if (hasDirtyStacks) { // mark others as dirty
+            i = series.length;
+            while (i--) {
+                serie = series[i];
+                if (serie.options.stacking &&
+                    // These series have their own dirting logic
+                    !serie.type.match(/column|columnrange|bar/g)) {
+                    serie.isDirty = true;
+                }
+            }
+        }
         // Handle updated data in the series
         series.forEach(function (serie) {
             if (serie.isDirty) {
@@ -459,13 +482,8 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             chart.isDirtyLegend = false;
         }
         // reset stacks
-        i = series.length;
-        while (i--) {
-            serie = series[i];
-            if (serie.options.stacking) {
-                chart.getStacks();
-                break;
-            }
+        if (hasStackedSeries) {
+            chart.getStacks();
         }
         if (hasCartesianSeries) {
             // set axes scales

--- a/js/parts/ColumnSeries.js
+++ b/js/parts/ColumnSeries.js
@@ -574,8 +574,15 @@ seriesType('column', 'line',
      * @return {void}
      */
     dirtyTheSeries: function (series, point) {
+        // No need to dirty the series when stacking and ignoreNulls
+        // are disabled.
+        if (!series.options.stacking &&
+            !series.options.ignoreNulls) {
+            return;
+        }
         series.xAxis.series.forEach(function (otherSeries) {
             if (otherSeries.type === series.type &&
+                !otherSeries.isDirty &&
                 otherSeries.hasValueInX(point, otherSeries)) {
                 otherSeries.isDirty = true;
             }

--- a/js/parts/ColumnSeries.js
+++ b/js/parts/ColumnSeries.js
@@ -506,6 +506,25 @@ seriesType('column', 'line',
         Series.prototype.addPoint.apply(series, arguments);
     },
     /**
+     * Correct stackLabels position after the columns are translated when
+     * ignoreNulls option is enabled.
+     *
+     * @private
+     * @function Highcharts.seriesTypes.column#correctStackLabels
+     * @param {ColumnPoint} point
+     * @param {number} pointXOffset
+     * @return {void}
+     */
+    correctStackLabels: function (point) {
+        var series = this, options = series.options, yAxis = series.yAxis, stack = yAxis.stacks[(series.negStacks &&
+            defined(point.y) &&
+            defined(options.threshold) &&
+            point.y < (options.startFromThreshold ? 0 : options.threshold) ? '-' : '') + series.stackKey], pointStack = defined(point.x) ? stack[point.x] : void 0;
+        if (stack && pointStack && !point.isNull) {
+            pointStack.setOffset(series.pointXOffset || 0, point.pointWidth || 0, void 0, void 0, point.plotX);
+        }
+    },
+    /**
      * Make the columns crisp. The edges are rounded to the nearest full
      * pixel.
      *
@@ -582,7 +601,8 @@ seriesType('column', 'line',
                 series.points) {
                 series.points.forEach(function (point) {
                     colWidth = series
-                        .getColumnMetrics(point).width;
+                        .getColumnMetrics(point)
+                        .width;
                     if (colWidth < minColWidth) {
                         minColWidth = colWidth;
                     }
@@ -827,6 +847,9 @@ seriesType('column', 'line',
                 // on xAxis, not floating in the middle of the chart
                 [barX, translatedThreshold, barW, 0] :
                 [barX, barY, barW, barH]);
+            if (ignoreNulls && series.options.stacking) {
+                series.correctStackLabels(point);
+            }
         });
     },
     getSymbol: noop,

--- a/js/parts/ColumnSeries.js
+++ b/js/parts/ColumnSeries.js
@@ -1215,7 +1215,7 @@ H.addEvent(H.Chart, 'getColumnProps', function () {
             var ignoreNulls = series.options.ignoreNulls;
             // TO DO: add more series like boxplot etc.
             if (ignoreNulls && ignoreNulls !== 'fillSpace' &&
-                (series.type.match(/column|columnrange|bar/g))) {
+                series.type.match(/column|columnrange|bar/g)) {
                 yAxis.minColumnWidth = series
                     .getMinColumnWidth();
                 if (ignoreNulls !== 'evenlySpaced') {

--- a/js/parts/ColumnSeries.js
+++ b/js/parts/ColumnSeries.js
@@ -445,9 +445,8 @@ seriesType('column', 'line',
      * `ignoreNulls: "normal"` instead.
      *
      *
-     * To do: sample
-     * @sample {highcharts} highcharts/plotoptions/column-bordercolor/
-     *         Dark gray border
+     * @sample {highcharts} highcharts/plotoptions/column-ignorenulls/
+     *         Compare different options
      *
      * @type      {boolean|string}
      * @default   false
@@ -579,9 +578,8 @@ seriesType('column', 'line',
         yAxis.series.forEach(function (series) {
             // Make sure that this series is the last
             // of column/columnrange/bar.
-            if ((series.type === 'column' ||
-                series.type === 'columnrange' ||
-                series.type === 'bar') && series.points) {
+            if (series.type.match(/column|columnrange|bar/g) &&
+                series.points) {
                 series.points.forEach(function (point) {
                     colWidth = series
                         .getColumnMetrics(point).width;
@@ -591,7 +589,7 @@ seriesType('column', 'line',
                 });
             }
         });
-        return minColWidth;
+        return Math.floor(minColWidth);
     },
     /**
      * Find how many columns are in the specific category.
@@ -1178,7 +1176,7 @@ seriesType('column', 'line',
 H.addEvent(H.Chart, 'getColumnProps', function () {
     this.yAxis.forEach(function (yAxis) {
         if (yAxis.minColumnWidth) {
-            yAxis.minColumnWidth;
+            delete yAxis.minColumnWidth;
         }
         if (yAxis.maxColumnCount) {
             delete yAxis.maxColumnCount;
@@ -1187,9 +1185,7 @@ H.addEvent(H.Chart, 'getColumnProps', function () {
             var ignoreNulls = series.options.ignoreNulls;
             // TO DO: add more series like boxplot etc.
             if (ignoreNulls && ignoreNulls !== 'fillSpace' &&
-                (series.type === 'column' ||
-                    series.type === 'columnrange' ||
-                    series.type === 'bar')) {
+                (series.type.match(/column|columnrange|bar/g))) {
                 yAxis.minColumnWidth = series
                     .getMinColumnWidth();
                 if (ignoreNulls !== 'evenlySpaced') {

--- a/samples/highcharts/plotoptions/column-ignorenulls/demo.details
+++ b/samples/highcharts/plotoptions/column-ignorenulls/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Rafal Sebestjanski
+ js_wrap: b
+...

--- a/samples/highcharts/plotoptions/column-ignorenulls/demo.html
+++ b/samples/highcharts/plotoptions/column-ignorenulls/demo.html
@@ -1,0 +1,8 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
+
+<div id="container" style="height: 400px; max-width: 1000px; margin: 0 auto;"></div>
+<button id="btnOld" class="buttons">Old behavior</button>
+<button id="btnNormal" class="buttons">'normal'</button>
+<button id="btnEvenlySpaced" class="buttons">'evenlySpaced'</button>
+<button id="btnFillSpace" class="buttons">'fillSpace'</button>

--- a/samples/highcharts/plotoptions/column-ignorenulls/demo.js
+++ b/samples/highcharts/plotoptions/column-ignorenulls/demo.js
@@ -1,0 +1,76 @@
+Highcharts.chart('container', {
+
+    chart: {
+        type: 'column'
+    },
+
+    plotOptions: {
+        column: {
+            minPointLength: 2
+        }
+    },
+
+    title: {
+        text: '8 biggest airlines\' fleet size by aircraft type'
+    },
+
+    subtitle: {
+        text: 'May 23, 2019'
+    },
+
+    xAxis: {
+        title: {
+            text: 'Aircraft type',
+            y: 5
+        },
+        categories: ['Widebody', 'Narrowbody', 'Regional aircraft'],
+        tickWidth: 1
+    },
+
+    yAxis: {
+        title: 'Fleet size'
+    },
+
+    series: [{
+        name: '1. American Airlines',
+        data: [155, 782, 20]
+    }, {
+        name: '2. Delta Air Lines',
+        data: [151, 729, null]
+    }, {
+        name: '3. United Airlines',
+        data: [191, 586, null]
+    }, {
+        name: '4. Southwest Airlines',
+        data: [null, 753, null]
+    }, {
+        name: '5. China Southern Airlines',
+        data: [97, 463, 19]
+    }, {
+        name: '6. China Eastern Airlines',
+        data: [91, 513, 3]
+    }, {
+        name: '7. SkyWest',
+        data: [null, null, 486]
+    }, {
+        name: '8. Ryanair',
+        data: [null, 456, null]
+    }]
+
+}, function (chart) {
+    const options = [false, 'normal', 'evenlySpaced', 'fillSpace'],
+        buttons = [...document.getElementsByTagName('button')];
+
+    buttons.forEach(function (btn, i) {
+        btn.addEventListener('click', function () {
+            chart.update({
+                plotOptions: {
+                    series: {
+                        ignoreNulls: options[i]
+                    }
+                }
+            });
+        });
+    });
+
+});

--- a/samples/unit-tests/series/ignorenulls/demo.details
+++ b/samples/unit-tests/series/ignorenulls/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series/ignorenulls/demo.html
+++ b/samples/unit-tests/series/ignorenulls/demo.html
@@ -1,0 +1,6 @@
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/series/ignorenulls/demo.html
+++ b/samples/unit-tests/series/ignorenulls/demo.html
@@ -1,4 +1,5 @@
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
+<script src="https://code.highcharts.com/stock/highcharts-more.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/series/ignorenulls/demo.js
+++ b/samples/unit-tests/series/ignorenulls/demo.js
@@ -77,7 +77,8 @@ QUnit.test('ignoreNulls', function (assert) {
     });
 
     assert.strictEqual(
-        chart.series[1].points[2].shapeArgs.x + chart.plotLeft > chart.xAxis[0].ticks[2].mark.element.getBBox().x,
+        chart.series[1].points[2].shapeArgs.x + chart.plotLeft >
+            chart.xAxis[0].ticks[2].mark.element.getBBox().x,
         true,
         'Point should be on the right side of the tick.'
     );
@@ -189,7 +190,8 @@ QUnit.test('ignoreNulls', function (assert) {
     chart.redraw();
 
     assert.strictEqual(
-        chart.series[1].points[1].shapeArgs.x + chart.plotLeft + chart.plotSizeX / 2 > chart.xAxis[1].ticks[1].mark.element.getBBox().x,
+        chart.series[1].points[1].shapeArgs.x + chart.plotLeft + chart.plotSizeX / 2 >
+            chart.xAxis[1].ticks[1].mark.element.getBBox().x,
         true,
         'ignoreNulls works for multiple x-axes.'
     );
@@ -214,8 +216,35 @@ QUnit.test('ignoreNulls', function (assert) {
         'yAxis.maxColumnCount works for multiple y-axes.'
     );
 
+    chart.update({
+        plotOptions: {
+            series: {
+                stacking: 'normal'
+            }
+        },
+        yAxis: {
+            stackLabels: {
+                enabled: true
+            }
+        }
+    }, false);
+
+    chart.series[2].update({
+        stack: 1
+    }, false);
+
+    chart.redraw();
+
+    assert.strictEqual(
+        chart.yAxis[0].stacks['column,1,,50%'][1].label.absoluteBox.x <
+            chart.xAxis[0].ticks[1].mark.element.getBBox().x,
+        true,
+        'stackLabels should be in a correct place.'
+    );
+
     const inheritedMethods = [
         'addPoint',
+        'correctStackLabels',
         'crispCol',
         'drawPoints',
         'drawTracker',

--- a/samples/unit-tests/series/ignorenulls/demo.js
+++ b/samples/unit-tests/series/ignorenulls/demo.js
@@ -214,4 +214,29 @@ QUnit.test('ignoreNulls', function (assert) {
         'yAxis.maxColumnCount works for multiple y-axes.'
     );
 
+    const inheritedMethods = [
+        'addPoint',
+        'crispCol',
+        'drawPoints',
+        'drawTracker',
+        'getMaxColumnCount',
+        'getMinColumnWidth',
+        'getColumnCount',
+        'getColumnMetrics',
+        'hasValueInX',
+        'pointAttribs',
+        'animate',
+        'polarArc',
+        'translate3dPoints',
+        'translate3dShapes'
+    ];
+
+    inheritedMethods.forEach(methodName => {
+        assert.notEqual(
+            Highcharts.seriesTypes.column.prototype[methodName],
+            Highcharts.seriesTypes.columnrange.prototype[methodName],
+            'Inherited methods should not be the same.'
+        );
+    });
+
 });

--- a/samples/unit-tests/series/ignorenulls/demo.js
+++ b/samples/unit-tests/series/ignorenulls/demo.js
@@ -1,0 +1,217 @@
+QUnit.test('ignoreNulls', function (assert) {
+    var chart = Highcharts.chart('container', {
+
+        chart: {
+            type: 'column'
+        },
+
+        xAxis: [{
+
+        }, {
+
+        }],
+
+        yAxis: [{
+
+        }, {
+            opposite: true,
+            title: null
+        }],
+
+        series: [{
+            name: 'Tokyo',
+            data: [
+                [0, 2],
+                [1, 3],
+                [2, 2],
+                [3, null]
+            ]
+        }, {
+            name: 'Warsaw',
+            data: [
+                [0, null],
+                [1, 5],
+                [2, 1]
+            ]
+        }, {
+            name: 'Madrid',
+            data: [
+                [0, null],
+                [1, 3]
+            ]
+        }, {
+            name: 'Another',
+            data: [
+                [0, 1],
+                [1, 2],
+                [3, 4]
+            ]
+        }]
+
+    });
+
+    assert.strictEqual(
+        chart.series[3].points[0].shapeArgs.width,
+        15,
+        '(ignoreNulls: false) - point\'s width is ok.'
+    );
+
+    assert.strictEqual(
+        chart.yAxis[0].maxColumnCount,
+        undefined,
+        '(ignoreNulls: false) - yAxis.maxColumnCount should not be calculated.'
+    );
+
+    assert.strictEqual(
+        chart.yAxis[0].minColumnWidth,
+        undefined,
+        '(ignoreNulls: false) - yAxis.minColumnWidth should not be calculated.'
+    );
+
+    chart.update({
+        plotOptions: {
+            series: {
+                ignoreNulls: 'normal'
+            }
+        }
+    });
+
+    assert.strictEqual(
+        chart.series[1].points[2].shapeArgs.x + chart.plotLeft > chart.xAxis[0].ticks[2].mark.element.getBBox().x,
+        true,
+        'Point should be on the right side of the tick.'
+    );
+
+    assert.strictEqual(
+        chart.series[3].points[0].shapeArgs.width,
+        15,
+        '(ignoreNulls: \'normal\') - point\'s width is ok.'
+    );
+
+    assert.strictEqual(
+        chart.yAxis[0].maxColumnCount,
+        4,
+        '(ignoreNulls: \'normal\') - yAxis.maxColumnCount is ok.'
+    );
+
+    assert.strictEqual(
+        chart.yAxis[0].minColumnWidth,
+        15,
+        '(ignoreNulls: \'normal\') - yAxis.minColumnWidth is ok.'
+    );
+
+    chart.update({
+        plotOptions: {
+            series: {
+                ignoreNulls: 'evenlySpaced'
+            }
+        }
+    });
+
+    assert.strictEqual(
+        chart.series[3].points[0].shapeArgs.width,
+        15,
+        '(ignoreNulls: \'evenlySpaced\') - point\'s width is ok.'
+    );
+
+    assert.strictEqual(
+        chart.yAxis[0].minColumnWidth,
+        15,
+        '(ignoreNulls: \'evenlySpaced\') - yAxis.minColumnWidth is ok.'
+    );
+
+    assert.strictEqual(
+        chart.yAxis[0].maxColumnCount,
+        undefined,
+        '(ignoreNulls: \'evenlySpaced\') - yAxis.maxColumnCount should not be calculated.'
+    );
+
+    chart.update({
+        plotOptions: {
+            series: {
+                ignoreNulls: 'fillSpace'
+            }
+        }
+    });
+
+    assert.strictEqual(
+        chart.series[3].points[0].shapeArgs.width,
+        31,
+        '(ignoreNulls: \'fillSpace\') - point\'s width is ok.'
+    );
+
+    assert.strictEqual(
+        chart.yAxis[0].maxColumnCount,
+        undefined,
+        '(ignoreNulls: \'fillSpace\') - yAxis.maxColumnCount should not be calculated.'
+    );
+
+    assert.strictEqual(
+        chart.yAxis[0].minColumnWidth,
+        undefined,
+        '(ignoreNulls: \'fillSpace\') - yAxis.minColumnWidth should not be calculated.'
+    );
+
+    chart.series[1].setData([
+        [0, null],
+        [1, null],
+        [1, 5],
+        [1, null],
+        [2, 1]
+    ]);
+
+    assert.notEqual(
+        chart.series[1].points[1].shapeArgs.x,
+        chart.series[2].points[1].shapeArgs.x,
+        'Nulls and value with the same x coordinates should be handled properly.'
+    );
+
+    chart.series[0].update({
+        xAxis: 1,
+        yAxis: 1
+    }, false);
+
+    chart.series[1].update({
+        xAxis: 1,
+        yAxis: 1
+    }, false);
+
+    chart.xAxis[0].update({
+        width: '50%'
+    }, false);
+
+    chart.xAxis[1].update({
+        width: '50%',
+        left: '50%',
+        offset: 0
+    }, false);
+
+    chart.redraw();
+
+    assert.strictEqual(
+        chart.series[1].points[1].shapeArgs.x + chart.plotLeft + chart.plotSizeX / 2 > chart.xAxis[1].ticks[1].mark.element.getBBox().x,
+        true,
+        'ignoreNulls works for multiple x-axes.'
+    );
+
+    chart.update({
+        plotOptions: {
+            series: {
+                ignoreNulls: 'normal'
+            }
+        }
+    });
+
+    assert.strictEqual(
+        chart.yAxis[1].maxColumnCount,
+        2,
+        'yAxis.maxColumnCount works for multiple y-axes.'
+    );
+
+    assert.strictEqual(
+        chart.yAxis[1].minColumnWidth,
+        14,
+        'yAxis.maxColumnCount works for multiple y-axes.'
+    );
+
+});

--- a/samples/unit-tests/series/ignorenulls/demo.js
+++ b/samples/unit-tests/series/ignorenulls/demo.js
@@ -229,14 +229,16 @@ QUnit.test('ignoreNulls', function (assert) {
         }
     }, false);
 
-    chart.series[2].update({
+    const thirdSeries = chart.series[2];
+
+    thirdSeries.update({
         stack: 1
     }, false);
 
     chart.redraw();
 
     assert.strictEqual(
-        chart.yAxis[0].stacks['column,1,,50%'][1].label.absoluteBox.x <
+        chart.yAxis[0].stacks[thirdSeries.stackKey][1].label.absoluteBox.x <
             chart.xAxis[0].ticks[1].mark.element.getBBox().x,
         true,
         'stackLabels should be in a correct place.'

--- a/samples/unit-tests/series/stacking/demo.js
+++ b/samples/unit-tests/series/stacking/demo.js
@@ -630,3 +630,69 @@ QUnit.test('Date objects as X values, column', function (assert) {
         );
     });
 }());
+
+// This test checks whether series dirting works for series in the same stack.
+QUnit.test("Redrawing dirty stacked series.", function (assert) {
+    var chart = Highcharts.chart('container', {
+            chart: {
+                type: 'area'
+            },
+            plotOptions: {
+                series: {
+                    stacking: 'normal'
+                }
+            },
+            series: [{
+                data: [106, 107, 111, 133]
+            }, {
+                data: [163, 203, 276, 208]
+            }]
+        }),
+        oldExtremes = chart.yAxis[0].getExtremes(),
+        otherPointPlotY = chart.series[0].points[2].plotY;
+
+    chart.series[1].points[2].update({
+        y: 300
+    });
+
+    // Extremes should not change in this test because when they do,
+    // all series are being redrawn immidiately - we don't want that
+    assert.strictEqual(
+        chart.yAxis[0].getExtremes().max,
+        oldExtremes.max,
+        'Extremes shold stay the same.'
+    );
+
+    // Series in dirty stack should be redrawn
+    assert.notEqual(
+        chart.series[0].points[2].plotY, // Other series' point
+        otherPointPlotY,
+        'Point should be moved up.'
+    );
+
+    chart.update({
+        chart: {
+            type: 'column'
+        }
+    });
+
+    oldExtremes = chart.yAxis[0].getExtremes();
+    otherPointPlotY = chart.series[0].points[2].plotY;
+
+    chart.series[1].points[2].update({
+        y: 276
+    });
+
+    assert.strictEqual(
+        chart.yAxis[0].getExtremes().max,
+        oldExtremes.max,
+        'Extremes should stay the same.'
+    );
+
+    assert.notEqual(
+        chart.series[0].points[2].plotY, // Other series' point
+        otherPointPlotY,
+        'Point should be moved down.'
+    );
+
+});

--- a/ts/indicators/ao.src.ts
+++ b/ts/indicators/ao.src.ts
@@ -26,6 +26,7 @@ declare global {
             public crispCol: ColumnSeries['crispCol'];
             public drawGraph(): void;
             public drawPoints: ColumnSeries['drawPoints'];
+            public getColumnCount: ColumnSeries['getColumnCount'];
             public getColumnMetrics: ColumnSeries['getColumnMetrics'];
             public getValues(
                 series: Series,
@@ -132,6 +133,7 @@ H.seriesType<Highcharts.AOIndicator>(
 
         // Columns support:
         markerAttribs: (noop as any),
+        getColumnCount: H.seriesTypes.column.prototype.getColumnCount,
         getColumnMetrics: H.seriesTypes.column.prototype.getColumnMetrics,
         crispCol: H.seriesTypes.column.prototype.crispCol,
         translate: H.seriesTypes.column.prototype.translate,

--- a/ts/parts-more/ColumnRangeSeries.ts
+++ b/ts/parts-more/ColumnRangeSeries.ts
@@ -33,10 +33,11 @@ declare global {
             public data: Array<ColumnRangePoint>;
             public drawPoints: ColumnSeries['drawPoints'];
             public drawTracker: ColumnSeries['drawTracker'];
-            public findMinColumnWidth: ColumnSeries['findMinColumnWidth'];
+            public getMaxColumnCount: ColumnSeries['getMaxColumnCount'];
+            public getMinColumnWidth: ColumnSeries['getMinColumnWidth'];
             public getColumnCount: ColumnSeries['getColumnCount'];
             public getColumnMetrics: ColumnSeries['getColumnMetrics'];
-            public hasPointInX: ColumnSeries['hasPointInX'];
+            public hasValueInX: ColumnSeries['hasValueInX'];
             public options: ColumnRangeSeriesOptions;
             public pointAttribs: ColumnSeries['pointAttribs'];
             public pointClass: typeof ColumnRangePoint;
@@ -245,8 +246,11 @@ seriesType<Highcharts.ColumnRangeSeries>('columnrange', 'arearange', merge(
     drawTracker: function (this: Highcharts.ColumnRangeSeries): void {
         return colProto.drawTracker.apply(this, arguments as any);
     },
-    findMinColumnWidth: function (this: Highcharts.ColumnRangeSeries): void {
-        return colProto.findMinColumnWidth.apply(this, arguments as any);
+    getMaxColumnCount: function (this: Highcharts.ColumnRangeSeries): number {
+        return colProto.getMaxColumnCount.apply(this, arguments as any);
+    },
+    getMinColumnWidth: function (this: Highcharts.ColumnRangeSeries): number {
+        return colProto.getMinColumnWidth.apply(this, arguments as any);
     },
     getColumnCount: function (
         this: Highcharts.ColumnRangeSeries,
@@ -259,12 +263,12 @@ seriesType<Highcharts.ColumnRangeSeries>('columnrange', 'arearange', merge(
     ): Highcharts.ColumnMetricsObject {
         return colProto.getColumnMetrics.apply(this, arguments as any);
     },
-    hasPointInX: function (
+    hasValueInX: function (
         this: Highcharts.ColumnRangeSeries,
         point: Highcharts.Point,
         otherSeries: Highcharts.Series
     ): boolean {
-        return colProto.hasPointInX.apply(this, arguments as any);
+        return colProto.hasValueInX.apply(this, arguments as any);
     },
     pointAttribs: function (
         this: Highcharts.ColumnRangeSeries

--- a/ts/parts-more/ColumnRangeSeries.ts
+++ b/ts/parts-more/ColumnRangeSeries.ts
@@ -246,7 +246,9 @@ seriesType<Highcharts.ColumnRangeSeries>('columnrange', 'arearange', merge(
     drawTracker: function (this: Highcharts.ColumnRangeSeries): void {
         return colProto.drawTracker.apply(this, arguments as any);
     },
-    getMaxColumnCount: function (this: Highcharts.ColumnRangeSeries): number {
+    getMaxColumnCount: function (
+        this: Highcharts.ColumnRangeSeries
+    ): number|undefined {
         return colProto.getMaxColumnCount.apply(this, arguments as any);
     },
     getMinColumnWidth: function (this: Highcharts.ColumnRangeSeries): number {

--- a/ts/parts-more/ColumnRangeSeries.ts
+++ b/ts/parts-more/ColumnRangeSeries.ts
@@ -29,6 +29,7 @@ declare global {
         class ColumnRangeSeries extends AreaRangeSeries {
             public addPoint: ColumnSeries['addPoint'];
             public animate: ColumnSeries['animate'];
+            public correctStackLabels: ColumnSeries['correctStackLabels'];
             public crispCol: ColumnSeries['crispCol'];
             public data: Array<ColumnRangePoint>;
             public drawPoints: ColumnSeries['drawPoints'];
@@ -237,6 +238,12 @@ seriesType<Highcharts.ColumnRangeSeries>('columnrange', 'arearange', merge(
     ): void {
         return colProto.addPoint.apply(this, arguments as any);
     },
+    correctStackLabels: function (
+        this: Highcharts.ColumnSeries,
+        point: Highcharts.ColumnPoint
+    ): void {
+        return colProto.correctStackLabels.apply(this, arguments as any);
+    },
     crispCol: function (
         this: Highcharts.ColumnRangeSeries
     ): Highcharts.BBoxObject {
@@ -258,7 +265,7 @@ seriesType<Highcharts.ColumnRangeSeries>('columnrange', 'arearange', merge(
     },
     getColumnCount: function (
         this: Highcharts.ColumnRangeSeries,
-        point: Highcharts.Point
+        point: Highcharts.ColumnPoint
     ): number {
         return colProto.getColumnCount.apply(this, arguments as any);
     },

--- a/ts/parts-more/ColumnRangeSeries.ts
+++ b/ts/parts-more/ColumnRangeSeries.ts
@@ -229,7 +229,9 @@ seriesType<Highcharts.ColumnRangeSeries>('columnrange', 'arearange', merge(
     drawGraph: noop as any,
     getSymbol: noop as any,
 
-    // Overrides from modules that may be loaded after this module
+    // Overrides from modules that may be loaded after this module.
+    // All below methods always fire the currect method from colProto
+    // even when we change/wrap them in colProto.
     addPoint: function (
         this: Highcharts.ColumnRangeSeries
     ): void {

--- a/ts/parts-more/ColumnRangeSeries.ts
+++ b/ts/parts-more/ColumnRangeSeries.ts
@@ -32,6 +32,8 @@ declare global {
             public data: Array<ColumnRangePoint>;
             public drawPoints: ColumnSeries['drawPoints'];
             public drawTracker: ColumnSeries['drawTracker'];
+            public hasPointInX: ColumnSeries['hasPointInX'];
+            public getColumnCount: ColumnSeries['getColumnCount'];
             public getColumnMetrics: ColumnSeries['getColumnMetrics'];
             public options: ColumnRangeSeriesOptions;
             public pointAttribs: ColumnSeries['pointAttribs'];
@@ -180,7 +182,7 @@ seriesType<Highcharts.ColumnRangeSeries>('columnrange', 'arearange', merge(
                 height += heightDifference;
                 y -= heightDifference / 2;
 
-            // Adjust for negative ranges or reversed Y axis (#1457)
+                // Adjust for negative ranges or reversed Y axis (#1457)
             } else if (height < 0) {
                 height *= -1;
                 y -= height;
@@ -236,6 +238,19 @@ seriesType<Highcharts.ColumnRangeSeries>('columnrange', 'arearange', merge(
     drawTracker: function (this: Highcharts.ColumnRangeSeries): void {
         return colProto.drawTracker.apply(this, arguments as any);
     },
+    hasPointInX: function (
+        this: Highcharts.ColumnRangeSeries,
+        point: Highcharts.Point,
+        otherSeries: Highcharts.Series
+    ): boolean {
+        return colProto.hasPointInX.apply(this, arguments as any);
+    },
+    getColumnCount: function (
+        this: Highcharts.ColumnRangeSeries,
+        point: Highcharts.Point
+    ): number {
+        return colProto.getColumnCount.apply(this, arguments as any);
+    },
     getColumnMetrics: function (
         this: Highcharts.ColumnRangeSeries
     ): Highcharts.ColumnMetricsObject {
@@ -259,7 +274,9 @@ seriesType<Highcharts.ColumnRangeSeries>('columnrange', 'arearange', merge(
         return colProto.translate3dShapes.apply(this, arguments as any);
     }
 }, {
-    setState: colProto.pointClass.prototype.setState
+    setState: colProto.pointClass.prototype.setState,
+    remove: colProto.pointClass.prototype.remove,
+    update: colProto.pointClass.prototype.update
 });
 
 

--- a/ts/parts-more/ColumnRangeSeries.ts
+++ b/ts/parts-more/ColumnRangeSeries.ts
@@ -27,14 +27,16 @@ declare global {
             public shapeType: ColumnPoint['shapeType'];
         }
         class ColumnRangeSeries extends AreaRangeSeries {
+            public addPoint: ColumnSeries['addPoint'];
             public animate: ColumnSeries['animate'];
             public crispCol: ColumnSeries['crispCol'];
             public data: Array<ColumnRangePoint>;
             public drawPoints: ColumnSeries['drawPoints'];
             public drawTracker: ColumnSeries['drawTracker'];
-            public hasPointInX: ColumnSeries['hasPointInX'];
+            public findMinColumnWidth: ColumnSeries['findMinColumnWidth'];
             public getColumnCount: ColumnSeries['getColumnCount'];
             public getColumnMetrics: ColumnSeries['getColumnMetrics'];
+            public hasPointInX: ColumnSeries['hasPointInX'];
             public options: ColumnRangeSeriesOptions;
             public pointAttribs: ColumnSeries['pointAttribs'];
             public pointClass: typeof ColumnRangePoint;
@@ -227,6 +229,11 @@ seriesType<Highcharts.ColumnRangeSeries>('columnrange', 'arearange', merge(
     getSymbol: noop as any,
 
     // Overrides from modules that may be loaded after this module
+    addPoint: function (
+        this: Highcharts.ColumnRangeSeries
+    ): void {
+        return colProto.addPoint.apply(this, arguments as any);
+    },
     crispCol: function (
         this: Highcharts.ColumnRangeSeries
     ): Highcharts.BBoxObject {
@@ -238,12 +245,8 @@ seriesType<Highcharts.ColumnRangeSeries>('columnrange', 'arearange', merge(
     drawTracker: function (this: Highcharts.ColumnRangeSeries): void {
         return colProto.drawTracker.apply(this, arguments as any);
     },
-    hasPointInX: function (
-        this: Highcharts.ColumnRangeSeries,
-        point: Highcharts.Point,
-        otherSeries: Highcharts.Series
-    ): boolean {
-        return colProto.hasPointInX.apply(this, arguments as any);
+    findMinColumnWidth: function (this: Highcharts.ColumnRangeSeries): void {
+        return colProto.findMinColumnWidth.apply(this, arguments as any);
     },
     getColumnCount: function (
         this: Highcharts.ColumnRangeSeries,
@@ -255,6 +258,13 @@ seriesType<Highcharts.ColumnRangeSeries>('columnrange', 'arearange', merge(
         this: Highcharts.ColumnRangeSeries
     ): Highcharts.ColumnMetricsObject {
         return colProto.getColumnMetrics.apply(this, arguments as any);
+    },
+    hasPointInX: function (
+        this: Highcharts.ColumnRangeSeries,
+        point: Highcharts.Point,
+        otherSeries: Highcharts.Series
+    ): boolean {
+        return colProto.hasPointInX.apply(this, arguments as any);
     },
     pointAttribs: function (
         this: Highcharts.ColumnRangeSeries

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -342,9 +342,11 @@ declare global {
             public len: number;
             public linkedParent?: Axis;
             public max: (null|number);
+            public maxColumnCount?: (number|undefined);
             public maxLabelDimensions?: SizeObject;
             public maxLabelLength: number;
             public min: (null|number);
+            public minColumnWidth?: (number|undefined);
             public minorTickInterval: number;
             public minorTicks: Dictionary<Tick>;
             public minPixelPadding: number;

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -92,6 +92,7 @@ declare global {
             public legend: Legend;
             public margin: Array<number>;
             public marginBottom?: number;
+            public minColumnWidth?: number;
             public oldChartHeight?: number;
             public oldChartWidth?: number;
             public options: Options;
@@ -870,6 +871,22 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         // Fire an event before redrawing series, used by the boost module to
         // clear previous series renderings.
         fireEvent(chart, 'predraw');
+
+        if (chart.minColumnWidth) {
+            delete chart.minColumnWidth;
+        }
+
+        chart.series.forEach(function (series: Highcharts.Series): void {
+            const ignoreNulls =
+                (series as Highcharts.ColumnSeries).options.ignoreNulls;
+
+            if (
+                series instanceof H.seriesTypes.column &&
+                ignoreNulls === 'evenlySpaced'
+            ) {
+                series.findMinColumnWidth();
+            }
+        });
 
         // redraw affected series
         series.forEach(function (serie: Highcharts.Series): void {
@@ -2318,9 +2335,20 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      * @return {void}
      */
     renderSeries: function (this: Highcharts.Chart): void {
-        this.series.forEach(function (serie: Highcharts.Series): void {
-            serie.translate();
-            serie.render();
+        this.series.forEach(function (series: Highcharts.Series): void {
+            const ignoreNulls =
+                (series as Highcharts.ColumnSeries).options.ignoreNulls;
+
+            if (
+                series instanceof H.seriesTypes.column &&
+                ignoreNulls === 'evenlySpaced'
+            ) {
+                series.findMinColumnWidth();
+            }
+        });
+        this.series.forEach(function (series: Highcharts.Series): void {
+            series.translate();
+            series.render();
         });
     },
 

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -93,7 +93,7 @@ declare global {
             public margin: Array<number>;
             public marginBottom?: number;
             public maxColumnCount?: number;
-            public minColumnWidth?: number;
+            public minColWidth?: number;
             public oldChartHeight?: number;
             public oldChartWidth?: number;
             public options: Options;
@@ -873,40 +873,9 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         // clear previous series renderings.
         fireEvent(chart, 'predraw');
 
-        if (chart.minColumnWidth) {
-            delete chart.minColumnWidth;
-        }
-
-        if (chart.maxColumnCount) {
-            delete chart.maxColumnCount;
-        }
-
-        chart.series.forEach(function (series: Highcharts.Series): void {
-            const ignoreNulls =
-                (series as Highcharts.ColumnSeries).options.ignoreNulls;
-
-            if (
-                (series.type === 'column' ||
-                series.type === 'columnrange' ||
-                series.type === 'bar') &&
-                (ignoreNulls === 'evenlySpaced' || ignoreNulls === 'centered')
-            ) {
-                (series as Highcharts.ColumnSeries).findMinColumnWidth();
-                if (ignoreNulls === 'centered') {
-                    series.points.forEach((point): void => {
-                        if (
-                            !chart.maxColumnCount ||
-                            (series as Highcharts.ColumnSeries)
-                                .getColumnCount(point) > chart.maxColumnCount
-                        ) {
-                            chart.maxColumnCount =
-                                (series as Highcharts.ColumnSeries)
-                                    .getColumnCount(point);
-                        }
-                    });
-                }
-            }
-        });
+        // Clear previous and calculate new column props before series
+        // renderings.
+        fireEvent(chart, 'getColumnProps');
 
         // redraw affected series
         series.forEach(function (serie: Highcharts.Series): void {
@@ -2356,33 +2325,12 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      */
     renderSeries: function (this: Highcharts.Chart): void {
         const chart = this;
-        chart.series.forEach(function (series: Highcharts.Series): void {
-            const ignoreNulls =
-                (series as Highcharts.ColumnSeries).options.ignoreNulls;
 
-            if (
-                (series.type === 'column' ||
-                series.type === 'columnrange' ||
-                series.type === 'bar') &&
-                (ignoreNulls === 'evenlySpaced' || ignoreNulls === 'centered')
-            ) {
-                (series as Highcharts.ColumnSeries).findMinColumnWidth();
-                if (ignoreNulls === 'centered') {
-                    series.points.forEach((point): void => {
-                        if (
-                            !chart.maxColumnCount ||
-                            (series as Highcharts.ColumnSeries)
-                                .getColumnCount(point) > chart.maxColumnCount
-                        ) {
-                            chart.maxColumnCount =
-                                (series as Highcharts.ColumnSeries)
-                                    .getColumnCount(point);
-                        }
-                    });
-                }
-            }
-        });
-        this.series.forEach(function (series: Highcharts.Series): void {
+        // Clear previous and calculate new column props before series
+        // renderings.
+        fireEvent(chart, 'getColumnProps');
+
+        chart.series.forEach(function (series: Highcharts.Series): void {
             series.translate();
             series.render();
         });

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -737,7 +737,6 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             legendUserOptions = chart.userOptions.legend,
             redrawLegend = chart.isDirtyLegend,
             hasStackedSeries: (boolean|undefined),
-            hasDirtyStacks,
             hasCartesianSeries = chart.hasCartesianSeries,
             isDirtyBox = chart.isDirtyBox,
             i,
@@ -759,30 +758,6 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
 
         // Adjust title layout (reflow multiline text)
         chart.layOutTitles();
-
-        // link stacked series
-        i = series.length;
-        while (i--) {
-            serie = series[i];
-
-            if (serie.options.stacking) {
-                hasStackedSeries = true;
-
-                if (serie.isDirty) {
-                    hasDirtyStacks = true;
-                    break;
-                }
-            }
-        }
-        if (hasDirtyStacks) { // mark others as dirty
-            i = series.length;
-            while (i--) {
-                serie = series[i];
-                if (serie.options.stacking) {
-                    serie.isDirty = true;
-                }
-            }
-        }
 
         // Handle updated data in the series
         series.forEach(function (serie: Highcharts.Series): void {
@@ -816,10 +791,14 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         }
 
         // reset stacks
-        if (hasStackedSeries) {
-            chart.getStacks();
+        i = series.length;
+        while (i--) {
+            serie = series[i];
+            if (serie.options.stacking) {
+                chart.getStacks();
+                break;
+            }
         }
-
 
         if (hasCartesianSeries) {
             // set axes scales

--- a/ts/parts/ColumnSeries.ts
+++ b/ts/parts/ColumnSeries.ts
@@ -1677,7 +1677,7 @@ H.addEvent(H.Chart, 'getColumnProps', function (this: Highcharts.Chart): void {
             // TO DO: add more series like boxplot etc.
             if (
                 ignoreNulls && ignoreNulls !== 'fillSpace' &&
-                (series.type.match(/column|columnrange|bar/g))
+                series.type.match(/column|columnrange|bar/g)
             ) {
                 yAxis.minColumnWidth = (series as Highcharts.ColumnSeries)
                     .getMinColumnWidth();

--- a/ts/parts/ColumnSeries.ts
+++ b/ts/parts/ColumnSeries.ts
@@ -90,7 +90,7 @@ declare global {
                 h: number
             ): BBoxObject;
             public dirtyTheSeries(
-                series: Highcharts.Series, point: any
+                series: Highcharts.ColumnSeries, point: Highcharts.ColumnPoint
             ): void;
             public getColumnCount(point?: ColumnPoint): number;
             public getColumnMetrics(point?: ColumnPoint): ColumnMetricsObject;
@@ -664,7 +664,7 @@ seriesType<Highcharts.ColumnSeries>(
 
             if (ignoreNulls) {
                 H.seriesTypes.column.prototype.dirtyTheSeries.call(
-                    series, series, point
+                    series, series, point as Highcharts.ColumnPoint
                 );
             }
 
@@ -774,11 +774,20 @@ seriesType<Highcharts.ColumnSeries>(
          * @return {void}
          */
         dirtyTheSeries: function (series, point): void {
+            // No need to dirty the series when stacking and ignoreNulls
+            // are disabled.
+            if (
+                !series.options.stacking &&
+                !series.options.ignoreNulls
+            ) {
+                return;
+            }
             series.xAxis.series.forEach(function (
                 otherSeries: Highcharts.Series
             ): void {
                 if (
                     otherSeries.type === series.type &&
+                    !otherSeries.isDirty &&
                     (otherSeries as any).hasValueInX(point, otherSeries)
                 ) {
                     otherSeries.isDirty = true;

--- a/ts/parts/ColumnSeries.ts
+++ b/ts/parts/ColumnSeries.ts
@@ -593,9 +593,8 @@ seriesType<Highcharts.ColumnSeries>(
          * `ignoreNulls: "normal"` instead.
          *
          *
-         * To do: sample
-         * @sample {highcharts} highcharts/plotoptions/column-bordercolor/
-         *         Dark gray border
+         * @sample {highcharts} highcharts/plotoptions/column-ignorenulls/
+         *         Compare different options
          *
          * @type      {boolean|string}
          * @default   false
@@ -769,11 +768,8 @@ seriesType<Highcharts.ColumnSeries>(
                 // Make sure that this series is the last
                 // of column/columnrange/bar.
                 if (
-                    (
-                        series.type === 'column' ||
-                        series.type === 'columnrange' ||
-                        series.type === 'bar'
-                    ) && series.points
+                    series.type.match(/column|columnrange|bar/g) &&
+                    series.points
                 ) {
                     series.points.forEach((point): void => {
                         colWidth = (series as Highcharts.ColumnSeries)
@@ -785,7 +781,7 @@ seriesType<Highcharts.ColumnSeries>(
                 }
             });
 
-            return minColWidth;
+            return Math.floor(minColWidth);
         },
         /**
          * Find how many columns are in the specific category.
@@ -1616,7 +1612,7 @@ H.addEvent(H.Chart, 'getColumnProps', function (this: Highcharts.Chart): void {
 
     this.yAxis.forEach((yAxis): void => { // eslint-disable-line no-invalid-this
         if (yAxis.minColumnWidth) {
-            yAxis.minColumnWidth;
+            delete yAxis.minColumnWidth;
         }
         if (yAxis.maxColumnCount) {
             delete yAxis.maxColumnCount;
@@ -1628,11 +1624,7 @@ H.addEvent(H.Chart, 'getColumnProps', function (this: Highcharts.Chart): void {
             // TO DO: add more series like boxplot etc.
             if (
                 ignoreNulls && ignoreNulls !== 'fillSpace' &&
-                (
-                    series.type === 'column' ||
-                    series.type === 'columnrange' ||
-                    series.type === 'bar'
-                )
+                (series.type.match(/column|columnrange|bar/g))
             ) {
                 yAxis.minColumnWidth = (series as Highcharts.ColumnSeries)
                     .getMinColumnWidth();


### PR DESCRIPTION
Added new property `series.ignoreNulls` which centers the columns within a group when others have a null value or missing points.

**Live demos**
column series: https://jsfiddle.net/BlackLabel/oeLvzgdw
columnrange series: https://jsfiddle.net/BlackLabel/yzj2pvht

Possible options:
- `false` (old behavior)
- `'normal'` (center columns and align them to the center of category),
- `'evenlySpaced'` (place columns evenly relative to the category width),
- `'fillSpace'` (columns fill the category width regardless of their quantity in the category).
Any naming or API structure suggestions are welcome.

To do:
- [x] tests
- [x] demos
- [x] stackLabels should be positioned correctly
- [x] `ignoreNulls: 'normal'` should work with multiple Y axes
- [x] `ignoreNulls` with `data` module

If `ignoreNulls: 'normal'` is gonna be the new default, I suggest adding this as an experimental feature with `ignoreNulls: false` in the next release and change the default in the future.