### PR TITLE
Fixed typos that broke multiple links in docs for exporting

### DIFF
--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -494,7 +494,7 @@ defaultOptions.exporting = {
      *
      * @sample {highcharts} highcharts/exporting/chartoptions-data-labels/
      *         Added data labels
-     * @sample {highstock} highcharts/exporting/chartoptions-data-labels/
+     * @sample {highstock} highstock/exporting/chartoptions-data-labels/
      *         Added data labels
      *
      * @type      {Highcharts.Options}
@@ -506,7 +506,7 @@ defaultOptions.exporting = {
      *
      * @sample {highcharts} highcharts/exporting/enabled-false/
      *         Exporting module is loaded but disabled
-     * @sample {highstock} highcharts/exporting/enabled-false/
+     * @sample {highstock} highstock/exporting/enabled-false/
      *         Exporting module is loaded but disabled
      *
      * @type      {boolean}
@@ -552,7 +552,7 @@ defaultOptions.exporting = {
      *
      * @sample {highcharts} highcharts/exporting/filename/
      *         Custom file name
-     * @sample {highstock} highcharts/exporting/filename/
+     * @sample {highstock} highstock/exporting/filename/
      *         Custom file name
      *
      * @type      {string}
@@ -599,9 +599,9 @@ defaultOptions.exporting = {
      *
      * @sample {highcharts} highcharts/exporting/sourcewidth/
      *         Source size demo
-     * @sample {highstock} highcharts/exporting/sourcewidth/
+     * @sample {highstock} highstock/exporting/sourcewidth/
      *         Source size demo
-     * @sample {highmaps} maps/exporting/sourcewidth/
+     * @sample {highmaps} highmaps/exporting/sourcewidth/
      *         Source size demo
      *
      * @type      {number}
@@ -616,7 +616,7 @@ defaultOptions.exporting = {
      *
      * @sample {highcharts} highcharts/exporting/width/
      *         Export to 200px wide images
-     * @sample {highstock} highcharts/exporting/width/
+     * @sample {highstock} highstock/exporting/width/
      *         Export to 200px wide images
      *
      * @type      {number}
@@ -660,9 +660,9 @@ defaultOptions.exporting = {
      *
      * @sample {highcharts} highcharts/exporting/scale/
      *         Scale demonstrated
-     * @sample {highstock} highcharts/exporting/scale/
+     * @sample {highstock} highstock/exporting/scale/
      *         Scale demonstrated
-     * @sample {highmaps} maps/exporting/scale/
+     * @sample {highmaps} highmaps/exporting/scale/
      *         Scale demonstrated
      *
      * @since 3.0
@@ -769,9 +769,9 @@ defaultOptions.exporting = {
              *
              * @sample {highcharts} highcharts/exporting/menuitemdefinitions/
              *         Menu item definitions
-             * @sample {highstock} highcharts/exporting/menuitemdefinitions/
+             * @sample {highstock} highstock/exporting/menuitemdefinitions/
              *         Menu item definitions
-             * @sample {highmaps} highcharts/exporting/menuitemdefinitions/
+             * @sample {highmaps} highmaps/exporting/menuitemdefinitions/
              *         Menu item definitions
              *
              * @type    {Array<string>}
@@ -807,9 +807,9 @@ defaultOptions.exporting = {
      *
      * @sample {highcharts} highcharts/exporting/menuitemdefinitions/
      *         Menu item definitions
-     * @sample {highstock} highcharts/exporting/menuitemdefinitions/
+     * @sample {highstock} highstock/exporting/menuitemdefinitions/
      *         Menu item definitions
-     * @sample {highmaps} highcharts/exporting/menuitemdefinitions/
+     * @sample {highmaps} highmaps/exporting/menuitemdefinitions/
      *         Menu item definitions
      *
      *


### PR DESCRIPTION
I noticed that several links were broken in the api documentation for exporting and it looks like there was a couple of small typos. I think I managed to fix them but I am not familiar with how the documentation system works. 

An example of a broken link can be found [here](https://api.highcharts.com/highmaps/exporting.buttons) at the navigation.buttonOptions link. The link is generated as https://api.highcharts.com//navigation.buttonOptions instead of https://api.highcharts.com/highmaps/navigation.buttonOptions and I am guessing because the... I realized when thinking about why that my commit will not actually fix that particular link but it should fix some other links. I can't find a simple fix for that but feel free to edit my pull request if there is a solution. 

