### PR TITLE
bugfix/12445-solid-gauge-update-border

### DIFF
--- a/js/modules/solid-gauge.src.js
+++ b/js/modules/solid-gauge.src.js
@@ -302,18 +302,18 @@ H.seriesType('solidgauge', 'gauge', solidGaugeOptions, {
                         'sweep-flag': 0
                     })
                         .add(series.group);
-                    if (!series.chart.styledMode) {
-                        if (options.linecap !== 'square') {
-                            graphic.attr({
-                                'stroke-linecap': 'round',
-                                'stroke-linejoin': 'round'
-                            });
-                        }
+                }
+                if (!series.chart.styledMode) {
+                    if (options.linecap !== 'square') {
                         graphic.attr({
-                            stroke: options.borderColor || 'none',
-                            'stroke-width': options.borderWidth || 0
+                            'stroke-linecap': 'round',
+                            'stroke-linejoin': 'round'
                         });
                     }
+                    graphic.attr({
+                        stroke: options.borderColor || 'none',
+                        'stroke-width': options.borderWidth || 0
+                    });
                 }
                 if (graphic) {
                     graphic.addClass(point.getClassName(), true);

--- a/samples/unit-tests/series-solidgauge/solidgauge/demo.js
+++ b/samples/unit-tests/series-solidgauge/solidgauge/demo.js
@@ -195,3 +195,39 @@ QUnit.test('Solid gauge null point (#10630)', function (assert) {
         'Series legend item: color taken from series'
     );
 });
+
+QUnit.test('Solid gauge updates', function (assert) {
+    var chart = Highcharts.chart('container', {
+            chart: {
+                type: 'solidgauge'
+            },
+
+            series: [{
+                name: 'Speed',
+                data: [10]
+            }]
+        }),
+        point = chart.series[0].points[0];
+
+    chart.series[0].update({
+        linecap: 'round',
+        borderWidth: 3,
+        borderColor: 'red'
+    });
+
+    assert.strictEqual(
+        point.graphic.element.getAttribute('stroke'),
+        'red',
+        'borderColor should be updated (#12445)'
+    );
+    assert.strictEqual(
+        point.graphic.element.getAttribute('stroke-width'),
+        '3',
+        'borderWidth should be updated (#12445)'
+    );
+    assert.strictEqual(
+        point.graphic.element.getAttribute('stroke-linecap'),
+        'round',
+        'linecap should be updated (#12445)'
+    );
+});

--- a/ts/modules/solid-gauge.src.ts
+++ b/ts/modules/solid-gauge.src.ts
@@ -532,19 +532,19 @@ H.seriesType<Highcharts.SolidGaugeSeries>(
                                 'sweep-flag': 0
                             })
                             .add(series.group);
+                    }
 
-                        if (!series.chart.styledMode) {
-                            if (options.linecap !== 'square') {
-                                graphic.attr({
-                                    'stroke-linecap': 'round',
-                                    'stroke-linejoin': 'round'
-                                });
-                            }
+                    if (!series.chart.styledMode) {
+                        if (options.linecap !== 'square') {
                             graphic.attr({
-                                stroke: options.borderColor || 'none',
-                                'stroke-width': options.borderWidth || 0
+                                'stroke-linecap': 'round',
+                                'stroke-linejoin': 'round'
                             });
                         }
+                        graphic.attr({
+                            stroke: options.borderColor || 'none',
+                            'stroke-width': options.borderWidth || 0
+                        });
                     }
 
                     if (graphic) {


### PR DESCRIPTION
Fixed #12445, updating `borderColor` and `borderWidth` didn't work for solid-gauge series.
___
Diff looks strange: border and linecap options were simply moved out from `if (graphic) { animate } else { create }` logic, just like in other series (e.g. column).