### PR TITLE
Tools: Fixed issue with CI and number of cores.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,7 +300,7 @@ jobs:
       - <<: *load_workspace
       - run:
           name: Compile build
-          command: npm run build
+          command: npm run build -- --num-threads 2
       - <<: *persist_workspace
 
   deploy_code:


### PR DESCRIPTION
The CI does not report the correct number of cores that are available based on you CI plan. I.e `os.cpus().length` gives 36 cores, but we only have 2 available. This fix sets the number of threads used for compilation explicitly.