### PR TITLE
Fixed #13680, addSeries failed after setSize

### DIFF
--- a/js/parts/Chart.js
+++ b/js/parts/Chart.js
@@ -561,7 +561,7 @@ var Chart = /** @class */ (function () {
                 // Don't do setScale again if we're only resizing. Regression
                 // #13507. But we need it after chart.update (responsive), as
                 // axis is initialized again (#12137).
-                if (!chart.isResizing || !axis.tickPositions) {
+                if (!chart.isResizing || !isNumber(axis.min)) {
                     axis.updateNames();
                     axis.setScale();
                 }

--- a/samples/unit-tests/chart/setsize/demo.js
+++ b/samples/unit-tests/chart/setsize/demo.js
@@ -506,3 +506,41 @@ QUnit.test('Plot area update(#3098)', function (assert) {
         "The legend overlaps the plot"
     );
 });
+
+QUnit.test('Succession of setSize and other dynamics', assert => {
+    const done = assert.async();
+    const chart = Highcharts.chart('container', {
+        chart: {
+            width: 600,
+            animation: {
+                duration: 1
+            }
+        },
+        legend: {
+            enabled: false
+        },
+        series: []
+    });
+    setTimeout(function () {
+        assert.strictEqual(
+            chart.chartWidth,
+            600,
+            'Initial chart width'
+        );
+        chart.setSize(500, 300);
+        assert.strictEqual(
+            chart.chartWidth,
+            500,
+            'Size should be set without errors'
+        );
+
+        chart.addSeries({ type: 'column', data: [1, 2, 3, 4] });
+        assert.notEqual(
+            chart.series[0].points[0].graphic.getBBox().height,
+            0,
+            'A series should be added with valid column heights (#13680)'
+        );
+
+        done();
+    }, 2);
+});

--- a/ts/parts/Chart.ts
+++ b/ts/parts/Chart.ts
@@ -820,7 +820,7 @@ class Chart {
                 // Don't do setScale again if we're only resizing. Regression
                 // #13507. But we need it after chart.update (responsive), as
                 // axis is initialized again (#12137).
-                if (!chart.isResizing || !axis.tickPositions) {
+                if (!chart.isResizing || !isNumber(axis.min)) {
                     axis.updateNames();
                     axis.setScale();
                 }


### PR DESCRIPTION
Fixed #13680, `chart.addSeries` failed after calling `chart.setSize` on a chart with no data.