### PR TITLE
bugfix/14254-missing-options-arg

### DIFF
--- a/js/Core/Axis/PlotLineOrBand.js
+++ b/js/Core/Axis/PlotLineOrBand.js
@@ -853,15 +853,15 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      *         The SVG path definition in array form.
      */
     getPlotBandPath: function (from, to, options) {
-        var _a, _b;
+        if (options === void 0) { options = this.options; }
         var toPath = this.getPlotLinePath({
             value: to,
             force: true,
-            acrossPanes: (_a = options === null || options === void 0 ? void 0 : options.acrossPanes) !== null && _a !== void 0 ? _a : this.options.acrossPanes
+            acrossPanes: options.acrossPanes
         }), path = this.getPlotLinePath({
             value: from,
             force: true,
-            acrossPanes: (_b = options === null || options === void 0 ? void 0 : options.acrossPanes) !== null && _b !== void 0 ? _b : this.options.acrossPanes
+            acrossPanes: options.acrossPanes
         }), result = [], i, 
         // #4964 check if chart is inverted or plotband is on yAxis
         horiz = this.horiz, plus = 1, isFlat, outside = (from < this.min && to < this.min) ||

--- a/js/Core/Axis/PlotLineOrBand.js
+++ b/js/Core/Axis/PlotLineOrBand.js
@@ -846,18 +846,22 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      * @param {number} to
      *        The axis value to end on.
      *
+     * @param {Highcharts.AxisPlotBandsOptions|Highcharts.AxisPlotLinesOptions} options
+     *        The plotBand or plotLine configuration object.
+     *
      * @return {Highcharts.SVGPathArray}
      *         The SVG path definition in array form.
      */
-    getPlotBandPath: function (from, to) {
+    getPlotBandPath: function (from, to, options) {
+        var _a, _b;
         var toPath = this.getPlotLinePath({
             value: to,
             force: true,
-            acrossPanes: this.options.acrossPanes
+            acrossPanes: (_a = options === null || options === void 0 ? void 0 : options.acrossPanes) !== null && _a !== void 0 ? _a : this.options.acrossPanes
         }), path = this.getPlotLinePath({
             value: from,
             force: true,
-            acrossPanes: this.options.acrossPanes
+            acrossPanes: (_b = options === null || options === void 0 ? void 0 : options.acrossPanes) !== null && _b !== void 0 ? _b : this.options.acrossPanes
         }), result = [], i, 
         // #4964 check if chart is inverted or plotband is on yAxis
         horiz = this.horiz, plus = 1, isFlat, outside = (from < this.min && to < this.min) ||

--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.html
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.html
@@ -1,4 +1,4 @@
-<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 <script src="https://code.highcharts.com/modules/solid-gauge.js"></script>
 

--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
@@ -559,3 +559,43 @@ QUnit.test('#14310: Visibility of dynamically added plotbands', function (assert
         'plotBand should render when axis visibility gets dynamically updated'
     );
 });
+
+QUnit.test('#14254: plotBands.acrossPanes', function (assert) {
+    var chart = Highcharts.stockChart('container', {
+        series: [{
+            data: [1, 2, 3, 4]
+        }, {
+            data: [1, 2, 3, 4],
+            yAxis: 1,
+            xAxis: 1
+        }],
+        yAxis: [{
+            height: '50%'
+        }, {
+            height: '50%',
+            top: '50%'
+        }],
+        xAxis: [{
+            plotBands: [{
+                from: 2,
+                to: 3,
+                acrossPanes: false
+            }, {
+                from: 2,
+                to: 3,
+                acrossPanes: true
+            }],
+            height: '50%'
+        }, {
+            top: '50%',
+            height: '50%'
+        }]
+    });
+
+    var bands = [
+        chart.xAxis[0].plotLinesAndBands[0].svgElem.getBBox(),
+        chart.xAxis[0].plotLinesAndBands[1].svgElem.getBBox()
+    ];
+
+    assert.ok(bands[1].height > bands[0].height, 'plotBand with acrossPanes = true has greater height');
+});

--- a/ts/Core/Axis/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand.ts
@@ -1151,17 +1151,17 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
         this: Highcharts.Axis,
         from: number,
         to: number,
-        options?: (Highcharts.AxisPlotBandsOptions|Highcharts.AxisPlotLinesOptions)
+        options: (Highcharts.AxisPlotBandsOptions|Highcharts.AxisPlotLinesOptions) = this.options
     ): SVGPath {
         var toPath = this.getPlotLinePath({
                 value: to,
                 force: true,
-                acrossPanes: options?.acrossPanes ?? (this.options as any).acrossPanes
+                acrossPanes: options.acrossPanes
             } as Highcharts.AxisPlotLinePathOptionsObject),
             path = this.getPlotLinePath({
                 value: from,
                 force: true,
-                acrossPanes: options?.acrossPanes ?? (this.options as any).acrossPanes
+                acrossPanes: options.acrossPanes
             } as Highcharts.AxisPlotLinePathOptionsObject),
             result = [] as SVGPath,
             i,

--- a/ts/Core/Axis/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand.ts
@@ -1141,23 +1141,27 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      * @param {number} to
      *        The axis value to end on.
      *
+     * @param {Highcharts.AxisPlotBandsOptions|Highcharts.AxisPlotLinesOptions} options
+     *        The plotBand or plotLine configuration object.
+     *
      * @return {Highcharts.SVGPathArray}
      *         The SVG path definition in array form.
      */
     getPlotBandPath: function (
         this: Highcharts.Axis,
         from: number,
-        to: number
+        to: number,
+        options?: (Highcharts.AxisPlotBandsOptions|Highcharts.AxisPlotLinesOptions)
     ): SVGPath {
         var toPath = this.getPlotLinePath({
                 value: to,
                 force: true,
-                acrossPanes: (this.options as any).acrossPanes
+                acrossPanes: options?.acrossPanes ?? (this.options as any).acrossPanes
             } as Highcharts.AxisPlotLinePathOptionsObject),
             path = this.getPlotLinePath({
                 value: from,
                 force: true,
-                acrossPanes: (this.options as any).acrossPanes
+                acrossPanes: options?.acrossPanes ?? (this.options as any).acrossPanes
             } as Highcharts.AxisPlotLinePathOptionsObject),
             result = [] as SVGPath,
             i,


### PR DESCRIPTION
Fixed #14254, the `plotBands.acrossPanes` option had no effect.

~Fixed #14254, `getPlotBandPath` had no options argument, but its interface did and other callers were using it.~