### PR TITLE
bugfix/13204-yaxis-labels-rotation-alignticks

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -1465,9 +1465,7 @@ var Axis = /** @class */ (function () {
                 axis.max < 9999)), !!this.tickAmount);
         }
         // Prevent ticks from getting so close that we can't draw the labels
-        if (!this.tickAmount) {
-            axis.tickInterval = axis.unsquish();
-        }
+        axis.tickInterval = axis.unsquish();
         this.setTickPositions();
     };
     /**

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -508,6 +508,7 @@ var Axis = /** @class */ (function () {
             typeof axis.reversed === 'undefined') {
             axis.reversed = true;
         }
+        axis.labelRotation = axis.options.labels.rotation;
         // register event listeners
         objectEach(events, function (event, eventType) {
             if (isFunction(event)) {
@@ -1465,7 +1466,9 @@ var Axis = /** @class */ (function () {
                 axis.max < 9999)), !!this.tickAmount);
         }
         // Prevent ticks from getting so close that we can't draw the labels
-        axis.tickInterval = axis.unsquish();
+        if (!this.tickAmount) {
+            axis.tickInterval = axis.unsquish();
+        }
         this.setTickPositions();
     };
     /**

--- a/samples/unit-tests/axis/alignticks/demo.js
+++ b/samples/unit-tests/axis/alignticks/demo.js
@@ -31,37 +31,59 @@ QUnit.test('Align ticks on opposite axis (#150)', function (assert) {
 
     var chart = Highcharts.chart('container', {
 
-        chart: {
-            height: 200,
-            width: 400
-        },
+            chart: {
+                height: 200,
+                width: 400
+            },
 
-        title: {
-            text: ''
-        },
+            title: {
+                text: ''
+            },
 
-        series: [{
-            yAxis: 0,
-            data: [1, 2]
-        }, {
-            yAxis: 1,
-            data: [1, 2]
-        }],
+            series: [{
+                yAxis: 0,
+                data: [1, 2]
+            }, {
+                yAxis: 1,
+                data: [1, 2]
+            }],
 
-        yAxis: [{
-            opposite: true
-        }, {
-            min: -100,
-            max: 100
-        }]
-    });
+            yAxis: [{
+                opposite: true,
+                labels: {
+                    rotation: 270
+                }
+            }, {
+                min: -100,
+                max: 100,
+                labels: {
+                    rotation: 270
+                }
+            }]
+        }),
+        rightYAxis = chart.yAxis[0],
+        leftYAxis = chart.yAxis[1];
 
-    var gridNodes1 = chart.yAxis[0].gridGroup.element.childNodes;
-    var gridNodes2 = chart.yAxis[1].gridGroup.element.childNodes;
+    var gridNodes1 = leftYAxis.gridGroup.element.childNodes;
+    var gridNodes2 = rightYAxis.gridGroup.element.childNodes;
 
     assert.equal(
         gridNodes1[gridNodes1.length - 1].getAttribute('d'),
         gridNodes2[gridNodes2.length - 1].getAttribute('d'),
-        'Ticks are not aligned'
+        'Ticks should be aligned.'
+    );
+
+    assert.strictEqual(
+        leftYAxis.ticks[leftYAxis.tickPositions[1]].label.attr('text-anchor'),
+        'middle',
+        `Second label should be centered over the gridline -
+            left yAxis (#13204).`
+    );
+
+    assert.strictEqual(
+        rightYAxis.ticks[rightYAxis.tickPositions[1]].label.attr('text-anchor'),
+        'middle',
+        `Second label should be centered over the gridline -
+            right yAxis (#13204).`
     );
 });

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -5503,9 +5503,7 @@ class Axis implements AxisComposition {
         }
 
         // Prevent ticks from getting so close that we can't draw the labels
-        if (!this.tickAmount) {
-            axis.tickInterval = axis.unsquish();
-        }
+        axis.tickInterval = axis.unsquish();
 
         this.setTickPositions();
     }

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -4157,6 +4157,8 @@ class Axis implements AxisComposition {
             axis.reversed = true;
         }
 
+        axis.labelRotation = (axis.options as any).labels.rotation;
+
         // register event listeners
         objectEach(events, function (event: any, eventType: string): void {
             if (isFunction(event)) {
@@ -5503,7 +5505,9 @@ class Axis implements AxisComposition {
         }
 
         // Prevent ticks from getting so close that we can't draw the labels
-        axis.tickInterval = axis.unsquish();
+        if (!this.tickAmount) {
+            axis.tickInterval = axis.unsquish();
+        }
 
         this.setTickPositions();
     }


### PR DESCRIPTION
Fixed #13204, multiple `yAxis` labels were not centered over the gridlines when rotation was set and `alignTicks` was enabled.
___
For now, just a draft PR, to compare visuals.

Short explanation:
- labels in SVG have different `text-anchor` which by default is autocalculated
- to set `text-anchor`, `autoLabelAlign(rotation)` is called with `this.labelRotation` as an argument
- `this.labelRotation` is calculated only when `tickAmount` is not set
- `alignTicks` sets default `tickAmount`