### PR TITLE
Fixed #12718, markers invisible on chart update with a11y module.

### DIFF
--- a/js/modules/accessibility/components/SeriesComponent/SeriesDescriber.js
+++ b/js/modules/accessibility/components/SeriesComponent/SeriesDescriber.js
@@ -52,7 +52,9 @@ function makeDummyElement(point, pos) {
     dummy.attr({
         'class': 'highcharts-a11y-dummy-point',
         fill: 'none',
-        opacity: 0
+        opacity: 0,
+        'fill-opacity': 0,
+        'stroke-opacity': 0
     });
     return dummy;
 }
@@ -73,6 +75,7 @@ function addDummyPointElement(point) {
     }, dummyElement = makeDummyElement(point, dummyPos);
     if (parentGroup && parentGroup.element) {
         point.graphic = dummyElement;
+        point.hasDummyGraphic = true;
         dummyElement.add(parentGroup);
         // Move to correct pos in DOM
         parentGroup.element.insertBefore(dummyElement.element, firstGraphic ? firstGraphic.element : null);

--- a/js/modules/accessibility/components/SeriesComponent/SeriesDescriber.js
+++ b/js/modules/accessibility/components/SeriesComponent/SeriesDescriber.js
@@ -52,8 +52,6 @@ function makeDummyElement(point, pos) {
     dummy.attr({
         'class': 'highcharts-a11y-dummy-point',
         fill: 'none',
-        'fill-opacity': 0,
-        'stroke-opacity': 0,
         opacity: 0
     });
     return dummy;

--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -699,9 +699,13 @@ extend(Point.prototype, /** @lends Highcharts.Point.prototype */ {
          */
         function update() {
             point.applyOptions(options);
-            // Update visuals
-            if (point.y === null && graphic) { // #4146
+            // Update visuals, #4146
+            // Handle dummy graphic elements for a11y, #12718
+            var hasDummyGraphic = graphic && point.hasDummyGraphic;
+            var shouldDestroyGraphic = point.y === null ? !hasDummyGraphic : hasDummyGraphic;
+            if (graphic && shouldDestroyGraphic) {
                 point.graphic = graphic.destroy();
+                delete point.hasDummyGraphic;
             }
             if (isObject(options, true)) {
                 // Destroy so we can get new elements

--- a/samples/unit-tests/accessibility/null-points/demo.js
+++ b/samples/unit-tests/accessibility/null-points/demo.js
@@ -12,3 +12,39 @@ QUnit.test('Null points are described to screen readers', function (assert) {
     assert.ok(getPointAttr(regularPoint, 'aria-label'));
     assert.ok(getPointAttr(nullPoint, 'aria-label'));
 });
+
+QUnit.test('Dynamic null points', function (assert) {
+    const chart = Highcharts.chart('container', {
+            series: [{
+                data: [1, null, null, 2, 3, 4, 5, 6]
+            }]
+        }),
+        series = chart.series[0],
+        nullPoint = series.points[1];
+
+    nullPoint.update({
+        y: 3
+    });
+
+    assert.notOk(
+        nullPoint.graphic.element.hasAttribute('fill-opacity'),
+        'Point should not have dummy hiding attributes after update.'
+    );
+    assert.strictEqual(
+        nullPoint.graphic.element.tagName, 'path',
+        'Point should not have the old dummy marker graphic, but a new marker element.'
+    );
+
+    nullPoint.update({
+        y: null
+    });
+
+    assert.ok(
+        nullPoint.graphic.element.hasAttribute('fill-opacity'),
+        'Point should have dummy hiding attributes after update to null point.'
+    );
+    assert.strictEqual(
+        nullPoint.graphic.element.tagName, 'rect',
+        'Point should have a new dummy marker graphic after update to null point.'
+    );
+});

--- a/ts/modules/accessibility/components/SeriesComponent/SeriesDescriber.ts
+++ b/ts/modules/accessibility/components/SeriesComponent/SeriesDescriber.ts
@@ -13,6 +13,20 @@
 'use strict';
 
 import H from '../../../../parts/Globals.js';
+
+/**
+ * Internal types.
+ * @private
+ */
+declare global {
+    namespace Highcharts {
+        interface Point {
+            /** @requires modules/accessibility */
+            hasDummyGraphic?: boolean;
+        }
+    }
+}
+
 var numberFormat = H.numberFormat,
     find = H.find;
 
@@ -84,7 +98,9 @@ function makeDummyElement(
     dummy.attr({
         'class': 'highcharts-a11y-dummy-point',
         fill: 'none',
-        opacity: 0
+        opacity: 0,
+        'fill-opacity': 0,
+        'stroke-opacity': 0
     });
 
     return dummy;
@@ -116,6 +132,7 @@ function addDummyPointElement(
 
     if (parentGroup && parentGroup.element) {
         point.graphic = dummyElement;
+        point.hasDummyGraphic = true;
 
         dummyElement.add(parentGroup);
 

--- a/ts/modules/accessibility/components/SeriesComponent/SeriesDescriber.ts
+++ b/ts/modules/accessibility/components/SeriesComponent/SeriesDescriber.ts
@@ -84,8 +84,6 @@ function makeDummyElement(
     dummy.attr({
         'class': 'highcharts-a11y-dummy-point',
         fill: 'none',
-        'fill-opacity': 0,
-        'stroke-opacity': 0,
         opacity: 0
     });
 

--- a/ts/parts/Dynamics.ts
+++ b/ts/parts/Dynamics.ts
@@ -1040,10 +1040,15 @@ extend(Point.prototype, /** @lends Highcharts.Point.prototype */ {
 
             point.applyOptions(options);
 
-            // Update visuals
-            if (point.y === null && graphic) { // #4146
+            // Update visuals, #4146
+            // Handle dummy graphic elements for a11y, #12718
+            const hasDummyGraphic = graphic && point.hasDummyGraphic;
+            const shouldDestroyGraphic = point.y === null ? !hasDummyGraphic : hasDummyGraphic;
+            if (graphic && shouldDestroyGraphic) {
                 point.graphic = graphic.destroy();
+                delete point.hasDummyGraphic;
             }
+
             if (isObject(options, true)) {
                 // Destroy so we can get new elements
                 if (graphic && graphic.element) {


### PR DESCRIPTION
Fixed #12718, markers invisible on chart update from null points with a11y module.
___

~Trying a simple fix first, if there are perceptible visual differences we'll have to get more clever.~

See comments.