### PR TITLE
bugfix/13576-boxplot-series-draggable-values

### DIFF
--- a/js/modules/draggable-points.src.js
+++ b/js/modules/draggable-points.src.js
@@ -473,7 +473,7 @@ if (seriesTypes.boxplot) {
             axis: 'y',
             move: true,
             resize: true,
-            resizeSide: 'draggableQ1',
+            resizeSide: 'bottom',
             handlePositioner: function (point) {
                 return {
                     x: point.shapeArgs.x,
@@ -504,7 +504,7 @@ if (seriesTypes.boxplot) {
             axis: 'y',
             move: true,
             resize: true,
-            resizeSide: 'draggableQ3',
+            resizeSide: 'top',
             handlePositioner: function (point) {
                 return {
                     x: point.shapeArgs.x,
@@ -1877,7 +1877,7 @@ Point.prototype.showDragHandles = function () {
             'stroke-width': handleOptions.lineWidth,
             fill: handleOptions.color,
             stroke: handleOptions.lineColor
-        }, pathFormatter = handleOptions.pathFormatter || val.handleFormatter, positioner = val.handlePositioner, pos, handle, handleSide, path, 
+        }, pathFormatter = handleOptions.pathFormatter || val.handleFormatter, positioner = val.handlePositioner, pos, handle, path, 
         // Run validation function on whether or not we allow individual
         // updating of this prop.
         validate = val.validateIndividualDrag ?
@@ -1902,8 +1902,6 @@ Point.prototype.showDragHandles = function () {
             // Find position and path of handle
             pos = positioner(point);
             handleAttrs.d = path = pathFormatter(point);
-            handleSide = typeof val.resizeSide === 'function' ?
-                val.resizeSide(point.options, point) : val.resizeSide;
             if (!path || pos.x < 0 || pos.y < 0) {
                 return;
             }
@@ -1912,9 +1910,9 @@ Point.prototype.showDragHandles = function () {
                 (val.axis === 'x') !== !!chart.inverted ?
                 'ew-resize' : 'ns-resize';
             // Create and add the handle element if it doesn't exist
-            handle = chart.dragHandles[handleSide];
+            handle = chart.dragHandles[val.optionName];
             if (!handle) {
-                handle = chart.dragHandles[handleSide] = renderer
+                handle = chart.dragHandles[val.optionName] = renderer
                     .path()
                     .add(chart.dragHandles.group);
             }

--- a/js/modules/draggable-points.src.js
+++ b/js/modules/draggable-points.src.js
@@ -473,7 +473,7 @@ if (seriesTypes.boxplot) {
             axis: 'y',
             move: true,
             resize: true,
-            resizeSide: 'bottom',
+            resizeSide: 'draggableQ1',
             handlePositioner: function (point) {
                 return {
                     x: point.shapeArgs.x,
@@ -504,7 +504,7 @@ if (seriesTypes.boxplot) {
             axis: 'y',
             move: true,
             resize: true,
-            resizeSide: 'top',
+            resizeSide: 'draggableQ3',
             handlePositioner: function (point) {
                 return {
                     x: point.shapeArgs.x,

--- a/samples/unit-tests/series-boxplot/boxplot/demo.html
+++ b/samples/unit-tests/series-boxplot/boxplot/demo.html
@@ -1,6 +1,6 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
-
+<script src="https://code.highcharts.com/modules/draggable-points.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/series-boxplot/boxplot/demo.js
+++ b/samples/unit-tests/series-boxplot/boxplot/demo.js
@@ -266,3 +266,50 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test('All values should be draggable (#13576)',
+    function (assert) {
+        const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'boxplot'
+            },
+            series: [{
+                dragDrop: {
+                    draggableY: true,
+                    draggableQ1: true,
+                    draggableQ3: true,
+                    draggableLow: true,
+                    draggableHigh: true
+                },
+                data: [
+                    [700, 750, 848, 905, 965],
+                    [650, 700, 939, 1080, 1180]
+                ]
+            }]
+        });
+
+        const point = chart.series[0].points[0];
+        let result;
+
+        point.showDragHandles();
+
+        const highHandleY = chart.dragHandles.draggableHigh.translateY,
+            lowHandleY = chart.dragHandles.draggableLow.translateY,
+            Q1HandleY = chart.dragHandles.draggableQ1.translateY,
+            Q3HandleY = chart.dragHandles.draggableQ3.translateY;
+
+        if (
+            Math.abs(highHandleY - point.highPlot) <= 1 &&
+            Math.abs(lowHandleY - point.lowPlot) <= 1 &&
+            Math.abs(Q1HandleY - point.q1Plot) <= 1 &&
+            Math.abs(Q3HandleY - point.q3Plot) <= 1
+        ) {
+            result = true;
+        }
+
+        assert.ok(
+            result,
+            'Drag handles are rendered in correct positions.'
+        );
+    }
+);

--- a/samples/unit-tests/series-xrange/xrange/demo.js
+++ b/samples/unit-tests/series-xrange/xrange/demo.js
@@ -253,14 +253,13 @@ QUnit.test('X-Range', function (assert) {
 
     point = chart.series[0].points[0];
     point.showDragHandles();
-
-    var leftHandleBBox = chart.dragHandles.left.getBBox(),
-        rightHandleBBox = chart.dragHandles.right.getBBox(),
-        leftHandleX = chart.dragHandles.left.translateX,
-        leftHandleY = chart.dragHandles.left.translateY +
+    var leftHandleBBox = chart.dragHandles.draggableX1.getBBox(),
+        rightHandleBBox = chart.dragHandles.draggableX2.getBBox(),
+        leftHandleX = chart.dragHandles.draggableX1.translateX,
+        leftHandleY = chart.dragHandles.draggableX1.translateY +
             leftHandleBBox.y + leftHandleBBox.height / 2,
-        rightHandleX = chart.dragHandles.right.translateX,
-        rightHandleY = chart.dragHandles.right.translateY +
+        rightHandleX = chart.dragHandles.draggableX2.translateX,
+        rightHandleY = chart.dragHandles.draggableX2.translateY +
             rightHandleBBox.y + rightHandleBBox.height / 2,
         plotX = point.plotX,
         plotY = point.plotY + point.series.columnMetrics.offset +

--- a/ts/modules/draggable-points.src.ts
+++ b/ts/modules/draggable-points.src.ts
@@ -731,7 +731,7 @@ if (seriesTypes.boxplot) {
             axis: 'y',
             move: true,
             resize: true,
-            resizeSide: 'bottom',
+            resizeSide: 'draggableQ1',
             handlePositioner: function (
                 point: Highcharts.BoxPlotPoint
             ): Highcharts.PositionObject {
@@ -767,7 +767,7 @@ if (seriesTypes.boxplot) {
             axis: 'y',
             move: true,
             resize: true,
-            resizeSide: 'top',
+            resizeSide: 'draggableQ3',
             handlePositioner: function (
                 point: Highcharts.BoxPlotPoint
             ): Highcharts.PositionObject {

--- a/ts/modules/draggable-points.src.ts
+++ b/ts/modules/draggable-points.src.ts
@@ -731,7 +731,7 @@ if (seriesTypes.boxplot) {
             axis: 'y',
             move: true,
             resize: true,
-            resizeSide: 'draggableQ1',
+            resizeSide: 'bottom',
             handlePositioner: function (
                 point: Highcharts.BoxPlotPoint
             ): Highcharts.PositionObject {
@@ -767,7 +767,7 @@ if (seriesTypes.boxplot) {
             axis: 'y',
             move: true,
             resize: true,
-            resizeSide: 'draggableQ3',
+            resizeSide: 'top',
             handlePositioner: function (
                 point: Highcharts.BoxPlotPoint
             ): Highcharts.PositionObject {
@@ -2555,7 +2555,6 @@ Point.prototype.showDragHandles = function (): void {
             positioner = val.handlePositioner,
             pos,
             handle,
-            handleSide,
             path,
             // Run validation function on whether or not we allow individual
             // updating of this prop.
@@ -2589,8 +2588,6 @@ Point.prototype.showDragHandles = function (): void {
             // Find position and path of handle
             pos = positioner(point);
             handleAttrs.d = path = pathFormatter(point);
-            handleSide = typeof val.resizeSide === 'function' ?
-                val.resizeSide(point.options, point) : val.resizeSide;
             if (!path || pos.x < 0 || pos.y < 0) {
                 return;
             }
@@ -2601,9 +2598,9 @@ Point.prototype.showDragHandles = function (): void {
                 'ew-resize' : 'ns-resize';
 
             // Create and add the handle element if it doesn't exist
-            handle = (chart.dragHandles as any)[handleSide];
+            handle = (chart.dragHandles as any)[val.optionName];
             if (!handle) {
-                handle = (chart.dragHandles as any)[handleSide] = renderer
+                handle = (chart.dragHandles as any)[val.optionName] = renderer
                     .path()
                     .add((chart.dragHandles as any).group);
             }


### PR DESCRIPTION
Fixed #13576, a regression causing drag and drop to fail for some values in the boxplot series.