### PR TITLE
bugfix/13884-scrollablePlotArea-collaps-nodes

### DIFF
--- a/js/Extensions/StaticScale.js
+++ b/js/Extensions/StaticScale.js
@@ -49,7 +49,7 @@ Chart.prototype.adjustHeight = function () {
                 // Minimum height is 1 x staticScale.
                 height = Math.max(height, staticScale);
                 diff = height - chart.plotHeight;
-                if (!chart.scrollablePixelsX && !chart.scrollablePixelsY) {
+                if (!chart.scrollablePixelsY) {
                     if (Math.abs(diff) >= 1) {
                         chart.plotHeight = height;
                         chart.redrawTrigger = 'adjustHeight';

--- a/js/Extensions/StaticScale.js
+++ b/js/Extensions/StaticScale.js
@@ -49,12 +49,11 @@ Chart.prototype.adjustHeight = function () {
                 // Minimum height is 1 x staticScale.
                 height = Math.max(height, staticScale);
                 diff = height - chart.plotHeight;
-                if (!chart.scrollablePixelsY) {
-                    if (Math.abs(diff) >= 1) {
-                        chart.plotHeight = height;
-                        chart.redrawTrigger = 'adjustHeight';
-                        chart.setSize(void 0, chart.chartHeight + diff, animate);
-                    }
+                // Adjust the size, but not if scrollable plot area (#13884)
+                if (!chart.scrollablePixelsY && Math.abs(diff) >= 1) {
+                    chart.plotHeight = height;
+                    chart.redrawTrigger = 'adjustHeight';
+                    chart.setSize(void 0, chart.chartHeight + diff, animate);
                 }
                 // Make sure clip rects have the right height before initial
                 // animation.

--- a/js/Extensions/StaticScale.js
+++ b/js/Extensions/StaticScale.js
@@ -49,10 +49,12 @@ Chart.prototype.adjustHeight = function () {
                 // Minimum height is 1 x staticScale.
                 height = Math.max(height, staticScale);
                 diff = height - chart.plotHeight;
-                if (Math.abs(diff) >= 1) {
-                    chart.plotHeight = height;
-                    chart.redrawTrigger = 'adjustHeight';
-                    chart.setSize(void 0, chart.chartHeight + diff, animate);
+                if (!chart.scrollablePixelsX && !chart.scrollablePixelsY) {
+                    if (Math.abs(diff) >= 1) {
+                        chart.plotHeight = height;
+                        chart.redrawTrigger = 'adjustHeight';
+                        chart.setSize(void 0, chart.chartHeight + diff, animate);
+                    }
                 }
                 // Make sure clip rects have the right height before initial
                 // animation.

--- a/samples/unit-tests/gantt/gantt/demo.html
+++ b/samples/unit-tests/gantt/gantt/demo.html
@@ -1,4 +1,5 @@
 <script src="https://code.highcharts.com/gantt/highcharts-gantt.js"></script>
+<script src="https://code.highcharts.com/gantt/modules/draggable-points.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/gantt/gantt/demo.js
+++ b/samples/unit-tests/gantt/gantt/demo.js
@@ -640,4 +640,49 @@
             'The processedYData should be applied by using the keys feature #13768'
         );
     });
+
+    QUnit.test('Collapsible nodes with scrollablePlotArea should not decrement the chart height, #13884.', assert => {
+        const { fireEvent } = Highcharts;
+        const chart = Highcharts.ganttChart('container', {
+            chart: {
+                scrollablePlotArea: {
+                    minHeight: 400,
+                    opacity: 1
+                },
+                height: 300
+            },
+            series: [{
+                data: [{
+                    name: 'New offices',
+                    id: 'new_offices'
+                }, {
+                    name: 'Prepare office building',
+                    parent: 'new_offices',
+                    start: 1,
+                    end: 10
+                }, {
+                    name: 'Inspect building',
+                    parent: 'new_offices',
+                    start: 3,
+                    end: 4
+                }, {
+                    name: 'Passed inspection',
+                    parent: 'new_offices',
+                    start: 3,
+                    milestone: true
+                }]
+            }]
+        });
+
+        const yAxis = chart.yAxis[0],
+            label = yAxis.ticks[0].label,
+            previousPlotHeight = chart.plotHeight;
+
+        fireEvent(label.element, 'click');
+        assert.strictEqual(
+            previousPlotHeight,
+            chart.plotHeight,
+            'The chart height should remain the same.'
+        );
+    });
 }());

--- a/samples/unit-tests/gantt/gantt/demo.js
+++ b/samples/unit-tests/gantt/gantt/demo.js
@@ -685,4 +685,40 @@
             'The chart height should remain the same.'
         );
     });
+
+    QUnit.test('The addPoint method should add only one point, #14188.', assert => {
+        const chart = Highcharts.ganttChart('container', {
+            plotOptions: {
+                series: {
+                    dragDrop: {
+                        draggableX: true
+                    }
+                }
+            },
+            series: [{
+                data: [{
+                    start: 1,
+                    end: 3,
+                    name: 'Task 1'
+                }, {
+                    start: 4,
+                    end: 8,
+                    name: 'Task 2'
+                }]
+            }]
+        });
+
+        const pointAmount = chart.series[0].data.length;
+
+        chart.series[0].addPoint({
+            start: 4,
+            end: 5,
+            name: 'Taks 3'
+        });
+
+        assert.ok(
+            chart.series[0].data.length - pointAmount === 1,
+            'Only one point should be added.'
+        );
+    });
 }());

--- a/ts/Extensions/StaticScale.ts
+++ b/ts/Extensions/StaticScale.ts
@@ -98,12 +98,11 @@ Chart.prototype.adjustHeight = function (): void {
 
                 diff = height - chart.plotHeight;
 
-                if (!chart.scrollablePixelsY) {
-                    if (Math.abs(diff) >= 1) {
-                        chart.plotHeight = height;
-                        chart.redrawTrigger = 'adjustHeight';
-                        chart.setSize(void 0, chart.chartHeight + diff, animate);
-                    }
+                // Adjust the size, but not if scrollable plot area (#13884)
+                if (!chart.scrollablePixelsY && Math.abs(diff) >= 1) {
+                    chart.plotHeight = height;
+                    chart.redrawTrigger = 'adjustHeight';
+                    chart.setSize(void 0, chart.chartHeight + diff, animate);
                 }
 
                 // Make sure clip rects have the right height before initial

--- a/ts/Extensions/StaticScale.ts
+++ b/ts/Extensions/StaticScale.ts
@@ -98,10 +98,12 @@ Chart.prototype.adjustHeight = function (): void {
 
                 diff = height - chart.plotHeight;
 
-                if (Math.abs(diff) >= 1) {
-                    chart.plotHeight = height;
-                    chart.redrawTrigger = 'adjustHeight';
-                    chart.setSize(void 0, chart.chartHeight + diff, animate);
+                if (!chart.scrollablePixelsX && !chart.scrollablePixelsY) {
+                    if (Math.abs(diff) >= 1) {
+                        chart.plotHeight = height;
+                        chart.redrawTrigger = 'adjustHeight';
+                        chart.setSize(void 0, chart.chartHeight + diff, animate);
+                    }
                 }
 
                 // Make sure clip rects have the right height before initial

--- a/ts/Extensions/StaticScale.ts
+++ b/ts/Extensions/StaticScale.ts
@@ -98,7 +98,7 @@ Chart.prototype.adjustHeight = function (): void {
 
                 diff = height - chart.plotHeight;
 
-                if (!chart.scrollablePixelsX && !chart.scrollablePixelsY) {
+                if (!chart.scrollablePixelsY) {
                     if (Math.abs(diff) >= 1) {
                         chart.plotHeight = height;
                         chart.redrawTrigger = 'adjustHeight';


### PR DESCRIPTION
Fixed #13884, collapsing node with `scrollablePlotArea` crashed the chart.