### PR TITLE
Bugfix, new Color failed

### DIFF
--- a/js/parts/Color.js
+++ b/js/parts/Color.js
@@ -153,6 +153,10 @@ var Color = /** @class */ (function () {
                 }
             }];
         this.rgba = [];
+        // Backwards compatibility, allow instanciation without new (#13053)
+        if (!(this instanceof Color)) {
+            return new Color(input);
+        }
         this.init(input);
     }
     /* *

--- a/samples/unit-tests/color/color/demo.js
+++ b/samples/unit-tests/color/color/demo.js
@@ -1,3 +1,11 @@
+QUnit.test('Compatibility', function (assert) {
+    assert.strictEqual(
+        Highcharts.Color('#ff0000').get('rgba'),
+        'rgba(255,0,0,1)',
+        'Backwards compatibility - the Color class should work without the "new" keyword'
+    );
+});
+
 QUnit.test('Interpolate colors', function (assert) {
 
     // Cache names from Boost module

--- a/ts/parts/Color.ts
+++ b/ts/parts/Color.ts
@@ -242,6 +242,10 @@ class Color {
     public constructor(
         input: (Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject|undefined)
     ) {
+        // Backwards compatibility, allow instanciation without new (#13053)
+        if (!(this instanceof Color)) {
+            return new Color(input);
+        }
         this.init(input);
     }
 


### PR DESCRIPTION
Fixed #13053, a regression that removed the compatibility feature of calling `Highcharts.Color` without the `new` keyword.