### PR TITLE
bugfix/12421-update-missing-coloraxis

### DIFF
--- a/js/parts-3d/Axis.js
+++ b/js/parts-3d/Axis.js
@@ -430,6 +430,11 @@ addEvent(Axis, 'destroy', function () {
 /*
 Z-AXIS
  */
+Chart.prototype.addZAxis = function (options) {
+    return new ZAxis(this, options);
+};
+Chart.prototype.collectionsWithUpdate.push('zAxis');
+Chart.prototype.collectionsWithInit.zAxis = [Chart.prototype.addZAxis];
 Axis.prototype.swapZ = function (p, insidePlotArea) {
     if (this.isZAxis) {
         var plotLeft = insidePlotArea ? 0 : this.chart.plotLeft;
@@ -502,7 +507,7 @@ addEvent(Chart, 'afterGetAxes', function () {
         axisOptions.index = i;
         // Z-Axis is shown horizontally, so it's kind of a X-Axis
         axisOptions.isX = true;
-        var zAxis = new ZAxis(chart, axisOptions);
+        var zAxis = chart.addZAxis(axisOptions);
         zAxis.setScale();
     });
 });

--- a/js/parts-map/ColorAxis.js
+++ b/js/parts-map/ColorAxis.js
@@ -24,6 +24,8 @@ import './ColorSeriesMixin.js';
 var addEvent = H.addEvent, Axis = H.Axis, Chart = H.Chart, Series = H.Series, Point = H.Point, color = H.color, ColorAxis, Legend = H.Legend, LegendSymbolMixin = H.LegendSymbolMixin, colorPointMixin = H.colorPointMixin, colorSeriesMixin = H.colorSeriesMixin, noop = H.noop, merge = H.merge;
 extend(Series.prototype, colorSeriesMixin);
 extend(Point.prototype, colorPointMixin);
+Chart.prototype.collectionsWithUpdate.push('colorAxis');
+Chart.prototype.collectionsWithInit.colorAxis = [Chart.prototype.addColorAxis];
 /* eslint-disable no-invalid-this, valid-jsdoc */
 /**
  * The ColorAxis object for inclusion in gradient legends.

--- a/js/parts-more/Pane.js
+++ b/js/parts-more/Pane.js
@@ -17,6 +17,7 @@ import U from '../parts/Utilities.js';
 var extend = U.extend, splat = U.splat;
 var CenteredSeriesMixin = H.CenteredSeriesMixin, merge = H.merge;
 /* eslint-disable valid-jsdoc */
+H.Chart.prototype.collectionsWithUpdate.push('pane');
 /**
  * The Pane object allows options that are common to a set of X and Y axes.
  *

--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -350,9 +350,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         'xAxis',
         'yAxis',
         'zAxis',
-        'colorAxis',
-        'series',
-        'pane'
+        'series'
     ],
     /**
      * A generic function to update any element of the chart. Elements can be
@@ -655,7 +653,6 @@ Chart.prototype.collectionsWithInit = {
     // collectionName: [ initializingMethod, [extraArguments] ]
     xAxis: [Chart.prototype.addAxis, [true]],
     yAxis: [Chart.prototype.addAxis, [false]],
-    colorAxis: [Chart.prototype.addColorAxis, [false]],
     series: [Chart.prototype.addSeries]
 };
 // extend the Point prototype for dynamic methods

--- a/ts/parts-3d/Axis.ts
+++ b/ts/parts-3d/Axis.ts
@@ -28,6 +28,9 @@ declare global {
         }
         interface Chart {
             zAxis?: Array<ZAxis>;
+            addZAxis(
+                options: ZAxisOptions
+            ): Axis;
         }
         interface Options {
             zAxis?: (ZAxisOptions|Array<ZAxisOptions>);
@@ -599,6 +602,15 @@ addEvent(Axis, 'destroy', function (): void {
 Z-AXIS
  */
 
+Chart.prototype.addZAxis = function (
+    options: Highcharts.ZAxisOptions
+): Highcharts.Axis {
+    return new ZAxis(this, options);
+};
+
+Chart.prototype.collectionsWithUpdate.push('zAxis');
+Chart.prototype.collectionsWithInit.zAxis = [Chart.prototype.addZAxis];
+
 Axis.prototype.swapZ = function (
     this: Highcharts.Axis,
     p: Highcharts.Position3dObject,
@@ -708,7 +720,7 @@ addEvent(Chart, 'afterGetAxes', function (): void {
         axisOptions.index = i;
         // Z-Axis is shown horizontally, so it's kind of a X-Axis
         axisOptions.isX = true;
-        var zAxis = new ZAxis(chart, axisOptions);
+        var zAxis = chart.addZAxis(axisOptions);
 
         zAxis.setScale();
     });

--- a/ts/parts-map/ColorAxis.ts
+++ b/ts/parts-map/ColorAxis.ts
@@ -167,6 +167,9 @@ var addEvent = H.addEvent,
 extend(Series.prototype, colorSeriesMixin);
 extend(Point.prototype, colorPointMixin);
 
+Chart.prototype.collectionsWithUpdate.push('colorAxis');
+Chart.prototype.collectionsWithInit.colorAxis = [Chart.prototype.addColorAxis];
+
 /* eslint-disable no-invalid-this, valid-jsdoc */
 /**
  * The ColorAxis object for inclusion in gradient legends.

--- a/ts/parts-more/Pane.ts
+++ b/ts/parts-more/Pane.ts
@@ -91,6 +91,8 @@ var CenteredSeriesMixin = H.CenteredSeriesMixin,
 
 /* eslint-disable valid-jsdoc */
 
+H.Chart.prototype.collectionsWithUpdate.push('pane');
+
 /**
  * The Pane object allows options that are common to a set of X and Y axes.
  *

--- a/ts/parts/Dynamics.ts
+++ b/ts/parts/Dynamics.ts
@@ -581,9 +581,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         'xAxis',
         'yAxis',
         'zAxis',
-        'colorAxis',
-        'series',
-        'pane'
+        'series'
     ],
 
     /**
@@ -980,7 +978,6 @@ Chart.prototype.collectionsWithInit = {
     // collectionName: [ initializingMethod, [extraArguments] ]
     xAxis: [Chart.prototype.addAxis, [true]],
     yAxis: [Chart.prototype.addAxis, [false]],
-    colorAxis: [Chart.prototype.addColorAxis, [false]],
     series: [Chart.prototype.addSeries]
 };
 


### PR DESCRIPTION
Fixed #12421, high contrast mode used to throw errors when `coloraxis` module was not loaded.
___
No test, karma loads all modules anyway..

Fixed demo (local): http://jsfiddle.net/BlackLabel/54mpkebg/4/