### PR TITLE
Fixed wrong initial animation with scrolable plot area

### DIFF
--- a/js/parts/Series.js
+++ b/js/parts/Series.js
@@ -4074,7 +4074,7 @@ null,
      * @return {Highcharts.Dictionary<number>}
      */
     getClipBox: function (animation, finalBox) {
-        var series = this, options = series.options, chart = series.chart, inverted = chart.inverted, xAxis = series.xAxis, yAxis = xAxis && series.yAxis, clipBox;
+        var series = this, options = series.options, chart = series.chart, inverted = chart.inverted, xAxis = series.xAxis, yAxis = xAxis && series.yAxis, clipBox, scrollablePlotAreaOptions = chart.options.chart.scrollablePlotArea || {};
         if (animation && options.clip === false && yAxis) {
             // support for not clipped series animation (#10450)
             clipBox = inverted ? {
@@ -4095,7 +4095,8 @@ null,
             clipBox = series.clipBox || chart.clipBox;
             if (finalBox) {
                 clipBox.width = chart.plotSizeX;
-                clipBox.x = 0;
+                clipBox.x = (chart.scrollablePixelsX || 0) *
+                    (scrollablePlotAreaOptions.scrollPositionX || 0);
             }
         }
         return !finalBox ? clipBox : {

--- a/ts/parts/Series.ts
+++ b/ts/parts/Series.ts
@@ -5412,7 +5412,9 @@ H.Series = seriesType<Highcharts.LineSeries>(
                 inverted = chart.inverted,
                 xAxis = series.xAxis,
                 yAxis = xAxis && series.yAxis,
-                clipBox;
+                clipBox,
+                scrollablePlotAreaOptions =
+                    (chart.options.chart as any).scrollablePlotArea || {};
 
             if (animation && options.clip === false && yAxis) {
                 // support for not clipped series animation (#10450)
@@ -5434,7 +5436,8 @@ H.Series = seriesType<Highcharts.LineSeries>(
 
                 if (finalBox) {
                     clipBox.width = chart.plotSizeX as any;
-                    clipBox.x = 0;
+                    clipBox.x = (chart.scrollablePixelsX || 0) *
+                        (scrollablePlotAreaOptions.scrollPositionX || 0);
                 }
             }
 


### PR DESCRIPTION
Fixed wrong initial animation when `scrollablePlotArea.scrollPositionX` was set.

The animation would start from 0, and in many cases would be performed outside the visible plot area. Demo with v8.1.0: https://jsfiddle.net/highcharts/xcyb5qLw/