### PR TITLE
Fixed missing compilation of highcharts-3d.js

### DIFF
--- a/tools/gulptasks/scripts-compile.js
+++ b/tools/gulptasks/scripts-compile.js
@@ -26,7 +26,7 @@ function chunk(arr, numParts) {
         result[p] = [];
     }
 
-    for (let i = arr.length - 1; i > 0; i--) {
+    for (let i = arr.length - 1; i >= 0; i--) {
         const arrIndex = Math.floor(i % numParts);
         result[arrIndex].push(arr[i]);
     }


### PR DESCRIPTION
Fixed #13056, the `highcharts-3d.js` file was not compiled and distributed to code.highcharts.com and npm.