### PR TITLE
bugfix/13681-data-highcharts-namespace

### DIFF
--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -56,8 +56,11 @@
         "security/detect-object-injection": 0,
         "security/detect-non-literal-fs-filename": 0 /* N/A for Highcharts, we do only client side */,
 
+        "highcharts/no-highcharts-object": 2,
         "highcharts/no-newline-in-doclet-code": 2,
         "highcharts/no-newline-in-doclet-link": 2,
+        "highcharts/no-private-constructor-doclet": 2,
+        "highcharts/doclet-apioption-last": 2,
         "highcharts/unparsable-doclet": 2
 
     },

--- a/js/annotations/eventEmitterMixin.js
+++ b/js/annotations/eventEmitterMixin.js
@@ -24,7 +24,7 @@ var eventEmitterMixin = {
      */
     addEvents: function () {
         var emitter = this, addMouseDownEvent = function (element) {
-            addEvent(element, Highcharts.isTouchDevice ? 'touchstart' : 'mousedown', function (e) {
+            addEvent(element, H.isTouchDevice ? 'touchstart' : 'mousedown', function (e) {
                 emitter.onMouseDown(e);
             });
         };
@@ -49,7 +49,7 @@ var eventEmitterMixin = {
             }
         });
         if (emitter.options.draggable) {
-            addEvent(emitter, Highcharts.isTouchDevice ? 'touchmove' : 'drag', emitter.onDrag);
+            addEvent(emitter, H.isTouchDevice ? 'touchmove' : 'drag', emitter.onDrag);
             if (!emitter.graphic.renderer.styledMode) {
                 var cssPointer_1 = {
                     cursor: {
@@ -98,7 +98,7 @@ var eventEmitterMixin = {
         prevChartY = e.chartY;
         emitter.cancelClick = false;
         emitter.chart.hasDraggedAnnotation = true;
-        emitter.removeDrag = addEvent(H.doc, Highcharts.isTouchDevice ? 'touchmove' : 'mousemove', function (e) {
+        emitter.removeDrag = addEvent(H.doc, H.isTouchDevice ? 'touchmove' : 'mousemove', function (e) {
             emitter.hasDragged = true;
             e = pointer.normalize(e);
             e.prevChartX = prevChartX;
@@ -107,7 +107,7 @@ var eventEmitterMixin = {
             prevChartX = e.chartX;
             prevChartY = e.chartY;
         });
-        emitter.removeMouseUp = addEvent(H.doc, Highcharts.isTouchDevice ? 'touchend' : 'mouseup', function (e) {
+        emitter.removeMouseUp = addEvent(H.doc, H.isTouchDevice ? 'touchend' : 'mouseup', function (e) {
             emitter.cancelClick = emitter.hasDragged;
             emitter.hasDragged = false;
             emitter.chart.hasDraggedAnnotation = false;

--- a/js/annotations/navigationBindings.js
+++ b/js/annotations/navigationBindings.js
@@ -182,7 +182,7 @@ var NavigationBindings = /** @class */ (function () {
                 navigation.bindingsChartClick(this, e);
             }
         }));
-        navigation.eventsToUnbind.push(addEvent(chart.container, Highcharts.isTouchDevice ? 'touchmove' : 'mousemove', function (e) {
+        navigation.eventsToUnbind.push(addEvent(chart.container, H.isTouchDevice ? 'touchmove' : 'mousemove', function (e) {
             navigation.bindingsContainerMouseMove(this, e);
         }));
     };

--- a/js/modules/accessibility/utils/chartUtilities.js
+++ b/js/modules/accessibility/utils/chartUtilities.js
@@ -13,7 +13,7 @@
 import HTMLUtilities from './htmlUtilities.js';
 var stripHTMLTags = HTMLUtilities.stripHTMLTagsFromString;
 import U from '../../../parts/Utilities.js';
-var defined = U.defined, find = U.find;
+var defined = U.defined, find = U.find, fireEvent = U.fireEvent;
 /* eslint-disable valid-jsdoc */
 /**
  * @return {string}
@@ -165,7 +165,7 @@ function scrollToPoint(point) {
         var range = scrollbar.to - scrollbar.from;
         var pos = getRelativePointAxisPosition(axis, point);
         scrollbar.updatePosition(pos - range / 2, pos + range / 2);
-        Highcharts.fireEvent(scrollbar, 'changed', {
+        fireEvent(scrollbar, 'changed', {
             from: scrollbar.from,
             to: scrollbar.to,
             trigger: 'scrollbar',

--- a/js/modules/data.src.js
+++ b/js/modules/data.src.js
@@ -88,6 +88,7 @@ var addEvent = U.addEvent, defined = U.defined, extend = U.extend, fireEvent = U
  *         continue async.
  */
 import '../mixins/ajax.js';
+var ajax = H.ajax;
 // Utilities
 var win = H.win, doc = win.document;
 /**
@@ -1232,7 +1233,7 @@ var Data = /** @class */ (function () {
                             setTimeout(performFetch, updateIntervalMs);
                     }
                 }
-                Highcharts.ajax({
+                ajax({
                     url: url,
                     dataType: tp || 'json',
                     success: function (res) {
@@ -1305,7 +1306,7 @@ var Data = /** @class */ (function () {
                 worksheet,
                 'public/values?alt=json'
             ].join('/');
-            Highcharts.ajax({
+            ajax({
                 url: url,
                 dataType: 'json',
                 success: function (json) {

--- a/js/modules/export-data.src.js
+++ b/js/modules/export-data.src.js
@@ -13,6 +13,7 @@
 // - Set up systematic tests for all series types, paired with tests of the data
 //   module importing the same data.
 'use strict';
+import Axis from '../parts/Axis.js';
 import Chart from '../parts/Chart.js';
 import H from '../parts/Globals.js';
 var doc = H.doc, seriesTypes = H.seriesTypes, win = H.win;
@@ -323,7 +324,7 @@ Chart.prototype.getDataRows = function (multiLevelHeaders) {
         if (!item) {
             return categoryHeader;
         }
-        if (item instanceof Highcharts.Axis) {
+        if (item instanceof Axis) {
             return (item.options.title && item.options.title.text) ||
                 (item.dateTime ? categoryDatetimeHeader : categoryHeader);
         }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "dtslint": "^3.5.2",
     "eslint": "^7.0.0",
     "eslint-config-eslint": "5.0.1",
-    "eslint-plugin-highcharts": "../eslint-plugin-highcharts",
+    "eslint-plugin-highcharts": "github:highcharts/eslint-plugin-highcharts",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-security": "^1.4.0",
     "fs-extra": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "dtslint": "^3.5.2",
     "eslint": "^7.0.0",
     "eslint-config-eslint": "5.0.1",
-    "eslint-plugin-highcharts": "github:highcharts/eslint-plugin-highcharts",
+    "eslint-plugin-highcharts": "../eslint-plugin-highcharts",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-security": "^1.4.0",
     "fs-extra": "^9.0.0",

--- a/ts/.eslintrc
+++ b/ts/.eslintrc
@@ -10,6 +10,7 @@
         "project": "./tsconfig.json"
     },
     "plugins": [
+        "highcharts",
         "@typescript-eslint"
     ],
     "rules": {
@@ -87,6 +88,9 @@
         "@typescript-eslint/prefer-regexp-exec": 0, // @todo
         "@typescript-eslint/prefer-string-starts-ends-with": 0, // @todo
         "@typescript-eslint/unbound-method": 0, // @todo
+        "highcharts/no-highcharts-object": 2,
+        "highcharts/no-private-constructor-doclet": 0,
+        "highcharts/doclet-apioption-last": 2,
         "node/no-missing-import": 0, // @todo
         "node/no-unsupported-features/es-syntax": 0, // @todo
     }

--- a/ts/annotations/eventEmitterMixin.ts
+++ b/ts/annotations/eventEmitterMixin.ts
@@ -86,7 +86,7 @@ const eventEmitterMixin: Highcharts.AnnotationEventEmitterMixin = {
             ): void {
                 addEvent(
                     element,
-                    Highcharts.isTouchDevice ? 'touchstart' : 'mousedown',
+                    H.isTouchDevice ? 'touchstart' : 'mousedown',
                     (e: Highcharts.AnnotationEventObject): void => {
                         emitter.onMouseDown(e);
                     }
@@ -125,7 +125,7 @@ const eventEmitterMixin: Highcharts.AnnotationEventEmitterMixin = {
 
         if (emitter.options.draggable) {
 
-            addEvent(emitter, Highcharts.isTouchDevice ? 'touchmove' : 'drag', emitter.onDrag);
+            addEvent(emitter, H.isTouchDevice ? 'touchmove' : 'drag', emitter.onDrag);
 
 
             if (!emitter.graphic.renderer.styledMode) {
@@ -193,7 +193,7 @@ const eventEmitterMixin: Highcharts.AnnotationEventEmitterMixin = {
         emitter.chart.hasDraggedAnnotation = true;
         emitter.removeDrag = addEvent(
             H.doc,
-            Highcharts.isTouchDevice ? 'touchmove' : 'mousemove',
+            H.isTouchDevice ? 'touchmove' : 'mousemove',
             function (e: Highcharts.AnnotationEventObject): void {
                 emitter.hasDragged = true;
 
@@ -209,7 +209,7 @@ const eventEmitterMixin: Highcharts.AnnotationEventEmitterMixin = {
         );
         emitter.removeMouseUp = addEvent(
             H.doc,
-            Highcharts.isTouchDevice ? 'touchend' : 'mouseup',
+            H.isTouchDevice ? 'touchend' : 'mouseup',
             function (e: Highcharts.AnnotationEventObject): void {
                 emitter.cancelClick = emitter.hasDragged;
                 emitter.hasDragged = false;

--- a/ts/annotations/navigationBindings.ts
+++ b/ts/annotations/navigationBindings.ts
@@ -413,7 +413,7 @@ class NavigationBindings {
             })
         );
         navigation.eventsToUnbind.push(
-            addEvent(chart.container, Highcharts.isTouchDevice ? 'touchmove' : 'mousemove', function (
+            addEvent(chart.container, H.isTouchDevice ? 'touchmove' : 'mousemove', function (
                 e: Highcharts.PointerEventObject
             ): void {
                 navigation.bindingsContainerMouseMove(this, e);

--- a/ts/modules/accessibility/utils/chartUtilities.ts
+++ b/ts/modules/accessibility/utils/chartUtilities.ts
@@ -22,7 +22,8 @@ const {
 import U from '../../../parts/Utilities.js';
 const {
     defined,
-    find
+    find,
+    fireEvent
 } = U;
 
 
@@ -273,7 +274,7 @@ function scrollToPoint(point: Point): void {
             pos + range / 2
         );
 
-        Highcharts.fireEvent(scrollbar, 'changed', {
+        fireEvent(scrollbar, 'changed', {
             from: scrollbar.from,
             to: scrollbar.to,
             trigger: 'scrollbar',

--- a/ts/modules/data.src.ts
+++ b/ts/modules/data.src.ts
@@ -261,6 +261,7 @@ declare global {
  */
 
 import '../mixins/ajax.js';
+const ajax = H.ajax;
 
 // Utilities
 var win = H.win,
@@ -1640,7 +1641,7 @@ class Data {
                     }
                 }
 
-                Highcharts.ajax({
+                ajax({
                     url: url,
                     dataType: tp || 'json',
                     success: function (
@@ -1748,7 +1749,7 @@ class Data {
                 'public/values?alt=json'
             ].join('/');
 
-            Highcharts.ajax({
+            ajax({
                 url: url,
                 dataType: 'json',
                 success: function (json: Highcharts.JSONType): void {

--- a/ts/modules/export-data.src.ts
+++ b/ts/modules/export-data.src.ts
@@ -17,6 +17,7 @@
 'use strict';
 
 import type Point from '../parts/Point';
+import Axis from '../parts/Axis.js';
 import Chart from '../parts/Chart.js';
 import H from '../parts/Globals.js';
 const {
@@ -480,7 +481,7 @@ Chart.prototype.getDataRows = function (
                 return categoryHeader;
             }
 
-            if (item instanceof Highcharts.Axis) {
+            if (item instanceof Axis) {
                 return (item.options.title && item.options.title.text) ||
                     (item.dateTime ? categoryDatetimeHeader : categoryHeader);
             }


### PR DESCRIPTION
Fixed #13681, reference to global Highcharts scope in module mode made some modules crash when loaded as ES modules.

Pending on https://github.com/highcharts/eslint-plugin-highcharts/pull/4