### PR TITLE
13726/export-datalabel-img

### DIFF
--- a/js/modules/exporting.src.js
+++ b/js/modules/exporting.src.js
@@ -990,7 +990,8 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                     'width="' + options.chart.width + '" ' +
                     'height="' + options.chart.height + '">' +
                     '<body xmlns="http://www.w3.org/1999/xhtml">' +
-                    html +
+                    // Some tags needs to be closed in xhtml (#13726)
+                    html.replace(/(<(?:img|br).*?(?=\>))>/g, '$1 />') +
                     '</body>' +
                     '</foreignObject>';
                 svg = svg.replace('</svg>', html + '</svg>');

--- a/samples/unit-tests/exporting/getsvg/demo.js
+++ b/samples/unit-tests/exporting/getsvg/demo.js
@@ -147,3 +147,49 @@ QUnit.test('Hide label with useHTML', function (assert) {
     );
 
 });
+
+QUnit.test('getSVGForExport XHTML', function (assert) {
+    var chart = Highcharts.chart('container', {
+
+        chart: {
+            type: 'bar'
+        },
+        exporting: {
+            enabled: true,
+            allowHTML: true
+        },
+
+        plotOptions: {
+            series: {
+                dataLabels: {
+                    enabled: true,
+                    useHTML: true,
+                    format: '<img width="20" height="20" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iNjRweCIgaGVpZ2h0PSI2NHB4IiB2aWV3Qm94PSIwIDAgNjQgNjQiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8IS0tIEdlbmVyYXRvcjogU2tldGNoIDU5LjEgKDg2MTQ0KSAtIGh0dHBzOi8vc2tldGNoLmNvbSAtLT4KICAgIDx0aXRsZT5wZXJzb25hbGludGVyZXN0cy1hcnRlbnRodXNpYXN0PC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGcgaWQ9IkRBU0hCT0FSRFMtLS1hdWRpZW5jZXMiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxnIGlkPSJEZXNrdG9wLUhELUNvcHktMiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTQzNy4wMDAwMDAsIC0xOTUuMDAwMDAwKSI+CiAgICAgICAgICAgIDxnIGlkPSJwZXJzb25hbGludGVyZXN0cy1hcnRlbnRodXNpYXN0IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSg0MzcuMDAwMDAwLCAxOTUuMDAwMDAwKSI+CiAgICAgICAgICAgICAgICA8Y2lyY2xlIGlkPSJPdmFsLUNvcHktNyIgZmlsbD0iI0VEQzdERSIgY3g9IjMyIiBjeT0iMzIiIHI9IjMyIj48L2NpcmNsZT4KICAgICAgICAgICAgICAgIDxnIGlkPSJHcm91cCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTQuMDAwMDAwLCAxMy4wMDAwMDApIj4KICAgICAgICAgICAgICAgICAgICA8cGF0aCBkPSJNMTMuNDQyMDgxMiwyLjQ4Njg5OTU4ZS0xNCBDMTkuMTg5MTM4OSwyLjQ4Njg5OTU4ZS0xNCAyNi43MzE0MjM1LDQuMDI1MzM3NyAyOS42MjE3NzU1LDEyLjEyMTkzNzYgQzI2LjkzOTU0MSwxNC42NDA2NDggMjMuNzM3MTQwMSwxNy44NzU0MDY0IDIwLjAxNDQ2MzYsMjEuODI2OTA0NSBDMTguODc0MTE3OCwyMS45MDgxNjI0IDE3LjY1NzY1ODksMjIuMjUxMDk4NCAxNi4zNjUwODcyLDIyLjg1NTcxMjYgQzE0LjU1NTQ4NjcsMjMuNzAyMTcyMyAxNC40MzQ4NDY3LDI2LjYwMTU4NjUgMTQuNDI2ODA0LDI3LjQwMzAxNzMgTDE0LjQyNjIyOTUsMjcuNTQxMTI3NyBDMTQuNDI2MjI5NSwzMC4wMzc2MjU2IDExLjI5NjExMzYsMjguOTUxMjkzOSAxMS4yOTYxMTM2LDMwLjMwMzU1MzYgQzExLjI5NjExMzYsMzEuNjU1ODEzNCAxNi4yMDAxMzc5LDMyLjEzMTIzODEgMTkuMDM1MzI1NywzMS40OTczNTQgQzIwLjkyNTQ1MDksMzEuMDc0NzY0NyAyMi41MjM3MjM1LDI5LjEwOTIzMDEgMjMuODMwMTQzNCwyNS42MDA3NTAyIEMyNi40ODU0NTk3LDIzLjAyNTEzMDYgMjguODExNjQ4NCwyMC42OTU3OTY1IDMwLjgwODcwOTYsMTguNjEyNzQ3OCBDMzAuODE1OTUyNCwxOC44NTYzMjIyIDMwLjgxOTY3MjEsMTkuMTAxODMyMSAzMC44MTk2NzIxLDE5LjM0OTczNTQgQzMwLjgxOTY3MjEsMzIuMjgwMzg1OSAyMC4yMTc3ODIsMzYuNDcwMzMwNSAxMy40NDIwODEyLDM2LjQ3MDMzMDUgQzYuNjY2MzgwNDcsMzYuNDcwMzMwNSAwLDMzLjMxNzYzMjMgMCwyNy40Mjk0NzkyIEMwLDIxLjU0MTMyNiA1LjA0MzY0NTM3LDI0LjMyNzQ4MzggNS4wNDM2NDUzNywxNy43ODE4MDU5IEM1LjA0MzY0NTM3LDExLjIzNjEyOCAwLDE0LjgwNjIxMDIgMCw4LjEzNjI5NjYyIEMwLDEuNDY2MzgzIDYuMTg0NjgyOTYsMi40ODY4OTk1OGUtMTQgMTMuNDQyMDgxMiwyLjQ4Njg5OTU4ZS0xNCBaIiBpZD0iQ29tYmluZWQtU2hhcGUiIHN0cm9rZT0iI0ZGRkZGRiIgc3Ryb2tlLXdpZHRoPSIyIj48L3BhdGg+CiAgICAgICAgICAgICAgICAgICAgPHBhdGggZD0iTTIwLjAxNDQ2MzYsMjEuODI2OTA0NSBDMzEuNTUzMTI5LDkuNTc4OTkyMzcgMzguMDkzMzU5OCw0LjIxNzAwMTYyIDM5LjYzNTE1NjEsNS43NDA5MzIyMSBDNDEuMTc2OTUyMyw3LjI2NDg2MjggMzUuOTA4NjE0OCwxMy44ODQ4MDIxIDIzLjgzMDE0MzQsMjUuNjAwNzUwMiBDMjIuNTIzNzIzNSwyOS4xMDkyMzAxIDIwLjkyNTQ1MDksMzEuMDc0NzY0NyAxOS4wMzUzMjU3LDMxLjQ5NzM1NCBDMTYuMjAwMTM3OSwzMi4xMzEyMzgxIDExLjI5NjExMzYsMzEuNjU1ODEzNCAxMS4yOTYxMTM2LDMwLjMwMzU1MzYgQzExLjI5NjExMzYsMjguOTUxMjkzOSAxNC40MjYyMjk1LDMwLjAzNzYyNTYgMTQuNDI2MjI5NSwyNy41NDExMjc3IEMxNC40MjYyMjk1LDI3LjAyNjI2MjggMTQuNDI2MjI5NSwyMy43NjI2MzM3IDE2LjM2NTA4NzIsMjIuODU1NzEyNiBDMTcuNjU3NjU4OSwyMi4yNTEwOTg0IDE4Ljg3NDExNzgsMjEuOTA4MTYyNCAyMC4wMTQ0NjM2LDIxLjgyNjkwNDUgWiIgaWQ9IlJlY3RhbmdsZSIgc3Ryb2tlPSIjRkZGRkZGIiBzdHJva2Utd2lkdGg9IjIiPjwvcGF0aD4KICAgICAgICAgICAgICAgICAgICA8Y2lyY2xlIGlkPSJPdmFsIiBmaWxsPSIjRkZGRkZGIiBjeD0iNy4yMTMxMTQ3NSIgY3k9IjEwLjI0MDgyMjMiIHI9IjIuNjIyOTUwODIiPjwvY2lyY2xlPgogICAgICAgICAgICAgICAgICAgIDxjaXJjbGUgaWQ9Ik92YWwtQ29weS0zIiBmaWxsPSIjRkZGRkZGIiBjeD0iNy44Njg4NTI0NiIgY3k9IjI2LjYzNDI2NDkiIHI9IjIuNjIyOTUwODIiPjwvY2lyY2xlPgogICAgICAgICAgICAgICAgICAgIDxjaXJjbGUgaWQ9Ik92YWwtQ29weSIgZmlsbD0iI0ZGRkZGRiIgY3g9IjE1LjczNzcwNDkiIGN5PSI3LjYxNzg3MTUiIHI9IjIuNjIyOTUwODIiPjwvY2lyY2xlPgogICAgICAgICAgICAgICAgICAgIDxjaXJjbGUgaWQ9Ik92YWwtQ29weS0yIiBmaWxsPSIjRkZGRkZGIiBjeD0iMjIuOTUwODE5NyIgY3k9IjEyLjIwODAzNTQiIHI9IjIuNjIyOTUwODIiPjwvY2lyY2xlPgogICAgICAgICAgICAgICAgPC9nPgogICAgICAgICAgICA8L2c+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4=" /><br>Draw',
+                    style: {
+                        color: "blue",
+                        fontSize: "13px"
+                    }
+                }
+            }
+        },
+
+        series: [{
+            data: [1, 2, 3, 4]
+        }]
+
+    });
+
+    const svg = chart.getSVGForExport();
+
+    assert.strictEqual(
+        (svg.match(/<img.*?(?=\/>)/gm) || []).length,
+        chart.series[0].data.length,
+        'Should export one self-closing <img /> for each point'
+    );
+    assert.strictEqual(
+        (svg.match(/<br \/>/gm) || []).length,
+        chart.series[0].data.length,
+        'Should export one self-closing <br /> for each point'
+    );
+
+});

--- a/ts/modules/exporting.src.ts
+++ b/ts/modules/exporting.src.ts
@@ -1323,7 +1323,8 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                             'width="' + (options.chart as any).width + '" ' +
                             'height="' + (options.chart as any).height + '">' +
                     '<body xmlns="http://www.w3.org/1999/xhtml">' +
-                    html +
+                    // Some tags needs to be closed in xhtml (#13726)
+                    html.replace(/(<(?:img|br).*?(?=\>))>/g, '$1 />') +
                     '</body>' +
                     '</foreignObject>';
                 svg = svg.replace('</svg>', html + '</svg>');


### PR DESCRIPTION
Fixed #13726, `img` and `br` tags in data labels not being proper XHTML on SVG export.

* Without fix: https://jsfiddle.net/BlackLabel/8rwjmkx4/ (export as SVG)
* With fix: https://jsfiddle.net/goransle/cdwj4mxL/