### PR TITLE
Fixed #13110, chart.sonify no longer working.

### DIFF
--- a/js/modules/accessibility/components/InfoRegionsComponent.js
+++ b/js/modules/accessibility/components/InfoRegionsComponent.js
@@ -254,8 +254,9 @@ extend(InfoRegionsComponent.prototype, /** @lends Highcharts.InfoRegionsComponen
      * @return {string}
      */
     defaultBeforeChartFormatter: function () {
+        var _a;
         var chart = this.chart, format = chart.options.accessibility
-            .screenReaderSection.beforeChartFormat, axesDesc = this.getAxesDescription(), sonifyButtonId = 'highcharts-a11y-sonify-data-btn-' +
+            .screenReaderSection.beforeChartFormat, axesDesc = this.getAxesDescription(), shouldHaveSonifyBtn = chart.sonify && ((_a = chart.options.sonification) === null || _a === void 0 ? void 0 : _a.enabled), sonifyButtonId = 'highcharts-a11y-sonify-data-btn-' +
             chart.index, dataTableButtonId = 'hc-linkto-highcharts-data-table-' +
             chart.index, annotationsList = getAnnotationsInfoHTML(chart), annotationsTitleStr = chart.langFormat('accessibility.screenReaderSection.annotations.heading', { chart: chart }), context = {
             chartTitle: getChartTitle(chart),
@@ -264,7 +265,7 @@ extend(InfoRegionsComponent.prototype, /** @lends Highcharts.InfoRegionsComponen
             chartLongdesc: this.getLongdescText(),
             xAxisDescription: axesDesc.xAxis,
             yAxisDescription: axesDesc.yAxis,
-            playAsSoundButton: chart.sonify ?
+            playAsSoundButton: shouldHaveSonifyBtn ?
                 this.getSonifyButtonText(sonifyButtonId) : '',
             viewTableButton: chart.getCSV ?
                 this.getDataTableButtonText(dataTableButtonId) : '',

--- a/js/modules/sonification/chartSonify.js
+++ b/js/modules/sonification/chartSonify.js
@@ -735,9 +735,6 @@ function getChartSonifyOptions(chart, userOptions) {
  */
 function chartSonify(options) {
     var opts = getChartSonifyOptions(this, options);
-    if (opts.enabled === false) {
-        return;
-    }
     // Only one timeline can play at a time.
     if (this.sonification.timeline) {
         this.sonification.timeline.pause();

--- a/ts/modules/accessibility/components/InfoRegionsComponent.ts
+++ b/ts/modules/accessibility/components/InfoRegionsComponent.ts
@@ -493,6 +493,7 @@ extend(InfoRegionsComponent.prototype, /** @lends Highcharts.InfoRegionsComponen
             format = chart.options.accessibility
                 .screenReaderSection.beforeChartFormat,
             axesDesc = this.getAxesDescription(),
+            shouldHaveSonifyBtn = chart.sonify && chart.options.sonification?.enabled,
             sonifyButtonId = 'highcharts-a11y-sonify-data-btn-' +
                 chart.index,
             dataTableButtonId = 'hc-linkto-highcharts-data-table-' +
@@ -509,7 +510,7 @@ extend(InfoRegionsComponent.prototype, /** @lends Highcharts.InfoRegionsComponen
                 chartLongdesc: this.getLongdescText(),
                 xAxisDescription: axesDesc.xAxis,
                 yAxisDescription: axesDesc.yAxis,
-                playAsSoundButton: chart.sonify ?
+                playAsSoundButton: shouldHaveSonifyBtn ?
                     this.getSonifyButtonText(sonifyButtonId) : '',
                 viewTableButton: chart.getCSV ?
                     this.getDataTableButtonText(dataTableButtonId) : '',

--- a/ts/modules/sonification/chartSonify.ts
+++ b/ts/modules/sonification/chartSonify.ts
@@ -1106,10 +1106,6 @@ function chartSonify(
 ): void {
     const opts = getChartSonifyOptions(this, options);
 
-    if (opts.enabled === false) {
-        return;
-    }
-
     // Only one timeline can play at a time.
     if (this.sonification.timeline) {
         this.sonification.timeline.pause();


### PR DESCRIPTION
Fixed #13110, `chart.sonify` no longer working after v8.0.1.

~~Fixed #13110, chart.sonify no longer working after v8.0.1.~~