### PR TITLE
Docs: Corrected link in accessibility API ref

### DIFF
--- a/docs/doc-config.js
+++ b/docs/doc-config.js
@@ -18,6 +18,7 @@ module.exports = {
         { from: 'getting-started/compatibility', to: 'getting-started/system-requirements' },
         { from: 'chart-and-series-types/packed-bubble-charts', to: 'chart-and-series-types/packed-bubble' },
         { from: 'chart-concepts/navigator', to: 'stock/navigator' },
-        { from: 'chart-concepts/range-selector', to: 'stock/range-selector' }
+        { from: 'chart-concepts/range-selector', to: 'stock/range-selector' },
+        { from: 'chart-concepts/accessibility', to: 'accessibility/accessibility-module' }
     ]
 };

--- a/js/Accessibility/Options/Options.js
+++ b/js/Accessibility/Options/Options.js
@@ -75,7 +75,7 @@ var options = {
      * [accessibility module](https://code.highcharts.com/modules/accessibility.js)
      * to be loaded. For a description of the module and information
      * on its features, see
-     * [Highcharts Accessibility](https://www.highcharts.com/docs/chart-concepts/accessibility).
+     * [Highcharts Accessibility](https://www.highcharts.com/docs/accessibility/accessibility-module).
      *
      * @since        5.0.0
      * @requires     modules/accessibility

--- a/ts/Accessibility/Options/Options.ts
+++ b/ts/Accessibility/Options/Options.ts
@@ -230,7 +230,7 @@ var options: DeepPartial<Highcharts.Options> = {
      * [accessibility module](https://code.highcharts.com/modules/accessibility.js)
      * to be loaded. For a description of the module and information
      * on its features, see
-     * [Highcharts Accessibility](https://www.highcharts.com/docs/chart-concepts/accessibility).
+     * [Highcharts Accessibility](https://www.highcharts.com/docs/accessibility/accessibility-module).
      *
      * @since        5.0.0
      * @requires     modules/accessibility


### PR DESCRIPTION
The link used to point to an old version of general doc of the accessibility.
Now it points to the up-to-date one.