### PR TITLE
bugfix/12515-update-3d-pie-depth

### DIFF
--- a/js/parts-3d/SVGRenderer.js
+++ b/js/parts-3d/SVGRenderer.js
@@ -440,7 +440,7 @@ H.SVGRenderer.prototype.cuboidPath = function (shapeArgs) {
 };
 // SECTORS //
 H.SVGRenderer.prototype.arc3d = function (attribs) {
-    var wrapper = this.g(), renderer = wrapper.renderer, customAttribs = ['x', 'y', 'r', 'innerR', 'start', 'end'];
+    var wrapper = this.g(), renderer = wrapper.renderer, customAttribs = ['x', 'y', 'r', 'innerR', 'start', 'end', 'depth'];
     /**
      * Get custom attributes. Don't mutate the original object and return an
      * object with only custom attr.
@@ -556,7 +556,6 @@ H.SVGRenderer.prototype.arc3d = function (attribs) {
         // in the attribs collection in the first place.
         delete params.center;
         delete params.z;
-        delete params.depth;
         delete params.alpha;
         delete params.beta;
         anim = animObject(pick(animation, this.renderer.globalAnimation));
@@ -584,7 +583,8 @@ H.SVGRenderer.prototype.arc3d = function (attribs) {
                             r: interpolate('r'),
                             innerR: interpolate('innerR'),
                             start: interpolate('start'),
-                            end: interpolate('end')
+                            end: interpolate('end'),
+                            depth: interpolate('depth')
                         }));
                     }
                 };

--- a/samples/unit-tests/3d/series-pie/demo.js
+++ b/samples/unit-tests/3d/series-pie/demo.js
@@ -313,3 +313,40 @@ QUnit.test('3d pie drilldown and drill up', function (assert) {
     TestUtilities.lolexRunAndUninstall(clock);
 
 });
+
+QUnit.test(
+    '3D pie updates',
+    assert => {
+        // Create the chart
+        const chart = Highcharts.chart('container', {
+                chart: {
+                    type: 'pie',
+                    options3d: {
+                        enabled: true,
+                        alpha: 45,
+                        beta: 0
+                    }
+                },
+                plotOptions: {
+                    pie: {
+                        depth: 35
+                    }
+                },
+                series: [{
+                    data: [5]
+                }]
+            }),
+            point = chart.series[0].points[0],
+            // use point.graphic.out to get outer part of the 3D arc
+            height = point.graphic.out.getBBox(true).height;
+
+        chart.series[0].update({
+            depth: 50
+        });
+
+        assert.ok(
+            height < point.graphic.out.getBBox(true).height,
+            'Updating series.depth should change slice\'s depth (#12515).'
+        );
+    }
+);

--- a/ts/parts-3d/SVGRenderer.ts
+++ b/ts/parts-3d/SVGRenderer.ts
@@ -798,7 +798,7 @@ H.SVGRenderer.prototype.arc3d = function (
 
     var wrapper = this.g(),
         renderer = wrapper.renderer,
-        customAttribs = ['x', 'y', 'r', 'innerR', 'start', 'end'];
+        customAttribs = ['x', 'y', 'r', 'innerR', 'start', 'end', 'depth'];
 
     /**
      * Get custom attributes. Don't mutate the original object and return an
@@ -971,7 +971,6 @@ H.SVGRenderer.prototype.arc3d = function (
         // in the attribs collection in the first place.
         delete params.center;
         delete params.z;
-        delete params.depth;
         delete params.alpha;
         delete params.beta;
 
@@ -1006,7 +1005,8 @@ H.SVGRenderer.prototype.arc3d = function (
                             r: interpolate('r'),
                             innerR: interpolate('innerR'),
                             start: interpolate('start'),
-                            end: interpolate('end')
+                            end: interpolate('end'),
+                            depth: interpolate('depth')
                         }));
                     }
                 };


### PR DESCRIPTION
Fixed #12515, updating depth in 3D pie chart did not work.
___
`arc3dPath` requires `depth` to render correctly, but was removed in animation. In old versions there was no animation, arc3d was always removed and added again so bug was invisible.