### PR TITLE
bugfix/13831-restart-simulation-after-click

### DIFF
--- a/js/Series/Networkgraph/DraggableNodes.js
+++ b/js/Series/Networkgraph/DraggableNodes.js
@@ -12,7 +12,7 @@
 import Chart from '../../Core/Chart/Chart.js';
 import H from '../../Core/Globals.js';
 import U from '../../Core/Utilities.js';
-var addEvent = U.addEvent, wrap = U.wrap;
+var addEvent = U.addEvent;
 /* eslint-disable no-invalid-this, valid-jsdoc */
 H.dragNodesMixin = {
     /**
@@ -70,12 +70,14 @@ H.dragNodesMixin = {
      * @return {void}
      */
     onMouseUp: function (point, event) {
-        if (point.fixedPosition && point.hasDragged) {
-            if (this.layout.enableSimulation) {
-                this.layout.start();
-            }
-            else {
-                this.chart.redraw();
+        if (point.fixedPosition) {
+            if (point.hasDragged) {
+                if (this.layout.enableSimulation) {
+                    this.layout.start();
+                }
+                else {
+                    this.chart.redraw();
+                }
             }
             point.inDragMode = point.hasDragged = false;
             if (!this.options.fixedDraggable) {
@@ -99,13 +101,6 @@ H.dragNodesMixin = {
         }
     }
 };
-// Extend the onMouseUp method to restart simulation after click.
-wrap(H.dragNodesMixin, 'onMouseUp', function (proceed, point) {
-    if (!this.options.fixedDraggable) {
-        delete point.fixedPosition;
-    }
-    return proceed.apply(this, Array.prototype.slice.call(arguments, 1));
-});
 /*
  * Draggable mode:
  */

--- a/js/Series/Networkgraph/DraggableNodes.js
+++ b/js/Series/Networkgraph/DraggableNodes.js
@@ -12,7 +12,7 @@
 import Chart from '../../Core/Chart/Chart.js';
 import H from '../../Core/Globals.js';
 import U from '../../Core/Utilities.js';
-var addEvent = U.addEvent;
+var addEvent = U.addEvent, wrap = U.wrap;
 /* eslint-disable no-invalid-this, valid-jsdoc */
 H.dragNodesMixin = {
     /**
@@ -99,6 +99,13 @@ H.dragNodesMixin = {
         }
     }
 };
+// Extend the onMouseUp method to restart simulation after click.
+wrap(H.dragNodesMixin, 'onMouseUp', function (proceed, point) {
+    if (!this.options.fixedDraggable) {
+        delete point.fixedPosition;
+    }
+    return proceed.apply(this, Array.prototype.slice.call(arguments, 1));
+});
 /*
  * Draggable mode:
  */

--- a/ts/Series/Networkgraph/DraggableNodes.ts
+++ b/ts/Series/Networkgraph/DraggableNodes.ts
@@ -70,7 +70,8 @@ declare global {
 
 import U from '../../Core/Utilities.js';
 const {
-    addEvent
+    addEvent,
+    wrap
 } = U;
 
 /* eslint-disable no-invalid-this, valid-jsdoc */
@@ -189,6 +190,23 @@ H.dragNodesMixin = {
         }
     }
 };
+
+// Extend the onMouseUp method to restart simulation after click.
+wrap(
+    H.dragNodesMixin,
+    'onMouseUp',
+    function (
+        this: Highcharts.DragNodesSeries,
+        proceed: Function,
+        point: Highcharts.DragNodesPoint
+    ): Function {
+        if (!this.options.fixedDraggable) {
+            delete point.fixedPosition;
+        }
+        return proceed.apply(this, Array.prototype.slice.call(arguments, 1));
+    }
+);
+
 /*
  * Draggable mode:
  */

--- a/ts/Series/Networkgraph/DraggableNodes.ts
+++ b/ts/Series/Networkgraph/DraggableNodes.ts
@@ -70,8 +70,7 @@ declare global {
 
 import U from '../../Core/Utilities.js';
 const {
-    addEvent,
-    wrap
+    addEvent
 } = U;
 
 /* eslint-disable no-invalid-this, valid-jsdoc */
@@ -157,11 +156,13 @@ H.dragNodesMixin = {
         point: Highcharts.DragNodesPoint,
         event?: Highcharts.PointerEventObject
     ): void {
-        if (point.fixedPosition && point.hasDragged) {
-            if (this.layout.enableSimulation) {
-                this.layout.start();
-            } else {
-                this.chart.redraw();
+        if (point.fixedPosition) {
+            if (point.hasDragged) {
+                if (this.layout.enableSimulation) {
+                    this.layout.start();
+                } else {
+                    this.chart.redraw();
+                }
             }
             point.inDragMode = point.hasDragged = false;
             if (!this.options.fixedDraggable) {
@@ -190,22 +191,6 @@ H.dragNodesMixin = {
         }
     }
 };
-
-// Extend the onMouseUp method to restart simulation after click.
-wrap(
-    H.dragNodesMixin,
-    'onMouseUp',
-    function (
-        this: Highcharts.DragNodesSeries,
-        proceed: Function,
-        point: Highcharts.DragNodesPoint
-    ): Function {
-        if (!this.options.fixedDraggable) {
-            delete point.fixedPosition;
-        }
-        return proceed.apply(this, Array.prototype.slice.call(arguments, 1));
-    }
-);
 
 /*
  * Draggable mode:


### PR DESCRIPTION
Fixed #13831, network graph simulation didn't restart after clicking a node.

~~Fixed #13831, restart simulation after a click.~~