### PR TITLE
 bugfix/12711-split-header-box

### DIFF
--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -929,7 +929,7 @@ H.Tooltip.prototype = {
                 tt = ren
                     .label(null, null, null, (options[isHeader ? 'headerShape' : 'shape']) ||
                     'callout', null, null, options.useHTML)
-                    .addClass(isHeader ? 'highcharts-tooltip-header ' : '' +
+                    .addClass((isHeader ? 'highcharts-tooltip-header ' : '') +
                     'highcharts-tooltip-box ' +
                     colorClass)
                     .attr(attribs)

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -1359,7 +1359,7 @@ H.Tooltip.prototype = {
                         options.useHTML
                     )
                     .addClass(
-                        isHeader ? 'highcharts-tooltip-header ' : '' +
+                        (isHeader ? 'highcharts-tooltip-header ' : '') +
                         'highcharts-tooltip-box ' +
                         colorClass
                     )


### PR DESCRIPTION
Fixed #12711, missing border and background for split tooltip's header in styled mode.