### PR TITLE
Fixed #12882, rendering problem with sankey circular links

### DIFF
--- a/js/modules/sankey.src.js
+++ b/js/modules/sankey.src.js
@@ -648,7 +648,7 @@ seriesType('sankey', 'column',
             return y;
         };
         var fromNode = point.fromNode, toNode = point.toNode, chart = this.chart, translationFactor = this.translationFactor, linkHeight = Math.max(point.weight * translationFactor, this.options.minLinkWidth), options = this.options, curvy = ((chart.inverted ? -this.colDistance : this.colDistance) *
-            options.curveFactor), fromY = getY(fromNode, 'linksFrom'), toY = getY(toNode, 'linksTo'), nodeLeft = fromNode.nodeX, nodeW = this.nodeWidth, right = toNode.column * this.colDistance, outgoing = point.outgoing, straight = right > nodeLeft;
+            options.curveFactor), fromY = getY(fromNode, 'linksFrom'), toY = getY(toNode, 'linksTo'), nodeLeft = fromNode.nodeX, nodeW = this.nodeWidth, right = toNode.column * this.colDistance, outgoing = point.outgoing, straight = right > nodeLeft + nodeW;
         if (chart.inverted) {
             fromY = chart.plotSizeY - fromY;
             toY = chart.plotSizeY - toY;

--- a/samples/unit-tests/series-sankey/sankey/demo.js
+++ b/samples/unit-tests/series-sankey/sankey/demo.js
@@ -491,8 +491,11 @@ QUnit.test(
     'Sankey and circular data',
     function (assert) {
 
-        Highcharts.chart('container', {
+        const chart = Highcharts.chart('container', {
 
+            chart: {
+                width: 489
+            },
             title: {
                 text: 'Highcharts Sankey Diagram'
             },
@@ -512,6 +515,24 @@ QUnit.test(
             true,
             'No errors with circular data (#10658).'
         );
+
+        chart.series[0].setData([
+            ['a', 'c', 5],
+            ['a', 'b', 5],
+            ['b', 'd', 5],
+            ['b', 'c', 5]
+        ]);
+
+        const numberOfCurves = chart.series[0].points[3].graphic
+            .attr('d')
+            .split(' ')
+            .filter(item => item === 'C')
+            .length;
+        assert.ok(
+            numberOfCurves > 4,
+            'The link should have a complex, circular structure, not direct (#12882)'
+        );
+
     }
 );
 

--- a/ts/modules/sankey.src.ts
+++ b/ts/modules/sankey.src.ts
@@ -1034,7 +1034,7 @@ seriesType<Highcharts.SankeySeries>(
                 nodeW = this.nodeWidth,
                 right = (toNode.column as any) * this.colDistance,
                 outgoing = point.outgoing,
-                straight = right > nodeLeft;
+                straight = right > nodeLeft + nodeW;
 
             if (chart.inverted) {
                 fromY = (chart.plotSizeY as any) - fromY;


### PR DESCRIPTION
Fixed #12882, sankey circular links were wrongly rendered in some edge cases with specific chart widths.