### PR TITLE
Docs: extending xAxis plotlines and plotbands to yAxis

### DIFF
--- a/js/parts/PlotLineOrBand.js
+++ b/js/parts/PlotLineOrBand.js
@@ -524,6 +524,10 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      *
      * @type      {Array<*>}
      * @product   highcharts highstock gantt
+     * @sample {highcharts} highcharts/xaxis/plotlines-color/
+     *         Basic plot line
+     * @sample {highcharts} highcharts/series-solidgauge/labels-auto-aligned/
+     *         Solid gauge plot line
      * @apioption xAxis.plotLines
      */
     /**
@@ -774,7 +778,6 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      * @apioption xAxis.plotLines.label.y
      */
     /**
-     * An array of objects defining plot bands on the Y axis.
      *
      * @type      {Array<*>}
      * @extends   xAxis.plotBands
@@ -826,13 +829,7 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      * @apioption yAxis.plotBands.thickness
      */
     /**
-     * An array of objects representing plot lines on the X axis
-     *
      * @type      {Array<*>}
-     * @sample {highcharts} highcharts/xaxis/plotlines-color/
-     *      Basic plot line
-     * @sample {highcharts} highcharts/series-solidgauge/labels-auto-aligned/
-     *      Solid gauge plot line
      * @extends   xAxis.plotLines
      * @apioption yAxis.plotLines
      */

--- a/ts/parts/PlotLineOrBand.ts
+++ b/ts/parts/PlotLineOrBand.ts
@@ -778,6 +778,10 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      *
      * @type      {Array<*>}
      * @product   highcharts highstock gantt
+     * @sample {highcharts} highcharts/xaxis/plotlines-color/
+     *         Basic plot line
+     * @sample {highcharts} highcharts/series-solidgauge/labels-auto-aligned/
+     *         Solid gauge plot line
      * @apioption xAxis.plotLines
      */
 
@@ -1053,7 +1057,6 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      */
 
     /**
-     * An array of objects defining plot bands on the Y axis.
      *
      * @type      {Array<*>}
      * @extends   xAxis.plotBands
@@ -1109,13 +1112,7 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      */
 
     /**
-     * An array of objects representing plot lines on the X axis
-     *
      * @type      {Array<*>}
-     * @sample {highcharts} highcharts/xaxis/plotlines-color/
-     *      Basic plot line
-     * @sample {highcharts} highcharts/series-solidgauge/labels-auto-aligned/
-     *      Solid gauge plot line
      * @extends   xAxis.plotLines
      * @apioption yAxis.plotLines
      */


### PR DESCRIPTION
Fixes #12803 by inheriting descriptions from the xAxis. Also moves yAxis.plotLine samples to xAxis as they apply to both axes.