### PR TITLE
bugfix/12696-set-data-with-crop

### DIFF
--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -1067,7 +1067,7 @@ extend(Series.prototype, /** @lends Series.prototype */ {
         // rules (#6912).
         animation = series.finishedAnimating && { animation: false }, kinds = {};
         if (keepPoints) {
-            preserve.push('data', 'isDirtyData', 'points', 'processedXData', 'processedYData', 'xIncrement', '_hasPointMarkers', '_hasPointLabels', 
+            preserve.push('data', 'isDirtyData', 'points', 'processedXData', 'processedYData', 'xIncrement', 'cropped', '_hasPointMarkers', '_hasPointLabels', 
             // Map specific, consider moving it to series-specific preserve-
             // properties (#10617)
             'mapMap', 'mapData', 'minY', 'maxY', 'minX', 'maxX');

--- a/samples/unit-tests/series/setdata/demo.js
+++ b/samples/unit-tests/series/setdata/demo.js
@@ -405,6 +405,42 @@ QUnit.test('Series.setData with updatePoints', function (assert) {
         'Auto incremented X should not overlap first point.'
     );
 
+    chart.update({
+        xAxis: {
+            min: 3
+        },
+        series: {
+            cropThreshold: 1,
+            data: [
+                [0, 2],
+                [2, 1],
+                [4, 2],
+                [6, 1],
+                [8, 2],
+                [10, 1]
+            ]
+        }
+    });
+    const correctSet = chart.series[0].processedXData.slice();
+
+    chart.series[0].update({
+        name: 'New test name'
+    }, false);
+    chart.series[0].setData([
+        [0, 2],
+        [2, 1],
+        [4, 2],
+        [6, 1],
+        [8, 2],
+        [10, 1]
+    ], false);
+    chart.redraw();
+
+    assert.deepEqual(
+        chart.series[0].processedXData,
+        correctSet,
+        'Setting data on a updated series with cropped dataset should keep correct x-values (#12696).'
+    );
 });
 
 QUnit.test('Boosted series with updatePoints', function (assert) {

--- a/ts/parts/Dynamics.ts
+++ b/ts/parts/Dynamics.ts
@@ -1515,6 +1515,7 @@ extend(Series.prototype, /** @lends Series.prototype */ {
                 'processedXData',
                 'processedYData',
                 'xIncrement',
+                'cropped',
                 '_hasPointMarkers',
                 '_hasPointLabels',
 


### PR DESCRIPTION
Fixed #12696, calling `series.setData()` after `series.update(options, redraw=false)` on a cropped/grouped dataset used to update wrong points.