### PR TITLE
Fixed issue with negative sonification timestamps.

### DIFF
--- a/js/modules/sonification/chartSonify.js
+++ b/js/modules/sonification/chartSonify.js
@@ -292,12 +292,12 @@ function buildTimelinePathFromSeries(series, options) {
     // chart.sonify can be reused.
     var timeExtremes = options.timeExtremes || getTimeExtremes(series, options.pointPlayTime), 
     // Compute any data extremes that aren't defined yet
-    dataExtremes = getExtremesForInstrumentProps(series.chart, options.instruments, options.dataExtremes), 
+    dataExtremes = getExtremesForInstrumentProps(series.chart, options.instruments, options.dataExtremes), minimumSeriesDurationMs = 10, 
     // Get the duration of the final note
     finalNoteDuration = getFinalNoteDuration(series, options.instruments, dataExtremes), 
     // Get time offset for a point, relative to duration
     pointToTime = function (point) {
-        return utilities.virtualAxisTranslate(getPointTimeValue(point, options.pointPlayTime), timeExtremes, { min: 0, max: options.duration - finalNoteDuration });
+        return utilities.virtualAxisTranslate(getPointTimeValue(point, options.pointPlayTime), timeExtremes, { min: 0, max: Math.max(options.duration - finalNoteDuration, minimumSeriesDurationMs) });
     }, masterVolume = pick(options.masterVolume, 1), 
     // Make copies of the instruments used for this series, to allow
     // multiple series with the same instrument to play together

--- a/js/modules/sonification/options.js
+++ b/js/modules/sonification/options.js
@@ -14,8 +14,8 @@
 var options = {
     sonification: {
         enabled: false,
-        duration: 2000,
-        afterSeriesWait: 900,
+        duration: 2500,
+        afterSeriesWait: 700,
         masterVolume: 1,
         order: 'sequential',
         defaultInstrumentOptions: {
@@ -25,7 +25,7 @@ var options = {
             maxFrequency: 1046,
             mapping: {
                 pointPlayTime: 'x',
-                duration: 400,
+                duration: 200,
                 frequency: 'y'
             }
         }

--- a/ts/modules/sonification/chartSonify.ts
+++ b/ts/modules/sonification/chartSonify.ts
@@ -495,6 +495,7 @@ function buildTimelinePathFromSeries(
         dataExtremes = getExtremesForInstrumentProps(
             series.chart, options.instruments, options.dataExtremes as any
         ),
+        minimumSeriesDurationMs = 10,
         // Get the duration of the final note
         finalNoteDuration = getFinalNoteDuration(series, options.instruments, dataExtremes),
         // Get time offset for a point, relative to duration
@@ -502,7 +503,7 @@ function buildTimelinePathFromSeries(
             return utilities.virtualAxisTranslate(
                 getPointTimeValue(point, options.pointPlayTime),
                 timeExtremes,
-                { min: 0, max: options.duration - finalNoteDuration }
+                { min: 0, max: Math.max(options.duration - finalNoteDuration, minimumSeriesDurationMs) }
             );
         },
         masterVolume = pick(options.masterVolume, 1),

--- a/ts/modules/sonification/options.ts
+++ b/ts/modules/sonification/options.ts
@@ -31,8 +31,8 @@ declare global {
 const options = {
     sonification: {
         enabled: false,
-        duration: 2000,
-        afterSeriesWait: 900,
+        duration: 2500,
+        afterSeriesWait: 700,
         masterVolume: 1,
         order: 'sequential',
         defaultInstrumentOptions: {
@@ -42,7 +42,7 @@ const options = {
             maxFrequency: 1046,
             mapping: {
                 pointPlayTime: 'x',
-                duration: 400,
+                duration: 200,
                 frequency: 'y'
             }
         }


### PR DESCRIPTION
After #14035, charts with multiple series playing sequentially, or charts with many data points are fragile if duration is too low. Fixed, and adjusted default parameters to better match current behavior.