### PR TITLE
Tools: CI use dist-release on nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
         default: "ChromeHeadless"
     steps:
       - <<: *load_workspace
-      - run: ./.circleci/scripts/test_timezones.sh -b <<parameters.browsers>>
+      - run: ./.circleci/scripts/test_timezones.sh -b=<<parameters.browsers>>
 
   check_for_docs_changes_and_deploy:
     <<: *defaults
@@ -418,7 +418,8 @@ workflows:
           requires: [lint]
           filters:
             branches:
-              only: [tools/report-slow-tests-and-set-bs-timezone]
+              only: [tools/ci-dist-release-yes]
+          browsers: "Mac.Safari"
       - test_browsers:
           name: "verify-samples-Chrome"
           browsers: "ChromeHeadless --tests highcharts/*/*,maps/*/*,stock/*/*,gantt/*/*"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,7 @@ jobs:
           command: cd ../highcharts-dist && git push origin --delete nightly || true
       - run:
           name: Run dist-release
-          command: cd ../highcharts && gulp dist-release
+          command: cd ../highcharts && npx gulp dist-release --force-yes
       - run:
           name: Push to highcharts-dist nightly branch
           command: |

--- a/tools/gulptasks/dist-release.js
+++ b/tools/gulptasks/dist-release.js
@@ -24,6 +24,10 @@ const pathToDistRepo = '../' + releaseRepo + '/';
  * @return {Promise<unknown>} answer.
  */
 async function askUser(question) {
+    if (argv.forceYes) {
+        return 'Y';
+    }
+
     const rl = readline.createInterface({
         input: process.stdin,
         output: process.stdout
@@ -294,7 +298,8 @@ release.description = 'Copies distribution contents to highcharts-dist repo, tag
 release.flags = {
     '--push': '(USE WITH CARE!) Will git commit, push and tag to the highcharts-dist repo, as well as publish to npm. ' +
                 'Note that credentials for git/npm must be configured. The user will be asked for input both before the ' +
-                'git commands and npm publish is run.'
+                'git commands and npm publish is run.',
+    '--force-yes': 'Automatically answers yes to all questions.'
 };
 
 gulp.task('dist-release', release);


### PR DESCRIPTION
CI can now use `gulp dist-release --force-yes` on nightly build to copy/create the files to the highcharts-dist repo. For now the commit to the nightly is done in a separate CI run command, so the above gulp task is not used for pushing the nightly.

Also fixed an issue with the timezone tests where the browser to test wasn't set properly.