### PR TITLE
bugfix/13334-ordinal-axis-panning

### DIFF
--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -489,6 +489,7 @@ extend(Chart.prototype, /** @lends Chart.prototype */ {
                 xy = [0];
             }
             xy.forEach(function (isX) {
+                var _a;
                 var axis = chart[isX ? 'xAxis' : 'yAxis'][0], axisOpt = axis.options, horiz = axis.horiz, mousePos = e[horiz ? 'chartX' : 'chartY'], mouseDown = horiz ? 'mouseDownX' : 'mouseDownY', startPos = chart[mouseDown], halfPointRange = (axis.pointRange || 0) / 2, pointRangeDirection = (axis.reversed && !chart.inverted) ||
                     (!axis.reversed && chart.inverted) ?
                     -1 :
@@ -523,41 +524,40 @@ extend(Chart.prototype, /** @lends Chart.prototype */ {
                     axis.toValue(axis.toPixels(extremes.max) +
                         axis.minPixelPadding));
                 axis.panningState = panningState;
-                // It is not necessary to calculate extremes on ordinal axis,
-                // because the are already calculated, so we don't want to
-                // override them.
-                if (!axisOpt.ordinal) {
-                    // If the new range spills over, either to the min or max,
-                    // adjust the new range.
-                    spill = paddedMin - newMin;
-                    if (spill > 0) {
-                        newMax += spill;
-                        newMin = paddedMin;
-                    }
-                    spill = newMax - paddedMax;
-                    if (spill > 0) {
-                        newMax = paddedMax;
-                        newMin -= spill;
-                    }
-                    // Set new extremes if they are actually new
-                    if (axis.series.length &&
-                        newMin !== extremes.min &&
-                        newMax !== extremes.max &&
-                        isX ? true : (panningState &&
-                        newMin >= paddedMin &&
-                        newMax <= paddedMax)) {
-                        axis.setExtremes(newMin, newMax, false, false, { trigger: 'pan' });
-                        if (!chart.resetZoomButton &&
-                            !hasMapNavigation &&
-                            type.match('y')) {
-                            chart.showResetZoom();
-                            axis.displayBtn = false;
-                        }
-                        doRedraw = true;
-                    }
-                    // set new reference for next run:
-                    chart[mouseDown] = mousePos;
+                // If the new range spills over, either to the min or max,
+                // adjust the new range.
+                spill = paddedMin - newMin;
+                if (spill > 0) {
+                    newMax += spill;
+                    newMin = paddedMin;
                 }
+                spill = newMax - paddedMax;
+                if (spill > 0) {
+                    newMax = paddedMax;
+                    newMin -= spill;
+                }
+                // Set new extremes if they are actually new
+                if (axis.series.length &&
+                    newMin !== extremes.min &&
+                    newMax !== extremes.max &&
+                    // It is not necessary to calculate extremes on ordinal
+                    // axis (with not equally spaced data), because they
+                    // are already calculated, and we don't want to
+                    // override them.
+                    isX && !((_a = axis.ordinal) === null || _a === void 0 ? void 0 : _a.getExtendedPositions()) ? true : (panningState &&
+                    newMin >= paddedMin &&
+                    newMax <= paddedMax)) {
+                    axis.setExtremes(newMin, newMax, false, false, { trigger: 'pan' });
+                    if (!chart.resetZoomButton &&
+                        !hasMapNavigation &&
+                        type.match('y')) {
+                        chart.showResetZoom();
+                        axis.displayBtn = false;
+                    }
+                    doRedraw = true;
+                }
+                // set new reference for next run:
+                chart[mouseDown] = mousePos;
             });
             if (doRedraw) {
                 chart.redraw(false);

--- a/samples/unit-tests/chart/panning/demo.js
+++ b/samples/unit-tests/chart/panning/demo.js
@@ -291,6 +291,56 @@ QUnit.test('Stock (ordinal axis) panning (#6276)', function (assert) {
     );
 });
 
+QUnit.test('Ordinal axis panning, when data is equally spaced (#13334).', function (assert) {
+    var chart = Highcharts.stockChart('container', {
+        xAxis: {
+            min: Date.UTC(2020, 1, 6),
+            max: Date.UTC(2020, 1, 9)
+        },
+        series: [{
+            data: [{
+                x: Date.UTC(2020, 1, 1),
+                y: 10
+            }, {
+                x: Date.UTC(2020, 1, 2),
+                y: 11
+            }, {
+                x: Date.UTC(2020, 1, 3),
+                y: 12
+            }, {
+                x: Date.UTC(2020, 1, 4),
+                y: 14
+            }, {
+                x: Date.UTC(2020, 1, 5),
+                y: 15
+            }, {
+                x: Date.UTC(2020, 1, 6),
+                y: 16
+            }, {
+                x: Date.UTC(2020, 1, 7),
+                y: 14
+            }, {
+                x: Date.UTC(2020, 1, 8),
+                y: 15
+            }, {
+                x: Date.UTC(2020, 1, 9),
+                y: 16
+            }]
+        }]
+    });
+
+    var controller = new TestController(chart),
+        initialMin = chart.xAxis[0].min;
+
+    controller.pan([100, 200], [200, 200], {}, true);
+
+    assert.notEqual(
+        initialMin,
+        chart.xAxis[0].min,
+        'Chart should pan horizontally.'
+    );
+});
+
 QUnit.test('Pan all the way to extremes (#5863)', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {

--- a/ts/parts/Interaction.ts
+++ b/ts/parts/Interaction.ts
@@ -884,58 +884,58 @@ extend(Chart.prototype, /** @lends Chart.prototype */ {
 
                 axis.panningState = panningState;
 
-                // It is not necessary to calculate extremes on ordinal axis,
-                // because the are already calculated, so we don't want to
-                // override them.
-                if (!axisOpt.ordinal) {
-                    // If the new range spills over, either to the min or max,
-                    // adjust the new range.
-                    spill = paddedMin - newMin;
-                    if (spill > 0) {
-                        newMax += spill;
-                        newMin = paddedMin;
-                    }
-
-                    spill = newMax - paddedMax;
-                    if (spill > 0) {
-                        newMax = paddedMax;
-                        newMin -= spill;
-                    }
-
-                    // Set new extremes if they are actually new
-                    if (
-                        axis.series.length &&
-                            newMin !== extremes.min &&
-                            newMax !== extremes.max &&
-                            isX ? true : (
-                                panningState &&
-                                newMin >= paddedMin &&
-                                newMax <= paddedMax
-                            )
-                    ) {
-                        axis.setExtremes(
-                            newMin,
-                            newMax,
-                            false,
-                            false,
-                            { trigger: 'pan' }
-                        );
-
-                        if (
-                            !chart.resetZoomButton &&
-                            !hasMapNavigation &&
-                            type.match('y')
-                        ) {
-                            chart.showResetZoom();
-                            axis.displayBtn = false;
-                        }
-
-                        doRedraw = true;
-                    }
-
-                    // set new reference for next run:
-                    (chart as any)[mouseDown] = mousePos;
+                // If the new range spills over, either to the min or max,
+                // adjust the new range.
+                spill = paddedMin - newMin;
+                if (spill > 0) {
+                    newMax += spill;
+                    newMin = paddedMin;
                 }
+
+                spill = newMax - paddedMax;
+                if (spill > 0) {
+                    newMax = paddedMax;
+                    newMin -= spill;
+                }
+
+                // Set new extremes if they are actually new
+                if (
+                    axis.series.length &&
+                        newMin !== extremes.min &&
+                        newMax !== extremes.max &&
+                        // It is not necessary to calculate extremes on ordinal
+                        // axis (with not equally spaced data), because they
+                        // are already calculated, and we don't want to
+                        // override them.
+                        isX && !axis.ordinal?.getExtendedPositions() ? true : (
+                            panningState &&
+                            newMin >= paddedMin &&
+                            newMax <= paddedMax
+                        )
+                ) {
+                    axis.setExtremes(
+                        newMin,
+                        newMax,
+                        false,
+                        false,
+                        { trigger: 'pan' }
+                    );
+
+                    if (
+                        !chart.resetZoomButton &&
+                        !hasMapNavigation &&
+                        type.match('y')
+                    ) {
+                        chart.showResetZoom();
+                        axis.displayBtn = false;
+                    }
+
+                    doRedraw = true;
+                }
+
+                // set new reference for next run:
+                (chart as any)[mouseDown] = mousePos;
+
             });
 
             if (doRedraw) {


### PR DESCRIPTION
Fixed #13334, panning an ordinal axis with equal spaced data did not work correctly.