### PR TITLE
Fixed #13001, scrollablePlotArea not inheriting chart style

### DIFF
--- a/js/parts/ScrollablePlotArea.js
+++ b/js/parts/ScrollablePlotArea.js
@@ -250,6 +250,7 @@ Chart.prototype.moveFixedElements = function () {
  * @return {void}
  */
 Chart.prototype.applyFixed = function () {
+    var _a;
     var fixedRenderer, scrollableWidth, scrollableHeight, firstTime = !this.fixedDiv, scrollableOptions = this.options.chart.scrollablePlotArea;
     // First render
     if (firstTime) {
@@ -263,7 +264,7 @@ Chart.prototype.applyFixed = function () {
         }, null, true);
         this.renderTo.insertBefore(this.fixedDiv, this.renderTo.firstChild);
         this.renderTo.style.overflow = 'visible';
-        this.fixedRenderer = fixedRenderer = new H.Renderer(this.fixedDiv, this.chartWidth, this.chartHeight);
+        this.fixedRenderer = fixedRenderer = new H.Renderer(this.fixedDiv, this.chartWidth, this.chartHeight, (_a = this.options.chart) === null || _a === void 0 ? void 0 : _a.style);
         // Mask
         this.scrollableMask = fixedRenderer
             .path()

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -8,6 +8,17 @@
  *
  * */
 'use strict';
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
 import H from './Globals.js';
 import U from './Utilities.js';
 var clamp = U.clamp, css = U.css, defined = U.defined, discardElement = U.discardElement, extend = U.extend, fireEvent = U.fireEvent, format = U.format, isNumber = U.isNumber, isString = U.isString, merge = U.merge, offset = U.offset, pick = U.pick, splat = U.splat, syncTimeout = U.syncTimeout, timeUnits = U.timeUnits;
@@ -394,7 +405,7 @@ var Tooltip = /** @class */ (function () {
      * @return {Highcharts.SVGElement}
      */
     Tooltip.prototype.getLabel = function () {
-        var _a;
+        var _a, _b;
         var tooltip = this, renderer = this.chart.renderer, styledMode = this.chart.styledMode, options = this.options, className = ('tooltip' + (defined(options.className) ?
             ' ' + options.className :
             '')), pointerEvents = (((_a = options.style) === null || _a === void 0 ? void 0 : _a.pointerEvents) ||
@@ -435,7 +446,7 @@ var Tooltip = /** @class */ (function () {
                  * @name Highcharts.Tooltip#renderer
                  * @type {Highcharts.SVGRenderer|undefined}
                  */
-                this.renderer = renderer = new H.Renderer(container, 0, 0, {}, void 0, void 0, renderer.styledMode);
+                this.renderer = renderer = new H.Renderer(container, 0, 0, __assign({}, (_b = this.chart.options.chart) === null || _b === void 0 ? void 0 : _b.style), void 0, void 0, renderer.styledMode);
             }
             // Create the label
             if (this.split) {

--- a/js/parts/Tooltip.js
+++ b/js/parts/Tooltip.js
@@ -8,17 +8,6 @@
  *
  * */
 'use strict';
-var __assign = (this && this.__assign) || function () {
-    __assign = Object.assign || function(t) {
-        for (var s, i = 1, n = arguments.length; i < n; i++) {
-            s = arguments[i];
-            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
-                t[p] = s[p];
-        }
-        return t;
-    };
-    return __assign.apply(this, arguments);
-};
 import H from './Globals.js';
 import U from './Utilities.js';
 var clamp = U.clamp, css = U.css, defined = U.defined, discardElement = U.discardElement, extend = U.extend, fireEvent = U.fireEvent, format = U.format, isNumber = U.isNumber, isString = U.isString, merge = U.merge, offset = U.offset, pick = U.pick, splat = U.splat, syncTimeout = U.syncTimeout, timeUnits = U.timeUnits;
@@ -446,7 +435,7 @@ var Tooltip = /** @class */ (function () {
                  * @name Highcharts.Tooltip#renderer
                  * @type {Highcharts.SVGRenderer|undefined}
                  */
-                this.renderer = renderer = new H.Renderer(container, 0, 0, __assign({}, (_b = this.chart.options.chart) === null || _b === void 0 ? void 0 : _b.style), void 0, void 0, renderer.styledMode);
+                this.renderer = renderer = new H.Renderer(container, 0, 0, (_b = this.chart.options.chart) === null || _b === void 0 ? void 0 : _b.style, void 0, void 0, renderer.styledMode);
             }
             // Create the label
             if (this.split) {

--- a/samples/unit-tests/scrollable-plotarea/options/demo.details
+++ b/samples/unit-tests/scrollable-plotarea/options/demo.details
@@ -1,0 +1,5 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+...

--- a/samples/unit-tests/scrollable-plotarea/options/demo.html
+++ b/samples/unit-tests/scrollable-plotarea/options/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/scrollable-plotarea/options/demo.js
+++ b/samples/unit-tests/scrollable-plotarea/options/demo.js
@@ -1,0 +1,29 @@
+QUnit.test('fixedRenderer options', function (assert) {
+
+    var chart = new Highcharts.Chart('container', {
+        chart: {
+            type: 'spline',
+            style: {
+                fontFamily: 'Papyrus'
+            },
+            scrollablePlotArea: {
+                minWidth: 2000,
+                scrollPositionX: 0,
+                scrollPositionY: 0
+            }
+        },
+        series: [{
+            name: 'Hestavollane',
+            data: [0.2, 0.8, 0.8, 0.8, 1, 1.3, 1.5, 2.9, 1.9, 2.6, 1.6, 3, 4, 3.6,
+                5.5, 6.2, 5.5, 4.5, 4, 3.1, 2.7, 4, 2.7, 2.3, 2.3, 4.1, 7.7, 7.1,
+                5.6, 6.1, 5.8, 8.6, 7.2, 9, 10.9, 11.5, 11.6, 11.1, 12, 12.3, 10.7,
+                9.4, 9.8, 9.6, 9.8, 9.5, 8.5, 7.4, 7.6]
+
+        }]
+    });
+    assert.equal(
+        chart.fixedRenderer.style.fontFamily,
+        chart.options.chart.style.fontFamily,
+        'fixedRenderer should inherit style from options'
+    );
+});

--- a/samples/unit-tests/tooltip/outside/demo.js
+++ b/samples/unit-tests/tooltip/outside/demo.js
@@ -29,3 +29,33 @@ QUnit.test('Outside tooltip and styledMode (#11783)', function (assert) {
     );
 
 });
+
+QUnit.test('Outside tooltip should inherit chart style', function (assert) {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            width: 400,
+            height: 400,
+            style: {
+                fontFamily: 'Papyrus'
+            }
+        },
+        tooltip: {
+            outside: true
+        },
+        series: [{
+            data: [1, 3, 2, 4]
+        }]
+    });
+
+    var point = chart.series[0].points[0];
+
+    // Set hoverPoint
+    point.onMouseOver();
+
+    assert.strictEqual(
+        chart.tooltip.renderer.box
+            .querySelector('.highcharts-tooltip').parentNode.style.fontFamily,
+        'Papyrus',
+        'Tooltip container should inherit chart style'
+    );
+});

--- a/ts/parts/ScrollablePlotArea.ts
+++ b/ts/parts/ScrollablePlotArea.ts
@@ -373,9 +373,9 @@ Chart.prototype.applyFixed = function (this: Highcharts.Chart): void {
         this.fixedRenderer = fixedRenderer = new H.Renderer(
             this.fixedDiv,
             this.chartWidth,
-            this.chartHeight
+            this.chartHeight,
+            this.options.chart?.style
         );
-
         // Mask
         this.scrollableMask = fixedRenderer
             .path()

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -728,7 +728,7 @@ class Tooltip {
                     container,
                     0,
                     0,
-                    {},
+                    { ...this.chart.options.chart?.style },
                     void 0,
                     void 0,
                     renderer.styledMode

--- a/ts/parts/Tooltip.ts
+++ b/ts/parts/Tooltip.ts
@@ -728,7 +728,7 @@ class Tooltip {
                     container,
                     0,
                     0,
-                    { ...this.chart.options.chart?.style },
+                    this.chart.options.chart?.style,
                     void 0,
                     void 0,
                     renderer.styledMode


### PR DESCRIPTION
Fixed #13001, `scrollablePlotArea` not inheriting chart style. Also applied chart styles to tooltip container when `tooltip.outside` is `true`.

~~Note that the style options does not apply to the tooltip unless `tooltip.outside` is set to `false` (defaults to `true` with scrollablePlotArea). If this is not considered an issue it should be noted in the API.~~