### PR TITLE
bugfix/tilemap-incorrect-marker-attributes

### DIFF
--- a/js/modules/tilemap.src.js
+++ b/js/modules/tilemap.src.js
@@ -331,13 +331,16 @@ seriesType('tilemap', 'heatmap'
  *
  * @extends      plotOptions.heatmap
  * @since        6.0.0
- * @excluding    jitter, joinBy, shadow, allAreas, mapData, data,
+ * @excluding    jitter, joinBy, shadow, allAreas, mapData, marker, data,
  *               dataSorting
  * @product      highcharts highmaps
  * @requires     modules/tilemap.js
  * @optionparent plotOptions.tilemap
  */
 , {
+    // Remove marker from tilemap default options, as it was before
+    // heatmap refactoring.
+    marker: null,
     states: {
         hover: {
             halo: {
@@ -398,8 +401,14 @@ seriesType('tilemap', 'heatmap'
      */
     tileShape: 'hexagon'
 }, {
-    // Use drawPoints method from old heatmap implementation
-    // Consider standarizing heatmap and tilemap into more consistent form.
+    // Use drawPoints, markerAttribs, pointAttribs methods from the old
+    // heatmap implementation.
+    // TODO: Consider standarizing heatmap and tilemap into more
+    // consistent form.
+    markerAttribs: H.seriesTypes.scatter.prototype.markerAttribs,
+    pointAttribs: H.seriesTypes.column.prototype.pointAttribs,
+    // Revert the noop on getSymbol.
+    getSymbol: H.noop,
     drawPoints: function () {
         var _this = this;
         // In styled mode, use CSS, otherwise the fill used in the style

--- a/samples/unit-tests/series-tilemap/coloraxis/demo.js
+++ b/samples/unit-tests/series-tilemap/coloraxis/demo.js
@@ -30,4 +30,23 @@ QUnit.test('Tilemap and ColorAxis', function (assert) {
         'ColorAxis.max should be the same as max value in points (#11644)'
     );
 
+    chart.series[0].update({
+        tileShape: 'circle'
+    });
+
+    var point = chart.series[0].points[1];
+    point.setState('hover');
+
+    assert.notEqual(
+        point.graphic.element.getAttribute('cx'),
+        "NaN",
+        "Circle shape of tilemap should not have cx attribute with NaN values on hover."
+    );
+
+    assert.notEqual(
+        point.graphic.element.getAttribute('cy'),
+        "NaN",
+        "Circle shape of tilemap should not have cy attribute with NaN values on hover."
+    );
+
 });

--- a/ts/modules/tilemap.src.ts
+++ b/ts/modules/tilemap.src.ts
@@ -725,14 +725,16 @@ seriesType<Highcharts.TilemapSeries>('tilemap', 'heatmap'
      *
      * @extends      plotOptions.heatmap
      * @since        6.0.0
-     * @excluding    jitter, joinBy, shadow, allAreas, mapData, data,
+     * @excluding    jitter, joinBy, shadow, allAreas, mapData, marker, data,
      *               dataSorting
      * @product      highcharts highmaps
      * @requires     modules/tilemap.js
      * @optionparent plotOptions.tilemap
      */
     , { // Default options
-
+        // Remove marker from tilemap default options, as it was before
+        // heatmap refactoring.
+        marker: null as any,
         states: {
 
             hover: {
@@ -805,8 +807,14 @@ seriesType<Highcharts.TilemapSeries>('tilemap', 'heatmap'
         tileShape: 'hexagon'
 
     }, { // Prototype functions
-        // Use drawPoints method from old heatmap implementation
-        // Consider standarizing heatmap and tilemap into more consistent form.
+        // Use drawPoints, markerAttribs, pointAttribs methods from the old
+        // heatmap implementation.
+        // TODO: Consider standarizing heatmap and tilemap into more
+        // consistent form.
+        markerAttribs: H.seriesTypes.scatter.prototype.markerAttribs,
+        pointAttribs: H.seriesTypes.column.prototype.pointAttribs,
+        // Revert the noop on getSymbol.
+        getSymbol: H.noop as any,
         drawPoints: function (
             this: Highcharts.TilemapSeries
         ): void {


### PR DESCRIPTION
Tilemap produced some errors after heatmap refactoring (on `master`), when hovering points.
Some prototype functions and features from the old tilemap series had to be restored back, in order to keep it work as before.