### PR TITLE
Fixed #12690, a11y module caused render issues for 3D funnel.

### DIFF
--- a/js/modules/accessibility/components/SeriesComponent/SeriesDescriber.js
+++ b/js/modules/accessibility/components/SeriesComponent/SeriesDescriber.js
@@ -328,12 +328,14 @@ function describeSeriesElement(series, seriesElement) {
  * @param {Highcharts.Series} series The series to add info on.
  */
 function describeSeries(series) {
-    var chart = series.chart, firstPointEl = getSeriesFirstPointElement(series), seriesEl = getSeriesA11yElement(series);
+    var _a, _b;
+    var chart = series.chart, firstPointEl = getSeriesFirstPointElement(series), seriesEl = getSeriesA11yElement(series), is3d = (_b = (_a = chart.options.chart) === null || _a === void 0 ? void 0 : _a.options3d) === null || _b === void 0 ? void 0 : _b.enabled;
     if (seriesEl) {
         // For some series types the order of elements do not match the
         // order of points in series. In that case we have to reverse them
-        // in order for AT to read them out in an understandable order
-        if (seriesEl.lastChild === firstPointEl) {
+        // in order for AT to read them out in an understandable order.
+        // Due to z-index issues we can not do this for 3D charts.
+        if (seriesEl.lastChild === firstPointEl && !is3d) {
             reverseChildNodes(seriesEl);
         }
         describePointsInSeries(series);

--- a/js/modules/accessibility/components/SeriesComponent/SeriesDescriber.js
+++ b/js/modules/accessibility/components/SeriesComponent/SeriesDescriber.js
@@ -328,8 +328,7 @@ function describeSeriesElement(series, seriesElement) {
  * @param {Highcharts.Series} series The series to add info on.
  */
 function describeSeries(series) {
-    var _a, _b;
-    var chart = series.chart, firstPointEl = getSeriesFirstPointElement(series), seriesEl = getSeriesA11yElement(series), is3d = (_b = (_a = chart.options.chart) === null || _a === void 0 ? void 0 : _a.options3d) === null || _b === void 0 ? void 0 : _b.enabled;
+    var chart = series.chart, firstPointEl = getSeriesFirstPointElement(series), seriesEl = getSeriesA11yElement(series), is3d = chart.is3d && chart.is3d();
     if (seriesEl) {
         // For some series types the order of elements do not match the
         // order of points in series. In that case we have to reverse them

--- a/ts/modules/accessibility/components/SeriesComponent/SeriesDescriber.ts
+++ b/ts/modules/accessibility/components/SeriesComponent/SeriesDescriber.ts
@@ -579,15 +579,17 @@ function describeSeriesElement(
  * @param {Highcharts.Series} series The series to add info on.
  */
 function describeSeries(series: Highcharts.AccessibilitySeries): void {
-    var chart = series.chart,
+    const chart = series.chart,
         firstPointEl = getSeriesFirstPointElement(series),
-        seriesEl = getSeriesA11yElement(series);
+        seriesEl = getSeriesA11yElement(series),
+        is3d = chart.options.chart?.options3d?.enabled;
 
     if (seriesEl) {
         // For some series types the order of elements do not match the
         // order of points in series. In that case we have to reverse them
-        // in order for AT to read them out in an understandable order
-        if (seriesEl.lastChild === firstPointEl) {
+        // in order for AT to read them out in an understandable order.
+        // Due to z-index issues we can not do this for 3D charts.
+        if (seriesEl.lastChild === firstPointEl && !is3d) {
             reverseChildNodes(seriesEl);
         }
 

--- a/ts/modules/accessibility/components/SeriesComponent/SeriesDescriber.ts
+++ b/ts/modules/accessibility/components/SeriesComponent/SeriesDescriber.ts
@@ -582,7 +582,7 @@ function describeSeries(series: Highcharts.AccessibilitySeries): void {
     const chart = series.chart,
         firstPointEl = getSeriesFirstPointElement(series),
         seriesEl = getSeriesA11yElement(series),
-        is3d = chart.options.chart?.options3d?.enabled;
+        is3d = chart.is3d && chart.is3d();
 
     if (seriesEl) {
         // For some series types the order of elements do not match the


### PR DESCRIPTION
Fixed #12690, a11y module caused render issues for 3D funnel.
___

A11y module reverses DOM order for series where it does not match order of points in points array. Changed to not do this for 3D charts.