### PR TITLE
Fixed #14230, time options not always updating

### DIFF
--- a/js/Core/Dynamics.js
+++ b/js/Core/Dynamics.js
@@ -475,11 +475,20 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         if (!chart.styledMode && options.colors) {
             this.options.colors = options.colors;
         }
-        // Maintaining legacy global time. If the chart is instanciated first
-        // with global time, then updated with time options, we need to create a
-        // new Time instance to avoid mutating the global time (#10536).
-        if (options.time && this.time === time) {
-            this.time = new Time(options.time);
+        if (options.time) {
+            // Maintaining legacy global time. If the chart is instanciated
+            // first with global time, then updated with time options, we need
+            // to create a new Time instance to avoid mutating the global time
+            // (#10536).
+            if (this.time === time) {
+                this.time = new Time(options.time);
+            }
+            // If we're updating, the time class is different from other chart
+            // classes (chart.legend, chart.tooltip etc) in that it doesn't know
+            // about the chart. The other chart[something].update functions also
+            // set the chart.options[something]. For the time class however we
+            // need to update the chart options separately. #14230.
+            merge(true, chart.options.time, options.time);
         }
         // Some option stuctures correspond one-to-one to chart objects that
         // have update methods, for example

--- a/samples/unit-tests/time/update/demo.js
+++ b/samples/unit-tests/time/update/demo.js
@@ -74,6 +74,12 @@ QUnit.test('Time zone update', function (assert) {
         'Ticks should be placed on local (New York) midnights'
     );
 
+    assert.strictEqual(
+        chart.options.time.timezone,
+        'America/New_York',
+        'Chart-level options should also be updated (#14230)'
+    );
+
 });
 
 QUnit.test('Updating from global to instance time', assert => {

--- a/ts/Core/Dynamics.ts
+++ b/ts/Core/Dynamics.ts
@@ -745,11 +745,21 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             this.options.colors = options.colors;
         }
 
-        // Maintaining legacy global time. If the chart is instanciated first
-        // with global time, then updated with time options, we need to create a
-        // new Time instance to avoid mutating the global time (#10536).
-        if (options.time && this.time === time) {
-            this.time = new Time(options.time);
+        if (options.time) {
+            // Maintaining legacy global time. If the chart is instanciated
+            // first with global time, then updated with time options, we need
+            // to create a new Time instance to avoid mutating the global time
+            // (#10536).
+            if (this.time === time) {
+                this.time = new Time(options.time);
+            }
+
+            // If we're updating, the time class is different from other chart
+            // classes (chart.legend, chart.tooltip etc) in that it doesn't know
+            // about the chart. The other chart[something].update functions also
+            // set the chart.options[something]. For the time class however we
+            // need to update the chart options separately. #14230.
+            merge(true, chart.options.time, options.time);
         }
 
         // Some option stuctures correspond one-to-one to chart objects that


### PR DESCRIPTION
Fixed #14230, `chart.update` failed to update `time` options in some cases.