### PR TITLE
bugfix/12710-colorAxis-legend-item-color

### DIFF
--- a/js/parts-map/ColorSeriesMixin.js
+++ b/js/parts-map/ColorSeriesMixin.js
@@ -61,8 +61,11 @@ H.colorSeriesMixin = {
                     (colorAxis && typeof value !== 'undefined') ?
                         colorAxis.toColor(value, point) :
                         point.color || series.color);
-            if (color) {
+            if (color && point.color !== color) {
                 point.color = color;
+                if (series.options.legendType === 'point' && point.legendItem) {
+                    series.chart.legend.colorizeItem(point, point.visible);
+                }
             }
         });
     }

--- a/samples/unit-tests/coloraxis/point-type-legend/demo.details
+++ b/samples/unit-tests/coloraxis/point-type-legend/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/coloraxis/point-type-legend/demo.html
+++ b/samples/unit-tests/coloraxis/point-type-legend/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/coloraxis.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/coloraxis/point-type-legend/demo.js
+++ b/samples/unit-tests/coloraxis/point-type-legend/demo.js
@@ -1,0 +1,24 @@
+QUnit.test('Point type legend item', function (assert) {
+    const chart = Highcharts.chart('container', {
+        colorAxis: {
+            minColor: 'rgb(0,0,255)',
+            maxColor: 'rgb(255,0,0)',
+            showInLegend: false
+        },
+        series: [{
+            type: 'pie',
+            showInLegend: true,
+            data: [{
+                y: 100
+            }, {
+                y: 1
+            }]
+        }]
+    });
+
+    assert.strictEqual(
+        chart.legend.allItems[0].legendSymbol.attr('fill'),
+        'rgb(255,0,0)',
+        'shoud have correct color.'
+    );
+});

--- a/ts/parts-map/ColorSeriesMixin.ts
+++ b/ts/parts-map/ColorSeriesMixin.ts
@@ -115,8 +115,12 @@ H.colorSeriesMixin = {
                             point.color || series.color
                 );
 
-            if (color) {
+            if (color && point.color !== color) {
                 point.color = color;
+
+                if (series.options.legendType === 'point' && point.legendItem) {
+                    series.chart.legend.colorizeItem(point, point.visible);
+                }
             }
         });
     }


### PR DESCRIPTION
Fixed #12710, `colorAxis` - wrong item legend color for point type legend.