### PR TITLE
Fixed issue with oneToOne and ids

### DIFF
--- a/js/parts/Dynamics.js
+++ b/js/parts/Dynamics.js
@@ -526,8 +526,21 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                     });
                 }
                 splat(options[coll]).forEach(function (newOptions, i) {
-                    var item = (defined(newOptions.id) &&
-                        chart.get(newOptions.id)) || chart[coll][indexMap ? indexMap[i] : i];
+                    var hasId = defined(newOptions.id);
+                    var item;
+                    // Match by id
+                    if (hasId) {
+                        item = chart.get(newOptions.id);
+                    }
+                    // No match by id found, match by index instead
+                    if (!item) {
+                        item = chart[coll][indexMap ? indexMap[i] : i];
+                        // Check if we grabbed an item with an exising but
+                        // different id (#13541)
+                        if (item && hasId && defined(item.options.id)) {
+                            item = void 0;
+                        }
+                    }
                     if (item && item.coll === coll) {
                         item.update(newOptions, false);
                         if (oneToOne) {

--- a/samples/unit-tests/chart/chart-update-onetoone/demo.js
+++ b/samples/unit-tests/chart/chart-update-onetoone/demo.js
@@ -151,6 +151,45 @@
 
 }());
 
+QUnit.test('Series update with ids', assert => {
+    const chart = Highcharts.chart('container', {
+        series: [{
+            id: 's1',
+            name: 'S1',
+            data: [1, 2, 3]
+        }, {
+            name: 'S2',
+            id: 's2',
+            data: [1.5, 2.5, 3.5]
+        }]
+    });
+
+    assert.deepEqual(
+        chart.series.map(s => s.name),
+        ['S1', 'S2'],
+        'Initial series names'
+    );
+
+    chart.update({
+        series: [{
+            name: 'S2',
+            id: 's2',
+            data: [1.5, 2.5, 3.5]
+        }, {
+            id: 's3',
+            name: 'S3',
+            data: [3, 2, 1]
+        }]
+    }, true, true);
+
+    assert.deepEqual(
+        chart.series.map(s => s.name),
+        ['S2', 'S3'],
+        'Updating with ids, cleanly update and replace (#13541)'
+    );
+
+});
+
 QUnit.test('Axis update', function (assert) {
     var chart = Highcharts.chart('container', {
         series: [{

--- a/samples/unit-tests/series-histogram/histogram/demo.js
+++ b/samples/unit-tests/series-histogram/histogram/demo.js
@@ -206,17 +206,19 @@ QUnit.test('Histogram', function (assert) {
             data: [2, 2.3, 2.6, 2.9, 3.2]
         }, {
             baseSeries: 's1',
+            id: 'histo-s1',
             type: 'histogram'
         }, {
             baseSeries: 's2',
+            id: 'histo-s2',
             type: 'histogram'
         }]
     }, true, true);
 
     assert.strictEqual(
         // Rounding is applied in order to crisp column edges
-        Math.round(chart.series[3].barW),
-        Math.round(chart.series[3].closestPointRangePx),
+        Math.round(chart.get('histo-s2').barW),
+        Math.round(chart.get('histo-s2').closestPointRangePx),
         'Histogram has appropriate pointRange value, when multiple series on the same axis, #9128, #10025'
     );
 
@@ -226,14 +228,15 @@ QUnit.test('Histogram', function (assert) {
             data: [132.8, 137, 139, 142, 145, 148, 151, 151.4]
         }, {
             baseSeries: 'baseSeries',
+            id: 'histo-pisto',
             type: 'histogram',
             binsNumber: 7
         }]
     }, true, true);
 
     assert.strictEqual(
-        chart.series[1].data.length,
-        chart.series[1].options.binsNumber,
+        chart.get('histo-pisto').data.length,
+        chart.get('histo-pisto').options.binsNumber,
         'Histogram produces correct number of bins set by user.'
     );
 
@@ -246,14 +249,15 @@ QUnit.test('Histogram', function (assert) {
         }, {
             type: 'histogram',
             baseSeries: 's1',
+            id: 'histo-s1',
             zIndex: -1,
             binsNumber: void 0
         }]
     }, true, true);
 
     assert.strictEqual(
-        chart.series[1].data.length,
-        chart.series[1].binsNumber(),
+        chart.get('histo-s1').data.length,
+        chart.get('histo-s1').binsNumber(),
         `Histogram produces correctnumber of bins on negative point values.`
     );
 

--- a/ts/parts/Dynamics.ts
+++ b/ts/parts/Dynamics.ts
@@ -805,17 +805,30 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                     });
                 }
 
-
                 splat((options as any)[coll]).forEach(function (
                     newOptions: Highcharts.Dictionary<any>,
                     i: number
                 ): void {
-                    var item = (
-                        defined(newOptions.id) &&
-                        chart.get(newOptions.id)
-                    ) || (chart as any)[coll][indexMap ? indexMap[i] : i];
+                    const hasId = defined(newOptions.id);
+                    let item: Axis|Point|Highcharts.Series|undefined;
 
-                    if (item && item.coll === coll) {
+                    // Match by id
+                    if (hasId) {
+                        item = chart.get(newOptions.id);
+                    }
+
+                    // No match by id found, match by index instead
+                    if (!item) {
+                        item = (chart as any)[coll][indexMap ? indexMap[i] : i];
+
+                        // Check if we grabbed an item with an exising but
+                        // different id (#13541)
+                        if (item && hasId && defined(item.options.id)) {
+                            item = void 0;
+                        }
+                    }
+
+                    if (item && (item as any).coll === coll) {
                         item.update(newOptions, false);
 
                         if (oneToOne) {


### PR DESCRIPTION
Fixed #13541, `chart.update` with `oneToOne` failed when removing and adding series, if all series had explicit id's.
