### PR TITLE
Fixed #13482, unable to disable markers in styled mode with a11y.

### DIFF
--- a/js/modules/accessibility/components/SeriesComponent/forcedMarkers.js
+++ b/js/modules/accessibility/components/SeriesComponent/forcedMarkers.js
@@ -37,9 +37,9 @@ function isWithinNavigationThreshold(series) {
  * @private
  */
 function shouldForceMarkers(series) {
-    var chartA11yEnabled = series.chart.options.accessibility.enabled, seriesA11yEnabled = (series.options.accessibility &&
-        series.options.accessibility.enabled) !== false, withinDescriptionThreshold = isWithinDescriptionThreshold(series), withinNavigationThreshold = isWithinNavigationThreshold(series);
-    return chartA11yEnabled && seriesA11yEnabled &&
+    var chart = series.chart, chartA11yEnabled = chart.options.accessibility.enabled, seriesA11yEnabled = (series.options.accessibility &&
+        series.options.accessibility.enabled) !== false, withinDescriptionThreshold = isWithinDescriptionThreshold(series), withinNavigationThreshold = isWithinNavigationThreshold(series), isStyledMode = chart.styledMode; // #13482
+    return chartA11yEnabled && seriesA11yEnabled && !isStyledMode &&
         (withinDescriptionThreshold || withinNavigationThreshold);
 }
 /**

--- a/ts/modules/accessibility/components/SeriesComponent/forcedMarkers.ts
+++ b/ts/modules/accessibility/components/SeriesComponent/forcedMarkers.ts
@@ -74,13 +74,15 @@ function isWithinNavigationThreshold(
 function shouldForceMarkers(
     series: Highcharts.AccessibilitySeries
 ): boolean {
-    var chartA11yEnabled = series.chart.options.accessibility.enabled,
+    const chart = series.chart,
+        chartA11yEnabled = chart.options.accessibility.enabled,
         seriesA11yEnabled = (series.options.accessibility &&
             series.options.accessibility.enabled) !== false,
         withinDescriptionThreshold = isWithinDescriptionThreshold(series),
-        withinNavigationThreshold = isWithinNavigationThreshold(series);
+        withinNavigationThreshold = isWithinNavigationThreshold(series),
+        isStyledMode = chart.styledMode; // #13482
 
-    return chartA11yEnabled && seriesA11yEnabled &&
+    return chartA11yEnabled && seriesA11yEnabled && !isStyledMode &&
         (withinDescriptionThreshold || withinNavigationThreshold);
 }
 


### PR DESCRIPTION
Fixed #13482, unable to disable markers in styled mode with a11y.
___
We are forcing marker options in order to set styling of invisible-but-enabled markers in a11y, and setting opacity to 0. This won't work in styled mode. Just disabled forced markers for styled mode for now since the issue is pretty critical. Ideally we would think of something smarter - maybe add a separate CSS class for this? This would require some refactoring of the forced markers logic.