### PR TITLE
bugfix/13489-print-chart-not-working

### DIFF
--- a/js/modules/networkgraph/layouts.js
+++ b/js/modules/networkgraph/layouts.js
@@ -510,16 +510,20 @@ addEvent(Chart, 'render', function () {
 });
 // disable simulation before print if enabled
 addEvent(Chart, 'beforePrint', function () {
-    this.graphLayoutsLookup.forEach(function (layout) {
-        layout.updateSimulation(false);
-    });
-    this.redraw();
+    if (this.graphLayoutsLookup) {
+        this.graphLayoutsLookup.forEach(function (layout) {
+            layout.updateSimulation(false);
+        });
+        this.redraw();
+    }
 });
 // re-enable simulation after print
 addEvent(Chart, 'afterPrint', function () {
-    this.graphLayoutsLookup.forEach(function (layout) {
-        // return to default simulation
-        layout.updateSimulation();
-    });
+    if (this.graphLayoutsLookup) {
+        this.graphLayoutsLookup.forEach(function (layout) {
+            // return to default simulation
+            layout.updateSimulation();
+        });
+    }
     this.redraw();
 });

--- a/ts/modules/networkgraph/layouts.ts
+++ b/ts/modules/networkgraph/layouts.ts
@@ -933,19 +933,23 @@ addEvent(Chart as any, 'render', function (
 addEvent(Chart as any, 'beforePrint', function (
     this: Highcharts.PackedBubbleChart
 ): void {
-    this.graphLayoutsLookup.forEach(function (layout): void {
-        layout.updateSimulation(false);
-    });
-    this.redraw();
+    if (this.graphLayoutsLookup) {
+        this.graphLayoutsLookup.forEach(function (layout): void {
+            layout.updateSimulation(false);
+        });
+        this.redraw();
+    }
 });
 
 // re-enable simulation after print
 addEvent(Chart as any, 'afterPrint', function (
     this: Highcharts.PackedBubbleChart
 ): void {
-    this.graphLayoutsLookup.forEach(function (layout): void {
-        // return to default simulation
-        layout.updateSimulation();
-    });
+    if (this.graphLayoutsLookup) {
+        this.graphLayoutsLookup.forEach(function (layout): void {
+            // return to default simulation
+            layout.updateSimulation();
+        });
+    }
     this.redraw();
 });


### PR DESCRIPTION
Fixed #13489, `Chart.print()` was not working correctly with `highcharts-more.js` (specifically network graphs) included.