### PR TITLE
bugfix/12326-wrong-options-after-drilldown-2

### DIFF
--- a/js/modules/drilldown.src.js
+++ b/js/modules/drilldown.src.js
@@ -652,7 +652,10 @@ Chart.prototype.drillUp = function () {
             }
             oldSeries.xData = []; // Overcome problems with minRange (#2898)
             level.levelSeriesOptions.forEach(addSeries);
-            fireEvent(chart, 'drillup', { seriesOptions: level.seriesOptions });
+            fireEvent(chart, 'drillup', {
+                seriesOptions: level.seriesPurgedOptions ||
+                    level.seriesOptions
+            });
             if (newSeries.type === oldSeries.type) {
                 newSeries.drilldownLevel = level;
                 newSeries.options.animation =

--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -42,7 +42,7 @@ recursive = function (item, func, context) {
     if (next !== false) {
         recursive(next, func, context);
     }
-}, updateRootId = mixinTreeSeries.updateRootId;
+}, updateRootId = mixinTreeSeries.updateRootId, treemapAxisDefaultValues = false;
 /* eslint-enable no-invalid-this */
 /**
  * @private
@@ -1362,25 +1362,6 @@ seriesType('treemap', 'scatter'
         Series.prototype.getExtremes.call(this);
     },
     getExtremesFromAll: true,
-    bindAxes: function () {
-        var treeAxis = {
-            endOnTick: false,
-            gridLineWidth: 0,
-            lineWidth: 0,
-            min: 0,
-            dataMin: 0,
-            minPadding: 0,
-            max: AXIS_MAX,
-            dataMax: AXIS_MAX,
-            maxPadding: 0,
-            startOnTick: false,
-            title: null,
-            tickPositions: []
-        };
-        Series.prototype.bindAxes.call(this);
-        extend(this.yAxis.options, treeAxis);
-        extend(this.xAxis.options, treeAxis);
-    },
     /**
      * Workaround for `inactive` state. Since `series.opacity` option is
      * already reserved, don't use that state at all by disabling
@@ -1439,8 +1420,37 @@ seriesType('treemap', 'scatter'
         var point = this;
         return isNumber(point.plotY) && point.y !== null;
     }
-    /* eslint-enable no-invalid-this, valid-jsdoc */
 });
+H.addEvent(H.Series, 'afterBindAxes', function () {
+    var series = this, xAxis = series.xAxis, yAxis = series.yAxis, treeAxis;
+    if (xAxis && yAxis) {
+        if (series.options.type === 'treemap') {
+            treeAxis = {
+                endOnTick: false,
+                gridLineWidth: 0,
+                lineWidth: 0,
+                min: 0,
+                dataMin: 0,
+                minPadding: 0,
+                max: AXIS_MAX,
+                dataMax: AXIS_MAX,
+                maxPadding: 0,
+                startOnTick: false,
+                title: null,
+                tickPositions: []
+            };
+            extend(yAxis.options, treeAxis);
+            extend(xAxis.options, treeAxis);
+            treemapAxisDefaultValues = true;
+        }
+        else if (treemapAxisDefaultValues) {
+            yAxis.setOptions(yAxis.userOptions);
+            xAxis.setOptions(xAxis.userOptions);
+            treemapAxisDefaultValues = false;
+        }
+    }
+});
+/* eslint-enable no-invalid-this, valid-jsdoc */
 /**
  * A `treemap` series. If the [type](#series.treemap.type) option is
  * not specified, it is inherited from [chart.type](#chart.type).

--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -1424,7 +1424,7 @@ seriesType('treemap', 'scatter'
 H.addEvent(H.Series, 'afterBindAxes', function () {
     var series = this, xAxis = series.xAxis, yAxis = series.yAxis, treeAxis;
     if (xAxis && yAxis) {
-        if (series.options.type === 'treemap') {
+        if (series.is('treemap')) {
             treeAxis = {
                 endOnTick: false,
                 gridLineWidth: 0,

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -2827,6 +2827,7 @@ null,
                 }
             });
         });
+        fireEvent(this, 'afterBindAxes');
     },
     /**
      * For simple series types like line and column, the data values are

--- a/samples/unit-tests/drilldown/across-types/demo.html
+++ b/samples/unit-tests/drilldown/across-types/demo.html
@@ -1,6 +1,6 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/drilldown.js"></script>
-
+<script src="https://code.highcharts.com/modules/treemap.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/drilldown/across-types/demo.js
+++ b/samples/unit-tests/drilldown/across-types/demo.js
@@ -124,4 +124,141 @@ QUnit.test('Drilldown across types', function (assert) {
         'First level type'
     );
 
+    chart = Highcharts.chart('container', {
+        xAxis: {
+            type: 'category',
+            title: ''
+        },
+        yAxis: {
+            title: ''
+        },
+        legend: {
+            enabled: false
+        },
+        series: [{
+            type: 'column',
+            data: [{
+                name: "Drilldown",
+                y: 62.74,
+                drilldown: "tree"
+            }, {
+                name: "A",
+                y: 10.57
+            }]
+        }],
+        drilldown: {
+            series: [{
+                type: "treemap",
+                id: 'tree',
+                layoutAlgorithm: 'stripes',
+                levels: [{
+                    level: 1,
+                    layoutAlgorithm: 'sliceAndDice'
+                }],
+                data: [{
+                    id: 'A',
+                    name: 'Apples',
+                    color: "#EC2500"
+                }, {
+                    id: 'B',
+                    name: 'Bananas',
+                    color: "#ECE100"
+                }, {
+                    name: 'Anne',
+                    parent: 'A',
+                    value: 5
+                }, {
+                    name: 'Rick',
+                    parent: 'A',
+                    value: 3
+                }, {
+                    name: 'Peter',
+                    parent: 'A',
+                    value: 4
+                }, {
+                    name: 'Anne',
+                    parent: 'B',
+                    value: 4
+                }]
+            }]
+        }
+    });
+
+    chart.series[0].points[0].doDrilldown();
+    chart.drillUp();
+
+    assert.strictEqual(
+        chart.xAxis[0].max,
+        1,
+        'After drillup treemap axes options should be reset (#12326).'
+    );
+
+    chart = Highcharts.chart('container', {
+        xAxis: {
+            type: 'category',
+            title: ''
+        },
+        yAxis: {
+            title: ''
+        },
+        legend: {
+            enabled: false
+        },
+        series: [{
+            type: "treemap",
+            id: 'tree',
+            layoutAlgorithm: 'stripes',
+            levels: [{
+                level: 1,
+                layoutAlgorithm: 'sliceAndDice'
+            }],
+            data: [{
+                id: 'A',
+                name: 'Apples',
+                color: "#EC2500"
+            }, {
+                id: 'B',
+                name: 'Bananas',
+                color: "#ECE100"
+            }, {
+                name: 'Anne',
+                parent: 'A',
+                value: 5,
+                drilldown: "column"
+            }, {
+                name: 'Rick',
+                parent: 'A',
+                value: 3
+            }, {
+                name: 'Peter',
+                parent: 'A',
+                value: 4
+            }, {
+                name: 'Anne',
+                parent: 'B',
+                value: 4
+            }]
+        }],
+        drilldown: {
+            series: [{
+                type: 'column',
+                id: 'column',
+                data: [{
+                    name: "Drilldown",
+                    y: 62.74
+                }, {
+                    name: "A",
+                    y: 10.57
+                }]
+            }]
+        }
+    });
+
+    chart.series[0].points[2].doDrilldown();
+
+    assert.strictEqual(
+        chart.xAxis[0].max,
+        1,
+        'After drilldown treemap axes options should be reset (#12326).'
+    );
 });

--- a/ts/modules/drilldown.src.ts
+++ b/ts/modules/drilldown.src.ts
@@ -951,7 +951,10 @@ Chart.prototype.drillUp = function (): void {
 
             level.levelSeriesOptions.forEach(addSeries);
 
-            fireEvent(chart, 'drillup', { seriesOptions: level.seriesOptions });
+            fireEvent(chart, 'drillup', {
+                seriesOptions: level.seriesPurgedOptions ||
+                    level.seriesOptions
+            });
 
             if ((newSeries as any).type === oldSeries.type) {
                 (newSeries as any).drilldownLevel = level;

--- a/ts/modules/treemap.src.ts
+++ b/ts/modules/treemap.src.ts
@@ -353,7 +353,8 @@ var seriesType = H.seriesType,
             recursive(next, func, context);
         }
     },
-    updateRootId = mixinTreeSeries.updateRootId;
+    updateRootId = mixinTreeSeries.updateRootId,
+    treemapAxisDefaultValues = false;
 
 /* eslint-enable no-invalid-this */
 
@@ -2140,26 +2141,6 @@ seriesType<Highcharts.TreemapSeries>(
             Series.prototype.getExtremes.call(this);
         },
         getExtremesFromAll: true,
-        bindAxes: function (this: Highcharts.TreemapSeries): void {
-            var treeAxis = {
-                endOnTick: false,
-                gridLineWidth: 0,
-                lineWidth: 0,
-                min: 0,
-                dataMin: 0,
-                minPadding: 0,
-                max: AXIS_MAX,
-                dataMax: AXIS_MAX,
-                maxPadding: 0,
-                startOnTick: false,
-                title: null,
-                tickPositions: []
-            };
-
-            Series.prototype.bindAxes.call(this);
-            extend(this.yAxis.options, treeAxis);
-            extend(this.xAxis.options, treeAxis);
-        },
 
         /**
          * Workaround for `inactive` state. Since `series.opacity` option is
@@ -2232,9 +2213,44 @@ seriesType<Highcharts.TreemapSeries>(
             var point = this;
             return isNumber(point.plotY) && point.y !== null;
         }
-        /* eslint-enable no-invalid-this, valid-jsdoc */
     }
 );
+
+H.addEvent(H.Series, 'afterBindAxes', function (): void {
+    var series = this,
+        xAxis = series.xAxis,
+        yAxis = series.yAxis,
+        treeAxis;
+
+    if (xAxis && yAxis) {
+        if (series.options.type === 'treemap') {
+            treeAxis = {
+                endOnTick: false,
+                gridLineWidth: 0,
+                lineWidth: 0,
+                min: 0,
+                dataMin: 0,
+                minPadding: 0,
+                max: AXIS_MAX,
+                dataMax: AXIS_MAX,
+                maxPadding: 0,
+                startOnTick: false,
+                title: null,
+                tickPositions: []
+            };
+
+            extend(yAxis.options, treeAxis);
+            extend(xAxis.options, treeAxis);
+            treemapAxisDefaultValues = true;
+
+        } else if (treemapAxisDefaultValues) {
+            yAxis.setOptions(yAxis.userOptions);
+            xAxis.setOptions(xAxis.userOptions);
+            treemapAxisDefaultValues = false;
+        }
+    }
+});
+/* eslint-enable no-invalid-this, valid-jsdoc */
 
 /**
  * A `treemap` series. If the [type](#series.treemap.type) option is

--- a/ts/modules/treemap.src.ts
+++ b/ts/modules/treemap.src.ts
@@ -2223,7 +2223,7 @@ H.addEvent(H.Series, 'afterBindAxes', function (): void {
         treeAxis;
 
     if (xAxis && yAxis) {
-        if (series.options.type === 'treemap') {
+        if (series.is('treemap')) {
             treeAxis = {
                 endOnTick: false,
                 gridLineWidth: 0,

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -3564,6 +3564,8 @@ H.Series = H.seriesType<Highcharts.LineSeries>(
 
                 });
             });
+
+            fireEvent(this, 'afterBindAxes');
         },
 
         /**


### PR DESCRIPTION
Fixed issue with wrong axis options after `drilldown` to treemap series, see #12326.
___

Reference: https://github.com/highcharts/highcharts/pull/12703