### PR TITLE
Fixed #13864, better accessible legend item labels.

### DIFF
--- a/js/Accessibility/Options/LangOptions.js
+++ b/js/Accessibility/Options/LangOptions.js
@@ -105,7 +105,7 @@ var langOptions = {
          */
         legend: {
             legendLabel: 'Toggle series visibility',
-            legendItem: 'Toggle visibility of {itemName}'
+            legendItem: 'Hide {itemName}'
         },
         /**
          * Chart and map zoom accessibility language options.

--- a/ts/Accessibility/Options/LangOptions.ts
+++ b/ts/Accessibility/Options/LangOptions.ts
@@ -279,7 +279,7 @@ var langOptions: Highcharts.LangOptions = {
          */
         legend: {
             legendLabel: 'Toggle series visibility',
-            legendItem: 'Toggle visibility of {itemName}'
+            legendItem: 'Hide {itemName}'
         },
 
         /**


### PR DESCRIPTION
Fixed #13864, better accessible legend item labels.
___
Since we are using `aria-pressed`, most screen readers will announce that this is a toggle button along with its state. This means it is less confusing to just specify what the pressed state does.