### PR TITLE
Fixed missing drag markers when loading highcharts-3d module.

### DIFF
--- a/js/modules/draggable-points.src.js
+++ b/js/modules/draggable-points.src.js
@@ -2010,17 +2010,15 @@ function getFirstProp(obj) {
  * @return {void}
  */
 function mouseOver(point) {
-    var series = point.series, chart = series && series.chart, dragDropData = chart && chart.dragDropData;
+    var series = point.series, chart = series && series.chart, dragDropData = chart && chart.dragDropData, is3d = chart && chart.is3d && chart.is3d();
     if (chart &&
         !(dragDropData &&
             dragDropData.isDragging && // Ignore if dragging a point
             dragDropData.draggedPastSensitivity) &&
         !chart.isDragDropAnimating && // Ignore if animating
         series.options.dragDrop && // No need to compute handles without this
-        !(chart.options &&
-            chart.options.chart &&
-            chart.options.chart.options3d // No 3D support
-        )) {
+        !is3d // No 3D support
+    ) {
         // Hide the handles if they exist on another point already
         if (chart.dragHandles) {
             chart.hideDragHandles();

--- a/ts/modules/draggable-points.src.ts
+++ b/ts/modules/draggable-points.src.ts
@@ -2725,7 +2725,8 @@ function getFirstProp<T>(obj: Highcharts.Dictionary<T>): (T|undefined) {
 function mouseOver(point: Highcharts.Point): void {
     var series = point.series,
         chart = series && series.chart,
-        dragDropData = chart && chart.dragDropData;
+        dragDropData = chart && chart.dragDropData,
+        is3d = chart && chart.is3d && chart.is3d();
 
     if (
         chart &&
@@ -2736,11 +2737,7 @@ function mouseOver(point: Highcharts.Point): void {
         ) &&
         !chart.isDragDropAnimating && // Ignore if animating
         series.options.dragDrop && // No need to compute handles without this
-        !(
-            chart.options &&
-            chart.options.chart &&
-            chart.options.chart.options3d // No 3D support
-        )
+        !is3d // No 3D support
     ) {
         // Hide the handles if they exist on another point already
         if (chart.dragHandles) {


### PR DESCRIPTION
Fixed #12484, drag markers for columns were not showing when `highcharts-3d` and `draggable-points` were loaded.

---
# Examples 
- [Demo of issue](https://jsfiddle.net/BlackLabel/9zpL7tdy/)
- [Demo of issue with fix applied](https://jsfiddle.net/k64y5ute/)
# Related issues
- Closes #12484 