### PR TITLE
Fixed #12617, children of collapsed tree nodes visible

### DIFF
--- a/js/modules/xrange.src.js
+++ b/js/modules/xrange.src.js
@@ -349,7 +349,7 @@ seriesType('xrange', 'column'
         var series = this, seriesOpts = series.options, renderer = series.chart.renderer, graphic = point.graphic, type = point.shapeType, shapeArgs = point.shapeArgs, partShapeArgs = point.partShapeArgs, clipRectArgs = point.clipRectArgs, pfOptions = point.partialFill, cutOff = seriesOpts.stacking && !seriesOpts.borderRadius, pointState = point.state, stateOpts = (seriesOpts.states[pointState || 'normal'] ||
             {}), pointStateVerb = typeof pointState === 'undefined' ?
             'attr' : verb, pointAttr = series.pointAttribs(point, pointState), animation = pick(series.chart.options.chart.animation, stateOpts.animation), fill;
-        if (!point.isNull) {
+        if (!point.isNull && point.visible !== false) {
             // Original graphic
             if (graphic) { // update
                 graphic.rect[verb](shapeArgs);

--- a/js/parts-gantt/GanttSeries.js
+++ b/js/parts-gantt/GanttSeries.js
@@ -132,7 +132,7 @@ seriesType('gantt', 'xrange'
     drawPoint: function (point, verb) {
         var series = this, seriesOpts = series.options, renderer = series.chart.renderer, shapeArgs = point.shapeArgs, plotY = point.plotY, graphic = point.graphic, state = point.selected && 'select', cutOff = seriesOpts.stacking && !seriesOpts.borderRadius, diamondShape;
         if (point.options.milestone) {
-            if (isNumber(plotY) && point.y !== null) {
+            if (isNumber(plotY) && point.y !== null && point.visible !== false) {
                 diamondShape = renderer.symbols.diamond(shapeArgs.x, shapeArgs.y, shapeArgs.width, shapeArgs.height);
                 if (graphic) {
                     graphic[verb]({

--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -463,6 +463,7 @@ Series.prototype.alignDataLabel = function (point, dataLabel, options, alignTo, 
     // labels (#2700)
     alignAttr, // the final position;
     justify = pick(options.overflow, (enabledDataSorting ? 'none' : 'justify')) === 'justify', visible = this.visible &&
+        point.visible !== false &&
         (point.series.forceDL ||
             (enabledDataSorting && !justify) ||
             isInsidePlot ||

--- a/samples/unit-tests/gantt/gantt/demo.js
+++ b/samples/unit-tests/gantt/gantt/demo.js
@@ -338,6 +338,11 @@
                     parent: 'moving',
                     start: today + 4 * day,
                     end: today + 5 * day
+                }, {
+                    name: 'Bye',
+                    parent: 'moving',
+                    start: today + 5 * day,
+                    milestone: true
                 }]
             }]
         });
@@ -364,8 +369,15 @@
         // Test that number of points has not changed
         assert.strictEqual(
             points.length,
-            4,
+            5,
             'Should not change the number of points after update. #11231, #11486'
+        );
+
+        // Test that collapsed graphics are removed
+        assert.strictEqual(
+            points.filter(p => Boolean(p.graphic)).length,
+            2,
+            'Collapsed graphics should not be rendered (#12617)'
         );
     });
 }());

--- a/ts/modules/xrange.src.ts
+++ b/ts/modules/xrange.src.ts
@@ -608,7 +608,7 @@ seriesType<Highcharts.XRangeSeries>('xrange', 'column'
                 ),
                 fill;
 
-            if (!point.isNull) {
+            if (!point.isNull && point.visible !== false) {
 
                 // Original graphic
                 if (graphic) { // update

--- a/ts/parts-gantt/GanttSeries.ts
+++ b/ts/parts-gantt/GanttSeries.ts
@@ -263,7 +263,7 @@ seriesType<Highcharts.GanttSeries>('gantt', 'xrange'
                 diamondShape: Highcharts.SVGPathArray;
 
             if (point.options.milestone) {
-                if (isNumber(plotY) && point.y !== null) {
+                if (isNumber(plotY) && point.y !== null && point.visible !== false) {
                     diamondShape = renderer.symbols.diamond(
                         shapeArgs.x,
                         shapeArgs.y,

--- a/ts/parts/DataLabels.ts
+++ b/ts/parts/DataLabels.ts
@@ -881,6 +881,7 @@ Series.prototype.alignDataLabel = function (
         ) === 'justify',
         visible =
             this.visible &&
+            point.visible !== false &&
             (
                 point.series.forceDL ||
                 (enabledDataSorting && !justify) ||


### PR DESCRIPTION
Fixed #12617, when collapsing a parent node in the tree grid, its child tasks were still rendered.