### PR TITLE
Fixed JSFiddle with trellis chart example

### DIFF
--- a/docs/chart-and-series-types/bar-chart.md
+++ b/docs/chart-and-series-types/bar-chart.md
@@ -14,4 +14,4 @@ The bar chart can be used as a trellis chart by drawing several bar charts in a 
 
 ![trellis.png](trellis.png)
 
-The example can be found at [https://jsfiddle.net/highcharts/VqruM/](https://jsfiddle.net/highcharts/VqruM/).
+The example can be found at [https://jsfiddle.net/zoknhwcx/](https://jsfiddle.net/zoknhwcx/).


### PR DESCRIPTION
I noticed that trellis example in JSFiddle is broken due to loading HighCharts over http instead of https. I forked existing example and updated URL.