### PR TITLE
bugfix/13694/area-low-value-breaks

### DIFF
--- a/js/Series/AreaSeries.js
+++ b/js/Series/AreaSeries.js
@@ -322,7 +322,7 @@ seriesType('area', 'line',
             }
             isNull = points[i].isNull;
             plotX = pick(points[i].rectPlotX, points[i].plotX);
-            yBottom = pick(points[i].yBottom, translatedThreshold);
+            yBottom = translatedThreshold;
             if (!isNull || connectNulls) {
                 if (!connectNulls) {
                     addDummyPoints(i, i - 1, 'left');

--- a/js/Series/AreaSeries.js
+++ b/js/Series/AreaSeries.js
@@ -322,7 +322,7 @@ seriesType('area', 'line',
             }
             isNull = points[i].isNull;
             plotX = pick(points[i].rectPlotX, points[i].plotX);
-            yBottom = translatedThreshold;
+            yBottom = stacking ? points[i].yBottom : translatedThreshold;
             if (!isNull || connectNulls) {
                 if (!connectNulls) {
                     addDummyPoints(i, i - 1, 'left');

--- a/samples/unit-tests/series-area/area-threshold/demo.details
+++ b/samples/unit-tests/series-area/area-threshold/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series-area/area-threshold/demo.html
+++ b/samples/unit-tests/series-area/area-threshold/demo.html
@@ -1,0 +1,8 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+
+<div id="container" style="width: 400px; margin: 0 auto;"></div>
+<div id="exported"></div>

--- a/samples/unit-tests/series-area/area-threshold/demo.js
+++ b/samples/unit-tests/series-area/area-threshold/demo.js
@@ -1,0 +1,31 @@
+QUnit.test("Area doesn't respect the threshold, when low value is defined #3694", assert => {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'area'
+        },
+        series: [{
+            data: [{
+                y: 5,
+                low: 3
+            }, {
+                y: 10,
+                low: 3.5
+            }]
+        }]
+    });
+
+    const areaPath = chart.series[0].areaPath,
+        thresholdValue = chart.yAxis[0].getThreshold(chart.series[0].options.threshold);
+
+    assert.strictEqual(
+        areaPath[2][2],
+        thresholdValue,
+        'The areaPath y bottom value should be same as the threshold'
+    );
+
+    assert.strictEqual(
+        areaPath[3][2],
+        thresholdValue,
+        'The areaPath y bottom value should be same as the threshold'
+    );
+});

--- a/ts/Series/AreaSeries.ts
+++ b/ts/Series/AreaSeries.ts
@@ -480,7 +480,7 @@ seriesType<Highcharts.AreaSeries>(
 
                 isNull = points[i].isNull;
                 plotX = pick(points[i].rectPlotX, points[i].plotX);
-                yBottom = pick(points[i].yBottom, translatedThreshold);
+                yBottom = translatedThreshold;
 
                 if (!isNull || connectNulls) {
 

--- a/ts/Series/AreaSeries.ts
+++ b/ts/Series/AreaSeries.ts
@@ -480,7 +480,7 @@ seriesType<Highcharts.AreaSeries>(
 
                 isNull = points[i].isNull;
                 plotX = pick(points[i].rectPlotX, points[i].plotX);
-                yBottom = translatedThreshold;
+                yBottom = stacking ? points[i].yBottom : translatedThreshold;
 
                 if (!isNull || connectNulls) {
 


### PR DESCRIPTION
Fixed #13694, threshold wasn't respected when low was defined.