### PR TITLE
bugfix/13330-stacklabels-backgroundColor-issue

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -5711,6 +5711,36 @@ var Axis = /** @class */ (function () {
              */
             allowOverlap: false,
             /**
+             * The background color or gradient for the stack label.
+             *
+             * @type      {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
+             * @since     next
+             * @apioption yAxis.stackLabels.backgroundColor
+             */
+            /**
+             * The border color for the stack label. Defaults to `undefined`.
+             *
+             * @type      {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
+             * @since     next
+             * @apioption yAxis.stackLabels.borderColor
+             */
+            /**
+             * The border radius in pixels for the stack label.
+             *
+             * @type      {number}
+             * @default   0
+             * @since     next
+             * @apioption yAxis.stackLabels.borderRadius
+             */
+            /**
+             * The border width in pixels for the stack label.
+             *
+             * @type      {number}
+             * @default   0
+             * @since     next
+             * @apioption yAxis.stackLabels.borderWidth
+             */
+            /**
              * Enable or disable the stack total labels.
              *
              * @sample {highcharts} highcharts/yaxis/stacklabels-enabled/

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -5713,6 +5713,8 @@ var Axis = /** @class */ (function () {
             /**
              * The background color or gradient for the stack label.
              *
+             * @sample {highcharts} highcharts/yaxis/stacklabels-box/
+             *          Stack labels box options
              * @type      {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
              * @since     next
              * @apioption yAxis.stackLabels.backgroundColor
@@ -5720,6 +5722,8 @@ var Axis = /** @class */ (function () {
             /**
              * The border color for the stack label. Defaults to `undefined`.
              *
+             * @sample {highcharts} highcharts/yaxis/stacklabels-box/
+             *          Stack labels box options
              * @type      {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
              * @since     next
              * @apioption yAxis.stackLabels.borderColor
@@ -5727,6 +5731,8 @@ var Axis = /** @class */ (function () {
             /**
              * The border radius in pixels for the stack label.
              *
+             * @sample {highcharts} highcharts/yaxis/stacklabels-box/
+             *          Stack labels box options
              * @type      {number}
              * @default   0
              * @since     next
@@ -5735,6 +5741,8 @@ var Axis = /** @class */ (function () {
             /**
              * The border width in pixels for the stack label.
              *
+             * @sample {highcharts} highcharts/yaxis/stacklabels-box/
+             *          Stack labels box options
              * @type      {number}
              * @default   0
              * @since     next

--- a/js/parts/Stacking.js
+++ b/js/parts/Stacking.js
@@ -132,15 +132,19 @@ var StackItem = /** @class */ (function () {
             this.label = chart.renderer
                 .label(str, null, null, options.shape, null, null, options.useHTML, false, 'stack-labels');
             attr = {
+                r: options.borderRadius || 0,
                 text: str,
                 rotation: options.rotation,
                 padding: pick(options.padding, 5),
                 visibility: 'hidden' // hidden until setOffset is called
             };
-            this.label.attr(attr);
             if (!chart.styledMode) {
+                attr.fill = options.backgroundColor;
+                attr.stroke = options.borderColor;
+                attr['stroke-width'] = options.borderWidth;
                 this.label.css(options.style);
             }
+            this.label.attr(attr);
             if (!this.label.added) {
                 this.label.add(group); // add to the labels-group
             }

--- a/samples/highcharts/yaxis/stacklabels-box/demo.details
+++ b/samples/highcharts/yaxis/stacklabels-box/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+...

--- a/samples/highcharts/yaxis/stacklabels-box/demo.html
+++ b/samples/highcharts/yaxis/stacklabels-box/demo.html
@@ -1,0 +1,3 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="container" style="height: 400px"></div>

--- a/samples/highcharts/yaxis/stacklabels-box/demo.js
+++ b/samples/highcharts/yaxis/stacklabels-box/demo.js
@@ -1,0 +1,40 @@
+Highcharts.chart('container', {
+    chart: {
+        type: 'column'
+    },
+
+    title: {
+        text: 'Stack labels box options'
+    },
+
+    subtitle: {
+        text: 'backgroundColor, borderColor, borderRadius, borderWidth'
+    },
+    xAxis: {
+        categories: ['Apples', 'Oranges', 'Pears', 'Grapes', 'Bananas']
+    },
+    yAxis: {
+        title: {
+            text: 'Total fruit consumption'
+        },
+        stackLabels: {
+            enabled: true,
+            borderRadius: 5,
+            backgroundColor: 'rgba(252, 255, 197, 0.7)',
+            borderWidth: 1,
+            borderColor: '#AAA',
+            y: -5
+        }
+    },
+
+    plotOptions: {
+        column: {
+            stacking: 'normal'
+        }
+    },
+    series: [{
+        data: [50, 32, 47, 51, 25]
+    }, {
+        data: [21, 28, 34, 22, 11]
+    }]
+});

--- a/samples/unit-tests/axis/stacklabels/demo.js
+++ b/samples/unit-tests/axis/stacklabels/demo.js
@@ -324,3 +324,65 @@ QUnit.test('StackLabels outside xAxis min & max range are displayed #12294', fun
         'This stack-label text x attribute should be equal to set padding #12308'
     );
 });
+
+QUnit.test('Stack labels styles options #13330', function (assert) {
+
+    var chart = Highcharts.chart('container', {
+        chart: {
+            type: 'column'
+        },
+
+        yAxis: {
+            stackLabels: {
+                enabled: true,
+                backgroundColor: 'black',
+                borderWidth: 2,
+                borderColor: 'red',
+                borderRadius: 4,
+                style: {
+                    color: 'red'
+                }
+            }
+        },
+
+        plotOptions: {
+            column: {
+                stacking: 'normal'
+            }
+        },
+
+        series: [{
+            name: 'A',
+            data: [5, 3]
+        }, {
+            name: 'B',
+            data: [15, 12]
+        }]
+    });
+
+    const stackLabel = chart.yAxis[0].stacking.stacks['column,,,'][0];
+
+    assert.strictEqual(
+        stackLabel.label.fill,
+        stackLabel.options.backgroundColor,
+        'This stack-label fill atribute should be same as set in options #13330'
+    );
+
+    assert.strictEqual(
+        stackLabel.label.stroke,
+        stackLabel.options.borderColor,
+        'This stack-label stroke atribute should be same as set in options #13330'
+    );
+
+    assert.strictEqual(
+        stackLabel.label["stroke-width"],
+        stackLabel.options.borderWidth,
+        'This stack-label stroke-width atribute should be same as set in options #13330'
+    );
+
+    assert.strictEqual(
+        stackLabel.label.box.r,
+        stackLabel.options.borderRadius,
+        'This stack-label box r atribute should be same as set in options #13330'
+    );
+});

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -3609,6 +3609,40 @@ class Axis implements AxisComposition, AxisLike {
             allowOverlap: false,
 
             /**
+             * The background color or gradient for the stack label.
+             *
+             * @type      {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
+             * @since     next
+             * @apioption yAxis.stackLabels.backgroundColor
+             */
+
+            /**
+             * The border color for the stack label. Defaults to `undefined`.
+             *
+             * @type      {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
+             * @since     next
+             * @apioption yAxis.stackLabels.borderColor
+             */
+
+            /**
+             * The border radius in pixels for the stack label.
+             *
+             * @type      {number}
+             * @default   0
+             * @since     next
+             * @apioption yAxis.stackLabels.borderRadius
+             */
+
+            /**
+             * The border width in pixels for the stack label.
+             *
+             * @type      {number}
+             * @default   0
+             * @since     next
+             * @apioption yAxis.stackLabels.borderWidth
+             */
+
+            /**
              * Enable or disable the stack total labels.
              *
              * @sample {highcharts} highcharts/yaxis/stacklabels-enabled/

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -3611,6 +3611,8 @@ class Axis implements AxisComposition, AxisLike {
             /**
              * The background color or gradient for the stack label.
              *
+             * @sample {highcharts} highcharts/yaxis/stacklabels-box/
+             *          Stack labels box options
              * @type      {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
              * @since     next
              * @apioption yAxis.stackLabels.backgroundColor
@@ -3619,6 +3621,8 @@ class Axis implements AxisComposition, AxisLike {
             /**
              * The border color for the stack label. Defaults to `undefined`.
              *
+             * @sample {highcharts} highcharts/yaxis/stacklabels-box/
+             *          Stack labels box options
              * @type      {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
              * @since     next
              * @apioption yAxis.stackLabels.borderColor
@@ -3627,6 +3631,8 @@ class Axis implements AxisComposition, AxisLike {
             /**
              * The border radius in pixels for the stack label.
              *
+             * @sample {highcharts} highcharts/yaxis/stacklabels-box/
+             *          Stack labels box options
              * @type      {number}
              * @default   0
              * @since     next
@@ -3636,6 +3642,8 @@ class Axis implements AxisComposition, AxisLike {
             /**
              * The border width in pixels for the stack label.
              *
+             * @sample {highcharts} highcharts/yaxis/stacklabels-box/
+             *          Stack labels box options
              * @type      {number}
              * @default   0
              * @since     next

--- a/ts/parts/Stacking.ts
+++ b/ts/parts/Stacking.ts
@@ -82,6 +82,10 @@ declare global {
         interface YAxisStackLabelsOptions {
             align?: AlignValue;
             allowOverlap?: boolean;
+            backgroundColor?: (ColorString|GradientColorObject|PatternObject);
+            borderColor?: (ColorString|GradientColorObject|PatternObject);
+            borderRadius?: number;
+            borderWidth?: number;
             crop?: boolean;
             enabled?: boolean;
             format?: string;
@@ -94,6 +98,9 @@ declare global {
             verticalAlign?: VerticalAlignValue;
             x?: number;
             y?: number;
+        }
+        interface AttrObject {
+            [key: string]: any;
         }
         class StackItem {
             public constructor(
@@ -288,7 +295,7 @@ class StackItem {
         var chart = this.axis.chart,
             options = this.options,
             formatOption = options.format,
-            attr = {},
+            attr: Highcharts.AttrObject = {},
             str = formatOption ? // format the text in the label
                 format(formatOption, this, chart) :
                 (options.formatter as any).call(this);
@@ -313,15 +320,22 @@ class StackItem {
                 );
 
             attr = {
+                r: options.borderRadius || 0,
                 text: str,
                 rotation: (options as any).rotation,
                 padding: pick((options as any).padding, 5), // set default padding to 5 as it is in datalabels #12308
                 visibility: 'hidden' // hidden until setOffset is called
             };
-            this.label.attr(attr);
+
             if (!chart.styledMode) {
+                attr.fill = options.backgroundColor;
+                attr.stroke = options.borderColor;
+                attr['stroke-width'] = options.borderWidth;
                 this.label.css(options.style as any);
             }
+
+            this.label.attr(attr);
+
             if (!this.label.added) {
                 this.label.add(group); // add to the labels-group
             }


### PR DESCRIPTION
Added box options for `yAxis.stackLabels`: `backgroundColor`, `borderWidth`, `borderRadius` and `borderColor`. See #13330.

~~Fixed #13330, adding the styling options, like: backgroundColor, borderWidth, borderRadius and borderColor for stack labels.~~