### PR TITLE
bugfix/12979-annotations-update-errors

### DIFF
--- a/js/annotations/annotations.src.js
+++ b/js/annotations/annotations.src.js
@@ -751,10 +751,10 @@ merge(true, Annotation.prototype, controllableMixin, eventEmitterMixin,
     },
     getClipBox: function () {
         return {
-            x: this.clipXAxis.left,
-            y: this.clipYAxis.top,
-            width: this.clipXAxis.width,
-            height: this.clipYAxis.height
+            x: this.clipXAxis.left || 0,
+            y: this.clipYAxis.top || 0,
+            width: this.clipXAxis.width || 0,
+            height: this.clipYAxis.height || 0
         };
     },
     setLabelCollector: function () {

--- a/js/annotations/annotations.src.js
+++ b/js/annotations/annotations.src.js
@@ -703,7 +703,6 @@ merge(true, Annotation.prototype, controllableMixin, eventEmitterMixin,
         this.addControlPoints();
         this.addShapes();
         this.addLabels();
-        this.addClipPaths();
         this.setLabelCollector();
     },
     getLabelsAndShapesOptions: function (baseOptions, newOptions) {
@@ -750,12 +749,14 @@ merge(true, Annotation.prototype, controllableMixin, eventEmitterMixin,
         this.clipYAxis = linkedAxes[1];
     },
     getClipBox: function () {
-        return {
-            x: this.clipXAxis.left || 0,
-            y: this.clipYAxis.top || 0,
-            width: this.clipXAxis.width || 0,
-            height: this.clipYAxis.height || 0
-        };
+        if (this.clipXAxis && this.clipYAxis) {
+            return {
+                x: this.clipXAxis.left,
+                y: this.clipYAxis.top,
+                width: this.clipXAxis.width,
+                height: this.clipYAxis.height
+            };
+        }
     },
     setLabelCollector: function () {
         var annotation = this;
@@ -826,6 +827,7 @@ merge(true, Annotation.prototype, controllableMixin, eventEmitterMixin,
             translateY: 0
         })
             .add(this.graphic);
+        this.addClipPaths();
         if (this.clipRect) {
             this.graphic.clip(this.clipRect);
         }
@@ -893,7 +895,7 @@ merge(true, Annotation.prototype, controllableMixin, eventEmitterMixin,
      *
      * @return {void}
      */
-    update: function (userOptions) {
+    update: function (userOptions, redraw) {
         var chart = this.chart, labelsAndShapes = this.getLabelsAndShapesOptions(this.userOptions, userOptions), userOptionsIndex = chart.annotations.indexOf(this), options = merge(true, this.userOptions, userOptions);
         options.labels = labelsAndShapes.labels;
         options.shapes = labelsAndShapes.shapes;
@@ -902,9 +904,11 @@ merge(true, Annotation.prototype, controllableMixin, eventEmitterMixin,
         // Update options in chart options, used in exporting (#9767):
         chart.options.annotations[userOptionsIndex] = options;
         this.isUpdating = true;
-        this.redraw();
-        this.isUpdating = false;
+        if (pick(redraw, true)) {
+            chart.redraw();
+        }
         fireEvent(this, 'afterUpdate');
+        this.isUpdating = false;
     },
     /* *************************************************************
      * ITEM SECTION

--- a/samples/unit-tests/annotations/annotations-dynamic/demo.details
+++ b/samples/unit-tests/annotations/annotations-dynamic/demo.details
@@ -2,5 +2,6 @@
  resources:
    - https://code.jquery.com/qunit/qunit-2.0.1.js
    - https://code.jquery.com/qunit/qunit-2.0.1.css
+   - https://cdn.jsdelivr.net/gh/sinonjs/lolex/lolex.js
  js_wrap: b
 ...

--- a/samples/unit-tests/annotations/annotations-dynamic/demo.js
+++ b/samples/unit-tests/annotations/annotations-dynamic/demo.js
@@ -179,30 +179,26 @@ QUnit.test('Hiding and showing annotations with linked points', function (assert
 
 QUnit.test('Annotation\'s update methods', function (assert) {
 
-    var clock = null;
+    var clock = TestUtilities.lolexInstall();
 
     try {
 
-        clock = TestUtilities.lolexInstall();
-
-        var chart = Highcharts.chart('container', {
-
-            annotations: [{
-                labels: [{
-                    point: {
-                        xAxis: 0,
-                        yAxis: 0,
-                        x: 0,
-                        y: 5
-                    }
+        var done = assert.async(),
+            chart = Highcharts.chart('container', {
+                annotations: [{
+                    labels: [{
+                        point: {
+                            xAxis: 0,
+                            yAxis: 0,
+                            x: 0,
+                            y: 5
+                        }
+                    }]
+                }],
+                series: [{
+                    data: [4, 3, 7, 8]
                 }]
-            }],
-
-            series: [{
-                data: [4, 3, 7, 8]
-            }]
-
-        });
+            });
 
         chart.update({
             annotations: [{
@@ -227,13 +223,11 @@ QUnit.test('Annotation\'s update methods', function (assert) {
                 'Annotation\'s clipRect cannot have a NaN for numerical attributes'
             );
 
-            assert.async();
+            done();
         }, 250);
 
         TestUtilities.lolexRunAndUninstall(clock);
-
     } finally {
-
         TestUtilities.lolexUninstall(clock);
     }
 });

--- a/samples/unit-tests/annotations/annotations-dynamic/demo.js
+++ b/samples/unit-tests/annotations/annotations-dynamic/demo.js
@@ -176,3 +176,64 @@ QUnit.test('Hiding and showing annotations with linked points', function (assert
         'Annotation correctly hidden.'
     );
 });
+
+QUnit.test('Annotation\'s update methods', function (assert) {
+
+    var clock = null;
+
+    try {
+
+        clock = TestUtilities.lolexInstall();
+
+        var chart = Highcharts.chart('container', {
+
+            annotations: [{
+                labels: [{
+                    point: {
+                        xAxis: 0,
+                        yAxis: 0,
+                        x: 0,
+                        y: 5
+                    }
+                }]
+            }],
+
+            series: [{
+                data: [4, 3, 7, 8]
+            }]
+
+        });
+
+        chart.update({
+            annotations: [{
+                labelOptions: {
+                    format: 'Sample text'
+                }
+            }],
+            xAxis: {
+                title: 'Test'
+            }
+        }, null, null, { duration: 500 });
+
+        setTimeout(function () {
+            const x = chart.annotations[0].clipRect.attr('x'),
+                y = chart.annotations[0].clipRect.attr('y'),
+                width = chart.annotations[0].clipRect.attr('width'),
+                height = chart.annotations[0].clipRect.attr('height');
+
+            assert.equal(
+                isNaN(+x) || isNaN(+y) || isNaN(+width) || isNaN(+height),
+                false,
+                'Annotation\'s clipRect cannot have a NaN for numerical attributes'
+            );
+
+            assert.async();
+        }, 250);
+
+        TestUtilities.lolexRunAndUninstall(clock);
+
+    } finally {
+
+        TestUtilities.lolexUninstall(clock);
+    }
+});

--- a/ts/annotations/annotations.src.ts
+++ b/ts/annotations/annotations.src.ts
@@ -1143,10 +1143,10 @@ merge(
 
         getClipBox: function (this: Highcharts.Annotation): Highcharts.BBoxObject {
             return {
-                x: (this.clipXAxis as any).left,
-                y: (this.clipYAxis as any).top,
-                width: (this.clipXAxis as any).width,
-                height: (this.clipYAxis as any).height
+                x: (this.clipXAxis as any).left || 0,
+                y: (this.clipYAxis as any).top || 0,
+                width: (this.clipXAxis as any).width || 0,
+                height: (this.clipYAxis as any).height || 0
             };
         },
 


### PR DESCRIPTION
Fixed #12979, console errors when updating an axis at the same time as updating a related annotation.

~~Fixed #12979, console errors after the update.~~