### PR TITLE
 bugfix/13025-auto-margin

### DIFF
--- a/js/parts/Legend.js
+++ b/js/parts/Legend.js
@@ -832,31 +832,43 @@ var Legend = /** @class */ (function () {
         legend.legendWidth = legendWidth;
         legend.legendHeight = legendHeight;
         if (display) {
-            // If aligning to the top and the layout is horizontal, adjust for
-            // the title (#7428)
-            var alignTo = chart.spacingBox;
-            var y = alignTo.y;
-            if (/(lth|ct|rth)/.test(legend.getAlignment()) &&
-                chart.titleOffset[0] > 0) {
-                y += chart.titleOffset[0];
-            }
-            else if (/(lbh|cb|rbh)/.test(legend.getAlignment()) &&
-                chart.titleOffset[2] > 0) {
-                y -= chart.titleOffset[2];
-            }
-            if (y !== alignTo.y) {
-                alignTo = merge(alignTo, { y: y });
-            }
-            legendGroup.align(merge(options, {
-                width: legendWidth,
-                height: legendHeight,
-                verticalAlign: this.proximate ? 'top' : options.verticalAlign
-            }), true, alignTo);
+            legend.align();
         }
         if (!this.proximate) {
             this.positionItems();
         }
         fireEvent(this, 'afterRender');
+    };
+    /**
+     * Align the legend to chart's box.
+     *
+     * @private
+     * @function Highcharts.align
+     * @param {Highcharts.BBoxObject} alignTo
+     * @return {void}
+     */
+    Legend.prototype.align = function (alignTo) {
+        if (alignTo === void 0) { alignTo = this.chart.spacingBox; }
+        var chart = this.chart, options = this.options;
+        // If aligning to the top and the layout is horizontal, adjust for
+        // the title (#7428)
+        var y = alignTo.y;
+        if (/(lth|ct|rth)/.test(this.getAlignment()) &&
+            chart.titleOffset[0] > 0) {
+            y += chart.titleOffset[0];
+        }
+        else if (/(lbh|cb|rbh)/.test(this.getAlignment()) &&
+            chart.titleOffset[2] > 0) {
+            y -= chart.titleOffset[2];
+        }
+        if (y !== alignTo.y) {
+            alignTo = merge(alignTo, { y: y });
+        }
+        this.group.align(merge(options, {
+            width: this.legendWidth,
+            height: this.legendHeight,
+            verticalAlign: this.proximate ? 'top' : options.verticalAlign
+        }), true, alignTo);
     };
     /**
      * Set up the overflow handling by adding navigation with up and down arrows

--- a/js/parts/RangeSelector.js
+++ b/js/parts/RangeSelector.js
@@ -1548,14 +1548,26 @@ if (!H.RangeSelector) {
         }
     });
     Chart.prototype.callbacks.push(function (chart) {
-        var extremes, rangeSelector = chart.rangeSelector, unbindRender, unbindSetExtremes;
+        var extremes, rangeSelector = chart.rangeSelector, unbindRender, unbindSetExtremes, legend, alignTo, verticalAlign;
         /**
          * @private
          */
         function renderRangeSelector() {
             extremes = chart.xAxis[0].getExtremes();
+            legend = chart.legend;
+            verticalAlign = rangeSelector === null || rangeSelector === void 0 ? void 0 : rangeSelector.options.verticalAlign;
             if (isNumber(extremes.min)) {
                 rangeSelector.render(extremes.min, extremes.max);
+            }
+            // Re-align the legend so that it's below the rangeselector
+            if (rangeSelector && legend.display &&
+                verticalAlign === 'top' &&
+                verticalAlign === legend.options.verticalAlign) {
+                // Create and use a new alignment box for the legend.
+                alignTo = merge(chart.spacingBox);
+                alignTo.y += rangeSelector.getHeight();
+                legend.group.placed = false; // Don't animate the alignment.
+                legend.align(alignTo);
             }
         }
         if (rangeSelector) {

--- a/js/parts/RangeSelector.js
+++ b/js/parts/RangeSelector.js
@@ -1563,9 +1563,14 @@ if (!H.RangeSelector) {
             if (rangeSelector && legend.display &&
                 verticalAlign === 'top' &&
                 verticalAlign === legend.options.verticalAlign) {
-                // Create and use a new alignment box for the legend.
+                // Create a new alignment box for the legend.
                 alignTo = merge(chart.spacingBox);
-                alignTo.y += rangeSelector.getHeight();
+                if (legend.options.layout === 'vertical') {
+                    alignTo.y = chart.plotTop;
+                }
+                else {
+                    alignTo.y += rangeSelector.getHeight();
+                }
                 legend.group.placed = false; // Don't animate the alignment.
                 legend.align(alignTo);
             }

--- a/samples/unit-tests/rangeselector/legend-position/demo.details
+++ b/samples/unit-tests/rangeselector/legend-position/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/rangeselector/legend-position/demo.html
+++ b/samples/unit-tests/rangeselector/legend-position/demo.html
@@ -1,0 +1,6 @@
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/rangeselector/legend-position/demo.js
+++ b/samples/unit-tests/rangeselector/legend-position/demo.js
@@ -1,5 +1,5 @@
 QUnit.test('Legend should be rendered below the range selector', function (assert) {
-    Highcharts.stockChart('container', {
+    var chart = Highcharts.stockChart('container', {
         rangeSelector: {
             enabled: true,
             inputEnabled: false,
@@ -17,8 +17,8 @@ QUnit.test('Legend should be rendered below the range selector', function (asser
         }]
     });
     assert.ok(
-        document.getElementsByClassName('highcharts-legend')[0].getBoundingClientRect().top >=
-        document.getElementsByClassName('highcharts-range-selector-group')[0].getBoundingClientRect().bottom,
+        chart.legend.group.element.getBoundingClientRect().top >=
+            chart.rangeSelector.group.element.getBoundingClientRect().bottom,
         'The legend is rendered below the range selector.'
     );
 });

--- a/samples/unit-tests/rangeselector/legend-position/demo.js
+++ b/samples/unit-tests/rangeselector/legend-position/demo.js
@@ -1,0 +1,24 @@
+QUnit.test('Legend should be rendered below the range selector', function (assert) {
+    Highcharts.stockChart('container', {
+        rangeSelector: {
+            enabled: true,
+            inputEnabled: false,
+            buttonPosition: {
+                align: 'right'
+            }
+        },
+        legend: {
+            enabled: true,
+            align: 'left',
+            verticalAlign: 'top'
+        },
+        series: [{
+            data: [101, 343, 11]
+        }]
+    });
+    assert.ok(
+        document.getElementsByClassName('highcharts-legend')[0].getBoundingClientRect().top >=
+        document.getElementsByClassName('highcharts-range-selector-group')[0].getBoundingClientRect().bottom,
+        'The legend is rendered below the range selector.'
+    );
+});

--- a/ts/parts/Legend.ts
+++ b/ts/parts/Legend.ts
@@ -78,6 +78,7 @@ declare global {
                 margin: Array<number>,
                 spacing: Array<number>
             ): void;
+            public align(alignTo?: BBoxObject): void;
             public colorizeItem(
                 item: (BubbleLegend|Point|Series),
                 visible?: boolean
@@ -1305,33 +1306,7 @@ class Legend {
         legend.legendHeight = legendHeight;
 
         if (display) {
-            // If aligning to the top and the layout is horizontal, adjust for
-            // the title (#7428)
-            let alignTo = chart.spacingBox;
-            let y = alignTo.y;
-
-            if (
-                /(lth|ct|rth)/.test(legend.getAlignment()) &&
-                chart.titleOffset[0] > 0
-            ) {
-                y += chart.titleOffset[0];
-
-            } else if (
-                /(lbh|cb|rbh)/.test(legend.getAlignment()) &&
-                chart.titleOffset[2] > 0
-            ) {
-                y -= chart.titleOffset[2];
-            }
-
-            if (y !== alignTo.y) {
-                alignTo = merge(alignTo, { y });
-            }
-
-            legendGroup.align(merge(options, {
-                width: legendWidth,
-                height: legendHeight,
-                verticalAlign: this.proximate ? 'top' : options.verticalAlign
-            }), true, alignTo);
+            legend.align();
         }
 
         if (!this.proximate) {
@@ -1339,6 +1314,47 @@ class Legend {
         }
 
         fireEvent(this, 'afterRender');
+    }
+
+    /**
+     * Align the legend to chart's box.
+     *
+     * @private
+     * @function Highcharts.align
+     * @param {Highcharts.BBoxObject} alignTo
+     * @return {void}
+     */
+    public align(
+        alignTo: Highcharts.BBoxObject = this.chart.spacingBox
+    ): void {
+        var chart = this.chart,
+            options = this.options;
+        // If aligning to the top and the layout is horizontal, adjust for
+        // the title (#7428)
+        let y = alignTo.y;
+
+        if (
+            /(lth|ct|rth)/.test(this.getAlignment()) &&
+            chart.titleOffset[0] > 0
+        ) {
+            y += chart.titleOffset[0];
+
+        } else if (
+            /(lbh|cb|rbh)/.test(this.getAlignment()) &&
+            chart.titleOffset[2] > 0
+        ) {
+            y -= chart.titleOffset[2];
+        }
+
+        if (y !== alignTo.y) {
+            alignTo = merge(alignTo, { y });
+        }
+
+        this.group.align(merge(options, {
+            width: this.legendWidth,
+            height: this.legendHeight,
+            verticalAlign: this.proximate ? 'top' : options.verticalAlign
+        }), true, alignTo);
     }
 
     /**

--- a/ts/parts/RangeSelector.ts
+++ b/ts/parts/RangeSelector.ts
@@ -2227,15 +2227,34 @@ if (!H.RangeSelector) {
         var extremes,
             rangeSelector = chart.rangeSelector,
             unbindRender: Function,
-            unbindSetExtremes: Function;
+            unbindSetExtremes: Function,
+            legend,
+            alignTo,
+            verticalAlign: Highcharts.VerticalAlignValue|undefined;
 
         /**
          * @private
          */
         function renderRangeSelector(): void {
             extremes = chart.xAxis[0].getExtremes();
+            legend = chart.legend;
+            verticalAlign = rangeSelector?.options.verticalAlign;
+
             if (isNumber(extremes.min)) {
                 (rangeSelector as any).render(extremes.min, extremes.max);
+            }
+
+            // Re-align the legend so that it's below the rangeselector
+            if (
+                rangeSelector && legend.display &&
+                verticalAlign === 'top' &&
+                verticalAlign === legend.options.verticalAlign
+            ) {
+                // Create and use a new alignment box for the legend.
+                alignTo = merge(chart.spacingBox);
+                alignTo.y += rangeSelector.getHeight();
+                legend.group.placed = false; // Don't animate the alignment.
+                legend.align(alignTo);
             }
         }
 

--- a/ts/parts/RangeSelector.ts
+++ b/ts/parts/RangeSelector.ts
@@ -2250,9 +2250,13 @@ if (!H.RangeSelector) {
                 verticalAlign === 'top' &&
                 verticalAlign === legend.options.verticalAlign
             ) {
-                // Create and use a new alignment box for the legend.
+                // Create a new alignment box for the legend.
                 alignTo = merge(chart.spacingBox);
-                alignTo.y += rangeSelector.getHeight();
+                if (legend.options.layout === 'vertical') {
+                    alignTo.y = chart.plotTop;
+                } else {
+                    alignTo.y += rangeSelector.getHeight();
+                }
                 legend.group.placed = false; // Don't animate the alignment.
                 legend.align(alignTo);
             }


### PR DESCRIPTION
Fixed #13025, legend was overlapping range selector when they were both vertically aligned to the top.