### PR TITLE
Tools: Fixed issue with old PRs not making it to the changelog

### DIFF
--- a/changelog/changelog.html
+++ b/changelog/changelog.html
@@ -23,6 +23,7 @@
               <li>Added new series label options, <code>series.label.format</code> and <a href="https://api.highcharts.com/highcharts/plotOptions.series.label.formatter">series.label.formatter</a>.</li>
               <li>Added individual dash style settings for various parts of box plots. See <a href="https://github.com/highcharts/highcharts/issues/13065">#13065</a>.</li>
               <li>Added language options for export-data table text, see <a href="https://github.com/highcharts/highcharts/issues/13166">#13166</a>.</li>
+              <li>Added ability to set markers of heatmap points to a custom shapes defined within <code>SVGRenderer.prototype.symbols</code> object, see <a href="https://github.com/highcharts/highcharts/issues/12508">#12508</a>.</li>
             </ul>
             <div id="accordion" class="card-group">
               <div class="card">

--- a/changelog/highcharts/8.1.0.md
+++ b/changelog/highcharts/8.1.0.md
@@ -5,6 +5,7 @@
 - Added new series label options, `series.label.format` and [series.label.formatter](https://api.highcharts.com/highcharts/plotOptions.series.label.formatter).
 - Added individual dash style settings for various parts of box plots. See #13065.
 - Added language options for export-data table text, see #13166.
+- Added ability to set markers of heatmap points to a custom shapes defined within `SVGRenderer.prototype.symbols` object, see #12508.
 
 ## Upgrade notes
 - The Axis class was refactored as part of the TypeScript migration. Axis extensions like log axis, broken axis, parallel axis, datetime axis and ordinal axis are now handled as compositions. Instead of adding multiple properties to the main axis instance, they now add a single object that holds all properties. This does not affect the options API, but it may affect implementations that are based on some of our samples that used the original properties. Our samples have been updated to use the new structure.

--- a/changelog/pr-log.js
+++ b/changelog/pr-log.js
@@ -67,7 +67,9 @@ module.exports = async since => {
                 repo: 'highcharts',
                 state: 'closed',
                 base,
-                page
+                page,
+                sort: 'updated',
+                direction: 'desc'
             }).catch(error);
 
             // On the master, keep only PRs that have been closed since last


### PR DESCRIPTION
When creating the changelog, we used to grab PRs ordered by creation date in chunks of 30. When a page had 0 PRs merged after the last release date, the loop would break. This caused a loophole for PRs that were created a long time ago and merged recently. Now we initially sort it by the last update, which will always be after the last release for the items that should go into the changelog.