### PR TITLE
bugfix/12915-variwide-stack-labels-export

### DIFF
--- a/js/modules/variwide.src.js
+++ b/js/modules/variwide.src.js
@@ -165,9 +165,11 @@ seriesType('variwide', 'column'
                     options.threshold) ?
                 '-' :
                 '') + series.stackKey];
-            pointStack = stack[xValue];
-            if (stack && pointStack && !point.isNull) {
-                pointStack.setOffset(-(pointWidth / 2) || 0, pointWidth || 0, void 0, void 0, point.plotX);
+            if (stack) {
+                pointStack = stack[xValue];
+                if (pointStack && !point.isNull) {
+                    pointStack.setOffset(-(pointWidth / 2) || 0, pointWidth || 0, void 0, void 0, point.plotX);
+                }
             }
         });
     }

--- a/ts/modules/variwide.src.ts
+++ b/ts/modules/variwide.src.ts
@@ -315,16 +315,18 @@ seriesType<Highcharts.VariwideSeries>('variwide', 'column'
                         '-' :
                         ''
                 ) + series.stackKey];
-                pointStack = stack[xValue as any];
 
-                if (stack && pointStack && !point.isNull) {
-                    pointStack.setOffset(
-                        -(pointWidth / 2) || 0,
-                        pointWidth || 0,
-                        void 0,
-                        void 0,
-                        point.plotX
-                    );
+                if (stack) {
+                    pointStack = stack[xValue as any];
+                    if (pointStack && !point.isNull) {
+                        pointStack.setOffset(
+                            -(pointWidth / 2) || 0,
+                            pointWidth || 0,
+                            void 0,
+                            void 0,
+                            point.plotX
+                        );
+                    }
                 }
             });
         }


### PR DESCRIPTION
Fixed #12915, exporting chart with stacked variwide series, when at least one series was disabled used to throw an error.