### PR TITLE
Fixed issues with tick animation

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -558,6 +558,9 @@ var Chart = /** @class */ (function () {
         if (hasCartesianSeries) {
             // set axes scales
             axes.forEach(function (axis) {
+                // Don't do setScale again if we're only resizing. Regression
+                // #13507. But we need it after chart.update (responsive), as
+                // axis is initialized again (#12137).
                 if (!chart.isResizing || !axis.tickPositions) {
                     axis.updateNames();
                     axis.setScale();

--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -558,8 +558,10 @@ var Chart = /** @class */ (function () {
         if (hasCartesianSeries) {
             // set axes scales
             axes.forEach(function (axis) {
-                axis.updateNames();
-                axis.setScale();
+                if (!chart.isResizing || !axis.tickPositions) {
+                    axis.updateNames();
+                    axis.setScale();
+                }
             });
         }
         chart.getMargins(); // #3098

--- a/samples/unit-tests/axis/ticks/demo.js
+++ b/samples/unit-tests/axis/ticks/demo.js
@@ -660,3 +660,67 @@ QUnit.test('The ticks should be visible when specified tick amount and chart hei
         "The amount of tick should be 5."
     );
 });
+
+QUnit.test('Ticks and setSize', assert => {
+    const clock = TestUtilities.lolexInstall();
+    const done = assert.async(2);
+
+    try {
+        const chart = Highcharts.chart('container', {
+
+            chart: {
+                width: 400,
+                height: 300,
+                animation: {
+                    duration: 100
+                }
+            },
+
+            series: [{
+                data: [30, 220]
+            }]
+        });
+
+        const pos100 = chart.yAxis[0].ticks[100].label.attr('y');
+        const pos200 = chart.yAxis[0].ticks[200].label.attr('y');
+
+        assert.strictEqual(
+            chart.yAxis[0].ticks[150],
+            undefined,
+            'There should be no tick on 150 initially with the current tick ' +
+            'position settings as of v8.1'
+        );
+        chart.setSize(undefined, 350);
+
+        setTimeout(() => {
+            const pos150 = chart.yAxis[0].ticks[150].label.attr('y');
+
+            assert.close(
+                pos150,
+                (pos100 + pos200) / 2,
+                1,
+                'The new tick should appear centered between the two existing ' +
+                'ticks (#13507)'
+            );
+            done();
+        }, 1);
+
+        setTimeout(() => {
+            chart.xAxis[0].update(undefined, false);
+            chart.setSize(500);
+
+            assert.strictEqual(
+                chart.xAxis[0].ticks[0].label.attr('opacity'),
+                1,
+                'The label should remain visible after the update sequence (#12137)'
+            );
+            done();
+        }, 2);
+
+
+        TestUtilities.lolexRunAndUninstall(clock);
+    } finally {
+        TestUtilities.lolexUninstall(clock);
+    }
+
+});

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -951,8 +951,10 @@ class Chart {
         if (hasCartesianSeries) {
             // set axes scales
             axes.forEach(function (axis: Highcharts.Axis): void {
-                axis.updateNames();
-                axis.setScale();
+                if (!chart.isResizing || !axis.tickPositions) {
+                    axis.updateNames();
+                    axis.setScale();
+                }
             });
         }
 

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -951,6 +951,9 @@ class Chart {
         if (hasCartesianSeries) {
             // set axes scales
             axes.forEach(function (axis: Highcharts.Axis): void {
+                // Don't do setScale again if we're only resizing. Regression
+                // #13507. But we need it after chart.update (responsive), as
+                // axis is initialized again (#12137).
                 if (!chart.isResizing || !axis.tickPositions) {
                     axis.updateNames();
                     axis.setScale();


### PR DESCRIPTION
Fixed issues with tick animation, causing blinking and wrong animation in some cases after running `chart.update` or `chart.setSize`.

* Fixed #12137, axis flashing after `chart.update`.
* Fixed #13507, wrong start position of ticks on animating in following `chart.setSize()`