### PR TITLE
bugfix/14050-empty-dataLabels

### DIFF
--- a/js/Series/AreaRangeSeries.js
+++ b/js/Series/AreaRangeSeries.js
@@ -298,7 +298,7 @@ BaseSeries.seriesType('arearange', 'area', {
                 lowerDataLabelOptions = dataLabelOptions[1];
             }
             else {
-                upperDataLabelOptions = dataLabelOptions[0];
+                upperDataLabelOptions = dataLabelOptions[0] || { enabled: false };
                 lowerDataLabelOptions = { enabled: false };
             }
         }

--- a/js/Series/AreaRangeSeries.js
+++ b/js/Series/AreaRangeSeries.js
@@ -293,14 +293,8 @@ BaseSeries.seriesType('arearange', 'area', {
         // since we now have to loop over all the points multiple times to work
         // around the data label logic.
         if (isArray(dataLabelOptions)) {
-            if (dataLabelOptions.length > 1) {
-                upperDataLabelOptions = dataLabelOptions[0];
-                lowerDataLabelOptions = dataLabelOptions[1];
-            }
-            else {
-                upperDataLabelOptions = dataLabelOptions[0] || { enabled: false };
-                lowerDataLabelOptions = { enabled: false };
-            }
+            upperDataLabelOptions = dataLabelOptions[0] || { enabled: false };
+            lowerDataLabelOptions = dataLabelOptions[1] || { enabled: false };
         }
         else {
             // Make copies

--- a/samples/unit-tests/series-columnrange/datalabels/demo.js
+++ b/samples/unit-tests/series-columnrange/datalabels/demo.js
@@ -143,3 +143,33 @@ QUnit.test("Change of label alignment after add(#4605)", function (assert) {
 
 
 });
+
+QUnit.test('#14050: Empty dataLabels', function (assert) {
+    Highcharts.chart('container', {
+        series: [{
+            data: [
+                [1, 2],
+                [4, 5],
+                [3, 7],
+                [5, 6]
+            ],
+            dataLabels: [],
+            type: 'arearange'
+        }]
+    });
+
+    Highcharts.chart('container', {
+        series: [{
+            data: [
+                [1, 2],
+                [4, 5],
+                [3, 7],
+                [5, 6]
+            ],
+            dataLabels: [undefined, { enabled: false }],
+            type: 'arearange'
+        }]
+    });
+
+    assert.ok(true, 'Does not throw when passed empty dataLabels');
+});

--- a/samples/unit-tests/series-columnrange/datalabels/demo.js
+++ b/samples/unit-tests/series-columnrange/datalabels/demo.js
@@ -145,30 +145,24 @@ QUnit.test("Change of label alignment after add(#4605)", function (assert) {
 });
 
 QUnit.test('#14050: Empty dataLabels', function (assert) {
-    Highcharts.chart('container', {
-        series: [{
-            data: [
-                [1, 2],
-                [4, 5],
-                [3, 7],
-                [5, 6]
-            ],
-            dataLabels: [],
-            type: 'arearange'
-        }]
-    });
-
-    Highcharts.chart('container', {
-        series: [{
-            data: [
-                [1, 2],
-                [4, 5],
-                [3, 7],
-                [5, 6]
-            ],
-            dataLabels: [undefined, { enabled: false }],
-            type: 'arearange'
-        }]
+    [
+        [],
+        [undefined, { enabled: false }],
+        [{ enabled: false }, undefined],
+        [undefined, undefined]
+    ].forEach(function (labels) {
+        Highcharts.chart('container', {
+            series: [{
+                data: [
+                    [1, 2],
+                    [4, 5],
+                    [3, 7],
+                    [5, 6]
+                ],
+                dataLabels: labels,
+                type: 'arearange'
+            }]
+        });
     });
 
     assert.ok(true, 'Does not throw when passed empty dataLabels');

--- a/ts/Series/AreaRangeSeries.ts
+++ b/ts/Series/AreaRangeSeries.ts
@@ -490,7 +490,7 @@ BaseSeries.seriesType<typeof Highcharts.AreaRangeSeries>('arearange', 'area', {
                 upperDataLabelOptions = dataLabelOptions[0];
                 lowerDataLabelOptions = dataLabelOptions[1];
             } else {
-                upperDataLabelOptions = dataLabelOptions[0];
+                upperDataLabelOptions = dataLabelOptions[0] || { enabled: false };
                 lowerDataLabelOptions = { enabled: false };
             }
         } else {

--- a/ts/Series/AreaRangeSeries.ts
+++ b/ts/Series/AreaRangeSeries.ts
@@ -486,13 +486,8 @@ BaseSeries.seriesType<typeof Highcharts.AreaRangeSeries>('arearange', 'area', {
         // since we now have to loop over all the points multiple times to work
         // around the data label logic.
         if (isArray(dataLabelOptions)) {
-            if (dataLabelOptions.length > 1) {
-                upperDataLabelOptions = dataLabelOptions[0];
-                lowerDataLabelOptions = dataLabelOptions[1];
-            } else {
-                upperDataLabelOptions = dataLabelOptions[0] || { enabled: false };
-                lowerDataLabelOptions = { enabled: false };
-            }
+            upperDataLabelOptions = dataLabelOptions[0] || { enabled: false };
+            lowerDataLabelOptions = dataLabelOptions[1] || { enabled: false };
         } else {
             // Make copies
             upperDataLabelOptions = extend({}, dataLabelOptions as any);


### PR DESCRIPTION
Fixed #14050, empty `dataLabels` array passed to `columnrange` and related series threw error.