### PR TITLE
Fix documentation typo for findNearestKDPoints / findNearestKDPoint

### DIFF
--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -390,7 +390,7 @@ var Pointer = /** @class */ (function () {
      * Finds the closest point to a set of coordinates, using the k-d-tree
      * algorithm.
      *
-     * @function Highcharts.Pointer#findNearestKDPoints
+     * @function Highcharts.Pointer#findNearestKDPoint
      *
      * @param {Array<Highcharts.Series>} series
      *        All the series to search in.

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -645,7 +645,7 @@ class Pointer {
      * Finds the closest point to a set of coordinates, using the k-d-tree
      * algorithm.
      *
-     * @function Highcharts.Pointer#findNearestKDPoints
+     * @function Highcharts.Pointer#findNearestKDPoint
      *
      * @param {Array<Highcharts.Series>} series
      *        All the series to search in.


### PR DESCRIPTION
The function name findNearestKDPoints in the comment didn't match the actual function name findNearestKDPoint (without an s). This means the documentation, and the TypeScript definitions are invalid.