### PR TITLE
bugfix/10365-gantt-tooltip-wrong-timezone

### DIFF
--- a/js/Series/GanttSeries.js
+++ b/js/Series/GanttSeries.js
@@ -55,8 +55,8 @@ seriesType('gantt', 'xrange'
             if (!format) {
                 format = splat(tooltip.getDateFormat(xAxis.closestPointRange, point.start, startOfWeek, formats))[0];
             }
-            start = dateFormat(format, point.start);
-            end = dateFormat(format, point.end);
+            start = series.chart.time.dateFormat(format, point.start);
+            end = series.chart.time.dateFormat(format, point.end);
             retVal += '<br/>';
             if (!milestone) {
                 retVal += 'Start: ' + start + '<br/>';

--- a/samples/unit-tests/gantt/tooltip/demo.js
+++ b/samples/unit-tests/gantt/tooltip/demo.js
@@ -56,3 +56,27 @@ QUnit.test('Gantt tooltip', assert => {
         'Intraday times - tooltip should show the date and time of day'
     );
 });
+
+QUnit.test('The tooltip should respect timezone/timezone offsets declared locally and globally (#10365)', function (assert) {
+    var chart = Highcharts.ganttChart('container', {
+            time: {
+                timezoneOffset: 6 * 60
+            },
+            series: [{
+                data: [{
+                    name: "Task 1",
+                    start: Date.UTC(2020, 5, 2),
+                    end: Date.UTC(2020, 5, 3)
+                }]
+            }]
+        }),
+        p1 = chart.series[0].points[0],
+        tooltip = chart.tooltip;
+
+    tooltip.refresh(p1);
+    assert.strictEqual(
+        chart.container.querySelector('.highcharts-tooltip').textContent,
+        'Series 1Task 1Start: Monday, Jun  1, 18:00End: Tuesday, Jun  2, 18:00',
+        'The tooltip should show the start and end shifted 6 hours relative to UTC.'
+    );
+});

--- a/ts/Series/GanttSeries.ts
+++ b/ts/Series/GanttSeries.ts
@@ -159,8 +159,8 @@ seriesType<Highcharts.GanttSeries>('gantt', 'xrange'
                     )[0];
                 }
 
-                start = dateFormat(format as any, point.start as any);
-                end = dateFormat(format as any, point.end as any);
+                start = series.chart.time.dateFormat(format as any, point.start as any);
+                end = series.chart.time.dateFormat(format as any, point.end as any);
 
                 retVal += '<br/>';
 


### PR DESCRIPTION
Fixed #10365, tooltip in Gantt did not respect time zones.