### PR TITLE
Tools: Added task for upload of map-collection

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,6 +36,7 @@ Gulp.registry(new GulpForwardReference());
     'dist-release',
     'dist-testresults',
     'dist-upload-code',
+    'dist-upload-mapcollection',
     'jsdoc',
     'jsdoc-classes',
     'jsdoc-clean',

--- a/tools/gulptasks/dist-upload-mapcollection.js
+++ b/tools/gulptasks/dist-upload-mapcollection.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) Highsoft AS
+ */
+
+/* eslint func-style: 0, no-console: 0, max-len: 0 */
+const gulp = require('gulp');
+const glob = require('glob');
+const log = require('./lib/log');
+const { uploadFiles, getVersionPaths, isDirectoryOrSystemFile, isDirectory } = require('./lib/uploadS3');
+
+
+const SOURCE_DIR = '../map-collection/';
+const S3_DEST_PATH = 'mapdata';
+
+/**
+ * Transforms a filepath to a similar named S3 destination path.
+ * @param {string} fromPath file to create a S3 destination path for.
+ * @param {string} removeFromDestPath, anything in the fromPath that you want to remove from destination path.
+ * @param {string} prefix for S3 destination key.
+ * @return {{from: *, to: string}} object for upload api.
+ */
+function toS3Path(fromPath, removeFromDestPath, prefix) {
+    return {
+        from: fromPath,
+        to: `${S3_DEST_PATH}/${prefix ? prefix + '/' : ''}${fromPath.replace(removeFromDestPath, '')}`
+    };
+}
+
+/**
+ * Upload code for map-collection to S3 (see example https://code.highcharts.com).
+ *
+ * @return {Promise<*> | Promise | Promise} Promise to keep
+ */
+function distUploadMapCollection() {
+    const argv = require('yargs').argv;
+    const bucket = argv.bucket;
+    const version = argv.releaseVersion;
+    let rootSourceDir = argv.sourceDir || SOURCE_DIR;
+
+    if (!rootSourceDir.endsWith('/')) {
+        rootSourceDir = rootSourceDir + '/';
+    }
+
+    if (!version) {
+        throw new Error('No --release-version specified.');
+    }
+    log.starting('Starting upload of map-collection v' + version);
+
+    if (!argv.sourceDir) {
+        log.message(`Using default folder ${SOURCE_DIR} as source. Use --source-dir to specify a different folder as source.`);
+    }
+
+    const sourceDir = rootSourceDir + 'Export/' + version;
+    if (!isDirectory(sourceDir)) {
+        throw new Error(`Could not find source directory ${rootSourceDir}. Have you cloned the map-collection repo into ../map-collection or tried to specify a different path with --source-dir?`);
+    }
+
+    if (!bucket) {
+        throw new Error('No --bucket specified.');
+    }
+
+    const sourceFiles = glob.sync(`${sourceDir}/**/*`).filter(file => !isDirectoryOrSystemFile(file));
+    const rootFiles = sourceFiles.map(file => toS3Path(file, sourceDir + '/'));
+    rootFiles.push({
+        from: rootSourceDir + 'Export/changelog.html',
+        to: `${S3_DEST_PATH}/changelog.html`
+    });
+
+    const versionedFiles = [];
+    const versionedPaths = getVersionPaths(version);
+    versionedPaths.forEach(versionPath => {
+        versionedFiles.push(...sourceFiles.map(file => toS3Path(file, sourceDir + '/', versionPath)));
+        versionedFiles.push({
+            from: rootSourceDir + 'Export/changelog.html',
+            to: `${S3_DEST_PATH}/${versionPath}/changelog.html`
+        });
+    });
+
+    return uploadFiles({
+        files: [...rootFiles, ...versionedFiles],
+        name: 'map-collection',
+        bucket,
+        profile: argv.profile
+    });
+}
+
+distUploadMapCollection.description = 'Uploads distribution for map-collection to code bucket.';
+distUploadMapCollection.flags = {
+    '--bucket': 'S3 bucket to upload to. Normally this is code.highcharts.com',
+    '--release-version': 'Version to upload.', // --version seems to be reserved by gulp
+    '--source-dir': 'Path to root folder of map-collection. .../map-collection is default. (optional) ',
+    '--profile': 'AWS profile to load from AWS credentials file. If no profile is provided the default profile or ' +
+        'standard AWS environment variables for credentials will be used. (optional)'
+};
+
+gulp.task('dist-upload-mapcollection', distUploadMapCollection);

--- a/tools/gulptasks/lib/uploadS3.js
+++ b/tools/gulptasks/lib/uploadS3.js
@@ -113,14 +113,24 @@ function getGitIgnoreMeProperties() {
  * Checks if source is a directory or system file.
  *
  * @param {string} source path to check
- * @return {boolean} true, if directory or system file.
+ * @return {boolean} true, if directory.
  */
-function isDirectoryOrSystemFile(source) {
-    return fs.lstatSync(source).isDirectory() || source.indexOf('.') === 0;
+function isDirectory(source) {
+    return fs.lstatSync(source).isDirectory();
 }
 
 /**
- * Transforms a filepath to a similar named S3 destination path.
+ * Checks if source is a directory or system file.
+ *
+ * @param {string} source path to check
+ * @return {boolean} true, if directory or system file.
+ */
+function isDirectoryOrSystemFile(source) {
+    return isDirectory(source) || (source.startsWith('../') ? source.substring(3, source.length - 1).indexOf('.') === 0 : source.indexOf('.') === 0);
+}
+
+/**
+ * Transforms a filepath to a similar named S3 destination path. Specific for highcharts js upload.
  * @param {string} filePath to create a S3 destination path for.
  * @param {string} localPath where the file resides. E.g 'highstock'. Will be substituted with cdnPath.
  * @param {string} cdnPath where the files should be uploaded. E.g 'stock'.
@@ -179,7 +189,7 @@ function uploadFiles(params) {
     }
 
     const defaultParams = {
-        batchSize: 400,
+        batchSize: 1500,
         bucket,
         onError: err => {
             log.failure(`File(s) errored:\n${err && err.message} ${err.from ? ' - ' + err.from : ''}`);
@@ -203,7 +213,7 @@ function uploadFiles(params) {
 
 
 /**
- * Uploads files for a specific product to S3.
+ * Uploads files for a specific highcharts product to S3.
  *
  * @param {object} productProps containing name, prettyName, cdnPath and version
  * @param {object} options that includes s3 options that will be passed to the sdk.
@@ -305,6 +315,9 @@ function uploadProductPackage(productProps, options = {}) {
 module.exports = {
     uploadFiles,
     uploadProductPackage,
+    getVersionPaths,
+    isDirectory,
+    isDirectoryOrSystemFile,
     getS3Object,
     putS3Object,
     getGitIgnoreMeProperties


### PR DESCRIPTION
Uploads a built version from <map-collection-dir>/Export/<version> to S3. 

Command to run is `gulp dist-upload-mapcollection --release-version <your-version> --bucket <your-bucket> --source-dir <optional-map-collection-dir-location>`. By default it will assume that map-collection directory is cloned in a sibling directory of highcharts (../map-collection).