### PR TITLE
bugfix/13302-marker-clusters-custom-symbol

### DIFF
--- a/js/modules/marker-clusters.src.js
+++ b/js/modules/marker-clusters.src.js
@@ -577,8 +577,8 @@ Scatter.prototype.animateClusterPoint = function (clusterObj) {
                     y: oldPointObj.point.plotY - offset
                 });
                 newPointObj.point.graphic.animate({
-                    x: newX - newPointObj.point.graphic.radius,
-                    y: newY - newPointObj.point.graphic.radius
+                    x: newX - (newPointObj.point.graphic.radius || 0),
+                    y: newY - (newPointObj.point.graphic.radius || 0)
                 }, animation, function () {
                     isCbHandled = true;
                     // Destroy old point.
@@ -624,8 +624,8 @@ Scatter.prototype.animateClusterPoint = function (clusterObj) {
                         isOldPointGrahic = true;
                         oldPointObj.point.graphic.show();
                         oldPointObj.point.graphic.animate({
-                            x: newX - oldPointObj.point.graphic.radius,
-                            y: newY - oldPointObj.point.graphic.radius,
+                            x: newX - (oldPointObj.point.graphic.radius || 0),
+                            y: newY - (oldPointObj.point.graphic.radius || 0),
                             opacity: 0.4
                         }, animation, function () {
                             isCbHandled = true;
@@ -638,8 +638,8 @@ Scatter.prototype.animateClusterPoint = function (clusterObj) {
                             newPointObj.point.dataLabel.alignAttr) {
                             oldPointObj.point.dataLabel.show();
                             oldPointObj.point.dataLabel.animate({
-                                x: newPointObj.point.dataLabel.alignAttr.x,
-                                y: newPointObj.point.dataLabel.alignAttr.y,
+                                x: newX - (oldPointObj.point.graphic.radius || 0),
+                                y: newY - (oldPointObj.point.graphic.radius || 0),
                                 opacity: 0.4
                             }, animation);
                         }

--- a/js/modules/marker-clusters.src.js
+++ b/js/modules/marker-clusters.src.js
@@ -638,8 +638,8 @@ Scatter.prototype.animateClusterPoint = function (clusterObj) {
                             newPointObj.point.dataLabel.alignAttr) {
                             oldPointObj.point.dataLabel.show();
                             oldPointObj.point.dataLabel.animate({
-                                x: newX - (oldPointObj.point.graphic.radius || 0),
-                                y: newY - (oldPointObj.point.graphic.radius || 0),
+                                x: newPointObj.point.dataLabel.alignAttr.x,
+                                y: newPointObj.point.dataLabel.alignAttr.y,
                                 opacity: 0.4
                             }, animation);
                         }

--- a/samples/unit-tests/series/marker-clusters/demo.js
+++ b/samples/unit-tests/series/marker-clusters/demo.js
@@ -379,9 +379,17 @@ QUnit.test('General marker-clusters', function (assert) {
                     point = chart.series[0].points[0];
                     graphicBBox = point.graphic.getBBox();
 
-                    assert.deepEqual(
-                        [point.plotX.toFixed(2), point.plotY.toFixed(2)],
-                        [graphicBBox.x.toFixed(2), graphicBBox.y.toFixed(2)],
+                    result = true;
+
+                    if (
+                        Math.abs(point.plotX - graphicBBox.x) > 1 &&
+                        Math.abs(point.plotY - graphicBBox.y) > 1
+                    ) {
+                        result = false;
+                    }
+
+                    assert.ok(
+                        result,
                         'Points with image marker symbol should be displayed ' +
                             'correctly after the zoom (#13302).'
                     );

--- a/samples/unit-tests/series/marker-clusters/demo.js
+++ b/samples/unit-tests/series/marker-clusters/demo.js
@@ -359,6 +359,66 @@ QUnit.test('General marker-clusters', function (assert) {
         resultVisibility,
         'Parent point should be hidden before animation.'
     );
+
+    // (#13302)
+    var done = assert.async(),
+        url = location.host.substr(0, 12) === 'localhost:98' ?
+            'url(base/test/testimage.png)' : // karma
+            'url(testimage.png)'; // utils
+
+    chart = Highcharts.chart('container', {
+        chart: {
+            events: {
+                load: function () {
+                    var chart = this,
+                        point,
+                        graphicBBox;
+
+                    chart.xAxis[0].setExtremes(49, 52);
+
+                    point = chart.series[0].points[0];
+                    graphicBBox = point.graphic.getBBox();
+
+                    assert.deepEqual(
+                        [point.plotX.toFixed(2), point.plotY.toFixed(2)],
+                        [graphicBBox.x.toFixed(2), graphicBBox.y.toFixed(2)],
+                        'Points with image marker symbol should be displayed ' +
+                            'correctly after the zoom (#13302).'
+                    );
+
+                    done();
+                }
+            }
+        },
+        plotOptions: {
+            series: {
+                cluster: {
+                    enabled: true
+                }
+            }
+        },
+        series: [{
+            type: 'scatter',
+            marker: {
+                symbol: url.replace(')', '?' + Date.now() + ')')
+            },
+            animation: {
+                duration: 0
+            },
+            cluster: {
+                animation: {
+                    duration: 0
+                }
+            },
+            data: [
+                [0, 0],
+                [50, 50],
+                [55, 53],
+                [52, 51],
+                [100, 100]
+            ]
+        }]
+    });
 });
 
 QUnit.test('Grid algorithm tests.', function (assert) {

--- a/ts/modules/marker-clusters.src.ts
+++ b/ts/modules/marker-clusters.src.ts
@@ -1012,8 +1012,8 @@ Scatter.prototype.animateClusterPoint = function (
                         ) {
                             oldPointObj.point.dataLabel.show();
                             oldPointObj.point.dataLabel.animate({
-                                x: newX - (oldPointObj.point.graphic.radius || 0),
-                                y: newY - (oldPointObj.point.graphic.radius || 0),
+                                x: newPointObj.point.dataLabel.alignAttr.x,
+                                y: newPointObj.point.dataLabel.alignAttr.y,
                                 opacity: 0.4
                             }, animation);
                         }

--- a/ts/modules/marker-clusters.src.ts
+++ b/ts/modules/marker-clusters.src.ts
@@ -936,8 +936,8 @@ Scatter.prototype.animateClusterPoint = function (
                 });
 
                 newPointObj.point.graphic.animate({
-                    x: newX - newPointObj.point.graphic.radius,
-                    y: newY - newPointObj.point.graphic.radius
+                    x: newX - (newPointObj.point.graphic.radius || 0),
+                    y: newY - (newPointObj.point.graphic.radius || 0)
                 }, animation, function (): void {
                     isCbHandled = true;
 
@@ -993,8 +993,8 @@ Scatter.prototype.animateClusterPoint = function (
                         isOldPointGrahic = true;
                         oldPointObj.point.graphic.show();
                         oldPointObj.point.graphic.animate({
-                            x: newX - oldPointObj.point.graphic.radius,
-                            y: newY - oldPointObj.point.graphic.radius,
+                            x: newX - (oldPointObj.point.graphic.radius || 0),
+                            y: newY - (oldPointObj.point.graphic.radius || 0),
                             opacity: 0.4
                         }, animation, function (): void {
                             isCbHandled = true;
@@ -1012,8 +1012,8 @@ Scatter.prototype.animateClusterPoint = function (
                         ) {
                             oldPointObj.point.dataLabel.show();
                             oldPointObj.point.dataLabel.animate({
-                                x: newPointObj.point.dataLabel.alignAttr.x,
-                                y: newPointObj.point.dataLabel.alignAttr.y,
+                                x: newX - (oldPointObj.point.graphic.radius || 0),
+                                y: newY - (oldPointObj.point.graphic.radius || 0),
                                 opacity: 0.4
                             }, animation);
                         }


### PR DESCRIPTION
Fixed #13302, marker cluster image symbol not displayed after the zoom.