### PR TITLE
Tools: Added gulp task for bumping version and cleaning up after release.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,11 +73,7 @@ nbproject/
 /samples/**/diff.gif
 /samples/**/reference.svg
 
-/tmp/report.html
-
-/tmp/missing.in.code.json
-
-/tmp/processed.api.json
+tmp/
 /package-lock.json
 /temp.*
 /env.file

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,6 +49,7 @@ Gulp.registry(new GulpForwardReference());
     'lint-js',
     'lint-samples',
     'lint-ts',
+    'prep-release',
     'scripts',
     'scripts-clean',
     'scripts-code',

--- a/tools/gulptasks/prep-release.js
+++ b/tools/gulptasks/prep-release.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) Highsoft AS
+ */
+
+const Gulp = require('gulp');
+const packageJson = require('../../package.json');
+const ChildProcess = require('child_process');
+const LogLib = require('./lib/log');
+const getBuildProperties = require('./lib/build').getBuildProperties;
+
+/**
+ * Prepares a new release by replacing version numbers with the supplied version. Replaces version numbers in
+ * package.json, bower.json, build.properties and replaces any "@ since next" tag in docs with the specified --nextversion
+ * Run using `gulp prep-release --nextversion` and `gulp prep-release --cleanup (--commit)`.
+ *
+ * @return {Promise<void>}
+ *         Promise to keep
+ */
+function prepareRelease() {
+    const argv = require('yargs').argv;
+
+    return new Promise((resolve, reject) => {
+        const packageJsonVersion = packageJson.version;
+        const bowerJsonVersion = require('../../bower.json').version;
+        const buildProperties = getBuildProperties();
+        const buildPropsVersion = buildProperties.highcharts.product.version;
+
+        LogLib.message(`Versions before applying next version are:\n
+            package.json: ${packageJsonVersion}
+            bower.json: ${bowerJsonVersion}
+            build.properties: ${buildPropsVersion}
+        `);
+
+        if (packageJsonVersion !== bowerJsonVersion ||
+            packageJsonVersion !== buildPropsVersion ||
+            buildPropsVersion !== bowerJsonVersion) {
+            LogLib.warn('The current versions declared in files package.json, ' +
+                                'bower.json and build.properties does not match!');
+        }
+
+        if (argv.cleanup) {
+            const stagedChanges = ChildProcess.execSync('git diff --cached --name-only').toString();
+            ChildProcess.execSync(`sed -i s/${buildPropsVersion}.*/${packageJsonVersion}-modified/g build.properties`);
+            ChildProcess.execSync('sed -i s/date=.*/date=/ build.properties');
+
+            if (argv.commit) {
+                if (stagedChanges) {
+                    reject(new Error('You have other staged changes. Please commit or remove them first.'));
+                    return;
+                }
+                ChildProcess.execSync(`git add build.properties && git commit -m"Cleaned up after v${packageJsonVersion}."`);
+                LogLib.message('Clean up commit added. git push when you are ready.');
+            }
+            LogLib.success(`Cleaned up after v${packageJsonVersion}`);
+            resolve();
+            return;
+        }
+
+        LogLib.message('Preparing version number update. Current version is ' + packageJsonVersion);
+
+        const nextVersion = argv.nextversion;
+        if (!argv.cleanup && !nextVersion) {
+            reject(new Error('Please provide either --version x.y.z or --cleanup when starting the command.'));
+            return;
+        }
+
+        /*
+            Replace version in relevant files (ideally all current versions should be equal, but since they
+            sometimes have proven not to be, we make sure to replace the existing version in the exact file
+            with the next version
+        */
+        ChildProcess.execSync(`sed -i '/version/s/"${packageJsonVersion}"/'\\"${nextVersion}\\"/ package.json`);
+        ChildProcess.execSync(`sed -i '/version/s/"${bowerJsonVersion}"/'\\"${nextVersion}\\"/ bower.json`);
+        ChildProcess.execSync(`sed -i s/${buildPropsVersion}/${nextVersion}/ build.properties`);
+
+        // replace/fill in date in build.properties
+        ChildProcess.execSync('sed -i s/date=.*/date=$(date +%Y-%m-%d)/ build.properties');
+
+        // replace occurences of @ since next in docs with @since x.y.z
+        ChildProcess.execSync(`grep -Rl --exclude-dir=node_modules --exclude-dir=code "@since\\s\\+\\next" . | xargs -r sed -i 's/@since *next/@since ${nextVersion}/'`);
+
+        LogLib.success('Updated version in package.json, bower.json, build.properties and replaced @ since next' +
+                        ' in the docs. Please review changes and commit & push when ready.');
+        resolve();
+    });
+}
+
+prepareRelease.description = 'Prepares a new release by replacing version numbers with the supplied version. ' +
+                                'Replaces version numbers in package.json, bower.json, build.properties and ' +
+                                'replaces any "@ since next" tag in docs with the specified nextversion';
+prepareRelease.flags = {
+    '--cleanup': 'Will add -modified to version and remove date from build.properties. Exludes --version',
+    '--commit': 'Commit cleanup changes. Implies --cleanup.',
+    '--nextversion': 'Version that will replace version in package.json, build.properties, bower.json and "since next" in the docs.'
+};
+
+Gulp.task('prep-release', prepareRelease);

--- a/tools/gulptasks/prep-release.js
+++ b/tools/gulptasks/prep-release.js
@@ -40,8 +40,8 @@ function prepareRelease() {
 
         if (argv.cleanup) {
             const stagedChanges = ChildProcess.execSync('git diff --cached --name-only').toString();
-            ChildProcess.execSync(`sed -i -e s/${buildPropsVersion}.*/${packageJsonVersion}-modified/g build.properties`);
-            ChildProcess.execSync('sed -i -e s/date=.*/date=/ build.properties');
+            ChildProcess.execSync(`sed -i'' -e s/${buildPropsVersion}.*/${packageJsonVersion}-modified/g build.properties`);
+            ChildProcess.execSync('sed -i\'\' -e s/date=.*/date=/ build.properties');
 
             if (argv.commit) {
                 if (stagedChanges) {
@@ -69,16 +69,16 @@ function prepareRelease() {
             sometimes have proven not to be, we make sure to replace the existing version in the exact file
             with the next version
         */
-        ChildProcess.execSync(`sed -i -e '/version/s/"${packageJsonVersion}"/'\\"${nextVersion}\\"/ package.json`);
-        ChildProcess.execSync(`sed -i -e '/version/s/"${bowerJsonVersion}"/'\\"${nextVersion}\\"/ bower.json`);
-        ChildProcess.execSync(`sed -i -e s/${buildPropsVersion}/${nextVersion}/ build.properties`);
+        ChildProcess.execSync(`sed -i'' -e '/version/s/"${packageJsonVersion}"/'\\"${nextVersion}\\"/ package.json`);
+        ChildProcess.execSync(`sed -i'' -e '/version/s/"${bowerJsonVersion}"/'\\"${nextVersion}\\"/ bower.json`);
+        ChildProcess.execSync(`sed -i'' -e s/${buildPropsVersion}/${nextVersion}/ build.properties`);
 
         // replace/fill in date in build.properties
-        ChildProcess.execSync('sed -i -e s/date=.*/date=$(date +%Y-%m-%d)/ build.properties');
+        ChildProcess.execSync('sed -i\'\' -e s/date=.*/date=$(date +%Y-%m-%d)/ build.properties');
 
         // replace occurences of @ since next in docs with @since x.y.z, first checking if xargs is on gnu (linux) or bsd (osx).
         const isGNU = ChildProcess.execSync('xargs --version 2>&1 |grep -s GNU >/dev/null && echo true || echo false').toString().replace('\n', '') === 'true';
-        ChildProcess.execSync(`grep -Rl --exclude-dir=node_modules --exclude-dir=code "@since\\s\\+\\next" . | xargs ${isGNU ? '-r' : ''} sed -i -e 's/@since *next/@since ${nextVersion}/'`);
+        ChildProcess.execSync(`grep -Rl --exclude-dir=node_modules --exclude-dir=code "@since\\s\\+\\next" . | xargs ${isGNU ? '-r' : ''} sed -i'' -e 's/@since *next/@since ${nextVersion}/'`);
 
         LogLib.success('Updated version in package.json, bower.json, build.properties and replaced @ since next' +
                         ' in the docs. Please review changes and commit & push when ready.');

--- a/tools/gulptasks/prep-release.js
+++ b/tools/gulptasks/prep-release.js
@@ -40,8 +40,8 @@ function prepareRelease() {
 
         if (argv.cleanup) {
             const stagedChanges = ChildProcess.execSync('git diff --cached --name-only').toString();
-            ChildProcess.execSync(`sed -i s/${buildPropsVersion}.*/${packageJsonVersion}-modified/g build.properties`);
-            ChildProcess.execSync('sed -i s/date=.*/date=/ build.properties');
+            ChildProcess.execSync(`sed -i -e s/${buildPropsVersion}.*/${packageJsonVersion}-modified/g build.properties`);
+            ChildProcess.execSync('sed -i -e s/date=.*/date=/ build.properties');
 
             if (argv.commit) {
                 if (stagedChanges) {
@@ -69,15 +69,15 @@ function prepareRelease() {
             sometimes have proven not to be, we make sure to replace the existing version in the exact file
             with the next version
         */
-        ChildProcess.execSync(`sed -i '/version/s/"${packageJsonVersion}"/'\\"${nextVersion}\\"/ package.json`);
-        ChildProcess.execSync(`sed -i '/version/s/"${bowerJsonVersion}"/'\\"${nextVersion}\\"/ bower.json`);
-        ChildProcess.execSync(`sed -i s/${buildPropsVersion}/${nextVersion}/ build.properties`);
+        ChildProcess.execSync(`sed -i -e '/version/s/"${packageJsonVersion}"/'\\"${nextVersion}\\"/ package.json`);
+        ChildProcess.execSync(`sed -i -e '/version/s/"${bowerJsonVersion}"/'\\"${nextVersion}\\"/ bower.json`);
+        ChildProcess.execSync(`sed -i -e s/${buildPropsVersion}/${nextVersion}/ build.properties`);
 
         // replace/fill in date in build.properties
-        ChildProcess.execSync('sed -i s/date=.*/date=$(date +%Y-%m-%d)/ build.properties');
+        ChildProcess.execSync('sed -i -e s/date=.*/date=$(date +%Y-%m-%d)/ build.properties');
 
         // replace occurences of @ since next in docs with @since x.y.z
-        ChildProcess.execSync(`grep -Rl --exclude-dir=node_modules --exclude-dir=code "@since\\s\\+\\next" . | xargs -r sed -i 's/@since *next/@since ${nextVersion}/'`);
+        ChildProcess.execSync(`grep -Rl --exclude-dir=node_modules --exclude-dir=code "@since\\s\\+\\next" . | xargs -r sed -i -e 's/@since *next/@since ${nextVersion}/'`);
 
         LogLib.success('Updated version in package.json, bower.json, build.properties and replaced @ since next' +
                         ' in the docs. Please review changes and commit & push when ready.');

--- a/tools/gulptasks/prep-release.js
+++ b/tools/gulptasks/prep-release.js
@@ -76,8 +76,9 @@ function prepareRelease() {
         // replace/fill in date in build.properties
         ChildProcess.execSync('sed -i -e s/date=.*/date=$(date +%Y-%m-%d)/ build.properties');
 
-        // replace occurences of @ since next in docs with @since x.y.z
-        ChildProcess.execSync(`grep -Rl --exclude-dir=node_modules --exclude-dir=code "@since\\s\\+\\next" . | xargs -r sed -i -e 's/@since *next/@since ${nextVersion}/'`);
+        // replace occurences of @ since next in docs with @since x.y.z, first checking if xargs is on gnu (linux) or bsd (osx).
+        const isGNU = ChildProcess.execSync('xargs --version 2>&1 |grep -s GNU >/dev/null && echo true || echo false').toString().replace('\n', '') === 'true';
+        ChildProcess.execSync(`grep -Rl --exclude-dir=node_modules --exclude-dir=code "@since\\s\\+\\next" . | xargs ${isGNU ? '-r' : ''} sed -i -e 's/@since *next/@since ${nextVersion}/'`);
 
         LogLib.success('Updated version in package.json, bower.json, build.properties and replaced @ since next' +
                         ' in the docs. Please review changes and commit & push when ready.');


### PR DESCRIPTION
Can be tested using `gulp prep-release --nextversion x.y.z` and `gulp prep-release --cleanup (--commit)`

@TorsteinHonsi Behind the scenes this is using sed which can be slightly different on OSX. Please test the command and let me know if you experience any issues. 