### PR TITLE
bugfix/13762-polar-labels-use-html

### DIFF
--- a/js/Core/Renderer/HTML/HTML.js
+++ b/js/Core/Renderer/HTML/HTML.js
@@ -291,9 +291,11 @@ extend(SVGRenderer.prototype, /** @lends SVGRenderer.prototype */ {
                         function (value, key) {
                             if (key === 'align') {
                                 // Do not overwrite the SVGElement.align method. Same as VML.
-                                key = 'textAlign';
+                                wrapper.alignValue = wrapper.textAlign = value;
                             }
-                            wrapper[key] = value;
+                            else {
+                                wrapper[key] = value;
+                            }
                             wrapper.doTransform = true;
                         };
         // Runs at the end of .attr()

--- a/js/Extensions/OverlappingDataLabels.js
+++ b/js/Extensions/OverlappingDataLabels.js
@@ -102,7 +102,7 @@ Chart.prototype.hideOverlappingLabels = function (labels) {
                 left: '0',
                 center: '0.5',
                 right: '1'
-            }[label.alignValue || label.textAlign];
+            }[label.alignValue];
             if (alignValue) {
                 xOffset = +alignValue * boxWidth;
             }

--- a/js/Extensions/OverlappingDataLabels.js
+++ b/js/Extensions/OverlappingDataLabels.js
@@ -102,7 +102,7 @@ Chart.prototype.hideOverlappingLabels = function (labels) {
                 left: '0',
                 center: '0.5',
                 right: '1'
-            }[label.alignValue];
+            }[label.alignValue || label.textAlign];
             if (alignValue) {
                 xOffset = +alignValue * boxWidth;
             }
@@ -110,7 +110,8 @@ Chart.prototype.hideOverlappingLabels = function (labels) {
                 xOffset = label.x - label.translateX;
             }
             return {
-                x: pos.x + (parent.translateX || 0) + padding - xOffset,
+                x: pos.x + (parent.translateX || 0) + padding -
+                    (xOffset || 0),
                 y: pos.y + (parent.translateY || 0) + padding -
                     lineHeightCorrection,
                 width: label.width - 2 * padding,

--- a/samples/unit-tests/axis/labels-usehtml/demo.js
+++ b/samples/unit-tests/axis/labels-usehtml/demo.js
@@ -496,3 +496,60 @@ QUnit.test('Ellipsis on single-word labels (#9537)', function (assert) {
         'The label should be within the tick bounds'
     );
 });
+
+// Highcharts 8.1.2, Issue #13762
+QUnit.test('Overlapping of xAxis labels (useHTML: true) in polar chart (#13762)', function (assert) {
+    var chart = Highcharts.chart('container', {
+            chart: {
+                polar: true,
+                width: 600,
+                height: 400
+            },
+            xAxis: {
+                tickmarkPlacement: 'on',
+                labels: {
+                    useHTML: true
+                },
+                categories: [
+                    'CATEGORY1',
+                    'CATEGORY2',
+                    'CATEGORY3',
+                    'CATEGORY4',
+                    'CATEGORY5',
+                    'CATEGORY6',
+                    'CATEGORY7',
+                    'CATEGORY8',
+                    'CATEGORY9',
+                    'CATEGORY10',
+                    'CATEGORY11',
+                    'CATEGORY12'
+                ]
+            },
+            series: [{
+                pointPlacement: 'on',
+                data: (numberOfPoints => {
+                    var data = [];
+                    while (numberOfPoints) {
+                        data.push(100);
+                        numberOfPoints--;
+                    }
+                    return data;
+                })(12)
+            }]
+        }),
+        ticks = chart.xAxis[0].ticks,
+        visible = true;
+
+    for (var prop in ticks) {
+        if (Object.prototype.hasOwnProperty.call(ticks, prop)) {
+            if (!ticks[prop].label.opacity) {
+                visible = false;
+            }
+        }
+    }
+
+    assert.ok(
+        visible,
+        'All xAxis labels are visible'
+    );
+});

--- a/ts/Core/Renderer/HTML/HTML.ts
+++ b/ts/Core/Renderer/HTML/HTML.ts
@@ -460,9 +460,10 @@ extend(SVGRenderer.prototype, /** @lends SVGRenderer.prototype */ {
         ): void {
             if (key === 'align') {
                 // Do not overwrite the SVGElement.align method. Same as VML.
-                key = 'textAlign';
+                wrapper.alignValue = wrapper.textAlign = value;
+            } else {
+                wrapper[key as any] = value;
             }
-            wrapper[key as any] = value;
             wrapper.doTransform = true;
         };
 

--- a/ts/Extensions/OverlappingDataLabels.ts
+++ b/ts/Extensions/OverlappingDataLabels.ts
@@ -190,7 +190,7 @@ Chart.prototype.hideOverlappingLabels = function (
                     left: '0',
                     center: '0.5',
                     right: '1'
-                }[label.alignValue as Highcharts.AlignValue];
+                }[label.alignValue as Highcharts.AlignValue || label.textAlign];
 
                 if (alignValue) {
                     xOffset = +alignValue * boxWidth;
@@ -199,7 +199,8 @@ Chart.prototype.hideOverlappingLabels = function (
                 }
 
                 return {
-                    x: pos.x + (parent.translateX || 0) + padding - xOffset,
+                    x: pos.x + (parent.translateX || 0) + padding -
+                        (xOffset || 0),
                     y: pos.y + (parent.translateY || 0) + padding -
                         lineHeightCorrection,
                     width: label.width - 2 * padding,

--- a/ts/Extensions/OverlappingDataLabels.ts
+++ b/ts/Extensions/OverlappingDataLabels.ts
@@ -190,7 +190,7 @@ Chart.prototype.hideOverlappingLabels = function (
                     left: '0',
                     center: '0.5',
                     right: '1'
-                }[label.alignValue as Highcharts.AlignValue || label.textAlign];
+                }[label.alignValue as Highcharts.AlignValue];
 
                 if (alignValue) {
                     xOffset = +alignValue * boxWidth;


### PR DESCRIPTION
Fixed #13762, missing `xAxis` labels on a polar chart when the `useHTML` option was set to true.