### PR TITLE
Tools: Added build metadata option to changelog.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,6 +318,10 @@ jobs:
 
   deploy_changelog:
     <<: *defaults
+    parameters:
+      add_build_metadata:
+        type: boolean
+        default: false
     steps:
       - <<: *load_workspace
       - <<: *add_gh_keys
@@ -327,7 +331,7 @@ jobs:
           command: sudo apt-get install cpio
       - run:
           name: Generate changelog since last tag
-          command: (git describe --abbrev=0 --tags | xargs -I{} node changelog/generate --pr --since {}) && node changelog/generate-html
+          command: (git describe --abbrev=0 --tags | xargs -I{} node changelog/generate --pr <<# parameters.add_build_metadata >>--build-metadata<</ parameters.add_build_metadata >> --since {}) && node changelog/generate-html
       - run:
           name: Changelog - Create git-describe named folder and copy changelog
           command: git ls-files -m --others --exclude-standard | grep -i changelog | cpio -pdm "$(git describe)/"
@@ -484,6 +488,7 @@ workflows:
           requires: [build_dist]
           context: highcharts-staging
       - deploy_changelog:
+          add_build_metadata: true
           requires: [build_dist]
           context: highcharts-staging
       - deploy_to_highcharts_dist:

--- a/changelog/generate.js
+++ b/changelog/generate.js
@@ -17,6 +17,7 @@
 const marked = require('marked');
 const prLog = require('./pr-log');
 const params = require('yargs').argv;
+const childProcess = require('child_process');
 
 (function () {
     'use strict';
@@ -258,6 +259,10 @@ const params = require('yargs').argv;
         console.log(`Review: ${filename}`);
     }
 
+    function getLatestGitSha() {
+        return childProcess.execSync('git log --pretty=format:\'%h\' -n 1').toString();
+    }
+
     // Get the Git log
     getLog(function (log) {
 
@@ -291,8 +296,9 @@ const params = require('yargs').argv;
                 for (name in products) {
 
                     if (products.hasOwnProperty(name)) { // eslint-disable-line no-prototype-builtins
+                        const version = params.buildMetadata ? `${pack.version}+build.${getLatestGitSha()}` : pack.version;
                         if (params.pr) {
-                            products[name].nr = pack.version;
+                            products[name].nr = version;
                             products[name].date =
                                 d.getFullYear() + '-' +
                                 pad(d.getMonth() + 1, 2) + '-' +
@@ -301,7 +307,7 @@ const params = require('yargs').argv;
 
                         review.push(buildMarkdown(
                             name,
-                            products[name].nr,
+                            version,
                             products[name].date,
                             log,
                             products,


### PR DESCRIPTION
When generating changelog it is now possible to add build metadata information that includes the git sha from which the changelog is generated.

Fixed #12634, by using third option.