### PR TITLE
Bugfix, new Color failed

### DIFF
--- a/js/modules/accessibility/components/AnnotationsA11y.js
+++ b/js/modules/accessibility/components/AnnotationsA11y.js
@@ -59,11 +59,11 @@ function getAnnotationLabelDescription(label) {
     var chart = label.chart;
     var labelText = getLabelText(label);
     var points = label.points;
-    var getAriaLabel = function (point) { var _a, _b, _c; return ((_c = (_b = (_a = point) === null || _a === void 0 ? void 0 : _a.graphic) === null || _b === void 0 ? void 0 : _b.element) === null || _c === void 0 ? void 0 : _c.getAttribute('aria-label')) || ''; };
+    var getAriaLabel = function (point) { var _a, _b; return ((_b = (_a = point === null || point === void 0 ? void 0 : point.graphic) === null || _a === void 0 ? void 0 : _a.element) === null || _b === void 0 ? void 0 : _b.getAttribute('aria-label')) || ''; };
     var getValueDesc = function (point) {
-        var _a, _b, _c;
-        var valDesc = ((_b = (_a = point) === null || _a === void 0 ? void 0 : _a.accessibility) === null || _b === void 0 ? void 0 : _b.valueDescription) || getAriaLabel(point);
-        var seriesName = ((_c = point) === null || _c === void 0 ? void 0 : _c.series.name) || '';
+        var _a;
+        var valDesc = ((_a = point === null || point === void 0 ? void 0 : point.accessibility) === null || _a === void 0 ? void 0 : _a.valueDescription) || getAriaLabel(point);
+        var seriesName = (point === null || point === void 0 ? void 0 : point.series.name) || '';
         return (seriesName ? seriesName + ', ' : '') + 'data point ' + valDesc;
     };
     var pointValueDescriptions = points

--- a/js/modules/accessibility/components/InfoRegionsComponent.js
+++ b/js/modules/accessibility/components/InfoRegionsComponent.js
@@ -385,17 +385,15 @@ extend(InfoRegionsComponent.prototype, /** @lends Highcharts.InfoRegionsComponen
         var el = this.sonifyButton = getElement(sonifyButtonId);
         var chart = this.chart;
         var defaultHandler = function (e) {
-            var _a, _b;
-            (_a = el) === null || _a === void 0 ? void 0 : _a.setAttribute('aria-hidden', 'true');
-            (_b = el) === null || _b === void 0 ? void 0 : _b.setAttribute('aria-label', '');
+            el === null || el === void 0 ? void 0 : el.setAttribute('aria-hidden', 'true');
+            el === null || el === void 0 ? void 0 : el.setAttribute('aria-label', '');
             e.preventDefault();
             e.stopPropagation();
             var announceMsg = chart.langFormat('accessibility.sonification.playAsSoundClickAnnouncement', { chart: chart });
             _this.announcer.announce(announceMsg);
             setTimeout(function () {
-                var _a, _b;
-                (_a = el) === null || _a === void 0 ? void 0 : _a.removeAttribute('aria-hidden');
-                (_b = el) === null || _b === void 0 ? void 0 : _b.removeAttribute('aria-label');
+                el === null || el === void 0 ? void 0 : el.removeAttribute('aria-hidden');
+                el === null || el === void 0 ? void 0 : el.removeAttribute('aria-label');
                 if (chart.sonify) {
                     chart.sonify();
                 }

--- a/js/modules/full-screen.src.js
+++ b/js/modules/full-screen.src.js
@@ -163,9 +163,9 @@ var Fullscreen = /** @class */ (function () {
      * @return {void}
      */
     Fullscreen.prototype.setButtonText = function () {
-        var _a, _b, _c, _d;
-        var chart = this.chart, exportDivElements = chart.exportDivElements, exportingOptions = chart.options.exporting, menuItems = (_b = (_a = exportingOptions) === null || _a === void 0 ? void 0 : _a.buttons) === null || _b === void 0 ? void 0 : _b.contextButton.menuItems, lang = chart.options.lang;
-        if (((_c = exportingOptions) === null || _c === void 0 ? void 0 : _c.menuItemDefinitions) && ((_d = lang) === null || _d === void 0 ? void 0 : _d.exitFullscreen) &&
+        var _a;
+        var chart = this.chart, exportDivElements = chart.exportDivElements, exportingOptions = chart.options.exporting, menuItems = (_a = exportingOptions === null || exportingOptions === void 0 ? void 0 : exportingOptions.buttons) === null || _a === void 0 ? void 0 : _a.contextButton.menuItems, lang = chart.options.lang;
+        if ((exportingOptions === null || exportingOptions === void 0 ? void 0 : exportingOptions.menuItemDefinitions) && (lang === null || lang === void 0 ? void 0 : lang.exitFullscreen) &&
             lang.viewFullscreen &&
             menuItems &&
             exportDivElements &&

--- a/js/parts/Color.js
+++ b/js/parts/Color.js
@@ -153,6 +153,10 @@ var Color = /** @class */ (function () {
                 }
             }];
         this.rgba = [];
+        // Backwards compatibility, allow instanciation without new (#13053)
+        if (!(this instanceof Color)) {
+            return new Color(input);
+        }
         this.init(input);
     }
     /* *

--- a/js/parts/Time.js
+++ b/js/parts/Time.js
@@ -402,14 +402,14 @@ var Time = /** @class */ (function () {
      *         The formatted date.
      */
     Time.prototype.dateFormat = function (format, timestamp, capitalize) {
-        var _a, _b, _c;
+        var _a;
         if (!defined(timestamp) || isNaN(timestamp)) {
             return ((_a = H.defaultOptions.lang) === null || _a === void 0 ? void 0 : _a.invalidDate) || '';
         }
         format = pick(format, '%Y-%m-%d %H:%M:%S');
         var time = this, date = new this.Date(timestamp), 
         // get the basic time values
-        hours = this.get('Hours', date), day = this.get('Day', date), dayOfMonth = this.get('Date', date), month = this.get('Month', date), fullYear = this.get('FullYear', date), lang = H.defaultOptions.lang, langWeekdays = (_b = lang) === null || _b === void 0 ? void 0 : _b.weekdays, shortWeekdays = (_c = lang) === null || _c === void 0 ? void 0 : _c.shortWeekdays, 
+        hours = this.get('Hours', date), day = this.get('Day', date), dayOfMonth = this.get('Date', date), month = this.get('Month', date), fullYear = this.get('FullYear', date), lang = H.defaultOptions.lang, langWeekdays = lang === null || lang === void 0 ? void 0 : lang.weekdays, shortWeekdays = lang === null || lang === void 0 ? void 0 : lang.shortWeekdays, 
         // List all format keys. Custom formats can be added from the
         // outside.
         replacements = extend({

--- a/samples/unit-tests/color/color/demo.js
+++ b/samples/unit-tests/color/color/demo.js
@@ -1,3 +1,11 @@
+QUnit.test('Compatibility', function (assert) {
+    assert.strictEqual(
+        Highcharts.Color('#ff0000').get('rgba'),
+        'rgba(255,0,0,1)',
+        'Backwards compatibility - the Color class should work without the "new" keyword'
+    );
+});
+
 QUnit.test('Interpolate colors', function (assert) {
 
     // Cache names from Boost module

--- a/ts/parts/Color.ts
+++ b/ts/parts/Color.ts
@@ -242,6 +242,10 @@ class Color {
     public constructor(
         input: (Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject|undefined)
     ) {
+        // Backwards compatibility, allow instanciation without new (#13053)
+        if (!(this instanceof Color)) {
+            return new Color(input);
+        }
         this.init(input);
     }
 


### PR DESCRIPTION
Fixed #13053, a regression that removed the compatibility feature of calling `Highcharts.Color` without the `new` keyword.