### PR TITLE
bugfix/13309-pdf-export-orientation

### DIFF
--- a/js/modules/offline-exporting.src.js
+++ b/js/modules/offline-exporting.src.js
@@ -200,7 +200,8 @@ Highcharts.downloadSVGLocal = function (svg, options, failCallback, successCallb
      */
     function svgToPdf(svgElement, margin) {
         var width = svgElement.width.baseVal.value + 2 * margin, height = svgElement.height.baseVal.value + 2 * margin, pdf = new win.jsPDF(// eslint-disable-line new-cap
-        'l', 'pt', [width, height]);
+        height > width ? 'p' : 'l', // setting orientation to portrait if height exceeds width
+        'pt', [width, height]);
         // Workaround for #7090, hidden elements were drawn anyway. It comes
         // down to https://github.com/yWorks/svg2pdf.js/issues/28. Check this
         // later.

--- a/js/modules/offline-exporting.src.js
+++ b/js/modules/offline-exporting.src.js
@@ -199,8 +199,15 @@ Highcharts.downloadSVGLocal = function (svg, options, failCallback, successCallb
      * @private
      */
     function svgToPdf(svgElement, margin) {
-        var width = svgElement.width.baseVal.value + 2 * margin, height = svgElement.height.baseVal.value + 2 * margin, pdf = new win.jsPDF(// eslint-disable-line new-cap
-        'l', 'pt', [width, height]);
+        var width = svgElement.width.baseVal.value + 2 * margin, height = svgElement.height.baseVal.value + 2 * margin, pdf;
+        if (width < height) {
+            pdf = new win.jsPDF(// eslint-disable-line new-cap
+            'p', 'pt', [width, height]);
+        }
+        else {
+            pdf = new win.jsPDF(// eslint-disable-line new-cap
+            'l', 'pt', [width, height]);
+        }
         // Workaround for #7090, hidden elements were drawn anyway. It comes
         // down to https://github.com/yWorks/svg2pdf.js/issues/28. Check this
         // later.

--- a/js/modules/offline-exporting.src.js
+++ b/js/modules/offline-exporting.src.js
@@ -199,15 +199,8 @@ Highcharts.downloadSVGLocal = function (svg, options, failCallback, successCallb
      * @private
      */
     function svgToPdf(svgElement, margin) {
-        var width = svgElement.width.baseVal.value + 2 * margin, height = svgElement.height.baseVal.value + 2 * margin, pdf;
-        if (width < height) {
-            pdf = new win.jsPDF(// eslint-disable-line new-cap
-            'p', 'pt', [width, height]);
-        }
-        else {
-            pdf = new win.jsPDF(// eslint-disable-line new-cap
-            'l', 'pt', [width, height]);
-        }
+        var width = svgElement.width.baseVal.value + 2 * margin, height = svgElement.height.baseVal.value + 2 * margin, pdf = new win.jsPDF(// eslint-disable-line new-cap
+        'l', 'pt', [width, height]);
         // Workaround for #7090, hidden elements were drawn anyway. It comes
         // down to https://github.com/yWorks/svg2pdf.js/issues/28. Check this
         // later.

--- a/ts/modules/offline-exporting.src.ts
+++ b/ts/modules/offline-exporting.src.ts
@@ -353,11 +353,21 @@ Highcharts.downloadSVGLocal = function (
     ): string {
         var width = svgElement.width.baseVal.value + 2 * margin,
             height = svgElement.height.baseVal.value + 2 * margin,
-            pdf = new win.jsPDF( // eslint-disable-line new-cap
+            pdf;
+
+        if (width < height) {
+            pdf = new win.jsPDF(// eslint-disable-line new-cap
+                'p',
+                'pt',
+                [width, height]
+            );
+        } else {
+            pdf = new win.jsPDF(// eslint-disable-line new-cap
                 'l',
                 'pt',
                 [width, height]
             );
+        }
 
         // Workaround for #7090, hidden elements were drawn anyway. It comes
         // down to https://github.com/yWorks/svg2pdf.js/issues/28. Check this

--- a/ts/modules/offline-exporting.src.ts
+++ b/ts/modules/offline-exporting.src.ts
@@ -353,21 +353,11 @@ Highcharts.downloadSVGLocal = function (
     ): string {
         var width = svgElement.width.baseVal.value + 2 * margin,
             height = svgElement.height.baseVal.value + 2 * margin,
-            pdf;
-
-        if (width < height) {
-            pdf = new win.jsPDF(// eslint-disable-line new-cap
-                'p',
-                'pt',
-                [width, height]
-            );
-        } else {
-            pdf = new win.jsPDF(// eslint-disable-line new-cap
+            pdf = new win.jsPDF( // eslint-disable-line new-cap
                 'l',
                 'pt',
                 [width, height]
             );
-        }
 
         // Workaround for #7090, hidden elements were drawn anyway. It comes
         // down to https://github.com/yWorks/svg2pdf.js/issues/28. Check this

--- a/ts/modules/offline-exporting.src.ts
+++ b/ts/modules/offline-exporting.src.ts
@@ -354,7 +354,7 @@ Highcharts.downloadSVGLocal = function (
         var width = svgElement.width.baseVal.value + 2 * margin,
             height = svgElement.height.baseVal.value + 2 * margin,
             pdf = new win.jsPDF( // eslint-disable-line new-cap
-                'l',
+                height > width ? 'p' : 'l', // setting orientation to portrait if height exceeds width
                 'pt',
                 [width, height]
             );


### PR DESCRIPTION
Fixed #13309, PDF exports always having landscape orientation when using the `offline-exporting` module.

Before: https://jsfiddle.net/goransle/zL3qyp07/
With fix applied: https://jsfiddle.net/goransle/5fw37pkc/
_____

_Related_: This workaround does not seem to be needed anymore: https://github.com/highcharts/highcharts/blob/f1768000e8720a7b26ed4179e49ab4c87561dfa3/ts/modules/offline-exporting.src.ts#L362 Should it be removed?