### PR TITLE
bugfix/13077-annotations-isInsidePlot-polar

### DIFF
--- a/js/annotations/MockPoint.js
+++ b/js/annotations/MockPoint.js
@@ -42,7 +42,7 @@ import H from '../parts/Globals.js';
  * @type {boolean|undefined}
  */
 import U from '../parts/Utilities.js';
-var defined = U.defined, extend = U.extend;
+var defined = U.defined, extend = U.extend, fireEvent = U.fireEvent;
 import '../parts/Axis.js';
 import '../parts/Series.js';
 /* eslint-disable no-invalid-this, valid-jsdoc */
@@ -285,18 +285,23 @@ extend(MockPoint.prototype, /** @lends Highcharts.AnnotationMockPoint# */ {
      * @private
      * @return {boolean} A flag indicating whether the point is inside the pane.
      */
-    isInsidePane: function () {
-        var plotX = this.plotX, plotY = this.plotY, xAxis = this.series.xAxis, yAxis = this.series.yAxis, isInside = true;
+    isInsidePlot: function () {
+        var plotX = this.plotX, plotY = this.plotY, xAxis = this.series.xAxis, yAxis = this.series.yAxis, e = {
+            x: plotX,
+            y: plotY,
+            isInsidePlot: true
+        };
         if (xAxis) {
-            isInside = defined(plotX) && plotX >= 0 && plotX <= xAxis.len;
+            e.isInsidePlot = defined(plotX) && plotX >= 0 && plotX <= xAxis.len;
         }
         if (yAxis) {
-            isInside =
-                isInside &&
+            e.isInsidePlot =
+                e.isInsidePlot &&
                     defined(plotY) &&
                     plotY >= 0 && plotY <= yAxis.len;
         }
-        return isInside;
+        fireEvent(this.series.chart, 'afterIsInsidePlot', e);
+        return e.isInsidePlot;
     },
     /**
      * Refresh point values and coordinates based on its options.
@@ -320,7 +325,7 @@ extend(MockPoint.prototype, /** @lends Highcharts.AnnotationMockPoint# */ {
             this.y = null;
             this.plotY = options.y;
         }
-        this.isInside = this.isInsidePane();
+        this.isInside = this.isInsidePlot();
     },
     /**
      * Translate the point.

--- a/js/annotations/controllable/ControllableLabel.js
+++ b/js/annotations/controllable/ControllableLabel.js
@@ -256,7 +256,7 @@ merge(true, ControllableLabel.prototype, controllableMixin,
      */
     position: function (anchor) {
         var item = this.graphic, chart = this.annotation.chart, point = this.points[0], itemOptions = this.options, anchorAbsolutePosition = anchor.absolutePosition, anchorRelativePosition = anchor.relativePosition, itemPosition, alignTo, itemPosRelativeX, itemPosRelativeY, showItem = point.series.visible &&
-            MockPoint.prototype.isInsidePane.call(point);
+            MockPoint.prototype.isInsidePlot.call(point);
         if (showItem) {
             if (itemOptions.distance) {
                 itemPosition = Tooltip.prototype.getPosition.call({

--- a/samples/unit-tests/annotations/annotations-labels-mock-point/demo.js
+++ b/samples/unit-tests/annotations/annotations-labels-mock-point/demo.js
@@ -104,53 +104,53 @@ QUnit.test('Mock Point translations from x/y in the options to plotX/plotY', fun
     );
 
 
-    var isInsidePane = MockPoint.prototype.isInsidePane;
+    var isInsidePlot = MockPoint.prototype.isInsidePlot;
     var points = chart.series[2].points;
 
     assert.notOk(
-        isInsidePane.call(points[0]),
+        isInsidePlot.call(points[0]),
         'The real point is outside the pane area'
     );
 
     assert.ok(
-        isInsidePane.call(points[1]),
+        isInsidePlot.call(points[1]),
         'The real point is inside the pane area'
     );
 
     assert.ok(
-        isInsidePane.call(points[2]),
+        isInsidePlot.call(points[2]),
         'The real point without marker is inside the pane area'
     );
 
     assert.notOk(
-        isInsidePane.call(points[3]),
+        isInsidePlot.call(points[3]),
         'The real point without marker is outside the pane area'
     );
 
     chart.xAxis[0].setExtremes(109, 113);
 
     assert.notOk(
-        isInsidePane.call(points[0]),
+        isInsidePlot.call(points[0]),
         'After set extremes - the real point is outside the pane area'
     );
 
     assert.notOk(
-        isInsidePane.call(points[1]),
+        isInsidePlot.call(points[1]),
         'After set extremes - the real point is outside the pane area'
     );
 
     assert.notOk(
-        isInsidePane.call(points[2]),
+        isInsidePlot.call(points[2]),
         'After set extremes - the real point without marker is outside the pane area'
     );
 
     assert.ok(
-        isInsidePane.call(points[3]),
+        isInsidePlot.call(points[3]),
         'After set extreems - the real point without marker is inside the pane area'
     );
 
     assert.ok(
-        isInsidePane.call(points[4]),
+        isInsidePlot.call(points[4]),
         'After set extreems - the real point is inside the pane area'
     );
 });

--- a/samples/unit-tests/annotations/annotations-labels-positioning/demo.html
+++ b/samples/unit-tests/annotations/annotations-labels-positioning/demo.html
@@ -1,4 +1,5 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
 <script src="https://code.highcharts.com/modules/annotations.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/annotations/annotations-labels-positioning/demo.js
+++ b/samples/unit-tests/annotations/annotations-labels-positioning/demo.js
@@ -367,3 +367,69 @@ QUnit.test('Positioning labels according to mock points - inverted chart', funct
     assert.strictEqual(Math.round(label4.x), x4, 'x position - positioner');
     assert.strictEqual(Math.round(label4.y), y4, 'y position - positioner');
 });
+
+
+QUnit.test('Visibility of labels - point.isInsidePlot() - polar chart', function (assert) {
+
+    var chart = Highcharts.chart('container', {
+            chart: {
+                polar: true
+            },
+
+            annotations: [{
+                labels: [{
+                    point: 'id1'
+                }, {
+                    point: 'id2'
+                }, {
+                    point: 'id3'
+                }, {
+                    point: 'id4'
+                }, {
+                    point: 'id5'
+                }, {
+                    point: 'id6'
+                }]
+            }],
+
+            yAxis: {
+                max: 10,
+                labels: {
+                    enabled: false
+                }
+            },
+
+            series: [{
+                data: [
+                    { y: 3, id: 'id1' },
+                    { y: 4, id: 'id2' },
+                    { y: 3, id: 'id3' },
+                    { y: 4, id: 'id4' },
+                    { y: 5, id: 'id5' },
+                    { y: 12, id: 'id6' }
+                ]
+            }]
+        }),
+        annotations = chart.annotations[0],
+        points = chart.series[0].points;
+
+    assert.strictEqual(
+        points[5].isInside,
+        false,
+        'Point should not be displayed - (out of plot area)'
+    );
+
+    for (var i = 0; i < annotations.labels.length - 1; i++) {
+        assert.strictEqual(
+            points[i].isInside,
+            true,
+            'All labels inside plot area should be displayed'
+        );
+        assert.notStrictEqual(
+            annotations.labels[i].graphic.y,
+            annotations.labels[5].graphic.y,
+            'All labels inside plot area should be displayed'
+        );
+    }
+
+});

--- a/ts/annotations/MockPoint.ts
+++ b/ts/annotations/MockPoint.ts
@@ -41,7 +41,7 @@ declare global {
             public getLabelConfig(): AnnotationMockLabelOptionsObject;
             public getOptions(): AnnotationMockPointOptionsObject;
             public hasDynamicOptions(): boolean;
-            public isInsidePane(): boolean;
+            public isInsidePlot(): boolean;
             public refresh(): void;
             public refreshOptions(): void;
             public rotate(cx: number, cy: number, radians: number): void;
@@ -111,7 +111,8 @@ declare global {
 
 import U from '../parts/Utilities.js';
 var defined = U.defined,
-    extend = U.extend;
+    extend = U.extend,
+    fireEvent = U.fireEvent;
 
 import '../parts/Axis.js';
 import '../parts/Series.js';
@@ -408,25 +409,31 @@ extend(MockPoint.prototype, /** @lends Highcharts.AnnotationMockPoint# */ {
      * @private
      * @return {boolean} A flag indicating whether the point is inside the pane.
      */
-    isInsidePane: function (this: Highcharts.AnnotationMockPoint): boolean {
+    isInsidePlot: function (this: Highcharts.AnnotationMockPoint): boolean {
         var plotX = this.plotX,
             plotY = this.plotY,
             xAxis = this.series.xAxis,
             yAxis = this.series.yAxis,
-            isInside = true;
+            e = {
+                x: plotX,
+                y: plotY,
+                isInsidePlot: true
+            };
 
         if (xAxis) {
-            isInside = defined(plotX) && plotX >= 0 && plotX <= xAxis.len;
+            e.isInsidePlot = defined(plotX) && plotX >= 0 && plotX <= xAxis.len;
         }
 
         if (yAxis) {
-            isInside =
-                isInside &&
+            e.isInsidePlot =
+                e.isInsidePlot &&
                 defined(plotY) &&
                 plotY >= 0 && plotY <= yAxis.len;
         }
 
-        return isInside;
+        fireEvent(this.series.chart, 'afterIsInsidePlot', e);
+
+        return e.isInsidePlot;
     },
 
     /**
@@ -455,7 +462,7 @@ extend(MockPoint.prototype, /** @lends Highcharts.AnnotationMockPoint# */ {
             this.plotY = options.y;
         }
 
-        this.isInside = this.isInsidePane();
+        this.isInside = this.isInsidePlot();
     },
 
     /**

--- a/ts/annotations/controllable/ControllableLabel.ts
+++ b/ts/annotations/controllable/ControllableLabel.ts
@@ -437,7 +437,7 @@ merge(
 
                 showItem =
                     point.series.visible &&
-                    MockPoint.prototype.isInsidePane.call(point);
+                    MockPoint.prototype.isInsidePlot.call(point);
 
             if (showItem) {
 


### PR DESCRIPTION
point._isInsidePane_ method didn't handle polar charts.

Because of that, some annotations were hidden. The method's name was changed to _isInsidePlot_ because, in general, it is more intuitive (non-polar charts).

- [x] todo: tests