### PR TITLE
bugfix/13570-update-networkgraph

### DIFF
--- a/js/Series/Networkgraph/Networkgraph.js
+++ b/js/Series/Networkgraph/Networkgraph.js
@@ -457,7 +457,9 @@ seriesType('networkgraph', 'line',
      */
     createNode: NodesMixin.createNode,
     destroy: function () {
-        this.layout.removeElementFromCollection(this, this.layout.series);
+        if (this.layout) {
+            this.layout.removeElementFromCollection(this, this.layout.series);
+        }
         NodesMixin.destroy.call(this);
     },
     /* eslint-disable no-invalid-this, valid-jsdoc */

--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.js
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.js
@@ -321,3 +321,31 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test(
+    'Networkgraph and series updates',
+    assert => {
+        var chart = Highcharts.chart('container', {
+            chart: {
+                type: 'line'
+            },
+            series: [{
+                data: [
+                    ['a', 'b']
+                ],
+                type: "networkgraph"
+            }]
+        });
+
+        chart.update({
+            chart: {
+                type: 'column'
+            },
+            series: [{
+                color: 'red'
+            }]
+        });
+
+        assert.ok(true, 'No errors when updating series and chart at the same time (#13570).');
+    }
+);

--- a/ts/Series/Networkgraph/Networkgraph.ts
+++ b/ts/Series/Networkgraph/Networkgraph.ts
@@ -679,10 +679,12 @@ seriesType<Highcharts.NetworkgraphSeries>(
          */
         createNode: NodesMixin.createNode,
         destroy: function (this: Highcharts.NetworkgraphSeries): void {
-            this.layout.removeElementFromCollection<Highcharts.Series>(
-                this,
-                this.layout.series
-            );
+            if (this.layout) {
+                this.layout.removeElementFromCollection<Highcharts.Series>(
+                    this,
+                    this.layout.series
+                );
+            }
             NodesMixin.destroy.call(this);
         },
 


### PR DESCRIPTION
Fixed #13570,  updating chart and networkgraph series simultaneously used to throw errors.