### PR TITLE
docs/12971-plotoptions-column-dashstyle

### DIFF
--- a/js/annotations/annotations.src.js
+++ b/js/annotations/annotations.src.js
@@ -598,6 +598,15 @@ merge(true, Annotation.prototype, controllableMixin, eventEmitterMixin,
              * @apioption annotations.shapeOptions.src
              */
             /**
+             * Name of the dash style to use for the shape's stroke.
+             *
+             * @sample {highcharts} highcharts/plotoptions/series-dashstyle-all/
+             *         Possible values demonstrated
+             *
+             * @type      {Highcharts.DashStyleValue}
+             * @apioption annotations.shapeOptions.dashStyle
+             */
+            /**
              * The color of the shape's stroke.
              *
              * @sample highcharts/annotations/shape/

--- a/js/parts/ColumnSeries.js
+++ b/js/parts/ColumnSeries.js
@@ -23,6 +23,7 @@ import H from './Globals.js';
 * @name Highcharts.ColumnMetricsObject#offset
 * @type {number}
 */
+''; // detach doclets above
 import U from './Utilities.js';
 var animObject = U.animObject, clamp = U.clamp, defined = U.defined, extend = U.extend, isNumber = U.isNumber, merge = U.merge, pick = U.pick, seriesType = U.seriesType;
 import './Color.js';
@@ -49,8 +50,8 @@ seriesType('column', 'line',
  *         Column chart
  *
  * @extends      plotOptions.line
- * @excluding    connectNulls, dashStyle, gapSize, gapUnit, linecap,
- *               lineWidth, marker, connectEnds, step, useOhlcData
+ * @excluding    connectEnds, connectNulls, gapSize, gapUnit, linecap,
+ *               lineWidth, marker, step, useOhlcData
  * @product      highcharts highstock
  * @optionparent plotOptions.column
  */

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -677,8 +677,8 @@ null,
      * @apioption plotOptions.series.custom
      */
     /**
-     * A name for the dash style to use for the graph, or for some series
-     * types the outline of each shape.
+     * Name of the dash style to use for the graph, or for some series types
+     * the outline of each shape.
      *
      * In styled mode, the
      * [stroke dash-array](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-dashstyle/)

--- a/test/typescript/highcharts/highcharts.ts
+++ b/test/typescript/highcharts/highcharts.ts
@@ -224,7 +224,8 @@ function test_seriesColumn() {
         plotOptions: {
             column: {
                 pointPadding: 0.2,
-                borderWidth: 0
+                borderWidth: 0,
+                dashStyle: 'Dash'
             }
         },
         series: [{

--- a/ts/annotations/annotations.src.ts
+++ b/ts/annotations/annotations.src.ts
@@ -932,6 +932,16 @@ merge(
                  */
 
                 /**
+                 * Name of the dash style to use for the shape's stroke.
+                 *
+                 * @sample {highcharts} highcharts/plotoptions/series-dashstyle-all/
+                 *         Possible values demonstrated
+                 *
+                 * @type      {Highcharts.DashStyleValue}
+                 * @apioption annotations.shapeOptions.dashStyle
+                 */
+
+                /**
                  * The color of the shape's stroke.
                  *
                  * @sample highcharts/annotations/shape/

--- a/ts/parts/ColumnSeries.ts
+++ b/ts/parts/ColumnSeries.ts
@@ -109,6 +109,8 @@ declare global {
  * @type {number}
  */
 
+''; // detach doclets above
+
 import U from './Utilities.js';
 const {
     animObject,
@@ -154,8 +156,8 @@ seriesType<Highcharts.ColumnSeries>(
      *         Column chart
      *
      * @extends      plotOptions.line
-     * @excluding    connectNulls, dashStyle, gapSize, gapUnit, linecap,
-     *               lineWidth, marker, connectEnds, step, useOhlcData
+     * @excluding    connectEnds, connectNulls, gapSize, gapUnit, linecap,
+     *               lineWidth, marker, step, useOhlcData
      * @product      highcharts highstock
      * @optionparent plotOptions.column
      */

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -1200,8 +1200,8 @@ H.Series = seriesType<Highcharts.LineSeries>(
          */
 
         /**
-         * A name for the dash style to use for the graph, or for some series
-         * types the outline of each shape.
+         * Name of the dash style to use for the graph, or for some series types
+         * the outline of each shape.
          *
          * In styled mode, the
          * [stroke dash-array](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/css/series-dashstyle/)


### PR DESCRIPTION
Close #12971, Included dashStyle option for column.
Close addition of #12971, Added dashStyle for annotation options.