### PR TITLE
Make tooltip.stickOnHover default with a11y module.

### DIFF
--- a/js/modules/accessibility/options/options.js
+++ b/js/modules/accessibility/options/options.js
@@ -734,6 +734,12 @@ var options = {
              */
             enabled: true
         }
+    },
+    /**
+     * @optionparent tooltip
+     */
+    tooltip: {
+        stickOnHover: true
     }
 };
 export default options;

--- a/js/parts/Options.js
+++ b/js/parts/Options.js
@@ -3095,6 +3095,10 @@ H.defaultOptions = {
          * Prevents the tooltip from switching or closing, when touched or
          * pointed.
          *
+         * Defaults to `true` if the
+         * [Accessibility Module](https://www.highcharts.com/docs/accessibility/accessibility-module)
+         * is loaded.
+         *
          * @sample highcharts/tooltip/stickonhover/
          *         Tooltip sticks on hover event
          *

--- a/ts/modules/accessibility/options/options.ts
+++ b/ts/modules/accessibility/options/options.ts
@@ -932,6 +932,13 @@ var options: DeepPartial<Highcharts.Options> = {
              */
             enabled: true
         }
+    },
+
+    /**
+     * @optionparent tooltip
+     */
+    tooltip: {
+        stickOnHover: true
     }
 
 };

--- a/ts/parts/Options.ts
+++ b/ts/parts/Options.ts
@@ -3680,6 +3680,10 @@ H.defaultOptions = {
          * Prevents the tooltip from switching or closing, when touched or
          * pointed.
          *
+         * Defaults to `true` if the
+         * [Accessibility Module](https://www.highcharts.com/docs/accessibility/accessibility-module)
+         * is loaded.
+         *
          * @sample highcharts/tooltip/stickonhover/
          *         Tooltip sticks on hover event
          *


### PR DESCRIPTION
Make the new `tooltip.stickOnHover` option on by default with the a11y module loaded.