### PR TITLE
docs/heatmap-marker-version-info

### DIFF
--- a/js/parts-map/HeatmapSeries.js
+++ b/js/parts-map/HeatmapSeries.js
@@ -139,6 +139,7 @@ seriesType('heatmap', 'scatter',
     },
     /**
      * @excluding radius, enabledThreshold
+     * @since     8.1
      */
     marker: {
         /**
@@ -741,11 +742,13 @@ seriesType('heatmap', 'scatter',
 /**
  * @excluding radius, enabledThreshold
  * @product   highcharts highmaps
+ * @since     8.1
  * @apioption series.heatmap.data.marker
  */
 /**
  * @excluding radius, enabledThreshold
  * @product   highcharts highmaps
+ * @since     8.1
  * @apioption series.heatmap.marker
  */
 /**

--- a/ts/parts-map/HeatmapSeries.ts
+++ b/ts/parts-map/HeatmapSeries.ts
@@ -261,6 +261,7 @@ seriesType<Highcharts.HeatmapSeries>(
         },
         /**
          * @excluding radius, enabledThreshold
+         * @since     8.1
          */
         marker: {
             /**
@@ -1086,12 +1087,14 @@ seriesType<Highcharts.HeatmapSeries>(
 /**
  * @excluding radius, enabledThreshold
  * @product   highcharts highmaps
+ * @since     8.1
  * @apioption series.heatmap.data.marker
  */
 
 /**
  * @excluding radius, enabledThreshold
  * @product   highcharts highmaps
+ * @since     8.1
  * @apioption series.heatmap.marker
  */
 


### PR DESCRIPTION
Fixed #13441, information about version added to `series.marker`.