### PR TITLE
Fixed issue with opacity rounding during animation

### DIFF
--- a/js/Core/Renderer/SVG/SVGElement.js
+++ b/js/Core/Renderer/SVG/SVGElement.js
@@ -1497,8 +1497,11 @@ var SVGElement = /** @class */ (function () {
      * @param {Highcharts.SVGDOMElement} element
      */
     SVGElement.prototype.opacitySetter = function (value, key, element) {
-        this[key] = value;
-        element.setAttribute(key, value);
+        // Round off to avoid float errors, like tests where opacity lands on
+        // 9.86957e-06 instead of 0
+        var opacity = Number(Number(value).toFixed(3));
+        this.opacity = opacity;
+        element.setAttribute(key, opacity);
     };
     /**
      * Remove a class name from the element.

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -2167,8 +2167,11 @@ class SVGElement {
         key: string,
         element: Highcharts.SVGDOMElement
     ): void {
-        (this as Record<string, any>)[key] = value;
-        element.setAttribute(key, value);
+        // Round off to avoid float errors, like tests where opacity lands on
+        // 9.86957e-06 instead of 0
+        const opacity = Number(Number(value).toFixed(3));
+        this.opacity = opacity;
+        element.setAttribute(key, opacity);
     }
 
     /**


### PR DESCRIPTION
Tests would fail randomly when checking animation against a target opacity