### PR TITLE
Tools: Avoid adding newline inside SVG links

### DIFF
--- a/test/karma-imagecapture-reporter.js
+++ b/test/karma-imagecapture-reporter.js
@@ -36,10 +36,12 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
         svg = svg
             .replace(/>/g, '>\n')
 
-            // Don't introduce newlines inside tspans, it will make the text
+            // Don't introduce newlines inside tspans or links, it will make the text
             // render differently
             .replace(/<tspan([^>]*)>\n/g, '<tspan$1>')
-            .replace(/<\/tspan>\n/g, '</tspan>');
+            .replace(/<\/tspan>\n/g, '</tspan>')
+            .replace(/<a([^>]*)>\n/g, '<a$1>')
+            .replace(/<\/a>\n/g, '</a>');
 
         return svg;
     }


### PR DESCRIPTION
Fixed an issue with the visual tests where a whitespace was introduced when prettifying SVGs.

Perhaps a side effect of the `SVGLabel` refactor? 