### PR TITLE
tools/utilities-refactor-formatSingle

### DIFF
--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -1302,62 +1302,6 @@ var wrap = H.wrap = function wrap(obj, method, func) {
     };
 };
 /**
- * Recursively converts all Date properties to timestamps.
- *
- * @private
- * @function Highcharts.datePropsToTimestamps
- *
- * @param {*} obj - any object to convert properties of
- *
- * @return {void}
- */
-H.datePropsToTimestamps = function (obj) {
-    objectEach(obj, function (val, key) {
-        if (isObject(val) && typeof val.getTime === 'function') {
-            obj[key] = val.getTime();
-        }
-        else if (isObject(val) || isArray(val)) {
-            H.datePropsToTimestamps(val);
-        }
-    });
-};
-/**
- * Format a single variable. Similar to sprintf, without the % prefix.
- *
- * @example
- * formatSingle('.2f', 5); // => '5.00'.
- *
- * @function Highcharts.formatSingle
- *
- * @param {string} format
- *        The format string.
- *
- * @param {*} val
- *        The value.
- *
- * @param {Highcharts.Chart} [chart]
- *        A `Chart` instance used to get numberFormatter and time.
- *
- * @return {string}
- *         The formatted representation of the value.
- */
-H.formatSingle = function (format, val, chart) {
-    var floatRegex = /f$/, decRegex = /\.([0-9])/, lang = H.defaultOptions.lang, decimals;
-    var time = chart && chart.time || H.time;
-    var numberFormatter = chart && chart.numberFormatter || numberFormat;
-    if (floatRegex.test(format)) { // float
-        decimals = format.match(decRegex);
-        decimals = decimals ? decimals[1] : -1;
-        if (val !== null) {
-            val = numberFormatter(val, decimals, lang.decimalPoint, format.indexOf(',') > -1 ? lang.thousandsSep : '');
-        }
-    }
-    else {
-        val = time.dateFormat(format, val);
-    }
-    return val;
-};
-/**
  * Format a string according to a subset of the rules of Python's String.format
  * method.
  *
@@ -1373,7 +1317,7 @@ H.formatSingle = function (format, val, chart) {
  * @param {string} str
  *        The string to format.
  *
- * @param {*} ctx
+ * @param {Record<string, *>} ctx
  *        The context, a collection of key-value pairs where each key is
  *        replaced by its value.
  *
@@ -1385,6 +1329,11 @@ H.formatSingle = function (format, val, chart) {
  */
 var format = H.format = function (str, ctx, chart) {
     var splitter = '{', isInside = false, segment, valueAndFormat, ret = [], val, index;
+    var floatRegex = /f$/;
+    var decRegex = /\.([0-9])/;
+    var lang = H.defaultOptions.lang;
+    var time = chart && chart.time || H.time;
+    var numberFormatter = chart && chart.numberFormatter || numberFormat;
     while (str) {
         index = str.indexOf(splitter);
         if (index === -1) {
@@ -1395,8 +1344,17 @@ var format = H.format = function (str, ctx, chart) {
             valueAndFormat = segment.split(':');
             val = getNestedProperty(valueAndFormat.shift() || '', ctx);
             // Format the replacement
-            if (valueAndFormat.length) {
-                val = H.formatSingle(valueAndFormat.join(':'), val, chart);
+            if (valueAndFormat.length && typeof val === 'number') {
+                segment = valueAndFormat.join(':');
+                if (floatRegex.test(segment)) { // float
+                    var decimals = parseInt((segment.match(decRegex) || ['', '-1'])[1], 10);
+                    if (val !== null) {
+                        val = numberFormatter(val, decimals, lang.decimalPoint, segment.indexOf(',') > -1 ? lang.thousandsSep : '');
+                    }
+                }
+                else {
+                    val = time.dateFormat(segment, val);
+                }
             }
             // Push the result and advance the cursor
             ret.push(val);

--- a/samples/highcharts/series/data-nested-keys/demo.js
+++ b/samples/highcharts/series/data-nested-keys/demo.js
@@ -6,7 +6,10 @@ Highcharts.chart('container', {
         text: 'Specifies which array options map to which keys'
     },
     tooltip: {
-        pointFormat: '{series.name}: <b>{point.percentage:.1f}%</b>'
+        pointFormat: '{series.name}: <b>{point.y:.1f}%</b>'
+    },
+    xAxis: {
+        categories: true
     },
     yAxis: {
         max: 100,


### PR DESCRIPTION
Integrated `formatSingle` into `format`. Removed `datePropsToTimestamps`.