### PR TITLE
Fixed #12286, nodes mixed up on treemap traversing back

### DIFF
--- a/js/Series/TreemapSeries.js
+++ b/js/Series/TreemapSeries.js
@@ -1205,8 +1205,7 @@ BaseSeries.seriesType('treemap', 'scatter'
     onClickDrillToNode: function (event) {
         var series = this, point = event.point, drillId = point && point.drillId;
         // If a drill id is returned, add click event and cursor.
-        if (isString(drillId) &&
-            (series.isDrillAllowed ? series.isDrillAllowed(drillId) : true)) {
+        if (isString(drillId)) {
             point.setState(''); // Remove hover
             series.setRootNode(drillId, true, { trigger: 'click' });
         }
@@ -1330,28 +1329,13 @@ BaseSeries.seriesType('treemap', 'scatter'
         // Fire setRootNode event.
         fireEvent(series, 'setRootNode', eventArgs, defaultFn);
     },
-    /**
-     * Check if the drill up/down is allowed.
-     *
-     * @private
-     */
-    isDrillAllowed: function (targetNode) {
-        var tree = this.tree, firstChild = tree.children[0];
-        // The sunburst series looks exactly the same on the level ''
-        // and level 1 if there’s only one element on level 1. Disable
-        // drilling up/down when it doesn't perform any visual
-        // difference (#13388).
-        return !(tree.children.length === 1 && ((this.rootNode === '' && targetNode === firstChild.id) ||
-            (this.rootNode === firstChild.id && targetNode === '')));
-    },
     renderTraverseUpButton: function (rootId) {
         var series = this, nodeMap = series.nodeMap, node = nodeMap[rootId], name = node.name, buttonOptions = series.options.traverseUpButton, backText = pick(buttonOptions.text, name, '< Back'), attr, states;
-        if (rootId === '' ||
-            (series.isDrillAllowed ?
-                !(isString(node.parent) && series.isDrillAllowed(node.parent)) : false)) {
+        if (rootId === '' || (series.is('sunburst') &&
+            series.tree.children.length === 1 &&
+            rootId === series.tree.children[0].id)) {
             if (series.drillUpButton) {
-                series.drillUpButton =
-                    series.drillUpButton.destroy();
+                series.drillUpButton = series.drillUpButton.destroy();
             }
         }
         else if (!this.drillUpButton) {

--- a/js/Series/TreemapSeries.js
+++ b/js/Series/TreemapSeries.js
@@ -1330,7 +1330,7 @@ BaseSeries.seriesType('treemap', 'scatter'
         fireEvent(series, 'setRootNode', eventArgs, defaultFn);
     },
     renderTraverseUpButton: function (rootId) {
-        var series = this, nodeMap = series.nodeMap, node = nodeMap[rootId], name = node.name, buttonOptions = series.options.traverseUpButton, backText = pick(buttonOptions.text, name, '< Back'), attr, states;
+        var series = this, nodeMap = series.nodeMap, node = nodeMap[rootId], name = node.name, buttonOptions = series.options.traverseUpButton, backText = pick(buttonOptions.text, name, '◁ Back'), attr, states;
         if (rootId === '' || (series.is('sunburst') &&
             series.tree.children.length === 1 &&
             rootId === series.tree.children[0].id)) {

--- a/js/Series/TreemapSeries.js
+++ b/js/Series/TreemapSeries.js
@@ -1148,7 +1148,7 @@ BaseSeries.seriesType('treemap', 'scatter'
     drawPoints: function () {
         var series = this, chart = series.chart, renderer = chart.renderer, points = series.points, styledMode = chart.styledMode, options = series.options, shadow = styledMode ? {} : options.shadow, borderRadius = options.borderRadius, withinAnimationLimit = chart.pointCount < options.animationLimit, allowTraversingTree = options.allowTraversingTree;
         points.forEach(function (point) {
-            var levelDynamic = point.node.levelDynamic, animate = {}, attr = {}, css = {}, groupKey = 'level-group-' + levelDynamic, hasGraphic = !!point.graphic, shouldAnimate = withinAnimationLimit && hasGraphic, shapeArgs = point.shapeArgs;
+            var levelDynamic = point.node.levelDynamic, animate = {}, attr = {}, css = {}, groupKey = 'level-group-' + point.node.level, hasGraphic = !!point.graphic, shouldAnimate = withinAnimationLimit && hasGraphic, shapeArgs = point.shapeArgs;
             // Don't bother with calculate styling if the point is not drawn
             if (point.shouldDraw()) {
                 if (borderRadius) {

--- a/samples/unit-tests/series-treemap/members/demo.js
+++ b/samples/unit-tests/series-treemap/members/demo.js
@@ -423,5 +423,21 @@ QUnit.test('Traversing single top node', assert => {
         'The root node should now be the first real node'
     );
 
+    // Drill down and up again
+    series.setRootNode('1_0');
+    series.setRootNode('2_0');
+    series.drillUp();
+    series.drillUp();
+
+    assert.ok(
+        chart.get('2_0').graphic.parentGroup,
+        'Parent group should be truthy'
+    );
+    assert.strictEqual(
+        chart.get('2_0').graphic.parentGroup.element.className.baseVal,
+        chart.get('2_1').graphic.parentGroup.element.className.baseVal,
+        'The ephemeral 2_1 node should be in the same group as the 2_0 node (#12286)'
+    );
+
 
 });

--- a/samples/unit-tests/series-treemap/members/demo.js
+++ b/samples/unit-tests/series-treemap/members/demo.js
@@ -315,31 +315,21 @@ QUnit.test('seriesTypes.treemap.onClickDrillToNode', function (assert) {
 });
 
 QUnit.test('traverseUpButton', assert => {
-    const { treemap: options } = Highcharts.defaultOptions.plotOptions;
-    const { renderTraverseUpButton } = Highcharts.seriesTypes.treemap.prototype;
-    const { SVGRenderer } = Highcharts;
-    const container = document.getElementById('container');
-    const renderer = new SVGRenderer(
-        container,
-        200,
-        200
-    );
-    const series = {
-        chart: { renderer: renderer },
-        nodeMap: {
-            '': {},
-            A: { parent: '', name: 'A' }
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'treemap'
         },
-        options: options
-    };
-    const after = () => {
-        container.removeChild(renderer.box);
-        renderer.destroy();
-        delete series.options.traverseUpButton.text;
-    };
+        series: [{
+            data: [{
+                id: 'A',
+                name: 'A'
+            }]
+        }]
+    });
+    const series = chart.series[0];
 
     // Render button when root id is ''
-    renderTraverseUpButton.call(series, '');
+    series.renderTraverseUpButton('');
     assert.strictEqual(
         series.drillUpButton,
         undefined,
@@ -347,7 +337,7 @@ QUnit.test('traverseUpButton', assert => {
     );
 
     // Render button when root id is 'A'
-    renderTraverseUpButton.call(series, 'A');
+    series.renderTraverseUpButton('A');
     assert.strictEqual(
         series.drillUpButton.text.textStr,
         'A',
@@ -356,13 +346,82 @@ QUnit.test('traverseUpButton', assert => {
 
     // Render button with custom text
     series.options.traverseUpButton.text = 'My Custom Text';
-    renderTraverseUpButton.call(series, 'A');
+    series.renderTraverseUpButton('A');
     assert.strictEqual(
         series.drillUpButton.text.textStr,
         'My Custom Text',
         'should set name to "My Custom Text" when traverseUpButton.text is set to "My Custom Text".'
     );
+});
 
-    // Clean up after the tests
-    after();
+QUnit.test('Traversing single top node', assert => {
+    const data = [{
+        value: 350,
+        id: "0_0",
+        name: "0_0",
+        parent: ""
+    }, {
+        value: 300,
+        id: "1_0",
+        name: "1_0",
+        parent: "0_0"
+    }, {
+        value: 50,
+        id: "1_1",
+        name: "1_1",
+        parent: "0_0"
+    }, {
+        value: 200,
+        id: "2_0",
+        name: "2_0",
+        parent: "1_0"
+    }, {
+        value: 100,
+        id: "2_1",
+        name: "2_1",
+        parent: "1_0"
+    }, {
+        value: 100,
+        id: "3_0",
+        name: "3_0",
+        parent: "2_0"
+    }, {
+        value: 100,
+        id: "3_1",
+        name: "3_1",
+        parent: "2_0"
+    }];
+
+    const chart = Highcharts.chart('container', {
+        series: [{
+            type: "treemap",
+            layoutAlgorithm: 'squarified',
+            levelIsConstant: false,
+            allowTraversingTree: true,
+            dataLabels: {
+                enabled: false
+            },
+            borderWidth: 3,
+            levels: [{
+                level: 1,
+                dataLabels: {
+                    enabled: true
+                },
+                borderWidth: 3
+            }],
+            data
+        }]
+    });
+
+    const series = chart.series[0];
+    const point = series.points[0];
+    series.onClickDrillToNode({ point });
+
+    assert.strictEqual(
+        series.rootNode,
+        '0_0',
+        'The root node should now be the first real node'
+    );
+
+
 });

--- a/ts/Series/TreemapSeries.ts
+++ b/ts/Series/TreemapSeries.ts
@@ -118,7 +118,7 @@ declare global {
             public colorValueData?: Array<number>;
             public data: Array<TreemapPoint>;
             public directTouch: boolean;
-            public drillUpButton: SVGElement;
+            public drillUpButton?: SVGElement;
             public getExtremesFromAll: boolean;
             public idPreviousRoot?: string;
             public mapOptionsToLevel: Dictionary<TreemapSeriesOptions>;
@@ -180,7 +180,6 @@ declare global {
             ): TreemapListOfParentsObject;
             public getTree(): this['tree'];
             public hasData(): boolean;
-            public isDrillAllowed(targetNode: string): boolean;
             public init(chart: Chart, options: TreemapSeriesOptions): void;
             public onClickDrillToNode(event: { point: TreemapPoint }): void;
             public pointAttribs(
@@ -1937,8 +1936,7 @@ BaseSeries.seriesType<typeof Highcharts.TreemapSeries>(
                 drillId = point && point.drillId;
 
             // If a drill id is returned, add click event and cursor.
-            if (isString(drillId) &&
-                (series.isDrillAllowed ? series.isDrillAllowed(drillId) : true)) {
+            if (isString(drillId)) {
                 point.setState(''); // Remove hover
                 series.setRootNode(drillId, true, { trigger: 'click' });
             }
@@ -2105,30 +2103,6 @@ BaseSeries.seriesType<typeof Highcharts.TreemapSeries>(
             fireEvent(series, 'setRootNode', eventArgs, defaultFn);
         },
 
-        /**
-         * Check if the drill up/down is allowed.
-         *
-         * @private
-         */
-        isDrillAllowed: function (
-            this: Highcharts.TreemapSeries,
-            targetNode: string
-        ): boolean {
-            var tree = this.tree,
-                firstChild = tree.children[0];
-
-            // The sunburst series looks exactly the same on the level ''
-            // and level 1 if there’s only one element on level 1. Disable
-            // drilling up/down when it doesn't perform any visual
-            // difference (#13388).
-            return !(
-                tree.children.length === 1 && (
-                    (this.rootNode === '' && targetNode === firstChild.id) ||
-                    (this.rootNode === firstChild.id && targetNode === '')
-                )
-            );
-        },
-
         renderTraverseUpButton: function (
             this: Highcharts.TreemapSeries,
             rootId: string
@@ -2143,13 +2117,13 @@ BaseSeries.seriesType<typeof Highcharts.TreemapSeries>(
                 attr,
                 states;
 
-            if (rootId === '' ||
-                (series.isDrillAllowed ?
-                    !(isString(node.parent) && series.isDrillAllowed(node.parent)) : false)
-            ) {
+            if (rootId === '' || (
+                series.is('sunburst') &&
+                series.tree.children.length === 1 &&
+                rootId === series.tree.children[0].id
+            )) {
                 if (series.drillUpButton) {
-                    series.drillUpButton =
-                        series.drillUpButton.destroy() as any;
+                    series.drillUpButton = series.drillUpButton.destroy();
                 }
             } else if (!this.drillUpButton) {
                 attr = buttonOptions.theme;

--- a/ts/Series/TreemapSeries.ts
+++ b/ts/Series/TreemapSeries.ts
@@ -521,7 +521,7 @@ BaseSeries.seriesType<typeof Highcharts.TreemapSeries>(
         /**
          * @ignore-option
          */
-        marker: false as any,
+        marker: void 0,
 
         /**
          * When using automatic point colors pulled from the `options.colors`
@@ -992,8 +992,8 @@ BaseSeries.seriesType<typeof Highcharts.TreemapSeries>(
                 }),
                 parentList = series.getListOfParents(this.data, allIds);
 
-            series.nodeMap = [] as any;
-            return series.buildNode('', -1, 0, parentList, null as any);
+            series.nodeMap = {};
+            return series.buildNode('', -1, 0, parentList);
         },
         // Define hasData function for non-cartesian series.
         // Returns true if the series has points at all.
@@ -1079,12 +1079,12 @@ BaseSeries.seriesType<typeof Highcharts.TreemapSeries>(
                 children.push(child);
             });
             node = {
-                id: id,
-                i: i,
-                children: children,
-                height: height,
-                level: level,
-                parent: parent,
+                id,
+                i,
+                children,
+                height,
+                level,
+                parent,
                 visible: false // @todo move this to better location
             } as any;
             series.nodeMap[node.id] = node;
@@ -1127,7 +1127,7 @@ BaseSeries.seriesType<typeof Highcharts.TreemapSeries>(
                 a: Highcharts.TreemapNodeObject,
                 b: Highcharts.TreemapNodeObject
             ): number {
-                return (a.sortIndex as any) - (b.sortIndex as any);
+                return (a.sortIndex || 0) - (b.sortIndex || 0);
             });
             // Set the values
             val = pick(point && point.options.value, childrenTotal);
@@ -1857,8 +1857,8 @@ BaseSeries.seriesType<typeof Highcharts.TreemapSeries>(
 
             points.forEach(function (point: Highcharts.TreemapPoint): void {
                 var levelDynamic = point.node.levelDynamic,
-                    animate: Partial<Highcharts.AnimationOptionsObject> = {},
-                    attr: SVGAttributes = {},
+                    animatableAttribs: Partial<Highcharts.AnimationOptionsObject> = {},
+                    attribs: SVGAttributes = {},
                     css: CSSObject = {},
                     groupKey = 'level-group-' + point.node.level,
                     hasGraphic = !!point.graphic,
@@ -1868,20 +1868,20 @@ BaseSeries.seriesType<typeof Highcharts.TreemapSeries>(
                 // Don't bother with calculate styling if the point is not drawn
                 if (point.shouldDraw()) {
                     if (borderRadius) {
-                        attr.r = borderRadius;
+                        attribs.r = borderRadius;
                     }
 
                     merge(
                         true, // Extend object
                         // Which object to extend
-                        shouldAnimate ? animate : attr,
+                        shouldAnimate ? animatableAttribs : attribs,
                         // Add shapeArgs to animate/attr if graphic exists
                         hasGraphic ? shapeArgs : {},
                         // Add style attribs if !styleMode
                         styledMode ?
                             {} :
                             series.pointAttribs(
-                                point, (point.selected && 'select') as any
+                                point, point.selected ? 'select' : void 0
                             )
                     );
 
@@ -1898,7 +1898,7 @@ BaseSeries.seriesType<typeof Highcharts.TreemapSeries>(
                             .attr({
                                 // @todo Set the zIndex based upon the number of
                                 // levels, instead of using 1000
-                                zIndex: 1000 - (levelDynamic as any)
+                                zIndex: 1000 - (levelDynamic || 0)
                             })
                             .add(series.group);
                         (series as any)[groupKey].survive = true;
@@ -1907,13 +1907,13 @@ BaseSeries.seriesType<typeof Highcharts.TreemapSeries>(
 
                 // Draw the point
                 point.draw({
-                    animatableAttribs: animate,
-                    attribs: attr,
-                    css: css,
+                    animatableAttribs,
+                    attribs,
+                    css,
                     group: (series as any)[groupKey],
-                    renderer: renderer,
-                    shadow: shadow,
-                    shapeArgs: shapeArgs,
+                    renderer,
+                    shadow,
+                    shapeArgs,
                     shapeType: 'rect'
                 });
 
@@ -2132,8 +2132,8 @@ BaseSeries.seriesType<typeof Highcharts.TreemapSeries>(
                 this.drillUpButton = this.chart.renderer
                     .button(
                         backText,
-                        null as any,
-                        null as any,
+                        0,
+                        0,
                         function (): void {
                             series.drillUp();
                         },
@@ -2228,7 +2228,7 @@ BaseSeries.seriesType<typeof Highcharts.TreemapSeries>(
          * @function Highcharts.Point#isValid
          */
         isValid: function (this: Highcharts.TreemapPoint): boolean {
-            return (this.id as any) || isNumber(this.value);
+            return Boolean(this.id || isNumber(this.value));
         },
         setState: function (
             this: Highcharts.TreemapPoint,
@@ -2244,8 +2244,7 @@ BaseSeries.seriesType<typeof Highcharts.TreemapSeries>(
             }
         },
         shouldDraw: function (this: Highcharts.TreemapPoint): boolean {
-            var point = this;
-            return isNumber(point.plotY) && point.y !== null;
+            return isNumber(this.plotY) && this.y !== null;
         }
     }
 );

--- a/ts/Series/TreemapSeries.ts
+++ b/ts/Series/TreemapSeries.ts
@@ -1860,7 +1860,7 @@ BaseSeries.seriesType<typeof Highcharts.TreemapSeries>(
                     animate: Partial<Highcharts.AnimationOptionsObject> = {},
                     attr: SVGAttributes = {},
                     css: CSSObject = {},
-                    groupKey = 'level-group-' + levelDynamic,
+                    groupKey = 'level-group-' + point.node.level,
                     hasGraphic = !!point.graphic,
                     shouldAnimate = withinAnimationLimit && hasGraphic,
                     shapeArgs = point.shapeArgs;

--- a/ts/Series/TreemapSeries.ts
+++ b/ts/Series/TreemapSeries.ts
@@ -2113,7 +2113,7 @@ BaseSeries.seriesType<typeof Highcharts.TreemapSeries>(
                 name = node.name,
                 buttonOptions: Highcharts.TreemapSeriesUpButtonOptions =
                     series.options.traverseUpButton as any,
-                backText = pick(buttonOptions.text, name, '< Back'),
+                backText = pick(buttonOptions.text, name, '◁ Back'),
                 attr,
                 states;
 


### PR DESCRIPTION
Fixed #12286, treemap nodes of different levels were sometimes mixed up when traversing up.