### PR TITLE
bugfix/panning-datagrouping-ordinal

### DIFF
--- a/js/parts/DataGrouping.js
+++ b/js/parts/DataGrouping.js
@@ -469,7 +469,7 @@ seriesProto.processData = function () {
                     xAxis.min === xAxis.dataMin) {
                     xAxis.min = Math.min(groupedXData[0], xAxis.min);
                 }
-                xAxis.dataMin = groupedXData[0];
+                xAxis.dataMin = Math.min(groupedXData[0], xAxis.dataMin);
             }
             // We calculated all group positions but we should render
             // only the ones within the visible range

--- a/ts/parts/DataGrouping.ts
+++ b/ts/parts/DataGrouping.ts
@@ -788,7 +788,11 @@ seriesProto.processData = function (this: Highcharts.Series): any {
                 ) {
                     xAxis.min = Math.min(groupedXData[0], (xAxis.min as any));
                 }
-                xAxis.dataMin = groupedXData[0];
+
+                xAxis.dataMin = Math.min(
+                    groupedXData[0],
+                    (xAxis.dataMin as any)
+                );
             }
 
             // We calculated all group positions but we should render


### PR DESCRIPTION
Fixed regression which prevented from panning to the left side when `dataGrouping` and `xAxis.ordinal` were enabled.
___
Fixes: https://github.com/highcharts/highcharts/pull/11779#issuecomment-559029328

v7.2.1 demo: https://jsfiddle.net/BlackLabel/db0cuhsj/