### PR TITLE
Sankey diagram and tooltip.followPointer = false

### DIFF
--- a/js/modules/sankey.src.js
+++ b/js/modules/sankey.src.js
@@ -615,6 +615,14 @@ seriesType('sankey', 'column',
             });
             // Pass test in drawPoints
             node.plotY = 1;
+            // Set the anchor position for tooltips
+            node.tooltipPos = chart.inverted ? [
+                chart.plotSizeY - node.shapeArgs.y - node.shapeArgs.height / 2,
+                chart.plotSizeX - node.shapeArgs.x - node.shapeArgs.width / 2
+            ] : [
+                node.shapeArgs.x + node.shapeArgs.width / 2,
+                node.shapeArgs.y + node.shapeArgs.height / 2
+            ];
         }
         else {
             node.dlOptions = {
@@ -709,6 +717,14 @@ seriesType('sankey', 'column',
             height: linkHeight,
             width: 0
         };
+        // And set the tooltip anchor in the middle
+        point.tooltipPos = chart.inverted ? [
+            chart.plotSizeY - point.dlBox.y - linkHeight / 2,
+            chart.plotSizeX - point.dlBox.x
+        ] : [
+            point.dlBox.x,
+            point.dlBox.y + linkHeight / 2
+        ];
         // Pass test in drawPoints
         point.y = point.plotY = 1;
         if (!point.color) {

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -305,7 +305,8 @@ var Tooltip = /** @class */ (function () {
                 mouseEvent.chartX - chart.plotLeft,
                 mouseEvent.chartY - plotTop
             ];
-            // Pie uses a special tooltipPos
+            // Some series types use a specificly calculated tooltip position for
+            // each point
         }
         else if (points[0].tooltipPos) {
             ret = points[0].tooltipPos;

--- a/ts/modules/sankey.src.ts
+++ b/ts/modules/sankey.src.ts
@@ -963,6 +963,15 @@ seriesType<Highcharts.SankeySeries>(
 
                 // Pass test in drawPoints
                 node.plotY = 1;
+
+                // Set the anchor position for tooltips
+                node.tooltipPos = chart.inverted ? [
+                    (chart.plotSizeY as any) - node.shapeArgs.y - node.shapeArgs.height / 2,
+                    (chart.plotSizeX as any) - node.shapeArgs.x - node.shapeArgs.width / 2
+                ] : [
+                    node.shapeArgs.x + node.shapeArgs.width / 2,
+                    node.shapeArgs.y + node.shapeArgs.height / 2
+                ];
             } else {
                 node.dlOptions = {
                     enabled: false
@@ -1116,6 +1125,16 @@ seriesType<Highcharts.SankeySeries>(
                 height: linkHeight,
                 width: 0
             };
+
+            // And set the tooltip anchor in the middle
+            point.tooltipPos = chart.inverted ? [
+                (chart.plotSizeY as any) - point.dlBox.y - linkHeight / 2,
+                (chart.plotSizeX as any) - point.dlBox.x
+            ] : [
+                point.dlBox.x,
+                point.dlBox.y + linkHeight / 2
+            ];
+
             // Pass test in drawPoints
             point.y = point.plotY = 1;
 

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -533,9 +533,12 @@ class Tooltip {
                 mouseEvent.chartX - chart.plotLeft,
                 mouseEvent.chartY - plotTop
             ];
-        // Pie uses a special tooltipPos
+
+        // Some series types use a specificly calculated tooltip position for
+        // each point
         } else if (points[0].tooltipPos) {
             ret = points[0].tooltipPos;
+
         // When shared, use the average position
         } else {
             points.forEach(function (point: Highcharts.Point): void {


### PR DESCRIPTION
Fixed tooltip position on sankey diagram links and nodes when `tooltip.followPointer` was `false`.