### PR TITLE
docs/sankey-dependency

### DIFF
--- a/js/Series/DependencyWheelSeries.js
+++ b/js/Series/DependencyWheelSeries.js
@@ -35,7 +35,7 @@ seriesType('dependencywheel', 'sankey',
  * @exclude      dataSorting
  * @since        7.1.0
  * @product      highcharts
- * @requires     modules/dependencywheel
+ * @requires     modules/dependency-wheel
  * @optionparent plotOptions.dependencywheel
  */
 {
@@ -287,7 +287,8 @@ seriesType('dependencywheel', 'sankey',
  * @extends   series,plotOptions.dependencywheel
  * @exclude   dataSorting
  * @product   highcharts
- * @requires  modules/dependencywheel
+ * @requires  modules/sankey
+ * @requires  modules/dependency-wheel
  * @apioption series.dependencywheel
  */
 /**

--- a/js/Series/OrganizationSeries.js
+++ b/js/Series/OrganizationSeries.js
@@ -416,6 +416,7 @@ seriesType('organization', 'sankey',
  * @extends   series,plotOptions.organization
  * @exclude   dataSorting, boostThreshold, boostBlending
  * @product   highcharts
+ * @requires  modules/sankey
  * @requires  modules/organization
  * @apioption series.organization
  */

--- a/ts/Series/DependencyWheelSeries.ts
+++ b/ts/Series/DependencyWheelSeries.ts
@@ -100,7 +100,7 @@ seriesType<Highcharts.DependencyWheelSeries>(
      * @exclude      dataSorting
      * @since        7.1.0
      * @product      highcharts
-     * @requires     modules/dependencywheel
+     * @requires     modules/dependency-wheel
      * @optionparent plotOptions.dependencywheel
      */
     {
@@ -463,7 +463,8 @@ seriesType<Highcharts.DependencyWheelSeries>(
  * @extends   series,plotOptions.dependencywheel
  * @exclude   dataSorting
  * @product   highcharts
- * @requires  modules/dependencywheel
+ * @requires  modules/sankey
+ * @requires  modules/dependency-wheel
  * @apioption series.dependencywheel
  */
 

--- a/ts/Series/OrganizationSeries.ts
+++ b/ts/Series/OrganizationSeries.ts
@@ -692,6 +692,7 @@ seriesType<Highcharts.OrganizationSeries>(
  * @extends   series,plotOptions.organization
  * @exclude   dataSorting, boostThreshold, boostBlending
  * @product   highcharts
+ * @requires  modules/sankey
  * @requires  modules/organization
  * @apioption series.organization
  */


### PR DESCRIPTION
Fixed #13954. Added jsdoc `@requires modules/sankey` to `organization` and `dependencywheel` series. Also corrected URLs to the dependencywheel js file (which has a `-`).