### PR TITLE
tools/js-readme

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -1,0 +1,6 @@
+This folder is deprecated
+=========================
+
+Please use the `./ts` folder for code changes to the sources. The `./js` folder
+contains only temporary compilations for tool pipelines that are not fully
+migrated yet.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "testall": "npx gulp test --browsers all --force --speak",
     "prebuild": "rimraf build/*.zip build/dist/ code/",
     "build": "npx gulp dist",
-    "jsdoc": "npx gulp jsdoc --skip-websearch --watch",
+    "jsdoc": "npx gulp jsdoc-watch --skip-websearch",
     "dts": "npx gulp dts && npx gulp dtslint",
     "ts-compile:test": "npx tsc -p test && npx tsc -p samples",
     "gulp": "npx gulp",


### PR DESCRIPTION
- Adds a readme to the deprecated js folder pointing that fact out
- Fix the watch functionality in the package script for jsdoc