### PR TITLE
docs/fix-13652-13793

### DIFF
--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -1477,6 +1477,7 @@ var Axis = /** @class */ (function () {
     /**
      * Now we have computed the normalized tickInterval, get the tick positions.
      *
+     * @private
      * @function Highcharts.Axis#setTickPositions
      *
      * @fires Highcharts.Axis#event:afterSetTickPositions

--- a/js/parts/Axis.js
+++ b/js/parts/Axis.js
@@ -1475,7 +1475,7 @@ var Axis = /** @class */ (function () {
         this.setTickPositions();
     };
     /**
-     * Now we have computed the normalized tickInterval, get the tick positions
+     * Now we have computed the normalized tickInterval, get the tick positions.
      *
      * @function Highcharts.Axis#setTickPositions
      *
@@ -3936,17 +3936,17 @@ var Axis = /** @class */ (function () {
              * @apioption xAxis.labels.useHTML
              */
             /**
-             * The x position offset of the label relative to the tick position
-             * on the axis.
+             * The x position offset of all labels relative to the tick
+             * positions on the axis.
              *
              * @sample {highcharts} highcharts/xaxis/labels-x/
              *         Y axis labels placed on grid lines
              */
             x: 0,
             /**
-             * The y position offset of the label relative to the tick position
-             * on the axis. The default makes it adapt to the font size on
-             * bottom axis.
+             * The y position offset of all labels relative to the tick
+             * positions on the axis. The default makes it adapt to the font
+             * size of the bottom axis.
              *
              * @sample {highcharts} highcharts/xaxis/labels-x/
              *         Y axis labels placed on grid lines
@@ -5219,7 +5219,7 @@ var Axis = /** @class */ (function () {
          * @sample {highcharts} highcharts/demo/gauge-solid/
          *         True by default
          *
-         * @type      {Array<Highcharts.GradientColorStopObject>}
+         * @type      {Array<Array<number,Highcharts.ColorType>>}
          * @since     4.0
          * @product   highcharts
          * @apioption yAxis.stops
@@ -5234,35 +5234,6 @@ var Axis = /** @class */ (function () {
          * @default   0
          * @product   highcharts highstock gantt
          * @apioption yAxis.tickWidth
-         */
-        /**
-         * Angular gauges and solid gauges only.
-         * The label's pixel distance from the perimeter of the plot area.
-         *
-         * Since v7.1.2: If it's a percentage string, it is interpreted the
-         * same as [series.radius](#plotOptions.gauge.radius), so label can be
-         * aligned under the gauge's shape.
-         *
-         * @sample {highcharts} highcharts/yaxis/labels-distance/
-         *                      Labels centered under the arc
-         *
-         * @type      {number|string}
-         * @default   -25
-         * @product   highcharts
-         * @apioption yAxis.labels.distance
-         */
-        /**
-         * The y position offset of the label relative to the tick position
-         * on the axis.
-         *
-         * @sample {highcharts} highcharts/xaxis/labels-x/
-         *         Y axis labels placed on grid lines
-         *
-         * @type      {number}
-         * @default   {highcharts} 3
-         * @default   {highstock} -2
-         * @default   {highmaps} 3
-         * @apioption yAxis.labels.y
          */
         /**
          * Whether to force the axis to end on a tick. Use this option with
@@ -5353,6 +5324,36 @@ var Axis = /** @class */ (function () {
          */
         labels: {
             /**
+             * Angular gauges and solid gauges only.
+             * The label's pixel distance from the perimeter of the plot area.
+             *
+             * Since v7.1.2: If it's a percentage string, it is interpreted the
+             * same as [series.radius](#plotOptions.gauge.radius), so label can be
+             * aligned under the gauge's shape.
+             *
+             * @sample {highcharts} highcharts/yaxis/labels-distance/
+             *         Labels centered under the arc
+             *
+             * @type      {number|string}
+             * @default   -25
+             * @product   highcharts
+             * @apioption yAxis.labels.distance
+             */
+            /**
+             * The y position offset of all labels relative to the tick
+             * positions on the axis. For polar and radial axis consider the use
+             * of the [distance](#yAxis.labels.distance) option.
+             *
+             * @sample {highcharts} highcharts/xaxis/labels-x/
+             *         Y axis labels placed on grid lines
+             *
+             * @type      {number}
+             * @default   {highcharts} 3
+             * @default   {highstock} -2
+             * @default   {highmaps} 3
+             * @apioption yAxis.labels.y
+             */
+            /**
              * What part of the string the given position is anchored to. Can
              * be one of `"left"`, `"center"` or `"right"`. The exact position
              * also depends on the `labels.x` setting.
@@ -5374,8 +5375,9 @@ var Axis = /** @class */ (function () {
              * @apioption  yAxis.labels.align
              */
             /**
-             * The x position offset of the label relative to the tick position
-             * on the axis. Defaults to -15 for left axis, 15 for right axis.
+             * The x position offset of all labels relative to the tick
+             * positions on the axis. Defaults to -15 for left axis, 15 for
+             * right axis.
              *
              * @sample {highcharts} highcharts/xaxis/labels-x/
              *         Y axis labels placed on grid lines

--- a/js/parts/Globals.js
+++ b/js/parts/Globals.js
@@ -51,6 +51,14 @@ var H = {
     marginNames: ['plotTop', 'marginRight', 'marginBottom', 'plotLeft'],
     noop: function () { },
     /**
+     * Theme options that should get applied to the chart. In module mode it
+     * might not be possible to change this property because of read-only
+     * restrictions, instead use {@link Highcharts.setOptions}.
+     *
+     * @name Highcharts.theme
+     * @type {Highcharts.Options}
+     */
+    /**
      * An array containing the current chart objects in the page. A chart's
      * position in the array is preserved throughout the page's lifetime. When
      * a chart is destroyed, the array item becomes `undefined`.

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@ without any bundling tools by using `<script type="module">` ([demo](https://jsf
 ```html
 <script type="module">
     import Highcharts from 'https://code.highcharts.com/es-modules/masters/highcharts.src.js';
+    import 'https://code.highcharts.com/es-modules/masters/modules/accessibility.src.js';
 
     Highcharts.chart('container', {
         ...

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -1713,8 +1713,8 @@ class Axis implements AxisComposition, AxisLike {
              */
 
             /**
-             * The x position offset of the label relative to the tick position
-             * on the axis.
+             * The x position offset of all labels relative to the tick
+             * positions on the axis.
              *
              * @sample {highcharts} highcharts/xaxis/labels-x/
              *         Y axis labels placed on grid lines
@@ -1722,9 +1722,9 @@ class Axis implements AxisComposition, AxisLike {
             x: 0,
 
             /**
-             * The y position offset of the label relative to the tick position
-             * on the axis. The default makes it adapt to the font size on
-             * bottom axis.
+             * The y position offset of all labels relative to the tick
+             * positions on the axis. The default makes it adapt to the font
+             * size of the bottom axis.
              *
              * @sample {highcharts} highcharts/xaxis/labels-x/
              *         Y axis labels placed on grid lines
@@ -3080,7 +3080,7 @@ class Axis implements AxisComposition, AxisLike {
          * @sample {highcharts} highcharts/demo/gauge-solid/
          *         True by default
          *
-         * @type      {Array<Highcharts.GradientColorStopObject>}
+         * @type      {Array<Array<number,Highcharts.ColorType>>}
          * @since     4.0
          * @product   highcharts
          * @apioption yAxis.stops
@@ -3096,37 +3096,6 @@ class Axis implements AxisComposition, AxisLike {
          * @default   0
          * @product   highcharts highstock gantt
          * @apioption yAxis.tickWidth
-         */
-
-        /**
-         * Angular gauges and solid gauges only.
-         * The label's pixel distance from the perimeter of the plot area.
-         *
-         * Since v7.1.2: If it's a percentage string, it is interpreted the
-         * same as [series.radius](#plotOptions.gauge.radius), so label can be
-         * aligned under the gauge's shape.
-         *
-         * @sample {highcharts} highcharts/yaxis/labels-distance/
-         *                      Labels centered under the arc
-         *
-         * @type      {number|string}
-         * @default   -25
-         * @product   highcharts
-         * @apioption yAxis.labels.distance
-         */
-
-        /**
-         * The y position offset of the label relative to the tick position
-         * on the axis.
-         *
-         * @sample {highcharts} highcharts/xaxis/labels-x/
-         *         Y axis labels placed on grid lines
-         *
-         * @type      {number}
-         * @default   {highcharts} 3
-         * @default   {highstock} -2
-         * @default   {highmaps} 3
-         * @apioption yAxis.labels.y
          */
 
         /**
@@ -3224,6 +3193,38 @@ class Axis implements AxisComposition, AxisLike {
          */
         labels: {
             /**
+             * Angular gauges and solid gauges only.
+             * The label's pixel distance from the perimeter of the plot area.
+             *
+             * Since v7.1.2: If it's a percentage string, it is interpreted the
+             * same as [series.radius](#plotOptions.gauge.radius), so label can be
+             * aligned under the gauge's shape.
+             *
+             * @sample {highcharts} highcharts/yaxis/labels-distance/
+             *         Labels centered under the arc
+             *
+             * @type      {number|string}
+             * @default   -25
+             * @product   highcharts
+             * @apioption yAxis.labels.distance
+             */
+
+            /**
+             * The y position offset of all labels relative to the tick
+             * positions on the axis. For polar and radial axis consider the use
+             * of the [distance](#yAxis.labels.distance) option.
+             *
+             * @sample {highcharts} highcharts/xaxis/labels-x/
+             *         Y axis labels placed on grid lines
+             *
+             * @type      {number}
+             * @default   {highcharts} 3
+             * @default   {highstock} -2
+             * @default   {highmaps} 3
+             * @apioption yAxis.labels.y
+             */
+
+            /**
              * What part of the string the given position is anchored to. Can
              * be one of `"left"`, `"center"` or `"right"`. The exact position
              * also depends on the `labels.x` setting.
@@ -3246,8 +3247,9 @@ class Axis implements AxisComposition, AxisLike {
              */
 
             /**
-             * The x position offset of the label relative to the tick position
-             * on the axis. Defaults to -15 for left axis, 15 for right axis.
+             * The x position offset of all labels relative to the tick
+             * positions on the axis. Defaults to -15 for left axis, 15 for
+             * right axis.
              *
              * @sample {highcharts} highcharts/xaxis/labels-x/
              *         Y axis labels placed on grid lines
@@ -5541,7 +5543,7 @@ class Axis implements AxisComposition, AxisLike {
     }
 
     /**
-     * Now we have computed the normalized tickInterval, get the tick positions
+     * Now we have computed the normalized tickInterval, get the tick positions.
      *
      * @function Highcharts.Axis#setTickPositions
      *

--- a/ts/parts/Axis.ts
+++ b/ts/parts/Axis.ts
@@ -5545,6 +5545,7 @@ class Axis implements AxisComposition, AxisLike {
     /**
      * Now we have computed the normalized tickInterval, get the tick positions.
      *
+     * @private
      * @function Highcharts.Axis#setTickPositions
      *
      * @fires Highcharts.Axis#event:afterSetTickPositions

--- a/ts/parts/Globals.ts
+++ b/ts/parts/Globals.ts
@@ -189,6 +189,16 @@ var H: typeof Highcharts = {
     win: glob,
     marginNames: ['plotTop', 'marginRight', 'marginBottom', 'plotLeft'],
     noop: function (): void {},
+
+    /**
+     * Theme options that should get applied to the chart. In module mode it
+     * might not be possible to change this property because of read-only
+     * restrictions, instead use {@link Highcharts.setOptions}.
+     *
+     * @name Highcharts.theme
+     * @type {Highcharts.Options}
+     */
+
     /**
      * An array containing the current chart objects in the page. A chart's
      * position in the array is preserved throughout the page's lifetime. When


### PR DESCRIPTION
- Fixed #13652, axis color stops with gradients.
- Fixed #13791, improved doclet about axis labels positioning.
- Fixed #13793, added theme doclet with workaround hint.
- Added module pattern to simple ES module example.
- Made Axis.setTickPositions a private function.
