### PR TITLE
bugfix/13811-partialFill-order

### DIFF
--- a/js/Series/XRangeSeries.js
+++ b/js/Series/XRangeSeries.js
@@ -406,7 +406,7 @@ BaseSeries.seriesType('xrange', 'column'
                         pfOptions = {};
                     }
                     if (isObject(seriesOpts.partialFill)) {
-                        pfOptions = merge(pfOptions, seriesOpts.partialFill);
+                        pfOptions = merge({}, seriesOpts.partialFill, pfOptions);
                     }
                     fill = (pfOptions.fill ||
                         color(pointAttr.fill).brighten(-0.3).get() ||

--- a/js/Series/XRangeSeries.js
+++ b/js/Series/XRangeSeries.js
@@ -406,7 +406,7 @@ BaseSeries.seriesType('xrange', 'column'
                         pfOptions = {};
                     }
                     if (isObject(seriesOpts.partialFill)) {
-                        pfOptions = merge({}, seriesOpts.partialFill, pfOptions);
+                        pfOptions = merge(seriesOpts.partialFill, pfOptions);
                     }
                     fill = (pfOptions.fill ||
                         color(pointAttr.fill).brighten(-0.3).get() ||

--- a/samples/unit-tests/series-xrange/xrange/demo.js
+++ b/samples/unit-tests/series-xrange/xrange/demo.js
@@ -534,11 +534,11 @@ QUnit.test('#13811: partialFill application order', function (assert) {
     assert.strictEqual(
         chart.series[0].points[0].graphic.partRect.attr('fill'),
         'black',
-        'Point.partialFill takes priority'
+        'Point.partialFill should take priority'
     );
     assert.strictEqual(
         chart.series[0].points[2].graphic.partRect.attr('fill'),
         'red',
-        'Series.partialFill still works'
+        'Series.partialFill should still work'
     );
 });

--- a/samples/unit-tests/series-xrange/xrange/demo.js
+++ b/samples/unit-tests/series-xrange/xrange/demo.js
@@ -477,3 +477,68 @@ QUnit.test('Stacking', assert => {
     );
 
 });
+
+QUnit.test('#13811: partialFill application order', function (assert) {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            type: 'xrange'
+        },
+        xAxis: {
+            type: 'datetime'
+        },
+        yAxis: {
+            categories: ['Prototyping', 'Development', 'Testing'],
+            reversed: true
+        },
+        series: [{
+            name: 'Project 1',
+            borderColor: 'gray',
+            pointWidth: 20,
+            partialFill: {
+                fill: 'red'
+            },
+            data: [{
+                x: Date.UTC(2014, 10, 21),
+                x2: Date.UTC(2014, 11, 2),
+                y: 0,
+                partialFill: {
+                    fill: 'black',
+                    amount: 0.25
+                }
+            }, {
+                x: Date.UTC(2014, 11, 2),
+                x2: Date.UTC(2014, 11, 5),
+                y: 1
+            }, {
+                x: Date.UTC(2014, 11, 8),
+                x2: Date.UTC(2014, 11, 9),
+                y: 2,
+                partialFill: {
+                    amount: 0.50
+                }
+            }, {
+                x: Date.UTC(2014, 11, 9),
+                x2: Date.UTC(2014, 11, 19),
+                y: 1
+            }, {
+                x: Date.UTC(2014, 11, 10),
+                x2: Date.UTC(2014, 11, 23),
+                y: 2
+            }],
+            dataLabels: {
+                enabled: true
+            }
+        }]
+    });
+
+    assert.strictEqual(
+        chart.series[0].points[0].graphic.partRect.attr('fill'),
+        'black',
+        'Point.partialFill takes priority'
+    );
+    assert.strictEqual(
+        chart.series[0].points[2].graphic.partRect.attr('fill'),
+        'red',
+        'Series.partialFill still works'
+    );
+});

--- a/ts/Series/XRangeSeries.ts
+++ b/ts/Series/XRangeSeries.ts
@@ -696,7 +696,7 @@ BaseSeries.seriesType<typeof Highcharts.XRangeSeries>('xrange', 'column'
                         }
                         if (isObject(seriesOpts.partialFill)) {
                             pfOptions = merge(
-                                pfOptions, seriesOpts.partialFill
+                                {}, seriesOpts.partialFill, pfOptions
                             );
                         }
 

--- a/ts/Series/XRangeSeries.ts
+++ b/ts/Series/XRangeSeries.ts
@@ -696,7 +696,7 @@ BaseSeries.seriesType<typeof Highcharts.XRangeSeries>('xrange', 'column'
                         }
                         if (isObject(seriesOpts.partialFill)) {
                             pfOptions = merge(
-                                {}, seriesOpts.partialFill, pfOptions
+                                seriesOpts.partialFill, pfOptions
                             );
                         }
 


### PR DESCRIPTION
Fixed #13811, `Point.partialFill` didn't override `Series.partialFill`.