### PR TITLE
Only calculate label values when venn point has a shape

### DIFF
--- a/js/mixins/geometry-circles.js
+++ b/js/mixins/geometry-circles.js
@@ -137,6 +137,19 @@ function getCirclesIntersectionPoints(circles) {
     }, []);
 }
 /**
+ * Tests wether the first circle is completely overlapping the second circle.
+ *
+ * @private
+ * @param {Highcharts.CircleObject} circle1 The first circle.
+ * @param {Highcharts.CircleObject} circle2 The The second circle.
+ * @return {boolean} Returns true if circle1 is completely overlapping circle2,
+ * false if not.
+ */
+function isCircle1CompletelyOverlappingCircle2(circle1, circle2) {
+    return getDistanceBetweenPoints(circle1, circle2) + circle2.r <
+        circle1.r + 1e-10;
+}
+/**
  * Tests wether a point lies within a given circle.
  * @private
  * @param {Highcharts.PositionObject} point
@@ -297,6 +310,7 @@ var geometryCircles = {
     getCirclesIntersectionPolygon: getCirclesIntersectionPolygon,
     getCircularSegmentArea: getCircularSegmentArea,
     getOverlapBetweenCircles: getOverlapBetweenCircles,
+    isCircle1CompletelyOverlappingCircle2: isCircle1CompletelyOverlappingCircle2,
     isPointInsideCircle: isPointInsideCircle,
     isPointInsideAllCircles: isPointInsideAllCircles,
     isPointOutsideAllCircles: isPointOutsideAllCircles,

--- a/js/modules/venn.src.js
+++ b/js/modules/venn.src.js
@@ -19,7 +19,7 @@ import H from '../parts/Globals.js';
 import draw from '../mixins/draw-point.js';
 import geometry from '../mixins/geometry.js';
 import GeometryCircleMixin from '../mixins/geometry-circles.js';
-var getAreaOfCircle = GeometryCircleMixin.getAreaOfCircle, getAreaOfIntersectionBetweenCircles = GeometryCircleMixin.getAreaOfIntersectionBetweenCircles, getCircleCircleIntersection = GeometryCircleMixin.getCircleCircleIntersection, getCirclesIntersectionPolygon = GeometryCircleMixin.getCirclesIntersectionPolygon, getOverlapBetweenCirclesByDistance = GeometryCircleMixin.getOverlapBetweenCircles, isPointInsideAllCircles = GeometryCircleMixin.isPointInsideAllCircles, isPointInsideCircle = GeometryCircleMixin.isPointInsideCircle, isPointOutsideAllCircles = GeometryCircleMixin.isPointOutsideAllCircles;
+var getAreaOfCircle = GeometryCircleMixin.getAreaOfCircle, getAreaOfIntersectionBetweenCircles = GeometryCircleMixin.getAreaOfIntersectionBetweenCircles, getCircleCircleIntersection = GeometryCircleMixin.getCircleCircleIntersection, getCirclesIntersectionPolygon = GeometryCircleMixin.getCirclesIntersectionPolygon, getOverlapBetweenCirclesByDistance = GeometryCircleMixin.getOverlapBetweenCircles, isCircle1CompletelyOverlappingCircle2 = GeometryCircleMixin.isCircle1CompletelyOverlappingCircle2, isPointInsideAllCircles = GeometryCircleMixin.isPointInsideAllCircles, isPointInsideCircle = GeometryCircleMixin.isPointInsideCircle, isPointOutsideAllCircles = GeometryCircleMixin.isPointOutsideAllCircles;
 import NelderMeadModule from '../mixins/nelder-mead.js';
 // TODO: replace with individual imports
 var nelderMead = NelderMeadModule.nelderMead;
@@ -330,6 +330,12 @@ function getLabelValues(relation, setRelations) {
     }, {
         internal: [],
         external: []
+    });
+    // Filter out external circles that are completely overlapping all internal
+    data.external = data.external.filter(function (externalCircle) {
+        return data.internal.some(function (internalCircle) {
+            return !isCircle1CompletelyOverlappingCircle2(externalCircle, internalCircle);
+        });
     });
     // Calulate the label position.
     var position = getLabelPosition(data.internal, data.external);

--- a/js/modules/venn.src.js
+++ b/js/modules/venn.src.js
@@ -18,14 +18,15 @@
 import H from '../parts/Globals.js';
 import draw from '../mixins/draw-point.js';
 import geometry from '../mixins/geometry.js';
-import geometryCircles from '../mixins/geometry-circles.js';
+import GeometryCircleMixin from '../mixins/geometry-circles.js';
+var getAreaOfCircle = GeometryCircleMixin.getAreaOfCircle, getAreaOfIntersectionBetweenCircles = GeometryCircleMixin.getAreaOfIntersectionBetweenCircles, getCircleCircleIntersection = GeometryCircleMixin.getCircleCircleIntersection, getCirclesIntersectionPolygon = GeometryCircleMixin.getCirclesIntersectionPolygon, getOverlapBetweenCirclesByDistance = GeometryCircleMixin.getOverlapBetweenCircles, isPointInsideAllCircles = GeometryCircleMixin.isPointInsideAllCircles, isPointInsideCircle = GeometryCircleMixin.isPointInsideCircle, isPointOutsideAllCircles = GeometryCircleMixin.isPointOutsideAllCircles;
 import NelderMeadModule from '../mixins/nelder-mead.js';
 // TODO: replace with individual imports
 var nelderMead = NelderMeadModule.nelderMead;
 import U from '../parts/Utilities.js';
 var animObject = U.animObject, isArray = U.isArray, isNumber = U.isNumber, isObject = U.isObject, isString = U.isString;
 import '../parts/Series.js';
-var addEvent = H.addEvent, color = H.Color, extend = H.extend, getAreaOfCircle = geometryCircles.getAreaOfCircle, getAreaOfIntersectionBetweenCircles = geometryCircles.getAreaOfIntersectionBetweenCircles, getCirclesIntersectionPolygon = geometryCircles.getCirclesIntersectionPolygon, getCircleCircleIntersection = geometryCircles.getCircleCircleIntersection, getCenterOfPoints = geometry.getCenterOfPoints, getDistanceBetweenPoints = geometry.getDistanceBetweenPoints, getOverlapBetweenCirclesByDistance = geometryCircles.getOverlapBetweenCircles, isPointInsideAllCircles = geometryCircles.isPointInsideAllCircles, isPointInsideCircle = geometryCircles.isPointInsideCircle, isPointOutsideAllCircles = geometryCircles.isPointOutsideAllCircles, merge = H.merge, seriesType = H.seriesType, seriesTypes = H.seriesTypes;
+var addEvent = H.addEvent, color = H.Color, extend = H.extend, getCenterOfPoints = geometry.getCenterOfPoints, getDistanceBetweenPoints = geometry.getDistanceBetweenPoints, merge = H.merge, seriesType = H.seriesType, seriesTypes = H.seriesTypes;
 var objectValues = function objectValues(obj) {
     return Object.keys(obj).map(function (x) {
         return obj[x];
@@ -899,7 +900,7 @@ var vennSeries = {
     utils: {
         addOverlapToSets: addOverlapToSets,
         geometry: geometry,
-        geometryCircles: geometryCircles,
+        geometryCircles: GeometryCircleMixin,
         getLabelWidth: getLabelWidth,
         getMarginFromCircles: getMarginFromCircles,
         getDistanceBetweenCirclesByOverlap: getDistanceBetweenCirclesByOverlap,

--- a/ts/mixins/geometry-circles.ts
+++ b/ts/mixins/geometry-circles.ts
@@ -207,6 +207,23 @@ function getCirclesIntersectionPoints(
 }
 
 /**
+ * Tests wether the first circle is completely overlapping the second circle.
+ *
+ * @private
+ * @param {Highcharts.CircleObject} circle1 The first circle.
+ * @param {Highcharts.CircleObject} circle2 The The second circle.
+ * @return {boolean} Returns true if circle1 is completely overlapping circle2,
+ * false if not.
+ */
+function isCircle1CompletelyOverlappingCircle2(
+    circle1: Highcharts.CircleObject,
+    circle2: Highcharts.CircleObject
+): boolean {
+    return getDistanceBetweenPoints(circle1, circle2) + circle2.r <
+        circle1.r + 1e-10;
+}
+
+/**
  * Tests wether a point lies within a given circle.
  * @private
  * @param {Highcharts.PositionObject} point
@@ -412,6 +429,7 @@ const geometryCircles = {
     getCirclesIntersectionPolygon,
     getCircularSegmentArea,
     getOverlapBetweenCircles,
+    isCircle1CompletelyOverlappingCircle2,
     isPointInsideCircle,
     isPointInsideAllCircles,
     isPointOutsideAllCircles,

--- a/ts/mixins/geometry-circles.ts
+++ b/ts/mixins/geometry-circles.ts
@@ -13,37 +13,6 @@ declare global {
         interface CircleObject extends PositionObject {
             r: number;
         }
-        interface GeometryCircleMixin {
-            getAreaOfCircle(r: number): number;
-            getAreaOfIntersectionBetweenCircles(
-                circles: Array<CircleObject>
-            ): (GeometryIntersectionObject|undefined);
-            getCircleCircleIntersection(
-                c1: CircleObject,
-                c2: CircleObject
-            ): Array<PositionObject>;
-            getCirclesIntersectionPoints(
-                circles: Array<CircleObject>
-            ): Array<PositionObject>;
-            getCirclesIntersectionPolygon(
-                circles: Array<CircleObject>
-            ): Array<GeometryObject>;
-            getCircularSegmentArea(r: number, h: number): number;
-            getOverlapBetweenCircles(r1: number, r2: number, d: number): number;
-            isPointInsideAllCircles(
-                point: PositionObject,
-                circles: Array<CircleObject>
-            ): boolean;
-            isPointInsideCircle(
-                point: PositionObject,
-                circle: CircleObject
-            ): boolean;
-            isPointOutsideAllCircles(
-                point: PositionObject,
-                circles: Array<CircleObject>
-            ): boolean;
-            round(x: number, decimals: number): number;
-        }
         interface GeometryIntersectionObject {
             center: PositionObject;
             d: Array<SVGPathArray>;
@@ -435,7 +404,7 @@ function getAreaOfIntersectionBetweenCircles(
     return result;
 }
 
-const geometryCircles: Highcharts.GeometryCircleMixin = {
+const geometryCircles = {
     getAreaOfCircle,
     getAreaOfIntersectionBetweenCircles,
     getCircleCircleIntersection,

--- a/ts/modules/venn.src.ts
+++ b/ts/modules/venn.src.ts
@@ -552,62 +552,49 @@ var getLabelWidth = function getLabelWidth(
 };
 
 /**
- * Calulates data label values for a list of relations.
+ * Calulates data label values for a given relations object.
+ *
  * @private
  * @todo add unit tests
- * @todo NOTE: may be better suited as a part of the layout function.
- * @param {Array<Highcharts.VennRelationObject>} relations
- * The list of relations.
- * @return {Highcharts.Dictionary<Highcharts.VennLabelValuesObject>}
- * Returns a map from id to the data label values.
+ * @param {Highcharts.VennRelationObject} relation A relations object.
+ * @param {Array<Highcharts.VennRelationObject>} setRelations The list of
+ * relations that is a set.
+ * @return {Highcharts.VennLabelValuesObject}
+ * Returns an object containing position and width of the label.
  */
-var getLabelValues = function getLabelValues(
-    relations: Array<Highcharts.VennRelationObject>
-): Highcharts.Dictionary<Highcharts.VennLabelValuesObject> {
-    var singleSets = relations.filter(isSet);
+function getLabelValues(
+    relation: Highcharts.VennRelationObject,
+    setRelations: Array<Highcharts.VennRelationObject>
+): Highcharts.VennLabelValuesObject {
+    const sets = relation.sets;
+    // Create a list of internal and external circles.
+    const data = setRelations.reduce(function (
+        data: Highcharts.Dictionary<(Array<Highcharts.CircleObject>)>,
+        set: Highcharts.VennRelationObject
+    ): Highcharts.Dictionary<Array<Highcharts.CircleObject>> {
+        // If the set exists in this relation, then it is internal,
+        // otherwise it will be external.
+        const isInternal = sets.indexOf(set.sets[0]) > -1;
+        const property = isInternal ? 'internal' : 'external';
 
-    return relations.reduce(function (
-        map: Highcharts.Dictionary<Highcharts.VennLabelValuesObject>,
-        relation: Highcharts.VennRelationObject
-    ): Highcharts.Dictionary<Highcharts.VennLabelValuesObject> {
-        if (relation.value) {
-            var sets = relation.sets,
-                id = sets.join(),
-                // Create a list of internal and external circles.
-                data = singleSets.reduce(function (
-                    data: Highcharts.Dictionary<(
-                        Array<Highcharts.CircleObject>
-                    )>,
-                    set: Highcharts.VennRelationObject
-                ): Highcharts.Dictionary<Array<Highcharts.CircleObject>> {
-                    // If the set exists in this relation, then it is internal,
-                    // otherwise it will be external.
-                    var isInternal = sets.indexOf(set.sets[0]) > -1,
-                        property = isInternal ? 'internal' : 'external';
+        // Add the circle to the list.
+        data[property].push(set.circle);
+        return data;
+    }, {
+        internal: [],
+        external: []
+    });
 
-                    // Add the circle to the list.
-                    data[property].push(set.circle as any);
-                    return data;
-                }, {
-                    internal: [],
-                    external: []
-                }),
-                // Calulate the label position.
-                position = getLabelPosition(
-                    data.internal,
-                    data.external
-                ),
-                // Calculate the label width
-                width = getLabelWidth(position, data.internal, data.external);
+    // Calulate the label position.
+    const position = getLabelPosition(data.internal, data.external);
+    // Calculate the label width
+    const width = getLabelWidth(position, data.internal, data.external);
 
-            map[id] = {
-                position: position,
-                width: width
-            };
-        }
-        return map;
-    }, {});
-};
+    return {
+        position,
+        width
+    };
+}
 
 /**
  * Takes an array of relations and adds the properties `totalOverlap` and
@@ -845,47 +832,62 @@ var layoutGreedyVenn = function layoutGreedyVenn(
 };
 
 /**
- * Calculates the positions of all the sets in the venn diagram.
+ * Calculates the positions, and the label values of all the sets in the venn
+ * diagram.
+ *
  * @private
  * @todo Add support for constrained MDS.
  * @param {Array<Highchats.VennRelationObject>} relations
  * List of the overlap between two or more sets, or the size of a single set.
- * @return {Highcharts.Dictionary<(Highcharts.CircleObject|Highcharts.GeometryIntersectionObject)>}
+ * @return {Highcharts.Dictionary<*>}
  * List of circles and their calculated positions.
  */
-var layout = function (
+function layout(
     relations: Array<Highcharts.VennRelationObject>
-): Highcharts.Dictionary<(
+): ({
+        mapOfIdToShape: Highcharts.Dictionary<(
+            Highcharts.CircleObject|Highcharts.GeometryIntersectionObject
+        )>;
+        mapOfIdToLabelValues: Highcharts.Dictionary<(
+            Highcharts.VennLabelValuesObject
+        )>;
+    }) {
+    const mapOfIdToShape: Highcharts.Dictionary<(
         Highcharts.CircleObject|Highcharts.GeometryIntersectionObject
-    )> {
-    var mapOfIdToShape: Highcharts.Dictionary<(
-        Highcharts.CircleObject|Highcharts.GeometryIntersectionObject
+    )> = {};
+    const mapOfIdToLabelValues: Highcharts.Dictionary<(
+        Highcharts.VennLabelValuesObject
     )> = {};
 
     // Calculate best initial positions by using greedy layout.
     if (relations.length > 0) {
-        mapOfIdToShape = layoutGreedyVenn(relations);
+        const mapOfIdToCircles = layoutGreedyVenn(relations);
+        const setRelations = relations.filter(isSet);
 
         relations
-            .filter(function (x: Highcharts.VennRelationObject): boolean {
-                return !isSet(x);
-            })
             .forEach(function (relation: Highcharts.VennRelationObject): void {
-                var sets = relation.sets,
-                    id = sets.join(),
-                    circles = sets.map(function (
-                        set: string
-                    ): Highcharts.CircleObject {
-                        return mapOfIdToShape[set] as any;
-                    });
+                const sets = relation.sets;
+                const id = sets.join();
 
-                // Add intersection shape to map
-                mapOfIdToShape[id] =
-                    getAreaOfIntersectionBetweenCircles(circles) as any;
+                // Get shape from map of circles, or calculate intersection.
+                const shape = isSet(relation) ?
+                    mapOfIdToCircles[id] :
+                    getAreaOfIntersectionBetweenCircles(
+                        sets.map((set): Highcharts.CircleObject =>
+                            mapOfIdToCircles[set])
+                    );
+
+                // Calculate label values if the set has a shape
+                if (shape) {
+                    mapOfIdToShape[id] = shape;
+                    mapOfIdToLabelValues[id] = getLabelValues(
+                        relation, setRelations
+                    );
+                }
             });
     }
-    return mapOfIdToShape;
-};
+    return { mapOfIdToShape, mapOfIdToLabelValues };
+}
 
 var isValidRelation = function (
     x: (Highcharts.VennPointOptions|Highcharts.VennRelationObject)
@@ -1139,10 +1141,7 @@ var vennSeries = {
         var relations = processVennData(this.options.data as any);
 
         // Calculate the positions of each circle.
-        var mapOfIdToShape = layout(relations);
-
-        // Calculate positions of each data label
-        var mapOfIdToLabelValues = getLabelValues(relations);
+        const { mapOfIdToShape, mapOfIdToLabelValues } = layout(relations);
 
         // Calculate the scale, and center of the plot area.
         var field = Object.keys(mapOfIdToShape)

--- a/ts/modules/venn.src.ts
+++ b/ts/modules/venn.src.ts
@@ -133,6 +133,7 @@ const {
     getCircleCircleIntersection,
     getCirclesIntersectionPolygon,
     getOverlapBetweenCircles: getOverlapBetweenCirclesByDistance,
+    isCircle1CompletelyOverlappingCircle2,
     isPointInsideAllCircles,
     isPointInsideCircle,
     isPointOutsideAllCircles
@@ -583,6 +584,15 @@ function getLabelValues(
         internal: [],
         external: []
     });
+
+    // Filter out external circles that are completely overlapping all internal
+    data.external = data.external.filter((externalCircle): boolean =>
+        data.internal.some((internalCircle): boolean =>
+            !isCircle1CompletelyOverlappingCircle2(
+                externalCircle, internalCircle
+            )
+        )
+    );
 
     // Calulate the label position.
     const position = getLabelPosition(data.internal, data.external);

--- a/ts/modules/venn.src.ts
+++ b/ts/modules/venn.src.ts
@@ -86,7 +86,7 @@ declare global {
         }
         interface VennUtilsObject {
             geometry: GeometryMixin;
-            geometryCircles: GeometryCircleMixin;
+            geometryCircles: object;
             nelderMead: NelderMeadMixin;
             addOverlapToSets(
                 relations: Array<VennRelationObject>
@@ -126,7 +126,17 @@ declare global {
 
 import draw from '../mixins/draw-point.js';
 import geometry from '../mixins/geometry.js';
-import geometryCircles from '../mixins/geometry-circles.js';
+import GeometryCircleMixin from '../mixins/geometry-circles.js';
+const {
+    getAreaOfCircle,
+    getAreaOfIntersectionBetweenCircles,
+    getCircleCircleIntersection,
+    getCirclesIntersectionPolygon,
+    getOverlapBetweenCircles: getOverlapBetweenCirclesByDistance,
+    isPointInsideAllCircles,
+    isPointInsideCircle,
+    isPointOutsideAllCircles
+} = GeometryCircleMixin;
 
 import NelderMeadModule from '../mixins/nelder-mead.js';
 // TODO: replace with individual imports
@@ -146,19 +156,8 @@ import '../parts/Series.js';
 var addEvent = H.addEvent,
     color = H.Color,
     extend = H.extend,
-    getAreaOfCircle = geometryCircles.getAreaOfCircle,
-    getAreaOfIntersectionBetweenCircles =
-        geometryCircles.getAreaOfIntersectionBetweenCircles,
-    getCirclesIntersectionPolygon =
-        geometryCircles.getCirclesIntersectionPolygon,
-    getCircleCircleIntersection = geometryCircles.getCircleCircleIntersection,
     getCenterOfPoints = geometry.getCenterOfPoints,
     getDistanceBetweenPoints = geometry.getDistanceBetweenPoints,
-    getOverlapBetweenCirclesByDistance =
-        geometryCircles.getOverlapBetweenCircles,
-    isPointInsideAllCircles = geometryCircles.isPointInsideAllCircles,
-    isPointInsideCircle = geometryCircles.isPointInsideCircle,
-    isPointOutsideAllCircles = geometryCircles.isPointOutsideAllCircles,
     merge = H.merge,
     seriesType = H.seriesType,
     seriesTypes = H.seriesTypes;
@@ -1365,7 +1364,7 @@ var vennSeries = {
     utils: {
         addOverlapToSets: addOverlapToSets,
         geometry: geometry,
-        geometryCircles: geometryCircles,
+        geometryCircles: GeometryCircleMixin,
         getLabelWidth: getLabelWidth,
         getMarginFromCircles: getMarginFromCircles,
         getDistanceBetweenCirclesByOverlap: getDistanceBetweenCirclesByOverlap,


### PR DESCRIPTION
Fixed #12434 and #12097, regression in venn series label positioning causing JavaScript error.

---
# Description
- Removed redundant and error prone calculations of label values for points without shapes
- Removed interface for `GeometryCirclesMixin`. This is just utility functions, so the interface won't be used anywhere.
- Improved label positioning by ignoring external circles that is completely overlapping all the internal circles.
# Example(s)
- [Example of issue #12434](https://jsfiddle.net/BlackLabel/jv0p8e3L/)
- [Example of issue #12434 with fix applied](https://jsfiddle.net/jon_a_nygaard/tvnc9jzx/)
- [Example of issue #12097](https://jsfiddle.net/smLn35cz/)
- [Example of issue #12097 with fix applied](https://jsfiddle.net/jon_a_nygaard/2gsjuhca/)

# Related issue(s)
- Closes #12434 
- Closes #12097 