### PR TITLE
Tools: Added task for upload of wrapper api docs.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,6 +68,7 @@ Gulp.registry(new GulpForwardReference());
     'tsdoc-next',
     'tsdoc-watch',
     'update',
+    'upload-wrapper-apidocs',
     'unsorted/build-modules',
     'unsorted/compare-filesize',
     'unsorted/default',

--- a/tools/gulptasks/dist-upload-code.js
+++ b/tools/gulptasks/dist-upload-code.js
@@ -5,12 +5,163 @@
 /* eslint func-style: 0, no-console: 0, max-len: 0 */
 const gulp = require('gulp');
 const glob = require('glob');
+const fs = require('fs-extra');
 const log = require('./lib/log');
 const build = require('./lib/build');
-const { uploadFiles, uploadProductPackage, getGitIgnoreMeProperties } = require('./lib/uploadS3');
+const {
+    uploadFiles,
+    getGitIgnoreMeProperties,
+    isDirectoryOrSystemFile,
+    getVersionPaths
+} = require('./lib/uploadS3');
 
+
+/**
+ * Adds number of days to the given date.
+ * @param {Date} date to add to
+ * @param {integer} days to add to the date.
+ * @return {Date} the new date with the added days.
+ */
+function addDays(date, days) {
+    var result = new Date(date);
+    result.setDate(result.getDate() + days);
+    return result;
+}
 
 const DIST_DIR = 'build/dist';
+
+const HTTP_MAX_AGE = {
+    oneDay: 86400,
+    month: 2592001,
+    fiveYears: 157680000
+};
+const TODAY = new Date();
+const HTTP_EXPIRES = {
+    // approximate dates
+    oneDay: addDays(TODAY, 1),
+    month: addDays(TODAY, 30),
+    fiveYears: addDays(TODAY, 365 * 5)
+};
+
+
+/**
+ * Transforms a filepath to a similar named S3 destination path. Specific for highcharts js upload.
+ * @param {string} filePath to create a S3 destination path for.
+ * @param {string} localPath where the file resides. E.g 'highstock'. Will be substituted with cdnPath.
+ * @param {string} cdnPath where the files should be uploaded. E.g 'stock'.
+ * @param {string} version for the distribution/release
+ * @return {object} containing from and to parameters
+ */
+function toS3FilePath(filePath, localPath, cdnPath, version = false) {
+    let toPath = filePath.replace(`${DIST_DIR}`, '').replace(`/${localPath}`, cdnPath).replace('/', '');
+    if (version) {
+        toPath = toPath.replace('js-gzip/', `${version}/`).replace('gfx/', `${version}/gfx/`);
+    } else {
+        toPath = toPath.replace('js-gzip/', '');
+    }
+    return {
+        from: filePath.trim(),
+        to: toPath
+    };
+}
+
+/**
+ * Uploads files for a specific highcharts product to S3.
+ *
+ * @param {object} productProps containing name, prettyName, cdnPath and version
+ * @param {object} options that includes s3 options that will be passed to the sdk.
+ * @return {Promise<*> | Promise | Promise} Promise to keep
+ */
+function uploadProductPackage(productProps, options = {}) {
+    const { productName: localPath, name: prettyName, version, cdnpath } = productProps;
+    const promises = [];
+    const fromDir = `${DIST_DIR}/${localPath}`;
+    const zipFilePaths = glob.sync(`${DIST_DIR}/${prettyName.replace(/ /g, '-')}-${version}.zip`);
+
+    if (zipFilePaths.length < 1) {
+        throw new Error('No zip files found. Did you forget to run gulp dist-compress?');
+    }
+
+    const zipFile = {
+        from: zipFilePaths[0],
+        to: 'zips/' + zipFilePaths[0].substring(zipFilePaths[0].lastIndexOf('/') + 1)
+    };
+
+    const gfxFromDir = `${fromDir}/gfx`;
+    const gfxFiles = glob.sync(`${gfxFromDir}/**/*.*`);
+    const gfxFilesToRootDir = gfxFiles.map(file => toS3FilePath(file, localPath, cdnpath));
+
+    const gzippedFileDir = `${fromDir}/js-gzip`;
+    if (!fs.existsSync(gzippedFileDir)) {
+        throw new Error(`Missing folder ${gzippedFileDir}`);
+    }
+
+    const gzippedFiles = glob.sync(`${gzippedFileDir}/**/*`);
+    const gzippedFilesToRootDir = gzippedFiles.map(file => toS3FilePath(file, localPath, cdnpath));
+
+    const versionPaths = getVersionPaths(version);
+    let gzippedFilesToVersionDir = [];
+    let gfxFilesToVersionedDir = [];
+
+    versionPaths.forEach(versionPath => {
+        gzippedFilesToVersionDir = [...gzippedFilesToVersionDir, ...gzippedFiles.map(file => toS3FilePath(file, localPath, cdnpath, versionPath))];
+        gfxFilesToVersionedDir = [...gfxFilesToVersionedDir, ...gfxFiles.map(file => toS3FilePath(file, localPath, cdnpath, versionPath))];
+    });
+
+    promises.push(uploadFiles({
+        bucket: options.bucket,
+        files: [zipFile],
+        name: prettyName
+    }));
+
+    promises.push(uploadFiles({
+        bucket: options.bucket,
+        files: gzippedFilesToRootDir.filter(path => !isDirectoryOrSystemFile(path.from)),
+        name: prettyName,
+        s3Params: {
+            ...options.s3Params,
+            CacheControl: `public, max-age=${HTTP_MAX_AGE.oneDay}`,
+            Expires: HTTP_EXPIRES.oneDay,
+            ContentEncoding: 'gzip'
+        }
+    }));
+
+    promises.push(uploadFiles({
+        bucket: options.bucket,
+        files: gfxFilesToRootDir.filter(path => !isDirectoryOrSystemFile(path.from)),
+        name: prettyName,
+        s3Params: {
+            ...options.s3Params,
+            CacheControl: `public, max-age=${HTTP_MAX_AGE.oneDay}`,
+            Expires: HTTP_EXPIRES.oneDay
+        }
+    }));
+
+    promises.push(uploadFiles({
+        bucket: options.bucket,
+        files: gzippedFilesToVersionDir.filter(path => !isDirectoryOrSystemFile(path.from)),
+        name: prettyName,
+        s3Params: {
+            ...options.s3Params,
+            CacheControl: `public, max-age=${HTTP_MAX_AGE.fiveYears}`,
+            Expires: HTTP_EXPIRES.fiveYears,
+            ContentEncoding: 'gzip'
+        }
+    }));
+
+    promises.push(uploadFiles({
+        bucket: options.bucket,
+        files: gfxFilesToVersionedDir.filter(path => !isDirectoryOrSystemFile(path.from)),
+        name: prettyName,
+        s3Params: {
+            ...options.s3Params,
+            CacheControl: `public, max-age=${HTTP_MAX_AGE.fiveYears}`,
+            Expires: HTTP_EXPIRES.fiveYears
+        }
+    }));
+
+    return Promise.all(promises);
+}
 
 /**
  * Upload code for all products (see example https://code.highcharts.com).

--- a/tools/gulptasks/jsdoc-wrappers.js
+++ b/tools/gulptasks/jsdoc-wrappers.js
@@ -36,7 +36,7 @@ function jsDocWrappers() {
             'mv highcharts-ios-dev/api build/api/ios && ' +
             'rm -rf highcharts-ios-dev'
         ))
-        .then(() => logLib.warn('Done. Upload with gulp task "upload-api".'));
+        .then(() => logLib.warn('Done. Upload with gulp task "upload-wrapper-apidocs".'));
 }
 
 require('./jsdoc.js');

--- a/tools/gulptasks/lib/uploadS3.js
+++ b/tools/gulptasks/lib/uploadS3.js
@@ -6,33 +6,6 @@ const S3 = new AWSS3({
 });
 
 /**
- * Adds number of days to the given date.
- * @param {Date} date to add to
- * @param {integer} days to add to the date.
- * @return {Date} the new date with the added days.
- */
-function addDays(date, days) {
-    var result = new Date(date);
-    result.setDate(result.getDate() + days);
-    return result;
-}
-
-const DIST_DIR = 'build/dist';
-
-const HTTP_MAX_AGE = {
-    oneDay: 86400,
-    month: 2592001,
-    fiveYears: 157680000
-};
-const TODAY = new Date();
-const HTTP_EXPIRES = {
-    // approximate dates
-    oneDay: addDays(TODAY, 1),
-    month: addDays(TODAY, 30),
-    fiveYears: addDays(TODAY, 365 * 5)
-};
-
-/**
  * Fetch an object from S3.
  *
  * @param {string} bucket to fetch from
@@ -130,27 +103,6 @@ function isDirectoryOrSystemFile(source) {
 }
 
 /**
- * Transforms a filepath to a similar named S3 destination path. Specific for highcharts js upload.
- * @param {string} filePath to create a S3 destination path for.
- * @param {string} localPath where the file resides. E.g 'highstock'. Will be substituted with cdnPath.
- * @param {string} cdnPath where the files should be uploaded. E.g 'stock'.
- * @param {string} version for the distribution/release
- * @return {object} containing from and to parameters
- */
-function toS3FilePath(filePath, localPath, cdnPath, version = false) {
-    let toPath = filePath.replace(`${DIST_DIR}`, '').replace(`/${localPath}`, cdnPath).replace('/', '');
-    if (version) {
-        toPath = toPath.replace('js-gzip/', `${version}/`).replace('gfx/', `${version}/gfx/`);
-    } else {
-        toPath = toPath.replace('js-gzip/', '');
-    }
-    return {
-        from: filePath.trim(),
-        to: toPath
-    };
-}
-
-/**
  * Creates an array of the version paths that are used when uploading to S3.
  *
  * @param {string} version, typically from package.json.
@@ -212,109 +164,8 @@ function uploadFiles(params) {
 }
 
 
-/**
- * Uploads files for a specific highcharts product to S3.
- *
- * @param {object} productProps containing name, prettyName, cdnPath and version
- * @param {object} options that includes s3 options that will be passed to the sdk.
- * @return {Promise<*> | Promise | Promise} Promise to keep
- */
-function uploadProductPackage(productProps, options = {}) {
-    const { productName: localPath, name: prettyName, version, cdnpath } = productProps;
-    const glob = require('glob');
-    const promises = [];
-    const fromDir = `${DIST_DIR}/${localPath}`;
-    const zipFilePaths = glob.sync(`${DIST_DIR}/${prettyName.replace(/ /g, '-')}-${version}.zip`);
-
-    if (zipFilePaths.length < 1) {
-        throw new Error('No zip files found. Did you forget to run gulp dist-compress?');
-    }
-
-    const zipFile = {
-        from: zipFilePaths[0],
-        to: 'zips/' + zipFilePaths[0].substring(zipFilePaths[0].lastIndexOf('/') + 1)
-    };
-
-    const gfxFromDir = `${fromDir}/gfx`;
-    const gfxFiles = glob.sync(`${gfxFromDir}/**/*.*`);
-    const gfxFilesToRootDir = gfxFiles.map(file => toS3FilePath(file, localPath, cdnpath));
-
-    const gzippedFileDir = `${fromDir}/js-gzip`;
-    if (!fs.existsSync(gzippedFileDir)) {
-        throw new Error(`Missing folder ${gzippedFileDir}`);
-    }
-
-    const gzippedFiles = glob.sync(`${gzippedFileDir}/**/*`);
-    const gzippedFilesToRootDir = gzippedFiles.map(file => toS3FilePath(file, localPath, cdnpath));
-
-    const versionPaths = getVersionPaths(version);
-    let gzippedFilesToVersionDir = [];
-    let gfxFilesToVersionedDir = [];
-
-    versionPaths.forEach(versionPath => {
-        gzippedFilesToVersionDir = [...gzippedFilesToVersionDir, ...gzippedFiles.map(file => toS3FilePath(file, localPath, cdnpath, versionPath))];
-        gfxFilesToVersionedDir = [...gfxFilesToVersionedDir, ...gfxFiles.map(file => toS3FilePath(file, localPath, cdnpath, versionPath))];
-    });
-
-    promises.push(uploadFiles({
-        bucket: options.bucket,
-        files: [zipFile],
-        name: prettyName
-    }));
-
-    promises.push(uploadFiles({
-        bucket: options.bucket,
-        files: gzippedFilesToRootDir.filter(path => !isDirectoryOrSystemFile(path.from)),
-        name: prettyName,
-        s3Params: {
-            ...options.s3Params,
-            CacheControl: `public, max-age=${HTTP_MAX_AGE.oneDay}`,
-            Expires: HTTP_EXPIRES.oneDay,
-            ContentEncoding: 'gzip'
-        }
-    }));
-
-    promises.push(uploadFiles({
-        bucket: options.bucket,
-        files: gfxFilesToRootDir.filter(path => !isDirectoryOrSystemFile(path.from)),
-        name: prettyName,
-        s3Params: {
-            ...options.s3Params,
-            CacheControl: `public, max-age=${HTTP_MAX_AGE.oneDay}`,
-            Expires: HTTP_EXPIRES.oneDay
-        }
-    }));
-
-    promises.push(uploadFiles({
-        bucket: options.bucket,
-        files: gzippedFilesToVersionDir.filter(path => !isDirectoryOrSystemFile(path.from)),
-        name: prettyName,
-        s3Params: {
-            ...options.s3Params,
-            CacheControl: `public, max-age=${HTTP_MAX_AGE.fiveYears}`,
-            Expires: HTTP_EXPIRES.fiveYears,
-            ContentEncoding: 'gzip'
-        }
-    }));
-
-    promises.push(uploadFiles({
-        bucket: options.bucket,
-        files: gfxFilesToVersionedDir.filter(path => !isDirectoryOrSystemFile(path.from)),
-        name: prettyName,
-        s3Params: {
-            ...options.s3Params,
-            CacheControl: `public, max-age=${HTTP_MAX_AGE.fiveYears}`,
-            Expires: HTTP_EXPIRES.fiveYears
-        }
-    }));
-
-    return Promise.all(promises);
-}
-
-
 module.exports = {
     uploadFiles,
-    uploadProductPackage,
     getVersionPaths,
     isDirectory,
     isDirectoryOrSystemFile,

--- a/tools/gulptasks/upload-wrapper-apidocs.js
+++ b/tools/gulptasks/upload-wrapper-apidocs.js
@@ -53,7 +53,7 @@ function uploadWrapperAPIDocs() {
         throw new Error('No --bucket specified.');
     }
 
-    const wrappersToUpload = argv.onlyUploadWrappers ? argv.onlyUploadWrappers.split(',') : WRAPPERS;
+    const wrappersToUpload = argv.onlyUpload ? argv.onlyUpload.split(',') : WRAPPERS;
     log.starting(`Starting upload of wrapper API ${wrappersToUpload.join(' and ')} version ${version}...`);
 
     const globPattern = wrappersToUpload.length > 1 ? `build/api/{${wrappersToUpload.join(',')}}/**/*` : `build/api/${wrappersToUpload[0]}/**/*`;
@@ -73,7 +73,7 @@ uploadWrapperAPIDocs.description = 'Uploads Wrapper API docs (ios, android) to S
 uploadWrapperAPIDocs.flags = {
     '--bucket': 'S3 bucket to upload to. Normally this is api-docs-bucket.highcharts.com',
     '--release-version': 'Version to upload.', // --version seems to be reserved by gulp
-    '--only-upload-wrappers': 'Comma separated list of wrappers to upload. I.e ios,android (optional)',
+    '--only-upload': 'Comma separated list of wrappers to upload. I.e ios,android (optional)',
     '--profile': 'AWS profile to load from AWS credentials file. If no profile is provided the default profile or ' +
         'standard AWS environment variables for credentials will be used. (optional)'
 };

--- a/tools/gulptasks/upload-wrapper-apidocs.js
+++ b/tools/gulptasks/upload-wrapper-apidocs.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) Highsoft AS
+ */
+
+/* eslint func-style: 0, no-console: 0, max-len: 0 */
+const gulp = require('gulp');
+const glob = require('glob');
+const log = require('./lib/log');
+const { uploadFiles, isDirectoryOrSystemFile, isDirectory } = require('./lib/uploadS3');
+
+
+const SOURCE_DIR = 'build/api';
+const WRAPPERS = ['ios', 'android'];
+
+/**
+ * Transforms a filepath to a similar named S3 destination path for the given wrapper product.
+ * @param {string} fromPath file to create a S3 destination path for.
+ * @param {string} prefix for S3 destination key.
+ * @return {{from: *, to: string}} object for upload api.
+ */
+function toS3Path(fromPath, prefix) {
+    const regex = new RegExp(`build/api/(${WRAPPERS.join('|')})`, 'gi');
+    const matches = regex.exec(fromPath);
+    if (matches.length > 2) {
+        throw new Error('Failed to extract wrapper name from path! Did you enter --only-upload-wrappers correct?');
+    }
+
+    const wrapper = matches[1];
+    return {
+        from: fromPath,
+        to: `${wrapper}/highcharts/${prefix ? prefix + '/' : ''}${fromPath.replace(`build/api/${wrapper}/`, '')}`
+    };
+}
+/**
+ * Upload code for wrapper api docs (iOS/Android) to S3 (see example https://api-docs-bucket.highcharts.com).
+ *
+ * @return {Promise<*> | Promise | Promise} Promise to keep
+ */
+function uploadWrapperAPIDocs() {
+    const argv = require('yargs').argv;
+    const bucket = argv.bucket;
+    const version = argv.releaseVersion;
+
+    if (!version) {
+        throw new Error('No --release-version specified.');
+    }
+
+    if (!isDirectory(SOURCE_DIR)) {
+        throw new Error(`Could not find source directory ${SOURCE_DIR}. Has the gulp jsdoc-wrappers task been run prior to this task?`);
+    }
+
+    if (!bucket) {
+        throw new Error('No --bucket specified.');
+    }
+
+    const wrappersToUpload = argv.onlyUploadWrappers ? argv.onlyUploadWrappers.split(',') : WRAPPERS;
+    log.starting(`Starting upload of wrapper API ${wrappersToUpload.join(' and ')} version ${version}...`);
+
+    const globPattern = wrappersToUpload.length > 1 ? `build/api/{${wrappersToUpload.join(',')}}/**/*` : `build/api/${wrappersToUpload[0]}/**/*`;
+    const sourceFiles = glob.sync(globPattern).filter(file => !isDirectoryOrSystemFile(file));
+    const rootDirFiles = sourceFiles.map(file => toS3Path(file));
+    const versionedFiles = [...sourceFiles.map(file => toS3Path(file, version))];
+
+    return uploadFiles({
+        files: [...rootDirFiles, ...versionedFiles],
+        name: 'Highcharts Wrapper API docs for ' + wrappersToUpload.join(' and '),
+        bucket,
+        profile: argv.profile
+    });
+}
+
+uploadWrapperAPIDocs.description = 'Uploads Wrapper API docs (ios, android) to S3';
+uploadWrapperAPIDocs.flags = {
+    '--bucket': 'S3 bucket to upload to. Normally this is api-docs-bucket.highcharts.com',
+    '--release-version': 'Version to upload.', // --version seems to be reserved by gulp
+    '--only-upload-wrappers': 'Comma separated list of wrappers to upload. I.e ios,android (optional)',
+    '--profile': 'AWS profile to load from AWS credentials file. If no profile is provided the default profile or ' +
+        'standard AWS environment variables for credentials will be used. (optional)'
+};
+
+gulp.task('upload-wrapper-apidocs', uploadWrapperAPIDocs);


### PR DESCRIPTION
The task can be used for both ios and android as they both follow the same structure on S3.

Command: `gulp upload-wrapper-apidocs --release-version <x.y.z> --bucket <your-bucket>`. Or for only uploading specific wrapper(s): `gulp upload-wrapper-apidocs --release-version <x.y.z> --bucket <your-bucket> --only-upload ios,android`

There is a slight chance that the user can mistype the version. Ideally we should retrieve the version number from the built api docs files. But I cannot see that it is possible at the current moment for either of the wrappers.

Also did a simple refactoring (moved code) from the uploadS3.js file to a more specific task as some functions were specific to that task.