### PR TITLE
bugfix/13846-dataLabels-hidden-pie

### DIFF
--- a/js/Extensions/OverlappingDataLabels.js
+++ b/js/Extensions/OverlappingDataLabels.js
@@ -69,10 +69,10 @@ addEvent(Chart, 'render', function collectAndHide() {
  */
 Chart.prototype.hideOverlappingLabels = function (labels) {
     var chart = this, len = labels.length, ren = chart.renderer, label, i, j, label1, label2, box1, box2, isLabelAffected = false, isIntersectRect = function (box1, box2) {
-        return !(box2.x > box1.x + box1.width ||
-            box2.x + box2.width < box1.x ||
-            box2.y > box1.y + box1.height ||
-            box2.y + box2.height < box1.y);
+        return !(box2.x >= box1.x + box1.width ||
+            box2.x + box2.width <= box1.x ||
+            box2.y >= box1.y + box1.height ||
+            box2.y + box2.height <= box1.y);
     }, 
     // Get the box with its position inside the chart, as opposed to getBBox
     // that only reports the position relative to the parent.

--- a/ts/Extensions/OverlappingDataLabels.ts
+++ b/ts/Extensions/OverlappingDataLabels.ts
@@ -141,10 +141,10 @@ Chart.prototype.hideOverlappingLabels = function (
             box2: Highcharts.BBoxObject
         ): boolean {
             return !(
-                box2.x > box1.x + box1.width ||
-                box2.x + box2.width < box1.x ||
-                box2.y > box1.y + box1.height ||
-                box2.y + box2.height < box1.y
+                box2.x >= box1.x + box1.width ||
+                box2.x + box2.width <= box1.x ||
+                box2.y >= box1.y + box1.height ||
+                box2.y + box2.height <= box1.y
             );
         },
 


### PR DESCRIPTION
Fixed #13846, data labels were initially hidden in some pie chart instances due to overlapping detection.