### PR TITLE
Fixed #14277, update scrollablePlotArea fixed elements in every applyFixed

### DIFF
--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -400,8 +400,6 @@ Chart.prototype.applyFixed = function (): void {
             .addClass('highcharts-scrollable-mask')
             .add();
 
-        this.moveFixedElements();
-
         addEvent(this, 'afterShowResetZoom', this.moveFixedElements);
         addEvent(this, 'afterLayOutTitles', this.moveFixedElements);
 
@@ -413,6 +411,8 @@ Chart.prototype.applyFixed = function (): void {
             this.chartHeight
         );
     }
+
+    this.moveFixedElements();
 
     // Increase the size of the scrollable renderer and background
     scrollableWidth = this.chartWidth + (this.scrollablePixelsX || 0);


### PR DESCRIPTION
This fixed the first issue mentioned in #14277. The issue seems to occur because `moveFixedElements` is only called on the _initial_ call to `applyFixed`. If the `minHeight` is then changed after that initial call, subsequent `applyFixed` invocations do not run `moveFixedElements`. This changes `applyFixed` to _always_ run `moveFixedElements`, which ensures that the fixed elements are always placed appropriately on every render.

I don't know if running it every time (rather than on some specific event) is overkill or might introduce performance or other concerns, so if there's a better place for `moveFixedElements` to be run I'm happy to update the PR accordingly.