### PR TITLE
Fixed #12462, replacing slash in filename

### DIFF
--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -1153,7 +1153,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
     getFilename: function () {
         var s = this.userOptions.title && this.userOptions.title.text, filename = this.options.exporting.filename;
         if (filename) {
-            return filename;
+            return filename.replace(/\//g, '-');
         }
         if (typeof s === 'string') {
             filename = s
@@ -1205,7 +1205,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         exportingOptions = merge(this.options.exporting, exportingOptions);
         // do the post
         H.post(exportingOptions.url, {
-            filename: exportingOptions.filename || this.getFilename(),
+            filename: exportingOptions.filename ? exportingOptions.filename.replace(/\//g, '-') : this.getFilename(),
             type: exportingOptions.type,
             // IE8 fails to post undefined correctly, so use 0
             width: exportingOptions.width || 0,

--- a/samples/unit-tests/exporting/filename/demo.js
+++ b/samples/unit-tests/exporting/filename/demo.js
@@ -119,6 +119,48 @@ QUnit.test('POST filename', function (assert) {
         Highcharts.post = originalPost;
 
     }
+    try {
+
+        Highcharts.post = function (url, data) {
+            postData = data;
+        };
 
 
+        // Run export width custom file name
+        chart.exportChart({
+            type: 'application/pdf',
+            filename: 'lorem/ipsum'
+        });
+
+        assert.strictEqual(
+            postData.filename,
+            'lorem-ipsum',
+            'Forward slash in filename was replaced'
+        );
+
+    } finally {
+
+        Highcharts.post = originalPost;
+
+    }
+
+
+});
+
+QUnit.test("Filename option", assert => {
+    const chart = title => Highcharts
+        .chart('container', {
+            title: {
+                text: 'Title text'
+            },
+            exporting: {
+                filename: title
+            }
+        });
+
+    assert.strictEqual(
+        chart('Medical/Dental office').getFilename(),
+        'Medical-Dental office',
+        'Forward slash should be replaced with dash'
+    );
 });

--- a/ts/modules/exporting.src.ts
+++ b/ts/modules/exporting.src.ts
@@ -1539,7 +1539,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             filename: string = (this.options.exporting as any).filename;
 
         if (filename) {
-            return filename;
+            return filename.replace(/\//g, '-');
         }
 
         if (typeof s === 'string') {
@@ -1602,7 +1602,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
 
         // do the post
         H.post(exportingOptions.url as any, {
-            filename: exportingOptions.filename || this.getFilename(),
+            filename: exportingOptions.filename ? exportingOptions.filename.replace(/\//g, '-') : this.getFilename(),
             type: exportingOptions.type,
             // IE8 fails to post undefined correctly, so use 0
             width: exportingOptions.width || 0,


### PR DESCRIPTION
Fixed #12462, filename with forward slash (`/`) not being replaced with safe character when exported. Now replaced with `-`.

# Description
Replaces `/` in the filename set in `exportChart` and `getFilename` in the export module.

# Example(s)
* [Demo of issue](https://jsfiddle.net/2wrxe7v3/1/)
* [Demo of issue with fix applied](https://jsfiddle.net/goransle/4jos3bkc/7/)
## Related issue(s)
Closes #12462