### PR TITLE
bugfix/13674-missing-drilldown-animation

### DIFF
--- a/js/modules/drilldown.src.js
+++ b/js/modules/drilldown.src.js
@@ -874,8 +874,11 @@ if (PieSeries) {
         animateDrillupFrom: ColumnSeries.prototype.animateDrillupFrom,
         animateDrilldown: function (init) {
             var level = this.chart.drilldownLevels[this.chart.drilldownLevels.length - 1], animationOptions = this.chart.options.drilldown.animation;
+            if (this.is('item')) {
+                animationOptions.duration = 0;
+            }
             // Unable to drill down in the horizontal item series #13372
-            if (this.is('item') && this.center) {
+            if (this.center) {
                 var animateFrom = level.shapeArgs, start = animateFrom.start, angle = animateFrom.end - start, startAngle = angle / this.points.length, styledMode = this.chart.styledMode;
                 if (!init) {
                     this.points.forEach(function (point, i) {
@@ -895,9 +898,6 @@ if (PieSeries) {
                     // Reset to prototype
                     delete this.animate;
                 }
-            }
-            else {
-                animationOptions.duration = 0;
             }
         }
     });

--- a/samples/unit-tests/drilldown/pie/demo.js
+++ b/samples/unit-tests/drilldown/pie/demo.js
@@ -321,3 +321,111 @@ QUnit.test('Slice color after drilldown and select (#4359)', function (assert) {
     document.body.removeChild(container1);
     document.body.removeChild(container2);
 });
+
+QUnit.test('Pie animation duration should be possible to change (#13674)', function (assert) {
+
+    var clock = TestUtilities.lolexInstall();
+
+    try {
+        var chart = Highcharts.chart('container', {
+                chart: {
+                    type: 'pie'
+                },
+                series: [{
+                    name: 'Things',
+                    data: [{
+                        name: 'Animals',
+                        y: 5,
+                        drilldown: 'animals'
+                    }, {
+                        name: 'Fruits',
+                        y: 2,
+                        drilldown: 'fruits'
+                    }]
+                }],
+                drilldown: {
+                    animation: {
+                        duration: 1000
+                    },
+                    series: [{
+                        id: 'animals',
+                        data: [
+                            ['Cats', 4],
+                            ['Dogs', 2],
+                            ['Cows', 1],
+                            ['Sheep', 2],
+                            ['Pigs', 1]
+                        ]
+                    }, {
+                        id: 'fruits',
+                        data: [
+                            ['Apples', 4],
+                            ['Oranges', 2]
+                        ]
+                    }]
+                }
+            }),
+            point = chart.series[0].points[0],
+            initialPos,
+            previousPos,
+            done = assert.async();
+
+        point.doDrilldown();
+        initialPos = chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start');
+
+        assert.strictEqual(
+            chart.drilldownLevels[0].lowerSeries.data[0].color,
+            chart.options.colors[0],
+            'Color of the first slice is correct'
+        );
+
+        assert.strictEqual(
+            chart.drilldownLevels[0].lowerSeries.data[3].color,
+            chart.options.colors[3],
+            'Color of the fourth slice is correct'
+        );
+
+        setTimeout(function () {
+            assert.strictEqual(
+                chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start') > initialPos,
+                true,
+                'Time 400- Point should start moving.'
+            );
+            previousPos = chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start');
+        }, 400);
+
+        setTimeout(function () {
+            assert.strictEqual(
+                chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start') > previousPos,
+                true,
+                'Time 800- Point should move.'
+            );
+            previousPos = chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start');
+        }, 800);
+
+        setTimeout(function () {
+            assert.strictEqual(
+                chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start') > previousPos,
+                true,
+                'Time 1200- Point should move.'
+            );
+            previousPos = chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start');
+        }, 1200);
+
+        setTimeout(function () {
+            assert.strictEqual(
+                chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start') === previousPos,
+                true,
+                'Time 1500- Point should stop.'
+            );
+            done();
+        }, 1500);
+
+        TestUtilities.lolexRunAndUninstall(clock);
+
+    } finally {
+
+        TestUtilities.lolexUninstall(clock);
+
+    }
+});

--- a/samples/unit-tests/drilldown/pie/demo.js
+++ b/samples/unit-tests/drilldown/pie/demo.js
@@ -329,7 +329,10 @@ QUnit.test('Pie animation duration should be possible to change (#13674)', funct
     try {
         var chart = Highcharts.chart('container', {
                 chart: {
-                    type: 'pie'
+                    type: 'pie',
+                    animation: {
+                        duration: 1000
+                    }
                 },
                 series: [{
                     name: 'Things',
@@ -368,10 +371,12 @@ QUnit.test('Pie animation duration should be possible to change (#13674)', funct
             point = chart.series[0].points[0],
             initialPos,
             previousPos,
+            previousColor,
             done = assert.async();
 
         point.doDrilldown();
         initialPos = chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start');
+        previousColor = chart.options.colors[0];
 
         assert.strictEqual(
             chart.drilldownLevels[0].lowerSeries.data[0].color,
@@ -385,38 +390,73 @@ QUnit.test('Pie animation duration should be possible to change (#13674)', funct
             'Color of the fourth slice is correct'
         );
 
+        const tweeningGraphic = chart.drilldownLevels[0].lowerSeries.data[3].graphic;
+
         setTimeout(function () {
-            assert.strictEqual(
+            assert.ok(
                 chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start') > initialPos,
-                true,
-                'Time 400- Point should start moving.'
+                'Time 400 - Point should start moving.'
             );
+
+            assert.notEqual(
+                tweeningGraphic.attr('fill'),
+                previousColor,
+                'Time 400 - Fill color should be tweening'
+            );
+
             previousPos = chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start');
+            previousColor = tweeningGraphic.attr('fill');
         }, 400);
 
         setTimeout(function () {
-            assert.strictEqual(
+            assert.ok(
                 chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start') > previousPos,
-                true,
-                'Time 800- Point should move.'
+                'Time 800 - Point should move.'
             );
+
+            assert.notEqual(
+                tweeningGraphic.attr('fill'),
+                previousColor,
+                'Time 800 - Fill color should be tweening'
+            );
+
             previousPos = chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start');
+            previousColor = tweeningGraphic.attr('fill');
         }, 800);
 
         setTimeout(function () {
-            assert.strictEqual(
+            assert.ok(
                 chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start') > previousPos,
-                true,
                 'Time 1200- Point should move.'
             );
+
+            assert.notEqual(
+                tweeningGraphic.attr('fill'),
+                previousColor,
+                'Time 1200 - Fill color should be tweening'
+            );
+
             previousPos = chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start');
+            previousColor = tweeningGraphic.attr('fill');
         }, 1200);
 
         setTimeout(function () {
             assert.strictEqual(
-                chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start') === previousPos,
-                true,
-                'Time 1500- Point should stop.'
+                chart.drilldownLevels[0].lowerSeries.data[4].graphic.attr('start'),
+                previousPos,
+                'Time 1500 - Point should stop.'
+            );
+
+            assert.strictEqual(
+                tweeningGraphic.attr('fill'),
+                previousColor,
+                'Time 1500 - Fill color should be finished tweening'
+            );
+
+            assert.strictEqual(
+                Highcharts.color(tweeningGraphic.attr('fill')).get(),
+                Highcharts.color(chart.options.colors[3]).get(),
+                'Time 1500 - Fill color should match options after finished tweening'
             );
             done();
         }, 1500);

--- a/ts/modules/drilldown.src.ts
+++ b/ts/modules/drilldown.src.ts
@@ -1279,8 +1279,11 @@ if (PieSeries) {
                 animationOptions =
                     (this.chart.options.drilldown as any).animation;
 
+            if (this.is('item')) {
+                animationOptions.duration = 0;
+            }
             // Unable to drill down in the horizontal item series #13372
-            if (this.is('item') && this.center) {
+            if (this.center) {
                 var animateFrom = level.shapeArgs,
                     start = (animateFrom as any).start,
                     angle = (animateFrom as any).end - start,
@@ -1314,8 +1317,6 @@ if (PieSeries) {
                     // Reset to prototype
                     delete this.animate;
                 }
-            } else {
-                animationOptions.duration = 0;
             }
         }
     });


### PR DESCRIPTION
Fixed #13674, a regression in v8.1.1 causing pie drilldown animation not to work.