### PR TITLE
Tools: Improve CI build time. Don't persist ci workspace every run.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,11 +92,14 @@ jobs:
            - npm-deps-{{ .Environment.HIGHCHARTS_CACHE_VERSION }}-{{ .Branch }}
      - run: npm install --quiet
      - save_cache:
-           paths:
+         paths:
            - /home/circleci/repo/highcharts/node_modules
          key: npm-deps-{{ .Environment.HIGHCHARTS_CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package.json" }}
      - run: npm run gulp scripts
      - run: git diff --name-only --exit-code || (echo "Untracked files found. Did you forget to commit any transpiled files? Failing build now as this likely will trigger errors later in the build.." && exit 1)
+     - run:
+         name: Prune stuff that is node needed to improve build time
+         command: curl -sfL https://install.goreleaser.com/github.com/tj/node-prune.sh | sh && ./bin/node-prune
      - <<: *persist_workspace
 
   generate_ts_declarations:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,6 @@ jobs:
       - run:
           name: Generate highcharts ts declarations
           command: npx gulp jsdoc-dts && npx gulp lint-dts
-      - <<: *persist_workspace
 
   lint:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,11 +91,8 @@ jobs:
            - npm-deps-{{ .Environment.HIGHCHARTS_CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package.json" }}
            - npm-deps-{{ .Environment.HIGHCHARTS_CACHE_VERSION }}-{{ .Branch }}
      - run: npm install --quiet
-     - run:
-        name: Prune stuff that is node needed to improve build time
-        command: curl -sfL https://install.goreleaser.com/github.com/tj/node-prune.sh | sh && ./bin/node-prune
      - save_cache:
-         paths:
+           paths:
            - /home/circleci/repo/highcharts/node_modules
          key: npm-deps-{{ .Environment.HIGHCHARTS_CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package.json" }}
      - run: npm run gulp scripts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,9 +97,6 @@ jobs:
          key: npm-deps-{{ .Environment.HIGHCHARTS_CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package.json" }}
      - run: npm run gulp scripts
      - run: git diff --name-only --exit-code || (echo "Untracked files found. Did you forget to commit any transpiled files? Failing build now as this likely will trigger errors later in the build.." && exit 1)
-     - run:
-         name: Prune stuff that is node needed to improve build time
-         command: curl -sfL https://install.goreleaser.com/github.com/tj/node-prune.sh | sh && ./bin/node-prune
      - <<: *persist_workspace
 
   generate_ts_declarations:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,7 +379,7 @@ workflows:
             tags:
               only: /^v\d+(?:\.\d+)+?$/
       - generate_ts_declarations:
-          requires: [lint]
+          requires: [checkout_and_install]
           filters:
             tags:
               only: /^v\d+(?:\.\d+)+?$/
@@ -408,7 +408,7 @@ workflows:
           browsers: "Win.IE8 --oldie"
       - test_browsers:
           name: "test-Mac.Safari"
-          requires: ["test-Win.IE8"]
+          requires: ["test-Win.IE8", "generate_ts_declarations"]
           browsers: "Mac.Safari"
       - test_browsers:
           name: "test-Mac.Firefox"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
      - run: npm install --quiet
      - run:
         name: Prune stuff that is node needed to improve build time
-        command: curl -sfL https://install.goreleaser.com/github.com/tj/node-prune.sh | sh
+        command: curl -sfL https://install.goreleaser.com/github.com/tj/node-prune.sh | sh && ./bin/node-prune
      - save_cache:
          paths:
            - /home/circleci/repo/highcharts/node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,9 @@ jobs:
            - npm-deps-{{ .Environment.HIGHCHARTS_CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package.json" }}
            - npm-deps-{{ .Environment.HIGHCHARTS_CACHE_VERSION }}-{{ .Branch }}
      - run: npm install --quiet
+     - run:
+        name: Prune stuff that is node needed to improve build time
+        command: curl -sfL https://install.goreleaser.com/github.com/tj/node-prune.sh | sh
      - save_cache:
          paths:
            - /home/circleci/repo/highcharts/node_modules

--- a/tools/gulptasks/lint.js
+++ b/tools/gulptasks/lint.js
@@ -13,4 +13,8 @@ const gulp = require('gulp');
 require('./lint-js');
 require('./update');
 
-gulp.task('lint', gulp.series('update', 'lint-js', 'lint-ts'));
+gulp.task('lint', gulp.series(
+    process.env.CI ?
+        ['lint-js', 'lint-ts'] :
+        ['update', 'lint-js', 'lint-ts']
+));


### PR DESCRIPTION
It shouldn't be necessary to persist the workspace after every jsdoc-dts run. Just a minor improvement to the current CI workflow which will improve total build time a bit.