### PR TITLE
bugfix/12326-wrong-options-after-drilldown

### DIFF
--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -41,7 +41,7 @@ recursive = function (item, func, context) {
     if (next !== false) {
         recursive(next, func, context);
     }
-}, updateRootId = mixinTreeSeries.updateRootId;
+}, updateRootId = mixinTreeSeries.updateRootId, treemapAxisDefaultValues = false;
 /* eslint-enable no-invalid-this */
 /**
  * @private
@@ -1361,25 +1361,6 @@ seriesType('treemap', 'scatter'
         Series.prototype.getExtremes.call(this);
     },
     getExtremesFromAll: true,
-    bindAxes: function () {
-        var treeAxis = {
-            endOnTick: false,
-            gridLineWidth: 0,
-            lineWidth: 0,
-            min: 0,
-            dataMin: 0,
-            minPadding: 0,
-            max: AXIS_MAX,
-            dataMax: AXIS_MAX,
-            maxPadding: 0,
-            startOnTick: false,
-            title: null,
-            tickPositions: []
-        };
-        Series.prototype.bindAxes.call(this);
-        extend(this.yAxis.options, treeAxis);
-        extend(this.xAxis.options, treeAxis);
-    },
     /**
      * Workaround for `inactive` state. Since `series.opacity` option is
      * already reserved, don't use that state at all by disabling
@@ -1438,8 +1419,37 @@ seriesType('treemap', 'scatter'
         var point = this;
         return isNumber(point.plotY) && point.y !== null;
     }
-    /* eslint-enable no-invalid-this, valid-jsdoc */
 });
+H.addEvent(H.Series, 'afterBindAxes', function () {
+    var series = this, xAxis = series.xAxis, yAxis = series.yAxis, treeAxis;
+    if (xAxis && yAxis) {
+        if (series.options.type === 'treemap') {
+            treeAxis = {
+                endOnTick: false,
+                gridLineWidth: 0,
+                lineWidth: 0,
+                min: 0,
+                dataMin: 0,
+                minPadding: 0,
+                max: AXIS_MAX,
+                dataMax: AXIS_MAX,
+                maxPadding: 0,
+                startOnTick: false,
+                title: null,
+                tickPositions: []
+            };
+            extend(yAxis.options, treeAxis);
+            extend(xAxis.options, treeAxis);
+            treemapAxisDefaultValues = true;
+        }
+        else if (treemapAxisDefaultValues) {
+            yAxis.setOptions(yAxis.userOptions);
+            xAxis.setOptions(xAxis.userOptions);
+            treemapAxisDefaultValues = false;
+        }
+    }
+});
+/* eslint-enable no-invalid-this, valid-jsdoc */
 /**
  * A `treemap` series. If the [type](#series.treemap.type) option is
  * not specified, it is inherited from [chart.type](#chart.type).

--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -1593,8 +1593,9 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      * @function Highcharts.Chart#propFromSeries
      * @return {void}
      */
-    propFromSeries: function () {
-        var chart = this, optionsChart = chart.options.chart, klass, seriesOptions = chart.options.series, i, value;
+    propFromSeries: function (seriesOptions) {
+        var chart = this, optionsChart = chart.options.chart, klass, seriesOptions = seriesOptions ||
+            chart.options.series, i, value;
         /**
          * The flag is set to `true` if a series of the chart is inverted.
          *

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -2805,6 +2805,7 @@ null,
                 }
             });
         });
+        fireEvent(this, 'afterBindAxes');
     },
     /**
      * For simple series types like line and column, the data values are

--- a/samples/unit-tests/drilldown/across-types/demo.html
+++ b/samples/unit-tests/drilldown/across-types/demo.html
@@ -1,5 +1,6 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/drilldown.js"></script>
+<script src="https://code.highcharts.com/modules/treemap.js"></script>
 
 
 <div id="qunit"></div>

--- a/samples/unit-tests/drilldown/across-types/demo.js
+++ b/samples/unit-tests/drilldown/across-types/demo.js
@@ -124,4 +124,177 @@ QUnit.test('Drilldown across types', function (assert) {
         'First level type'
     );
 
+    chart = Highcharts.chart('container', {
+        xAxis: {
+            type: 'category',
+            title: ''
+        },
+        yAxis: {
+            title: ''
+        },
+        legend: {
+            enabled: false
+        },
+        series: [{
+            type: 'column',
+            data: [{
+                name: "Drilldown",
+                y: 62.74,
+                drilldown: "tree"
+            }, {
+                name: "A",
+                y: 10.57
+            }]
+        }],
+        drilldown: {
+            series: [{
+                type: "treemap",
+                id: 'tree',
+                layoutAlgorithm: 'stripes',
+                levels: [{
+                    level: 1,
+                    layoutAlgorithm: 'sliceAndDice'
+                }],
+                data: [{
+                    id: 'A',
+                    name: 'Apples',
+                    color: "#EC2500"
+                }, {
+                    id: 'B',
+                    name: 'Bananas',
+                    color: "#ECE100"
+                }, {
+                    name: 'Anne',
+                    parent: 'A',
+                    value: 5
+                }, {
+                    name: 'Rick',
+                    parent: 'A',
+                    value: 3
+                }, {
+                    name: 'Peter',
+                    parent: 'A',
+                    value: 4
+                }, {
+                    name: 'Anne',
+                    parent: 'B',
+                    value: 4
+                }]
+            }]
+        }
+    });
+
+    chart.series[0].points[0].doDrilldown();
+    chart.drillUp();
+
+    assert.strictEqual(
+        chart.xAxis[0].max,
+        1,
+        'After drillup treemap axes options should be reset (#12326).'
+    );
+
+    chart = Highcharts.chart('container', {
+        xAxis: {
+            type: 'category',
+            title: ''
+        },
+        yAxis: {
+            title: ''
+        },
+        legend: {
+            enabled: false
+        },
+        series: [{
+            type: "treemap",
+            id: 'tree',
+            layoutAlgorithm: 'stripes',
+            levels: [{
+                level: 1,
+                layoutAlgorithm: 'sliceAndDice'
+            }],
+            data: [{
+                id: 'A',
+                name: 'Apples',
+                color: "#EC2500"
+            }, {
+                id: 'B',
+                name: 'Bananas',
+                color: "#ECE100"
+            }, {
+                name: 'Anne',
+                parent: 'A',
+                value: 5,
+                drilldown: "column"
+            }, {
+                name: 'Rick',
+                parent: 'A',
+                value: 3
+            }, {
+                name: 'Peter',
+                parent: 'A',
+                value: 4
+            }, {
+                name: 'Anne',
+                parent: 'B',
+                value: 4
+            }]
+        }],
+        drilldown: {
+            series: [{
+                type: 'column',
+                id: 'column',
+                data: [{
+                    name: "Drilldown",
+                    y: 62.74
+                }, {
+                    name: "A",
+                    y: 10.57
+                }]
+            }]
+        }
+    });
+
+    chart.series[0].points[2].doDrilldown();
+
+    assert.strictEqual(
+        chart.xAxis[0].max,
+        1,
+        'After drilldown treemap axes options should be reset (#12326).'
+    );
+
+    chart = Highcharts.chart('container', {
+        xAxis: {
+            type: 'category'
+        },
+        series: [{
+            type: 'column',
+            data: [{
+                name: "Chrome",
+                y: 62.74,
+                drilldown: "Chrome"
+            }, {
+                name: "Firefox",
+                y: 10.57
+            }]
+        }],
+        drilldown: {
+            series: [{
+                type: 'bar',
+                name: "Chrome",
+                id: "Chrome",
+                data: [
+                    ["v65.0", 0.1],
+                    ["v64.0", 1.3],
+                    ["v63.0", 53.02]
+                ]
+            }]
+        }
+    });
+
+    chart.series[0].points[0].doDrilldown();
+
+    assert.ok(
+        chart.inverted,
+        'After drilldown chart should be inverted.'
+    );
 });

--- a/ts/modules/treemap.src.ts
+++ b/ts/modules/treemap.src.ts
@@ -351,7 +351,8 @@ var seriesType = H.seriesType,
             recursive(next, func, context);
         }
     },
-    updateRootId = mixinTreeSeries.updateRootId;
+    updateRootId = mixinTreeSeries.updateRootId,
+    treemapAxisDefaultValues = false;
 
 /* eslint-enable no-invalid-this */
 
@@ -2138,26 +2139,6 @@ seriesType<Highcharts.TreemapSeries>(
             Series.prototype.getExtremes.call(this);
         },
         getExtremesFromAll: true,
-        bindAxes: function (this: Highcharts.TreemapSeries): void {
-            var treeAxis = {
-                endOnTick: false,
-                gridLineWidth: 0,
-                lineWidth: 0,
-                min: 0,
-                dataMin: 0,
-                minPadding: 0,
-                max: AXIS_MAX,
-                dataMax: AXIS_MAX,
-                maxPadding: 0,
-                startOnTick: false,
-                title: null,
-                tickPositions: []
-            };
-
-            Series.prototype.bindAxes.call(this);
-            extend(this.yAxis.options, treeAxis);
-            extend(this.xAxis.options, treeAxis);
-        },
 
         /**
          * Workaround for `inactive` state. Since `series.opacity` option is
@@ -2230,9 +2211,44 @@ seriesType<Highcharts.TreemapSeries>(
             var point = this;
             return isNumber(point.plotY) && point.y !== null;
         }
-        /* eslint-enable no-invalid-this, valid-jsdoc */
     }
 );
+
+H.addEvent(H.Series, 'afterBindAxes', function (): void {
+    var series = this,
+        xAxis = series.xAxis,
+        yAxis = series.yAxis,
+        treeAxis;
+
+    if (xAxis && yAxis) {
+        if (series.options.type === 'treemap') {
+            treeAxis = {
+                endOnTick: false,
+                gridLineWidth: 0,
+                lineWidth: 0,
+                min: 0,
+                dataMin: 0,
+                minPadding: 0,
+                max: AXIS_MAX,
+                dataMax: AXIS_MAX,
+                maxPadding: 0,
+                startOnTick: false,
+                title: null,
+                tickPositions: []
+            };
+
+            extend(yAxis.options, treeAxis);
+            extend(xAxis.options, treeAxis);
+            treemapAxisDefaultValues = true;
+
+        } else if (treemapAxisDefaultValues) {
+            yAxis.setOptions(yAxis.userOptions);
+            xAxis.setOptions(xAxis.userOptions);
+            treemapAxisDefaultValues = false;
+        }
+    }
+});
+/* eslint-enable no-invalid-this, valid-jsdoc */
 
 /**
  * A `treemap` series. If the [type](#series.treemap.type) option is

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -158,7 +158,7 @@ declare global {
             public layOutTitles(redraw?: boolean): void;
             public onload(): void;
             public orderSeries(fromIndex?: number): void;
-            public propFromSeries(): void;
+            public propFromSeries(seriesOptions?: Array<SeriesOptions>): void;
             public redraw(animation?: (boolean|AnimationOptionsObject)): void;
             public reflow(e?: Event): void;
             public render(): void;
@@ -2318,11 +2318,14 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
      * @function Highcharts.Chart#propFromSeries
      * @return {void}
      */
-    propFromSeries: function (this: Highcharts.Chart): void {
+    propFromSeries: function (
+        this: Highcharts.Chart,
+        seriesOptions: Array<Highcharts.SeriesOptions>
+    ): void {
         var chart = this,
             optionsChart = chart.options.chart as Highcharts.ChartOptions,
             klass,
-            seriesOptions =
+            seriesOptions = seriesOptions ||
                 chart.options.series as Array<Highcharts.SeriesOptions>,
             i,
             value;

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -3534,6 +3534,8 @@ H.Series = H.seriesType<Highcharts.LineSeries>(
 
                 });
             });
+
+            fireEvent(this, 'afterBindAxes');
         },
 
         /**


### PR DESCRIPTION
Fixed issue with wrong axis options after `drilldown` to treemap series, see #12326.
___

Also, fixed issue mentioned by @pawelfus with "column"->"bar" `drilldown`.