### PR TITLE
bugfix/14310-plotband-axis-visibility

### DIFF
--- a/js/Core/Axis/PlotLineOrBand.js
+++ b/js/Core/Axis/PlotLineOrBand.js
@@ -947,7 +947,10 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      * @return {Highcharts.PlotLineOrBand|undefined}
      */
     addPlotBandOrLine: function (options, coll) {
-        var obj = new PlotLineOrBand(this, options).render(), userOptions = this.userOptions;
+        var obj = new Highcharts.PlotLineOrBand(this, options), userOptions = this.userOptions;
+        if (this.visible) {
+            obj = obj.render();
+        }
         if (obj) { // #2189
             // Add it to the user options for exporting and Axis.update
             if (coll) {

--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
@@ -519,3 +519,43 @@ QUnit.test('#13375: Click event on dynamically added plotBands.', function (asse
     );
 
 });
+
+QUnit.test('#14310: Visibility of dynamically added plotbands', function (assert) {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            zoomType: 'xy'
+        },
+        xAxis: {
+            tickInterval: 24 * 3600 * 1000,
+            type: 'datetime',
+            visible: false
+        },
+        series: [{
+            data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 100, 110, 120, 101, 115, 128, 99, 80, 132],
+            pointStart: Date.UTC(2010, 0, 1),
+            pointInterval: 24 * 3600 * 1000
+        }]
+    });
+
+    chart.xAxis[0].addPlotBand({
+        color: '#FCFFC5',
+        from: Date.UTC(2010, 0, 2),
+        to: Date.UTC(2010, 0, 4)
+    });
+
+    assert.ok(
+        !chart.xAxis[0].plotLinesAndBands[0].svgElem,
+        'plotBand should not render when axis is not visible'
+    );
+
+    chart.update({
+        xAxis: {
+            visible: true
+        }
+    });
+
+    assert.ok(
+        !!chart.xAxis[0].plotLinesAndBands[0].svgElem,
+        'plotBand should render when axis visibility gets dynamically updated'
+    );
+});

--- a/ts/Core/Axis/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand.ts
@@ -1288,8 +1288,12 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
                 'plotLines'
         )
     ): (Highcharts.PlotLineOrBand|undefined) {
-        var obj = new PlotLineOrBand(this, options).render(),
+        var obj: Highcharts.PlotLineOrBand|undefined = new Highcharts.PlotLineOrBand(this, options),
             userOptions = this.userOptions;
+
+        if (this.visible) {
+            obj = obj.render();
+        }
 
         if (obj) { // #2189
             // Add it to the user options for exporting and Axis.update


### PR DESCRIPTION
Fixed #14310, `addPlotBandOrLine` didn't check if the axis was visible before rendering.