### PR TITLE
bugfix/13567-legend-proximate-navigator

### DIFF
--- a/js/parts/Navigator.js
+++ b/js/parts/Navigator.js
@@ -1844,6 +1844,7 @@ if (!H.Navigator) {
                             0) -
                         ((legendOptions &&
                             legendOptions.verticalAlign === 'bottom' &&
+                            legendOptions.layout !== 'proximate' && // #13392
                             legendOptions.enabled &&
                             !legendOptions.floating) ?
                             legend.legendHeight +

--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -974,3 +974,23 @@ QUnit.test('Add a navigator by chart update (#7067)', function (assert) {
         'Navigator correctly added (#7067).'
     );
 });
+
+QUnit.test('Navigator overlaps chart (#13392).', function (assert) {
+    var chart = Highcharts.stockChart('container', {
+        legend: {
+            enabled: true,
+            layout: 'proximate',
+            align: 'right'
+        },
+        series: [{
+            data: [2, 20]
+        }, {
+            data: [1, 3]
+        }]
+    });
+
+    assert.ok(
+        chart.navigator.top > 330,
+        'Navigator should not overlap the chart (#13392).'
+    );
+});

--- a/ts/parts/Navigator.ts
+++ b/ts/parts/Navigator.ts
@@ -2717,6 +2717,7 @@ if (!H.Navigator) {
                         (
                             legendOptions &&
                             legendOptions.verticalAlign === 'bottom' &&
+                            legendOptions.layout !== 'proximate' && // #13392
                             legendOptions.enabled &&
                             !legendOptions.floating
                         ) ?


### PR DESCRIPTION
Fixed #13392, navigator had wrong top, when `legend.layout` was `proximate`.