### PR TITLE
Tools: Wait for svg file writes to complete

### DIFF
--- a/test/karma-imagecapture-reporter.js
+++ b/test/karma-imagecapture-reporter.js
@@ -15,6 +15,11 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
     baseReporterDecorator(this);
     const LOG = logger.create('reporter.imagecapture');
     const gitSha = getLatestCommitShaSync();
+
+    // eslint-disable-next-line func-style
+    let fileWritingFinished = function () {};
+    let pendingFileWritings = 0;
+
     const {
         imageCapture = {
             resultsOutputPath: 'test/visual-test-results.json'
@@ -70,9 +75,13 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
         encoder.finish();
 
         var buf = encoder.out.getData();
+        pendingFileWritings++;
         fs.writeFile(filename, buf, function (err) {
             if (err) {
                 throw err;
+            }
+            if (!--pendingFileWritings) {
+                fileWritingFinished();
             }
         });
     }
@@ -146,9 +155,13 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
         const filename = info.filename;
         try {
             if (/\.svg$/.test(filename)) {
+                pendingFileWritings++;
                 fs.writeFile(filename, prettyXML(data), err => {
                     if (err) {
                         throw err;
+                    }
+                    if (!--pendingFileWritings) {
+                        fileWritingFinished();
                     }
                 });
 
@@ -166,6 +179,15 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
         }
 
     });
+
+    // wait for async file writes before exiting
+    this.onExit = function (done) {
+        if (pendingFileWritings) {
+            fileWritingFinished = done;
+        } else {
+            done();
+        }
+    };
 
 }
 /* eslint-enable require-jsdoc */

--- a/tools/gulptasks/update-pr-testresults.js
+++ b/tools/gulptasks/update-pr-testresults.js
@@ -442,12 +442,18 @@ async function uploadVisualTestFiles(diffingSamples = [], pr, includeReview = tr
         }
 
         if (!argv.dryrun) {
-            result = await uploadFiles({
-                files,
-                bucket: VISUAL_TESTS_BUCKET,
-                profile: argv.profile,
-                name: `image diff on PR #${pr}`
-            });
+            try {
+                result = await uploadFiles({
+                    files,
+                    bucket: VISUAL_TESTS_BUCKET,
+                    profile: argv.profile,
+                    name: `image diff on PR #${pr}`
+                });
+            } catch (err) {
+                logLib.failure('One or more files were not uploaded. Continuing to let task finish gracefully. ' +
+                    'Original error: ' + err.message);
+            }
+
         } else {
             logLib.message('Dry run - Skipping upload of files.');
         }


### PR DESCRIPTION
There seems to be an issue with `karma-imagecapture-reporter` exiting before all file writes are complete. At least that is the theory, but it is hard to reproduce. Latest example is https://circleci.com/gh/highcharts/highcharts/25460 where there are no reported file write errors, which indicates that nothing has gone wrong (as it then should produce a log line with a short error message).

Thus I have added some code to make sure the files are written before karma is exiting, which is more or less same approach as [karma-junit-reporter uses](https://github.com/karma-runner/karma-junit-reporter/blob/2f43e5063e050b7853ebcc82c24ecc26310e0cff/index.js#L251-L257).