### PR TITLE
Docs: Fixed broken links in Marker clusters docs

### DIFF
--- a/docs/advanced-chart-features/marker-clusters.md
+++ b/docs/advanced-chart-features/marker-clusters.md
@@ -125,4 +125,4 @@ Use Cases
 API documentation
 -----------------
 
-For more details check the [API documentation](https://api.highcharts.com/highcharts/scatter.cluster).
+For more details check the [API documentation](https://api.highcharts.com/highcharts/series.scatter.cluster).


### PR DESCRIPTION
Correct link: https://api.highcharts.com/highcharts/series.scatter.cluster