### PR TITLE
bugfix/11480-priceIndicator-yAxis-crosshair

### DIFF
--- a/js/modules/price-indicator.src.js
+++ b/js/modules/price-indicator.src.js
@@ -102,14 +102,17 @@ addEvent(H.Series, 'afterRender', function () {
             }, seriesOptions.lastVisiblePrice);
             yAxis.cross = serie.lastVisiblePrice;
             lastPoint = points[pLength - crop];
+            if (serie.crossLabel) {
+                serie.crossLabel.destroy();
+                // Set to undefined to avoid collision with
+                // the yAxis crosshair #11480
+                delete yAxis.crossLabel;
+            }
             // Save price
             yAxis.drawCrosshair(null, lastPoint);
             if (yAxis.cross) {
                 serie.lastVisiblePrice = yAxis.cross;
                 serie.lastVisiblePrice.y = lastPoint.y;
-            }
-            if (serie.crossLabel) {
-                serie.crossLabel.destroy();
             }
             serie.crossLabel = yAxis.crossLabel;
         }

--- a/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
+++ b/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
@@ -94,3 +94,51 @@ QUnit.test('Datagrouping and setExtremes.', function (assert) {
         'Indicator should show the close value of the last non-grouped point.'
     );
 });
+
+
+QUnit.test('CurrentPriceIndicator && yAxis crosshair label #11480.', function (assert) {
+
+    var chart = Highcharts.stockChart('container', {
+        xAxis: {
+            crosshair: {
+                snap: false,
+                label: {
+                    enabled: true
+                }
+            }
+        },
+        yAxis: {
+            crosshair: {
+                snap: false,
+                label: {
+                    enabled: true
+                }
+            }
+        },
+        series: [{
+            lastVisiblePrice: {
+                enabled: true,
+                label: {
+                    enabled: true
+                }
+            },
+            data: getData()
+        }]
+    });
+
+    var min = chart.xAxis[0].min,
+        max = min + 100 * 3600,
+        max1 = min + 200 * 3600,
+        controller = new TestController(chart);
+
+    controller.moveTo(300, 200);
+
+    chart.xAxis[0].setExtremes(min, max);
+    chart.xAxis[0].setExtremes(min, max1);
+
+    assert.strictEqual(
+        chart.series[0].crossLabel.added,
+        true,
+        'Label shouldn\t be deleted #11480'
+    );
+});

--- a/ts/modules/price-indicator.src.ts
+++ b/ts/modules/price-indicator.src.ts
@@ -169,16 +169,20 @@ addEvent(H.Series, 'afterRender', function (): void {
 
             yAxis.cross = serie.lastVisiblePrice;
             lastPoint = points[pLength - crop];
+
+            if (serie.crossLabel) {
+                serie.crossLabel.destroy();
+                // Set to undefined to avoid collision with
+                // the yAxis crosshair #11480
+                delete yAxis.crossLabel;
+            }
+
             // Save price
             yAxis.drawCrosshair((null as any), lastPoint);
 
             if (yAxis.cross) {
                 serie.lastVisiblePrice = yAxis.cross;
                 serie.lastVisiblePrice.y = lastPoint.y;
-            }
-
-            if (serie.crossLabel) {
-                serie.crossLabel.destroy();
             }
 
             serie.crossLabel = yAxis.crossLabel;


### PR DESCRIPTION
Fixed #11480, error with crosshair labels after enabling the Stock Tools' current price indicator and changing the timeframe of the chart.

~~Fixed #11480, fixing the crosshair labels and the lastVisiblePrice labels collision.~~