### PR TITLE
bugfix/12897-annotations-outside-plot-area

### DIFF
--- a/samples/unit-tests/annotations/annotations-general/demo.details
+++ b/samples/unit-tests/annotations/annotations-general/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/annotations/annotations-general/demo.html
+++ b/samples/unit-tests/annotations/annotations-general/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/annotations.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/annotations/annotations-general/demo.js
+++ b/samples/unit-tests/annotations/annotations-general/demo.js
@@ -1,0 +1,39 @@
+QUnit.test('Annotations clipping', function (assert) {
+    var chart = Highcharts.chart('container', {
+        annotations: [{
+            clip: false,
+            labels: [{
+                point: '1',
+                text: 'label1',
+                overflow: 'allow',
+                y: 70
+            }, {
+                point: '2',
+                text: 'label2'
+            }]
+        }],
+        series: [{
+            data: [{
+                y: 29.9,
+                id: '1'
+            }, {
+                y: 71.5,
+                id: '2'
+            }, 106.4, 129.2, 144.0]
+        }]
+    });
+
+    assert.notOk(
+        chart.annotations[0].clipRect,
+        'Clip rect should not be set (#12897).'
+    );
+
+    chart.annotations[0].update({
+        clip: true
+    });
+
+    assert.ok(
+        chart.annotations[0].clipRect,
+        'Clip rect should be set after update (#12897).'
+    );
+});


### PR DESCRIPTION
Fixed #12897, a regression that caused annotations outside the plot area to be hidden even if the `overflow` setting was `allow`. 

~~Fixed #12897, the issue with annotations outside the plot area.~~