### PR TITLE
bugfix/14385-exporting-svg-local

### DIFF
--- a/js/Extensions/OfflineExporting.js
+++ b/js/Extensions/OfflineExporting.js
@@ -591,3 +591,5 @@ merge(true, getOptions().exporting, {
         }
     }
 });
+// Compatibility
+H.downloadSVGLocal = downloadSVGLocal;

--- a/ts/Extensions/OfflineExporting.ts
+++ b/ts/Extensions/OfflineExporting.ts
@@ -873,3 +873,6 @@ merge(true, getOptions().exporting, {
 
     }
 });
+
+// Compatibility
+H.downloadSVGLocal = downloadSVGLocal;


### PR DESCRIPTION
Fixed #14385, missing downloadSVGLocal function.