### PR TITLE
bugfix/13749-negative-ticks-on-positive-axes

### DIFF
--- a/js/Core/Axis/Axis.js
+++ b/js/Core/Axis/Axis.js
@@ -1705,6 +1705,17 @@ var Axis = /** @class */ (function () {
         this.tickAmount = tickAmount;
     };
     /**
+     * Check if the series assigned to the axis have equal values
+     *
+     * @private
+     * @function Highcharts.Axis#haveSeriesEqualValues
+     * @return {boolean}
+     */
+    Axis.prototype.haveSeriesEqualValues = function () {
+        var series = this.series, seriesWithEqualValues = series.filter(function (series) { return series.dataMin === series.dataMax; });
+        return seriesWithEqualValues.length === series.length;
+    };
+    /**
      * When using multiple axes, adjust the number of ticks to match the highest
      * number of ticks in that group.
      *
@@ -1712,14 +1723,17 @@ var Axis = /** @class */ (function () {
      * @function Highcharts.Axis#adjustTickAmount
      */
     Axis.prototype.adjustTickAmount = function () {
-        var axis = this, axisOptions = axis.options, tickInterval = axis.tickInterval, tickPositions = axis.tickPositions, tickAmount = axis.tickAmount, finalTickAmt = axis.finalTickAmt, currentTickAmount = tickPositions && tickPositions.length, threshold = pick(axis.threshold, axis.softThreshold ? 0 : null), min, len, i;
+        var axis = this, axisOptions = axis.options, series = this.series, tickInterval = axis.tickInterval, tickPositions = axis.tickPositions, tickAmount = axis.tickAmount, finalTickAmt = axis.finalTickAmt, currentTickAmount = tickPositions && tickPositions.length, threshold = pick(axis.threshold, axis.softThreshold ? 0 : null);
+        var min, len, i;
         if (axis.hasData()) {
             if (currentTickAmount < tickAmount) {
                 min = axis.min;
                 while (tickPositions.length < tickAmount) {
+                    var isMinHigherThanTickInterval = (min || min === 0) && (min < tickInterval);
                     // Extend evenly for both sides unless we're on the
                     // threshold (#3965)
-                    if (tickPositions.length % 2 ||
+                    if ((isMinHigherThanTickInterval && axis.haveSeriesEqualValues()) ||
+                        tickPositions.length % 2 ||
                         min === threshold) {
                         // to the end
                         tickPositions.push(correctFloat(tickPositions[tickPositions.length - 1] +

--- a/js/Core/Axis/Axis.js
+++ b/js/Core/Axis/Axis.js
@@ -1729,10 +1729,10 @@ var Axis = /** @class */ (function () {
             if (currentTickAmount < tickAmount) {
                 min = axis.min;
                 while (tickPositions.length < tickAmount) {
-                    var isMinHigherThanTickInterval = (min || min === 0) && (min < tickInterval);
+                    var isMinLowerThanTickInterval = (min || min === 0) && (min < tickInterval);
                     // Extend evenly for both sides unless we're on the
                     // threshold (#3965)
-                    if ((isMinHigherThanTickInterval && axis.haveSeriesEqualValues()) ||
+                    if ((isMinLowerThanTickInterval && axis.haveSeriesEqualValues()) ||
                         tickPositions.length % 2 ||
                         min === threshold) {
                         // to the end

--- a/samples/unit-tests/axis/ticks/demo.js
+++ b/samples/unit-tests/axis/ticks/demo.js
@@ -783,3 +783,32 @@ QUnit.test('The tick interval after updating series visibility should stay the s
         "After adding columns series the tick interval should change to make a place for columns."
     );
 });
+
+QUnit.test('tickAmount with min', function (assert) {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'scatter'
+        },
+        xAxis: {
+            tickAmount: 5,
+            min: 0
+        },
+        series: [{
+            data: [
+                [8.4, 4]
+            ]
+        }]
+    });
+
+    assert.deepEqual(
+        chart.xAxis[0].haveSeriesEqualValues(),
+        true,
+        "haveSeriesEqualValues() method should return true when series.dataMin === series.dataMax"
+    );
+
+    assert.deepEqual(
+        chart.xAxis[0].tickPositions[0],
+        0,
+        "There should not be negative ticks when the data is positive and xAxis.min is equal 0"
+    );
+});

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -5890,6 +5890,18 @@ class Axis implements AxisComposition, AxisLike {
 
         this.tickAmount = (tickAmount as any);
     }
+    /**
+     * Check if the series assigned to the axis have equal values
+     *
+     * @private
+     * @function Highcharts.Axis#haveSeriesEqualValues
+     * @return {boolean}
+     */
+    public haveSeriesEqualValues(): boolean {
+        const series = this.series,
+            seriesWithEqualValues = series.filter((series): boolean => series.dataMin === series.dataMax);
+        return seriesWithEqualValues.length === series.length;
+    }
 
     /**
      * When using multiple axes, adjust the number of ticks to match the highest
@@ -5899,27 +5911,29 @@ class Axis implements AxisComposition, AxisLike {
      * @function Highcharts.Axis#adjustTickAmount
      */
     public adjustTickAmount(): void {
-        var axis = this,
+        const axis = this,
             axisOptions = axis.options,
+            series = this.series,
             tickInterval = axis.tickInterval,
             tickPositions = axis.tickPositions,
             tickAmount = axis.tickAmount,
             finalTickAmt = axis.finalTickAmt,
             currentTickAmount = tickPositions && tickPositions.length,
-            threshold = pick(axis.threshold, axis.softThreshold ? 0 : null),
-            min,
-            len,
-            i;
+            threshold = pick(axis.threshold, axis.softThreshold ? 0 : null);
+
+        let min, len, i;
 
         if (axis.hasData()) {
             if (currentTickAmount < tickAmount) {
                 min = axis.min;
 
                 while (tickPositions.length < tickAmount) {
+                    const isMinHigherThanTickInterval = (min || min === 0) && (min < tickInterval);
 
                     // Extend evenly for both sides unless we're on the
                     // threshold (#3965)
                     if (
+                        (isMinHigherThanTickInterval && axis.haveSeriesEqualValues()) ||
                         tickPositions.length % 2 ||
                         min === threshold
                     ) {

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -5928,12 +5928,12 @@ class Axis implements AxisComposition, AxisLike {
                 min = axis.min;
 
                 while (tickPositions.length < tickAmount) {
-                    const isMinHigherThanTickInterval = (min || min === 0) && (min < tickInterval);
+                    const isMinLowerThanTickInterval = (min || min === 0) && (min < tickInterval);
 
                     // Extend evenly for both sides unless we're on the
                     // threshold (#3965)
                     if (
-                        (isMinHigherThanTickInterval && axis.haveSeriesEqualValues()) ||
+                        (isMinLowerThanTickInterval && axis.haveSeriesEqualValues()) ||
                         tickPositions.length % 2 ||
                         min === threshold
                     ) {


### PR DESCRIPTION
Fixed #13749, negative ticks on positive axes with the `xAxis.min` = 0.