### PR TITLE
bugfix/12926-dumbbell-state-color

### DIFF
--- a/js/modules/dumbbell.src.js
+++ b/js/modules/dumbbell.src.js
@@ -340,9 +340,9 @@ seriesType('dumbbell', 'arearange', {
      * @return {void}
      */
     setState: function () {
-        var point = this, series = point.series, chart = series.chart, seriesLowColor = series.options.lowColor, pointOptions = point.options, pointLowColor = pointOptions.lowColor, zoneColor = point.zone && point.zone.color, lowerGraphicColor = pick(pointLowColor, seriesLowColor, pointOptions.color, zoneColor, point.color, series.color), verb = 'attr', upperGraphicColor, origProps;
+        var point = this, series = point.series, chart = series.chart, seriesLowColor = series.options.lowColor, seriesMarker = series.options.marker, pointOptions = point.options, pointLowColor = pointOptions.lowColor, zoneColor = point.zone && point.zone.color, lowerGraphicColor = pick(pointLowColor, seriesLowColor, pointOptions.color, zoneColor, point.color, series.color), verb = 'attr', upperGraphicColor, origProps;
         this.pointSetState.apply(this, arguments);
-        if (!this.state) {
+        if (!point.state) {
             verb = 'animate';
             if (point.lowerGraphic && !chart.styledMode) {
                 point.lowerGraphic.attr({
@@ -355,7 +355,7 @@ seriesType('dumbbell', 'arearange', {
                     };
                     point.y = point.high;
                     point.zone = point.zone ? point.getZone() : void 0;
-                    upperGraphicColor = pick(point.marker ? point.marker.fillColor : void 0, pointOptions.color, point.zone ? point.zone.color : void 0, point.color);
+                    upperGraphicColor = pick(point.marker ? point.marker.fillColor : void 0, seriesMarker ? seriesMarker.fillColor : void 0, pointOptions.color, point.zone ? point.zone.color : void 0, point.color);
                     point.upperGraphic.attr({
                         fill: upperGraphicColor
                     });

--- a/samples/unit-tests/series-dumbbell/markers/demo.js
+++ b/samples/unit-tests/series-dumbbell/markers/demo.js
@@ -93,6 +93,23 @@ QUnit.test('Markers and zones for dumbbell.', function (assert) {
         'The lower marker should have a correct color (lowColor) without any state.'
     );
 
+    // Color all upper graphics
+    chart.series[0].update({
+        marker: {
+            fillColor: '#ffa500'
+        }
+    });
+
+    // Mouse over and mouse out of the point
+    chart.series[0].points[1].setState('hover');
+    chart.series[0].points[1].setState('');
+
+    assert.strictEqual(
+        chart.series[0].points[1].upperGraphic.attr('fill'),
+        chart.series[0].options.marker.fillColor,
+        'After mouseOut (without any state), the upper marker should have a correct color.'
+    );
+
 });
 
 QUnit.test('setData() and marker update for dumbbell.', function (assert) {

--- a/ts/modules/dumbbell.src.ts
+++ b/ts/modules/dumbbell.src.ts
@@ -526,6 +526,7 @@ seriesType<Highcharts.DumbbellSeries>('dumbbell', 'arearange', {
             series = point.series,
             chart = series.chart,
             seriesLowColor = series.options.lowColor,
+            seriesMarker = series.options.marker,
             pointOptions = point.options,
             pointLowColor = pointOptions.lowColor,
             zoneColor = point.zone && point.zone.color,
@@ -543,7 +544,7 @@ seriesType<Highcharts.DumbbellSeries>('dumbbell', 'arearange', {
 
         this.pointSetState.apply(this, arguments);
 
-        if (!this.state) {
+        if (!point.state) {
             verb = 'animate';
             if (point.lowerGraphic && !chart.styledMode) {
                 point.lowerGraphic.attr({
@@ -558,6 +559,7 @@ seriesType<Highcharts.DumbbellSeries>('dumbbell', 'arearange', {
                     point.zone = point.zone ? point.getZone() : void 0;
                     upperGraphicColor = pick(
                         point.marker ? point.marker.fillColor : void 0,
+                        seriesMarker ? seriesMarker.fillColor : void 0,
                         pointOptions.color,
                         point.zone ? point.zone.color : void 0,
                         point.color


### PR DESCRIPTION
Fixed #12926, dumbbell marker was incorrectly colored after mouse out when `series.marker.fillColor` was defined.