### PR TITLE
bugfix/13069-histogram-wrong-bins-number-on-negatives

### DIFF
--- a/js/modules/histogram.src.js
+++ b/js/modules/histogram.src.js
@@ -127,7 +127,11 @@ seriesType('histogram', 'column',
         x < max &&
             (series.userOptions.binWidth ||
                 correctFloat(max - x) >= binWidth ||
-                correctFloat(min + (frequencies.length * binWidth) - x) <= 0); x = correctFloat(x + binWidth)) {
+                // #13069 - Every add and subtract operation should
+                // be corrected, due to general problems with
+                // operations on float numbers in JS.
+                correctFloat(correctFloat(min + (frequencies.length * binWidth)) -
+                    x) <= 0); x = correctFloat(x + binWidth)) {
             frequencies.push(x);
             bins[x] = 0;
         }

--- a/samples/unit-tests/series-histogram/histogram/demo.js
+++ b/samples/unit-tests/series-histogram/histogram/demo.js
@@ -237,4 +237,24 @@ QUnit.test('Histogram', function (assert) {
         'Histogram produces correct number of bins set by user.'
     );
 
+    chart.update({
+        series: [{
+            name: 'Data',
+            type: 'scatter',
+            data: [-12, -21, -27, -10, -10, -50, -17, -36, -34, -55, -38, -39, -37, -43, -50, -29, -67, -59, -68, -63, -53, -46, -70, -57, -56, -41, -76, -104],
+            id: 's1'
+        }, {
+            type: 'histogram',
+            baseSeries: 's1',
+            zIndex: -1,
+            binsNumber: void 0
+        }]
+    }, true, true);
+
+    assert.strictEqual(
+        chart.series[1].data.length,
+        chart.series[1].binsNumber(),
+        `Histogram produces correctnumber of bins on negative point values.`
+    );
+
 });

--- a/ts/modules/histogram.src.ts
+++ b/ts/modules/histogram.src.ts
@@ -231,8 +231,12 @@ seriesType<Highcharts.HistogramSeries>(
                     (
                         series.userOptions.binWidth ||
                         correctFloat(max - x) >= binWidth ||
+                        // #13069 - Every add and subtract operation should
+                        // be corrected, due to general problems with
+                        // operations on float numbers in JS.
                         correctFloat(
-                            min + (frequencies.length * binWidth) - x
+                            correctFloat(min + (frequencies.length * binWidth)) -
+                            x
                         ) <= 0
                     );
                 x = correctFloat(x + binWidth)


### PR DESCRIPTION
Fixed #13069, histogram produced the wrong number of bins when `baseSeries` was filled by points with negative values.