### PR TITLE
bugfix/12982-failing-packedbubble-test

### DIFF
--- a/js/parts-more/PackedBubbleSeries.js
+++ b/js/parts-more/PackedBubbleSeries.js
@@ -570,7 +570,12 @@ seriesType('packedbubble', 'bubble',
                     });
                 }
             });
-            series.chart.hideOverlappingLabels(dataLabels);
+            // Only hide overlapping dataLabels for layouts that
+            // use simulation. Spiral packedbubble don't need
+            // additional dataLabel hiding on every simulation step
+            if (series.options.useSimulation) {
+                series.chart.hideOverlappingLabels(dataLabels);
+            }
         }
     },
     // Needed because of z-indexing issue if point is added in series.group

--- a/ts/parts-more/PackedBubbleSeries.ts
+++ b/ts/parts-more/PackedBubbleSeries.ts
@@ -943,7 +943,13 @@ seriesType<Highcharts.PackedBubbleSeries>(
                         });
                     }
                 });
-                series.chart.hideOverlappingLabels(dataLabels);
+
+                // Only hide overlapping dataLabels for layouts that
+                // use simulation. Spiral packedbubble don't need
+                // additional dataLabel hiding on every simulation step
+                if (series.options.useSimulation) {
+                    series.chart.hideOverlappingLabels(dataLabels);
+                }
             }
         },
         // Needed because of z-indexing issue if point is added in series.group


### PR DESCRIPTION
Fixed #12982, packedBubble test was failing randomly.

___

Test was failing due to a small time difference of hiding overlapping labels. 

Long story short: The reason was that "dataLabels overlapping" check was fired every time new series was rendered. Even though this check is necessary when standard packed bubble series (with simulation) is used, for spiral-packing only one verification is needed.