### PR TITLE
Fixed #13071, unnecessary network request in IE11.

### DIFF
--- a/js/modules/accessibility/high-contrast-mode.js
+++ b/js/modules/accessibility/high-contrast-mode.js
@@ -29,7 +29,8 @@ var whcm = {
         // Test BG image for IE
         if (isMS && win.getComputedStyle) {
             var testDiv = doc.createElement('div');
-            testDiv.style.backgroundImage = 'url(#)';
+            var imageSrc = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+            testDiv.style.backgroundImage = "url(" + imageSrc + ")"; // #13071
             doc.body.appendChild(testDiv);
             var bi = (testDiv.currentStyle ||
                 win.getComputedStyle(testDiv)).backgroundImage;

--- a/ts/modules/accessibility/high-contrast-mode.ts
+++ b/ts/modules/accessibility/high-contrast-mode.ts
@@ -52,7 +52,8 @@ var whcm = {
         // Test BG image for IE
         if (isMS && win.getComputedStyle) {
             const testDiv = doc.createElement('div');
-            testDiv.style.backgroundImage = 'url(#)';
+            const imageSrc = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+            testDiv.style.backgroundImage = `url(${imageSrc})`; // #13071
             doc.body.appendChild(testDiv);
 
             const bi = (


### PR DESCRIPTION
Fixed #13071, unnecessary network request in IE11.
___
`url(#)` generates an additional network request that is not necessary. Changed to a minimal valid dataURI.