### PR TITLE
Fixed #12438, reset zoom not working with a11y module on mobile.

### DIFF
--- a/js/modules/accessibility/AccessibilityComponent.js
+++ b/js/modules/accessibility/AccessibilityComponent.js
@@ -275,7 +275,8 @@ AccessibilityComponent.prototype = {
     proxyMouseEventsForButton: function (source, button) {
         var component = this;
         [
-            'click', 'mouseover', 'mouseenter', 'mouseleave', 'mouseout'
+            'click', 'touchstart', 'touchend', 'touchcancel', 'touchmove',
+            'mouseover', 'mouseenter', 'mouseleave', 'mouseout'
         ].forEach(function (evtType) {
             component.addEvent(button, evtType, function (e) {
                 var clonedEvent = component.cloneMouseEvent(e);

--- a/ts/modules/accessibility/AccessibilityComponent.ts
+++ b/ts/modules/accessibility/AccessibilityComponent.ts
@@ -440,7 +440,8 @@ AccessibilityComponent.prototype = {
         var component = this;
 
         [
-            'click', 'mouseover', 'mouseenter', 'mouseleave', 'mouseout'
+            'click', 'touchstart', 'touchend', 'touchcancel', 'touchmove',
+            'mouseover', 'mouseenter', 'mouseleave', 'mouseout'
         ].forEach(function (evtType: string): void {
             component.addEvent(button, evtType, function (e: MouseEvent): void {
                 const clonedEvent = component.cloneMouseEvent(e);


### PR DESCRIPTION
Fixed #12438, a regression causing the reset zoom button not to work with the a11y module on mobile.
___
Proxy overlay was not positioned correctly before, so this was not caught. After fix in 7.2.1, the overlay positioning logic was improved, and now the overlay obstructed the button without catching touch events.