### PR TITLE
bugfix/13018-polar-startAngle

### DIFF
--- a/ts/parts-more/RadialAxis.ts
+++ b/ts/parts-more/RadialAxis.ts
@@ -344,7 +344,7 @@ radialAxisMixin = {
         radius?: number,
         innerRadius?: number
     ): Highcharts.RadialAxisPath {
-        var center = this.center,
+        var center = this.pane.center,
             end,
             chart = this.chart,
             r = pick(radius, center[2] / 2 - this.offset),
@@ -362,7 +362,7 @@ radialAxisMixin = {
         if (this.isCircular || typeof radius !== 'undefined') {
             path = this.chart.renderer.symbols.arc(
                 this.left + center[0],
-                this.top + center[1] + (innerRadius || 0),
+                this.top + center[1],
                 r,
                 r,
                 {
@@ -382,8 +382,8 @@ radialAxisMixin = {
             end = this.postTranslate(this.angleRad, r);
             path = [
                 'M',
-                center[0] + chart.plotLeft,
-                center[1] + chart.plotTop,
+                this.center[0] + chart.plotLeft,
+                this.center[1] + chart.plotTop,
                 'L',
                 end.x,
                 end.y
@@ -468,6 +468,8 @@ radialAxisMixin = {
      * @private
      */
     setAxisSize: function (this: Highcharts.RadialAxis): void {
+        var center: number[],
+            start;
 
         axisProto.setAxisSize.call(this);
 
@@ -476,18 +478,25 @@ radialAxisMixin = {
             // Set the center array
             this.pane.updateCenter(this);
 
+            // In case when the innerSize is set in a polar chart, the axis'
+            // center cannot be a reference to pane's center
+            center = this.center = extend([], this.pane.center);
+
             // The sector is used in Axis.translate to compute the
             // translation of reversed axis points (#2570)
             if (this.isCircular) {
                 this.sector = this.endAngleRad - this.startAngleRad;
             } else {
-                this.center[1] -= this.center[3] / 2;
+                // When the pane's startAngle or the axis' angle is set then new
+                // x and y values for vertical axis' center must be calulated
+                start = this.postTranslate(this.angleRad, center[3] / 2);
+                center[0] = start.x - this.chart.plotLeft;
+                center[1] = start.y - this.chart.plotTop;
             }
 
             // Axis len is used to lay out the ticks
             this.len = this.width = this.height =
-                (this.center[2] - this.center[3]) *
-                pick(this.sector, 1) / 2;
+                (center[2] - center[3]) * pick(this.sector, 1) / 2;
         }
     },
 
@@ -724,7 +733,7 @@ radialAxisMixin = {
         options: Highcharts.AxisPlotLinesOptions
     ): Highcharts.SVGPathArray {
         var axis = this,
-            center = axis.center,
+            center = axis.pane.center,
             chart = axis.chart,
             inverted = chart.inverted,
             value = options.value,


### PR DESCRIPTION
Fixed #13018, the vertical axis line and labels were incorrectly positioned when the `pane.startAngle`, `xAxis.angle` (inverted chart) or `yAxis.angle` (non-inverted chart) were set.