### PR TITLE
bugfix/11993-wordcloud-setdata

### DIFF
--- a/js/modules/wordcloud.src.js
+++ b/js/modules/wordcloud.src.js
@@ -667,9 +667,16 @@ var wordCloudSeries = {
     drawPoints: function () {
         var series = this, hasRendered = series.hasRendered, xAxis = series.xAxis, yAxis = series.yAxis, chart = series.chart, group = series.group, options = series.options, animation = options.animation, allowExtendPlayingField = options.allowExtendPlayingField, renderer = chart.renderer, testElement = renderer.text().add(group), placed = [], placementStrategy = series.placementStrategy[options.placementStrategy], spiral, rotation = options.rotation, scale, weights = series.points.map(function (p) {
             return p.weight;
-        }), maxWeight = Math.max.apply(null, weights), data = series.points.sort(function (a, b) {
+        }), maxWeight = Math.max.apply(null, weights), 
+        // concat() prevents from sorting the original array.
+        data = series.points.concat().sort(function (a, b) {
             return b.weight - a.weight; // Sort descending
         }), field;
+        // Reset the scale before finding the dimensions (#11993)
+        series.group.attr({
+            scaleX: 1,
+            scaleY: 1
+        });
         // Get the dimensions for each word.
         // Used in calculating the playing field.
         data.forEach(function (point) {

--- a/js/modules/wordcloud.src.js
+++ b/js/modules/wordcloud.src.js
@@ -672,7 +672,11 @@ var wordCloudSeries = {
         data = series.points.concat().sort(function (a, b) {
             return b.weight - a.weight; // Sort descending
         }), field;
-        // Reset the scale before finding the dimensions (#11993)
+        // Reset the scale before finding the dimensions (#11993).
+        // SVGGRaphicsElement.getBBox() (used in SVGElement.getBBox(boolean))
+        // returns slightly different values for the same element depending on
+        // whether it is rendered in a group which has already defined scale
+        // (e.g. 6) or in the group without a scale (scale = 1).
         series.group.attr({
             scaleX: 1,
             scaleY: 1

--- a/samples/unit-tests/series-wordcloud/setdata/demo.details
+++ b/samples/unit-tests/series-wordcloud/setdata/demo.details
@@ -1,0 +1,5 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+...

--- a/samples/unit-tests/series-wordcloud/setdata/demo.html
+++ b/samples/unit-tests/series-wordcloud/setdata/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/wordcloud.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="height: 500px; width: 1000px;"></div>

--- a/samples/unit-tests/series-wordcloud/setdata/demo.js
+++ b/samples/unit-tests/series-wordcloud/setdata/demo.js
@@ -23,13 +23,13 @@ QUnit.test('Update the chart using the same data (#11993)', function (assert) {
                 data: data
             }]
         }),
-        widthBeforeUpdate = chart.series[0].points[0].graphic.element.getBBox(true).width;
+        widthBeforeUpdate = chart.series[0].points[0].graphic.getBBox(true).width;
 
     chart.series[0].setData(data);
 
     assert.strictEqual(
         widthBeforeUpdate,
-        chart.series[0].points[0].graphic.element.getBBox(true).width,
+        chart.series[0].points[0].graphic.getBBox(true).width,
         'Width of the element should be exactly the same after the update.'
     );
 });

--- a/samples/unit-tests/series-wordcloud/setdata/demo.js
+++ b/samples/unit-tests/series-wordcloud/setdata/demo.js
@@ -1,0 +1,35 @@
+QUnit.test('Update the chart using the same data (#11993)', function (assert) {
+
+    var data = [{
+            name: 'Test',
+            weight: 10
+        }, {
+            name: 'Test',
+            weight: 100
+        }, {
+            name: 'Test',
+            weight: 1000
+        }],
+        chart = Highcharts.chart('container', {
+            chart: {
+                type: 'wordcloud',
+                height: 500,
+                width: 1000
+            },
+            series: [{
+                style: {
+                    fontFamily: 'Impact'
+                },
+                data: data
+            }]
+        }),
+        widthBeforeUpdate = chart.series[0].points[0].graphic.element.getBBox(true).width;
+
+    chart.series[0].setData(data);
+
+    assert.strictEqual(
+        widthBeforeUpdate,
+        chart.series[0].points[0].graphic.element.getBBox(true).width,
+        'Width of the element should be exactly the same after the update.'
+    );
+});

--- a/ts/modules/wordcloud.src.ts
+++ b/ts/modules/wordcloud.src.ts
@@ -980,13 +980,20 @@ var wordCloudSeries: Partial<Highcharts.WordcloudSeries> = {
                 return p.weight;
             }),
             maxWeight = Math.max.apply(null, weights),
-            data = series.points.sort(function (
+            // concat() prevents from sorting the original array.
+            data = series.points.concat().sort(function (
                 a: Highcharts.WordcloudPoint,
                 b: Highcharts.WordcloudPoint
             ): number {
                 return b.weight - a.weight; // Sort descending
             }),
             field: Highcharts.WordcloudFieldObject;
+
+        // Reset the scale before finding the dimensions (#11993)
+        series.group.attr({
+            scaleX: 1,
+            scaleY: 1
+        });
 
         // Get the dimensions for each word.
         // Used in calculating the playing field.

--- a/ts/modules/wordcloud.src.ts
+++ b/ts/modules/wordcloud.src.ts
@@ -989,7 +989,11 @@ var wordCloudSeries: Partial<Highcharts.WordcloudSeries> = {
             }),
             field: Highcharts.WordcloudFieldObject;
 
-        // Reset the scale before finding the dimensions (#11993)
+        // Reset the scale before finding the dimensions (#11993).
+        // SVGGRaphicsElement.getBBox() (used in SVGElement.getBBox(boolean))
+        // returns slightly different values for the same element depending on
+        // whether it is rendered in a group which has already defined scale
+        // (e.g. 6) or in the group without a scale (scale = 1).
         series.group.attr({
             scaleX: 1,
             scaleY: 1


### PR DESCRIPTION
Fixed #11993, wordcloud looked incorrect after running `setData()`.