### PR TITLE
Docs: Excluded dataSorting from series and plot options

### DIFF
--- a/js/modules/bullet.src.js
+++ b/js/modules/bullet.src.js
@@ -34,7 +34,8 @@ seriesType('bullet', 'column'
  * @extends      plotOptions.column
  * @since        6.0.0
  * @product      highcharts
- * @excluding    allAreas, boostThreshold, colorAxis, compare, compareBase
+ * @excluding    allAreas, boostThreshold, colorAxis, compare, compareBase,
+ *               dataSorting
  * @requires     modules/bullet
  * @optionparent plotOptions.bullet
  */
@@ -225,7 +226,7 @@ seriesType('bullet', 'column'
  * @extends   series,plotOptions.bullet
  * @since     6.0.0
  * @product   highcharts
- * @excluding dataParser, dataURL, marker
+ * @excluding dataParser, dataURL, marker, dataSorting
  * @requires  modules/bullet
  * @apioption series.bullet
  */

--- a/js/modules/dependency-wheel.src.js
+++ b/js/modules/dependency-wheel.src.js
@@ -32,6 +32,7 @@ H.seriesType('dependencywheel', 'sankey',
  *         Dependency wheel
  *
  * @extends      plotOptions.sankey
+ * @exclude      dataSorting
  * @since        7.1.0
  * @product      highcharts
  * @requires     modules/dependencywheel
@@ -276,6 +277,7 @@ H.seriesType('dependencywheel', 'sankey',
  * option is not specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.dependencywheel
+ * @exclude   dataSorting
  * @product   highcharts
  * @requires  modules/dependencywheel
  * @apioption series.dependencywheel

--- a/js/modules/funnel.src.js
+++ b/js/modules/funnel.src.js
@@ -35,7 +35,7 @@ seriesType('funnel', 'pie',
  *         Funnel demo
  *
  * @extends      plotOptions.pie
- * @excluding    innerSize,size
+ * @excluding    innerSize,size,dataSorting
  * @product      highcharts
  * @requires     modules/funnel
  * @optionparent plotOptions.funnel
@@ -396,7 +396,7 @@ addEvent(Highcharts.Chart, 'afterHideAllOverlappingLabels', function () {
  * not specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.funnel
- * @excluding dataParser, dataURL, stack, xAxis, yAxis
+ * @excluding dataParser, dataURL, stack, xAxis, yAxis, dataSorting
  * @product   highcharts
  * @requires  modules/funnel
  * @apioption series.funnel
@@ -496,7 +496,7 @@ seriesType('pyramid', 'funnel',
  * not specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.pyramid
- * @excluding dataParser, dataURL, stack, xAxis, yAxis
+ * @excluding dataParser, dataURL, stack, xAxis, yAxis, dataSorting
  * @product   highcharts
  * @requires  modules/funnel
  * @apioption series.pyramid

--- a/js/modules/funnel3d.src.js
+++ b/js/modules/funnel3d.src.js
@@ -44,7 +44,8 @@ seriesType('funnel3d', 'column',
  *         Funnel3d
  *
  * @extends      plotOptions.column
- * @excluding    allAreas, boostThreshold, colorAxis, compare, compareBase
+ * @excluding    allAreas, boostThreshold, colorAxis, compare, compareBase,
+ *               dataSorting
  * @product      highcharts
  * @since        7.1.0
  * @requires     highcharts-3d

--- a/js/modules/item-series.src.js
+++ b/js/modules/item-series.src.js
@@ -388,7 +388,7 @@ H.seriesType('item',
  * it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.item
- * @excluding dataParser, dataURL, stack, xAxis, yAxis
+ * @excluding dataParser, dataURL, stack, xAxis, yAxis, dataSorting
  * @product   highcharts
  * @requires  modules/item-series
  * @apioption series.item

--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -75,7 +75,7 @@ seriesType('networkgraph', 'line',
  *               getExtremesFromAll, label, linecap, negativeColor,
  *               pointInterval, pointIntervalUnit, pointPlacement,
  *               pointStart, softThreshold, stack, stacking, step,
- *               threshold, xAxis, yAxis, zoneAxis
+ *               threshold, xAxis, yAxis, zoneAxis, dataSorting
  * @requires     modules/networkgraph
  * @optionparent plotOptions.networkgraph
  */
@@ -940,7 +940,7 @@ seriesType('networkgraph', 'line',
  *            connectNulls, dragDrop, getExtremesFromAll, label, linecap,
  *            negativeColor, pointInterval, pointIntervalUnit,
  *            pointPlacement, pointStart, softThreshold, stack, stacking,
- *            step, threshold, xAxis, yAxis, zoneAxis
+ *            step, threshold, xAxis, yAxis, zoneAxis, dataSorting
  * @product   highcharts
  * @requires  modules/networkgraph
  * @apioption series.networkgraph

--- a/js/modules/organization.src.js
+++ b/js/modules/organization.src.js
@@ -44,7 +44,7 @@ H.seriesType('organization', 'sankey',
  *               Centered layout
  *
  * @extends      plotOptions.sankey
- * @excluding    allowPointSelect, curveFactor
+ * @excluding    allowPointSelect, curveFactor, dataSorting
  * @since        7.1.0
  * @product      highcharts
  * @requires     modules/organization
@@ -389,6 +389,7 @@ H.seriesType('organization', 'sankey',
  * not specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.organization
+ * @exclude   dataSorting
  * @product   highcharts
  * @requires  modules/organization
  * @apioption series.organization

--- a/js/modules/pyramid3d.src.js
+++ b/js/modules/pyramid3d.src.js
@@ -36,7 +36,7 @@ seriesType('pyramid3d', 'funnel3d',
  *         Pyramid3d
  *
  * @extends      plotOptions.funnel3d
- * @excluding    neckHeight, neckWidth
+ * @excluding    neckHeight, neckWidth, dataSorting
  * @product      highcharts
  * @since        7.1.0
  * @requires     highcharts-3d
@@ -65,7 +65,7 @@ seriesType('pyramid3d', 'funnel3d',
  *
  * @since     7.1.0
  * @extends   series,plotOptions.pyramid3d
- * @excluding allAreas,boostThreshold,colorAxis,compare,compareBase
+ * @excluding allAreas,boostThreshold,colorAxis,compare,compareBase,dataSorting
  * @product   highcharts
  * @sample    {highcharts} highcharts/demo/pyramid3d/ Pyramid3d
  * @requires  modules/pyramid3d

--- a/js/modules/sankey.src.js
+++ b/js/modules/sankey.src.js
@@ -139,7 +139,7 @@ seriesType('sankey', 'column',
  *               pointInterval, pointIntervalUnit, pointPadding,
  *               pointPlacement, pointRange, pointStart, pointWidth,
  *               shadow, softThreshold, stacking, threshold, zoneAxis,
- *               zones, minPointLength
+ *               zones, minPointLength, dataSorting
  * @requires     modules/sankey
  * @optionparent plotOptions.sankey
  */
@@ -785,7 +785,7 @@ seriesType('sankey', 'column',
  *            groupZPadding, label, maxPointWidth, negativeColor, pointInterval,
  *            pointIntervalUnit, pointPadding, pointPlacement, pointRange,
  *            pointStart, pointWidth, shadow, softThreshold, stacking,
- *            threshold, zoneAxis, zones
+ *            threshold, zoneAxis, zones, dataSorting
  * @product   highcharts
  * @requires  modules/sankey
  * @apioption series.sankey

--- a/js/modules/solid-gauge.src.js
+++ b/js/modules/solid-gauge.src.js
@@ -339,7 +339,8 @@ H.seriesType('solidgauge', 'gauge', solidGaugeOptions, {
  *            cropThreshold, dashStyle, dataParser, dataURL, dial,
  *            findNearestPointBy, getExtremesFromAll, marker, negativeColor,
  *            pointPlacement, pivot, shadow, softThreshold, stack, stacking,
- *            states, step, threshold, turboThreshold, wrap, zoneAxis, zones
+ *            states, step, threshold, turboThreshold, wrap, zoneAxis, zones,
+ *            dataSorting
  * @product   highcharts
  * @requires  modules/solid-gauge
  * @apioption series.solidgauge

--- a/js/modules/sunburst.src.js
+++ b/js/modules/sunburst.src.js
@@ -893,7 +893,7 @@ var sunburstPoint = {
  * not specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.sunburst
- * @excluding dataParser, dataURL, stack
+ * @excluding dataParser, dataURL, stack, dataSorting
  * @product   highcharts
  * @requires  modules/sunburst.js
  * @apioption series.sunburst

--- a/js/modules/tilemap.src.js
+++ b/js/modules/tilemap.src.js
@@ -321,7 +321,8 @@ seriesType('tilemap', 'heatmap'
  *
  * @extends      plotOptions.heatmap
  * @since        6.0.0
- * @excluding    jitter, joinBy, shadow, allAreas, mapData, data
+ * @excluding    jitter, joinBy, shadow, allAreas, mapData, data,
+ *               dataSorting
  * @product      highcharts highmaps
  * @requires     modules/tilemap.js
  * @optionparent plotOptions.tilemap
@@ -447,7 +448,7 @@ seriesType('tilemap', 'heatmap'
  *
  * @extends   series,plotOptions.tilemap
  * @excluding allAreas, dataParser, dataURL, joinBy, mapData, marker,
- *            pointRange, shadow, stack
+ *            pointRange, shadow, stack, dataSorting
  * @product   highcharts highmaps
  * @requires  modules/tilemap.js
  * @apioption series.tilemap

--- a/js/modules/timeline.src.js
+++ b/js/modules/timeline.src.js
@@ -70,7 +70,7 @@ seriesType('timeline', 'line',
  *               getExtremesFromAll, lineWidth, negativeColor,
  *               pointInterval, pointIntervalUnit, pointPlacement,
  *               pointStart, softThreshold, stacking, step, threshold,
- *               turboThreshold, zoneAxis, zones
+ *               turboThreshold, zoneAxis, zones, dataSorting
  * @requires     modules/timeline
  * @optionparent plotOptions.timeline
  */
@@ -530,7 +530,7 @@ seriesType('timeline', 'line',
  *            getExtremesFromAll, lineWidth, negativeColor,
  *            pointInterval, pointIntervalUnit, pointPlacement, pointStart,
  *            softThreshold, stacking, stack, step, threshold, turboThreshold,
- *            zoneAxis, zones
+ *            zoneAxis, zones, dataSorting
  * @product   highcharts
  * @requires  modules/timeline
  * @apioption series.timeline

--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -59,7 +59,7 @@ seriesType('treemap', 'scatter'
  *         Treemap
  *
  * @extends      plotOptions.scatter
- * @excluding    dragDrop, marker, jitter
+ * @excluding    dragDrop, marker, jitter, dataSorting
  * @product      highcharts
  * @requires     modules/treemap
  * @optionparent plotOptions.treemap
@@ -1445,7 +1445,7 @@ seriesType('treemap', 'scatter'
  * not specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.treemap
- * @excluding dataParser, dataURL, stack
+ * @excluding dataParser, dataURL, stack, dataSorting
  * @product   highcharts
  * @requires  modules/treemap
  * @apioption series.treemap

--- a/js/modules/variable-pie.src.js
+++ b/js/modules/variable-pie.src.js
@@ -317,7 +317,7 @@ seriesType('variablepie', 'pie',
  * specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.variablepie
- * @excluding dataParser, dataURL, stack, xAxis, yAxis
+ * @excluding dataParser, dataURL, stack, xAxis, yAxis, dataSorting
  * @product   highcharts
  * @requires  modules/variable-pie.js
  * @apioption series.variablepie

--- a/js/modules/venn.src.js
+++ b/js/modules/venn.src.js
@@ -681,7 +681,8 @@ var updateFieldBoundaries = function updateFieldBoundaries(field, circle) {
  *               findNearestPointBy, getExtremesFromAll, jitter, label, linecap,
  *               lineWidth, linkedTo, marker, negativeColor, pointInterval,
  *               pointIntervalUnit, pointPlacement, pointStart, softThreshold,
- *               stacking, steps, threshold, xAxis, yAxis, zoneAxis, zones
+ *               stacking, steps, threshold, xAxis, yAxis, zoneAxis, zones,
+ *               dataSorting
  * @product      highcharts
  * @requires     modules/venn
  * @optionparent plotOptions.venn
@@ -937,7 +938,7 @@ var vennPoint = {
  *            findNearestPointBy, getExtremesFromAll, label, linecap, lineWidth,
  *            linkedTo, marker, negativeColor, pointInterval, pointIntervalUnit,
  *            pointPlacement, pointStart, softThreshold, stack, stacking, steps,
- *            threshold, xAxis, yAxis, zoneAxis, zones
+ *            threshold, xAxis, yAxis, zoneAxis, zones, dataSorting
  * @product   highcharts
  * @requires  modules/venn
  * @apioption series.venn

--- a/js/modules/wordcloud.src.js
+++ b/js/modules/wordcloud.src.js
@@ -515,7 +515,8 @@ function updateFieldBoundaries(field, rectangle) {
  *               negativeColor, pointInterval, pointIntervalUnit, pointPadding,
  *               pointPlacement, pointRange, pointStart, pointWidth, pointStart,
  *               pointWidth, shadow, showCheckbox, showInNavigator,
- *               softThreshold, stacking, threshold, zoneAxis, zones
+ *               softThreshold, stacking, threshold, zoneAxis, zones,
+ *               dataSorting
  * @product      highcharts
  * @since        6.0.0
  * @requires     modules/wordcloud
@@ -854,6 +855,7 @@ var wordCloudPoint = {
  * specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.wordcloud
+ * @exclude   dataSorting
  * @product   highcharts
  * @requires  modules/wordcloud
  * @apioption series.wordcloud

--- a/js/modules/xrange.src.js
+++ b/js/modules/xrange.src.js
@@ -72,7 +72,7 @@ seriesType('xrange', 'column'
  *               edgeWidth, findNearestPointBy, getExtremesFromAll,
  *               negativeColor, pointInterval, pointIntervalUnit,
  *               pointPlacement, pointRange, pointStart, softThreshold,
- *               stacking, threshold, data
+ *               stacking, threshold, data, dataSorting
  * @requires     modules/xrange
  * @optionparent plotOptions.xrange
  */
@@ -559,7 +559,7 @@ addEvent(Axis, 'afterGetSeriesExtremes', function () {
  * @excluding boostThreshold, crisp, cropThreshold, depth, edgeColor, edgeWidth,
  *            findNearestPointBy, getExtremesFromAll, negativeColor,
  *            pointInterval, pointIntervalUnit, pointPlacement, pointRange,
- *            pointStart, softThreshold, stacking, threshold
+ *            pointStart, softThreshold, stacking, threshold, dataSorting
  * @product   highcharts highstock gantt
  * @requires  modules/xrange
  * @apioption series.xrange

--- a/js/parts-more/GaugeSeries.js
+++ b/js/parts-more/GaugeSeries.js
@@ -28,7 +28,7 @@ var merge = H.merge, noop = H.noop, Series = H.Series, seriesType = H.seriesType
  *               connectEnds, connectNulls, cropThreshold, dashStyle, dragDrop,
  *               findNearestPointBy, getExtremesFromAll, marker, negativeColor,
  *               pointPlacement, shadow, softThreshold, stacking, states, step,
- *               threshold, turboThreshold, xAxis, zoneAxis, zones
+ *               threshold, turboThreshold, xAxis, zoneAxis, zones, dataSorting
  * @product      highcharts
  * @requires     highcharts-more
  * @optionparent plotOptions.gauge
@@ -464,7 +464,7 @@ seriesType('gauge', 'line', {
  *            cropThreshold, dashStyle, dataParser, dataURL, findNearestPointBy,
  *            getExtremesFromAll, marker, negativeColor, pointPlacement, shadow,
  *            softThreshold, stack, stacking, states, step, threshold,
- *            turboThreshold, zoneAxis, zones
+ *            turboThreshold, zoneAxis, zones, dataSorting
  * @product   highcharts
  * @requires  highcharts-more
  * @apioption series.gauge

--- a/js/parts-more/PackedBubbleSeries.js
+++ b/js/parts-more/PackedBubbleSeries.js
@@ -210,7 +210,7 @@ seriesType('packedbubble', 'bubble',
  * @extends      plotOptions.bubble
  * @excluding    connectEnds, connectNulls, dragDrop, jitter, keys,
  *               pointPlacement, sizeByAbsoluteValue, step, xAxis, yAxis,
- *               zMax, zMin
+ *               zMax, zMin, dataSorting
  * @product      highcharts
  * @since        7.0.0
  * @requires     highcharts-more
@@ -1213,7 +1213,7 @@ addEvent(Chart, 'beforeRedraw', function () {
  *
  * @type      {Object}
  * @extends   series,plotOptions.packedbubble
- * @excluding dataParser,dataURL,stack
+ * @excluding dataParser,dataURL,stack,dataSorting
  * @product   highcharts highstock
  * @requires  highcharts-more
  * @apioption series.packedbubble

--- a/js/parts/PieSeries.js
+++ b/js/parts/PieSeries.js
@@ -41,7 +41,7 @@ seriesType('pie', 'line',
  *               findNearestPointBy, getExtremesFromAll, label, lineWidth,
  *               marker, negativeColor, pointInterval, pointIntervalUnit,
  *               pointPlacement, pointStart, softThreshold, stacking, step,
- *               threshold, turboThreshold, zoneAxis, zones
+ *               threshold, turboThreshold, zoneAxis, zones, dataSorting
  * @product      highcharts
  * @optionparent plotOptions.pie
  */
@@ -1175,7 +1175,7 @@ seriesType('pie', 'line',
  * it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.pie
- * @excluding dataParser, dataURL, stack, xAxis, yAxis
+ * @excluding dataParser, dataURL, stack, xAxis, yAxis, dataSorting
  * @product   highcharts
  * @apioption series.pie
  */

--- a/ts/modules/bullet.src.ts
+++ b/ts/modules/bullet.src.ts
@@ -91,7 +91,8 @@ seriesType<Highcharts.BulletSeries>('bullet', 'column'
      * @extends      plotOptions.column
      * @since        6.0.0
      * @product      highcharts
-     * @excluding    allAreas, boostThreshold, colorAxis, compare, compareBase
+     * @excluding    allAreas, boostThreshold, colorAxis, compare, compareBase,
+     *               dataSorting
      * @requires     modules/bullet
      * @optionparent plotOptions.bullet
      */
@@ -352,7 +353,7 @@ seriesType<Highcharts.BulletSeries>('bullet', 'column'
  * @extends   series,plotOptions.bullet
  * @since     6.0.0
  * @product   highcharts
- * @excluding dataParser, dataURL, marker
+ * @excluding dataParser, dataURL, marker, dataSorting
  * @requires  modules/bullet
  * @apioption series.bullet
  */

--- a/ts/modules/dependency-wheel.src.ts
+++ b/ts/modules/dependency-wheel.src.ts
@@ -96,6 +96,7 @@ H.seriesType<Highcharts.DependencyWheelSeries>(
      *         Dependency wheel
      *
      * @extends      plotOptions.sankey
+     * @exclude      dataSorting
      * @since        7.1.0
      * @product      highcharts
      * @requires     modules/dependencywheel
@@ -452,6 +453,7 @@ H.seriesType<Highcharts.DependencyWheelSeries>(
  * option is not specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.dependencywheel
+ * @exclude   dataSorting
  * @product   highcharts
  * @requires  modules/dependencywheel
  * @apioption series.dependencywheel

--- a/ts/modules/funnel.src.ts
+++ b/ts/modules/funnel.src.ts
@@ -127,7 +127,7 @@ seriesType<Highcharts.FunnelSeries>(
      *         Funnel demo
      *
      * @extends      plotOptions.pie
-     * @excluding    innerSize,size
+     * @excluding    innerSize,size,dataSorting
      * @product      highcharts
      * @requires     modules/funnel
      * @optionparent plotOptions.funnel
@@ -640,7 +640,7 @@ addEvent(Highcharts.Chart, 'afterHideAllOverlappingLabels', function (
  * not specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.funnel
- * @excluding dataParser, dataURL, stack, xAxis, yAxis
+ * @excluding dataParser, dataURL, stack, xAxis, yAxis, dataSorting
  * @product   highcharts
  * @requires  modules/funnel
  * @apioption series.funnel
@@ -748,7 +748,7 @@ seriesType<Highcharts.PyramidSeries>(
  * not specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.pyramid
- * @excluding dataParser, dataURL, stack, xAxis, yAxis
+ * @excluding dataParser, dataURL, stack, xAxis, yAxis, dataSorting
  * @product   highcharts
  * @requires  modules/funnel
  * @apioption series.pyramid

--- a/ts/modules/funnel3d.src.ts
+++ b/ts/modules/funnel3d.src.ts
@@ -135,7 +135,8 @@ seriesType<Highcharts.Funnel3dSeries>('funnel3d', 'column',
      *         Funnel3d
      *
      * @extends      plotOptions.column
-     * @excluding    allAreas, boostThreshold, colorAxis, compare, compareBase
+     * @excluding    allAreas, boostThreshold, colorAxis, compare, compareBase,
+     *               dataSorting
      * @product      highcharts
      * @since        7.1.0
      * @requires     highcharts-3d

--- a/ts/modules/item-series.src.ts
+++ b/ts/modules/item-series.src.ts
@@ -583,7 +583,7 @@ H.seriesType<Highcharts.ItemSeries>(
  * it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.item
- * @excluding dataParser, dataURL, stack, xAxis, yAxis
+ * @excluding dataParser, dataURL, stack, xAxis, yAxis, dataSorting
  * @product   highcharts
  * @requires  modules/item-series
  * @apioption series.item

--- a/ts/modules/networkgraph/networkgraph.src.ts
+++ b/ts/modules/networkgraph/networkgraph.src.ts
@@ -262,7 +262,7 @@ seriesType<Highcharts.NetworkgraphSeries>(
      *               getExtremesFromAll, label, linecap, negativeColor,
      *               pointInterval, pointIntervalUnit, pointPlacement,
      *               pointStart, softThreshold, stack, stacking, step,
-     *               threshold, xAxis, yAxis, zoneAxis
+     *               threshold, xAxis, yAxis, zoneAxis, dataSorting
      * @requires     modules/networkgraph
      * @optionparent plotOptions.networkgraph
      */
@@ -1367,7 +1367,7 @@ seriesType<Highcharts.NetworkgraphSeries>(
  *            connectNulls, dragDrop, getExtremesFromAll, label, linecap,
  *            negativeColor, pointInterval, pointIntervalUnit,
  *            pointPlacement, pointStart, softThreshold, stack, stacking,
- *            step, threshold, xAxis, yAxis, zoneAxis
+ *            step, threshold, xAxis, yAxis, zoneAxis, dataSorting
  * @product   highcharts
  * @requires  modules/networkgraph
  * @apioption series.networkgraph

--- a/ts/modules/organization.src.ts
+++ b/ts/modules/organization.src.ts
@@ -158,7 +158,7 @@ H.seriesType<Highcharts.OrganizationSeries>(
      *               Centered layout
      *
      * @extends      plotOptions.sankey
-     * @excluding    allowPointSelect, curveFactor
+     * @excluding    allowPointSelect, curveFactor, dataSorting
      * @since        7.1.0
      * @product      highcharts
      * @requires     modules/organization
@@ -673,6 +673,7 @@ H.seriesType<Highcharts.OrganizationSeries>(
  * not specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.organization
+ * @exclude   dataSorting
  * @product   highcharts
  * @requires  modules/organization
  * @apioption series.organization

--- a/ts/modules/pyramid3d.src.ts
+++ b/ts/modules/pyramid3d.src.ts
@@ -67,7 +67,7 @@ seriesType<Highcharts.Pyramid3dSeries>('pyramid3d', 'funnel3d',
      *         Pyramid3d
      *
      * @extends      plotOptions.funnel3d
-     * @excluding    neckHeight, neckWidth
+     * @excluding    neckHeight, neckWidth, dataSorting
      * @product      highcharts
      * @since        7.1.0
      * @requires     highcharts-3d
@@ -99,7 +99,7 @@ seriesType<Highcharts.Pyramid3dSeries>('pyramid3d', 'funnel3d',
  *
  * @since     7.1.0
  * @extends   series,plotOptions.pyramid3d
- * @excluding allAreas,boostThreshold,colorAxis,compare,compareBase
+ * @excluding allAreas,boostThreshold,colorAxis,compare,compareBase,dataSorting
  * @product   highcharts
  * @sample    {highcharts} highcharts/demo/pyramid3d/ Pyramid3d
  * @requires  modules/pyramid3d

--- a/ts/modules/sankey.src.ts
+++ b/ts/modules/sankey.src.ts
@@ -330,7 +330,7 @@ seriesType<Highcharts.SankeySeries>(
      *               pointInterval, pointIntervalUnit, pointPadding,
      *               pointPlacement, pointRange, pointStart, pointWidth,
      *               shadow, softThreshold, stacking, threshold, zoneAxis,
-     *               zones, minPointLength
+     *               zones, minPointLength, dataSorting
      * @requires     modules/sankey
      * @optionparent plotOptions.sankey
      */
@@ -1235,7 +1235,7 @@ seriesType<Highcharts.SankeySeries>(
  *            groupZPadding, label, maxPointWidth, negativeColor, pointInterval,
  *            pointIntervalUnit, pointPadding, pointPlacement, pointRange,
  *            pointStart, pointWidth, shadow, softThreshold, stacking,
- *            threshold, zoneAxis, zones
+ *            threshold, zoneAxis, zones, dataSorting
  * @product   highcharts
  * @requires  modules/sankey
  * @apioption series.sankey

--- a/ts/modules/solid-gauge.src.ts
+++ b/ts/modules/solid-gauge.src.ts
@@ -578,7 +578,8 @@ H.seriesType<Highcharts.SolidGaugeSeries>(
  *            cropThreshold, dashStyle, dataParser, dataURL, dial,
  *            findNearestPointBy, getExtremesFromAll, marker, negativeColor,
  *            pointPlacement, pivot, shadow, softThreshold, stack, stacking,
- *            states, step, threshold, turboThreshold, wrap, zoneAxis, zones
+ *            states, step, threshold, turboThreshold, wrap, zoneAxis, zones,
+ *            dataSorting
  * @product   highcharts
  * @requires  modules/solid-gauge
  * @apioption series.solidgauge

--- a/ts/modules/sunburst.src.ts
+++ b/ts/modules/sunburst.src.ts
@@ -1368,7 +1368,7 @@ var sunburstPoint = {
  * not specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.sunburst
- * @excluding dataParser, dataURL, stack
+ * @excluding dataParser, dataURL, stack, dataSorting
  * @product   highcharts
  * @requires  modules/sunburst.js
  * @apioption series.sunburst

--- a/ts/modules/tilemap.src.ts
+++ b/ts/modules/tilemap.src.ts
@@ -711,7 +711,8 @@ seriesType<Highcharts.TilemapSeries>('tilemap', 'heatmap'
      *
      * @extends      plotOptions.heatmap
      * @since        6.0.0
-     * @excluding    jitter, joinBy, shadow, allAreas, mapData, data
+     * @excluding    jitter, joinBy, shadow, allAreas, mapData, data,
+     *               dataSorting
      * @product      highcharts highmaps
      * @requires     modules/tilemap.js
      * @optionparent plotOptions.tilemap
@@ -909,7 +910,7 @@ seriesType<Highcharts.TilemapSeries>('tilemap', 'heatmap'
  *
  * @extends   series,plotOptions.tilemap
  * @excluding allAreas, dataParser, dataURL, joinBy, mapData, marker,
- *            pointRange, shadow, stack
+ *            pointRange, shadow, stack, dataSorting
  * @product   highcharts highmaps
  * @requires  modules/tilemap.js
  * @apioption series.tilemap

--- a/ts/modules/timeline.src.ts
+++ b/ts/modules/timeline.src.ts
@@ -191,7 +191,7 @@ seriesType<Highcharts.TimelineSeries>('timeline', 'line',
      *               getExtremesFromAll, lineWidth, negativeColor,
      *               pointInterval, pointIntervalUnit, pointPlacement,
      *               pointStart, softThreshold, stacking, step, threshold,
-     *               turboThreshold, zoneAxis, zones
+     *               turboThreshold, zoneAxis, zones, dataSorting
      * @requires     modules/timeline
      * @optionparent plotOptions.timeline
      */
@@ -895,7 +895,7 @@ seriesType<Highcharts.TimelineSeries>('timeline', 'line',
  *            getExtremesFromAll, lineWidth, negativeColor,
  *            pointInterval, pointIntervalUnit, pointPlacement, pointStart,
  *            softThreshold, stacking, stack, step, threshold, turboThreshold,
- *            zoneAxis, zones
+ *            zoneAxis, zones, dataSorting
  * @product   highcharts
  * @requires  modules/timeline
  * @apioption series.timeline

--- a/ts/modules/treemap.src.ts
+++ b/ts/modules/treemap.src.ts
@@ -374,7 +374,7 @@ seriesType<Highcharts.TreemapSeries>(
      *         Treemap
      *
      * @extends      plotOptions.scatter
-     * @excluding    dragDrop, marker, jitter
+     * @excluding    dragDrop, marker, jitter, dataSorting
      * @product      highcharts
      * @requires     modules/treemap
      * @optionparent plotOptions.treemap
@@ -2239,7 +2239,7 @@ seriesType<Highcharts.TreemapSeries>(
  * not specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.treemap
- * @excluding dataParser, dataURL, stack
+ * @excluding dataParser, dataURL, stack, dataSorting
  * @product   highcharts
  * @requires  modules/treemap
  * @apioption series.treemap

--- a/ts/modules/variable-pie.src.ts
+++ b/ts/modules/variable-pie.src.ts
@@ -488,7 +488,7 @@ seriesType<Highcharts.VariablePieSeries>(
  * specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.variablepie
- * @excluding dataParser, dataURL, stack, xAxis, yAxis
+ * @excluding dataParser, dataURL, stack, xAxis, yAxis, dataSorting
  * @product   highcharts
  * @requires  modules/variable-pie.js
  * @apioption series.variablepie

--- a/ts/modules/venn.src.ts
+++ b/ts/modules/venn.src.ts
@@ -1085,7 +1085,8 @@ var updateFieldBoundaries = function updateFieldBoundaries(
  *               findNearestPointBy, getExtremesFromAll, jitter, label, linecap,
  *               lineWidth, linkedTo, marker, negativeColor, pointInterval,
  *               pointIntervalUnit, pointPlacement, pointStart, softThreshold,
- *               stacking, steps, threshold, xAxis, yAxis, zoneAxis, zones
+ *               stacking, steps, threshold, xAxis, yAxis, zoneAxis, zones,
+ *               dataSorting
  * @product      highcharts
  * @requires     modules/venn
  * @optionparent plotOptions.venn
@@ -1408,7 +1409,7 @@ var vennPoint = {
  *            findNearestPointBy, getExtremesFromAll, label, linecap, lineWidth,
  *            linkedTo, marker, negativeColor, pointInterval, pointIntervalUnit,
  *            pointPlacement, pointStart, softThreshold, stack, stacking, steps,
- *            threshold, xAxis, yAxis, zoneAxis, zones
+ *            threshold, xAxis, yAxis, zoneAxis, zones, dataSorting
  * @product   highcharts
  * @requires  modules/venn
  * @apioption series.venn

--- a/ts/modules/wordcloud.src.ts
+++ b/ts/modules/wordcloud.src.ts
@@ -788,7 +788,8 @@ function updateFieldBoundaries(
  *               negativeColor, pointInterval, pointIntervalUnit, pointPadding,
  *               pointPlacement, pointRange, pointStart, pointWidth, pointStart,
  *               pointWidth, shadow, showCheckbox, showInNavigator,
- *               softThreshold, stacking, threshold, zoneAxis, zones
+ *               softThreshold, stacking, threshold, zoneAxis, zones,
+ *               dataSorting
  * @product      highcharts
  * @since        6.0.0
  * @requires     modules/wordcloud
@@ -1228,6 +1229,7 @@ var wordCloudPoint: Partial<Highcharts.WordcloudPoint> = {
  * specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.wordcloud
+ * @exclude   dataSorting
  * @product   highcharts
  * @requires  modules/wordcloud
  * @apioption series.wordcloud

--- a/ts/modules/xrange.src.ts
+++ b/ts/modules/xrange.src.ts
@@ -182,7 +182,7 @@ seriesType<Highcharts.XRangeSeries>('xrange', 'column'
      *               edgeWidth, findNearestPointBy, getExtremesFromAll,
      *               negativeColor, pointInterval, pointIntervalUnit,
      *               pointPlacement, pointRange, pointStart, softThreshold,
-     *               stacking, threshold, data
+     *               stacking, threshold, data, dataSorting
      * @requires     modules/xrange
      * @optionparent plotOptions.xrange
      */
@@ -887,7 +887,7 @@ addEvent(Axis, 'afterGetSeriesExtremes', function (): void {
  * @excluding boostThreshold, crisp, cropThreshold, depth, edgeColor, edgeWidth,
  *            findNearestPointBy, getExtremesFromAll, negativeColor,
  *            pointInterval, pointIntervalUnit, pointPlacement, pointRange,
- *            pointStart, softThreshold, stacking, threshold
+ *            pointStart, softThreshold, stacking, threshold, dataSorting
  * @product   highcharts highstock gantt
  * @requires  modules/xrange
  * @apioption series.xrange

--- a/ts/parts-more/GaugeSeries.ts
+++ b/ts/parts-more/GaugeSeries.ts
@@ -116,7 +116,7 @@ var merge = H.merge,
  *               connectEnds, connectNulls, cropThreshold, dashStyle, dragDrop,
  *               findNearestPointBy, getExtremesFromAll, marker, negativeColor,
  *               pointPlacement, shadow, softThreshold, stacking, states, step,
- *               threshold, turboThreshold, xAxis, zoneAxis, zones
+ *               threshold, turboThreshold, xAxis, zoneAxis, zones, dataSorting
  * @product      highcharts
  * @requires     highcharts-more
  * @optionparent plotOptions.gauge
@@ -648,7 +648,7 @@ seriesType<Highcharts.GaugeSeries>('gauge', 'line', {
  *            cropThreshold, dashStyle, dataParser, dataURL, findNearestPointBy,
  *            getExtremesFromAll, marker, negativeColor, pointPlacement, shadow,
  *            softThreshold, stack, stacking, states, step, threshold,
- *            turboThreshold, zoneAxis, zones
+ *            turboThreshold, zoneAxis, zones, dataSorting
  * @product   highcharts
  * @requires  highcharts-more
  * @apioption series.gauge

--- a/ts/parts-more/PackedBubbleSeries.ts
+++ b/ts/parts-more/PackedBubbleSeries.ts
@@ -535,7 +535,7 @@ seriesType<Highcharts.PackedBubbleSeries>(
      * @extends      plotOptions.bubble
      * @excluding    connectEnds, connectNulls, dragDrop, jitter, keys,
      *               pointPlacement, sizeByAbsoluteValue, step, xAxis, yAxis,
-     *               zMax, zMin
+     *               zMax, zMin, dataSorting
      * @product      highcharts
      * @since        7.0.0
      * @requires     highcharts-more
@@ -1895,7 +1895,7 @@ addEvent(Chart as any, 'beforeRedraw', function (
  *
  * @type      {Object}
  * @extends   series,plotOptions.packedbubble
- * @excluding dataParser,dataURL,stack
+ * @excluding dataParser,dataURL,stack,dataSorting
  * @product   highcharts highstock
  * @requires  highcharts-more
  * @apioption series.packedbubble

--- a/ts/parts/PieSeries.ts
+++ b/ts/parts/PieSeries.ts
@@ -175,7 +175,7 @@ seriesType<Highcharts.PieSeries>(
      *               findNearestPointBy, getExtremesFromAll, label, lineWidth,
      *               marker, negativeColor, pointInterval, pointIntervalUnit,
      *               pointPlacement, pointStart, softThreshold, stacking, step,
-     *               threshold, turboThreshold, zoneAxis, zones
+     *               threshold, turboThreshold, zoneAxis, zones, dataSorting
      * @product      highcharts
      * @optionparent plotOptions.pie
      */
@@ -1604,7 +1604,7 @@ seriesType<Highcharts.PieSeries>(
  * it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.pie
- * @excluding dataParser, dataURL, stack, xAxis, yAxis
+ * @excluding dataParser, dataURL, stack, xAxis, yAxis, dataSorting
  * @product   highcharts
  * @apioption series.pie
  */


### PR DESCRIPTION
Closes #12612. Excludes the `dataSorting` series and/or plot option from the documentation for the following series types:
- Pie
- Variable pie
- Gauge
- Solid-gauge
- Venn
- Sankey
- Organization
- Funnel (3D)
- Pyramid (3D)
- Bullet
- Packed Bubbles
- Item-series
- Treemap
- Tilemap
- X-range
- Sunburst
- Wordcloud
- Network graphs
- Dependency wheel
- Timeline