### PR TITLE
bugfix/13789-polar-connect-ends

### DIFF
--- a/js/Series/AreaRangeSeries.js
+++ b/js/Series/AreaRangeSeries.js
@@ -179,24 +179,29 @@ seriesType('arearange', 'area', {
      * @private
      */
     getGraphPath: function (points) {
-        var highPoints = [], highAreaPoints = [], i, getGraphPath = seriesTypes.area.prototype.getGraphPath, point, pointShim, linePath, lowerPath, options = this.options, connectEnds = this.chart.polar && options.connectEnds !== false, connectNulls = options.connectNulls, step = options.step, higherPath, higherAreaPath;
+        var highPoints = [], highAreaPoints = [], i, getGraphPath = seriesTypes.area.prototype.getGraphPath, point, pointShim, linePath, lowerPath, options = this.options, polar = this.chart.polar, connectEnds = polar && options.connectEnds !== false, connectNulls = options.connectNulls, step = options.step, higherPath, higherAreaPath;
         points = points || this.points;
-        i = points.length;
         // Create the top line and the top part of the area fill. The area fill
         // compensates for null points by drawing down to the lower graph,
         // moving across the null gap and starting again at the lower graph.
         i = points.length;
         while (i--) {
             point = points[i];
+            // Support for polar
+            var highAreaPoint = polar ? {
+                plotX: point.rectPlotX,
+                plotY: point.yBottom,
+                doCurve: false // #5186, gaps in areasplinerange fill
+            } : {
+                plotX: point.plotX,
+                plotY: point.plotY,
+                doCurve: false // #5186, gaps in areasplinerange fill
+            };
             if (!point.isNull &&
                 !connectEnds &&
                 !connectNulls &&
                 (!points[i + 1] || points[i + 1].isNull)) {
-                highAreaPoints.push({
-                    plotX: point.plotX,
-                    plotY: point.plotY,
-                    doCurve: false // #5186, gaps in areasplinerange fill
-                });
+                highAreaPoints.push(highAreaPoint);
             }
             pointShim = {
                 polarPlotY: point.polarPlotY,
@@ -213,11 +218,7 @@ seriesType('arearange', 'area', {
                 !connectEnds &&
                 !connectNulls &&
                 (!points[i - 1] || points[i - 1].isNull)) {
-                highAreaPoints.push({
-                    plotX: point.plotX,
-                    plotY: point.plotY,
-                    doCurve: false // #5186, gaps in areasplinerange fill
-                });
+                highAreaPoints.push(highAreaPoint);
             }
         }
         // Get the paths

--- a/samples/unit-tests/series-arearange/polar/demo.details
+++ b/samples/unit-tests/series-arearange/polar/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series-arearange/polar/demo.html
+++ b/samples/unit-tests/series-arearange/polar/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/series-arearange/polar/demo.js
+++ b/samples/unit-tests/series-arearange/polar/demo.js
@@ -1,0 +1,32 @@
+QUnit.test('(#13789) Arearange on polar with connectEnds set to false.', function (assert) {
+    var chart = Highcharts.chart('container', {
+            chart: {
+                polar: true,
+                type: 'arearange'
+            },
+            pane: {
+                size: '100%'
+            },
+            series: [{
+                connectEnds: false,
+                lineWidth: 2,
+                lineColor: '#000',
+                data: [
+                    [0, 20, 70],
+                    [1, 70, 120],
+                    [2, -20, 320]
+                ]
+            }]
+        }),
+        areaPath = chart.series[0].areaPath;
+
+    assert.ok(
+        areaPath[0][1] === areaPath[7][1] && areaPath[0][2] === areaPath[7][2],
+        'The arearange is correcty closed at the start.'
+    );
+
+    assert.ok(
+        areaPath[2][1] === areaPath[3][1] && areaPath[2][2] === areaPath[3][2],
+        'The arearange is correcty closed at the end.'
+    );
+});

--- a/ts/Series/AreaRangeSeries.ts
+++ b/ts/Series/AreaRangeSeries.ts
@@ -329,14 +329,14 @@ seriesType<Highcharts.AreaRangeSeries>('arearange', 'area', {
             linePath: SVGPath & Highcharts.Dictionary<any>,
             lowerPath: SVGPath & Highcharts.Dictionary<any>,
             options = this.options,
-            connectEnds = this.chart.polar && options.connectEnds !== false,
+            polar = this.chart.polar,
+            connectEnds = polar && options.connectEnds !== false,
             connectNulls = options.connectNulls,
             step = options.step,
             higherPath,
             higherAreaPath;
 
         points = points || this.points;
-        i = points.length;
 
         // Create the top line and the top part of the area fill. The area fill
         // compensates for null points by drawing down to the lower graph,
@@ -345,17 +345,24 @@ seriesType<Highcharts.AreaRangeSeries>('arearange', 'area', {
         while (i--) {
             point = points[i];
 
+            // Support for polar
+            var highAreaPoint = polar ? {
+                plotX: point.rectPlotX,
+                plotY: point.yBottom,
+                doCurve: false // #5186, gaps in areasplinerange fill
+            } : {
+                plotX: point.plotX,
+                plotY: point.plotY,
+                doCurve: false // #5186, gaps in areasplinerange fill
+            } as any;
+
             if (
                 !point.isNull &&
                 !connectEnds &&
                 !connectNulls &&
                 (!points[i + 1] || points[i + 1].isNull)
             ) {
-                highAreaPoints.push({
-                    plotX: point.plotX,
-                    plotY: point.plotY,
-                    doCurve: false // #5186, gaps in areasplinerange fill
-                } as any);
+                highAreaPoints.push(highAreaPoint);
             }
 
             pointShim = {
@@ -378,11 +385,7 @@ seriesType<Highcharts.AreaRangeSeries>('arearange', 'area', {
                 !connectNulls &&
                 (!points[i - 1] || points[i - 1].isNull)
             ) {
-                highAreaPoints.push({
-                    plotX: point.plotX,
-                    plotY: point.plotY,
-                    doCurve: false // #5186, gaps in areasplinerange fill
-                } as any);
+                highAreaPoints.push(highAreaPoint);
             }
         }
 


### PR DESCRIPTION
Fixed #13789, an incorrect arearange path on polar chart when the `connectEnds` option is set to false.