### PR TITLE
Fixed #13463, closing export menu should not move focus.

### DIFF
--- a/js/modules/accessibility/components/MenuComponent.js
+++ b/js/modules/accessibility/components/MenuComponent.js
@@ -261,13 +261,6 @@ extend(MenuComponent.prototype, /** @lends Highcharts.MenuComponent */ {
                     function () {
                         return component.onKbdClick(this);
                     }
-                ],
-                // ESC handler
-                [
-                    [keys.esc],
-                    function () {
-                        return this.response.prev;
-                    }
                 ]
             ],
             // Only run exporting navigation if exporting support exists and is

--- a/ts/modules/accessibility/components/MenuComponent.ts
+++ b/ts/modules/accessibility/components/MenuComponent.ts
@@ -414,16 +414,6 @@ extend(MenuComponent.prototype, /** @lends Highcharts.MenuComponent */ {
                     ): number {
                         return component.onKbdClick(this);
                     }
-                ],
-
-                // ESC handler
-                [
-                    [keys.esc],
-                    function (
-                        this: Highcharts.KeyboardNavigationHandler
-                    ): number {
-                        return this.response.prev;
-                    }
                 ]
             ],
 


### PR DESCRIPTION
Fixed #13463, closing export menu using ESC key should not move focus.