### PR TITLE
Fixed #12812, high contrast mode not detected in new Edge.

### DIFF
--- a/js/modules/accessibility/high-contrast-mode.js
+++ b/js/modules/accessibility/high-contrast-mode.js
@@ -21,14 +21,13 @@ var whcm = {
      * @return {boolean} Returns true if the browser is in High Contrast mode.
      */
     isHighContrastModeActive: function () {
-        if (win.matchMedia &&
-            isMS &&
-            /Edge\/\d./i.test(win.navigator.userAgent)) {
-            // Use media query for Edge
+        // Use media query on Edge, but not on IE
+        var isEdge = /(Edg)/.test(win.navigator.userAgent);
+        if (win.matchMedia && isEdge) {
             return win.matchMedia('(-ms-high-contrast: active)').matches;
         }
+        // Test BG image for IE
         if (isMS && win.getComputedStyle) {
-            // Test BG image for IE
             var testDiv = doc.createElement('div');
             testDiv.style.backgroundImage = 'url(#)';
             doc.body.appendChild(testDiv);

--- a/ts/modules/accessibility/high-contrast-mode.ts
+++ b/ts/modules/accessibility/high-contrast-mode.ts
@@ -43,26 +43,28 @@ var whcm = {
      * @return {boolean} Returns true if the browser is in High Contrast mode.
      */
     isHighContrastModeActive: function (): boolean {
-        if (
-            win.matchMedia &&
-            isMS &&
-            /Edge\/\d./i.test(win.navigator.userAgent)
-        ) {
-            // Use media query for Edge
+        // Use media query on Edge, but not on IE
+        const isEdge = /(Edg)/.test(win.navigator.userAgent);
+        if (win.matchMedia && isEdge) {
             return win.matchMedia('(-ms-high-contrast: active)').matches;
         }
+
+        // Test BG image for IE
         if (isMS && win.getComputedStyle) {
-            // Test BG image for IE
-            var testDiv = doc.createElement('div');
+            const testDiv = doc.createElement('div');
             testDiv.style.backgroundImage = 'url(#)';
             doc.body.appendChild(testDiv);
-            var bi = (
+
+            const bi = (
                 testDiv.currentStyle as unknown as CSSStyleDeclaration ||
                 win.getComputedStyle(testDiv)
             ).backgroundImage;
+
             doc.body.removeChild(testDiv);
+
             return bi === 'none';
         }
+
         // Not used for other browsers
         return false;
     },


### PR DESCRIPTION
Fixed #12812, high contrast mode not detected in new Edge.
___
With new Chromium-based Edge, the user agent string has changed, causing the browser detection part to fail. (Browser detection is needed, since the media query solution doesn't work on IE.)