### PR TITLE
tools/color-class-es6

### DIFF
--- a/js/modules/boost-canvas.src.js
+++ b/js/modules/boost-canvas.src.js
@@ -14,12 +14,13 @@
  * */
 'use strict';
 import H from '../parts/Globals.js';
-import U from '../parts/Utilities.js';
-var extend = U.extend, isNumber = U.isNumber, wrap = U.wrap;
-import '../parts/Color.js';
+import colorModule from '../parts/Color.js';
+var Color = colorModule.Color, color = colorModule.color;
+import utilitiesModule from '../parts/Utilities.js';
+var extend = utilitiesModule.extend, isNumber = utilitiesModule.isNumber, wrap = utilitiesModule.wrap;
 import '../parts/Series.js';
 import '../parts/Options.js';
-var win = H.win, doc = win.document, noop = function () { }, Color = H.Color, Series = H.Series, seriesTypes = H.seriesTypes, addEvent = H.addEvent, fireEvent = H.fireEvent, merge = H.merge, pick = H.pick, CHUNK_SIZE = 50000, destroyLoadingDiv;
+var win = H.win, doc = win.document, noop = function () { }, Series = H.Series, seriesTypes = H.seriesTypes, addEvent = H.addEvent, fireEvent = H.fireEvent, merge = H.merge, pick = H.pick, CHUNK_SIZE = 50000, destroyLoadingDiv;
 /* eslint-disable no-invalid-this, valid-jsdoc */
 /**
  * Initialize the canvas boost.
@@ -289,8 +290,7 @@ H.initCanvasBoost = function () {
             if (rawData.length > 99999) {
                 chart.options.loading = merge(loadingOptions, {
                     labelStyle: {
-                        backgroundColor: H.color('${palette.backgroundColor}')
-                            .setOpacity(0.75).get(),
+                        backgroundColor: color('${palette.backgroundColor}').setOpacity(0.75).get(),
                         padding: '1em',
                         borderRadius: '0.5em'
                     },

--- a/js/modules/boost/named-colors.js
+++ b/js/modules/boost/named-colors.js
@@ -10,9 +10,8 @@
  *
  * */
 'use strict';
-import H from '../../parts/Globals.js';
-import '../../parts/Color.js';
-var Color = H.Color;
+import colorModule from '../../parts/Color.js';
+var Color = colorModule.Color;
 // Register color names since GL can't render those directly.
 // TODO: When supporting modern syntax, make this a const and a named export
 var defaultHTMLColorMap = {
@@ -160,5 +159,5 @@ var defaultHTMLColorMap = {
     yellow: '#ffff00',
     yellowgreen: '#9acd32'
 };
-Color.prototype.names = defaultHTMLColorMap;
+Color.names = defaultHTMLColorMap;
 export default defaultHTMLColorMap;

--- a/js/modules/boost/wgl-renderer.js
+++ b/js/modules/boost/wgl-renderer.js
@@ -13,10 +13,11 @@
 import H from '../../parts/Globals.js';
 import GLShader from './wgl-shader.js';
 import GLVertexBuffer from './wgl-vbuffer.js';
-import U from '../../parts/Utilities.js';
-var isNumber = U.isNumber, objEach = U.objectEach;
-import '../../parts/Color.js';
-var win = H.win, doc = win.document, merge = H.merge, some = H.some, Color = H.Color, pick = H.pick;
+import colorModule from '../../parts/Color.js';
+var Color = colorModule.Color, color = colorModule.color;
+import utilitiesModule from '../../parts/Utilities.js';
+var isNumber = utilitiesModule.isNumber, objectEach = utilitiesModule.objectEach;
+var win = H.win, doc = win.document, merge = H.merge, some = H.some, pick = H.pick;
 /* eslint-disable valid-jsdoc */
 /**
  * Main renderer. Used to render series.
@@ -200,7 +201,7 @@ function GLRenderer(postRenderCallback) {
         // For some reason eslint/TypeScript don't pick up that this is
         // actually used: --- bre1470: it is never read, just set
         // maxVal: (number|undefined), // eslint-disable-line no-unused-vars
-        points = series.points || false, lastX = false, lastY = false, minVal, color, scolor, sdata = isStacked ? series.data : (xData || rawData), closestLeft = { x: Number.MAX_VALUE, y: 0 }, closestRight = { x: -Number.MAX_VALUE, y: 0 }, 
+        points = series.points || false, lastX = false, lastY = false, minVal, pcolor, scolor, sdata = isStacked ? series.data : (xData || rawData), closestLeft = { x: Number.MAX_VALUE, y: 0 }, closestRight = { x: -Number.MAX_VALUE, y: 0 }, 
         //
         skipped = 0, hadPoints = false, 
         //
@@ -218,14 +219,14 @@ function GLRenderer(postRenderCallback) {
         if (zones) {
             some(zones, function (zone) {
                 if (typeof zone.value === 'undefined') {
-                    zoneDefColor = new H.Color(zone.color);
+                    zoneDefColor = new Color(zone.color);
                     return true;
                 }
             });
             if (!zoneDefColor) {
                 zoneDefColor = ((series.pointAttribs && series.pointAttribs().fill) ||
                     series.color);
-                zoneDefColor = new H.Color(zoneDefColor);
+                zoneDefColor = new Color(zoneDefColor);
             }
         }
         if (chart.inverted) {
@@ -342,10 +343,10 @@ function GLRenderer(postRenderCallback) {
                         pointAttr = point.series.pointAttribs(point);
                     swidth = pointAttr['stroke-width'] || 0;
                     // Handle point colors
-                    color = H.color(pointAttr.fill).rgba;
-                    color[0] /= 255.0;
-                    color[1] /= 255.0;
-                    color[2] /= 255.0;
+                    pcolor = color(pointAttr.fill).rgba;
+                    pcolor[0] /= 255.0;
+                    pcolor[1] /= 255.0;
+                    pcolor[2] /= 255.0;
                     // So there are two ways of doing this. Either we can
                     // create a rectangle of two triangles, or we can do a
                     // point and use point size. Latter is faster, but
@@ -355,7 +356,7 @@ function GLRenderer(postRenderCallback) {
                     // If there's stroking, we do an additional rect
                     if (series.type === 'treemap') {
                         swidth = swidth || 1;
-                        scolor = H.color(pointAttr.stroke).rgba;
+                        scolor = color(pointAttr.stroke).rgba;
                         scolor[0] /= 255.0;
                         scolor[1] /= 255.0;
                         scolor[2] /= 255.0;
@@ -376,7 +377,7 @@ function GLRenderer(postRenderCallback) {
                         shapeArgs.width = -shapeArgs.width;
                         shapeArgs.height = -shapeArgs.height;
                     }
-                    pushRect(shapeArgs.x + swidth, shapeArgs.y + swidth, shapeArgs.width - (swidth * 2), shapeArgs.height - (swidth * 2), color);
+                    pushRect(shapeArgs.x + swidth, shapeArgs.y + swidth, shapeArgs.width - (swidth * 2), shapeArgs.height - (swidth * 2), pcolor);
                 }
             });
             closeSegment();
@@ -511,7 +512,7 @@ function GLRenderer(postRenderCallback) {
                     var last = zones[i - 1];
                     if (typeof zone.value !== 'undefined' && y <= zone.value) {
                         if (!last || y >= last.value) {
-                            pcolor = H.color(zone.color).rgba;
+                            pcolor = color(zone.color).rgba;
                         }
                         return true;
                     }
@@ -604,7 +605,7 @@ function GLRenderer(postRenderCallback) {
             vertice(x, y, 0, series.type === 'bubble' ? (z || 1) : 2, pcolor);
             // Uncomment this to support color axis.
             // if (caxis) {
-            //     color = H.color(caxis.toColor(y)).rgba;
+            //     pcolor = color(caxis.toColor(y)).rgba;
             //     inst.colorData.push(color[0] / 255.0);
             //     inst.colorData.push(color[1] / 255.0);
             //     inst.colorData.push(color[2] / 255.0);
@@ -802,7 +803,7 @@ function GLRenderer(postRenderCallback) {
                 2 * ((options.marker ?
                     options.marker.radius :
                     10) || 10)), fillColor, shapeTexture = textureHandles[(shapeOptions && shapeOptions.symbol) ||
-                s.series.symbol] || textureHandles.circle, color;
+                s.series.symbol] || textureHandles.circle, scolor = [];
             if (s.segments.length === 0 ||
                 (s.segmentslength &&
                     s.segments[0].from === s.segments[0].to)) {
@@ -827,15 +828,15 @@ function GLRenderer(postRenderCallback) {
             if (s.series.fillOpacity && options.fillOpacity) {
                 fillColor = new Color(fillColor).setOpacity(pick(options.fillOpacity, 1.0)).get();
             }
-            color = H.color(fillColor).rgba;
+            scolor = color(fillColor).rgba;
             if (!settings.useAlpha) {
-                color[3] = 1.0;
+                scolor[3] = 1.0;
             }
             // This is very much temporary
             if (s.drawMode === 'lines' &&
                 settings.useAlpha &&
-                color[3] < 1) {
-                color[3] /= 10;
+                scolor[3] < 1) {
+                scolor[3] /= 10;
             }
             // Blending
             if (options.boostBlending === 'add') {
@@ -864,7 +865,7 @@ function GLRenderer(postRenderCallback) {
                 cbuffer.bind();
             }
             // Set series specific uniforms
-            shader.setColor(color);
+            shader.setColor(scolor);
             setXAxis(s.series.xAxis);
             setYAxis(s.series.yAxis);
             setThreshold(hasThreshold, translatedThreshold);
@@ -1102,7 +1103,7 @@ function GLRenderer(postRenderCallback) {
         vbuffer.destroy();
         shader.destroy();
         if (gl) {
-            objEach(textureHandles, function (key) {
+            objectEach(textureHandles, function (key) {
                 if (textureHandles[key].handle) {
                     gl.deleteTexture(textureHandles[key].handle);
                 }

--- a/js/modules/drilldown.src.js
+++ b/js/modules/drilldown.src.js
@@ -511,8 +511,8 @@ Chart.prototype.addSingleSeriesAsDrilldown = function (point, ddOptions) {
         // no graphic in line series with markers disabled
         bBox: point.graphic ? point.graphic.getBBox() : {},
         color: point.isNull ?
-            new Color(colorProp).setOpacity(0).get() :
-            colorProp,
+            new Color(colorProp.color).setOpacity(0).get() :
+            colorProp.color,
         lowerSeriesOptions: ddOptions,
         pointOptions: oldSeries.options.data[pointIndex],
         pointIndex: pointIndex,

--- a/js/modules/drilldown.src.js
+++ b/js/modules/drilldown.src.js
@@ -124,14 +124,16 @@ import H from '../parts/Globals.js';
 * @name Highcharts.DrillupEventObject#type
 * @type {"drillup"}
 */
-import U from '../parts/Utilities.js';
-var animObject = U.animObject, extend = U.extend, objectEach = U.objectEach, pick = U.pick, syncTimeout = U.syncTimeout;
+import colorModule from '../parts/Color.js';
+var Color = colorModule.Color;
+import utilitiesModule from '../parts/Utilities.js';
+var animObject = utilitiesModule.animObject, extend = utilitiesModule.extend, objectEach = utilitiesModule.objectEach, pick = utilitiesModule.pick, syncTimeout = utilitiesModule.syncTimeout;
 import '../parts/Options.js';
 import '../parts/Chart.js';
 import '../parts/Series.js';
 import '../parts/ColumnSeries.js';
 import '../parts/Tick.js';
-var addEvent = H.addEvent, noop = H.noop, color = H.color, defaultOptions = H.defaultOptions, format = H.format, Chart = H.Chart, seriesTypes = H.seriesTypes, PieSeries = seriesTypes.pie, ColumnSeries = seriesTypes.column, Tick = H.Tick, fireEvent = H.fireEvent, ddSeriesId = 1;
+var addEvent = H.addEvent, noop = H.noop, defaultOptions = H.defaultOptions, format = H.format, Chart = H.Chart, seriesTypes = H.seriesTypes, PieSeries = seriesTypes.pie, ColumnSeries = seriesTypes.column, Tick = H.Tick, fireEvent = H.fireEvent, ddSeriesId = 1;
 // Add language
 extend(defaultOptions.lang, 
 /**
@@ -509,8 +511,8 @@ Chart.prototype.addSingleSeriesAsDrilldown = function (point, ddOptions) {
         // no graphic in line series with markers disabled
         bBox: point.graphic ? point.graphic.getBBox() : {},
         color: point.isNull ?
-            new H.Color(color).setOpacity(0).get() :
-            color,
+            new Color(colorProp.color).setOpacity(0).get() :
+            colorProp.color,
         lowerSeriesOptions: ddOptions,
         pointOptions: oldSeries.options.data[pointIndex],
         pointIndex: pointIndex,

--- a/js/modules/drilldown.src.js
+++ b/js/modules/drilldown.src.js
@@ -511,8 +511,8 @@ Chart.prototype.addSingleSeriesAsDrilldown = function (point, ddOptions) {
         // no graphic in line series with markers disabled
         bBox: point.graphic ? point.graphic.getBBox() : {},
         color: point.isNull ?
-            new Color(colorProp.color).setOpacity(0).get() :
-            colorProp.color,
+            new Color(colorProp).setOpacity(0).get() :
+            colorProp,
         lowerSeriesOptions: ddOptions,
         pointOptions: oldSeries.options.data[pointIndex],
         pointIndex: pointIndex,

--- a/js/modules/oldie.src.js
+++ b/js/modules/oldie.src.js
@@ -11,8 +11,10 @@
  * */
 'use strict';
 import H from '../parts/Globals.js';
-import U from '../parts/Utilities.js';
-var defined = U.defined, discardElement = U.discardElement, erase = U.erase, extend = U.extend, extendClass = U.extendClass, isArray = U.isArray, isNumber = U.isNumber, isObject = U.isObject, offset = U.offset, pick = U.pick, pInt = U.pInt;
+import colorModule from '../parts/Color.js';
+var color = colorModule.color;
+import utilitiesModule from '../parts/Utilities.js';
+var defined = utilitiesModule.defined, discardElement = utilitiesModule.discardElement, erase = utilitiesModule.erase, extend = utilitiesModule.extend, extendClass = utilitiesModule.extendClass, isArray = utilitiesModule.isArray, isNumber = utilitiesModule.isNumber, isObject = utilitiesModule.isObject, offset = utilitiesModule.offset, pick = utilitiesModule.pick, pInt = utilitiesModule.pInt;
 import '../parts/SvgRenderer.js';
 var VMLRenderer, VMLRendererExtension, VMLElement, Chart = H.Chart, createElement = H.createElement, css = H.css, deg2rad = H.deg2rad, doc = H.doc, merge = H.merge, noop = H.noop, svg = H.svg, SVGElement = H.SVGElement, SVGRenderer = H.SVGRenderer, win = H.win;
 /**
@@ -817,20 +819,20 @@ if (!svg) {
          *
          * @return {T}
          */
-        color: function (color, elem, prop, wrapper) {
+        color: function (colorOption, elem, prop, wrapper) {
             var renderer = this, colorObject, regexRgba = /^rgba/, markup, fillType, ret = 'none';
             // Check for linear or radial gradient
-            if (color &&
-                color.linearGradient) {
+            if (colorOption &&
+                colorOption.linearGradient) {
                 fillType = 'gradient';
             }
-            else if (color &&
-                color.radialGradient) {
+            else if (colorOption &&
+                colorOption.radialGradient) {
                 fillType = 'pattern';
             }
             if (fillType) {
-                var stopColor, stopOpacity, gradient = (color.linearGradient ||
-                    color.radialGradient), x1, y1, x2, y2, opacity1, opacity2, color1, color2, fillAttr = '', stops = color.stops, firstStop, lastStop, colors = [], addFillNode = function () {
+                var stopColor, stopOpacity, gradient = (colorOption.linearGradient ||
+                    colorOption.radialGradient), x1, y1, x2, y2, opacity1, opacity2, color1, color2, fillAttr = '', stops = colorOption.stops, firstStop, lastStop, colors = [], addFillNode = function () {
                     // Add the fill subnode. When colors attribute is used,
                     // the meanings of opacity and o:opacity2 are reversed.
                     markup = ['<fill colors="' + colors.join(',') +
@@ -857,7 +859,7 @@ if (!svg) {
                 // Compute the stops
                 stops.forEach(function (stop, i) {
                     if (regexRgba.test(stop[1])) {
-                        colorObject = H.color(stop[1]);
+                        colorObject = color(stop[1]);
                         stopColor = colorObject.get('rgb');
                         stopOpacity = colorObject.get('a');
                     }
@@ -935,8 +937,8 @@ if (!svg) {
                 // If the color is an rgba color, split it and add a fill node
                 // to hold the opacity component
             }
-            else if (regexRgba.test(color) && elem.tagName !== 'IMG') {
-                colorObject = H.color(color);
+            else if (regexRgba.test(colorOption) && elem.tagName !== 'IMG') {
+                colorObject = color(colorOption);
                 wrapper[prop + '-opacitySetter'](colorObject.get('a'), prop, elem);
                 ret = colorObject.get('rgb');
             }
@@ -947,7 +949,7 @@ if (!svg) {
                     propNodes[0].opacity = 1;
                     propNodes[0].type = 'solid';
                 }
-                ret = color;
+                ret = colorOption;
             }
             return ret;
         },

--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -13,18 +13,19 @@
 import H from '../parts/Globals.js';
 import mixinTreeSeries from '../mixins/tree-series.js';
 import drawPoint from '../mixins/draw-point.js';
-import U from '../parts/Utilities.js';
-var correctFloat = U.correctFloat, defined = U.defined, extend = U.extend, isArray = U.isArray, isNumber = U.isNumber, isObject = U.isObject, isString = U.isString, objectEach = U.objectEach, pick = U.pick, stableSort = U.stableSort;
+import colorModule from '../parts/Color.js';
+var color = colorModule.color;
+import utilitiesModule from '../parts/Utilities.js';
+var correctFloat = utilitiesModule.correctFloat, defined = utilitiesModule.defined, extend = utilitiesModule.extend, isArray = utilitiesModule.isArray, isNumber = utilitiesModule.isNumber, isObject = utilitiesModule.isObject, isString = utilitiesModule.isString, objectEach = utilitiesModule.objectEach, pick = utilitiesModule.pick, stableSort = utilitiesModule.stableSort;
 import '../parts/Options.js';
 import '../parts/Series.js';
-import '../parts/Color.js';
 /* eslint-disable no-invalid-this */
 var AXIS_MAX = 100;
 var seriesType = H.seriesType, seriesTypes = H.seriesTypes, addEvent = H.addEvent, merge = H.merge, error = H.error, noop = H.noop, fireEvent = H.fireEvent, getColor = mixinTreeSeries.getColor, getLevelOptions = mixinTreeSeries.getLevelOptions, 
 // @todo Similar to eachObject, this function is likely redundant
 isBoolean = function (x) {
     return typeof x === 'boolean';
-}, Series = H.Series, color = H.Color, 
+}, Series = H.Series, 
 // @todo Similar to recursive, this function is likely redundant
 eachObject = function (list, func, context) {
     context = context || this;

--- a/js/modules/venn.src.js
+++ b/js/modules/venn.src.js
@@ -18,15 +18,17 @@
 import H from '../parts/Globals.js';
 import draw from '../mixins/draw-point.js';
 import geometry from '../mixins/geometry.js';
-import GeometryCircleMixin from '../mixins/geometry-circles.js';
-var getAreaOfCircle = GeometryCircleMixin.getAreaOfCircle, getAreaOfIntersectionBetweenCircles = GeometryCircleMixin.getAreaOfIntersectionBetweenCircles, getCircleCircleIntersection = GeometryCircleMixin.getCircleCircleIntersection, getCirclesIntersectionPolygon = GeometryCircleMixin.getCirclesIntersectionPolygon, getOverlapBetweenCirclesByDistance = GeometryCircleMixin.getOverlapBetweenCircles, isCircle1CompletelyOverlappingCircle2 = GeometryCircleMixin.isCircle1CompletelyOverlappingCircle2, isPointInsideAllCircles = GeometryCircleMixin.isPointInsideAllCircles, isPointInsideCircle = GeometryCircleMixin.isPointInsideCircle, isPointOutsideAllCircles = GeometryCircleMixin.isPointOutsideAllCircles;
-import NelderMeadModule from '../mixins/nelder-mead.js';
+import geometryCirclesModule from '../mixins/geometry-circles.js';
+var getAreaOfCircle = geometryCirclesModule.getAreaOfCircle, getAreaOfIntersectionBetweenCircles = geometryCirclesModule.getAreaOfIntersectionBetweenCircles, getCircleCircleIntersection = geometryCirclesModule.getCircleCircleIntersection, getCirclesIntersectionPolygon = geometryCirclesModule.getCirclesIntersectionPolygon, getOverlapBetweenCirclesByDistance = geometryCirclesModule.getOverlapBetweenCircles, isCircle1CompletelyOverlappingCircle2 = geometryCirclesModule.isCircle1CompletelyOverlappingCircle2, isPointInsideAllCircles = geometryCirclesModule.isPointInsideAllCircles, isPointInsideCircle = geometryCirclesModule.isPointInsideCircle, isPointOutsideAllCircles = geometryCirclesModule.isPointOutsideAllCircles;
+import nelderMeadModule from '../mixins/nelder-mead.js';
 // TODO: replace with individual imports
-var nelderMead = NelderMeadModule.nelderMead;
-import U from '../parts/Utilities.js';
-var animObject = U.animObject, isArray = U.isArray, isNumber = U.isNumber, isObject = U.isObject, isString = U.isString;
+var nelderMead = nelderMeadModule.nelderMead;
+import colorModule from '../parts/Color.js';
+var color = colorModule.color;
+import utilitiesModule from '../parts/Utilities.js';
+var animObject = utilitiesModule.animObject, isArray = utilitiesModule.isArray, isNumber = utilitiesModule.isNumber, isObject = utilitiesModule.isObject, isString = utilitiesModule.isString;
 import '../parts/Series.js';
-var addEvent = H.addEvent, color = H.Color, extend = H.extend, getCenterOfPoints = geometry.getCenterOfPoints, getDistanceBetweenPoints = geometry.getDistanceBetweenPoints, merge = H.merge, seriesType = H.seriesType, seriesTypes = H.seriesTypes;
+var addEvent = H.addEvent, extend = H.extend, getCenterOfPoints = geometry.getCenterOfPoints, getDistanceBetweenPoints = geometry.getDistanceBetweenPoints, merge = H.merge, seriesType = H.seriesType, seriesTypes = H.seriesTypes;
 var objectValues = function objectValues(obj) {
     return Object.keys(obj).map(function (x) {
         return obj[x];
@@ -907,13 +909,13 @@ var vennSeries = {
     utils: {
         addOverlapToSets: addOverlapToSets,
         geometry: geometry,
-        geometryCircles: GeometryCircleMixin,
+        geometryCircles: geometryCirclesModule,
         getLabelWidth: getLabelWidth,
         getMarginFromCircles: getMarginFromCircles,
         getDistanceBetweenCirclesByOverlap: getDistanceBetweenCirclesByOverlap,
         layoutGreedyVenn: layoutGreedyVenn,
         loss: loss,
-        nelderMead: NelderMeadModule,
+        nelderMead: nelderMeadModule,
         processVennData: processVennData,
         sortByTotalOverlap: sortByTotalOverlap
     }

--- a/js/parts-more/PackedBubbleSeries.js
+++ b/js/parts-more/PackedBubbleSeries.js
@@ -44,15 +44,17 @@ import H from '../parts/Globals.js';
 * @type {string}
 * @since 7.0.0
 */
-import U from '../parts/Utilities.js';
-var clamp = U.clamp, defined = U.defined, extend = U.extend, extendClass = U.extendClass, isArray = U.isArray, isNumber = U.isNumber, pick = U.pick;
+import colorModule from '../parts/Color.js';
+var color = colorModule.color;
+import utilitiesModule from '../parts/Utilities.js';
+var clamp = utilitiesModule.clamp, defined = utilitiesModule.defined, extend = utilitiesModule.extend, extendClass = utilitiesModule.extendClass, isArray = utilitiesModule.isArray, isNumber = utilitiesModule.isNumber, pick = utilitiesModule.pick;
 import '../parts/Axis.js';
 import '../parts/Color.js';
 import '../parts/Point.js';
 import '../parts/Series.js';
 import '../modules/networkgraph/layouts.js';
 import '../modules/networkgraph/draggable-nodes.js';
-var seriesType = H.seriesType, Series = H.Series, Point = H.Point, addEvent = H.addEvent, fireEvent = H.fireEvent, Chart = H.Chart, color = H.Color, Reingold = H.layouts['reingold-fruchterman'], NetworkPoint = H.seriesTypes.bubble.prototype.pointClass, dragNodesMixin = H.dragNodesMixin;
+var seriesType = H.seriesType, Series = H.Series, Point = H.Point, addEvent = H.addEvent, fireEvent = H.fireEvent, Chart = H.Chart, Reingold = H.layouts['reingold-fruchterman'], NetworkPoint = H.seriesTypes.bubble.prototype.pointClass, dragNodesMixin = H.dragNodesMixin;
 H.networkgraphIntegrations.packedbubble = {
     repulsiveForceFunction: function (d, k, node, repNode) {
         return Math.min(d, (node.marker.radius + repNode.marker.radius) / 2);
@@ -675,8 +677,7 @@ seriesType('packedbubble', 'bubble',
             return;
         }
         var series = this, chart = series.chart, parentAttribs = {}, nodeMarker = this.layout.options.parentNodeOptions.marker, parentOptions = {
-            fill: nodeMarker.fillColor ||
-                color(series.color).brighten(0.4).get(),
+            fill: nodeMarker.fillColor || color(series.color).brighten(0.4).get(),
             opacity: nodeMarker.fillOpacity,
             stroke: nodeMarker.lineColor || series.color,
             'stroke-width': nodeMarker.lineWidth

--- a/js/parts/Color.js
+++ b/js/parts/Color.js
@@ -121,46 +121,74 @@ var merge = H.merge;
  *
  * @class
  * @name Highcharts.Color
- *
- * @param {Highcharts.ColorType} input
- *        The input color in either rbga or hex format
  */
-H.Color = function (input) {
-    // Backwards compatibility, allow instanciation without new
-    if (!(this instanceof H.Color)) {
-        return new H.Color(input);
+var Color = /** @class */ (function () {
+    /* *
+     *
+     *  Constructors
+     *
+     * */
+    /**
+     * Handle color operations. Some object methods are chainable.
+     *
+     * @param {Highcharts.ColorType} input
+     *        The input color in either rbga or hex format
+     */
+    function Color(input) {
+        // Collection of named colors. Can be extended from the outside by adding
+        // colors to Highcharts.Color.prototype.names.
+        this.names = {
+            white: '#ffffff',
+            black: '#000000'
+        };
+        // Collection of parsers. This can be extended from the outside by pushing
+        // parsers to Highcharts.Color.prototype.parsers.
+        this.parsers = [{
+                // RGBA color
+                // eslint-disable-next-line max-len
+                regex: /rgba\(\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]?(?:\.[0-9]+)?)\s*\)/,
+                parse: function (result) {
+                    return [
+                        pInt(result[1]),
+                        pInt(result[2]),
+                        pInt(result[3]),
+                        parseFloat(result[4], 10)
+                    ];
+                }
+            }, {
+                // RGB color
+                regex: /rgb\(\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*\)/,
+                parse: function (result) {
+                    return [pInt(result[1]), pInt(result[2]), pInt(result[3]), 1];
+                }
+            }];
+        this.rgba = [];
+        this.init(input);
     }
-    // Initialize
-    this.init(input);
-};
-H.Color.prototype = {
-    // Collection of parsers. This can be extended from the outside by pushing
-    // parsers to Highcharts.Color.prototype.parsers.
-    parsers: [{
-            // RGBA color
-            // eslint-disable-next-line max-len
-            regex: /rgba\(\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]?(?:\.[0-9]+)?)\s*\)/,
-            parse: function (result) {
-                return [
-                    pInt(result[1]),
-                    pInt(result[2]),
-                    pInt(result[3]),
-                    parseFloat(result[4], 10)
-                ];
-            }
-        }, {
-            // RGB color
-            regex: /rgb\(\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*\)/,
-            parse: function (result) {
-                return [pInt(result[1]), pInt(result[2]), pInt(result[3]), 1];
-            }
-        }],
-    // Collection of named colors. Can be extended from the outside by adding
-    // colors to Highcharts.Color.prototype.names.
-    names: {
-        white: '#ffffff',
-        black: '#000000'
-    },
+    /* *
+     *
+     *  Static Functions
+     *
+     * */
+    /**
+     * Creates a color instance out of a color string or object.
+     *
+     * @function Highcharts.Color.parse
+     *
+     * @param {Highcharts.ColorType} input
+     * The input color in either rbga or hex format.
+     *
+     * @return {Highcharts.Color}
+     * Color instance.
+     */
+    Color.parse = function (input) {
+        return new H.Color(input);
+    };
+    /* *
+     *
+     *  Functions
+     *
+     * */
     /**
      * Parse the input color to rgba array
      *
@@ -172,7 +200,7 @@ H.Color.prototype = {
      *
      * @return {void}
      */
-    init: function (input) {
+    Color.prototype.init = function (input) {
         var result, rgba, i, parser, len;
         this.input = input = this.names[input && input.toLowerCase ?
             input.toLowerCase() :
@@ -227,7 +255,7 @@ H.Color.prototype = {
             }
         }
         this.rgba = rgba || [];
-    },
+    };
     /**
      * Return the color or gradient stops in the specified format
      *
@@ -239,9 +267,9 @@ H.Color.prototype = {
      * @return {Highcharts.ColorType}
      *         This color as a string or gradient stops.
      */
-    get: function (format) {
+    Color.prototype.get = function (format) {
         var input = this.input, rgba = this.rgba, ret;
-        if (this.stops) {
+        if (typeof this.stops !== 'undefined') {
             ret = merge(input);
             ret.stops = [].concat(ret.stops);
             this.stops.forEach(function (stop, i) {
@@ -267,7 +295,7 @@ H.Color.prototype = {
             ret = input;
         }
         return ret;
-    },
+    };
     /**
      * Brighten the color instance.
      *
@@ -279,7 +307,7 @@ H.Color.prototype = {
      * @return {Highcharts.Color}
      *         This color with modifications.
      */
-    brighten: function (alpha) {
+    Color.prototype.brighten = function (alpha) {
         var i, rgba = this.rgba;
         if (this.stops) {
             this.stops.forEach(function (stop) {
@@ -298,7 +326,7 @@ H.Color.prototype = {
             }
         }
         return this;
-    },
+    };
     /**
      * Set the color's opacity to a given alpha value.
      *
@@ -310,10 +338,10 @@ H.Color.prototype = {
      * @return {Highcharts.Color}
      *         Color with modifications.
      */
-    setOpacity: function (alpha) {
+    Color.prototype.setOpacity = function (alpha) {
         this.rgba[3] = alpha;
         return this;
-    },
+    };
     /**
      * Return an intermediate color between two colors.
      *
@@ -329,7 +357,7 @@ H.Color.prototype = {
      * @return {Highcharts.ColorString}
      *         The intermediate color in rgba notation.
      */
-    tweenTo: function (to, pos) {
+    Color.prototype.tweenTo = function (to, pos) {
         // Check for has alpha, because rgba colors perform worse due to lack of
         // support in WebKit.
         var fromRgba = this.rgba, toRgba = to.rgba, hasAlpha, ret;
@@ -353,8 +381,10 @@ H.Color.prototype = {
                 ')';
         }
         return ret;
-    }
-};
+    };
+    return Color;
+}());
+H.Color = Color;
 /**
  * Creates a color instance out of a color string.
  *
@@ -366,6 +396,9 @@ H.Color.prototype = {
  * @return {Highcharts.Color}
  *         Color instance
  */
-H.color = function (input) {
-    return new H.Color(input);
+var color = H.color = Color.parse;
+var exports = {
+    Color: Color,
+    color: color
 };
+export default exports;

--- a/js/parts/Color.js
+++ b/js/parts/Color.js
@@ -135,12 +135,6 @@ var Color = /** @class */ (function () {
      *        The input color in either rbga or hex format
      */
     function Color(input) {
-        // Collection of named colors. Can be extended from the outside by adding
-        // colors to Highcharts.Color.prototype.names.
-        this.names = {
-            white: '#ffffff',
-            black: '#000000'
-        };
         // Collection of parsers. This can be extended from the outside by pushing
         // parsers to Highcharts.Color.prototype.parsers.
         this.parsers = [{
@@ -202,7 +196,7 @@ var Color = /** @class */ (function () {
      */
     Color.prototype.init = function (input) {
         var result, rgba, i, parser, len;
-        this.input = input = this.names[input && input.toLowerCase ?
+        this.input = input = Color.names[input && input.toLowerCase ?
             input.toLowerCase() :
             ''] || input;
         // Gradients
@@ -381,6 +375,17 @@ var Color = /** @class */ (function () {
                 ')';
         }
         return ret;
+    };
+    /* *
+     *
+     *  Static Properties
+     *
+     * */
+    // Collection of named colors. Can be extended from the outside by adding
+    // colors to Highcharts.Color.names.
+    Color.names = {
+        white: '#ffffff',
+        black: '#000000'
     };
     return Color;
 }());

--- a/js/parts/SvgRenderer.js
+++ b/js/parts/SvgRenderer.js
@@ -372,10 +372,11 @@ import H from './Globals.js';
  * @typedef {"bottom"|"middle"|"top"} Highcharts.VerticalAlignValue
  */
 /* eslint-disable no-invalid-this, valid-jsdoc */
-import U from './Utilities.js';
-var animObject = U.animObject, attr = U.attr, defined = U.defined, destroyObjectProperties = U.destroyObjectProperties, erase = U.erase, extend = U.extend, isArray = U.isArray, isNumber = U.isNumber, isObject = U.isObject, isString = U.isString, objectEach = U.objectEach, pick = U.pick, pInt = U.pInt, removeEvent = U.removeEvent, splat = U.splat;
-import './Color.js';
-var SVGElement, SVGRenderer, addEvent = H.addEvent, animate = H.animate, charts = H.charts, color = H.color, css = H.css, createElement = H.createElement, deg2rad = H.deg2rad, doc = H.doc, hasTouch = H.hasTouch, isFirefox = H.isFirefox, isMS = H.isMS, isWebKit = H.isWebKit, merge = H.merge, noop = H.noop, stop = H.stop, svg = H.svg, SVG_NS = H.SVG_NS, symbolSizes = H.symbolSizes, win = H.win;
+import colorModule from './Color.js';
+var color = colorModule.color;
+import utilitiesModule from './Utilities.js';
+var animObject = utilitiesModule.animObject, attr = utilitiesModule.attr, defined = utilitiesModule.defined, destroyObjectProperties = utilitiesModule.destroyObjectProperties, erase = utilitiesModule.erase, extend = utilitiesModule.extend, isArray = utilitiesModule.isArray, isNumber = utilitiesModule.isNumber, isObject = utilitiesModule.isObject, isString = utilitiesModule.isString, objectEach = utilitiesModule.objectEach, pick = utilitiesModule.pick, pInt = utilitiesModule.pInt, removeEvent = utilitiesModule.removeEvent, splat = utilitiesModule.splat;
+var SVGElement, SVGRenderer, addEvent = H.addEvent, animate = H.animate, charts = H.charts, css = H.css, createElement = H.createElement, deg2rad = H.deg2rad, doc = H.doc, hasTouch = H.hasTouch, isFirefox = H.isFirefox, isMS = H.isMS, isWebKit = H.isWebKit, merge = H.merge, noop = H.noop, stop = H.stop, svg = H.svg, SVG_NS = H.SVG_NS, symbolSizes = H.symbolSizes, win = H.win;
 /**
  * The SVGElement prototype is a JavaScript wrapper for SVG elements used in the
  * rendering layer of Highcharts. Combined with the {@link
@@ -498,7 +499,7 @@ extend(SVGElement.prototype, /** @lends Highcharts.SVGElement.prototype */ {
      * @private
      * @function Highcharts.SVGElement#complexColor
      *
-     * @param {Highcharts.GradientColorObject} color
+     * @param {Highcharts.GradientColorObject} colorOptions
      *        The gradient options structure.
      *
      * @param {string} prop
@@ -509,26 +510,26 @@ extend(SVGElement.prototype, /** @lends Highcharts.SVGElement.prototype */ {
      *
      * @return {void}
      */
-    complexColor: function (color, prop, elem) {
+    complexColor: function (colorOptions, prop, elem) {
         var renderer = this.renderer, colorObject, gradName, gradAttr, radAttr, gradients, gradientObject, stops, stopColor, stopOpacity, radialReference, id, key = [], value;
         H.fireEvent(this.renderer, 'complexColor', {
             args: arguments
         }, function () {
             // Apply linear or radial gradients
-            if (color.radialGradient) {
+            if (colorOptions.radialGradient) {
                 gradName = 'radialGradient';
             }
-            else if (color.linearGradient) {
+            else if (colorOptions.linearGradient) {
                 gradName = 'linearGradient';
             }
             if (gradName) {
-                gradAttr = color[gradName];
+                gradAttr = colorOptions[gradName];
                 gradients = renderer.gradients;
-                stops = color.stops;
+                stops = colorOptions.stops;
                 radialReference = elem.radialReference;
                 // Keep < 2.2 kompatibility
                 if (isArray(gradAttr)) {
-                    color[gradName] = gradAttr = {
+                    colorOptions[gradName] = gradAttr = {
                         x1: gradAttr[0],
                         y1: gradAttr[1],
                         x2: gradAttr[2],
@@ -574,7 +575,7 @@ extend(SVGElement.prototype, /** @lends Highcharts.SVGElement.prototype */ {
                     stops.forEach(function (stop) {
                         var stopObject;
                         if (stop[1].indexOf('rgba') === 0) {
-                            colorObject = H.color(stop[1]);
+                            colorObject = color(stop[1]);
                             stopColor = colorObject.get('rgb');
                             stopOpacity = colorObject.get('a');
                         }
@@ -597,7 +598,7 @@ extend(SVGElement.prototype, /** @lends Highcharts.SVGElement.prototype */ {
                 elem.gradient = key;
                 // Allow the color to be concatenated into tooltips formatters
                 // etc. (#2995)
-                color.toString = function () {
+                colorOptions.toString = function () {
                     return value;
                 };
             }

--- a/samples/highcharts/3d/scatter-frame/demo.js
+++ b/samples/highcharts/3d/scatter-frame/demo.js
@@ -9,7 +9,7 @@ Highcharts.setOptions({
             },
             stops: [
                 [0, color],
-                [1, Highcharts.Color(color).brighten(-0.2).get('rgb')]
+                [1, Highcharts.color(color).brighten(-0.2).get('rgb')]
             ]
         };
     })

--- a/samples/highcharts/3d/scatter-zaxis-plotbands-lines/demo.js
+++ b/samples/highcharts/3d/scatter-zaxis-plotbands-lines/demo.js
@@ -38,7 +38,7 @@ Highcharts.chart('container', {
         plotBands: [{
             from: 4,
             to: 6,
-            color: Highcharts.Color(Highcharts.getOptions().colors[2]).setOpacity(0.5).get()
+            color: Highcharts.color(Highcharts.getOptions().colors[2]).setOpacity(0.5).get()
         }],
         tickInterval: 2,
         min: 0,

--- a/samples/highcharts/accessibility/multiple-charts/demo.js
+++ b/samples/highcharts/accessibility/multiple-charts/demo.js
@@ -200,7 +200,7 @@ Highcharts.getOptions().plotOptions.pie.colors = (function () {
     for (i = 0; i < 10; i += 1) {
         // Start out with a darkened base color (negative brighten), and end
         // up with a much brighter color
-        colors.push(Highcharts.Color(base).brighten((i - 3) / 10).get());
+        colors.push(Highcharts.color(base).brighten((i - 3) / 10).get());
     }
     return colors;
 }());

--- a/samples/highcharts/accessibility/webaim/demo.js
+++ b/samples/highcharts/accessibility/webaim/demo.js
@@ -91,7 +91,7 @@ Highcharts.getOptions().plotOptions.pie.colors = (function () {
     for (i = 0; i < 10; i += 1) {
         // Start out with a darkened base color (negative brighten), and end
         // up with a much brighter color
-        colors.push(Highcharts.Color(base).brighten((i - 3) / 10).get());
+        colors.push(Highcharts.color(base).brighten((i - 3) / 10).get());
     }
     return colors;
 }());

--- a/samples/highcharts/datasorting/animation/demo.js
+++ b/samples/highcharts/datasorting/animation/demo.js
@@ -8,7 +8,7 @@ Highcharts.setOptions({
             },
             stops: [
                 [0, color],
-                [1, Highcharts.Color(color).brighten(-0.2).get('rgb')]
+                [1, Highcharts.color(color).brighten(-0.2).get('rgb')]
             ]
         };
     })

--- a/samples/highcharts/datasorting/sort-key/demo.js
+++ b/samples/highcharts/datasorting/sort-key/demo.js
@@ -8,7 +8,7 @@ function getGradientColors() {
             },
             stops: [
                 [0, color],
-                [1, Highcharts.Color(color).brighten(-0.2).get('rgb')]
+                [1, Highcharts.color(color).brighten(-0.2).get('rgb')]
             ]
         };
     });

--- a/samples/highcharts/demo/3d-scatter-draggable/demo.js
+++ b/samples/highcharts/demo/3d-scatter-draggable/demo.js
@@ -9,7 +9,7 @@ Highcharts.setOptions({
             },
             stops: [
                 [0, color],
-                [1, Highcharts.Color(color).brighten(-0.2).get('rgb')]
+                [1, Highcharts.color(color).brighten(-0.2).get('rgb')]
             ]
         };
     })

--- a/samples/highcharts/demo/bubble-3d/demo.js
+++ b/samples/highcharts/demo/bubble-3d/demo.js
@@ -47,7 +47,7 @@ Highcharts.chart('container', {
                 radialGradient: { cx: 0.4, cy: 0.3, r: 0.7 },
                 stops: [
                     [0, 'rgba(255,255,255,0.5)'],
-                    [1, Highcharts.Color(Highcharts.getOptions().colors[0]).setOpacity(0.5).get('rgba')]
+                    [1, Highcharts.color(Highcharts.getOptions().colors[0]).setOpacity(0.5).get('rgba')]
                 ]
             }
         }
@@ -73,7 +73,7 @@ Highcharts.chart('container', {
                 radialGradient: { cx: 0.4, cy: 0.3, r: 0.7 },
                 stops: [
                     [0, 'rgba(255,255,255,0.5)'],
-                    [1, Highcharts.Color(Highcharts.getOptions().colors[1]).setOpacity(0.5).get('rgba')]
+                    [1, Highcharts.color(Highcharts.getOptions().colors[1]).setOpacity(0.5).get('rgba')]
                 ]
             }
         }

--- a/samples/highcharts/demo/combo-timeline/demo.js
+++ b/samples/highcharts/demo/combo-timeline/demo.js
@@ -14,7 +14,7 @@ function onChartLoad() {
         path = [],
         angle,
         radius,
-        badgeColor = Highcharts.Color(Highcharts.getOptions().colors[0]).brighten(-0.2).get(),
+        badgeColor = Highcharts.color(Highcharts.getOptions().colors[0]).brighten(-0.2).get(),
         spike,
         empImage,
         big5,

--- a/samples/highcharts/demo/gauge-activity/demo.js
+++ b/samples/highcharts/demo/gauge-activity/demo.js
@@ -124,21 +124,21 @@ Highcharts.chart('container', {
         background: [{ // Track for Move
             outerRadius: '112%',
             innerRadius: '88%',
-            backgroundColor: Highcharts.Color(Highcharts.getOptions().colors[0])
+            backgroundColor: Highcharts.color(Highcharts.getOptions().colors[0])
                 .setOpacity(0.3)
                 .get(),
             borderWidth: 0
         }, { // Track for Exercise
             outerRadius: '87%',
             innerRadius: '63%',
-            backgroundColor: Highcharts.Color(Highcharts.getOptions().colors[1])
+            backgroundColor: Highcharts.color(Highcharts.getOptions().colors[1])
                 .setOpacity(0.3)
                 .get(),
             borderWidth: 0
         }, { // Track for Stand
             outerRadius: '62%',
             innerRadius: '38%',
-            backgroundColor: Highcharts.Color(Highcharts.getOptions().colors[2])
+            backgroundColor: Highcharts.color(Highcharts.getOptions().colors[2])
                 .setOpacity(0.3)
                 .get(),
             borderWidth: 0

--- a/samples/highcharts/demo/line-time-series/demo.js
+++ b/samples/highcharts/demo/line-time-series/demo.js
@@ -35,7 +35,7 @@ Highcharts.getJSON(
                         },
                         stops: [
                             [0, Highcharts.getOptions().colors[0]],
-                            [1, Highcharts.Color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
+                            [1, Highcharts.color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
                         ]
                     },
                     marker: {

--- a/samples/highcharts/demo/pie-donut/demo.js
+++ b/samples/highcharts/demo/pie-donut/demo.js
@@ -205,7 +205,7 @@ for (i = 0; i < dataLen; i += 1) {
         versionsData.push({
             name: data[i].drilldown.categories[j],
             y: data[i].drilldown.data[j],
-            color: Highcharts.Color(data[i].color).brighten(brightness).get()
+            color: Highcharts.color(data[i].color).brighten(brightness).get()
         });
     }
 }

--- a/samples/highcharts/demo/pie-gradient/demo.js
+++ b/samples/highcharts/demo/pie-gradient/demo.js
@@ -9,7 +9,7 @@ Highcharts.setOptions({
             },
             stops: [
                 [0, color],
-                [1, Highcharts.Color(color).brighten(-0.3).get('rgb')] // darken
+                [1, Highcharts.color(color).brighten(-0.3).get('rgb')] // darken
             ]
         };
     })

--- a/samples/highcharts/demo/pie-monochrome/demo.js
+++ b/samples/highcharts/demo/pie-monochrome/demo.js
@@ -7,7 +7,7 @@ var pieColors = (function () {
     for (i = 0; i < 10; i += 1) {
         // Start out with a darkened base color (negative brighten), and end
         // up with a much brighter color
-        colors.push(Highcharts.Color(base).brighten((i - 3) / 7).get());
+        colors.push(Highcharts.color(base).brighten((i - 3) / 7).get());
     }
     return colors;
 }());

--- a/samples/highcharts/demo/polygon/demo.js
+++ b/samples/highcharts/demo/polygon/demo.js
@@ -30,7 +30,7 @@ Highcharts.chart('container', {
         type: 'polygon',
         data: [[153, 42], [149, 46], [149, 55], [152, 60], [159, 70], [170, 77], [180, 70],
             [180, 60], [173, 52], [166, 45]],
-        color: Highcharts.Color(Highcharts.getOptions().colors[0]).setOpacity(0.5).get(),
+        color: Highcharts.color(Highcharts.getOptions().colors[0]).setOpacity(0.5).get(),
         enableMouseTracking: false,
         accessibility: {
             exposeAsGroupOnly: true,

--- a/samples/highcharts/plotoptions/area-fillcolor-gradient/demo.js
+++ b/samples/highcharts/plotoptions/area-fillcolor-gradient/demo.js
@@ -12,7 +12,7 @@ Highcharts.chart('container', {
                 linearGradient: [0, 0, 0, 300],
                 stops: [
                     [0, Highcharts.getOptions().colors[0]],
-                    [1, Highcharts.Color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
+                    [1, Highcharts.color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
                 ]
             }
         }

--- a/samples/highcharts/plotoptions/column-grouping-false/demo.js
+++ b/samples/highcharts/plotoptions/column-grouping-false/demo.js
@@ -1,7 +1,7 @@
 // First, let's make the colors transparent
 Highcharts.setOptions({
     colors: Highcharts.map(Highcharts.getOptions().colors, function (color) {
-        return Highcharts.Color(color)
+        return Highcharts.color(color)
             .setOpacity(0.5)
             .get('rgba');
     })

--- a/samples/highcharts/series-packedbubble/parentnode-style/demo.js
+++ b/samples/highcharts/series-packedbubble/parentnode-style/demo.js
@@ -17,7 +17,7 @@ Highcharts.chart('container', {
                     radialGradient: { cx: 0.4, cy: 0.3, r: 0.7 },
                     stops: [
                         [0, 'rgba(255,255,255,0.5)'],
-                        [1, Highcharts.Color(Highcharts.getOptions().colors[0]).setOpacity(0.5).get('rgba')]
+                        [1, Highcharts.color(Highcharts.getOptions().colors[0]).setOpacity(0.5).get('rgba')]
                     ]
                 }
             },
@@ -33,7 +33,7 @@ Highcharts.chart('container', {
                             radialGradient: { cx: 0.4, cy: 0.3, r: 0.7 },
                             stops: [
                                 [0, 'rgba(255,255,255,0.5)'],
-                                [1, Highcharts.Color('#00ff00').setOpacity(0.5).get('rgba')]
+                                [1, Highcharts.color('#00ff00').setOpacity(0.5).get('rgba')]
                             ]
                         },
                         fillOpacity: 0.5,

--- a/samples/highcharts/studies/combo-timeline-updated/demo.js
+++ b/samples/highcharts/studies/combo-timeline-updated/demo.js
@@ -14,7 +14,7 @@ function onChartLoad() {
         path = [],
         angle,
         radius,
-        badgeColor = Highcharts.Color(Highcharts.getOptions().colors[0]).brighten(-0.2).get(),
+        badgeColor = Highcharts.color(Highcharts.getOptions().colors[0]).brighten(-0.2).get(),
         spike,
         empImage,
         big5,

--- a/samples/highcharts/studies/tilemap-generator/demo.js
+++ b/samples/highcharts/studies/tilemap-generator/demo.js
@@ -1069,7 +1069,7 @@ $("#mapDropdown").change(function () {
                 stops: [
                     [0, '#EFEFFF'],
                     [0.5, Highcharts.getOptions().colors[0]],
-                    [1, Highcharts.Color(Highcharts.getOptions().colors[0]).brighten(-0.5).get()]
+                    [1, Highcharts.color(Highcharts.getOptions().colors[0]).brighten(-0.5).get()]
                 ]
             },
 

--- a/samples/issues/highstock-2.1.1/3882-plotbands-on-edge/demo.js
+++ b/samples/issues/highstock-2.1.1/3882-plotbands-on-edge/demo.js
@@ -5,7 +5,7 @@ $(function () {
             plotBands: [{
                 from: -1.1,
                 to: 1.1,
-                color: Highcharts.Color(Highcharts.getOptions().colors[4]).setOpacity(0.75).get()
+                color: Highcharts.color(Highcharts.getOptions().colors[4]).setOpacity(0.75).get()
             }]
         },
 
@@ -13,7 +13,7 @@ $(function () {
             plotBands: [{
                 from: 0.1,
                 to: 3.1,
-                color: Highcharts.Color(Highcharts.getOptions().colors[3]).setOpacity(0.75).get()
+                color: Highcharts.color(Highcharts.getOptions().colors[3]).setOpacity(0.75).get()
             }]
         },
 

--- a/samples/maps/demo/all-maps/demo.js
+++ b/samples/maps/demo/all-maps/demo.js
@@ -131,7 +131,7 @@ $("#mapDropdown").change(function () {
                 stops: [
                     [0, '#EFEFFF'],
                     [0.5, Highcharts.getOptions().colors[0]],
-                    [1, Highcharts.Color(Highcharts.getOptions().colors[0]).brighten(-0.5).get()]
+                    [1, Highcharts.color(Highcharts.getOptions().colors[0]).brighten(-0.5).get()]
                 ]
             },
 

--- a/samples/stock/demo/area/demo.js
+++ b/samples/stock/demo/area/demo.js
@@ -28,7 +28,7 @@ Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', functi
                 },
                 stops: [
                     [0, Highcharts.getOptions().colors[0]],
-                    [1, Highcharts.Color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
+                    [1, Highcharts.color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
                 ]
             }
         }]

--- a/samples/stock/demo/areaspline/demo.js
+++ b/samples/stock/demo/areaspline/demo.js
@@ -29,7 +29,7 @@ Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', functi
                 },
                 stops: [
                     [0, Highcharts.getOptions().colors[0]],
-                    [1, Highcharts.Color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
+                    [1, Highcharts.color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
                 ]
             }
         }]

--- a/samples/stock/demo/intraday-area/demo.js
+++ b/samples/stock/demo/intraday-area/demo.js
@@ -51,7 +51,7 @@ Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/sam
                 },
                 stops: [
                     [0, Highcharts.getOptions().colors[0]],
-                    [1, Highcharts.Color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
+                    [1, Highcharts.color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
                 ]
             },
             threshold: null

--- a/samples/stock/demo/intraday-breaks/demo.js
+++ b/samples/stock/demo/intraday-breaks/demo.js
@@ -59,7 +59,7 @@ Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/sam
                 },
                 stops: [
                     [0, Highcharts.getOptions().colors[0]],
-                    [1, Highcharts.Color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
+                    [1, Highcharts.color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
                 ]
             },
             threshold: null

--- a/samples/stock/demo/yaxis-reversed/demo.js
+++ b/samples/stock/demo/yaxis-reversed/demo.js
@@ -33,7 +33,7 @@ Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', functi
                 },
                 stops: [
                     [0, Highcharts.getOptions().colors[0]],
-                    [1, Highcharts.Color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
+                    [1, Highcharts.color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
                 ]
             },
             tooltip: {

--- a/samples/stock/time/individual/demo.js
+++ b/samples/stock/time/individual/demo.js
@@ -51,7 +51,7 @@ Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/sam
                 },
                 stops: [
                     [0, Highcharts.getOptions().colors[0]],
-                    [1, Highcharts.Color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
+                    [1, Highcharts.color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
                 ]
             },
             threshold: null
@@ -109,7 +109,7 @@ Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/sam
                 },
                 stops: [
                     [0, Highcharts.getOptions().colors[0]],
-                    [1, Highcharts.Color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
+                    [1, Highcharts.color(Highcharts.getOptions().colors[0]).setOpacity(0).get('rgba')]
                 ]
             },
             threshold: null

--- a/samples/unit-tests/color/color/demo.js
+++ b/samples/unit-tests/color/color/demo.js
@@ -5,52 +5,52 @@ QUnit.test('Interpolate colors', function (assert) {
     Highcharts.Color.prototype.names = {};
 
 
-    var Color = Highcharts.Color;
+    var color = Highcharts.color;
 
     assert.equal(
-        Color('#FF0000').tweenTo(Color('#0000FF'), 0.5),
+        color('#FF0000').tweenTo(color('#0000FF'), 0.5),
         'rgb(128,0,128)',
         'Hex colors'
     );
 
     assert.equal(
-        Color('rgb(255, 0, 0)').tweenTo(Color('rgb(0, 0, 255)'), 0.5),
+        color('rgb(255, 0, 0)').tweenTo(color('rgb(0, 0, 255)'), 0.5),
         'rgb(128,0,128)',
         'RGB colors'
     );
 
     assert.equal(
-        Color('rgba(255, 0, 0, 1)').tweenTo(Color('rgba(0, 0, 255, 0.5)'), 0.5),
+        color('rgba(255, 0, 0, 1)').tweenTo(color('rgba(0, 0, 255, 0.5)'), 0.5),
         'rgba(128,0,128,0.75)',
         'RGBA colors'
     );
 
     assert.equal(
-        Color('red').tweenTo(Color('blue'), 0.5),
+        color('red').tweenTo(color('blue'), 0.5),
         'blue',
         'Named colors'
     );
 
     assert.equal(
-        Color('red').tweenTo(Color('#FFFFFF'), 0.5),
+        color('red').tweenTo(color('#FFFFFF'), 0.5),
         '#FFFFFF',
         'Named color to hex'
     );
 
     assert.equal(
-        Color('#FFFFFF').tweenTo(Color('red'), 0.5),
+        color('#FFFFFF').tweenTo(color('red'), 0.5),
         'red',
         'Hex to named color'
     );
 
     assert.equal(
-        JSON.stringify(Color({
+        JSON.stringify(color({
             radialGradient: { cx: 0.5, cy: 0.3, r: 0.7 },
             stops: [
                 [0, '#FF0000'],
                 [1, '#00FF00']
             ]
-        }).tweenTo(Color({
+        }).tweenTo(color({
             radialGradient: { cx: 0.5, cy: 0.3, r: 0.7 },
             stops: [
                 [0, '#FFFF00'],
@@ -61,7 +61,7 @@ QUnit.test('Interpolate colors', function (assert) {
         'Gradients'
     );
     assert.equal(
-        Color().tweenTo(Color(), 0.5),
+        color().tweenTo(color(), 0.5),
         'none',
         'Undefined colors'
     );

--- a/samples/unit-tests/color/color/demo.js
+++ b/samples/unit-tests/color/color/demo.js
@@ -1,8 +1,8 @@
 QUnit.test('Interpolate colors', function (assert) {
 
     // Cache names from Boost module
-    var colorNames = Highcharts.Color.prototype.names;
-    Highcharts.Color.prototype.names = {};
+    var colorNames = Highcharts.Color.names;
+    Highcharts.Color.names = {};
 
 
     var color = Highcharts.color;
@@ -66,7 +66,7 @@ QUnit.test('Interpolate colors', function (assert) {
         'Undefined colors'
     );
 
-    Highcharts.Color.prototype.names = colorNames;
+    Highcharts.Color.names = colorNames;
 
 
 });

--- a/samples/unit-tests/datalabels/contrast/demo.js
+++ b/samples/unit-tests/datalabels/contrast/demo.js
@@ -28,10 +28,10 @@ QUnit.test('#6487: Column\'s data label with contrast after justification.', fun
         point = chart.series[0].points[1];
 
     assert.strictEqual(
-        Highcharts.Color(
+        Highcharts.color(
             point.dataLabel.element.childNodes[0].style.color
         ).get(),
-        Highcharts.Color(
+        Highcharts.color(
             chart.renderer.getContrast(point.color)
         ).get(),
         'Contrast color should be used for a justified label on a column.'
@@ -43,7 +43,7 @@ QUnit.test('#6487: Column\'s data label with contrast after justification.', fun
     });
 
     assert.strictEqual(
-        Highcharts.Color(
+        Highcharts.color(
             point.dataLabel.element.childNodes[0].style.color
         ).get(),
         'rgb(0,0,0)',
@@ -83,10 +83,10 @@ QUnit.test('Pie dataLabels and contrast', function (assert) {
         points = chart.series[0].points;
 
     assert.strictEqual(
-        Highcharts.Color(
+        Highcharts.color(
             points[1].dataLabel.element.childNodes[0].style.color
         ).get(),
-        Highcharts.Color(
+        Highcharts.color(
             points[0].dataLabel.element.childNodes[0].style.color
         ).get(),
         'DataLabels outside the pie chart should not get contrast color (#11140).'

--- a/samples/unit-tests/highcharts/color/demo.js
+++ b/samples/unit-tests/highcharts/color/demo.js
@@ -1,51 +1,51 @@
 QUnit.test('Color object', function (assert) {
 
-    var Color = Highcharts.Color;
+    var color = Highcharts.color;
 
     assert.strictEqual(
-        Color('#FF0000').get(),
+        color('#FF0000').get(),
         'rgb(255,0,0)',
         'Hex, no new'
     );
     assert.strictEqual(
-        new Color('#FF0000').get(),
+        new color('#FF0000').get(),
         'rgb(255,0,0)',
         'Hex, new'
     );
     assert.strictEqual(
-        Color('#FF0000').get('rgb'),
+        color('#FF0000').get('rgb'),
         'rgb(255,0,0)',
         'Get RGB'
     );
     assert.strictEqual(
-        Color('rgb(255, 0, 0)').get(),
+        color('rgb(255, 0, 0)').get(),
         'rgb(255,0,0)',
         'RGB'
     );
     assert.strictEqual(
-        Color('rgb(255,0,0)').get(),
+        color('rgb(255,0,0)').get(),
         'rgb(255,0,0)',
         'RGB'
     );
     assert.strictEqual(
-        Color('rgba(255, 0, 0, 0.9)').get(),
+        color('rgba(255, 0, 0, 0.9)').get(),
         'rgba(255,0,0,0.9)',
         'RGBA'
     );
     assert.strictEqual(
-        Color('rgba(255,0,0,1)').get(),
+        color('rgba(255,0,0,1)').get(),
         'rgb(255,0,0)',
         'RGBA'
     );
 
     assert.strictEqual(
-        Color('#FF0000').brighten(0.2).get(),
+        color('#FF0000').brighten(0.2).get(),
         'rgb(255,51,51)',
         'Brighten'
     );
 
     assert.strictEqual(
-        Color('#FF0000').setOpacity(0.2).get(),
+        color('#FF0000').setOpacity(0.2).get(),
         'rgba(255,0,0,0.2)',
         'Set opacity'
     );

--- a/samples/unit-tests/series-heatmap/animation/demo.js
+++ b/samples/unit-tests/series-heatmap/animation/demo.js
@@ -9,31 +9,30 @@ QUnit.test('Animation', function (assert) {
         clock = TestUtilities.lolexInstall();
 
         var maxColor = 'rgb(255,255,255)',
-            chart = Highcharts
-                .chart('container', {
+            chart = Highcharts.chart('container', {
 
-                    chart: {
-                        animation: {
-                            duration: 1000
-                        }
-                    },
+                chart: {
+                    animation: {
+                        duration: 1000
+                    }
+                },
 
-                    colorAxis: {
-                        minColor: 'rgb(0,0,0)',
-                        maxColor: maxColor
-                    },
+                colorAxis: {
+                    minColor: 'rgb(0,0,0)',
+                    maxColor: maxColor
+                },
 
-                    series: [{
-                        type: 'heatmap',
-                        data: [
-                            [0, 0, 1],
-                            [0, 1, 10]
-                        ]
-                    }]
+                series: [{
+                    type: 'heatmap',
+                    data: [
+                        [0, 0, 1],
+                        [0, 1, 10]
+                    ]
+                }]
 
-                }),
+            }),
             point = chart.series[0].points[0],
-            initialColor = Highcharts.Color(
+            initialColor = Highcharts.color(
                 point.graphic.attr('fill')
             ).get(),
             currentColor,
@@ -45,7 +44,7 @@ QUnit.test('Animation', function (assert) {
         ]);
 
         setTimeout(function () {
-            currentColor = Highcharts.Color(
+            currentColor = Highcharts.color(
                 point.graphic.attr('fill')
             ).get();
 
@@ -63,7 +62,7 @@ QUnit.test('Animation', function (assert) {
         }, 500);
 
         setTimeout(function () {
-            currentColor = Highcharts.Color(
+            currentColor = Highcharts.color(
                 point.graphic.attr('fill')
             ).get();
 

--- a/samples/unit-tests/series/negativecolor/demo.js
+++ b/samples/unit-tests/series/negativecolor/demo.js
@@ -28,11 +28,11 @@ QUnit.test("Negative color shoud be respected for hover state (#3636)", function
         pointColor;
 
     var sColumn = chart.series[1];
-    seriesNegColor = Highcharts.Color(sColumn.options.negativeColor).brighten(0.1).get();
-    seriesPosColor = Highcharts.Color(sColumn.options.color).brighten(0.1).get();
+    seriesNegColor = Highcharts.color(sColumn.options.negativeColor).brighten(0.1).get();
+    seriesPosColor = Highcharts.color(sColumn.options.color).brighten(0.1).get();
     $.each(sColumn.points, function (j, point) {
         point.setState("hover");
-        pointColor = Highcharts.Color(point.graphic.attr("fill")).brighten(sColumn.options.brightness).get();
+        pointColor = Highcharts.color(point.graphic.attr("fill")).brighten(sColumn.options.brightness).get();
         assert.strictEqual(
             point.y <= 0 ? pointColor === seriesNegColor : pointColor === seriesPosColor,
             true,
@@ -42,11 +42,11 @@ QUnit.test("Negative color shoud be respected for hover state (#3636)", function
 
 
     var sLine = chart.series[0];
-    seriesNegColor = Highcharts.Color(sLine.options.negativeColor).get();
-    seriesPosColor = Highcharts.Color(sLine.options.color).get();
+    seriesNegColor = Highcharts.color(sLine.options.negativeColor).get();
+    seriesPosColor = Highcharts.color(sLine.options.color).get();
     $.each(sLine.points, function (j, point) {
         point.setState("hover");
-        pointColor = Highcharts.Color(point.graphic.attr("fill")).get();
+        pointColor = Highcharts.color(point.graphic.attr("fill")).get();
         assert.strictEqual(
             point.y <= 0 ? pointColor === seriesNegColor : pointColor === seriesPosColor,
             true,
@@ -57,10 +57,10 @@ QUnit.test("Negative color shoud be respected for hover state (#3636)", function
 
     // Higher priority for states.fillColor than series.negativeColor
     sLine = chart.series[2];
-    seriesPosColor = Highcharts.Color(sLine.options.marker.states.hover.fillColor).get();
+    seriesPosColor = Highcharts.color(sLine.options.marker.states.hover.fillColor).get();
     $.each(sLine.points, function (j, point) {
         point.setState("hover");
-        pointColor = Highcharts.Color(point.graphic.attr("fill")).get();
+        pointColor = Highcharts.color(point.graphic.attr("fill")).get();
         assert.strictEqual(
             pointColor === seriesPosColor,
             true,

--- a/samples/unit-tests/svgrenderer/animate/demo.js
+++ b/samples/unit-tests/svgrenderer/animate/demo.js
@@ -732,7 +732,7 @@ QUnit.test('3D arc animation (#7097)', function (assert) {
                 'End should continue to run after second animation'
             );
             assert.strictEqual(
-                Highcharts.Color(arc.top.attr('fill')).get(),
+                Highcharts.color(arc.top.attr('fill')).get(),
                 'rgb(15,240,15)',
                 'Fill from second animation should apply'
             );

--- a/tools/code.js
+++ b/tools/code.js
@@ -42,7 +42,10 @@ function processVariables(content) {
                 prefix + indent + statement +
                 variables.split(/\n/g).map(function (line) {
 
-                    if (variables.match(/(['"])[^\1\n]*,[^\1\n]*\1/g)) {
+                    if (
+                        variables.match(/\/\*\* @class \*\//g) ||
+                        variables.match(/(['"])[^\1\n]*,[^\1\n]*\1/g)
+                    ) {
                         // skip lines with complex strings
                         return line;
                     }

--- a/ts/modules/boost-canvas.src.ts
+++ b/ts/modules/boost-canvas.src.ts
@@ -73,21 +73,24 @@ declare global {
     }
 }
 
-import U from '../parts/Utilities.js';
+import colorModule from '../parts/Color.js';
+const {
+    Color,
+    color
+} = colorModule;
+import utilitiesModule from '../parts/Utilities.js';
 const {
     extend,
     isNumber,
     wrap
-} = U;
+} = utilitiesModule;
 
-import '../parts/Color.js';
 import '../parts/Series.js';
 import '../parts/Options.js';
 
 var win = H.win,
     doc = win.document,
     noop = function (): void {},
-    Color = H.Color,
     Series = H.Series,
     seriesTypes = H.seriesTypes,
     addEvent = H.addEvent,
@@ -552,8 +555,7 @@ H.initCanvasBoost = function (): void {
             if (rawData.length > 99999) {
                 chart.options.loading = merge(loadingOptions, {
                     labelStyle: {
-                        backgroundColor: H.color('${palette.backgroundColor}')
-                            .setOpacity(0.75).get(),
+                        backgroundColor: color('${palette.backgroundColor}').setOpacity(0.75).get(),
                         padding: '1em',
                         borderRadius: '0.5em'
                     },

--- a/ts/modules/boost/named-colors.ts
+++ b/ts/modules/boost/named-colors.ts
@@ -11,23 +11,10 @@
  * */
 
 'use strict';
-import H from '../../parts/Globals.js';
-
-/**
- * Internal types
- * @private
- */
-declare global {
-    namespace Highcharts {
-        interface Color {
-            names: Dictionary<ColorString>;
-        }
-    }
-}
-
-import '../../parts/Color.js';
-
-var Color = H.Color;
+import colorModule from '../../parts/Color.js';
+const {
+    Color
+} = colorModule;
 
 // Register color names since GL can't render those directly.
 // TODO: When supporting modern syntax, make this a const and a named export
@@ -177,6 +164,6 @@ var defaultHTMLColorMap: Highcharts.Dictionary<Highcharts.ColorString> = {
     yellowgreen: '#9acd32'
 };
 
-Color.prototype.names = defaultHTMLColorMap;
+Color.names = defaultHTMLColorMap;
 
 export default defaultHTMLColorMap;

--- a/ts/modules/boost/wgl-renderer.ts
+++ b/ts/modules/boost/wgl-renderer.ts
@@ -107,17 +107,21 @@ declare global {
 
 import GLShader from './wgl-shader.js';
 import GLVertexBuffer from './wgl-vbuffer.js';
-import U from '../../parts/Utilities.js';
-var isNumber = U.isNumber,
-    objEach = U.objectEach;
-
-import '../../parts/Color.js';
+import colorModule from '../../parts/Color.js';
+const {
+    Color,
+    color
+} = colorModule;
+import utilitiesModule from '../../parts/Utilities.js';
+const {
+    isNumber,
+    objectEach
+} = utilitiesModule;
 
 var win = H.win,
     doc = win.document,
     merge = H.merge,
     some = H.some,
-    Color = H.Color,
     pick = H.pick;
 
 /* eslint-disable valid-jsdoc */
@@ -362,7 +366,7 @@ function GLRenderer(
             lastX: number = false as any,
             lastY: number = false as any,
             minVal: (number|undefined),
-            color: Highcharts.ColorRGBA,
+            pcolor: Highcharts.ColorRGBA,
             scolor: Highcharts.ColorRGBA,
             sdata = isStacked ? series.data : (xData || rawData),
             closestLeft = { x: Number.MAX_VALUE, y: 0 },
@@ -410,7 +414,7 @@ function GLRenderer(
                 zone: Highcharts.SeriesZonesOptions
             ): (boolean|undefined) {
                 if (typeof zone.value === 'undefined') {
-                    zoneDefColor = new H.Color(zone.color);
+                    zoneDefColor = new Color(zone.color);
                     return true;
                 }
             });
@@ -420,7 +424,7 @@ function GLRenderer(
                     (series.pointAttribs && series.pointAttribs().fill) ||
                     series.color
                 ) as any;
-                zoneDefColor = new H.Color(zoneDefColor as any);
+                zoneDefColor = new Color(zoneDefColor as any);
             }
         }
 
@@ -582,10 +586,10 @@ function GLRenderer(
                     swidth = pointAttr['stroke-width'] || 0;
 
                     // Handle point colors
-                    color = H.color(pointAttr.fill).rgba as any;
-                    color[0] /= 255.0;
-                    color[1] /= 255.0;
-                    color[2] /= 255.0;
+                    pcolor = color(pointAttr.fill).rgba as any;
+                    pcolor[0] /= 255.0;
+                    pcolor[1] /= 255.0;
+                    pcolor[2] /= 255.0;
 
                     // So there are two ways of doing this. Either we can
                     // create a rectangle of two triangles, or we can do a
@@ -597,7 +601,7 @@ function GLRenderer(
                     // If there's stroking, we do an additional rect
                     if (series.type === 'treemap') {
                         swidth = swidth || 1;
-                        scolor = H.color(pointAttr.stroke).rgba as any;
+                        scolor = color(pointAttr.stroke).rgba as any;
 
                         scolor[0] /= 255.0;
                         scolor[1] /= 255.0;
@@ -634,7 +638,7 @@ function GLRenderer(
                         shapeArgs.y + swidth,
                         shapeArgs.width - (swidth * 2),
                         shapeArgs.height - (swidth * 2),
-                        color
+                        pcolor
                     );
                 }
             });
@@ -809,7 +813,7 @@ function GLRenderer(
 
                     if (typeof zone.value !== 'undefined' && y <= zone.value) {
                         if (!last || y >= (last.value as any)) {
-                            pcolor = H.color(zone.color).rgba as any;
+                            pcolor = color(zone.color).rgba as any;
 
                         }
 
@@ -944,7 +948,7 @@ function GLRenderer(
 
             // Uncomment this to support color axis.
             // if (caxis) {
-            //     color = H.color(caxis.toColor(y)).rgba;
+            //     pcolor = color(caxis.toColor(y)).rgba;
 
             //     inst.colorData.push(color[0] / 255.0);
             //     inst.colorData.push(color[1] / 255.0);
@@ -1213,7 +1217,7 @@ function GLRenderer(
                     (shapeOptions && shapeOptions.symbol) ||
                     (s.series.symbol as any)
                 ] || textureHandles.circle,
-                color;
+                scolor = [];
 
             if (
                 s.segments.length === 0 ||
@@ -1252,19 +1256,19 @@ function GLRenderer(
                 ).get();
             }
 
-            color = H.color(fillColor).rgba;
+            scolor = color(fillColor).rgba;
 
             if (!settings.useAlpha) {
-                color[3] = 1.0;
+                scolor[3] = 1.0;
             }
 
             // This is very much temporary
             if (
                 s.drawMode === 'lines' &&
                 settings.useAlpha &&
-                (color as any)[3] < 1
+                (scolor[3] as any) < 1
             ) {
-                (color as any)[3] /= 10;
+                (scolor[3] as any) /= 10;
             }
 
             // Blending
@@ -1303,7 +1307,7 @@ function GLRenderer(
             }
 
             // Set series specific uniforms
-            shader.setColor(color);
+            shader.setColor(scolor);
             setXAxis(s.series.xAxis);
             setYAxis(s.series.yAxis);
             setThreshold(hasThreshold, translatedThreshold as any);
@@ -1634,7 +1638,7 @@ function GLRenderer(
         shader.destroy();
         if (gl) {
 
-            objEach(textureHandles, function (key: string): void {
+            objectEach(textureHandles, function (key: string): void {
                 if (textureHandles[key].handle) {
                     gl.deleteTexture(textureHandles[key].handle);
                 }

--- a/ts/modules/drilldown.src.ts
+++ b/ts/modules/drilldown.src.ts
@@ -292,14 +292,18 @@ declare global {
  * @type {"drillup"}
  */
 
-import U from '../parts/Utilities.js';
+import colorModule from '../parts/Color.js';
+const {
+    Color
+} = colorModule;
+import utilitiesModule from '../parts/Utilities.js';
 const {
     animObject,
     extend,
     objectEach,
     pick,
     syncTimeout
-} = U;
+} = utilitiesModule;
 
 import '../parts/Options.js';
 import '../parts/Chart.js';
@@ -309,7 +313,6 @@ import '../parts/Tick.js';
 
 var addEvent = H.addEvent,
     noop = H.noop,
-    color = H.color,
     defaultOptions = H.defaultOptions,
     format = H.format,
     Chart = H.Chart,
@@ -747,8 +750,8 @@ Chart.prototype.addSingleSeriesAsDrilldown = function (
         // no graphic in line series with markers disabled
         bBox: point.graphic ? point.graphic.getBBox() : {},
         color: point.isNull ?
-            new H.Color(color as any).setOpacity(0).get() :
-            color,
+            new Color(colorProp.color).setOpacity(0).get() :
+            colorProp.color,
         lowerSeriesOptions: ddOptions,
         pointOptions: (oldSeries.options.data as any)[pointIndex],
         pointIndex: pointIndex,

--- a/ts/modules/drilldown.src.ts
+++ b/ts/modules/drilldown.src.ts
@@ -750,8 +750,8 @@ Chart.prototype.addSingleSeriesAsDrilldown = function (
         // no graphic in line series with markers disabled
         bBox: point.graphic ? point.graphic.getBBox() : {},
         color: point.isNull ?
-            new Color(colorProp as any).setOpacity(0).get() :
-            colorProp,
+            new Color(colorProp.color).setOpacity(0).get() :
+            colorProp.color,
         lowerSeriesOptions: ddOptions,
         pointOptions: (oldSeries.options.data as any)[pointIndex],
         pointIndex: pointIndex,

--- a/ts/modules/drilldown.src.ts
+++ b/ts/modules/drilldown.src.ts
@@ -750,8 +750,8 @@ Chart.prototype.addSingleSeriesAsDrilldown = function (
         // no graphic in line series with markers disabled
         bBox: point.graphic ? point.graphic.getBBox() : {},
         color: point.isNull ?
-            new Color(colorProp.color).setOpacity(0).get() :
-            colorProp.color,
+            new Color(colorProp as any).setOpacity(0).get() :
+            colorProp,
         lowerSeriesOptions: ddOptions,
         pointOptions: (oldSeries.options.data as any)[pointIndex],
         pointIndex: pointIndex,

--- a/ts/modules/oldie.src.ts
+++ b/ts/modules/oldie.src.ts
@@ -315,7 +315,11 @@ declare global {
     }
 }
 
-import U from '../parts/Utilities.js';
+import colorModule from '../parts/Color.js';
+const {
+    color
+} = colorModule;
+import utilitiesModule from '../parts/Utilities.js';
 const {
     defined,
     discardElement,
@@ -328,7 +332,7 @@ const {
     offset,
     pick,
     pInt
-} = U;
+} = utilitiesModule;
 
 import '../parts/SvgRenderer.js';
 
@@ -1509,7 +1513,7 @@ if (!svg) {
             Highcharts.PatternObject
         )> (
             this: Highcharts.VMLRenderer,
-            color: T,
+            colorOption: T,
             elem: Highcharts.VMLDOMElement,
             prop: string,
             wrapper: Highcharts.VMLElement
@@ -1523,13 +1527,13 @@ if (!svg) {
 
             // Check for linear or radial gradient
             if (
-                color &&
-                (color as Highcharts.GradientColorObject).linearGradient
+                colorOption &&
+                (colorOption as Highcharts.GradientColorObject).linearGradient
             ) {
                 fillType = 'gradient';
             } else if (
-                color &&
-                (color as Highcharts.GradientColorObject).radialGradient
+                colorOption &&
+                (colorOption as Highcharts.GradientColorObject).radialGradient
             ) {
                 fillType = 'pattern';
             }
@@ -1544,10 +1548,10 @@ if (!svg) {
                         Highcharts.RadialGradientColorObject
                     ) = (
                         (
-                            color as Highcharts.GradientColorObject
+                            colorOption as Highcharts.GradientColorObject
                         ).linearGradient ||
                         (
-                            color as Highcharts.GradientColorObject
+                            colorOption as Highcharts.GradientColorObject
                         ).radialGradient
                     ) as any,
                     x1,
@@ -1559,7 +1563,7 @@ if (!svg) {
                     color1: (Highcharts.ColorString|undefined),
                     color2: (Highcharts.ColorString|undefined),
                     fillAttr = '',
-                    stops = (color as Highcharts.GradientColorObject).stops,
+                    stops = (colorOption as Highcharts.GradientColorObject).stops,
                     firstStop,
                     lastStop,
                     colors = [] as Array<Highcharts.ColorString>,
@@ -1600,7 +1604,7 @@ if (!svg) {
                     i: number
                 ): void {
                     if (regexRgba.test(stop[1])) {
-                        colorObject = H.color(stop[1]);
+                        colorObject = color(stop[1]);
                         stopColor = colorObject.get('rgb') as any;
                         stopOpacity = colorObject.get('a') as any;
                     } else {
@@ -1694,9 +1698,9 @@ if (!svg) {
 
             // If the color is an rgba color, split it and add a fill node
             // to hold the opacity component
-            } else if (regexRgba.test(color as any) && elem.tagName !== 'IMG') {
+            } else if (regexRgba.test(colorOption as any) && elem.tagName !== 'IMG') {
 
-                colorObject = H.color(color);
+                colorObject = color(colorOption);
 
                 (wrapper as any)[prop + '-opacitySetter'](
                     colorObject.get('a'),
@@ -1715,7 +1719,7 @@ if (!svg) {
                     propNodes[0].opacity = 1;
                     propNodes[0].type = 'solid';
                 }
-                ret = color;
+                ret = colorOption;
             }
 
             return ret;

--- a/ts/modules/treemap.src.ts
+++ b/ts/modules/treemap.src.ts
@@ -287,7 +287,11 @@ declare global {
 
 import mixinTreeSeries from '../mixins/tree-series.js';
 import drawPoint from '../mixins/draw-point.js';
-import U from '../parts/Utilities.js';
+import colorModule from '../parts/Color.js';
+const {
+    color
+} = colorModule;
+import utilitiesModule from '../parts/Utilities.js';
 const {
     correctFloat,
     defined,
@@ -299,11 +303,10 @@ const {
     objectEach,
     pick,
     stableSort
-} = U;
+} = utilitiesModule;
 
 import '../parts/Options.js';
 import '../parts/Series.js';
-import '../parts/Color.js';
 
 /* eslint-disable no-invalid-this */
 const AXIS_MAX = 100;
@@ -322,7 +325,6 @@ var seriesType = H.seriesType,
         return typeof x === 'boolean';
     },
     Series = H.Series,
-    color = H.Color,
     // @todo Similar to recursive, this function is likely redundant
     eachObject = function (
         this: unknown,
@@ -1793,7 +1795,7 @@ seriesType<Highcharts.TreemapSeries>(
                 className.indexOf('highcharts-internal-node-interactive') !== -1
             ) {
                 opacity = pick(stateOptions.opacity, options.opacity as any);
-                attr.fill = (color as any)(attr.fill).setOpacity(opacity).get();
+                attr.fill = color(attr.fill).setOpacity(opacity).get();
                 attr.cursor = 'pointer';
                 // Hide nodes that have children
             } else if (className.indexOf('highcharts-internal-node') !== -1) {
@@ -1801,8 +1803,8 @@ seriesType<Highcharts.TreemapSeries>(
 
             } else if (state) {
             // Brighten and hoist the hover nodes
-                attr.fill = (color as any)(attr.fill)
-                    .brighten(stateOptions.brightness)
+                attr.fill = color(attr.fill)
+                    .brighten(stateOptions.brightness as any)
                     .get();
             }
             return attr;

--- a/ts/modules/venn.src.ts
+++ b/ts/modules/venn.src.ts
@@ -126,7 +126,8 @@ declare global {
 
 import draw from '../mixins/draw-point.js';
 import geometry from '../mixins/geometry.js';
-import GeometryCircleMixin from '../mixins/geometry-circles.js';
+
+import geometryCirclesModule from '../mixins/geometry-circles.js';
 const {
     getAreaOfCircle,
     getAreaOfIntersectionBetweenCircles,
@@ -137,25 +138,29 @@ const {
     isPointInsideAllCircles,
     isPointInsideCircle,
     isPointOutsideAllCircles
-} = GeometryCircleMixin;
+} = geometryCirclesModule;
 
-import NelderMeadModule from '../mixins/nelder-mead.js';
+import nelderMeadModule from '../mixins/nelder-mead.js';
 // TODO: replace with individual imports
-var nelderMead = NelderMeadModule.nelderMead;
+var nelderMead = nelderMeadModule.nelderMead;
 
-import U from '../parts/Utilities.js';
+import colorModule from '../parts/Color.js';
+const {
+    color
+} = colorModule;
+
+import utilitiesModule from '../parts/Utilities.js';
 const {
     animObject,
     isArray,
     isNumber,
     isObject,
     isString
-} = U;
+} = utilitiesModule;
 
 import '../parts/Series.js';
 
 var addEvent = H.addEvent,
-    color = H.Color,
     extend = H.extend,
     getCenterOfPoints = geometry.getCenterOfPoints,
     getDistanceBetweenPoints = geometry.getDistanceBetweenPoints,
@@ -1321,9 +1326,9 @@ var vennSeries = {
 
         // Return resulting values for the attributes.
         return {
-            'fill': (color as any)(options.color)
-                .setOpacity(options.opacity)
-                .brighten(options.brightness)
+            'fill': color(options.color)
+                .setOpacity(options.opacity as any)
+                .brighten(options.brightness as any)
                 .get(),
             'stroke': options.borderColor,
             'stroke-width': options.borderWidth,
@@ -1375,13 +1380,13 @@ var vennSeries = {
     utils: {
         addOverlapToSets: addOverlapToSets,
         geometry: geometry,
-        geometryCircles: GeometryCircleMixin,
+        geometryCircles: geometryCirclesModule,
         getLabelWidth: getLabelWidth,
         getMarginFromCircles: getMarginFromCircles,
         getDistanceBetweenCirclesByOverlap: getDistanceBetweenCirclesByOverlap,
         layoutGreedyVenn: layoutGreedyVenn,
         loss: loss,
-        nelderMead: NelderMeadModule,
+        nelderMead: nelderMeadModule,
         processVennData: processVennData,
         sortByTotalOverlap: sortByTotalOverlap
     }

--- a/ts/parts-more/PackedBubbleSeries.ts
+++ b/ts/parts-more/PackedBubbleSeries.ts
@@ -239,7 +239,11 @@ declare global {
  * @since 7.0.0
  */
 
-import U from '../parts/Utilities.js';
+import colorModule from '../parts/Color.js';
+const {
+    color
+} = colorModule;
+import utilitiesModule from '../parts/Utilities.js';
 const {
     clamp,
     defined,
@@ -248,7 +252,7 @@ const {
     isArray,
     isNumber,
     pick
-} = U;
+} = utilitiesModule;
 
 import '../parts/Axis.js';
 import '../parts/Color.js';
@@ -264,7 +268,6 @@ var seriesType = H.seriesType,
     addEvent = H.addEvent,
     fireEvent = H.fireEvent,
     Chart = H.Chart,
-    color = H.Color,
     Reingold = H.layouts['reingold-fruchterman'],
     NetworkPoint = H.seriesTypes.bubble.prototype.pointClass,
     dragNodesMixin = H.dragNodesMixin;
@@ -1096,8 +1099,7 @@ seriesType<Highcharts.PackedBubbleSeries>(
                 nodeMarker: Highcharts.BubblePointMarkerOptions =
                     (this.layout.options.parentNodeOptions as any).marker,
                 parentOptions: Highcharts.SVGAttributes = {
-                    fill: nodeMarker.fillColor ||
-                        (color as any)(series.color).brighten(0.4).get(),
+                    fill: nodeMarker.fillColor || color(series.color).brighten(0.4).get(),
                     opacity: nodeMarker.fillOpacity,
                     stroke: nodeMarker.lineColor || series.color,
                     'stroke-width': nodeMarker.lineWidth

--- a/ts/parts/Color.ts
+++ b/ts/parts/Color.ts
@@ -56,12 +56,9 @@ declare global {
             public input?: ColorType;
             public parsers: Array<ColorParser>;
             public rgba: (ColorNone|ColorRGBA);
-            public stops: Array<Color>;
+            public stops?: Array<Color>;
             public brighten(alpha: number): Color;
             public get(format?: ('a'|'rgb'|'rgba')): Color['input'];
-            public init(
-                input: (ColorString|GradientColorObject|PatternObject|undefined)
-            ): void;
             public setOpacity(alpha: number): Color;
             public tweenTo(to: Color, alpha: number): ColorString;
         }
@@ -195,29 +192,71 @@ var merge = H.merge;
  *
  * @class
  * @name Highcharts.Color
- *
- * @param {Highcharts.ColorType} input
- *        The input color in either rbga or hex format
  */
-H.Color = function (
-    this: Highcharts.Color,
-    input: (
-        Highcharts.ColorString|Highcharts.GradientColorObject|
-        Highcharts.PatternObject|undefined
-    )
-): any {
-    // Backwards compatibility, allow instanciation without new
-    if (!(this instanceof H.Color)) {
+class Color {
+
+    /* *
+     *
+     *  Static Functions
+     *
+     * */
+
+    /**
+     * Creates a color instance out of a color string or object.
+     *
+     * @function Highcharts.Color.parse
+     *
+     * @param {Highcharts.ColorType} input
+     * The input color in either rbga or hex format.
+     *
+     * @return {Highcharts.Color}
+     * Color instance.
+     */
+    public static parse(
+        input: (
+            Highcharts.ColorString|Highcharts.GradientColorObject|
+            Highcharts.PatternObject|undefined
+        )
+    ): Highcharts.Color {
         return new H.Color(input);
     }
-    // Initialize
-    this.init(input);
-} as any;
-H.Color.prototype = {
+
+    /* *
+     *
+     *  Constructors
+     *
+     * */
+
+    /**
+     * Handle color operations. Some object methods are chainable.
+     *
+     * @param {Highcharts.ColorType} input
+     *        The input color in either rbga or hex format
+     */
+    public constructor(
+        input: (Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject|undefined)
+    ) {
+        this.init(input);
+    }
+
+    /* *
+     *
+     *  Properties
+     *
+     * */
+
+    public input: (Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject|undefined)
+
+    // Collection of named colors. Can be extended from the outside by adding
+    // colors to Highcharts.Color.prototype.names.
+    public names: Record<string, Highcharts.ColorString> = {
+        white: '#ffffff',
+        black: '#000000'
+    };
 
     // Collection of parsers. This can be extended from the outside by pushing
     // parsers to Highcharts.Color.prototype.parsers.
-    parsers: [{
+    public parsers = [{
         // RGBA color
         // eslint-disable-next-line max-len
         regex: /rgba\(\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]?(?:\.[0-9]+)?)\s*\)/,
@@ -236,14 +275,16 @@ H.Color.prototype = {
         parse: function (result: RegExpExecArray): Highcharts.ColorRGBA {
             return [pInt(result[1]), pInt(result[2]), pInt(result[3]), 1];
         }
-    }],
+    }];
 
-    // Collection of named colors. Can be extended from the outside by adding
-    // colors to Highcharts.Color.prototype.names.
-    names: {
-        white: '#ffffff',
-        black: '#000000'
-    },
+    public rgba: (Highcharts.ColorNone|Highcharts.ColorRGBA) = [];
+    public stops?: Array<Color>;
+
+    /* *
+     *
+     *  Functions
+     *
+     * */
 
     /**
      * Parse the input color to rgba array
@@ -256,12 +297,8 @@ H.Color.prototype = {
      *
      * @return {void}
      */
-    init: function (
-        this: Highcharts.Color,
-        input: (
-            Highcharts.ColorString|Highcharts.GradientColorObject|
-            Highcharts.PatternObject|undefined
-        )
+    private init(
+        input: (Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject|undefined)
     ): void {
         var result: (RegExpExecArray|null),
             rgba: any,
@@ -338,7 +375,7 @@ H.Color.prototype = {
             }
         }
         this.rgba = rgba || [];
-    },
+    }
 
     /**
      * Return the color or gradient stops in the specified format
@@ -351,21 +388,15 @@ H.Color.prototype = {
      * @return {Highcharts.ColorType}
      *         This color as a string or gradient stops.
      */
-    get: function (
-        this: Highcharts.Color,
-        format?: ('a'|'rgb'|'rgba')
-    ): Highcharts.Color['input'] {
+    public get(format?: ('a'|'rgb'|'rgba')): Color['input'] {
         var input = this.input,
             rgba = this.rgba,
             ret: Highcharts.Color['input'];
 
-        if (this.stops) {
+        if (typeof this.stops !== 'undefined') {
             ret = merge(input as any);
             (ret as any).stops = [].concat((ret as any).stops);
-            this.stops.forEach(function (
-                stop: Highcharts.Color,
-                i: number
-            ): void {
+            this.stops.forEach((stop: Color, i: number): void => {
                 (ret as any).stops[i] = [
                     (ret as any).stops[i][0],
                     stop.get(format)
@@ -385,7 +416,7 @@ H.Color.prototype = {
             ret = input;
         }
         return ret as any;
-    },
+    }
 
     /**
      * Brighten the color instance.
@@ -398,15 +429,12 @@ H.Color.prototype = {
      * @return {Highcharts.Color}
      *         This color with modifications.
      */
-    brighten: function (
-        this: Highcharts.Color,
-        alpha: number
-    ): Highcharts.Color {
-        var i,
+    public brighten(alpha: number): this {
+        var i: number,
             rgba = this.rgba;
 
         if (this.stops) {
-            this.stops.forEach(function (stop: Highcharts.Color): void {
+            this.stops.forEach(function (stop: Color): void {
                 stop.brighten(alpha);
             });
 
@@ -423,7 +451,7 @@ H.Color.prototype = {
             }
         }
         return this;
-    },
+    }
 
     /**
      * Set the color's opacity to a given alpha value.
@@ -436,13 +464,10 @@ H.Color.prototype = {
      * @return {Highcharts.Color}
      *         Color with modifications.
      */
-    setOpacity: function (
-        this: Highcharts.Color,
-        alpha: number
-    ): Highcharts.Color {
+    public setOpacity(alpha: number): this {
         this.rgba[3] = alpha;
         return this;
-    },
+    }
 
     /**
      * Return an intermediate color between two colors.
@@ -459,11 +484,7 @@ H.Color.prototype = {
      * @return {Highcharts.ColorString}
      *         The intermediate color in rgba notation.
      */
-    tweenTo: function (
-        this: Highcharts.Color,
-        to: Highcharts.Color,
-        pos: number
-    ): Highcharts.ColorString {
+    public tweenTo(to: Color, pos: number): Highcharts.ColorString {
         // Check for has alpha, because rgba colors perform worse due to lack of
         // support in WebKit.
         var fromRgba = this.rgba,
@@ -496,7 +517,9 @@ H.Color.prototype = {
         }
         return ret;
     }
-} as any;
+}
+
+H.Color = Color;
 
 /**
  * Creates a color instance out of a color string.
@@ -509,11 +532,11 @@ H.Color.prototype = {
  * @return {Highcharts.Color}
  *         Color instance
  */
-H.color = function (
-    input: (
-        Highcharts.ColorString|Highcharts.GradientColorObject|
-        Highcharts.PatternObject|undefined
-    )
-): Highcharts.Color {
-    return new H.Color(input);
+const color = H.color = Color.parse;
+
+const exports = {
+    Color,
+    color
 };
+
+export default exports;

--- a/ts/parts/Color.ts
+++ b/ts/parts/Color.ts
@@ -197,6 +197,19 @@ class Color {
 
     /* *
      *
+     *  Static Properties
+     *
+     * */
+
+    // Collection of named colors. Can be extended from the outside by adding
+    // colors to Highcharts.Color.names.
+    public static names: Record<string, Highcharts.ColorString> = {
+        white: '#ffffff',
+        black: '#000000'
+    };
+
+    /* *
+     *
      *  Static Functions
      *
      * */
@@ -246,13 +259,6 @@ class Color {
      * */
 
     public input: (Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject|undefined)
-
-    // Collection of named colors. Can be extended from the outside by adding
-    // colors to Highcharts.Color.prototype.names.
-    public names: Record<string, Highcharts.ColorString> = {
-        white: '#ffffff',
-        black: '#000000'
-    };
 
     // Collection of parsers. This can be extended from the outside by pushing
     // parsers to Highcharts.Color.prototype.parsers.
@@ -306,7 +312,7 @@ class Color {
             parser: Highcharts.ColorParser,
             len: number;
 
-        this.input = input = this.names[
+        this.input = input = Color.names[
             input && (input as any).toLowerCase ?
                 (input as any).toLowerCase() :
                 ''

--- a/ts/parts/PlotLineOrBand.ts
+++ b/ts/parts/PlotLineOrBand.ts
@@ -248,7 +248,7 @@ H.PlotLineOrBand.prototype = {
         // Set the presentational attributes
         if (!axis.chart.styledMode) {
             if (isLine) {
-                attribs.stroke = (color as any) || '${palette.neutralColor40}';
+                attribs.stroke = color || '${palette.neutralColor40}';
                 attribs['stroke-width'] = pick(
                     (options as Highcharts.AxisPlotLinesOptions).width,
                     1
@@ -259,7 +259,7 @@ H.PlotLineOrBand.prototype = {
                 }
 
             } else if (isBand) { // plot band
-                attribs.fill = (color as any) || '${palette.highlightColor10}';
+                attribs.fill = color || '${palette.highlightColor10}';
                 if ((options as Highcharts.AxisPlotBandsOptions).borderWidth) {
                     attribs.stroke = (
                         options as Highcharts.AxisPlotBandsOptions

--- a/ts/parts/SvgRenderer.ts
+++ b/ts/parts/SvgRenderer.ts
@@ -807,7 +807,11 @@ declare global {
 
 /* eslint-disable no-invalid-this, valid-jsdoc */
 
-import U from './Utilities.js';
+import colorModule from './Color.js';
+const {
+    color
+} = colorModule;
+import utilitiesModule from './Utilities.js';
 const {
     animObject,
     attr,
@@ -824,9 +828,7 @@ const {
     pInt,
     removeEvent,
     splat
-} = U;
-
-import './Color.js';
+} = utilitiesModule;
 
 var SVGElement: Highcharts.SVGElement,
     SVGRenderer,
@@ -834,7 +836,6 @@ var SVGElement: Highcharts.SVGElement,
     addEvent = H.addEvent,
     animate = H.animate,
     charts = H.charts,
-    color = H.color,
     css = H.css,
     createElement = H.createElement,
     deg2rad = H.deg2rad,
@@ -997,7 +998,7 @@ extend((
      * @private
      * @function Highcharts.SVGElement#complexColor
      *
-     * @param {Highcharts.GradientColorObject} color
+     * @param {Highcharts.GradientColorObject} colorOptions
      *        The gradient options structure.
      *
      * @param {string} prop
@@ -1010,7 +1011,7 @@ extend((
      */
     complexColor: function (
         this: Highcharts.SVGElement,
-        color: Highcharts.GradientColorObject,
+        colorOptions: Highcharts.GradientColorObject,
         prop: string,
         elem: Highcharts.SVGDOMElement
     ): void {
@@ -1033,21 +1034,21 @@ extend((
             args: arguments
         }, function (): void {
             // Apply linear or radial gradients
-            if (color.radialGradient) {
+            if (colorOptions.radialGradient) {
                 gradName = 'radialGradient';
-            } else if (color.linearGradient) {
+            } else if (colorOptions.linearGradient) {
                 gradName = 'linearGradient';
             }
 
             if (gradName) {
-                gradAttr = color[gradName] as any;
+                gradAttr = colorOptions[gradName] as any;
                 gradients = renderer.gradients;
-                stops = color.stops;
+                stops = colorOptions.stops;
                 radialReference = (elem as any).radialReference;
 
                 // Keep < 2.2 kompatibility
                 if (isArray(gradAttr)) {
-                    (color as any)[gradName] = gradAttr = {
+                    (colorOptions as any)[gradName] = gradAttr = {
                         x1: gradAttr[0],
                         y1: gradAttr[1],
                         x2: gradAttr[2],
@@ -1108,7 +1109,7 @@ extend((
                         var stopObject;
 
                         if (stop[1].indexOf('rgba') === 0) {
-                            colorObject = H.color(stop[1]);
+                            colorObject = color(stop[1]);
                             stopColor = colorObject.get('rgb') as any;
                             stopOpacity = colorObject.get('a');
                         } else {
@@ -1133,7 +1134,7 @@ extend((
 
                 // Allow the color to be concatenated into tooltips formatters
                 // etc. (#2995)
-                color.toString = function (): string {
+                colorOptions.toString = function (): string {
                     return value;
                 };
             }


### PR DESCRIPTION
Made color class ES6 compliant. This breaks the usage of the constructor without `new` keyword, which is not allowed in ES6.