### PR TITLE
bugfix/13353-item-series-overlap

### DIFF
--- a/js/modules/item-series.src.js
+++ b/js/modules/item-series.src.js
@@ -139,9 +139,9 @@ seriesType('item',
     getSlots: function () {
         var center = this.center, diameter = center[2], innerSize = center[3], row, slots = this.slots, x, y, rowRadius, rowLength, colCount, increment, angle, col, itemSize = 0, rowCount, fullAngle = (this.endAngleRad - this.startAngleRad), itemCount = Number.MAX_VALUE, finalItemCount, rows, testRows, rowsOption = this.options.rows, 
         // How many rows (arcs) should be used
-        rowFraction = (diameter - innerSize) / diameter;
+        rowFraction = (diameter - innerSize) / diameter, isCircle = fullAngle % (2 * Math.PI) === 0;
         // Increase the itemSize until we find the best fit
-        while (itemCount > this.total) {
+        while (itemCount > this.total + (rows && isCircle ? rows.length : 0)) {
             finalItemCount = itemCount;
             // Reset
             slots.length = 0;
@@ -189,7 +189,8 @@ seriesType('item',
         // the rows and remove the last slot until the count is correct.
         // For each iteration we sort the last slot by the angle, and
         // remove those with the highest angles.
-        var overshoot = finalItemCount - this.total;
+        var overshoot = finalItemCount - this.total -
+            (isCircle ? rows.length : 0);
         /**
          * @private
          * @param {Highcharts.ItemRowContainerObject} item

--- a/samples/unit-tests/series-item/dynamic/demo.js
+++ b/samples/unit-tests/series-item/dynamic/demo.js
@@ -39,3 +39,28 @@ QUnit.test('Item series dynamics', assert => {
         'Point length modified'
     );
 });
+
+QUnit.test('Full circle- points should not overlap.', function (assert) {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            type: 'item'
+        },
+        series: [{
+            keys: ['name', 'y', 'color'],
+            data: [
+                ['a', 5, 'rgba(200,0,200,0.3)'],
+                ['b', 5, 'rgba(0,200,0,0.3)']
+            ],
+            center: ['50%', '50%'],
+            size: '100%',
+            rows: 1,
+            startAngle: -180,
+            endAngle: 180
+        }]
+    });
+
+    assert.notEqual(
+        Math.round(chart.series[0].points[0].graphics[0].x),
+        Math.round(chart.series[0].points[1].graphics[4].x),
+        'Points are not overlapped.');
+});

--- a/ts/modules/item-series.src.ts
+++ b/ts/modules/item-series.src.ts
@@ -242,10 +242,11 @@ seriesType<Highcharts.ItemSeries>(
                 testRows: (Array<Highcharts.ItemRowObject>|undefined),
                 rowsOption = this.options.rows,
                 // How many rows (arcs) should be used
-                rowFraction = (diameter - innerSize) / diameter;
+                rowFraction = (diameter - innerSize) / diameter,
+                isCircle: boolean = fullAngle % (2 * Math.PI) === 0;
 
             // Increase the itemSize until we find the best fit
-            while (itemCount > (this.total as any)) {
+            while (itemCount > (this.total as any) + (rows && isCircle ? rows.length : 0)) {
 
                 finalItemCount = itemCount;
 
@@ -305,7 +306,8 @@ seriesType<Highcharts.ItemSeries>(
             // the rows and remove the last slot until the count is correct.
             // For each iteration we sort the last slot by the angle, and
             // remove those with the highest angles.
-            var overshoot = (finalItemCount as any) - (this.total as any);
+            var overshoot = (finalItemCount as any) - (this.total as any) -
+                (isCircle ? rows.length : 0);
             /**
              * @private
              * @param {Highcharts.ItemRowContainerObject} item


### PR DESCRIPTION
Fixed #13353, item series - when rendered in a full circle, points overlapped.