### PR TITLE
docs/demo-tags

### DIFF
--- a/samples/gantt/demo/custom-labels/demo.details
+++ b/samples/gantt/demo/custom-labels/demo.details
@@ -5,7 +5,8 @@ authors:
   - Torstein Hønsi
 resources:
   - 'https://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css'
-tags: []
+tags:
+  - Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/download-pdf/demo.details
+++ b/samples/gantt/demo/download-pdf/demo.details
@@ -6,7 +6,8 @@ authors:
 resources:
   - 'https://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css'
 requiresManualTesting: true
-tags: []
+tags:
+  - Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/interactive-gantt/demo.details
+++ b/samples/gantt/demo/interactive-gantt/demo.details
@@ -6,7 +6,8 @@ authors:
 resources:
   - 'https://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css'
 requiresManualTesting: true
-tags: []
+tags:
+  - Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/inverted/demo.details
+++ b/samples/gantt/demo/inverted/demo.details
@@ -3,7 +3,8 @@ name: Inverted chart
 js_wrap: b
 authors:
   - Lars Cabrera
-tags: []
+tags:
+  - Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/left-axis-table/demo.details
+++ b/samples/gantt/demo/left-axis-table/demo.details
@@ -3,7 +3,8 @@ name: Left axis as a table
 js_wrap: b
 authors:
   - Lars Cabrera
-tags: []
+tags:
+  - Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/progress-indicator/demo.details
+++ b/samples/gantt/demo/progress-indicator/demo.details
@@ -4,7 +4,8 @@ js_wrap: b
 authors:
   - Lars Cabrera
 compareTooltips: true
-tags: []
+tags:
+  - Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/project-management/demo.details
+++ b/samples/gantt/demo/project-management/demo.details
@@ -3,7 +3,8 @@ name: Project Management
 js_wrap: b
 authors:
   - Jon Arild Nygård
-tags: []
+tags:
+  - Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/resource-management/demo.details
+++ b/samples/gantt/demo/resource-management/demo.details
@@ -3,7 +3,8 @@ name: Resource Management
 js_wrap: b
 authors:
   - Jon Arild Nygård
-tags: []
+tags:
+  - Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/styled-mode/demo.details
+++ b/samples/gantt/demo/styled-mode/demo.details
@@ -3,7 +3,8 @@ name: Styled mode
 js_wrap: b
 authors:
   - Lars Cabrera
-tags: []
+tags:
+  - Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/subtasks/demo.details
+++ b/samples/gantt/demo/subtasks/demo.details
@@ -3,7 +3,8 @@ name: Subtasks
 js_wrap: b
 authors:
   - Lars Cabrera
-tags: []
+tags:
+  - Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/with-navigation/demo.details
+++ b/samples/gantt/demo/with-navigation/demo.details
@@ -3,7 +3,8 @@ name: With navigation
 js_wrap: b
 authors:
   - Torstein Hønsi
-tags: []
+tags:
+  - Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/highcharts/demo/3d-column-interactive/demo.details
+++ b/samples/highcharts/demo/3d-column-interactive/demo.details
@@ -3,7 +3,8 @@ name: 3D column
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - 3D charts
 ...

--- a/samples/highcharts/demo/3d-column-null-values/demo.details
+++ b/samples/highcharts/demo/3d-column-null-values/demo.details
@@ -3,7 +3,8 @@ name: 3D column with null and 0 values
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - 3D charts
 ...

--- a/samples/highcharts/demo/3d-column-stacking-grouping/demo.details
+++ b/samples/highcharts/demo/3d-column-stacking-grouping/demo.details
@@ -3,7 +3,8 @@ name: 3D column with stacking and grouping
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - 3D charts
 ...

--- a/samples/highcharts/demo/3d-pie-donut/demo.details
+++ b/samples/highcharts/demo/3d-pie-donut/demo.details
@@ -3,7 +3,8 @@ name: 3D donut
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - 3D charts
 ...

--- a/samples/highcharts/demo/3d-pie/demo.details
+++ b/samples/highcharts/demo/3d-pie/demo.details
@@ -3,7 +3,8 @@ name: 3D pie
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - 3D charts
 ...

--- a/samples/highcharts/demo/3d-scatter-draggable/demo.details
+++ b/samples/highcharts/demo/3d-scatter-draggable/demo.details
@@ -3,7 +3,8 @@ name: 3D scatter chart
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - 3D charts
 ...

--- a/samples/highcharts/demo/accessible-line/demo.details
+++ b/samples/highcharts/demo/accessible-line/demo.details
@@ -3,7 +3,8 @@ name: Accessible line chart
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Accessible charts
 ...

--- a/samples/highcharts/demo/accessible-pie/demo.details
+++ b/samples/highcharts/demo/accessible-pie/demo.details
@@ -3,7 +3,8 @@ name: Accessible pie chart
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Accessible charts
 ...

--- a/samples/highcharts/demo/advanced-accessible/demo.details
+++ b/samples/highcharts/demo/advanced-accessible/demo.details
@@ -3,7 +3,8 @@ name: Advanced accessible chart
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Accessible charts
 ...

--- a/samples/highcharts/demo/annotations/demo.details
+++ b/samples/highcharts/demo/annotations/demo.details
@@ -6,7 +6,8 @@ js_wrap: b
 alt_text: >-
   Highcharts basic line chart with annotations JavaScript example displays
   annotated shaded graph plot of Tour France.
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Line charts
 ...

--- a/samples/highcharts/demo/area-basic/demo.details
+++ b/samples/highcharts/demo/area-basic/demo.details
@@ -6,7 +6,8 @@ js_wrap: b
 alt_text: >-
   Highcharts basic area chart JavaScript example graph compares cold war nuclear
   weapon stockpile peaks over time.
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Area charts
 ...

--- a/samples/highcharts/demo/area-basic/demo.details
+++ b/samples/highcharts/demo/area-basic/demo.details
@@ -10,4 +10,5 @@ tags:
   - Highcharts demo
 categories:
   - Area charts
+priority: 1
 ...

--- a/samples/highcharts/demo/area-inverted/demo.details
+++ b/samples/highcharts/demo/area-inverted/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 compareTooltips: true
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Area charts
 ...

--- a/samples/highcharts/demo/area-missing/demo.details
+++ b/samples/highcharts/demo/area-missing/demo.details
@@ -3,7 +3,8 @@ name: Area with missing points
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Area charts
 ...

--- a/samples/highcharts/demo/area-negative/demo.details
+++ b/samples/highcharts/demo/area-negative/demo.details
@@ -3,7 +3,8 @@ name: Area with negative values
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Area charts
 ...

--- a/samples/highcharts/demo/area-stacked-percent/demo.details
+++ b/samples/highcharts/demo/area-stacked-percent/demo.details
@@ -3,7 +3,8 @@ name: Percentage area
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Area charts
 ...

--- a/samples/highcharts/demo/area-stacked/demo.details
+++ b/samples/highcharts/demo/area-stacked/demo.details
@@ -6,7 +6,8 @@ js_wrap: b
 alt_text: >-
   Highcharts percentage area chart JavaScript example graph compares and
   estimates global continental population growth over time.
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Area charts
 ...

--- a/samples/highcharts/demo/arearange-line/demo.details
+++ b/samples/highcharts/demo/arearange-line/demo.details
@@ -3,7 +3,8 @@ name: Area range and line
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Area charts
 ...

--- a/samples/highcharts/demo/arearange/demo.details
+++ b/samples/highcharts/demo/arearange/demo.details
@@ -3,7 +3,8 @@ name: Area range
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Area charts
 ...

--- a/samples/highcharts/demo/areaspline/demo.details
+++ b/samples/highcharts/demo/areaspline/demo.details
@@ -3,7 +3,8 @@ name: Area-spline
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Area charts
 ...

--- a/samples/highcharts/demo/bar-basic/demo.details
+++ b/samples/highcharts/demo/bar-basic/demo.details
@@ -3,7 +3,8 @@ name: Basic bar
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Column and bar charts
 ...

--- a/samples/highcharts/demo/bar-negative-stack/demo.details
+++ b/samples/highcharts/demo/bar-negative-stack/demo.details
@@ -3,7 +3,8 @@ name: Bar with negative stack
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Column and bar charts
 ...

--- a/samples/highcharts/demo/bar-stacked/demo.details
+++ b/samples/highcharts/demo/bar-stacked/demo.details
@@ -6,7 +6,8 @@ js_wrap: b
 alt_text: >-
   Highcharts horizontal stacked bar chart JavaScript example graph compares
   human fruit consumption of apple pear grape.
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Column and bar charts
 ...

--- a/samples/highcharts/demo/bellcurve/demo.details
+++ b/samples/highcharts/demo/bellcurve/demo.details
@@ -1,7 +1,8 @@
 ---
 name: Bell curve
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/box-plot/demo.details
+++ b/samples/highcharts/demo/box-plot/demo.details
@@ -3,7 +3,8 @@ name: Box plot
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/bubble-3d/demo.details
+++ b/samples/highcharts/demo/bubble-3d/demo.details
@@ -6,7 +6,8 @@ js_wrap: b
 alt_text: >-
   Highcharts 3D Bubbles chart JavaScript example graph compares series values as
   radial gradient fill bubble diagram.
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Scatter and bubble charts
 ...

--- a/samples/highcharts/demo/bubble/demo.details
+++ b/samples/highcharts/demo/bubble/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 compareTooltips: true
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Scatter and bubble charts
 ...

--- a/samples/highcharts/demo/bullet-graph/demo.details
+++ b/samples/highcharts/demo/bullet-graph/demo.details
@@ -3,7 +3,8 @@ name: Bullet graph
 authors:
   - Kacper Madej
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Gauges
 ...

--- a/samples/highcharts/demo/chart-update/demo.details
+++ b/samples/highcharts/demo/chart-update/demo.details
@@ -3,7 +3,8 @@ name: Update options after render
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Dynamic charts
 ...

--- a/samples/highcharts/demo/column-basic/demo.details
+++ b/samples/highcharts/demo/column-basic/demo.details
@@ -6,7 +6,8 @@ js_wrap: b
 alt_text: >-
   Highcharts vertical basic column chart JavaScript example graph compares
   monthly average rainfall in major cities clusters.
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Column and bar charts
 ...

--- a/samples/highcharts/demo/column-drilldown/demo.details
+++ b/samples/highcharts/demo/column-drilldown/demo.details
@@ -3,7 +3,8 @@ name: Column with drilldown
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Column and bar charts
 ...

--- a/samples/highcharts/demo/column-negative/demo.details
+++ b/samples/highcharts/demo/column-negative/demo.details
@@ -3,7 +3,8 @@ name: Column with negative values
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Column and bar charts
 ...

--- a/samples/highcharts/demo/column-parsed/demo.details
+++ b/samples/highcharts/demo/column-parsed/demo.details
@@ -3,7 +3,8 @@ name: Data defined in a HTML table
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Column and bar charts
 ...

--- a/samples/highcharts/demo/column-placement/demo.details
+++ b/samples/highcharts/demo/column-placement/demo.details
@@ -3,7 +3,8 @@ name: Fixed placement columns
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Column and bar charts
 ...

--- a/samples/highcharts/demo/column-pyramid/demo.details
+++ b/samples/highcharts/demo/column-pyramid/demo.details
@@ -3,7 +3,8 @@ name: Column pyramid chart
 authors:
   - Sebastian Bochan
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/column-rotated-labels/demo.details
+++ b/samples/highcharts/demo/column-rotated-labels/demo.details
@@ -3,7 +3,8 @@ name: Column with rotated labels
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Column and bar charts
 ...

--- a/samples/highcharts/demo/column-stacked-and-grouped/demo.details
+++ b/samples/highcharts/demo/column-stacked-and-grouped/demo.details
@@ -3,7 +3,8 @@ name: Stacked and grouped column
 js_wrap: b
 authors:
   - Torstein Hønsi
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Column and bar charts
 ...

--- a/samples/highcharts/demo/column-stacked-percent/demo.details
+++ b/samples/highcharts/demo/column-stacked-percent/demo.details
@@ -3,7 +3,8 @@ name: Stacked percentage column
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Column and bar charts
 ...

--- a/samples/highcharts/demo/column-stacked/demo.details
+++ b/samples/highcharts/demo/column-stacked/demo.details
@@ -3,7 +3,8 @@ name: Stacked column
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Column and bar charts
 ...

--- a/samples/highcharts/demo/columnrange/demo.details
+++ b/samples/highcharts/demo/columnrange/demo.details
@@ -3,7 +3,8 @@ name: Column range
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Column and bar charts
 ...

--- a/samples/highcharts/demo/combo-dual-axes/demo.details
+++ b/samples/highcharts/demo/combo-dual-axes/demo.details
@@ -3,7 +3,8 @@ name: 'Dual axes, line and column'
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Combinations
 ...

--- a/samples/highcharts/demo/combo-meteogram/demo.details
+++ b/samples/highcharts/demo/combo-meteogram/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 requiresManualTesting: true
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Combinations
 ...

--- a/samples/highcharts/demo/combo-multi-axes/demo.details
+++ b/samples/highcharts/demo/combo-multi-axes/demo.details
@@ -3,7 +3,8 @@ name: Multiple axes
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Combinations
 ...

--- a/samples/highcharts/demo/combo-regression/demo.details
+++ b/samples/highcharts/demo/combo-regression/demo.details
@@ -3,7 +3,8 @@ name: Scatter with regression line
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Combinations
 ...

--- a/samples/highcharts/demo/combo-timeline/demo.details
+++ b/samples/highcharts/demo/combo-timeline/demo.details
@@ -3,7 +3,8 @@ name: Advanced timeline
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Combinations
 ...

--- a/samples/highcharts/demo/combo/demo.details
+++ b/samples/highcharts/demo/combo/demo.details
@@ -3,7 +3,8 @@ name: 'Column, line and pie'
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Combinations
 ...

--- a/samples/highcharts/demo/cylinder/demo.details
+++ b/samples/highcharts/demo/cylinder/demo.details
@@ -7,7 +7,8 @@ js_wrap: b
 alt_text: >-
   Highcharts 3D cylinder chart JavaScript example graph compares variables as
   three dimensional vertical color bar chart.
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - 3D charts
 ...

--- a/samples/highcharts/demo/dependency-wheel/demo.details
+++ b/samples/highcharts/demo/dependency-wheel/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 isNew: true
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/dumbbell/demo.details
+++ b/samples/highcharts/demo/dumbbell/demo.details
@@ -1,6 +1,9 @@
 ---
- name: Highcharts Demo
- authors:
-   - Rafal Sebestjanski
- js_wrap: b
+name: Highcharts Demo
+authors:
+  - Rafal Sebestjanski
+js_wrap: b
+tags:
+  - Highcharts demo
+categories: []
 ...

--- a/samples/highcharts/demo/dynamic-click-to-add/demo.details
+++ b/samples/highcharts/demo/dynamic-click-to-add/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 skipTest: true
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Dynamic charts
 ...

--- a/samples/highcharts/demo/dynamic-master-detail/demo.details
+++ b/samples/highcharts/demo/dynamic-master-detail/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 requiresManualTesting: true
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Dynamic charts
 ...

--- a/samples/highcharts/demo/dynamic-update/demo.details
+++ b/samples/highcharts/demo/dynamic-update/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 requiresManualTesting: true
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Dynamic charts
 ...

--- a/samples/highcharts/demo/error-bar/demo.details
+++ b/samples/highcharts/demo/error-bar/demo.details
@@ -3,7 +3,8 @@ name: Error bar
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/euler-diagram/demo.details
+++ b/samples/highcharts/demo/euler-diagram/demo.details
@@ -3,7 +3,8 @@ name: Euler diagram
 authors:
   - Jon Arild Nygård
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/flame/demo.details
+++ b/samples/highcharts/demo/flame/demo.details
@@ -4,9 +4,10 @@ authors:
   - Kacper Madej
 js_wrap: b
 alt_text: >-
-  Highcharts flame chart JavaScript example graph shows
-  a chart rendering process as stacked tasks and subtasks.
-tags: []
+  Highcharts flame chart JavaScript example graph shows a chart rendering
+  process as stacked tasks and subtasks.
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/funnel/demo.details
+++ b/samples/highcharts/demo/funnel/demo.details
@@ -3,7 +3,8 @@ name: Funnel chart
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/funnel3d/demo.details
+++ b/samples/highcharts/demo/funnel3d/demo.details
@@ -7,7 +7,8 @@ isNew: true
 alt_text: >-
   Highcharts 3D funnel chart JavaScript example graph visualizes pipeline
   conversion of website visits to customers downloads.
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - 3D charts
 ...

--- a/samples/highcharts/demo/gauge-activity/demo.details
+++ b/samples/highcharts/demo/gauge-activity/demo.details
@@ -3,7 +3,8 @@ name: Activity gauge
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Gauges
 ...

--- a/samples/highcharts/demo/gauge-clock/demo.details
+++ b/samples/highcharts/demo/gauge-clock/demo.details
@@ -3,7 +3,8 @@ name: Clock
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Gauges
 ...

--- a/samples/highcharts/demo/gauge-dual/demo.details
+++ b/samples/highcharts/demo/gauge-dual/demo.details
@@ -3,7 +3,8 @@ name: Gauge with dual axes
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Gauges
 ...

--- a/samples/highcharts/demo/gauge-solid/demo.details
+++ b/samples/highcharts/demo/gauge-solid/demo.details
@@ -3,7 +3,8 @@ name: Solid gauge
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Gauges
 ...

--- a/samples/highcharts/demo/gauge-speedometer/demo.details
+++ b/samples/highcharts/demo/gauge-speedometer/demo.details
@@ -3,7 +3,8 @@ name: Gauge series
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Gauges
 ...

--- a/samples/highcharts/demo/gauge-vu-meter/demo.details
+++ b/samples/highcharts/demo/gauge-vu-meter/demo.details
@@ -3,7 +3,8 @@ name: VU meter
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Gauges
 ...

--- a/samples/highcharts/demo/heatmap-canvas/demo.details
+++ b/samples/highcharts/demo/heatmap-canvas/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 requiresManualTesting: true
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Heat and tree maps
 ...

--- a/samples/highcharts/demo/heatmap/demo.details
+++ b/samples/highcharts/demo/heatmap/demo.details
@@ -8,4 +8,5 @@ tags:
   - Highcharts demo
 categories:
   - Heat and tree maps
+priority: 1
 ...

--- a/samples/highcharts/demo/heatmap/demo.details
+++ b/samples/highcharts/demo/heatmap/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 compareTooltips: true
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Heat and tree maps
 ...

--- a/samples/highcharts/demo/histogram/demo.details
+++ b/samples/highcharts/demo/histogram/demo.details
@@ -1,7 +1,8 @@
 ---
 name: Histogram
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/honeycomb-usa/demo.details
+++ b/samples/highcharts/demo/honeycomb-usa/demo.details
@@ -6,7 +6,8 @@ js_wrap: b
 alt_text: >-
   Highcharts honeycomb tile map JavaScript example graph visualizes US
   population geographically by state with color chart.
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Heat and tree maps
 ...

--- a/samples/highcharts/demo/line-ajax/demo.details
+++ b/samples/highcharts/demo/line-ajax/demo.details
@@ -3,7 +3,8 @@ name: 'Ajax loaded data, clickable points'
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Line charts
 ...

--- a/samples/highcharts/demo/line-basic/demo.details
+++ b/samples/highcharts/demo/line-basic/demo.details
@@ -6,7 +6,8 @@ js_wrap: b
 alt_text: >-
   Highcharts basic line chart JavaScript example displays graph plot of solar
   employment growth areas over time.
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Line charts
 ...

--- a/samples/highcharts/demo/line-basic/demo.details
+++ b/samples/highcharts/demo/line-basic/demo.details
@@ -10,4 +10,5 @@ tags:
   - Highcharts demo
 categories:
   - Line charts
+priority: 1
 ...

--- a/samples/highcharts/demo/line-boost/demo.details
+++ b/samples/highcharts/demo/line-boost/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 requiresManualTesting: true
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Line charts
 ...

--- a/samples/highcharts/demo/line-labels/demo.details
+++ b/samples/highcharts/demo/line-labels/demo.details
@@ -3,7 +3,8 @@ name: With data labels
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Line charts
 ...

--- a/samples/highcharts/demo/line-log-axis/demo.details
+++ b/samples/highcharts/demo/line-log-axis/demo.details
@@ -3,7 +3,8 @@ name: Logarithmic axis
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Line charts
 ...

--- a/samples/highcharts/demo/line-time-series/demo.details
+++ b/samples/highcharts/demo/line-time-series/demo.details
@@ -3,7 +3,8 @@ name: 'Time series, zoomable'
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Line charts
 ...

--- a/samples/highcharts/demo/live-data/demo.details
+++ b/samples/highcharts/demo/live-data/demo.details
@@ -3,7 +3,8 @@ name: Live data from dynamic CSV
 authors:
   - Christer Vasseng
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Dynamic charts
 ...

--- a/samples/highcharts/demo/lollipop/demo.details
+++ b/samples/highcharts/demo/lollipop/demo.details
@@ -1,6 +1,9 @@
 ---
- name: Highcharts Demo
- authors:
-   - Rafal Sebestjanski
- js_wrap: b
+name: Highcharts Demo
+authors:
+  - Rafal Sebestjanski
+js_wrap: b
+tags:
+  - Highcharts demo
+categories: []
 ...

--- a/samples/highcharts/demo/network-graph/demo.details
+++ b/samples/highcharts/demo/network-graph/demo.details
@@ -3,7 +3,8 @@ name: Network graph (force directed graph)
 authors:
   - Paweł Fus
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/organization-chart/demo.details
+++ b/samples/highcharts/demo/organization-chart/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 isNew: true
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/packed-bubble-split/demo.details
+++ b/samples/highcharts/demo/packed-bubble-split/demo.details
@@ -4,7 +4,8 @@ authors:
   - Sebastian Bochan
 js_wrap: b
 isNew: true
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Scatter and bubble charts
 ...

--- a/samples/highcharts/demo/packed-bubble/demo.details
+++ b/samples/highcharts/demo/packed-bubble/demo.details
@@ -4,7 +4,8 @@ authors:
   - Sebastian Bochan
 js_wrap: b
 isNew: true
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Scatter and bubble charts
 ...

--- a/samples/highcharts/demo/parallel-coordinates/demo.details
+++ b/samples/highcharts/demo/parallel-coordinates/demo.details
@@ -3,7 +3,8 @@ name: Parallel coordinates
 authors:
   - Paweł Fus
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/pareto/demo.details
+++ b/samples/highcharts/demo/pareto/demo.details
@@ -6,7 +6,8 @@ js_wrap: b
 alt_text: >-
   Highcharts pareto chart JavaScript example visualizes percentage restaurant
   complaints by combining line and vertical bar graphs.
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/parliament-chart/demo.details
+++ b/samples/highcharts/demo/parliament-chart/demo.details
@@ -7,7 +7,8 @@ isNew: true
 alt_text: >-
   Highcharts parliament item chart JavaScript example visualizes German
   political party breakdown by color and percentage proportion.
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/pie-basic/demo.details
+++ b/samples/highcharts/demo/pie-basic/demo.details
@@ -6,7 +6,8 @@ js_wrap: b
 alt_text: >-
   Highcharts basic pie chart JavaScript example compares Chrome Firefox Safari
   browser market share as proportional segments.
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Pie charts
 ...

--- a/samples/highcharts/demo/pie-basic/demo.details
+++ b/samples/highcharts/demo/pie-basic/demo.details
@@ -10,4 +10,5 @@ tags:
   - Highcharts demo
 categories:
   - Pie charts
+priority: 1
 ...

--- a/samples/highcharts/demo/pie-donut/demo.details
+++ b/samples/highcharts/demo/pie-donut/demo.details
@@ -3,7 +3,8 @@ name: Donut chart
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Pie charts
 ...

--- a/samples/highcharts/demo/pie-drilldown/demo.details
+++ b/samples/highcharts/demo/pie-drilldown/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 skipTest: true
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Pie charts
 ...

--- a/samples/highcharts/demo/pie-gradient/demo.details
+++ b/samples/highcharts/demo/pie-gradient/demo.details
@@ -3,7 +3,8 @@ name: Pie with gradient fill
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Pie charts
 ...

--- a/samples/highcharts/demo/pie-legend/demo.details
+++ b/samples/highcharts/demo/pie-legend/demo.details
@@ -3,7 +3,8 @@ name: Pie with legend
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Pie charts
 ...

--- a/samples/highcharts/demo/pie-monochrome/demo.details
+++ b/samples/highcharts/demo/pie-monochrome/demo.details
@@ -3,7 +3,8 @@ name: Pie with monochrome fill
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Pie charts
 ...

--- a/samples/highcharts/demo/pie-semi-circle/demo.details
+++ b/samples/highcharts/demo/pie-semi-circle/demo.details
@@ -3,7 +3,8 @@ name: Semi circle donut
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Pie charts
 ...

--- a/samples/highcharts/demo/polar-radial-bar/demo.details
+++ b/samples/highcharts/demo/polar-radial-bar/demo.details
@@ -3,7 +3,8 @@ name: Radial bar chart
 authors:
   - Pawel Dalek
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/polar-spider/demo.details
+++ b/samples/highcharts/demo/polar-spider/demo.details
@@ -3,7 +3,8 @@ name: Spiderweb
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/polar-wind-rose/demo.details
+++ b/samples/highcharts/demo/polar-wind-rose/demo.details
@@ -6,7 +6,8 @@ js_wrap: b
 alt_text: >-
   Highcharts wind rose chart JavaScript example visualizes weather frequency
   conditions by compass direction using polar graph.
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/polar/demo.details
+++ b/samples/highcharts/demo/polar/demo.details
@@ -3,7 +3,8 @@ name: Polar (radar) chart
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/polygon/demo.details
+++ b/samples/highcharts/demo/polygon/demo.details
@@ -3,7 +3,8 @@ name: Polygon series
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/pyramid/demo.details
+++ b/samples/highcharts/demo/pyramid/demo.details
@@ -3,7 +3,8 @@ name: Pyramid chart
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/pyramid3d/demo.details
+++ b/samples/highcharts/demo/pyramid3d/demo.details
@@ -4,7 +4,8 @@ authors:
   - Kacper Madej
 js_wrap: b
 isNew: true
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - 3D charts
 ...

--- a/samples/highcharts/demo/renderer/demo.details
+++ b/samples/highcharts/demo/renderer/demo.details
@@ -3,7 +3,8 @@ name: General drawing
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/responsive/demo.details
+++ b/samples/highcharts/demo/responsive/demo.details
@@ -3,7 +3,8 @@ name: Responsive chart
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Dynamic charts
 ...

--- a/samples/highcharts/demo/sankey-diagram/demo.details
+++ b/samples/highcharts/demo/sankey-diagram/demo.details
@@ -3,7 +3,8 @@ name: Sankey diagram
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/scatter-boost/demo.details
+++ b/samples/highcharts/demo/scatter-boost/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 requiresManualTesting: true
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Scatter and bubble charts
 ...

--- a/samples/highcharts/demo/scatter/demo.details
+++ b/samples/highcharts/demo/scatter/demo.details
@@ -6,7 +6,8 @@ js_wrap: b
 alt_text: >-
   Highcharts basic scatter plot JavaScript example graph compares male female
   gender type height and weight variables.
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Scatter and bubble charts
 ...

--- a/samples/highcharts/demo/scatter/demo.details
+++ b/samples/highcharts/demo/scatter/demo.details
@@ -10,4 +10,5 @@ tags:
   - Highcharts demo
 categories:
   - Scatter and bubble charts
+priority: 1
 ...

--- a/samples/highcharts/demo/sonification/demo.details
+++ b/samples/highcharts/demo/sonification/demo.details
@@ -4,7 +4,8 @@ authors:
   - Øystein Moseng
 skipTest: true
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Accessible charts
 ...

--- a/samples/highcharts/demo/sparkline/demo.details
+++ b/samples/highcharts/demo/sparkline/demo.details
@@ -3,7 +3,8 @@ name: Sparkline charts
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Area charts
 ...

--- a/samples/highcharts/demo/spline-inverted/demo.details
+++ b/samples/highcharts/demo/spline-inverted/demo.details
@@ -3,7 +3,8 @@ name: Spline with inverted axes
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Line charts
 ...

--- a/samples/highcharts/demo/spline-irregular-time/demo.details
+++ b/samples/highcharts/demo/spline-irregular-time/demo.details
@@ -3,7 +3,8 @@ name: Time data with irregular intervals
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Line charts
 ...

--- a/samples/highcharts/demo/spline-plot-bands/demo.details
+++ b/samples/highcharts/demo/spline-plot-bands/demo.details
@@ -3,7 +3,8 @@ name: Spline with plot bands
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Line charts
 ...

--- a/samples/highcharts/demo/spline-symbols/demo.details
+++ b/samples/highcharts/demo/spline-symbols/demo.details
@@ -3,7 +3,8 @@ name: Spline with symbols
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Line charts
 ...

--- a/samples/highcharts/demo/streamgraph/demo.details
+++ b/samples/highcharts/demo/streamgraph/demo.details
@@ -3,7 +3,8 @@ name: Streamgraph
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Area charts
 ...

--- a/samples/highcharts/demo/styled-mode-column/demo.details
+++ b/samples/highcharts/demo/styled-mode-column/demo.details
@@ -3,7 +3,8 @@ name: Styled mode column
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Styled mode (CSS styling)
 ...

--- a/samples/highcharts/demo/styled-mode-pie/demo.details
+++ b/samples/highcharts/demo/styled-mode-pie/demo.details
@@ -3,7 +3,8 @@ name: Styled mode pie
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Styled mode (CSS styling)
 ...

--- a/samples/highcharts/demo/sunburst/demo.details
+++ b/samples/highcharts/demo/sunburst/demo.details
@@ -3,7 +3,8 @@ name: Sunburst
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/synchronized-charts/demo.details
+++ b/samples/highcharts/demo/synchronized-charts/demo.details
@@ -3,7 +3,8 @@ name: Synchronized charts
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Combinations
 ...

--- a/samples/highcharts/demo/timeline/demo.details
+++ b/samples/highcharts/demo/timeline/demo.details
@@ -7,7 +7,8 @@ isNew: true
 alt_text: >-
   Highcharts timeline diagram JavaScript example visualizes space exploration
   over time with Sputnik to Apollo story chart.
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/treemap-coloraxis/demo.details
+++ b/samples/highcharts/demo/treemap-coloraxis/demo.details
@@ -3,7 +3,8 @@ name: Tree map with color axis
 authors:
   - Jon Arild Nygård
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Heat and tree maps
 ...

--- a/samples/highcharts/demo/treemap-large-dataset/demo.details
+++ b/samples/highcharts/demo/treemap-large-dataset/demo.details
@@ -3,7 +3,8 @@ name: Large tree map
 authors:
   - Jon Arild Nygård
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Heat and tree maps
 ...

--- a/samples/highcharts/demo/treemap-with-levels/demo.details
+++ b/samples/highcharts/demo/treemap-with-levels/demo.details
@@ -3,7 +3,8 @@ name: Tree map with levels
 authors:
   - Jon Arild Nygård
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Heat and tree maps
 ...

--- a/samples/highcharts/demo/variable-radius-pie/demo.details
+++ b/samples/highcharts/demo/variable-radius-pie/demo.details
@@ -3,7 +3,8 @@ name: Variable radius pie
 authors:
   - Grzegorz Blachliński
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - Pie charts
 ...

--- a/samples/highcharts/demo/variwide/demo.details
+++ b/samples/highcharts/demo/variwide/demo.details
@@ -3,7 +3,8 @@ name: Variwide
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/vector-plot/demo.details
+++ b/samples/highcharts/demo/vector-plot/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 compareTooltips: true
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/venn-diagram/demo.details
+++ b/samples/highcharts/demo/venn-diagram/demo.details
@@ -3,7 +3,8 @@ name: Venn diagram
 authors:
   - Jon Arild Nygård
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/waterfall/demo.details
+++ b/samples/highcharts/demo/waterfall/demo.details
@@ -3,7 +3,8 @@ name: Waterfall
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/windbarb-series/demo.details
+++ b/samples/highcharts/demo/windbarb-series/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 compareTooltips: true
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/wordcloud/demo.details
+++ b/samples/highcharts/demo/wordcloud/demo.details
@@ -3,7 +3,8 @@ name: Word cloud
 authors:
   - Jon Arild Nygård
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/highcharts/demo/x-range/demo.details
+++ b/samples/highcharts/demo/x-range/demo.details
@@ -3,7 +3,8 @@ name: X-range series
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highcharts demo
 categories:
   - More chart types
 ...

--- a/samples/maps/demo/all-areas-as-null/demo.details
+++ b/samples/maps/demo/all-areas-as-null/demo.details
@@ -3,7 +3,8 @@ name: Highlighted areas
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/all-maps/demo.details
+++ b/samples/maps/demo/all-maps/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 requiresManualTesting: true
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/category-map/demo.details
+++ b/samples/maps/demo/category-map/demo.details
@@ -3,7 +3,8 @@ name: Categorized areas
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/circlemap-africa/demo.details
+++ b/samples/maps/demo/circlemap-africa/demo.details
@@ -3,7 +3,8 @@ name: 'Tile map, circles'
 authors:
   - Mustapha Mekhatria
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - Series types
 ...

--- a/samples/maps/demo/color-axis/demo.details
+++ b/samples/maps/demo/color-axis/demo.details
@@ -3,7 +3,8 @@ name: Color axis and data labels
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/data-class-ranges/demo.details
+++ b/samples/maps/demo/data-class-ranges/demo.details
@@ -5,7 +5,8 @@ authors:
 resources:
   - 'https://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css'
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/data-class-two-ranges/demo.details
+++ b/samples/maps/demo/data-class-two-ranges/demo.details
@@ -3,7 +3,8 @@ name: Data classes and popup
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/diamondmap/demo.details
+++ b/samples/maps/demo/diamondmap/demo.details
@@ -3,7 +3,8 @@ name: 'Tile map, diamonds'
 authors:
   - Øystein Moseng
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - Series types
 ...

--- a/samples/maps/demo/distribution/demo.details
+++ b/samples/maps/demo/distribution/demo.details
@@ -3,7 +3,8 @@ name: Distribution map
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/doubleclickzoomto/demo.details
+++ b/samples/maps/demo/doubleclickzoomto/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 requiresManualTesting: true
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - Dynamic
 ...

--- a/samples/maps/demo/eu-capitals-temp/demo.details
+++ b/samples/maps/demo/eu-capitals-temp/demo.details
@@ -4,7 +4,8 @@ authors:
   - Daniel Studencki
 js_wrap: b
 requiresManualTesting: true
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - Dynamic
 ...

--- a/samples/maps/demo/flight-routes/demo.details
+++ b/samples/maps/demo/flight-routes/demo.details
@@ -3,7 +3,8 @@ name: Simple flight routes
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/geojson-multiple-types/demo.details
+++ b/samples/maps/demo/geojson-multiple-types/demo.details
@@ -3,7 +3,8 @@ name: GeoJSON with rivers and cities
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - Input formats
 ...

--- a/samples/maps/demo/geojson/demo.details
+++ b/samples/maps/demo/geojson/demo.details
@@ -3,7 +3,8 @@ name: GeoJSON areas
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - Input formats
 ...

--- a/samples/maps/demo/heatmap/demo.details
+++ b/samples/maps/demo/heatmap/demo.details
@@ -3,7 +3,8 @@ name: Heat map
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - Series types
 ...

--- a/samples/maps/demo/honeycomb-usa/demo.details
+++ b/samples/maps/demo/honeycomb-usa/demo.details
@@ -3,7 +3,8 @@ name: 'Tile map, honeycomb'
 authors:
   - Mustapha Mekhatria
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - Series types
 ...

--- a/samples/maps/demo/latlon-advanced/demo.details
+++ b/samples/maps/demo/latlon-advanced/demo.details
@@ -4,7 +4,8 @@ authors:
   - Øystein Moseng
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - Input formats
 ...

--- a/samples/maps/demo/map-bubble/demo.details
+++ b/samples/maps/demo/map-bubble/demo.details
@@ -3,7 +3,8 @@ name: Map bubble
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - Series types
 ...

--- a/samples/maps/demo/map-drilldown/demo.details
+++ b/samples/maps/demo/map-drilldown/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 requiresManualTesting: true
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - Dynamic
 ...

--- a/samples/maps/demo/map-pies/demo.details
+++ b/samples/maps/demo/map-pies/demo.details
@@ -3,7 +3,8 @@ name: Map with overlaid pie charts
 authors:
   - Øystein Moseng
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/mapline-mappoint/demo.details
+++ b/samples/maps/demo/mapline-mappoint/demo.details
@@ -3,7 +3,8 @@ name: Lines and points in maps
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - Series types
 ...

--- a/samples/maps/demo/mappoint-latlon/demo.details
+++ b/samples/maps/demo/mappoint-latlon/demo.details
@@ -4,7 +4,8 @@ authors:
   - Øystein Moseng
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - Input formats
 ...

--- a/samples/maps/demo/marker-clusters/demo.details
+++ b/samples/maps/demo/marker-clusters/demo.details
@@ -1,6 +1,9 @@
 ---
- name: Highcharts Demo
- authors:
-   - Wojciech Chmiel
- js_wrap: b
+name: Highcharts Demo
+authors:
+  - Wojciech Chmiel
+js_wrap: b
+tags:
+  - Highmaps demo
+categories: []
 ...

--- a/samples/maps/demo/pattern-fill-map/demo.details
+++ b/samples/maps/demo/pattern-fill-map/demo.details
@@ -3,7 +3,8 @@ name: Map with pattern fills
 authors:
   - Øystein Moseng
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/rich-info/demo.details
+++ b/samples/maps/demo/rich-info/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 requiresManualTesting: true
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - Dynamic
 ...

--- a/samples/maps/demo/tooltip/demo.details
+++ b/samples/maps/demo/tooltip/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 requiresManualTesting: true
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - Dynamic
 ...

--- a/samples/maps/demo/us-counties/demo.details
+++ b/samples/maps/demo/us-counties/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 requiresManualTesting: true
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/us-data-labels/demo.details
+++ b/samples/maps/demo/us-data-labels/demo.details
@@ -3,7 +3,8 @@ name: Small US with data labels
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highmaps demo
 categories:
   - General
 ...

--- a/samples/stock/demo/area/demo.details
+++ b/samples/stock/demo/area/demo.details
@@ -3,7 +3,8 @@ name: Area
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/arearange/demo.details
+++ b/samples/stock/demo/arearange/demo.details
@@ -3,7 +3,8 @@ name: Area range
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/areaspline/demo.details
+++ b/samples/stock/demo/areaspline/demo.details
@@ -3,7 +3,8 @@ name: Area spline
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/areasplinerange/demo.details
+++ b/samples/stock/demo/areasplinerange/demo.details
@@ -3,7 +3,8 @@ name: Area spline range
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/basic-line/demo.details
+++ b/samples/stock/demo/basic-line/demo.details
@@ -3,7 +3,8 @@ name: Single line series
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/candlestick-and-volume/demo.details
+++ b/samples/stock/demo/candlestick-and-volume/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 compareTooltips: true
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/candlestick/demo.details
+++ b/samples/stock/demo/candlestick/demo.details
@@ -3,7 +3,8 @@ name: Candlestick
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/column/demo.details
+++ b/samples/stock/demo/column/demo.details
@@ -3,7 +3,8 @@ name: Column
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/columnrange/demo.details
+++ b/samples/stock/demo/columnrange/demo.details
@@ -3,7 +3,8 @@ name: Column range
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/compare/demo.details
+++ b/samples/stock/demo/compare/demo.details
@@ -3,7 +3,8 @@ name: Compare multiple series
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/data-grouping/demo.details
+++ b/samples/stock/demo/data-grouping/demo.details
@@ -3,7 +3,8 @@ name: '52,000 points with data grouping'
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/depth-chart/demo.details
+++ b/samples/stock/demo/depth-chart/demo.details
@@ -3,7 +3,8 @@ name: Depth chart
 authors:
   - Daniel Studencki
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/dynamic-update/demo.details
+++ b/samples/stock/demo/dynamic-update/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 requiresManualTesting: true
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/flags-general/demo.details
+++ b/samples/stock/demo/flags-general/demo.details
@@ -3,7 +3,8 @@ name: Flags marking events
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/flags-placement/demo.details
+++ b/samples/stock/demo/flags-placement/demo.details
@@ -3,7 +3,8 @@ name: Flags placement
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Flags and Indicators
 ...

--- a/samples/stock/demo/flags-shapes/demo.details
+++ b/samples/stock/demo/flags-shapes/demo.details
@@ -3,7 +3,8 @@ name: Flags shapes and colors
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Flags and Indicators
 ...

--- a/samples/stock/demo/intraday-area/demo.details
+++ b/samples/stock/demo/intraday-area/demo.details
@@ -3,7 +3,8 @@ name: Intraday area
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/intraday-breaks/demo.details
+++ b/samples/stock/demo/intraday-breaks/demo.details
@@ -3,7 +3,8 @@ name: Intraday with breaks
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/intraday-candlestick/demo.details
+++ b/samples/stock/demo/intraday-candlestick/demo.details
@@ -3,7 +3,8 @@ name: Intraday candlestick
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/lazy-loading/demo.details
+++ b/samples/stock/demo/lazy-loading/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 requiresManualTesting: true
-tags: []
+tags:
+  - Highstock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/line-markers/demo.details
+++ b/samples/stock/demo/line-markers/demo.details
@@ -3,7 +3,8 @@ name: Line with markers and shadow
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/macd-pivot-points/demo.details
+++ b/samples/stock/demo/macd-pivot-points/demo.details
@@ -3,7 +3,8 @@ name: MACD pivot points
 authors:
   - Pawel fus
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Flags and Indicators
 ...

--- a/samples/stock/demo/markers-only/demo.details
+++ b/samples/stock/demo/markers-only/demo.details
@@ -3,7 +3,8 @@ name: Point markers only
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/navigator-disabled/demo.details
+++ b/samples/stock/demo/navigator-disabled/demo.details
@@ -3,7 +3,8 @@ name: Disabled navigator
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Various features
 ...

--- a/samples/stock/demo/ohlc/demo.details
+++ b/samples/stock/demo/ohlc/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 compareTooltips: true
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/responsive/demo.details
+++ b/samples/stock/demo/responsive/demo.details
@@ -3,7 +3,8 @@ name: Responsive chart
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/scrollbar-disabled/demo.details
+++ b/samples/stock/demo/scrollbar-disabled/demo.details
@@ -3,7 +3,8 @@ name: Disabled scrollbar
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Various features
 ...

--- a/samples/stock/demo/sma-volume-by-price/demo.details
+++ b/samples/stock/demo/sma-volume-by-price/demo.details
@@ -4,7 +4,8 @@ authors:
   - Torstein Hønsi
 compareTooltips: true
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Flags and Indicators
 ...

--- a/samples/stock/demo/spline/demo.details
+++ b/samples/stock/demo/spline/demo.details
@@ -3,7 +3,8 @@ name: Spline
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/step-line/demo.details
+++ b/samples/stock/demo/step-line/demo.details
@@ -3,7 +3,8 @@ name: Step line
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/stock-tools-custom-gui/demo.details
+++ b/samples/stock/demo/stock-tools-custom-gui/demo.details
@@ -3,7 +3,8 @@ name: Stock chart with custom GUI
 authors:
   - Sebastian Bochan
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Various features
 ...

--- a/samples/stock/demo/stock-tools-gui/demo.details
+++ b/samples/stock/demo/stock-tools-gui/demo.details
@@ -4,7 +4,8 @@ authors:
   - Sebastian Bochan
 requiresManualTesting: true
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/styled-scrollbar/demo.details
+++ b/samples/stock/demo/styled-scrollbar/demo.details
@@ -3,7 +3,8 @@ name: Styled scrollbar
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Various features
 ...

--- a/samples/stock/demo/yaxis-plotbands/demo.details
+++ b/samples/stock/demo/yaxis-plotbands/demo.details
@@ -3,7 +3,8 @@ name: Plot bands on Y axis
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Various features
 ...

--- a/samples/stock/demo/yaxis-plotlines/demo.details
+++ b/samples/stock/demo/yaxis-plotlines/demo.details
@@ -3,7 +3,8 @@ name: Plot lines on Y axis
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Various features
 ...

--- a/samples/stock/demo/yaxis-reversed/demo.details
+++ b/samples/stock/demo/yaxis-reversed/demo.details
@@ -3,7 +3,8 @@ name: Reversed Y axis
 authors:
   - Torstein Hønsi
 js_wrap: b
-tags: []
+tags:
+  - Highstock demo
 categories:
   - Various features
 ...


### PR DESCRIPTION
* Adds tags such as 'Highcharts demo' to current demos. Used when building demo pages using `highcharts demo-manager`
* Set priority of a few demos such as 'Basic line'. This is for sorting demos when building the sidebar, etc.