### PR TITLE
bugfix/12424-fdg-in-legend

### DIFF
--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -632,8 +632,8 @@ seriesType('networkgraph', 'line',
     // Return the presentational attributes.
     pointAttribs: function (point, state) {
         // By default, only `selected` state is passed on
-        var pointState = state || point.state || 'normal', attribs = Series.prototype.pointAttribs.call(this, point, pointState), stateOptions = this.options.states[pointState];
-        if (!point.isNode) {
+        var pointState = state || point && point.state || 'normal', attribs = Series.prototype.pointAttribs.call(this, point, pointState), stateOptions = this.options.states[pointState];
+        if (point && !point.isNode) {
             attribs = point.getLinkAttributes();
             // For link, get prefixed names:
             if (stateOptions) {

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.js
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.js
@@ -290,3 +290,24 @@ QUnit.test('Layout operations', function (assert) {
         'Series is removed from layout.series collection.'
     );
 });
+
+QUnit.test(
+    'Network Graph and legend',
+    assert => {
+        Highcharts.chart('container', {
+            series: [{
+                type: 'networkgraph',
+                showInLegend: true,
+                data: [{
+                    from: 'A',
+                    to: 'B'
+                }]
+            }]
+        });
+
+        assert.ok(
+            true,
+            'No errors when networkgraph rendered in legend (#12424).'
+        );
+    }
+);

--- a/ts/modules/networkgraph/networkgraph.src.ts
+++ b/ts/modules/networkgraph/networkgraph.src.ts
@@ -941,7 +941,7 @@ seriesType<Highcharts.NetworkgraphSeries>(
             state?: string
         ): Highcharts.SVGAttributes {
             // By default, only `selected` state is passed on
-            var pointState = state || point.state || 'normal',
+            var pointState = state || point && point.state || 'normal',
                 attribs = Series.prototype.pointAttribs.call(
                     this,
                     point,
@@ -949,7 +949,7 @@ seriesType<Highcharts.NetworkgraphSeries>(
                 ),
                 stateOptions = (this.options.states as any)[pointState];
 
-            if (!point.isNode) {
+            if (point && !point.isNode) {
                 attribs = point.getLinkAttributes();
                 // For link, get prefixed names:
                 if (stateOptions) {


### PR DESCRIPTION
Fixed #12424, enabling networkgraph series in legend used to throw errors.