### PR TITLE
PoC: module loader/synchronizer.

### DIFF
--- a/js/parts-3d/Column.js
+++ b/js/parts-3d/Column.js
@@ -10,7 +10,7 @@
 'use strict';
 import H from '../parts/Globals.js';
 import U from '../parts/Utilities.js';
-var pick = U.pick, wrap = U.wrap;
+var moduleLoader = U.moduleLoader, pick = U.pick, wrap = U.wrap;
 import '../parts/Series.js';
 var addEvent = H.addEvent, perspective = H.perspective, Series = H.Series, seriesTypes = H.seriesTypes, svg = H.svg;
 /**
@@ -315,7 +315,7 @@ function hasNewShapeType(proceed) {
 wrap(seriesTypes.column.prototype, 'pointAttribs', pointAttribs);
 wrap(seriesTypes.column.prototype, 'setState', setState);
 wrap(seriesTypes.column.prototype.pointClass.prototype, 'hasNewShapeType', hasNewShapeType);
-if (seriesTypes.columnrange) {
+moduleLoader.onLoadModule('highcharts-more').then(function () {
     wrap(seriesTypes.columnrange.prototype, 'pointAttribs', pointAttribs);
     wrap(seriesTypes.columnrange.prototype, 'setState', setState);
     wrap(seriesTypes.columnrange.prototype.pointClass.prototype, 'hasNewShapeType', hasNewShapeType);
@@ -323,7 +323,7 @@ if (seriesTypes.columnrange) {
         seriesTypes.column.prototype.plotGroup;
     seriesTypes.columnrange.prototype.setVisible =
         seriesTypes.column.prototype.setVisible;
-}
+});
 wrap(Series.prototype, 'alignDataLabel', function (proceed) {
     // Only do this for 3D columns and it's derived series
     if (this.chart.is3d() &&

--- a/js/parts-more/Polar.js
+++ b/js/parts-more/Polar.js
@@ -10,7 +10,7 @@
 'use strict';
 import H from '../parts/Globals.js';
 import U from '../parts/Utilities.js';
-var defined = U.defined, pick = U.pick, splat = U.splat, wrap = U.wrap;
+var defined = U.defined, moduleLoader = U.moduleLoader, pick = U.pick, splat = U.splat, wrap = U.wrap;
 import '../parts/Pointer.js';
 import '../parts/Series.js';
 import '../parts/Pointer.js';
@@ -664,3 +664,4 @@ wrap(H.Chart.prototype, 'get', function (proceed, id) {
         return pane.options.id === id;
     }) || proceed.call(this, id);
 });
+moduleLoader.loadedModule('highcharts-more');

--- a/ts/parts-3d/Column.ts
+++ b/ts/parts-3d/Column.ts
@@ -49,6 +49,7 @@ declare global {
 
 import U from '../parts/Utilities.js';
 const {
+    moduleLoader,
     pick,
     wrap
 } = U;
@@ -484,7 +485,7 @@ wrap(
     hasNewShapeType
 );
 
-if (seriesTypes.columnrange) {
+moduleLoader.onLoadModule('highcharts-more').then((): void => {
     wrap(seriesTypes.columnrange.prototype, 'pointAttribs', pointAttribs);
     wrap(seriesTypes.columnrange.prototype, 'setState', setState);
     wrap(
@@ -496,7 +497,7 @@ if (seriesTypes.columnrange) {
         seriesTypes.column.prototype.plotGroup;
     seriesTypes.columnrange.prototype.setVisible =
         seriesTypes.column.prototype.setVisible;
-}
+});
 
 wrap(Series.prototype, 'alignDataLabel', function (
     this: Highcharts.Series,

--- a/ts/parts-more/Polar.ts
+++ b/ts/parts-more/Polar.ts
@@ -99,6 +99,7 @@ declare global {
 import U from '../parts/Utilities.js';
 const {
     defined,
+    moduleLoader,
     pick,
     splat,
     wrap
@@ -1067,3 +1068,5 @@ wrap(H.Chart.prototype, 'get', function (
         return (pane.options as any).id === id;
     }) || proceed.call(this, id);
 });
+
+moduleLoader.loadedModule('highcharts-more');

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -17,7 +17,8 @@
         "target": "es5",
         "lib": [
             "dom",
-            "es5"
+            "es5",
+            "es2015"
         ],
         "types": [
             "jquery"


### PR DESCRIPTION
A simple implementation for module loader/synchronizer. We have more and more modules that depend on each other. That means it's getting harder to manage them, especially for users: what's the order of loading modules and where it's documented?

PR shows an example how we can sync column-3d and highcharts-more.

In this solution, every module should fire `moduleLoader.loadedModule('module-A');`. Then all other modules can add wraps/events to be applied only when a specific module is loaded: 

```js
// module B
moduleLoader.onLoadModule('module-A').then(function () {
  addEvent(Something.That.ModuleA.Created, function () {});
  
  wrap(Something.That.ModuleA.Created.prototype, function () {});
});
```

If `ModuleA` was already loaded, callback is executed immediately. Otherwise it waits for the module to be loaded.

Example in demos:
- correct order of files: http://jsfiddle.net/BlackLabel/njL697m4/
- wrong order of files: http://jsfiddle.net/BlackLabel/7ojp5tnu/6/ (overlapping columns)
- wrong order of files, with PR'ed version: http://jsfiddle.net/BlackLabel/7ojp5tnu/9/

I think we can depromisify this loader, using `addEvent`/`fireEvent`. Maybe even we can place this automatically in distribution files when assembling those? Or perhaps there's much better solution available (something with register module)?

Why we can't use `addEvent`/`fireEvent` out of the box? Because if `fireEvent` would be called before `moduleB` registers it's callback then it never would be called.