### PR TITLE
Added 1 as a default value to zIndex, in no data to display

### DIFF
--- a/js/modules/no-data-to-display.src.js
+++ b/js/modules/no-data-to-display.src.js
@@ -62,6 +62,9 @@ defaultOptions.noData = {
      * @product   highcharts highstock gantt
      * @apioption noData.attr
      */
+    attr: {
+        zIndex: 1
+    },
     /**
      * Whether to insert the label as HTML, or as pseudo-HTML rendered with
      * SVG.

--- a/samples/unit-tests/no-data/members/demo.details
+++ b/samples/unit-tests/no-data/members/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/no-data/members/demo.html
+++ b/samples/unit-tests/no-data/members/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/no-data-to-display.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/no-data/members/demo.js
+++ b/samples/unit-tests/no-data/members/demo.js
@@ -1,0 +1,15 @@
+QUnit.test("defaultOptions", assert => {
+    const {
+        noData: {
+            attr: {
+                zIndex
+            }
+        }
+    } = Highcharts.getOptions();
+
+    assert.equal(
+        zIndex,
+        1,
+        "Default z index should be 1 (#12343)"
+    );
+});

--- a/ts/modules/no-data-to-display.src.ts
+++ b/ts/modules/no-data-to-display.src.ts
@@ -106,6 +106,9 @@ defaultOptions.noData = {
      * @product   highcharts highstock gantt
      * @apioption noData.attr
      */
+    attr: {
+        zIndex: 1
+    },
 
     /**
      * Whether to insert the label as HTML, or as pseudo-HTML rendered with
@@ -185,7 +188,6 @@ chartPrototype.showNoData = function (str?: string): void {
         text = str || (options && (options.lang as any).noData),
         noDataOptions: Highcharts.NoDataOptions =
             options && (options.noData as any);
-
     if (!chart.noDataLabel && chart.renderer) {
         chart.noDataLabel = chart.renderer
             .label(


### PR DESCRIPTION
Fixed #12343, `noData` message was not visible with gauge series. Added 1 as default `zIndex` to render the message in front.

---
# Examples
- [Demo of issue](https://jsfiddle.net/nq0hos8m/)
- [Demo of issue with fix applied](https://jsfiddle.net/kxnuh3j0/)
# Related issues
- Closes #12343 