### PR TITLE
Tools: Add option to pass AWS credentials profile

### DIFF
--- a/tools/gulptasks/dist-testresults.js
+++ b/tools/gulptasks/dist-testresults.js
@@ -20,7 +20,9 @@ function uploadVisualTestResults() {
     const argv = require('yargs').argv;
     const dateString = new Date().toISOString().slice(0, 10);
     const promises = [];
-    const defaultParams = {};
+    const defaultParams = {
+        profile: argv.profile
+    };
 
     if (argv.bucket) {
         defaultParams.bucket = argv.bucket;

--- a/tools/gulptasks/dist-upload.js
+++ b/tools/gulptasks/dist-upload.js
@@ -45,7 +45,7 @@ function distUpload() {
         return uploadPackage(product, properties[product].product);
     });
 
-    promises.push(uploadFiles({ files: productJs, name: 'products.js' }));
+    promises.push(uploadFiles({ files: productJs, name: 'products.js', profile: argv.profile }));
     return Promise.all(promises);
 }
 

--- a/tools/gulptasks/unsorted/upload-api.js
+++ b/tools/gulptasks/unsorted/upload-api.js
@@ -1,5 +1,6 @@
 /* eslint func-style: 0, no-console: 0, max-len: 0 */
 const gulp = require('gulp');
+
 const uploadAPIDocs = () => {
     const {
         getFilesInFolder
@@ -46,9 +47,11 @@ const uploadAPIDocs = () => {
                 error: `\n${errors.length} file(s) errored:\n${errors.join('\n')}`
             });
         };
+
         const params = {
             batchSize,
             bucket,
+            profile: argv.profile,
             callback: argv.silent ? false : doTick,
             onError
         };
@@ -93,4 +96,16 @@ const uploadAPIDocs = () => {
             }
         });
 };
+
+uploadAPIDocs.description = 'Uploads API docs to the designated bucket';
+uploadAPIDocs.flags = {
+    '--bucket': 'The S3 bucket to upload to.',
+    '--profile': 'AWS profile to load from AWS credentials file. If no profile is provided the default profile or ' +
+                    'standard AWS environment variables for credentials will be used. (optional)',
+    '--tags': 'Tags to upload under (optional)',
+    '--noextensions': 'Remove file extensions for uploaded files (destination). Useful for testing/serving directly from S3 bucket (optional)',
+    '--silent': 'Don\'t produce progress output. (optional)'
+};
+
+
 gulp.task('upload-api', uploadAPIDocs);

--- a/tools/gulptasks/unsorted/upload-files.js
+++ b/tools/gulptasks/unsorted/upload-files.js
@@ -44,6 +44,7 @@ const fileUpload = () => {
         const params = {
             batchSize,
             bucket,
+            profile: argv.profile,
             callback: doTick,
             onError
         };

--- a/tools/gulptasks/update-pr-testresults.js
+++ b/tools/gulptasks/update-pr-testresults.js
@@ -440,7 +440,12 @@ async function uploadVisualTestFiles(diffingSamples = [], pr, includeReview = tr
         }
 
         if (!argv.dryrun) {
-            result = await uploadFiles({ files, bucket: VISUAL_TESTS_BUCKET, name: `image diff on PR #${pr}` });
+            result = await uploadFiles({
+                files,
+                bucket: VISUAL_TESTS_BUCKET,
+                profile: argv.profile,
+                name: `image diff on PR #${pr}`
+            });
         } else {
             logLib.message('Dry run - Skipping upload of files.');
         }
@@ -512,7 +517,9 @@ commentOnPR.flags = {
     '--contains-text': 'Filter text used to find PR comment to overwrite',
     '--always-add': 'If present any old test results comment won\'t be overwritten',
     '--fail-silently': 'Will always return exitCode 0 (success)',
-    '--dryrun': 'Just runs through the task for testing purposes without doing external requests. '
+    '--dryrun': 'Just runs through the task for testing purposes without doing external requests. ',
+    '--profile': 'AWS profile to load from AWS credentials file. If no profile is provided the default profile or ' +
+        'standard AWS environment variables for credentials will be used. (optional)'
 };
 
 gulp.task('update-pr-testresults', commentOnPR);

--- a/tools/jsdoc/storage/cdn.storage.js
+++ b/tools/jsdoc/storage/cdn.storage.js
@@ -35,8 +35,17 @@ const error = require('./errors');
 
 const builtIns = {
   s3: (config) => {
+    const AWS = require('aws-sdk');
+    if (config.profile) {
+      AWS.config.credentials = new AWS.SharedIniFileCredentials({ profile: config.profile });
+
+      if (!AWS.config.credentials.accessKeyId) {
+        return { error: { message: 'No accessKeyId found for profile ' + config.profile }};
+      }
+    }
+
     return (filename, data, mime, s3Params = {}) => {
-      var s3 = new (require('aws-sdk').S3)();
+      var s3 = new (AWS.S3)();
 
       return new Promise((resolve, reject) => {
         s3.putObject({

--- a/tools/upload.js
+++ b/tools/upload.js
@@ -58,6 +58,7 @@ const uploadFiles = params => {
     const {
         batchSize,
         bucket,
+        profile,
         callback,
         onError = Promise.reject,
         files,
@@ -67,8 +68,14 @@ const uploadFiles = params => {
     let result;
     if (isString(bucket) && isArray(files)) {
         const cdn = storage.strategy.s3({
-            Bucket: bucket
+            Bucket: bucket,
+            profile
         });
+
+        if (cdn.error) {
+            return Promise.reject(cdn.error.message);
+        }
+
         const uploadFile = file => {
             const { from, to } = file;
             let filePromise;


### PR DESCRIPTION
Added option for passing AWS credentials profile when using gulp tasks that uses the S3 upload.

Profile can be passed like this: `gulp upload-api --bucket <bucket> --profile <profilename>`

