### PR TITLE
Tools: Added `scripts-code` task to `dist` task

### DIFF
--- a/tools/gulptasks/dist.js
+++ b/tools/gulptasks/dist.js
@@ -32,6 +32,7 @@ Gulp.task(
         'scripts-css',
         'scripts-ts',
         'scripts-js',
+        'scripts-code',
         'scripts-compile',
         'dist-clean',
         'dist-copy',


### PR DESCRIPTION
The `dist` gulp task was missing `scripts-code` which had the side effect of the `highcharts.src.js` files on [code.highcharts.com](//code.highcharts.com) and [highcharts-dist](/highcharts/highcharts-dist) being [slightly different](https://github.com/highcharts/highcharts/issues/13598#issuecomment-636708779) (part of #13598).