### PR TITLE
bugfix/13184-scrollbar-toggle-extremes

### DIFF
--- a/js/parts/Navigator.js
+++ b/js/parts/Navigator.js
@@ -1702,9 +1702,10 @@ var Navigator = /** @class */ (function () {
             // as new data comes in
             if (stickToMax) {
                 newMax = baseDataMax + overscroll;
-                // if stickToMin is true, the new min value is set above
+                // If stickToMin is true, the new min value is set above
                 if (!stickToMin) {
-                    newMin = Math.max(newMax - range, navigator.getBaseSeriesMin(navigatorSeries && navigatorSeries.xData ?
+                    newMin = Math.max(baseDataMin, // don't go below data extremes (#13184)
+                    newMax - range, navigator.getBaseSeriesMin(navigatorSeries && navigatorSeries.xData ?
                         navigatorSeries.xData[0] :
                         -Number.MAX_VALUE));
                 }

--- a/samples/unit-tests/scrollbar/extremes/demo.js
+++ b/samples/unit-tests/scrollbar/extremes/demo.js
@@ -254,3 +254,45 @@ QUnit.test('#12834 - xAxis had wrong extremes after scroll .', function (assert)
     );
 
 });
+
+QUnit.test('Toggle chart.scrollbar', assert => {
+    const chart = Highcharts.chart('container', {
+        series: [{
+            data: [5, 6, 2]
+        }],
+        scrollbar: {
+            enabled: true
+        }
+    });
+
+    chart.update({
+        scrollbar: {
+            enabled: false
+        },
+        series: [{
+            data: [5, 6, 2, 4]
+        }]
+    });
+
+    chart.update({
+        xAxis: {
+            min: 0,
+            max: 0
+        },
+        series: [{
+            data: [5]
+        }]
+    });
+
+    assert.strictEqual(
+        chart.xAxis[0].tickPositions.length,
+        1,
+        'xAxis should have just one tick (#13184).'
+    );
+
+    assert.strictEqual(
+        chart.xAxis[0].tickPositions[0],
+        0,
+        'xAxis\'s tick should equal min and max values (#13184).'
+    );
+});

--- a/ts/parts/Navigator.ts
+++ b/ts/parts/Navigator.ts
@@ -2510,9 +2510,10 @@ class Navigator {
             if (stickToMax) {
                 newMax = baseDataMax + overscroll;
 
-                // if stickToMin is true, the new min value is set above
+                // If stickToMin is true, the new min value is set above
                 if (!stickToMin) {
                     newMin = Math.max(
+                        baseDataMin, // don't go below data extremes (#13184)
                         newMax - range,
                         (navigator as any).getBaseSeriesMin(
                             navigatorSeries && navigatorSeries.xData ?


### PR DESCRIPTION
Fixed #13184, dynamically disabling scrollbar and decreasing number of points in `chart.update()`  caused wrong extremes on `xAxis`. 