### PR TITLE
bugfix/13332-3d-column-ie-not-working

### DIFF
--- a/js/parts-3d/SVGRenderer.js
+++ b/js/parts-3d/SVGRenderer.js
@@ -298,8 +298,8 @@ cuboidMethods = merge(element3dMethods, {
         elem3d.singleSetterForParts('fill', null, {
             front: fill,
             // Do not change color if side was forced to render.
-            top: color(fill).brighten(elem3d.forcedSides.includes('top') ? 0 : 0.1).get(),
-            side: color(fill).brighten(elem3d.forcedSides.includes('side') ? 0 : -0.1).get()
+            top: color(fill).brighten(elem3d.forcedSides.indexOf('top') >= 0 ? 0 : 0.1).get(),
+            side: color(fill).brighten(elem3d.forcedSides.indexOf('side') >= 0 ? 0 : -0.1).get()
         });
         // fill for animation getter (#6776)
         elem3d.color = elem3d.fill = fill;

--- a/ts/parts-3d/SVGRenderer.ts
+++ b/ts/parts-3d/SVGRenderer.ts
@@ -593,10 +593,10 @@ cuboidMethods = merge(element3dMethods, {
             front: fill,
             // Do not change color if side was forced to render.
             top: color(fill).brighten(
-                elem3d.forcedSides.includes('top') ? 0 : 0.1
+                elem3d.forcedSides.indexOf('top') >= 0 ? 0 : 0.1
             ).get(),
             side: color(fill).brighten(
-                elem3d.forcedSides.includes('side') ? 0 : -0.1
+                elem3d.forcedSides.indexOf('side') >= 0 ? 0 : -0.1
             ).get()
         });
 


### PR DESCRIPTION
Fixed #13332, 3D column not working on IE browsers. Refactored `fillSetter` in cuboid methods.

~~Fixed #13332, refactored fillSeter in cuboid methods.~~