### PR TITLE
bugfix/12856-polar-tooltip-regression

### DIFF
--- a/js/parts-more/Pane.js
+++ b/js/parts-more/Pane.js
@@ -368,7 +368,7 @@ addEvent(H.Pointer, 'beforeGetHoverData', function (eventArgs) {
             return (s.visible &&
                 !(!eventArgs.shared && s.directTouch) && // #3821
                 pick(s.options.enableMouseTracking, true) &&
-                (!chart.polar || s.xAxis.pane === chart.hoverPane));
+                (!chart.hoverPane || s.xAxis.pane === chart.hoverPane));
         };
     }
 });

--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -1333,7 +1333,7 @@ var Pointer = /** @class */ (function () {
              */
             chart.hoverPoint = hoverPoint;
             // Draw tooltip if necessary
-            if (tooltip && !chart.polar) {
+            if (tooltip) {
                 tooltip.refresh(useSharedTooltip ? points : hoverPoint, e);
             }
             // Update positions (regardless of kdpoint or hoverPoint)

--- a/samples/unit-tests/pointer/hover/demo.js
+++ b/samples/unit-tests/pointer/hover/demo.js
@@ -141,4 +141,22 @@ QUnit.test('Testing hovering over panes.', function (assert) {
         chart.tooltip.isHidden,
         'Tooltip should not be displayed (point is out of pane)' // #11148
     );
+
+    chart.update({
+        tooltip: {
+            shared: true
+        }
+    }, false);
+
+    chart.addSeries({
+        data: [125, 110, 43, 44, 20]
+    });
+
+    chart.series[0].points[0].onMouseOver();
+
+    assert.ok(
+        !chart.tooltip.isHidden,
+        'Tooltip should be displayed without any errors' // #12856
+    );
+
 });

--- a/ts/parts-more/Pane.ts
+++ b/ts/parts-more/Pane.ts
@@ -577,7 +577,7 @@ addEvent(H.Pointer, 'beforeGetHoverData', function (
                 s.visible &&
                 !(!eventArgs.shared && s.directTouch) && // #3821
                 pick(s.options.enableMouseTracking, true) &&
-                (!chart.polar || s.xAxis.pane === chart.hoverPane)
+                (!chart.hoverPane || s.xAxis.pane === chart.hoverPane)
             );
         };
     }

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -2057,7 +2057,7 @@ class Pointer {
             chart.hoverPoint = hoverPoint;
 
             // Draw tooltip if necessary
-            if (tooltip && !chart.polar) {
+            if (tooltip) {
                 tooltip.refresh(useSharedTooltip ? points : hoverPoint, e);
             }
         // Update positions (regardless of kdpoint or hoverPoint)


### PR DESCRIPTION
Fixed #12856, shared tooltip did not work with polar charts.