### PR TITLE
Fix zoom issues in treemap

### DIFF
--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -698,24 +698,28 @@ seriesType('treemap', 'scatter'
         });
     },
     setPointValues: function () {
-        var series = this, xAxis = series.xAxis, yAxis = series.yAxis;
-        series.points.forEach(function (point) {
-            var node = point.node, values = node.pointValues, x1, x2, y1, y2, crispCorr = 0;
-            // Get the crisp correction in classic mode. For this to work in
-            // styled mode, we would need to first add the shape (without x,
-            // y, width and height), then read the rendered stroke width
-            // using point.graphic.strokeWidth(), then modify and apply the
-            // shapeArgs. This applies also to column series, but the
-            // downside is performance and code complexity.
-            if (!series.chart.styledMode) {
-                crispCorr = ((series.pointAttribs(point)['stroke-width'] || 0) % 2) / 2;
-            }
+        var series = this;
+        var points = series.points, xAxis = series.xAxis, yAxis = series.yAxis;
+        var styledMode = series.chart.styledMode;
+        // Get the crisp correction in classic mode. For this to work in
+        // styled mode, we would need to first add the shape (without x,
+        // y, width and height), then read the rendered stroke width
+        // using point.graphic.strokeWidth(), then modify and apply the
+        // shapeArgs. This applies also to column series, but the
+        // downside is performance and code complexity.
+        var getCrispCorrection = function (point) { return (styledMode ?
+            0 :
+            ((series.pointAttribs(point)['stroke-width'] || 0) % 2) / 2); };
+        points.forEach(function (point) {
+            var _a = point.node, values = _a.pointValues, visible = _a.visible;
             // Points which is ignored, have no values.
-            if (values && node.visible) {
-                x1 = Math.round(xAxis.translate(values.x, 0, 0, 0, 1)) - crispCorr;
-                x2 = Math.round(xAxis.translate(values.x + values.width, 0, 0, 0, 1)) - crispCorr;
-                y1 = Math.round(yAxis.translate(values.y, 0, 0, 0, 1)) - crispCorr;
-                y2 = Math.round(yAxis.translate(values.y + values.height, 0, 0, 0, 1)) - crispCorr;
+            if (values && visible) {
+                var height = values.height, width = values.width, x = values.x, y = values.y;
+                var crispCorr = getCrispCorrection(point);
+                var x1 = Math.round(xAxis.toPixels(x, true)) - crispCorr;
+                var x2 = Math.round(xAxis.toPixels(x + width, true)) - crispCorr;
+                var y1 = Math.round(yAxis.toPixels(100 - y, true)) - crispCorr;
+                var y2 = Math.round(yAxis.toPixels(100 - y - height, true)) - crispCorr;
                 // Set point values
                 point.shapeArgs = {
                     x: Math.min(x1, x2),

--- a/ts/modules/treemap.src.ts
+++ b/ts/modules/treemap.src.ts
@@ -1188,71 +1188,34 @@ seriesType<Highcharts.TreemapSeries>(
             });
         },
         setPointValues: function (this: Highcharts.TreemapSeries): void {
-            var series = this,
-                xAxis = series.xAxis,
-                yAxis = series.yAxis;
+            const series = this;
+            const { points, xAxis, yAxis } = series;
+            const styledMode = series.chart.styledMode;
 
-            series.points.forEach(function (
-                point: Highcharts.TreemapPoint
-            ): void {
-                var node = point.node,
-                    values = node.pointValues,
-                    x1,
-                    x2,
-                    y1,
-                    y2,
-                    crispCorr = 0;
+            // Get the crisp correction in classic mode. For this to work in
+            // styled mode, we would need to first add the shape (without x,
+            // y, width and height), then read the rendered stroke width
+            // using point.graphic.strokeWidth(), then modify and apply the
+            // shapeArgs. This applies also to column series, but the
+            // downside is performance and code complexity.
+            const getCrispCorrection = (point: Highcharts.TreemapPoint): number => (
+                styledMode ?
+                    0 :
+                    ((series.pointAttribs(point)['stroke-width'] || 0) % 2) / 2
+            );
 
-                // Get the crisp correction in classic mode. For this to work in
-                // styled mode, we would need to first add the shape (without x,
-                // y, width and height), then read the rendered stroke width
-                // using point.graphic.strokeWidth(), then modify and apply the
-                // shapeArgs. This applies also to column series, but the
-                // downside is performance and code complexity.
-                if (!series.chart.styledMode) {
-                    crispCorr = (
-                        (series.pointAttribs(point)['stroke-width'] || 0) % 2
-                    ) / 2;
-                }
+            points.forEach(function (point: Highcharts.TreemapPoint): void {
+                const { pointValues: values, visible } = point.node;
 
                 // Points which is ignored, have no values.
-                if (values && node.visible) {
-                    x1 = Math.round(
-                        xAxis.translate(
-                            values.x,
-                            0 as any,
-                            0 as any,
-                            0 as any,
-                            1 as any
-                        ) as any
-                    ) - crispCorr;
-                    x2 = Math.round(
-                        xAxis.translate(
-                            values.x + values.width,
-                            0 as any,
-                            0 as any,
-                            0 as any,
-                            1 as any
-                        ) as any
-                    ) - crispCorr;
-                    y1 = Math.round(
-                        yAxis.translate(
-                            values.y as any,
-                            0 as any,
-                            0 as any,
-                            0 as any,
-                            1 as any
-                        ) as any
-                    ) - crispCorr;
-                    y2 = Math.round(
-                        yAxis.translate(
-                            (values.y as any) + (values.height as any),
-                            0 as any,
-                            0 as any,
-                            0 as any,
-                            1 as any
-                        ) as any
-                    ) - crispCorr;
+                if (values && visible) {
+                    const { height, width, x, y } = values;
+                    const crispCorr = getCrispCorrection(point);
+                    const x1 = Math.round(xAxis.toPixels(x, true)) - crispCorr;
+                    const x2 = Math.round(xAxis.toPixels(x + width, true)) - crispCorr;
+                    const y1 = Math.round(yAxis.toPixels(100 - y, true)) - crispCorr;
+                    const y2 = Math.round(yAxis.toPixels(100 - y - height, true)) - crispCorr;
+
                     // Set point values
                     point.shapeArgs = {
                         x: Math.min(x1, x2),


### PR DESCRIPTION
Fixed #12488, selection zoomed to wrong area in the Treemap series.

---
# Description
The treemap series used `csvCoord=false` when calling `Axis.translate` for the y values, while `Axis.toValue` that is used to find new min and max for `Chart.zoom` assumes `csvCoord=true` for the y axis.
Solved by setting `csvCoord=true` when translating y values, and reversing the y-values before passing them into translate.

# Example(s)
- [Demo of issue](https://jsfiddle.net/jon_a_nygaard/s4xqouf2/)
- [Demo of issue with fix applied](https://jsfiddle.net/jon_a_nygaard/v529z0hs/)

# Related issue(s)
- Closes #12488 