### PR TITLE
Fixed #14349, first point being null breaks screen reader a11y.

### DIFF
--- a/js/Accessibility/Utils/ChartUtilities.js
+++ b/js/Accessibility/Utils/ChartUtilities.js
@@ -44,10 +44,10 @@ function getAxisDescription(axis) {
  * The DOM element for the point.
  */
 function getSeriesFirstPointElement(series) {
-    if (series.points &&
-        series.points.length &&
-        series.points[0].graphic) {
-        return series.points[0].graphic.element;
+    var _a, _b;
+    if ((_a = series.points) === null || _a === void 0 ? void 0 : _a.length) {
+        var firstPointWithGraphic = find(series.points, function (p) { return !!p.graphic; });
+        return (_b = firstPointWithGraphic === null || firstPointWithGraphic === void 0 ? void 0 : firstPointWithGraphic.graphic) === null || _b === void 0 ? void 0 : _b.element;
     }
 }
 /**

--- a/ts/Accessibility/Utils/ChartUtilities.ts
+++ b/ts/Accessibility/Utils/ChartUtilities.ts
@@ -106,12 +106,9 @@ function getAxisDescription(axis: Highcharts.Axis): string {
 function getSeriesFirstPointElement(
     series: Highcharts.Series
 ): (DOMElementType|undefined) {
-    if (
-        series.points &&
-        series.points.length &&
-        series.points[0].graphic
-    ) {
-        return series.points[0].graphic.element;
+    if (series.points?.length) {
+        const firstPointWithGraphic = find(series.points, (p: Point): boolean => !!p.graphic);
+        return firstPointWithGraphic?.graphic?.element;
     }
 }
 


### PR DESCRIPTION
Fixed #14349, first point being `null` broke the accessibility screen reader