### PR TITLE
Tools: Trigger deploy of docs on release/tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,9 +144,14 @@ jobs:
   check_for_docs_changes_and_deploy:
     <<: *defaults
     description: Checks for changes in docs/ and triggers deploy via doc-builder
+    parameters:
+      always_deploy:
+        description: "Deploy regardless of finding changes in docs/ on last commit"
+        type: boolean
+        default: false
     steps:
       - <<: *load_workspace
-      - run: ./.circleci/scripts/check_and_trigger_docs_deploy.sh  --bucket=${DOCS_DEPLOY_BUCKET} --token=${CIRCLE_API_TOKEN}
+      - run: ./.circleci/scripts/check_and_trigger_docs_deploy.sh  --bucket=${DOCS_DEPLOY_BUCKET} --token=${CIRCLE_API_TOKEN} <<# parameters.always_deploy >>-f<</ parameters.always_deploy >>
 
   generate_release_reference_images:
     <<: *defaults
@@ -167,7 +172,7 @@ jobs:
 
   reset_visual_references_job:
     <<: *defaults
-    description: Reset reference images stored on S3 based on
+    description: Reset reference images stored on S3 based. I.e recently added/changed samples will be treated as always being a part of this release.
     parameters:
       reset_tests:
         description: "Which tests to run?"
@@ -420,6 +425,16 @@ workflows:
           filters:
             branches:
               only: [master]
+          context: highcharts-prod
+      - check_for_docs_changes_and_deploy:
+          # need to add this release deploy job separately as it has different requires tag than master branch.
+          requires: [generate_release_reference_images]
+          always_deploy: true
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+(?:\.\d+)+?$/
           context: highcharts-prod
 
   nightly:

--- a/.circleci/scripts/check_and_trigger_docs_deploy.sh
+++ b/.circleci/scripts/check_and_trigger_docs_deploy.sh
@@ -5,6 +5,7 @@ set -e
 LATEST_COMMIT=$(git rev-parse HEAD)
 BUCKET=""
 TOKEN=""
+FORCE_DEPLOY=false
 
 for i in "$@"
 do
@@ -14,6 +15,9 @@ case $i in
     ;;
       -t=*|--token=*)
     TOKEN="${i#*=}"
+    ;;
+      -f|--force-deploy)
+    FORCE_DEPLOY=true
     ;;
     *)
      # unknown option
@@ -34,8 +38,9 @@ fi
 # latest commit where docs/ was changed
 DOCS_COMMIT=$(git log -1 --format=format:%H --full-diff docs/)
 
-if [ $DOCS_COMMIT = $LATEST_COMMIT ]; then
-    echo "Files in docs/ has changed, triggering deploy of docs via doc-builder to bucket ${BUCKET}"
+if [ $DOCS_COMMIT = $LATEST_COMMIT ] || [ "$FORCE_DEPLOY" = true  ]; then
+    echo "Force deployed: ${FORCE_DEPLOY}"
+    echo "Files in docs/ has changed or forcing deploy. Triggering deploy of docs via doc-builder to bucket ${BUCKET}"
     payload="{ \"branch\":\"master\", \"parameters\": { \"run_deploy\": true, \"target_bucket\": \"${BUCKET}\" }}"
     echo "$payload"
 


### PR DESCRIPTION
When a new release (tag) is pushed this will now trigger deploy of docs in production.

Also added a manual option to deploy by using add `-f` or `--force-deploy`.

Full command: `./.circleci/scripts/check_and_trigger_docs_deploy.sh --token <circle-token> --bucket <your.bucket> -f`