### PR TITLE
bugfix/13287-wrong-vbp-position

### DIFF
--- a/js/indicators/volume-by-price.src.js
+++ b/js/indicators/volume-by-price.src.js
@@ -195,13 +195,13 @@ seriesType('vbp', 'sma',
     },
     // Initial animation
     animate: function (init) {
-        var series = this, inverted = series.chart.inverted, attr = {}, translate, position;
+        var series = this, inverted = series.chart.inverted, group = series.group, attr = {}, translate, position;
         if (!init) {
             translate = inverted ? 'translateY' : 'translateX';
             position = inverted ? series.yAxis.top : series.xAxis.left;
-            series.group['forceAnimate:' + translate] = true;
+            group['forceAnimate:' + translate] = true;
             attr[translate] = position;
-            series.group.animate(attr, extend(animObject(series.options.animation), {
+            group.animate(attr, extend(animObject(series.options.animation), {
                 step: function (val, fx) {
                     series.group.attr({
                         scaleX: Math.max(0.001, fx.pos)

--- a/js/indicators/volume-by-price.src.js
+++ b/js/indicators/volume-by-price.src.js
@@ -196,7 +196,7 @@ seriesType('vbp', 'sma',
     // Initial animation
     animate: function (init) {
         var series = this, inverted = series.chart.inverted, group = series.group, attr = {}, translate, position;
-        if (!init) {
+        if (!init && group) {
             translate = inverted ? 'translateY' : 'translateX';
             position = inverted ? series.yAxis.top : series.xAxis.left;
             group['forceAnimate:' + translate] = true;

--- a/js/indicators/volume-by-price.src.js
+++ b/js/indicators/volume-by-price.src.js
@@ -195,9 +195,12 @@ seriesType('vbp', 'sma',
     },
     // Initial animation
     animate: function (init) {
-        var series = this, attr = {};
+        var series = this, inverted = series.chart.inverted, attr = {}, translate, position;
         if (!init) {
-            attr.translateX = series.yAxis.pos;
+            translate = inverted ? 'translateY' : 'translateX';
+            position = inverted ? series.yAxis.top : series.xAxis.left;
+            series.group['forceAnimate:' + translate] = true;
+            attr[translate] = position;
             series.group.animate(attr, extend(animObject(series.options.animation), {
                 step: function (val, fx) {
                     series.group.attr({

--- a/samples/unit-tests/indicator-volume-by-price/recalculations/demo.js
+++ b/samples/unit-tests/indicator-volume-by-price/recalculations/demo.js
@@ -117,6 +117,12 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
         indicator = chart.series[2];
 
     assert.deepEqual(
+        chart.series[2].group.translateX,
+        chart.series[2].xAxis.left,
+        'The vbp series is positioned correctly (non-inverted).'
+    );
+
+    assert.deepEqual(
         round(indicator.volumeDataArray),
         expectedData,
         'volumeDataArray is correct after the chart is loaded.'

--- a/ts/indicators/volume-by-price.src.ts
+++ b/ts/indicators/volume-by-price.src.ts
@@ -361,10 +361,16 @@ seriesType<Highcharts.VBPIndicator>(
             init: boolean
         ): void {
             var series = this,
-                attr: Highcharts.SVGAttributes = {};
+                inverted = series.chart.inverted,
+                attr: Highcharts.SVGAttributes = {},
+                translate,
+                position;
 
             if (!init) {
-                attr.translateX = series.yAxis.pos;
+                translate = inverted ? 'translateY' : 'translateX';
+                position = inverted ? series.yAxis.top : series.xAxis.left;
+                (series.group as any)['forceAnimate:' + translate] = true;
+                attr[translate] = position;
                 (series.group as any).animate(
                     attr,
                     extend(animObject(series.options.animation), {

--- a/ts/indicators/volume-by-price.src.ts
+++ b/ts/indicators/volume-by-price.src.ts
@@ -362,7 +362,7 @@ seriesType<Highcharts.VBPIndicator>(
         ): void {
             var series = this,
                 inverted = series.chart.inverted,
-                group = series.group as Highcharts.SVGElement,
+                group = series.group,
                 attr: Highcharts.SVGAttributes = {},
                 translate,
                 position;

--- a/ts/indicators/volume-by-price.src.ts
+++ b/ts/indicators/volume-by-price.src.ts
@@ -362,6 +362,7 @@ seriesType<Highcharts.VBPIndicator>(
         ): void {
             var series = this,
                 inverted = series.chart.inverted,
+                group = series.group as Highcharts.SVGElement,
                 attr: Highcharts.SVGAttributes = {},
                 translate,
                 position;
@@ -369,9 +370,9 @@ seriesType<Highcharts.VBPIndicator>(
             if (!init) {
                 translate = inverted ? 'translateY' : 'translateX';
                 position = inverted ? series.yAxis.top : series.xAxis.left;
-                (series.group as any)['forceAnimate:' + translate] = true;
+                group['forceAnimate:' + translate] = true;
                 attr[translate] = position;
-                (series.group as any).animate(
+                group.animate(
                     attr,
                     extend(animObject(series.options.animation), {
                         step: function (val: any, fx: any): void {

--- a/ts/indicators/volume-by-price.src.ts
+++ b/ts/indicators/volume-by-price.src.ts
@@ -367,7 +367,7 @@ seriesType<Highcharts.VBPIndicator>(
                 translate,
                 position;
 
-            if (!init) {
+            if (!init && group) {
                 translate = inverted ? 'translateY' : 'translateX';
                 position = inverted ? series.yAxis.top : series.xAxis.left;
                 group['forceAnimate:' + translate] = true;


### PR DESCRIPTION
Fixed #13287, incorrect position of the `vpb` (volume by price) series after the initial animation.