### PR TITLE
Bugfix/11917 sankey crammed

### DIFF
--- a/js/modules/overlapping-datalabels.src.js
+++ b/js/modules/overlapping-datalabels.src.js
@@ -40,7 +40,7 @@ addEvent(Chart, 'render', function collectAndHide() {
         var dlOptions = series.options.dataLabels;
         if (series.visible &&
             !(dlOptions.enabled === false && !series._hasPointLabels)) { // #3866
-            series.points.forEach(function (point) {
+            (series.nodes || series.points).forEach(function (point) {
                 if (point.visible) {
                     var dataLabels = (isArray(point.dataLabels) ?
                         point.dataLabels :

--- a/js/modules/sankey.src.js
+++ b/js/modules/sankey.src.js
@@ -304,6 +304,10 @@ seriesType('sankey', 'column',
      * The padding between nodes in a sankey diagram or dependency wheel, in
      * pixels.
      *
+     * If the number of nodes is so great that it is possible to lay them
+     * out within the plot area with the given `nodePadding`, they will be
+     * rendered with a smaller padding as a strategy to avoid overflow.
+     *
      * @private
      */
     nodePadding: 10,
@@ -388,14 +392,24 @@ seriesType('sankey', 'column',
      * @private
      */
     getNodePadding: function () {
-        return this.options.nodePadding;
+        var nodePadding = this.options.nodePadding || 0;
+        // If the number of columns is so great that they will overflow with
+        // the given nodePadding, we sacrifice the padding in order to
+        // render all nodes within the plot area (#11917).
+        if (this.nodeColumns) {
+            var maxLength = this.nodeColumns.reduce(function (acc, col) { return Math.max(acc, col.length); }, 0);
+            if (maxLength * nodePadding > this.chart.plotSizeY) {
+                nodePadding = this.chart.plotSizeY / maxLength;
+            }
+        }
+        return nodePadding;
     },
     /**
      * Create a node column.
      * @private
      */
     createNodeColumn: function () {
-        var chart = this.chart, column = [], nodePadding = this.getNodePadding();
+        var series = this, chart = this.chart, column = [];
         column.sum = function () {
             return this.reduce(function (sum, node) {
                 return sum + node.getSum();
@@ -403,7 +417,7 @@ seriesType('sankey', 'column',
         };
         // Get the offset in pixels of a node inside the column.
         column.offset = function (node, factor) {
-            var offset = 0, totalNodeOffset;
+            var offset = 0, totalNodeOffset, nodePadding = series.nodePadding;
             for (var i = 0; i < column.length; i++) {
                 var sum = column[i].getSum();
                 if (sum) {
@@ -423,6 +437,7 @@ seriesType('sankey', 'column',
         };
         // Get the column height in pixels.
         column.top = function (factor) {
+            var nodePadding = series.nodePadding;
             var height = this.reduce(function (height, node) {
                 if (height > 0) {
                     height += nodePadding;
@@ -711,13 +726,14 @@ seriesType('sankey', 'column',
         this.generatePoints();
         this.nodeColumns = this.createNodeColumns();
         this.nodeWidth = relativeLength(this.options.nodeWidth, this.chart.plotSizeX);
-        var series = this, chart = this.chart, options = this.options, nodeWidth = this.nodeWidth, nodeColumns = this.nodeColumns, nodePadding = this.getNodePadding();
+        var series = this, chart = this.chart, options = this.options, nodeWidth = this.nodeWidth, nodeColumns = this.nodeColumns;
+        this.nodePadding = this.getNodePadding();
         // Find out how much space is needed. Base it on the translation
         // factor of the most spaceous column.
         this.translationFactor = nodeColumns.reduce(function (translationFactor, column) {
             var height = chart.plotSizeY -
                 options.borderWidth -
-                (column.length - 1) * nodePadding;
+                (column.length - 1) * series.nodePadding;
             return Math.min(translationFactor, height / column.sum());
         }, Infinity);
         this.colDistance =

--- a/samples/highcharts/series-sankey/dense/demo.css
+++ b/samples/highcharts/series-sankey/dense/demo.css
@@ -1,0 +1,5 @@
+#container {
+    height: 400px;
+    max-width: 800px;
+    margin: 0 auto;
+}

--- a/samples/highcharts/series-sankey/dense/demo.details
+++ b/samples/highcharts/series-sankey/dense/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Sankey Diagram with Dense Data
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+...

--- a/samples/highcharts/series-sankey/dense/demo.html
+++ b/samples/highcharts/series-sankey/dense/demo.html
@@ -1,0 +1,5 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/sankey.js"></script>
+
+<div id="container"></div>
+

--- a/samples/highcharts/series-sankey/dense/demo.js
+++ b/samples/highcharts/series-sankey/dense/demo.js
@@ -1,0 +1,248 @@
+Highcharts.chart('container', {
+
+    title: {
+        text: 'Highcharts Sankey Diagram'
+    },
+    subtitle: {
+        text: 'Dense data. Node padding should shrink and data labels not overlap.'
+    },
+    series: [{
+        type: 'sankey',
+        name: 'Sankey demo series',
+        dataLabels: {
+            padding: 0
+        },
+        minLinkWidth: 1,
+        data: [{
+            from: 'Austria',
+            to: 'Vienna',
+            weight: 1
+        },
+        {
+            from: 'Cambodia',
+            to: 'Phnom Penh',
+            weight: 1
+        },
+        {
+            from: 'Sri Lanka',
+            to: 'Colombo',
+            weight: 1
+        },
+        {
+            from: 'Senegal',
+            to: 'Dakar',
+            weight: 1
+        },
+        {
+            from: 'United States',
+            to: 'Fort Lauderdale',
+            weight: 1
+        },
+        {
+            from: 'United States',
+            to: 'Boston',
+            weight: 1
+        },
+        {
+            from: 'United States',
+            to: 'Washington, D.C.',
+            weight: 1
+        },
+        {
+            from: 'United States',
+            to: 'Orlando',
+            weight: 1
+        },
+        {
+            from: 'United States',
+            to: 'Los Angeles',
+            weight: 1
+        },
+        {
+            from: 'United States',
+            to: 'Houston',
+            weight: 1
+        },
+        {
+            from: 'South Africa',
+            to: 'Johannesburg',
+            weight: 1
+        },
+        {
+            from: 'South Africa',
+            to: 'Cape Town',
+            weight: 1
+        },
+        {
+            from: 'Australia',
+            to: 'Sydney',
+            weight: 1
+        },
+        {
+            from: 'Australia',
+            to: 'Adelaide',
+            weight: 1
+        },
+        {
+            from: 'Norway',
+            to: 'Oslo',
+            weight: 1
+        },
+        {
+            from: 'Ireland',
+            to: 'Dublin',
+            weight: 1
+        },
+        {
+            from: 'Turkey',
+            to: 'Istanbul',
+            weight: 1
+        },
+        {
+            from: 'Nigeria',
+            to: 'Abuja',
+            weight: 1
+        },
+        {
+            from: 'Denmark',
+            to: 'Cairo',
+            weight: 1
+        },
+        {
+            from: 'Guinea',
+            to: 'Conakry',
+            weight: 1
+        },
+        {
+            from: 'Bangladesh',
+            to: 'Dhaka',
+            weight: 1
+        },
+        {
+            from: 'Bahrain',
+            to: 'Manama',
+            weight: 1
+        },
+        {
+            from: 'Pakistan',
+            to: 'Islamabad',
+            weight: 1
+        },
+        {
+            from: 'Sweden',
+            to: 'Stockholm',
+            weight: 1
+        },
+        {
+            from: 'India',
+            to: 'Ahmedabad',
+            weight: 1
+        },
+        {
+            from: 'India',
+            to: 'Mumbai',
+            weight: 1
+        },
+        {
+            from: 'Singapore',
+            to: 'Singapore city',
+            weight: 1
+        },
+        {
+            from: 'Poland',
+            to: 'Warsaw',
+            weight: 1
+        },
+        {
+            from: 'Saudi Arabia',
+            to: 'Dammam',
+            weight: 1
+        },
+        {
+            from: 'Switzerland',
+            to: 'Geneva',
+            weight: 1
+        },
+        {
+            from: 'Switzerland',
+            to: 'Zürich',
+            weight: 1
+        },
+        {
+            from: 'Taiwan',
+            to: 'Taipei',
+            weight: 1
+        },
+        {
+            from: 'Kenya',
+            to: 'Nairobi',
+            weight: 1
+        },
+        {
+            from: 'Indonesia',
+            to: 'Denpasar',
+            weight: 1
+        },
+        {
+            from: 'Chile',
+            to: 'Santiago',
+            weight: 1
+        },
+        {
+            from: 'Brazil',
+            to: 'São Paulo',
+            weight: 1
+        },
+        {
+            from: 'Canada',
+            to: 'Toronto',
+            weight: 1
+        },
+        {
+            from: 'Sudan',
+            to: 'Khartoum',
+            weight: 1
+        },
+        {
+            from: 'Iraq',
+            to: 'Basra',
+            weight: 1
+        },
+        {
+            from: 'Cyprus',
+            to: 'Larnaca',
+            weight: 1
+        },
+        {
+            from: 'Ethiopia',
+            to: 'Addis Ababa',
+            weight: 1
+        },
+        {
+            from: 'Russia',
+            to: 'Moscow',
+            weight: 1
+        },
+        {
+            from: 'Algeria',
+            to: 'Algiers',
+            weight: 1
+        },
+        {
+            from: 'United Kingdom',
+            to: 'Birmingham',
+            weight: 1
+        },
+        {
+            from: 'Hungary',
+            to: 'Budapest',
+            weight: 1
+        },
+        {
+            from: 'Afghanistan',
+            to: 'Kabul',
+            weight: 1
+        }]
+    }]
+
+});

--- a/ts/modules/overlapping-datalabels.src.ts
+++ b/ts/modules/overlapping-datalabels.src.ts
@@ -68,7 +68,7 @@ addEvent(Chart, 'render', function collectAndHide(): void {
             series.visible &&
             !(dlOptions.enabled === false && !series._hasPointLabels)
         ) { // #3866
-            series.points.forEach(function (point: Highcharts.Point): void {
+            (series.nodes || series.points).forEach(function (point: Highcharts.Point): void {
                 if (point.visible) {
                     var dataLabels = (
                         isArray(point.dataLabels) ?

--- a/ts/modules/sankey.src.ts
+++ b/ts/modules/sankey.src.ts
@@ -69,6 +69,7 @@ declare global {
             );
             public nodeColumns: Array<SankeyColumnArray>;
             public nodeLookup: NodesSeries['nodeLookup'];
+            public nodePadding: number;
             public nodes: Array<SankeyPoint>;
             public nodeWidth: number;
             public pointArrayMap: Array<string>;
@@ -523,6 +524,10 @@ seriesType<Highcharts.SankeySeries>(
          * The padding between nodes in a sankey diagram or dependency wheel, in
          * pixels.
          *
+         * If the number of nodes is so great that it is possible to lay them
+         * out within the plot area with the given `nodePadding`, they will be
+         * rendered with a smaller padding as a strategy to avoid overflow.
+         *
          * @private
          */
         nodePadding: 10,
@@ -617,7 +622,22 @@ seriesType<Highcharts.SankeySeries>(
          * @private
          */
         getNodePadding: function (this: Highcharts.SankeySeries): number {
-            return this.options.nodePadding as any;
+            let nodePadding = this.options.nodePadding || 0;
+
+            // If the number of columns is so great that they will overflow with
+            // the given nodePadding, we sacrifice the padding in order to
+            // render all nodes within the plot area (#11917).
+            if (this.nodeColumns) {
+                const maxLength = this.nodeColumns.reduce(
+                    (acc, col): number => Math.max(acc, col.length),
+                    0
+                );
+                if (maxLength * nodePadding > (this.chart.plotSizeY as any)) {
+                    nodePadding = (this.chart.plotSizeY as any) / maxLength;
+                }
+            }
+
+            return nodePadding;
         },
 
         /**
@@ -627,9 +647,9 @@ seriesType<Highcharts.SankeySeries>(
         createNodeColumn: function (
             this: Highcharts.SankeySeries
         ): Highcharts.SankeyColumnArray {
-            var chart = this.chart,
-                column: Highcharts.SankeyColumnArray = [] as any,
-                nodePadding = this.getNodePadding();
+            var series = this,
+                chart = this.chart,
+                column: Highcharts.SankeyColumnArray = [] as any;
 
             column.sum = function (this: Highcharts.SankeyColumnArray): number {
                 return this.reduce(function (
@@ -646,7 +666,8 @@ seriesType<Highcharts.SankeySeries>(
                 factor: number
             ): (Highcharts.Dictionary<number>|undefined) {
                 var offset = 0,
-                    totalNodeOffset;
+                    totalNodeOffset,
+                    nodePadding = series.nodePadding;
 
                 for (var i = 0; i < column.length; i++) {
                     const sum = column[i].getSum();
@@ -674,6 +695,7 @@ seriesType<Highcharts.SankeySeries>(
                 this: Highcharts.SankeyColumnArray,
                 factor: number
             ): number {
+                var nodePadding = series.nodePadding;
                 var height = this.reduce(function (
                     height: number,
                     node: Highcharts.SankeyPoint
@@ -1123,8 +1145,9 @@ seriesType<Highcharts.SankeySeries>(
                 chart = this.chart,
                 options = this.options,
                 nodeWidth = this.nodeWidth,
-                nodeColumns = this.nodeColumns,
-                nodePadding = this.getNodePadding();
+                nodeColumns = this.nodeColumns;
+
+            this.nodePadding = this.getNodePadding();
 
             // Find out how much space is needed. Base it on the translation
             // factor of the most spaceous column.
@@ -1135,7 +1158,7 @@ seriesType<Highcharts.SankeySeries>(
                 ): number {
                     var height = (chart.plotSizeY as any) -
                     (options.borderWidth as any) -
-                    (column.length - 1) * nodePadding;
+                    (column.length - 1) * series.nodePadding;
 
                     return Math.min(translationFactor, height / column.sum());
                 },


### PR DESCRIPTION
Fixed #11917, errors and failed rendering of sankey chart if the number of nodes was too great. Fixed by reducing the `nodePadding` below its setting to allocate space for all nodes.