### PR TITLE
Added patternTransform option for pattern fills. Closes #12763.

### DIFF
--- a/js/modules/pattern-fill.src.js
+++ b/js/modules/pattern-fill.src.js
@@ -58,7 +58,7 @@ import H from '../parts/Globals.js';
 * @name Highcharts.PatternOptionsObject#path
 * @type {string|Highcharts.SVGAttributes}
 */ /**
-* SVG patternTransform to apply to the entire pattern.
+* SVG `patternTransform` to apply to the entire pattern.
 * @name Highcharts.PatternOptionsObject#patternTransform
 * @type {string}
 * @see [patternTransform demo](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/series/pattern-fill-transform)

--- a/js/modules/pattern-fill.src.js
+++ b/js/modules/pattern-fill.src.js
@@ -58,6 +58,11 @@ import H from '../parts/Globals.js';
 * @name Highcharts.PatternOptionsObject#path
 * @type {string|Highcharts.SVGAttributes}
 */ /**
+* SVG patternTransform to apply to the entire pattern.
+* @name Highcharts.PatternOptionsObject#patternTransform
+* @type {string}
+* @see [patternTransform demo](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/series/pattern-fill-transform)
+*/ /**
 * Pattern color, used as default path stroke.
 * @name Highcharts.PatternOptionsObject#color
 * @type {Highcharts.ColorString}
@@ -286,8 +291,8 @@ H.SVGRenderer.prototype.addPattern = function (options, animation) {
     }
     // Store ID in list to avoid duplicates
     this.defIds.push(id);
-    // Create pattern element
-    pattern = this.createElement('pattern').attr({
+    // Calculate pattern element attributes
+    var attrs = {
         id: id,
         patternUnits: 'userSpaceOnUse',
         patternContentUnits: options.patternContentUnits || 'userSpaceOnUse',
@@ -295,7 +300,11 @@ H.SVGRenderer.prototype.addPattern = function (options, animation) {
         height: height,
         x: options._x || options.x || 0,
         y: options._y || options.y || 0
-    }).add(this.defs);
+    };
+    if (options.patternTransform) {
+        attrs.patternTransform = options.patternTransform;
+    }
+    pattern = this.createElement('pattern').attr(attrs).add(this.defs);
     // Set id on the SVGRenderer object
     pattern.id = id;
     // Use an SVG path for the pattern

--- a/samples/highcharts/series/pattern-fill-transform/demo.details
+++ b/samples/highcharts/series/pattern-fill-transform/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Øystein Moseng
+ js_wrap: b
+...

--- a/samples/highcharts/series/pattern-fill-transform/demo.html
+++ b/samples/highcharts/series/pattern-fill-transform/demo.html
@@ -1,0 +1,4 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/pattern-fill.js"></script>
+
+<div id="container" style="height: 400px; max-width: 800px; margin: 0 auto"></div>

--- a/samples/highcharts/series/pattern-fill-transform/demo.js
+++ b/samples/highcharts/series/pattern-fill-transform/demo.js
@@ -1,0 +1,27 @@
+Highcharts.chart('container', {
+    title: {
+        text: 'Pattern fill module'
+    },
+    subtitle: {
+        text: 'With pattern transform'
+    },
+    series: [{
+        type: 'pie',
+        borderColor: Highcharts.getOptions().colors[0],
+        data: [{
+            y: 1,
+            color: {
+                pattern: {
+                    path: 'M 0 0 L 5 10 L 10 0',
+                    width: 10,
+                    height: 10,
+                    color: '#6070a0',
+                    patternTransform: 'scale(3) rotate(30)'
+                }
+            }
+        }],
+        dataLabels: {
+            enabled: false
+        }
+    }]
+});

--- a/ts/modules/pattern-fill.src.ts
+++ b/ts/modules/pattern-fill.src.ts
@@ -112,7 +112,7 @@ declare global {
  * @name Highcharts.PatternOptionsObject#path
  * @type {string|Highcharts.SVGAttributes}
  *//**
- * SVG patternTransform to apply to the entire pattern.
+ * SVG `patternTransform` to apply to the entire pattern.
  * @name Highcharts.PatternOptionsObject#patternTransform
  * @type {string}
  * @see [patternTransform demo](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/series/pattern-fill-transform)

--- a/ts/modules/pattern-fill.src.ts
+++ b/ts/modules/pattern-fill.src.ts
@@ -45,6 +45,7 @@ declare global {
             opacity?: number;
             path: (string|SVGAttributes);
             patternContentUnits?: 'string';
+            patternTransform?: string;
             width: number;
             x?: number;
             y?: number;
@@ -110,6 +111,11 @@ declare global {
  * pattern, the `image` property is ignored.
  * @name Highcharts.PatternOptionsObject#path
  * @type {string|Highcharts.SVGAttributes}
+ *//**
+ * SVG patternTransform to apply to the entire pattern.
+ * @name Highcharts.PatternOptionsObject#patternTransform
+ * @type {string}
+ * @see [patternTransform demo](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/series/pattern-fill-transform)
  *//**
  * Pattern color, used as default path stroke.
  * @name Highcharts.PatternOptionsObject#color
@@ -401,8 +407,8 @@ H.SVGRenderer.prototype.addPattern = function (
     // Store ID in list to avoid duplicates
     this.defIds.push(id);
 
-    // Create pattern element
-    pattern = this.createElement('pattern').attr({
+    // Calculate pattern element attributes
+    const attrs: Highcharts.SVGAttributes = {
         id: id,
         patternUnits: 'userSpaceOnUse',
         patternContentUnits: options.patternContentUnits || 'userSpaceOnUse',
@@ -410,7 +416,12 @@ H.SVGRenderer.prototype.addPattern = function (
         height: height,
         x: options._x || options.x || 0,
         y: options._y || options.y || 0
-    }).add(this.defs);
+    };
+    if (options.patternTransform) {
+        attrs.patternTransform = options.patternTransform;
+    }
+
+    pattern = this.createElement('pattern').attr(attrs).add(this.defs);
 
     // Set id on the SVGRenderer object
     pattern.id = id;


### PR DESCRIPTION
Added new option `pattern.patternTransform` that allows SVG `patternTransform` functions on a pattern.
___
Debatable if naming should be `pattern.transform` instead, but leaning towards `pattern.patternTransform` since it is a one-to-one with the SVG attribute.