### PR TITLE
bugfix/7255-print-cancel-safari

### DIFF
--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -1030,8 +1030,22 @@ H.afterPrint = function (chart) {
         chart.setSize.apply(chart, resetParams);
     }
     delete chart.printReverseInfo;
+    delete H.printingChart;
     fireEvent(chart, 'afterPrint');
 };
+if (H.isSafari) {
+    H.win.matchMedia('print').addListener(function (mqlEvent) {
+        if (!H.printingChart) {
+            return void 0;
+        }
+        if (mqlEvent.matches) {
+            H.beforePrint(H.printingChart);
+        }
+        else {
+            H.afterPrint(H.printingChart);
+        }
+    });
+}
 extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
     /* eslint-disable no-invalid-this, valid-jsdoc */
     /**
@@ -1335,6 +1349,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         if (chart.isPrinting) { // block the button while in printing mode
             return;
         }
+        H.printingChart = chart;
         if (!H.isSafari) {
             H.beforePrint(chart);
         }

--- a/ts/modules/exporting.src.ts
+++ b/ts/modules/exporting.src.ts
@@ -36,6 +36,7 @@ declare global {
             isDirtyExporting?: boolean;
             isPrinting?: boolean;
             openMenu?: boolean;
+            printReverseInfo?: PrintReverseInfoObject;
             /** @requires modules/exporting */
             addButton(options: ExportingButtonOptions): void;
             /** @requires modules/exporting */
@@ -171,6 +172,15 @@ declare global {
             exporting?: ExportingOptions;
             navigation?: NavigationOptions;
         }
+        interface PrintReverseInfoObject {
+            childNodes: NodeListOf<ChildNode>;
+            origDisplay: Array<(string|null)> ;
+            resetParams?: [
+                (number|null)?,
+                (number|null)?,
+                (boolean|AnimationOptionsObject)?
+            ];
+        }
         interface SVGRenderer {
             inlineBlacklist?: Array<RegExp>;
             inlineToAttributes?: Array<string>;
@@ -188,6 +198,19 @@ declare global {
             url: string,
             data: object,
             formAttributes?: Dictionary<string>
+        ): void;
+        /** @requires modules/exporting */
+        function afterPrint(
+            chart: Chart
+        ): void;
+        /** @requires modules/exporting */
+        function beforePrint(
+            chart: Chart
+        ): void;
+        /** @requires modules/exporting */
+        function moveContainers(
+            chart: Chart,
+            moveTo: HTMLDOMElement
         ): void;
     }
 }
@@ -1234,6 +1257,141 @@ H.post = function (
     discardElement(form);
 };
 
+/**
+* Move the chart container(s) to another div.
+*
+* @function Highcharts#moveContainers
+*
+* @private
+*
+* @param {Highcharts.Chart} chart
+*        Move from chart
+* @param {Highcharts.HTMLDOMElement} moveTo
+*        Move target
+* @return {void}
+*/
+H.moveContainers = function (
+    chart: Highcharts.Chart,
+    moveTo: Highcharts.HTMLDOMElement
+): void {
+    (
+        chart.fixedDiv ? // When scrollablePlotArea is active (#9533)
+            [chart.fixedDiv, chart.scrollingContainer as any] :
+            [chart.container]
+
+    ).forEach(function (div: Highcharts.HTMLDOMElement): void {
+        moveTo.appendChild(div);
+    });
+};
+
+/**
+* Prepare chart and document before printing a chart.
+*
+* @function Highcharts#beforePrint
+*
+* @private
+*
+* @param {Highcharts.Chart} chart
+*        Chart to be printed
+* @return {void}
+*
+* @fires Highcharts.Chart#event:beforePrint
+*/
+H.beforePrint = function (
+    chart: Highcharts.Chart
+): void {
+    const body = doc.body,
+        printMaxWidth: number =
+            (chart.options.exporting as any).printMaxWidth,
+        printReverseInfo: Highcharts.PrintReverseInfoObject = {
+            childNodes: body.childNodes,
+            origDisplay: [],
+            resetParams: void 0
+        };
+
+    var handleMaxWidth: (boolean|number);
+
+    chart.isPrinting = true;
+    chart.pointer.reset(null as any, 0);
+
+    fireEvent(chart, 'beforePrint');
+
+    // Handle printMaxWidth
+    handleMaxWidth = printMaxWidth && chart.chartWidth > printMaxWidth;
+    if (handleMaxWidth) {
+        printReverseInfo.resetParams = [
+            (chart.options.chart as any).width,
+            void 0,
+            false
+        ];
+        chart.setSize(printMaxWidth, void 0, false);
+    }
+
+    // hide all body content
+    [].forEach.call(printReverseInfo.childNodes, function (
+        node: Highcharts.HTMLDOMElement,
+        i: number
+    ): void {
+        if (node.nodeType === 1) {
+            printReverseInfo.origDisplay[i] = node.style.display;
+            node.style.display = 'none';
+        }
+    });
+
+    // pull out the chart
+    H.moveContainers(chart, body);
+    // Storage details for undo action after printing
+    chart.printReverseInfo = printReverseInfo;
+};
+
+/**
+* Clena up after printing a chart.
+*
+* @function Highcharts#afterPrint
+*
+* @private
+*
+* @param {Highcharts.Chart} chart
+*        Chart that was (or suppose to be) printed
+* @return {void}
+*
+* @fires Highcharts.Chart#event:afterPrint
+*/
+H.afterPrint = function (
+    chart: Highcharts.Chart
+): void {
+    if (!chart.printReverseInfo) {
+        return void 0;
+    }
+    const childNodes = chart.printReverseInfo.childNodes,
+        origDisplay = chart.printReverseInfo.origDisplay,
+        resetParams = chart.printReverseInfo.resetParams;
+
+    // put the chart back in
+    H.moveContainers(chart, chart.renderTo);
+
+    // restore all body content
+    [].forEach.call(childNodes, function (
+        node: Highcharts.HTMLDOMElement,
+        i: number
+    ): void {
+        if (node.nodeType === 1) {
+            node.style.display = (origDisplay[i] || '');
+        }
+    });
+
+    chart.isPrinting = false;
+
+    // Reset printMaxWidth
+    if (resetParams) {
+        chart.setSize.apply(chart, resetParams);
+    }
+
+    delete chart.printReverseInfo;
+
+    fireEvent(chart, 'afterPrint');
+};
+
 extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
 
     /* eslint-disable no-invalid-this, valid-jsdoc */
@@ -1630,71 +1788,15 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      * @requires modules/exporting
      */
     print: function (this: Highcharts.Chart): void {
-
-        var chart = this,
-            origDisplay: Array<(string|null)> = [],
-            body = doc.body,
-            childNodes = body.childNodes,
-            printMaxWidth: number =
-                (chart.options.exporting as any).printMaxWidth,
-            resetParams: [
-                (number|null)?,
-                (number|null)?,
-                (boolean|Highcharts.AnimationOptionsObject)?
-            ],
-            handleMaxWidth: (boolean|number);
-
-        /**
-         * Move the chart container(s) to another div.
-         * @private
-         * @param {Highcharts.HTMLDOMElement} moveTo
-         *        Move target
-         * @return {void}
-         */
-        function moveContainers(moveTo: Highcharts.HTMLDOMElement): void {
-            (
-                chart.fixedDiv ? // When scrollablePlotArea is active (#9533)
-                    [chart.fixedDiv, chart.scrollingContainer as any] :
-                    [chart.container]
-
-            ).forEach(function (div: Highcharts.HTMLDOMElement): void {
-                moveTo.appendChild(div);
-            });
-        }
+        var chart = this;
 
         if (chart.isPrinting) { // block the button while in printing mode
             return;
         }
 
-        chart.isPrinting = true;
-        chart.pointer.reset(null as any, 0);
-
-        fireEvent(chart, 'beforePrint');
-
-        // Handle printMaxWidth
-        handleMaxWidth = printMaxWidth && chart.chartWidth > printMaxWidth;
-        if (handleMaxWidth) {
-            resetParams = [
-                (chart.options.chart as any).width,
-                void 0,
-                false
-            ];
-            chart.setSize(printMaxWidth, void 0, false);
+        if (!H.isSafari) {
+            H.beforePrint(chart);
         }
-
-        // hide all body content
-        [].forEach.call(childNodes, function (
-            node: Highcharts.HTMLDOMElement,
-            i: number
-        ): void {
-            if (node.nodeType === 1) {
-                origDisplay[i] = node.style.display;
-                node.style.display = 'none';
-            }
-        });
-
-        // pull out the chart
-        moveContainers(body);
 
         // Give the browser time to draw WebGL content, an issue that randomly
         // appears (at least) in Chrome ~67 on the Mac (#8708).
@@ -1704,31 +1806,11 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             win.print();
 
             // allow the browser to prepare before reverting
-            setTimeout(function (): void {
-
-                // put the chart back in
-                moveContainers(chart.renderTo);
-
-                // restore all body content
-                [].forEach.call(childNodes, function (
-                    node: Highcharts.HTMLDOMElement,
-                    i: number
-                ): void {
-                    if (node.nodeType === 1) {
-                        node.style.display = (origDisplay[i] || '');
-                    }
-                });
-
-                chart.isPrinting = false;
-
-                // Reset printMaxWidth
-                if (handleMaxWidth) {
-                    chart.setSize.apply(chart, resetParams);
-                }
-
-                fireEvent(chart, 'afterPrint');
-
-            }, 1000);
+            if (!H.isSafari) {
+                setTimeout(function (): void {
+                    H.afterPrint(chart);
+                }, 1000);
+            }
         }, 1);
 
     },

--- a/ts/modules/exporting.src.ts
+++ b/ts/modules/exporting.src.ts
@@ -212,6 +212,8 @@ declare global {
             chart: Chart,
             moveTo: HTMLDOMElement
         ): void;
+
+        let printingChart: (Chart|undefined);
     }
 }
 
@@ -1388,9 +1390,28 @@ H.afterPrint = function (
     }
 
     delete chart.printReverseInfo;
+    delete H.printingChart;
 
     fireEvent(chart, 'afterPrint');
 };
+
+if (H.isSafari) {
+    H.win.matchMedia('print').addListener(
+        function (
+            this: MediaQueryList,
+            mqlEvent: MediaQueryListEvent
+        ): void {
+            if (!H.printingChart) {
+                return void 0;
+            }
+            if (mqlEvent.matches) {
+                H.beforePrint(H.printingChart);
+            } else {
+                H.afterPrint(H.printingChart);
+            }
+        }
+    );
+}
 
 extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
 
@@ -1793,6 +1814,8 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         if (chart.isPrinting) { // block the button while in printing mode
             return;
         }
+
+        H.printingChart = chart;
 
         if (!H.isSafari) {
             H.beforePrint(chart);


### PR DESCRIPTION
Fixed #7255, trying to printing chart again, after cancelling in Safari, elements other than chart were not hidden.
___
### Solution (Safari only)
In Safari (I assume `Highcharts.isSafari` is safe to use), instead of `setTimeout` for hiding and restoring DOM elements for printing, `window.matchMedia('print')` will be used. That required a bit refactoring in `Chart.print` method.

### Other browsers:
- Chrome - can use `matchMedia` too, can be replaced
- FireFox - doesn't work because of this bug: https://bugzilla.mozilla.org/show_bug.cgi?id=774398 
- IE 10-11/Edge - doesn't work, haven't found the reason for that
- IE 6-9 - don't support `matchMedia`

### Notes
- Solution pollutes `Highcharts` namespace with: `beforePrint`, `afterPrint`, `moveContainers` methods and `printingChart` property. I'm open for suggestions here.
- No test, I'm afraid karma won't support such test. Needs to be verified manually.

### Samples
- without fix: https://jsfiddle.net/BlackLabel/bj9hd6mg/
- with fix: https://jsfiddle.net/BlackLabel/kfpatbs5/

Steps (in Safari): Try to print the chart, but cancel it. Try to print again, so confirm box will show up. Click "print" in the box. in Safari "Test" elements will be visible in the print preview.
