### PR TITLE
bugfix/11928-3d-pie-position-after-update

### DIFF
--- a/js/parts-3d/Pie.js
+++ b/js/parts-3d/Pie.js
@@ -109,8 +109,8 @@ wrap(seriesTypes.pie.prototype, 'animate', function (proceed) {
             // Initialize the animation
             if (init) {
                 // Scale down the group and place it in the center
-                group.oldtranslateX = group.translateX;
-                group.oldtranslateY = group.translateY;
+                group.oldtranslateX = pick(group.oldtranslateX, group.translateX);
+                group.oldtranslateY = pick(group.oldtranslateY, group.translateY);
                 attribs = {
                     translateX: center[0],
                     translateY: center[1],

--- a/samples/unit-tests/3d/series-pie/demo.js
+++ b/samples/unit-tests/3d/series-pie/demo.js
@@ -328,6 +328,9 @@ QUnit.test(
                     }
                 },
                 plotOptions: {
+                    series: {
+                        animation: true
+                    },
                     pie: {
                         depth: 35
                     }
@@ -348,5 +351,11 @@ QUnit.test(
             height < point.graphic.out.getBBox(true).height,
             'Updating series.depth should change slice\'s depth (#12515).'
         );
-    }
-);
+
+        assert.ok(
+            chart.series[0].group.oldtranslateX === chart.plotLeft &&
+            chart.series[0].group.oldtranslateY === chart.plotTop,
+            'Updating series shouldn\'t change pie position (#11928).'
+        );
+
+    });

--- a/samples/unit-tests/3d/series-pie/demo.js
+++ b/samples/unit-tests/3d/series-pie/demo.js
@@ -352,10 +352,16 @@ QUnit.test(
             'Updating series.depth should change slice\'s depth (#12515).'
         );
 
-        assert.ok(
-            chart.series[0].group.oldtranslateX === chart.plotLeft &&
-            chart.series[0].group.oldtranslateY === chart.plotTop,
-            'Updating series shouldn\'t change pie position (#11928).'
+        assert.strictEqual(
+            chart.series[0].group.oldtranslateX,
+            chart.plotLeft,
+            'Updating series shouldn\'t change pie x position (#11928).'
+        );
+
+        assert.strictEqual(
+            chart.series[0].group.oldtranslateY,
+            chart.plotTop,
+            'Updating series shouldn\'t change pie y position (#11928).'
         );
 
     });

--- a/ts/parts-3d/Pie.ts
+++ b/ts/parts-3d/Pie.ts
@@ -213,8 +213,8 @@ wrap(seriesTypes.pie.prototype, 'animate', function (
             if (init) {
 
                 // Scale down the group and place it in the center
-                (group as any).oldtranslateX = (group as any).translateX;
-                (group as any).oldtranslateY = (group as any).translateY;
+                (group as any).oldtranslateX = pick((group as any).oldtranslateX, (group as any).translateX);
+                (group as any).oldtranslateY = pick((group as any).oldtranslateY, (group as any).translateY);
                 attribs = {
                     translateX: center[0],
                     translateY: center[1],

--- a/ts/parts-3d/Pie.ts
+++ b/ts/parts-3d/Pie.ts
@@ -213,8 +213,12 @@ wrap(seriesTypes.pie.prototype, 'animate', function (
             if (init) {
 
                 // Scale down the group and place it in the center
-                (group as any).oldtranslateX = pick((group as any).oldtranslateX, (group as any).translateX);
-                (group as any).oldtranslateY = pick((group as any).oldtranslateY, (group as any).translateY);
+                (group as any).oldtranslateX = pick(
+                    (group as any).oldtranslateX,
+                    (group as any).translateX);
+                (group as any).oldtranslateY = pick(
+                    (group as any).oldtranslateY,
+                    (group as any).translateY);
                 attribs = {
                     translateX: center[0],
                     translateY: center[1],


### PR DESCRIPTION
Fixed #11928, 3D pie was misplaced after calling `Series.update`.

