### PR TITLE
Updated docs for stickOnContact, touch #14329.

### DIFF
--- a/js/Core/Series/CartesianSeries.js
+++ b/js/Core/Series/CartesianSeries.js
@@ -2502,7 +2502,8 @@ void 0,
      * @excluding animation, backgroundColor, borderColor, borderRadius,
      *            borderWidth, className, crosshairs, enabled, formatter,
      *            headerShape, hideDelay, outside, padding, positioner,
-     *            shadow, shape, shared, snap, split, style, useHTML
+     *            shadow, shape, shared, snap, split, stickOnContact,
+     *            style, useHTML
      * @apioption plotOptions.series.tooltip
      */
     /**

--- a/ts/Core/Series/CartesianSeries.ts
+++ b/ts/Core/Series/CartesianSeries.ts
@@ -2983,7 +2983,8 @@ const CartesianSeries = BaseSeries.seriesType<typeof Highcharts.LineSeries>(
          * @excluding animation, backgroundColor, borderColor, borderRadius,
          *            borderWidth, className, crosshairs, enabled, formatter,
          *            headerShape, hideDelay, outside, padding, positioner,
-         *            shadow, shape, shared, snap, split, style, useHTML
+         *            shadow, shape, shared, snap, split, stickOnContact,
+         *            style, useHTML
          * @apioption plotOptions.series.tooltip
          */
 


### PR DESCRIPTION
Temporary removed `series.tooltip.stickOnContact` option to avoid further confusion.