### PR TITLE
bugfix/12868-zoom-not-working-after-scrolling-multiple-charts

### DIFF
--- a/js/parts/Pointer.js
+++ b/js/parts/Pointer.js
@@ -130,6 +130,7 @@ var Pointer = /** @class */ (function () {
         this.hasDragged = false;
         this.options = options;
         this.unbindContainerMouseLeave = function () { };
+        this.unbindContainerMouseEnter = function () { };
         this.init(chart, options);
     }
     /* *
@@ -844,6 +845,19 @@ var Pointer = /** @class */ (function () {
         }
     };
     /**
+     * When mouse enters the container, delete pointer's chartPosition.
+     *
+     * @private
+     * @function Highcharts.Pointer#onContainerMouseEnter
+     *
+     * @param {global.MouseEvent} e
+     *
+     * @return {void}
+     */
+    Pointer.prototype.onContainerMouseEnter = function (e) {
+        delete this.chartPosition;
+    };
+    /**
      * The mousemove, touchmove and touchstart event handler
      *
      * @private
@@ -1390,6 +1404,7 @@ var Pointer = /** @class */ (function () {
         container.onmousedown = this.onContainerMouseDown.bind(this);
         container.onmousemove = this.onContainerMouseMove.bind(this);
         container.onclick = this.onContainerClick.bind(this);
+        this.unbindContainerMouseEnter = addEvent(container, 'mouseenter', this.onContainerMouseEnter.bind(this));
         this.unbindContainerMouseLeave = addEvent(container, 'mouseleave', this.onContainerMouseLeave.bind(this));
         if (!H.unbindDocumentMouseUp) {
             H.unbindDocumentMouseUp = addEvent(ownerDoc, 'mouseup', this.onDocumentMouseUp.bind(this));

--- a/ts/parts/Pointer.ts
+++ b/ts/parts/Pointer.ts
@@ -226,6 +226,7 @@ class Pointer {
         this.hasDragged = false;
         this.options = options;
         this.unbindContainerMouseLeave = function (): void {};
+        this.unbindContainerMouseEnter = function (): void {};
         this.init(chart, options);
     }
 
@@ -272,6 +273,8 @@ class Pointer {
     public tooltipTimeout?: number;
 
     public unbindContainerMouseLeave: Function;
+
+    public unbindContainerMouseEnter: Function;
 
     public unDocMouseMove?: Function;
 
@@ -1234,6 +1237,20 @@ class Pointer {
     }
 
     /**
+     * When mouse enters the container, delete pointer's chartPosition.
+     *
+     * @private
+     * @function Highcharts.Pointer#onContainerMouseEnter
+     *
+     * @param {global.MouseEvent} e
+     *
+     * @return {void}
+     */
+    public onContainerMouseEnter(e: MouseEvent): void {
+        delete this.chartPosition;
+    }
+
+    /**
      * The mousemove, touchmove and touchstart event handler
      *
      * @private
@@ -2012,6 +2029,11 @@ class Pointer {
         container.onmousedown = this.onContainerMouseDown.bind(this);
         container.onmousemove = this.onContainerMouseMove.bind(this);
         container.onclick = this.onContainerClick.bind(this);
+        this.unbindContainerMouseEnter = addEvent(
+            container,
+            'mouseenter',
+            this.onContainerMouseEnter.bind(this)
+        );
         this.unbindContainerMouseLeave = addEvent(
             container,
             'mouseleave',


### PR DESCRIPTION
Fixed #12868, drag zoom was not working on multiple charts after scrolling.