### PR TITLE
docs/gantt-point-id

### DIFF
--- a/js/parts-gantt/GanttSeries.js
+++ b/js/parts-gantt/GanttSeries.js
@@ -232,7 +232,7 @@ seriesType('gantt', 'xrange'
  * @declare   Highcharts.GanttPointOptionsObject
  * @type      {Array<*>}
  * @extends   series.xrange.data
- * @excluding className, color, colorIndex, connect, dataLabels, events, id,
+ * @excluding className, color, colorIndex, connect, dataLabels, events,
  *            partialFill, selected, x, x2
  * @product   gantt
  * @apioption series.gantt.data

--- a/ts/parts-gantt/GanttSeries.ts
+++ b/ts/parts-gantt/GanttSeries.ts
@@ -399,7 +399,7 @@ seriesType<Highcharts.GanttSeries>('gantt', 'xrange'
  * @declare   Highcharts.GanttPointOptionsObject
  * @type      {Array<*>}
  * @extends   series.xrange.data
- * @excluding className, color, colorIndex, connect, dataLabels, events, id,
+ * @excluding className, color, colorIndex, connect, dataLabels, events,
  *            partialFill, selected, x, x2
  * @product   gantt
  * @apioption series.gantt.data


### PR DESCRIPTION
Close #13614, Restored id option for gantt data points.