### PR TITLE
Fix typo 'corresponing'

### DIFF
--- a/js/modules/drilldown.src.js
+++ b/js/modules/drilldown.src.js
@@ -45,7 +45,7 @@ import H from '../parts/Globals.js';
 * @name Highcharts.DrilldownEventObject#point
 * @type {Highcharts.Point}
 */ /**
-* If a category label was clicked, this array holds all points corresponing to
+* If a category label was clicked, this array holds all points corresponding to
 * the category. Otherwise it is set to false.
 * @name Highcharts.DrilldownEventObject#points
 * @type {boolean|Array<Highcharts.Point>|undefined}
@@ -361,7 +361,7 @@ defaultOptions.drilldown = {
  * - `point`: The originating point.
  *
  * - `points`: If a category label was clicked, this array holds all points
- *   corresponing to the category.
+ *   corresponding to the category.
  *
  * - `seriesOptions`: Options for the new series.
  *

--- a/js/parts/AreaSeries.js
+++ b/js/parts/AreaSeries.js
@@ -143,7 +143,7 @@ seriesType('area', 'line',
      * * If `null`, the scaling behaves like a line series with fill between
      *   the graph and the Y axis minimum.
      * * If `Infinity` or `-Infinity`, the area between the graph and the
-     *   corresponing Y axis extreme is filled (since v6.1.0).
+     *   corresponding Y axis extreme is filled (since v6.1.0).
      *
      * @sample {highcharts} highcharts/plotoptions/area-threshold/
      *         A threshold of 100

--- a/ts/modules/drilldown.src.ts
+++ b/ts/modules/drilldown.src.ts
@@ -208,7 +208,7 @@ declare global {
  * @name Highcharts.DrilldownEventObject#point
  * @type {Highcharts.Point}
  *//**
- * If a category label was clicked, this array holds all points corresponing to
+ * If a category label was clicked, this array holds all points corresponding to
  * the category. Otherwise it is set to false.
  * @name Highcharts.DrilldownEventObject#points
  * @type {boolean|Array<Highcharts.Point>|undefined}
@@ -566,7 +566,7 @@ defaultOptions.drilldown = {
  * - `point`: The originating point.
  *
  * - `points`: If a category label was clicked, this array holds all points
- *   corresponing to the category.
+ *   corresponding to the category.
  *
  * - `seriesOptions`: Options for the new series.
  *

--- a/ts/parts/AreaSeries.ts
+++ b/ts/parts/AreaSeries.ts
@@ -204,7 +204,7 @@ seriesType<Highcharts.AreaSeries>(
          * * If `null`, the scaling behaves like a line series with fill between
          *   the graph and the Y axis minimum.
          * * If `Infinity` or `-Infinity`, the area between the graph and the
-         *   corresponing Y axis extreme is filled (since v6.1.0).
+         *   corresponding Y axis extreme is filled (since v6.1.0).
          *
          * @sample {highcharts} highcharts/plotoptions/area-threshold/
          *         A threshold of 100


### PR DESCRIPTION
Stumbled across this typo while browsing the API docs.

As i guess those are intelligently generated from source comments (please advise if that is not the case), i decided to quickly fix it here.