### PR TITLE
Fixed #13305, focus border not updated with scrolling points.

### DIFF
--- a/js/modules/accessibility/components/SeriesComponent/SeriesKeyboardNavigation.js
+++ b/js/modules/accessibility/components/SeriesComponent/SeriesKeyboardNavigation.js
@@ -17,7 +17,7 @@ var extend = U.extend, defined = U.defined;
 import KeyboardNavigationHandler from '../../KeyboardNavigationHandler.js';
 import EventProvider from '../../utils/EventProvider.js';
 import ChartUtilities from '../../utils/chartUtilities.js';
-var getPointFromXY = ChartUtilities.getPointFromXY, getSeriesFromName = ChartUtilities.getSeriesFromName;
+var getPointFromXY = ChartUtilities.getPointFromXY, getSeriesFromName = ChartUtilities.getSeriesFromName, scrollToPoint = ChartUtilities.scrollToPoint;
 /* eslint-disable no-invalid-this, valid-jsdoc */
 /*
  * Set for which series types it makes sense to move to the closest point with
@@ -153,6 +153,7 @@ Point.prototype.highlight = function () {
         }
         // Don't call blur on the element, as it messes up the chart div's focus
     }
+    scrollToPoint(this);
     // We focus only after calling onMouseOver because the state change can
     // change z-index and mess up the element.
     if (this.graphic) {
@@ -519,15 +520,12 @@ extend(SeriesKeyboardNavigation.prototype, /** @lends Highcharts.SeriesKeyboardN
      * @private
      */
     onHandlerTerminate: function () {
+        var _a, _b;
         var chart = this.chart;
         var curPoint = chart.highlightedPoint;
-        if (chart.tooltip) {
-            chart.tooltip.hide(0);
-        }
-        if (curPoint) {
-            curPoint.onMouseOut();
-            delete chart.highlightedPoint;
-        }
+        (_a = chart.tooltip) === null || _a === void 0 ? void 0 : _a.hide(0);
+        (_b = curPoint === null || curPoint === void 0 ? void 0 : curPoint.onMouseOut) === null || _b === void 0 ? void 0 : _b.call(curPoint);
+        delete chart.highlightedPoint;
     },
     /**
      * Function that attempts to highlight next/prev point. Handles wrap around.

--- a/js/modules/accessibility/utils/chartUtilities.js
+++ b/js/modules/accessibility/utils/chartUtilities.js
@@ -13,7 +13,7 @@
 import HTMLUtilities from './htmlUtilities.js';
 var stripHTMLTags = HTMLUtilities.stripHTMLTagsFromString;
 import U from '../../../parts/Utilities.js';
-var find = U.find;
+var defined = U.defined, find = U.find;
 /* eslint-disable valid-jsdoc */
 /**
  * @return {string}
@@ -134,6 +134,46 @@ function getPointFromXY(series, x, y) {
         }
     }
 }
+/**
+ * Get relative position of point on an x/y axis from 0 to 1.
+ * @private
+ * @param {Highcharts.Axis} axis
+ * @param {Highcharts.Point} point
+ * @return {number}
+ */
+function getRelativePointAxisPosition(axis, point) {
+    if (!defined(axis.dataMin) || !defined(axis.dataMax)) {
+        return 0;
+    }
+    var axisStart = axis.toPixels(axis.dataMin);
+    var axisEnd = axis.toPixels(axis.dataMax);
+    // We have to use pixel position because of axis breaks, log axis etc.
+    var positionProp = axis.coll === 'xAxis' ? 'x' : 'y';
+    var pointPos = axis.toPixels(point[positionProp] || 0);
+    return (pointPos - axisStart) / (axisEnd - axisStart);
+}
+/**
+ * Get relative position of point on an x/y axis from 0 to 1.
+ * @private
+ * @param {Highcharts.Point} point
+ */
+function scrollToPoint(point) {
+    var xAxis = point.series.xAxis;
+    var yAxis = point.series.yAxis;
+    var axis = (xAxis === null || xAxis === void 0 ? void 0 : xAxis.scrollbar) ? xAxis : yAxis;
+    var scrollbar = axis === null || axis === void 0 ? void 0 : axis.scrollbar;
+    if (scrollbar && defined(scrollbar.to) && defined(scrollbar.from)) {
+        var range = scrollbar.to - scrollbar.from;
+        var pos = getRelativePointAxisPosition(axis, point);
+        scrollbar.updatePosition(pos - range / 2, pos + range / 2);
+        Highcharts.fireEvent(scrollbar, 'changed', {
+            from: scrollbar.from,
+            to: scrollbar.to,
+            trigger: 'scrollbar',
+            DOMEvent: null
+        });
+    }
+}
 var ChartUtilities = {
     getChartTitle: getChartTitle,
     getAxisDescription: getAxisDescription,
@@ -142,6 +182,7 @@ var ChartUtilities = {
     getSeriesFromName: getSeriesFromName,
     getSeriesA11yElement: getSeriesA11yElement,
     unhideChartElementFromAT: unhideChartElementFromAT,
-    hideSeriesFromAT: hideSeriesFromAT
+    hideSeriesFromAT: hideSeriesFromAT,
+    scrollToPoint: scrollToPoint
 };
 export default ChartUtilities;

--- a/samples/stock/yaxis/inverted-bar-scrollbar/demo.html
+++ b/samples/stock/yaxis/inverted-bar-scrollbar/demo.html
@@ -2,3 +2,4 @@
 
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/stock/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/stock/modules/accessibility.js"></script>

--- a/samples/unit-tests/accessibility/focus-border/demo.details
+++ b/samples/unit-tests/accessibility/focus-border/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/accessibility/focus-border/demo.html
+++ b/samples/unit-tests/accessibility/focus-border/demo.html
@@ -1,0 +1,8 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/modules/accessibility.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 400px; margin: 0 auto"></div>

--- a/samples/unit-tests/accessibility/focus-border/demo.js
+++ b/samples/unit-tests/accessibility/focus-border/demo.js
@@ -1,0 +1,57 @@
+QUnit.test('Point should have focus border when focused', function (assert) {
+    const focusBorderColor = '#ff0000';
+    const chart = Highcharts.chart('container', {
+            accessibility: {
+                keyboardNavigation: {
+                    focusBorder: {
+                        style: {
+                            color: focusBorderColor
+                        }
+                    }
+                }
+            },
+            series: [{
+                data: [1, 2, 3]
+            }]
+        }),
+        point = chart.series[0].points[0];
+
+    point.highlight();
+
+    const focusedGraphic = chart.focusElement;
+
+    assert.strictEqual(
+        focusedGraphic,
+        point.graphic,
+        'Focused graphic should equal the point graphic'
+    );
+
+    assert.strictEqual(
+        focusedGraphic.focusBorder.attr('stroke'),
+        focusBorderColor,
+        'Focused graphic should have a border element with correct stroke'
+    );
+});
+
+QUnit.test('Updating point should update focus border', function (assert) {
+    const chart = Highcharts.chart('container', {
+            series: [{
+                data: [1, 2, 3]
+            }]
+        }),
+        point = chart.series[0].points[0];
+
+    point.highlight();
+
+    const initialPosition = chart.focusElement.focusBorder.element.getBBox().y;
+
+    point.update(10);
+
+    const newPosition = chart.focusElement.focusBorder.element.getBBox().y;
+
+    assert.notStrictEqual(
+        initialPosition,
+        newPosition,
+        'Focus border should have moved'
+    );
+});

--- a/ts/modules/accessibility/components/SeriesComponent/SeriesKeyboardNavigation.ts
+++ b/ts/modules/accessibility/components/SeriesComponent/SeriesKeyboardNavigation.ts
@@ -91,7 +91,8 @@ import EventProvider from '../../utils/EventProvider.js';
 
 import ChartUtilities from '../../utils/chartUtilities.js';
 var getPointFromXY = ChartUtilities.getPointFromXY,
-    getSeriesFromName = ChartUtilities.getSeriesFromName;
+    getSeriesFromName = ChartUtilities.getSeriesFromName,
+    scrollToPoint = ChartUtilities.scrollToPoint;
 
 
 /* eslint-disable no-invalid-this, valid-jsdoc */
@@ -269,6 +270,8 @@ Point.prototype.highlight = function (): Highcharts.Point {
         }
         // Don't call blur on the element, as it messes up the chart div's focus
     }
+
+    scrollToPoint(this);
 
     // We focus only after calling onMouseOver because the state change can
     // change z-index and mess up the element.
@@ -817,14 +820,10 @@ extend(SeriesKeyboardNavigation.prototype, /** @lends Highcharts.SeriesKeyboardN
         const chart = this.chart;
         const curPoint = chart.highlightedPoint;
 
-        if (chart.tooltip) {
-            chart.tooltip.hide(0);
-        }
+        chart.tooltip?.hide(0);
 
-        if (curPoint) {
-            curPoint.onMouseOut();
-            delete chart.highlightedPoint;
-        }
+        curPoint?.onMouseOut?.();
+        delete chart.highlightedPoint;
     },
 
 


### PR DESCRIPTION
Fixed #13305, focus border not updated with scrolling points.
____
Focus border now updates when SVG elements they are connected to move. They also destroy when the SVG element is destroyed (e.g. through `point.remove`). When keyboard navigating through a chart with a scrollbar, the chart is scrolled as you navigate.