### PR TITLE
bugfix/12425-sunburst-drilldown-after-update

### DIFF
--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -580,7 +580,7 @@ seriesType('treemap', 'scatter'
             this.colorAttribs = colorMapSeriesMixin.colorAttribs;
         }
         // Handle deprecated options.
-        addEvent(series, 'setOptions', function (event) {
+        series.eventsToUnbind.push(addEvent(series, 'setOptions', function (event) {
             var options = event.userOptions;
             if (defined(options.allowDrillToNode) &&
                 !defined(options.allowTraversingTree)) {
@@ -592,10 +592,10 @@ seriesType('treemap', 'scatter'
                 options.traverseUpButton = options.drillUpButton;
                 delete options.drillUpButton;
             }
-        });
+        }));
         Series.prototype.init.call(series, chart, options);
         if (series.options.allowTraversingTree) {
-            addEvent(series, 'click', series.onClickDrillToNode);
+            series.eventsToUnbind.push(addEvent(series, 'click', series.onClickDrillToNode));
         }
     },
     buildNode: function (id, i, level, list, parent) {

--- a/samples/unit-tests/series-sunburst/api-dynamics/demo.js
+++ b/samples/unit-tests/series-sunburst/api-dynamics/demo.js
@@ -290,7 +290,8 @@ QUnit.test('Series.update.', function (assert) {
                 data: [1, 2, 3]
             }]
         }),
-        series = chart.series[0];
+        series = chart.series[0],
+        controller = new TestController(chart);
     assert.strictEqual(
         series.color,
         '#7cb5ec',
@@ -303,5 +304,56 @@ QUnit.test('Series.update.', function (assert) {
         series.color,
         '#ff0000',
         'series.color should equal #ff0000 after update.'
+    );
+
+    series.update({
+        dataLabels: {
+            enabled: false
+        },
+        allowDrillToNode: true,
+        data: [{
+            id: '0.0',
+            parent: ''
+        }, {
+            id: '1.1',
+            parent: '0.0'
+        }, {
+            id: '1.2',
+            parent: '0.0'
+        }, {
+            parent: '1.1',
+            value: 3
+        }, {
+            parent: '1.1',
+            value: 2
+        }, {
+            parent: '1.1',
+            value: 1
+        }, {
+            parent: '1.2',
+            value: 3
+        }, {
+            parent: '1.2',
+            value: 2
+        }, {
+            parent: '1.2',
+            value: 1
+        }]
+    });
+
+    controller.mouseOver(
+        series.center[0] - series.center[2] / 4 + chart.plotLeft,
+        series.center[1] + chart.plotTop
+    );
+
+    controller.click(
+        series.center[0] - series.center[2] / 4 + chart.plotLeft,
+        series.center[1] + chart.plotTop
+    );
+
+    assert.strictEqual(
+        chart.series[0].rootNode,
+        '1.2',
+        'Drilldown should work after series.update (#12425).'
     );
 });

--- a/ts/modules/treemap.src.ts
+++ b/ts/modules/treemap.src.ts
@@ -983,34 +983,38 @@ seriesType<Highcharts.TreemapSeries>(
             }
 
             // Handle deprecated options.
-            addEvent(series, 'setOptions', function (
-                event: {
-                    userOptions: Highcharts.TreemapSeriesOptions;
-                }
-            ): void {
-                var options = event.userOptions;
+            series.eventsToUnbind.push(
+                addEvent(series, 'setOptions', function (
+                    event: {
+                        userOptions: Highcharts.TreemapSeriesOptions;
+                    }
+                ): void {
+                    var options = event.userOptions;
 
-                if (
-                    defined(options.allowDrillToNode) &&
-                    !defined(options.allowTraversingTree)
-                ) {
-                    options.allowTraversingTree = options.allowDrillToNode;
-                    delete options.allowDrillToNode;
-                }
+                    if (
+                        defined(options.allowDrillToNode) &&
+                        !defined(options.allowTraversingTree)
+                    ) {
+                        options.allowTraversingTree = options.allowDrillToNode;
+                        delete options.allowDrillToNode;
+                    }
 
-                if (
-                    defined(options.drillUpButton) &&
-                    !defined(options.traverseUpButton)
-                ) {
-                    options.traverseUpButton = options.drillUpButton;
-                    delete options.drillUpButton;
-                }
-            });
+                    if (
+                        defined(options.drillUpButton) &&
+                        !defined(options.traverseUpButton)
+                    ) {
+                        options.traverseUpButton = options.drillUpButton;
+                        delete options.drillUpButton;
+                    }
+                })
+            );
 
             Series.prototype.init.call(series, chart, options);
 
             if (series.options.allowTraversingTree) {
-                addEvent(series, 'click', series.onClickDrillToNode as any);
+                series.eventsToUnbind.push(
+                    addEvent(series, 'click', series.onClickDrillToNode as any)
+                );
             }
         },
         buildNode: function (


### PR DESCRIPTION
Fixed #12425, updating sunburst series used to disable traversing.
___
It was general problem with events leaking. Multiple click events were added. Additionally removed leaking `setOptions` event.