### PR TITLE
Change a link in network-graph.md

### DIFF
--- a/docs/chart-and-series-types/network-graph.md
+++ b/docs/chart-and-series-types/network-graph.md
@@ -12,7 +12,7 @@ _Example of loading both files in a webpage_
 
 ```html
 <script src="https://code.highcharts.com/highcharts.js"></script>
-<script src="https://code.highcharts.com/gantt/modules/networkgraph.js"></script> 
+<script src="https://code.highcharts.com/modules/networkgraph.js"></script> 
 ```
 
 Data format


### PR DESCRIPTION
Removed `gantt` part of the URL that suggested the module is for Gantt only.