### PR TITLE
bugfix/12027-packedbubble-print

### DIFF
--- a/js/modules/networkgraph/layouts.js
+++ b/js/modules/networkgraph/layouts.js
@@ -12,7 +12,7 @@
 'use strict';
 import H from '../../parts/Globals.js';
 import U from '../../parts/Utilities.js';
-var addEvent = U.addEvent, clamp = U.clamp, defined = U.defined, extend = U.extend, isFunction = U.isFunction, pick = U.pick, setAnimation = U.setAnimation;
+var addEvent = U.addEvent, merge = U.merge, clamp = U.clamp, defined = U.defined, extend = U.extend, isFunction = U.isFunction, pick = U.pick, setAnimation = U.setAnimation;
 import './integrations.js';
 import './QuadTree.js';
 var Chart = H.Chart;
@@ -47,7 +47,7 @@ H.layouts['reingold-fruchterman'].prototype, {
         this.approximation = options.approximation;
     },
     update: function (options, redraw) {
-        this.options = H.merge(this.options, options);
+        this.options = merge(this.options, options);
         if (pick(redraw, true) && this.chart) {
             this.chart.redraw();
         }

--- a/js/modules/networkgraph/layouts.js
+++ b/js/modules/networkgraph/layouts.js
@@ -46,10 +46,17 @@ H.layouts['reingold-fruchterman'].prototype, {
         this.repulsiveForce = pick(options.repulsiveForce, this.integration.repulsiveForceFunction);
         this.approximation = options.approximation;
     },
+    update: function (options, redraw) {
+        this.options = H.merge(this.options, options);
+        if (pick(redraw, true) && this.chart) {
+            this.chart.redraw();
+        }
+    },
     start: function () {
         var layout = this, series = this.series, options = this.options;
         layout.currentStep = 0;
         layout.forces = series[0] && series[0].forces || [];
+        layout.chart = series[0] && series[0].chart;
         if (layout.initialRendering) {
             layout.initPositions();
             // Render elements in initial positions:

--- a/js/modules/networkgraph/layouts.js
+++ b/js/modules/networkgraph/layouts.js
@@ -42,6 +42,7 @@ H.layouts['reingold-fruchterman'].prototype, {
         this.setInitialRendering(true);
         this.integration =
             H.networkgraphIntegrations[options.integration];
+        this.enableSimulation = options.enableSimulation;
         this.attractiveForce = pick(options.attractiveForce, this.integration.attractiveForceFunction);
         this.repulsiveForce = pick(options.repulsiveForce, this.integration.repulsiveForceFunction);
         this.approximation = options.approximation;
@@ -51,6 +52,9 @@ H.layouts['reingold-fruchterman'].prototype, {
         if (pick(redraw, true) && this.chart) {
             this.chart.redraw();
         }
+    },
+    updateSimulation: function (forced, enable) {
+        this.enableSimulation = forced ? enable : this.options.enableSimulation;
     },
     start: function () {
         var layout = this, series = this.series, options = this.options;
@@ -66,7 +70,7 @@ H.layouts['reingold-fruchterman'].prototype, {
         }
         layout.setK();
         layout.resetSimulation(options);
-        if (options.enableSimulation) {
+        if (layout.enableSimulation) {
             layout.step();
         }
     },
@@ -87,7 +91,7 @@ H.layouts['reingold-fruchterman'].prototype, {
         layout.temperature = layout.coolDown(layout.startTemperature, layout.diffTemperature, layout.currentStep);
         layout.prevSystemTemperature = layout.systemTemperature;
         layout.systemTemperature = layout.getSystemTemperature();
-        if (options.enableSimulation) {
+        if (layout.enableSimulation) {
             series.forEach(function (s) {
                 // Chart could be destroyed during the simulation
                 if (s.chart) {
@@ -474,7 +478,7 @@ addEvent(Chart, 'render', function () {
         if (layout.maxIterations-- &&
             isFinite(layout.temperature) &&
             !layout.isStable() &&
-            !layout.options.enableSimulation) {
+            !layout.enableSimulation) {
             // Hook similar to build-in addEvent, but instead of
             // creating whole events logic, use just a function.
             // It's faster which is important for rAF code.

--- a/js/modules/networkgraph/layouts.js
+++ b/js/modules/networkgraph/layouts.js
@@ -47,14 +47,8 @@ H.layouts['reingold-fruchterman'].prototype, {
         this.repulsiveForce = pick(options.repulsiveForce, this.integration.repulsiveForceFunction);
         this.approximation = options.approximation;
     },
-    update: function (options, redraw) {
-        this.options = merge(this.options, options);
-        if (pick(redraw, true) && this.chart) {
-            this.chart.redraw();
-        }
-    },
-    updateSimulation: function (forced, enable) {
-        this.enableSimulation = forced ? enable : this.options.enableSimulation;
+    updateSimulation: function (enable) {
+        this.enableSimulation = pick(enable, this.options.enableSimulation);
     },
     start: function () {
         var layout = this, series = this.series, options = this.options;
@@ -512,4 +506,19 @@ addEvent(Chart, 'render', function () {
             });
         }
     }
+});
+// disable simulation before print if enabled
+addEvent(Chart, 'beforePrint', function () {
+    this.graphLayoutsLookup.forEach(function (layout) {
+        layout.updateSimulation(false);
+    });
+    this.redraw();
+});
+// re-enable simulation after print
+addEvent(Chart, 'afterPrint', function () {
+    this.graphLayoutsLookup.forEach(function (layout) {
+        // return to default simulation
+        layout.updateSimulation();
+    });
+    this.redraw();
 });

--- a/js/parts-more/PackedBubbleSeries.js
+++ b/js/parts-more/PackedBubbleSeries.js
@@ -175,18 +175,6 @@ H.layouts.packedbubble = extendClass(Reingold, {
             }
         }
         Reingold.prototype.applyLimitBox.apply(this, arguments);
-    },
-    isStable: function () {
-        return Math.abs(this.systemTemperature -
-            this.prevSystemTemperature) < 0.00001 ||
-            this.temperature <= 0 ||
-            (
-            // In first iteration system does not move:
-            this.systemTemperature > 0 &&
-                (this.systemTemperature /
-                    this.nodes.length < 0.02 &&
-                    this.enableSimulation) // Use only when simulation is enabled
-            );
     }
 });
 /**
@@ -1210,6 +1198,20 @@ addEvent(Chart, 'beforeRedraw', function () {
     if (this.allDataPoints) {
         delete this.allDataPoints;
     }
+});
+// disable simulation before print if enabled
+addEvent(Chart, 'beforePrint', function () {
+    this.graphLayoutsLookup.forEach(function (layout) {
+        layout.updateSimulation(true, false);
+    });
+    this.redraw();
+});
+// re-enable simulation after print
+addEvent(Chart, 'afterPrint', function () {
+    this.graphLayoutsLookup.forEach(function (layout) {
+        layout.updateSimulation(false);
+    });
+    this.redraw();
 });
 /* eslint-enable no-invalid-this, valid-jsdoc */
 /**

--- a/js/parts-more/PackedBubbleSeries.js
+++ b/js/parts-more/PackedBubbleSeries.js
@@ -1199,20 +1199,6 @@ addEvent(Chart, 'beforeRedraw', function () {
         delete this.allDataPoints;
     }
 });
-// disable simulation before print if enabled
-addEvent(Chart, 'beforePrint', function () {
-    this.graphLayoutsLookup.forEach(function (layout) {
-        layout.updateSimulation(true, false);
-    });
-    this.redraw();
-});
-// re-enable simulation after print
-addEvent(Chart, 'afterPrint', function () {
-    this.graphLayoutsLookup.forEach(function (layout) {
-        layout.updateSimulation(false);
-    });
-    this.redraw();
-});
 /* eslint-enable no-invalid-this, valid-jsdoc */
 /**
  * A `packedbubble` series. If the [type](#series.packedbubble.type) option is

--- a/ts/modules/networkgraph/layouts.ts
+++ b/ts/modules/networkgraph/layouts.ts
@@ -120,7 +120,7 @@ declare global {
             public init(options: NetworkgraphLayoutAlgorithmOptions): void;
             public initPositions(): void;
             public isStable(): boolean;
-            public updateSimulation(force: boolean, enable?: boolean): void;
+            public updateSimulation(enable?: boolean): void;
             public removeElementFromCollection<T>(
                 element: T, collection: Array<T>
             ): void
@@ -211,22 +211,11 @@ extend(
 
             this.approximation = options.approximation;
         },
-        update: function (
-            this: Highcharts.NetworkgraphLayout,
-            options: Highcharts.NetworkgraphLayoutAlgorithmOptions,
-            redraw?: boolean
-        ): void {
-            this.options = merge(this.options, options);
-            if (pick(redraw, true) && this.chart) {
-                this.chart.redraw();
-            }
-        },
         updateSimulation: function (
             this: Highcharts.NetworkgraphLayout,
-            forced: boolean,
             enable?: boolean
         ): void {
-            this.enableSimulation = forced ? enable : this.options.enableSimulation;
+            this.enableSimulation = pick(enable, this.options.enableSimulation);
         },
         start: function (this: Highcharts.NetworkgraphLayout): void {
             var layout = this,
@@ -937,4 +926,25 @@ addEvent(Chart as any, 'render', function (
             });
         }
     }
+});
+
+// disable simulation before print if enabled
+addEvent(Chart as any, 'beforePrint', function (
+    this: Highcharts.PackedBubbleChart
+): void {
+    this.graphLayoutsLookup.forEach(function (layout): void {
+        layout.updateSimulation(false);
+    });
+    this.redraw();
+});
+
+// re-enable simulation after print
+addEvent(Chart as any, 'afterPrint', function (
+    this: Highcharts.PackedBubbleChart
+): void {
+    this.graphLayoutsLookup.forEach(function (layout): void {
+        // return to default simulation
+        layout.updateSimulation();
+    });
+    this.redraw();
 });

--- a/ts/modules/networkgraph/layouts.ts
+++ b/ts/modules/networkgraph/layouts.ts
@@ -70,6 +70,7 @@ declare global {
             public enableSimulation?: boolean;
             public forcedStop?: boolean;
             public forces?: Array<string>;
+            public chart?: Chart;
             public initialRendering: boolean;
             public integration: NetworkgraphIntegrationObject;
             public k?: number;
@@ -206,6 +207,16 @@ extend(
 
             this.approximation = options.approximation;
         },
+        update: function (
+            this: Highcharts.NetworkgraphLayout,
+            options: Highcharts.NetworkgraphLayoutAlgorithmOptions,
+            redraw?: boolean
+        ): void {
+            this.options = H.merge(this.options, options);
+            if (pick(redraw, true) && this.chart) {
+                this.chart.redraw();
+            }
+        },
         start: function (this: Highcharts.NetworkgraphLayout): void {
             var layout = this,
                 series = this.series,
@@ -214,6 +225,7 @@ extend(
 
             layout.currentStep = 0;
             layout.forces = series[0] && series[0].forces || [];
+            layout.chart = series[0] && series[0].chart;
 
             if (layout.initialRendering) {
                 layout.initPositions();

--- a/ts/modules/networkgraph/layouts.ts
+++ b/ts/modules/networkgraph/layouts.ts
@@ -120,6 +120,7 @@ declare global {
             public init(options: NetworkgraphLayoutAlgorithmOptions): void;
             public initPositions(): void;
             public isStable(): boolean;
+            public updateSimulation(force: boolean, enable?: boolean): void;
             public removeElementFromCollection<T>(
                 element: T, collection: Array<T>
             ): void
@@ -196,6 +197,8 @@ extend(
             this.integration =
                 H.networkgraphIntegrations[options.integration as any];
 
+            this.enableSimulation = options.enableSimulation;
+
             this.attractiveForce = pick(
                 options.attractiveForce,
                 this.integration.attractiveForceFunction
@@ -217,6 +220,13 @@ extend(
             if (pick(redraw, true) && this.chart) {
                 this.chart.redraw();
             }
+        },
+        updateSimulation: function (
+            this: Highcharts.NetworkgraphLayout,
+            forced: boolean,
+            enable?: boolean
+        ): void {
+            this.enableSimulation = forced ? enable : this.options.enableSimulation;
         },
         start: function (this: Highcharts.NetworkgraphLayout): void {
             var layout = this,
@@ -240,7 +250,7 @@ extend(
             layout.setK();
             (layout.resetSimulation as any)(options);
 
-            if (options.enableSimulation) {
+            if (layout.enableSimulation) {
                 layout.step();
             }
         },
@@ -273,7 +283,7 @@ extend(
 
             layout.prevSystemTemperature = layout.systemTemperature;
             layout.systemTemperature = layout.getSystemTemperature();
-            if (options.enableSimulation) {
+            if (layout.enableSimulation) {
                 series.forEach(function (s: Highcharts.Series): void {
                     // Chart could be destroyed during the simulation
                     if (s.chart) {
@@ -886,7 +896,7 @@ addEvent(Chart as any, 'render', function (
             (layout.maxIterations as any)-- &&
             isFinite(layout.temperature as any) &&
             !layout.isStable() &&
-            !layout.options.enableSimulation
+            !layout.enableSimulation
         ) {
             // Hook similar to build-in addEvent, but instead of
             // creating whole events logic, use just a function.

--- a/ts/modules/networkgraph/layouts.ts
+++ b/ts/modules/networkgraph/layouts.ts
@@ -145,6 +145,7 @@ declare global {
 import U from '../../parts/Utilities.js';
 const {
     addEvent,
+    merge,
     clamp,
     defined,
     extend,
@@ -212,7 +213,7 @@ extend(
             options: Highcharts.NetworkgraphLayoutAlgorithmOptions,
             redraw?: boolean
         ): void {
-            this.options = H.merge(this.options, options);
+            this.options = merge(this.options, options);
             if (pick(redraw, true) && this.chart) {
                 this.chart.redraw();
             }

--- a/ts/parts-more/PackedBubbleSeries.ts
+++ b/ts/parts-more/PackedBubbleSeries.ts
@@ -490,22 +490,6 @@ H.layouts.packedbubble = extendClass(
             }
 
             Reingold.prototype.applyLimitBox.apply(this, arguments as any);
-        },
-        isStable: function (this: Highcharts.PackedBubbleLayout): boolean {
-            return Math.abs(
-                (this.systemTemperature as any) -
-                (this.prevSystemTemperature as any)
-            ) < 0.00001 ||
-            (this.temperature as any) <= 0 ||
-            (
-                // In first iteration system does not move:
-                (this.systemTemperature as any) > 0 &&
-                (
-                    (this.systemTemperature as any) /
-                    this.nodes.length < 0.02 &&
-                    (this.enableSimulation as any)
-                ) // Use only when simulation is enabled
-            );
         }
     }
 );
@@ -1889,6 +1873,27 @@ addEvent(Chart as any, 'beforeRedraw', function (
     if (this.allDataPoints) {
         delete this.allDataPoints;
     }
+});
+
+
+// disable simulation before print if enabled
+addEvent(Chart as any, 'beforePrint', function (
+    this: Highcharts.PackedBubbleChart
+): void {
+    this.graphLayoutsLookup.forEach(function (layout): void {
+        layout.updateSimulation(true, false);
+    });
+    this.redraw();
+});
+
+// re-enable simulation after print
+addEvent(Chart as any, 'afterPrint', function (
+    this: Highcharts.PackedBubbleChart
+): void {
+    this.graphLayoutsLookup.forEach(function (layout): void {
+        layout.updateSimulation(false);
+    });
+    this.redraw();
 });
 
 /* eslint-enable no-invalid-this, valid-jsdoc */

--- a/ts/parts-more/PackedBubbleSeries.ts
+++ b/ts/parts-more/PackedBubbleSeries.ts
@@ -1875,27 +1875,6 @@ addEvent(Chart as any, 'beforeRedraw', function (
     }
 });
 
-
-// disable simulation before print if enabled
-addEvent(Chart as any, 'beforePrint', function (
-    this: Highcharts.PackedBubbleChart
-): void {
-    this.graphLayoutsLookup.forEach(function (layout): void {
-        layout.updateSimulation(true, false);
-    });
-    this.redraw();
-});
-
-// re-enable simulation after print
-addEvent(Chart as any, 'afterPrint', function (
-    this: Highcharts.PackedBubbleChart
-): void {
-    this.graphLayoutsLookup.forEach(function (layout): void {
-        layout.updateSimulation(false);
-    });
-    this.redraw();
-});
-
 /* eslint-enable no-invalid-this, valid-jsdoc */
 
 /**


### PR DESCRIPTION
Fixed #12027, print was not working correctly in packed bubble charts.

___

Added update method for layouts in both packedbubble and networkgraph series