### PR TITLE
Refactor Series.getExtremes

### DIFF
--- a/js/modules/boost/boost-overrides.js
+++ b/js/modules/boost/boost-overrides.js
@@ -157,6 +157,7 @@ wrap(Series.prototype, 'getExtremes', function (proceed) {
     if (!this.isSeriesBoosting || (!this.hasExtremes || !this.hasExtremes())) {
         return proceed.apply(this, Array.prototype.slice.call(arguments, 1));
     }
+    return {};
 });
 /*
  * Override a bunch of methods the same way. If the number of points is

--- a/js/modules/bullet.src.js
+++ b/js/modules/bullet.src.js
@@ -193,10 +193,10 @@ seriesType('bullet', 'column'
         var dataExtremes = columnProto.getExtremes.call(this, yData);
         if (targetData && targetData.length) {
             var targetExtremes = columnProto.getExtremes.call(this, targetData);
-            if (typeof targetExtremes.dataMin === 'number') {
+            if (isNumber(targetExtremes.dataMin)) {
                 dataExtremes.dataMin = Math.min(pick(dataExtremes.dataMin, Infinity), targetExtremes.dataMin);
             }
-            if (typeof targetExtremes.dataMax === 'number') {
+            if (isNumber(targetExtremes.dataMax)) {
                 dataExtremes.dataMax = Math.max(pick(dataExtremes.dataMax, -Infinity), targetExtremes.dataMax);
             }
         }

--- a/js/modules/bullet.src.js
+++ b/js/modules/bullet.src.js
@@ -190,14 +190,17 @@ seriesType('bullet', 'column'
      */
     getExtremes: function (yData) {
         var series = this, targetData = series.targetData, yMax, yMin;
-        columnProto.getExtremes.call(this, yData);
+        var dataExtremes = columnProto.getExtremes.call(this, yData);
         if (targetData && targetData.length) {
-            yMax = series.dataMax;
-            yMin = series.dataMin;
-            columnProto.getExtremes.call(this, targetData);
-            series.dataMax = Math.max(series.dataMax, yMax);
-            series.dataMin = Math.min(series.dataMin, yMin);
+            var targetExtremes = columnProto.getExtremes.call(this, targetData);
+            if (typeof targetExtremes.dataMin === 'number') {
+                dataExtremes.dataMin = Math.min(pick(dataExtremes.dataMin, Infinity), targetExtremes.dataMin);
+            }
+            if (typeof targetExtremes.dataMax === 'number') {
+                dataExtremes.dataMax = Math.max(pick(dataExtremes.dataMax, -Infinity), targetExtremes.dataMax);
+            }
         }
+        return dataExtremes;
     }
     /* eslint-enable valid-jsdoc */
 }, 

--- a/js/modules/sonification/utilities.js
+++ b/js/modules/sonification/utilities.js
@@ -154,9 +154,9 @@ var utilities = {
      * @return {number}
      * The value mapped to the virtual axis.
      */
-    virtualAxisTranslate: function (value, DataExtremesObject, limits) {
-        var lenValueAxis = DataExtremesObject.max - DataExtremesObject.min, lenVirtualAxis = limits.max - limits.min, virtualAxisValue = limits.min +
-            lenVirtualAxis * (value - DataExtremesObject.min) / lenValueAxis;
+    virtualAxisTranslate: function (value, dataExtremes, limits) {
+        var lenValueAxis = dataExtremes.max - dataExtremes.min, lenVirtualAxis = limits.max - limits.min, virtualAxisValue = limits.min +
+            lenVirtualAxis * (value - dataExtremes.min) / lenValueAxis;
         return lenValueAxis > 0 ?
             clamp(virtualAxisValue, limits.min, limits.max) :
             limits.min;

--- a/js/modules/sonification/utilities.js
+++ b/js/modules/sonification/utilities.js
@@ -147,16 +147,16 @@ var utilities = {
      * @private
      * @param {number} value
      * The relative data value to translate.
-     * @param {Highcharts.RangeObject} dataExtremes
+     * @param {Highcharts.RangeObject} DataExtremesObject
      * The possible extremes for this value.
      * @param {object} limits
      * Limits for the virtual axis.
      * @return {number}
      * The value mapped to the virtual axis.
      */
-    virtualAxisTranslate: function (value, dataExtremes, limits) {
-        var lenValueAxis = dataExtremes.max - dataExtremes.min, lenVirtualAxis = limits.max - limits.min, virtualAxisValue = limits.min +
-            lenVirtualAxis * (value - dataExtremes.min) / lenValueAxis;
+    virtualAxisTranslate: function (value, DataExtremesObject, limits) {
+        var lenValueAxis = DataExtremesObject.max - DataExtremesObject.min, lenVirtualAxis = limits.max - limits.min, virtualAxisValue = limits.min +
+            lenVirtualAxis * (value - DataExtremesObject.min) / lenValueAxis;
         return lenValueAxis > 0 ?
             clamp(virtualAxisValue, limits.min, limits.max) :
             limits.min;

--- a/js/modules/treemap.src.js
+++ b/js/modules/treemap.src.js
@@ -1357,11 +1357,12 @@ seriesType('treemap', 'scatter'
     drawLegendSymbol: LegendSymbolMixin.drawRectangle,
     getExtremes: function () {
         // Get the extremes from the value data
-        Series.prototype.getExtremes.call(this, this.colorValueData);
-        this.valueMin = this.dataMin;
-        this.valueMax = this.dataMax;
+        var _a = Series.prototype.getExtremes
+            .call(this, this.colorValueData), dataMin = _a.dataMin, dataMax = _a.dataMax;
+        this.valueMin = dataMin;
+        this.valueMax = dataMax;
         // Get the extremes from the y data
-        Series.prototype.getExtremes.call(this);
+        return Series.prototype.getExtremes.call(this);
     },
     getExtremesFromAll: true,
     /**

--- a/js/modules/windbarb.src.js
+++ b/js/modules/windbarb.src.js
@@ -312,7 +312,7 @@ seriesType('windbarb', 'column'
     // Don't invert the marker group (#4960)
     invertGroups: noop,
     // No data extremes for the Y axis
-    getExtremes: noop
+    getExtremes: function () { return ({}); }
 }, {
     isValid: function () {
         return isNumber(this.value) && this.value >= 0;

--- a/js/parts-map/ColorAxis.js
+++ b/js/parts-map/ColorAxis.js
@@ -806,9 +806,9 @@ extend(ColorAxis.prototype, {
                 cSeries.maxColorValue = cSeries[colorKey + 'Max'];
             }
             else {
-                Series.prototype.getExtremes.call(cSeries, colorValArray);
-                cSeries.minColorValue = cSeries.dataMin;
-                cSeries.maxColorValue = cSeries.dataMax;
+                var cExtremes = Series.prototype.getExtremes.call(cSeries, colorValArray);
+                cSeries.minColorValue = cExtremes.dataMin;
+                cSeries.maxColorValue = cExtremes.dataMax;
             }
             if (typeof cSeries.minColorValue !== 'undefined') {
                 this.dataMin =
@@ -817,7 +817,7 @@ extend(ColorAxis.prototype, {
                     Math.max(this.dataMax, cSeries.maxColorValue);
             }
             if (!calculatedExtremes) {
-                Series.prototype.getExtremes.call(cSeries);
+                Series.prototype.applyExtremes.call(cSeries);
             }
         }
     },

--- a/js/parts-map/HeatmapSeries.js
+++ b/js/parts-map/HeatmapSeries.js
@@ -510,11 +510,16 @@ seriesType('heatmap', 'scatter',
      */
     getExtremes: function () {
         // Get the extremes from the value data
-        Series.prototype.getExtremes.call(this, this.valueData);
-        this.valueMin = this.dataMin;
-        this.valueMax = this.dataMax;
+        var _a = Series.prototype.getExtremes
+            .call(this, this.valueData), dataMin = _a.dataMin, dataMax = _a.dataMax;
+        if (typeof dataMin === 'number') {
+            this.valueMin = dataMin;
+        }
+        if (typeof dataMax === 'number') {
+            this.valueMax = dataMax;
+        }
         // Get the extremes from the y data
-        Series.prototype.getExtremes.call(this);
+        return Series.prototype.getExtremes.call(this);
     }
     /* eslint-enable valid-jsdoc */
 }), merge(colorMapPointMixin, {

--- a/js/parts-map/HeatmapSeries.js
+++ b/js/parts-map/HeatmapSeries.js
@@ -23,7 +23,7 @@ import H from '../parts/Globals.js';
 */
 import LegendSymbolMixin from '../mixins/legend-symbol.js';
 import U from '../parts/Utilities.js';
-var clamp = U.clamp, extend = U.extend, fireEvent = U.fireEvent, merge = U.merge, pick = U.pick, seriesType = U.seriesType;
+var clamp = U.clamp, extend = U.extend, fireEvent = U.fireEvent, isNumber = U.isNumber, merge = U.merge, pick = U.pick, seriesType = U.seriesType;
 import '../parts/Options.js';
 import '../parts/Series.js';
 import './ColorMapSeriesMixin.js';
@@ -512,10 +512,10 @@ seriesType('heatmap', 'scatter',
         // Get the extremes from the value data
         var _a = Series.prototype.getExtremes
             .call(this, this.valueData), dataMin = _a.dataMin, dataMax = _a.dataMax;
-        if (typeof dataMin === 'number') {
+        if (isNumber(dataMin)) {
             this.valueMin = dataMin;
         }
-        if (typeof dataMax === 'number') {
+        if (isNumber(dataMax)) {
             this.valueMax = dataMax;
         }
         // Get the extremes from the y data

--- a/js/parts-map/MapSeries.js
+++ b/js/parts-map/MapSeries.js
@@ -363,16 +363,20 @@ seriesType('map', 'scatter',
     },
     getExtremes: function () {
         // Get the actual value extremes for colors
-        Series.prototype.getExtremes.call(this, this.valueData);
+        var _a = Series.prototype.getExtremes
+            .call(this, this.valueData), dataMin = _a.dataMin, dataMax = _a.dataMax;
         // Recalculate box on updated data
         if (this.chart.hasRendered && this.isDirtyData) {
             this.getBox(this.options.data);
         }
-        this.valueMin = this.dataMin;
-        this.valueMax = this.dataMax;
+        if (typeof dataMin === 'number') {
+            this.valueMin = dataMin;
+        }
+        if (typeof dataMax === 'number') {
+            this.valueMax = dataMax;
+        }
         // Extremes for the mock Y axis
-        this.dataMin = this.minY;
-        this.dataMax = this.maxY;
+        return { dataMin: this.minY, dataMax: this.maxY };
     },
     // Translate the path, so it automatically fits into the plot area box
     translatePath: function (path) {

--- a/js/parts-map/MapSeries.js
+++ b/js/parts-map/MapSeries.js
@@ -369,10 +369,10 @@ seriesType('map', 'scatter',
         if (this.chart.hasRendered && this.isDirtyData) {
             this.getBox(this.options.data);
         }
-        if (typeof dataMin === 'number') {
+        if (isNumber(dataMin)) {
             this.valueMin = dataMin;
         }
-        if (typeof dataMax === 'number') {
+        if (isNumber(dataMax)) {
             this.valueMax = dataMax;
         }
         // Extremes for the mock Y axis

--- a/js/parts-more/WaterfallSeries.js
+++ b/js/parts-more/WaterfallSeries.js
@@ -603,9 +603,12 @@ seriesType('waterfall', 'column', {
                     stackedYPos.push(stackX.posTotal + stackX.threshold);
                 });
             }
-            this.dataMin = arrayMin(stackedYNeg);
-            this.dataMax = arrayMax(stackedYPos);
+            return {
+                dataMin: arrayMin(stackedYNeg),
+                dataMax: arrayMax(stackedYPos)
+            };
         }
+        return Series.prototype.getExtremes.call(this);
     }
     // Point members
 }, {

--- a/js/parts-more/WaterfallSeries.js
+++ b/js/parts-more/WaterfallSeries.js
@@ -608,7 +608,12 @@ seriesType('waterfall', 'column', {
                 dataMax: arrayMax(stackedYPos)
             };
         }
-        return Series.prototype.getExtremes.call(this);
+        // When not stacking, data extremes have already been computed in the
+        // processData function.
+        return {
+            dataMin: this.dataMin,
+            dataMax: this.dataMax
+        };
     }
     // Point members
 }, {
@@ -626,7 +631,7 @@ seriesType('waterfall', 'column', {
     isValid: function () {
         return (isNumber(this.y) ||
             this.isSum ||
-            this.isIntermediateSum);
+            Boolean(this.isIntermediateSum));
     }
 });
 /**

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -678,11 +678,11 @@ var Axis = /** @class */ (function () {
                         // used, the min and max are always 0 and 100. If
                         // seriesDataMin and seriesDataMax is null, then series
                         // doesn't have active y data, we continue with nulls
-                        if (typeof dataExtremes.dataMin === 'number') {
+                        if (isNumber(dataExtremes.dataMin)) {
                             seriesDataMin = dataExtremes.dataMin;
                             axis.dataMin = Math.min(pick(axis.dataMin, seriesDataMin), seriesDataMin);
                         }
-                        if (typeof dataExtremes.dataMax === 'number') {
+                        if (isNumber(dataExtremes.dataMax)) {
                             seriesDataMax = dataExtremes.dataMax;
                             axis.dataMax = Math.max(pick(axis.dataMax, seriesDataMax), seriesDataMax);
                         }

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -673,15 +673,17 @@ var Axis = /** @class */ (function () {
                     }
                     else {
                         // Get this particular series extremes
-                        series.getExtremes();
-                        seriesDataMax = series.dataMax;
-                        seriesDataMin = series.dataMin;
+                        var dataExtremes = series.getExtremes();
                         // Get the dataMin and dataMax so far. If percentage is
                         // used, the min and max are always 0 and 100. If
                         // seriesDataMin and seriesDataMax is null, then series
                         // doesn't have active y data, we continue with nulls
-                        if (defined(seriesDataMin) && defined(seriesDataMax)) {
+                        if (typeof dataExtremes.dataMin === 'number') {
+                            seriesDataMin = dataExtremes.dataMin;
                             axis.dataMin = Math.min(pick(axis.dataMin, seriesDataMin), seriesDataMin);
+                        }
+                        if (typeof dataExtremes.dataMax === 'number') {
+                            seriesDataMax = dataExtremes.dataMax;
                             axis.dataMax = Math.max(pick(axis.dataMax, seriesDataMax), seriesDataMax);
                         }
                         // Adjust to threshold

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -673,7 +673,7 @@ var Axis = /** @class */ (function () {
                     }
                     else {
                         // Get this particular series extremes
-                        var dataExtremes = series.getExtremes();
+                        var dataExtremes = series.applyExtremes();
                         // Get the dataMin and dataMax so far. If percentage is
                         // used, the min and max are always 0 and 100. If
                         // seriesDataMin and seriesDataMax is null, then series

--- a/js/parts/ColumnSeries.js
+++ b/js/parts/ColumnSeries.js
@@ -591,10 +591,12 @@ seriesType('column', 'line',
                     (yAxis.reversed && point.negative);
                 // Reverse zeros if there's no positive value in the series
                 // in visible range (#7046)
-                if (point.y === threshold &&
-                    series.dataMax <= threshold &&
+                if (isNumber(threshold) &&
+                    isNumber(dataMax) &&
+                    point.y === threshold &&
+                    dataMax <= threshold &&
                     // and if there's room for it (#7311)
-                    yAxis.min < threshold &&
+                    (yAxis.min || 0) < threshold &&
                     // if all points are the same value (i.e zero) not draw
                     // as negative points (#10646)
                     dataMin !== dataMax) {

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -3758,8 +3758,8 @@ null,
         };
     },
     /**
-     * Calculate Y extremes for the visible data. The result is set as
-     * `dataMin` and `dataMax` on the Series item.
+     * Calculate Y extremes for the visible data. The result is returned
+     * as an object with `dataMin` and `dataMax` properties.
      *
      * @private
      * @function Highcharts.Series#getExtremes

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -3766,7 +3766,7 @@ null,
      * @param {Array<number>} [yData]
      *        The data to inspect. Defaults to the current data within the
      *        visible range.
-     * @return {void}
+     * @return {Highcharts.DataExtremesObject}
      */
     getExtremes: function (yData) {
         var xAxis = this.xAxis, yAxis = this.yAxis, xData = this.processedXData || this.xData, yDataLength, activeYData = [], activeCounter = 0, 
@@ -3809,21 +3809,26 @@ null,
                 }
             }
         }
+        var dataExtremes = {
+            dataMin: arrayMin(activeYData),
+            dataMax: arrayMax(activeYData)
+        };
         /**
          * Contains the minimum value of the series' data point.
          * @name Highcharts.Series#dataMin
          * @type {number}
          * @readonly
          */
-        this.dataMin = arrayMin(activeYData);
-        /**
+        this.dataMin = dataExtremes.dataMin;
+        /* *
          * Contains the maximum value of the series' data point.
          * @name Highcharts.Series#dataMax
          * @type {number}
          * @readonly
          */
-        this.dataMax = arrayMax(activeYData);
-        fireEvent(this, 'afterGetExtremes');
+        this.dataMax = dataExtremes.dataMax;
+        fireEvent(this, 'afterGetExtremes', { dataExtremes: dataExtremes });
+        return dataExtremes;
     },
     /**
      * Find and return the first non null point in the data

--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -3813,6 +3813,20 @@ null,
             dataMin: arrayMin(activeYData),
             dataMax: arrayMax(activeYData)
         };
+        fireEvent(this, 'afterGetExtremes', { dataExtremes: dataExtremes });
+        return dataExtremes;
+    },
+    /**
+     * Set the current data extremes as `dataMin` and `dataMax` on the
+     * Series item. Use this only when the series properties should be
+     * updated.
+     *
+     * @private
+     * @function Highcharts.Series#applyExtremes
+     * @return {void}
+     */
+    applyExtremes: function () {
+        var dataExtremes = this.getExtremes();
         /**
          * Contains the minimum value of the series' data point.
          * @name Highcharts.Series#dataMin
@@ -3827,7 +3841,6 @@ null,
          * @readonly
          */
         this.dataMax = dataExtremes.dataMax;
-        fireEvent(this, 'afterGetExtremes', { dataExtremes: dataExtremes });
         return dataExtremes;
     },
     /**

--- a/js/parts/StockChart.js
+++ b/js/parts/StockChart.js
@@ -649,14 +649,15 @@ seriesProto.processData = function (force) {
     return;
 };
 // Modify series extremes
-addEvent(Series, 'afterGetExtremes', function () {
-    if (this.modifyValue) {
+addEvent(Series, 'afterGetExtremes', function (e) {
+    var dataExtremes = e.dataExtremes;
+    if (this.modifyValue && dataExtremes) {
         var extremes = [
-            this.modifyValue(this.dataMin),
-            this.modifyValue(this.dataMax)
+            this.modifyValue(dataExtremes.dataMin),
+            this.modifyValue(dataExtremes.dataMax)
         ];
-        this.dataMin = arrayMin(extremes);
-        this.dataMax = arrayMax(extremes);
+        dataExtremes.dataMin = arrayMin(extremes);
+        dataExtremes.dataMax = arrayMax(extremes);
     }
 });
 /**

--- a/ts/modules/boost/boost-overrides.ts
+++ b/ts/modules/boost/boost-overrides.ts
@@ -282,10 +282,11 @@ addEvent(Series, 'destroy', function (): void {
 wrap(Series.prototype, 'getExtremes', function (
     this: Highcharts.Series,
     proceed: Function
-): void {
+): Highcharts.DataExtremesObject {
     if (!this.isSeriesBoosting || (!this.hasExtremes || !this.hasExtremes())) {
         return proceed.apply(this, Array.prototype.slice.call(arguments, 1));
     }
+    return {};
 });
 
 /*

--- a/ts/modules/bullet.src.ts
+++ b/ts/modules/bullet.src.ts
@@ -317,13 +317,13 @@ seriesType<Highcharts.BulletSeries>('bullet', 'column'
                     this,
                     targetData
                 );
-                if (typeof targetExtremes.dataMin === 'number') {
+                if (isNumber(targetExtremes.dataMin)) {
                     dataExtremes.dataMin = Math.min(
                         pick(dataExtremes.dataMin, Infinity),
                         targetExtremes.dataMin
                     );
                 }
-                if (typeof targetExtremes.dataMax === 'number') {
+                if (isNumber(targetExtremes.dataMax)) {
                     dataExtremes.dataMax = Math.max(
                         pick(dataExtremes.dataMax, -Infinity),
                         targetExtremes.dataMax

--- a/ts/modules/bullet.src.ts
+++ b/ts/modules/bullet.src.ts
@@ -35,7 +35,7 @@ declare global {
             public points: Array<BulletPoint>;
             public targetData: Array<number>;
             public drawPoints(): void;
-            public getExtremes(yData?: Array<number>): void;
+            public getExtremes(yData?: Array<number>): DataExtremesObject;
         }
         interface BulletPointOptions extends ColumnPointOptions {
             borderColor?: ColorType;
@@ -304,21 +304,33 @@ seriesType<Highcharts.BulletSeries>('bullet', 'column'
         getExtremes: function (
             this: Highcharts.BulletSeries,
             yData?: Array<number>
-        ): void {
+        ): Highcharts.DataExtremesObject {
             var series = this,
                 targetData = series.targetData,
                 yMax,
                 yMin;
 
-            columnProto.getExtremes.call(this, yData);
+            const dataExtremes = columnProto.getExtremes.call(this, yData);
 
             if (targetData && targetData.length) {
-                yMax = series.dataMax;
-                yMin = series.dataMin;
-                columnProto.getExtremes.call(this, targetData);
-                series.dataMax = Math.max(series.dataMax, yMax);
-                series.dataMin = Math.min(series.dataMin, yMin);
+                const targetExtremes = columnProto.getExtremes.call(
+                    this,
+                    targetData
+                );
+                if (typeof targetExtremes.dataMin === 'number') {
+                    dataExtremes.dataMin = Math.min(
+                        pick(dataExtremes.dataMin, Infinity),
+                        targetExtremes.dataMin
+                    );
+                }
+                if (typeof targetExtremes.dataMax === 'number') {
+                    dataExtremes.dataMax = Math.max(
+                        pick(dataExtremes.dataMax, -Infinity),
+                        targetExtremes.dataMax
+                    );
+                }
             }
+            return dataExtremes;
         }
 
         /* eslint-enable valid-jsdoc */

--- a/ts/modules/sonification/utilities.ts
+++ b/ts/modules/sonification/utilities.ts
@@ -232,7 +232,7 @@ var utilities: Highcharts.SonificationUtilitiesObject = {
      * @private
      * @param {number} value
      * The relative data value to translate.
-     * @param {Highcharts.RangeObject} dataExtremes
+     * @param {Highcharts.RangeObject} DataExtremesObject
      * The possible extremes for this value.
      * @param {object} limits
      * Limits for the virtual axis.
@@ -241,13 +241,13 @@ var utilities: Highcharts.SonificationUtilitiesObject = {
      */
     virtualAxisTranslate: function (
         value: number,
-        dataExtremes: Highcharts.RangeObject,
+        DataExtremesObject: Highcharts.RangeObject,
         limits: Highcharts.RangeObject
     ): number {
-        var lenValueAxis = dataExtremes.max - dataExtremes.min,
+        var lenValueAxis = DataExtremesObject.max - DataExtremesObject.min,
             lenVirtualAxis = limits.max - limits.min,
             virtualAxisValue = limits.min +
-                lenVirtualAxis * (value - dataExtremes.min) / lenValueAxis;
+                lenVirtualAxis * (value - DataExtremesObject.min) / lenValueAxis;
 
         return lenValueAxis > 0 ?
             clamp(virtualAxisValue, limits.min, limits.max) :

--- a/ts/modules/sonification/utilities.ts
+++ b/ts/modules/sonification/utilities.ts
@@ -241,13 +241,13 @@ var utilities: Highcharts.SonificationUtilitiesObject = {
      */
     virtualAxisTranslate: function (
         value: number,
-        DataExtremesObject: Highcharts.RangeObject,
+        dataExtremes: Highcharts.RangeObject,
         limits: Highcharts.RangeObject
     ): number {
-        var lenValueAxis = DataExtremesObject.max - DataExtremesObject.min,
+        var lenValueAxis = dataExtremes.max - dataExtremes.min,
             lenVirtualAxis = limits.max - limits.min,
             virtualAxisValue = limits.min +
-                lenVirtualAxis * (value - DataExtremesObject.min) / lenValueAxis;
+                lenVirtualAxis * (value - dataExtremes.min) / lenValueAxis;
 
         return lenValueAxis > 0 ?
             clamp(virtualAxisValue, limits.min, limits.max) :

--- a/ts/modules/treemap.src.ts
+++ b/ts/modules/treemap.src.ts
@@ -122,7 +122,7 @@ declare global {
             public drillToByGroup(point: TreemapPoint): (boolean|string);
             public drillToNode(id: string, redraw?: boolean): void;
             public drillUp(): void;
-            public getExtremes(): void;
+            public getExtremes(): DataExtremesObject;
             public getListOfParents(
                 data?: Array<TreemapPoint>,
                 existingIds?: Array<string>
@@ -2133,14 +2133,17 @@ seriesType<Highcharts.TreemapSeries>(
         },
         buildKDTree: noop as any,
         drawLegendSymbol: LegendSymbolMixin.drawRectangle,
-        getExtremes: function (this: Highcharts.TreemapSeries): void {
-        // Get the extremes from the value data
-            Series.prototype.getExtremes.call(this, this.colorValueData);
-            this.valueMin = this.dataMin;
-            this.valueMax = this.dataMax;
+        getExtremes: function (
+            this: Highcharts.TreemapSeries
+        ): Highcharts.DataExtremesObject {
+            // Get the extremes from the value data
+            const { dataMin, dataMax } = Series.prototype.getExtremes
+                .call(this, this.colorValueData);
+            this.valueMin = dataMin;
+            this.valueMax = dataMax;
 
             // Get the extremes from the y data
-            Series.prototype.getExtremes.call(this);
+            return Series.prototype.getExtremes.call(this);
         },
         getExtremesFromAll: true,
 

--- a/ts/modules/windbarb.src.ts
+++ b/ts/modules/windbarb.src.ts
@@ -491,7 +491,7 @@ seriesType<Highcharts.WindbarbSeries>('windbarb', 'column'
         invertGroups: noop as any,
 
         // No data extremes for the Y axis
-        getExtremes: noop as any
+        getExtremes: (): Highcharts.DataExtremesObject => ({})
     }, {
         isValid: function (this: Highcharts.WindbarbPoint): boolean {
             return isNumber(this.value) && this.value >= 0;

--- a/ts/parts-map/ColorAxis.ts
+++ b/ts/parts-map/ColorAxis.ts
@@ -1166,10 +1166,13 @@ extend(ColorAxis.prototype, {
                 cSeries.maxColorValue = (cSeries as any)[colorKey + 'Max'];
 
             } else {
-                Series.prototype.getExtremes.call(cSeries, colorValArray);
+                const cExtremes = Series.prototype.getExtremes.call(
+                    cSeries,
+                    colorValArray
+                );
 
-                cSeries.minColorValue = cSeries.dataMin;
-                cSeries.maxColorValue = cSeries.dataMax;
+                cSeries.minColorValue = cExtremes.dataMin;
+                cSeries.maxColorValue = cExtremes.dataMax;
             }
 
             if (typeof cSeries.minColorValue !== 'undefined') {
@@ -1180,7 +1183,7 @@ extend(ColorAxis.prototype, {
             }
 
             if (!calculatedExtremes) {
-                Series.prototype.getExtremes.call(cSeries);
+                Series.prototype.applyExtremes.call(cSeries);
             }
         }
     },

--- a/ts/parts-map/HeatmapSeries.ts
+++ b/ts/parts-map/HeatmapSeries.ts
@@ -47,7 +47,7 @@ declare global {
             public valueMax: number;
             public valueMin: number;
             public drawPoints(): void;
-            public getExtremes(): void;
+            public getExtremes(): DataExtremesObject;
             public getValidPoints(
                 points?: Array<HeatmapPoint>,
                 insideOnly?: boolean
@@ -749,14 +749,22 @@ seriesType<Highcharts.HeatmapSeries>(
          * @function Highcharts.seriesTypes.heatmap#getExtremes
          * @return {void}
          */
-        getExtremes: function (this: Highcharts.HeatmapSeries): void {
-        // Get the extremes from the value data
-            Series.prototype.getExtremes.call(this, this.valueData);
-            this.valueMin = this.dataMin;
-            this.valueMax = this.dataMax;
+        getExtremes: function (
+            this: Highcharts.HeatmapSeries
+        ): Highcharts.DataExtremesObject {
+            // Get the extremes from the value data
+            const { dataMin, dataMax } = Series.prototype.getExtremes
+                .call(this, this.valueData);
+
+            if (typeof dataMin === 'number') {
+                this.valueMin = dataMin;
+            }
+            if (typeof dataMax === 'number') {
+                this.valueMax = dataMax;
+            }
 
             // Get the extremes from the y data
-            Series.prototype.getExtremes.call(this);
+            return Series.prototype.getExtremes.call(this);
         }
 
         /* eslint-enable valid-jsdoc */

--- a/ts/parts-map/HeatmapSeries.ts
+++ b/ts/parts-map/HeatmapSeries.ts
@@ -120,6 +120,7 @@ const {
     clamp,
     extend,
     fireEvent,
+    isNumber,
     merge,
     pick,
     seriesType
@@ -756,10 +757,10 @@ seriesType<Highcharts.HeatmapSeries>(
             const { dataMin, dataMax } = Series.prototype.getExtremes
                 .call(this, this.valueData);
 
-            if (typeof dataMin === 'number') {
+            if (isNumber(dataMin)) {
                 this.valueMin = dataMin;
             }
-            if (typeof dataMax === 'number') {
+            if (isNumber(dataMax)) {
                 this.valueMax = dataMax;
             }
 

--- a/ts/parts-map/MapSeries.ts
+++ b/ts/parts-map/MapSeries.ts
@@ -612,10 +612,10 @@ seriesType<Highcharts.MapSeries>(
                 this.getBox(this.options.data as any);
             }
 
-            if (typeof dataMin === 'number') {
+            if (isNumber(dataMin)) {
                 this.valueMin = dataMin;
             }
-            if (typeof dataMax === 'number') {
+            if (isNumber(dataMax)) {
                 this.valueMax = dataMax;
             }
 

--- a/ts/parts-map/MapSeries.ts
+++ b/ts/parts-map/MapSeries.ts
@@ -65,7 +65,7 @@ declare global {
             public drawMapDataLabels(): void;
             public drawPoints(): void;
             public getBox(paths: Array<MapPointOptions>): void;
-            public getExtremes(): void;
+            public getExtremes(): DataExtremesObject;
             public hasData(): boolean;
             public pointAttribs(point: MapPoint, state?: string): SVGAttributes;
             public render(): void;
@@ -600,21 +600,27 @@ seriesType<Highcharts.MapSeries>(
             return !!this.processedXData.length; // != 0
         },
 
-        getExtremes: function (this: Highcharts.MapSeries): void {
+        getExtremes: function (
+            this: Highcharts.MapSeries
+        ): Highcharts.DataExtremesObject {
             // Get the actual value extremes for colors
-            Series.prototype.getExtremes.call(this, this.valueData);
+            const { dataMin, dataMax } = Series.prototype.getExtremes
+                .call(this, this.valueData);
 
             // Recalculate box on updated data
             if (this.chart.hasRendered && this.isDirtyData) {
                 this.getBox(this.options.data as any);
             }
 
-            this.valueMin = this.dataMin;
-            this.valueMax = this.dataMax;
+            if (typeof dataMin === 'number') {
+                this.valueMin = dataMin;
+            }
+            if (typeof dataMax === 'number') {
+                this.valueMax = dataMax;
+            }
 
             // Extremes for the mock Y axis
-            this.dataMin = this.minY;
-            this.dataMax = this.maxY;
+            return { dataMin: this.minY, dataMax: this.maxY };
         },
 
         // Translate the path, so it automatically fits into the plot area box

--- a/ts/parts-more/WaterfallSeries.ts
+++ b/ts/parts-more/WaterfallSeries.ts
@@ -1050,8 +1050,15 @@ seriesType<Highcharts.WaterfallSeries>('waterfall', 'column', {
                 dataMin: arrayMin(stackedYNeg),
                 dataMax: arrayMax(stackedYPos)
             };
+
         }
-        return Series.prototype.getExtremes.call(this);
+
+        // When not stacking, data extremes have already been computed in the
+        // processData function.
+        return {
+            dataMin: this.dataMin,
+            dataMax: this.dataMax
+        };
     }
 
 
@@ -1071,8 +1078,8 @@ seriesType<Highcharts.WaterfallSeries>('waterfall', 'column', {
     isValid: function (this: Highcharts.WaterfallPoint): boolean {
         return (
             isNumber(this.y) ||
-            (this.isSum as any) ||
-            (this.isIntermediateSum as any)
+            this.isSum ||
+            Boolean(this.isIntermediateSum)
         );
     }
 

--- a/ts/parts-more/WaterfallSeries.ts
+++ b/ts/parts-more/WaterfallSeries.ts
@@ -46,7 +46,7 @@ declare global {
             public drawGraph(): void;
             public generatePoints(): void;
             public getCrispPath(): SVGPathArray;
-            public getExtremes(): void;
+            public getExtremes(): DataExtremesObject;
             public getGraphPath(): SVGPathArray;
             public pointAttribs(
                 point: WaterfallPoint,
@@ -1013,7 +1013,9 @@ seriesType<Highcharts.WaterfallSeries>('waterfall', 'column', {
 
     // Extremes for a non-stacked series are recorded in processData.
     // In case of stacking, use Series.stackedYData to calculate extremes.
-    getExtremes: function (this: Highcharts.WaterfallSeries): void {
+    getExtremes: function (
+        this: Highcharts.WaterfallSeries
+    ): Highcharts.DataExtremesObject {
         var stacking = this.options.stacking,
             yAxis,
             waterfallStacks,
@@ -1044,9 +1046,12 @@ seriesType<Highcharts.WaterfallSeries>('waterfall', 'column', {
                 });
             }
 
-            this.dataMin = arrayMin(stackedYNeg);
-            this.dataMax = arrayMax(stackedYPos);
+            return {
+                dataMin: arrayMin(stackedYNeg),
+                dataMax: arrayMax(stackedYPos)
+            };
         }
+        return Series.prototype.getExtremes.call(this);
     }
 
 

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -4308,8 +4308,8 @@ class Axis {
                     var seriesOptions = series.options,
                         xData,
                         threshold = seriesOptions.threshold,
-                        seriesDataMin,
-                        seriesDataMax;
+                        seriesDataMin: number,
+                        seriesDataMax: number;
 
                     axis.hasVisibleSeries = true;
 
@@ -4360,19 +4360,21 @@ class Axis {
                     } else {
 
                         // Get this particular series extremes
-                        series.getExtremes();
-                        seriesDataMax = series.dataMax;
-                        seriesDataMin = series.dataMin;
+                        const dataExtremes = series.getExtremes();
 
                         // Get the dataMin and dataMax so far. If percentage is
                         // used, the min and max are always 0 and 100. If
                         // seriesDataMin and seriesDataMax is null, then series
                         // doesn't have active y data, we continue with nulls
-                        if (defined(seriesDataMin) && defined(seriesDataMax)) {
+                        if (typeof dataExtremes.dataMin === 'number') {
+                            seriesDataMin = dataExtremes.dataMin;
                             axis.dataMin = Math.min(
                                 pick(axis.dataMin, seriesDataMin),
                                 seriesDataMin
                             );
+                        }
+                        if (typeof dataExtremes.dataMax === 'number') {
+                            seriesDataMax = dataExtremes.dataMax;
                             axis.dataMax = Math.max(
                                 pick(axis.dataMax, seriesDataMax),
                                 seriesDataMax

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -4366,14 +4366,14 @@ class Axis {
                         // used, the min and max are always 0 and 100. If
                         // seriesDataMin and seriesDataMax is null, then series
                         // doesn't have active y data, we continue with nulls
-                        if (typeof dataExtremes.dataMin === 'number') {
+                        if (isNumber(dataExtremes.dataMin)) {
                             seriesDataMin = dataExtremes.dataMin;
                             axis.dataMin = Math.min(
                                 pick(axis.dataMin, seriesDataMin),
                                 seriesDataMin
                             );
                         }
-                        if (typeof dataExtremes.dataMax === 'number') {
+                        if (isNumber(dataExtremes.dataMax)) {
                             seriesDataMax = dataExtremes.dataMax;
                             axis.dataMax = Math.max(
                                 pick(axis.dataMax, seriesDataMax),

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -4360,7 +4360,7 @@ class Axis {
                     } else {
 
                         // Get this particular series extremes
-                        const dataExtremes = series.getExtremes();
+                        const dataExtremes = series.applyExtremes();
 
                         // Get the dataMin and dataMax so far. If percentage is
                         // used, the min and max are always 0 and 100. If

--- a/ts/parts/ColumnSeries.ts
+++ b/ts/parts/ColumnSeries.ts
@@ -835,10 +835,12 @@ seriesType<Highcharts.ColumnSeries>(
                     // Reverse zeros if there's no positive value in the series
                     // in visible range (#7046)
                     if (
+                        isNumber(threshold) &&
+                        isNumber(dataMax) &&
                         point.y === threshold &&
-                        (series.dataMax as any) <= (threshold as any) &&
+                        dataMax <= threshold &&
                         // and if there's room for it (#7311)
-                        (yAxis.min as any) < (threshold as any) &&
+                        (yAxis.min || 0) < threshold &&
                         // if all points are the same value (i.e zero) not draw
                         // as negative points (#10646)
                         dataMin !== dataMax

--- a/ts/parts/ColumnSeries.ts
+++ b/ts/parts/ColumnSeries.ts
@@ -836,7 +836,7 @@ seriesType<Highcharts.ColumnSeries>(
                     // in visible range (#7046)
                     if (
                         point.y === threshold &&
-                        series.dataMax <= (threshold as any) &&
+                        (series.dataMax as any) <= (threshold as any) &&
                         // and if there's room for it (#7311)
                         (yAxis.min as any) < (threshold as any) &&
                         // if all points are the same value (i.e zero) not draw

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -47,8 +47,8 @@ declare global {
             public cropped?: boolean;
             public cropShoulder: number;
             public data: Array<Point>;
-            public dataMax: number;
-            public dataMin: number;
+            public dataMax?: number;
+            public dataMin?: number;
             public directTouch: boolean;
             public drawLegendSymbol: (
                 LegendSymbolMixin['drawLineMarker']|
@@ -108,6 +108,7 @@ declare global {
             public zones: Array<SeriesZonesOptions>;
             public afterAnimate(): void;
             public animate(init?: boolean): void;
+            public applyExtremes(): DataExtremesObject;
             public applyZones(): void;
             public autoIncrement(): void;
             public bindAxes(): void;
@@ -4996,6 +4997,25 @@ H.Series = seriesType<Highcharts.LineSeries>(
                 dataMax: arrayMax(activeYData)
             };
 
+            fireEvent(this, 'afterGetExtremes', { dataExtremes });
+
+            return dataExtremes;
+        },
+
+        /**
+         * Set the current data extremes as `dataMin` and `dataMax` on the
+         * Series item. Use this only when the series properties should be
+         * updated.
+         *
+         * @private
+         * @function Highcharts.Series#applyExtremes
+         * @return {void}
+         */
+        applyExtremes: function (
+            this: Highcharts.Series
+        ): Highcharts.DataExtremesObject {
+            const dataExtremes = this.getExtremes();
+
             /**
              * Contains the minimum value of the series' data point.
              * @name Highcharts.Series#dataMin
@@ -5011,8 +5031,6 @@ H.Series = seriesType<Highcharts.LineSeries>(
              * @readonly
              */
             this.dataMax = dataExtremes.dataMax;
-
-            fireEvent(this, 'afterGetExtremes', { dataExtremes });
 
             return dataExtremes;
         },

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -4911,8 +4911,8 @@ H.Series = seriesType<Highcharts.LineSeries>(
         },
 
         /**
-         * Calculate Y extremes for the visible data. The result is set as
-         * `dataMin` and `dataMax` on the Series item.
+         * Calculate Y extremes for the visible data. The result is returned
+         * as an object with `dataMin` and `dataMax` properties.
          *
          * @private
          * @function Highcharts.Series#getExtremes

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -141,7 +141,7 @@ declare global {
                 value?: any,
                 defaults?: Dictionary<any>
             ): void;
-            public getExtremes(yData?: Array<number>): void;
+            public getExtremes(yData?: Array<number>): DataExtremesObject;
             public getName(): string;
             public getGraphPath(
                 points: Array<Point>,
@@ -217,6 +217,10 @@ declare global {
         }
         interface Chart {
             runTrackerClick?: boolean;
+        }
+        interface DataExtremesObject {
+            dataMin?: number;
+            dataMax?: number;
         }
         interface DataSortingOptionsObject {
             enabled?: boolean;
@@ -4914,12 +4918,12 @@ H.Series = seriesType<Highcharts.LineSeries>(
          * @param {Array<number>} [yData]
          *        The data to inspect. Defaults to the current data within the
          *        visible range.
-         * @return {void}
+         * @return {Highcharts.DataExtremesObject}
          */
         getExtremes: function (
             this: Highcharts.Series,
             yData?: (Array<number>|Array<Array<number>>)
-        ): void {
+        ): Highcharts.DataExtremesObject {
             var xAxis = this.xAxis,
                 yAxis = this.yAxis,
                 xData = this.processedXData || this.xData,
@@ -4987,23 +4991,30 @@ H.Series = seriesType<Highcharts.LineSeries>(
                 }
             }
 
+            const dataExtremes = {
+                dataMin: arrayMin(activeYData),
+                dataMax: arrayMax(activeYData)
+            };
+
             /**
              * Contains the minimum value of the series' data point.
              * @name Highcharts.Series#dataMin
              * @type {number}
              * @readonly
              */
-            this.dataMin = arrayMin(activeYData);
+            this.dataMin = dataExtremes.dataMin;
 
-            /**
+            /* *
              * Contains the maximum value of the series' data point.
              * @name Highcharts.Series#dataMax
              * @type {number}
              * @readonly
              */
-            this.dataMax = arrayMax(activeYData);
+            this.dataMax = dataExtremes.dataMax;
 
-            fireEvent(this, 'afterGetExtremes');
+            fireEvent(this, 'afterGetExtremes', { dataExtremes });
+
+            return dataExtremes;
         },
 
         /**

--- a/ts/parts/StockChart.ts
+++ b/ts/parts/StockChart.ts
@@ -953,17 +953,22 @@ seriesProto.processData = function (
 };
 
 // Modify series extremes
-addEvent(Series, 'afterGetExtremes', function (this: Highcharts.Series): void {
-    if (this.modifyValue) {
-        var extremes = [
-            this.modifyValue(this.dataMin),
-            this.modifyValue(this.dataMax)
-        ];
+addEvent(
+    Series,
+    'afterGetExtremes',
+    function (this: Highcharts.Series, e): void {
+        const dataExtremes: Highcharts.DataExtremesObject = (e as any).dataExtremes;
+        if (this.modifyValue && dataExtremes) {
+            var extremes = [
+                this.modifyValue(dataExtremes.dataMin),
+                this.modifyValue(dataExtremes.dataMax)
+            ];
 
-        this.dataMin = arrayMin(extremes);
-        this.dataMax = arrayMax(extremes);
+            dataExtremes.dataMin = arrayMin(extremes);
+            dataExtremes.dataMax = arrayMax(extremes);
+        }
     }
-});
+);
 
 /**
  * Highstock only. Set the compare mode on all series belonging to an Y axis


### PR DESCRIPTION
Refactored `Series.getExtremes` so that it now only returns values instead of setting them on the series instance. It makes it easier to override, easier to use in different contexts, and more consistent with the `get` naming.