### PR TITLE
bugfix/13736-draggable-annotations-touch-devices

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,13 +7,17 @@ assignees: ''
 
 ---
 
+<!-- Before submitting a feature request, please consider searching for a similar request allready made, and upvote that instead. This makes it easier for us to filter on the most requested features. -->
+
 # Description of the feature
-Add information about the feature with standard use-case.
+<!-- Add information about the feature along with typical use-cases. -->
 
 # Library related to the feature
-Might be Highcharts/Highstock/Highmaps/Gantt
+<!-- Might be Highcharts/Highstock/Highmaps/Gantt. -->
 
-# Proof of Concept/ Live example for the feature
-If you have a POC or live example of the feature, please add it here.
+# Proof of Concept/Live example for the feature
+<!-- If you have a POC, live example of the feature, or screenshots please add it here. -->
 
-You can vote for the feature by adding thumbs-up reaction for this post.
+----
+
+**You can vote for this feature by a adding thumbs-up reaction to this post.**

--- a/js/Extensions/Annotations/Mixins/EventEmitterMixin.js
+++ b/js/Extensions/Annotations/Mixins/EventEmitterMixin.js
@@ -49,7 +49,7 @@ var eventEmitterMixin = {
             }
         });
         if (emitter.options.draggable) {
-            addEvent(emitter, H.isTouchDevice ? 'touchmove' : 'drag', emitter.onDrag);
+            addEvent(emitter, 'drag', emitter.onDrag);
             if (!emitter.graphic.renderer.styledMode) {
                 var cssPointer_1 = {
                     cursor: {

--- a/ts/Extensions/Annotations/Mixins/EventEmitterMixin.ts
+++ b/ts/Extensions/Annotations/Mixins/EventEmitterMixin.ts
@@ -124,7 +124,7 @@ const eventEmitterMixin: Highcharts.AnnotationEventEmitterMixin = {
 
         if (emitter.options.draggable) {
 
-            addEvent(emitter, H.isTouchDevice ? 'touchmove' : 'drag', emitter.onDrag);
+            addEvent(emitter, 'drag', emitter.onDrag);
 
 
             if (!emitter.graphic.renderer.styledMode) {


### PR DESCRIPTION
Fixed #13736, draggable annotations did not work on touch devices.