### PR TITLE
Extracted AST functionality to new class.

### DIFF
--- a/js/Core/Renderer/HTML/AST.js
+++ b/js/Core/Renderer/HTML/AST.js
@@ -1,0 +1,214 @@
+/* *
+ *
+ *  (c) 2010-2020 Torstein Honsi
+ *
+ *  License: www.highcharts.com/license
+ *
+ *  !!!!!!! SOURCE GETS TRANSPILED BY TYPESCRIPT. EDIT TS FILE ONLY. !!!!!!!
+ *
+ * */
+'use strict';
+import H from '../../Globals.js';
+import U from '../../Utilities.js';
+var attr = U.attr, objectEach = U.objectEach, splat = U.splat;
+/**
+ * Represents an AST
+ * @private
+ * @class
+ * @name Highcharts.AST
+ */
+var AST = /** @class */ (function () {
+    // Construct an AST from HTML markup, or wrap an array of existing AST nodes
+    function AST(source) {
+        this.nodes = typeof source === 'string' ?
+            this.parseMarkup(source) : source;
+    }
+    /**
+     * Add the tree defined as a hierarchical JS structure to the DOM
+     *
+     * @private
+     *
+     * @function Highcharts.AST#add
+     *
+     * @param {SVGElement} parent
+     * The node where it should be added
+     *
+     * @return {Highcharts.HTMLDOMElement|Highcharts.SVGDOMElement}
+     * The inserted node.
+     */
+    AST.prototype.addToDOM = function (parent) {
+        var NS = parent.namespaceURI || H.SVG_NS;
+        /**
+         * @private
+         * @param {Highcharts.ASTNode} subtree - HTML/SVG definition
+         * @param {Element} [subParent] - parent node
+         * @return {Highcharts.SVGDOMElement|Highcharts.HTMLDOMElement} The inserted node.
+         */
+        function recurse(subtree, subParent) {
+            var ret;
+            splat(subtree).forEach(function (item) {
+                var textNode = item.textContent ?
+                    H.doc.createTextNode(item.textContent) :
+                    void 0;
+                var node;
+                if (item.tagName === '#text') {
+                    node = textNode;
+                }
+                else if (item.tagName) {
+                    node = H.doc.createElementNS(NS, item.tagName);
+                    var attributes_1 = item.attributes || {};
+                    // Apply attributes from root of AST node, legacy from
+                    // from before TextBuilder
+                    objectEach(item, function (val, key) {
+                        if (key !== 'tagName' &&
+                            key !== 'attributes' &&
+                            key !== 'children' &&
+                            key !== 'textContent') {
+                            attributes_1[key] = val;
+                        }
+                    });
+                    attr(node, attributes_1);
+                    // Add text content
+                    if (textNode) {
+                        node.appendChild(textNode);
+                    }
+                    // Recurse
+                    recurse(item.children || [], node);
+                }
+                // Add to the tree
+                if (node) {
+                    subParent.appendChild(node);
+                }
+                ret = node;
+            });
+            // Return last node added (on top level it's the only one)
+            return ret;
+        }
+        return recurse(this.nodes, parent);
+    };
+    /**
+     * Parse HTML/SVG markup into AST Node objects.
+     *
+     * @private
+     *
+     * @function Highcharts.AST#getNodesFromMarkup
+     *
+     * @param {string} markup The markup string.
+     *
+     * @return {Array<Highcharts.ASTNode>} The parsed nodes.
+     */
+    AST.prototype.parseMarkup = function (markup) {
+        var nodes = [];
+        var doc;
+        var body;
+        if (
+        // IE9 is only able to parse XML
+        /MSIE 9.0/.test(navigator.userAgent) ||
+            // IE8-
+            typeof DOMParser === 'undefined') {
+            body = H.createElement('div');
+            body.innerHTML = markup;
+            doc = { body: body };
+        }
+        else {
+            doc = new DOMParser().parseFromString(markup, 'text/html');
+        }
+        var validateDirective = function (attrib) {
+            if (['background', 'dynsrc', 'href', 'lowsrc', 'src']
+                .indexOf(attrib.name) !== -1) {
+                return /^(http|\/)/.test(attrib.value);
+            }
+            return true;
+        };
+        var validateChildNodes = function (node, addTo) {
+            var tagName = node.nodeName.toLowerCase();
+            // Add allowed tags
+            if (AST.allowedTags.indexOf(tagName) !== -1) {
+                var astNode = {
+                    tagName: tagName
+                };
+                if (tagName === '#text') {
+                    var textContent = node.textContent || '';
+                    // Whitespace text node, don't append it to the AST
+                    if (/^[\s]*$/.test(textContent)) {
+                        return;
+                    }
+                    astNode.textContent = textContent;
+                }
+                var parsedAttributes = node.attributes;
+                // Add allowed attributes
+                if (parsedAttributes) {
+                    var attributes_2 = {};
+                    [].forEach.call(parsedAttributes, function (attrib) {
+                        if (AST.allowedAttributes
+                            .indexOf(attrib.name) !== -1 &&
+                            validateDirective(attrib)) {
+                            attributes_2[attrib.name] = attrib.value;
+                        }
+                    });
+                    astNode.attributes = attributes_2;
+                }
+                // Handle children
+                if (node.childNodes.length) {
+                    var children_1 = [];
+                    [].forEach.call(node.childNodes, function (childNode) {
+                        validateChildNodes(childNode, children_1);
+                    });
+                    if (children_1.length) {
+                        astNode.children = children_1;
+                    }
+                }
+                addTo.push(astNode);
+            }
+        };
+        [].forEach.call(doc.body.childNodes, function (childNode) { return validateChildNodes(childNode, nodes); });
+        if (body) {
+            H.discardElement(body);
+        }
+        return nodes;
+    };
+    AST.allowedTags = [
+        'a',
+        'b',
+        'br',
+        'caption',
+        'code',
+        'div',
+        'em',
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'i',
+        'img',
+        'li',
+        'ol',
+        'p',
+        'pre',
+        'small',
+        'span',
+        'strong',
+        'sub',
+        'sup',
+        'table',
+        'tbody',
+        'td',
+        'th',
+        'tr',
+        'ul',
+        '#text'
+    ];
+    AST.allowedAttributes = [
+        'class',
+        'colspan',
+        'href',
+        'id',
+        'src',
+        'rowspan',
+        'style'
+    ];
+    return AST;
+}());
+export default AST;

--- a/js/Core/Renderer/HTML/AST.js
+++ b/js/Core/Renderer/HTML/AST.js
@@ -12,6 +12,25 @@ import H from '../../Globals.js';
 import U from '../../Utilities.js';
 var attr = U.attr, objectEach = U.objectEach, splat = U.splat;
 /**
+ * Serialized form of an SVG/HTML definition, including children. Some key
+ * property names are reserved: tagName, textContent, and children.
+ *
+ * @interface Highcharts.ASTNode
+ */ /**
+* @name Highcharts.ASTNode#[key:string]
+* @type {boolean|number|string|Array<Highcharts.ASTNode>|undefined}
+*/ /**
+* @name Highcharts.ASTNode#children
+* @type {Array<Highcharts.ASTNode>|undefined}
+*/ /**
+* @name Highcharts.ASTNode#tagName
+* @type {string|undefined}
+*/ /**
+* @name Highcharts.ASTNode#textContent
+* @type {string|undefined}
+*/
+''; // detach doclets above
+/**
  * Represents an AST
  * @private
  * @class

--- a/js/Extensions/Annotations/Mixins/MarkerMixin.js
+++ b/js/Extensions/Annotations/Mixins/MarkerMixin.js
@@ -38,13 +38,13 @@ var addEvent = U.addEvent, defined = U.defined, merge = U.merge, objectEach = U.
  * @sample highcharts/css/annotations-markers/
  *         Define markers in a styled mode
  *
- * @type         {Highcharts.Dictionary<Highcharts.ASTObject>}
+ * @type         {Highcharts.Dictionary<Highcharts.ASTNode>}
  * @since        6.0.0
  * @optionparent defs
  */
 var defaultMarkers = {
     /**
-     * @type {Highcharts.ASTObject}
+     * @type {Highcharts.ASTNode}
      */
     arrow: {
         tagName: 'marker',
@@ -68,7 +68,7 @@ var defaultMarkers = {
             }]
     },
     /**
-     * @type {Highcharts.ASTObject}
+     * @type {Highcharts.ASTNode}
      */
     'reverse-arrow': {
         tagName: 'marker',

--- a/js/Extensions/ExportData.js
+++ b/js/Extensions/ExportData.js
@@ -15,6 +15,7 @@
 'use strict';
 import Axis from '../Core/Axis/Axis.js';
 import Chart from '../Core/Chart/Chart.js';
+import AST from '../Core/Renderer/HTML/AST.js';
 import H from '../Core/Globals.js';
 var doc = H.doc, seriesTypes = H.seriesTypes, win = H.win;
 import U from '../Core/Utilities.js';
@@ -662,7 +663,7 @@ Chart.prototype.getTable = function (useLocalDecimalPoint) {
  *        This makes it easier to export data to Excel in the same locale as the
  *        user is.
  *
- * @return {Highcharts.ASTObject}
+ * @return {Highcharts.ASTNode}
  *         The abstract syntax tree
  */
 Chart.prototype.getTableAST = function (useLocalDecimalPoint) {
@@ -928,7 +929,8 @@ Chart.prototype.viewData = function () {
         this.dataTableDiv.style.display = 'block';
     }
     this.isDataTableVisible = true;
-    this.renderer.addAST(this.getTableAST(), this.dataTableDiv);
+    var ast = new AST([this.getTableAST()]);
+    ast.addToDOM(this.dataTableDiv);
     fireEvent(this, 'afterViewData', this.dataTableDiv);
 };
 /**

--- a/ts/Accessibility/Components/InfoRegionsComponent.ts
+++ b/ts/Accessibility/Components/InfoRegionsComponent.ts
@@ -86,7 +86,7 @@ declare global {
             public initRegionsDefinitions(): void;
             public initSonifyButton(sonifyButtonId: string): void;
             public onChartUpdate(): void;
-            public onDataTableCreated(e: { tree: ASTObject }): void;
+            public onDataTableCreated(e: { tree: ASTNode }): void;
             public setLinkedDescriptionAttrs(): void;
             public setScreenReaderSectionAttribs(
                 sectionDiv: HTMLDOMElement,
@@ -274,7 +274,7 @@ extend(InfoRegionsComponent.prototype, /** @lends Highcharts.InfoRegionsComponen
         this.initRegionsDefinitions();
 
         this.addEvent(chart, 'afterGetTree', function (
-            e: { tree: Highcharts.ASTObject }
+            e: { tree: Highcharts.ASTNode }
         ): void {
             component.onDataTableCreated(e);
         });
@@ -675,7 +675,7 @@ extend(InfoRegionsComponent.prototype, /** @lends Highcharts.InfoRegionsComponen
      */
     onDataTableCreated: function (
         this: Highcharts.InfoRegionsComponent,
-        e: { tree: Highcharts.ASTObject }
+        e: { tree: Highcharts.ASTNode }
     ): void {
         var chart = this.chart;
 

--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -1,0 +1,315 @@
+/* *
+ *
+ *  (c) 2010-2020 Torstein Honsi
+ *
+ *  License: www.highcharts.com/license
+ *
+ *  !!!!!!! SOURCE GETS TRANSPILED BY TYPESCRIPT. EDIT TS FILE ONLY. !!!!!!!
+ *
+ * */
+
+'use strict';
+
+import H from '../../Globals.js';
+import U from '../../Utilities.js';
+const {
+    attr,
+    objectEach,
+    splat
+} = U;
+
+/**
+ * Serialized form of an SVG/HTML definition, including children. Some key
+ * property names are reserved: tagName, textContent, and children.
+ *
+ * @interface Highcharts.ASTNode
+ *//**
+ * @name Highcharts.ASTNode#[key:string]
+ * @type {boolean|number|string|Array<Highcharts.ASTNode>|undefined}
+ *//**
+ * @name Highcharts.ASTNode#children
+ * @type {Array<Highcharts.ASTNode>|undefined}
+ *//**
+ * @name Highcharts.ASTNode#tagName
+ * @type {string|undefined}
+ *//**
+ * @name Highcharts.ASTNode#textContent
+ * @type {string|undefined}
+ */
+
+/**
+ * Internal types
+ * @private
+ */
+declare global {
+    namespace Highcharts {
+        interface ASTNode {
+            attributes?: SVGAttributes;
+            children?: Array<ASTNode>;
+            tagName?: string;
+            textContent?: string;
+        }
+    }
+}
+
+/**
+ * Represents an AST
+ * @private
+ * @class
+ * @name Highcharts.AST
+ */
+class AST {
+    public static allowedTags = [
+        'a',
+        'b',
+        'br',
+        'caption',
+        'code',
+        'div',
+        'em',
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'i',
+        'img',
+        'li',
+        'ol',
+        'p',
+        'pre',
+        'small',
+        'span',
+        'strong',
+        'sub',
+        'sup',
+        'table',
+        'tbody',
+        'td',
+        'th',
+        'tr',
+        'ul',
+        '#text'
+    ];
+
+    public static allowedAttributes = [
+        'class',
+        'colspan',
+        'href',
+        'id',
+        'src',
+        'rowspan',
+        'style'
+    ];
+
+    // Public list of the nodes of this tree, can be modified before adding the
+    // tree to the DOM.
+    public nodes: Highcharts.ASTNode[];
+
+    // Construct an AST from HTML markup, or wrap an array of existing AST nodes
+    constructor(source: string|Highcharts.ASTNode[]) {
+        this.nodes = typeof source === 'string' ?
+            this.parseMarkup(source) : source;
+    }
+
+    /**
+     * Add the tree defined as a hierarchical JS structure to the DOM
+     *
+     * @private
+     *
+     * @function Highcharts.AST#add
+     *
+     * @param {SVGElement} parent
+     * The node where it should be added
+     *
+     * @return {Highcharts.HTMLDOMElement|Highcharts.SVGDOMElement}
+     * The inserted node.
+     */
+    public addToDOM(parent: Element): HTMLElement|SVGElement {
+        const NS = parent.namespaceURI || H.SVG_NS;
+
+        /**
+         * @private
+         * @param {Highcharts.ASTNode} subtree - HTML/SVG definition
+         * @param {Element} [subParent] - parent node
+         * @return {Highcharts.SVGDOMElement|Highcharts.HTMLDOMElement} The inserted node.
+         */
+        function recurse(
+            subtree: (
+                Highcharts.ASTNode|
+                Array<Highcharts.ASTNode>
+            ),
+            subParent: Element
+        ): SVGElement|HTMLElement {
+            let ret: any;
+
+            splat(subtree).forEach(function (
+                item: Highcharts.ASTNode
+            ): void {
+                const textNode = item.textContent ?
+                    H.doc.createTextNode(item.textContent) :
+                    void 0;
+                let node;
+
+                if (item.tagName === '#text') {
+                    node = textNode;
+
+                } else if (item.tagName) {
+                    node = H.doc.createElementNS(NS, item.tagName);
+                    const attributes = item.attributes || {};
+
+                    // Apply attributes from root of AST node, legacy from
+                    // from before TextBuilder
+                    objectEach(item, function (val, key): void {
+                        if (
+                            key !== 'tagName' &&
+                            key !== 'attributes' &&
+                            key !== 'children' &&
+                            key !== 'textContent'
+                        ) {
+                            attributes[key] = val;
+                        }
+                    });
+                    attr(node as any, attributes);
+
+                    // Add text content
+                    if (textNode) {
+                        node.appendChild(textNode);
+                    }
+
+                    // Recurse
+                    recurse(item.children || [], node);
+                }
+
+                // Add to the tree
+                if (node) {
+                    subParent.appendChild(node);
+                }
+
+                ret = node;
+            });
+
+            // Return last node added (on top level it's the only one)
+            return ret;
+        }
+
+        return recurse(this.nodes, parent);
+    }
+
+    /**
+     * Parse HTML/SVG markup into AST Node objects.
+     *
+     * @private
+     *
+     * @function Highcharts.AST#getNodesFromMarkup
+     *
+     * @param {string} markup The markup string.
+     *
+     * @return {Array<Highcharts.ASTNode>} The parsed nodes.
+     */
+    private parseMarkup(markup: string): Highcharts.ASTNode[] {
+        interface Attribute {
+            name: string;
+            value: string;
+        }
+
+        const nodes: Highcharts.ASTNode[] = [];
+        let doc;
+        let body;
+        if (
+            // IE9 is only able to parse XML
+            /MSIE 9.0/.test(navigator.userAgent) ||
+            // IE8-
+            typeof DOMParser === 'undefined'
+        ) {
+            body = H.createElement('div');
+            body.innerHTML = markup;
+            doc = { body };
+        } else {
+            doc = new DOMParser().parseFromString(markup, 'text/html');
+        }
+
+        const validateDirective = (attrib: Attribute): boolean => {
+            if (
+                ['background', 'dynsrc', 'href', 'lowsrc', 'src']
+                    .indexOf(attrib.name) !== -1
+            ) {
+                return /^(http|\/)/.test(attrib.value);
+            }
+            return true;
+        };
+
+        const validateChildNodes = (
+            node: ChildNode,
+            addTo: Highcharts.ASTNode[]
+        ): void => {
+            const tagName = node.nodeName.toLowerCase();
+
+            // Add allowed tags
+            if (AST.allowedTags.indexOf(tagName) !== -1) {
+                const astNode: Highcharts.ASTNode = {
+                    tagName
+                };
+                if (tagName === '#text') {
+                    const textContent = node.textContent || '';
+
+                    // Whitespace text node, don't append it to the AST
+                    if (/^[\s]*$/.test(textContent)) {
+                        return;
+                    }
+
+                    astNode.textContent = textContent;
+                }
+                const parsedAttributes = (node as any).attributes;
+
+                // Add allowed attributes
+                if (parsedAttributes) {
+                    const attributes: Highcharts.SVGAttributes = {};
+                    [].forEach.call(parsedAttributes, (attrib: Attribute): void => {
+                        if (
+                            AST.allowedAttributes
+                                .indexOf(attrib.name) !== -1 &&
+                            validateDirective(attrib)
+                        ) {
+                            attributes[attrib.name] = attrib.value;
+                        }
+                    });
+                    astNode.attributes = attributes;
+                }
+
+                // Handle children
+                if (node.childNodes.length) {
+                    const children: Highcharts.ASTNode[] = [];
+                    [].forEach.call(
+                        node.childNodes,
+                        (childNode: ChildNode): void => {
+                            validateChildNodes(
+                                childNode,
+                                children
+                            );
+                        }
+                    );
+                    if (children.length) {
+                        astNode.children = children;
+                    }
+                }
+
+                addTo.push(astNode);
+            }
+        };
+
+        [].forEach.call(
+            doc.body.childNodes,
+            (childNode): void => validateChildNodes(childNode, nodes)
+        );
+
+        if (body) {
+            H.discardElement(body);
+        }
+
+        return nodes;
+    }
+}
+
+export default AST;

--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -37,6 +37,8 @@ const {
  * @type {string|undefined}
  */
 
+''; // detach doclets above
+
 /**
  * Internal types
  * @private

--- a/ts/Extensions/Annotations/Annotations.ts
+++ b/ts/Extensions/Annotations/Annotations.ts
@@ -60,7 +60,7 @@ declare global {
         }
         interface AnnotationChartOptionsObject extends Options {
             annotations: Array<AnnotationsOptions>;
-            defs: Dictionary<ASTObject>;
+            defs: Dictionary<ASTNode>;
             navigation: NavigationOptions;
         }
         interface AnnotationControlPointEventsOptionsObject {

--- a/ts/Extensions/Annotations/Mixins/MarkerMixin.ts
+++ b/ts/Extensions/Annotations/Mixins/MarkerMixin.ts
@@ -34,7 +34,7 @@ declare global {
             setItemMarkers(this: ControllablePath, item: ControllablePath): void;
         }
         interface Options {
-            defs?: Dictionary<ASTObject>;
+            defs?: Dictionary<ASTNode>;
         }
         interface SVGRenderer {
             addMarker(id: string, markerOptions: SVGAttributes): SVGElement;
@@ -72,13 +72,13 @@ declare global {
  * @sample highcharts/css/annotations-markers/
  *         Define markers in a styled mode
  *
- * @type         {Highcharts.Dictionary<Highcharts.ASTObject>}
+ * @type         {Highcharts.Dictionary<Highcharts.ASTNode>}
  * @since        6.0.0
  * @optionparent defs
  */
-var defaultMarkers: Record<string, Highcharts.ASTObject> = {
+var defaultMarkers: Record<string, Highcharts.ASTNode> = {
     /**
-     * @type {Highcharts.ASTObject}
+     * @type {Highcharts.ASTNode}
      */
     arrow: {
         tagName: 'marker',
@@ -102,7 +102,7 @@ var defaultMarkers: Record<string, Highcharts.ASTObject> = {
         }]
     },
     /**
-     * @type {Highcharts.ASTObject}
+     * @type {Highcharts.ASTNode}
      */
     'reverse-arrow': {
         tagName: 'marker',
@@ -129,7 +129,7 @@ SVGRenderer.prototype.addMarker = function (
     id: string,
     markerOptions: Highcharts.SVGAttributes
 ): Highcharts.SVGElement {
-    var options: Highcharts.ASTObject = { attributes: { id } };
+    var options: Highcharts.ASTNode = { attributes: { id } };
 
     var attrs: Highcharts.SVGAttributes = {
         stroke: markerOptions.color || 'none',
@@ -137,8 +137,8 @@ SVGRenderer.prototype.addMarker = function (
     };
 
     options.children = markerOptions.children.map(function (
-        child: Highcharts.ASTObject
-    ): Highcharts.ASTObject {
+        child: Highcharts.ASTNode
+    ): Highcharts.ASTNode {
         return merge(attrs, child);
     });
 


### PR DESCRIPTION
@TorsteinHonsi See if you agree with this setup, or if we want to make some changes - definitely many ways to structure this. Will add to a11y once it's merged.

The PR adds a new `AST` class. The class just has a constructor and an `addToDOM` function, and a public `nodes` member that holds a reference to an array of nodes that make up the tree (renamed `ASTObject` to `ASTNode` to avoid confusion between these objects and the new class). To modify the tree before adding to the DOM, we would in other words just access the public `nodes` property.

It could be cleaner at times to have `ASTNode/ASTObject` keep all of this functionality itself, e.g. `ASTNode.addToDOM()` and `new ASTNode(markup)`, as well as `astNode.attributes[key] = val`. There seems to be some code where root properties on elements are copied over to the nodes for backwards compatibility, though, so I figured it was best avoided.