### PR TITLE
bugfix/13950-stocktools-dg-approximation

### DIFF
--- a/js/Stock/StockToolsBindings.js
+++ b/js/Stock/StockToolsBindings.js
@@ -161,7 +161,7 @@ bindingsUtils.manageIndicators = function (data) {
         defaultOptions = getOptions().plotOptions;
         // Make sure that indicator uses the SUM approx if SUM approx is used
         // by parent series (#13950).
-        if (parentSeries &&
+        if (typeof parentSeries !== 'undefined' &&
             parentSeries instanceof Highcharts.Series &&
             parentSeries.getDGApproximation() === 'sum' &&
             // If indicator has defined approx type, use it (e.g. "ranges")

--- a/js/Stock/StockToolsBindings.js
+++ b/js/Stock/StockToolsBindings.js
@@ -13,7 +13,7 @@
 import H from '../Core/Globals.js';
 import NavigationBindings from '../Extensions/Annotations/NavigationBindings.js';
 import U from '../Core/Utilities.js';
-var correctFloat = U.correctFloat, defined = U.defined, extend = U.extend, fireEvent = U.fireEvent, isNumber = U.isNumber, merge = U.merge, pick = U.pick, setOptions = U.setOptions, uniqueKey = U.uniqueKey;
+var correctFloat = U.correctFloat, defined = U.defined, extend = U.extend, fireEvent = U.fireEvent, getOptions = U.getOptions, isNumber = U.isNumber, merge = U.merge, pick = U.pick, setOptions = U.setOptions, uniqueKey = U.uniqueKey;
 var bindingsUtils = NavigationBindings.prototype.utils, PREFIX = 'highcharts-';
 /* eslint-disable no-invalid-this, valid-jsdoc */
 /**
@@ -96,6 +96,7 @@ bindingsUtils.addFlagFromForm = function (type) {
     };
 };
 bindingsUtils.manageIndicators = function (data) {
+    var _a;
     var navigation = this, chart = navigation.chart, seriesConfig = {
         linkedTo: data.linkedTo,
         type: data.type
@@ -129,7 +130,7 @@ bindingsUtils.manageIndicators = function (data) {
         'linearRegressionSlope',
         'linearRegressionIntercept',
         'linearRegressionAngle'
-    ], yAxis, parentSeries, series;
+    ], yAxis, parentSeries, defaultOptions, series;
     if (data.actionType === 'edit') {
         navigation.fieldsToOptions(data.fields, seriesConfig);
         series = chart.get(data.seriesId);
@@ -157,11 +158,14 @@ bindingsUtils.manageIndicators = function (data) {
         seriesConfig.id = uniqueKey();
         navigation.fieldsToOptions(data.fields, seriesConfig);
         parentSeries = chart.get(seriesConfig.linkedTo);
+        defaultOptions = getOptions().plotOptions;
         // Make sure that indicator uses the SUM approx if SUM approx is used
         // by parent series (#13950).
         if (parentSeries &&
             parentSeries instanceof Highcharts.Series &&
-            parentSeries.getDGApproximation() === 'sum') {
+            parentSeries.getDGApproximation() === 'sum' &&
+            // If indicator has defined approx type, use it (e.g. "ranges")
+            !defined(defaultOptions && defaultOptions[seriesConfig.type] && ((_a = defaultOptions.dataGrouping) === null || _a === void 0 ? void 0 : _a.approximation))) {
             seriesConfig.dataGrouping = {
                 approximation: 'sum'
             };

--- a/js/Stock/StockToolsBindings.js
+++ b/js/Stock/StockToolsBindings.js
@@ -129,7 +129,7 @@ bindingsUtils.manageIndicators = function (data) {
         'linearRegressionSlope',
         'linearRegressionIntercept',
         'linearRegressionAngle'
-    ], yAxis, series;
+    ], yAxis, parentSeries, series;
     if (data.actionType === 'edit') {
         navigation.fieldsToOptions(data.fields, seriesConfig);
         series = chart.get(data.seriesId);
@@ -156,6 +156,16 @@ bindingsUtils.manageIndicators = function (data) {
     else {
         seriesConfig.id = uniqueKey();
         navigation.fieldsToOptions(data.fields, seriesConfig);
+        parentSeries = chart.get(seriesConfig.linkedTo);
+        // Make sure that indicator uses the SUM approx if SUM approx is used
+        // by parent series (#13950).
+        if (parentSeries &&
+            parentSeries instanceof Highcharts.Series &&
+            parentSeries.getDGApproximation() === 'sum') {
+            seriesConfig.dataGrouping = {
+                approximation: 'sum'
+            };
+        }
         if (indicatorsWithAxes.indexOf(data.type) >= 0) {
             yAxis = chart.addAxis({
                 id: uniqueKey(),

--- a/samples/unit-tests/stock-tools/bindings/demo.js
+++ b/samples/unit-tests/stock-tools/bindings/demo.js
@@ -36,8 +36,7 @@ QUnit.test('Bindings general tests', function (assert) {
         plotTop = chart.plotTop,
         points = chart.series[0].points,
         controller = new TestController(chart),
-        annotationsCounter = 0,
-        i = 0;
+        annotationsCounter = 0;
 
     // CSS Styles are not loaded, so hide left bar. If we don't hide the bar,
     // chart will be rendered outside the visible page and events will not be
@@ -270,60 +269,6 @@ QUnit.test('Bindings general tests', function (assert) {
 
     localStorage.removeItem('highcharts-chart');
 
-    // Test yAxis resizers and adding indicators:
-    for (i = 0; i < 9; i++) {
-        chart.navigationBindings.selectedButtonElement = document
-            .getElementsByClassName('highcharts-indicators')[0];
-        chart.navigationBindings.utils.manageIndicators.call(
-            chart.navigationBindings,
-            {
-                actionType: 'add',
-                linkedTo: 'aapl',
-                fields: {
-                    'params.index': '0',
-                    'params.period': '5'
-                },
-                type: 'atr'
-            }
-        );
-        assert.close(
-            parseFloat(chart.yAxis[0].options.height),
-            i < 4 ?
-                (100 - (i + 1) * 20) :
-                100 / (i + 2),
-            0.0001, // up to 0.0001% is fine
-            'Correct height for MAIN yAxis (' + (i + 2) + ' panes - indicator.add).'
-        );
-        assert.close(
-            parseFloat(chart.yAxis[i + 2].options.height),
-            i < 4 ?
-                20 :
-                100 / (i + 2),
-            0.0001, // up to 0.0001% is fine
-            'Correct height for LAST yAxis (' + (i + 2) + ' panes - indicator.add).'
-        );
-    }
-
-    for (i = 9; i > 0; i--) {
-        chart.navigationBindings.selectedButtonElement = document
-            .getElementsByClassName('highcharts-indicators')[0];
-        chart.navigationBindings.utils.manageIndicators.call(
-            chart.navigationBindings,
-            {
-                actionType: 'remove',
-                seriesId: chart.series[chart.series.length - 2].options.id
-            }
-        );
-
-        assert.close(
-            parseFloat(chart.yAxis[0].options.height),
-            i < 6 ?
-                100 - (i - 1) * 20 :
-                100 / i,
-            0.005, // up to 0.5% is fine
-            'Correct height for main yAxis (' + (i + 1) + ' pane(s) - indicator.remove).'
-        );
-    }
     // Test annotation events:
     points = chart.series[0].points;
     chart.navigationBindings.popup.closePopup();

--- a/samples/unit-tests/stock-tools/indicators/demo.details
+++ b/samples/unit-tests/stock-tools/indicators/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/stock-tools/indicators/demo.html
+++ b/samples/unit-tests/stock-tools/indicators/demo.html
@@ -1,0 +1,15 @@
+<link rel="stylesheet" type="text/css" href="https://code.highcharts.com/css/stocktools/gui.css">
+<link rel="stylesheet" type="text/css" href="https://code.highcharts.com/css/annotations/popup.css">
+
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+
+<script src="https://code.highcharts.com/stock/indicators/indicators-all.js"></script>
+<script src="https://code.highcharts.com/stock/modules/annotations-advanced.js"></script>
+<script src="https://code.highcharts.com/stock/modules/price-indicator.js"></script>
+
+<script src="https://code.highcharts.com/stock/modules/stock-tools.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/stock-tools/indicators/demo.js
+++ b/samples/unit-tests/stock-tools/indicators/demo.js
@@ -1,0 +1,128 @@
+QUnit.test('Managing tech indicators in Stock Tools', function (assert) {
+
+    const chart = Highcharts.stockChart('container', {
+        chart: {
+            width: 800
+        },
+        yAxis: {
+            labels: {
+                align: 'left'
+            }
+        },
+        series: [{
+            type: 'ohlc',
+            id: 'aapl',
+            name: 'AAPL Stock Price',
+            data: [
+                [0, 12, 15, 10, 13],
+                [1, 13, 16, 91, 15],
+                [2, 15, 15, 11, 12],
+                [3, 12, 12, 11, 12],
+                [4, 12, 15, 12, 15],
+                [5, 11, 11, 10, 10],
+                [6, 10, 16, 10, 12],
+                [7, 12, 17, 12, 17],
+                [8, 17, 18, 15, 15],
+                [9, 15, 19, 12, 12]
+            ]
+        }, {
+            type: 'column',
+            id: 'column-1',
+            data: [
+                [0, 10],
+                [1, 11],
+                [2, 12],
+                [3, 13],
+                [4, 14],
+                [5, 15],
+                [6, 16],
+                [7, 17],
+                [8, 18],
+                [9, 19]
+            ]
+        }],
+        stockTools: {
+            gui: {
+                enabled: true
+            }
+        }
+    });
+    let i;
+
+    // Test yAxis resizers and adding indicators:
+    for (i = 0; i < 9; i++) {
+        chart.navigationBindings.selectedButtonElement = document
+            .getElementsByClassName('highcharts-indicators')[0];
+        chart.navigationBindings.utils.manageIndicators.call(
+            chart.navigationBindings,
+            {
+                actionType: 'add',
+                linkedTo: 'aapl',
+                fields: {
+                    'params.index': '0',
+                    'params.period': '5'
+                },
+                type: 'atr'
+            }
+        );
+        assert.close(
+            parseFloat(chart.yAxis[0].options.height),
+            i < 4 ?
+                (100 - (i + 1) * 20) :
+                100 / (i + 2),
+            0.0001, // up to 0.0001% is fine
+            'Correct height for MAIN yAxis (' + (i + 2) + ' panes - indicator.add).'
+        );
+        assert.close(
+            parseFloat(chart.yAxis[i + 2].options.height),
+            i < 4 ?
+                20 :
+                100 / (i + 2),
+            0.0001, // up to 0.0001% is fine
+            'Correct height for LAST yAxis (' + (i + 2) + ' panes - indicator.add).'
+        );
+    }
+
+    for (i = 9; i > 0; i--) {
+        chart.navigationBindings.selectedButtonElement = document
+            .getElementsByClassName('highcharts-indicators')[0];
+        chart.navigationBindings.utils.manageIndicators.call(
+            chart.navigationBindings,
+            {
+                actionType: 'remove',
+                seriesId: chart.series[chart.series.length - 2].options.id
+            }
+        );
+
+        assert.close(
+            parseFloat(chart.yAxis[0].options.height),
+            i < 6 ?
+                100 - (i - 1) * 20 :
+                100 / i,
+            0.005, // up to 0.5% is fine
+            'Correct height for main yAxis (' + (i + 1) + ' pane(s) - indicator.remove).'
+        );
+    }
+
+
+    chart.navigationBindings.selectedButtonElement = document
+        .getElementsByClassName('highcharts-indicators')[0];
+    chart.navigationBindings.utils.manageIndicators.call(
+        chart.navigationBindings,
+        {
+            actionType: 'add',
+            linkedTo: 'column-1',
+            fields: {
+                'params.index': '0',
+                'params.period': '5'
+            },
+            type: 'sma'
+        }
+    );
+
+    assert.strictEqual(
+        chart.series[1].getDGApproximation(),
+        chart.series[chart.series.length - 2].options.dataGrouping.approximation,
+        'Indicator on column series should use the same DG approximation (#13950).'
+    );
+});

--- a/ts/Stock/StockToolsBindings.ts
+++ b/ts/Stock/StockToolsBindings.ts
@@ -295,7 +295,7 @@ bindingsUtils.manageIndicators = function (
         // Make sure that indicator uses the SUM approx if SUM approx is used
         // by parent series (#13950).
         if (
-            parentSeries &&
+            typeof parentSeries !== 'undefined' &&
             parentSeries instanceof Highcharts.Series &&
             parentSeries.getDGApproximation() === 'sum' &&
             // If indicator has defined approx type, use it (e.g. "ranges")

--- a/ts/Stock/StockToolsBindings.ts
+++ b/ts/Stock/StockToolsBindings.ts
@@ -19,11 +19,13 @@ import type Point from '../Core/Series/Point';
 import H from '../Core/Globals.js';
 import NavigationBindings from '../Extensions/Annotations/NavigationBindings.js';
 import U from '../Core/Utilities.js';
+import dataGrouping from '../Extensions/DataGrouping';
 const {
     correctFloat,
     defined,
     extend,
     fireEvent,
+    getOptions,
     isNumber,
     merge,
     pick,
@@ -255,6 +257,7 @@ bindingsUtils.manageIndicators = function (
         ],
         yAxis,
         parentSeries,
+        defaultOptions,
         series: Highcharts.Series;
 
     if (data.actionType === 'edit') {
@@ -288,13 +291,19 @@ bindingsUtils.manageIndicators = function (
         seriesConfig.id = uniqueKey();
         navigation.fieldsToOptions(data.fields, seriesConfig);
         parentSeries = chart.get(seriesConfig.linkedTo);
+        defaultOptions = getOptions().plotOptions as any;
 
         // Make sure that indicator uses the SUM approx if SUM approx is used
         // by parent series (#13950).
         if (
             parentSeries &&
             parentSeries instanceof Highcharts.Series &&
-            parentSeries.getDGApproximation() === 'sum'
+            parentSeries.getDGApproximation() === 'sum' &&
+            // If indicator has defined approx type, use it (e.g. "ranges")
+            !defined(
+                defaultOptions && defaultOptions[seriesConfig.type] &&
+                defaultOptions.dataGrouping?.approximation
+            )
         ) {
             seriesConfig.dataGrouping = {
                 approximation: 'sum'

--- a/ts/Stock/StockToolsBindings.ts
+++ b/ts/Stock/StockToolsBindings.ts
@@ -254,6 +254,7 @@ bindingsUtils.manageIndicators = function (
             'linearRegressionAngle'
         ],
         yAxis,
+        parentSeries,
         series: Highcharts.Series;
 
     if (data.actionType === 'edit') {
@@ -286,6 +287,19 @@ bindingsUtils.manageIndicators = function (
     } else {
         seriesConfig.id = uniqueKey();
         navigation.fieldsToOptions(data.fields, seriesConfig);
+        parentSeries = chart.get(seriesConfig.linkedTo);
+
+        // Make sure that indicator uses the SUM approx if SUM approx is used
+        // by parent series (#13950).
+        if (
+            parentSeries &&
+            parentSeries instanceof Highcharts.Series &&
+            parentSeries.getDGApproximation() === 'sum'
+        ) {
+            seriesConfig.dataGrouping = {
+                approximation: 'sum'
+            };
+        }
 
         if (indicatorsWithAxes.indexOf(data.type) >= 0) {
             yAxis = chart.addAxis({

--- a/ts/Stock/StockToolsBindings.ts
+++ b/ts/Stock/StockToolsBindings.ts
@@ -19,7 +19,6 @@ import type Point from '../Core/Series/Point';
 import H from '../Core/Globals.js';
 import NavigationBindings from '../Extensions/Annotations/NavigationBindings.js';
 import U from '../Core/Utilities.js';
-import dataGrouping from '../Extensions/DataGrouping';
 const {
     correctFloat,
     defined,


### PR DESCRIPTION
Fixed #13950, in StockTools, adding technical indicators to column-type series did not use the same `dataGrouping.approximation`.
___
Alternative approach is to add this logic in Indicators core (instead of StockTools, like in this PR), where indicator will decide its approximation by overwriting `getDGApproximation()`. But that would be inconsistent (DG approx would depend on parent series type) and might be misleading for developers ("I'm adding SMA to A-type and B-type series, why lines are different?!"). Right now it's up to the developer to decide DG approx when using indicator. We need this change in StockTools because end-user has no way to choose an approximation, so we must set approx to the best one we can guess.