### PR TITLE
bugfix/13956-annotations-different-yAxis-size

### DIFF
--- a/js/Extensions/Annotations/Mixins/ControllableMixin.js
+++ b/js/Extensions/Annotations/Mixins/ControllableMixin.js
@@ -126,7 +126,7 @@ var controllableMixin = {
         return {
             relativePosition: anchor,
             absolutePosition: merge(anchor, {
-                x: anchor.x + plotBox.translateX,
+                x: anchor.x + (point.mock ? plotBox.translateX : chart.plotLeft),
                 y: anchor.y + (point.mock ? plotBox.translateY : chart.plotTop)
             })
         };

--- a/js/Extensions/Annotations/Mixins/ControllableMixin.js
+++ b/js/Extensions/Annotations/Mixins/ControllableMixin.js
@@ -113,7 +113,7 @@ var controllableMixin = {
      * @return {Highcharts.AnnotationAnchorObject} a controllable anchor
      */
     anchor: function (point) {
-        var plotBox = point.series.getPlotBox(), box = point.mock ?
+        var plotBox = point.series.getPlotBox(), chart = point.series.chart, box = point.mock ?
             point.toAnchor() :
             Tooltip.prototype.getAnchor.call({
                 chart: point.series.chart
@@ -127,7 +127,7 @@ var controllableMixin = {
             relativePosition: anchor,
             absolutePosition: merge(anchor, {
                 x: anchor.x + plotBox.translateX,
-                y: anchor.y + plotBox.translateY
+                y: anchor.y + (point.mock ? plotBox.translateY : chart.plotTop)
             })
         };
     },

--- a/samples/unit-tests/annotations/annotations-labels-positioning/demo.js
+++ b/samples/unit-tests/annotations/annotations-labels-positioning/demo.js
@@ -433,3 +433,35 @@ QUnit.test('Visibility of labels - point.isInsidePlot() - polar chart', function
     }
 
 });
+
+QUnit.test('Positioning labels according to real points for half of the yAxis height #13956', function (assert) {
+    var chart = Highcharts.chart('container', {
+            yAxis: [{
+                top: '50%',
+                height: '50%'
+            }],
+            series: [{
+                data: [2, 11, 60, {
+                    y: 44,
+                    id: 'pointII'
+                }, 44]
+            }],
+
+            annotations: [{
+                labels: [{
+                    point: 'pointII',
+                    y: 0
+                }]
+            }]
+        }),
+
+        xAxis = chart.xAxis[0],
+        yAxis = chart.yAxis[0],
+        point = chart.series[0].points[3],
+        label = chart.annotations[0].labels[0].graphic,
+        y = yAxis.toPixels(point.y),
+        x = xAxis.toPixels(point.x);
+
+    assert.strictEqual(Math.round(label.x + label.width / 2), Math.round(x), 'x position');
+    assert.strictEqual(Math.round(label.y + label.height), Math.round(y), 'y position');
+});

--- a/samples/unit-tests/annotations/annotations-labels-positioning/demo.js
+++ b/samples/unit-tests/annotations/annotations-labels-positioning/demo.js
@@ -440,6 +440,10 @@ QUnit.test('Positioning labels according to real points for half of the yAxis he
                 top: '50%',
                 height: '50%'
             }],
+            xAxis: [{
+                left: '50%',
+                width: '50%'
+            }],
             series: [{
                 data: [2, 11, 60, {
                     y: 44,

--- a/ts/Extensions/Annotations/Mixins/ControllableMixin.ts
+++ b/ts/Extensions/Annotations/Mixins/ControllableMixin.ts
@@ -259,7 +259,7 @@ var controllableMixin: Highcharts.AnnotationControllableMixin = {
         point: Highcharts.AnnotationPointType
     ): Highcharts.AnnotationAnchorObject {
         var plotBox = point.series.getPlotBox(),
-
+            chart = point.series.chart,
             box = point.mock ?
                 point.toAnchor() :
                 Tooltip.prototype.getAnchor.call({
@@ -277,7 +277,7 @@ var controllableMixin: Highcharts.AnnotationControllableMixin = {
             relativePosition: anchor,
             absolutePosition: merge(anchor, {
                 x: anchor.x + plotBox.translateX,
-                y: anchor.y + plotBox.translateY
+                y: anchor.y + (point.mock ? plotBox.translateY : chart.plotTop)
             })
         };
     },

--- a/ts/Extensions/Annotations/Mixins/ControllableMixin.ts
+++ b/ts/Extensions/Annotations/Mixins/ControllableMixin.ts
@@ -276,7 +276,7 @@ var controllableMixin: Highcharts.AnnotationControllableMixin = {
         return {
             relativePosition: anchor,
             absolutePosition: merge(anchor, {
-                x: anchor.x + plotBox.translateX,
+                x: anchor.x + (point.mock ? plotBox.translateX : chart.plotLeft),
                 y: anchor.y + (point.mock ? plotBox.translateY : chart.plotTop)
             })
         };


### PR DESCRIPTION
Fixed #13956, annotations had the wrong position for resized Y axis.