### PR TITLE
samples/typo-in-capital-name

### DIFF
--- a/samples/data/us-capitals.json
+++ b/samples/data/us-capitals.json
@@ -202,7 +202,7 @@
   {
     "abbrev":"MT",
     "parentState":"Montana",
-    "capital":"Helana",
+    "capital":"Helena",
     "lat":46.589760,
     "lon":-112.021202,
     "population":28190


### PR DESCRIPTION
Samples: Corrected a typo in capital's name.