### PR TITLE
Feature/a11y annotations

### DIFF
--- a/js/modules/accessibility/accessibility.js
+++ b/js/modules/accessibility/accessibility.js
@@ -98,11 +98,27 @@ Accessibility.prototype = {
             extend(this.components, a11yOptions.customComponents);
         }
         var components = this.components;
-        // Refactor to use Object.values if we polyfill
-        Object.keys(components).forEach(function (componentName) {
+        this.getComponentOrder().forEach(function (componentName) {
             components[componentName].initBase(chart);
             components[componentName].init();
         });
+    },
+    /**
+     * Get order to update components in.
+     * @private
+     */
+    getComponentOrder: function () {
+        if (!this.components) {
+            return []; // For zombie accessibility object on old browsers
+        }
+        if (!this.components.series) {
+            return Object.keys(this.components);
+        }
+        var componentsExceptSeries = Object.keys(this.components)
+            .filter(function (c) { return c !== 'series'; });
+        // Update series first, so that other components can read accessibility
+        // info on points.
+        return ['series'].concat(componentsExceptSeries);
     },
     /**
      * Update all components.
@@ -113,7 +129,7 @@ Accessibility.prototype = {
         // Update the chart type list as this is used by multiple modules
         chart.types = this.getChartTypes();
         // Update markup
-        Object.keys(components).forEach(function (componentName) {
+        this.getComponentOrder().forEach(function (componentName) {
             components[componentName].onChartUpdate();
             fireEvent(chart, 'afterA11yComponentUpdate', {
                 name: componentName,
@@ -127,7 +143,9 @@ Accessibility.prototype = {
             whcm.isHighContrastModeActive()) {
             whcm.setHighContrastTheme(chart);
         }
-        fireEvent(chart, 'afterA11yUpdate');
+        fireEvent(chart, 'afterA11yUpdate', {
+            accessibility: this
+        });
     },
     /**
      * Destroy all elements.
@@ -199,7 +217,7 @@ addEvent(H.Chart, 'render', function (e) {
     }
     var a11y = this.accessibility;
     if (a11y) {
-        Object.keys(a11y.components).forEach(function (componentName) {
+        a11y.getComponentOrder().forEach(function (componentName) {
             a11y.components[componentName].onChartRender();
         });
     }

--- a/js/modules/accessibility/components/AnnotationsA11y.js
+++ b/js/modules/accessibility/components/AnnotationsA11y.js
@@ -1,0 +1,131 @@
+/* *
+ *
+ *  (c) 2009-2019 Øystein Moseng
+ *
+ *  Annotations accessibility code.
+ *
+ *  License: www.highcharts.com/license
+ *
+ *  !!!!!!! SOURCE GETS TRANSPILED BY TYPESCRIPT. EDIT TS FILE ONLY. !!!!!!!
+ *
+ * */
+'use strict';
+import '../../../parts/Utilities.js';
+import H from '../../../parts/Globals.js';
+var inArray = H.inArray;
+import HTMLUtilities from '../utils/htmlUtilities.js';
+var escapeStringForHTML = HTMLUtilities.escapeStringForHTML, stripHTMLTagsFromString = HTMLUtilities.stripHTMLTagsFromString;
+/**
+ * Get list of all annotation labels in the chart.
+ *
+ * @private
+ * @param {Highcharts.Chart} chart The chart to get annotation info on.
+ * @return {Array<object>} The labels, or empty array if none.
+ */
+function getChartAnnotationLabels(chart) {
+    var annotations = chart.annotations || [];
+    return annotations.reduce(function (acc, cur) {
+        var _a;
+        if (((_a = cur.options) === null || _a === void 0 ? void 0 : _a.visible) !== false) {
+            acc = acc.concat(cur.labels);
+        }
+        return acc;
+    }, []);
+}
+/**
+ * Get the text of an annotation label.
+ *
+ * @private
+ * @param {object} label The annotation label object
+ * @return {string} The text in the label.
+ */
+function getLabelText(label) {
+    var _a, _b;
+    return ((_b = (_a = label.graphic) === null || _a === void 0 ? void 0 : _a.text) === null || _b === void 0 ? void 0 : _b.textStr) || '';
+}
+/**
+ * Describe an annotation label.
+ *
+ * @private
+ * @param {object} label The annotation label object to describe
+ * @return {string} The description for the label.
+ */
+function getAnnotationLabelDescription(label) {
+    var chart = label.chart;
+    var labelText = getLabelText(label);
+    var points = label.points;
+    var getAriaLabel = function (point) { var _a, _b, _c; return ((_c = (_b = (_a = point) === null || _a === void 0 ? void 0 : _a.graphic) === null || _b === void 0 ? void 0 : _b.element) === null || _c === void 0 ? void 0 : _c.getAttribute('aria-label')) || ''; };
+    var getValueDesc = function (point) {
+        var _a, _b, _c;
+        var valDesc = ((_b = (_a = point) === null || _a === void 0 ? void 0 : _a.accessibility) === null || _b === void 0 ? void 0 : _b.valueDescription) || getAriaLabel(point);
+        var seriesName = ((_c = point) === null || _c === void 0 ? void 0 : _c.series.name) || '';
+        return (seriesName ? seriesName + ', ' : '') + 'data point ' + valDesc;
+    };
+    var pointValueDescriptions = points
+        .filter(function (p) { return !!p.graphic; }) // Filter out mock points
+        .map(getValueDesc)
+        .filter(function (desc) { return !!desc; }); // Filter out points we can't describe
+    var numPoints = pointValueDescriptions.length;
+    var pointsSelector = numPoints > 1 ? 'MultiplePoints' : numPoints ? 'SinglePoint' : 'NoPoints';
+    var langFormatStr = 'accessibility.screenReaderSection.annotations.description' + pointsSelector;
+    var context = {
+        annotationText: labelText,
+        numPoints: numPoints,
+        annotationPoint: pointValueDescriptions[0],
+        additionalAnnotationPoints: pointValueDescriptions.slice(1)
+    };
+    return chart.langFormat(langFormatStr, context);
+}
+/**
+ * Return array of HTML strings for each annotation label in the chart.
+ *
+ * @private
+ * @param {Highcharts.Chart} chart The chart to get annotation info on.
+ * @return {Array<string>} Array of strings with HTML content for each annotation label.
+ */
+function getAnnotationListItems(chart) {
+    var labels = getChartAnnotationLabels(chart);
+    return labels.map(function (label) {
+        var desc = escapeStringForHTML(stripHTMLTagsFromString(getAnnotationLabelDescription(label)));
+        return desc ? "<li>" + desc + "</li>" : '';
+    });
+}
+/**
+ * Return the annotation info for a chart as string.
+ *
+ * @private
+ * @param {Highcharts.Chart} chart The chart to get annotation info on.
+ * @return {string} String with HTML content or empty string if no annotations.
+ */
+function getAnnotationsInfoHTML(chart) {
+    var annotations = chart.annotations;
+    if (!(annotations && annotations.length)) {
+        return '';
+    }
+    var annotationItems = getAnnotationListItems(chart);
+    return "<ul>" + annotationItems.join(' ') + "</ul>";
+}
+/**
+ * Return the texts for the annotation(s) connected to a point, or empty array
+ * if none.
+ *
+ * @private
+ * @param {Highcharts.Point} point The data point to get the annotation info from.
+ * @return {Array<string>} Annotation texts
+ */
+function getPointAnnotationTexts(point) {
+    var labels = getChartAnnotationLabels(point.series.chart);
+    var pointLabels = labels
+        .filter(function (label) { return inArray(point, label.points) > -1; });
+    if (!pointLabels.length) {
+        return [];
+    }
+    return pointLabels.map(function (label) { return "" + getLabelText(label); });
+}
+var AnnotationsA11y = {
+    getAnnotationsInfoHTML: getAnnotationsInfoHTML,
+    getAnnotationLabelDescription: getAnnotationLabelDescription,
+    getAnnotationListItems: getAnnotationListItems,
+    getPointAnnotationTexts: getPointAnnotationTexts
+};
+export default AnnotationsA11y;

--- a/js/modules/accessibility/components/InfoRegionsComponent/AnnotationsA11y.js
+++ b/js/modules/accessibility/components/InfoRegionsComponent/AnnotationsA11y.js
@@ -1,0 +1,80 @@
+/* *
+ *
+ *  (c) 2009-2019 Øystein Moseng
+ *
+ *  Annotations accessibility code.
+ *
+ *  License: www.highcharts.com/license
+ *
+ *  !!!!!!! SOURCE GETS TRANSPILED BY TYPESCRIPT. EDIT TS FILE ONLY. !!!!!!!
+ *
+ * */
+'use strict';
+/**
+ * Describe an annotation label.
+ *
+ * @private
+ * @param {object} label The annotation label object to describe
+ * @return {string} The description for the label.
+ */
+function getAnnotationLabelDescription(label) {
+    var _a, _b;
+    var chart = label.chart;
+    var labelText = ((_b = (_a = label.graphic) === null || _a === void 0 ? void 0 : _a.text) === null || _b === void 0 ? void 0 : _b.textStr) || '';
+    var points = label.points;
+    var getAriaLabel = function (point) { var _a, _b, _c; return ((_c = (_b = (_a = point) === null || _a === void 0 ? void 0 : _a.graphic) === null || _b === void 0 ? void 0 : _b.element) === null || _c === void 0 ? void 0 : _c.getAttribute('aria-label')) || ''; };
+    var ariaLabels = points.map(getAriaLabel)
+        .filter(function (label) { return !!label; });
+    var numPoints = ariaLabels.length;
+    var pointsSelector = numPoints > 1 ? 'MultiplePoints' : numPoints ? 'SinglePoint' : 'NoPoints';
+    var langFormatStr = 'accessibility.screenReaderSection.annotations.description' + pointsSelector;
+    var context = {
+        annotationText: labelText,
+        numPoints: numPoints,
+        annotationPoints: ariaLabels,
+        annotationPoint: ariaLabels[0]
+    };
+    return chart.langFormat(langFormatStr, context);
+}
+/**
+ * Return array of HTML strings for each annotation label in the chart.
+ *
+ * @private
+ * @param {Highcharts.Chart} chart The chart to get annotation info on.
+ * @return {Array<string>} Array of strings with HTML content for each annotation label.
+ */
+function getAnnotationItems(chart) {
+    var annotations = chart.annotations || [];
+    var labels = annotations.reduce(function (acc, cur) {
+        var _a;
+        if (((_a = cur.options) === null || _a === void 0 ? void 0 : _a.visible) !== false) {
+            acc = acc.concat(cur.labels);
+        }
+        return acc;
+    }, []);
+    return labels.map(function (label) {
+        var desc = getAnnotationLabelDescription(label);
+        return desc ? "<li>" + desc + "</li>" : '';
+    });
+}
+/**
+ * Return the annotation info for a chart as string.
+ *
+ * @private
+ * @param {Highcharts.Chart} chart The chart to get annotation info on.
+ * @return {string} String with HTML content or empty string if no annotations.
+ */
+function getAnnotationsInfoHTML(chart) {
+    var annotations = chart.annotations;
+    if (!(annotations && annotations.length)) {
+        return '';
+    }
+    var annotationItems = getAnnotationItems(chart);
+    return "<ul>" + annotationItems.join(' ') + "</ul>";
+}
+var AnnotationsA11y = {
+    getAnnotationsInfoHTML: getAnnotationsInfoHTML,
+    getAnnotationItems: getAnnotationItems,
+    getAnnotationLabelDescription: getAnnotationLabelDescription
+};
+export default AnnotationsA11y;

--- a/js/modules/accessibility/components/InfoRegionsComponent/InfoRegionsComponent.js
+++ b/js/modules/accessibility/components/InfoRegionsComponent/InfoRegionsComponent.js
@@ -1,6 +1,6 @@
 /* *
  *
- *  (c) 2009-2020 Øystein Moseng
+ *  (c) 2009-2019 Øystein Moseng
  *
  *  Accessibility component for chart info region and table.
  *
@@ -10,16 +10,16 @@
  *
  * */
 'use strict';
-import H from '../../../parts/Globals.js';
-var doc = H.win.document;
-import U from '../../../parts/Utilities.js';
-var extend = U.extend, format = U.format, pick = U.pick;
-import AccessibilityComponent from '../AccessibilityComponent.js';
-import AnnotationsA11y from './AnnotationsA11y.js';
+import H from '../../../../parts/Globals.js';
+var doc = H.win.document, format = H.format;
+import U from '../../../../parts/Utilities.js';
+var extend = U.extend, pick = U.pick;
+import AccessibilityComponent from '../../AccessibilityComponent.js';
+import AnnotationsA11y from '../AnnotationsA11y.js';
 var getAnnotationsInfoHTML = AnnotationsA11y.getAnnotationsInfoHTML;
-import ChartUtilities from '../utils/chartUtilities.js';
+import ChartUtilities from '../../utils/chartUtilities.js';
 var unhideChartElementFromAT = ChartUtilities.unhideChartElementFromAT, getChartTitle = ChartUtilities.getChartTitle, getAxisDescription = ChartUtilities.getAxisDescription;
-import HTMLUtilities from '../utils/htmlUtilities.js';
+import HTMLUtilities from '../../utils/htmlUtilities.js';
 var addClass = HTMLUtilities.addClass, setElAttrs = HTMLUtilities.setElAttrs, escapeStringForHTML = HTMLUtilities.escapeStringForHTML, stripHTMLTagsFromString = HTMLUtilities.stripHTMLTagsFromString, getElement = HTMLUtilities.getElement, visuallyHideElement = HTMLUtilities.visuallyHideElement;
 /* eslint-disable no-invalid-this, valid-jsdoc */
 /**
@@ -250,7 +250,7 @@ extend(InfoRegionsComponent.prototype, /** @lends Highcharts.InfoRegionsComponen
     defaultBeforeChartFormatter: function () {
         var chart = this.chart, format = chart.options.accessibility
             .screenReaderSection.beforeChartFormat, axesDesc = this.getAxesDescription(), dataTableButtonId = 'hc-linkto-highcharts-data-table-' +
-            chart.index, annotationsList = getAnnotationsInfoHTML(chart), annotationsTitleStr = chart.langFormat('accessibility.screenReaderSection.annotations.heading', { chart: chart }), context = {
+            chart.index, annotationsTitleStr = chart.langFormat('accessibility.screenReaderSection.annotations.heading', { chart: chart }), context = {
             chartTitle: getChartTitle(chart),
             typeDescription: this.getTypeDescriptionText(),
             chartSubtitle: this.getSubtitleText(),
@@ -259,8 +259,8 @@ extend(InfoRegionsComponent.prototype, /** @lends Highcharts.InfoRegionsComponen
             yAxisDescription: axesDesc.yAxis,
             viewTableButton: chart.getCSV ?
                 this.getDataTableButtonText(dataTableButtonId) : '',
-            annotationsTitle: annotationsList ? annotationsTitleStr : '',
-            annotationsList: annotationsList
+            annotationsTitle: annotationsTitleStr,
+            annotationsList: getAnnotationsInfoHTML(chart)
         }, formattedString = H.i18nFormat(format, context, chart);
         this.dataTableButtonId = dataTableButtonId;
         return stringToSimpleHTML(formattedString);

--- a/js/modules/accessibility/components/SeriesComponent/SeriesDescriber.js
+++ b/js/modules/accessibility/components/SeriesComponent/SeriesDescriber.js
@@ -11,11 +11,13 @@
  * */
 'use strict';
 import H from '../../../../parts/Globals.js';
-var numberFormat = H.numberFormat, find = H.find;
+var numberFormat = H.numberFormat, format = H.format, find = H.find;
 import U from '../../../../parts/Utilities.js';
 var isNumber = U.isNumber, pick = U.pick, defined = U.defined;
+import AnnotationsA11y from '../AnnotationsA11y.js';
+var getPointAnnotationTexts = AnnotationsA11y.getPointAnnotationTexts;
 import HTMLUtilities from '../../utils/htmlUtilities.js';
-var reverseChildNodes = HTMLUtilities.reverseChildNodes, stripHTMLTags = HTMLUtilities.stripHTMLTagsFromString;
+var escapeStringForHTML = HTMLUtilities.escapeStringForHTML, reverseChildNodes = HTMLUtilities.reverseChildNodes, stripHTMLTags = HTMLUtilities.stripHTMLTagsFromString;
 import ChartUtilities from '../../utils/chartUtilities.js';
 var getAxisDescription = ChartUtilities.getAxisDescription, getSeriesFirstPointElement = ChartUtilities.getSeriesFirstPointElement, getSeriesA11yElement = ChartUtilities.getSeriesA11yElement, unhideChartElementFromAT = ChartUtilities.unhideChartElementFromAT;
 import Tooltip from '../../../../parts/Tooltip.js';
@@ -219,7 +221,7 @@ function getPointArrayMapValueDescription(point, prefix, suffix) {
  * @param {Highcharts.Point} point
  * @return {string}
  */
-function getPointValueDescription(point) {
+function getPointValue(point) {
     var series = point.series, a11yPointOpts = series.chart.options.accessibility.point || {}, tooltipOptions = series.tooltipOptions || {}, valuePrefix = a11yPointOpts.valuePrefix ||
         tooltipOptions.valuePrefix || '', valueSuffix = a11yPointOpts.valueSuffix ||
         tooltipOptions.valueSuffix || '', fallbackKey = (typeof point.value !==
@@ -236,17 +238,50 @@ function getPointValueDescription(point) {
     return valuePrefix + fallbackDesc + valueSuffix;
 }
 /**
+ * Return the description for the annotation(s) connected to a point, or empty
+ * string if none.
+ *
+ * @private
+ * @param {Highcharts.Point} point The data point to get the annotation info from.
+ * @return {string} Annotation description
+ */
+function getPointAnnotationDescription(point) {
+    var chart = point.series.chart;
+    var langKey = 'accessibility.series.pointAnnotationsDescription';
+    var annotations = getPointAnnotationTexts(point);
+    var context = { point: point, annotations: annotations };
+    return annotations.length ? chart.langFormat(langKey, context) : '';
+}
+/**
+ * Return string with information about point.
+ * @private
+ * @return {string}
+ */
+function getPointValueDescription(point) {
+    var series = point.series, chart = series.chart, pointValueDescriptionFormat = chart.options.accessibility
+        .point.valueDescriptionFormat, showXDescription = pick(series.xAxis &&
+        series.xAxis.options.accessibility &&
+        series.xAxis.options.accessibility.enabled, !chart.angular), xDesc = showXDescription ? getPointXDescription(point) : '', context = {
+        point: point,
+        index: defined(point.index) ? (point.index + 1) : '',
+        xDescription: xDesc,
+        value: getPointValue(point),
+        separator: showXDescription ? ', ' : ''
+    };
+    return format(pointValueDescriptionFormat, context, chart);
+}
+/**
  * Return string with information about point.
  * @private
  * @return {string}
  */
 function defaultPointDescriptionFormatter(point) {
-    var series = point.series, chart = series.chart, description = point.options && point.options.accessibility &&
-        point.options.accessibility.description, showXDescription = pick(series.xAxis &&
-        series.xAxis.options.accessibility &&
-        series.xAxis.options.accessibility.enabled, !chart.angular), xDesc = getPointXDescription(point), valueDesc = getPointValueDescription(point), indexText = defined(point.index) ? (point.index + 1) + '. ' : '', xDescText = showXDescription ? xDesc + ', ' : '', valText = valueDesc + '.', userDescText = description ? ' ' + description : '', seriesNameText = chart.series.length > 1 && series.name ?
-        ' ' + series.name + '.' : '';
-    return indexText + xDescText + valText + userDescText + seriesNameText;
+    var series = point.series, chart = series.chart, valText = getPointValueDescription(point), description = point.options && point.options.accessibility &&
+        point.options.accessibility.description, userDescText = description ? ' ' + description : '', seriesNameText = chart.series.length > 1 && series.name ?
+        ' ' + series.name + '.' : '', annotationsDesc = getPointAnnotationDescription(point), pointAnnotationsText = annotationsDesc ? ' ' + annotationsDesc : '';
+    point.accessibility = point.accessibility || {};
+    point.accessibility.valueDescription = valText;
+    return valText + userDescText + seriesNameText + pointAnnotationsText;
 }
 /**
  * Set a11y props on a point element
@@ -255,11 +290,11 @@ function defaultPointDescriptionFormatter(point) {
  * @param {Highcharts.HTMLDOMElement|Highcharts.SVGDOMElement} pointElement
  */
 function setPointScreenReaderAttribs(point, pointElement) {
-    var series = point.series, a11yPointOptions = series.chart.options.accessibility.point || {}, seriesA11yOptions = series.options.accessibility || {}, label = stripHTMLTags(seriesA11yOptions.pointDescriptionFormatter &&
+    var series = point.series, a11yPointOptions = series.chart.options.accessibility.point || {}, seriesA11yOptions = series.options.accessibility || {}, label = escapeStringForHTML(stripHTMLTags(seriesA11yOptions.pointDescriptionFormatter &&
         seriesA11yOptions.pointDescriptionFormatter(point) ||
         a11yPointOptions.descriptionFormatter &&
             a11yPointOptions.descriptionFormatter(point) ||
-        defaultPointDescriptionFormatter(point));
+        defaultPointDescriptionFormatter(point)));
     pointElement.setAttribute('role', 'img');
     pointElement.setAttribute('aria-label', label);
 }
@@ -321,9 +356,9 @@ function describeSeriesElement(series, seriesElement) {
         seriesElement.setAttribute('role', 'region');
     } /* else do not add role */
     seriesElement.setAttribute('tabindex', '-1');
-    seriesElement.setAttribute('aria-label', stripHTMLTags(a11yOptions.series.descriptionFormatter &&
+    seriesElement.setAttribute('aria-label', escapeStringForHTML(stripHTMLTags(a11yOptions.series.descriptionFormatter &&
         a11yOptions.series.descriptionFormatter(series) ||
-        defaultSeriesDescriptionFormatter(series)));
+        defaultSeriesDescriptionFormatter(series))));
 }
 /**
  * Put accessible info on series and points of a series.
@@ -355,6 +390,7 @@ var SeriesDescriber = {
     defaultSeriesDescriptionFormatter: defaultSeriesDescriptionFormatter,
     getPointA11yTimeDescription: getPointA11yTimeDescription,
     getPointXDescription: getPointXDescription,
+    getPointValue: getPointValue,
     getPointValueDescription: getPointValueDescription
 };
 export default SeriesDescriber;

--- a/js/modules/accessibility/options/langOptions.js
+++ b/js/modules/accessibility/options/langOptions.js
@@ -71,6 +71,18 @@ var langOptions = {
             beforeRegionLabel: 'Chart screen reader information.',
             afterRegionLabel: '',
             /**
+             * Language options for annotation descriptions.
+             *
+             * @since next
+             */
+            annotations: {
+                heading: 'Chart annotations',
+                descriptionSinglePoint: '{annotationText}. Related to {annotationPoint}',
+                descriptionMultiplePoints: '{annotationText}. Related to {annotationPoint}' +
+                    '{ Also related to, #each(additionalAnnotationPoints)}',
+                descriptionNoPoints: '{annotationText}'
+            },
+            /**
              * Label for the end of the chart. Announced by screen readers.
              *
              * @since 8.0.0
@@ -278,8 +290,8 @@ var langOptions = {
                 mapbubbleCombination: '{name}, series {ix} of {numSeries}. Bubble series with {numPoints} {#plural(numPoints, bubbles, bubble)}.'
             },
             /**
-             * User supplied description text. This is added after the main
-             * summary if present.
+             * User supplied description text. This is added in the point
+             * comment description by default if present.
              *
              * @since 6.0.6
              */
@@ -303,7 +315,14 @@ var langOptions = {
              *
              * @since 8.0.0
              */
-            nullPointValue: 'No value'
+            nullPointValue: 'No value',
+            /**
+             * Description for annotations on a point, as it is made available
+             * to assistive technology.
+             *
+             * @since next
+             */
+            pointAnnotationsDescription: '{Annotation: "#each(annotations)". }'
         }
     }
 };

--- a/js/modules/accessibility/options/options.js
+++ b/js/modules/accessibility/options/options.js
@@ -121,11 +121,12 @@ var options = {
              */
             /**
              * Format for the screen reader information region before the chart.
-             * Supported HTML tags are `<h1-7>`, `<p>`, `<div>`, `<a>`, and
-             * `<button>`. Attributes are not supported, except for id on
-             * `<div>`, `<a>`, and `<button>`. Id is required on `<a>` and
-             * `<button>` in the format `<tag id="abcd">`. Numbers, lower- and
-             * uppercase letters, "-" and "#" are valid characters in IDs.
+             * Supported HTML tags are `<h1-7>`, `<p>`, `<div>`, `<a>`, `<ul>`,
+             * `<ol>`, `<li>`, and `<button>`. Attributes are not supported,
+             * except for id on `<div>`, `<a>`, and `<button>`. Id is required
+             * on `<a>` and `<button>` in the format `<tag id="abcd">`. Numbers,
+             * lower- and uppercase letters, "-" and "#" are valid characters in
+             * IDs.
              *
              * @since 8.0.0
              */
@@ -133,9 +134,10 @@ var options = {
                 '<div>{typeDescription}</div>' +
                 '<div>{chartSubtitle}</div>' +
                 '<div>{chartLongdesc}</div>' +
+                '<div>{viewTableButton}</div>' +
                 '<div>{xAxisDescription}</div>' +
                 '<div>{yAxisDescription}</div>' +
-                '<div>{viewTableButton}</div>',
+                '<div>{annotationsTitle}{annotationsList}</div>',
             /**
              * A formatter function to create the HTML contents of the hidden
              * screen reader information region after the chart. Analogous to
@@ -202,6 +204,103 @@ var options = {
              * @since 8.0.0
              */
             pointDescriptionEnabledThreshold: 200
+        },
+        /**
+         * Options for descriptions of individual data points.
+         *
+         * @since 8.0.0
+         */
+        point: {
+            /**
+             * Format to use for describing the values of data points
+             * to assistive technology - including screen readers.
+             * The point context is available as `{point}`.
+             *
+             * Additionally, the series name, annotation info, and
+             * description added in `point.accessibility.description`
+             * is added by default if relevant. To override this, use the
+             * [accessibility.point.descriptionFormatter](#accessibility.point.descriptionFormatter)
+             * option.
+             *
+             * @see [point.accessibility.description](#series.line.data.accessibility.description)
+             * @see [accessibility.point.descriptionFormatter](#accessibility.point.descriptionFormatter)
+             *
+             * @type      {string}
+             * @since next
+             */
+            valueDescriptionFormat: '{index}. {xDescription}{separator}{value}.'
+            /**
+             * Date format to use for points on datetime axes when describing
+             * them to screen reader users.
+             *
+             * Defaults to the same format as in tooltip.
+             *
+             * For an overview of the replacement codes, see
+             * [dateFormat](/class-reference/Highcharts#dateFormat).
+             *
+             * @see [dateFormatter](#accessibility.point.dateFormatter)
+             *
+             * @type      {string}
+             * @since 8.0.0
+             * @apioption accessibility.point.dateFormat
+             */
+            /**
+             * Formatter function to determine the date/time format used with
+             * points on datetime axes when describing them to screen reader
+             * users. Receives one argument, `point`, referring to the point
+             * to describe. Should return a date format string compatible with
+             * [dateFormat](/class-reference/Highcharts#dateFormat).
+             *
+             * @see [dateFormat](#accessibility.point.dateFormat)
+             *
+             * @type      {Highcharts.ScreenReaderFormatterCallbackFunction<Highcharts.Point>}
+             * @since 8.0.0
+             * @apioption accessibility.point.dateFormatter
+             */
+            /**
+             * Prefix to add to the values in the point descriptions. Uses
+             * [tooltip.valuePrefix](#tooltip.valuePrefix) if not defined.
+             *
+             * @type        {string}
+             * @since 8.0.0
+             * @apioption   accessibility.point.valuePrefix
+             */
+            /**
+             * Suffix to add to the values in the point descriptions. Uses
+             * [tooltip.valueSuffix](#tooltip.valueSuffix) if not defined.
+             *
+             * @type        {string}
+             * @since 8.0.0
+             * @apioption   accessibility.point.valueSuffix
+             */
+            /**
+             * Decimals to use for the values in the point descriptions. Uses
+             * [tooltip.valueDecimals](#tooltip.valueDecimals) if not defined.
+             *
+             * @type        {number}
+             * @since 8.0.0
+             * @apioption   accessibility.point.valueDecimals
+             */
+            /**
+             * Formatter function to use instead of the default for point
+             * descriptions.
+             *
+             * Receives one argument, `point`, referring to the point to
+             * describe. Should return a string with the description of the
+             * point for a screen reader user. If `false` is returned, the
+             * default formatter will be used for that point.
+             *
+             * Note: Prefer using [accessibility.point.valueDescriptionFormat](#accessibility.point.valueDescriptionFormat)
+             * instead if possible, as default functionality such as describing
+             * annotations will be preserved.
+             *
+             * @see [accessibility.point.valueDescriptionFormat](#accessibility.point.valueDescriptionFormat)
+             * @see [point.accessibility.description](#series.line.data.accessibility.description)
+             *
+             * @type      {Highcharts.ScreenReaderFormatterCallbackFunction<Highcharts.Point>}
+             * @since 8.0.0
+             * @apioption accessibility.point.descriptionFormatter
+             */
         },
         /**
          * Amount of landmarks/regions to create for screen reader users. More
@@ -319,78 +418,6 @@ var options = {
          * @type      {string}
          * @since     5.0.0
          * @apioption accessibility.typeDescription
-         */
-        /**
-         * Options for descriptions of individual data points.
-         *
-         * @since 8.0.0
-         * @apioption accessibility.point
-         */
-        /**
-         * Date format to use for points on datetime axes when describing them
-         * to screen reader users.
-         *
-         * Defaults to the same format as in tooltip.
-         *
-         * For an overview of the replacement codes, see
-         * [dateFormat](/class-reference/Highcharts#dateFormat).
-         *
-         * @see [dateFormatter](#accessibility.point.dateFormatter)
-         *
-         * @type      {string}
-         * @since 8.0.0
-         * @apioption accessibility.point.dateFormat
-         */
-        /**
-         * Formatter function to determine the date/time format used with
-         * points on datetime axes when describing them to screen reader users.
-         * Receives one argument, `point`, referring to the point to describe.
-         * Should return a date format string compatible with
-         * [dateFormat](/class-reference/Highcharts#dateFormat).
-         *
-         * @see [dateFormat](#accessibility.point.dateFormat)
-         *
-         * @type      {Highcharts.ScreenReaderFormatterCallbackFunction<Highcharts.Point>}
-         * @since 8.0.0
-         * @apioption accessibility.point.dateFormatter
-         */
-        /**
-         * Prefix to add to the values in the point descriptions. Uses
-         * [tooltip.valuePrefix](#tooltip.valuePrefix) if not defined.
-         *
-         * @type        {string}
-         * @since 8.0.0
-         * @apioption   accessibility.point.valuePrefix
-         */
-        /**
-         * Suffix to add to the values in the point descriptions. Uses
-         * [tooltip.valueSuffix](#tooltip.valueSuffix) if not defined.
-         *
-         * @type        {string}
-         * @since 8.0.0
-         * @apioption   accessibility.point.valueSuffix
-         */
-        /**
-         * Decimals to use for the values in the point descriptions. Uses
-         * [tooltip.valueDecimals](#tooltip.valueDecimals) if not defined.
-         *
-         * @type        {number}
-         * @since 8.0.0
-         * @apioption   accessibility.point.valueDecimals
-         */
-        /**
-         * Formatter function to use instead of the default for point
-         * descriptions.
-         * Receives one argument, `point`, referring to the point to describe.
-         * Should return a string with the description of the point for a screen
-         * reader user. If `false` is returned, the default formatter will be
-         * used for that point.
-         *
-         * @see [point.accessibility.description](#series.line.data.accessibility.description)
-         *
-         * @type      {Highcharts.ScreenReaderFormatterCallbackFunction<Highcharts.Point>}
-         * @since 8.0.0
-         * @apioption accessibility.point.descriptionFormatter
          */
         /**
          * Options for keyboard navigation.

--- a/js/modules/accessibility/utils/htmlUtilities.js
+++ b/js/modules/accessibility/utils/htmlUtilities.js
@@ -150,6 +150,7 @@ function visuallyHideElement(element) {
         width: '1px',
         height: '1px',
         overflow: 'hidden',
+        whiteSpace: 'nowrap',
         clip: 'rect(1px, 1px, 1px, 1px)',
         marginTop: '-3px',
         '-ms-filter': 'progid:DXImageTransform.Microsoft.Alpha(Opacity=1)',

--- a/samples/highcharts/accessibility/accessible-annotations/demo.css
+++ b/samples/highcharts/accessibility/accessible-annotations/demo.css
@@ -1,0 +1,37 @@
+#container {
+    height: 500px; 
+}
+
+.highcharts-figure, .highcharts-data-table table {
+    min-width: 360px; 
+    max-width: 820px;
+    margin: 1em auto;
+}
+
+.highcharts-data-table table {
+	font-family: Verdana, sans-serif;
+	border-collapse: collapse;
+	border: 1px solid #EBEBEB;
+	margin: 10px auto;
+	text-align: center;
+	width: 100%;
+	max-width: 500px;
+}
+.highcharts-data-table caption {
+    padding: 1em 0;
+    font-size: 1.2em;
+    color: #555;
+}
+.highcharts-data-table th {
+	font-weight: 600;
+    padding: 0.5em;
+}
+.highcharts-data-table td, .highcharts-data-table th, .highcharts-data-table caption {
+    padding: 0.5em;
+}
+.highcharts-data-table thead tr, .highcharts-data-table tr:nth-child(even) {
+    background: #f8f8f8;
+}
+.highcharts-data-table tr:hover {
+    background: #f1f7ff;
+}

--- a/samples/highcharts/accessibility/accessible-annotations/demo.css
+++ b/samples/highcharts/accessibility/accessible-annotations/demo.css
@@ -4,7 +4,7 @@
 
 .highcharts-figure, .highcharts-data-table table {
     min-width: 360px; 
-    max-width: 820px;
+    max-width: 920px;
     margin: 1em auto;
 }
 

--- a/samples/highcharts/accessibility/accessible-annotations/demo.details
+++ b/samples/highcharts/accessibility/accessible-annotations/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Øystein Moseng
+ js_wrap: b
+...

--- a/samples/highcharts/accessibility/accessible-annotations/demo.html
+++ b/samples/highcharts/accessibility/accessible-annotations/demo.html
@@ -1,0 +1,13 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/annotations.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/modules/export-data.js"></script>
+<script src="https://code.highcharts.com/modules/accessibility.js"></script>
+
+<figure class="highcharts-figure">
+    <div id="container"></div>
+    <p class="highcharts-description">
+        A line chart showing CSUN session data by year, with some data points having
+        annotations. The chart demonstrates the accessibility features of annotations.
+    </p>
+</figure>

--- a/samples/highcharts/accessibility/accessible-annotations/demo.js
+++ b/samples/highcharts/accessibility/accessible-annotations/demo.js
@@ -3,6 +3,10 @@ Highcharts.chart('container', {
         text: 'Total CSUN conference sessions by year'
     },
 
+    subtitle: {
+        text: 'Highlighting our sessions and Stevie Wonder encounters'
+    },
+
     series: [{
         name: 'Total sessions',
         pointStart: 2015,
@@ -56,10 +60,8 @@ Highcharts.chart('container', {
             const isClose = (a, b) => Math.abs(a - b) < 1;
             let y = point.plotY;
 
-            if (isClose(x, firstPoint.plotX)) {
-                y -= 15; // Display above
-            } else {
-                y += labelHeight + 15; // Display below
+            if (!isClose(x, firstPoint.plotX)) {
+                y += labelHeight + 30; // Display below
             }
 
             return { x, y };
@@ -89,41 +91,34 @@ Highcharts.chart('container', {
         draggable: false,
         labelOptions: {
             allowOverlap: true,
-            distance: 15
+            distance: 15,
+            style: {
+                width: 180
+            }
         },
         labels: [{
             point: '2015',
-            text: 'Ted nearly plows into Stevie Wonder<br> on his way to the bathroom',
+            text: 'Ted nearly plows into Stevie Wonder on his way to the bathroom',
             distance: null,
-            y: 50
+            y: 60
         }, {
             point: '2016',
-            text: 'Elsevier & Highcharts presented together'
-        }, {
-            points: '2017',
-            text: 'Elsevier presented on VPATs'
+            text: 'Elsevier & Highcharts presented first session together: Accessible SVG Charts'
         }, {
             point: '2018',
-            text: 'Vidar got selfie with Stevie',
-            shape: 'rect',
-            verticalAlign: 'top',
-            distance: 65
-        }, {
-            point: '2018',
-            text: 'Elsevier presented 2 sessions',
-            shape: 'rect',
-            verticalAlign: 'top',
-            distance: 40
-        }, {
-            point: '2018',
-            text: 'Highcharts presented 1 session',
-            verticalAlign: 'top'
+            text: 'Vidar got selfie with Stevie'
         }, {
             point: '2019',
-            text: 'Elsevier & Highcharts presented together',
+            text: 'First year in Anaheim',
             shape: 'rect',
             verticalAlign: 'top',
-            distance: 40
+            distance: 110
+        }, {
+            point: '2019',
+            text: 'Elsevier & Highcharts presented 2nd session together:  Highcharts, The Next Chapter',
+            shape: 'rect',
+            verticalAlign: 'top',
+            distance: 55
         }, {
             point: '2019',
             text: 'Ted passes by Stevie in the hotel lobby'

--- a/samples/highcharts/accessibility/accessible-annotations/demo.js
+++ b/samples/highcharts/accessibility/accessible-annotations/demo.js
@@ -1,0 +1,136 @@
+Highcharts.chart('container', {
+    title: {
+        text: 'Total CSUN conference sessions by year'
+    },
+
+    series: [{
+        name: 'Total sessions',
+        pointStart: 2015,
+        data: [{
+            id: '2015',
+            y: 382
+        }, {
+            id: '2016',
+            y: 389
+        }, {
+            id: '2017',
+            y: 426
+        }, {
+            id: '2018',
+            y: 442
+        }, {
+            id: '2019',
+            y: 381
+        }, {
+            id: '2020',
+            y: 468
+        }]
+    }],
+
+    legend: {
+        enabled: false
+    },
+
+    xAxis: {
+        type: 'category',
+        accessibility: {
+            description: 'Year',
+            rangeDescription: 'Range: 2015 to 2020.'
+        }
+    },
+
+    yAxis: {
+        title: {
+            text: 'Sessions'
+        },
+        labels: {
+            format: '{value}'
+        }
+    },
+
+    tooltip: {
+        // Position tooltip below points except for the first one
+        positioner: function (_, labelHeight, point) {
+            const x = point.plotX;
+            const firstPoint = this.chart.series[0].points[0];
+            const isClose = (a, b) => Math.abs(a - b) < 1;
+            let y = point.plotY;
+
+            if (isClose(x, firstPoint.plotX)) {
+                y -= 15; // Display above
+            } else {
+                y += labelHeight + 15; // Display below
+            }
+
+            return { x, y };
+        },
+        backgroundColor: 'rgba(250, 250, 250, 0.97)'
+    },
+
+    annotations: [{
+        draggable: false,
+        labels: [{
+            point: {
+                x: 0, y: 0
+            },
+            x: -10,
+            y: 10,
+            style: {
+                width: 150
+            },
+            borderRadius: 5,
+            shape: 'rect',
+            text: 'Annotations showing presentation info for Elsevier and Highcharts',
+            backgroundColor: 'rgb(250, 245, 245)',
+            borderColor: 'rgb(255, 250, 250)',
+            padding: 10
+        }]
+    }, {
+        draggable: false,
+        labelOptions: {
+            allowOverlap: true,
+            distance: 15
+        },
+        labels: [{
+            point: '2015',
+            text: 'Ted nearly plows into Stevie Wonder<br> on his way to the bathroom',
+            distance: null,
+            y: 50
+        }, {
+            point: '2016',
+            text: 'Elsevier & Highcharts presented together'
+        }, {
+            points: '2017',
+            text: 'Elsevier presented on VPATs'
+        }, {
+            point: '2018',
+            text: 'Vidar got selfie with Stevie',
+            shape: 'rect',
+            verticalAlign: 'top',
+            distance: 65
+        }, {
+            point: '2018',
+            text: 'Elsevier presented 2 sessions',
+            shape: 'rect',
+            verticalAlign: 'top',
+            distance: 40
+        }, {
+            point: '2018',
+            text: 'Highcharts presented 1 session',
+            verticalAlign: 'top'
+        }, {
+            point: '2019',
+            text: 'Elsevier & Highcharts presented together',
+            shape: 'rect',
+            verticalAlign: 'top',
+            distance: 40
+        }, {
+            point: '2019',
+            text: 'Ted passes by Stevie in the hotel lobby'
+        }, {
+            point: '2020',
+            text: 'Elsevier & Highcharts is presenting together',
+            y: -35
+        }]
+    }]
+});

--- a/samples/highcharts/demo/bar-negative-stack/demo.js
+++ b/samples/highcharts/demo/bar-negative-stack/demo.js
@@ -21,14 +21,7 @@ Highcharts.chart('container', {
     },
     accessibility: {
         point: {
-            descriptionFormatter: function (point) {
-                var index = point.index + 1,
-                    category = point.category,
-                    val = Math.abs(point.y),
-                    series = point.series.name;
-
-                return index + ', Age ' + category + ', ' + val + '%. ' + series + '.';
-            }
+            valueDescriptionFormat: '{index}. Age {xDescription}, {value}%.'
         }
     },
     xAxis: [{

--- a/samples/highcharts/demo/bubble/demo.js
+++ b/samples/highcharts/demo/bubble/demo.js
@@ -20,16 +20,7 @@ Highcharts.chart('container', {
 
     accessibility: {
         point: {
-            descriptionFormatter: function (point) {
-                var index = point.index + 1,
-                    country = point.name,
-                    fatIntake = point.x,
-                    sugarIntake = point.y,
-                    obesity = point.z;
-
-                return index + ', ' + country + ', fat: ' + fatIntake +
-                    'g, sugar: ' + sugarIntake + 'g, obesity: ' + obesity + '%.';
-            }
+            valueDescriptionFormat: '{index}. {point.name}, fat: {point.x}g, sugar: {point.y}g, obesity: {point.z}%.'
         }
     },
 

--- a/samples/highcharts/demo/dependency-wheel/demo.js
+++ b/samples/highcharts/demo/dependency-wheel/demo.js
@@ -6,14 +6,7 @@ Highcharts.chart('container', {
 
     accessibility: {
         point: {
-            descriptionFormatter: function (point) {
-                var index = point.index + 1,
-                    from = point.from,
-                    to = point.to,
-                    weight = point.weight;
-
-                return index + '. From ' + from + ' to ' + to + ': ' + weight + '.';
-            }
+            valueDescriptionFormat: '{index}. From {point.from} to {point.to}: {point.weight}.'
         }
     },
 

--- a/samples/highcharts/demo/euler-diagram/demo.js
+++ b/samples/highcharts/demo/euler-diagram/demo.js
@@ -1,9 +1,7 @@
 Highcharts.chart('container', {
     accessibility: {
         point: {
-            descriptionFormatter: function (point) {
-                return point.name + ': ' + point.longDescription;
-            }
+            valueDescriptionFormat: '{point.name}: {point.longDescription}.'
         }
     },
     series: [{

--- a/samples/highcharts/demo/honeycomb-usa/demo.js
+++ b/samples/highcharts/demo/honeycomb-usa/demo.js
@@ -15,12 +15,7 @@ Highcharts.chart('container', {
                 '<div>{viewTableButton}</div>'
         },
         point: {
-            descriptionFormatter: function (point) {
-                var ix = point.index + 1,
-                    name = point.name,
-                    val = point.value;
-                return ix + '. ' + name + ', ' + val + '.';
-            }
+            valueDescriptionFormat: '{index}. {xDescription}, {point.value}.'
         }
     },
 

--- a/samples/highcharts/demo/lollipop/demo.js
+++ b/samples/highcharts/demo/lollipop/demo.js
@@ -6,12 +6,7 @@ Highcharts.chart('container', {
 
     accessibility: {
         point: {
-            descriptionFormatter: function (point) {
-                var ix = point.index + 1,
-                    x = point.name,
-                    y = point.y;
-                return ix + '. ' + x + ', ' + y + '.';
-            }
+            valueDescriptionFormat: '{index}. {xDescription}, {point.y}.'
         }
     },
 

--- a/samples/highcharts/demo/sankey-diagram/demo.js
+++ b/samples/highcharts/demo/sankey-diagram/demo.js
@@ -5,13 +5,7 @@ Highcharts.chart('container', {
     },
     accessibility: {
         point: {
-            descriptionFormatter: function (point) {
-                var index = point.index + 1,
-                    from = point.from,
-                    to = point.to,
-                    weight = point.weight;
-                return index + '. ' + from + ' to ' + to + ', ' + weight + '.';
-            }
+            valueDescriptionFormat: '{index}. {point.from} to {point.to}, {point.weight}.'
         }
     },
     series: [{

--- a/samples/highcharts/demo/timeline/demo.js
+++ b/samples/highcharts/demo/timeline/demo.js
@@ -11,9 +11,7 @@ Highcharts.chart('container', {
                 '<div>{viewTableButton}</div>'
         },
         point: {
-            descriptionFormatter: function (point) {
-                return point.label + '. ' + point.description + '.';
-            }
+            valueDescriptionFormat: '{index}. {point.label}. {point.description}.'
         }
     },
     xAxis: {

--- a/ts/modules/accessibility/accessibility.ts
+++ b/ts/modules/accessibility/accessibility.ts
@@ -31,6 +31,7 @@ declare global {
             public getChartTypes(): Array<string>;
             public init(chart: Chart): void;
             public initComponents(): void;
+            public getComponentOrder(): Array<string>;
             public update(): void;
         }
         interface AccessibilityComponentsObject {
@@ -171,7 +172,7 @@ Accessibility.prototype = {
      * @private
      */
     initComponents: function (this: Highcharts.Accessibility): void {
-        var chart = this.chart,
+        const chart = this.chart,
             a11yOptions = chart.options.accessibility;
 
         this.components = {
@@ -183,16 +184,38 @@ Accessibility.prototype = {
             series: new SeriesComponent(),
             zoom: new ZoomComponent()
         };
+
         if (a11yOptions.customComponents) {
             extend(this.components, a11yOptions.customComponents);
         }
 
-        var components = this.components;
-        // Refactor to use Object.values if we polyfill
-        Object.keys(components).forEach(function (componentName: string): void {
+        const components = this.components;
+        this.getComponentOrder().forEach(function (componentName: string): void {
             components[componentName].initBase(chart);
             components[componentName].init();
         });
+    },
+
+
+    /**
+     * Get order to update components in.
+     * @private
+     */
+    getComponentOrder: function (this: Highcharts.Accessibility): string[] {
+        if (!this.components) {
+            return []; // For zombie accessibility object on old browsers
+        }
+
+        if (!this.components.series) {
+            return Object.keys(this.components);
+        }
+
+        const componentsExceptSeries = Object.keys(this.components)
+            .filter((c): boolean => c !== 'series');
+
+        // Update series first, so that other components can read accessibility
+        // info on points.
+        return ['series'].concat(componentsExceptSeries);
     },
 
 
@@ -210,7 +233,7 @@ Accessibility.prototype = {
         chart.types = this.getChartTypes();
 
         // Update markup
-        Object.keys(components).forEach(function (componentName: string): void {
+        this.getComponentOrder().forEach(function (componentName: string): void {
             components[componentName].onChartUpdate();
 
             fireEvent(chart, 'afterA11yComponentUpdate', {
@@ -232,7 +255,9 @@ Accessibility.prototype = {
             whcm.setHighContrastTheme(chart);
         }
 
-        fireEvent(chart, 'afterA11yUpdate');
+        fireEvent(chart, 'afterA11yUpdate', {
+            accessibility: this
+        });
     },
 
 
@@ -314,7 +339,7 @@ addEvent(H.Chart, 'render', function (e: Event): void {
 
     const a11y = this.accessibility;
     if (a11y) {
-        Object.keys(a11y.components).forEach(function (
+        a11y.getComponentOrder().forEach(function (
             componentName: string
         ): void {
             a11y.components[componentName].onChartRender();

--- a/ts/modules/accessibility/components/AnnotationsA11y.ts
+++ b/ts/modules/accessibility/components/AnnotationsA11y.ts
@@ -1,0 +1,166 @@
+/* *
+ *
+ *  (c) 2009-2019 Øystein Moseng
+ *
+ *  Annotations accessibility code.
+ *
+ *  License: www.highcharts.com/license
+ *
+ *  !!!!!!! SOURCE GETS TRANSPILED BY TYPESCRIPT. EDIT TS FILE ONLY. !!!!!!!
+ *
+ * */
+
+'use strict';
+
+import '../../../parts/Utilities.js';
+import H from '../../../parts/Globals.js';
+const inArray = H.inArray;
+
+import HTMLUtilities from '../utils/htmlUtilities.js';
+const {
+    escapeStringForHTML,
+    stripHTMLTagsFromString
+} = HTMLUtilities;
+
+
+/**
+ * Get list of all annotation labels in the chart.
+ *
+ * @private
+ * @param {Highcharts.Chart} chart The chart to get annotation info on.
+ * @return {Array<object>} The labels, or empty array if none.
+ */
+function getChartAnnotationLabels(
+    chart: Highcharts.AnnotationChart
+): Array<Highcharts.AnnotationLabelType> {
+    const annotations = chart.annotations || [];
+
+    return annotations.reduce((
+        acc: Array<Highcharts.AnnotationLabelType>,
+        cur: Highcharts.Annotation
+    ): Array<Highcharts.AnnotationLabelType> => {
+        if (cur.options?.visible !== false) {
+            acc = acc.concat(cur.labels);
+        }
+        return acc;
+    }, []);
+}
+
+
+/**
+ * Get the text of an annotation label.
+ *
+ * @private
+ * @param {object} label The annotation label object
+ * @return {string} The text in the label.
+ */
+function getLabelText(label: Highcharts.AnnotationLabelType): string {
+    return label.graphic?.text?.textStr || '';
+}
+
+
+/**
+ * Describe an annotation label.
+ *
+ * @private
+ * @param {object} label The annotation label object to describe
+ * @return {string} The description for the label.
+ */
+function getAnnotationLabelDescription(label: Highcharts.AnnotationLabelType): string {
+    const chart = label.chart;
+    const labelText = getLabelText(label);
+    const points = label.points as Array<Highcharts.AccessibilityPoint>;
+    const getAriaLabel = (point: Highcharts.Point): string =>
+        point?.graphic?.element?.getAttribute('aria-label') || '';
+    const getValueDesc = (point: Highcharts.AccessibilityPoint): string => {
+        const valDesc = point?.accessibility?.valueDescription || getAriaLabel(point);
+        const seriesName = point?.series.name || '';
+        return (seriesName ? seriesName + ', ' : '') + 'data point ' + valDesc;
+    };
+    const pointValueDescriptions = points
+        .filter((p): boolean => !!p.graphic) // Filter out mock points
+        .map(getValueDesc)
+        .filter((desc: string): boolean => !!desc); // Filter out points we can't describe
+    const numPoints = pointValueDescriptions.length;
+    const pointsSelector = numPoints > 1 ? 'MultiplePoints' : numPoints ? 'SinglePoint' : 'NoPoints';
+    const langFormatStr = 'accessibility.screenReaderSection.annotations.description' + pointsSelector;
+    const context = {
+        annotationText: labelText,
+        numPoints: numPoints,
+        annotationPoint: pointValueDescriptions[0],
+        additionalAnnotationPoints: pointValueDescriptions.slice(1)
+    };
+
+    return chart.langFormat(langFormatStr, context);
+}
+
+
+/**
+ * Return array of HTML strings for each annotation label in the chart.
+ *
+ * @private
+ * @param {Highcharts.Chart} chart The chart to get annotation info on.
+ * @return {Array<string>} Array of strings with HTML content for each annotation label.
+ */
+function getAnnotationListItems(chart: Highcharts.AnnotationChart): string[] {
+    const labels = getChartAnnotationLabels(chart);
+
+    return labels.map((label): string => {
+        const desc = escapeStringForHTML(
+            stripHTMLTagsFromString(
+                getAnnotationLabelDescription(label)
+            )
+        );
+        return desc ? `<li>${desc}</li>` : '';
+    });
+}
+
+
+/**
+ * Return the annotation info for a chart as string.
+ *
+ * @private
+ * @param {Highcharts.Chart} chart The chart to get annotation info on.
+ * @return {string} String with HTML content or empty string if no annotations.
+ */
+function getAnnotationsInfoHTML(chart: Highcharts.AnnotationChart): string {
+    const annotations = chart.annotations;
+
+    if (!(annotations && annotations.length)) {
+        return '';
+    }
+
+    const annotationItems = getAnnotationListItems(chart);
+    return `<ul>${annotationItems.join(' ')}</ul>`;
+}
+
+
+/**
+ * Return the texts for the annotation(s) connected to a point, or empty array
+ * if none.
+ *
+ * @private
+ * @param {Highcharts.Point} point The data point to get the annotation info from.
+ * @return {Array<string>} Annotation texts
+ */
+function getPointAnnotationTexts(point: Highcharts.AnnotationPoint): Array<string> {
+    const labels = getChartAnnotationLabels(point.series.chart);
+    const pointLabels = labels
+        .filter((label): boolean => inArray(point, label.points) > -1);
+
+    if (!pointLabels.length) {
+        return [];
+    }
+
+    return pointLabels.map((label): string => `${getLabelText(label)}`);
+}
+
+
+const AnnotationsA11y = {
+    getAnnotationsInfoHTML,
+    getAnnotationLabelDescription,
+    getAnnotationListItems,
+    getPointAnnotationTexts
+};
+
+export default AnnotationsA11y;

--- a/ts/modules/accessibility/components/SeriesComponent/SeriesDescriber.ts
+++ b/ts/modules/accessibility/components/SeriesComponent/SeriesDescriber.ts
@@ -28,6 +28,7 @@ declare global {
 }
 
 var numberFormat = H.numberFormat,
+    format = H.format,
     find = H.find;
 
 import U from '../../../../parts/Utilities.js';
@@ -37,8 +38,12 @@ const {
     defined
 } = U;
 
+import AnnotationsA11y from '../AnnotationsA11y.js';
+const getPointAnnotationTexts = AnnotationsA11y.getPointAnnotationTexts;
+
 import HTMLUtilities from '../../utils/htmlUtilities.js';
 const {
+    escapeStringForHTML,
     reverseChildNodes,
     stripHTMLTagsFromString: stripHTMLTags
 } = HTMLUtilities;
@@ -53,6 +58,20 @@ const {
 
 import Tooltip from '../../../../parts/Tooltip.js';
 
+/**
+ * Internal types.
+ * @private
+ */
+declare global {
+    namespace Highcharts {
+        interface AccessibilityPoint {
+            accessibility?: AccessibilityPointStateObject;
+        }
+        interface AccessibilityPointStateObject {
+            valueDescription?: string;
+        }
+    }
+}
 
 /* eslint-disable valid-jsdoc */
 
@@ -400,7 +419,7 @@ function getPointArrayMapValueDescription(
  * @param {Highcharts.Point} point
  * @return {string}
  */
-function getPointValueDescription(
+function getPointValue(
     point: Highcharts.AccessibilityPoint
 ): string {
     var series = point.series,
@@ -434,6 +453,53 @@ function getPointValueDescription(
 
 
 /**
+ * Return the description for the annotation(s) connected to a point, or empty
+ * string if none.
+ *
+ * @private
+ * @param {Highcharts.Point} point The data point to get the annotation info from.
+ * @return {string} Annotation description
+ */
+function getPointAnnotationDescription(point: Highcharts.Point): string {
+    const chart = point.series.chart;
+    const langKey = 'accessibility.series.pointAnnotationsDescription';
+    const annotations = getPointAnnotationTexts(point as Highcharts.AnnotationPoint);
+    const context = { point, annotations };
+
+    return annotations.length ? chart.langFormat(langKey, context) : '';
+}
+
+
+/**
+ * Return string with information about point.
+ * @private
+ * @return {string}
+ */
+function getPointValueDescription(point: Highcharts.AccessibilityPoint): string {
+    const series = point.series,
+        chart = series.chart,
+        pointValueDescriptionFormat = chart.options.accessibility
+            .point.valueDescriptionFormat,
+        showXDescription = pick(
+            series.xAxis &&
+            series.xAxis.options.accessibility &&
+            series.xAxis.options.accessibility.enabled,
+            !chart.angular
+        ),
+        xDesc = showXDescription ? getPointXDescription(point) : '',
+        context = {
+            point: point,
+            index: defined(point.index) ? (point.index + 1) : '',
+            xDescription: xDesc,
+            value: getPointValue(point),
+            separator: showXDescription ? ', ' : ''
+        };
+
+    return format(pointValueDescriptionFormat, context, chart);
+}
+
+
+/**
  * Return string with information about point.
  * @private
  * @return {string}
@@ -443,24 +509,19 @@ function defaultPointDescriptionFormatter(
 ): string {
     var series = point.series,
         chart = series.chart,
+        valText = getPointValueDescription(point),
         description = point.options && point.options.accessibility &&
-            point.options.accessibility.description,
-        showXDescription = pick(
-            series.xAxis &&
-            series.xAxis.options.accessibility &&
-            series.xAxis.options.accessibility.enabled,
-            !chart.angular
-        ),
-        xDesc = getPointXDescription(point),
-        valueDesc = getPointValueDescription(point),
-        indexText = defined(point.index) ? (point.index + 1) + '. ' : '',
-        xDescText = showXDescription ? xDesc + ', ' : '',
-        valText = valueDesc + '.',
+        point.options.accessibility.description,
         userDescText = description ? ' ' + description : '',
         seriesNameText = chart.series.length > 1 && series.name ?
-            ' ' + series.name + '.' : '';
+            ' ' + series.name + '.' : '',
+        annotationsDesc = getPointAnnotationDescription(point),
+        pointAnnotationsText = annotationsDesc ? ' ' + annotationsDesc : '';
 
-    return indexText + xDescText + valText + userDescText + seriesNameText;
+    point.accessibility = point.accessibility || {};
+    point.accessibility.valueDescription = valText;
+
+    return valText + userDescText + seriesNameText + pointAnnotationsText;
 }
 
 
@@ -477,12 +538,14 @@ function setPointScreenReaderAttribs(
     var series = point.series,
         a11yPointOptions = series.chart.options.accessibility.point || {},
         seriesA11yOptions = series.options.accessibility || {},
-        label = stripHTMLTags(
-            seriesA11yOptions.pointDescriptionFormatter &&
-            seriesA11yOptions.pointDescriptionFormatter(point) ||
-            a11yPointOptions.descriptionFormatter &&
-            a11yPointOptions.descriptionFormatter(point) ||
-            defaultPointDescriptionFormatter(point)
+        label = escapeStringForHTML(
+            stripHTMLTags(
+                seriesA11yOptions.pointDescriptionFormatter &&
+                seriesA11yOptions.pointDescriptionFormatter(point) ||
+                a11yPointOptions.descriptionFormatter &&
+                a11yPointOptions.descriptionFormatter(point) ||
+                defaultPointDescriptionFormatter(point)
+            )
         );
 
     pointElement.setAttribute('role', 'img');
@@ -588,10 +651,12 @@ function describeSeriesElement(
     seriesElement.setAttribute('tabindex', '-1');
     seriesElement.setAttribute(
         'aria-label',
-        stripHTMLTags(
-            (a11yOptions.series as any).descriptionFormatter &&
-            (a11yOptions.series as any).descriptionFormatter(series) ||
-            defaultSeriesDescriptionFormatter(series)
+        escapeStringForHTML(
+            stripHTMLTags(
+                (a11yOptions.series as any).descriptionFormatter &&
+                (a11yOptions.series as any).descriptionFormatter(series) ||
+                defaultSeriesDescriptionFormatter(series)
+            )
         )
     );
 }
@@ -628,13 +693,15 @@ function describeSeries(series: Highcharts.AccessibilitySeries): void {
     }
 }
 
-var SeriesDescriber = {
-    describeSeries: describeSeries,
-    defaultPointDescriptionFormatter: defaultPointDescriptionFormatter,
-    defaultSeriesDescriptionFormatter: defaultSeriesDescriptionFormatter,
-    getPointA11yTimeDescription: getPointA11yTimeDescription,
-    getPointXDescription: getPointXDescription,
-    getPointValueDescription: getPointValueDescription
+
+const SeriesDescriber = {
+    describeSeries,
+    defaultPointDescriptionFormatter,
+    defaultSeriesDescriptionFormatter,
+    getPointA11yTimeDescription,
+    getPointXDescription,
+    getPointValue,
+    getPointValueDescription
 };
 
 export default SeriesDescriber;

--- a/ts/modules/accessibility/options/langOptions.ts
+++ b/ts/modules/accessibility/options/langOptions.ts
@@ -98,14 +98,22 @@ declare global {
             maxInputLabel: string;
             minInputLabel: string;
         }
+        interface LangAccessibilityAnnotationOptions {
+            heading: string;
+            descriptionSinglePoint: string;
+            descriptionMultiplePoints: string;
+            descriptionNoPoints: string;
+        }
         interface LangAccessibilityScreenReaderSectionOptions {
             afterRegionLabel: string;
+            annotations: LangAccessibilityAnnotationOptions;
             beforeRegionLabel: string;
             endOfChartMarker: string;
         }
         interface LangAccessibilitySeriesOptions {
             description: string;
             nullPointValue: string;
+            pointAnnotationsDescription: string;
             summary: LangAccessibilitySeriesSummaryOptions;
             xAxisDescription: string;
             yAxisDescription: string;
@@ -227,6 +235,19 @@ var langOptions: Highcharts.LangOptions = {
         screenReaderSection: {
             beforeRegionLabel: 'Chart screen reader information.',
             afterRegionLabel: '',
+
+            /**
+             * Language options for annotation descriptions.
+             *
+             * @since next
+             */
+            annotations: {
+                heading: 'Chart annotations',
+                descriptionSinglePoint: '{annotationText}. Related to {annotationPoint}',
+                descriptionMultiplePoints: '{annotationText}. Related to {annotationPoint}' +
+                    '{ Also related to, #each(additionalAnnotationPoints)}',
+                descriptionNoPoints: '{annotationText}'
+            },
 
             /**
              * Label for the end of the chart. Announced by screen readers.
@@ -449,8 +470,8 @@ var langOptions: Highcharts.LangOptions = {
             }, /* eslint-enable max-len */
 
             /**
-             * User supplied description text. This is added after the main
-             * summary if present.
+             * User supplied description text. This is added in the point
+             * comment description by default if present.
              *
              * @since 6.0.6
              */
@@ -477,8 +498,15 @@ var langOptions: Highcharts.LangOptions = {
              *
              * @since 8.0.0
              */
-            nullPointValue: 'No value'
+            nullPointValue: 'No value',
 
+            /**
+             * Description for annotations on a point, as it is made available
+             * to assistive technology.
+             *
+             * @since next
+             */
+            pointAnnotationsDescription: '{Annotation: "#each(annotations)". }'
         }
     }
 };

--- a/ts/modules/accessibility/options/options.ts
+++ b/ts/modules/accessibility/options/options.ts
@@ -60,8 +60,8 @@ declare global {
             keyboardNavigation: AccessibilityKeyboardNavigationOptions;
             landmarkVerbosity: string;
             linkedDescription: (string|HTMLDOMElement);
-            point?: AccessibilityPointOptions;
-            series?: AccessibilitySeriesOptions;
+            point: AccessibilityPointOptions;
+            series: AccessibilitySeriesOptions;
             screenReaderSection: AccessibilityScreenReaderSectionOptions;
             typeDescription?: string;
         }
@@ -70,6 +70,7 @@ declare global {
             dateFormatter?: ScreenReaderFormatterCallbackFunction<Point>;
             descriptionFormatter?: ScreenReaderFormatterCallbackFunction<Point>;
             valueDecimals?: number;
+            valueDescriptionFormat: string;
             valuePrefix?: string;
             valueSuffix?: string;
         }
@@ -265,11 +266,12 @@ var options: DeepPartial<Highcharts.Options> = {
 
             /**
              * Format for the screen reader information region before the chart.
-             * Supported HTML tags are `<h1-7>`, `<p>`, `<div>`, `<a>`, and
-             * `<button>`. Attributes are not supported, except for id on
-             * `<div>`, `<a>`, and `<button>`. Id is required on `<a>` and
-             * `<button>` in the format `<tag id="abcd">`. Numbers, lower- and
-             * uppercase letters, "-" and "#" are valid characters in IDs.
+             * Supported HTML tags are `<h1-7>`, `<p>`, `<div>`, `<a>`, `<ul>`,
+             * `<ol>`, `<li>`, and `<button>`. Attributes are not supported,
+             * except for id on `<div>`, `<a>`, and `<button>`. Id is required
+             * on `<a>` and `<button>` in the format `<tag id="abcd">`. Numbers,
+             * lower- and uppercase letters, "-" and "#" are valid characters in
+             * IDs.
              *
              * @since 8.0.0
              */
@@ -278,9 +280,10 @@ var options: DeepPartial<Highcharts.Options> = {
                 '<div>{typeDescription}</div>' +
                 '<div>{chartSubtitle}</div>' +
                 '<div>{chartLongdesc}</div>' +
+                '<div>{viewTableButton}</div>' +
                 '<div>{xAxisDescription}</div>' +
                 '<div>{yAxisDescription}</div>' +
-                '<div>{viewTableButton}</div>',
+                '<div>{annotationsTitle}{annotationsList}</div>',
 
             /**
              * A formatter function to create the HTML contents of the hidden
@@ -353,6 +356,110 @@ var options: DeepPartial<Highcharts.Options> = {
              * @since 8.0.0
              */
             pointDescriptionEnabledThreshold: 200
+        },
+
+        /**
+         * Options for descriptions of individual data points.
+         *
+         * @since 8.0.0
+         */
+        point: {
+            /**
+             * Format to use for describing the values of data points
+             * to assistive technology - including screen readers.
+             * The point context is available as `{point}`.
+             *
+             * Additionally, the series name, annotation info, and
+             * description added in `point.accessibility.description`
+             * is added by default if relevant. To override this, use the
+             * [accessibility.point.descriptionFormatter](#accessibility.point.descriptionFormatter)
+             * option.
+             *
+             * @see [point.accessibility.description](#series.line.data.accessibility.description)
+             * @see [accessibility.point.descriptionFormatter](#accessibility.point.descriptionFormatter)
+             *
+             * @type      {string}
+             * @since next
+             */
+            valueDescriptionFormat: '{index}. {xDescription}{separator}{value}.'
+
+            /**
+             * Date format to use for points on datetime axes when describing
+             * them to screen reader users.
+             *
+             * Defaults to the same format as in tooltip.
+             *
+             * For an overview of the replacement codes, see
+             * [dateFormat](/class-reference/Highcharts#dateFormat).
+             *
+             * @see [dateFormatter](#accessibility.point.dateFormatter)
+             *
+             * @type      {string}
+             * @since 8.0.0
+             * @apioption accessibility.point.dateFormat
+             */
+
+            /**
+             * Formatter function to determine the date/time format used with
+             * points on datetime axes when describing them to screen reader
+             * users. Receives one argument, `point`, referring to the point
+             * to describe. Should return a date format string compatible with
+             * [dateFormat](/class-reference/Highcharts#dateFormat).
+             *
+             * @see [dateFormat](#accessibility.point.dateFormat)
+             *
+             * @type      {Highcharts.ScreenReaderFormatterCallbackFunction<Highcharts.Point>}
+             * @since 8.0.0
+             * @apioption accessibility.point.dateFormatter
+             */
+
+            /**
+             * Prefix to add to the values in the point descriptions. Uses
+             * [tooltip.valuePrefix](#tooltip.valuePrefix) if not defined.
+             *
+             * @type        {string}
+             * @since 8.0.0
+             * @apioption   accessibility.point.valuePrefix
+             */
+
+            /**
+             * Suffix to add to the values in the point descriptions. Uses
+             * [tooltip.valueSuffix](#tooltip.valueSuffix) if not defined.
+             *
+             * @type        {string}
+             * @since 8.0.0
+             * @apioption   accessibility.point.valueSuffix
+             */
+
+            /**
+             * Decimals to use for the values in the point descriptions. Uses
+             * [tooltip.valueDecimals](#tooltip.valueDecimals) if not defined.
+             *
+             * @type        {number}
+             * @since 8.0.0
+             * @apioption   accessibility.point.valueDecimals
+             */
+
+            /**
+             * Formatter function to use instead of the default for point
+             * descriptions.
+             *
+             * Receives one argument, `point`, referring to the point to
+             * describe. Should return a string with the description of the
+             * point for a screen reader user. If `false` is returned, the
+             * default formatter will be used for that point.
+             *
+             * Note: Prefer using [accessibility.point.valueDescriptionFormat](#accessibility.point.valueDescriptionFormat)
+             * instead if possible, as default functionality such as describing
+             * annotations will be preserved.
+             *
+             * @see [accessibility.point.valueDescriptionFormat](#accessibility.point.valueDescriptionFormat)
+             * @see [point.accessibility.description](#series.line.data.accessibility.description)
+             *
+             * @type      {Highcharts.ScreenReaderFormatterCallbackFunction<Highcharts.Point>}
+             * @since 8.0.0
+             * @apioption accessibility.point.descriptionFormatter
+             */
         },
 
         /**
@@ -476,85 +583,6 @@ var options: DeepPartial<Highcharts.Options> = {
          * @type      {string}
          * @since     5.0.0
          * @apioption accessibility.typeDescription
-         */
-
-        /**
-         * Options for descriptions of individual data points.
-         *
-         * @since 8.0.0
-         * @apioption accessibility.point
-         */
-
-        /**
-         * Date format to use for points on datetime axes when describing them
-         * to screen reader users.
-         *
-         * Defaults to the same format as in tooltip.
-         *
-         * For an overview of the replacement codes, see
-         * [dateFormat](/class-reference/Highcharts#dateFormat).
-         *
-         * @see [dateFormatter](#accessibility.point.dateFormatter)
-         *
-         * @type      {string}
-         * @since 8.0.0
-         * @apioption accessibility.point.dateFormat
-         */
-
-        /**
-         * Formatter function to determine the date/time format used with
-         * points on datetime axes when describing them to screen reader users.
-         * Receives one argument, `point`, referring to the point to describe.
-         * Should return a date format string compatible with
-         * [dateFormat](/class-reference/Highcharts#dateFormat).
-         *
-         * @see [dateFormat](#accessibility.point.dateFormat)
-         *
-         * @type      {Highcharts.ScreenReaderFormatterCallbackFunction<Highcharts.Point>}
-         * @since 8.0.0
-         * @apioption accessibility.point.dateFormatter
-         */
-
-        /**
-         * Prefix to add to the values in the point descriptions. Uses
-         * [tooltip.valuePrefix](#tooltip.valuePrefix) if not defined.
-         *
-         * @type        {string}
-         * @since 8.0.0
-         * @apioption   accessibility.point.valuePrefix
-         */
-
-        /**
-         * Suffix to add to the values in the point descriptions. Uses
-         * [tooltip.valueSuffix](#tooltip.valueSuffix) if not defined.
-         *
-         * @type        {string}
-         * @since 8.0.0
-         * @apioption   accessibility.point.valueSuffix
-         */
-
-        /**
-         * Decimals to use for the values in the point descriptions. Uses
-         * [tooltip.valueDecimals](#tooltip.valueDecimals) if not defined.
-         *
-         * @type        {number}
-         * @since 8.0.0
-         * @apioption   accessibility.point.valueDecimals
-         */
-
-        /**
-         * Formatter function to use instead of the default for point
-         * descriptions.
-         * Receives one argument, `point`, referring to the point to describe.
-         * Should return a string with the description of the point for a screen
-         * reader user. If `false` is returned, the default formatter will be
-         * used for that point.
-         *
-         * @see [point.accessibility.description](#series.line.data.accessibility.description)
-         *
-         * @type      {Highcharts.ScreenReaderFormatterCallbackFunction<Highcharts.Point>}
-         * @since 8.0.0
-         * @apioption accessibility.point.descriptionFormatter
          */
 
         /**

--- a/ts/modules/accessibility/utils/htmlUtilities.ts
+++ b/ts/modules/accessibility/utils/htmlUtilities.ts
@@ -193,6 +193,7 @@ function visuallyHideElement(element: Highcharts.HTMLDOMElement): void {
         width: '1px',
         height: '1px',
         overflow: 'hidden',
+        whiteSpace: 'nowrap',
         clip: 'rect(1px, 1px, 1px, 1px)',
         marginTop: '-3px',
         '-ms-filter': 'progid:DXImageTransform.Microsoft.Alpha(Opacity=1)',


### PR DESCRIPTION
Added accessibility functionality for annotations. Also added new option `accessibility.point.valueDescriptionFormat`.
___
Annotations are now accessible to screen readers and other assistive technology relying on the AOM.

A list of the chart's annotations is added to the hidden info region before the chart. In addition, points with annotations connected to them will include a description of these annotations in their aria-labels by default.

New i18n options have been added under `langOptions.accessibility.screenReaderSection.annotations`, as well as `langOptions.accessibility.series.pointAnnotationsDescription`.

Because of the way annotation descriptions are computed, we have refactored out the logic that deals with describing the axis values of the data points. This allowed for the addition of the `accessibility.point.valueDescriptionFormat` option, which makes it a lot simpler to define custom descriptions in a declarative way, rather than having to write a description formatter function. Demos using description formatter functions have been updated to use this new option where possible.

No changes have been made to the annotations module.