### PR TITLE
Fixed #13494, bubble animation failed when redrawing

### DIFF
--- a/js/parts-more/BubbleSeries.js
+++ b/js/parts-more/BubbleSeries.js
@@ -332,23 +332,19 @@ seriesType('bubble', 'scatter', {
             this.points.length < this.options.animationLimit // #8099
         ) {
             this.points.forEach(function (point) {
-                var graphic = point.graphic, animationTarget;
+                var graphic = point.graphic;
                 if (graphic && graphic.width) { // URL symbols don't have width
-                    animationTarget = {
-                        x: graphic.x,
-                        y: graphic.y,
-                        width: graphic.width,
-                        height: graphic.height
-                    };
                     // Start values
-                    graphic.attr({
-                        x: point.plotX,
-                        y: point.plotY,
-                        width: 1,
-                        height: 1
-                    });
+                    if (!this.hasRendered) {
+                        graphic.attr({
+                            x: point.plotX,
+                            y: point.plotY,
+                            width: 1,
+                            height: 1
+                        });
+                    }
                     // Run animation
-                    graphic.animate(animationTarget, this.options.animation);
+                    graphic.animate(this.markerAttribs(point), this.options.animation);
                 }
             }, this);
         }

--- a/samples/unit-tests/series-bubble/marker/demo.js
+++ b/samples/unit-tests/series-bubble/marker/demo.js
@@ -109,3 +109,74 @@ QUnit.test('Bubble data points without z-param.(#8608)', function (assert) {
         'Has marker'
     );
 });
+
+QUnit.test('Bubble animation and async redraws (#13494)', assert => {
+    const clock = TestUtilities.lolexInstall();
+
+    try {
+
+        const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'bubble'
+            },
+            plotOptions: {
+                series: {
+                    animation: {
+                        duration: 100
+                    }
+                }
+            }
+        });
+
+        chart.addSeries({
+            data: [
+                [9, 81, 10],
+                [3, 52, 9],
+                [31, 18, 47],
+                [79, 91, 13],
+                [93, 23, -27],
+                [44, 83, -28]
+            ]
+        });
+
+        assert.strictEqual(
+            chart.series[0].points[0].graphic.attr('width'),
+            1,
+            'Points should be in animation start position'
+        );
+        setTimeout(() => {
+            chart.addSeries({
+                data: [
+                    [13, 30, 10],
+                    [23, 20, -10],
+                    [23, 40, 10]
+                ]
+            });
+            assert.notEqual(
+                chart.series[0].points[0].graphic.attr('width'),
+                1,
+                'First series points should continue animating'
+            );
+            assert.strictEqual(
+                chart.series[1].points[0].graphic.attr('width'),
+                1,
+                'Second series points should be in animation start position'
+            );
+        }, 50);
+
+        setTimeout(() => {
+            assert.strictEqual(
+                chart.series[0].points[0].graphic.attr('width'),
+                chart.series[1].points[0].graphic.attr('width'),
+                'Equal weight points for both series should now be the same size'
+            );
+        }, 200);
+
+        TestUtilities.lolexRunAndUninstall(clock);
+
+    } finally {
+
+        TestUtilities.lolexUninstall(clock);
+
+    }
+});

--- a/ts/parts-more/BubbleSeries.ts
+++ b/ts/parts-more/BubbleSeries.ts
@@ -520,27 +520,25 @@ seriesType<Highcharts.BubbleSeries>('bubble', 'scatter', {
             this.points.length < (this.options.animationLimit as any) // #8099
         ) {
             this.points.forEach(function (point: Highcharts.BubblePoint): void {
-                var graphic = point.graphic,
-                    animationTarget;
+                const { graphic } = point;
 
                 if (graphic && graphic.width) { // URL symbols don't have width
-                    animationTarget = {
-                        x: graphic.x,
-                        y: graphic.y,
-                        width: graphic.width,
-                        height: graphic.height
-                    };
 
                     // Start values
-                    graphic.attr({
-                        x: point.plotX,
-                        y: point.plotY,
-                        width: 1,
-                        height: 1
-                    });
+                    if (!this.hasRendered) {
+                        graphic.attr({
+                            x: point.plotX,
+                            y: point.plotY,
+                            width: 1,
+                            height: 1
+                        });
+                    }
 
                     // Run animation
-                    graphic.animate(animationTarget, this.options.animation);
+                    graphic.animate(
+                        this.markerAttribs(point),
+                        this.options.animation
+                    );
                 }
             }, this);
         }


### PR DESCRIPTION
Fixed #13494, a regression causing bubble animation to fail when redrawing, like when running `addSeries` in quick succession.