### PR TITLE
Fixed #12648, datetime axis ticks wrong in Indian time

### DIFF
--- a/js/parts/Time.js
+++ b/js/parts/Time.js
@@ -280,16 +280,12 @@ Highcharts.Time.prototype = {
             };
             this.set = function (unit, date, value) {
                 var ms, offset, newOffset;
-                // For lower order time units, just set it directly using local
+                // For lower order time units, just set it directly using UTC
                 // time
                 if (unit === 'Milliseconds' ||
                     unit === 'Seconds' ||
-                    // If we're dealting with minutes, we only need to
-                    // consider timezone if we're in Indian time zones with
-                    // half-hour offsets (#8768).
-                    (unit === 'Minutes' &&
-                        date.getTimezoneOffset() % 60 === 0)) {
-                    date['set' + unit](value);
+                    unit === 'Minutes') {
+                    date['setUTC' + unit](value);
                     // Higher order time units need to take the time zone into
                     // account
                 }

--- a/samples/unit-tests/time/timeticks/demo.js
+++ b/samples/unit-tests/time/timeticks/demo.js
@@ -428,4 +428,54 @@
             'All ticks created (#7051).'
         );
     });
+
+    QUnit.test('Time ticks, Indian time (#8768)', function (assert) {
+        var time = new Highcharts.Time({
+            timezone: 'America/New_York'
+        });
+
+        var ticks = time.getTimeTicks(
+            {
+                unitRange: 60000,
+                count: 5
+            },
+            Date.UTC(2018, 7, 8, 9, 0),
+            Date.UTC(2018, 7, 8, 9, 99)
+        );
+
+        assert.deepEqual(
+            ticks.map(function (tick) {
+                return [
+                    Highcharts.pad(new Date(tick).getUTCHours(), 2),
+                    Highcharts.pad(new Date(tick).getUTCMinutes(), 2)
+                ].join(':');
+            }),
+            [
+                "09:00",
+                "09:05",
+                "09:10",
+                "09:15",
+                "09:20",
+                "09:25",
+                "09:30",
+                "09:35",
+                "09:40",
+                "09:45",
+                "09:50",
+                "09:55",
+                "10:00",
+                "10:05",
+                "10:10",
+                "10:15",
+                "10:20",
+                "10:25",
+                "10:30",
+                "10:35",
+                "10:40"
+            ],
+            'Relevant test when the timezone is India. Should start at 09:00. ' +
+            'Current time: ' + new Date().toString() + '. Timezone offset: ' +
+            new Date().getTimezoneOffset()
+        );
+    });
 }());

--- a/ts/parts/Time.ts
+++ b/ts/parts/Time.ts
@@ -395,7 +395,6 @@ Highcharts.Time.prototype = {
                 date.setTime(ms); // Temporary adjust to timezone
                 ret = (date as any)['getUTC' + unit]();
                 date.setTime(realMs); // Reset
-
                 return ret;
             };
             this.set = function (
@@ -405,21 +404,14 @@ Highcharts.Time.prototype = {
             ): any {
                 var ms, offset, newOffset;
 
-                // For lower order time units, just set it directly using local
+                // For lower order time units, just set it directly using UTC
                 // time
                 if (
                     unit === 'Milliseconds' ||
                     unit === 'Seconds' ||
-
-                    // If we're dealting with minutes, we only need to
-                    // consider timezone if we're in Indian time zones with
-                    // half-hour offsets (#8768).
-                    (
-                        unit === 'Minutes' &&
-                        date.getTimezoneOffset() % 60 === 0
-                    )
+                    unit === 'Minutes'
                 ) {
-                    (date as any)['set' + unit](value);
+                    (date as any)['setUTC' + unit](value);
 
                 // Higher order time units need to take the time zone into
                 // account


### PR DESCRIPTION
Fixed #12648, datetime axis ticks were wrong in Indian time zone when close to the DST crossover