### PR TITLE
Tools: Fixed filesize gulp task failing

### DIFF
--- a/tools/gulptasks/unsorted/filesize.js
+++ b/tools/gulptasks/unsorted/filesize.js
@@ -23,7 +23,7 @@ const commandLine = command => new Promise((resolve, reject) => {
 });
 const filesize = () => {
     const {
-        scripts
+        getBuildScripts
     } = require('../../build.js');
     const colors = require('colors');
     const {
@@ -70,8 +70,7 @@ const filesize = () => {
         ].join('\n'));
     };
 
-    const runFileSize = (obj, key) => Promise
-        .resolve(scripts({}))
+    const runFileSize = (obj, key) => getBuildScripts({ files }).fnFirstBuild()
         .then(() => compile(files, sourceFolder))
         .then(() => files.reduce(
             (o, n) => {

--- a/tools/gulptasks/unsorted/filesize.js
+++ b/tools/gulptasks/unsorted/filesize.js
@@ -38,7 +38,7 @@ const filesize = () => {
     const sourceFolder = './code/';
     // @todo Correct type names to classic and styled and rename the param to
     // 'mode'
-    const types = argv.type ? [argv.type] : ['classic', 'css'];
+    const types = argv.type ? [argv.type] : ['classic'];
     const filenames = argv.file ? argv.file.split(',') : ['highcharts.src.js'];
     const files = filenames.reduce((arr, name) => {
         const p = types.map(t => (t === 'css' ? 'js/' : '') + name);
@@ -71,7 +71,7 @@ const filesize = () => {
     };
 
     const runFileSize = (obj, key) => Promise
-        .resolve(scripts())
+        .resolve(scripts({}))
         .then(() => compile(files, sourceFolder))
         .then(() => files.reduce(
             (o, n) => {


### PR DESCRIPTION
Fixed #13323, 'filesize' gulp task failing. Removed 'css' from default `type` parameter, as this does not seem to be built anymore.