### PR TITLE
Fixed #13554, a11y not supporting proximate legend layout.

### DIFF
--- a/js/modules/accessibility/AccessibilityComponent.js
+++ b/js/modules/accessibility/AccessibilityComponent.js
@@ -200,7 +200,7 @@ AccessibilityComponent.prototype = {
     createProxyButton: function (svgElement, parentGroup, attributes, posElement, preClickEvent) {
         var svgEl = svgElement.element, proxy = this.createElement('button'), attrs = merge({
             'aria-label': svgEl.getAttribute('aria-label')
-        }, attributes), bBox = this.getElementPosition(posElement || svgElement);
+        }, attributes);
         Object.keys(attrs).forEach(function (prop) {
             if (attrs[prop] !== null) {
                 proxy.setAttribute(prop, attrs[prop]);
@@ -210,7 +210,8 @@ AccessibilityComponent.prototype = {
         if (preClickEvent) {
             this.addEvent(proxy, 'click', preClickEvent);
         }
-        this.setProxyButtonStyle(proxy, bBox);
+        this.setProxyButtonStyle(proxy);
+        this.updateProxyButtonPosition(proxy, posElement || svgElement);
         this.proxyMouseEventsForButton(svgEl, proxy);
         // Add to chart div and unhide from screen readers
         parentGroup.appendChild(proxy);
@@ -242,10 +243,9 @@ AccessibilityComponent.prototype = {
     },
     /**
      * @private
-     * @param {Highcharts.HTMLElement} button
-     * @param {Highcharts.BBoxObject} bBox
+     * @param {Highcharts.HTMLElement} button The proxy element.
      */
-    setProxyButtonStyle: function (button, bBox) {
+    setProxyButtonStyle: function (button) {
         merge(true, button.style, {
             'border-width': 0,
             'background-color': 'transparent',
@@ -259,7 +259,17 @@ AccessibilityComponent.prototype = {
             padding: 0,
             margin: 0,
             display: 'block',
-            position: 'absolute',
+            position: 'absolute'
+        });
+    },
+    /**
+     * @private
+     * @param {Highcharts.HTMLElement} proxy The proxy to update position of.
+     * @param {Highcharts.SVGElement} posElement The element to overlay and take position from.
+     */
+    updateProxyButtonPosition: function (proxy, posElement) {
+        var bBox = this.getElementPosition(posElement);
+        merge(true, proxy.style, {
             width: (bBox.width || 1) + 'px',
             height: (bBox.height || 1) + 'px',
             left: (bBox.x || 0) + 'px',

--- a/js/modules/accessibility/components/LegendComponent.js
+++ b/js/modules/accessibility/components/LegendComponent.js
@@ -10,17 +10,6 @@
  *
  * */
 'use strict';
-var __values = (this && this.__values) || function(o) {
-    var s = typeof Symbol === "function" && Symbol.iterator, m = s && o[s], i = 0;
-    if (m) return m.call(o);
-    if (o && typeof o.length === "number") return {
-        next: function () {
-            if (o && i >= o.length) o = void 0;
-            return { value: o && o[i++], done: !o };
-        }
-    };
-    throw new TypeError(s ? "Object is not iterable." : "Symbol.iterator is not defined.");
-};
 import H from '../../../parts/Globals.js';
 import Legend from '../../../parts/Legend.js';
 import U from '../../../parts/Utilities.js';
@@ -140,20 +129,11 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
      * @private
      */
     updateProxiesPositions: function () {
-        var e_1, _a;
-        try {
-            for (var _b = __values(this.proxyElementsList), _c = _b.next(); !_c.done; _c = _b.next()) {
-                var _d = _c.value, element = _d.element, posElement = _d.posElement;
-                this.updateProxyButtonPosition(element, posElement);
-            }
-        }
-        catch (e_1_1) { e_1 = { error: e_1_1 }; }
-        finally {
-            try {
-                if (_c && !_c.done && (_a = _b.return)) _a.call(_b);
-            }
-            finally { if (e_1) throw e_1.error; }
-        }
+        var _this = this;
+        this.proxyElementsList.forEach(function (_a) {
+            var element = _a.element, posElement = _a.posElement;
+            return _this.updateProxyButtonPosition(element, posElement);
+        });
     },
     /**
      * @private

--- a/js/modules/accessibility/components/LegendComponent.js
+++ b/js/modules/accessibility/components/LegendComponent.js
@@ -95,7 +95,7 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
             }
         });
         this.addEvent(Legend, 'afterPositionItem', function (e) {
-            if (this.chart === component.chart) {
+            if (this.chart === component.chart && this.chart.renderer) {
                 component.updateProxyPositionForItem(e.item);
             }
         });

--- a/js/modules/accessibility/components/LegendComponent.js
+++ b/js/modules/accessibility/components/LegendComponent.js
@@ -129,11 +129,10 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
      * @private
      */
     updateProxiesPositions: function () {
-        var _this = this;
-        this.proxyElementsList.forEach(function (_a) {
-            var element = _a.element, posElement = _a.posElement;
-            return _this.updateProxyButtonPosition(element, posElement);
-        });
+        for (var _i = 0, _a = this.proxyElementsList; _i < _a.length; _i++) {
+            var _b = _a[_i], element = _b.element, posElement = _b.posElement;
+            this.updateProxyButtonPosition(element, posElement);
+        }
     },
     /**
      * @private

--- a/js/modules/marker-clusters.src.js
+++ b/js/modules/marker-clusters.src.js
@@ -12,22 +12,6 @@
  *
  * */
 'use strict';
-var __read = (this && this.__read) || function (o, n) {
-    var m = typeof Symbol === "function" && o[Symbol.iterator];
-    if (!m) return o;
-    var i = m.call(o), r, ar = [], e;
-    try {
-        while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
-    }
-    catch (error) { e = { error: error }; }
-    finally {
-        try {
-            if (r && !r.done && (m = i["return"])) m.call(i);
-        }
-        finally { if (e) throw e.error; }
-    }
-    return ar;
-};
 import Chart from '../parts/Chart.js';
 import H from '../parts/Globals.js';
 import O from '../parts/Options.js';
@@ -726,10 +710,10 @@ Scatter.prototype.getRealExtremes = function () {
         xAxis.toValue(chart.plotLeft + chart.plotWidth) : 0, realMinY = yAxis ? yAxis.toValue(chart.plotTop) : 0, realMaxY = yAxis ?
         yAxis.toValue(chart.plotTop + chart.plotHeight) : 0;
     if (realMinX > realMaxX) {
-        _a = __read([realMinX, realMaxX], 2), realMaxX = _a[0], realMinX = _a[1];
+        _a = [realMinX, realMaxX], realMaxX = _a[0], realMinX = _a[1];
     }
     if (realMinY > realMaxY) {
-        _b = __read([realMinY, realMaxY], 2), realMaxY = _b[0], realMinY = _b[1];
+        _b = [realMinY, realMaxY], realMaxY = _b[0], realMinY = _b[1];
     }
     return {
         minX: realMinX,
@@ -760,10 +744,10 @@ Scatter.prototype.onDrillToCluster = function (event) {
             chart.pointer.zoomY = true;
             // Swap when minus values.
             if (minX > maxX) {
-                _a = __read([maxX, minX], 2), minX = _a[0], maxX = _a[1];
+                _a = [maxX, minX], minX = _a[0], maxX = _a[1];
             }
             if (minY > maxY) {
-                _b = __read([maxY, minY], 2), minY = _b[0], maxY = _b[1];
+                _b = [maxY, minY], minY = _b[0], maxY = _b[1];
             }
             chart.zoom({
                 originalEvent: e,
@@ -1027,7 +1011,7 @@ Scatter.prototype.markerClusterAlgorithms = {
     }
 };
 Scatter.prototype.preventClusterCollisions = function (props) {
-    var series = this, xAxis = series.xAxis, yAxis = series.yAxis, _a = __read(props.key.split('-').map(parseFloat), 2), gridY = _a[0], gridX = _a[1], gridSize = props.gridSize, groupedData = props.groupedData, defaultRadius = props.defaultRadius, clusterRadius = props.clusterRadius, gridXPx = gridX * gridSize, gridYPx = gridY * gridSize, xPixel = xAxis.toPixels(props.x), yPixel = yAxis.toPixels(props.y), gridsToCheckCollision = [], pointsLen = 0, radius = 0, clusterMarkerOptions = (series.options.cluster || {}).marker, zoneOptions = (series.options.cluster || {}).zones, gridOffset = series.getGridOffset(), nextXPixel, nextYPixel, signX, signY, cornerGridX, cornerGridY, i, j, itemX, itemY, nextClusterPos, maxDist, keys, x, y;
+    var series = this, xAxis = series.xAxis, yAxis = series.yAxis, _a = props.key.split('-').map(parseFloat), gridY = _a[0], gridX = _a[1], gridSize = props.gridSize, groupedData = props.groupedData, defaultRadius = props.defaultRadius, clusterRadius = props.clusterRadius, gridXPx = gridX * gridSize, gridYPx = gridY * gridSize, xPixel = xAxis.toPixels(props.x), yPixel = yAxis.toPixels(props.y), gridsToCheckCollision = [], pointsLen = 0, radius = 0, clusterMarkerOptions = (series.options.cluster || {}).marker, zoneOptions = (series.options.cluster || {}).zones, gridOffset = series.getGridOffset(), nextXPixel, nextYPixel, signX, signY, cornerGridX, cornerGridY, i, j, itemX, itemY, nextClusterPos, maxDist, keys, x, y;
     // Distance to the grid start.
     xPixel -= gridOffset.plotLeft;
     yPixel -= gridOffset.plotTop;
@@ -1061,7 +1045,7 @@ Scatter.prototype.preventClusterCollisions = function (props) {
                 gridOffset.plotLeft;
             nextYPixel = yAxis.toPixels(groupedData[item].posY || 0) -
                 gridOffset.plotTop;
-            _a = __read(item.split('-').map(parseFloat), 2), itemY = _a[0], itemX = _a[1];
+            _a = item.split('-').map(parseFloat), itemY = _a[0], itemX = _a[1];
             if (zoneOptions) {
                 pointsLen = groupedData[item].length;
                 for (i = 0; i < zoneOptions.length; i++) {

--- a/js/parts/Legend.js
+++ b/js/parts/Legend.js
@@ -308,17 +308,22 @@ var Legend = /** @class */ (function () {
         var _this = this;
         var legend = this, options = legend.options, symbolPadding = options.symbolPadding, ltr = !options.rtl, legendItemPos = item._legendItemPos, itemX = legendItemPos[0], itemY = legendItemPos[1], checkbox = item.checkbox, legendGroup = item.legendGroup;
         if (legendGroup && legendGroup.element) {
-            var shouldAnimate = defined(legendGroup.translateY);
-            legendGroup[shouldAnimate ? 'animate' : 'attr']({
+            var attribs = {
                 translateX: ltr ?
                     itemX :
                     legend.legendWidth - itemX - 2 * symbolPadding - 4,
                 translateY: itemY
-            });
-            var animOptions = animObject(pick(this.chart.renderer.globalAnimation, true));
-            syncTimeout(function () {
+            };
+            var complete = function () {
                 fireEvent(_this, 'afterPositionItem', { item: item });
-            }, shouldAnimate && animOptions.duration || 0);
+            };
+            if (defined(legendGroup.translateY)) {
+                legendGroup.animate(attribs, { complete: complete });
+            }
+            else {
+                legendGroup.attr(attribs);
+                complete();
+            }
         }
         if (checkbox) {
             checkbox.x = itemX;

--- a/js/parts/Legend.js
+++ b/js/parts/Legend.js
@@ -305,14 +305,20 @@ var Legend = /** @class */ (function () {
      * The item to position
      */
     Legend.prototype.positionItem = function (item) {
+        var _this = this;
         var legend = this, options = legend.options, symbolPadding = options.symbolPadding, ltr = !options.rtl, legendItemPos = item._legendItemPos, itemX = legendItemPos[0], itemY = legendItemPos[1], checkbox = item.checkbox, legendGroup = item.legendGroup;
         if (legendGroup && legendGroup.element) {
-            legendGroup[defined(legendGroup.translateY) ? 'animate' : 'attr']({
+            var shouldAnimate = defined(legendGroup.translateY);
+            legendGroup[shouldAnimate ? 'animate' : 'attr']({
                 translateX: ltr ?
                     itemX :
                     legend.legendWidth - itemX - 2 * symbolPadding - 4,
                 translateY: itemY
             });
+            var animOptions = animObject(pick(this.chart.renderer.globalAnimation, true));
+            syncTimeout(function () {
+                fireEvent(_this, 'afterPositionItem', { item: item });
+            }, shouldAnimate && animOptions.duration || 0);
         }
         if (checkbox) {
             checkbox.x = itemX;

--- a/samples/highcharts/accessibility/accessible-keyboardnav/demo.js
+++ b/samples/highcharts/accessibility/accessible-keyboardnav/demo.js
@@ -8,10 +8,14 @@ Highcharts.chart('container', {
     },
 
     legend: {
-        useHTML: true
+        useHTML: true,
+        layout: 'proximate',
+        align: 'right'
     },
 
     series: [{
-        data: [74, 69.6, 63.7, 63.9, 43.7]
+        data: [74, 69.6, 63.7, 43.7]
+    }, {
+        data: [74, 63.7, 23.9, 13.7]
     }]
 });

--- a/samples/highcharts/accessibility/accessible-keyboardnav/test-notes.md
+++ b/samples/highcharts/accessibility/accessible-keyboardnav/test-notes.md
@@ -1,1 +1,1 @@
-Click next to the chart. Tab through chart. Make sure there are no errors in console. Interact with legend using Space/Enter and make sure series is hidden.
+Click next to the chart. Tab through chart. Make sure there are no errors in console. Interact with legend using Space/Enter and make sure series is hidden. Interact with legend using mouse and make sure it is working.

--- a/ts/modules/accessibility/AccessibilityComponent.ts
+++ b/ts/modules/accessibility/AccessibilityComponent.ts
@@ -79,9 +79,10 @@ declare global {
                 el: (SVGElement|HTMLElement|HTMLDOMElement|SVGDOMElement),
                 eventObject: Event
             ): void;
-            public setProxyButtonStyle(
-                button: HTMLDOMElement,
-                bBox: (BBoxObject|Dictionary<number>)
+            public setProxyButtonStyle(button: HTMLDOMElement): void;
+            public updateProxyButtonPosition(
+                proxy: HTMLDOMElement,
+                posElement: Highcharts.SVGElement
             ): void;
         }
         interface AccessibilityChart {
@@ -335,8 +336,7 @@ AccessibilityComponent.prototype = {
             proxy = this.createElement('button'),
             attrs = merge({
                 'aria-label': svgEl.getAttribute('aria-label')
-            }, attributes),
-            bBox = this.getElementPosition(posElement || svgElement);
+            }, attributes);
 
         Object.keys(attrs).forEach(function (prop: string): void {
             if (attrs[prop] !== null) {
@@ -350,7 +350,8 @@ AccessibilityComponent.prototype = {
             this.addEvent(proxy, 'click', preClickEvent);
         }
 
-        this.setProxyButtonStyle(proxy, bBox);
+        this.setProxyButtonStyle(proxy);
+        this.updateProxyButtonPosition(proxy, posElement || svgElement);
         this.proxyMouseEventsForButton(svgEl, proxy);
 
         // Add to chart div and unhide from screen readers
@@ -396,13 +397,9 @@ AccessibilityComponent.prototype = {
 
     /**
      * @private
-     * @param {Highcharts.HTMLElement} button
-     * @param {Highcharts.BBoxObject} bBox
+     * @param {Highcharts.HTMLElement} button The proxy element.
      */
-    setProxyButtonStyle: function (
-        button: Highcharts.HTMLDOMElement,
-        bBox: Highcharts.BBoxObject
-    ): void {
+    setProxyButtonStyle: function (button: Highcharts.HTMLDOMElement): void {
         merge(true, button.style, {
             'border-width': 0,
             'background-color': 'transparent',
@@ -416,7 +413,22 @@ AccessibilityComponent.prototype = {
             padding: 0,
             margin: 0,
             display: 'block',
-            position: 'absolute',
+            position: 'absolute'
+        });
+    },
+
+
+    /**
+     * @private
+     * @param {Highcharts.HTMLElement} proxy The proxy to update position of.
+     * @param {Highcharts.SVGElement} posElement The element to overlay and take position from.
+     */
+    updateProxyButtonPosition: function (
+        proxy: Highcharts.HTMLDOMElement,
+        posElement: Highcharts.SVGElement
+    ): void {
+        const bBox = this.getElementPosition(posElement);
+        merge(true, proxy.style, {
             width: (bBox.width || 1) + 'px',
             height: (bBox.height || 1) + 'px',
             left: (bBox.x || 0) + 'px',

--- a/ts/modules/accessibility/components/LegendComponent.ts
+++ b/ts/modules/accessibility/components/LegendComponent.ts
@@ -252,8 +252,9 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
      * @private
      */
     updateProxiesPositions: function (this: Highcharts.LegendComponent): void {
-        this.proxyElementsList.forEach(({ element, posElement }): void =>
-            this.updateProxyButtonPosition(element, posElement));
+        for (const { element, posElement } of this.proxyElementsList) {
+            this.updateProxyButtonPosition(element, posElement);
+        }
     },
 
 

--- a/ts/modules/accessibility/components/LegendComponent.ts
+++ b/ts/modules/accessibility/components/LegendComponent.ts
@@ -203,7 +203,7 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
             }
         });
         this.addEvent(Legend, 'afterPositionItem', function (e: Highcharts.Dictionary<any>): void {
-            if (this.chart === component.chart) {
+            if (this.chart === component.chart && this.chart.renderer) {
                 component.updateProxyPositionForItem(e.item);
             }
         });

--- a/ts/modules/accessibility/components/LegendComponent.ts
+++ b/ts/modules/accessibility/components/LegendComponent.ts
@@ -252,9 +252,8 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
      * @private
      */
     updateProxiesPositions: function (this: Highcharts.LegendComponent): void {
-        for (const { element, posElement } of this.proxyElementsList) {
-            this.updateProxyButtonPosition(element, posElement);
-        }
+        this.proxyElementsList.forEach(({ element, posElement }): void =>
+            this.updateProxyButtonPosition(element, posElement));
     },
 
 

--- a/ts/parts/Legend.ts
+++ b/ts/parts/Legend.ts
@@ -561,12 +561,21 @@ class Legend {
             legendGroup = item.legendGroup;
 
         if (legendGroup && legendGroup.element) {
-            legendGroup[defined(legendGroup.translateY) ? 'animate' : 'attr']({
+            const shouldAnimate = defined(legendGroup.translateY);
+
+            legendGroup[shouldAnimate ? 'animate' : 'attr']({
                 translateX: ltr ?
                     itemX :
                     legend.legendWidth - itemX - 2 * (symbolPadding as any) - 4,
                 translateY: itemY
             });
+
+            const animOptions = animObject(
+                pick(this.chart.renderer.globalAnimation, true)
+            );
+            syncTimeout((): void => {
+                fireEvent(this, 'afterPositionItem', { item });
+            }, shouldAnimate && animOptions.duration || 0);
         }
 
         if (checkbox) {

--- a/ts/parts/Legend.ts
+++ b/ts/parts/Legend.ts
@@ -561,21 +561,22 @@ class Legend {
             legendGroup = item.legendGroup;
 
         if (legendGroup && legendGroup.element) {
-            const shouldAnimate = defined(legendGroup.translateY);
-
-            legendGroup[shouldAnimate ? 'animate' : 'attr']({
+            const attribs = {
                 translateX: ltr ?
                     itemX :
                     legend.legendWidth - itemX - 2 * (symbolPadding as any) - 4,
                 translateY: itemY
-            });
-
-            const animOptions = animObject(
-                pick(this.chart.renderer.globalAnimation, true)
-            );
-            syncTimeout((): void => {
+            };
+            const complete = (): void => {
                 fireEvent(this, 'afterPositionItem', { item });
-            }, shouldAnimate && animOptions.duration || 0);
+            };
+
+            if (defined(legendGroup.translateY)) {
+                legendGroup.animate(attribs, { complete });
+            } else {
+                legendGroup.attr(attribs);
+                complete();
+            }
         }
 
         if (checkbox) {

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -3,7 +3,6 @@
         "allowJs": true,
         "allowSyntheticDefaultImports": true,
         "declaration": false,
-        "downlevelIteration": true,
         "esModuleInterop": true,
         "keyofStringsOnly": true,
         "noEmitOnError": true,


### PR DESCRIPTION
Fixed #13554, a11y not supporting proximate legend layout.
___
Moderately pragmatic approach taken. We need to recalculate positions of the proxy overlays when legend item position changes, but this is not trivial because of animation. Decided to take the same approach as with legend scrolling and fire an event after the animation duration has passed. It seems overkill to recalculate the position for every step (like we do with focus border by overriding position setters in the renderer).

There is a repeating pattern of the a11y module having to create HTML overlays for SVG elements that are animated, so we might want to find an overall better solution to this when we have time, rather than firing events and always calculating bounding boxes.