### PR TITLE
Sonification improvements

### DIFF
--- a/js/modules/sonification/Earcon.js
+++ b/js/modules/sonification/Earcon.js
@@ -109,11 +109,6 @@ Earcon.prototype.sonify = function (options) {
             H.sonification.instruments[opts.instrument] : opts.instrument, instrumentOpts = merge(opts.playOptions), instrOnEnd, instrumentCopy, copyId = '';
         if (instrument && instrument.play) {
             if (opts.playOptions) {
-                // Handle master pan/volume
-                if (typeof opts.playOptions.volume !== 'function') {
-                    instrumentOpts.volume = pick(masterVolume, 1) *
-                        pick(opts.playOptions.volume, 1);
-                }
                 instrumentOpts.pan = pick(masterPan, instrumentOpts.pan);
                 // Handle onEnd
                 instrOnEnd = instrumentOpts.onEnd;
@@ -134,6 +129,7 @@ Earcon.prototype.sonify = function (options) {
                 // Play the instrument. Use a copy so we can play multiple at
                 // the same time.
                 instrumentCopy = instrument.copy();
+                instrumentCopy.setMasterVolume(masterVolume);
                 copyId = instrumentCopy.id;
                 earcon.instrumentsPlaying[copyId] = instrumentCopy;
                 instrumentCopy.play(instrumentOpts);

--- a/js/modules/sonification/Instrument.js
+++ b/js/modules/sonification/Instrument.js
@@ -29,6 +29,11 @@ var error = U.error, merge = U.merge, pick = U.pick, uniqueKey = U.uniqueKey;
 * @name Highcharts.InstrumentOptionsObject#id
 * @type {string|undefined}
 */ /**
+* The master volume multiplier to apply to the instrument, regardless of other
+* volume changes. Defaults to 1.
+* @name Highcharts.InstrumentPlayOptionsObject#masterVolume
+* @type {number|undefined}
+*/ /**
 * When using functions to determine frequency or other parameters during
 * playback, this options specifies how often to call the callback functions.
 * Number given in milliseconds. Defaults to 20.
@@ -110,6 +115,7 @@ var error = U.error, merge = U.merge, pick = U.pick, uniqueKey = U.uniqueKey;
 var defaultOptions = {
     type: 'oscillator',
     playCallbackInterval: 20,
+    masterVolume: 1,
     oscillator: {
         waveformShape: 'sine'
     }
@@ -142,6 +148,7 @@ Instrument.prototype.init = function (options) {
     }
     this.options = merge(defaultOptions, options);
     this.id = this.options.id = options && options.id || uniqueKey();
+    this.masterVolume = this.options.masterVolume || 0;
     // Init the audio nodes
     var ctx = H.audioContext;
     this.gainNode = ctx.createGain();
@@ -227,7 +234,8 @@ Instrument.prototype.setPan = function (panValue) {
 };
 /**
  * Set gain level. A maximum of 1.2 is allowed before we emit a warning. The
- * actual volume is not set above this level regardless of input.
+ * actual volume is not set above this level regardless of input. This function
+ * also handles the Instrument's master volume.
  * @private
  * @param {number} gainValue
  * The gain level to set for the instrument.
@@ -236,19 +244,21 @@ Instrument.prototype.setPan = function (panValue) {
  * @return {void}
  */
 Instrument.prototype.setGain = function (gainValue, rampTime) {
-    if (this.gainNode) {
-        if (gainValue > 1.2) {
+    var gainNode = this.gainNode;
+    var newVal = gainValue * this.masterVolume;
+    if (gainNode) {
+        if (newVal > 1.2) {
             console.warn(// eslint-disable-line
             'Highcharts sonification warning: ' +
                 'Volume of instrument set too high.');
-            gainValue = 1.2;
+            newVal = 1.2;
         }
         if (rampTime) {
-            this.gainNode.gain.setValueAtTime(this.gainNode.gain.value, H.audioContext.currentTime);
-            this.gainNode.gain.linearRampToValueAtTime(gainValue, H.audioContext.currentTime + rampTime / 1000);
+            gainNode.gain.setValueAtTime(gainNode.gain.value, H.audioContext.currentTime);
+            gainNode.gain.linearRampToValueAtTime(newVal, H.audioContext.currentTime + rampTime / 1000);
         }
         else {
-            this.gainNode.gain.setValueAtTime(gainValue, H.audioContext.currentTime);
+            gainNode.gain.setValueAtTime(newVal, H.audioContext.currentTime);
         }
     }
 };
@@ -261,6 +271,15 @@ Instrument.prototype.cancelGainRamp = function () {
     if (this.gainNode) {
         this.gainNode.gain.cancelScheduledValues(0);
     }
+};
+/**
+ * Set the master volume multiplier of the instrument after creation.
+ * @param {number} volumeMultiplier
+ * The gain level to set for the instrument.
+ * @return {void}
+ */
+Instrument.prototype.setMasterVolume = function (volumeMultiplier) {
+    this.masterVolume = volumeMultiplier || 0;
 };
 /**
  * Get the closest valid frequency for this instrument.

--- a/js/modules/sonification/chartSonify.js
+++ b/js/modules/sonification/chartSonify.js
@@ -706,21 +706,16 @@ function chartOptionsToSonifySeriesOptions(series) {
     var chartOpts = series.chart.options.sonification || {};
     var chartEvents = chartOpts.events || {};
     var seriesEvents = seriesOpts.events || {};
-    return merge({
-        onEnd: chartEvents.onSeriesEnd,
-        onStart: chartEvents.onSeriesStart,
-        onPointEnd: chartEvents.onPointEnd,
-        onPointStart: chartEvents.onPointStart,
+    return {
+        onEnd: seriesEvents.onSeriesEnd || chartEvents.onSeriesEnd,
+        onStart: seriesEvents.onSeriesStart || chartEvents.onSeriesStart,
+        onPointEnd: seriesEvents.onPointEnd || chartEvents.onPointEnd,
+        onPointStart: seriesEvents.onPointStart || chartEvents.onPointStart,
         pointPlayTime: (_b = (_a = chartOpts.defaultInstrumentOptions) === null || _a === void 0 ? void 0 : _a.mapping) === null || _b === void 0 ? void 0 : _b.pointPlayTime,
-        masterVolume: chartOpts.masterVolume
-    }, {
-        onEnd: seriesEvents.onSeriesEnd,
-        onPointEnd: seriesEvents.onPointEnd,
-        onPointStart: seriesEvents.onPointStart,
-        onStart: seriesEvents.onSeriesStart,
+        masterVolume: chartOpts.masterVolume,
         instruments: getSeriesInstrumentOptions(series),
         earcons: seriesOpts.earcons || chartOpts.earcons
-    });
+    };
 }
 /**
  * @private

--- a/js/modules/sonification/chartSonify.js
+++ b/js/modules/sonification/chartSonify.js
@@ -138,19 +138,36 @@ function getTimeExtremes(series, timeProp) {
     });
 }
 /**
- * Calculate value extremes for used instrument data properties.
+ * Calculate value extremes for used instrument data properties on a chart.
  * @private
  * @param {Highcharts.Chart} chart
  * The chart to calculate extremes from.
- * @param {Array<Highcharts.PointInstrumentObject>} instruments
- * The instrument definitions used.
+ * @param {Array<Highcharts.PointInstrumentObject>} [instruments]
+ * Additional instrument definitions to inspect for data props used, in
+ * addition to the instruments defined in the chart options.
  * @param {Highcharts.Dictionary<Highcharts.RangeObject>} [dataExtremes]
  * Predefined extremes for each data prop.
  * @return {Highcharts.Dictionary<Highcharts.RangeObject>}
  * New extremes with data properties mapped to min/max objects.
  */
 function getExtremesForInstrumentProps(chart, instruments, dataExtremes) {
-    return (instruments || []).reduce(function (newExtremes, instrumentDefinition) {
+    var _a;
+    var allInstrumentDefinitions = (instruments || []).slice(0);
+    var defaultInstrumentDef = (_a = chart.options.sonification) === null || _a === void 0 ? void 0 : _a.defaultInstrumentOptions;
+    var optionDefToInstrDef = function (optionDef) { return ({
+        instrumentMapping: optionDef.mapping
+    }); };
+    if (defaultInstrumentDef) {
+        allInstrumentDefinitions.push(optionDefToInstrDef(defaultInstrumentDef));
+    }
+    chart.series.forEach(function (series) {
+        var _a;
+        var instrOptions = (_a = series.options.sonification) === null || _a === void 0 ? void 0 : _a.instruments;
+        if (instrOptions) {
+            allInstrumentDefinitions = allInstrumentDefinitions.concat(instrOptions.map(optionDefToInstrDef));
+        }
+    });
+    return (allInstrumentDefinitions).reduce(function (newExtremes, instrumentDefinition) {
         Object.keys(instrumentDefinition.instrumentMapping || {}).forEach(function (instrumentParameter) {
             var value = instrumentDefinition.instrumentMapping[instrumentParameter];
             if (typeof value === 'string' && !newExtremes[value]) {
@@ -317,20 +334,23 @@ function buildTimelinePathFromSeries(series, options) {
  *
  * @function Highcharts.Series#sonify
  *
- * @param {Highcharts.SonifySeriesOptionsObject} options
- *        The options for sonifying this series.
+ * @param {Highcharts.SonifySeriesOptionsObject} [options]
+ *        The options for sonifying this series. If not provided,
+ *        uses options set on chart and series.
  *
  * @return {void}
  */
 function seriesSonify(options) {
-    var timelinePath = buildTimelinePathFromSeries(this, options), chartSonification = this.chart.sonification;
+    var mergedOptions = getSeriesSonifyOptions(this, options);
+    var timelinePath = buildTimelinePathFromSeries(this, mergedOptions);
+    var chartSonification = this.chart.sonification;
     // Only one timeline can play at a time. If we want multiple series playing
     // at the same time, use chart.sonify.
     if (chartSonification.timeline) {
         chartSonification.timeline.pause();
     }
     // Store reference to duration
-    chartSonification.duration = options.duration;
+    chartSonification.duration = mergedOptions.duration;
     // Create new timeline for this series, and play it.
     chartSonification.timeline = new H.sonification.Timeline({
         paths: [timelinePath]
@@ -350,27 +370,34 @@ function seriesSonify(options) {
  * @return {Partial<Highcharts.SonifySeriesOptionsObject>}
  * Options for buildTimelinePathFromSeries.
  */
-function buildSeriesOptions(series, dataExtremes, chartSonifyOptions) {
-    var seriesOptions = chartSonifyOptions.seriesOptions || {};
-    return merge({
+function buildChartSonifySeriesOptions(series, dataExtremes, chartSonifyOptions) {
+    var _a, _b, _c;
+    var additionalSeriesOptions = chartSonifyOptions.seriesOptions || {};
+    var pointPlayTime = ((_c = (_b = (_a = series.chart.options.sonification) === null || _a === void 0 ? void 0 : _a.defaultInstrumentOptions) === null || _b === void 0 ? void 0 : _b.mapping) === null || _c === void 0 ? void 0 : _c.pointPlayTime) || 'x';
+    var configOptions = chartOptionsToSonifySeriesOptions(series);
+    return merge(
+    // Options from chart configuration
+    configOptions, 
+    // Options passed in
+    {
         // Calculated dataExtremes for chart
         dataExtremes: dataExtremes,
         // We need to get timeExtremes for each series. We pass this
         // in when building the TimelinePath objects to avoid
         // calculating twice.
-        timeExtremes: getTimeExtremes(series, chartSonifyOptions.pointPlayTime),
+        timeExtremes: getTimeExtremes(series, pointPlayTime),
         // Some options we just pass on
-        instruments: chartSonifyOptions.instruments,
-        onStart: chartSonifyOptions.onSeriesStart,
-        onEnd: chartSonifyOptions.onSeriesEnd,
-        earcons: chartSonifyOptions.earcons
+        instruments: chartSonifyOptions.instruments || configOptions.instruments,
+        onStart: chartSonifyOptions.onSeriesStart || configOptions.onStart,
+        onEnd: chartSonifyOptions.onSeriesEnd || configOptions.onEnd,
+        earcons: chartSonifyOptions.earcons || configOptions.earcons
     }, 
-    // Merge in the specific series options by ID
-    isArray(seriesOptions) ? (find(seriesOptions, function (optEntry) {
+    // Merge in the specific series options by ID if any are passed in
+    isArray(additionalSeriesOptions) ? (find(additionalSeriesOptions, function (optEntry) {
         return optEntry.id === pick(series.id, series.options.id);
-    }) || {}) : seriesOptions, {
+    }) || {}) : additionalSeriesOptions, {
         // Forced options
-        pointPlayTime: chartSonifyOptions.pointPlayTime
+        pointPlayTime: pointPlayTime
     });
 }
 /**
@@ -613,13 +640,93 @@ function buildPathsFromOrder(order, duration) {
 }
 /**
  * @private
+ * @param {Highcharts.Series} series The series to get options for.
+ * @param {Highcharts.SonifySeriesOptionsObject} options
+ *  Options to merge with user options on series/chart and default options.
+ * @returns {Array<Highcharts.PointInstrumentObject>} The merged options.
+ */
+function getSeriesInstrumentOptions(series, options) {
+    var _a, _b;
+    if (options === null || options === void 0 ? void 0 : options.instruments) {
+        return options.instruments;
+    }
+    var defaultInstrOpts = ((_a = series.chart.options.sonification) === null || _a === void 0 ? void 0 : _a.defaultInstrumentOptions) || {};
+    var seriesInstrOpts = ((_b = series.options.sonification) === null || _b === void 0 ? void 0 : _b.instruments) || [{}];
+    // Convert series options to PointInstrumentObjects and merge with
+    // default options
+    return (seriesInstrOpts).map(function (optionSet) { return ({
+        instrument: optionSet.instrument || defaultInstrOpts.instrument,
+        instrumentOptions: merge(defaultInstrOpts, optionSet, {
+            // Instrument options are lifted to root in the API options object,
+            // so merge all in order to avoid missing any. But remove the
+            // following which are not instrumentOptions:
+            mapping: void 0,
+            instrument: void 0
+        }),
+        instrumentMapping: merge(defaultInstrOpts.mapping, optionSet.mapping)
+    }); });
+}
+/**
+ * Utility function to translate between options set in chart configuration and
+ * a SonifySeriesOptionsObject.
+ * @private
+ * @param {Highcharts.Series} series The series to get options for.
+ * @returns {Highcharts.SonifySeriesOptionsObject} Options for chart/series.sonify()
+ */
+function chartOptionsToSonifySeriesOptions(series) {
+    var _a, _b;
+    var seriesOpts = series.options.sonification || {};
+    var chartOpts = series.chart.options.sonification || {};
+    var chartEvents = chartOpts.events || {};
+    var seriesEvents = seriesOpts.events || {};
+    return merge({
+        onEnd: chartEvents.onSeriesEnd,
+        onStart: chartEvents.onSeriesStart,
+        onPointEnd: chartEvents.onPointEnd,
+        onPointStart: chartEvents.onPointStart,
+        pointPlayTime: (_b = (_a = chartOpts.defaultInstrumentOptions) === null || _a === void 0 ? void 0 : _a.mapping) === null || _b === void 0 ? void 0 : _b.pointPlayTime
+    }, {
+        onEnd: seriesEvents.onSeriesEnd,
+        onPointEnd: seriesEvents.onPointEnd,
+        onPointStart: seriesEvents.onPointStart,
+        onStart: seriesEvents.onSeriesStart,
+        instruments: getSeriesInstrumentOptions(series) // Deals with chart-level defaults
+    });
+}
+/**
+ * @private
+ * @param {Highcharts.Series} series The series to get options for.
+ * @param {Highcharts.SonifySeriesOptionsObject} options
+ *  Options to merge with user options on series/chart and default options.
+ * @returns {Highcharts.SonifySeriesOptionsObject} The merged options.
+ */
+function getSeriesSonifyOptions(series, options) {
+    var chartOpts = series.chart.options.sonification;
+    var seriesOpts = series.options.sonification;
+    return merge({
+        duration: (seriesOpts === null || seriesOpts === void 0 ? void 0 : seriesOpts.duration) || (chartOpts === null || chartOpts === void 0 ? void 0 : chartOpts.duration),
+        masterVolume: chartOpts === null || chartOpts === void 0 ? void 0 : chartOpts.masterVolume
+    }, chartOptionsToSonifySeriesOptions(series), options);
+}
+/**
+ * @private
  * @param {Highcharts.Chart} chart The chart to get options for.
- * @param {Highcharts.SonificationOptions} userOptions
- *  Options to merge with options on chart and default options.
+ * @param {Highcharts.SonificationOptions} options
+ *  Options to merge with user options on chart and default options.
  * @returns {Highcharts.SonificationOptions} The merged options.
  */
-function getChartSonifyOptions(chart, userOptions) {
-    return merge(chart.options.sonification, userOptions);
+function getChartSonifyOptions(chart, options) {
+    var _a, _b, _c, _d, _e;
+    var chartOpts = chart.options.sonification || {};
+    return merge({
+        duration: chartOpts.duration,
+        afterSeriesWait: chartOpts.afterSeriesWait,
+        pointPlayTime: (_b = (_a = chartOpts.defaultInstrumentOptions) === null || _a === void 0 ? void 0 : _a.mapping) === null || _b === void 0 ? void 0 : _b.pointPlayTime,
+        order: chartOpts.order,
+        onSeriesStart: (_c = chartOpts.events) === null || _c === void 0 ? void 0 : _c.onSeriesStart,
+        onSeriesEnd: (_d = chartOpts.events) === null || _d === void 0 ? void 0 : _d.onSeriesEnd,
+        onEnd: (_e = chartOpts.events) === null || _e === void 0 ? void 0 : _e.onEnd
+    }, options);
 }
 /**
  * Options for sonifying a chart.
@@ -728,8 +835,9 @@ function getChartSonifyOptions(chart, userOptions) {
  *
  * @function Highcharts.Chart#sonify
  *
- * @param {Highcharts.SonificationOptions} options
- *        The options for sonifying this chart.
+ * @param {Highcharts.SonificationOptions} [options]
+ *        The options for sonifying this chart. If not provided,
+ *        uses options set on chart and series.
  *
  * @return {void}
  */
@@ -745,7 +853,7 @@ function chartSonify(options) {
     var dataExtremes = getExtremesForInstrumentProps(this, opts.instruments, opts.dataExtremes);
     // Figure out ordering of series and custom paths
     var order = buildPathOrder(opts.order, this, function (series) {
-        return buildSeriesOptions(series, dataExtremes, opts);
+        return buildChartSonifySeriesOptions(series, dataExtremes, opts);
     });
     // Add waits after simultaneous paths with series in them.
     order = addAfterSeriesWaits(order, opts.afterSeriesWait || 0);

--- a/js/modules/sonification/chartSonify.js
+++ b/js/modules/sonification/chartSonify.js
@@ -421,7 +421,8 @@ function buildPathOrder(orderOptions, chart, seriesOptionsCallback) {
     if (orderOptions === 'sequential' || orderOptions === 'simultaneous') {
         // Just add the series from the chart
         order = chart.series.reduce(function (seriesList, series) {
-            if (series.visible) {
+            var _a;
+            if (series.visible && ((_a = series.options.sonification) === null || _a === void 0 ? void 0 : _a.enabled) !== false) {
                 seriesList.push({
                     series: series,
                     seriesOptions: seriesOptionsCallback(series)

--- a/js/modules/sonification/chartSonify.js
+++ b/js/modules/sonification/chartSonify.js
@@ -690,7 +690,8 @@ function chartOptionsToSonifySeriesOptions(series) {
         onPointEnd: seriesEvents.onPointEnd,
         onPointStart: seriesEvents.onPointStart,
         onStart: seriesEvents.onSeriesStart,
-        instruments: getSeriesInstrumentOptions(series) // Deals with chart-level defaults
+        instruments: getSeriesInstrumentOptions(series),
+        earcons: seriesOpts.earcons || chartOpts.earcons
     });
 }
 /**

--- a/js/modules/sonification/options.js
+++ b/js/modules/sonification/options.js
@@ -16,21 +16,19 @@ var options = {
         enabled: false,
         duration: 2000,
         afterSeriesWait: 1000,
+        masterVolume: 0.7,
         order: 'sequential',
-        pointPlayTime: 'x',
-        instruments: [{
-                instrument: 'sineMusical',
-                instrumentMapping: {
-                    duration: 400,
-                    frequency: 'y',
-                    volume: 0.7
-                },
-                // Start at G4 note, end at C6
-                instrumentOptions: {
-                    minFrequency: 392,
-                    maxFrequency: 1046
-                }
-            }]
+        defaultInstrumentOptions: {
+            instrument: 'sineMusical',
+            // Start at G4 note, end at C6
+            minFrequency: 392,
+            maxFrequency: 1046,
+            mapping: {
+                pointPlayTime: 'x',
+                duration: 400,
+                frequency: 'y'
+            }
+        }
     }
 };
 export default options;

--- a/js/modules/sonification/options.js
+++ b/js/modules/sonification/options.js
@@ -15,7 +15,7 @@ var options = {
     sonification: {
         enabled: false,
         duration: 2000,
-        afterSeriesWait: 1000,
+        afterSeriesWait: 900,
         masterVolume: 0.7,
         order: 'sequential',
         defaultInstrumentOptions: {

--- a/js/modules/sonification/options.js
+++ b/js/modules/sonification/options.js
@@ -16,7 +16,7 @@ var options = {
         enabled: false,
         duration: 2000,
         afterSeriesWait: 900,
-        masterVolume: 0.7,
+        masterVolume: 1,
         order: 'sequential',
         defaultInstrumentOptions: {
             instrument: 'sineMusical',

--- a/js/modules/sonification/pointSonify.js
+++ b/js/modules/sonification/pointSonify.js
@@ -23,20 +23,24 @@ var error = U.error, merge = U.merge, pick = U.pick;
 * Define the volume of the instrument. This can be a string with a data
 * property name, e.g. `'y'`, in which case this data property is used to define
 * the volume relative to the `y`-values of the other points. A higher `y` value
-* would then result in a higher volume. This option can also be a fixed number
-* or a function. If it is a function, this function is called in regular
-* intervals while the note is playing. It receives three arguments: The point,
-* the dataExtremes, and the current relative time - where 0 is the beginning of
-* the note and 1 is the end. The function should return the volume of the note
-* as a number between 0 and 1.
+* would then result in a higher volume. Alternatively, `'-y'` can be used,
+* which inverts the polarity, so that a higher `y` value results in a lower
+* volume. This option can also be a fixed number or a function. If it is a
+* function, this function is called in regular intervals while the note is
+* playing. It receives three arguments: The point, the dataExtremes, and the
+* current relative time - where 0 is the beginning of the note and 1 is the
+* end. The function should return the volume of the note as a number between
+* 0 and 1.
 * @name Highcharts.PointInstrumentMappingObject#volume
 * @type {string|number|Function}
 */ /**
 * Define the duration of the notes for this instrument. This can be a string
 * with a data property name, e.g. `'y'`, in which case this data property is
 * used to define the duration relative to the `y`-values of the other points. A
-* higher `y` value would then result in a longer duration. This option can also
-* be a fixed number or a function. If it is a function, this function is called
+* higher `y` value would then result in a longer duration. Alternatively,
+* `'-y'` can be used, in which case the polarity is inverted, and a higher
+* `y` value would result in a shorter duration. This option can also be a
+* fixed number or a function. If it is a function, this function is called
 * once before the note starts playing, and should return the duration in
 * milliseconds. It receives two arguments: The point, and the dataExtremes.
 * @name Highcharts.PointInstrumentMappingObject#duration
@@ -46,24 +50,28 @@ var error = U.error, merge = U.merge, pick = U.pick;
 * property name, e.g. `'x'`, in which case this data property is used to define
 * the panning relative to the `x`-values of the other points. A higher `x`
 * value would then result in a higher panning value (panned further to the
-* right). This option can also be a fixed number or a function. If it is a
-* function, this function is called in regular intervals while the note is
-* playing. It receives three arguments: The point, the dataExtremes, and the
-* current relative time - where 0 is the beginning of the note and 1 is the
-* end. The function should return the panning of the note as a number between
-* -1 and 1.
+* right). Alternatively, `'-x'` can be used, in which case the polarity is
+* inverted, and a higher `x` value would result in a lower panning value
+* (panned further to the left). This option can also be a fixed number or a
+* function. If it is a function, this function is called in regular intervals
+* while the note is playing. It receives three arguments: The point, the
+* dataExtremes, and the current relative time - where 0 is the beginning of
+* the note and 1 is the end. The function should return the panning of the
+* note as a number between -1 and 1.
 * @name Highcharts.PointInstrumentMappingObject#pan
 * @type {string|number|Function|undefined}
 */ /**
 * Define the frequency of the instrument. This can be a string with a data
 * property name, e.g. `'y'`, in which case this data property is used to define
 * the frequency relative to the `y`-values of the other points. A higher `y`
-* value would then result in a higher frequency. This option can also be a
-* fixed number or a function. If it is a function, this function is called in
-* regular intervals while the note is playing. It receives three arguments:
-* The point, the dataExtremes, and the current relative time - where 0 is the
-* beginning of the note and 1 is the end. The function should return the
-* frequency of the note as a number (in Hz).
+* value would then result in a higher frequency. Alternatively, `'-y'` can be
+* used, in which case the polarity is inverted, and a higher `y` value would
+* result in a lower frequency. This option can also be a fixed number or a
+* function. If it is a function, this function is called in regular intervals
+* while the note is playing. It receives three arguments: The point, the
+* dataExtremes, and the current relative time - where 0 is the beginning of
+* the note and 1 is the end. The function should return the frequency of the
+* note as a number (in Hz).
 * @name Highcharts.PointInstrumentMappingObject#frequency
 * @type {string|number|Function}
 */
@@ -222,13 +230,16 @@ function pointSonify(options) {
                 } :
                 value(point, dataExtremes);
         }
-        // String, this is a data prop.
+        // String, this is a data prop. Potentially with negative polarity.
         if (typeof value === 'string') {
+            var hasInvertedPolarity = value.charAt(0) === '-';
+            var dataProp = hasInvertedPolarity ? value.slice(1) : value;
+            var pointValue = pick(point[dataProp], point.options[dataProp]);
             // Find data extremes if we don't have them
-            dataExtremes[value] = dataExtremes[value] ||
-                utilities.calculateDataExtremes(point.series.chart, value);
+            dataExtremes[dataProp] = dataExtremes[dataProp] ||
+                utilities.calculateDataExtremes(point.series.chart, dataProp);
             // Find the value
-            return utilities.virtualAxisTranslate(pick(point[value], point.options[value]), dataExtremes[value], allowedExtremes);
+            return utilities.virtualAxisTranslate(pointValue, dataExtremes[dataProp], allowedExtremes, hasInvertedPolarity);
         }
         // Fixed number or something else weird, just use that
         return value;

--- a/js/modules/sonification/pointSonify.js
+++ b/js/modules/sonification/pointSonify.js
@@ -208,7 +208,8 @@ var defaultInstrumentOptions = {
  * @return {void}
  */
 function pointSonify(options) {
-    var point = this, chart = point.series.chart, dataExtremes = options.dataExtremes || {}, 
+    var _a;
+    var point = this, chart = point.series.chart, masterVolume = pick(options.masterVolume, (_a = chart.options.sonification) === null || _a === void 0 ? void 0 : _a.masterVolume), dataExtremes = options.dataExtremes || {}, 
     // Get the value to pass to instrument.play from the mapping value
     // passed in.
     getMappingValue = function (value, makeFunction, allowedExtremes) {
@@ -274,6 +275,9 @@ function pointSonify(options) {
         };
         // Play the note on the instrument
         if (instrument && instrument.play) {
+            if (typeof masterVolume !== 'undefined') {
+                instrument.setMasterVolume(masterVolume);
+            }
             point.sonification.instrumentsPlaying[instrument.id] =
                 instrument;
             instrument.play({

--- a/js/modules/sonification/utilities.js
+++ b/js/modules/sonification/utilities.js
@@ -151,12 +151,15 @@ var utilities = {
      * The possible extremes for this value.
      * @param {object} limits
      * Limits for the virtual axis.
+     * @param {boolean} [invert]
+     * Invert the virtual axis.
      * @return {number}
      * The value mapped to the virtual axis.
      */
-    virtualAxisTranslate: function (value, dataExtremes, limits) {
-        var lenValueAxis = dataExtremes.max - dataExtremes.min, lenVirtualAxis = limits.max - limits.min, virtualAxisValue = limits.min +
-            lenVirtualAxis * (value - dataExtremes.min) / lenValueAxis;
+    virtualAxisTranslate: function (value, dataExtremes, limits, invert) {
+        var lenValueAxis = dataExtremes.max - dataExtremes.min, lenVirtualAxis = Math.abs(limits.max - limits.min), valueDelta = invert ?
+            dataExtremes.max - value :
+            value - dataExtremes.min, virtualValueDelta = lenVirtualAxis * valueDelta / lenValueAxis, virtualAxisValue = limits.min + virtualValueDelta;
         return lenValueAxis > 0 ?
             clamp(virtualAxisValue, limits.min, limits.max) :
             limits.min;

--- a/samples/highcharts/sonification/big-data/demo.js
+++ b/samples/highcharts/sonification/big-data/demo.js
@@ -16,25 +16,21 @@ Highcharts.chart('container', {
         cursor: 'pointer',
         events: {
             click: function () {
-                // Sonify the series when clicked
-                this.sonify({
-                    duration: 3000,
-                    pointPlayTime: 'x',
-                    instruments: [{
-                        instrument: 'triangleMajor',
-                        instrumentMapping: {
-                            volume: 0.6,
-                            duration: 50,
-                            pan: 'x',
-                            frequency: 'y'
-                        },
-                        instrumentOptions: {
-                            minFrequency: 200,
-                            maxFrequency: 2000
-                        }
-                    }]
-                });
+                this.sonify();
             }
+        },
+        sonification: {
+            duration: 3000,
+            instruments: [{
+                instrument: 'triangleMajor',
+                minFrequency: 200,
+                maxFrequency: 2000,
+                mapping: {
+                    volume: 0.6,
+                    duration: 50,
+                    pan: 'x'
+                }
+            }]
         }
     }]
 });

--- a/samples/highcharts/sonification/chart-custom-order/demo.js
+++ b/samples/highcharts/sonification/chart-custom-order/demo.js
@@ -6,6 +6,20 @@ var chart = Highcharts.chart('container', {
     legend: {
         enabled: false
     },
+    sonification: {
+        duration: 5000,
+        order: ['columnSeries', ['scatterSeriesA', 'scatterSeriesB']],
+        defaultInstrumentOptions: {
+            instrument: 'triangleMajor',
+            minFrequency: 220,
+            maxFrequency: 2200,
+            mapping: {
+                volume: 0.8,
+                duration: 250,
+                pan: 'x'
+            }
+        }
+    },
     series: [{
         type: 'column',
         id: 'columnSeries',
@@ -13,55 +27,30 @@ var chart = Highcharts.chart('container', {
     }, {
         type: 'scatter',
         id: 'scatterSeriesA',
-        data: [4, null, 7, 11, 13, 13]
+        data: [4, null, 7, 11, 13, 13],
+        sonification: {
+            instruments: [{
+                instrument: 'sineMajor',
+                mapping: {
+                    pan: -1
+                }
+            }]
+        }
     }, {
         type: 'scatter',
         id: 'scatterSeriesB',
-        data: [2, 3, 9, 9, 11, 11, 9]
+        data: [2, 3, 9, 9, 11, 11, 9],
+        sonification: {
+            instruments: [{
+                mapping: {
+                    volume: 0.4,
+                    pan: 1
+                }
+            }]
+        }
     }]
 });
 
-// Click button to call chart.sonify()
 document.getElementById('sonify').onclick = function () {
-    chart.sonify({
-        duration: 5000,
-        afterSeriesWait: 1000,
-        order: ['columnSeries', ['scatterSeriesA', 'scatterSeriesB']],
-        pointPlayTime: 'x',
-        // We can use separate instrument options for each series
-        seriesOptions: [{
-            id: 'columnSeries',
-            instruments: [{
-                instrument: 'triangleMajor',
-                instrumentMapping: {
-                    volume: 0.8,
-                    duration: 250,
-                    pan: 'x',
-                    frequency: 'y'
-                }
-            }]
-        }, {
-            id: 'scatterSeriesA',
-            instruments: [{
-                instrument: 'sineMajor',
-                instrumentMapping: {
-                    volume: 0.8,
-                    duration: 250,
-                    pan: -1,
-                    frequency: 'y'
-                }
-            }]
-        }, {
-            id: 'scatterSeriesB',
-            instruments: [{
-                instrument: 'triangleMajor',
-                instrumentMapping: {
-                    volume: 0.4,
-                    duration: 250,
-                    pan: 1,
-                    frequency: 'y'
-                }
-            }]
-        }]
-    });
+    chart.sonify();
 };

--- a/samples/highcharts/sonification/chart-earcon/demo.js
+++ b/samples/highcharts/sonification/chart-earcon/demo.js
@@ -8,30 +8,15 @@ var chart = Highcharts.chart('container', {
     subtitle: {
         text: 'Earcon on highest point in series'
     },
-    series: [{
-        data: [1, 2, 4, 5, 7, 9, 11, 13]
-    }, {
-        data: [4, 5, 9, 5, 2, 1, 4, 6]
-    }, {
-        data: [2, 2, 2, 7, 9, 11, 13, 12]
-    }]
-});
-
-
-document.getElementById('sonify').onclick = function () {
-    chart.sonify({
+    sonification: {
         duration: 7000,
-        afterSeriesWait: 1000,
-        order: 'sequential',
-        pointPlayTime: 'x',
-        instruments: [{
-            instrument: 'sineMusical',
-            instrumentMapping: {
-                duration: 200,
-                frequency: 'y',
-                volume: 0.7
+        defaultInstrumentOptions: {
+            minFrequency: 220,
+            maxFrequency: 2200,
+            mapping: {
+                duration: 200
             }
-        }],
+        },
         earcons: [{
             // Define the earcon we want to play
             earcon: new Highcharts.sonification.Earcon({
@@ -57,5 +42,17 @@ document.getElementById('sonify').onclick = function () {
                 ));
             }
         }]
-    });
+    },
+    series: [{
+        data: [1, 2, 4, 5, 7, 9, 11, 13]
+    }, {
+        data: [4, 5, 9, 5, 2, 1, 4, 6]
+    }, {
+        data: [2, 2, 2, 7, 9, 11, 13, 12]
+    }]
+});
+
+
+document.getElementById('sonify').onclick = function () {
+    chart.sonify();
 };

--- a/samples/highcharts/sonification/chart-events/demo.js
+++ b/samples/highcharts/sonification/chart-events/demo.js
@@ -8,6 +8,64 @@ var chart = Highcharts.chart('container', {
     subtitle: {
         text: 'Earcons played on series begin and end'
     },
+    sonification: {
+        duration: 7000,
+        defaultInstrumentOptions: {
+            minFrequency: 220,
+            maxFrequency: 2200,
+            mapping: {
+                duration: 200
+            }
+        },
+        events: {
+            // Play a quick triangle tone on series start
+            onSeriesStart: function () {
+                (new Highcharts.sonification.Earcon({
+                    instruments: [{
+                        instrument: 'triangleMajor',
+                        playOptions: {
+                            // Play a quick rising frequency
+                            frequency: function (time) {
+                                return time * 1760 + 440;
+                            },
+                            volume: 0.3,
+                            duration: 120
+                        }
+                    }]
+                })).sonify();
+            },
+            // Play a quick sawtooth tone on series end
+            onSeriesEnd: function () {
+                (new Highcharts.sonification.Earcon({
+                    instruments: [{
+                        instrument: 'sawtoothMajor',
+                        playOptions: {
+                            // Play a quick falling frequency
+                            frequency: function (time) {
+                                return (1 - time) * 1760;
+                            },
+                            volume: 0.3,
+                            duration: 120
+                        }
+                    }]
+                })).sonify();
+            },
+            // Play a low tone on chart end
+            onEnd: function () {
+                (new Highcharts.sonification.Earcon({
+                    instruments: [{
+                        instrument: 'squareMajor',
+                        playOptions: {
+                            // Play a longer low frequency
+                            frequency: 55,
+                            volume: 0.2,
+                            duration: 320
+                        }
+                    }]
+                })).sonify();
+            }
+        }
+    },
     series: [{
         data: [1, 2, 4, 6, 9, 12, 15, 16]
     }, {
@@ -19,64 +77,5 @@ var chart = Highcharts.chart('container', {
 
 
 document.getElementById('sonify').onclick = function () {
-    chart.sonify({
-        duration: 7000,
-        afterSeriesWait: 1000,
-        order: 'sequential',
-        pointPlayTime: 'x',
-        instruments: [{
-            instrument: 'sineMusical',
-            instrumentMapping: {
-                duration: 200,
-                frequency: 'y',
-                volume: 0.7
-            }
-        }],
-        // Play a quick triangle tone on series start
-        onSeriesStart: function () {
-            (new Highcharts.sonification.Earcon({
-                instruments: [{
-                    instrument: 'triangleMajor',
-                    playOptions: {
-                        // Play a quick rising frequency
-                        frequency: function (time) {
-                            return time * 1760 + 440;
-                        },
-                        volume: 0.3,
-                        duration: 120
-                    }
-                }]
-            })).sonify();
-        },
-        // Play a quick sawtooth tone on series end
-        onSeriesEnd: function () {
-            (new Highcharts.sonification.Earcon({
-                instruments: [{
-                    instrument: 'sawtoothMajor',
-                    playOptions: {
-                        // Play a quick falling frequency
-                        frequency: function (time) {
-                            return (1 - time) * 1760;
-                        },
-                        volume: 0.3,
-                        duration: 120
-                    }
-                }]
-            })).sonify();
-        },
-        // Play a low tone on chart end
-        onEnd: function () {
-            (new Highcharts.sonification.Earcon({
-                instruments: [{
-                    instrument: 'squareMajor',
-                    playOptions: {
-                        // Play a longer low frequency
-                        frequency: 55,
-                        volume: 0.2,
-                        duration: 320
-                    }
-                }]
-            })).sonify();
-        }
-    });
+    chart.sonify();
 };

--- a/samples/highcharts/sonification/chart-sequential/demo.js
+++ b/samples/highcharts/sonification/chart-sequential/demo.js
@@ -18,7 +18,6 @@ document.getElementById('sonify').onclick = function () {
     chart.sonify({
         duration: 3000,
         order: 'sequential',
-        pointPlayTime: 'x',
         afterSeriesWait: 1000,
         instruments: [{
             instrument: 'triangleMajor',

--- a/samples/highcharts/sonification/polarity-invert/demo.details
+++ b/samples/highcharts/sonification/polarity-invert/demo.details
@@ -2,6 +2,6 @@
  name: Highcharts Demo
  authors:
    - Øystein Moseng
- skipTest: true
+ requiresManualTesting: true
  js_wrap: b
 ...

--- a/samples/highcharts/sonification/polarity-invert/demo.html
+++ b/samples/highcharts/sonification/polarity-invert/demo.html
@@ -1,0 +1,4 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/sonification.js"></script>
+
+<div id="container" style="max-width:700px; margin: auto"></div>

--- a/samples/highcharts/sonification/polarity-invert/demo.js
+++ b/samples/highcharts/sonification/polarity-invert/demo.js
@@ -1,0 +1,50 @@
+Highcharts.chart('container', {
+    title: {
+        text: 'Click on series to sonify'
+    },
+    legend: {
+        enabled: false
+    },
+    sonification: {
+        defaultInstrumentOptions: {
+            instrument: 'triangleMajor',
+            minFrequency: 523, // C5
+            maxFrequency: 1047, // C6
+            mapping: {
+                pan: 'x'
+            }
+        },
+        events: {
+            onPointStart: function (e, point) {
+                point.onMouseOver();
+            }
+        }
+    },
+    plotOptions: {
+        series: {
+            marker: {
+                radius: 8
+            },
+            cursor: 'pointer',
+            events: {
+                click: function () {
+                    this.sonify();
+                }
+            }
+        }
+    },
+    series: [{
+        data: [523, 587, 659, 696, 784, 880, 988, 1046]
+    }, {
+        // Frequencies such that when played with inverse polarity,
+        // the intervals correspond to the C5-C6 major scale
+        data: [1046, 1569 - 587, 1569 - 659, 1569 - 696, 1569 - 784, 1569 - 880, 1569 - 988, 1569 - 1046],
+        sonification: {
+            instruments: [{
+                mapping: {
+                    frequency: '-y'
+                }
+            }]
+        }
+    }]
+});

--- a/samples/highcharts/sonification/polarity-invert/test-notes.md
+++ b/samples/highcharts/sonification/polarity-invert/test-notes.md
@@ -1,5 +1,5 @@
 1. Click on series to sonify. Verify that the series plays the points in order with rising frequency.
-2. Series 1 (blue series) should play the C-major scale.
+2. Both series should play the C-major scale ascending. Series 2 (black series) has inverted polarity.
 3. The notes should pan from left to right speaker as the sonification moves along the x-axis.
 4. The tooltip should follow the points as they play.
 5. Make sure clicking multiple series only plays one at a time.

--- a/samples/highcharts/sonification/series-basic/demo.js
+++ b/samples/highcharts/sonification/series-basic/demo.js
@@ -1,37 +1,34 @@
 Highcharts.chart('container', {
     title: {
-        text: 'Click series to sonify'
+        text: 'Click on series to sonify'
     },
     legend: {
         enabled: false
     },
     plotOptions: {
         series: {
+            sonification: {
+                instruments: [{
+                    instrument: 'triangleMajor',
+                    minFrequency: 523, // C5
+                    maxFrequency: 1047, // C6
+                    mapping: {
+                        pan: 'x'
+                    }
+                }],
+                events: {
+                    onPointStart: function (e, point) {
+                        point.onMouseOver();
+                    }
+                }
+            },
             marker: {
                 radius: 8
             },
             cursor: 'pointer',
             events: {
                 click: function () {
-                    // Sonify the series when clicked
-                    this.sonify({
-                        duration: 2200,
-                        pointPlayTime: 'x',
-                        instruments: [{
-                            instrument: 'triangleMajor',
-                            instrumentMapping: {
-                                volume: 0.8,
-                                duration: 250,
-                                pan: 'x',
-                                frequency: 'y'
-                            },
-                            // Start at C5 note, end at C6
-                            instrumentOptions: {
-                                minFrequency: 520,
-                                maxFrequency: 1050
-                            }
-                        }]
-                    });
+                    this.sonify();
                 }
             }
         }

--- a/samples/highcharts/sonification/series-basic/test-notes.md
+++ b/samples/highcharts/sonification/series-basic/test-notes.md
@@ -1,2 +1,5 @@
 1. Click on series to sonify. Verify that the series plays the points in order with rising frequency.
-2. Make sure clicking multiple series only plays one at a time.
+2. Series 1 (blue series) should play the C-major scale.
+3. The notes should pan from left to right speaker as the sonification moves along the x-axis.
+4. The tooltip should follow the points as they play.
+5. Make sure clicking multiple series only plays one at a time.

--- a/samples/unit-tests/sonification/options/demo.details
+++ b/samples/unit-tests/sonification/options/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/sonification/options/demo.html
+++ b/samples/unit-tests/sonification/options/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/sonification.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/sonification/options/demo.js
+++ b/samples/unit-tests/sonification/options/demo.js
@@ -1,0 +1,174 @@
+function getFirstEventsInTimeline(timeline) {
+    return timeline.paths[0][0].events;
+}
+
+// Get an instrument object from a basic timeline
+function getTimelineInstrumentObject(timeline) {
+    return getFirstEventsInTimeline(timeline)[0].options.playOptions.instruments[0];
+}
+
+// Crude function to get duration of a basic timeline
+function getTimelineDuration(timeline) {
+    const events = getFirstEventsInTimeline(timeline);
+    return events[events.length - 1].time;
+}
+
+// Crude test to see if two instruments are the same
+function isSameInstrument(a, b) {
+    const freqA = a.options.allowedFrequencies;
+    const freqB = b.options.allowedFrequencies;
+    return a.options.oscillator.waveformShape === b.options.oscillator.waveformShape &&
+        freqA.length === freqB.length &&
+        freqA.every((val, ix) => val === freqB[ix]);
+}
+
+const timelinePrototype = Highcharts.sonification.Timeline.prototype;
+const defaultSonificationOptions = Highcharts.getOptions().sonification;
+const allInstruments = Highcharts.sonification.instruments;
+let oldPlayFunc;
+let actualDuration;
+let instrObject;
+
+QUnit.module('Test that sonification options in chart config are translated to sonify API format', {
+    before: function () {
+        oldPlayFunc = timelinePrototype.play;
+        timelinePrototype.play = function () {
+            instrObject = getTimelineInstrumentObject(this);
+            actualDuration = getTimelineDuration(this);
+        };
+    },
+    after: function () {
+        timelinePrototype.play = oldPlayFunc;
+    }
+}, function () {
+
+    QUnit.test('Default options should be translated', function (assert) {
+        const chart = Highcharts.chart('container', {
+            series: [{
+                data: [1, 2, 3, 4]
+            }]
+        });
+        const defaultDuration = defaultSonificationOptions.duration;
+
+        chart.sonify();
+
+        const actualInstrument = instrObject.instrument;
+        const actualInstrumentMapping = instrObject.instrumentMapping;
+        const actualMinFreq = instrObject.instrumentOptions.minFrequency;
+        const actualMaxFreq = instrObject.instrumentOptions.maxFrequency;
+        const defaultInstrumentOptions = defaultSonificationOptions.defaultInstrumentOptions;
+        const defaultInstrument = allInstruments[defaultInstrumentOptions.instrument];
+        const defaultInstrumentMapping = defaultInstrumentOptions.mapping;
+        const defaultMinFreq = defaultInstrumentOptions.minFrequency;
+        const defaultMaxFreq = defaultInstrumentOptions.maxFrequency;
+
+        assert.strictEqual(actualDuration, defaultDuration,
+            'Duration should equal default duration');
+        assert.ok(isSameInstrument(actualInstrument, defaultInstrument),
+            'Instrument used should be the default instrument');
+        assert.propEqual(actualInstrumentMapping, defaultInstrumentMapping,
+            'Instrument mapping should be the default instrument mapping');
+        assert.strictEqual(actualMinFreq, defaultMinFreq,
+            'Min freq should be the default min freq');
+        assert.strictEqual(actualMaxFreq, defaultMaxFreq,
+            'Max freq should be the default max freq');
+    });
+
+
+    QUnit.test('Chart options should be translated', function (assert) {
+        const mapping = {
+            frequency: 'x',
+            pan: 'y',
+            pointPlayTime: 'y',
+            duration: 10
+        };
+        const chart = Highcharts.chart('container', {
+            sonification: {
+                duration: 950,
+                defaultInstrumentOptions: {
+                    instrument: 'triangleMajor',
+                    minFrequency: 1,
+                    maxFrequency: 1000,
+                    mapping
+                }
+            },
+            series: [{
+                data: [1, 2, 3, 4]
+            }]
+        });
+
+        chart.sonify();
+
+        const actualInstrument = instrObject.instrument;
+        const actualInstrumentMapping = instrObject.instrumentMapping;
+        const actualMinFreq = instrObject.instrumentOptions.minFrequency;
+        const actualMaxFreq = instrObject.instrumentOptions.maxFrequency;
+
+        assert.strictEqual(actualDuration, 950,
+            'Duration should override default duration');
+        assert.ok(isSameInstrument(actualInstrument, allInstruments.triangleMajor),
+            'Instrument used should override the default instrument');
+        assert.propEqual(actualInstrumentMapping, mapping,
+            'Instrument mapping should override the default instrument mapping');
+        assert.strictEqual(actualMinFreq, 1,
+            'Min freq should override the default min freq');
+        assert.strictEqual(actualMaxFreq, 1000,
+            'Max freq should override the default max freq');
+    });
+
+
+    QUnit.test('Series options should be translated and override chart options', function (assert) {
+        const seriesMapping = {
+            frequency: 'x',
+            pan: 'y',
+            pointPlayTime: 'x',
+            duration: 10
+        };
+        const chart = Highcharts.chart('container', {
+            sonification: {
+                duration: 950,
+                defaultInstrumentOptions: {
+                    instrument: 'squareMajor',
+                    minFrequency: 1,
+                    maxFrequency: 1000,
+                    mapping: {
+                        frequency: 440,
+                        pan: 'x',
+                        pointPlayTime: 'y',
+                        duration: 90
+                    }
+                }
+            },
+            series: [{
+                data: [1, 2, 3, 4],
+                sonification: {
+                    duration: 1200,
+                    instruments: [{
+                        minFrequency: 200,
+                        maxFrequency: 2000,
+                        mapping: seriesMapping
+                    }]
+                }
+            }]
+        });
+
+        chart.sonify();
+
+        const actualInstrument = instrObject.instrument;
+        const actualInstrumentMapping = instrObject.instrumentMapping;
+        const actualMinFreq = instrObject.instrumentOptions.minFrequency;
+        const actualMaxFreq = instrObject.instrumentOptions.maxFrequency;
+
+        assert.strictEqual(actualDuration, 950,
+            'Duration should not override chart-wide duration with chart.sonify()');
+        assert.ok(isSameInstrument(actualInstrument, allInstruments.squareMajor),
+            'Series should inherit chart instrument');
+        assert.propEqual(actualInstrumentMapping, seriesMapping,
+            'Series should override chart instrument mapping');
+        assert.strictEqual(actualMinFreq, 200,
+            'Series should override min freq');
+        assert.strictEqual(actualMaxFreq, 2000,
+            'Series should override max freq');
+    });
+
+});

--- a/ts/modules/sonification/Earcon.ts
+++ b/ts/modules/sonification/Earcon.ts
@@ -150,7 +150,7 @@ Earcon.prototype.init = function (
  */
 Earcon.prototype.sonify = function (
     this: Highcharts.Earcon,
-    options: Highcharts.EarconOptionsObject
+    options: Partial<Highcharts.EarconOptionsObject>
 ): void {
     var playOptions = merge(this.options, options);
 
@@ -174,11 +174,6 @@ Earcon.prototype.sonify = function (
 
         if (instrument && instrument.play) {
             if (opts.playOptions) {
-                // Handle master pan/volume
-                if (typeof opts.playOptions.volume !== 'function') {
-                    instrumentOpts.volume = pick(masterVolume, 1) *
-                        pick(opts.playOptions.volume, 1);
-                }
                 instrumentOpts.pan = pick(masterPan, instrumentOpts.pan);
 
                 // Handle onEnd
@@ -201,6 +196,7 @@ Earcon.prototype.sonify = function (
                 // Play the instrument. Use a copy so we can play multiple at
                 // the same time.
                 instrumentCopy = instrument.copy();
+                instrumentCopy.setMasterVolume(masterVolume);
                 copyId = instrumentCopy.id;
                 earcon.instrumentsPlaying[copyId] = instrumentCopy;
                 instrumentCopy.play(instrumentOpts);

--- a/ts/modules/sonification/Timeline.ts
+++ b/ts/modules/sonification/Timeline.ts
@@ -73,7 +73,7 @@ declare global {
             eventObject?: TimelineEventObject;
             id?: string;
             onEnd?: Function;
-            playOptions?: PointSonifyOptionsObject;
+            playOptions?: PointSonifyOptionsObject|Partial<EarconOptionsObject>;
             time?: number;
         }
         interface TimelineOptionsObject {

--- a/ts/modules/sonification/chartSonify.ts
+++ b/ts/modules/sonification/chartSonify.ts
@@ -21,11 +21,62 @@ import H from '../../parts/Globals.js';
  */
 declare global {
     namespace Highcharts {
+        interface ChartSonificationEventsOptions {
+            onEnd?: Function;
+            onPointEnd?: Function;
+            onPointStart?: Function;
+            onSeriesEnd?: Function;
+            onSeriesStart?: Function;
+        }
+        interface DefaultSonificationInstrumentMappingOptions extends SonificationInstrumentMappingOptions {
+            pointPlayTime?: (string|Function);
+        }
+        interface DefaultSonificationInstrumentOptions {
+            instrument: (string|Instrument);
+            mapping?: DefaultSonificationInstrumentMappingOptions;
+        }
+        interface EarconConfiguration {
+            condition: Function;
+            earcon: Earcon;
+            onPoint?: string;
+        }
+        interface SeriesSonificationEventsOptions {
+            onPointEnd?: Function;
+            onPointStart?: Function;
+            onSeriesEnd?: Function;
+            onSeriesStart?: Function;
+        }
+        interface SeriesSonificationOptions {
+            enabled?: boolean;
+            events?: SeriesSonificationEventsOptions;
+            duration?: number;
+            instruments?: Array<SonificationInstrumentOptions>;
+        }
+        interface SonificationInstrumentOptions extends PointInstrumentOptionsObject {
+            instrument: (string|Instrument);
+            mapping?: SonificationInstrumentMappingOptions;
+        }
+        interface SonificationInstrumentMappingOptions {
+            duration?: (number|string|Function);
+            frequency?: (number|string|Function);
+            pan?: (number|string|Function);
+            volume?: (number|string|Function);
+        }
+        interface ChartSonificationOptions {
+            afterSeriesWait?: number;
+            dataExtremes?: Dictionary<RangeObject>;
+            defaultInstrumentOptions?: DefaultSonificationInstrumentOptions;
+            duration: number;
+            enabled?: boolean;
+            events?: ChartSonificationEventsOptions;
+            masterVolume?: number;
+            order: (string|Array<string|Earcon|Array<string|Earcon>>);
+        }
         interface SonifyChartFunctionsObject {
             cancel(this: SonifyableChart, fadeOut?: boolean): void;
             chartSonify(
                 this: SonifyableChart,
-                options?: SonificationOptions
+                options?: ChartSonificationOptions
             ): void;
             getCurrentPoints(this: SonifyableChart): Array<Point>;
             pause(this: SonifyableChart, fadeOut?: boolean): void;
@@ -42,32 +93,28 @@ declare global {
                 points: (Point|Array<Point>)
             ): void;
         }
-        interface SonificationOptions {
+        interface SonifyChartOptionsObject {
             afterSeriesWait?: number;
             dataExtremes?: Dictionary<RangeObject>;
             duration: number;
             earcons?: Array<EarconConfiguration>;
-            enabled?: boolean;
             instruments?: Array<PointInstrumentObject>;
-            onEnd?: Function;
+            masterVolume?: number;
             onSeriesEnd?: Function;
             onSeriesStart?: Function;
+            onEnd?: Function;
             order: (string|Array<string|Earcon|Array<string|Earcon>>);
             pointPlayTime: (string|Function);
             seriesOptions?: (
                 SonifySeriesOptionsObject|Array<SonifySeriesOptionsObject>
             );
         }
-        interface EarconConfiguration {
-            condition: Function;
-            earcon: Earcon;
-            onPoint?: string;
-        }
         interface SonifySeriesOptionsObject extends SeriesOptions {
             dataExtremes?: Dictionary<RangeObject>;
             duration: number;
             earcons?: Array<EarconConfiguration>;
             instruments: Array<PointInstrumentObject>;
+            masterVolume?: number;
             onEnd?: Function;
             onPointEnd?: Function;
             onPointStart?: Function;
@@ -235,12 +282,13 @@ function getTimeExtremes(
 
 
 /**
- * Calculate value extremes for used instrument data properties.
+ * Calculate value extremes for used instrument data properties on a chart.
  * @private
  * @param {Highcharts.Chart} chart
  * The chart to calculate extremes from.
- * @param {Array<Highcharts.PointInstrumentObject>} instruments
- * The instrument definitions used.
+ * @param {Array<Highcharts.PointInstrumentObject>} [instruments]
+ * Additional instrument definitions to inspect for data props used, in
+ * addition to the instruments defined in the chart options.
  * @param {Highcharts.Dictionary<Highcharts.RangeObject>} [dataExtremes]
  * Predefined extremes for each data prop.
  * @return {Highcharts.Dictionary<Highcharts.RangeObject>}
@@ -248,12 +296,29 @@ function getTimeExtremes(
  */
 function getExtremesForInstrumentProps(
     chart: Chart,
-    instruments: Array<Highcharts.PointInstrumentObject>,
-    dataExtremes: Highcharts.Dictionary<Highcharts.RangeObject>
+    instruments?: Array<Highcharts.PointInstrumentObject>,
+    dataExtremes?: Highcharts.Dictionary<Highcharts.RangeObject>
 ): Highcharts.Dictionary<Highcharts.RangeObject> {
-    return (
-        instruments || []
-    ).reduce(function (
+    let allInstrumentDefinitions = (instruments || []).slice(0);
+    const defaultInstrumentDef = chart.options.sonification?.defaultInstrumentOptions;
+    const optionDefToInstrDef = (
+        optionDef: Highcharts.SonificationInstrumentOptions|Highcharts.DefaultSonificationInstrumentOptions
+    ): Highcharts.PointInstrumentObject => ({
+        instrumentMapping: optionDef.mapping
+    } as Highcharts.PointInstrumentObject);
+
+    if (defaultInstrumentDef) {
+        allInstrumentDefinitions.push(optionDefToInstrDef(defaultInstrumentDef));
+    }
+
+    chart.series.forEach((series): void => {
+        const instrOptions = series.options.sonification?.instruments;
+        if (instrOptions) {
+            allInstrumentDefinitions = allInstrumentDefinitions.concat(instrOptions.map(optionDefToInstrDef));
+        }
+    });
+
+    return (allInstrumentDefinitions).reduce(function (
         newExtremes: Highcharts.Dictionary<Highcharts.RangeObject>,
         instrumentDefinition: Highcharts.PointInstrumentObject
     ): Highcharts.Dictionary<Highcharts.RangeObject> {
@@ -480,17 +545,19 @@ function buildTimelinePathFromSeries(
  *
  * @function Highcharts.Series#sonify
  *
- * @param {Highcharts.SonifySeriesOptionsObject} options
- *        The options for sonifying this series.
+ * @param {Highcharts.SonifySeriesOptionsObject} [options]
+ *        The options for sonifying this series. If not provided,
+ *        uses options set on chart and series.
  *
  * @return {void}
  */
 function seriesSonify(
     this: Highcharts.SonifyableSeries,
-    options: Highcharts.SonifySeriesOptionsObject
+    options?: Highcharts.SonifySeriesOptionsObject
 ): void {
-    var timelinePath = buildTimelinePathFromSeries(this, options),
-        chartSonification = this.chart.sonification;
+    const mergedOptions = getSeriesSonifyOptions(this, options);
+    const timelinePath = buildTimelinePathFromSeries(this, mergedOptions);
+    const chartSonification = this.chart.sonification;
 
     // Only one timeline can play at a time. If we want multiple series playing
     // at the same time, use chart.sonify.
@@ -499,7 +566,7 @@ function seriesSonify(
     }
 
     // Store reference to duration
-    chartSonification.duration = options.duration;
+    chartSonification.duration = mergedOptions.duration;
 
     // Create new timeline for this series, and play it.
     chartSonification.timeline = new H.sonification.Timeline({
@@ -523,41 +590,45 @@ function seriesSonify(
  * @return {Partial<Highcharts.SonifySeriesOptionsObject>}
  * Options for buildTimelinePathFromSeries.
  */
-function buildSeriesOptions(
+function buildChartSonifySeriesOptions(
     series: Highcharts.SonifyableSeries,
     dataExtremes: Highcharts.Dictionary<Highcharts.RangeObject>,
-    chartSonifyOptions: Highcharts.SonificationOptions
+    chartSonifyOptions: Highcharts.SonifyChartOptionsObject
 ): Partial<Highcharts.SonifySeriesOptionsObject> {
-    var seriesOptions: (
+    const additionalSeriesOptions: (
         Partial<Highcharts.SonifySeriesOptionsObject>|
         Array<Partial<Highcharts.SonifySeriesOptionsObject>>
     ) = chartSonifyOptions.seriesOptions || {};
+    const pointPlayTime = series.chart.options.sonification?.
+        defaultInstrumentOptions?.mapping?.pointPlayTime || 'x';
+    const configOptions = chartOptionsToSonifySeriesOptions(series);
 
     return merge(
+        // Options from chart configuration
+        configOptions,
+        // Options passed in
         {
             // Calculated dataExtremes for chart
             dataExtremes: dataExtremes,
             // We need to get timeExtremes for each series. We pass this
             // in when building the TimelinePath objects to avoid
             // calculating twice.
-            timeExtremes: getTimeExtremes(
-                series, chartSonifyOptions.pointPlayTime
-            ),
+            timeExtremes: getTimeExtremes(series, pointPlayTime),
             // Some options we just pass on
-            instruments: chartSonifyOptions.instruments,
-            onStart: chartSonifyOptions.onSeriesStart,
-            onEnd: chartSonifyOptions.onSeriesEnd,
-            earcons: chartSonifyOptions.earcons
+            instruments: chartSonifyOptions.instruments || configOptions.instruments,
+            onStart: chartSonifyOptions.onSeriesStart || configOptions.onStart,
+            onEnd: chartSonifyOptions.onSeriesEnd || configOptions.onEnd,
+            earcons: chartSonifyOptions.earcons || configOptions.earcons
         },
-        // Merge in the specific series options by ID
-        isArray(seriesOptions) ? (
-            find(seriesOptions, function (optEntry: any): boolean {
+        // Merge in the specific series options by ID if any are passed in
+        isArray(additionalSeriesOptions) ? (
+            find(additionalSeriesOptions, function (optEntry: any): boolean {
                 return optEntry.id === pick(series.id, series.options.id);
             }) || {}
-        ) : seriesOptions,
+        ) : additionalSeriesOptions,
         {
             // Forced options
-            pointPlayTime: chartSonifyOptions.pointPlayTime
+            pointPlayTime: pointPlayTime
         }
     );
 }
@@ -972,18 +1043,122 @@ function buildPathsFromOrder(
 
 /**
  * @private
+ * @param {Highcharts.Series} series The series to get options for.
+ * @param {Highcharts.SonifySeriesOptionsObject} options
+ *  Options to merge with user options on series/chart and default options.
+ * @returns {Array<Highcharts.PointInstrumentObject>} The merged options.
+ */
+function getSeriesInstrumentOptions(
+    series: Highcharts.SonifyableSeries,
+    options?: Highcharts.SonifySeriesOptionsObject
+): (Array<Highcharts.PointInstrumentObject>|undefined) {
+    if (options?.instruments) {
+        return options.instruments;
+    }
+
+    const defaultInstrOpts: Highcharts.Dictionary<any> =
+        series.chart.options.sonification?.defaultInstrumentOptions || {};
+    const seriesInstrOpts: Array<Highcharts.Dictionary<any>> =
+        series.options.sonification?.instruments || [{}];
+
+    // Convert series options to PointInstrumentObjects and merge with
+    // default options
+    return (seriesInstrOpts).map((optionSet): Highcharts.PointInstrumentObject => ({
+        instrument: optionSet.instrument || defaultInstrOpts.instrument,
+        instrumentOptions: merge(defaultInstrOpts, optionSet, {
+            // Instrument options are lifted to root in the API options object,
+            // so merge all in order to avoid missing any. But remove the
+            // following which are not instrumentOptions:
+            mapping: void 0,
+            instrument: void 0
+        }) as Partial<Highcharts.PointInstrumentOptionsObject>,
+        instrumentMapping: merge(defaultInstrOpts.mapping, optionSet.mapping)
+    }));
+}
+
+
+/**
+ * Utility function to translate between options set in chart configuration and
+ * a SonifySeriesOptionsObject.
+ * @private
+ * @param {Highcharts.Series} series The series to get options for.
+ * @returns {Highcharts.SonifySeriesOptionsObject} Options for chart/series.sonify()
+ */
+function chartOptionsToSonifySeriesOptions(
+    series: Highcharts.SonifyableSeries
+): Partial<Highcharts.SonifySeriesOptionsObject> {
+    const seriesOpts = series.options.sonification || {} as Highcharts.SeriesSonificationOptions;
+    const chartOpts = series.chart.options.sonification || {} as Highcharts.ChartSonificationOptions;
+    const chartEvents = chartOpts.events || {} as Highcharts.ChartSonificationEventsOptions;
+    const seriesEvents = seriesOpts.events || {} as Highcharts.SeriesSonificationEventsOptions;
+
+    return merge(
+        { // Chart options
+            onEnd: chartEvents.onSeriesEnd,
+            onStart: chartEvents.onSeriesStart,
+            onPointEnd: chartEvents.onPointEnd,
+            onPointStart: chartEvents.onPointStart,
+            pointPlayTime: chartOpts.defaultInstrumentOptions?.mapping?.pointPlayTime
+        },
+        { // Series options
+            onEnd: seriesEvents.onSeriesEnd,
+            onPointEnd: seriesEvents.onPointEnd,
+            onPointStart: seriesEvents.onPointStart,
+            onStart: seriesEvents.onSeriesStart,
+            instruments: getSeriesInstrumentOptions(series) // Deals with chart-level defaults
+        }
+    );
+}
+
+
+/**
+ * @private
+ * @param {Highcharts.Series} series The series to get options for.
+ * @param {Highcharts.SonifySeriesOptionsObject} options
+ *  Options to merge with user options on series/chart and default options.
+ * @returns {Highcharts.SonifySeriesOptionsObject} The merged options.
+ */
+function getSeriesSonifyOptions(
+    series: Highcharts.SonifyableSeries,
+    options?: Highcharts.SonifySeriesOptionsObject
+): Highcharts.SonifySeriesOptionsObject {
+    const chartOpts = series.chart.options.sonification;
+    const seriesOpts = series.options.sonification;
+    return merge(
+        {
+            duration: seriesOpts?.duration || chartOpts?.duration,
+            masterVolume: chartOpts?.masterVolume
+        },
+        chartOptionsToSonifySeriesOptions(series),
+        options
+    );
+}
+
+
+/**
+ * @private
  * @param {Highcharts.Chart} chart The chart to get options for.
- * @param {Highcharts.SonificationOptions} userOptions
- *  Options to merge with options on chart and default options.
+ * @param {Highcharts.SonificationOptions} options
+ *  Options to merge with user options on chart and default options.
  * @returns {Highcharts.SonificationOptions} The merged options.
  */
 function getChartSonifyOptions(
     chart: Highcharts.SonifyableChart,
-    userOptions?: Highcharts.SonificationOptions
-): Highcharts.SonificationOptions {
+    options?: Highcharts.SonifyChartOptionsObject
+): Highcharts.SonifyChartOptionsObject {
+    const chartOpts: Highcharts.Dictionary<any> = chart.options.sonification || {};
+
     return merge(
-        chart.options.sonification,
-        userOptions
+        {
+            duration: chartOpts.duration,
+            afterSeriesWait: chartOpts.afterSeriesWait,
+            pointPlayTime: chartOpts.defaultInstrumentOptions?.mapping?.pointPlayTime,
+            order: chartOpts.order,
+            onSeriesStart: chartOpts.events?.onSeriesStart,
+            onSeriesEnd: chartOpts.events?.onSeriesEnd,
+            onEnd: chartOpts.events?.onEnd
+        },
+        options
     );
 }
 
@@ -1097,14 +1272,15 @@ function getChartSonifyOptions(
  *
  * @function Highcharts.Chart#sonify
  *
- * @param {Highcharts.SonificationOptions} options
- *        The options for sonifying this chart.
+ * @param {Highcharts.SonificationOptions} [options]
+ *        The options for sonifying this chart. If not provided,
+ *        uses options set on chart and series.
  *
  * @return {void}
  */
 function chartSonify(
     this: Highcharts.SonifyableChart,
-    options?: Highcharts.SonificationOptions
+    options?: Highcharts.SonifyChartOptionsObject
 ): void {
     const opts = getChartSonifyOptions(this, options);
 
@@ -1118,14 +1294,14 @@ function chartSonify(
 
     // Calculate data extremes for the props used
     const dataExtremes = getExtremesForInstrumentProps(
-        this, opts.instruments as any, opts.dataExtremes as any
+        this, opts.instruments, opts.dataExtremes
     );
 
     // Figure out ordering of series and custom paths
     let order = buildPathOrder(opts.order, this, function (
         series: Highcharts.SonifyableSeries
     ): Partial<Highcharts.SonifySeriesOptionsObject> {
-        return buildSeriesOptions(series, dataExtremes, opts);
+        return buildChartSonifySeriesOptions(series, dataExtremes, opts);
     });
 
     // Add waits after simultaneous paths with series in them.

--- a/ts/modules/sonification/chartSonify.ts
+++ b/ts/modules/sonification/chartSonify.ts
@@ -1127,24 +1127,16 @@ function chartOptionsToSonifySeriesOptions(
     const chartEvents = chartOpts.events || {} as Highcharts.ChartSonificationEventsOptions;
     const seriesEvents = seriesOpts.events || {} as Highcharts.SeriesSonificationEventsOptions;
 
-    return merge(
-        { // Chart options
-            onEnd: chartEvents.onSeriesEnd,
-            onStart: chartEvents.onSeriesStart,
-            onPointEnd: chartEvents.onPointEnd,
-            onPointStart: chartEvents.onPointStart,
-            pointPlayTime: chartOpts.defaultInstrumentOptions?.mapping?.pointPlayTime,
-            masterVolume: chartOpts.masterVolume
-        },
-        { // Series options
-            onEnd: seriesEvents.onSeriesEnd,
-            onPointEnd: seriesEvents.onPointEnd,
-            onPointStart: seriesEvents.onPointStart,
-            onStart: seriesEvents.onSeriesStart,
-            instruments: getSeriesInstrumentOptions(series), // Deals with chart-level defaults
-            earcons: seriesOpts.earcons || chartOpts.earcons
-        }
-    );
+    return { // Chart options
+        onEnd: seriesEvents.onSeriesEnd || chartEvents.onSeriesEnd,
+        onStart: seriesEvents.onSeriesStart || chartEvents.onSeriesStart,
+        onPointEnd: seriesEvents.onPointEnd || chartEvents.onPointEnd,
+        onPointStart: seriesEvents.onPointStart || chartEvents.onPointStart,
+        pointPlayTime: chartOpts.defaultInstrumentOptions?.mapping?.pointPlayTime,
+        masterVolume: chartOpts.masterVolume,
+        instruments: getSeriesInstrumentOptions(series), // Deals with chart-level defaults
+        earcons: seriesOpts.earcons || chartOpts.earcons
+    };
 }
 
 

--- a/ts/modules/sonification/chartSonify.ts
+++ b/ts/modules/sonification/chartSonify.ts
@@ -47,6 +47,7 @@ declare global {
             onSeriesStart?: Function;
         }
         interface SeriesSonificationOptions {
+            earcons?: Array<EarconConfiguration>;
             enabled?: boolean;
             events?: SeriesSonificationEventsOptions;
             duration?: number;
@@ -67,6 +68,7 @@ declare global {
             dataExtremes?: Dictionary<RangeObject>;
             defaultInstrumentOptions?: DefaultSonificationInstrumentOptions;
             duration: number;
+            earcons?: Array<EarconConfiguration>;
             enabled?: boolean;
             events?: ChartSonificationEventsOptions;
             masterVolume?: number;
@@ -1105,7 +1107,8 @@ function chartOptionsToSonifySeriesOptions(
             onPointEnd: seriesEvents.onPointEnd,
             onPointStart: seriesEvents.onPointStart,
             onStart: seriesEvents.onSeriesStart,
-            instruments: getSeriesInstrumentOptions(series) // Deals with chart-level defaults
+            instruments: getSeriesInstrumentOptions(series), // Deals with chart-level defaults
+            earcons: seriesOpts.earcons || chartOpts.earcons
         }
     );
 }

--- a/ts/modules/sonification/chartSonify.ts
+++ b/ts/modules/sonification/chartSonify.ts
@@ -672,7 +672,7 @@ function buildPathOrder(
             seriesList: Array<Highcharts.SonifySeriesOrderObject>,
             series: Highcharts.SonifyableSeries
         ): Array<Highcharts.SonifySeriesOrderObject> {
-            if (series.visible) {
+            if (series.visible && series.options.sonification?.enabled !== false) {
                 seriesList.push({
                     series: series,
                     seriesOptions: seriesOptionsCallback(series)

--- a/ts/modules/sonification/options.ts
+++ b/ts/modules/sonification/options.ts
@@ -32,7 +32,7 @@ const options = {
     sonification: {
         enabled: false,
         duration: 2000,
-        afterSeriesWait: 1000,
+        afterSeriesWait: 900,
         masterVolume: 0.7,
         order: 'sequential',
         defaultInstrumentOptions: {

--- a/ts/modules/sonification/options.ts
+++ b/ts/modules/sonification/options.ts
@@ -19,7 +19,10 @@
 declare global {
     namespace Highcharts {
         interface Options {
-            sonification?: SonificationOptions;
+            sonification?: ChartSonificationOptions;
+        }
+        interface SeriesOptions {
+            sonification?: SeriesSonificationOptions;
         }
     }
 }
@@ -30,21 +33,19 @@ const options = {
         enabled: false,
         duration: 2000,
         afterSeriesWait: 1000,
+        masterVolume: 0.7,
         order: 'sequential',
-        pointPlayTime: 'x',
-        instruments: [{
+        defaultInstrumentOptions: {
             instrument: 'sineMusical',
-            instrumentMapping: {
-                duration: 400,
-                frequency: 'y',
-                volume: 0.7
-            },
             // Start at G4 note, end at C6
-            instrumentOptions: {
-                minFrequency: 392,
-                maxFrequency: 1046
+            minFrequency: 392,
+            maxFrequency: 1046,
+            mapping: {
+                pointPlayTime: 'x',
+                duration: 400,
+                frequency: 'y'
             }
-        }]
+        }
     }
 };
 

--- a/ts/modules/sonification/options.ts
+++ b/ts/modules/sonification/options.ts
@@ -33,7 +33,7 @@ const options = {
         enabled: false,
         duration: 2000,
         afterSeriesWait: 900,
-        masterVolume: 0.7,
+        masterVolume: 1,
         order: 'sequential',
         defaultInstrumentOptions: {
             instrument: 'sineMusical',

--- a/ts/modules/sonification/pointSonify.ts
+++ b/ts/modules/sonification/pointSonify.ts
@@ -59,6 +59,7 @@ declare global {
             dataExtremes?: Dictionary<RangeObject>;
             instruments: Array<PointInstrumentObject>;
             onEnd?: Function;
+            masterVolume?: number;
         }
     }
 }
@@ -274,6 +275,7 @@ function pointSonify(
 ): void {
     var point = this,
         chart = point.series.chart,
+        masterVolume = pick(options.masterVolume, chart.options.sonification?.masterVolume),
         dataExtremes = options.dataExtremes || {},
         // Get the value to pass to instrument.play from the mapping value
         // passed in.
@@ -377,6 +379,10 @@ function pointSonify(
 
         // Play the note on the instrument
         if (instrument && instrument.play) {
+            if (typeof masterVolume !== 'undefined') {
+                instrument.setMasterVolume(masterVolume);
+            }
+
             (point.sonification.instrumentsPlaying as any)[instrument.id] =
                 instrument;
             instrument.play({

--- a/ts/modules/sonification/pointSonify.ts
+++ b/ts/modules/sonification/pointSonify.ts
@@ -74,20 +74,24 @@ declare global {
  * Define the volume of the instrument. This can be a string with a data
  * property name, e.g. `'y'`, in which case this data property is used to define
  * the volume relative to the `y`-values of the other points. A higher `y` value
- * would then result in a higher volume. This option can also be a fixed number
- * or a function. If it is a function, this function is called in regular
- * intervals while the note is playing. It receives three arguments: The point,
- * the dataExtremes, and the current relative time - where 0 is the beginning of
- * the note and 1 is the end. The function should return the volume of the note
- * as a number between 0 and 1.
+ * would then result in a higher volume. Alternatively, `'-y'` can be used,
+ * which inverts the polarity, so that a higher `y` value results in a lower
+ * volume. This option can also be a fixed number or a function. If it is a
+ * function, this function is called in regular intervals while the note is
+ * playing. It receives three arguments: The point, the dataExtremes, and the
+ * current relative time - where 0 is the beginning of the note and 1 is the
+ * end. The function should return the volume of the note as a number between
+ * 0 and 1.
  * @name Highcharts.PointInstrumentMappingObject#volume
  * @type {string|number|Function}
  *//**
  * Define the duration of the notes for this instrument. This can be a string
  * with a data property name, e.g. `'y'`, in which case this data property is
  * used to define the duration relative to the `y`-values of the other points. A
- * higher `y` value would then result in a longer duration. This option can also
- * be a fixed number or a function. If it is a function, this function is called
+ * higher `y` value would then result in a longer duration. Alternatively,
+ * `'-y'` can be used, in which case the polarity is inverted, and a higher
+ * `y` value would result in a shorter duration. This option can also be a
+ * fixed number or a function. If it is a function, this function is called
  * once before the note starts playing, and should return the duration in
  * milliseconds. It receives two arguments: The point, and the dataExtremes.
  * @name Highcharts.PointInstrumentMappingObject#duration
@@ -97,24 +101,28 @@ declare global {
  * property name, e.g. `'x'`, in which case this data property is used to define
  * the panning relative to the `x`-values of the other points. A higher `x`
  * value would then result in a higher panning value (panned further to the
- * right). This option can also be a fixed number or a function. If it is a
- * function, this function is called in regular intervals while the note is
- * playing. It receives three arguments: The point, the dataExtremes, and the
- * current relative time - where 0 is the beginning of the note and 1 is the
- * end. The function should return the panning of the note as a number between
- * -1 and 1.
+ * right). Alternatively, `'-x'` can be used, in which case the polarity is
+ * inverted, and a higher `x` value would result in a lower panning value
+ * (panned further to the left). This option can also be a fixed number or a
+ * function. If it is a function, this function is called in regular intervals
+ * while the note is playing. It receives three arguments: The point, the
+ * dataExtremes, and the current relative time - where 0 is the beginning of
+ * the note and 1 is the end. The function should return the panning of the
+ * note as a number between -1 and 1.
  * @name Highcharts.PointInstrumentMappingObject#pan
  * @type {string|number|Function|undefined}
  *//**
  * Define the frequency of the instrument. This can be a string with a data
  * property name, e.g. `'y'`, in which case this data property is used to define
  * the frequency relative to the `y`-values of the other points. A higher `y`
- * value would then result in a higher frequency. This option can also be a
- * fixed number or a function. If it is a function, this function is called in
- * regular intervals while the note is playing. It receives three arguments:
- * The point, the dataExtremes, and the current relative time - where 0 is the
- * beginning of the note and 1 is the end. The function should return the
- * frequency of the note as a number (in Hz).
+ * value would then result in a higher frequency. Alternatively, `'-y'` can be
+ * used, in which case the polarity is inverted, and a higher `y` value would
+ * result in a lower frequency. This option can also be a fixed number or a
+ * function. If it is a function, this function is called in regular intervals
+ * while the note is playing. It receives three arguments: The point, the
+ * dataExtremes, and the current relative time - where 0 is the beginning of
+ * the note and 1 is the end. The function should return the frequency of the
+ * note as a number (in Hz).
  * @name Highcharts.PointInstrumentMappingObject#frequency
  * @type {string|number|Function}
  */
@@ -293,18 +301,24 @@ function pointSonify(
                     } :
                     value(point, dataExtremes);
             }
-            // String, this is a data prop.
+            // String, this is a data prop. Potentially with negative polarity.
             if (typeof value === 'string') {
+                const hasInvertedPolarity = value.charAt(0) === '-';
+                const dataProp = hasInvertedPolarity ? value.slice(1) : value;
+                const pointValue = pick((point as any)[dataProp], (point.options as any)[dataProp]);
+
                 // Find data extremes if we don't have them
-                dataExtremes[value] = dataExtremes[value] ||
+                dataExtremes[dataProp] = dataExtremes[dataProp] ||
                     utilities.calculateDataExtremes(
-                        point.series.chart, value
+                        point.series.chart, dataProp
                     );
+
                 // Find the value
                 return utilities.virtualAxisTranslate(
-                    pick((point as any)[value], (point.options as any)[value]),
-                    dataExtremes[value],
-                    allowedExtremes
+                    pointValue,
+                    dataExtremes[dataProp],
+                    allowedExtremes,
+                    hasInvertedPolarity
                 );
             }
             // Fixed number or something else weird, just use that

--- a/ts/modules/sonification/utilities.ts
+++ b/ts/modules/sonification/utilities.ts
@@ -46,7 +46,8 @@ declare global {
             virtualAxisTranslate(
                 value: number,
                 dataExtremes: RangeObject,
-                limits: RangeObject
+                limits: RangeObject,
+                invert?: boolean
             ): number;
         }
     }
@@ -239,18 +240,24 @@ var utilities: Highcharts.SonificationUtilitiesObject = {
      * The possible extremes for this value.
      * @param {object} limits
      * Limits for the virtual axis.
+     * @param {boolean} [invert]
+     * Invert the virtual axis.
      * @return {number}
      * The value mapped to the virtual axis.
      */
     virtualAxisTranslate: function (
         value: number,
         dataExtremes: Highcharts.RangeObject,
-        limits: Highcharts.RangeObject
+        limits: Highcharts.RangeObject,
+        invert?: boolean
     ): number {
-        var lenValueAxis = dataExtremes.max - dataExtremes.min,
-            lenVirtualAxis = limits.max - limits.min,
-            virtualAxisValue = limits.min +
-                lenVirtualAxis * (value - dataExtremes.min) / lenValueAxis;
+        const lenValueAxis = dataExtremes.max - dataExtremes.min,
+            lenVirtualAxis = Math.abs(limits.max - limits.min),
+            valueDelta = invert ?
+                dataExtremes.max - value :
+                value - dataExtremes.min,
+            virtualValueDelta = lenVirtualAxis * valueDelta / lenValueAxis,
+            virtualAxisValue = limits.min + virtualValueDelta;
 
         return lenValueAxis > 0 ?
             clamp(virtualAxisValue, limits.min, limits.max) :


### PR DESCRIPTION
Added support for configuring sonification options in the chart configuration, as well as support for disabling individual series, configuring master volume, and inverted polarity mapping. Note that chart configuration options are still considered experimental and may change.
____
Relatively comprehensive sonification overhaul that adds the following:

### Support for chart configuration API
Revamp of the top level `sonification` options, as well as the introduction of new `series.sonification` options.

Example configuration:

```javascript
Highcharts.chart('container', {    
    sonification: {
        duration: 5000,
        order: ['columnSeries', ['scatterSeriesA', 'scatterSeriesB']],
        defaultInstrumentOptions: {
            instrument: 'triangleMajor',
            minFrequency: 220,
            maxFrequency: 2200,
            mapping: {
                volume: 0.8,
                duration: 250,
                pan: 'x'
            }
        }
    },
    // ...
    series: [{
        id: 'columnSeries',
        sonification: {
            instruments: [{
                mapping: {
                    volume: 0.4,
                    pan: 1
                }
            }]
        }
```

The introduction of `defaultInstrumentOptions` that are merged into other instruments on specific data series removes a lot of complexity, and also makes it easier for us to define default behavior. The simplification of options and mapping structure should help the configuration be more intuitive.

The parameters for `chart.sonify()`, `series.sonify()`, and `point.sonify()` have not changed, but are optional, and are merged with chart configuration options if both are present. There should be no issues with backwards compatibility.

The chart options remain undocumented and officially experimental for now, but are considered unlikely to change. Some of the tests have been converted to use this new API, but most are kept as is for documentation purposes. When the API has been finalized we will want to update our documentation, and have our official demos reflect the changes.


### Disabling individual data series

This is made a lot simpler by the introduction of a `series.sonification.enabled` option.


### Master volume

`chart.sonify()` and `series.sonify()` now support a new `masterVolume` option, and this has also been added to the top level `sonification` options. This makes it a lot easier to control the overall volume level of a chart, including all Earcons and Instruments, even if these are using dynamic data-mapped or functional volumes.


### Inverted polarity mapping

It is now possible to map sonification parameters to data properties with the polarity inverted. This is done by prepending the property name with `-`. Example:

```javascript
mapping: {
    duration: 250,
    pan: 'x',
    frequency: '-y'
}
```

In the above example, as the `y`-value gets higher, the frequency goes down - rather than up.

Any data property can be inverse mapped to like this, both for volume, panning, frequency, and duration.
