### PR TITLE
bugfix/14060-navigator-match-chart

### DIFF
--- a/js/Core/Chart/GanttChart.js
+++ b/js/Core/Chart/GanttChart.js
@@ -96,7 +96,11 @@ H.ganttChart = function (renderTo, options, callback) {
             enabled: false
         },
         navigator: {
-            series: { type: 'gantt' }
+            series: { type: 'gantt' },
+            // Bars were clipped, #14060.
+            yAxis: {
+                type: 'category'
+            }
         }
     }, options, // user's options
     // forced options

--- a/js/Core/Navigator.js
+++ b/js/Core/Navigator.js
@@ -1297,6 +1297,7 @@ var Navigator = /** @class */ (function () {
                 offset: 0,
                 index: yAxisIndex,
                 isInternal: true,
+                reversed: pick((navigatorOptions.yAxis && navigatorOptions.yAxis.reversed), (chart.yAxis[0] && chart.yAxis[0].reversed), false),
                 zoomEnabled: false
             }, chart.inverted ? {
                 width: height

--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -1015,3 +1015,30 @@ QUnit.test('Navigator with adding series on chart load.', function (assert) {
         }]
     });
 });
+
+QUnit.test('yAxis in navigator does not match the one in the chart, #14060.', function (assert) {
+    const chart = Highcharts.stockChart('container', {
+        yAxis: {
+            reversed: true
+        },
+        series: [{
+            data: [1, 2, 3]
+        }]
+    });
+
+    assert.ok(
+        chart.navigator.yAxis.reversed,
+        'Navigator should inherit the reversed property from the main axis.'
+    );
+    chart.update({
+        navigator: {
+            yAxis: {
+                reversed: false
+            }
+        }
+    });
+    assert.notOk(
+        chart.navigator.yAxis.reversed,
+        'Navigator options should have higher priority and the axis should not be reversed anymore.'
+    );
+});

--- a/ts/Core/Chart/GanttChart.ts
+++ b/ts/Core/Chart/GanttChart.ts
@@ -155,7 +155,11 @@ H.ganttChart = function (
                 enabled: false
             },
             navigator: {
-                series: { type: 'gantt' }
+                series: { type: 'gantt' },
+                // Bars were clipped, #14060.
+                yAxis: {
+                    type: 'category'
+                }
             }
         } as Highcharts.Options,
 

--- a/ts/Core/Navigator.ts
+++ b/ts/Core/Navigator.ts
@@ -1908,6 +1908,9 @@ class Navigator {
                     offset: 0,
                     index: yAxisIndex,
                     isInternal: true,
+                    reversed: pick((navigatorOptions.yAxis && navigatorOptions.yAxis.reversed),
+                        (chart.yAxis[0] && chart.yAxis[0].reversed),
+                        false), // #14060
                     zoomEnabled: false
                 }, chart.inverted ? {
                     width: height


### PR DESCRIPTION
Fixed #14060, navigator's `yAxis` did not match the chart.