### PR TITLE
Docs: Added redirect for old link to technical-indicators

### DIFF
--- a/docs/doc-config.js
+++ b/docs/doc-config.js
@@ -10,6 +10,7 @@ module.exports = {
     ],
     /* List of old paths that should be redirected */
     redirects: [
-        { 'chart-and-series-types/networkgraph': 'chart-and-series-types/network-graph' }
+        { from: 'chart-and-series-types/networkgraph', to: 'chart-and-series-types/network-graph' },
+        { from: 'chart-and-series-types/technical-indicator-series', to: 'stock/technical-indicator-series' }
     ]
 };


### PR DESCRIPTION
* Adds a redirect for a legacy path to the `technical-indicator-series`
* Changed the structure of the redirect object to make implementation more convenient (and potentially support many-to-one cases).