### PR TITLE
Docs: updated product demo tags

### DIFF
--- a/samples/gantt/demo/custom-labels/demo.details
+++ b/samples/gantt/demo/custom-labels/demo.details
@@ -6,7 +6,7 @@ authors:
 resources:
   - 'https://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css'
 tags:
-  - Gantt demo
+  - Highcharts Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/download-pdf/demo.details
+++ b/samples/gantt/demo/download-pdf/demo.details
@@ -7,7 +7,7 @@ resources:
   - 'https://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css'
 requiresManualTesting: true
 tags:
-  - Gantt demo
+  - Highcharts Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/interactive-gantt/demo.details
+++ b/samples/gantt/demo/interactive-gantt/demo.details
@@ -7,7 +7,7 @@ resources:
   - 'https://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css'
 requiresManualTesting: true
 tags:
-  - Gantt demo
+  - Highcharts Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/inverted/demo.details
+++ b/samples/gantt/demo/inverted/demo.details
@@ -4,7 +4,7 @@ js_wrap: b
 authors:
   - Lars Cabrera
 tags:
-  - Gantt demo
+  - Highcharts Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/left-axis-table/demo.details
+++ b/samples/gantt/demo/left-axis-table/demo.details
@@ -4,7 +4,7 @@ js_wrap: b
 authors:
   - Lars Cabrera
 tags:
-  - Gantt demo
+  - Highcharts Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/progress-indicator/demo.details
+++ b/samples/gantt/demo/progress-indicator/demo.details
@@ -5,7 +5,7 @@ authors:
   - Lars Cabrera
 compareTooltips: true
 tags:
-  - Gantt demo
+  - Highcharts Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/project-management/demo.details
+++ b/samples/gantt/demo/project-management/demo.details
@@ -4,7 +4,7 @@ js_wrap: b
 authors:
   - Jon Arild Nygård
 tags:
-  - Gantt demo
+  - Highcharts Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/resource-management/demo.details
+++ b/samples/gantt/demo/resource-management/demo.details
@@ -4,7 +4,7 @@ js_wrap: b
 authors:
   - Jon Arild Nygård
 tags:
-  - Gantt demo
+  - Highcharts Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/styled-mode/demo.details
+++ b/samples/gantt/demo/styled-mode/demo.details
@@ -4,7 +4,7 @@ js_wrap: b
 authors:
   - Lars Cabrera
 tags:
-  - Gantt demo
+  - Highcharts Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/subtasks/demo.details
+++ b/samples/gantt/demo/subtasks/demo.details
@@ -4,7 +4,7 @@ js_wrap: b
 authors:
   - Lars Cabrera
 tags:
-  - Gantt demo
+  - Highcharts Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/gantt/demo/with-navigation/demo.details
+++ b/samples/gantt/demo/with-navigation/demo.details
@@ -4,7 +4,7 @@ js_wrap: b
 authors:
   - Torstein Hønsi
 tags:
-  - Gantt demo
+  - Highcharts Gantt demo
 categories:
   - Highcharts Gantt
 ...

--- a/samples/maps/demo/all-areas-as-null/demo.details
+++ b/samples/maps/demo/all-areas-as-null/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/all-maps/demo.details
+++ b/samples/maps/demo/all-maps/demo.details
@@ -5,7 +5,7 @@ authors:
 js_wrap: b
 requiresManualTesting: true
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/category-map/demo.details
+++ b/samples/maps/demo/category-map/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/circlemap-africa/demo.details
+++ b/samples/maps/demo/circlemap-africa/demo.details
@@ -4,7 +4,7 @@ authors:
   - Mustapha Mekhatria
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - Series types
 ...

--- a/samples/maps/demo/color-axis/demo.details
+++ b/samples/maps/demo/color-axis/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/data-class-ranges/demo.details
+++ b/samples/maps/demo/data-class-ranges/demo.details
@@ -6,7 +6,7 @@ resources:
   - 'https://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css'
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/data-class-two-ranges/demo.details
+++ b/samples/maps/demo/data-class-two-ranges/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/diamondmap/demo.details
+++ b/samples/maps/demo/diamondmap/demo.details
@@ -4,7 +4,7 @@ authors:
   - Øystein Moseng
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - Series types
 ...

--- a/samples/maps/demo/distribution/demo.details
+++ b/samples/maps/demo/distribution/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/doubleclickzoomto/demo.details
+++ b/samples/maps/demo/doubleclickzoomto/demo.details
@@ -5,7 +5,7 @@ authors:
 requiresManualTesting: true
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - Dynamic
 ...

--- a/samples/maps/demo/eu-capitals-temp/demo.details
+++ b/samples/maps/demo/eu-capitals-temp/demo.details
@@ -5,7 +5,7 @@ authors:
 js_wrap: b
 requiresManualTesting: true
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - Dynamic
 ...

--- a/samples/maps/demo/flight-routes/demo.details
+++ b/samples/maps/demo/flight-routes/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/geojson-multiple-types/demo.details
+++ b/samples/maps/demo/geojson-multiple-types/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - Input formats
 ...

--- a/samples/maps/demo/geojson/demo.details
+++ b/samples/maps/demo/geojson/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - Input formats
 ...

--- a/samples/maps/demo/heatmap/demo.details
+++ b/samples/maps/demo/heatmap/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - Series types
 ...

--- a/samples/maps/demo/honeycomb-usa/demo.details
+++ b/samples/maps/demo/honeycomb-usa/demo.details
@@ -4,7 +4,7 @@ authors:
   - Mustapha Mekhatria
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - Series types
 ...

--- a/samples/maps/demo/latlon-advanced/demo.details
+++ b/samples/maps/demo/latlon-advanced/demo.details
@@ -5,7 +5,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - Input formats
 ...

--- a/samples/maps/demo/map-bubble/demo.details
+++ b/samples/maps/demo/map-bubble/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - Series types
 ...

--- a/samples/maps/demo/map-drilldown/demo.details
+++ b/samples/maps/demo/map-drilldown/demo.details
@@ -5,7 +5,7 @@ authors:
 requiresManualTesting: true
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - Dynamic
 ...

--- a/samples/maps/demo/map-pies/demo.details
+++ b/samples/maps/demo/map-pies/demo.details
@@ -4,7 +4,7 @@ authors:
   - Øystein Moseng
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/mapline-mappoint/demo.details
+++ b/samples/maps/demo/mapline-mappoint/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - Series types
 ...

--- a/samples/maps/demo/mappoint-latlon/demo.details
+++ b/samples/maps/demo/mappoint-latlon/demo.details
@@ -5,7 +5,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - Input formats
 ...

--- a/samples/maps/demo/marker-clusters/demo.details
+++ b/samples/maps/demo/marker-clusters/demo.details
@@ -5,6 +5,6 @@ authors:
 js_wrap: b
 new_until: 2020-03-11
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories: []
 ...

--- a/samples/maps/demo/pattern-fill-map/demo.details
+++ b/samples/maps/demo/pattern-fill-map/demo.details
@@ -4,7 +4,7 @@ authors:
   - Øystein Moseng
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/rich-info/demo.details
+++ b/samples/maps/demo/rich-info/demo.details
@@ -5,7 +5,7 @@ authors:
 requiresManualTesting: true
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - Dynamic
 ...

--- a/samples/maps/demo/tooltip/demo.details
+++ b/samples/maps/demo/tooltip/demo.details
@@ -5,7 +5,7 @@ authors:
 requiresManualTesting: true
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - Dynamic
 ...

--- a/samples/maps/demo/us-counties/demo.details
+++ b/samples/maps/demo/us-counties/demo.details
@@ -5,7 +5,7 @@ authors:
 requiresManualTesting: true
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - General
 ...

--- a/samples/maps/demo/us-data-labels/demo.details
+++ b/samples/maps/demo/us-data-labels/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highmaps demo
+  - Highcharts Maps demo
 categories:
   - General
 ...

--- a/samples/stock/demo/area/demo.details
+++ b/samples/stock/demo/area/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/arearange/demo.details
+++ b/samples/stock/demo/arearange/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/areaspline/demo.details
+++ b/samples/stock/demo/areaspline/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/areasplinerange/demo.details
+++ b/samples/stock/demo/areasplinerange/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/basic-line/demo.details
+++ b/samples/stock/demo/basic-line/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/candlestick-and-volume/demo.details
+++ b/samples/stock/demo/candlestick-and-volume/demo.details
@@ -5,7 +5,7 @@ authors:
 compareTooltips: true
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/candlestick/demo.details
+++ b/samples/stock/demo/candlestick/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/column/demo.details
+++ b/samples/stock/demo/column/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/columnrange/demo.details
+++ b/samples/stock/demo/columnrange/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/compare/demo.details
+++ b/samples/stock/demo/compare/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/data-grouping/demo.details
+++ b/samples/stock/demo/data-grouping/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/depth-chart/demo.details
+++ b/samples/stock/demo/depth-chart/demo.details
@@ -4,7 +4,7 @@ authors:
   - Daniel Studencki
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/dynamic-update/demo.details
+++ b/samples/stock/demo/dynamic-update/demo.details
@@ -5,7 +5,7 @@ authors:
 requiresManualTesting: true
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/flags-general/demo.details
+++ b/samples/stock/demo/flags-general/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/flags-placement/demo.details
+++ b/samples/stock/demo/flags-placement/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Flags and Indicators
 ...

--- a/samples/stock/demo/flags-shapes/demo.details
+++ b/samples/stock/demo/flags-shapes/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Flags and Indicators
 ...

--- a/samples/stock/demo/intraday-area/demo.details
+++ b/samples/stock/demo/intraday-area/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/intraday-breaks/demo.details
+++ b/samples/stock/demo/intraday-breaks/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/intraday-candlestick/demo.details
+++ b/samples/stock/demo/intraday-candlestick/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/lazy-loading/demo.details
+++ b/samples/stock/demo/lazy-loading/demo.details
@@ -5,7 +5,7 @@ authors:
 js_wrap: b
 requiresManualTesting: true
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/line-markers/demo.details
+++ b/samples/stock/demo/line-markers/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/macd-pivot-points/demo.details
+++ b/samples/stock/demo/macd-pivot-points/demo.details
@@ -4,7 +4,7 @@ authors:
   - Pawel fus
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Flags and Indicators
 ...

--- a/samples/stock/demo/markers-only/demo.details
+++ b/samples/stock/demo/markers-only/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/navigator-disabled/demo.details
+++ b/samples/stock/demo/navigator-disabled/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Various features
 ...

--- a/samples/stock/demo/ohlc/demo.details
+++ b/samples/stock/demo/ohlc/demo.details
@@ -5,7 +5,7 @@ authors:
 compareTooltips: true
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/responsive/demo.details
+++ b/samples/stock/demo/responsive/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/scrollbar-disabled/demo.details
+++ b/samples/stock/demo/scrollbar-disabled/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Various features
 ...

--- a/samples/stock/demo/sma-volume-by-price/demo.details
+++ b/samples/stock/demo/sma-volume-by-price/demo.details
@@ -5,7 +5,7 @@ authors:
 compareTooltips: true
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Flags and Indicators
 ...

--- a/samples/stock/demo/spline/demo.details
+++ b/samples/stock/demo/spline/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/step-line/demo.details
+++ b/samples/stock/demo/step-line/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Chart types
 ...

--- a/samples/stock/demo/stock-tools-custom-gui/demo.details
+++ b/samples/stock/demo/stock-tools-custom-gui/demo.details
@@ -4,7 +4,7 @@ authors:
   - Sebastian Bochan
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Various features
 ...

--- a/samples/stock/demo/stock-tools-gui/demo.details
+++ b/samples/stock/demo/stock-tools-gui/demo.details
@@ -5,7 +5,7 @@ authors:
 requiresManualTesting: true
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - General
 ...

--- a/samples/stock/demo/styled-scrollbar/demo.details
+++ b/samples/stock/demo/styled-scrollbar/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Various features
 ...

--- a/samples/stock/demo/yaxis-plotbands/demo.details
+++ b/samples/stock/demo/yaxis-plotbands/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Various features
 ...

--- a/samples/stock/demo/yaxis-plotlines/demo.details
+++ b/samples/stock/demo/yaxis-plotlines/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Various features
 ...

--- a/samples/stock/demo/yaxis-reversed/demo.details
+++ b/samples/stock/demo/yaxis-reversed/demo.details
@@ -4,7 +4,7 @@ authors:
   - Torstein Hønsi
 js_wrap: b
 tags:
-  - Highstock demo
+  - Highcharts Stock demo
 categories:
   - Various features
 ...


### PR DESCRIPTION
Updated Highstock, Highmaps and Gantt demo tags to the new naming convention.