### PR TITLE
bugfix/13426-panning-reset-zoom-button

### DIFF
--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -490,7 +490,7 @@ extend(Chart.prototype, /** @lends Chart.prototype */ {
                 xy = [0];
             }
             xy.forEach(function (isX) {
-                var axis = chart[isX ? 'xAxis' : 'yAxis'][0], axisOpt = axis.options, horiz = axis.horiz, mousePos = e[horiz ? 'chartX' : 'chartY'], mouseDown = horiz ? 'mouseDownX' : 'mouseDownY', startPos = chart[mouseDown], halfPointRange = (axis.pointRange || 0) / 2, pointRangeDirection = (axis.reversed && !chart.inverted) ||
+                var axis = chart[isX ? 'xAxis' : 'yAxis'][0], horiz = axis.horiz, mousePos = e[horiz ? 'chartX' : 'chartY'], mouseDown = horiz ? 'mouseDownX' : 'mouseDownY', startPos = chart[mouseDown], halfPointRange = (axis.pointRange || 0) / 2, pointRangeDirection = (axis.reversed && !chart.inverted) ||
                     (!axis.reversed && chart.inverted) ?
                     -1 :
                     1, extremes = axis.getExtremes(), panMin = axis.toValue(startPos - mousePos, true) +

--- a/js/parts/Interaction.js
+++ b/js/parts/Interaction.js
@@ -544,12 +544,15 @@ extend(Chart.prototype, /** @lends Chart.prototype */ {
                     if (axis.series.length &&
                         newMin !== extremes.min &&
                         newMax !== extremes.max &&
-                        isX ? true : (panningState &&
                         newMin >= paddedMin &&
-                        newMax <= paddedMax)) {
+                        newMax <= paddedMax) {
                         axis.setExtremes(newMin, newMax, false, false, { trigger: 'pan' });
                         if (!chart.resetZoomButton &&
                             !hasMapNavigation &&
+                            // Show reset zoom button only when both newMin and
+                            // newMax values are between padded axis range.
+                            newMin !== paddedMin &&
+                            newMax !== paddedMax &&
                             type.match('y')) {
                             chart.showResetZoom();
                             axis.displayBtn = false;

--- a/samples/unit-tests/maps/map-navigation/demo.js
+++ b/samples/unit-tests/maps/map-navigation/demo.js
@@ -7,11 +7,7 @@ QUnit.test('Zoom in - zoomout with padding, panning in both directions.', functi
         },
 
         mapNavigation: {
-            enabled: true,
-            buttonOptions: {
-                alignTo: 'spacingBox',
-                verticalAlign: 'bottom'
-            }
+            enabled: false
         },
 
         colorAxis: {
@@ -46,8 +42,19 @@ QUnit.test('Zoom in - zoomout with padding, panning in both directions.', functi
 
     var xExtremes = chart.xAxis[0].getExtremes(),
         yExtremes,
+        plotLeft = chart.plotLeft,
+        plotTop = chart.plotTop,
         controller = new TestController(chart);
 
+    controller.pan(
+        [plotLeft + 50, plotTop + 50],
+        [plotLeft + 100, plotTop + 100]
+    );
+
+    assert.ok(
+        !chart.resetZoomButton,
+        'Reset zoom button should not appear while panning and chart is not zoomed.'
+    );
 
     chart.mapZoom(0.5);
 
@@ -70,8 +77,8 @@ QUnit.test('Zoom in - zoomout with padding, panning in both directions.', functi
     yExtremes = chart.yAxis[0].getExtremes();
 
     controller.pan(
-        [chart.plotLeft + 50, chart.plotTop + 50],
-        [chart.plotLeft + 100, chart.plotTop + 100]
+        [plotLeft + 50, plotTop + 50],
+        [plotLeft + 100, plotTop + 100]
     );
 
     assert.notEqual(

--- a/ts/parts/Interaction.ts
+++ b/ts/parts/Interaction.ts
@@ -904,13 +904,10 @@ extend(Chart.prototype, /** @lends Chart.prototype */ {
                     // Set new extremes if they are actually new
                     if (
                         axis.series.length &&
-                            newMin !== extremes.min &&
-                            newMax !== extremes.max &&
-                            isX ? true : (
-                                panningState &&
-                                newMin >= paddedMin &&
-                                newMax <= paddedMax
-                            )
+                        newMin !== extremes.min &&
+                        newMax !== extremes.max &&
+                        newMin >= paddedMin &&
+                        newMax <= paddedMax
                     ) {
                         axis.setExtremes(
                             newMin,
@@ -923,6 +920,10 @@ extend(Chart.prototype, /** @lends Chart.prototype */ {
                         if (
                             !chart.resetZoomButton &&
                             !hasMapNavigation &&
+                            // Show reset zoom button only when both newMin and
+                            // newMax values are between padded axis range.
+                            newMin !== paddedMin &&
+                            newMax !== paddedMax &&
                             type.match('y')
                         ) {
                             chart.showResetZoom();

--- a/ts/parts/Interaction.ts
+++ b/ts/parts/Interaction.ts
@@ -797,7 +797,6 @@ extend(Chart.prototype, /** @lends Chart.prototype */ {
             ): void {
 
                 var axis = chart[isX ? 'xAxis' : 'yAxis'][0],
-                    axisOpt = axis.options,
                     horiz = axis.horiz,
                     mousePos = e[horiz ? 'chartX' : 'chartY'],
                     mouseDown = horiz ? 'mouseDownX' : 'mouseDownY',


### PR DESCRIPTION
Fixed #13426, reset zoom button appeared while panning maps and the chart was not zoomed in.