### PR TITLE
Fixed issue where browser outline was visible on point click.

### DIFF
--- a/js/modules/accessibility/KeyboardNavigation.js
+++ b/js/modules/accessibility/KeyboardNavigation.js
@@ -79,6 +79,9 @@ KeyboardNavigation.prototype = {
         ep.addEvent(chart.renderTo, 'keydown', function (e) { return _this.onKeydown(e); });
         ep.addEvent(chart.container, 'focus', function (e) { return _this.onFocus(e); });
         ep.addEvent(doc, 'mouseup', function () { return _this.onMouseUp(); });
+        ep.addEvent(chart.renderTo, 'mousedown', function () {
+            _this.isClickingChart = true;
+        });
         ep.addEvent(chart.renderTo, 'mouseover', function () {
             _this.pointerIsOverChart = true;
         });
@@ -127,7 +130,8 @@ KeyboardNavigation.prototype = {
         var chart = this.chart;
         var focusComesFromChart = (e.relatedTarget &&
             chart.container.contains(e.relatedTarget));
-        if (!focusComesFromChart) {
+        // Init keyboard nav if tabbing into chart
+        if (!this.isClickingChart && !focusComesFromChart) {
             (_a = this.modules[0]) === null || _a === void 0 ? void 0 : _a.init(1);
         }
     },
@@ -137,6 +141,7 @@ KeyboardNavigation.prototype = {
      * @private
      */
     onMouseUp: function () {
+        delete this.isClickingChart;
         if (!this.keyboardReset && !this.pointerIsOverChart) {
             var chart = this.chart, curMod = this.modules &&
                 this.modules[this.currentModuleIx || 0];

--- a/js/modules/accessibility/components/SeriesComponent/SeriesDescriber.js
+++ b/js/modules/accessibility/components/SeriesComponent/SeriesDescriber.js
@@ -308,9 +308,11 @@ function describePointsInSeries(series) {
             var pointEl = point.graphic && point.graphic.element ||
                 shouldAddDummyPoint(point) && addDummyPointElement(point);
             if (pointEl) {
-                // We always set tabindex, as long as we are setting
-                // props.
+                // We always set tabindex, as long as we are setting props.
+                // When setting tabindex, also remove default outline to
+                // avoid ugly border on click.
                 pointEl.setAttribute('tabindex', '-1');
+                pointEl.style.outline = '0';
                 if (setScreenReaderProps) {
                     setPointScreenReaderAttribs(point, pointEl);
                 }
@@ -354,6 +356,7 @@ function describeSeriesElement(series, seriesElement) {
         seriesElement.setAttribute('role', 'region');
     } /* else do not add role */
     seriesElement.setAttribute('tabindex', '-1');
+    seriesElement.style.outline = '0'; // Don't show browser outline on click, despite tabindex
     seriesElement.setAttribute('aria-label', escapeStringForHTML(stripHTMLTags(a11yOptions.series.descriptionFormatter &&
         a11yOptions.series.descriptionFormatter(series) ||
         defaultSeriesDescriptionFormatter(series))));

--- a/samples/unit-tests/svgrenderer/styled-mode/demo.js
+++ b/samples/unit-tests/svgrenderer/styled-mode/demo.js
@@ -6,6 +6,11 @@ QUnit.test('No inline CSS should be allowed (#6173)', function (assert) {
             styledMode: true
         },
 
+        // A11y uses outline:0 on points
+        accessibility: {
+            enabled: false
+        },
+
         title: {
             text: 'Styling axes'
         },

--- a/ts/modules/accessibility/KeyboardNavigation.ts
+++ b/ts/modules/accessibility/KeyboardNavigation.ts
@@ -42,6 +42,7 @@ declare global {
             public eventProvider: EventProvider;
             public exitAnchor: (HTMLDOMElement|SVGDOMElement);
             public exiting?: boolean;
+            public isClickingChart?: boolean;
             public keyboardReset?: boolean;
             public modules: Array<KeyboardNavigationHandler>;
             public pointerIsOverChart?: boolean;
@@ -158,6 +159,10 @@ KeyboardNavigation.prototype = {
 
         ep.addEvent(doc, 'mouseup', (): void => this.onMouseUp());
 
+        ep.addEvent(chart.renderTo, 'mousedown', (): void => {
+            this.isClickingChart = true;
+        });
+
         ep.addEvent(chart.renderTo, 'mouseover', (): void => {
             this.pointerIsOverChart = true;
         });
@@ -228,7 +233,8 @@ KeyboardNavigation.prototype = {
             chart.container.contains(e.relatedTarget as any)
         );
 
-        if (!focusComesFromChart) {
+        // Init keyboard nav if tabbing into chart
+        if (!this.isClickingChart && !focusComesFromChart) {
             this.modules[0]?.init(1);
         }
     },
@@ -240,6 +246,8 @@ KeyboardNavigation.prototype = {
      * @private
      */
     onMouseUp: function (this: Highcharts.KeyboardNavigation): void {
+        delete this.isClickingChart;
+
         if (!this.keyboardReset && !this.pointerIsOverChart) {
             var chart = this.chart,
                 curMod = this.modules &&

--- a/ts/modules/accessibility/components/SeriesComponent/SeriesDescriber.ts
+++ b/ts/modules/accessibility/components/SeriesComponent/SeriesDescriber.ts
@@ -569,9 +569,11 @@ function describePointsInSeries(series: Highcharts.AccessibilitySeries): void {
                     shouldAddDummyPoint(point) && addDummyPointElement(point);
 
             if (pointEl) {
-                // We always set tabindex, as long as we are setting
-                // props.
+                // We always set tabindex, as long as we are setting props.
+                // When setting tabindex, also remove default outline to
+                // avoid ugly border on click.
                 pointEl.setAttribute('tabindex', '-1');
+                pointEl.style.outline = '0';
 
                 if (setScreenReaderProps) {
                     setPointScreenReaderAttribs(point, pointEl);
@@ -648,6 +650,7 @@ function describeSeriesElement(
     } /* else do not add role */
 
     seriesElement.setAttribute('tabindex', '-1');
+    seriesElement.style.outline = '0'; // Don't show browser outline on click, despite tabindex
     seriesElement.setAttribute(
         'aria-label',
         escapeStringForHTML(


### PR DESCRIPTION
As in title.

Caused by adding `tabindex` to point graphics. Chrome does not currently seem to honor setting `outline: none` or `0` on parent elements, so we are setting it on the individual point graphics and the series graphic.

Also fixes issue where clicking into the chart sometimes causes keyboard navigation to be initialized, and the first point to be focused.