### PR TITLE
bugfix/12513-networkgraph-select-points

### DIFF
--- a/js/modules/networkgraph/networkgraph.src.js
+++ b/js/modules/networkgraph/networkgraph.src.js
@@ -502,6 +502,13 @@ seriesType('networkgraph', 'line',
         this.indexateNodes();
     },
     /**
+     * In networkgraph, series.points refers to links,
+     * but series.nodes refers to actual points.
+     */
+    getPointsCollection: function () {
+        return this.nodes || [];
+    },
+    /**
      * Set index for each node. Required for proper `node.update()`.
      * Note that links are indexated out of the box in `generatePoints()`.
      *

--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -708,7 +708,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             // For one-to-one points inspect series.data in order to retrieve
             // points outside the visible range (#6445). For grouped data,
             // inspect the generated series.points.
-            points = points.concat((serie[serie.hasGroupedData ? 'points' : 'data'] || []).filter(function (point) {
+            points = points.concat(serie.getPointsCollection().filter(function (point) {
                 return pick(point.selectedStaging, point.selected);
             }));
         });

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -3055,8 +3055,7 @@ null,
         }
     },
     /**
-     * Get the series' color based on either the options or pulled from
-     * global options.
+     * Get all points' instances created for this series.
      *
      * @private
      * @function Highcharts.Series#getPointsCollection

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -3055,6 +3055,17 @@ null,
         }
     },
     /**
+     * Get the series' color based on either the options or pulled from
+     * global options.
+     *
+     * @private
+     * @function Highcharts.Series#getPointsCollection
+     * @return {Array<Highcharts.Point>}
+     */
+    getPointsCollection: function () {
+        return (this.hasGroupedData ? this.points : this.data) || [];
+    },
+    /**
      * Get the series' symbol based on either the options or pulled from
      * global options.
      *

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.js
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.js
@@ -210,7 +210,8 @@ QUnit.test('Markers', function (assert) {
                 },
                 marker: {
                     radius: 50
-                }
+                },
+                allowPointSelect: true
             }
         },
         title: {
@@ -250,6 +251,15 @@ QUnit.test('Markers', function (assert) {
             `Node: ${node.id} should be within the plotting area - left edge (#11632).`
         );
     });
+
+    chart.series[0].nodes[0].select();
+    chart.series[0].nodes[1].select();
+
+    assert.strictEqual(
+        chart.series[0].nodes[0].selected,
+        false,
+        'First node should be deselected after selecting another node (#12513).'
+    );
 });
 
 QUnit.test('Layout operations', function (assert) {

--- a/ts/modules/networkgraph/networkgraph.src.ts
+++ b/ts/modules/networkgraph/networkgraph.src.ts
@@ -121,7 +121,8 @@ declare global {
             public getDegree(): number;
             public getLinkAttributes(): SVGAttributes;
             public getLinkPath(): SVGPathArray;
-            public getMass(): Dictionary<number>
+            public getMass(): Dictionary<number>;
+            public getPointsCollection(): Array<NetworkgraphPoint>;
             public init(
                 series: NetworkgraphSeries,
                 options: NetworkgraphPointOptions,
@@ -748,6 +749,16 @@ seriesType<Highcharts.NetworkgraphSeries>(
             });
 
             this.indexateNodes();
+        },
+
+        /**
+         * In networkgraph, series.points refers to links,
+         * but series.nodes refers to actual points.
+         */
+        getPointsCollection: function (
+            this: Highcharts.NetworkgraphSeries
+        ): Array<Highcharts.NetworkgraphPoint> {
+            return this.nodes || [];
         },
 
         /**

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -1114,7 +1114,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             // points outside the visible range (#6445). For grouped data,
             // inspect the generated series.points.
             points = points.concat(
-                (serie[serie.hasGroupedData ? 'points' : 'data'] || []).filter(
+                serie.getPointsCollection().filter(
                     function (point: Highcharts.Point): boolean {
                         return pick(
                             point.selectedStaging, point.selected as any

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -135,6 +135,7 @@ declare global {
                 finalBox?: boolean
             ): Dictionary<number>;
             public getColor(): void;
+            public getPointsCollection(): Array<Point>;
             public getCyclic(
                 prop: string,
                 value?: any,
@@ -3894,6 +3895,20 @@ H.Series = H.seriesType<Highcharts.LineSeries>(
                     this.chart.options.colors
                 );
             }
+        },
+
+        /**
+         * Get the series' color based on either the options or pulled from
+         * global options.
+         *
+         * @private
+         * @function Highcharts.Series#getPointsCollection
+         * @return {Array<Highcharts.Point>}
+         */
+        getPointsCollection: function (
+            this: Highcharts.Series
+        ): Array<Highcharts.Point> {
+            return (this.hasGroupedData ? this.points : this.data) || [];
         },
 
         /**

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -3898,8 +3898,7 @@ H.Series = H.seriesType<Highcharts.LineSeries>(
         },
 
         /**
-         * Get the series' color based on either the options or pulled from
-         * global options.
+         * Get all points' instances created for this series.
          *
          * @private
          * @function Highcharts.Series#getPointsCollection


### PR DESCRIPTION
Fixed #12513, deselecting previously selected nodes did not work for networkgraph series.