### PR TITLE
bugfix/13678-private-constructor-props

### DIFF
--- a/js/annotations/annotations.src.js
+++ b/js/annotations/annotations.src.js
@@ -77,9 +77,6 @@ var Annotation = /** @class */ (function () {
      *  Constructors
      *
      * */
-    /**
-     * @private
-     */
     function Annotation(chart, userOptions) {
         /* *
          *

--- a/js/parts/SVGRenderer.js
+++ b/js/parts/SVGRenderer.js
@@ -284,9 +284,6 @@ var SVGRenderer = /** @class */ (function () {
      *  Constructors
      *
      * */
-    /**
-     * @private
-     */
     function SVGRenderer(container, width, height, style, forExport, allowHTML, styledMode) {
         /* *
          *
@@ -294,11 +291,29 @@ var SVGRenderer = /** @class */ (function () {
          *
          * */
         this.alignedObjects = void 0;
+        /**
+         * The root `svg` node of the renderer.
+         *
+         * @name Highcharts.SVGRenderer#box
+         * @type {Highcharts.SVGDOMElement}
+         */
         this.box = void 0;
+        /**
+         * The wrapper for the root `svg` node of the renderer.
+         *
+         * @name Highcharts.SVGRenderer#boxWrapper
+         * @type {Highcharts.SVGElement}
+         */
         this.boxWrapper = void 0;
         this.cache = void 0;
         this.cacheKeys = void 0;
         this.chartIndex = void 0;
+        /**
+         * A pointer to the `defs` node of the root SVG.
+         *
+         * @name Highcharts.SVGRenderer#defs
+         * @type {Highcharts.SVGElement}
+         */
         this.defs = void 0;
         this.globalAnimation = void 0;
         this.gradients = void 0;
@@ -306,6 +321,13 @@ var SVGRenderer = /** @class */ (function () {
         this.imgCount = void 0;
         this.isSVG = void 0;
         this.style = void 0;
+        /**
+         * Page url used for internal references.
+         *
+         * @private
+         * @name Highcharts.SVGRenderer#url
+         * @type {string}
+         */
         this.url = void 0;
         this.width = void 0;
         this.init(container, width, height, style, forExport, allowHTML, styledMode);
@@ -366,28 +388,9 @@ var SVGRenderer = /** @class */ (function () {
         }
         // object properties
         renderer.isSVG = true;
-        /**
-         * The root `svg` node of the renderer.
-         *
-         * @name Highcharts.SVGRenderer#box
-         * @type {Highcharts.SVGDOMElement}
-         */
         this.box = element;
-        /**
-         * The wrapper for the root `svg` node of the renderer.
-         *
-         * @name Highcharts.SVGRenderer#boxWrapper
-         * @type {Highcharts.SVGElement}
-         */
         this.boxWrapper = boxWrapper;
         renderer.alignedObjects = [];
-        /**
-         * Page url used for internal references.
-         *
-         * @private
-         * @name Highcharts.SVGRenderer#url
-         * @type {string}
-         */
         // #24, #672, #1070
         this.url = ((isFirefox || isWebKit) &&
             doc.getElementsByTagName('base').length) ?
@@ -402,12 +405,6 @@ var SVGRenderer = /** @class */ (function () {
         // Add description
         desc = this.createElement('desc').add();
         desc.element.appendChild(doc.createTextNode('Created with @product.name@ @product.version@'));
-        /**
-         * A pointer to the `defs` node of the root SVG.
-         *
-         * @name Highcharts.SVGRenderer#defs
-         * @type {Highcharts.SVGElement}
-         */
         renderer.defs = this.createElement('defs').add();
         renderer.allowHTML = allowHTML;
         renderer.forExport = forExport;

--- a/test/typescript/classes/SVGRenderer.ts
+++ b/test/typescript/classes/SVGRenderer.ts
@@ -1,0 +1,13 @@
+import * as Highcharts from 'highcharts';
+
+test_SVGRenderer();
+
+function test_SVGRenderer() {
+    const chart = new Highcharts.Chart('container', {}),
+        renderer = chart.renderer;
+
+    // #13678 tests
+    renderer.g();
+    renderer.box = renderer.box;
+    renderer.rect();
+}

--- a/ts/annotations/annotations.src.ts
+++ b/ts/annotations/annotations.src.ts
@@ -286,9 +286,6 @@ class Annotation implements EventEmitterMixin.Type, ControllableMixin.Type {
      *
      * */
 
-    /**
-     * @private
-     */
     public constructor(
         chart: Highcharts.AnnotationChart,
         userOptions: Highcharts.AnnotationsOptions

--- a/ts/parts/SVGRenderer.ts
+++ b/ts/parts/SVGRenderer.ts
@@ -568,9 +568,6 @@ class SVGRenderer {
      *
      * */
 
-    /**
-     * @private
-     */
     public constructor(
         container: Highcharts.HTMLDOMElement,
         width: number,
@@ -590,12 +587,37 @@ class SVGRenderer {
      * */
 
     public alignedObjects: Array<SVGElement> = void 0 as any;
+
     public allowHTML?: boolean;
+
+    /**
+     * The root `svg` node of the renderer.
+     *
+     * @name Highcharts.SVGRenderer#box
+     * @type {Highcharts.SVGDOMElement}
+     */
     public box: globalThis.SVGElement = void 0 as any;
+
+    /**
+     * The wrapper for the root `svg` node of the renderer.
+     *
+     * @name Highcharts.SVGRenderer#boxWrapper
+     * @type {Highcharts.SVGElement}
+     */
     public boxWrapper: SVGElement = void 0 as any;
+
     public cache: Record<string, Highcharts.BBoxObject> = void 0 as any;
+
     public cacheKeys: Array<string> = void 0 as any;
+
     public chartIndex: number = void 0 as any;
+
+    /**
+     * A pointer to the `defs` node of the root SVG.
+     *
+     * @name Highcharts.SVGRenderer#defs
+     * @type {Highcharts.SVGElement}
+     */
     public defs: SVGElement = void 0 as any;
     public forExport?: boolean;
     public globalAnimation: Highcharts.AnimationOptionsObject = void 0 as any;
@@ -606,6 +628,14 @@ class SVGRenderer {
     public style: Highcharts.CSSObject = void 0 as any;
     public styledMode?: boolean;
     public unSubPixelFix?: Function;
+
+    /**
+     * Page url used for internal references.
+     *
+     * @private
+     * @name Highcharts.SVGRenderer#url
+     * @type {string}
+     */
     public url: string = void 0 as any;
     public width: number = void 0 as any;
 
@@ -684,29 +714,10 @@ class SVGRenderer {
         // object properties
         renderer.isSVG = true;
 
-        /**
-         * The root `svg` node of the renderer.
-         *
-         * @name Highcharts.SVGRenderer#box
-         * @type {Highcharts.SVGDOMElement}
-         */
         this.box = element as any;
-        /**
-         * The wrapper for the root `svg` node of the renderer.
-         *
-         * @name Highcharts.SVGRenderer#boxWrapper
-         * @type {Highcharts.SVGElement}
-         */
         this.boxWrapper = boxWrapper;
         renderer.alignedObjects = [];
 
-        /**
-         * Page url used for internal references.
-         *
-         * @private
-         * @name Highcharts.SVGRenderer#url
-         * @type {string}
-         */
         // #24, #672, #1070
         this.url = (
             (isFirefox || isWebKit) &&
@@ -727,12 +738,6 @@ class SVGRenderer {
             doc.createTextNode('Created with @product.name@ @product.version@')
         );
 
-        /**
-         * A pointer to the `defs` node of the root SVG.
-         *
-         * @name Highcharts.SVGRenderer#defs
-         * @type {Highcharts.SVGElement}
-         */
         renderer.defs = this.createElement('defs').add();
         renderer.allowHTML = allowHTML;
         renderer.forExport = forExport;


### PR DESCRIPTION
Fixed #13678, private constructor hides properties.

Related lint rule is here included https://github.com/highcharts/highcharts/pull/13686
