### PR TITLE
docs/11300-missing-quotes-api

### DIFF
--- a/js/modules/broken-axis.src.js
+++ b/js/modules/broken-axis.src.js
@@ -385,9 +385,9 @@ H.Series.prototype.gappedPath = function () {
      * that if the distance between two points is greater than five times
      * that of the two closest points, the graph will be broken.
      *
-     * When the `gapUnit` is `"value"`, the gap is based on absolute axis values,
-     * which on a datetime axis is milliseconds. This also applies to the
-     * navigator series that inherits gap options from the base series.
+     * When the `gapUnit` is `"value"`, the gap is based on absolute axis
+     * values, which on a datetime axis is milliseconds. This also applies
+     * to the navigator series that inherits gap options from the base series.
      *
      * @see [gapSize](plotOptions.series.gapSize)
      *

--- a/js/modules/broken-axis.src.js
+++ b/js/modules/broken-axis.src.js
@@ -381,11 +381,11 @@ H.Series.prototype.gappedPath = function () {
      * Together with [gapSize](plotOptions.series.gapSize), this option defines
      * where to draw gaps in the graph.
      *
-     * When the `gapUnit` is `relative` (default), a gap size of 5 means
+     * When the `gapUnit` is `"relative"` (default), a gap size of 5 means
      * that if the distance between two points is greater than five times
      * that of the two closest points, the graph will be broken.
      *
-     * When the `gapUnit` is `value`, the gap is based on absolute axis values,
+     * When the `gapUnit` is `"value"`, the gap is based on absolute axis values,
      * which on a datetime axis is milliseconds. This also applies to the
      * navigator series that inherits gap options from the base series.
      *

--- a/ts/modules/broken-axis.src.ts
+++ b/ts/modules/broken-axis.src.ts
@@ -612,9 +612,9 @@ H.Series.prototype.gappedPath = function (): Highcharts.SVGPathArray {
      * that if the distance between two points is greater than five times
      * that of the two closest points, the graph will be broken.
      *
-     * When the `gapUnit` is `"value"`, the gap is based on absolute axis values,
-     * which on a datetime axis is milliseconds. This also applies to the
-     * navigator series that inherits gap options from the base series.
+     * When the `gapUnit` is `"value"`, the gap is based on absolute axis
+     * values, which on a datetime axis is milliseconds. This also applies
+     * to the navigator series that inherits gap options from the base series.
      *
      * @see [gapSize](plotOptions.series.gapSize)
      *

--- a/ts/modules/broken-axis.src.ts
+++ b/ts/modules/broken-axis.src.ts
@@ -608,11 +608,11 @@ H.Series.prototype.gappedPath = function (): Highcharts.SVGPathArray {
      * Together with [gapSize](plotOptions.series.gapSize), this option defines
      * where to draw gaps in the graph.
      *
-     * When the `gapUnit` is `relative` (default), a gap size of 5 means
+     * When the `gapUnit` is `"relative"` (default), a gap size of 5 means
      * that if the distance between two points is greater than five times
      * that of the two closest points, the graph will be broken.
      *
-     * When the `gapUnit` is `value`, the gap is based on absolute axis values,
+     * When the `gapUnit` is `"value"`, the gap is based on absolute axis values,
      * which on a datetime axis is milliseconds. This also applies to the
      * navigator series that inherits gap options from the base series.
      *


### PR DESCRIPTION
Fixed #11300, properties string values in API should be inside string quotes.