### PR TITLE
bugfix/12991-responsive-scrollableplotarea

### DIFF
--- a/js/parts/ScrollablePlotArea.js
+++ b/js/parts/ScrollablePlotArea.js
@@ -297,9 +297,7 @@ Chart.prototype.applyFixed = function () {
         width: scrollableWidth,
         height: scrollableHeight
     });
-    if (this.scrollablePixelsY) {
-        this.scrollingContainer.style.height = this.chartHeight + 'px';
-    }
+    this.scrollingContainer.style.height = this.chartHeight + 'px';
     // Set scroll position
     if (firstTime) {
         if (scrollableOptions.scrollPositionX) {

--- a/samples/unit-tests/scrollable-plotarea/dynamics/demo.js
+++ b/samples/unit-tests/scrollable-plotarea/dynamics/demo.js
@@ -18,3 +18,30 @@ QUnit.test('Test dynamic behaviour of Scrollable PlotArea', function (assert) {
         'Title should be outside the scrollable plot area (#11966)'
     );
 });
+
+
+QUnit.test('Responsive scrollable plot area (#12991)', function (assert) {
+
+    var chart = Highcharts.chart('container', {
+        chart: {
+            type: 'column',
+            scrollablePlotArea: {
+                minHeight: 400
+            },
+            height: 300
+        },
+        series: [{
+            data: [1]
+        }]
+    });
+
+    chart.setSize(null, 500);
+
+    var scrolling = document.getElementsByClassName('highcharts-scrolling')[0];
+    console.log('Test: ' + (scrolling.clientHeight > 300));
+
+    assert.ok(
+        document.getElementsByClassName('highcharts-scrolling')[0].clientHeight > 300,
+        'The scrollbar should disasppear after increasing the height of the chart (#12991)'
+    );
+});

--- a/samples/unit-tests/scrollable-plotarea/dynamics/demo.js
+++ b/samples/unit-tests/scrollable-plotarea/dynamics/demo.js
@@ -37,9 +37,6 @@ QUnit.test('Responsive scrollable plot area (#12991)', function (assert) {
 
     chart.setSize(null, 500);
 
-    var scrolling = document.getElementsByClassName('highcharts-scrolling')[0];
-    console.log('Test: ' + (scrolling.clientHeight > 300));
-
     assert.ok(
         document.getElementsByClassName('highcharts-scrolling')[0].clientHeight > 300,
         'The scrollbar should disasppear after increasing the height of the chart (#12991)'

--- a/ts/parts/ScrollablePlotArea.ts
+++ b/ts/parts/ScrollablePlotArea.ts
@@ -417,9 +417,7 @@ Chart.prototype.applyFixed = function (this: Highcharts.Chart): void {
         height: scrollableHeight
     });
 
-    if (this.scrollablePixelsY) {
-        (this.scrollingContainer as any).style.height = this.chartHeight + 'px';
-    }
+    (this.scrollingContainer as any).style.height = this.chartHeight + 'px';
 
     // Set scroll position
     if (firstTime) {


### PR DESCRIPTION
Fixed #12991, `scrollablePlotArea.minHeight` was not responsive when changing window height.
___
~~Fixed #12991: highcharts-scrolling didn't adjust its height properly.~~