### PR TITLE
bugfix/13136-tickAmount-small-chart-height

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -1674,7 +1674,7 @@ var Axis = /** @class */ (function () {
     Axis.prototype.getTickAmount = function () {
         var axis = this, options = this.options, tickAmount = options.tickAmount, tickPixelInterval = options.tickPixelInterval;
         if (!defined(options.tickInterval) &&
-            this.len < tickPixelInterval &&
+            !tickAmount && this.len < tickPixelInterval &&
             !this.isRadial &&
             !axis.logarithmic &&
             options.startOnTick &&

--- a/samples/unit-tests/axis/ticks/demo.js
+++ b/samples/unit-tests/axis/ticks/demo.js
@@ -637,3 +637,26 @@ QUnit.test('No ticks on short axis (#3195)', function (assert) {
         "Grid lines is not visible"
     );
 });
+
+QUnit.test('The ticks should be visible when specified tick amount and chart height <200px', function (assert) {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            height: 170
+        },
+        yAxis: {
+            tickAmount: 5
+        },
+        series: [{
+            data: [3, 5, 6, 7, 9, 5]
+        }]
+    });
+
+    var yAxis = chart.yAxis[0],
+        tickAmount = yAxis.tickPositions.length;
+
+    assert.strictEqual(
+        tickAmount,
+        5,
+        "The amount of tick should be 5."
+    );
+});

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -5794,11 +5794,11 @@ class Axis implements AxisComposition {
         var axis: Highcharts.Axis = this as any,
             options = this.options,
             tickAmount = options.tickAmount,
-            tickPixelInterval = options.tickPixelInterval;
+            tickPixelInterval = options.tickPixelInterval as number;
 
         if (
             !defined(options.tickInterval) &&
-            this.len < (tickPixelInterval as any) &&
+            !tickAmount && this.len < tickPixelInterval &&
             !this.isRadial &&
             !axis.logarithmic &&
             options.startOnTick &&

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -5794,7 +5794,7 @@ class Axis implements AxisComposition {
         var axis: Highcharts.Axis = this as any,
             options = this.options,
             tickAmount = options.tickAmount,
-            tickPixelInterval = options.tickPixelInterval as number;
+            tickPixelInterval = options.tickPixelInterval as any;
 
         if (
             !defined(options.tickInterval) &&


### PR DESCRIPTION
Fixed #13136, couldn't set `yAxis.tickAmount` when the chart size was small.

~~Fixed #13136, didn't able to set the tick amount when the chart size was small.~~