### PR TITLE
bugfix/13195-dataclasses-hidden-points

### DIFF
--- a/js/parts-map/ColorSeriesMixin.js
+++ b/js/parts-map/ColorSeriesMixin.js
@@ -33,6 +33,7 @@ H.colorPointMixin = {
                 point[key][method]();
             }
         });
+        this.series.buildKDTree(); // rebuild kdtree #13195
     }
     /* eslint-enable valid-jsdoc */
 };

--- a/samples/unit-tests/coloraxis/dataclasses/demo.js
+++ b/samples/unit-tests/coloraxis/dataclasses/demo.js
@@ -62,3 +62,54 @@ QUnit.test('Data classes and redundant text labels', function (assert) {
         'The number of child nodes should not change after adding a pie (#8478)'
     );
 });
+
+QUnit.test('Data classes - interactions', function (assert) {
+    var chart = Highcharts.chart('container', {
+            colorAxis: {
+                dataClasses: [{
+                    from: 0,
+                    to: 1,
+                    color: '#FF0000'
+                }, {
+                    from: 1,
+                    to: 2,
+                    color: '#0000FF'
+                }]
+            },
+            series: [{
+                type: 'scatter',
+                data: [{
+                    y: 0,
+                    x: 0
+                }, {
+                    y: 1,
+                    x: 1
+                }]
+            }]
+        }),
+        test = TestController(chart),
+        point = chart.series[0].points[0],
+        pointPos = { x: chart.plotLeft + point.plotX, y: chart.plotTop + point.plotY },
+        legend = chart.legend,
+        legendItemBBox = legend.allItems[0].legendGroup.getBBox(true),
+        legendItemX = legend.group.translateX + legendItemBBox.x + legendItemBBox.width / 2,
+        legendItemY = legend.group.translateY + legendItemBBox.y + legendItemBBox.height / 2;
+
+    test.click(legendItemX, legendItemY);
+    test.mouseMove(pointPos.x, pointPos.y);
+
+    assert.strictEqual(
+        chart.hoverPoint,
+        chart.series[0].points[1],
+        'The hidden point should not be hovered.'
+    );
+
+    test.click(legendItemX, legendItemY);
+    test.mouseMove(pointPos.x, pointPos.y);
+
+    assert.strictEqual(
+        chart.hoverPoint,
+        point,
+        'The shown point should be hovered.'
+    );
+});

--- a/ts/parts-map/ColorSeriesMixin.ts
+++ b/ts/parts-map/ColorSeriesMixin.ts
@@ -73,6 +73,7 @@ H.colorPointMixin = {
                 (point as any)[key][method]();
             }
         });
+        this.series.buildKDTree(); // rebuild kdtree #13195
     }
 
     /* eslint-enable valid-jsdoc */


### PR DESCRIPTION
Fixed #13195, tooltip was shown for points that were hidden by data classes.