### PR TITLE
bugfix/12619-empty-pie-animation

### DIFF
--- a/js/parts/PieSeries.js
+++ b/js/parts/PieSeries.js
@@ -794,7 +794,7 @@ seriesType('pie', 'line',
                 fill: options.fillColor || 'none',
                 stroke: options.color ||
                     '${palette.neutralColor20}'
-            });
+            }, this.options.animation);
         }
         else if (this.graph) { // Destroy the graph object.
             this.graph = this.graph.destroy();

--- a/samples/unit-tests/chart/animation/demo.js
+++ b/samples/unit-tests/chart/animation/demo.js
@@ -78,6 +78,67 @@ QUnit.test('Animation duration', function (assert) {
 
 });
 
+QUnit.test('Animation - Empty pie', function (assert) {
+
+    var clock = null;
+
+    try {
+
+        clock = TestUtilities.lolexInstall();
+
+        var chart = Highcharts
+                .chart('container', {
+                    chart: {
+                        type: 'pie'
+                    },
+                    series: [{
+                        animation: {
+                            duration: 1000
+                        },
+                        data: null
+                    }, {
+                        animation: false,
+                        data: null
+                    }]
+                }),
+            animationCircle = chart.series[0].graph,
+            notAnimated = chart.series[1].graph,
+            animatedInitialRadius = animationCircle.attr('r'),
+            notAnimatedInitialRadius = notAnimated.attr('r'),
+            done = assert.async();
+
+        assert.ok(
+            animationCircle.attr('r') === animatedInitialRadius,
+            'Time 0 - animated radius has not changed.'
+        );
+
+        assert.ok(
+            notAnimated.attr('r') === notAnimatedInitialRadius,
+            'Time 0 - not animated radius has not changed.(#12619)'
+        );
+
+        setTimeout(function () {
+            assert.ok(
+                animationCircle.attr('r') !== animatedInitialRadius,
+                'Time 800 - animated radius has changed.'
+            );
+            assert.ok(
+                notAnimated.attr('r') === notAnimatedInitialRadius,
+                'Time 800 - not animated radius has not changed. (#12619)'
+            );
+            done();
+        }, 800);
+
+        TestUtilities.lolexRunAndUninstall(clock);
+
+    } finally {
+
+        TestUtilities.lolexUninstall(clock);
+
+    }
+
+});
+
 QUnit.test('No animation', function (assert) {
 
     var chart = Highcharts

--- a/samples/unit-tests/chart/animation/demo.js
+++ b/samples/unit-tests/chart/animation/demo.js
@@ -78,67 +78,6 @@ QUnit.test('Animation duration', function (assert) {
 
 });
 
-QUnit.test('Animation - Empty pie', function (assert) {
-
-    var clock = null;
-
-    try {
-
-        clock = TestUtilities.lolexInstall();
-
-        var chart = Highcharts
-                .chart('container', {
-                    chart: {
-                        type: 'pie'
-                    },
-                    series: [{
-                        animation: {
-                            duration: 1000
-                        },
-                        data: null
-                    }, {
-                        animation: false,
-                        data: null
-                    }]
-                }),
-            animationCircle = chart.series[0].graph,
-            notAnimated = chart.series[1].graph,
-            animatedInitialRadius = animationCircle.attr('r'),
-            notAnimatedInitialRadius = notAnimated.attr('r'),
-            done = assert.async();
-
-        assert.ok(
-            animationCircle.attr('r') === animatedInitialRadius,
-            'Time 0 - animated radius has not changed.'
-        );
-
-        assert.ok(
-            notAnimated.attr('r') === notAnimatedInitialRadius,
-            'Time 0 - not animated radius has not changed.(#12619)'
-        );
-
-        setTimeout(function () {
-            assert.ok(
-                animationCircle.attr('r') !== animatedInitialRadius,
-                'Time 800 - animated radius has changed.'
-            );
-            assert.ok(
-                notAnimated.attr('r') === notAnimatedInitialRadius,
-                'Time 800 - not animated radius has not changed. (#12619)'
-            );
-            done();
-        }, 800);
-
-        TestUtilities.lolexRunAndUninstall(clock);
-
-    } finally {
-
-        TestUtilities.lolexUninstall(clock);
-
-    }
-
-});
-
 QUnit.test('No animation', function (assert) {
 
     var chart = Highcharts

--- a/samples/unit-tests/series-pie/pie/demo.js
+++ b/samples/unit-tests/series-pie/pie/demo.js
@@ -183,3 +183,64 @@ QUnit.test('Updating point visibility (#8428)', function (assert) {
         'Hidden point should not have a data label'
     );
 });
+
+QUnit.test('Animation - Empty pie', function (assert) {
+
+    var clock = null;
+
+    try {
+
+        clock = TestUtilities.lolexInstall();
+
+        var chart = Highcharts
+                .chart('container', {
+                    chart: {
+                        type: 'pie'
+                    },
+                    series: [{
+                        animation: {
+                            duration: 1000
+                        },
+                        data: null
+                    }, {
+                        animation: false,
+                        data: null
+                    }]
+                }),
+            animationCircle = chart.series[0].graph,
+            notAnimated = chart.series[1].graph,
+            animatedInitialRadius = animationCircle.attr('r'),
+            notAnimatedInitialRadius = notAnimated.attr('r'),
+            done = assert.async();
+
+        assert.ok(
+            animationCircle.attr('r') === animatedInitialRadius,
+            'Time 0 - animated radius has not changed.'
+        );
+
+        assert.ok(
+            notAnimated.attr('r') === notAnimatedInitialRadius,
+            'Time 0 - not animated radius has not changed.(#12619)'
+        );
+
+        setTimeout(function () {
+            assert.ok(
+                animationCircle.attr('r') !== animatedInitialRadius,
+                'Time 800 - animated radius has changed.'
+            );
+            assert.ok(
+                notAnimated.attr('r') === notAnimatedInitialRadius,
+                'Time 800 - not animated radius has not changed. (#12619)'
+            );
+            done();
+        }, 800);
+
+        TestUtilities.lolexRunAndUninstall(clock);
+
+    } finally {
+
+        TestUtilities.lolexUninstall(clock);
+
+    }
+
+});

--- a/ts/parts/PieSeries.ts
+++ b/ts/parts/PieSeries.ts
@@ -1078,7 +1078,7 @@ seriesType<Highcharts.PieSeries>(
                     fill: (options.fillColor as any) || 'none',
                     stroke: (options.color as any) ||
                         '${palette.neutralColor20}'
-                });
+                }, this.options.animation);
 
             } else if (this.graph) { // Destroy the graph object.
                 this.graph = this.graph.destroy();


### PR DESCRIPTION
Fixed issue with disabled animation for empty pie, see #12619.