### PR TITLE
bugfix/13838-exporting-collapsed-points

### DIFF
--- a/js/Core/Axis/TreeGridAxis.js
+++ b/js/Core/Axis/TreeGridAxis.js
@@ -542,6 +542,30 @@ var TreeGridAxis;
          *
          * */
         /**
+         * Set the collapse status.
+         *
+         * @private
+         *
+         * @param {Highcharts.Axis} axis
+         * The axis to check against.
+         *
+         * @param {Highcharts.GridNode} node
+         * The node to collapse.
+         */
+        Additions.prototype.setCollapsedStatus = function (node) {
+            var axis = this.axis, chart = axis.chart;
+            axis.series.forEach(function (series) {
+                var data = series.options.data;
+                if (node.id && data) {
+                    var point = chart.get(node.id), dataPoint = data[series.data.indexOf(point)];
+                    if (point && dataPoint) {
+                        point.collapsed = node.collapsed;
+                        dataPoint.collapsed = node.collapsed;
+                    }
+                }
+            });
+        };
+        /**
          * Calculates the new axis breaks to collapse a node.
          *
          * @private
@@ -563,16 +587,7 @@ var TreeGridAxis;
             breaks.push(obj);
             // Change the collapsed flag #13838
             node.collapsed = true;
-            axis.series.forEach(function (series) {
-                var data = series.options.data;
-                if (data && data.length) {
-                    data.forEach(function (data) {
-                        if (data.id === node.id) {
-                            data.collapsed = true;
-                        }
-                    });
-                }
-            });
+            axis.treeGrid.setCollapsedStatus(node);
             return breaks;
         };
         /**
@@ -596,16 +611,7 @@ var TreeGridAxis;
             var axis = this.axis, breaks = (axis.options.breaks || []), obj = getBreakFromNode(node, axis.max);
             // Change the collapsed flag #13838
             node.collapsed = false;
-            axis.series.forEach(function (series) {
-                var data = series.options.data;
-                if (data && data.length) {
-                    data.forEach(function (data) {
-                        if (data.id === node.id) {
-                            data.collapsed = false;
-                        }
-                    });
-                }
-            });
+            axis.treeGrid.setCollapsedStatus(node);
             // Remove the break from the axis breaks array.
             return breaks.reduce(function (arr, b) {
                 if (b.to !== obj.to || b.from !== obj.from) {

--- a/js/Core/Axis/TreeGridAxis.js
+++ b/js/Core/Axis/TreeGridAxis.js
@@ -140,6 +140,7 @@ var TreeGridAxis;
                     mapOfPosToGridNode[pos] = gridNode = {
                         depth: parentGridNode ? parentGridNode.depth + 1 : 0,
                         name: name,
+                        id: data.id,
                         nodes: [node],
                         children: [],
                         pos: pos
@@ -560,6 +561,18 @@ var TreeGridAxis;
         Additions.prototype.collapse = function (node) {
             var axis = this.axis, breaks = (axis.options.breaks || []), obj = getBreakFromNode(node, axis.max);
             breaks.push(obj);
+            // Change the collapsed flag #13838
+            node.collapsed = true;
+            axis.series.forEach(function (series) {
+                var data = series.options.data;
+                if (data && data.length) {
+                    data.forEach(function (data) {
+                        if (data.id === node.id) {
+                            data.collapsed = true;
+                        }
+                    });
+                }
+            });
             return breaks;
         };
         /**
@@ -581,6 +594,18 @@ var TreeGridAxis;
          */
         Additions.prototype.expand = function (node) {
             var axis = this.axis, breaks = (axis.options.breaks || []), obj = getBreakFromNode(node, axis.max);
+            // Change the collapsed flag #13838
+            node.collapsed = false;
+            axis.series.forEach(function (series) {
+                var data = series.options.data;
+                if (data && data.length) {
+                    data.forEach(function (data) {
+                        if (data.id === node.id) {
+                            data.collapsed = false;
+                        }
+                    });
+                }
+            });
             // Remove the break from the axis breaks array.
             return breaks.reduce(function (arr, b) {
                 if (b.to !== obj.to || b.from !== obj.from) {

--- a/samples/unit-tests/gantt/treegrid/demo.js
+++ b/samples/unit-tests/gantt/treegrid/demo.js
@@ -439,4 +439,10 @@ QUnit.test('series.data[].collapsed', assert => {
         false,
         'This point should be expanded #13838'
     );
+
+    assert.strictEqual(
+        axis.series[0].options.data[0].collapsed,
+        false,
+        'This point should be expanded #13838'
+    );
 });

--- a/samples/unit-tests/gantt/treegrid/demo.js
+++ b/samples/unit-tests/gantt/treegrid/demo.js
@@ -433,4 +433,10 @@ QUnit.test('series.data[].collapsed', assert => {
         2,
         'should have axis.max equal 2 when "Node 1" is expanded.'
     );
+
+    assert.strictEqual(
+        axis.series[0].points[0].collapsed,
+        false,
+        'This point should be expanded #13838'
+    );
 });

--- a/ts/Core/Axis/TreeGridAxis.ts
+++ b/ts/Core/Axis/TreeGridAxis.ts
@@ -99,6 +99,7 @@ namespace TreeGridAxis {
         collapseStart?: number;
         depth: number;
         descendants?: number;
+        id?: number | string | null;
         height?: number;
         name: string;
         nodes: [TreeGridNode];
@@ -284,6 +285,7 @@ namespace TreeGridAxis {
                     mapOfPosToGridNode[pos] = gridNode = {
                         depth: parentGridNode ? parentGridNode.depth + 1 : 0,
                         name: name,
+                        id: data.id,
                         nodes: [node as TreeGridNode],
                         children: [],
                         pos: pos
@@ -851,6 +853,19 @@ namespace TreeGridAxis {
                 obj = getBreakFromNode(node, axis.max);
 
             breaks.push(obj);
+            // Change the collapsed flag #13838
+            node.collapsed = true;
+            axis.series.forEach(function (series): void {
+                const data = series.options.data;
+
+                if (data && data.length) {
+                    data.forEach(function (data): void {
+                        if ((data as PointOptionsObject).id === node.id) {
+                            (data as PointOptionsObject).collapsed = true;
+                        }
+                    });
+                }
+            });
 
             return breaks;
         }
@@ -876,6 +891,20 @@ namespace TreeGridAxis {
             const axis = this.axis,
                 breaks = (axis.options.breaks || []),
                 obj = getBreakFromNode(node, axis.max);
+
+            // Change the collapsed flag #13838
+            node.collapsed = false;
+            axis.series.forEach(function (series): void {
+                const data = series.options.data;
+
+                if (data && data.length) {
+                    data.forEach(function (data): void {
+                        if ((data as PointOptionsObject).id === node.id) {
+                            (data as PointOptionsObject).collapsed = false;
+                        }
+                    });
+                }
+            });
 
             // Remove the break from the axis breaks array.
             return breaks.reduce(function (

--- a/ts/Core/Axis/TreeGridAxis.ts
+++ b/ts/Core/Axis/TreeGridAxis.ts
@@ -99,7 +99,7 @@ namespace TreeGridAxis {
         collapseStart?: number;
         depth: number;
         descendants?: number;
-        id?: number | string | null;
+        id?: string;
         height?: number;
         name: string;
         nodes: [TreeGridNode];
@@ -831,6 +831,35 @@ namespace TreeGridAxis {
          * */
 
         /**
+         * Set the collapse status.
+         *
+         * @private
+         *
+         * @param {Highcharts.Axis} axis
+         * The axis to check against.
+         *
+         * @param {Highcharts.GridNode} node
+         * The node to collapse.
+         */
+        public setCollapsedStatus(node: GridNode): void {
+            const axis = this.axis,
+                chart = axis.chart;
+
+            axis.series.forEach(function (series): void {
+                const data = series.options.data;
+                if (node.id && data) {
+                    const point = chart.get(node.id),
+                        dataPoint = data[series.data.indexOf(point as Highcharts.GanttPoint)];
+
+                    if (point && dataPoint) {
+                        (point as Highcharts.GanttPoint).collapsed = node.collapsed;
+                        (dataPoint as Highcharts.GanttPoint).collapsed = node.collapsed;
+                    }
+                }
+            });
+        }
+
+        /**
          * Calculates the new axis breaks to collapse a node.
          *
          * @private
@@ -855,17 +884,7 @@ namespace TreeGridAxis {
             breaks.push(obj);
             // Change the collapsed flag #13838
             node.collapsed = true;
-            axis.series.forEach(function (series): void {
-                const data = series.options.data;
-
-                if (data && data.length) {
-                    data.forEach(function (data): void {
-                        if ((data as PointOptionsObject).id === node.id) {
-                            (data as PointOptionsObject).collapsed = true;
-                        }
-                    });
-                }
-            });
+            axis.treeGrid.setCollapsedStatus(node);
 
             return breaks;
         }
@@ -894,17 +913,7 @@ namespace TreeGridAxis {
 
             // Change the collapsed flag #13838
             node.collapsed = false;
-            axis.series.forEach(function (series): void {
-                const data = series.options.data;
-
-                if (data && data.length) {
-                    data.forEach(function (data): void {
-                        if ((data as PointOptionsObject).id === node.id) {
-                            (data as PointOptionsObject).collapsed = false;
-                        }
-                    });
-                }
-            });
+            axis.treeGrid.setCollapsedStatus(node);
 
             // Remove the break from the axis breaks array.
             return breaks.reduce(function (

--- a/ts/Series/GanttSeries.ts
+++ b/ts/Series/GanttSeries.ts
@@ -34,6 +34,7 @@ const {
 declare global {
     namespace Highcharts {
         class GanttPoint extends XRangePoint {
+            public collapsed?: boolean;
             public end?: GanttPointOptions['end'];
             public milestone?: GanttPointOptions['milestone'];
             public options: GanttPointOptions;


### PR DESCRIPTION
Fixed #13838, toggled nodes in the tree grid were not reflected correctly in the exported chart.