### PR TITLE
bugfix/13737-draggable-container-zoom

### DIFF
--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -802,6 +802,7 @@ var Pointer = /** @class */ (function () {
      * @param {global.MouseEvent} e
      */
     Pointer.prototype.onContainerMouseDown = function (e) {
+        var isPrimaryButton = ((e.buttons || e.button) & 1) === 1;
         // Normalize before the 'if' for the legacy IE (#7850)
         e = this.normalize(e);
         // #11635, Firefox does not reliable fire move event after click scroll
@@ -811,8 +812,13 @@ var Pointer = /** @class */ (function () {
         }
         // #11635, limiting to primary button (incl. IE 8 support)
         if (typeof e.button === 'undefined' ||
-            ((e.buttons || e.button) & 1) === 1) {
+            isPrimaryButton) {
             this.zoomOption(e);
+            // #295, #13737 solve conflict between container drag and chart zoom
+            if (isPrimaryButton &&
+                e.preventDefault) {
+                e.preventDefault();
+            }
             this.dragStart(e);
         }
     };

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -1178,6 +1178,8 @@ class Pointer {
      * @param {global.MouseEvent} e
      */
     public onContainerMouseDown(e: MouseEvent): void {
+        const isPrimaryButton = ((e.buttons || e.button) & 1) === 1;
+
         // Normalize before the 'if' for the legacy IE (#7850)
         e = this.normalize(e);
 
@@ -1192,9 +1194,18 @@ class Pointer {
         // #11635, limiting to primary button (incl. IE 8 support)
         if (
             typeof e.button === 'undefined' ||
-            ((e.buttons || e.button) & 1) === 1
+            isPrimaryButton
         ) {
             this.zoomOption(e);
+
+            // #295, #13737 solve conflict between container drag and chart zoom
+            if (
+                isPrimaryButton &&
+                e.preventDefault
+            ) {
+                e.preventDefault();
+            }
+
             this.dragStart(e as Highcharts.PointerEventObject);
         }
     }


### PR DESCRIPTION
Fixed #13737, a regression causing chart zoom to conflict with the browser's drag-and-drop behaviour.

~~Fixed #13737, zoom glitch in draggable container.~~