### PR TITLE
bugfix/14352-data-table-button-text

### DIFF
--- a/js/Extensions/Exporting.js
+++ b/js/Extensions/Exporting.js
@@ -1469,6 +1469,11 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                         element = createElement('hr', null, null, innerMenu);
                     }
                     else {
+                        // When chart initialized with the table,
+                        // wrong button text displayed, #14352.
+                        if (item.textKey === 'viewData' && chart.isDataTableVisible) {
+                            item.textKey = 'hideData';
+                        }
                         element = createElement('li', {
                             className: 'highcharts-menu-item',
                             onclick: function (e) {

--- a/samples/unit-tests/exporting/buttons/demo.js
+++ b/samples/unit-tests/exporting/buttons/demo.js
@@ -169,3 +169,39 @@ QUnit.test('View/hide data table button, #14338.', function (assert) {
         'There should be text indicating that the table is hidden and can be visible again.'
     );
 });
+
+QUnit.test('When chart initialized with the table, show a proper button for hiding the table, #14352.', function (assert) {
+    const chart = Highcharts.chart('container', {
+        exporting: {
+            showTable: true,
+            buttons: {
+                contextButton: {
+                    menuItems: ['viewData']
+                }
+            }
+        },
+        series: [{
+            data: [1, 4, 3, 5]
+        }]
+    });
+
+    // Test menu items
+    const controller = new TestController(chart),
+        alignAttr = chart.exportSVGElements[0].alignAttr;
+
+    // Click on the export menu to trigger list creation.
+    controller.click(alignAttr.translateX + 5, alignAttr.translateY + 5);
+
+    assert.strictEqual(
+        chart.exportDivElements[0].innerText,
+        'Hide data table',
+        'There should be text indicating that the table is visible and can be hidden.'
+    );
+
+    chart.toggleDataTable();
+    assert.strictEqual(
+        chart.exportDivElements[0].innerText,
+        'View data table',
+        'There should be text indicating that the table is hidden and can be visible again.'
+    );
+});

--- a/ts/Extensions/Exporting.ts
+++ b/ts/Extensions/Exporting.ts
@@ -1993,6 +1993,12 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
                         );
 
                     } else {
+                        // When chart initialized with the table,
+                        // wrong button text displayed, #14352.
+                        if (item.textKey === 'viewData' && chart.isDataTableVisible) {
+                            item.textKey = 'hideData';
+                        }
+
                         element = createElement('li', {
                             className: 'highcharts-menu-item',
                             onclick: function (e: PointerEvent): void {


### PR DESCRIPTION
Fixed #14352, wrong button text displayed when chart initialized with the table.