### PR TITLE
Samples/live data demos update

### DIFF
--- a/samples/highcharts/css/crosshair-label/demo.js
+++ b/samples/highcharts/css/crosshair-label/demo.js
@@ -1,5 +1,5 @@
 Highcharts.getJSON(
-    'https://www.highcharts.com/samples/data/aapl-c.json',
+    'https://demo-live-data.highcharts.com/aapl-c.json',
     function (data) {
         // Create the chart
         Highcharts.stockChart('container', {

--- a/samples/highcharts/css/dark-unica-highstock/demo.js
+++ b/samples/highcharts/css/dark-unica-highstock/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     // Create the chart
     Highcharts.stockChart('container', {
 

--- a/samples/highcharts/css/grid-light-highstock/demo.js
+++ b/samples/highcharts/css/grid-light-highstock/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     // Create the chart
     Highcharts.stockChart('container', {
 

--- a/samples/highcharts/css/sand-signika-highstock/demo.js
+++ b/samples/highcharts/css/sand-signika-highstock/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     // Create the chart
     Highcharts.stockChart('container', {
 

--- a/samples/highcharts/demo/combo-meteogram/demo.js
+++ b/samples/highcharts/demo/combo-meteogram/demo.js
@@ -553,11 +553,15 @@ if (!location.hash) {
     location.hash = 'https://www.yr.no/place/' + place + '/forecast_hour_by_hour.xml';
 }
 
-// Then get the XML file through CORS proxy.
+// Then get the XML file through Highcharts' CORS proxy. Our proxy is limited to
+// this specific location. Useing the third party, rate limited cors.io service
+// for experimenting with other locations.
 url = location.hash.substr(1);
 $.ajax({
     dataType: 'xml',
-    url: 'https://cors-anywhere.herokuapp.com/' + url,
+    url: url === 'https://www.yr.no/place/United_Kingdom/England/London/forecast_hour_by_hour.xml' ?
+        'https://www.highcharts.com/samples/data/cors.php?url=' + url :
+        'https://cors.io/?' + url,
     success: function (xml) {
         window.meteogram = new Meteogram(xml, 'container');
     },

--- a/samples/highcharts/demo/combo-meteogram/demo.js
+++ b/samples/highcharts/demo/combo-meteogram/demo.js
@@ -560,8 +560,8 @@ url = location.hash.substr(1);
 $.ajax({
     dataType: 'xml',
     url: url === 'https://www.yr.no/place/United_Kingdom/England/London/forecast_hour_by_hour.xml' ?
-        'https://www.highcharts.com/samples/data/cors.php?url=' + url :
-        'https://cors.io/?' + url,
+        'https://demo-live-data.highcharts.com/weather-forecast.xml' :
+        'https://cors-anywhere.herokuapp.com/' + url,
     success: function (xml) {
         window.meteogram = new Meteogram(xml, 'container');
     },

--- a/samples/highcharts/demo/combo-meteogram/demo.js
+++ b/samples/highcharts/demo/combo-meteogram/demo.js
@@ -553,15 +553,11 @@ if (!location.hash) {
     location.hash = 'https://www.yr.no/place/' + place + '/forecast_hour_by_hour.xml';
 }
 
-// Then get the XML file through Highcharts' CORS proxy. Our proxy is limited to
-// this specific location. Useing the third party, rate limited cors.io service
-// for experimenting with other locations.
+// Then get the XML file through CORS proxy.
 url = location.hash.substr(1);
 $.ajax({
     dataType: 'xml',
-    url: url === 'https://www.yr.no/place/United_Kingdom/England/London/forecast_hour_by_hour.xml' ?
-        'https://www.highcharts.com/samples/data/cors.php?url=' + url :
-        'https://cors.io/?' + url,
+    url: 'https://cors-anywhere.herokuapp.com/' + url,
     success: function (xml) {
         window.meteogram = new Meteogram(xml, 'container');
     },

--- a/samples/highcharts/tooltip/trackball-plugin/demo.js
+++ b/samples/highcharts/tooltip/trackball-plugin/demo.js
@@ -48,7 +48,7 @@
     });
 }(Highcharts));
 
-$.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+$.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
     // Split the data set into ohlc and volume
     var ohlc = [],

--- a/samples/issues/highstock-2.0.3/3299-axis-labels-panes/demo.js
+++ b/samples/issues/highstock-2.0.3/3299-axis-labels-panes/demo.js
@@ -1,5 +1,5 @@
 $(function () {
-    Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+    Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
         // split the data set into ohlc and volume
         var ohlc = [],

--- a/samples/stock/accessibility/accessible-stock/demo.js
+++ b/samples/stock/accessibility/accessible-stock/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     Highcharts.stockChart('container', {
         accessibility: {
             description: 'Chart shows Apple stock prices from mid 2008 to mid 2015. It shows steady growth with one significant peak lasting through most of 2012 before normalizing.'

--- a/samples/stock/annotations/fibonacci-retracements/demo.js
+++ b/samples/stock/annotations/fibonacci-retracements/demo.js
@@ -85,7 +85,7 @@ function fibonacciRetracements(x1, y1, x2, y2) {
     };
 }
 
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
     // create the chart
     Highcharts.stockChart('container', {
 

--- a/samples/stock/annotations/fibonacci-retracements/demo.js
+++ b/samples/stock/annotations/fibonacci-retracements/demo.js
@@ -85,7 +85,7 @@ function fibonacciRetracements(x1, y1, x2, y2) {
     };
 }
 
-Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
     // create the chart
     Highcharts.stockChart('container', {
 

--- a/samples/stock/demo/area/demo.js
+++ b/samples/stock/demo/area/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
 
     // Create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/demo/areaspline/demo.js
+++ b/samples/stock/demo/areaspline/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
 
     // Create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/demo/basic-line/demo.js
+++ b/samples/stock/demo/basic-line/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     // Create the chart
     Highcharts.stockChart('container', {
 

--- a/samples/stock/demo/candlestick-and-volume/demo.js
+++ b/samples/stock/demo/candlestick-and-volume/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
     // split the data set into ohlc and volume
     var ohlc = [],

--- a/samples/stock/demo/candlestick/demo.js
+++ b/samples/stock/demo/candlestick/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     // create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/demo/column/demo.js
+++ b/samples/stock/demo/column/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-v.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-v.json', function (data) {
 
     // create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/demo/lazy-loading/demo.html
+++ b/samples/stock/demo/lazy-loading/demo.html
@@ -1,4 +1,3 @@
-<script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/stock/modules/exporting.js"></script>
 

--- a/samples/stock/demo/lazy-loading/demo.js
+++ b/samples/stock/demo/lazy-loading/demo.js
@@ -1,92 +1,93 @@
+const dataURL = 'https://demo-live-data.highcharts.com/aapl-historical.json';
+
 /**
  * Load new data depending on the selected min and max
  */
 function afterSetExtremes(e) {
-
-    var chart = Highcharts.charts[0];
-
+    const { chart } = e.target;
     chart.showLoading('Loading data from server...');
-    $.getJSON('https://www.highcharts.com/samples/data/from-sql.php?start=' + Math.round(e.min) +
-            '&end=' + Math.round(e.max) + '&callback=?', function (data) {
-
-        chart.series[0].setData(data);
-        chart.hideLoading();
-    });
+    fetch(`${dataURL}?start=${Math.round(e.min)}&end=${Math.round(e.max)}`)
+        .then(res => res.ok && res.json())
+        .then(data => {
+            chart.series[0].setData(data);
+            chart.hideLoading();
+        }).catch(error => console.error(error.message));
 }
 
-// See source code from the JSONP handler at https://github.com/highcharts/highcharts/blob/v7.0.0/samples/data/from-sql.php
-$.getJSON('https://www.highcharts.com/samples/data/from-sql.php?callback=?', function (data) {
+fetch(dataURL)
+    .then(res => res.ok && res.json())
+    .then(data => {
 
-    // Add a null value for the end date
-    data = [].concat(data, [[Date.UTC(2011, 9, 14, 19, 59), null, null, null, null]]);
+        // Add a null value for the end date
+        data = [].concat(data, [[Date.UTC(2011, 9, 14, 19, 59), null, null, null, null]]);
 
-    // create the chart
-    Highcharts.stockChart('container', {
-        chart: {
-            type: 'candlestick',
-            zoomType: 'x'
-        },
-
-        navigator: {
-            adaptToUpdatedData: false,
-            series: {
-                data: data
-            }
-        },
-
-        scrollbar: {
-            liveRedraw: false
-        },
-
-        title: {
-            text: 'AAPL history by the minute from 1998 to 2011'
-        },
-
-        subtitle: {
-            text: 'Displaying 1.7 million data points in Highcharts Stock by async server loading'
-        },
-
-        rangeSelector: {
-            buttons: [{
-                type: 'hour',
-                count: 1,
-                text: '1h'
-            }, {
-                type: 'day',
-                count: 1,
-                text: '1d'
-            }, {
-                type: 'month',
-                count: 1,
-                text: '1m'
-            }, {
-                type: 'year',
-                count: 1,
-                text: '1y'
-            }, {
-                type: 'all',
-                text: 'All'
-            }],
-            inputEnabled: false, // it supports only days
-            selected: 4 // all
-        },
-
-        xAxis: {
-            events: {
-                afterSetExtremes: afterSetExtremes
+        // create the chart
+        Highcharts.stockChart('container', {
+            chart: {
+                type: 'candlestick',
+                zoomType: 'x'
             },
-            minRange: 3600 * 1000 // one hour
-        },
 
-        yAxis: {
-            floor: 0
-        },
+            navigator: {
+                adaptToUpdatedData: false,
+                series: {
+                    data: data
+                }
+            },
 
-        series: [{
-            data: data,
-            dataGrouping: {
-                enabled: false
-            }
-        }]
-    });
-});
+            scrollbar: {
+                liveRedraw: false
+            },
+
+            title: {
+                text: 'AAPL history by the minute from 1998 to 2011'
+            },
+
+            subtitle: {
+                text: 'Displaying 1.7 million data points in Highcharts Stock by async server loading'
+            },
+
+            rangeSelector: {
+                buttons: [{
+                    type: 'hour',
+                    count: 1,
+                    text: '1h'
+                }, {
+                    type: 'day',
+                    count: 1,
+                    text: '1d'
+                }, {
+                    type: 'month',
+                    count: 1,
+                    text: '1m'
+                }, {
+                    type: 'year',
+                    count: 1,
+                    text: '1y'
+                }, {
+                    type: 'all',
+                    text: 'All'
+                }],
+                inputEnabled: false, // it supports only days
+                selected: 4 // all
+            },
+
+            xAxis: {
+                events: {
+                    afterSetExtremes: afterSetExtremes
+                },
+                minRange: 3600 * 1000 // one hour
+            },
+
+            yAxis: {
+                floor: 0
+            },
+
+            series: [{
+                data: data,
+                dataGrouping: {
+                    enabled: false
+                }
+            }]
+        });
+    }).catch(error => console.error(error.message));

--- a/samples/stock/demo/line-markers/demo.js
+++ b/samples/stock/demo/line-markers/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
 
     // Create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/demo/macd-pivot-points/demo.js
+++ b/samples/stock/demo/macd-pivot-points/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/demo/markers-only/demo.js
+++ b/samples/stock/demo/markers-only/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
 
     // Create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/demo/navigator-disabled/demo.js
+++ b/samples/stock/demo/navigator-disabled/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
 
     // Create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/demo/ohlc/demo.js
+++ b/samples/stock/demo/ohlc/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     // create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/demo/responsive/demo.js
+++ b/samples/stock/demo/responsive/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
 
     // Create the chart
     var chart = Highcharts.stockChart('container', {

--- a/samples/stock/demo/scrollbar-disabled/demo.js
+++ b/samples/stock/demo/scrollbar-disabled/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
 
     // Create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/demo/sma-volume-by-price/demo.js
+++ b/samples/stock/demo/sma-volume-by-price/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
     // split the data set into ohlc and volume
     var ohlc = [],

--- a/samples/stock/demo/spline/demo.js
+++ b/samples/stock/demo/spline/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
 
     // Create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/demo/step-line/demo.js
+++ b/samples/stock/demo/step-line/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
 
     // Create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/demo/stock-tools-custom-gui/demo.js
+++ b/samples/stock/demo/stock-tools-custom-gui/demo.js
@@ -103,7 +103,7 @@ function addPopupEvents(chart) {
     );
 }
 
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
     // split the data set into ohlc and volume
     var ohlc = [],

--- a/samples/stock/demo/stock-tools-gui/demo.js
+++ b/samples/stock/demo/stock-tools-gui/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
     // split the data set into ohlc and volume
     var ohlc = [],

--- a/samples/stock/demo/styled-scrollbar/demo.js
+++ b/samples/stock/demo/styled-scrollbar/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
 
     // Create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/demo/yaxis-reversed/demo.js
+++ b/samples/stock/demo/yaxis-reversed/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
 
     // Create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/indicators/acceleration-bands/demo.js
+++ b/samples/stock/indicators/acceleration-bands/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/accumulation-distribution/demo.js
+++ b/samples/stock/indicators/accumulation-distribution/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
     // split the data set into ohlc and volume
     var ohlc = [],

--- a/samples/stock/indicators/ao/demo.js
+++ b/samples/stock/indicators/ao/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/apo/demo.js
+++ b/samples/stock/indicators/apo/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/aroon-oscillator/demo.js
+++ b/samples/stock/indicators/aroon-oscillator/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/aroon/demo.js
+++ b/samples/stock/indicators/aroon/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/atr/demo.js
+++ b/samples/stock/indicators/atr/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/bollinger-bands/demo.js
+++ b/samples/stock/indicators/bollinger-bands/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/cci/demo.js
+++ b/samples/stock/indicators/cci/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/chaikin/demo.js
+++ b/samples/stock/indicators/chaikin/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
     // split the data set into ohlc and volume
     var ohlc = [],

--- a/samples/stock/indicators/cmf/demo.js
+++ b/samples/stock/indicators/cmf/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
     // split the data set into ohlc and volume
     var ohlc = [],

--- a/samples/stock/indicators/custom-regression-aapl/demo.js
+++ b/samples/stock/indicators/custom-regression-aapl/demo.js
@@ -61,7 +61,7 @@ Highcharts.seriesType(
     }
 );
 
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/dema/demo.js
+++ b/samples/stock/indicators/dema/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/dpo/demo.js
+++ b/samples/stock/indicators/dpo/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/ema/demo.js
+++ b/samples/stock/indicators/ema/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/ichimoku-kinko-hyo/demo.js
+++ b/samples/stock/indicators/ichimoku-kinko-hyo/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
     // split the data set into ohlc and volume
     var ohlc = [],

--- a/samples/stock/indicators/ikh-negative-color/demo.js
+++ b/samples/stock/indicators/ikh-negative-color/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
     // split the data set into ohlc and volume
     var ohlc = [],

--- a/samples/stock/indicators/keltner-channels/demo.js
+++ b/samples/stock/indicators/keltner-channels/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/last-price/demo.js
+++ b/samples/stock/indicators/last-price/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/last-visible-price/demo.js
+++ b/samples/stock/indicators/last-visible-price/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/linear-regression-angle/demo.js
+++ b/samples/stock/indicators/linear-regression-angle/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.setOptions({
         yAxis: {

--- a/samples/stock/indicators/linear-regression-intercept/demo.js
+++ b/samples/stock/indicators/linear-regression-intercept/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.setOptions({
         yAxis: {

--- a/samples/stock/indicators/linear-regression-slope/demo.js
+++ b/samples/stock/indicators/linear-regression-slope/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.setOptions({
         yAxis: {

--- a/samples/stock/indicators/linear-regression/demo.js
+++ b/samples/stock/indicators/linear-regression/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
         rangeSelector: {

--- a/samples/stock/indicators/macd-zones/demo.js
+++ b/samples/stock/indicators/macd-zones/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/macd/demo.js
+++ b/samples/stock/indicators/macd/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/mfi/demo.js
+++ b/samples/stock/indicators/mfi/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
     var ohlc = [],
         volume = [];
 

--- a/samples/stock/indicators/momentum/demo.js
+++ b/samples/stock/indicators/momentum/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/natr/demo.js
+++ b/samples/stock/indicators/natr/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
     Highcharts.stockChart('container', {
         rangeSelector: {
             selected: 2

--- a/samples/stock/indicators/pivot-points/demo.js
+++ b/samples/stock/indicators/pivot-points/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/ppo/demo.js
+++ b/samples/stock/indicators/ppo/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/price-channel/demo.js
+++ b/samples/stock/indicators/price-channel/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/price-envelopes/demo.js
+++ b/samples/stock/indicators/price-envelopes/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/psar/demo.js
+++ b/samples/stock/indicators/psar/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/roc/demo.js
+++ b/samples/stock/indicators/roc/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/rsi/demo.js
+++ b/samples/stock/indicators/rsi/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/slow-stochastic/demo.js
+++ b/samples/stock/indicators/slow-stochastic/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/sma/demo.js
+++ b/samples/stock/indicators/sma/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/stochastic/demo.js
+++ b/samples/stock/indicators/stochastic/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/supertrend/demo.js
+++ b/samples/stock/indicators/supertrend/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/tema/demo.js
+++ b/samples/stock/indicators/tema/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/trendline/demo.js
+++ b/samples/stock/indicators/trendline/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/trix/demo.js
+++ b/samples/stock/indicators/trix/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/use-ohlc-data/demo.js
+++ b/samples/stock/indicators/use-ohlc-data/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/volume-by-price/demo.js
+++ b/samples/stock/indicators/volume-by-price/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
     var ohlc = [],
         volume = [];
 

--- a/samples/stock/indicators/vwap/demo.js
+++ b/samples/stock/indicators/vwap/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
     var ohlc = [],
         volume = [];
 

--- a/samples/stock/indicators/williams-r/demo.js
+++ b/samples/stock/indicators/williams-r/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/wma/demo.js
+++ b/samples/stock/indicators/wma/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/indicators/zigzag/demo.js
+++ b/samples/stock/indicators/zigzag/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/issues/2590/demo.js
+++ b/samples/stock/issues/2590/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     // Create the chart
     Highcharts.stockChart('container', {
 

--- a/samples/stock/issues/622/demo.js
+++ b/samples/stock/issues/622/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
     // split the data set into ohlc and volume
     var ohlc = [],

--- a/samples/stock/members/series-update/demo.js
+++ b/samples/stock/members/series-update/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     // The data point configurations are arrays on the form [x, open, high, low, close].
     // In order to make this understandable for different series types like line, column

--- a/samples/stock/navigator/column/demo.js
+++ b/samples/stock/navigator/column/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-v.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-v.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/plotoptions/linear-regression-xaxisunit/demo.js
+++ b/samples/stock/plotoptions/linear-regression-xaxisunit/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.setOptions({
         yAxis: {

--- a/samples/stock/plotoptions/series-comparetomain/demo.js
+++ b/samples/stock/plotoptions/series-comparetomain/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     // Create the chart
     Highcharts.stockChart('container', {
 

--- a/samples/stock/rangeselector/button-click/demo.js
+++ b/samples/stock/rangeselector/button-click/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     // Create the chart
     Highcharts.stockChart('container', {
         rangeSelector: {

--- a/samples/stock/rangeselector/datagrouping/demo.js
+++ b/samples/stock/rangeselector/datagrouping/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     // Create the chart
     Highcharts.stockChart('container', {
 

--- a/samples/stock/rangeselector/floating/demo.js
+++ b/samples/stock/rangeselector/floating/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     // Create the chart
     Highcharts.stockChart('container', {
 

--- a/samples/stock/rangeselector/input-datepicker/demo.js
+++ b/samples/stock/rangeselector/input-datepicker/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     // Create the chart
     Highcharts.stockChart('container', {
 

--- a/samples/stock/rangeselector/min-max-offsets/demo.js
+++ b/samples/stock/rangeselector/min-max-offsets/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     // Create the chart
     Highcharts.stockChart('container', {
 

--- a/samples/stock/rangeselector/preserve-datagrouping/demo.js
+++ b/samples/stock/rangeselector/preserve-datagrouping/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     // Create the chart
     Highcharts.stockChart('container', {
 

--- a/samples/stock/scrollbar/liveredraw/demo.js
+++ b/samples/stock/scrollbar/liveredraw/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     // create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/stocktools/advanced-stock-chart/demo.js
+++ b/samples/stock/stocktools/advanced-stock-chart/demo.js
@@ -2584,7 +2584,7 @@ window.onload = function () {
         highchartsReset.addEventListener('click', function () {
             if (confirm('Are you sure you want to clear the chart?')) {
                 Highcharts.ajax({
-                    url: 'https://www.highcharts.com/samples/data/aapl-ohlc.json',
+                    url: 'https://demo-live-data.highcharts.com/aapl-ohlc.json',
                     dataType: 'text',
                     success: function (data) {
                         var chart = Highcharts.getChartById('container-inner');
@@ -2641,7 +2641,7 @@ window.onload = function () {
         );
     } else {
         Highcharts.ajax({
-            url: 'https://www.highcharts.com/samples/data/aapl-ohlc.json',
+            url: 'https://demo-live-data.highcharts.com/aapl-ohlc.json',
             dataType: 'text',
             success: function (data) {
                 data = data.replace(/\/\*.*\*\//g, '');

--- a/samples/stock/stocktools/basic-gui/demo.js
+++ b/samples/stock/stocktools/basic-gui/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     // Create the chart
     Highcharts.stockChart('container', {
         navigation: {

--- a/samples/stock/stocktools/custom-popup/demo.js
+++ b/samples/stock/stocktools/custom-popup/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     // Create the chart
     Highcharts.stockChart('container', {
         chart: {

--- a/samples/stock/stocktools/navigation-annotation-options/demo.js
+++ b/samples/stock/stocktools/navigation-annotation-options/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
     // split the data set into ohlc and volume
     var ohlc = [],

--- a/samples/stock/stocktools/stocktools-thresholds/demo.js
+++ b/samples/stock/stocktools/stocktools-thresholds/demo.js
@@ -13,7 +13,7 @@ Highcharts.setOptions({
     }
 });
 
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
     // split the data set into ohlc and volume
     var ohlc = [],

--- a/samples/stock/tooltip/split-positioner/demo.js
+++ b/samples/stock/tooltip/split-positioner/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/xaxis/crosshair-label/demo.js
+++ b/samples/stock/xaxis/crosshair-label/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     // Create the chart
     Highcharts.stockChart('container', {
 

--- a/samples/stock/xaxis/offset/demo.js
+++ b/samples/stock/xaxis/offset/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
     // Create the chart
     Highcharts.stockChart('container', {
 

--- a/samples/stock/xaxis/ordinal-false/demo.js
+++ b/samples/stock/xaxis/ordinal-false/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
 
     // Create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/xaxis/ordinal-true/demo.js
+++ b/samples/stock/xaxis/ordinal-true/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-c.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
 
     // Create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/yaxis/multiple-resizers/demo.js
+++ b/samples/stock/yaxis/multiple-resizers/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/yaxis/resize-min-max-length/demo.js
+++ b/samples/stock/yaxis/resize-min-max-length/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
     // split the data set into ohlc and volume
     var ohlc = [],

--- a/samples/stock/yaxis/resize-multiple-axes/demo.js
+++ b/samples/stock/yaxis/resize-multiple-axes/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlc.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlc.json', function (data) {
 
     Highcharts.stockChart('container', {
 

--- a/samples/stock/yaxis/styled-resizer/demo.js
+++ b/samples/stock/yaxis/styled-resizer/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://www.highcharts.com/samples/data/aapl-ohlcv.json', function (data) {
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', function (data) {
 
     // split the data set into ohlc and volume
     var ohlc = [],

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -77,7 +77,7 @@ function getHTML(path) {
  *         JavaScript extended with the sample data.
  */
 function resolveJSON(js) {
-    const regex = /(\$|Highcharts)\.getJSON\([ \n]*'([^']+)/g;
+    const regex = /(?:(\$|Highcharts)\.getJSON|fetch)\([ \n]*'([^']+)/g;
     let match;
     const codeblocks = [];
 
@@ -86,7 +86,7 @@ function resolveJSON(js) {
 
         let innerMatch = src.match(
             /^(https:\/\/cdn.jsdelivr.net\/gh\/highcharts\/highcharts@[a-z0-9\.]+|https:\/\/www.highcharts.com)\/samples\/data\/([a-z0-9\-\.]+$)/
-        );
+        ) || src.match(/^(https:\/\/demo-live-data.highcharts.com)\/([a-z0-9\-\.]+$)/);
 
         if (innerMatch) {
 


### PR DESCRIPTION
Changed datasets for samples/demos using dynamically updated files in `samples/data/`. These are now served from [demo-live-data.highcharts.com](https://demo-live-data.highcharts.com). Changed the dataset and alternate CORS proxy for the `combo-meteogram` demo.

Also added support for fetch and the new subdomain in the `resolveJSON` function in `karma-conf`.