### PR TITLE
Tools: VSC debugging karma test.

### DIFF
--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -263,9 +263,15 @@ module.exports = function (config) {
         ['unit-tests/oldie/*'] :
         ['unit-tests/*/*'];
 
-    const tests = (argv.tests ? argv.tests.split(',') : defaultTests)
+    const tests = (
+            argv.tests ? argv.tests.split(',') :
+            (
+                argv.testsAbsolutePath ? argv.testsAbsolutePath.split(',') :
+                defaultTests
+            )
+        )
         .filter(path => !!path)
-        .map(path => `samples/${path}/demo.js`);
+        .map(path => argv.testsAbsolutePath ? path : `samples/${path}/demo.js`);
 
     // Get the files
     let files = require('./karma-files.json');
@@ -644,6 +650,17 @@ module.exports = function (config) {
             'BrowserStack initialized. Please wait while tests are uploaded and VMs prepared. ' +
             `Any other test runs must complete before this test run will start. Current Browserstack concurrency rate is ${options.concurrency}.`
         );
+    } else if (argv.testsAbsolutePath) {
+        options.customLaunchers = {
+            'ChromeHeadless.Debugging': {
+                base: 'ChromeHeadless',
+                flags: [
+                    '--remote-debugging-port=9333'
+                ]
+            }
+        };
+        options.browserDisconnectTimeout = 30 * 60 * 1000;
+        options.browserNoActivityTimeout = 30 * 60 * 1000;
     }
 
     config.set(options);

--- a/tools/gulptasks/test.js
+++ b/tools/gulptasks/test.js
@@ -322,6 +322,8 @@ Available arguments for 'gulp test':
     'Mac.Chrome, Mac.Firefox, Mac.Safari, Win.Chrome, Win.Edge, Win.Firefox,
     Win.IE'.
 
+    For debugging in Visual Studio Code, use 'ChromeHeadless.Debugging'.
+
     A shorthand option, '--browsers all', runs all BrowserStack machines.
 
 --browsercount
@@ -344,6 +346,13 @@ Available arguments for 'gulp test':
     Example: 'gulp test --tests unit-tests/chart/*' runs all tests in the chart
     directory.
 
+--testsAbsolutePath
+    Comma separated list of tests to run. By default runs all tests
+    in the 'samples/' directory.
+    Example:
+    'gulp test --testsAbsolutePath /User/{userName}/{path}/{to}/highcharts/samples/unit-tests/3d/axis/demo.js'
+    runs all tests in the file.
+
 --visualcompare
     Performs a visual comparison of the output and creates a reference.svg and candidate.svg
     when doing so. A JSON file with the results is produced in the location
@@ -359,7 +368,7 @@ Available arguments for 'gulp test':
         checkSamplesConsistency();
         checkJSWrap();
 
-        const forceRun = !!(argv.browsers || argv.browsercount || argv.force || argv.tests);
+        const forceRun = !!(argv.browsers || argv.browsercount || argv.force || argv.tests || argv.testsAbsolutePath);
 
         if (forceRun || shouldRun()) {
 


### PR DESCRIPTION
Debugging failing tests in Karma was always a bit problematic. In case, where test is passing in Chrome, but failing in ChromeHeadless it is not an easy task to figure out why. Perhaps there's a better way, if so, please let me know.

I'm not an expert in VSC (using this just for a few months), but with since we can inspect node/chrome process, we can bind this to VSC and our code. This PR is focused on VSC only, but there are other [inspectors](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients) that can support it. Tested on OSX only and max debugging time is set to ~30minutes. Karma is disconnecting from headless when browser does not ping Karma every once in a while.

Prerequisities:
- Visual Studio Code 1.38+ (tested with 1.38 and 1.43)
- Debugger for Chrome extension 4.12.6+ (tested with 4.12.6)

Steps (image below):
1) Click debug icon
2) Click gear icon to edit `launch.json`
3) Insert config (required only the first time):
```js
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
          "type": "node",
          "request": "launch",
          "name": "Gulp Test Current File",
          "program": "${workspaceFolder}/node_modules/.bin/gulp",
          "args": [ 
            "test",
            "--testsAbsolutePath",
            "${file}",
            "--browserCount",
            "1",
            "--browsers",
            "ChromeHeadless.Debugging",   
            "--force",
            "--detectOpenHandles", 
          ],
          "autoAttachChildProcesses": true,
          "trace": "verbose",
          "console": "integratedTerminal",
          //"internalConsoleOptions": "neverOpen",
          "windows": {
            "program": "${workspaceFolder}\\node_modules\\gulp\\bin\\gulp"
          }
        },
        {
            "type": "chrome",
            "request": "attach",
            "name": "Attach Karma Chrome",
            "address": "localhost",
            "port": 9333,
            "timeout": 900000, // 15min
            "pathMapping": {
                "/": "${workspaceRoot}/",
                "/base/": "${workspaceRoot}/"
            }
        }
    ],
    "compounds": [
        {
            "name": "Debug integration",
            "configurations": ["Gulp Test Current File", "Attach Karma Chrome"],
        }
    ]
}
```
4) Go to the `demo.js` file - that is the most important part, because debugger is running current file.
5) Add breakpoints.
4) Choose "Debug integration" from the debug dropdown and click "Start debugging" icon

![Screen Shot 2020-04-06 at 12 00 32](https://user-images.githubusercontent.com/1453926/78547156-e70cdd80-77fe-11ea-8199-7b81994071a3.png)

6) Debug! :) Example (click to enlarge):

![dbggr](https://user-images.githubusercontent.com/1453926/78546223-597cbe00-77fd-11ea-98d4-4866b3622edb.gif)
