### PR TITLE
docs/14094-axis-oposite-gantt

### DIFF
--- a/js/Core/Axis/Axis.js
+++ b/js/Core/Axis/Axis.js
@@ -4310,7 +4310,10 @@ var Axis = /** @class */ (function () {
          *         Y axis on left side
          *
          * @type      {boolean}
-         * @default   false
+         * @default   {highcharts} false
+         * @default   {highstock} false
+         * @default   {highmaps} false
+         * @default   {gantt} true
          * @apioption xAxis.opposite
          */
         /**

--- a/js/Core/Axis/Axis.js
+++ b/js/Core/Axis/Axis.js
@@ -4310,9 +4310,7 @@ var Axis = /** @class */ (function () {
          *         Y axis on left side
          *
          * @type      {boolean}
-         * @default   {highcharts} false
-         * @default   {highstock} false
-         * @default   {highmaps} false
+         * @default   {highcharts|highstock|highmaps} false
          * @default   {gantt} true
          * @apioption xAxis.opposite
          */

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -2088,9 +2088,7 @@ class Axis implements AxisComposition, AxisLike {
          *         Y axis on left side
          *
          * @type      {boolean}
-         * @default   {highcharts} false
-         * @default   {highstock} false
-         * @default   {highmaps} false
+         * @default   {highcharts|highstock|highmaps} false
          * @default   {gantt} true
          * @apioption xAxis.opposite
          */

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -2088,7 +2088,10 @@ class Axis implements AxisComposition, AxisLike {
          *         Y axis on left side
          *
          * @type      {boolean}
-         * @default   false
+         * @default   {highcharts} false
+         * @default   {highstock} false
+         * @default   {highmaps} false
+         * @default   {gantt} true
          * @apioption xAxis.opposite
          */
 


### PR DESCRIPTION
Fixed #14094, changed docs for the `opposite` property on `xAxis` in Gantt.