### PR TITLE
bugfix/13202-lollipop-data-format

### DIFF
--- a/js/modules/lollipop.src.js
+++ b/js/modules/lollipop.src.js
@@ -56,6 +56,11 @@ seriesType('lollipop', 'dumbbell', {
         pointFormat: '<span style="color:{series.color}">●</span> {series.name}: <b>{point.low}</b><br/>'
     }
 }, {
+    pointArrayMap: ['y'],
+    pointValKey: 'y',
+    toYData: function (point) {
+        return point.y;
+    },
     translatePoint: areaProto.translate,
     drawPoint: areaProto.drawPoints,
     drawDataLabels: colProto.drawDataLabels,
@@ -133,8 +138,15 @@ seriesType('lollipop', 'dumbbell', {
  *
  * @type      {Array<number|Array<(number|string),(number|null)>|null|*>}
  * @extends   series.dumbbell.data
- * @excluding lowColor
+ * @excluding high, low, lowColor
  * @product   highcharts highstock
  * @apioption series.lollipop.data
  */
+/**
+* The y value of the point.
+*
+* @type      {number|null}
+* @product   highcharts highstock
+* @apioption series.line.data.y
+*/
 ''; // adds doclets above to transpiled file

--- a/ts/modules/lollipop.src.ts
+++ b/ts/modules/lollipop.src.ts
@@ -37,6 +37,7 @@ declare global {
             public drawPoint: AreaSeries['drawPoints'];
             public drawDataLabels: ColumnSeries['drawDataLabels'];
             public setShapeArgs: ColumnSeries['translate'];
+            public toYData(point: Highcharts.LollipopPoint): any;
         }
     }
 }
@@ -93,6 +94,11 @@ seriesType<Highcharts.LollipopSeries>('lollipop', 'dumbbell', {
         pointFormat: '<span style="color:{series.color}">●</span> {series.name}: <b>{point.low}</b><br/>'
     }
 }, {
+    pointArrayMap: ['y'],
+    pointValKey: 'y',
+    toYData: function (point): any {
+        return point.y;
+    },
     translatePoint: areaProto.translate,
     drawPoint: areaProto.drawPoints,
     drawDataLabels: colProto.drawDataLabels,
@@ -171,8 +177,16 @@ seriesType<Highcharts.LollipopSeries>('lollipop', 'dumbbell', {
  *
  * @type      {Array<number|Array<(number|string),(number|null)>|null|*>}
  * @extends   series.dumbbell.data
- * @excluding lowColor
+ * @excluding high, low, lowColor
  * @product   highcharts highstock
  * @apioption series.lollipop.data
  */
+
+/**
+* The y value of the point.
+*
+* @type      {number|null}
+* @product   highcharts highstock
+* @apioption series.line.data.y
+*/
 ''; // adds doclets above to transpiled file


### PR DESCRIPTION
Fixed #13202 , lollipop series didn't work with all data formats.

@bre1470 could you suggest how to avoid `any` in this commit?
**Background:** lollipop series (one-dimension data format, ['y']) inherits from dumbbell series (two-dimension ['low', 'high']).