### PR TITLE
Fixed #13526, gradient fills not working in edge

### DIFF
--- a/js/parts/Point.js
+++ b/js/parts/Point.js
@@ -495,8 +495,6 @@ var Point = /** @class */ (function () {
             (point.selected ? ' highcharts-point-select' : '') +
             (point.negative ? ' highcharts-negative' : '') +
             (point.isNull ? ' highcharts-null-point' : '') +
-            (typeof point.colorIndex !== 'undefined' ?
-                ' highcharts-color-' + point.colorIndex : '') +
             (point.options.className ? ' ' + point.options.className : '') +
             (point.zone && point.zone.className ? ' ' +
                 point.zone.className.replace('highcharts-negative', '') : '');


### PR DESCRIPTION
This fixes gradient fills not working in edge browser as logged in #13526. An alternate fix would be to not add the _highcharts-color-x_ class at the group level, which I think is done inside `Series.js` inside the *plotGroup* function.  