### PR TITLE
tools/dist-upload-etc

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,6 +38,7 @@ Gulp.registry(new GulpForwardReference());
     'dist-upload-code',
     'dist-upload-mapcollection',
     'dist-upload-errors',
+    'dist-upload-samples-data',
     'jsdoc',
     'jsdoc-classes',
     'jsdoc-clean',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,6 +37,7 @@ Gulp.registry(new GulpForwardReference());
     'dist-testresults',
     'dist-upload-code',
     'dist-upload-mapcollection',
+    'dist-upload-errors',
     'jsdoc',
     'jsdoc-classes',
     'jsdoc-clean',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,6 +40,7 @@ Gulp.registry(new GulpForwardReference());
     'dist-upload-errors',
     'dist-upload-samples-data',
     'dist-upload-studies',
+    'dist-upload-more',
     'jsdoc',
     'jsdoc-classes',
     'jsdoc-clean',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,6 +39,7 @@ Gulp.registry(new GulpForwardReference());
     'dist-upload-mapcollection',
     'dist-upload-errors',
     'dist-upload-samples-data',
+    'dist-upload-studies',
     'jsdoc',
     'jsdoc-classes',
     'jsdoc-clean',

--- a/tools/gulptasks/dist-upload-errors.js
+++ b/tools/gulptasks/dist-upload-errors.js
@@ -1,0 +1,48 @@
+const gulp = require('gulp');
+const errors = require('../../errors/errors.json');
+const log = require('./lib/log');
+const { putS3Object } = require('./lib/uploadS3');
+
+const bucket = 'assets.highcharts.com';
+const errorLocation = 'errors';
+
+
+// eslint-disable-next-line require-jsdoc
+function makeHTML(errorNo, obj) {
+    return `<!DOCTYPE html>
+    <html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Highcharts Error #${errorNo}</title>
+        <script src="https://code.highcharts.com/products.js"></script>
+    </head>
+    <body>
+        ${obj.text}
+    </body>
+    </html>`;
+}
+
+/**
+ * Makes full HTML documents of each error in `errors.json`
+ * and uploads it to S3
+ * @return {Promise} Promise for Gulp to keep
+ */
+async function uploadErrors() {
+    await Promise.all(
+        Object.keys(errors)
+            .filter(key => key !== 'meta')
+            .map(err => putS3Object(`${errorLocation}/${err}`, null, {
+                Bucket: bucket,
+                Body: makeHTML(err, errors[err]),
+                ContentType: 'text/html; charset=utf-8'
+            }))
+    ).catch(error => {
+        throw error;
+    });
+    log.success('Finished uploading errors');
+}
+
+uploadErrors();
+
+gulp.task('dist-upload-errors', uploadErrors);

--- a/tools/gulptasks/dist-upload-errors.js
+++ b/tools/gulptasks/dist-upload-errors.js
@@ -43,6 +43,4 @@ async function uploadErrors() {
     log.success('Finished uploading errors');
 }
 
-uploadErrors();
-
 gulp.task('dist-upload-errors', uploadErrors);

--- a/tools/gulptasks/dist-upload-more.js
+++ b/tools/gulptasks/dist-upload-more.js
@@ -1,0 +1,5 @@
+const { series, task } = require('gulp');
+/**
+ * Task that uploads release assets that are not code or API docs
+ */
+task('dist-upload-more', series('dist-upload-errors', 'dist-upload-samples-data', 'dist-upload-studies'));

--- a/tools/gulptasks/dist-upload-samples-data.js
+++ b/tools/gulptasks/dist-upload-samples-data.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) Highsoft AS
+ */
+
+/* eslint func-style: 0, no-console: 0, max-len: 0 */
+const gulp = require('gulp');
+const glob = require('glob');
+const { uploadFiles, isDirectoryOrSystemFile, toS3Path } = require('./lib/uploadS3');
+
+
+const SOURCE_DIR = 'samples/data';
+const S3_DEST_PATH = 'demos';
+const BUCKET = 'assets.highcharts.com';
+
+
+/**
+ * Upload samples data to S3.
+ *
+ * @return {Promise<*> | Promise | Promise} Promise to keep
+ */
+async function distUploadSamplesData() {
+    const argv = require('yargs').argv;
+    const bucket = argv.bucket || BUCKET;
+    let sourceDir = argv.sourceDir || SOURCE_DIR;
+
+    if (!sourceDir.endsWith('/')) {
+        sourceDir = sourceDir + '/';
+    }
+
+    const sourceFiles = glob.sync(`${sourceDir}/**/*`).filter(file => !isDirectoryOrSystemFile(file));
+    const rootFiles = sourceFiles.map(file => toS3Path(file, sourceDir + '/', S3_DEST_PATH));
+
+    return uploadFiles({
+        files: [...rootFiles],
+        name: 'highcharts-samples-data',
+        bucket,
+        profile: argv.profile
+    });
+}
+
+distUploadSamplesData.description = 'Uploads samples data to S3';
+distUploadSamplesData.flags = {
+    '--profile': 'AWS profile to load from AWS credentials file. If no profile is provided the default profile or ' +
+        'standard AWS environment variables for credentials will be used. (optional)'
+};
+
+gulp.task('dist-upload-samples-data', distUploadSamplesData);

--- a/tools/gulptasks/dist-upload-studies.js
+++ b/tools/gulptasks/dist-upload-studies.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) Highsoft AS
+ */
+
+/* eslint func-style: 0, no-console: 0, max-len: 0 */
+const gulp = require('gulp');
+const glob = require('glob');
+const { uploadFiles, isDirectoryOrSystemFile, toS3Path } = require('./lib/uploadS3');
+
+
+const SOURCE_DIR = 'studies';
+const S3_DEST_PATH = '';
+const BUCKET = 'assets.highcharts.com';
+
+
+/**
+ * Upload samples data to S3.
+ *
+ * @return {Promise<*> | Promise | Promise} Promise to keep
+ */
+async function distUploadStudies() {
+    const argv = require('yargs').argv;
+    const bucket = argv.bucket || BUCKET;
+    let sourceDir = argv.sourceDir || SOURCE_DIR;
+
+    if (!sourceDir.endsWith('/')) {
+        sourceDir = sourceDir + '/';
+    }
+
+    const sourceFiles = glob.sync(`${sourceDir}/**/*`).filter(file => !isDirectoryOrSystemFile(file));
+    const rootFiles = sourceFiles.map(file => toS3Path(file, sourceDir + '/', S3_DEST_PATH));
+
+    return uploadFiles({
+        files: [...rootFiles],
+        name: 'highcharts-studies',
+        bucket,
+        profile: argv.profile
+    });
+}
+
+distUploadStudies.description = 'Uploads samples data to S3';
+distUploadStudies.flags = {
+    '--profile': 'AWS profile to load from AWS credentials file. If no profile is provided the default profile or ' +
+        'standard AWS environment variables for credentials will be used. (optional)'
+};
+
+gulp.task('dist-upload-studies', distUploadStudies);

--- a/tools/gulptasks/lib/uploadS3.js
+++ b/tools/gulptasks/lib/uploadS3.js
@@ -54,7 +54,7 @@ async function putS3Object(key, body, config = {}) {
                     log.success(`Saved object to ${key}`);
                     resolve(resp);
                 } else {
-                    log.warn(`An error occured while storing an object to ${config.BUCKET}/${key}`, error);
+                    log.warn(`An error occured while storing an object to ${config.Bucket}/${key}`, error);
                     reject(error);
                 }
             });

--- a/tools/gulptasks/lib/uploadS3.js
+++ b/tools/gulptasks/lib/uploadS3.js
@@ -163,6 +163,20 @@ function uploadFiles(params) {
     });
 }
 
+/**
+ * Transforms a filepath to a similar named S3 destination path.
+ * @param {string} fromPath file to create a S3 destination path for.
+ * @param {string} removeFromDestPath, anything in the fromPath that you want to remove from destination path.
+ * @param {string} prefix for S3 destination key.
+ * @return {{from: *, to: string}} object for upload api.
+ */
+function toS3Path(fromPath, removeFromDestPath, prefix) {
+    return {
+        from: fromPath,
+        to: `${prefix ? prefix + '/' : ''}${fromPath.replace(removeFromDestPath, '')}`
+    };
+}
+
 
 module.exports = {
     uploadFiles,
@@ -171,5 +185,6 @@ module.exports = {
     isDirectoryOrSystemFile,
     getS3Object,
     putS3Object,
-    getGitIgnoreMeProperties
+    getGitIgnoreMeProperties,
+    toS3Path
 };

--- a/tools/upload.js
+++ b/tools/upload.js
@@ -43,6 +43,8 @@ const uploadFiles = params => {
         eot: 'application/vnd.ms-fontobject',
         gif: 'image/gif',
         html: 'text/html',
+        htm: 'text/html',
+        php: 'text/plain',
         ico: 'image/x-icon',
         jpeg: 'image/jpeg',
         jpg: 'image/jpeg',
@@ -92,7 +94,7 @@ const uploadFiles = params => {
                 const fileMime = mimeType[fileType];
                 if (content && content.length > 0) {
                     filePromise = storage.push(cdn, to, content, fileMime, s3Params)
-                        .then(() => isFunction(callback) && callback(from, to))
+                        .then(() => isFunction(callback) && callback(from, to, fileMime))
                         .catch(err => {
                             const error = {
                                 message: `S3: ${(err.pri && err.pri.message) || (err.internal && err.internal.message)}`,


### PR DESCRIPTION
To-dones:
- [x] Gulp task for uploading errors
- [x] Gulp task for uploading studies
- [x] Gulp task for uploading `samples/data`
- [x] Create one `dist-upload-more` to run all of the above ~~Integrate with dist-upload-code (or CI?)~~

Samples of uploaded files:
* [Error uploaded](https://assets.highcharts.com/errors/10)
* [studies uploaded](https://assets.highcharts.com/studies/dashboard)
* [sample-data](https://assets.highcharts.com/demos/samples/data/olympic-medals.node.js)