### PR TITLE
bugfix/12500-update-datalabel-contrast

### DIFF
--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -334,6 +334,9 @@ Series.prototype.drawDataLabels = function () {
                                 point.contrastColor :
                                 '${palette.neutralColor100}';
                         }
+                        else {
+                            delete point.contrastColor;
+                        }
                         if (seriesOptions.cursor) {
                             style.cursor = seriesOptions.cursor;
                         }

--- a/samples/unit-tests/datalabels/contrast/demo.js
+++ b/samples/unit-tests/datalabels/contrast/demo.js
@@ -50,6 +50,19 @@ QUnit.test('#6487: Column\'s data label with contrast after justification.', fun
         `Contrast color should not be used when dataLabel does not collide  
             with column (#6657).`
     );
+
+    chart.series[1].update({
+        dataLabels: {
+            inside: true,
+            color: 'red'
+        }
+    });
+    assert.strictEqual(
+        chart.series[1].points[11].dataLabel.element.childNodes[0].style.color,
+        'red',
+        `After updating from contrast color,
+            label should have new color (#12500)`
+    );
 });
 
 QUnit.test('Pie dataLabels and contrast', function (assert) {

--- a/ts/parts/DataLabels.ts
+++ b/ts/parts/DataLabels.ts
@@ -687,6 +687,8 @@ Series.prototype.drawDataLabels = function (this: Highcharts.Series): void {
                                 !!seriesOptions.stacking ?
                                 point.contrastColor :
                                 '${palette.neutralColor100}';
+                        } else {
+                            delete point.contrastColor;
                         }
                         if (seriesOptions.cursor) {
                             (style as any).cursor = seriesOptions.cursor;


### PR DESCRIPTION
Fixed #12500, updating `dataLabel` color from contrast to a different one was not working.
___
As in commit, once `point.contrast` was set, then it was never cleared.