### PR TITLE
bugfix/13095-scrollable-tooltip-show-outside

### DIFF
--- a/js/modules/overlapping-datalabels.src.js
+++ b/js/modules/overlapping-datalabels.src.js
@@ -13,7 +13,7 @@
 'use strict';
 import H from '../parts/Globals.js';
 import U from '../parts/Utilities.js';
-var addEvent = U.addEvent, fireEvent = U.fireEvent, isArray = U.isArray, objectEach = U.objectEach, pick = U.pick;
+var addEvent = U.addEvent, fireEvent = U.fireEvent, isArray = U.isArray, objectEach = U.objectEach, pick = U.pick, isIntersectRect = U.isIntersectRect;
 import '../parts/Chart.js';
 var Chart = H.Chart;
 /* eslint-disable no-invalid-this */
@@ -70,12 +70,7 @@ addEvent(Chart, 'render', function collectAndHide() {
  * @requires modules/overlapping-datalabels
  */
 Chart.prototype.hideOverlappingLabels = function (labels) {
-    var chart = this, len = labels.length, ren = chart.renderer, label, i, j, label1, label2, box1, box2, isLabelAffected = false, isIntersectRect = function (box1, box2) {
-        return !(box2.x > box1.x + box1.width ||
-            box2.x + box2.width < box1.x ||
-            box2.y > box1.y + box1.height ||
-            box2.y + box2.height < box1.y);
-    }, 
+    var chart = this, len = labels.length, ren = chart.renderer, label, i, j, label1, label2, box1, box2, isLabelAffected = false, 
     // Get the box with its position inside the chart, as opposed to getBBox
     // that only reports the position relative to the parent.
     getAbsoluteBox = function (label) {

--- a/js/parts/Point.js
+++ b/js/parts/Point.js
@@ -542,23 +542,27 @@ var Point = /** @class */ (function () {
      */
     Point.prototype.isVisibleInPlot = function () {
         var point = this, shapeArgs = point.shapeArgs, pointHeight = shapeArgs && shapeArgs.height || 0, pointWidth = shapeArgs && shapeArgs.width || 0, series = point.series, chart = series.chart, scrollCont = chart.scrollingContainer || { scrollLeft: 0, scrollTop: 0 };
-        return !series.isCartesian || chart.polar || isIntersectRect(chart.inverted ?
-            {
-                x: series.yAxis.len - pick(point.yBottom, point.plotY + pointHeight, 0),
-                y: series.xAxis.len - (point.plotX || 0) - pointWidth / 2,
-                width: pointHeight,
-                height: pointWidth
-            } : {
-            x: (point.plotX || 0) - pointWidth / 2,
-            y: pick(point.plotHigh, point.plotY, 0),
-            width: pointWidth,
-            height: pointHeight
-        }, {
-            x: scrollCont.scrollLeft,
-            y: scrollCont.scrollTop,
-            width: chart.plotWidth,
-            height: chart.plotHeight - (chart.scrollablePixelsY || 0)
-        });
+        return !series.isCartesian || chart.polar ||
+            // if series is using x or y offset, don't check visibility.
+            series.options.xOffset ||
+            series.options.yOffset ||
+            isIntersectRect(chart.inverted ?
+                {
+                    x: series.yAxis.len - pick(point.yBottom, point.plotY + pointHeight, 0),
+                    y: series.xAxis.len - (point.plotX || 0) - pointWidth / 2,
+                    width: pointHeight,
+                    height: pointWidth
+                } : {
+                x: (point.plotX || 0) - pointWidth / 2,
+                y: pick(point.plotHigh, point.plotY, 0),
+                width: pointWidth,
+                height: pointHeight
+            }, {
+                x: scrollCont.scrollLeft,
+                y: scrollCont.scrollTop,
+                width: chart.plotWidth,
+                height: chart.plotHeight - (chart.scrollablePixelsY || 0)
+            });
     };
     /**
      * Return the configuration hash needed for the data label and tooltip

--- a/js/parts/Point.js
+++ b/js/parts/Point.js
@@ -157,7 +157,7 @@ import Highcharts from './Globals.js';
 */
 ''; // detach doclet above
 import U from './Utilities.js';
-var animObject = U.animObject, defined = U.defined, erase = U.erase, extend = U.extend, fireEvent = U.fireEvent, format = U.format, getNestedProperty = U.getNestedProperty, isArray = U.isArray, isNumber = U.isNumber, isObject = U.isObject, syncTimeout = U.syncTimeout, pick = U.pick, removeEvent = U.removeEvent, uniqueKey = U.uniqueKey;
+var animObject = U.animObject, defined = U.defined, erase = U.erase, extend = U.extend, fireEvent = U.fireEvent, format = U.format, getNestedProperty = U.getNestedProperty, isArray = U.isArray, isNumber = U.isNumber, isObject = U.isObject, syncTimeout = U.syncTimeout, pick = U.pick, removeEvent = U.removeEvent, uniqueKey = U.uniqueKey, isIntersectRect = U.isIntersectRect;
 var H = Highcharts;
 /* eslint-disable no-invalid-this, valid-jsdoc */
 /**
@@ -532,6 +532,33 @@ var Point = /** @class */ (function () {
             }
         });
         return graphicalProps;
+    };
+    /**
+     * Check if point is visible inside plotArea
+     *
+     * @private
+     * @function Highcharts.Point#isVisibleInPlot
+     * @return {boolean} return if the point is visible inside plotArea
+     */
+    Point.prototype.isVisibleInPlot = function () {
+        var point = this, shapeArgs = point.shapeArgs, pointHeight = shapeArgs && shapeArgs.height || 0, pointWidth = shapeArgs && shapeArgs.width || 0, series = point.series, chart = series.chart, scrollCont = chart.scrollingContainer || { scrollLeft: 0, scrollTop: 0 };
+        return !series.isCartesian || chart.polar || isIntersectRect(chart.inverted ?
+            {
+                x: series.yAxis.len - pick(point.yBottom, point.plotY + pointHeight, 0),
+                y: series.xAxis.len - (point.plotX || 0) - pointWidth / 2,
+                width: pointHeight,
+                height: pointWidth
+            } : {
+            x: (point.plotX || 0) - pointWidth / 2,
+            y: pick(point.plotHigh, point.plotY, 0),
+            width: pointWidth,
+            height: pointHeight
+        }, {
+            x: scrollCont.scrollLeft,
+            y: scrollCont.scrollTop,
+            width: chart.plotWidth,
+            height: chart.plotHeight - (chart.scrollablePixelsY || 0)
+        });
     };
     /**
      * Return the configuration hash needed for the data label and tooltip

--- a/js/parts/Point.js
+++ b/js/parts/Point.js
@@ -546,6 +546,7 @@ var Point = /** @class */ (function () {
             // if series is using x or y offset, don't check visibility.
             series.options.xOffset ||
             series.options.yOffset ||
+            !series.options.cropTooltip ||
             isIntersectRect(chart.inverted ?
                 {
                     x: series.yAxis.len - pick(point.yBottom, point.plotY + pointHeight, 0),

--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -1259,6 +1259,7 @@ var Pointer = /** @class */ (function () {
         // Refresh tooltip for kdpoint if new hover point or tooltip was hidden
         // #3926, #4200
         if (hoverPoint &&
+            hoverPoint.isVisibleInPlot() && // only refresh tooltip for points inside plotArea
             // !(hoverSeries && hoverSeries.directTouch) &&
             (hoverPoint !== chart.hoverPoint || (tooltip && tooltip.isHidden))) {
             (chart.hoverPoints || []).forEach(function (p) {

--- a/js/parts/Utilities.js
+++ b/js/parts/Utilities.js
@@ -841,6 +841,20 @@ function clamp(value, min, max) {
     return value > min ? value < max ? value : max : min;
 }
 /**
+ * Utility function checking if two rectangles are overlapping
+ *
+ * @private
+ * @param {Highcharts.BBoxObject} box1 BBox of the first rectangle
+ * @param {Highcharts.BBoxObject} box2 BBox of the second rectangle
+ * @return {number} Returns a boolean value if two rectangles intersect.
+*/
+function isIntersectRect(box1, box2) {
+    return !(box2.x > box1.x + box1.width ||
+        box2.x + box2.width < box1.x ||
+        box2.y > box1.y + box1.height ||
+        box2.y + box2.height < box1.y);
+}
+/**
  * Shortcut for parseInt
  *
  * @private
@@ -2524,6 +2538,7 @@ var utilitiesModule = {
     arrayMin: arrayMin,
     attr: attr,
     clamp: clamp,
+    isIntersectRect: isIntersectRect,
     clearTimeout: internalClearTimeout,
     correctFloat: correctFloat,
     createElement: createElement,

--- a/ts/modules/overlapping-datalabels.src.ts
+++ b/ts/modules/overlapping-datalabels.src.ts
@@ -20,7 +20,8 @@ const {
     fireEvent,
     isArray,
     objectEach,
-    pick
+    pick,
+    isIntersectRect
 } = U;
 
 import '../parts/Chart.js';
@@ -125,17 +126,6 @@ Chart.prototype.hideOverlappingLabels = function (
         box1,
         box2,
         isLabelAffected = false,
-        isIntersectRect = function (
-            box1: Highcharts.BBoxObject,
-            box2: Highcharts.BBoxObject
-        ): boolean {
-            return !(
-                box2.x > box1.x + box1.width ||
-                box2.x + box2.width < box1.x ||
-                box2.y > box1.y + box1.height ||
-                box2.y + box2.height < box1.y
-            );
-        },
 
         // Get the box with its position inside the chart, as opposed to getBBox
         // that only reports the position relative to the parent.

--- a/ts/parts/Point.ts
+++ b/ts/parts/Point.ts
@@ -187,6 +187,7 @@ declare global {
             data?: Array<PointOptionsType>;
             marker?: PointMarkerOptionsObject;
             point?: PlotSeriesPointOptions;
+            cropTooltip?: boolean;
         }
         interface SeriesPointOptions {
             events?: PointEventsOptionsObject;
@@ -888,6 +889,7 @@ class Point {
             // if series is using x or y offset, don't check visibility.
             (series.options as any).xOffset ||
             (series.options as any).yOffset ||
+            !series.options.cropTooltip ||
             isIntersectRect(
                 chart.inverted ?
                     {

--- a/ts/parts/Point.ts
+++ b/ts/parts/Point.ts
@@ -884,25 +884,29 @@ class Point {
             chart = series.chart,
             scrollCont = chart.scrollingContainer || { scrollLeft: 0, scrollTop: 0 };
 
-        return !series.isCartesian || chart.polar || isIntersectRect(
-            chart.inverted ?
-                {
-                    x: series.yAxis.len - pick(point.yBottom, point.plotY + pointHeight, 0),
-                    y: series.xAxis.len - (point.plotX || 0) - pointWidth / 2,
-                    width: pointHeight,
-                    height: pointWidth
-                } : {
-                    x: (point.plotX || 0) - pointWidth / 2,
-                    y: pick(point.plotHigh, point.plotY, 0),
-                    width: pointWidth,
-                    height: pointHeight
-                },
-            { // plotArea Box
-                x: scrollCont.scrollLeft,
-                y: scrollCont.scrollTop,
-                width: chart.plotWidth,
-                height: chart.plotHeight - (chart.scrollablePixelsY || 0)
-            });
+        return !series.isCartesian || chart.polar ||
+            // if series is using x or y offset, don't check visibility.
+            (series.options as any).xOffset ||
+            (series.options as any).yOffset ||
+            isIntersectRect(
+                chart.inverted ?
+                    {
+                        x: series.yAxis.len - pick(point.yBottom, point.plotY + pointHeight, 0),
+                        y: series.xAxis.len - (point.plotX || 0) - pointWidth / 2,
+                        width: pointHeight,
+                        height: pointWidth
+                    } : {
+                        x: (point.plotX || 0) - pointWidth / 2,
+                        y: pick(point.plotHigh, point.plotY, 0),
+                        width: pointWidth,
+                        height: pointHeight
+                    },
+                { // plotArea Box
+                    x: scrollCont.scrollLeft,
+                    y: scrollCont.scrollTop,
+                    width: chart.plotWidth,
+                    height: chart.plotHeight - (chart.scrollablePixelsY || 0)
+                });
     }
 
     /**

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -1947,6 +1947,7 @@ class Pointer {
         // #3926, #4200
         if (
             hoverPoint &&
+            hoverPoint.isVisibleInPlot() && // only refresh tooltip for points inside plotArea
             // !(hoverSeries && hoverSeries.directTouch) &&
             (hoverPoint !== chart.hoverPoint || (tooltip && tooltip.isHidden))
         ) {

--- a/ts/parts/Utilities.ts
+++ b/ts/parts/Utilities.ts
@@ -1383,6 +1383,26 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 /**
+ * Utility function checking if two rectangles are overlapping
+ *
+ * @private
+ * @param {Highcharts.BBoxObject} box1 BBox of the first rectangle
+ * @param {Highcharts.BBoxObject} box2 BBox of the second rectangle
+ * @return {number} Returns a boolean value if two rectangles intersect.
+*/
+function isIntersectRect(
+    box1: Highcharts.BBoxObject,
+    box2: Highcharts.BBoxObject
+): boolean {
+    return !(
+        box2.x > box1.x + box1.width ||
+        box2.x + box2.width < box1.x ||
+        box2.y > box1.y + box1.height ||
+        box2.y + box2.height < box1.y
+    );
+}
+
+/**
  * Shortcut for parseInt
  *
  * @private
@@ -3449,6 +3469,7 @@ const utilitiesModule = {
     arrayMin,
     attr,
     clamp,
+    isIntersectRect,
     clearTimeout: internalClearTimeout,
     correctFloat,
     createElement,


### PR DESCRIPTION
Fixed #13095, tooltip was showing outside `plotArea` for scrollable graphs.