### PR TITLE
bugfix/13042-getTimezoneOffset-param-type

### DIFF
--- a/js/parts/Time.js
+++ b/js/parts/Time.js
@@ -65,7 +65,7 @@ import Highcharts from './Globals.js';
  * @callback Highcharts.TimezoneOffsetCallbackFunction
  *
  * @param {number} timestamp
- * Timestamp in terms of milliseconds since January 1 1970.
+ * Date instance or timestamp in terms of milliseconds since January 1 1970.
  *
  * @return {number}
  * Timezone offset in minutes.
@@ -107,10 +107,13 @@ var H = Highcharts, win = H.win;
  *        chart.time.dateFormat('%Y-%m-%d %H:%M:%S', Date.now())
  * );
  *
+ * @since 6.0.5
+ *
  * @class
  * @name Highcharts.Time
  *
- * @since 6.0.5
+ * @param {Highcharts.TimeOptions} options
+ * Time options as defined in [chart.options.time](/highcharts/time).
  */
 var Time = /** @class */ (function () {
     /* *
@@ -118,14 +121,6 @@ var Time = /** @class */ (function () {
      *  Constructors
      *
      * */
-    /**
-     * Time settings are applied in general for each page using
-     * `Highcharts.setOptions`, or individually for each Chart item through the
-     * [time](https://api.highcharts.com/highcharts/time) options set.
-     *
-     * @param {Highcharts.TimeOptions} options
-     * Time options as defined in [chart.options.time](/highcharts/time).
-     */
     function Time(options) {
         /* *
          *
@@ -351,7 +346,7 @@ var Time = /** @class */ (function () {
         // If not timezone is set, look for the getTimezoneOffset callback
         if (this.useUTC && options.getTimezoneOffset) {
             return function (timestamp) {
-                return options.getTimezoneOffset(timestamp) * 60000;
+                return options.getTimezoneOffset(timestamp.valueOf()) * 60000;
             };
         }
         // Last, use the `timezoneOffset` option if set

--- a/js/parts/Time.js
+++ b/js/parts/Time.js
@@ -65,7 +65,7 @@ import Highcharts from './Globals.js';
  * @callback Highcharts.TimezoneOffsetCallbackFunction
  *
  * @param {number} timestamp
- * Date instance or timestamp in terms of milliseconds since January 1 1970.
+ * Timestamp in terms of milliseconds since January 1 1970.
  *
  * @return {number}
  * Timezone offset in minutes.

--- a/ts/parts/Time.ts
+++ b/ts/parts/Time.ts
@@ -152,7 +152,7 @@ declare global {
  * @callback Highcharts.TimezoneOffsetCallbackFunction
  *
  * @param {number} timestamp
- * Timestamp in terms of milliseconds since January 1 1970.
+ * Date instance or timestamp in terms of milliseconds since January 1 1970.
  *
  * @return {number}
  * Timezone offset in minutes.
@@ -210,10 +210,13 @@ var H = Highcharts,
  *        chart.time.dateFormat('%Y-%m-%d %H:%M:%S', Date.now())
  * );
  *
+ * @since 6.0.5
+ *
  * @class
  * @name Highcharts.Time
  *
- * @since 6.0.5
+ * @param {Highcharts.TimeOptions} options
+ * Time options as defined in [chart.options.time](/highcharts/time).
  */
 class Time {
 
@@ -359,14 +362,6 @@ class Time {
      *
      * */
 
-    /**
-     * Time settings are applied in general for each page using
-     * `Highcharts.setOptions`, or individually for each Chart item through the
-     * [time](https://api.highcharts.com/highcharts/time) options set.
-     *
-     * @param {Highcharts.TimeOptions} options
-     * Time options as defined in [chart.options.time](/highcharts/time).
-     */
     public constructor(
         options: Highcharts.TimeOptions
     ) {
@@ -656,7 +651,7 @@ class Time {
         // If not timezone is set, look for the getTimezoneOffset callback
         if (this.useUTC && options.getTimezoneOffset) {
             return function (timestamp: (number|Date)): number {
-                return (options.getTimezoneOffset as any)(timestamp) * 60000;
+                return (options.getTimezoneOffset as any)(timestamp.valueOf()) * 60000;
             };
         }
 

--- a/ts/parts/Time.ts
+++ b/ts/parts/Time.ts
@@ -152,7 +152,7 @@ declare global {
  * @callback Highcharts.TimezoneOffsetCallbackFunction
  *
  * @param {number} timestamp
- * Date instance or timestamp in terms of milliseconds since January 1 1970.
+ * Timestamp in terms of milliseconds since January 1 1970.
  *
  * @return {number}
  * Timezone offset in minutes.


### PR DESCRIPTION
Fixed #13042, `getTimeZoneOffset` callback passed inconsistent value type.