### PR TITLE
bugfix/12012-gantt-collapse-chart-height

### DIFF
--- a/js/parts-gantt/TreeGridAxis.js
+++ b/js/parts-gantt/TreeGridAxis.js
@@ -385,6 +385,15 @@ var TreeGridAxis;
                     });
                 }
             });
+            // If staticScale is not defined on the yAxis
+            // and chart height is set, set axis.isDirty
+            // to ensure collapsing works (#13601)
+            addEvent(axis, 'afterBreaks', function () {
+                var _a;
+                if (axis.coll === 'yAxis' && !axis.staticScale && ((_a = axis.chart.userOptions.chart) === null || _a === void 0 ? void 0 : _a.height)) {
+                    axis.isDirty = true;
+                }
+            });
             userOptions = merge({
                 // Default options
                 grid: {

--- a/js/parts-gantt/TreeGridAxis.js
+++ b/js/parts-gantt/TreeGridAxis.js
@@ -387,10 +387,10 @@ var TreeGridAxis;
             });
             // If staticScale is not defined on the yAxis
             // and chart height is set, set axis.isDirty
-            // to ensure collapsing works (#13601)
+            // to ensure collapsing works (#12012)
             addEvent(axis, 'afterBreaks', function () {
                 var _a;
-                if (axis.coll === 'yAxis' && !axis.staticScale && ((_a = axis.chart.userOptions.chart) === null || _a === void 0 ? void 0 : _a.height)) {
+                if (axis.coll === 'yAxis' && !axis.staticScale && ((_a = axis.chart.options.chart) === null || _a === void 0 ? void 0 : _a.height)) {
                     axis.isDirty = true;
                 }
             });

--- a/samples/unit-tests/gantt/gantt/demo.js
+++ b/samples/unit-tests/gantt/gantt/demo.js
@@ -381,6 +381,65 @@
         );
     });
 
+    QUnit.test('Collapsing subtasks', assert => {
+        const today = new Date();
+        const day = 24 * 60 * 60 * 1000;
+
+        const chart = Highcharts.ganttChart('container', {
+            chart: {
+                height: 300
+            },
+            title: {
+                text: 'Highcharts Gantt With Subtasks'
+            },
+            xAxis: {
+                min: today.getTime() - (2 * day),
+                max: today.getTime() + (32 * day)
+            },
+            series: [{
+                name: 'Project 1',
+                data: [{
+                    name: 'Planning',
+                    id: 'planning',
+                    start: today.getTime(),
+                    end: today.getTime() + (20 * day)
+                }, {
+                    name: 'Requirements',
+                    id: 'requirements',
+                    parent: 'planning',
+                    start: today.getTime(),
+                    end: today.getTime() + (5 * day)
+                }, {
+                    name: 'Design',
+                    id: 'design',
+                    dependency: 'requirements',
+                    parent: 'planning',
+                    start: today.getTime() + (3 * day),
+                    end: today.getTime() + (20 * day)
+                }, {
+                    name: 'Layout',
+                    id: 'layout',
+                    parent: 'design',
+                    start: today.getTime() + (3 * day),
+                    end: today.getTime() + (10 * day)
+                }, {
+                    name: 'Develop',
+                    id: 'develop',
+                    start: today.getTime() + (5 * day),
+                    end: today.getTime() + (30 * day)
+                }]
+            }]
+        });
+        click(chart.yAxis[0].ticks['2'].label.element);
+        click(chart.yAxis[0].ticks['0'].label.element);
+
+        assert.strictEqual(
+            document.querySelectorAll('.highcharts-yaxis .highcharts-tick').length,
+            chart.yAxis[0].tickPositions.length + 1,
+            'Should have the correct amount of ticks remaining after collapsing subtask before parent (#12012)'
+        );
+    });
+
     QUnit.test('No series', function (assert) {
         Highcharts.ganttChart('container', {
             title: {

--- a/ts/parts-gantt/TreeGridAxis.ts
+++ b/ts/parts-gantt/TreeGridAxis.ts
@@ -643,9 +643,9 @@ namespace TreeGridAxis {
 
             // If staticScale is not defined on the yAxis
             // and chart height is set, set axis.isDirty
-            // to ensure collapsing works (#13601)
+            // to ensure collapsing works (#12012)
             addEvent(axis, 'afterBreaks', function (): void {
-                if (axis.coll === 'yAxis' && !axis.staticScale && axis.chart.userOptions.chart?.height) {
+                if (axis.coll === 'yAxis' && !axis.staticScale && axis.chart.options.chart?.height) {
                     axis.isDirty = true;
                 }
             });

--- a/ts/parts-gantt/TreeGridAxis.ts
+++ b/ts/parts-gantt/TreeGridAxis.ts
@@ -641,6 +641,15 @@ namespace TreeGridAxis {
                 }
             });
 
+            // If staticScale is not defined on the yAxis
+            // and chart height is set, set axis.isDirty
+            // to ensure collapsing works (#13601)
+            addEvent(axis, 'afterBreaks', function (): void {
+                if (axis.coll === 'yAxis' && !axis.staticScale && axis.chart.userOptions.chart?.height) {
+                    axis.isDirty = true;
+                }
+            });
+
             userOptions = merge({
                 // Default options
                 grid: {


### PR DESCRIPTION
Fixed #12012, collapse not working when chart had set height