### PR TITLE
bugfix/9424-button-styles-dom

### DIFF
--- a/js/parts/SVGRenderer.js
+++ b/js/parts/SVGRenderer.js
@@ -1003,7 +1003,11 @@ var SVGRenderer = /** @class */ (function () {
      * The button element.
      */
     SVGRenderer.prototype.button = function (text, x, y, callback, normalState, hoverState, pressedState, disabledState, shape, useHTML) {
-        var label = this.label(text, x, y, shape, void 0, void 0, useHTML, void 0, 'button'), curState = 0, styledMode = this.styledMode;
+        var label = this.label(text, x, y, shape, void 0, void 0, useHTML, void 0, 'button'), curState = 0, styledMode = this.styledMode, userNormalStyle = normalState && normalState.style || {};
+        // Remove stylable attributes
+        if (normalState && normalState.style) {
+            delete normalState.style;
+        }
         // Default, non-stylable attributes
         label.attr(merge({ padding: 8, r: 2 }, normalState));
         if (!styledMode) {
@@ -1019,6 +1023,8 @@ var SVGRenderer = /** @class */ (function () {
                     cursor: 'pointer',
                     fontWeight: 'normal'
                 }
+            }, {
+                style: userNormalStyle
             }, normalState);
             normalStyle = normalState.style;
             delete normalState.style;

--- a/samples/unit-tests/svgrenderer/button/demo.js
+++ b/samples/unit-tests/svgrenderer/button/demo.js
@@ -1,4 +1,4 @@
-QUnit.test('Dynamic fontWeight - button width (#12163)', function (assert) {
+QUnit.test('General button() tests', function (assert) {
     var ren = new Highcharts.Renderer(
         document.getElementById('container'),
         500,
@@ -38,6 +38,12 @@ QUnit.test('Dynamic fontWeight - button width (#12163)', function (assert) {
     assert.strictEqual(
         button.width > normalButtonWidth,
         true,
-        'Width of button should be updated.'
+        'Width of button should be updated  when fontWeight has changed (#12163)'
+    );
+
+    assert.notStrictEqual(
+        button.attr('style'),
+        '[Object object]',
+        'Button should not set wrong styles (#9424).'
     );
 });

--- a/ts/parts/SVGRenderer.ts
+++ b/ts/parts/SVGRenderer.ts
@@ -1606,10 +1606,16 @@ class SVGRenderer {
                 'button'
             ),
             curState = 0,
-            styledMode = this.styledMode;
+            styledMode = this.styledMode,
+            userNormalStyle = normalState && normalState.style || {};
+
+        // Remove stylable attributes
+        if (normalState && normalState.style) {
+            delete normalState.style;
+        }
 
         // Default, non-stylable attributes
-        label.attr(merge({ padding: 8, r: 2 }, normalState as any));
+        label.attr(merge({ padding: 8, r: 2 }, normalState));
 
         if (!styledMode) {
             // Presentational
@@ -1628,6 +1634,8 @@ class SVGRenderer {
                     cursor: 'pointer',
                     fontWeight: 'normal'
                 }
+            }, {
+                style: userNormalStyle
             }, normalState);
             normalStyle = normalState.style;
             delete normalState.style;


### PR DESCRIPTION
Fixed #9424, Map navigation zoom buttons used to have `[Object object]` in DOM styles.
___
Note: Fix applies to all elements rendered via `renderer.button()`. `style="[Object object]"` should no longer happen.