### PR TITLE
bugfix/12459-annotations-control-points

### DIFF
--- a/js/annotations/eventEmitterMixin.js
+++ b/js/annotations/eventEmitterMixin.js
@@ -23,6 +23,14 @@ var eventEmitterMixin = {
     addEvents: function () {
         var emitter = this;
 
+        H.addEvent(
+            emitter.graphic.element,
+            'mousedown',
+            function (e) {
+                emitter.onMouseDown(e);
+            }
+        );
+
         objectEach(emitter.options.events, function (event, type) {
             var eventHandler = function (e) {
                 if (type !== 'click' || !emitter.cancelClick) {
@@ -42,13 +50,6 @@ var eventEmitterMixin = {
         });
 
         if (emitter.options.draggable) {
-            H.addEvent(
-                emitter.graphic.element,
-                'mousedown',
-                function (e) {
-                    emitter.onMouseDown(e);
-                }
-            );
 
             H.addEvent(emitter, 'drag', emitter.onDrag);
 

--- a/samples/unit-tests/stock-tools/bindings/demo.js
+++ b/samples/unit-tests/stock-tools/bindings/demo.js
@@ -316,8 +316,8 @@ QUnit.test('Bindings general tests', function (assert) {
     points = chart.series[0].points;
     chart.navigationBindings.popup.closePopup();
     controller.click(
-        points[2].plotX + plotLeft - 5,
-        points[2].plotY + plotTop - 25
+        points[2].plotX + plotLeft + 15,
+        points[2].plotY + plotTop + 25
     );
     assert.strictEqual(
         chart.navigationBindings.popup.container.classList

--- a/samples/unit-tests/stock-tools/bindings/demo.js
+++ b/samples/unit-tests/stock-tools/bindings/demo.js
@@ -142,6 +142,35 @@ QUnit.test('Bindings general tests', function (assert) {
         }
     );
 
+    // Test control points, measure-y annotation
+    controller.click(
+        chart.plotLeft + chart.plotWidth / 2,
+        chart.plotTop + chart.plotHeight / 2
+    );
+
+    controller.mouseDown(
+        chart.plotLeft + chart.plotWidth / 2,
+        chart.plotTop + chart.plotHeight / 2 +
+            chart.annotations[16].shapes[1].graphic.getBBox().height / 2
+    );
+
+    controller.mouseMove(
+        chart.plotLeft + chart.plotWidth / 2,
+        chart.plotTop + chart.plotHeight / 2 + 10
+    );
+
+    controller.mouseUp(
+        chart.plotLeft + chart.plotWidth / 2,
+        chart.plotTop + chart.plotHeight / 2 + 10
+    );
+
+    assert.close(
+        chart.annotations[16].yAxisMax,
+        chart.yAxis[0].toValue(chart.plotHeight / 2 + 10),
+        1,
+        'Annotation should updated after control point\'s drag&drop (#12459)'
+    );
+
     // Individual button events:
 
     // Current Price Indicator


### PR DESCRIPTION
Fixed #12459, annotation's control points were not draggable.