### PR TITLE
bugfix/12627-overlapping-legend-drilldown

### DIFF
--- a/js/parts/Point.js
+++ b/js/parts/Point.js
@@ -520,6 +520,9 @@ Highcharts.Point.prototype = {
                 point[prop] = null;
             }
         }
+        if (point.legendItem) { // pies have legend items
+            chart.legend.destroyItem(point);
+        }
         // Remove properties after animation
         if (!dataSorting || !dataSorting.enabled) {
             destroyPoint();
@@ -529,9 +532,6 @@ Highcharts.Point.prototype = {
             syncTimeout(destroyPoint, animation.duration);
         }
         chart.pointCount--;
-        if (point.legendItem) { // pies have legend items
-            chart.legend.destroyItem(point);
-        }
     },
     /**
      * Animate SVG elements associated with the point.

--- a/samples/unit-tests/drilldown/pie/demo.js
+++ b/samples/unit-tests/drilldown/pie/demo.js
@@ -26,6 +26,7 @@ QUnit.test('Pie color and data labels', function (assert) {
             pointFormat: '<span style="color:{point.color}">{point.name}</span>: <b>{point.y:.2f}%</b> of total<br/>'
         },
         series: [{
+            showInLegend: true,
             name: 'Brands',
             colorByPoint: true,
             id: 'brands',
@@ -100,6 +101,7 @@ QUnit.test('Pie color and data labels', function (assert) {
                 duration: 1
             },
             series: [{
+                showInLegend: true,
                 name: 'Microsoft Internet Explorer',
                 id: 'Microsoft Internet Explorer',
                 data: [
@@ -194,6 +196,12 @@ QUnit.test('Pie color and data labels', function (assert) {
                 chart.series[0].name,
                 'Microsoft Internet Explorer',
                 'Second level name'
+            );
+
+            assert.strictEqual(
+                chart.legend.contentGroup.element.children[0].children.length,
+                6,
+                'The number of the legend items should be adapted to the current drilldown level.'
             );
 
             assert.strictEqual(

--- a/ts/parts/Point.ts
+++ b/ts/parts/Point.ts
@@ -832,6 +832,10 @@ Highcharts.Point.prototype = {
             }
         }
 
+        if (point.legendItem) { // pies have legend items
+            chart.legend.destroyItem(point);
+        }
+
         // Remove properties after animation
         if (!dataSorting || !dataSorting.enabled) {
             destroyPoint();
@@ -842,10 +846,6 @@ Highcharts.Point.prototype = {
         }
 
         chart.pointCount--;
-
-        if (point.legendItem) { // pies have legend items
-            chart.legend.destroyItem(point);
-        }
     },
 
     /**


### PR DESCRIPTION
Fixed #12627, legend items in pie chart overlapped on drilldown.