### PR TITLE
Tools: Enable deploy of docs to production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -402,7 +402,7 @@ workflows:
           filters:
             branches:
               only: [master]
-          context: highcharts-staging
+          context: highcharts-prod
 
   nightly:
     triggers:


### PR DESCRIPTION
This will enable deploy of docs to production.

Note that there is currently a caveat which only will execute the deploy if the last commit in pr contains changes in the docs/ folder.

Perhaps we should also make a test commit to docs after this is merged to master in order to verify that everything works as expected.