### PR TITLE
Fixed #14356 `dataURLtoBlob` failed

### DIFF
--- a/js/Extensions/DownloadURL.js
+++ b/js/Extensions/DownloadURL.js
@@ -22,7 +22,9 @@ var win = Highcharts.win, nav = win.navigator, doc = win.document, domurl = win.
  *         Blob
  */
 var dataURLtoBlob = Highcharts.dataURLtoBlob = function (dataURL) {
-    var parts = dataURL.match(/data:([^;]*)(;base64)?,([0-9A-Za-z+/]+)/);
+    var parts = dataURL
+        .replace(/filename=.*;/, '')
+        .match(/data:([^;]*)(;base64)?,([0-9A-Za-z+/]+)/);
     if (parts &&
         parts.length > 3 &&
         win.atob &&
@@ -31,11 +33,11 @@ var dataURLtoBlob = Highcharts.dataURLtoBlob = function (dataURL) {
         win.Blob &&
         domurl.createObjectURL) {
         // Try to convert data URL to Blob
-        var binStr = win.atob(parts[3]), buf = new win.ArrayBuffer(binStr.length), binary = new win.Uint8Array(buf), blob;
+        var binStr = win.atob(parts[3]), buf = new win.ArrayBuffer(binStr.length), binary = new win.Uint8Array(buf);
         for (var i = 0; i < binary.length; ++i) {
             binary[i] = binStr.charCodeAt(i);
         }
-        blob = new win.Blob([binary], { 'type': parts[1] });
+        var blob = new win.Blob([binary], { 'type': parts[1] });
         return domurl.createObjectURL(blob);
     }
 };

--- a/ts/Extensions/DownloadURL.ts
+++ b/ts/Extensions/DownloadURL.ts
@@ -41,7 +41,10 @@ var win = Highcharts.win,
  *         Blob
  */
 const dataURLtoBlob = Highcharts.dataURLtoBlob = function (dataURL: string): (string|undefined) {
-    var parts = dataURL.match(/data:([^;]*)(;base64)?,([0-9A-Za-z+/]+)/);
+    const parts = dataURL
+        .replace(/filename=.*;/, '')
+        .match(/data:([^;]*)(;base64)?,([0-9A-Za-z+/]+)/);
+
 
     if (
         parts &&
@@ -53,16 +56,15 @@ const dataURLtoBlob = Highcharts.dataURLtoBlob = function (dataURL: string): (st
         domurl.createObjectURL
     ) {
         // Try to convert data URL to Blob
-        var binStr = win.atob(parts[3]),
+        const binStr = win.atob(parts[3]),
             buf = new win.ArrayBuffer(binStr.length),
-            binary = new win.Uint8Array(buf),
-            blob;
+            binary = new win.Uint8Array(buf);
 
         for (var i = 0; i < binary.length; ++i) {
             binary[i] = binStr.charCodeAt(i);
         }
 
-        blob = new win.Blob([binary], { 'type': parts[1] });
+        const blob = new win.Blob([binary], { 'type': parts[1] });
         return domurl.createObjectURL(blob);
     }
 };


### PR DESCRIPTION
Fixed #14356, offline PDF export failed for larger datasets.

This was due to `dataURLtoBlob` failing when the `dataURL` contained the filename.

[With fix applied](http://jsfiddle.net/goransle/0h7o631m/)
[Without](http://jsfiddle.net/goransle/d7v95ahn/)