### PR TITLE
bugfix/12273-exporting-getSVG-iFrame

### DIFF
--- a/js/Extensions/Exporting.js
+++ b/js/Extensions/Exporting.js
@@ -1872,7 +1872,9 @@ Chart.prototype.inlineStyles = function () {
      * @return {void}
      */
     function tearDown() {
-        dummySVG.parentNode.removeChild(dummySVG);
+        dummySVG.parentNode.remove();
+        // Remove trash from DOM that stayed after each exporting
+        iframe.remove();
     }
     recurse(this.container.querySelector('svg'));
     tearDown();

--- a/samples/unit-tests/exporting/getsvg/demo.js
+++ b/samples/unit-tests/exporting/getsvg/demo.js
@@ -23,7 +23,9 @@ QUnit.test('getSVG', function (assert) {
 
     var initialChartsLength = Highcharts.charts.length,
         svg,
-        output;
+        output,
+        isIframe,
+        siblings;
 
     svg = chart.getSVG({
         yAxis: [{
@@ -95,6 +97,25 @@ QUnit.test('getSVG', function (assert) {
         'Reference by id, series name ok'
     );
 
+    chart.getSVG({
+        chart: {
+            styledMode: true
+        }
+    });
+
+    siblings = Array.prototype.slice.call(
+        chart.container.parentNode.parentNode.childNodes
+    );
+
+    isIframe = siblings.some(function (elem) {
+        return elem.tagName === 'IFRAME';
+    });
+
+    assert.strictEqual( // (#12273)
+        isIframe,
+        false,
+        'Iframe should be destroyed in DOM after getSVG().'
+    );
 });
 
 QUnit.test('Hide label with useHTML', function (assert) {

--- a/ts/Extensions/Exporting.ts
+++ b/ts/Extensions/Exporting.ts
@@ -2551,7 +2551,9 @@ Chart.prototype.inlineStyles = function (): void {
      * @return {void}
      */
     function tearDown(): void {
-        (dummySVG.parentNode as any).removeChild(dummySVG);
+        (dummySVG.parentNode as any).remove();
+        // Remove trash from DOM that stayed after each exporting
+        iframe.remove();
     }
 
     recurse(this.container.querySelector('svg') as any);


### PR DESCRIPTION
Fixed #12273, iframe wasn't being destroyed after `getSVG` method called.