### PR TITLE
Fixed #5999, point.color for boost

### DIFF
--- a/js/modules/boost/wgl-renderer.js
+++ b/js/modules/boost/wgl-renderer.js
@@ -16,7 +16,7 @@ import GLVertexBuffer from './wgl-vbuffer.js';
 import Color from '../../parts/Color.js';
 var color = Color.parse;
 import U from '../../parts/Utilities.js';
-var isNumber = U.isNumber, merge = U.merge, objectEach = U.objectEach, pick = U.pick;
+var isNumber = U.isNumber, isObject = U.isObject, merge = U.merge, objectEach = U.objectEach, pick = U.pick;
 var win = H.win, doc = win.document;
 /* eslint-disable valid-jsdoc */
 /**
@@ -411,6 +411,16 @@ function GLRenderer(postRenderCallback) {
             //     pcolor[1] /= 255.0;
             //     pcolor[2] /= 255.0;
             // }
+            // Handle the point.color option (#5999)
+            var pointOptions = rawData && rawData[i];
+            if (!useRaw && isObject(pointOptions, true)) {
+                if (pointOptions.color) {
+                    pcolor = color(pointOptions.color).rgba;
+                    pcolor[0] /= 255.0;
+                    pcolor[1] /= 255.0;
+                    pcolor[2] /= 255.0;
+                }
+            }
             if (useRaw) {
                 x = d[0];
                 y = d[1];

--- a/ts/modules/boost/wgl-renderer.ts
+++ b/ts/modules/boost/wgl-renderer.ts
@@ -112,6 +112,7 @@ const color = Color.parse;
 import U from '../../parts/Utilities.js';
 const {
     isNumber,
+    isObject,
     merge,
     objectEach,
     pick
@@ -674,6 +675,17 @@ function GLRenderer(
             //     pcolor[1] /= 255.0;
             //     pcolor[2] /= 255.0;
             // }
+
+            // Handle the point.color option (#5999)
+            const pointOptions = rawData && rawData[i];
+            if (!useRaw && isObject(pointOptions, true)) {
+                if (pointOptions.color) {
+                    pcolor = color(pointOptions.color).rgba as any;
+                    pcolor[0] /= 255.0;
+                    pcolor[1] /= 255.0;
+                    pcolor[2] /= 255.0;
+                }
+            }
 
             if (useRaw) {
                 x = (d as any)[0];


### PR DESCRIPTION
Fixed #5999, `point.color` was not respected for boosted series.
___
Demo with the fix applied: https://jsfiddle.net/highcharts/2kn59z8a/