### PR TITLE
bugfix/7204-ohlc-stem-extend

### DIFF
--- a/js/parts/OHLCSeries.js
+++ b/js/parts/OHLCSeries.js
@@ -201,9 +201,18 @@ seriesType('ohlc', 'column'
      * @return {void}
      */
     drawPoints: function () {
-        var series = this, points = series.points, chart = series.chart;
+        var series = this, points = series.points, chart = series.chart, 
+        /**
+         * Extend vertical stem to open and close values.
+         */
+        extendStem = function (path, halfStrokeWidth, openOrClose) {
+            // We don't need to worry about crisp - openOrClose value
+            // is already crisped and halfStrokeWidth should remove it.
+            path[2] = Math.max(openOrClose + halfStrokeWidth, path[2]);
+            path[5] = Math.min(openOrClose - halfStrokeWidth, path[5]);
+        };
         points.forEach(function (point) {
-            var plotOpen, plotClose, crispCorr, halfWidth, path, graphic = point.graphic, crispX, isNew = !graphic;
+            var plotOpen, plotClose, crispCorr, halfWidth, path, graphic = point.graphic, crispX, isNew = !graphic, strokeWidth;
             if (typeof point.plotY !== 'undefined') {
                 // Create and/or update the graphic
                 if (!graphic) {
@@ -214,7 +223,8 @@ seriesType('ohlc', 'column'
                     graphic.attr(series.pointAttribs(point, (point.selected && 'select'))); // #3897
                 }
                 // crisp vector coordinates
-                crispCorr = (graphic.strokeWidth() % 2) / 2;
+                strokeWidth = graphic.strokeWidth();
+                crispCorr = (strokeWidth % 2) / 2;
                 // #2596:
                 crispX = Math.round(point.plotX) - crispCorr;
                 halfWidth = Math.round(point.shapeArgs.width / 2);
@@ -229,11 +239,13 @@ seriesType('ohlc', 'column'
                 if (point.open !== null) {
                     plotOpen = Math.round(point.plotOpen) + crispCorr;
                     path.push('M', crispX, plotOpen, 'L', crispX - halfWidth, plotOpen);
+                    extendStem(path, strokeWidth / 2, plotOpen);
                 }
                 // close
                 if (point.close !== null) {
                     plotClose = Math.round(point.plotClose) + crispCorr;
                     path.push('M', crispX, plotClose, 'L', crispX + halfWidth, plotClose);
+                    extendStem(path, strokeWidth / 2, plotClose);
                 }
                 graphic[isNew ? 'attr' : 'animate']({ d: path })
                     .addClass(point.getClassName(), true);

--- a/samples/unit-tests/series-ohlc/points/demo.details
+++ b/samples/unit-tests/series-ohlc/points/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series-ohlc/points/demo.html
+++ b/samples/unit-tests/series-ohlc/points/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/series-ohlc/points/demo.js
+++ b/samples/unit-tests/series-ohlc/points/demo.js
@@ -1,0 +1,41 @@
+QUnit.test(
+    'directTouch',
+    function (assert) {
+        const lineWidth = 11,
+            halfWidth = lineWidth / 2,
+            points = Highcharts.stockChart('container', {
+                series: [{
+                    type: 'ohlc',
+                    data: [
+                        [1, 100, 200, 100, 200],
+                        [2, 200, 100, 200, 100]
+                    ],
+                    lineWidth: lineWidth
+                }]
+            }).series[0].points,
+            path1 = points[0].graphic.attr('d').split(' ').map(parseFloat),
+            path2 = points[1].graphic.attr('d').split(' ').map(parseFloat);
+
+        assert.strictEqual(
+            path1[2] <= path1[8] + halfWidth,
+            true,
+            'Stem should start at least where open is rendered (#7204)'
+        );
+        assert.strictEqual(
+            path1[5] >= path1[14] - halfWidth,
+            true,
+            'Stem should end at least where close is rendered (#7204)'
+        );
+
+        assert.strictEqual(
+            path2[2] <= path2[14] + halfWidth,
+            true,
+            'Stem should end at least where open is rendered (#7204)'
+        );
+        assert.strictEqual(
+            path2[5] >= path2[8] - halfWidth,
+            true,
+            'Stem should end at least where close is rendered (#7204)'
+        );
+    }
+);

--- a/test/karma-imagecapture-reporter.js
+++ b/test/karma-imagecapture-reporter.js
@@ -146,7 +146,11 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
         const filename = info.filename;
         try {
             if (/\.svg$/.test(filename)) {
-                fs.writeFileSync(filename, prettyXML(data));
+                fs.writeFile(filename, prettyXML(data), err => {
+                    if (err) {
+                        throw err;
+                    }
+                });
 
             } else if (/\.png$/.test(filename)) {
                 data = data.replace(/^data:image\/\w+;base64,/, '');


### PR DESCRIPTION
Fixed #7204, OHLC ticks were rendered incorrectly with higher `series.lineWidth` values.
___
Now stem is stretched to open/close values, to prevent case when it seems that open/close are below/above low/close values.

Before:
![Screen Shot 2019-12-31 at 15 34 43](https://user-images.githubusercontent.com/1453926/71625208-e6085680-2be6-11ea-97d8-fb0830d5a439.png)
After:
![Screen Shot 2019-12-31 at 15 34 36](https://user-images.githubusercontent.com/1453926/71625209-e6a0ed00-2be6-11ea-81fb-23d6778cdcb3.png)

I expect some visual changes.