### PR TITLE
bugfix/13992-ikh-empty-series-error

### DIFF
--- a/js/Stock/Indicators/IKHIndicator.js
+++ b/js/Stock/Indicators/IKHIndicator.js
@@ -548,11 +548,13 @@ seriesType('ikh', 'sma',
             spanA = SMA.prototype.getGraphPath.call(indicator, 
             // Reverse points, so Senkou Span A will start from the end:
             indicator.nextPoints);
-            spanA[0][0] = 'L';
-            path = SMA.prototype.getGraphPath.call(indicator, points);
-            spanAarr = spanA.slice(0, path.length);
-            for (var i = spanAarr.length - 1; i >= 0; i--) {
-                path.push(spanAarr[i]);
+            if (spanA.length) {
+                spanA[0][0] = 'L';
+                path = SMA.prototype.getGraphPath.call(indicator, points);
+                spanAarr = spanA.slice(0, path.length);
+                for (var i = spanAarr.length - 1; i >= 0; i--) {
+                    path.push(spanAarr[i]);
+                }
             }
         }
         else {

--- a/js/Stock/Indicators/IKHIndicator.js
+++ b/js/Stock/Indicators/IKHIndicator.js
@@ -548,7 +548,7 @@ seriesType('ikh', 'sma',
             spanA = SMA.prototype.getGraphPath.call(indicator, 
             // Reverse points, so Senkou Span A will start from the end:
             indicator.nextPoints);
-            if (spanA.length) {
+            if (spanA && spanA.length) {
                 spanA[0][0] = 'L';
                 path = SMA.prototype.getGraphPath.call(indicator, points);
                 spanAarr = spanA.slice(0, path.length);

--- a/samples/unit-tests/indicator-ichimoku-kinko-hyo/recalculations/demo.js
+++ b/samples/unit-tests/indicator-ichimoku-kinko-hyo/recalculations/demo.js
@@ -454,4 +454,20 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
         chart.series[1].points.length - chart.series[1].options.params.periodSenkouSpanB,
         'After removePoint number of Ichimoku points is correct'
     );
+
+    chart.series[0].update({
+        id: 'main',
+        data: []
+    });
+
+    chart.series[1].update({
+        type: 'ikh',
+        linkedTo: 'main'
+    });
+
+    // Issue #13992
+    assert.ok(
+        true,
+        'No errors when created chart without series data (#13992)'
+    );
 });

--- a/ts/Stock/Indicators/IKHIndicator.ts
+++ b/ts/Stock/Indicators/IKHIndicator.ts
@@ -867,7 +867,7 @@ seriesType<Highcharts.IKHIndicator>(
                     indicator.nextPoints
                 );
 
-                if (spanA.length) {
+                if (spanA && spanA.length) {
                     spanA[0][0] = 'L';
 
                     path = SMA.prototype.getGraphPath.call(

--- a/ts/Stock/Indicators/IKHIndicator.ts
+++ b/ts/Stock/Indicators/IKHIndicator.ts
@@ -867,19 +867,20 @@ seriesType<Highcharts.IKHIndicator>(
                     indicator.nextPoints
                 );
 
-                spanA[0][0] = 'L';
+                if (spanA.length) {
+                    spanA[0][0] = 'L';
 
-                path = SMA.prototype.getGraphPath.call(
-                    indicator,
-                    points
-                );
+                    path = SMA.prototype.getGraphPath.call(
+                        indicator,
+                        points
+                    );
 
-                spanAarr = spanA.slice(0, path.length);
+                    spanAarr = spanA.slice(0, path.length);
 
-                for (let i = spanAarr.length - 1; i >= 0; i--) {
-                    path.push(spanAarr[i]);
+                    for (let i = spanAarr.length - 1; i >= 0; i--) {
+                        path.push(spanAarr[i]);
+                    }
                 }
-
             } else {
                 path = SMA.prototype.getGraphPath.apply(indicator, arguments);
             }


### PR DESCRIPTION
Fixed #13992, the Ichimoku Kinco Hyo indicator threw errors in the console when the base series had no data.