### PR TITLE
bugfix/14166-currentDateIndicator-time

### DIFF
--- a/js/Extensions/CurrentDateIndication.js
+++ b/js/Extensions/CurrentDateIndication.js
@@ -10,8 +10,6 @@
  *
  * */
 import Axis from '../Core/Axis/Axis.js';
-import O from '../Core/Options.js';
-var dateFormat = O.dateFormat;
 import U from '../Core/Utilities.js';
 var addEvent = U.addEvent, merge = U.merge, wrap = U.wrap;
 import PlotLineOrBand from '../Core/Axis/PlotLineOrBand.js';
@@ -52,7 +50,7 @@ var defaultConfig = {
          */
         format: '%a, %b %d %Y, %H:%M',
         formatter: function (value, format) {
-            return dateFormat(format, value);
+            return this.axis.chart.time.dateFormat(format, value);
         },
         rotation: 0,
         /**

--- a/samples/unit-tests/gantt/current-date-indicator/demo.js
+++ b/samples/unit-tests/gantt/current-date-indicator/demo.js
@@ -230,4 +230,18 @@
             'Formatter is ignored when custom format is defined'
         );
     });
+
+    QUnit.test('#14166: Per-chart time options', function (assert) {
+        var chart = Highcharts.chart('container', defaultConfig);
+        var t0 = Date.parse(chart.xAxis[0].plotLinesAndBands[0].label.textStr);
+
+        chart = Highcharts.chart('container', Highcharts.merge(defaultConfig, {
+            time: {
+                timezoneOffset: -5
+            }
+        }));
+        var t1 = Date.parse(chart.xAxis[0].plotLinesAndBands[0].label.textStr);
+
+        assert.ok(t1 - t0 >= 300000, 'Per-chart time options work');
+    });
 }());

--- a/ts/Extensions/CurrentDateIndication.ts
+++ b/ts/Extensions/CurrentDateIndication.ts
@@ -17,8 +17,6 @@ import type {
 import type ColorString from '../Core/Color/ColorString';
 import type CSSObject from '../Core/Renderer/CSSObject';
 import Axis from '../Core/Axis/Axis.js';
-import O from '../Core/Options.js';
-const { dateFormat } = O;
 
 /**
  * Internal types
@@ -109,7 +107,7 @@ const defaultConfig: (
          */
         format: '%a, %b %d %Y, %H:%M',
         formatter: function (value: number, format: string): string {
-            return dateFormat(format, value);
+            return (this as PlotLineOrBand).axis.chart.time.dateFormat(format, value);
         },
         rotation: 0,
         /**
@@ -127,6 +125,7 @@ const defaultConfig: (
 addEvent(Axis, 'afterSetOptions', function (): void {
     var options = this.options,
         cdiOptions = options.currentDateIndicator;
+
 
     if (cdiOptions) {
         cdiOptions = typeof cdiOptions === 'object' ?


### PR DESCRIPTION
Fixed #14166, `currentDateIndicator` ignored per-chart time options, default label formatter used global `dateFormat`.