### PR TITLE
Tools: Fail CI build when workspace is dirty

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
            - /home/circleci/repo/highcharts/node_modules
          key: npm-deps-{{ .Environment.HIGHCHARTS_CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package.json" }}
      - run: npm run gulp scripts
-     - run: git diff --name-only --exit-code || (echo "Untracked files found. Failing build.." && exit 1)
+     - run: git diff --name-only --exit-code || (echo "Untracked files found. Did you forget to commit any transpiled files? Failing build now as this likely will trigger errors later in the build.." && exit 1)
      - <<: *persist_workspace
 
   generate_ts_declarations:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ jobs:
            - /home/circleci/repo/highcharts/node_modules
          key: npm-deps-{{ .Environment.HIGHCHARTS_CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package.json" }}
      - run: npm run gulp scripts
+     - run: git diff --name-only --exit-code || (echo "Untracked files found. Failing build.." && exit 1)
      - <<: *persist_workspace
 
   generate_ts_declarations:

--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -265,8 +265,8 @@ extend(Legend.prototype, {
     setItemEvents: function (item, legendItem, useHTML) {
         var legend = this, boxWrapper = legend.chart.renderer.boxWrapper, isPoint = item instanceof Point, activeClass = 'highcharts-legend-' +
             (isPoint ? 'point' : 'series') + '-active', styledMode = legend.chart.styledMode, 
-        // When useHTML symbol is rendered in other group, so
-        // it is need to put in array with the item to setting properties
+        // When `useHTML`, the symbol is rendered in other group, so
+        // we need to apply events listeners to both places
         legendItems = useHTML ?
             [legendItem, item.legendSymbol] :
             [item.legendGroup];


### PR DESCRIPTION
Added missing transpiled js file changes.

If someone forgets to e.g commit a js file after editing a TS file the build will now fail early.

