### PR TITLE
Docs: updated product names

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -15,15 +15,15 @@ Demo
 For live examples see our demo pages:
 
 *   [Highcharts demo](https://highcharts.com/demo/)
-*   [Highstock demo](https://highcharts.com/stock/demo/)
+*   [Highcharts Stock demo](https://highcharts.com/stock/demo/)
 *   [Highmaps demo](https://highcharts.com/maps/demo/)
 
 API
 ---
 
-For more specific information on Highcharts and Highstock options and functions, visit our API sites which also include several live and customizeable examples.
+For more specific information on Highcharts and Highcharts Stock options and functions, visit our API sites which also include several live and customizeable examples.
 
 *   [Highcharts API reference](https://api.highcharts.com/highcharts)
-*   [Highstock API reference](https://api.highcharts.com/highstock)
+*   [Highcharts Stock API reference](https://api.highcharts.com/highstock)
 *   [Highmaps API reference](https://api.highcharts.com/highmaps)
 

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -22,7 +22,7 @@ For live examples see our demo pages:
 API
 ---
 
-For more specific information on Highcharts and Highcharts Stock options and functions, visit our API sites which also include several live and customizeable examples.
+For more specific information on Highcharts options and functions, visit our API sites which also include several live and customizeable examples.
 
 *   [Highcharts API reference](https://api.highcharts.com/highcharts)
 *   [Highcharts Stock API reference](https://api.highcharts.com/highstock)

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -17,6 +17,7 @@ For live examples see our demo pages:
 *   [Highcharts demo](https://highcharts.com/demo/)
 *   [Highcharts Stock demo](https://highcharts.com/stock/demo/)
 *   [Highcharts Maps demo](https://highcharts.com/maps/demo/)
+*   [Highcharts Gantt demo](https://highcharts.com/gantt/demo/)
 
 API
 ---
@@ -26,4 +27,5 @@ For more specific information on Highcharts and Highcharts Stock options and fun
 *   [Highcharts API reference](https://api.highcharts.com/highcharts)
 *   [Highcharts Stock API reference](https://api.highcharts.com/highstock)
 *   [Highcharts Maps API reference](https://api.highcharts.com/highmaps)
+*   [Highcharts Gantt API reference](https://api.highcharts.com/gantt)
 

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -16,7 +16,7 @@ For live examples see our demo pages:
 
 *   [Highcharts demo](https://highcharts.com/demo/)
 *   [Highcharts Stock demo](https://highcharts.com/stock/demo/)
-*   [Highmaps demo](https://highcharts.com/maps/demo/)
+*   [Highcharts Maps demo](https://highcharts.com/maps/demo/)
 
 API
 ---
@@ -25,5 +25,5 @@ For more specific information on Highcharts and Highcharts Stock options and fun
 
 *   [Highcharts API reference](https://api.highcharts.com/highcharts)
 *   [Highcharts Stock API reference](https://api.highcharts.com/highstock)
-*   [Highmaps API reference](https://api.highcharts.com/highmaps)
+*   [Highcharts Maps API reference](https://api.highcharts.com/highmaps)
 

--- a/docs/advanced-chart-features/axis-resizer.md
+++ b/docs/advanced-chart-features/axis-resizer.md
@@ -1,7 +1,7 @@
 Axis resizer
 ===
 
-The Resizer module allows the end-user to define which axes can be resized in a multiple-pane Highstock layout. The module allows controlling multiple axes within one config. This feature is very useful, especially when combining multiple technical indicators, where each of them requires a separate axis.
+The Resizer module allows the end-user to define which axes can be resized in a multiple-pane Highcharts Stock layout. The module allows controlling multiple axes within one config. This feature is very useful, especially when combining multiple technical indicators, where each of them requires a separate axis.
 
 Basic configuration:
 

--- a/docs/advanced-chart-features/boost-module.md
+++ b/docs/advanced-chart-features/boost-module.md
@@ -1,7 +1,7 @@
 Boost module
 ===
 
-Boost is a stripped-down renderer-in-a-module for Highcharts and Highcharts Stock. It bypasses some of the standard Highcharts features (such as animation), and focuses on pushing as many points as possible as quickly as possible.
+Boost is a stripped-down renderer-in-a-module for Highcharts. It bypasses some of the standard Highcharts features (such as animation), and focuses on pushing as many points as possible as quickly as possible.
 
 This document will guide you through your first steps with the Highcharts boost module.
 

--- a/docs/advanced-chart-features/boost-module.md
+++ b/docs/advanced-chart-features/boost-module.md
@@ -1,7 +1,7 @@
 Boost module
 ===
 
-Boost is a stripped-down renderer-in-a-module for Highcharts and Highstock. It bypasses some of the standard Highcharts features (such as animation), and focuses on pushing as many points as possible as quickly as possible.
+Boost is a stripped-down renderer-in-a-module for Highcharts and Highcharts Stock. It bypasses some of the standard Highcharts features (such as animation), and focuses on pushing as many points as possible as quickly as possible.
 
 This document will guide you through your first steps with the Highcharts boost module.
 

--- a/docs/advanced-chart-features/highcharts-typescript-declarations.md
+++ b/docs/advanced-chart-features/highcharts-typescript-declarations.md
@@ -66,7 +66,7 @@ require.config({
 })
 ```
 
-For Highstock and other additions it is recommended to use the previous
+For Highcharts Stock and other additions it is recommended to use the previous
 configuration and load the module (`highcharts/modules/stock`) instead. For the
 package you have to change the configuration in the following way:
 

--- a/docs/chart-and-series-types/chart-types.md
+++ b/docs/chart-and-series-types/chart-types.md
@@ -44,7 +44,7 @@ For more information on each chart type, see:
 *   [Treemap](https://highcharts.com/docs/chart-and-series-types/treemap)
 *   [Waterfall series](https://highcharts.com/docs/chart-and-series-types/waterfall-series)
 
-Highstock specific charts are:
+Highcharts Stock specific charts are:
 
 *   [Candlestick chart](https://highcharts.com/docs/chart-and-series-types/candlestick-chart)
 *   [OHLC chart](https://highcharts.com/docs/chart-and-series-types/ohlc-chart)

--- a/docs/chart-and-series-types/heatmap.md
+++ b/docs/chart-and-series-types/heatmap.md
@@ -13,10 +13,10 @@ The heat map series is defined by setting the type to `heatmap`. A heat map has 
 
 ### The color axis
 
-Heat maps borrow a central concept from Highmaps, the color axis. See the docs article on [color axis](https://highcharts.com/docs/maps/color-axis/) for details
+Heat maps borrow a central concept from Highcharts Maps, the color axis. See the docs article on [color axis](https://highcharts.com/docs/maps/color-axis/) for details
 
 ### Resources
 
 See the featured demos at [Heat map](https://highcharts.com/demo/heatmap/) and [Large heatmap](https://highcharts.com/demo/heatmap-canvas/). The latter demonstrates how a HTML5 canvas can be plugged in to optimize rendering times.
 
-See [heatmap](https://api.highcharts.com/highmaps/plotOptions.heatmap) in the Highmaps docs.
+See [heatmap](https://api.highcharts.com/highmaps/plotOptions.heatmap) in the Highcharts Maps docs.

--- a/docs/chart-and-series-types/tilemap-series.md
+++ b/docs/chart-and-series-types/tilemap-series.md
@@ -1,7 +1,7 @@
 Tilemaps
 ===
 
-Tilemaps are maps where each area is represented by tiles of equal shape. Highmaps supports four different tilemap types: Circlemap, Diamondmap, Honeycomb, and Squaremap, each with a different tile shape.
+Tilemaps are maps where each area is represented by tiles of equal shape. Highcharts Maps supports four different tilemap types: Circlemap, Diamondmap, Honeycomb, and Squaremap, each with a different tile shape.
 
 _For more detailed samples and documentation check the [API.](https://api.highcharts.com/highcharts/plotOptions.tilemap)_
 
@@ -40,7 +40,7 @@ Square tilemaps are just Heatmap series with slightly different default values. 
 How to create a tilemap
 -----------------------
 
-Tilemaps require the following module [modules/tilemap.js](https://code.highcharts.com/maps/modules/tilemap.js) with Highmaps only. Add also this module [modules/heatmap.js](https://code.highcharts.com/modules/heatmap.js) in case of using Highcharts.
+Tilemaps require the following module [modules/tilemap.js](https://code.highcharts.com/maps/modules/tilemap.js) with Highcharts Maps only. Add also this module [modules/heatmap.js](https://code.highcharts.com/modules/heatmap.js) in case of using Highcharts.
 
 Use the [series.tileShape](https://api.highcharts.com/highmaps/series.tilemap.tileShape) option to switch between the different tile shapes. Currently, four shapes are supported “circle”, “diamond”, “hexagon”and “square”. The default shape is “hexagon”.
 

--- a/docs/chart-concepts/axes.md
+++ b/docs/chart-concepts/axes.md
@@ -177,7 +177,7 @@ Some useful functions are:
 
 Note that Unix based server timestamps are represented as seconds not milliseconds. This is useful to know since PHP time is based on a Unix timestamp, so to use it with Highcharts the value only needs to be multiplied by 1000.
 
-In Highstock the x-axis is always a datetime axis.
+In Highcharts Stock the x-axis is always a datetime axis.
 
 ### Categories
 

--- a/docs/chart-concepts/scrollbar.md
+++ b/docs/chart-concepts/scrollbar.md
@@ -13,9 +13,9 @@ These scrollbars are applied by setting a [scrollablePlotArea with a minWidth](h
 2. Axis scrollbars through an API option
 -----------------------------------------
 
-These scrollbars are enabled per axis and appear next to the axis. Scrollbars can be applied to any axis in Highstock.
+These scrollbars are enabled per axis and appear next to the axis. Scrollbars can be applied to any axis in Highcharts Stock.
 
-The full documentation and available options can be seen in our [API docs](https://api.highcharts.com/highstock#yAxis.scrollbar) for Highstock.
+The full documentation and available options can be seen in our [API docs](https://api.highcharts.com/highstock#yAxis.scrollbar) for Highcharts Stock.
 
 Scrollbars are not limited to stock charts or Y axis. Using the _highstock.js_ file, it can be applied to regular Highcharts axes too. See examples of:
 

--- a/docs/chart-concepts/series.md
+++ b/docs/chart-concepts/series.md
@@ -37,7 +37,7 @@ data: [[5, 2], [6, 3], [8, 2]]
 
 [Online example](https://jsfiddle.net/gh/get/jquery/1.7.1/highslide-software/highcharts.com/tree/master/samples/highcharts/series/data-array-of-arrays/)
 
-3.  A list of object with named values. In this case the objects are point configuration objects as seen under options.point. The full list of available properties can be seen from the API, for [example for line series](https://api.highcharts.com/highcharts/series.line.data). Note that for this option to work in Highstock, the total number of points must not exceed the [turboThreshold](https://api.highcharts.com/highstock/series.line.turboThreshold), or the _turboThreshold_ setting must be increased. Example:
+3.  A list of object with named values. In this case the objects are point configuration objects as seen under options.point. The full list of available properties can be seen from the API, for [example for line series](https://api.highcharts.com/highcharts/series.line.data). Note that for this option to work in Highcharts Stock, the total number of points must not exceed the [turboThreshold](https://api.highcharts.com/highstock/series.line.turboThreshold), or the _turboThreshold_ setting must be increased. Example:
 
 ```js   
 data: [{

--- a/docs/chart-concepts/tooltip.md
+++ b/docs/chart-concepts/tooltip.md
@@ -44,7 +44,7 @@ tooltip: {
 Crosshairs
 ----------
 
-Crosshairs display a line connecting the points with their corresponding axis. Crosshairs are disabled by default in Highcharts, but enabled by default in Highstock. See the full set of options for [crosshairs](https://api.highcharts.com/highcharts/tooltip.crosshairs).
+Crosshairs display a line connecting the points with their corresponding axis. Crosshairs are disabled by default in Highcharts, but enabled by default in Highcharts Stock. See the full set of options for [crosshairs](https://api.highcharts.com/highcharts/tooltip.crosshairs).
 
 ![crosshairs.png](crosshairs.png)
 

--- a/docs/chart-concepts/zooming.md
+++ b/docs/chart-concepts/zooming.md
@@ -28,9 +28,9 @@ and
 [endOnTick](https://api.highcharts.com/highcharts/yAxis.endOnTick)
 are set to `false`.
 
-### Highstock
+### Highcharts Stock
 
-In Highstock, we also have the Navigator, Range Selector, and Scrollbar to ease
+In Highcharts Stock, we also have the Navigator, Range Selector, and Scrollbar to ease
 navigation, so zooming is disabled by default. Instead, panning is enabled so
 that moving the zoomed area is easier. 
 

--- a/docs/chart-design-and-style/style-by-css.md
+++ b/docs/chart-design-and-style/style-by-css.md
@@ -67,7 +67,7 @@ The various graphic items for box plot series. The box, median, stem and whisker
     
     .highcharts-button
 
-Used for the wrapping group of the exporting button, range selector buttons in Highstock etc.
+Used for the wrapping group of the exporting button, range selector buttons in Highcharts Stock etc.
 
     
     .highcharts-button-symbol
@@ -80,7 +80,7 @@ The symbol for the exporting button, can be used to set stroke and fill etc. 
     .highcharts-candlestick-series .highcharts-point-up  
     .highcharts-candlestick-series .highcharts-point-down
 
-Rules to differentiate between up or down points in Highstock candlesticks.
+Rules to differentiate between up or down points in Highcharts Stock candlesticks.
 
 [View live demo](https://jsfiddle.net/gh/get/jquery/1.7.2/highcharts/highcharts/tree/master/samples/highcharts/css/candlestick/).
 
@@ -115,7 +115,7 @@ Styles for the crosshair extending from the axis to the currently highlighted po
     
     .highcharts-crosshair-label
 
-The label next to the crosshair in Highstock. 
+The label next to the crosshair in Highcharts Stock. 
 
 [View live demo](https://jsfiddle.net/gh/get/jquery/1.7.2/highcharts/highcharts/tree/master/samples/highcharts/css/crosshair-label/).
 
@@ -239,7 +239,7 @@ Replaces [axis.minorGridLineColor](https://api.highcharts.com/highcharts/xAxis.
     .highcharts-navigator-handle-left  
     .highcharts-navigator-handle-left
 
-Fills and strokes for the navigator handles in Highstock. Replaces [navigator.handles.backgroundColor](https://api.highcharts.com/highstock#navigator.handles.backgroundColor) and [navigator.handles.borderColor](https://api.highcharts.com/highstock#navigator.handles.borderColor).
+Fills and strokes for the navigator handles in Highcharts Stock. Replaces [navigator.handles.backgroundColor](https://api.highcharts.com/highstock#navigator.handles.backgroundColor) and [navigator.handles.borderColor](https://api.highcharts.com/highstock#navigator.handles.borderColor).
 
 [View live demo](https://jsfiddle.net/gh/get/jquery/1.7.2/highcharts/highcharts/tree/master/samples/highcharts/css/stock-navigator/).
 
@@ -247,21 +247,21 @@ Fills and strokes for the navigator handles in Highstock. Replaces [navigator.h
     .highcharts-navigator-mask-outside  
     .highcharts-navigator-mask-inside
 
-Styles for the navigator mask in Highstock, the shaded element that shows the selected area. Replaces [navigator.maskFill](https://api.highcharts.com/highstock#navigator.maskFill).
+Styles for the navigator mask in Highcharts Stock, the shaded element that shows the selected area. Replaces [navigator.maskFill](https://api.highcharts.com/highstock#navigator.maskFill).
 
 [View live demo](https://jsfiddle.net/gh/get/jquery/1.7.2/highcharts/highcharts/tree/master/samples/highcharts/css/stock-navigator/).
 
     
     .highcharts-navigator-outline
 
-Styles for the Highstock navigator outline, a path element that highlights the zoomed area. Replaces [navigator.outlineColor](https://api.highcharts.com/highstock#navigator.outlineColor) and [navigator.outlineWidth](https://api.highcharts.com/highstock#navigator.outlineWidth).
+Styles for the Highcharts Stock navigator outline, a path element that highlights the zoomed area. Replaces [navigator.outlineColor](https://api.highcharts.com/highstock#navigator.outlineColor) and [navigator.outlineWidth](https://api.highcharts.com/highstock#navigator.outlineWidth).
 
 [View live demo](https://jsfiddle.net/gh/get/jquery/1.7.2/highcharts/highcharts/tree/master/samples/highcharts/css/stock-navigator/).
 
     
     .highcharts-navigator-series
 
-Styles for the navigator series in Highstock. Replaces options like lineWidth, fillOpacity and color for the navigator series.
+Styles for the navigator series in Highcharts Stock. Replaces options like lineWidth, fillOpacity and color for the navigator series.
 
     
     .highcharts-negative
@@ -284,7 +284,7 @@ Styles for null points in maps or heat maps. Replaces [plotOptions.map.nullColo
     .highcharts-ohlc-series .highcharts-point-up  
     .highcharts-ohlc-series .highcharts-point-down
 
-Rules to differentiate between up or down points in Highstock OHLC series.
+Rules to differentiate between up or down points in Highcharts Stock OHLC series.
 
 [View live demo](https://jsfiddle.net/gh/get/jquery/1.7.2/highcharts/highcharts/tree/master/samples/highcharts/css/ohlc/).
 
@@ -358,21 +358,21 @@ Style the plot line labels. Use the _className_ option on each line to disting
     
     .highcharts-range-input text
 
-Text styling for the range selector input boxes in Highstock. Use _input.highcharts-range-selector_ for the HTML input (when the boxes are active). Replaces [rangeSelector.inputStyle](https://api.highcharts.com/highstock#rangeSelector.inputStyle).
+Text styling for the range selector input boxes in Highcharts Stock. Use _input.highcharts-range-selector_ for the HTML input (when the boxes are active). Replaces [rangeSelector.inputStyle](https://api.highcharts.com/highstock#rangeSelector.inputStyle).
 
 [View live demo](https://jsfiddle.net/gh/get/jquery/1.7.2/highcharts/highcharts/tree/master/samples/highcharts/css/stock-navigator/).
 
     
     .highcharts-range-label
 
-Styles for the Highstock range selector labels saying "Zoom", "From" and "To". Replaces [rangeSelector.labelStyle](https://api.highcharts.com/highstock#rangeSelector.labelStyle).
+Styles for the Highcharts Stock range selector labels saying "Zoom", "From" and "To". Replaces [rangeSelector.labelStyle](https://api.highcharts.com/highstock#rangeSelector.labelStyle).
 
 [View live demo](https://jsfiddle.net/gh/get/jquery/1.7.2/highcharts/highcharts/tree/master/samples/highcharts/css/stock-navigator/).
 
     
     .highcharts-range-selector-buttons
 
-Top level group for the Highstock range selector buttons. Replaces [rangeSelector.buttonTheme](https://api.highcharts.com/highstock#rangeSelector.buttonTheme).
+Top level group for the Highcharts Stock range selector buttons. Replaces [rangeSelector.buttonTheme](https://api.highcharts.com/highstock#rangeSelector.buttonTheme).
 
 [View live demo](https://jsfiddle.net/gh/get/jquery/1.7.2/highcharts/highcharts/tree/master/samples/highcharts/css/stock-navigator/).
 
@@ -391,7 +391,7 @@ Matches the root _svg_ element of the chart. Use this to set styles that shoul
     .highcharts-scrollbar-thumb  
     .highcharts-scrollbar-track
 
-Styles for the Highstock scrollbar. The thumb is the actual bar. The buttons are in each end, and each has an arrow inside it. The rifles are the small strokes on the center of the bar.
+Styles for the Highcharts Stock scrollbar. The thumb is the actual bar. The buttons are in each end, and each has an arrow inside it. The rifles are the small strokes on the center of the bar.
 
 [View live demo](https://jsfiddle.net/gh/get/jquery/1.7.2/highcharts/highcharts/tree/master/samples/highcharts/css/chart/).
 

--- a/docs/export-module/export-module-overview.md
+++ b/docs/export-module/export-module-overview.md
@@ -23,7 +23,7 @@ To unleash the full power of HTML5, it is also possible to fully [disregard](htt
 
 ### Controling the size of the exported image
 
-Since Highcharts 3.0 and Highstock 1.3, the size of the exported image is computed based on a few rules:
+Since Highcharts 3.0 and Highcharts Stock 1.3, the size of the exported image is computed based on a few rules:
 
 *   If the [exporting.sourceWidth](https://api.highcharts.com/highcharts/exporting.sourceWidth) and [exporting.sourceHeight](https://api.highcharts.com/highcharts/exporting.sourceHeight) options are set, they take predence. This provides a convenient way of having separate sizes of the on-screen chart and the exported one.
 *   If not, and the [chart.width](https://api.highcharts.com/highcharts/chart.width) and [chart.height](https://api.highcharts.com/highcharts/chart.height) options are set, those are used for the exported chart.
@@ -47,7 +47,7 @@ Normally Highcharts sends data to the export server for saving a graph as an im
 |filename|The name of the exported file. Defaults to 'Chart'.|
 |scale|To scale the original SVG. For example, if the chart.width option in the chart configuration is set to 600 and the scale is set to 2, the output raster image will have a pixel width of 1200. So this is a convenient way of increasing the resolution without decreasing the font size and line widths in the chart. This is ignored if the -width parameter is set. For now we allow a maximum scaling of 4. This is for ensuring a good repsonse time. Scaling is a bit resource intensive.|
 |width|Set the exact pixel width of the exported image or pdf. This overrides the -scale parameter. The maximum allowed width is 2000px|
-|constr|The constructor name. Can be one of 'Chart' or 'StockChart'. This depends on whether you want to generate Highstock or basic Highcharts. Only applicable when using this in combination with the options parameter.|
+|constr|The constructor name. Can be one of 'Chart' or 'StockChart'. This depends on whether you want to generate Highcharts Stock or basic Highcharts. Only applicable when using this in combination with the options parameter.|
 |callback|String containing a callback JavaScript. The callback is a function which will be called in the constructor of Highcharts to be executed on chart load. All code of the callback must be enclosed by a function. Only applicable when using this in combination with theoptions parameter. Example of contents of the callback file:`function(chart) { chart.renderer.arc(200, 150, 100, 50, -Math.PI, 0).attr({ fill : '#FCFFC5', stroke : 'black', 'stroke-width' : 1 }).add(); }`|
 |resources|Stringified JSON which can contain three properties js and css. Example: `{"css": "g.highcharts-series path {stroke-width:2;stroke: pink}", "js": "document.body.style.webkitTransform = \"rotate(-10deg)\";" }`css: css inserted in the body of the page, js: javascript inserted in the body of the page|
 |async|Can be of true or false. Default is false. When setting async to true a download link is returned to the client, instead of an image. This download link can be reused for 30 seconds. After that, the file will be deleted from the server.|

--- a/docs/export-module/render-charts-serverside.md
+++ b/docs/export-module/render-charts-serverside.md
@@ -60,7 +60,7 @@ Set the exact pixel width of the exported image or pdf. This overrides the -scal
 
 \-constr
 
-The constructor name. Can be one of Chart or StockChart. This depends on whether you want to generate Highstock or basic Highcharts.
+The constructor name. Can be one of Chart or StockChart. This depends on whether you want to generate Highcharts Stock or basic Highcharts.
 
 \-callback
 

--- a/docs/extending-highcharts/extending-highcharts.md
+++ b/docs/extending-highcharts/extending-highcharts.md
@@ -76,7 +76,7 @@ H.wrap(H.Series.prototype, 'drawGraph', function (proceed) {
 Example extension
 -----------------
 
-In this example the client wanted to use markers ("trackballs") on column type series in Highstock. Markers is currently only supported in line type series. To get this functionality, a small plugin can be written.
+In this example the client wanted to use markers ("trackballs") on column type series in Highcharts Stock. Markers is currently only supported in line type series. To get this functionality, a small plugin can be written.
 
 This plugin will add a trackball to each series in the chart, that does not already support and contain a marker.
 

--- a/docs/gantt/getting-started-gantt.md
+++ b/docs/gantt/getting-started-gantt.md
@@ -15,7 +15,7 @@ _Example of loading Highcharts Gantt into a webpage_
     
     <script src="https://code.highcharts.com/gantt/highcharts-gantt.js"></script> 
 
-Load Highcharts Gantt as a module when a project needs both Highcharts and Gantt loaded at the same time. Place the script tag or import statement after loading the main library, Highcharts or Highstock.
+Load Highcharts Gantt as a module when a project needs both Highcharts and Gantt loaded at the same time. Place the script tag or import statement after loading the main library, Highcharts or Highcharts Stock.
 
 _Example of loading both libraries in a webpage_
 

--- a/docs/getting-started/compatibility.md
+++ b/docs/getting-started/compatibility.md
@@ -55,7 +55,7 @@ Android 2.x
 
 Android 2.x doesn't have SVG support built in, so we have created a separate renderer based on the canvg library for this system. This solution has some limitations:
 
-*   Using Highstock on Android 2.x is not recommended as it relies heavily on zooming and mouse interaction
+*   Using Highcharts Stock on Android 2.x is not recommended as it relies heavily on zooming and mouse interaction
 *   Shared tooltip is always enabled.
 *   During first render, the canvg renderer + rgbcolor.js + canvg.js (concatenated to one file) will be downloaded from code.highcharts.com This is configurable with the `global.canvasToolsURL` option.
 *   Chart and series animation is turned off.

--- a/docs/getting-started/frequently-asked-questions.md
+++ b/docs/getting-started/frequently-asked-questions.md
@@ -4,7 +4,7 @@ Frequently asked questions
 *   [Does Highcharts refer to files outside our domain?](#does-highcharts-refer-to-files-outside-our-domain)
 *   [My charts are not showing in Internet Explorer 7 or 8](#my-charts-are-not-showing-in-internet-explorer-7-or-8)
 *   [Can I use Highcharts with a ... server?](#can-i-use-highcharts-with-a-server)
-*   [Can I use features from Highstock in Highcharts?](#can-i-use-features-from-highstock-in-highcharts)
+*   [Can I use features from Highcharts Stock in Highcharts?](#can-i-use-features-from-highstock-in-highcharts)
 *   [Can I add a data table to the exported chart?](#can-i-add-a-data-table-to-the-exported-chart)
 *   [How can I get the best performance out of Highcharts?](#how-can-i-get-the-best-performance-out-of-highcharts)
 *   [Can I export multiple charts to the same image or PDF?](#can-i-export-multiple-charts-to-the-same-image-or-pdf)
@@ -67,10 +67,10 @@ Before you start to set up a complex backend, you may want to check out [highcha
 
 * * *
 
-Can I use features from Highstock in Highcharts?
+Can I use features from Highcharts Stock in Highcharts?
 ------------------------------------------------
 
-Yes, most Highstock features can be applied to standard charts. From a licensing point of view, using features of the Stock package obviously requires a Highstock license.
+Yes, most Highcharts Stock features can be applied to standard charts. From a licensing point of view, using features of the Stock package obviously requires a Highcharts Stock license.
 
 Technically Highcharts Stock is implemented as a set of plugins for Highcharts. The entire code base for Highcharts is included in the Stock package, and you can invoke a chart using `Highcharts.Chart` and enable certain features that are normally associated with a stock chart.
 

--- a/docs/getting-started/how-to-set-options.md
+++ b/docs/getting-started/how-to-set-options.md
@@ -153,4 +153,4 @@ var chart2 = new Highcharts.Chart({
 
 Note: The themes supplied with Highcharts download use this function. See [Themes](https://highcharts.com/docs/chart-design-and-style/themes) for more information.
 
-For a full reference of the options available, see the [Highcharts options reference](https://api.highcharts.com/highcharts) or the [Highstock options reference](https://api.highcharts.com/highstock).
+For a full reference of the options available, see the [Highcharts options reference](https://api.highcharts.com/highcharts) or the [Highcharts Stock options reference](https://api.highcharts.com/highstock).

--- a/docs/getting-started/install-from-bower.md
+++ b/docs/getting-started/install-from-bower.md
@@ -3,7 +3,7 @@ Installing with Bower
 
 Bower is no longer the dependency manager of choice for front-end projects. While the open source project is still maintained, its creators decided to deprecate it, and advise how to migrate to other solutions—namely Yarn and webpack.
 
-The Bower package contains Highcharts, Highstock and Highmaps. Start by loading Highcharts from Bower:
+The Bower package contains Highcharts, Highcharts Stock and Highmaps. Start by loading Highcharts from Bower:
 
 `bower install highcharts`
 
@@ -28,10 +28,10 @@ To load additional functionality onto Highcharts, include the modules:
 <script src="./bower_components/highcharts/modules/exporting.js"></script>
 ```
 
-Load Highstock or Highmaps
+Load Highcharts Stock or Highmaps
 --------------------------
 
-Highcharts is already included in Highstock, so it not necessary to load both. The highstock.js file is included in the package. The highmaps.js file is also included, but unlike highstock.js, this doesn't include the complete Highcharts feature set. To load the full suite in one page, load Highmaps as a module.
+Highcharts is already included in Highcharts Stock, so it not necessary to load both. The highstock.js file is included in the package. The highmaps.js file is also included, but unlike highstock.js, this doesn't include the complete Highcharts feature set. To load the full suite in one page, load Highmaps as a module.
 
 ```html
 <script src="./bower_components/highcharts/highstock.js"></script>

--- a/docs/getting-started/install-from-bower.md
+++ b/docs/getting-started/install-from-bower.md
@@ -3,7 +3,7 @@ Installing with Bower
 
 Bower is no longer the dependency manager of choice for front-end projects. While the open source project is still maintained, its creators decided to deprecate it, and advise how to migrate to other solutions—namely Yarn and webpack.
 
-The Bower package contains Highcharts, Highcharts Stock and Highmaps. Start by loading Highcharts from Bower:
+The Bower package contains Highcharts, Highcharts Stock and Highcharts Maps. Start by loading Highcharts from Bower:
 
 `bower install highcharts`
 
@@ -28,10 +28,10 @@ To load additional functionality onto Highcharts, include the modules:
 <script src="./bower_components/highcharts/modules/exporting.js"></script>
 ```
 
-Load Highcharts Stock or Highmaps
+Load Highcharts Stock or Highcharts Maps
 --------------------------
 
-Highcharts is already included in Highcharts Stock, so it not necessary to load both. The highstock.js file is included in the package. The highmaps.js file is also included, but unlike highstock.js, this doesn't include the complete Highcharts feature set. To load the full suite in one page, load Highmaps as a module.
+Highcharts is already included in Highcharts Stock, so it not necessary to load both. The highstock.js file is included in the package. The highmaps.js file is also included, but unlike highstock.js, this doesn't include the complete Highcharts feature set. To load the full suite in one page, load Highcharts Maps as a module.
 
 ```html
 <script src="./bower_components/highcharts/highstock.js"></script>

--- a/docs/getting-started/install-from-npm.md
+++ b/docs/getting-started/install-from-npm.md
@@ -1,7 +1,7 @@
 Installing with NPM
 ===
 
-The official npm package contains Highcharts, Highstock and Highmaps plus all modules. Start by installing Highcharts as a node module and save it as a dependency in your package.json:
+The official npm package contains Highcharts, Highcharts Stock and Highmaps plus all modules. Start by installing Highcharts as a node module and save it as a dependency in your package.json:
 
 `npm install highcharts --save`
 
@@ -17,10 +17,10 @@ Highcharts.chart('container', { /*Highcharts options*/ });
 ```
     
 
-Load Highstock or Highmaps
+Load Highcharts Stock or Highmaps
 --------------------------
 
-Highcharts is already included in Highstock, so it is not necessary to load both. The highstock.js file is included in the package. The highmaps.js file is also included, but unlike highstock.js, this doesn't include the complete Highcharts feature set. To load the full suite in one page, load Highmaps as a module.
+Highcharts is already included in Highcharts Stock, so it is not necessary to load both. The highstock.js file is included in the package. The highmaps.js file is also included, but unlike highstock.js, this doesn't include the complete Highcharts feature set. To load the full suite in one page, load Highmaps as a module.
 
 ```js
 var Highcharts = require('highcharts/highstock');  

--- a/docs/getting-started/install-from-npm.md
+++ b/docs/getting-started/install-from-npm.md
@@ -1,7 +1,7 @@
 Installing with NPM
 ===
 
-The official npm package contains Highcharts, Highcharts Stock and Highmaps plus all modules. Start by installing Highcharts as a node module and save it as a dependency in your package.json:
+The official npm package contains Highcharts, Highcharts Stock and Highcharts Maps plus all modules. Start by installing Highcharts as a node module and save it as a dependency in your package.json:
 
 `npm install highcharts --save`
 
@@ -17,14 +17,14 @@ Highcharts.chart('container', { /*Highcharts options*/ });
 ```
     
 
-Load Highcharts Stock or Highmaps
+Load Highcharts Stock or Highcharts Maps
 --------------------------
 
-Highcharts is already included in Highcharts Stock, so it is not necessary to load both. The highstock.js file is included in the package. The highmaps.js file is also included, but unlike highstock.js, this doesn't include the complete Highcharts feature set. To load the full suite in one page, load Highmaps as a module.
+Highcharts is already included in Highcharts Stock, so it is not necessary to load both. The highstock.js file is included in the package. The highmaps.js file is also included, but unlike highstock.js, this doesn't include the complete Highcharts feature set. To load the full suite in one page, load Highcharts Maps as a module.
 
 ```js
 var Highcharts = require('highcharts/highstock');  
-// Load Highmaps as a module
+// Load Highcharts Maps as a module
 require('highcharts/modules/map')(Highcharts);
 ```
 

--- a/docs/getting-started/install-from-npm.md
+++ b/docs/getting-started/install-from-npm.md
@@ -1,7 +1,7 @@
 Installing with NPM
 ===
 
-The official npm package contains Highcharts, Highcharts Stock and Highcharts Maps plus all modules. Start by installing Highcharts as a node module and save it as a dependency in your package.json:
+The official npm package contains Highcharts, including the Stock, Maps and Gantt packages, plus all modules. Start by installing Highcharts as a node module and save it as a dependency in your package.json:
 
 `npm install highcharts --save`
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -23,9 +23,9 @@ In the example above the JavaScript files are loaded from ajax.googleapis.com an
 <script src="/js/highcharts.js"></script>
 ```
 
-### C. Load Highstock or Highmaps
+### C. Load Highcharts Stock or Highmaps
 
-Highcharts is already included in Highstock, so it is not necessary to load both. The highstock.js file is included in the package. The highmaps.js file is also included, but unlike highstock.js, this doesn't include the complete Highcharts feature set. Highstock and Highmaps can be loaded separate files like this:
+Highcharts is already included in Highcharts Stock, so it is not necessary to load both. The highstock.js file is included in the package. The highmaps.js file is also included, but unlike highstock.js, this doesn't include the complete Highcharts feature set. Highcharts Stock and Highmaps can be loaded separate files like this:
 
 ```html
 <script src="/js/highstock.js"></script>
@@ -44,4 +44,4 @@ But the separate files can't run in the same page along with each other or with 
 
 You are now ready to use Highcharts, see [Your first chart](https://highcharts.com/docs/getting-started/your-first-chart) to get started.
 
-*) Highcharts version 1.x relied on excanvas.js for rendering in IE. From Highcharts 2.0 (and all Highstock versions) IE VML rendering is built into the library.
+*) Highcharts version 1.x relied on excanvas.js for rendering in IE. From Highcharts 2.0 (and all Highcharts Stock versions) IE VML rendering is built into the library.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -23,9 +23,9 @@ In the example above the JavaScript files are loaded from ajax.googleapis.com an
 <script src="/js/highcharts.js"></script>
 ```
 
-### C. Load Highcharts Stock or Highmaps
+### C. Load Highcharts Stock or Highcharts Maps
 
-Highcharts is already included in Highcharts Stock, so it is not necessary to load both. The highstock.js file is included in the package. The highmaps.js file is also included, but unlike highstock.js, this doesn't include the complete Highcharts feature set. Highcharts Stock and Highmaps can be loaded separate files like this:
+Highcharts is already included in Highcharts Stock, so it is not necessary to load both. The highstock.js file is included in the package. The highmaps.js file is also included, but unlike highstock.js, this doesn't include the complete Highcharts feature set. Highcharts Stock and Highcharts Maps can be loaded separate files like this:
 
 ```html
 <script src="/js/highstock.js"></script>

--- a/docs/getting-started/optional-dependencies.md
+++ b/docs/getting-started/optional-dependencies.md
@@ -1,7 +1,7 @@
 Optional dependencies
 ---------------------
 
-Highcharts by default is self-contained, but in some situations Highcharts, Highstock and Highmaps require external dependencies to enable certain features. The following is an overview of these dependencies, along with the required license and security information. The loading of the dependencies is always configurable in such a way that you can load the files from your own servers if this is a security requirement. Note that even when loading these files, your chart data is never sent to our servers.
+Highcharts by default is self-contained, but in some situations Highcharts, Highcharts Stock and Highmaps require external dependencies to enable certain features. The following is an overview of these dependencies, along with the required license and security information. The loading of the dependencies is always configurable in such a way that you can load the files from your own servers if this is a security requirement. Note that even when loading these files, your chart data is never sent to our servers.
 
 |File with source link|License|Loading|Usage
 |---|---|---|---|

--- a/docs/getting-started/optional-dependencies.md
+++ b/docs/getting-started/optional-dependencies.md
@@ -1,7 +1,7 @@
 Optional dependencies
 ---------------------
 
-Highcharts by default is self-contained, but in some situations Highcharts, Highcharts Stock and Highmaps require external dependencies to enable certain features. The following is an overview of these dependencies, along with the required license and security information. The loading of the dependencies is always configurable in such a way that you can load the files from your own servers if this is a security requirement. Note that even when loading these files, your chart data is never sent to our servers.
+Highcharts by default is self-contained, but in some situations Highcharts, Highcharts Stock and Highcharts Maps require external dependencies to enable certain features. The following is an overview of these dependencies, along with the required license and security information. The loading of the dependencies is always configurable in such a way that you can load the files from your own servers if this is a security requirement. Note that even when loading these files, your chart data is never sent to our servers.
 
 |File with source link|License|Loading|Usage
 |---|---|---|---|
@@ -10,5 +10,5 @@ Highcharts by default is self-contained, but in some situations Highcharts, High
 |[jspdf.js](https://code.highcharts.com/lib/jspdf.js)|MIT. [Open source](https://github.com/yWorks/jsPDF).|Loaded on demand from [exporting.libURL](https://api.highcharts.com/highcharts/exporting.libURL) if not present on page.|Dependency of svg2p.|
 |[canvg.js](https://code.highcharts.com/lib/canvg.js)|MIT. [Open source](https://github.com/canvg/canvg).|Loaded on demand from [exporting.libURL](https://api.highcharts.com/highcharts/exporting.libURL) if not present on page.|Required by the [client side exporting module](https://highcharts.com/docs/export-module/client-side-export) to export certain image types in Internet Explorer and Edge browsers.|
 |[rgbColor.js](https://code.highcharts.com/lib/rgbcolor.js)|"Use it if you like it", also available under MIT. [Open source](https://github.com/canvg/canvg/blob/master/rgbcolor.js).|Loaded on demand from [exporting.libURL](https://api.highcharts.com/highcharts/exporting.libURL) if not present on page.|Dependency of CanVG and svg2pdf.|
-|[proj4.js](http://proj4js.org/)|MIT. [Open source](https://github.com/proj4js/proj4js).|Not loaded automatically, must be included on page.|Required for [latitude/longitude](https://highcharts.com/docs/maps/latlon) support in Highmaps.|
+|[proj4.js](http://proj4js.org/)|MIT. [Open source](https://github.com/proj4js/proj4js).|Not loaded automatically, must be included on page.|Required for [latitude/longitude](https://highcharts.com/docs/maps/latlon) support in Highcharts Maps.|
 |[export-csv.js](https://highcharts.github.io/export-csv/export-csv.js)|MIT. [Open source](https://github.com/highcharts/export-csv). Authored by the Highcharts team.|Not loaded automatically, must be included on page.|Official Highcharts CSV export plugin, required by the [Accessibility module](https://highcharts.com/docs/chart-concepts/accessibility).|

--- a/docs/getting-started/system-requirements.md
+++ b/docs/getting-started/system-requirements.md
@@ -3,9 +3,9 @@ System requirements
 
 Highcharts is solely based on native browser technologies and doesn't require client side plugins like Flash or Java. Furthermore you don't need to install anything on your server. No PHP or ASP.NET. Highcharts needs only the highcharts.js core to run.
 
-Highcharts work in all modern browsers including mobile devices and Internet Explorer from version 6. Standard browsers use [SVG](https://www.w3.org/Graphics/SVG/) for the graphics rendering. In legacy Internet Explorer (IE8 and before) graphics are drawn using [VML](https://www.w3.org/TR/NOTE-VML).
+Highcharts works in all modern browsers including mobile devices and Internet Explorer from version 6. Standard browsers use [SVG](https://www.w3.org/Graphics/SVG/) for the graphics rendering. In legacy Internet Explorer (IE8 and before) graphics are drawn using [VML](https://www.w3.org/TR/NOTE-VML).
 
-Highcharts run on any server that supports HTML. You can even run Highcharts locally from a filesystem, since all the rendering is done locally in a browser.
+Highcharts runs on any server that supports HTML. You can even run Highcharts locally from a filesystem, since all the rendering is done locally in a browser.
 
 Browser compatibility
 ---------------------

--- a/docs/getting-started/system-requirements.md
+++ b/docs/getting-started/system-requirements.md
@@ -3,9 +3,9 @@ System requirements
 
 Highcharts is solely based on native browser technologies and doesn't require client side plugins like Flash or Java. Furthermore you don't need to install anything on your server. No PHP or ASP.NET. Highcharts needs only the highcharts.js core to run.
 
-Highcharts and Highstock work in all modern browsers including mobile devices and Internet Explorer from version 6. Standard browsers use [SVG](https://www.w3.org/Graphics/SVG/) for the graphics rendering. In legacy Internet Explorer (IE8 and before) graphics are drawn using [VML](https://www.w3.org/TR/NOTE-VML).
+Highcharts and Highcharts Stock work in all modern browsers including mobile devices and Internet Explorer from version 6. Standard browsers use [SVG](https://www.w3.org/Graphics/SVG/) for the graphics rendering. In legacy Internet Explorer (IE8 and before) graphics are drawn using [VML](https://www.w3.org/TR/NOTE-VML).
 
-Highcharts and Highstock run on any server that supports HTML. You can even run Highcharts locally from a filesystem, since all the rendering is done locally in a browser.
+Highcharts and Highcharts Stock run on any server that supports HTML. You can even run Highcharts locally from a filesystem, since all the rendering is done locally in a browser.
 
 Browser compatibility
 ---------------------

--- a/docs/getting-started/system-requirements.md
+++ b/docs/getting-started/system-requirements.md
@@ -3,9 +3,9 @@ System requirements
 
 Highcharts is solely based on native browser technologies and doesn't require client side plugins like Flash or Java. Furthermore you don't need to install anything on your server. No PHP or ASP.NET. Highcharts needs only the highcharts.js core to run.
 
-Highcharts and Highcharts Stock work in all modern browsers including mobile devices and Internet Explorer from version 6. Standard browsers use [SVG](https://www.w3.org/Graphics/SVG/) for the graphics rendering. In legacy Internet Explorer (IE8 and before) graphics are drawn using [VML](https://www.w3.org/TR/NOTE-VML).
+Highcharts work in all modern browsers including mobile devices and Internet Explorer from version 6. Standard browsers use [SVG](https://www.w3.org/Graphics/SVG/) for the graphics rendering. In legacy Internet Explorer (IE8 and before) graphics are drawn using [VML](https://www.w3.org/TR/NOTE-VML).
 
-Highcharts and Highcharts Stock run on any server that supports HTML. You can even run Highcharts locally from a filesystem, since all the rendering is done locally in a browser.
+Highcharts run on any server that supports HTML. You can even run Highcharts locally from a filesystem, since all the rendering is done locally in a browser.
 
 Browser compatibility
 ---------------------

--- a/docs/getting-started/your-first-chart.md
+++ b/docs/getting-started/your-first-chart.md
@@ -72,4 +72,4 @@ For more details on how the options or settings in Highcharts work see [How to 
 Below is a list of online examples of the examples shown in this article:
 
 *   [Simple bar chart](https://jsfiddle.net/highcharts/kh5jY/)
-*   [Highstock Example](https://jsfiddle.net/gh/get/jquery/1.7.2/highslide-software/highcharts.com/tree/master/samples/stock/demo/basic-line/)
+*   [Highcharts Stock Example](https://jsfiddle.net/gh/get/jquery/1.7.2/highslide-software/highcharts.com/tree/master/samples/stock/demo/basic-line/)

--- a/docs/maps/color-axis.md
+++ b/docs/maps/color-axis.md
@@ -1,7 +1,7 @@
 Color axis
 ===
 
-The values on a [choropleth](https://en.wikipedia.org/wiki/Choropleth_map) geo map or heat map are plotted against a color axis. The Highmaps color axis is a special case of an axis that is drawn inside the legend, displaying a gradient or single items depending on whether the axis is scalar or has data classes. See detailed reference and live examples in the [API](https://api.highcharts.com/highmaps/colorAxis).
+The values on a [choropleth](https://en.wikipedia.org/wiki/Choropleth_map) geo map or heat map are plotted against a color axis. The Highcharts Maps color axis is a special case of an axis that is drawn inside the legend, displaying a gradient or single items depending on whether the axis is scalar or has data classes. See detailed reference and live examples in the [API](https://api.highcharts.com/highmaps/colorAxis).
 
 Scalar axis
 -----------

--- a/docs/maps/create-custom-maps-for-highmaps.md
+++ b/docs/maps/create-custom-maps-for-highmaps.md
@@ -1,7 +1,7 @@
 Creating custom maps 
 ===
 
-Highmaps can be used for more than geographic data, and more than the featured maps provided in the demos. This article goes through the process of drawing your own map in Inkscape, and using our online map converter tool to construct an interactive map with data values. We use a map of Australia for demo purposes. (Do not use that in production, we have a better one in our mapdata collection).
+Highcharts Maps can be used for more than geographic data, and more than the featured maps provided in the demos. This article goes through the process of drawing your own map in Inkscape, and using our online map converter tool to construct an interactive map with data values. We use a map of Australia for demo purposes. (Do not use that in production, we have a better one in our mapdata collection).
 
 1. The first step is to install [Inkscape](https://www.inkscape.org/en/) on your system. This is the only tool you need to install, and it's free. Open up Inkscape, it opens a new document by default.
 
@@ -13,11 +13,11 @@ Highmaps can be used for more than geographic data, and more than the featured m
 
 ![map-from-svg-3.png](map-from-svg-3.png)
 
-5. The Highmaps converter tool expects fills for areas in order to distinguish it from separators and other lines. In the lower left corner of Inkscape, it says _Fill: None_. Click the text None to bring up the Fill and Stroke dialog. Next to the cross depicting no fill, select the solid fill button. Pick a color.
+5. The Highcharts Maps converter tool expects fills for areas in order to distinguish it from separators and other lines. In the lower left corner of Inkscape, it says _Fill: None_. Click the text None to bring up the Fill and Stroke dialog. Next to the cross depicting no fill, select the solid fill button. Pick a color.
 
 ![map-from-svg-4.png](map-from-svg-4.png)
 
-6. Next, we want to give the territory a name that Highmaps can use for labels and identification. In the Object menu, select _Object Properties (Shift + Ctrl + O)_. Set an _id_ and a _label_. The label is used by Highmaps. Remember to click the _Set_ button, otherwise Inkscape won't apply the information.
+6. Next, we want to give the territory a name that Highcharts Maps can use for labels and identification. In the Object menu, select _Object Properties (Shift + Ctrl + O)_. Set an _id_ and a _label_. The label is used by Highcharts Maps. Remember to click the _Set_ button, otherwise Inkscape won't apply the information.
 
 ![map-from-svg-5.png](map-from-svg-5.png)
 
@@ -47,7 +47,7 @@ Highmaps can be used for more than geographic data, and more than the featured m
 
 ![map-from-svg-10.png](map-from-svg-10.png)
 
-15. Go to [jsfiddle.net/highcharts/TUy7x/](https://jsfiddle.net/highcharts/TUy7x/), an empty boilerplate for Highmaps. Add a series configuration object and paste your data. It should now look like [jsfiddle.net/highcharts/TUy7x/1/](https://jsfiddle.net/highcharts/TUy7x/1/).
+15. Go to [jsfiddle.net/highcharts/TUy7x/](https://jsfiddle.net/highcharts/TUy7x/), an empty boilerplate for Highcharts Maps. Add a series configuration object and paste your data. It should now look like [jsfiddle.net/highcharts/TUy7x/1/](https://jsfiddle.net/highcharts/TUy7x/1/).
 
 ```js
 // Initiate the chart

--- a/docs/maps/custom-geojson-maps.md
+++ b/docs/maps/custom-geojson-maps.md
@@ -1,18 +1,18 @@
 Custom GeoJSON maps
 ===================
 
-This article contains information on creating maps from data in common mapping formats, as well as modifying the [Highmaps Map Collection](https://code.highcharts.com/mapdata "Highmaps Map Collection"). For information on drawing your own maps and creating maps from SVG, see [this article](https://highcharts.com/docs/maps/custom-maps "Custom maps").
+This article contains information on creating maps from data in common mapping formats, as well as modifying the [Highcharts Maps Map Collection](https://code.highcharts.com/mapdata "Highcharts Maps Map Collection"). For information on drawing your own maps and creating maps from SVG, see [this article](https://highcharts.com/docs/maps/custom-maps "Custom maps").
 
-We see that many users have map data in ESRI Shapefile format or other common mapping formats. These can easily be converted for use with Highmaps using an editor with GeoJSON exporting capabilities, as Highmaps supports the GeoJSON format natively. Most full-featured GIS editors will be able to perform this conversion. [QGIS](https://qgis.org "QGIS") is a free alternative that supports both Shapefile, KML, and a number of other formats. See [this demo](https://highcharts.com/maps/demo/geojson-multiple-types/maps/demo/geojson "GeoJSON demo") for an example of how to load polygonal data from a GeoJSON file, and [this demo](https://highcharts.com/maps/demo/geojson-multiple-types "GeoJSON multiple types demo") for a more complex example with line and point data.
+We see that many users have map data in ESRI Shapefile format or other common mapping formats. These can easily be converted for use with Highcharts Maps using an editor with GeoJSON exporting capabilities, as Highcharts Maps supports the GeoJSON format natively. Most full-featured GIS editors will be able to perform this conversion. [QGIS](https://qgis.org "QGIS") is a free alternative that supports both Shapefile, KML, and a number of other formats. See [this demo](https://highcharts.com/maps/demo/geojson-multiple-types/maps/demo/geojson "GeoJSON demo") for an example of how to load polygonal data from a GeoJSON file, and [this demo](https://highcharts.com/maps/demo/geojson-multiple-types "GeoJSON multiple types demo") for a more complex example with line and point data.
 
-The Highmaps map collection is supplied in both SVG and GeoJSON formats, and can be edited using any compatible editor. Simple changes can be made using a text editor. [InkScape](https://inkscape.org "InkScape") is a free visual editor for SVG files. Please note that different coordinate systems are used in the SVG and GeoJSON files, mainly for optimization reasons. The map collection is also supplied as executable Javascript files. These Javascript files are identical to the GeoJSON files, except for a small amount of wrapping code.
+The Highcharts Maps map collection is supplied in both SVG and GeoJSON formats, and can be edited using any compatible editor. Simple changes can be made using a text editor. [InkScape](https://inkscape.org "InkScape") is a free visual editor for SVG files. Please note that different coordinate systems are used in the SVG and GeoJSON files, mainly for optimization reasons. The map collection is also supplied as executable Javascript files. These Javascript files are identical to the GeoJSON files, except for a small amount of wrapping code.
 
-Creating maps for Highmaps
+Creating maps for Highcharts Maps
 --------------------------
 
-We will now go through the process of importing a Shapefile in QGIS and converting it for use with Highmaps. The process is the same when editing the GeoJSON files from our map collection. Note that there are many ways of accomplishing this with QGIS, and that details might vary depending on program version and platform. If you have issues using QGIS, check out their extensive [documentation](https://qgis.org/en/docs/index.html "QGIS Documentation").
+We will now go through the process of importing a Shapefile in QGIS and converting it for use with Highcharts Maps. The process is the same when editing the GeoJSON files from our map collection. Note that there are many ways of accomplishing this with QGIS, and that details might vary depending on program version and platform. If you have issues using QGIS, check out their extensive [documentation](https://qgis.org/en/docs/index.html "QGIS Documentation").
 
-1. Once QGIS is installed, the first step is to import your data. To do this, select the "Add Vector Layer" option from the Layer menu. For demonstration purposes, we will use a dataset with USA Zip Code Tabulation Areas available from the [US Census Bureau](http://www.census.gov/cgi-bin/geo/shapefiles2012/main "Zip Code Tabulation Areas"). Our goal is to create a map of the Alaskan Zip codes for use with Highmaps.
+1. Once QGIS is installed, the first step is to import your data. To do this, select the "Add Vector Layer" option from the Layer menu. For demonstration purposes, we will use a dataset with USA Zip Code Tabulation Areas available from the [US Census Bureau](http://www.census.gov/cgi-bin/geo/shapefiles2012/main "Zip Code Tabulation Areas"). Our goal is to create a map of the Alaskan Zip codes for use with Highcharts Maps.
 
 ![custom-geojson-maps-0.jpg](custom-geojson-maps-0.jpg)
 
@@ -38,15 +38,15 @@ We will now go through the process of importing a Shapefile in QGIS and converti
 
 ![custom-geojson-maps-7.jpg](custom-geojson-maps-7.jpg)
 
-6. Now, we would like to simplify the geometry. The less detail we include in our map, the faster Highmaps will work, and the faster your page will load. QGIS has several tools for this, but the simplest can be found in the Vector menu, under Geometry Tools. Set a tolerance of around 1000, and select a new file to save the result to. Also tick the "Add result to canvas" box. Once the process has finished, you should have a new layer with the simplified geometry.
+6. Now, we would like to simplify the geometry. The less detail we include in our map, the faster Highcharts Maps will work, and the faster your page will load. QGIS has several tools for this, but the simplest can be found in the Vector menu, under Geometry Tools. Set a tolerance of around 1000, and select a new file to save the result to. Also tick the "Add result to canvas" box. Once the process has finished, you should have a new layer with the simplified geometry.
 
 ![custom-geojson-maps-8.jpg](custom-geojson-maps-8.jpg)
 
-7. Before exporting, we might want to inspect and modify the properties of our map. To do this, right click the layer in the table of contents and select "Open Attribute Table". These attributes will be included in the GeoJSON when we export our map. Highmaps was designed to be used with user defined maps, and is very flexible in the way that it handles map data. There are therefore no special requirements for metadata in the maps. 
+7. Before exporting, we might want to inspect and modify the properties of our map. To do this, right click the layer in the table of contents and select "Open Attribute Table". These attributes will be included in the GeoJSON when we export our map. Highcharts Maps was designed to be used with user defined maps, and is very flexible in the way that it handles map data. There are therefore no special requirements for metadata in the maps. 
 
 ![custom-geojson-maps-9.jpg](custom-geojson-maps-9.jpg)
 
-8. When you are satisfied with your map, you need to export it to GeoJSON format in order to use it with Highmaps. To export your map, right click the layer you want to export in the table of contents, and select "Save As". Make sure to select to save in GeoJSON format. The resulting file can be used directly with Highmaps. You will notice that QGIS by default includes a large amount of decimals in the GeoJSON coordinates. These can be stripped using a Regex or similar, for optimization. Try using [this jsFiddle tool](https://jsfiddle.net/highcharts/92oymdb7/ "jsFiddle tool") on the resulting file contents.
+8. When you are satisfied with your map, you need to export it to GeoJSON format in order to use it with Highcharts Maps. To export your map, right click the layer you want to export in the table of contents, and select "Save As". Make sure to select to save in GeoJSON format. The resulting file can be used directly with Highcharts Maps. You will notice that QGIS by default includes a large amount of decimals in the GeoJSON coordinates. These can be stripped using a Regex or similar, for optimization. Try using [this jsFiddle tool](https://jsfiddle.net/highcharts/92oymdb7/ "jsFiddle tool") on the resulting file contents.
 
 ![custom-geojson-maps-10.jpg](custom-geojson-maps-10.jpg)
 
@@ -54,4 +54,4 @@ We will now go through the process of importing a Shapefile in QGIS and converti
 
 ![custom-geojson-maps-11.jpg](custom-geojson-maps-11.jpg)
 
-You now have your map ready for use with Highmaps.
+You now have your map ready for use with Highcharts Maps.

--- a/docs/maps/getting-started.md
+++ b/docs/maps/getting-started.md
@@ -1,17 +1,17 @@
-Getting started with Highmaps
+Getting started with Highcharts Maps
 ===
 
-Highmaps is Highcharts for geo maps. Mainly [choropleth maps](https://en.wikipedia.org/wiki/Choropleth_map) where the color intensity relates to some value of a geographic area, but Highmaps also supports different features like lines (roads, rivers etc.) and points (cities, points of interest) and more. Highmaps comes in two flavors, either as a standalone JavaScript file, or as a plugin for Highcharts.
+Highcharts Maps is Highcharts for geo maps. Mainly [choropleth maps](https://en.wikipedia.org/wiki/Choropleth_map) where the color intensity relates to some value of a geographic area, but Highcharts Maps also supports different features like lines (roads, rivers etc.) and points (cities, points of interest) and more. Highcharts Maps comes in two flavors, either as a standalone JavaScript file, or as a plugin for Highcharts.
 
 Load the required files
 -----------------------
 
-For basics, see [Highcharts installation](https://highcharts.com/docs/getting-started/installation). The framework requirements and installation is the same for Highmaps as for Highcharts. To load Highmaps as a standalone product (if you don't have a license for Highcharts), include this script tag:
+For basics, see [Highcharts installation](https://highcharts.com/docs/getting-started/installation). The framework requirements and installation is the same for Highcharts Maps as for Highcharts. To load Highcharts Maps as a standalone product (if you don't have a license for Highcharts), include this script tag:
 
     
     <script src="https://code.highcharts.com/maps/highmaps.js"></script>
 
-If you already have Highcharts installed in the web page and want to run Highmaps as a plugin, include this script tag _after_ `highcharts.js`:
+If you already have Highcharts installed in the web page and want to run Highcharts Maps as a plugin, include this script tag _after_ `highcharts.js`:
 
     
     <script src="https://code.highcharts.com/maps/modules/map.js"></script>
@@ -19,18 +19,18 @@ If you already have Highcharts installed in the web page and want to run Highmap
 Load the map
 ------------
 
-Highmaps loads its maps from [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON), an open standard for description of geographic features. Most GIS software supports this format as export from for instance Shapefile or KML export. Read more in the [API reference](https://api.highcharts.com/highmaps#Highcharts.geojson) and [see the live demo](https://jsfiddle.net/gh/get/jquery/1.7.2/highslide-software/highcharts.com/tree/master/samples/maps/demo/geojson-multiple-types/).
+Highcharts Maps loads its maps from [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON), an open standard for description of geographic features. Most GIS software supports this format as export from for instance Shapefile or KML export. Read more in the [API reference](https://api.highcharts.com/highmaps#Highcharts.geojson) and [see the live demo](https://jsfiddle.net/gh/get/jquery/1.7.2/highslide-software/highcharts.com/tree/master/samples/maps/demo/geojson-multiple-types/).
 
 There are three basic sources for your map:
 
 1.  Use our [Map collection](https://code.highcharts.com/mapdata/). Read the [tutorial article](https://highcharts.com/docs/maps/map-collection) on the map collection to get started.
 2.  Find an SVG map online and convert it using our (experimental) [online converter](https://highcharts.com/studies/map-from-svg.htm). 
-3.  Create your own map from scratch using an SVG editor, then convert them online. Read our tutorial on [Custom maps for Highmaps](https://highcharts.com/docs/maps/custom-maps).
+3.  Create your own map from scratch using an SVG editor, then convert them online. Read our tutorial on [Custom maps for Highcharts Maps](https://highcharts.com/docs/maps/custom-maps).
 
 Initialize the map
 ------------------
 
-Read more on initializing a chart in [Your first chart](https://highcharts.com/docs/getting-started/your-first-chart). If you're running Highmaps as a jQuery plugin, the map is constructed with "Map" as the first argument:
+Read more on initializing a chart in [Your first chart](https://highcharts.com/docs/getting-started/your-first-chart). If you're running Highcharts Maps as a jQuery plugin, the map is constructed with "Map" as the first argument:
 
     
     $('#container').highcharts('Map', {  

--- a/docs/maps/latlon.md
+++ b/docs/maps/latlon.md
@@ -3,7 +3,7 @@ Latitude/longitude
 
 <iframe style="width: 100%; height: 550px; border: 0;" src=https://www.highcharts.com/samples/embed/maps/demo/latlon-advanced allow="fullscreen"></iframe>
 
-Highmaps from version 1.1.0 comes with support for latitude/longitude. This feature requires that the [proj4js](http://proj4js.org) library has been loaded before Highmaps. The latest version of the proj4js library can be loaded from [cdnjs](https://cdnjs.com/libraries/proj4js).
+Highcharts Maps from version 1.1.0 comes with support for latitude/longitude. This feature requires that the [proj4js](http://proj4js.org) library has been loaded before Highcharts Maps. The latest version of the proj4js library can be loaded from [cdnjs](https://cdnjs.com/libraries/proj4js).
 
     
     <!-- Example of loading from CDNJS: -->
@@ -78,4 +78,4 @@ It is possible to expand on the definition above for more complex maps. The foll
 
 The `hitZone` property is a GeoJSON geometry object, specifying the extent of the zone in the map. The `scale` property specifies a scaling factor applied to the projected coordinates. The `xpan` and `ypan` properties specify offsets applied to the projected coordinates after scaling. Using these parameters it is possible to move and resize areas in the projected map coordinate system while retaining lat/lon support. The `rotation` property specifies the clockwise rotation of the coordinates before scaling and panning, in radians. The rotation is relative to the coordinate system origin.
 
-Highmaps will automatically detect which transform object to use when transforming to and from lat/lon on a map. If you want to manually perform a conversion using a specific transform object, use the [Chart.transformToLatLon](https://api.highcharts.com/class-reference/Highcharts.Chart#transformToLatLon) and [Chart.transformFromLatLon](https://api.highcharts.com/class-reference/Highcharts.Chart#transformFromLatLon) functions.
+Highcharts Maps will automatically detect which transform object to use when transforming to and from lat/lon on a map. If you want to manually perform a conversion using a specific transform object, use the [Chart.transformToLatLon](https://api.highcharts.com/class-reference/Highcharts.Chart#transformToLatLon) and [Chart.transformFromLatLon](https://api.highcharts.com/class-reference/Highcharts.Chart#transformFromLatLon) functions.

--- a/docs/maps/map-collection.md
+++ b/docs/maps/map-collection.md
@@ -1,12 +1,12 @@
 Map collection
 ===
 
-For your convenience, Highmaps offers a free [collection of maps](https://code.highcharts.com/mapdata/), optimized for use with Highmaps. For common maps, it saves you the trouble of finding or drawing suitable SVG or GeoJSON maps. Instead, you can choose between hundres of pre-generated maps of countries, regions and other administration levels.
+For your convenience, Highcharts Maps offers a free [collection of maps](https://code.highcharts.com/mapdata/), optimized for use with Highcharts Maps. For common maps, it saves you the trouble of finding or drawing suitable SVG or GeoJSON maps. Instead, you can choose between hundres of pre-generated maps of countries, regions and other administration levels.
 
 License
 -------
 
-The Highmaps Map Collection comes with the license of the source data. For Admin0 (countries) and Admin1 (US states, German Bundesländer, Dutch regions etc), the source data is [Natural Earth](https://www.naturalearthdata.com/), which is [Public Domain](https://en.wikipedia.org/wiki/Public_domain). For Admin2, we have only compiled selected countries, and these maps are created from national files with their own license which is specified on the SVG map and in the other format files as meta data. If your country is missing from the list, please contact us and we'll try to find a suitable shapefile and generate more maps. 
+The Highcharts Maps Map Collection comes with the license of the source data. For Admin0 (countries) and Admin1 (US states, German Bundesländer, Dutch regions etc), the source data is [Natural Earth](https://www.naturalearthdata.com/), which is [Public Domain](https://en.wikipedia.org/wiki/Public_domain). For Admin2, we have only compiled selected countries, and these maps are created from national files with their own license which is specified on the SVG map and in the other format files as meta data. If your country is missing from the list, please contact us and we'll try to find a suitable shapefile and generate more maps. 
 
 For maps loaded using the default GeoJSON input into the mapData option, a short version of the copyright will be printed in the chart's credits label.
 
@@ -36,7 +36,7 @@ Alternatively, you can set the default map for all series with the [`chart.map`]
 ```js
 map: 'custom/world'
 
-3. Join your data with the map. By default Highmaps is set up to map your data against the `hc-key`property of the map collection, allowing you to define your data like this:
+3. Join your data with the map. By default Highcharts Maps is set up to map your data against the `hc-key`property of the map collection, allowing you to define your data like this:
 ```js 
 data: [['us-ny', 0], ['us-mi', 5], ['us-tx', 3], ['us-ak', 5]]
 ```
@@ -49,7 +49,7 @@ Our map collection is available on npm as [@highcharts/map-collection](https://w
 npm i @highcharts/map-collection
 ```
 
-To load a map in Node.js and use it in Highmaps you can do the following:
+To load a map in Node.js and use it in Highcharts Maps you can do the following:
 
 ```js    
 var Highcharts = require('highcharts/highmaps.js'),
@@ -67,7 +67,7 @@ Highcharts.mapChart('container', {
 Map properties
 --------------
 
-The following table outlines the properties available in the Highmaps Map Collection maps, and their meaning. The properties are accessible from the **point.properties** object ([example](https://jsfiddle.net/oysteinmoseng/52rgg5zq/)).
+The following table outlines the properties available in the Highcharts Maps Map Collection maps, and their meaning. The properties are accessible from the **point.properties** object ([example](https://jsfiddle.net/oysteinmoseng/52rgg5zq/)).
 
 | Property       | Example values                        | Description                                                                                                                                                                                                                                                                                                                                                                           | Availability                                                      |
 | -------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
@@ -117,4 +117,4 @@ Our maps are also a good starting points for your own modified maps. Borders can
 Disclaimer
 ----------
 
-We offer the map collection for free to use with Highmaps, for your convenience. We will not be held responsible for errors in the maps, although we will strive to respond to bug reports and keep the maps correct.
+We offer the map collection for free to use with Highcharts Maps, for your convenience. We will not be held responsible for errors in the maps, although we will strive to respond to bug reports and keep the maps correct.

--- a/docs/maps/map-navigation.md
+++ b/docs/maps/map-navigation.md
@@ -1,9 +1,9 @@
 Map navigation
 ===
 
-Highmaps supports different ways of navigating around the map - zooming, panning, zooming to an area etc. The API options related to this can be viewed at [mapNavigation](https://api.highcharts.com/highmaps/mapNavigation).
+Highcharts Maps supports different ways of navigating around the map - zooming, panning, zooming to an area etc. The API options related to this can be viewed at [mapNavigation](https://api.highcharts.com/highmaps/mapNavigation).
 
-Please note that mapNavigation is disabled by default because the implementer should be concious that it may interfere with the navigation of the web page in general. When scrolling the mouse wheel over a map, the user may expect the web page to scroll, while Highmaps will capture the mousewheel event and zoom the map. The same goes for touch devices, where unless used right, the map may trap the user unable to zoom out to the page outside the map. So zooming should only be enabled in cases where the map actually needs it.
+Please note that mapNavigation is disabled by default because the implementer should be concious that it may interfere with the navigation of the web page in general. When scrolling the mouse wheel over a map, the user may expect the web page to scroll, while Highcharts Maps will capture the mousewheel event and zoom the map. The same goes for touch devices, where unless used right, the map may trap the user unable to zoom out to the page outside the map. So zooming should only be enabled in cases where the map actually needs it.
 
 ### Buttons
 

--- a/docs/public-index.md
+++ b/docs/public-index.md
@@ -15,6 +15,7 @@ For live examples see our demo pages:
 *   [Highcharts demo](https://highcharts.com/demo/)
 *   [Highcharts Stock demo](https://highcharts.com/stock/demo/)
 *   [Highcharts Maps demo](https://highcharts.com/maps/demo/)
+*   [Highcharts Gantt demo](https://highcharts.com/gantt/demo/)
 
 API
 ---
@@ -24,4 +25,4 @@ For more specific information on Highcharts and Highcharts Stock options and fun
 *   [Highcharts API reference](https://api.highcharts.com/highcharts)
 *   [Highcharts Stock API reference](https://api.highcharts.com/highstock)
 *   [Highcharts Maps API reference](https://api.highcharts.com/highmaps)
-
+*   [Highcharts Gantt API reference](https://api.highcharts.com/gantt)

--- a/docs/public-index.md
+++ b/docs/public-index.md
@@ -20,7 +20,7 @@ For live examples see our demo pages:
 API
 ---
 
-For more specific information on Highcharts and Highcharts Stock options and functions, visit our API sites which also include several live and customizeable examples.
+For more specific information on Highcharts options and functions, visit our API sites which also include several live and customizeable examples.
 
 *   [Highcharts API reference](https://api.highcharts.com/highcharts)
 *   [Highcharts Stock API reference](https://api.highcharts.com/highstock)

--- a/docs/public-index.md
+++ b/docs/public-index.md
@@ -13,15 +13,15 @@ Demo
 For live examples see our demo pages:
 
 *   [Highcharts demo](https://highcharts.com/demo/)
-*   [Highstock demo](https://highcharts.com/stock/demo/)
+*   [Highcharts Stock demo](https://highcharts.com/stock/demo/)
 *   [Highmaps demo](https://highcharts.com/maps/demo/)
 
 API
 ---
 
-For more specific information on Highcharts and Highstock options and functions, visit our API sites which also include several live and customizeable examples.
+For more specific information on Highcharts and Highcharts Stock options and functions, visit our API sites which also include several live and customizeable examples.
 
 *   [Highcharts API reference](https://api.highcharts.com/highcharts)
-*   [Highstock API reference](https://api.highcharts.com/highstock)
+*   [Highcharts Stock API reference](https://api.highcharts.com/highstock)
 *   [Highmaps API reference](https://api.highcharts.com/highmaps)
 

--- a/docs/public-index.md
+++ b/docs/public-index.md
@@ -14,7 +14,7 @@ For live examples see our demo pages:
 
 *   [Highcharts demo](https://highcharts.com/demo/)
 *   [Highcharts Stock demo](https://highcharts.com/stock/demo/)
-*   [Highmaps demo](https://highcharts.com/maps/demo/)
+*   [Highcharts Maps demo](https://highcharts.com/maps/demo/)
 
 API
 ---
@@ -23,5 +23,5 @@ For more specific information on Highcharts and Highcharts Stock options and fun
 
 *   [Highcharts API reference](https://api.highcharts.com/highcharts)
 *   [Highcharts Stock API reference](https://api.highcharts.com/highstock)
-*   [Highmaps API reference](https://api.highcharts.com/highmaps)
+*   [Highcharts Maps API reference](https://api.highcharts.com/highmaps)
 

--- a/docs/stock/candlestick-chart.md
+++ b/docs/stock/candlestick-chart.md
@@ -1,4 +1,4 @@
-Candlestick chart (Highstock only)
+Candlestick chart (Highcharts Stock only)
 ================
 
 A candlestick chart is typically used to present the open, high, low and close price over a period of time. A candlestick chart is composed of a body and an upper and a lower wick. The body represents the the opening and closing price. If the opening price is higher than the closing price the body is filled. If the closing price is higher than the opening price the body is unfilled. The upper wich represent the highest price during a time period and the lower wick represents the lowest price during a time period.

--- a/docs/stock/data-grouping.md
+++ b/docs/stock/data-grouping.md
@@ -1,4 +1,4 @@
-Data grouping (Highstock)
+Data grouping (Highcharts Stock)
 ===========
 
 Data grouping replaces a sequence of data points in a series with one grouped point. The values of each grouped point is calculated from the original values of every point used. The [groupPixelWidth](https://api.highcharts.com/highstock/plotOptions.series.dataGrouping.groupPixelWidth) option defines how large the groups should be.
@@ -12,4 +12,4 @@ By default, the grouping [approximation](https://api.highcharts.com/highstock/pl
 
 Grouping is activated when there are many data points in the chart. As well as increasing performance it makes it easier to spot trends in a chart.
 
-Data grouping is a Highstock feature and is enabled by default. To see dataGrouping options see the [API reference](https://api.highcharts.com/highstock/plotOptions.series.dataGrouping).
+Data grouping is a Highcharts Stock feature and is enabled by default. To see dataGrouping options see the [API reference](https://api.highcharts.com/highstock/plotOptions.series.dataGrouping).

--- a/docs/stock/flag-series.md
+++ b/docs/stock/flag-series.md
@@ -1,9 +1,9 @@
-Flag series (Highstock only)
+Flag series (Highcharts Stock only)
 ================
 
 A flag series consists of flags marking events or points of interests. Used alone flag series will make no sense. Flags can be placed on either the series of the chart or on the axis.
 
-Flag series belong to Highstock, but they can also be applied to a regular Highcharts chart created with the Highcharts.Chart() constructor as long as the highstock.js file is loaded in the page. See the [FAQ item](https://www.highcharts.com/docs/getting-started/frequently-asked-questions#can-i-use-features-from-highstock-in-highcharts) on the matter. 
+Flag series belong to Highcharts Stock, but they can also be applied to a regular Highcharts chart created with the Highcharts.Chart() constructor as long as the highstock.js file is loaded in the page. See the [FAQ item](https://www.highcharts.com/docs/getting-started/frequently-asked-questions#can-i-use-features-from-highstock-in-highcharts) on the matter. 
 
 ![flagseries.png](flagseries.png)
 

--- a/docs/stock/navigator.md
+++ b/docs/stock/navigator.md
@@ -1,11 +1,11 @@
-Navigator (Highstock only)
+Navigator (Highcharts Stock only)
 ================
 
 The navigator is a small series below the main series, displaying a view of the entire data set. It provides tools to zoom in and out on parts of the data as well as panning across the dataset.
 
 ![navigator.png](navigator.png)
 
-The navigator is enabled by default for the first series in all Highstock charts. To configure which series are shown in the navigator, use the [`series.showInNavigator`](https://api.highcharts.com/highstock/plotOptions.series.showInNavigator) option.
+The navigator is enabled by default for the first series in all Highcharts Stock charts. To configure which series are shown in the navigator, use the [`series.showInNavigator`](https://api.highcharts.com/highstock/plotOptions.series.showInNavigator) option.
 
     
     series: {

--- a/docs/stock/ohlc-chart.md
+++ b/docs/stock/ohlc-chart.md
@@ -1,4 +1,4 @@
-OHLC chart (Highstock only)
+OHLC chart (Highcharts Stock only)
 ================
 
 The Open-High-Low-Close chart is typically used to show the change in price over a period of time. A vertical line shows the range of the price change where the top of the line is the highest and the bottom is the lowest. A tickmark on the left side of the chart indicates the opening price and a tickmark on the rightside indicates the closing price.

--- a/docs/stock/range-selector.md
+++ b/docs/stock/range-selector.md
@@ -1,4 +1,4 @@
-Range selector (Highstock only)
+Range selector (Highcharts Stock only)
 ================
 
 The range selector is a tool for selecting ranges to display within the chart. It provides buttons to select pre-configured ranges in the chart, like 1 day, 1 week, 1 month, etc. It also provides input boxes where min and max dates can be manually input.

--- a/docs/stock/stock-tools.md
+++ b/docs/stock/stock-tools.md
@@ -1,7 +1,7 @@
 Stock tools
 ===
 
-Stock Tools is a Highstock module for building a GUI that enables user interaction with the chart, such as adding annotations, technical indicators or just for zooming in or out. The module is released with Highstock 7 and won't work with previous versions.
+Stock Tools is a Highcharts Stock module for building a GUI that enables user interaction with the chart, such as adding annotations, technical indicators or just for zooming in or out. The module is released with Highcharts Stock 7 and won't work with previous versions.
 
 Building the GUI is facilitated by the Stock Tools module, where your HTML elements for user interaction are automatically bound to predefined events in this module. Full list of the available bindings can be found in the API [navigation.bindings](https://api.highcharts.com/highstock/navigation.bindings).
 
@@ -9,7 +9,7 @@ Building the GUI is facilitated by the Stock Tools module, where your HTML eleme
 ## Quick start
 To get started quickly it's recommended to use the default toolbar of the Stock Tools module. We need to load the JavaScript files in the following order.
 
-1. First load Highstock and the bundle with all the technical indicators for convenience.
+1. First load Highcharts Stock and the bundle with all the technical indicators for convenience.
   ```html
   <script src="https://code.highcharts.com/indicators/indicators-all.js"></script>
   ```

--- a/docs/stock/understanding-highstock.md
+++ b/docs/stock/understanding-highstock.md
@@ -1,11 +1,11 @@
-Understanding Highstock
+Understanding Highcharts Stock
 ===
 
-Highstock is based on Highcharts, meaning it has all the core functionality of Highcharts, plus some additional features.
+Highcharts Stock is based on Highcharts, meaning it has all the core functionality of Highcharts, plus some additional features.
 
 ![understanding_highstock.png](understanding_highstock.png)
 
-Highstock also supports candlestick and OHLC charts.
+Highcharts Stock also supports candlestick and OHLC charts.
 
 Navigator
 ---------

--- a/docs/working-with-data/server-side-data-grouping.md
+++ b/docs/working-with-data/server-side-data-grouping.md
@@ -1,9 +1,9 @@
 Server-side data grouping
 ===
 
-Since Highcharts version 7.1 it is possible to perform data grouping on the server side in a node environment. Client-side data grouping has been a part of Highstock since its beginning, but there are cases where it is beneficial to move the grouping to the server.
+Since Highcharts version 7.1 it is possible to perform data grouping on the server side in a node environment. Client-side data grouping has been a part of Highcharts Stock since its beginning, but there are cases where it is beneficial to move the grouping to the server.
 
-Server-side grouping means less data has to be pushed over the network, and less processing has to be performed in the client browser. On the downside, if the chart has to poll the server for new data every time a user zooms in or out, it may be perceived as non-performant. The Highstock [lazy-loading demo](https://www.highcharts.com/stock/demo/lazy-loading), although it doesn't use our node server-side grouping, shows the concept of separate loading data for different resolutions.
+Server-side grouping means less data has to be pushed over the network, and less processing has to be performed in the client browser. On the downside, if the chart has to poll the server for new data every time a user zooms in or out, it may be perceived as non-performant. The Highcharts Stock [lazy-loading demo](https://www.highcharts.com/stock/demo/lazy-loading), although it doesn't use our node server-side grouping, shows the concept of separate loading data for different resolutions.
 
 Setting it up in node
 ---------------------


### PR DESCRIPTION
Updated product names with `Highcharts Stock` and `Highcharts Maps` in place of `Highstock`and `Highmaps`. Also added links for Gantt to the index page.