### PR TITLE
bugfix/12077-histogram-decimals-crash

### DIFF
--- a/js/modules/histogram.src.js
+++ b/js/modules/histogram.src.js
@@ -117,8 +117,8 @@ seriesType('histogram', 'column',
         binWidth = series.binWidth = (correctFloat(isNumber(binWidth) ?
             (binWidth || 1) :
             (max - min) / binsNumber));
-        // #12077 negative pointRange causes wrong calculations
-        // and browser hanging.
+        // #12077 negative pointRange causes wrong calculations,
+        // browser hanging.
         series.options.pointRange = Math.max(binWidth, 0);
         // If binWidth is 0 then max and min are equaled,
         // increment the x with some positive value to quit the loop

--- a/js/modules/histogram.src.js
+++ b/js/modules/histogram.src.js
@@ -114,9 +114,12 @@ seriesType('histogram', 'column',
         // Float correction needed, because first frequency value is not
         // corrected when generating frequencies (within for loop).
         min = correctFloat(arrayMin(baseData)), frequencies = [], bins = {}, data = [], x, fitToBin;
-        binWidth = series.binWidth = series.options.pointRange = (correctFloat(isNumber(binWidth) ?
+        binWidth = series.binWidth = (correctFloat(isNumber(binWidth) ?
             (binWidth || 1) :
             (max - min) / binsNumber));
+        // #12077 negative pointRange causes wrong calculations
+        // and browser hanging.
+        series.options.pointRange = Math.max(binWidth, 0);
         // If binWidth is 0 then max and min are equaled,
         // increment the x with some positive value to quit the loop
         for (x = min; 

--- a/samples/unit-tests/series-histogram/histogram/demo.js
+++ b/samples/unit-tests/series-histogram/histogram/demo.js
@@ -258,3 +258,31 @@ QUnit.test('Histogram', function (assert) {
     );
 
 });
+
+QUnit.test('#12077 - Histogram long digits', function (assert) {
+    var chart = Highcharts.chart('container', {
+        xAxis: [{}, {
+            opposite: true
+        }],
+        yAxis: [{}, {
+            opposite: true
+        }],
+        series: [{
+            type: 'histogram',
+            xAxis: 1,
+            yAxis: 1,
+            baseSeries: 's1'
+        }, {
+            type: 'scatter',
+            data: Array.from({
+                length: 10000
+            }, () => 6.6429209090989899214),
+            id: 's1'
+        }]
+    });
+
+    assert.ok(
+        chart.series[0].data.length,
+        `Histogram should be draw when long digits.`
+    );
+});

--- a/samples/unit-tests/series-histogram/histogram/demo.js
+++ b/samples/unit-tests/series-histogram/histogram/demo.js
@@ -259,7 +259,7 @@ QUnit.test('Histogram', function (assert) {
 
 });
 
-QUnit.test('#12077 - Histogram long digits', function (assert) {
+QUnit.test('#12077 - Histogram long digits.', function (assert) {
     var chart = Highcharts.chart('container', {
         xAxis: [{}, {
             opposite: true

--- a/ts/modules/histogram.src.ts
+++ b/ts/modules/histogram.src.ts
@@ -211,13 +211,17 @@ seriesType<Highcharts.HistogramSeries>(
                 x: number,
                 fitToBin: Function;
 
-            binWidth = series.binWidth = series.options.pointRange = (
+            binWidth = series.binWidth = (
                 correctFloat(
                     isNumber(binWidth) ?
                         (binWidth || 1) :
                         (max - min) / binsNumber
                 )
             );
+
+            // #12077 negative pointRange causes wrong calculations
+            // and browser hanging.
+            series.options.pointRange = Math.max(binWidth, 0);
 
             // If binWidth is 0 then max and min are equaled,
             // increment the x with some positive value to quit the loop

--- a/ts/modules/histogram.src.ts
+++ b/ts/modules/histogram.src.ts
@@ -219,8 +219,8 @@ seriesType<Highcharts.HistogramSeries>(
                 )
             );
 
-            // #12077 negative pointRange causes wrong calculations
-            // and browser hanging.
+            // #12077 negative pointRange causes wrong calculations,
+            // browser hanging.
             series.options.pointRange = Math.max(binWidth, 0);
 
             // If binWidth is 0 then max and min are equaled,


### PR DESCRIPTION
Fixed #12077, histogram long decimals crashed browsers.