### PR TITLE
Tools: Fixed wrong commit state when approved.

### DIFF
--- a/tools/gulptasks/update-pr-testresults.js
+++ b/tools/gulptasks/update-pr-testresults.js
@@ -101,7 +101,9 @@ async function postGitCommitStatusUpdate(pr, newReview) {
         logLib.message('No diffing samples found.');
     } else {
         if (newReview.samples.every(sample => sample.approved)) {
+            // on every subsequent run we don't need to re-approve same samples.
             description = 'Diffing samples are approved';
+            commitState = 'success';
         }
         logLib.message('All samples are already approved.');
     }


### PR DESCRIPTION
The CI set the incorrect commit state of visual review when all samples already were approved. E.g this is the case for the last build of #12616 

This fixes the above issue.