### PR TITLE
Tools: Report slow tests to create awareness. Browserstack timezone set to UTC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,18 @@ jobs:
             - slack/status:
                 fail_only: true
 
+  test_timezones:
+    <<: *defaults
+    description: Run tests with different browser configs at BrowserStack
+    parameters:
+      browsers:
+        description: "Which browser to test?"
+        type: string
+        default: "ChromeHeadless"
+    steps:
+      - <<: *load_workspace
+      - run: ./.circleci/scripts/test_timezones.sh -b <<parameters.browsers>>
+
   check_for_docs_changes_and_deploy:
     <<: *defaults
     description: Checks for changes in docs/ and triggers deploy via doc-builder
@@ -398,6 +410,11 @@ workflows:
             tags:
               only: /^v\d+(?:\.\d+)+?$/
           context: highcharts-staging
+      - test_timezones:
+          requires: [lint]
+          filters:
+            branches:
+              only: [tools/report-slow-tests-and-set-bs-timezone]
       - test_browsers:
           name: "verify-samples-Chrome"
           browsers: "ChromeHeadless --tests highcharts/*/*,maps/*/*,stock/*/*,gantt/*/*"
@@ -453,6 +470,24 @@ workflows:
           name: "Test visual differences and distribute diff log to S3."
           requires: [checkout_and_install]
           context: highcharts-staging
+      - test_timezones:
+          name: "timezone-Mac.Safari"
+          requires: [checkout_and_install]
+          browsers: "Mac.Safari"
+          notify_on_failure: true
+      - test_timezones:
+          requires: [checkout_and_install]
+          notify_on_failure: true
+      - test_timezones:
+          name: "timezone-Mac.Firefox"
+          requires: ["timezone-Mac.Safari"]
+          browsers: "Mac.Firefox"
+          notify_on_failure: true
+      - test_timezones:
+          name: "timezone-Win.Chrome"
+          requires: ["timezone-Mac.Firefox"]
+          browsers: "Win.Chrome"
+          notify_on_failure: true
       - test_browsers:
           name: "test-Mac.Safari"
           requires: [checkout_and_install]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -471,23 +471,19 @@ workflows:
           requires: [checkout_and_install]
           context: highcharts-staging
       - test_timezones:
+          requires: [checkout_and_install]
+      - test_timezones:
           name: "timezone-Mac.Safari"
           requires: [checkout_and_install]
           browsers: "Mac.Safari"
-          notify_on_failure: true
-      - test_timezones:
-          requires: [checkout_and_install]
-          notify_on_failure: true
       - test_timezones:
           name: "timezone-Mac.Firefox"
           requires: ["timezone-Mac.Safari"]
           browsers: "Mac.Firefox"
-          notify_on_failure: true
       - test_timezones:
           name: "timezone-Win.Chrome"
           requires: ["timezone-Mac.Firefox"]
           browsers: "Win.Chrome"
-          notify_on_failure: true
       - test_browsers:
           name: "test-Mac.Safari"
           requires: [checkout_and_install]

--- a/.circleci/scripts/print_timezone.js
+++ b/.circleci/scripts/print_timezone.js
@@ -1,0 +1,3 @@
+module.exports.timezone = function() {
+    console.log(Intl.DateTimeFormat().resolvedOptions().timeZone);
+};

--- a/.circleci/scripts/test_timezones.sh
+++ b/.circleci/scripts/test_timezones.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -e
+
+TESTS="unit-tests/time/*"
+BROWSER="ChromeHeadless"
+
+for i in "$@"
+do
+case $i in
+    -t=*|--tests=*)
+    TESTS="${i#*=}"
+    ;;
+    -b=*|--splitbrowsers=*)
+    BROWSER="${i#*=}"
+    ;;
+    *)
+     # unknown option
+    ;;
+esac
+done
+
+
+echo "Triggering timezone tests.."
+
+orig_timezone=$(cat /etc/timezone)
+trap "sudo ln -sf /usr/share/zoneinfo/${orig_timezone} /etc/localtime && export TZ=${orig_timezone}" EXIT
+
+export TZ=Australia/Melbourne
+sudo ln -sf /usr/share/zoneinfo/Australia/Melbourne /etc/localtime && node -e 'require("./.circleci/scripts/print_timezone.js").timezone()'
+npx karma start test/karma-conf.js --single-run --splitbrowsers ${BROWSER} --browsercount 1 --tests unit-tests/time/* --timezone Australia/Melbourne
+
+export TZ=America/Los_Angeles
+sudo ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime && node -e 'require("./.circleci/scripts/print_timezone.js").timezone()'
+npx karma start test/karma-conf.js --single-run --splitbrowsers ${BROWSER} --browsercount 1 --tests unit-tests/time/* --timezone America/Los_Angeles
+
+export TZ=Asia/Kolkata
+sudo ln -sf /usr/share/zoneinfo/Asia/Kolkata /etc/localtime && node -e 'require("./.circleci/scripts/print_timezone.js").timezone()'
+npx karma start test/karma-conf.js --single-run --splitbrowsers ${BROWSER} --browsercount 1 --tests unit-tests/time/* --timezone Asia/Kolkata
+
+export TZ=UTC
+sudo ln -sf /usr/share/zoneinfo/UTC /etc/localtime && node -e 'require("./.circleci/scripts/print_timezone.js").timezone()'
+npx karma start test/karma-conf.js --single-run --splitbrowsers ${BROWSER} --browsercount 1 --tests unit-tests/time/* --timezone UTC
+
+export TZ=Atlantic/Reykjavik
+sudo ln -sf /usr/share/zoneinfo/Atlantic/Reykjavik /etc/localtime && node -e 'require("./.circleci/scripts/print_timezone.js").timezone()'
+npx karma start test/karma-conf.js --single-run --splitbrowsers ${BROWSER} --browsercount 1 --tests unit-tests/time/* --timezone Atlantic/Reykjavik
+
+export TZ=Pacific/Fiji
+sudo ln -sf /usr/share/zoneinfo/Pacific/Fiji /etc/localtime && node -e 'require("./.circleci/scripts/print_timezone.js").timezone()'
+npx karma start test/karma-conf.js --single-run --splitbrowsers ${BROWSER} --browsercount 1 --tests unit-tests/time/* --timezone Pacific/Fiji
+

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -606,7 +606,7 @@ module.exports = function (config) {
             video: false,
             retryLimit: 1,
             pollingTimeout: 5000, // to avoid rate limit errors with browserstack.
-            'browserstack.timezone': 'UTC'
+            'browserstack.timezone': argv.timezone || 'UTC'
         };
         options.customLaunchers = argv.oldie ?
             {

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -397,6 +397,7 @@ module.exports = function (config) {
         autoWatch: false,
         singleRun: true, // Karma captures browsers, runs the tests and exits
         concurrency: Infinity,
+        reportSlowerThan: 3000,
         plugins: [
             'karma-*',
             require('./karma-imagecapture-reporter.js')

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -605,7 +605,8 @@ module.exports = function (config) {
             localIdentifier: randomString, // to avoid instances interfering with each other.
             video: false,
             retryLimit: 1,
-            pollingTimeout: 5000 // to avoid rate limit errors with browserstack.
+            pollingTimeout: 5000, // to avoid rate limit errors with browserstack.
+            'browserstack.timezone': 'UTC'
         };
         options.customLaunchers = argv.oldie ?
             {
@@ -648,7 +649,6 @@ module.exports = function (config) {
             'BrowserStack initialized. Please wait while tests are uploaded and VMs prepared. ' +
             `Any other test runs must complete before this test run will start. Current Browserstack concurrency rate is ${options.concurrency}.`
         );
-
     }
 
     config.set(options);


### PR DESCRIPTION
Just some small changes that may - or may not be merged depending if you think it is reasonable.

Tests slower than 3 seconds will be logged in the output in order to create some awareness around slow tests and to reduce amount of slow tests.

Set browserstack timezone to UTC in order to have a deterministic timezone to relate to. Not sure if this will fix/mask the issue on the nightly, but at least we now have a timezone to relate to that can be changed if we want to test other timezones.