### PR TITLE
bugfix/12054-stocktools-restore-annotations

### DIFF
--- a/js/annotations/navigationBindings.js
+++ b/js/annotations/navigationBindings.js
@@ -151,7 +151,8 @@ H.NavigationBindings.annotationsEditable = {
     pitchfork: ['innerBackground', 'outerBackground'],
     rect: ['shapes'],
     // Crooked lines, elliots, arrows etc:
-    crookedLine: []
+    crookedLine: [],
+    basicAnnotation: []
 };
 // Define non editable fields per annotation, for example Rectangle inherits
 // options from Measure, but crosshairs are not available
@@ -809,33 +810,10 @@ H.setOptions({
                 className: 'highcharts-circle-annotation',
                 /** @ignore-option */
                 start: function (e) {
-                    var coords = this.chart.pointer.getCoordinates(e), navigation = this.chart.options.navigation, controlPoints = [{
-                            positioner: function (target) {
-                                var xy = H.Annotation.MockPoint.pointToPixels(target.points[0]), r = target.options.r;
-                                return {
-                                    x: xy.x + r * Math.cos(Math.PI / 4) -
-                                        this.graphic.width / 2,
-                                    y: xy.y + r * Math.sin(Math.PI / 4) -
-                                        this.graphic.height / 2
-                                };
-                            },
-                            events: {
-                                // TRANSFORM RADIUS ACCORDING TO Y
-                                // TRANSLATION
-                                drag: function (e, target) {
-                                    var annotation = target.annotation, position = this.mouseMoveToTranslation(e);
-                                    target.setRadius(Math.max(target.options.r +
-                                        position.y /
-                                            Math.sin(Math.PI / 4), 5));
-                                    annotation.options.shapes[0] =
-                                        annotation.userOptions.shapes[0] =
-                                            target.options;
-                                    target.redraw(false);
-                                }
-                            }
-                        }];
+                    var coords = this.chart.pointer.getCoordinates(e), navigation = this.chart.options.navigation;
                     return this.chart.addAnnotation(merge({
                         langKey: 'circle',
+                        type: 'basicAnnotation',
                         shapes: [{
                                 type: 'circle',
                                 point: {
@@ -844,8 +822,7 @@ H.setOptions({
                                     x: coords.xAxis[0].value,
                                     y: coords.yAxis[0].value
                                 },
-                                r: 5,
-                                controlPoints: controlPoints
+                                r: 5
                             }]
                     }, navigation
                         .annotationsOptions, navigation
@@ -878,32 +855,10 @@ H.setOptions({
                 className: 'highcharts-rectangle-annotation',
                 /** @ignore-option */
                 start: function (e) {
-                    var coords = this.chart.pointer.getCoordinates(e), navigation = this.chart.options.navigation, x = coords.xAxis[0].value, y = coords.yAxis[0].value, controlPoints = [{
-                            positioner: function (annotation) {
-                                var xy = H.Annotation.MockPoint
-                                    .pointToPixels(annotation.shapes[0].points[2]);
-                                return {
-                                    x: xy.x - 4,
-                                    y: xy.y - 4
-                                };
-                            },
-                            events: {
-                                drag: function (target) {
-                                    var coords = this.chart.pointer.getCoordinates(e), x = coords.xAxis[0].value, y = coords.yAxis[0].value, shape = target.options.shapes[0], points = shape.points;
-                                    // Top right point
-                                    points[1].x = x;
-                                    // Bottom right point (cursor position)
-                                    points[2].x = x;
-                                    points[2].y = y;
-                                    // Bottom left
-                                    points[3].y = y;
-                                    target.options.shapes[0].points = points;
-                                    target.redraw(false);
-                                }
-                            }
-                        }];
+                    var coords = this.chart.pointer.getCoordinates(e), navigation = this.chart.options.navigation, x = coords.xAxis[0].value, y = coords.yAxis[0].value;
                     return this.chart.addAnnotation(merge({
                         langKey: 'rectangle',
+                        type: 'basicAnnotation',
                         shapes: [{
                                 type: 'path',
                                 points: [{
@@ -927,8 +882,7 @@ H.setOptions({
                                         x: x,
                                         y: y
                                     }]
-                            }],
-                        controlPoints: controlPoints
+                            }]
                     }, navigation
                         .annotationsOptions, navigation
                         .bindings
@@ -965,62 +919,10 @@ H.setOptions({
                 className: 'highcharts-label-annotation',
                 /** @ignore-option */
                 start: function (e) {
-                    var coords = this.chart.pointer.getCoordinates(e), navigation = this.chart.options.navigation, controlPoints = [{
-                            symbol: 'triangle-down',
-                            positioner: function (target) {
-                                if (!target.graphic.placed) {
-                                    return {
-                                        x: 0,
-                                        y: -9e7
-                                    };
-                                }
-                                var xy = H.Annotation.MockPoint
-                                    .pointToPixels(target.points[0]);
-                                return {
-                                    x: xy.x - this.graphic.width / 2,
-                                    y: xy.y - this.graphic.height / 2
-                                };
-                            },
-                            // TRANSLATE POINT/ANCHOR
-                            events: {
-                                drag: function (e, target) {
-                                    var xy = this.mouseMoveToTranslation(e);
-                                    target.translatePoint(xy.x, xy.y);
-                                    target.annotation.labels[0].options =
-                                        target.options;
-                                    target.redraw(false);
-                                }
-                            }
-                        }, {
-                            symbol: 'square',
-                            positioner: function (target) {
-                                if (!target.graphic.placed) {
-                                    return {
-                                        x: 0,
-                                        y: -9e7
-                                    };
-                                }
-                                return {
-                                    x: target.graphic.alignAttr.x -
-                                        this.graphic.width / 2,
-                                    y: target.graphic.alignAttr.y -
-                                        this.graphic.height / 2
-                                };
-                            },
-                            // TRANSLATE POSITION WITHOUT CHANGING THE
-                            // ANCHOR
-                            events: {
-                                drag: function (e, target) {
-                                    var xy = this.mouseMoveToTranslation(e);
-                                    target.translate(xy.x, xy.y);
-                                    target.annotation.labels[0].options =
-                                        target.options;
-                                    target.redraw(false);
-                                }
-                            }
-                        }];
+                    var coords = this.chart.pointer.getCoordinates(e), navigation = this.chart.options.navigation;
                     return this.chart.addAnnotation(merge({
                         langKey: 'label',
+                        type: 'basicAnnotation',
                         labelOptions: {
                             format: '{y:.2f}'
                         },
@@ -1032,8 +934,7 @@ H.setOptions({
                                     y: coords.yAxis[0].value
                                 },
                                 overflow: 'none',
-                                crop: true,
-                                controlPoints: controlPoints
+                                crop: true
                             }]
                     }, navigation
                         .annotationsOptions, navigation
@@ -1103,7 +1004,7 @@ H.setOptions({
          * @type      {Highcharts.AnnotationsOptions}
          * @extends   annotations
          * @exclude   crookedLine, elliottWave, fibonacci, infinityLine,
-         *            measure, pitchfork, tunnel, verticalLine
+         *            measure, pitchfork, tunnel, verticalLine, basicAnnotation
          * @apioption navigation.annotationsOptions
          */
         annotationsOptions: {}

--- a/js/annotations/types/BasicAnnotation.js
+++ b/js/annotations/types/BasicAnnotation.js
@@ -1,0 +1,130 @@
+/* *
+ *
+ *  !!!!!!! SOURCE GETS TRANSPILED BY TYPESCRIPT. EDIT TS FILE ONLY. !!!!!!!
+ *
+ * */
+'use strict';
+import H from '../../parts/Globals.js';
+var Annotation = H.Annotation;
+/* eslint-disable no-invalid-this */
+var BasicAnnotation = function () {
+    Annotation.apply(this, arguments);
+};
+H.extendAnnotation(BasicAnnotation, null, {
+    basicControlPoints: {
+        label: [{
+                symbol: 'triangle-down',
+                positioner: function (target) {
+                    if (!target.graphic.placed) {
+                        return {
+                            x: 0,
+                            y: -9e7
+                        };
+                    }
+                    var xy = H.Annotation.MockPoint
+                        .pointToPixels(target.points[0]);
+                    return {
+                        x: xy.x - this.graphic.width / 2,
+                        y: xy.y - this.graphic.height / 2
+                    };
+                },
+                // TRANSLATE POINT/ANCHOR
+                events: {
+                    drag: function (e, target) {
+                        var xy = this.mouseMoveToTranslation(e);
+                        target.translatePoint(xy.x, xy.y);
+                        target.annotation.userOptions.labels[0].point =
+                            target.options.point;
+                        target.redraw(false);
+                    }
+                }
+            }, {
+                symbol: 'square',
+                positioner: function (target) {
+                    if (!target.graphic.placed) {
+                        return {
+                            x: 0,
+                            y: -9e7
+                        };
+                    }
+                    return {
+                        x: target.graphic.alignAttr.x -
+                            this.graphic.width / 2,
+                        y: target.graphic.alignAttr.y -
+                            this.graphic.height / 2
+                    };
+                },
+                // TRANSLATE POSITION WITHOUT CHANGING THE
+                // ANCHOR
+                events: {
+                    drag: function (e, target) {
+                        var xy = this.mouseMoveToTranslation(e);
+                        target.translate(xy.x, xy.y);
+                        target.annotation.userOptions.labels[0].point =
+                            target.options.point;
+                        target.redraw(false);
+                    }
+                }
+            }],
+        rectangle: [{
+                positioner: function (annotation) {
+                    var xy = H.Annotation.MockPoint
+                        .pointToPixels(annotation.points[2]);
+                    return {
+                        x: xy.x - 4,
+                        y: xy.y - 4
+                    };
+                },
+                events: {
+                    drag: function (e, target) {
+                        var annotation = target.annotation, coords = this.chart.pointer.getCoordinates(e), x = coords.xAxis[0].value, y = coords.yAxis[0].value, points = target.options.points;
+                        // Top right point
+                        points[1].x = x;
+                        // Bottom right point (cursor position)
+                        points[2].x = x;
+                        points[2].y = y;
+                        // Bottom left
+                        points[3].y = y;
+                        annotation.userOptions.shapes[0].points =
+                            target.options.points;
+                        annotation.redraw(false);
+                    }
+                }
+            }],
+        circle: [{
+                positioner: function (target) {
+                    var xy = H.Annotation.MockPoint.pointToPixels(target.points[0]), r = target.options.r;
+                    return {
+                        x: xy.x + r * Math.cos(Math.PI / 4) -
+                            this.graphic.width / 2,
+                        y: xy.y + r * Math.sin(Math.PI / 4) -
+                            this.graphic.height / 2
+                    };
+                },
+                events: {
+                    // TRANSFORM RADIUS ACCORDING TO Y
+                    // TRANSLATION
+                    drag: function (e, target) {
+                        var annotation = target.annotation, position = this.mouseMoveToTranslation(e);
+                        target.setRadius(Math.max(target.options.r +
+                            position.y /
+                                Math.sin(Math.PI / 4), 5));
+                        annotation.userOptions.shapes[0].r = target.options.r;
+                        annotation.userOptions.shapes[0].point =
+                            target.options.point;
+                        target.redraw(false);
+                    }
+                }
+            }]
+    },
+    addControlPoints: function () {
+        var options = this.options, controlPoints = this.basicControlPoints, langKey = options.langKey, optionsGroup = options.labels || options.shapes;
+        optionsGroup.forEach(function (group) {
+            if (langKey) {
+                group.controlPoints = controlPoints[langKey];
+            }
+        });
+    }
+});
+Annotation.types.basicAnnotation = BasicAnnotation;
+export default BasicAnnotation;

--- a/js/masters/modules/annotations-advanced.src.js
+++ b/js/masters/modules/annotations-advanced.src.js
@@ -11,6 +11,7 @@
  */
 'use strict';
 import '../../annotations/annotations.src.js';
+import '../../annotations/types/BasicAnnotation.js';
 import '../../annotations/types/CrookedLine.js';
 import '../../annotations/types/ElliottWave.js';
 import '../../annotations/types/Tunnel.js';

--- a/samples/unit-tests/stock-tools/bindings/demo.js
+++ b/samples/unit-tests/stock-tools/bindings/demo.js
@@ -255,6 +255,19 @@ QUnit.test('Bindings general tests', function (assert) {
         true,
         'Chart saved in the local storage'
     );
+    // Restore basic annotations
+    JSON.parse(localStorage['highcharts-chart']).annotations.forEach(annotation => {
+        if (!annotation.typeOptions) {
+            chart.addAnnotation(annotation);
+
+            assert.ok(
+                1,
+                'No errors should be thrown after setting the basic annotations (#12054)'
+            );
+            ++annotationsCounter;
+        }
+    });
+
     localStorage.removeItem('highcharts-chart');
 
     // Test yAxis resizers and adding indicators:

--- a/ts/annotations/navigationBindings.ts
+++ b/ts/annotations/navigationBindings.ts
@@ -21,6 +21,7 @@ declare global {
             navigationBindings: NavigationBindings;
         }
         interface AnnotationEditableObject {
+            basicAnnotation: Array<string>;
             circle: Array<string>;
             crookedLine: Array<string>;
             fibonacci: Array<string>;
@@ -303,7 +304,8 @@ H.NavigationBindings.annotationsEditable = {
     pitchfork: ['innerBackground', 'outerBackground'],
     rect: ['shapes'],
     // Crooked lines, elliots, arrows etc:
-    crookedLine: []
+    crookedLine: [],
+    basicAnnotation: []
 };
 
 // Define non editable fields per annotation, for example Rectangle inherits
@@ -1200,55 +1202,13 @@ H.setOptions({
                     e: Highcharts.PointerEventObject
                 ): Highcharts.Annotation {
                     var coords = this.chart.pointer.getCoordinates(e),
-                        navigation = this.chart.options.navigation,
-                        controlPoints: Array<Partial<Highcharts.AnnotationControlPointOptionsObject>> = [{
-                            positioner: function (
-                                this: Highcharts.AnnotationControlPoint,
-                                target: Highcharts.AnnotationControllable
-                            ): Highcharts.PositionObject {
-                                var xy = H.Annotation.MockPoint.pointToPixels(target.points[0]),
-                                    r: number = target.options.r as any;
-
-                                return {
-                                    x: xy.x + r * Math.cos(Math.PI / 4) -
-                                        this.graphic.width / 2,
-                                    y: xy.y + r * Math.sin(Math.PI / 4) -
-                                        this.graphic.height / 2
-                                };
-                            },
-                            events: {
-                                // TRANSFORM RADIUS ACCORDING TO Y
-                                // TRANSLATION
-                                drag: function (
-                                    this: Highcharts.Annotation,
-                                    e: Highcharts.AnnotationEventObject,
-                                    target: Highcharts.AnnotationControllableCircle
-                                ): void {
-                                    var annotation = target.annotation,
-                                        position = this.mouseMoveToTranslation(e);
-
-                                    target.setRadius(
-                                        Math.max(
-                                            (target.options.r as any) +
-                                                position.y /
-                                                Math.sin(Math.PI / 4),
-                                            5
-                                        )
-                                    );
-
-                                    annotation.options.shapes[0] =
-                                        annotation.userOptions.shapes[0] =
-                                        target.options;
-
-                                    target.redraw(false);
-                                } as any
-                            }
-                        }];
+                        navigation = this.chart.options.navigation;
 
                     return this.chart.addAnnotation(
                         merge(
                             {
                                 langKey: 'circle',
+                                type: 'basicAnnotation',
                                 shapes: [{
                                     type: 'circle',
                                     point: {
@@ -1257,8 +1217,7 @@ H.setOptions({
                                         x: coords.xAxis[0].value,
                                         y: coords.yAxis[0].value
                                     },
-                                    r: 5,
-                                    controlPoints: controlPoints
+                                    r: 5
                                 }]
                             },
                             navigation
@@ -1321,50 +1280,13 @@ H.setOptions({
                     var coords = this.chart.pointer.getCoordinates(e),
                         navigation = this.chart.options.navigation,
                         x = coords.xAxis[0].value,
-                        y = coords.yAxis[0].value,
-                        controlPoints = [{
-                            positioner: function (annotation: Highcharts.Annotation): Highcharts.PositionObject {
-                                var xy = H.Annotation.MockPoint
-                                    .pointToPixels(
-                                        annotation.shapes[0].points[2]
-                                    );
-
-                                return {
-                                    x: xy.x - 4,
-                                    y: xy.y - 4
-                                };
-                            },
-                            events: {
-                                drag: function (
-                                    this: Highcharts.Annotation,
-                                    target: Highcharts.AnnotationControllableRect
-                                ): void {
-                                    var coords = this.chart.pointer.getCoordinates(e),
-                                        x = coords.xAxis[0].value,
-                                        y = coords.yAxis[0].value,
-                                        shape = target.options.shapes[0],
-                                        points: Array<Highcharts.AnnotationMockPointOptionsObject> =
-                                            shape.points as any;
-
-                                    // Top right point
-                                    points[1].x = x;
-                                    // Bottom right point (cursor position)
-                                    points[2].x = x;
-                                    points[2].y = y;
-                                    // Bottom left
-                                    points[3].y = y;
-
-                                    target.options.shapes[0].points = points;
-
-                                    target.redraw(false);
-                                }
-                            }
-                        }];
+                        y = coords.yAxis[0].value;
 
                     return this.chart.addAnnotation(
                         merge(
                             {
                                 langKey: 'rectangle',
+                                type: 'basicAnnotation',
                                 shapes: [{
                                     type: 'path',
                                     points: [{
@@ -1388,8 +1310,7 @@ H.setOptions({
                                         x: x,
                                         y: y
                                     }]
-                                }],
-                                controlPoints: controlPoints
+                                }]
                             },
                             navigation
                                 .annotationsOptions,
@@ -1444,93 +1365,13 @@ H.setOptions({
                     e: Highcharts.PointerEventObject
                 ): Highcharts.Annotation {
                     var coords = this.chart.pointer.getCoordinates(e),
-                        navigation = this.chart.options.navigation,
-                        controlPoints = [{
-                            symbol: 'triangle-down',
-                            positioner: function (
-                                this: Highcharts.AnnotationControlPoint,
-                                target: Highcharts.AnnotationControllable
-                            ): Highcharts.PositionObject {
-                                if (!target.graphic.placed) {
-                                    return {
-                                        x: 0,
-                                        y: -9e7
-                                    };
-                                }
-
-                                var xy = H.Annotation.MockPoint
-                                    .pointToPixels(
-                                        target.points[0]
-                                    );
-
-                                return {
-                                    x: xy.x - this.graphic.width / 2,
-                                    y: xy.y - this.graphic.height / 2
-                                };
-                            },
-
-                            // TRANSLATE POINT/ANCHOR
-                            events: {
-                                drag: function (
-                                    this: Highcharts.Annotation,
-                                    e: Highcharts.AnnotationEventObject,
-                                    target: Highcharts.Annotation
-                                ): void {
-                                    var xy = this.mouseMoveToTranslation(e);
-
-                                    (target.translatePoint as any)(xy.x, xy.y);
-
-                                    target.annotation.labels[0].options =
-                                        target.options as any;
-
-                                    target.redraw(false);
-                                }
-                            }
-                        }, {
-                            symbol: 'square',
-                            positioner: function (
-                                this: Highcharts.AnnotationControlPoint,
-                                target: Highcharts.AnnotationControllable
-                            ): Highcharts.PositionObject {
-                                if (!target.graphic.placed) {
-                                    return {
-                                        x: 0,
-                                        y: -9e7
-                                    };
-                                }
-
-                                return {
-                                    x: target.graphic.alignAttr.x -
-                                        this.graphic.width / 2,
-                                    y: target.graphic.alignAttr.y -
-                                        this.graphic.height / 2
-                                };
-                            },
-
-                            // TRANSLATE POSITION WITHOUT CHANGING THE
-                            // ANCHOR
-                            events: {
-                                drag: function (
-                                    this: Highcharts.Annotation,
-                                    e: Highcharts.AnnotationEventObject,
-                                    target: Highcharts.AnnotationControllable
-                                ): void {
-                                    var xy = this.mouseMoveToTranslation(e);
-
-                                    target.translate(xy.x, xy.y);
-
-                                    target.annotation.labels[0].options =
-                                        target.options as any;
-
-                                    target.redraw(false);
-                                }
-                            }
-                        }];
+                        navigation = this.chart.options.navigation;
 
                     return this.chart.addAnnotation(
                         merge(
                             {
                                 langKey: 'label',
+                                type: 'basicAnnotation',
                                 labelOptions: {
                                     format: '{y:.2f}'
                                 },
@@ -1542,8 +1383,7 @@ H.setOptions({
                                         y: coords.yAxis[0].value
                                     },
                                     overflow: 'none',
-                                    crop: true,
-                                    controlPoints: controlPoints
+                                    crop: true
                                 }]
                             },
                             navigation
@@ -1622,7 +1462,7 @@ H.setOptions({
          * @type      {Highcharts.AnnotationsOptions}
          * @extends   annotations
          * @exclude   crookedLine, elliottWave, fibonacci, infinityLine,
-         *            measure, pitchfork, tunnel, verticalLine
+         *            measure, pitchfork, tunnel, verticalLine, basicAnnotation
          * @apioption navigation.annotationsOptions
          */
         annotationsOptions: {}

--- a/ts/annotations/types/BasicAnnotation.ts
+++ b/ts/annotations/types/BasicAnnotation.ts
@@ -1,0 +1,218 @@
+/* *
+ *
+ *  !!!!!!! SOURCE GETS TRANSPILED BY TYPESCRIPT. EDIT TS FILE ONLY. !!!!!!!
+ *
+ * */
+
+'use strict';
+import H from '../../parts/Globals.js';
+
+/**
+ * Internal types.
+ * @private
+ */
+declare global {
+    namespace Highcharts {
+        class AnnotationBasicAnnotation extends Annotation {
+            public basicControlPoints: AnnotationBasicControlPoints
+            addControlPoints: () => void;
+        }
+
+        interface AnnotationBasicControlPoints {
+            label: DeepPartial<AnnotationControlPointOptionsObject>[];
+            rectangle: DeepPartial<AnnotationControlPointOptionsObject>[];
+            circle: DeepPartial<AnnotationControlPointOptionsObject>[];
+        }
+    }
+}
+
+var Annotation = H.Annotation;
+
+/* eslint-disable no-invalid-this */
+
+const BasicAnnotation: typeof Highcharts.AnnotationBasicAnnotation =
+function (
+    this: Highcharts.AnnotationBasicAnnotation
+): void {
+    Annotation.apply(this, arguments as any);
+} as any;
+
+H.extendAnnotation(
+    BasicAnnotation,
+    null,
+    {
+        basicControlPoints: {
+            label: [{
+                symbol: 'triangle-down',
+                positioner: function (
+                    this: Highcharts.AnnotationControlPoint,
+                    target: Highcharts.AnnotationControllable
+                ): Highcharts.PositionObject {
+                    if (!target.graphic.placed) {
+                        return {
+                            x: 0,
+                            y: -9e7
+                        };
+                    }
+                    var xy = H.Annotation.MockPoint
+                        .pointToPixels(target.points[0]);
+                    return {
+                        x: xy.x - this.graphic.width / 2,
+                        y: xy.y - this.graphic.height / 2
+                    };
+                },
+                // TRANSLATE POINT/ANCHOR
+                events: {
+                    drag: function (
+                        this: Highcharts.Annotation,
+                        e: Highcharts.AnnotationEventObject,
+                        target: Highcharts.Annotation
+                    ): void {
+                        var xy = this.mouseMoveToTranslation(e);
+
+                        (target.translatePoint as any)(xy.x, xy.y);
+
+                        target.annotation.userOptions.labels[0].point =
+                            target.options.point;
+                        target.redraw(false);
+                    }
+                }
+            }, {
+                symbol: 'square',
+                positioner: function (
+                    this: Highcharts.AnnotationControlPoint,
+                    target: Highcharts.AnnotationControllable
+                ): Highcharts.PositionObject {
+                    if (!target.graphic.placed) {
+                        return {
+                            x: 0,
+                            y: -9e7
+                        };
+                    }
+                    return {
+                        x: target.graphic.alignAttr.x -
+                            this.graphic.width / 2,
+                        y: target.graphic.alignAttr.y -
+                            this.graphic.height / 2
+                    };
+                },
+                // TRANSLATE POSITION WITHOUT CHANGING THE
+                // ANCHOR
+                events: {
+                    drag: function (
+                        this: Highcharts.Annotation,
+                        e: Highcharts.AnnotationEventObject,
+                        target: Highcharts.AnnotationControllable
+                    ): void {
+                        var xy = this.mouseMoveToTranslation(e);
+                        target.translate(xy.x, xy.y);
+
+                        target.annotation.userOptions.labels[0].point =
+                            target.options.point;
+
+                        target.redraw(false);
+                    }
+                }
+            }],
+
+            rectangle: [{
+                positioner: function (annotation: Highcharts.Annotation): Highcharts.PositionObject {
+                    var xy = H.Annotation.MockPoint
+                        .pointToPixels(annotation.points[2]);
+                    return {
+                        x: xy.x - 4,
+                        y: xy.y - 4
+                    };
+                },
+                events: {
+                    drag: function (
+                        this: Highcharts.Annotation,
+                        e: Highcharts.PointerEventObject,
+                        target: Highcharts.AnnotationControllableRect
+                    ): void {
+                        var annotation = target.annotation,
+                            coords = this.chart.pointer.getCoordinates(e),
+                            x = coords.xAxis[0].value,
+                            y = coords.yAxis[0].value,
+                            points: Array<Highcharts.AnnotationMockPointOptionsObject> = target.options.points as any;
+
+                        // Top right point
+                        points[1].x = x;
+                        // Bottom right point (cursor position)
+                        points[2].x = x;
+                        points[2].y = y;
+                        // Bottom left
+                        points[3].y = y;
+
+                        annotation.userOptions.shapes[0].points =
+                            target.options.points;
+                        annotation.redraw(false);
+                    }
+                }
+            }],
+
+            circle: [{
+                positioner: function (
+                    this: Highcharts.AnnotationControlPoint,
+                    target: Highcharts.AnnotationControllable
+                ): Highcharts.PositionObject {
+                    var xy = H.Annotation.MockPoint.pointToPixels(target.points[0]),
+                        r: number = target.options.r as any;
+                    return {
+                        x: xy.x + r * Math.cos(Math.PI / 4) -
+                        this.graphic.width / 2,
+                        y: xy.y + r * Math.sin(Math.PI / 4) -
+                        this.graphic.height / 2
+                    };
+                },
+                events: {
+                // TRANSFORM RADIUS ACCORDING TO Y
+                // TRANSLATION
+                    drag: function (
+                        this: Highcharts.Annotation,
+                        e: Highcharts.AnnotationEventObject,
+                        target: Highcharts.AnnotationControllableCircle
+                    ): void {
+                        var annotation = target.annotation,
+                            position = this.mouseMoveToTranslation(e);
+
+                        target.setRadius(
+                            Math.max(
+                                target.options.r +
+                                    position.y /
+                                    Math.sin(Math.PI / 4),
+                                5
+                            )
+                        );
+
+                        annotation.userOptions.shapes[0].r = target.options.r;
+                        annotation.userOptions.shapes[0].point =
+                            target.options.point;
+
+                        target.redraw(false);
+                    }
+                }
+            }]
+        },
+
+        addControlPoints: function (this: Highcharts.AnnotationBasicAnnotation): void {
+            const options = this.options,
+                controlPoints = this.basicControlPoints,
+                langKey = options.langKey,
+                optionsGroup = options.labels || options.shapes;
+
+            optionsGroup.forEach(function (
+                this: Highcharts.AnnotationsLabelsOptions[] | Highcharts.AnnotationsShapesOptions[],
+                group: Highcharts.AnnotationControllableOptionsObject
+            ): void {
+                if (langKey) {
+                    group.controlPoints = (controlPoints as any)[langKey];
+                }
+            });
+        }
+    }
+);
+
+Annotation.types.basicAnnotation = BasicAnnotation;
+
+export default BasicAnnotation;


### PR DESCRIPTION
Fixed #12054, saving and loading simple annotations (label, rectangle and circle) from `localStorage` added via StockTools. 