### PR TITLE
bugfix/13169-packedbubble-initial-animation

### DIFF
--- a/js/modules/networkgraph/layouts.js
+++ b/js/modules/networkgraph/layouts.js
@@ -59,6 +59,7 @@ H.layouts['reingold-fruchterman'].prototype, {
             layout.initPositions();
             // Render elements in initial positions:
             series.forEach(function (s) {
+                s.finishedAnimating = true; // #13169
                 s.render();
             });
         }

--- a/ts/modules/networkgraph/layouts.ts
+++ b/ts/modules/networkgraph/layouts.ts
@@ -232,6 +232,7 @@ extend(
 
                 // Render elements in initial positions:
                 series.forEach(function (s: Highcharts.Series): void {
+                    s.finishedAnimating = true; // #13169
                     s.render();
                 });
             }


### PR DESCRIPTION
Fixed #13169, a regression causing packed bubble's initial simulation not to work smoothly.