### PR TITLE
bugfix/11635-wheelscroll-click-tooltip

### DIFF
--- a/js/modules/oldie.src.js
+++ b/js/modules/oldie.src.js
@@ -448,9 +448,9 @@ if (!svg) {
         on: function (eventType, handler) {
             // simplest possible event model for internal use
             this.element['on' + eventType] = function () {
-                var evt = win.event;
-                evt.target = evt.srcElement;
-                handler(evt);
+                var e = win.event;
+                e.target = e.srcElement;
+                handler(e);
             };
             return this;
         },

--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -146,11 +146,8 @@ TrackerMixin = H.TrackerMixin = {
     drawTrackerGraph: function () {
         var series = this, options = series.options, trackByArea = options.trackByArea, trackerPath = [].concat(trackByArea ?
             series.areaPath :
-            series.graphPath), trackerPathLength = trackerPath.length, chart = series.chart, pointer = chart.pointer, renderer = chart.renderer, snap = chart.options.tooltip.snap, tooltip = chart.tooltip, tracker = series.tracker, i, onMouseOver = function (e) {
-            pointer.normalize(e);
-            if (chart.hoverSeries !== series &&
-                (!tooltip ||
-                    !tooltip.isStickyOnContact())) {
+            series.graphPath), trackerPathLength = trackerPath.length, chart = series.chart, pointer = chart.pointer, renderer = chart.renderer, snap = chart.options.tooltip.snap, tracker = series.tracker, i, onMouseOver = function (e) {
+            if (chart.hoverSeries !== series) {
                 series.onMouseOver();
             }
         }, 

--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -146,8 +146,11 @@ TrackerMixin = H.TrackerMixin = {
     drawTrackerGraph: function () {
         var series = this, options = series.options, trackByArea = options.trackByArea, trackerPath = [].concat(trackByArea ?
             series.areaPath :
-            series.graphPath), trackerPathLength = trackerPath.length, chart = series.chart, pointer = chart.pointer, renderer = chart.renderer, snap = chart.options.tooltip.snap, tracker = series.tracker, i, onMouseOver = function () {
-            if (chart.hoverSeries !== series) {
+            series.graphPath), trackerPathLength = trackerPath.length, chart = series.chart, pointer = chart.pointer, renderer = chart.renderer, snap = chart.options.tooltip.snap, tooltip = chart.tooltip, tracker = series.tracker, i, onMouseOver = function (e) {
+            pointer.normalize(e);
+            if (chart.hoverSeries !== series &&
+                (!tooltip ||
+                    !tooltip.isStickyOnContact())) {
                 series.onMouseOver();
             }
         }, 
@@ -868,7 +871,8 @@ extend(Series.prototype, /** @lends Highcharts.Series.prototype */ {
      * @fires Highcharts.Series#event:mouseOver
      */
     onMouseOver: function () {
-        var series = this, chart = series.chart, hoverSeries = chart.hoverSeries;
+        var series = this, chart = series.chart, hoverSeries = chart.hoverSeries, pointer = chart.pointer;
+        pointer.setHoverChartIndex();
         // set normal state to previous series
         if (hoverSeries && hoverSeries !== series) {
             hoverSeries.onMouseOut();

--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -643,13 +643,10 @@ var Pointer = /** @class */ (function () {
         var chart = this.chart;
         var relatedTarget = e.relatedTarget || e.toElement;
         var series = chart.hoverSeries;
-        var tooltip = chart.tooltip;
         this.isDirectTouch = false;
         if (series &&
             relatedTarget &&
             !series.stickyTracking &&
-            (!tooltip ||
-                !tooltip.isStickyOnContact()) &&
             !this.inClass(relatedTarget, 'highcharts-tooltip') &&
             (!this.inClass(relatedTarget, 'highcharts-series-' + series.index) || // #2499, #4465, #5553
                 !this.inClass(relatedTarget, 'highcharts-tracker'))) {

--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -814,9 +814,9 @@ var Pointer = /** @class */ (function () {
             pEvt.button !== 0) {
             this.onContainerMouseMove(pEvt);
         }
+        // #11635, limiting to primary button (incl. IE 8 support)
         if (typeof pEvt.button === 'undefined' ||
-            pEvt.button === 0 // #11635, limiting to primary button
-        ) {
+            ((pEvt.buttons || pEvt.button) & 1) === 1) {
             this.zoomOption(pEvt);
             this.dragStart(pEvt);
         }

--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -318,13 +318,13 @@ var Pointer = /** @class */ (function () {
      * @private
      * @function Highcharts.Pointer#drop
      *
-     * @param {global.Event} evt
+     * @param {global.Event} e
      */
-    Pointer.prototype.drop = function (evt) {
+    Pointer.prototype.drop = function (e) {
         var pointer = this, chart = this.chart, hasPinched = this.hasPinched;
         if (this.selectionMarker) {
             var selectionData = {
-                originalEvent: evt,
+                originalEvent: e,
                 xAxis: [],
                 yAxis: []
             }, selectionBox = this.selectionMarker, selectionLeft = selectionBox.attr ?
@@ -347,7 +347,7 @@ var Pointer = /** @class */ (function () {
                                 xAxis: 'zoomX',
                                 yAxis: 'zoomY'
                             }[axis.coll]])) { // #859, #3569
-                        var horiz = axis.horiz, minPixelPadding = evt.type === 'touchend' ?
+                        var horiz = axis.horiz, minPixelPadding = e.type === 'touchend' ?
                             axis.minPixelPadding :
                             0, // #1207, #3075
                         selectionMin = axis.toValue((horiz ? selectionLeft : selectionTop) +
@@ -767,14 +767,14 @@ var Pointer = /** @class */ (function () {
      * @private
      * @function Highcharts.Pointer#onContainerClick
      *
-     * @param {global.MouseEvent} evt
+     * @param {global.MouseEvent} e
      *
      * @return {void}
      */
-    Pointer.prototype.onContainerClick = function (evt) {
+    Pointer.prototype.onContainerClick = function (e) {
         var chart = this.chart;
         var hoverPoint = chart.hoverPoint;
-        var pEvt = this.normalize(evt);
+        var pEvt = this.normalize(e);
         var plotLeft = chart.plotLeft;
         var plotTop = chart.plotTop;
         if (!chart.cancelClick) {
@@ -804,21 +804,21 @@ var Pointer = /** @class */ (function () {
      * @private
      * @function Highcharts.Pointer#onContainerMouseDown
      *
-     * @param {global.MouseEvent} evt
+     * @param {global.MouseEvent} e
      */
-    Pointer.prototype.onContainerMouseDown = function (evt) {
+    Pointer.prototype.onContainerMouseDown = function (e) {
         // Normalize before the 'if' for the legacy IE (#7850)
-        var pEvt = this.normalize(evt);
+        e = this.normalize(e);
         // #11635, Firefox does not reliable fire move event after click scroll
         if (H.isFirefox &&
-            pEvt.button !== 0) {
-            this.onContainerMouseMove(pEvt);
+            e.button !== 0) {
+            this.onContainerMouseMove(e);
         }
         // #11635, limiting to primary button (incl. IE 8 support)
-        if (typeof pEvt.button === 'undefined' ||
-            ((pEvt.buttons || pEvt.button) & 1) === 1) {
-            this.zoomOption(pEvt);
-            this.dragStart(pEvt);
+        if (typeof e.button === 'undefined' ||
+            ((e.buttons || e.button) & 1) === 1) {
+            this.zoomOption(e);
+            this.dragStart(e);
         }
     };
     /**
@@ -827,17 +827,17 @@ var Pointer = /** @class */ (function () {
      * @private
      * @function Highcharts.Pointer#onContainerMouseLeave
      *
-     * @param {global.MouseEvent} evt
+     * @param {global.MouseEvent} e
      *
      * @return {void}
      */
-    Pointer.prototype.onContainerMouseLeave = function (evt) {
+    Pointer.prototype.onContainerMouseLeave = function (e) {
         var chart = charts[pick(H.hoverChartIndex, -1)];
-        var pEvt = this.normalize(evt);
         var tooltip = this.chart.tooltip;
+        e = this.normalize(e);
         // #4886, MS Touch end fires mouseleave but with no related target
         if (chart &&
-            (pEvt.relatedTarget || pEvt.toElement)) {
+            (e.relatedTarget || e.toElement)) {
             chart.pointer.reset();
             // Also reset the chart position, used in #149 fix
             chart.pointer.chartPosition = void 0;
@@ -854,13 +854,13 @@ var Pointer = /** @class */ (function () {
      * @private
      * @function Highcharts.Pointer#onContainerMouseMove
      *
-     * @param {global.MouseEvent} evt
+     * @param {global.MouseEvent} e
      *
      * @return {void}
      */
-    Pointer.prototype.onContainerMouseMove = function (evt) {
+    Pointer.prototype.onContainerMouseMove = function (e) {
         var chart = this.chart;
-        var pEvt = this.normalize(evt);
+        var pEvt = this.normalize(e);
         this.setHoverChartIndex();
         // In IE8 we apparently need this returnValue set to false in order to
         // avoid text being selected. But in Chrome, e.returnValue is prevented,
@@ -924,14 +924,14 @@ var Pointer = /** @class */ (function () {
      * @private
      * @function Highcharts.Pointer#onDocumentMouseMove
      *
-     * @param {global.MouseEvent} evt
+     * @param {global.MouseEvent} e
      *
      * @return {void}
      */
-    Pointer.prototype.onDocumentMouseMove = function (evt) {
+    Pointer.prototype.onDocumentMouseMove = function (e) {
         var chart = this.chart;
         var chartPosition = this.chartPosition;
-        var pEvt = this.normalize(evt, chartPosition);
+        var pEvt = this.normalize(e, chartPosition);
         var tooltip = chart.tooltip;
         // If we're outside, hide the tooltip
         if (chartPosition &&
@@ -946,14 +946,14 @@ var Pointer = /** @class */ (function () {
      * @private
      * @function Highcharts.Pointer#onDocumentMouseUp
      *
-     * @param {global.MouseEvent} evt
+     * @param {global.MouseEvent} e
      *
      * @return {void}
      */
-    Pointer.prototype.onDocumentMouseUp = function (evt) {
+    Pointer.prototype.onDocumentMouseUp = function (e) {
         var chart = charts[pick(H.hoverChartIndex, -1)];
         if (chart) {
-            chart.pointer.drop(evt);
+            chart.pointer.drop(e);
         }
     };
     /**

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -1245,11 +1245,11 @@ var Tooltip = /** @class */ (function () {
     Tooltip.prototype.tooltipFooterHeaderFormatter = function (labelConfig, isFooter) {
         var footOrHead = isFooter ? 'footer' : 'header', series = labelConfig.series, tooltipOptions = series.tooltipOptions, xDateFormat = tooltipOptions.xDateFormat, xAxis = series.xAxis, isDateTime = (xAxis &&
             xAxis.options.type === 'datetime' &&
-            isNumber(labelConfig.key)), formatString = tooltipOptions[footOrHead + 'Format'], evt = {
+            isNumber(labelConfig.key)), formatString = tooltipOptions[footOrHead + 'Format'], e = {
             isFooter: isFooter,
             labelConfig: labelConfig
         };
-        fireEvent(this, 'headerFormatter', evt, function (e) {
+        fireEvent(this, 'headerFormatter', e, function (e) {
             // Guess the best date format based on the closest point distance
             // (#568, #3418)
             if (isDateTime && !xDateFormat) {
@@ -1271,7 +1271,7 @@ var Tooltip = /** @class */ (function () {
                 series: series
             }, this.chart);
         });
-        return evt.text;
+        return e.text;
     };
     /**
      * Updates the tooltip with the provided tooltip options.

--- a/samples/unit-tests/pointer/scroll/demo.details
+++ b/samples/unit-tests/pointer/scroll/demo.details
@@ -1,0 +1,5 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+...

--- a/samples/unit-tests/pointer/scroll/demo.html
+++ b/samples/unit-tests/pointer/scroll/demo.html
@@ -1,0 +1,10 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<div id="container"></div>
+<style>
+.highcharts-tracker {
+	stroke: red;
+}
+</style>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>

--- a/samples/unit-tests/pointer/scroll/demo.js
+++ b/samples/unit-tests/pointer/scroll/demo.js
@@ -1,0 +1,111 @@
+QUnit.test('Wheel scroll with middle click should hide tooltip (#11635)', function (assert) {
+
+    var container1 = document.getElementById('container'),
+        container2 = document.createElement('div');
+
+    container1.style.position = 'absolute';
+    container1.style.left = '0px';
+    container1.style.top = '0px';
+    container1.style.width = '400px';
+    container1.style.height = '400px';
+    container1.style.zIndex = 1;
+
+    container2.setAttribute('id', 'container2');
+    container2.style.position = container1.style.position;
+    container2.style.left = container1.style.left;
+    container2.style.top = container1.style.height;
+    container2.style.width = container1.style.width;
+    container2.style.height = container1.style.height;
+    container2.style.zIndex = container1.style.zIndex;
+    container1.parentNode.insertBefore(container2, container1.nextSibling);
+
+    var chartOptions = {
+            tooltip: {
+                hideDelay: 0
+            },
+            series: [{
+                type: 'column',
+                data: [3, 2, 1]
+            }]
+        },
+        chart1 = Highcharts.chart('container', chartOptions),
+        chart2 = Highcharts.chart('container2', chartOptions);
+
+    try {
+
+        var controller1 = new TestController(chart1),
+            controller2 = new TestController(chart2),
+            point1 = chart1.series[0].points[0],
+            point2 = chart2.series[0].points[0],
+            point1Position = {
+                x: (point1.plotX + chart1.plotLeft + 1),
+                y: (point1.plotY + chart1.plotTop + 1)
+            },
+            point2Position = {
+                x: (point2.plotX + chart2.plotLeft + 1),
+                y: (point2.plotY + chart2.plotTop + 1)
+            };
+
+        assert.strictEqual(
+            chart1.tooltip.isHidden,
+            true,
+            'Tooltip of first chart should be hidden.'
+        );
+
+        assert.strictEqual(
+            chart2.tooltip.isHidden,
+            true,
+            'Tooltip of second chart should be hidden.'
+        );
+
+        controller1.moveTo(point1Position.x, point1Position.y);
+
+        assert.strictEqual(
+            !chart1.tooltip.isHidden,
+            true,
+            'Tooltip of first chart should not be hidden.'
+        );
+
+        assert.strictEqual(
+            chart2.tooltip.isHidden,
+            true,
+            'Tooltip of second chart should be hidden. (2)'
+        );
+
+        // simulate wheel scroll effect with middle click in Chrome-based browsers
+        controller1.setPosition(point1Position.x, chart1.plotHeight + point2Position.y);
+        controller1.moveTo(-1, -1);
+        controller1.setPosition(point2Position.x, point2Position.y);
+        controller2.moveTo(point2Position.x, point2Position.y);
+        controller2.mouseDown(
+            point2Position.x, point2Position.y,
+            {
+                button: TestController.MouseButtons.middle,
+                target: controller2.relatedTarget
+            }
+        );
+        controller2.mouseUp(
+            point2Position.x, point2Position.y,
+            {
+                button: TestController.MouseButtons.middle,
+                target: controller2.relatedTarget
+            }
+        );
+
+        assert.strictEqual(
+            chart1.tooltip.isHidden,
+            true,
+            'Tooltip of first chart should be hidden. (2)'
+        );
+
+        assert.strictEqual(
+            !chart2.tooltip.isHidden,
+            true,
+            'Tooltip of second chart should not be hidden.'
+        );
+
+    } finally {
+        chart2.destroy();
+        document.body.removeChild(container2);
+    }
+});

--- a/test/test-controller.d.ts
+++ b/test/test-controller.d.ts
@@ -489,4 +489,5 @@ declare namespace TestController {
         middle = 1,
         right = 2
     }
+    const MouseButtonsBitMap: Record<number, number>;
 }

--- a/test/test-controller.js
+++ b/test/test-controller.js
@@ -164,6 +164,9 @@ var TestController = /** @class */ (function () {
                 extra.cancelable = false;
                 break;
         }
+        if (typeof extra.buttons === 'undefined') {
+            extra.buttons = (TestController.MouseButtonsBitMap[extra.button] || 0);
+        }
         Object.keys(extra).forEach(function (key) {
             evt[key] = extra[key];
         });
@@ -969,4 +972,11 @@ var TestController = /** @class */ (function () {
         MouseButtons[MouseButtons["middle"] = 1] = "middle";
         MouseButtons[MouseButtons["right"] = 2] = "right";
     })(MouseButtons = TestController.MouseButtons || (TestController.MouseButtons = {}));
+    TestController.MouseButtonsBitMap = {
+        0: 1,
+        1: 4,
+        2: 2,
+        3: 8,
+        4: 16,
+    };
 })(TestController || (TestController = {}));

--- a/test/test-controller.ts
+++ b/test/test-controller.ts
@@ -274,6 +274,10 @@ class TestController {
                 break;
         }
 
+        if (typeof extra.buttons === 'undefined') {
+            extra.buttons = (TestController.MouseButtonsBitMap[extra.button] || 0);
+        }
+
         Object.keys(extra).forEach(function (key) {
             (evt as any)[key] = extra[key];
         });
@@ -1242,13 +1246,21 @@ namespace TestController {
     export enum DebugMarkTypes {
         activation,
         movement,
-        normal
+        normal,
     }
 
     export enum MouseButtons {
         left = 0,
         middle = 1,
-        right = 2
+        right = 2,
+    }
+
+    export const MouseButtonsBitMap: Record<number, number> = {
+        0: 1,
+        1: 4,
+        2: 2,
+        3: 8,
+        4: 16,
     }
 
 }

--- a/ts/annotations/ControlPoint.ts
+++ b/ts/annotations/ControlPoint.ts
@@ -38,7 +38,7 @@ declare global {
             public update(userOptions: Partial<AnnotationControlPointOptionsObject>): void;
         }
         interface AnnotationControlPointDragEventFunction {
-            (this: Annotation, evt: AnnotationEventObject, target: AnnotationControllable): void;
+            (this: Annotation, e: AnnotationEventObject, target: AnnotationControllable): void;
         }
         interface AnnotationControlPointPositionerFunction {
             (this: AnnotationControlPoint, target: AnnotationControllable): PositionObject;

--- a/ts/modules/oldie.src.ts
+++ b/ts/modules/oldie.src.ts
@@ -933,10 +933,10 @@ if (!svg) {
         ): Highcharts.VMLElement {
             // simplest possible event model for internal use
             this.element['on' + eventType] = function (): void {
-                var evt = win.event as Event;
+                var e = win.event as Event;
 
-                (evt.target as any) = evt.srcElement;
-                handler(evt);
+                (e.target as any) = e.srcElement;
+                handler(e);
             };
             return this;
         },

--- a/ts/parts/Interaction.ts
+++ b/ts/parts/Interaction.ts
@@ -291,10 +291,20 @@ TrackerMixin = H.TrackerMixin = {
             pointer = chart.pointer,
             renderer = chart.renderer,
             snap = (chart.options.tooltip as any).snap,
+            tooltip = chart.tooltip,
             tracker = series.tracker,
-            i,
-            onMouseOver = function (): void {
-                if (chart.hoverSeries !== series) {
+            i: number,
+            onMouseOver = function (e: Highcharts.PointerEventObject): void {
+
+                pointer.normalize(e);
+
+                if (
+                    chart.hoverSeries !== series &&
+                    (
+                        !tooltip ||
+                        !tooltip.isStickyOnContact()
+                    )
+                ) {
                     series.onMouseOver();
                 }
             },
@@ -1386,7 +1396,10 @@ extend(Series.prototype, /** @lends Highcharts.Series.prototype */ {
     onMouseOver: function (this: Highcharts.Series): void {
         var series = this,
             chart = series.chart,
-            hoverSeries = chart.hoverSeries;
+            hoverSeries = chart.hoverSeries,
+            pointer = chart.pointer;
+
+        pointer.setHoverChartIndex();
 
         // set normal state to previous series
         if (hoverSeries && hoverSeries !== series) {

--- a/ts/parts/Interaction.ts
+++ b/ts/parts/Interaction.ts
@@ -291,20 +291,10 @@ TrackerMixin = H.TrackerMixin = {
             pointer = chart.pointer,
             renderer = chart.renderer,
             snap = (chart.options.tooltip as any).snap,
-            tooltip = chart.tooltip,
             tracker = series.tracker,
             i: number,
             onMouseOver = function (e: Highcharts.PointerEventObject): void {
-
-                pointer.normalize(e);
-
-                if (
-                    chart.hoverSeries !== series &&
-                    (
-                        !tooltip ||
-                        !tooltip.isStickyOnContact()
-                    )
-                ) {
+                if (chart.hoverSeries !== series) {
                     series.onMouseOver();
                 }
             },

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -1067,7 +1067,6 @@ class Pointer {
         const chart = this.chart;
         const relatedTarget = e.relatedTarget || e.toElement;
         const series = chart.hoverSeries;
-        const tooltip = chart.tooltip;
 
         this.isDirectTouch = false;
 
@@ -1075,10 +1074,6 @@ class Pointer {
             series &&
             relatedTarget &&
             !series.stickyTracking &&
-            (
-                !tooltip ||
-                !tooltip.isStickyOnContact()
-            ) &&
             !this.inClass(relatedTarget as any, 'highcharts-tooltip') &&
             (
                 !this.inClass(

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -122,8 +122,8 @@ declare global {
                 e: (T|PointerEvent|TouchEvent),
                 chartPosition?: OffsetObject
             ): T;
-            public onContainerClick(evt: MouseEvent): void
-            public onContainerMouseDown(evt: MouseEvent): void;
+            public onContainerClick(e: MouseEvent): void
+            public onContainerMouseDown(e: MouseEvent): void;
             public onContainerMouseLeave(e: MouseEvent): void;
             public onContainerMouseMove(e: MouseEvent): void;
             public onContainerTouchMove(e: PointerEventObject): void;
@@ -623,16 +623,16 @@ class Pointer {
      * @private
      * @function Highcharts.Pointer#drop
      *
-     * @param {global.Event} evt
+     * @param {global.Event} e
      */
-    public drop(evt: Event): void {
+    public drop(e: Event): void {
         var pointer = this,
             chart = this.chart,
             hasPinched = this.hasPinched;
 
         if (this.selectionMarker) {
             var selectionData = {
-                    originalEvent: evt, // #4890
+                    originalEvent: e, // #4890
                     xAxis: [],
                     yAxis: []
                 },
@@ -671,7 +671,7 @@ class Pointer {
                         )
                     ) { // #859, #3569
                         var horiz = axis.horiz,
-                            minPixelPadding = evt.type === 'touchend' ?
+                            minPixelPadding = e.type === 'touchend' ?
                                 axis.minPixelPadding :
                                 0, // #1207, #3075
                             selectionMin = axis.toValue(
@@ -1226,14 +1226,14 @@ class Pointer {
      * @private
      * @function Highcharts.Pointer#onContainerClick
      *
-     * @param {global.MouseEvent} evt
+     * @param {global.MouseEvent} e
      *
      * @return {void}
      */
-    public onContainerClick(evt: MouseEvent): void {
+    public onContainerClick(e: MouseEvent): void {
         const chart = this.chart;
         const hoverPoint = chart.hoverPoint;
-        const pEvt = this.normalize(evt);
+        const pEvt = this.normalize(e);
         const plotLeft = chart.plotLeft;
         const plotTop = chart.plotTop;
 
@@ -1272,27 +1272,27 @@ class Pointer {
      * @private
      * @function Highcharts.Pointer#onContainerMouseDown
      *
-     * @param {global.MouseEvent} evt
+     * @param {global.MouseEvent} e
      */
-    public onContainerMouseDown(evt: MouseEvent): void {
+    public onContainerMouseDown(e: MouseEvent): void {
         // Normalize before the 'if' for the legacy IE (#7850)
-        const pEvt = this.normalize(evt);
+        e = this.normalize(e);
 
         // #11635, Firefox does not reliable fire move event after click scroll
         if (
             H.isFirefox &&
-            pEvt.button !== 0
+            e.button !== 0
         ) {
-            this.onContainerMouseMove(pEvt);
+            this.onContainerMouseMove(e);
         }
 
         // #11635, limiting to primary button (incl. IE 8 support)
         if (
-            typeof pEvt.button === 'undefined' ||
-            ((pEvt.buttons || pEvt.button) & 1) === 1
+            typeof e.button === 'undefined' ||
+            ((e.buttons || e.button) & 1) === 1
         ) {
-            this.zoomOption(pEvt);
-            this.dragStart(pEvt);
+            this.zoomOption(e);
+            this.dragStart(e as Highcharts.PointerEventObject);
         }
     }
 
@@ -1302,19 +1302,20 @@ class Pointer {
      * @private
      * @function Highcharts.Pointer#onContainerMouseLeave
      *
-     * @param {global.MouseEvent} evt
+     * @param {global.MouseEvent} e
      *
      * @return {void}
      */
-    public onContainerMouseLeave(evt: MouseEvent): void {
+    public onContainerMouseLeave(e: MouseEvent): void {
         const chart = charts[pick(H.hoverChartIndex, -1)];
-        const pEvt = this.normalize(evt);
         const tooltip = this.chart.tooltip;
+
+        e = this.normalize(e);
 
         // #4886, MS Touch end fires mouseleave but with no related target
         if (
             chart &&
-            (pEvt.relatedTarget || pEvt.toElement)
+            (e.relatedTarget || (e as Highcharts.PointerEventObject).toElement)
         ) {
             chart.pointer.reset();
             // Also reset the chart position, used in #149 fix
@@ -1335,13 +1336,13 @@ class Pointer {
      * @private
      * @function Highcharts.Pointer#onContainerMouseMove
      *
-     * @param {global.MouseEvent} evt
+     * @param {global.MouseEvent} e
      *
      * @return {void}
      */
-    public onContainerMouseMove(evt: MouseEvent): void {
+    public onContainerMouseMove(e: MouseEvent): void {
         const chart = this.chart;
-        const pEvt = this.normalize(evt);
+        const pEvt = this.normalize(e);
 
         this.setHoverChartIndex();
 
@@ -1420,14 +1421,14 @@ class Pointer {
      * @private
      * @function Highcharts.Pointer#onDocumentMouseMove
      *
-     * @param {global.MouseEvent} evt
+     * @param {global.MouseEvent} e
      *
      * @return {void}
      */
-    public onDocumentMouseMove(evt: MouseEvent): void {
+    public onDocumentMouseMove(e: MouseEvent): void {
         const chart = this.chart;
         const chartPosition = this.chartPosition;
-        const pEvt = this.normalize(evt, chartPosition);
+        const pEvt = this.normalize(e, chartPosition);
         const tooltip = chart.tooltip;
 
         // If we're outside, hide the tooltip
@@ -1451,14 +1452,14 @@ class Pointer {
      * @private
      * @function Highcharts.Pointer#onDocumentMouseUp
      *
-     * @param {global.MouseEvent} evt
+     * @param {global.MouseEvent} e
      *
      * @return {void}
      */
-    public onDocumentMouseUp(evt: MouseEvent): void {
+    public onDocumentMouseUp(e: MouseEvent): void {
         const chart = charts[pick(H.hoverChartIndex, -1)];
         if (chart) {
-            chart.pointer.drop(evt);
+            chart.pointer.drop(e);
         }
     }
 

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -1286,9 +1286,10 @@ class Pointer {
             this.onContainerMouseMove(pEvt);
         }
 
+        // #11635, limiting to primary button (incl. IE 8 support)
         if (
             typeof pEvt.button === 'undefined' ||
-            pEvt.button === 0 // #11635, limiting to primary button
+            ((pEvt.buttons || pEvt.button) & 1) === 1
         ) {
             this.zoomOption(pEvt);
             this.dragStart(pEvt);

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -48,8 +48,6 @@ declare global {
             shared?: boolean;
         }
         interface PointerEventObject extends PointerCoordinatesObject, PointerEvent {
-            chartX: number;
-            chartY: number;
             touches?: Array<Touch>;
         }
         interface PointerHoverDataObject {
@@ -160,6 +158,7 @@ declare global {
                 clip?: boolean
             ): void;
             public setDOMEvents(): void;
+            public setHoverChartIndex(): void;
             public touch(e: PointerEventObject, start?: boolean): void;
             public zoomOption(e: Event): void;
         }
@@ -1065,8 +1064,9 @@ class Pointer {
      */
     public onTrackerMouseOut(e: Highcharts.PointerEventObject): void {
         const chart = this.chart;
-        const series = chart.hoverSeries;
         const relatedTarget = e.relatedTarget || e.toElement;
+        const series = chart.hoverSeries;
+        const tooltip = chart.tooltip;
 
         this.isDirectTouch = false;
 
@@ -1074,6 +1074,10 @@ class Pointer {
             series &&
             relatedTarget &&
             !series.stickyTracking &&
+            (
+                !tooltip ||
+                !tooltip.isStickyOnContact()
+            ) &&
             !this.inClass(relatedTarget as any, 'highcharts-tooltip') &&
             (
                 !this.inClass(
@@ -1176,7 +1180,7 @@ class Pointer {
      *
      * @function Highcharts.Pointer#normalize
      *
-     * @param {global.PointerEvent|global.TouchEvent} e
+     * @param {global.MouseEvent|global.PointerEvent|global.TouchEvent} e
      *        Event object in standard browsers.
      *
      * @param {Highcharts.OffsetObject} [chartPosition]
@@ -1186,7 +1190,7 @@ class Pointer {
      *         A browser event with extended properties `chartX` and `chartY`.
      */
     public normalize<T extends Highcharts.PointerEventObject>(
-        e: (T|PointerEvent|TouchEvent),
+        e: (T|MouseEvent|PointerEvent|TouchEvent),
         chartPosition?: Highcharts.OffsetObject
     ): T {
         const touches = (e as TouchEvent).touches;
@@ -1283,15 +1287,21 @@ class Pointer {
         // Normalize before the 'if' for the legacy IE (#7850)
         e = this.normalize(e);
 
-        if ((e as any).button !== 2) {
+        this.onContainerMouseMove(e);
+
+        if (
+            typeof e.button === 'undefined' ||
+            e.button === 0 // #11635, limiting to primary button
+        ) {
 
             this.zoomOption(e);
-
-            // issue #295, dragging not always working in Firefox
-            if (e.preventDefault) {
+            /*
+            // #295, dragging not always working in Firefox
+            // #11635, turn off condition because of wheel click issue
+            if (H.isFirefox) {
                 e.preventDefault();
             }
-
+             */
             this.dragStart(e);
         }
     }
@@ -1307,7 +1317,8 @@ class Pointer {
      * @return {void}
      */
     public onContainerMouseLeave(e: Highcharts.PointerEventObject): void {
-        const chart = charts[H.hoverChartIndex as any];
+        const chart = charts[pick(H.hoverChartIndex, -1)];
+        const tooltip = this.chart.tooltip;
 
         // #4886, MS Touch end fires mouseleave but with no related target
         if (
@@ -1317,6 +1328,13 @@ class Pointer {
             chart.pointer.reset();
             // Also reset the chart position, used in #149 fix
             chart.pointer.chartPosition = void 0;
+        }
+
+        if ( // #11635, Firefox wheel scroll does not fire out events consistently
+            tooltip &&
+            !tooltip.isHidden
+        ) {
+            this.reset();
         }
     }
 
@@ -1333,6 +1351,7 @@ class Pointer {
     public onContainerMouseMove(e: Highcharts.PointerEventObject): void {
         const chart = this.chart;
 
+        /*
         if (
             !defined(H.hoverChartIndex) ||
             !charts[H.hoverChartIndex as any] ||
@@ -1340,6 +1359,8 @@ class Pointer {
         ) {
             H.hoverChartIndex = chart.index;
         }
+         */
+        this.setHoverChartIndex();
 
         e = this.normalize(e);
 
@@ -2101,24 +2122,28 @@ class Pointer {
             ownerDoc = container.ownerDocument;
 
         container.onmousedown = function (e: MouseEvent): void {
-            pointer.onContainerMouseDown(e as any);
+            pointer.onContainerMouseDown(pointer.normalize(e));
         };
         container.onmousemove = function (e: MouseEvent): void {
-            pointer.onContainerMouseMove(e as any);
+            pointer.onContainerMouseMove(pointer.normalize(e));
         };
         container.onclick = function (e: MouseEvent): void {
-            pointer.onContainerClick(e as any);
+            pointer.onContainerClick(pointer.normalize(e));
         };
         this.unbindContainerMouseLeave = addEvent(
             container,
             'mouseleave',
-            pointer.onContainerMouseLeave as any
+            function (e: MouseEvent): void {
+                pointer.onContainerMouseLeave(pointer.normalize(e));
+            }
         );
         if (!H.unbindDocumentMouseUp) {
             H.unbindDocumentMouseUp = addEvent(
                 ownerDoc,
                 'mouseup',
-                pointer.onDocumentMouseUp as any
+                function (e: MouseEvent): void {
+                    pointer.onDocumentMouseUp(pointer.normalize(e));
+                }
             );
         }
         if (H.hasTouch) {
@@ -2126,23 +2151,51 @@ class Pointer {
                 container,
                 'touchstart',
                 function (e: TouchEvent): void {
-                    pointer.onContainerTouchStart(e as any);
+                    pointer.onContainerTouchStart(pointer.normalize(e));
                 }
             );
             addEvent(
                 container,
                 'touchmove',
                 function (e: TouchEvent): void {
-                    pointer.onContainerTouchMove(e as any);
+                    pointer.onContainerTouchMove(pointer.normalize(e));
                 }
             );
             if (!H.unbindDocumentTouchEnd) {
                 H.unbindDocumentTouchEnd = addEvent(
                     ownerDoc,
                     'touchend',
-                    pointer.onDocumentTouchEnd as any
+                    function (e: TouchEvent): void {
+                        pointer.onDocumentTouchEnd(pointer.normalize(e));
+                    }
                 );
             }
+        }
+    }
+
+    /**
+     * Sets the index of the hovered chart and leaves the previous hovered
+     * chart, to reset states like tooltip.
+     *
+     * @private
+     * @function Highcharts.Pointer#setHoverChartIndex
+     */
+    public setHoverChartIndex(): void {
+        const chart = this.chart;
+        const hoverChart = H.charts[H.hoverChartIndex || -1];
+
+        if (
+            hoverChart &&
+            hoverChart.index !== chart.index
+        ) {
+            hoverChart.pointer.onContainerMouseLeave({ relatedTarget: true } as any);
+        }
+
+        if (
+            !hoverChart ||
+            !hoverChart.mouseIsDown
+        ) {
+            H.hoverChartIndex = chart.index;
         }
     }
 
@@ -2164,10 +2217,13 @@ class Pointer {
             pinchDown,
             isInside;
 
+        /*
         if (chart.index !== H.hoverChartIndex) {
             this.onContainerMouseLeave({ relatedTarget: true } as any);
         }
         H.hoverChartIndex = chart.index;
+         */
+        this.setHoverChartIndex();
 
         if ((e as any).touches.length === 1) {
 

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -1835,12 +1835,12 @@ class Tooltip {
                 isNumber(labelConfig.key)
             ),
             formatString = (tooltipOptions as any)[footOrHead + 'Format'],
-            evt = {
+            e = {
                 isFooter: isFooter,
                 labelConfig: labelConfig
             } as Highcharts.Dictionary<any>;
 
-        fireEvent(this, 'headerFormatter', evt, function (
+        fireEvent(this, 'headerFormatter', e, function (
             this: Highcharts.Tooltip,
             e: Highcharts.Dictionary<any>
         ): void {
@@ -1879,7 +1879,7 @@ class Tooltip {
             }, this.chart);
 
         });
-        return evt.text;
+        return e.text;
     }
 
     /**


### PR DESCRIPTION
Fixed #11635, scrolling didn't trigger hiding of the tooltip when the cursor left the chart's container.

___

- Close #11635, Tooltip hides with wheelscroll click. https://jsfiddle.net/g643wuLj/
- Improved TestController.