### PR TITLE
bugfix/12566-data-module-null-point

### DIFF
--- a/js/modules/data.src.js
+++ b/js/modules/data.src.js
@@ -1093,6 +1093,8 @@ extend(Data.prototype, {
             [].forEach.call(table.getElementsByTagName('tr'), function (tr, rowNo) {
                 if (rowNo >= startRow && rowNo <= endRow) {
                     [].forEach.call(tr.children, function (item, colNo) {
+                        var row = columns[colNo - startColumn];
+                        var i = 1;
                         if ((item.tagName === 'TD' ||
                             item.tagName === 'TH') &&
                             colNo >= startColumn &&
@@ -1101,6 +1103,13 @@ extend(Data.prototype, {
                                 columns[colNo - startColumn] = [];
                             }
                             columns[colNo - startColumn][rowNo - startRow] = item.innerHTML;
+                            // Loop over all previous indices and make sure
+                            // they are nulls, not undefined.
+                            while (rowNo - startRow >= i &&
+                                row[rowNo - startRow - i] === void 0) {
+                                row[rowNo - startRow - i] = null;
+                                i++;
+                            }
                         }
                     });
                 }

--- a/samples/unit-tests/data/general/demo.js
+++ b/samples/unit-tests/data/general/demo.js
@@ -194,3 +194,57 @@ QUnit.test('Data config on updates', function (assert) {
         'Switching back switchRowsAndColumns should restore number of series (#11095).'
     );
 });
+
+QUnit.test("Data module - empty point should be parsed to null (#12566).", function (assert) {
+    document.body.innerHTML += `<table id="secondTable">
+        <thead>
+        <tr>
+            <th></th>
+            <th>Jane</th>
+            <th>John</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th>Apples</th>
+            <td>-3,4</td>
+        </tr>
+        <tr>
+            <th>Pears</th>
+            <td>-1,2</td>
+        </tr>
+        <tr>
+            <th>Plums</th>
+            <td>5,1</td>
+            <td>11,1</td>
+        </tr>
+        <tr>
+            <th>Bananas</th>
+            <td>-1,1</td>
+            <td>-1,1</td>
+        </tr>
+        <tr>
+            <th>Oranges</th>
+            <td>-3,12</td>
+            <td>-2,9</td>
+        </tr>
+    </tbody>
+    </table>`;
+
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'column'
+        },
+
+        data: {
+            table: 'secondTable',
+            decimalPoint: ','
+        }
+    });
+
+    assert.strictEqual(
+        chart.data.columns[2][0],
+        null,
+        'Empty point should be parsed to null instead of undefined.'
+    );
+});

--- a/ts/modules/data.src.ts
+++ b/ts/modules/data.src.ts
@@ -1534,6 +1534,9 @@ extend(Data.prototype, {
                         item: Element,
                         colNo: number
                     ): void {
+                        const row = (columns as any)[colNo - startColumn];
+                        let i = 1;
+
                         if (
                             (
                                 item.tagName === 'TD' ||
@@ -1549,6 +1552,16 @@ extend(Data.prototype, {
                             (columns as any)[colNo - startColumn][
                                 rowNo - startRow
                             ] = item.innerHTML;
+
+                            // Loop over all previous indices and make sure
+                            // they are nulls, not undefined.
+                            while (
+                                rowNo - startRow >= i &&
+                                row[rowNo - startRow - i] === void 0
+                            ) {
+                                row[rowNo - startRow - i] = null;
+                                i++;
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
Fixed #12566, now, in data module, empty points are beeing parsed to null instead of undefined.