### PR TITLE
bugfix/13421-boosted-series-animation

### DIFF
--- a/js/modules/boost/boost-overrides.js
+++ b/js/modules/boost/boost-overrides.js
@@ -285,6 +285,8 @@ Series.prototype.enterBoost = function () {
     this.allowDG = false;
     this.directTouch = false;
     this.stickyTracking = true;
+    // Prevent animation when zooming in on boosted series(#13421).
+    this.finishedAnimating = true;
     // Hide series label if any
     if (this.labelBySeries) {
         this.labelBySeries = this.labelBySeries.destroy();

--- a/ts/modules/boost/boost-overrides.ts
+++ b/ts/modules/boost/boost-overrides.ts
@@ -451,6 +451,9 @@ Series.prototype.enterBoost = function (): void {
     this.directTouch = false;
     this.stickyTracking = true;
 
+    // Prevent animation when zooming in on boosted series(#13421).
+    this.finishedAnimating = true;
+
     // Hide series label if any
     if (this.labelBySeries) {
         this.labelBySeries = this.labelBySeries.destroy();


### PR DESCRIPTION
Fixed #13421, animation was fired when zooming boosted series.