### PR TITLE
bugfix/13629-pie-gauge-inner-size

### DIFF
--- a/js/mixins/centered-series.js
+++ b/js/mixins/centered-series.js
@@ -52,8 +52,9 @@ H.CenteredSeriesMixin = {
             pick(size && size < 0 ? void 0 : options.size, '100%'),
             pick(innerSize && innerSize < 0 ? void 0 : options.innerSize || 0, '0%')
         ];
-        // No need for inner size in angular (gauges) series
-        if (chart.angular) {
+        // No need for inner size in angular (gauges) series but still required
+        // for pie series
+        if (chart.angular && !(this instanceof H.Series)) {
             positions[3] = 0;
         }
         for (i = 0; i < 4; ++i) {

--- a/samples/unit-tests/series-pie/innersize/demo.html
+++ b/samples/unit-tests/series-pie/innersize/demo.html
@@ -1,4 +1,5 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/series-pie/innersize/demo.js
+++ b/samples/unit-tests/series-pie/innersize/demo.js
@@ -52,3 +52,26 @@ QUnit.test('Percentage inner size', function (assert) {
     );
 
 });
+
+QUnit.test('The inner size of a pie with an additional gauge series (#13629).', function (assert) {
+
+    var chart = Highcharts.chart('container', {
+        series: [{
+            type: 'gauge',
+            data: [10]
+        }, {
+            type: 'pie',
+            innerSize: '50%',
+            startAngle: -90,
+            endAngle: 90,
+            center: ['50%', '60%'],
+            data: [1, 2, 3]
+        }]
+    });
+
+    assert.notEqual(
+        chart.series[1].center[3],
+        0,
+        'The innerSize is not equal 0.'
+    );
+});

--- a/ts/mixins/centered-series.ts
+++ b/ts/mixins/centered-series.ts
@@ -111,8 +111,9 @@ H.CenteredSeriesMixin = {
             pick(innerSize && innerSize < 0 ? void 0 : options.innerSize || 0, '0%')
         ];
 
-        // No need for inner size in angular (gauges) series
-        if (chart.angular) {
+        // No need for inner size in angular (gauges) series but still required
+        // for pie series
+        if (chart.angular && !(this instanceof H.Series)) {
             positions[3] = 0;
         }
 


### PR DESCRIPTION
Fixed #13629, the `innerSize` of a pie series was set to 0 when there was also an additional gauge series.