### PR TITLE
enhancement/#10663-venn-inactive-visiblity

### DIFF
--- a/js/modules/venn.src.js
+++ b/js/modules/venn.src.js
@@ -726,6 +726,9 @@ var vennOptions = {
             color: '${palette.neutralColor20}',
             borderColor: '${palette.neutralColor100}',
             animation: false
+        },
+        inactive: {
+            opacity: 0.075
         }
     },
     tooltip: {

--- a/ts/modules/venn.src.ts
+++ b/ts/modules/venn.src.ts
@@ -1131,6 +1131,9 @@ var vennOptions: Highcharts.VennSeriesOptions = {
             color: '${palette.neutralColor20}',
             borderColor: '${palette.neutralColor100}',
             animation: false
+        },
+        inactive: {
+            opacity: 0.075
         }
     },
     tooltip: {


### PR DESCRIPTION
Changed the default `inactive.opacity` for venn diagrams to ease perception, see #10663.