### PR TITLE
bugfix/13771-polar-chart-tooltip-max-value

### DIFF
--- a/js/parts-more/Pane.js
+++ b/js/parts-more/Pane.js
@@ -354,7 +354,7 @@ var Pane = /** @class */ (function () {
  * @return {boolean}
  */
 function isInsidePane(x, y, center) {
-    return Math.sqrt(Math.pow(x - center[0], 2) + Math.pow(y - center[1], 2)) < center[2] / 2;
+    return Math.sqrt(Math.pow(x - center[0], 2) + Math.pow(y - center[1], 2)) <= center[2] / 2;
 }
 H.Chart.prototype.getHoverPane = function (eventArgs) {
     var chart = this;

--- a/samples/unit-tests/pointer/hover/demo.js
+++ b/samples/unit-tests/pointer/hover/demo.js
@@ -161,6 +161,50 @@ QUnit.test('Testing hovering over panes.', function (assert) {
 
 });
 
+QUnit.test('Tooltip should be shown for value equal to max', function (assert) {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            polar: true,
+            type: 'line'
+        },
+
+        yAxis: {
+            gridLineInterpolation: 'polygon',
+            lineWidth: 0,
+            min: 0,
+            max: 100
+        },
+
+        tooltip: {
+            //shared: true
+        },
+
+        series: [{
+            data: [99, 100, 101, 36, 47, 16],
+            pointPlacement: 'on'
+        }]
+    });
+
+    const controller = new TestController(chart);
+
+    const series = chart.series[0];
+    let point = series.points[1];
+    controller.mouseMove(point.plotX, point.plotY);
+    assert.strictEqual(
+        chart.tooltip.isHidden,
+        true,
+        'Tooltip at max + 1 should be hidden'
+    );
+
+    point = series.points[2];
+    controller.mouseMove(point.plotX, point.plotY);
+    assert.strictEqual(
+        chart.tooltip.isHidden,
+        false,
+        'Tooltip at max should be drawn'
+    );
+});
+
 QUnit.test('Hover state when axis is updated (#12569).', function (assert) {
     var chart = Highcharts.chart('container', {
         series: [{

--- a/ts/parts-more/Pane.ts
+++ b/ts/parts-more/Pane.ts
@@ -521,7 +521,7 @@ function isInsidePane(
 ): boolean {
     return Math.sqrt(
         Math.pow(x - center[0], 2) + Math.pow(y - center[1], 2)
-    ) < center[2] / 2;
+    ) <= center[2] / 2;
 }
 
 H.Chart.prototype.getHoverPane = function (


### PR DESCRIPTION
Fixed #13771, polar chart tooltip was hidden when point value was equal to max