### PR TITLE
bugfix/13202-data-format-lollipop

### DIFF
--- a/js/modules/lollipop.src.js
+++ b/js/modules/lollipop.src.js
@@ -56,13 +56,25 @@ seriesType('lollipop', 'dumbbell', {
         pointFormat: '<span style="color:{series.color}">●</span> {series.name}: <b>{point.low}</b><br/>'
     }
 }, {
+    pointArrayMap: ['y'],
+    pointValKey: 'y',
+    toYData: function (point) {
+        return [H.pick(point.y, point.low)];
+    },
     translatePoint: areaProto.translate,
     drawPoint: areaProto.drawPoints,
     drawDataLabels: colProto.drawDataLabels,
     setShapeArgs: colProto.translate
 }, {
     pointSetState: areaProto.pointClass.prototype.setState,
-    setState: H.seriesTypes.dumbbell.prototype.pointClass.prototype.setState
+    setState: H.seriesTypes.dumbbell.prototype.pointClass.prototype.setState,
+    init: function (series, options, x) {
+        if (H.isObject(options) && 'low' in options) {
+            options.y = options.low;
+            delete options.low;
+        }
+        return H.Point.prototype.init.apply(this, arguments);
+    }
 });
 /**
  * The `lollipop` series. If the [type](#series.lollipop.type) option is
@@ -133,8 +145,15 @@ seriesType('lollipop', 'dumbbell', {
  *
  * @type      {Array<number|Array<(number|string),(number|null)>|null|*>}
  * @extends   series.dumbbell.data
- * @excluding lowColor
+ * @excluding high, low, lowColor
  * @product   highcharts highstock
  * @apioption series.lollipop.data
  */
+/**
+* The y value of the point.
+*
+* @type      {number|null}
+* @product   highcharts highstock
+* @apioption series.line.data.y
+*/
 ''; // adds doclets above to transpiled file

--- a/js/modules/lollipop.src.js
+++ b/js/modules/lollipop.src.js
@@ -53,7 +53,7 @@ seriesType('lollipop', 'dumbbell', {
         }
     },
     tooltip: {
-        pointFormat: '<span style="color:{series.color}">●</span> {series.name}: <b>{point.low}</b><br/>'
+        pointFormat: '<span style="color:{series.color}">●</span> {series.name}: <b>{point.y}</b><br/>'
     }
 }, {
     pointArrayMap: ['y'],

--- a/ts/modules/lollipop.src.ts
+++ b/ts/modules/lollipop.src.ts
@@ -93,13 +93,29 @@ seriesType<Highcharts.LollipopSeries>('lollipop', 'dumbbell', {
         pointFormat: '<span style="color:{series.color}">●</span> {series.name}: <b>{point.low}</b><br/>'
     }
 }, {
+    pointArrayMap: ['y'],
+    pointValKey: 'y',
+    toYData: function (point: Highcharts.LollipopPoint): Array<number> {
+        return [H.pick(point.y, point.low)];
+    },
     translatePoint: areaProto.translate,
     drawPoint: areaProto.drawPoints,
     drawDataLabels: colProto.drawDataLabels,
     setShapeArgs: colProto.translate
 }, {
     pointSetState: areaProto.pointClass.prototype.setState,
-    setState: H.seriesTypes.dumbbell.prototype.pointClass.prototype.setState
+    setState: H.seriesTypes.dumbbell.prototype.pointClass.prototype.setState,
+    init: function (
+        series: Highcharts.LollipopSeries,
+        options: Highcharts.LollipopPointOptions,
+        x?: number
+    ): Highcharts.Point {
+        if (H.isObject(options) && 'low' in options) {
+            options.y = options.low;
+            delete options.low;
+        }
+        return H.Point.prototype.init.apply(this, arguments);
+    }
 });
 
 /**
@@ -171,8 +187,16 @@ seriesType<Highcharts.LollipopSeries>('lollipop', 'dumbbell', {
  *
  * @type      {Array<number|Array<(number|string),(number|null)>|null|*>}
  * @extends   series.dumbbell.data
- * @excluding lowColor
+ * @excluding high, low, lowColor
  * @product   highcharts highstock
  * @apioption series.lollipop.data
  */
+
+/**
+* The y value of the point.
+*
+* @type      {number|null}
+* @product   highcharts highstock
+* @apioption series.line.data.y
+*/
 ''; // adds doclets above to transpiled file

--- a/ts/modules/lollipop.src.ts
+++ b/ts/modules/lollipop.src.ts
@@ -90,7 +90,7 @@ seriesType<Highcharts.LollipopSeries>('lollipop', 'dumbbell', {
         }
     },
     tooltip: {
-        pointFormat: '<span style="color:{series.color}">●</span> {series.name}: <b>{point.low}</b><br/>'
+        pointFormat: '<span style="color:{series.color}">●</span> {series.name}: <b>{point.y}</b><br/>'
     }
 }, {
     pointArrayMap: ['y'],

--- a/ts/parts-more/AreaRangeSeries.ts
+++ b/ts/parts-more/AreaRangeSeries.ts
@@ -82,7 +82,7 @@ declare global {
             public getGraphPath(points: Array<AreaRangePoint>): SVGPath;
             public highToXY(point: (AreaRangePoint & PolarPoint)): void;
             public translate(): void;
-            public toYData(point: AreaRangePoint): [number, number];
+            public toYData(point: AreaRangePoint): Array<number>;
         }
     }
 }


### PR DESCRIPTION
Fixed #13202, the lollipop series didn't work with all data formats.

This is a continuation of https://github.com/highcharts/highcharts/pull/13335 - had some issues with TS while merging master so I decided to create a fresh PR. The old one can be removed.