### PR TITLE
Fixed #13580, unpredictable data label justify with x and y options

### DIFF
--- a/js/parts-more/AreaRangeSeries.js
+++ b/js/parts-more/AreaRangeSeries.js
@@ -80,8 +80,8 @@ seriesType('arearange', 'area', {
      * @private
      */
     dataLabels: {
-        align: null,
-        verticalAlign: null,
+        align: void 0,
+        verticalAlign: void 0,
         /**
          * X offset of the lower data labels relative to the point value.
          *

--- a/js/parts/ColumnSeries.js
+++ b/js/parts/ColumnSeries.js
@@ -322,9 +322,9 @@ seriesType('column', 'line',
         }
     },
     dataLabels: {
-        align: null,
-        verticalAlign: null,
-        y: null
+        align: void 0,
+        verticalAlign: void 0,
+        y: void 0
     },
     /**
      * When this is true, the series will not cause the Y axis to cross

--- a/js/parts/DataLabels.js
+++ b/js/parts/DataLabels.js
@@ -454,11 +454,11 @@ Series.prototype.alignDataLabel = function (point, dataLabel, options, alignTo, 
             rotCorr = chart.renderer.rotCorr(baseline, rotation); // #3723
             alignAttr = {
                 x: (alignTo.x +
-                    options.x +
+                    (options.x || 0) +
                     alignTo.width / 2 +
                     rotCorr.x),
                 y: (alignTo.y +
-                    options.y +
+                    (options.y || 0) +
                     { top: 0, middle: 0.5, bottom: 1 }[options.verticalAlign] *
                         alignTo.height)
             };
@@ -586,57 +586,60 @@ Series.prototype.setDataLabelStartPos = function (point, dataLabel, isNew, isIns
  */
 Series.prototype.justifyDataLabel = function (dataLabel, options, alignAttr, bBox, alignTo, isNew) {
     var chart = this.chart, align = options.align, verticalAlign = options.verticalAlign, off, justified, padding = dataLabel.box ? 0 : (dataLabel.padding || 0);
+    var _a = options.x, x = _a === void 0 ? 0 : _a, _b = options.y, y = _b === void 0 ? 0 : _b;
     // Off left
     off = alignAttr.x + padding;
     if (off < 0) {
-        if (align === 'right') {
+        if (align === 'right' && x >= 0) {
             options.align = 'left';
             options.inside = true;
         }
         else {
-            options.x = -off;
+            x -= off;
         }
         justified = true;
     }
     // Off right
     off = alignAttr.x + bBox.width - padding;
     if (off > chart.plotWidth) {
-        if (align === 'left') {
+        if (align === 'left' && x <= 0) {
             options.align = 'right';
             options.inside = true;
         }
         else {
-            options.x = chart.plotWidth - off;
+            x += chart.plotWidth - off;
         }
         justified = true;
     }
     // Off top
     off = alignAttr.y + padding;
     if (off < 0) {
-        if (verticalAlign === 'bottom') {
+        if (verticalAlign === 'bottom' && y >= 0) {
             options.verticalAlign = 'top';
             options.inside = true;
         }
         else {
-            options.y = -off;
+            y -= off;
         }
         justified = true;
     }
     // Off bottom
     off = alignAttr.y + bBox.height - padding;
     if (off > chart.plotHeight) {
-        if (verticalAlign === 'top') {
+        if (verticalAlign === 'top' && y <= 0) {
             options.verticalAlign = 'bottom';
             options.inside = true;
         }
         else {
-            options.y = chart.plotHeight - off;
+            y += chart.plotHeight - off;
         }
         justified = true;
     }
     if (justified) {
+        options.x = x;
+        options.y = y;
         dataLabel.placed = !isNew;
-        dataLabel.align(options, null, alignTo);
+        dataLabel.align(options, void 0, alignTo);
     }
     return justified;
 };

--- a/samples/unit-tests/axis/stacklabels/demo.js
+++ b/samples/unit-tests/axis/stacklabels/demo.js
@@ -90,6 +90,7 @@ QUnit.test('Stack labels crop and overflow features #8912', function (assert) {
         0,
         'Stack label should be inside plot area left'
     );
+
     assert.close(
         lastStackLabel.alignAttr.x +
         lastStackLabel.width - lastStackLabel.padding,

--- a/samples/unit-tests/datalabels/xy/demo.details
+++ b/samples/unit-tests/datalabels/xy/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/datalabels/xy/demo.html
+++ b/samples/unit-tests/datalabels/xy/demo.html
@@ -1,0 +1,6 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/datalabels/xy/demo.js
+++ b/samples/unit-tests/datalabels/xy/demo.js
@@ -1,0 +1,63 @@
+QUnit.test('Data label alignment and x/y options (#13580)', assert => {
+
+    const chart = Highcharts.chart('container', {
+        chart: {
+            width: 300,
+            height: 300,
+            plotBorderWidth: 1
+        },
+        yAxis: {
+            max: 2000
+        },
+        series: [{
+            data: [1000],
+            dataLabels: {
+                enabled: true,
+                backgroundColor: 'black'
+            },
+            type: 'column',
+            animation: false
+        }]
+    });
+
+    const label = chart.series[0].points[0].dataLabel;
+
+    const testAlignment = (align, verticalAlign) => {
+        chart.series[0].update({
+            dataLabels: {
+                align,
+                verticalAlign,
+                x: -1000,
+                y: -1000
+            }
+        });
+        assert.close(
+            label.translateX,
+            0,
+            1,
+            `The label should be X justified left (${align}, ${verticalAlign})`
+        );
+
+        chart.series[0].update({
+            dataLabels: {
+                x: 1000,
+                y: 1000
+            }
+        });
+        assert.close(
+            label.translateX + label.getBBox().width,
+            chart.plotWidth,
+            1,
+            `The label should be X justified right (${align}, ${verticalAlign})`
+        );
+    };
+
+    assert.ok(
+        chart.isInsidePlot(label.translateX, label.translateY),
+        'Start position should be inside the plot'
+    );
+
+    testAlignment('left', 'top');
+    testAlignment('center', 'middle');
+    testAlignment('right', 'bottom');
+});

--- a/ts/parts-more/AreaRangeSeries.ts
+++ b/ts/parts-more/AreaRangeSeries.ts
@@ -180,9 +180,9 @@ seriesType<Highcharts.AreaRangeSeries>('arearange', 'area', {
      */
     dataLabels: {
 
-        align: null,
+        align: void 0,
 
-        verticalAlign: null,
+        verticalAlign: void 0,
 
         /**
          * X offset of the lower data labels relative to the point value.

--- a/ts/parts/ColumnSeries.ts
+++ b/ts/parts/ColumnSeries.ts
@@ -450,9 +450,9 @@ seriesType<Highcharts.ColumnSeries>(
         },
 
         dataLabels: {
-            align: null,
-            verticalAlign: null,
-            y: null
+            align: void 0,
+            verticalAlign: void 0,
+            y: void 0
         },
 
         /**

--- a/ts/parts/DataLabels.ts
+++ b/ts/parts/DataLabels.ts
@@ -42,7 +42,7 @@ declare global {
             );
         }
         interface DataLabelsOptions {
-            align?: (AlignValue|null);
+            align?: AlignValue;
             allowOverlap?: boolean;
             backgroundColor?: (ColorString|GradientColorObject|PatternObject);
             borderColor?: (ColorString|GradientColorObject|PatternObject);
@@ -66,9 +66,9 @@ declare global {
             style?: CSSObject;
             textPath?: DataLabelsTextPathOptionsObject;
             useHTML?: boolean;
-            verticalAlign?: (VerticalAlignValue|null);
+            verticalAlign?: VerticalAlignValue;
             x?: number;
-            y?: (number|null);
+            y?: number;
             zIndex?: number;
         }
         interface DataLabelsTextPathOptionsObject {
@@ -890,13 +890,13 @@ Series.prototype.alignDataLabel = function (
             alignAttr = {
                 x: (
                     alignTo.x +
-                    (options.x as any) +
+                    (options.x || 0) +
                     alignTo.width / 2 +
                     rotCorr.x
                 ),
                 y: (
                     alignTo.y +
-                    (options.y as any) +
+                    (options.y || 0) +
                     ({ top: 0, middle: 0.5, bottom: 1 } as any)[
                         options.verticalAlign as any
                     ] *
@@ -1084,14 +1084,16 @@ Series.prototype.justifyDataLabel = function (
         justified,
         padding = dataLabel.box ? 0 : (dataLabel.padding || 0);
 
+    let { x = 0, y = 0 } = options;
+
     // Off left
     off = alignAttr.x + padding;
     if (off < 0) {
-        if (align === 'right') {
+        if (align === 'right' && x >= 0) {
             options.align = 'left';
             options.inside = true;
         } else {
-            options.x = -off;
+            x -= off;
         }
         justified = true;
     }
@@ -1099,11 +1101,11 @@ Series.prototype.justifyDataLabel = function (
     // Off right
     off = alignAttr.x + bBox.width - padding;
     if (off > chart.plotWidth) {
-        if (align === 'left') {
+        if (align === 'left' && x <= 0) {
             options.align = 'right';
             options.inside = true;
         } else {
-            options.x = chart.plotWidth - off;
+            x += chart.plotWidth - off;
         }
         justified = true;
     }
@@ -1111,11 +1113,11 @@ Series.prototype.justifyDataLabel = function (
     // Off top
     off = alignAttr.y + padding;
     if (off < 0) {
-        if (verticalAlign === 'bottom') {
+        if (verticalAlign === 'bottom' && y >= 0) {
             options.verticalAlign = 'top';
             options.inside = true;
         } else {
-            options.y = -off;
+            y -= off;
         }
         justified = true;
     }
@@ -1123,18 +1125,20 @@ Series.prototype.justifyDataLabel = function (
     // Off bottom
     off = alignAttr.y + bBox.height - padding;
     if (off > chart.plotHeight) {
-        if (verticalAlign === 'top') {
+        if (verticalAlign === 'top' && y <= 0) {
             options.verticalAlign = 'bottom';
             options.inside = true;
         } else {
-            options.y = chart.plotHeight - off;
+            y += chart.plotHeight - off;
         }
         justified = true;
     }
 
     if (justified) {
+        options.x = x;
+        options.y = y;
         dataLabel.placed = !isNew;
-        dataLabel.align(options as any, null as any, alignTo);
+        dataLabel.align(options, void 0, alignTo);
     }
 
     return justified;


### PR DESCRIPTION
Fixed #13580, data label `overflow: 'justify'` didn't work as announced when `x` and `y` offset options were set.