### PR TITLE
bugfix/13710-pie-drawempty-regression

### DIFF
--- a/js/parts/PieSeries.js
+++ b/js/parts/PieSeries.js
@@ -9,6 +9,7 @@
  * */
 'use strict';
 import H from './Globals.js';
+import SVGRenderer from './SVGRenderer.js';
 import LegendSymbolMixin from '../mixins/legend-symbol.js';
 import Point from './Point.js';
 import U from './Utilities.js';
@@ -786,7 +787,7 @@ seriesType('pie', 'line',
                     .add(this.group);
             }
             this.graph.attr({
-                d: H.SVGRenderer.prototype.symbols.arc(centerX, centerY, this.center[2] / 2, 0, {
+                d: SVGRenderer.prototype.symbols.arc(centerX, centerY, this.center[2] / 2, 0, {
                     start: start,
                     end: end,
                     innerR: this.center[3] / 2

--- a/js/parts/PieSeries.js
+++ b/js/parts/PieSeries.js
@@ -786,7 +786,7 @@ seriesType('pie', 'line',
                     .add(this.group);
             }
             this.graph.attr({
-                d: Highcharts.SVGRenderer.prototype.symbols.arc(centerX, centerY, this.center[2] / 2, 0, {
+                d: H.SVGRenderer.prototype.symbols.arc(centerX, centerY, this.center[2] / 2, 0, {
                     start: start,
                     end: end,
                     innerR: this.center[3] / 2

--- a/ts/parts/PieSeries.ts
+++ b/ts/parts/PieSeries.ts
@@ -12,6 +12,7 @@
 
 import type SVGPath from '../parts/SVGPath';
 import H from './Globals.js';
+import SVGRenderer from './SVGRenderer.js';
 
 /**
  * Internal types
@@ -1069,7 +1070,7 @@ seriesType<Highcharts.PieSeries>(
                 }
 
                 this.graph.attr({
-                    d: H.SVGRenderer.prototype.symbols.arc(
+                    d: SVGRenderer.prototype.symbols.arc(
                         centerX,
                         centerY,
                         this.center[2] / 2,

--- a/ts/parts/PieSeries.ts
+++ b/ts/parts/PieSeries.ts
@@ -1069,7 +1069,7 @@ seriesType<Highcharts.PieSeries>(
                 }
 
                 this.graph.attr({
-                    d: Highcharts.SVGRenderer.prototype.symbols.arc(
+                    d: H.SVGRenderer.prototype.symbols.arc(
                         centerX,
                         centerY,
                         this.center[2] / 2,


### PR DESCRIPTION
Fixed #13710, a regression causing errors on empty pie series.

Seems this one snuck out from the fix in 8.12.

With fix: https://codesandbox.io/s/highcharts-vue-demo-b37nm?file=/src/main.js
Without fix: https://codesandbox.io/s/highcharts-vue-demo-ye65e