### PR TITLE
bugfix/11500-stacklabels-moved-yAxis

### DIFF
--- a/js/parts/Stacking.js
+++ b/js/parts/Stacking.js
@@ -251,9 +251,10 @@ var StackItem = /** @class */ (function () {
             (inverted ? chart.plotLeft : chart.plotTop), neg = (stackItem.isNegative && !reversed) ||
             (!stackItem.isNegative && reversed); // #4056
         return {
-            x: inverted ? (neg ? y : y - h) : x,
+            x: inverted ? (neg ? y - axis.right : y - h + axis.pos - chart.plotLeft) :
+                x + chart.xAxis[0].transB - chart.plotLeft,
             y: inverted ?
-                axisPos - x - xWidth :
+                axis.height - x - xWidth :
                 (neg ?
                     (axisPos - y - h) :
                     axisPos - y),

--- a/samples/unit-tests/axis/stacklabels/demo.js
+++ b/samples/unit-tests/axis/stacklabels/demo.js
@@ -324,3 +324,74 @@ QUnit.test('StackLabels outside xAxis min & max range are displayed #12294', fun
         'This stack-label text x attribute should be equal to set padding #12308'
     );
 });
+
+QUnit.test('Stack labels align issue when yAxis/xAxis is moved #11500', function (assert) {
+
+    var chart = Highcharts.chart('container', {
+        chart: {
+            type: 'column'
+        },
+
+        yAxis: {
+            stackLabels: {
+                enabled: true
+            }
+        },
+        xAxis: {
+            left: '50%',
+            width: '50%'
+        },
+
+        plotOptions: {
+            series: {
+                stacking: 'normal'
+            }
+        },
+
+        series: [{
+            name: 'Year 1800',
+            data: [107, 31, 635, 203, 2],
+            dataLabels: {
+                enabled: true
+            }
+        }, {
+            name: 'Year 1900',
+            data: [133, 156, 947, 408, 6]
+        }]
+    });
+
+    const getStack = () => {
+        const stacks = chart.yAxis[0].stacking.stacks,
+            stackKey = Object.keys(stacks)[0];
+
+        return stacks[stackKey][0].label;
+
+    };
+
+    let dataLabel = chart.series[0].points[0].dataLabel,
+        stackLabel = getStack();
+
+    assert.strictEqual(
+        stackLabel.parentGroup.translateX + stackLabel.translateX,
+        dataLabel.parentGroup.translateX + dataLabel.x,
+        'This stack-label should moved to the same position as dataLabel #11500'
+    );
+
+    chart.update({
+        chart: {
+            type: 'bar'
+        },
+        yAxis: {
+            left: '50%'
+        }
+    });
+
+    dataLabel = chart.series[0].points[0].dataLabel;
+    stackLabel = getStack();
+
+    assert.ok(
+        stackLabel.parentGroup.translateY + stackLabel.translateY,
+        dataLabel.parentGroup.translateY + dataLabel.y,
+        'This stack-label should moved to the same position as dataLabel #11500'
+    );
+});

--- a/ts/parts/Stacking.ts
+++ b/ts/parts/Stacking.ts
@@ -496,9 +496,10 @@ class StackItem {
                 (!stackItem.isNegative && reversed); // #4056
 
         return { // this is the box for the complete stack
-            x: inverted ? (neg ? y : y - h) : x,
+            x: inverted ? (neg ? y - axis.right : y - h + axis.pos - chart.plotLeft) :
+                x + chart.xAxis[0].transB - chart.plotLeft,
             y: inverted ?
-                axisPos - x - xWidth :
+                axis.height - x - xWidth :
                 (neg ?
                     (axisPos - y - h) :
                     axisPos - y


### PR DESCRIPTION
Fixed #11500, stack labels had a wrong position after moving X axis or Y axis.