### PR TITLE
bugfix/9682-scroll-page-while-touching-legend

### DIFF
--- a/ts/parts/SvgRenderer.ts
+++ b/ts/parts/SvgRenderer.ts
@@ -1923,7 +1923,7 @@ extend((
         if (hasTouch && eventType === 'click') {
             element.ontouchstart = function (e: Event): void {
                 svgElement.touchEventFired = Date.now(); // #2269
-                e.preventDefault();
+                // e.preventDefault(); #9682
                 handler.call(element, e);
             };
             element.onclick = function (e: Event): void {


### PR DESCRIPTION
Fixed #9682, page couldn't be scrolled while touching a legend item.