### PR TITLE
docs/12495-exclude-bubble-dragdrop

### DIFF
--- a/js/parts-more/BubbleSeries.js
+++ b/js/parts-more/BubbleSeries.js
@@ -31,7 +31,7 @@ var Axis = H.Axis, color = H.color, noop = H.noop, Point = H.Point, Series = H.S
  *         Bubble chart
  *
  * @extends      plotOptions.scatter
- * @excluding    cluster
+ * @excluding    cluster, dragDrop
  * @product      highcharts highstock
  * @requires     highcharts-more
  * @optionparent plotOptions.bubble
@@ -487,7 +487,7 @@ Axis.prototype.beforePadding = function () {
  * not specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.bubble
- * @excluding dataParser, dataURL, stack
+ * @excluding dataParser, dataURL, dragDrop, stack
  * @product   highcharts highstock
  * @requires  highcharts-more
  * @apioption series.bubble

--- a/ts/parts-more/BubbleSeries.ts
+++ b/ts/parts-more/BubbleSeries.ts
@@ -136,7 +136,7 @@ var Axis = H.Axis,
  *         Bubble chart
  *
  * @extends      plotOptions.scatter
- * @excluding    cluster
+ * @excluding    cluster, dragDrop
  * @product      highcharts highstock
  * @requires     highcharts-more
  * @optionparent plotOptions.bubble
@@ -763,7 +763,7 @@ Axis.prototype.beforePadding = function (this: Highcharts.Axis): void {
  * not specified, it is inherited from [chart.type](#chart.type).
  *
  * @extends   series,plotOptions.bubble
- * @excluding dataParser, dataURL, stack
+ * @excluding dataParser, dataURL, dragDrop, stack
  * @product   highcharts highstock
  * @requires  highcharts-more
  * @apioption series.bubble


### PR DESCRIPTION
Close #12495, Excluded dragDrop options in bubble series.