### PR TITLE
bugfix/13813-datagrouping-proximate-legend

### DIFF
--- a/js/Core/Legend.js
+++ b/js/Core/Legend.js
@@ -318,7 +318,7 @@ var Legend = /** @class */ (function () {
                 fireEvent(_this, 'afterPositionItem', { item: item });
             };
             if (defined(legendGroup.translateY)) {
-                legendGroup.animate(attribs, { complete: complete });
+                legendGroup.animate(attribs, void 0, complete);
             }
             else {
                 legendGroup.attr(attribs);

--- a/js/Core/Legend.js
+++ b/js/Core/Legend.js
@@ -686,15 +686,17 @@ var Legend = /** @class */ (function () {
         var chart = this.chart, boxes = [], alignLeft = this.options.align === 'left';
         this.allItems.forEach(function (item) {
             var lastPoint, height, useFirstPoint = alignLeft, target, top;
-            if (item.yAxis && item.points) {
+            if (item.yAxis) {
                 if (item.xAxis.options.reversed) {
                     useFirstPoint = !useFirstPoint;
                 }
-                lastPoint = find(useFirstPoint ?
-                    item.points :
-                    item.points.slice(0).reverse(), function (item) {
-                    return isNumber(item.plotY);
-                });
+                if (item.points) {
+                    lastPoint = find(useFirstPoint ?
+                        item.points :
+                        item.points.slice(0).reverse(), function (item) {
+                        return isNumber(item.plotY);
+                    });
+                }
                 height = this.itemMarginTop +
                     item.legendItem.getBBox().height +
                     this.itemMarginBottom;

--- a/samples/unit-tests/legend/layout/demo.js
+++ b/samples/unit-tests/legend/layout/demo.js
@@ -81,7 +81,7 @@ QUnit.test(
     }
 );
 
-QUnit.skip(
+QUnit.test(
     'Proximate layout and dataGrouping',
     assert => {
         const chart = new Highcharts.chart(

--- a/samples/unit-tests/legend/layout/demo.js
+++ b/samples/unit-tests/legend/layout/demo.js
@@ -80,3 +80,55 @@ QUnit.test(
         );
     }
 );
+
+QUnit.skip(
+    'Proximate layout and dataGrouping',
+    assert => {
+        const chart = new Highcharts.chart(
+            'container',
+            {
+                chart: {
+                    animation: false
+                },
+                legend: {
+                    align: 'right',
+                    layout: 'proximate'
+                },
+                plotOptions: {
+                    series: {
+                        dataGrouping: {
+                            enabled: true,
+                            forced: true
+                        }
+                    }
+                },
+                series: [{
+                    data: [
+                        [Date.UTC(2019, 0, 1, 20, 10), 10],
+                        [Date.UTC(2019, 0, 1, 20, 15), 11],
+                        [Date.UTC(2019, 0, 1, 20, 23), 12],
+                        [Date.UTC(2019, 0, 1, 20, 44), 13],
+                        [Date.UTC(2019, 0, 1, 20, 56), 14]
+                    ]
+                }, {
+                    data: [
+                        [Date.UTC(2019, 0, 1, 20, 10), 10],
+                        [Date.UTC(2019, 0, 1, 20, 15), 11],
+                        [Date.UTC(2019, 0, 1, 20, 23), 12],
+                        [Date.UTC(2019, 0, 1, 20, 44), 13],
+                        [Date.UTC(2019, 0, 1, 20, 56), 14]
+                    ]
+                }]
+            }
+        );
+
+        chart.series[1].hide();
+
+        // Avoid using strict position as it may vary between browsers
+        assert.ok(
+            chart.series[1].legendGroup.translateY > chart.plotHeight / 2,
+            `Legend item for a hidden series should be placed at the bottom
+            of chart even when dataGrouping is enabled (#13813).`
+        );
+    }
+);

--- a/ts/Core/Legend.ts
+++ b/ts/Core/Legend.ts
@@ -1116,19 +1116,21 @@ class Legend {
                 target,
                 top;
 
-            if ((item as any).yAxis && (item as any).points) {
+            if ((item as any).yAxis) {
 
                 if ((item as any).xAxis.options.reversed) {
                     useFirstPoint = !useFirstPoint;
                 }
-                lastPoint = find(
-                    useFirstPoint ?
-                        (item as any).points :
-                        (item as any).points.slice(0).reverse(),
-                    function (item: Point): boolean {
-                        return isNumber(item.plotY);
-                    }
-                );
+                if ((item as any).points) {
+                    lastPoint = find(
+                        useFirstPoint ?
+                            (item as any).points :
+                            (item as any).points.slice(0).reverse(),
+                        function (item: Point): boolean {
+                            return isNumber(item.plotY);
+                        }
+                    );
+                }
 
                 height = this.itemMarginTop +
                     (item.legendItem as any).getBBox().height +

--- a/ts/Core/Legend.ts
+++ b/ts/Core/Legend.ts
@@ -572,7 +572,7 @@ class Legend {
             };
 
             if (defined(legendGroup.translateY)) {
-                legendGroup.animate(attribs, { complete });
+                legendGroup.animate(attribs, void 0, complete);
             } else {
                 legendGroup.attr(attribs);
                 complete();


### PR DESCRIPTION
Fixed #13813, hiding series when `dataGrouping` was enabled and `legend.layout` was set to `"proximate"` used to render legend item at the wrong position.
___
Extra note: During tests I realized that proximate animation can not be disabled: https://jsfiddle.net/BlackLabel/4qLmxb6y/ (hide any legend item, everything is rendered right away, except proximate positions). It was necessary for a test, so fixed too (fix: instead of `animate(params, { complete })` used `animate(params, void 0, complete)`).