### PR TITLE
Improved fix for #13482, forced markers in styled mode.

### DIFF
--- a/css/highcharts.scss
+++ b/css/highcharts.scss
@@ -282,6 +282,10 @@ g.highcharts-series,
     stroke-width: 1px;
     stroke: $background-color;
 }
+.highcharts-a11y-markers-hidden .highcharts-point:not(.highcharts-point-hover):not(.highcharts-a11y-marker-visible),
+.highcharts-a11y-marker-hidden {
+    opacity: 0;
+}
 .highcharts-point {
     stroke-width: 1px;
 }

--- a/js/modules/accessibility/components/SeriesComponent/forcedMarkers.js
+++ b/js/modules/accessibility/components/SeriesComponent/forcedMarkers.js
@@ -26,21 +26,10 @@ function isWithinDescriptionThreshold(series) {
 /**
  * @private
  */
-function isWithinNavigationThreshold(series) {
-    var navOptions = series.chart.options.accessibility
-        .keyboardNavigation.seriesNavigation;
-    return series.points.length <
-        navOptions.pointNavigationEnabledThreshold ||
-        navOptions.pointNavigationEnabledThreshold === false;
-}
-/**
- * @private
- */
 function shouldForceMarkers(series) {
     var chart = series.chart, chartA11yEnabled = chart.options.accessibility.enabled, seriesA11yEnabled = (series.options.accessibility &&
-        series.options.accessibility.enabled) !== false, withinDescriptionThreshold = isWithinDescriptionThreshold(series), withinNavigationThreshold = isWithinNavigationThreshold(series);
-    return chartA11yEnabled && seriesA11yEnabled &&
-        (withinDescriptionThreshold || withinNavigationThreshold);
+        series.options.accessibility.enabled) !== false;
+    return chartA11yEnabled && seriesA11yEnabled && isWithinDescriptionThreshold(series);
 }
 /**
  * @private
@@ -53,18 +42,20 @@ function hasIndividualPointMarkerOptions(series) {
  */
 function unforceSeriesMarkerOptions(series) {
     var resetMarkerOptions = series.resetA11yMarkerOptions;
-    merge(true, series.options, {
-        marker: {
-            enabled: resetMarkerOptions.enabled,
-            states: {
-                normal: {
-                    opacity: resetMarkerOptions.states &&
-                        resetMarkerOptions.states.normal &&
-                        resetMarkerOptions.states.normal.opacity
+    if (resetMarkerOptions) {
+        merge(true, series.options, {
+            marker: {
+                enabled: resetMarkerOptions.enabled,
+                states: {
+                    normal: {
+                        opacity: resetMarkerOptions.states &&
+                            resetMarkerOptions.states.normal &&
+                            resetMarkerOptions.states.normal.opacity
+                    }
                 }
             }
-        }
-    });
+        });
+    }
 }
 /**
  * @private
@@ -141,7 +132,7 @@ function addForceMarkersEvents() {
                 handleForcePointMarkers(series);
             }
         }
-        else if (series.a11yMarkersForced && series.resetMarkerOptions) {
+        else if (series.a11yMarkersForced) {
             delete series.a11yMarkersForced;
             unforceSeriesMarkerOptions(series);
         }

--- a/samples/highcharts/css/a11y/demo.css
+++ b/samples/highcharts/css/a11y/demo.css
@@ -1,0 +1,7 @@
+@import 'https://code.highcharts.com/css/highcharts.css';
+
+#container {
+	height: 400px;
+	max-width: 800px;
+	margin: 0 auto;
+}

--- a/samples/highcharts/css/a11y/demo.details
+++ b/samples/highcharts/css/a11y/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Øystein Moseng
+ js_wrap: b
+...

--- a/samples/highcharts/css/a11y/demo.html
+++ b/samples/highcharts/css/a11y/demo.html
@@ -1,0 +1,6 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/modules/export-data.js"></script>
+<script src="https://code.highcharts.com/modules/accessibility.js"></script>
+
+<div id="container"></div>

--- a/samples/highcharts/css/a11y/demo.js
+++ b/samples/highcharts/css/a11y/demo.js
@@ -1,0 +1,29 @@
+Highcharts.chart('container', {
+    chart: {
+        styledMode: true
+    },
+
+    title: {
+        text: 'Styled mode with a11y module'
+    },
+
+    subtitle: {
+        text: 'Markers should be invisible, except point #4'
+    },
+
+    xAxis: {
+        categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+    },
+
+    series: [{
+        data: [29.9, 71.5, 106.4, {
+            y: 129.2,
+            marker: {
+                enabled: true
+            }
+        }, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4],
+        marker: {
+            enabled: false
+        }
+    }]
+});

--- a/samples/unit-tests/accessibility/accessible-highstock/demo.js
+++ b/samples/unit-tests/accessibility/accessible-highstock/demo.js
@@ -11,7 +11,7 @@ QUnit.test('Basic stock chart', function (assert) {
     });
 
     assert.ok(
-        chart.series[0].markerGroup.element.getAttribute('aria-label'),
+        chart.series[0].graph.element.getAttribute('aria-label'),
         'There be ARIA on series'
     );
 

--- a/samples/unit-tests/accessibility/forced-markers/demo.js
+++ b/samples/unit-tests/accessibility/forced-markers/demo.js
@@ -46,11 +46,6 @@ QUnit.test('Too many points for a11y', function (assert) {
             accessibility: {
                 series: {
                     pointDescriptionEnabledThreshold: 1
-                },
-                keyboardNavigation: {
-                    seriesNavigation: {
-                        pointNavigationEnabledThreshold: 1
-                    }
                 }
             },
             series: [{

--- a/ts/modules/accessibility/components/SeriesComponent/forcedMarkers.ts
+++ b/ts/modules/accessibility/components/SeriesComponent/forcedMarkers.ts
@@ -60,33 +60,15 @@ function isWithinDescriptionThreshold(
 /**
  * @private
  */
-function isWithinNavigationThreshold(
-    series: Highcharts.AccessibilitySeries
-): boolean {
-    const navOptions = series.chart.options.accessibility
-        .keyboardNavigation.seriesNavigation;
-
-    return series.points.length <
-        navOptions.pointNavigationEnabledThreshold ||
-        navOptions.pointNavigationEnabledThreshold === false;
-}
-
-
-/**
- * @private
- */
 function shouldForceMarkers(
     series: Highcharts.AccessibilitySeries
 ): boolean {
     const chart = series.chart,
         chartA11yEnabled = chart.options.accessibility.enabled,
         seriesA11yEnabled = (series.options.accessibility &&
-            series.options.accessibility.enabled) !== false,
-        withinDescriptionThreshold = isWithinDescriptionThreshold(series),
-        withinNavigationThreshold = isWithinNavigationThreshold(series);
+            series.options.accessibility.enabled) !== false;
 
-    return chartA11yEnabled && seriesA11yEnabled &&
-        (withinDescriptionThreshold || withinNavigationThreshold);
+    return chartA11yEnabled && seriesA11yEnabled && isWithinDescriptionThreshold(series);
 }
 
 
@@ -104,18 +86,20 @@ function hasIndividualPointMarkerOptions(series: Highcharts.Series): boolean {
 function unforceSeriesMarkerOptions(series: Highcharts.AccessibilitySeries): void {
     const resetMarkerOptions = series.resetA11yMarkerOptions;
 
-    merge(true, series.options, {
-        marker: {
-            enabled: resetMarkerOptions.enabled,
-            states: {
-                normal: {
-                    opacity: resetMarkerOptions.states &&
-                        resetMarkerOptions.states.normal &&
-                        resetMarkerOptions.states.normal.opacity
+    if (resetMarkerOptions) {
+        merge(true, series.options, {
+            marker: {
+                enabled: resetMarkerOptions.enabled,
+                states: {
+                    normal: {
+                        opacity: resetMarkerOptions.states &&
+                            resetMarkerOptions.states.normal &&
+                            resetMarkerOptions.states.normal.opacity
+                    }
                 }
             }
-        }
-    });
+        });
+    }
 }
 
 
@@ -215,7 +199,7 @@ function addForceMarkersEvents(): void {
                 handleForcePointMarkers(series);
             }
 
-        } else if (series.a11yMarkersForced && series.resetMarkerOptions) {
+        } else if (series.a11yMarkersForced) {
             delete series.a11yMarkersForced;
             unforceSeriesMarkerOptions(series);
         }


### PR DESCRIPTION
Improved fix for #13482, support for forced markers in styled mode.
___
As discussed in #13482, adds proper support for forced markers in styled mode. 3 new classes are added:
- `highcharts-a11y-markers-hidden` for indicating a series with invisible markers (`marker.enabled: false` on series)
- `highcharts-a11y-marker-hidden` indicates a point with an invisible marker (`marker.enabled: false` on point).
- `highcharts-a11y-marker-visible` indicates a forced visible marker (`marker.enabled: false` on series, but `enabled: true` on point).

The latter two are only used when a series has individual point marker settings. All of the above is only added in styled mode.