### PR TITLE
Docs: Fixed typos

### DIFF
--- a/docs/chart-concepts/understanding-highcharts.md
+++ b/docs/chart-concepts/understanding-highcharts.md
@@ -24,7 +24,7 @@ See [Series](https://highcharts.com/docs/chart-concepts/series) for more infor
 Tooltip
 -------
 
-When hovering over a series or a point on the chart you can get a tooltip that describes the values on that perticular part of the chart.
+When hovering over a series or a point on the chart you can get a tooltip that describes the values on that particular part of the chart.
 
 See [Tooltip](https://highcharts.com/docs/chart-concepts/tooltip) for more information.
 

--- a/js/Series/Bubble/BubbleLegend.js
+++ b/js/Series/Bubble/BubbleLegend.js
@@ -55,7 +55,7 @@ setOptions({
              * individual range.
              *
              * @sample highcharts/bubble-legend/similartoseries/
-             *         Similat look to the bubble series
+             *         Similar look to the bubble series
              * @sample highcharts/bubble-legend/bordercolor/
              *         Individual bubble border color
              *
@@ -83,7 +83,7 @@ setOptions({
              * individual color is not defined.
              *
              * @sample highcharts/bubble-legend/similartoseries/
-             *         Similat look to the bubble series
+             *         Similar look to the bubble series
              * @sample highcharts/bubble-legend/color/
              *         Individual bubble color
              *

--- a/ts/Series/Bubble/BubbleLegend.ts
+++ b/ts/Series/Bubble/BubbleLegend.ts
@@ -195,7 +195,7 @@ setOptions({ // Set default bubble legend options
              * individual range.
              *
              * @sample highcharts/bubble-legend/similartoseries/
-             *         Similat look to the bubble series
+             *         Similar look to the bubble series
              * @sample highcharts/bubble-legend/bordercolor/
              *         Individual bubble border color
              *
@@ -223,7 +223,7 @@ setOptions({ // Set default bubble legend options
              * individual color is not defined.
              *
              * @sample highcharts/bubble-legend/similartoseries/
-             *         Similat look to the bubble series
+             *         Similar look to the bubble series
              * @sample highcharts/bubble-legend/color/
              *         Individual bubble color
              *


### PR DESCRIPTION
The docs and API reference pages had some typos.
These typos have been fixed.