### PR TITLE
Fixed #13559, no JS execution should be allowed from chart config

### DIFF
--- a/samples/unit-tests/svgrenderer/text/demo.js
+++ b/samples/unit-tests/svgrenderer/text/demo.js
@@ -801,3 +801,37 @@ QUnit.test('RTL characters with outline (#10162)', function (assert) {
         renderer.destroy();
     }
 });
+
+QUnit.test('XSS and script injection', assert => {
+    const ren = new Highcharts.Renderer(
+        document.getElementById('container'),
+        600,
+        400
+    );
+
+    ren.text(
+        'This is a link to <a href="https://www.highcharts.com">highcharts.com</a>',
+        30,
+        30
+    )
+        .add();
+
+    assert.strictEqual(
+        document.getElementById('container').innerHTML.indexOf('onclick'),
+        -1,
+        'There should be no translation of anchors to onclick like historically'
+    );
+
+    ren.text(
+        'This is a link to <a href="javascript:alert(\'XSS\')">an alert</a>',
+        30,
+        60
+    )
+        .add();
+
+    assert.strictEqual(
+        document.getElementById('container').innerHTML.indexOf('javascript'),
+        -1,
+        'JavaScript execution should not be allowed from config'
+    );
+});


### PR DESCRIPTION
Fixed #13559, no JavaScript execution should be allowed from chart configuration strings, except from callbacks like event handlers and formatters. This prevents JavaScript from being injected from forms and other inputs relaying directly to text properties in the chart config.