### PR TITLE
bugfix/13742-dataLabels-allowoverlap-not-working

### DIFF
--- a/js/modules/overlapping-datalabels.src.js
+++ b/js/modules/overlapping-datalabels.src.js
@@ -166,7 +166,6 @@ Chart.prototype.hideOverlappingLabels = function (labels) {
                             label.css({ pointerEvents: newOpacity ? 'auto' : 'none' });
                         }
                         label.visibility = newOpacity ? 'inherit' : 'hidden';
-                        label.placed = !!newOpacity;
                     };
                     isLabelAffected = true;
                     // Animate or set the opacity

--- a/ts/modules/overlapping-datalabels.src.ts
+++ b/ts/modules/overlapping-datalabels.src.ts
@@ -276,7 +276,6 @@ Chart.prototype.hideOverlappingLabels = function (
                             label.css({ pointerEvents: newOpacity ? 'auto' : 'none' });
                         }
                         label.visibility = newOpacity ? 'inherit' : 'hidden';
-                        label.placed = !!newOpacity;
                     };
 
                     isLabelAffected = true;


### PR DESCRIPTION
Fixed #13742, data labels were overlapping after chart redraw.