### PR TITLE
bugfix/13982-update-noDataLabel

### DIFF
--- a/js/Core/Dynamics.js
+++ b/js/Core/Dynamics.js
@@ -473,9 +473,6 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         if (!chart.styledMode && options.colors) {
             this.options.colors = options.colors;
         }
-        if (options.plotOptions) {
-            merge(true, this.options.plotOptions, options.plotOptions);
-        }
         // Maintaining legacy global time. If the chart is instanciated first
         // with global time, then updated with time options, we need to create a
         // new Time instance to avoid mutating the global time (#10536).
@@ -500,6 +497,12 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             }
             else if (typeof chart[adders[key]] === 'function') {
                 chart[adders[key]](val);
+                // Else, just merge the options. For nodes like loading, noData,
+                // plotOptions
+            }
+            else if (key !== 'color' &&
+                chart.collectionsWithUpdate.indexOf(key) === -1) {
+                merge(true, chart.options[key], options[key]);
             }
             if (key !== 'chart' &&
                 chart.propsRequireUpdateSeries.indexOf(key) !== -1) {
@@ -593,10 +596,6 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                     series.update({}, false);
                 }
             }, this);
-        }
-        // For loading, just update the options, do not redraw
-        if (options.loading) {
-            merge(true, chart.options.loading, options.loading);
         }
         // Update size. Redraw is forced.
         newWidth = optionsChart && optionsChart.width;

--- a/js/Extensions/NoDataToDisplay.js
+++ b/js/Extensions/NoDataToDisplay.js
@@ -140,8 +140,7 @@ chartPrototype.showNoData = function (str) {
         chart.noDataLabel.add();
         chart.noDataLabel.align(extend(chart.noDataLabel.getBBox(), noDataOptions.position), false, 'plotBox');
     }
-    // Update label if already exists. #13982
-    else if (chart.noDataLabel) {
+    else if (chart.noDataLabel) { // Update label if already exists. #13982
         chart.noDataLabel.attr(noDataOptions)
             .css(noDataOptions.style);
         chart.noDataLabel.align(extend(chart.noDataLabel.getBBox(), noDataOptions.position), false, 'plotBox');

--- a/js/Extensions/NoDataToDisplay.js
+++ b/js/Extensions/NoDataToDisplay.js
@@ -14,7 +14,7 @@
 'use strict';
 import Chart from '../Core/Chart/Chart.js';
 import U from '../Core/Utilities.js';
-var addEvent = U.addEvent, extend = U.extend, getOptions = U.getOptions;
+var addEvent = U.addEvent, extend = U.extend, getOptions = U.getOptions, merge = U.merge;
 var chartPrototype = Chart.prototype, defaultOptions = getOptions();
 // Add language option
 extend(defaultOptions.lang, 
@@ -128,7 +128,7 @@ defaultOptions.noData = {
  * @requires modules/no-data-to-display
  */
 chartPrototype.showNoData = function (str) {
-    var chart = this, options = chart.options, text = str || (options && options.lang.noData), noDataOptions = options && options.noData;
+    var chart = this, options = chart.options, userOptions = chart.userOptions, text = str || (options && options.lang.noData), noDataOptions = merge(options && options.noData, userOptions && userOptions.noData);
     if (!chart.noDataLabel && chart.renderer) {
         chart.noDataLabel = chart.renderer
             .label(text, 0, 0, null, null, null, noDataOptions.useHTML, null, 'no-data');
@@ -138,6 +138,12 @@ chartPrototype.showNoData = function (str) {
                 .css(noDataOptions.style);
         }
         chart.noDataLabel.add();
+        chart.noDataLabel.align(extend(chart.noDataLabel.getBBox(), noDataOptions.position), false, 'plotBox');
+    }
+    // Update label if already exists. #13982
+    else if (chart.noDataLabel) {
+        chart.noDataLabel.attr(noDataOptions)
+            .css(noDataOptions.style);
         chart.noDataLabel.align(extend(chart.noDataLabel.getBBox(), noDataOptions.position), false, 'plotBox');
     }
 };

--- a/js/Extensions/NoDataToDisplay.js
+++ b/js/Extensions/NoDataToDisplay.js
@@ -128,22 +128,19 @@ defaultOptions.noData = {
  * @requires modules/no-data-to-display
  */
 chartPrototype.showNoData = function (str) {
-    var chart = this, options = chart.options, userOptions = chart.userOptions, text = str || (options && options.lang.noData), noDataOptions = merge(options && options.noData, userOptions && userOptions.noData);
-    if (!chart.noDataLabel && chart.renderer) {
-        chart.noDataLabel = chart.renderer
-            .label(text, 0, 0, null, null, null, noDataOptions.useHTML, null, 'no-data');
+    var chart = this, options = chart.options, text = str || (options && options.lang.noData), noDataOptions = options && (options.noData || {});
+    if (chart.renderer) { // Meaning chart is not destroyed
+        if (!chart.noDataLabel) {
+            chart.noDataLabel = chart.renderer
+                .label(text, 0, 0, void 0, void 0, void 0, noDataOptions.useHTML, void 0, 'no-data')
+                .add();
+        }
         if (!chart.styledMode) {
             chart.noDataLabel
                 .attr(noDataOptions.attr)
-                .css(noDataOptions.style);
+                .css(noDataOptions.style || {});
         }
-        chart.noDataLabel.add();
-        chart.noDataLabel.align(extend(chart.noDataLabel.getBBox(), noDataOptions.position), false, 'plotBox');
-    }
-    else if (chart.noDataLabel) { // Update label if already exists. #13982
-        chart.noDataLabel.attr(noDataOptions)
-            .css(noDataOptions.style);
-        chart.noDataLabel.align(extend(chart.noDataLabel.getBBox(), noDataOptions.position), false, 'plotBox');
+        chart.noDataLabel.align(extend(chart.noDataLabel.getBBox(), noDataOptions.position || {}), false, 'plotBox');
     }
 };
 /**

--- a/samples/unit-tests/no-data/members/demo.js
+++ b/samples/unit-tests/no-data/members/demo.js
@@ -13,3 +13,21 @@ QUnit.test("defaultOptions", assert => {
         "Default z index should be 1 (#12343)"
     );
 });
+
+QUnit.test("Updating no-data element.", assert => {
+    const chart = Highcharts.chart('container', {});
+
+    chart.update({
+        noData: {
+            style: {
+                color: '#ff0000'
+            }
+        }
+    });
+
+    assert.equal(
+        chart.noDataLabel.text.styles.color,
+        '#ff0000',
+        "Updated color should be red (#13982)"
+    );
+});

--- a/tools/validate-commit-msg.js
+++ b/tools/validate-commit-msg.js
@@ -13,7 +13,9 @@
 const validators = [
     msg => msg.indexOf('Fixes') >= 0 ? 'Use past tense (Fixed, not Fixes)' : 0,
     msg => msg[0].toUpperCase() !== msg[0] ? 'First letter should be caps' : 0,
-    msg => msg.split('\n')[0].length > 72 ? 'First line of the commit message should not exceed 72 characters' : 0
+    msg => msg.split('\n')[0].length > 72 ?
+        `First line of the commit message should not exceed 72 characters (currently ${msg.split('\n')[0].length})` :
+        0
 ];
 
 const args = process.argv;

--- a/ts/Core/Dynamics.ts
+++ b/ts/Core/Dynamics.ts
@@ -737,10 +737,6 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             this.options.colors = options.colors;
         }
 
-        if (options.plotOptions) {
-            merge(true, this.options.plotOptions, options.plotOptions);
-        }
-
         // Maintaining legacy global time. If the chart is instanciated first
         // with global time, then updated with time options, we need to create a
         // new Time instance to avoid mutating the global time (#10536).
@@ -770,6 +766,14 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             // If a one-to-one object does not exist, look for an adder function
             } else if (typeof (chart as any)[adders[key]] === 'function') {
                 (chart as any)[adders[key]](val);
+
+            // Else, just merge the options. For nodes like loading, noData,
+            // plotOptions
+            } else if (
+                key !== 'color' &&
+                chart.collectionsWithUpdate.indexOf(key) === -1
+            ) {
+                merge(true, (chart.options as any)[key], (options as any)[key]);
             }
 
             if (
@@ -893,11 +897,6 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                     series.update({}, false);
                 }
             }, this);
-        }
-
-        // For loading, just update the options, do not redraw
-        if (options.loading) {
-            merge(true, chart.options.loading, options.loading);
         }
 
         // Update size. Redraw is forced.

--- a/ts/Extensions/NoDataToDisplay.ts
+++ b/ts/Extensions/NoDataToDisplay.ts
@@ -184,46 +184,36 @@ defaultOptions.noData = {
 chartPrototype.showNoData = function (str?: string): void {
     var chart = this,
         options = chart.options,
-        userOptions = chart.userOptions,
         text = str || (options && (options.lang as any).noData),
-        noDataOptions: Highcharts.NoDataOptions = merge(
-            options && options.noData,
-            userOptions && userOptions.noData
-        );
+        noDataOptions: Highcharts.NoDataOptions =
+            options && (options.noData || {});
 
-    if (!chart.noDataLabel && chart.renderer) {
-        chart.noDataLabel = chart.renderer
-            .label(
-                text,
-                0,
-                0,
-                null as any,
-                null as any,
-                null as any,
-                noDataOptions.useHTML,
-                null as any,
-                'no-data'
-            );
+    if (chart.renderer) { // Meaning chart is not destroyed
+
+        if (!chart.noDataLabel) {
+            chart.noDataLabel = chart.renderer
+                .label(
+                    text,
+                    0,
+                    0,
+                    void 0,
+                    void 0,
+                    void 0,
+                    noDataOptions.useHTML,
+                    void 0,
+                    'no-data'
+                )
+                .add();
+        }
 
         if (!chart.styledMode) {
             chart.noDataLabel
                 .attr(noDataOptions.attr)
-                .css(noDataOptions.style as any);
+                .css(noDataOptions.style || {});
         }
 
-        chart.noDataLabel.add();
-
         chart.noDataLabel.align(
-            extend(chart.noDataLabel.getBBox(), noDataOptions.position as any),
-            false,
-            'plotBox'
-        );
-    } else if (chart.noDataLabel) { // Update label if already exists. #13982
-        chart.noDataLabel.attr(noDataOptions)
-            .css(noDataOptions.style as any);
-
-        chart.noDataLabel.align(
-            extend(chart.noDataLabel.getBBox(), noDataOptions.position as any),
+            extend(chart.noDataLabel.getBBox(), noDataOptions.position || {}),
             false,
             'plotBox'
         );

--- a/ts/Extensions/NoDataToDisplay.ts
+++ b/ts/Extensions/NoDataToDisplay.ts
@@ -19,7 +19,8 @@ import U from '../Core/Utilities.js';
 const {
     addEvent,
     extend,
-    getOptions
+    getOptions,
+    merge
 } = U;
 
 /**
@@ -183,9 +184,13 @@ defaultOptions.noData = {
 chartPrototype.showNoData = function (str?: string): void {
     var chart = this,
         options = chart.options,
+        userOptions = chart.userOptions,
         text = str || (options && (options.lang as any).noData),
-        noDataOptions: Highcharts.NoDataOptions =
-            options && (options.noData as any);
+        noDataOptions: Highcharts.NoDataOptions = merge(
+            options && options.noData,
+            userOptions && userOptions.noData
+        );
+
     if (!chart.noDataLabel && chart.renderer) {
         chart.noDataLabel = chart.renderer
             .label(
@@ -213,8 +218,18 @@ chartPrototype.showNoData = function (str?: string): void {
             false,
             'plotBox'
         );
+    } else if (chart.noDataLabel) { // Update label if already exists. #13982
+        chart.noDataLabel.attr(noDataOptions)
+            .css(noDataOptions.style as any);
+
+        chart.noDataLabel.align(
+            extend(chart.noDataLabel.getBBox(), noDataOptions.position as any),
+            false,
+            'plotBox'
+        );
     }
 };
+
 
 /**
  * Hide no-data message.


### PR DESCRIPTION
Fixed #13982, `chart.update` didn't work on no-data label options.

~~Fixed #13982, label update wasn't working properly.~~