### PR TITLE
bugfix/13957-mixing-array-object-error-boost

### DIFF
--- a/js/Core/Axis/OrdinalAxis.js
+++ b/js/Core/Axis/OrdinalAxis.js
@@ -436,8 +436,8 @@ var OrdinalAxis;
             // the same for all segments.
             if (segmentPositions) {
                 info = segmentPositions.info;
-                // Optionally identify ticks with higher rank, for example when the
-                // ticks have crossed midnight.
+                // Optionally identify ticks with higher rank, for example
+                // when the ticks have crossed midnight.
                 if (findHigherRanks && info.unitRange <= timeUnits.hour) {
                     end = groupPositions.length - 1;
                     // Compare points two by two
@@ -448,8 +448,8 @@ var OrdinalAxis;
                             hasCrossedHigherRank = true;
                         }
                     }
-                    // If the complete array has crossed midnight, we want to mark
-                    // the first positions also as higher rank
+                    // If the complete array has crossed midnight, we want
+                    // to mark the first positions also as higher rank
                     if (hasCrossedHigherRank) {
                         higherRanks[groupPositions[0]] = 'day';
                     }

--- a/js/Core/Axis/OrdinalAxis.js
+++ b/js/Core/Axis/OrdinalAxis.js
@@ -12,7 +12,7 @@ import Axis from './Axis.js';
 import H from '../Globals.js';
 import CartesianSeries from '../Series/CartesianSeries.js';
 import U from '../Utilities.js';
-var addEvent = U.addEvent, css = U.css, defined = U.defined, pick = U.pick, timeUnits = U.timeUnits;
+var addEvent = U.addEvent, css = U.css, defined = U.defined, error = U.error, pick = U.pick, timeUnits = U.timeUnits;
 import Chart from '../Chart/Chart.js';
 // Has a dependency on Navigator due to the use of Axis.toFixedRange
 import '../Navigator.js';
@@ -434,29 +434,34 @@ var OrdinalAxis;
             }
             // Get the grouping info from the last of the segments. The info is
             // the same for all segments.
-            info = segmentPositions.info;
-            // Optionally identify ticks with higher rank, for example when the
-            // ticks have crossed midnight.
-            if (findHigherRanks && info.unitRange <= timeUnits.hour) {
-                end = groupPositions.length - 1;
-                // Compare points two by two
-                for (start = 1; start < end; start++) {
-                    if (time.dateFormat('%d', groupPositions[start]) !==
-                        time.dateFormat('%d', groupPositions[start - 1])) {
-                        higherRanks[groupPositions[start]] = 'day';
-                        hasCrossedHigherRank = true;
+            if (segmentPositions) {
+                info = segmentPositions.info;
+                // Optionally identify ticks with higher rank, for example when the
+                // ticks have crossed midnight.
+                if (findHigherRanks && info.unitRange <= timeUnits.hour) {
+                    end = groupPositions.length - 1;
+                    // Compare points two by two
+                    for (start = 1; start < end; start++) {
+                        if (time.dateFormat('%d', groupPositions[start]) !==
+                            time.dateFormat('%d', groupPositions[start - 1])) {
+                            higherRanks[groupPositions[start]] = 'day';
+                            hasCrossedHigherRank = true;
+                        }
                     }
+                    // If the complete array has crossed midnight, we want to mark
+                    // the first positions also as higher rank
+                    if (hasCrossedHigherRank) {
+                        higherRanks[groupPositions[0]] = 'day';
+                    }
+                    info.higherRanks = higherRanks;
                 }
-                // If the complete array has crossed midnight, we want to mark
-                // the first positions also as higher rank
-                if (hasCrossedHigherRank) {
-                    higherRanks[groupPositions[0]] = 'day';
-                }
-                info.higherRanks = higherRanks;
+                // Save the info
+                info.segmentStarts = segmentStarts;
+                groupPositions.info = info;
             }
-            // Save the info
-            info.segmentStarts = segmentStarts;
-            groupPositions.info = info;
+            else {
+                error(12, false, this.chart);
+            }
             // Don't show ticks within a gap in the ordinal axis, where the
             // space between two points is greater than a portion of the tick
             // pixel interval

--- a/samples/unit-tests/boost/general/demo.js
+++ b/samples/unit-tests/boost/general/demo.js
@@ -208,3 +208,32 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
         });
     }
 );
+
+QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
+    'Error handler while the series is not declared as an array of numbers and turbo threshold enabled, #13957.',
+    function (assert) {
+        Highcharts.addEvent(Highcharts.Chart, 'displayError', function (e) {
+            assert.strictEqual(
+                e.code,
+                12,
+                'Error 12 should be invoked'
+            );
+        });
+        Highcharts.stockChart('container', {
+            series: [{
+                data: [
+                    [1, 2],
+                    {
+                        x: 2,
+                        y: 46.7407
+                    },
+                    [3, 46.6135],
+                    [4, 47.0005],
+                    [5, 48.1701],
+                    [6, 47.5816]
+                ],
+                turboThreshold: 2
+            }]
+        });
+    }
+);

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -20,6 +20,7 @@ const {
     addEvent,
     css,
     defined,
+    error,
     pick,
     timeUnits
 } = U;
@@ -716,36 +717,40 @@ namespace OrdinalAxis {
 
             // Get the grouping info from the last of the segments. The info is
             // the same for all segments.
-            info = (segmentPositions as any).info;
+            if (segmentPositions) {
+                info = (segmentPositions as any).info;
 
-            // Optionally identify ticks with higher rank, for example when the
-            // ticks have crossed midnight.
-            if (findHigherRanks && info.unitRange <= timeUnits.hour) {
-                end = groupPositions.length - 1;
+                // Optionally identify ticks with higher rank, for example
+                // when the ticks have crossed midnight.
+                if (findHigherRanks && info.unitRange <= timeUnits.hour) {
+                    end = groupPositions.length - 1;
 
-                // Compare points two by two
-                for (start = 1; start < end; start++) {
-                    if (
-                        time.dateFormat('%d', groupPositions[start]) !==
-                        time.dateFormat('%d', groupPositions[start - 1])
-                    ) {
-                        higherRanks[groupPositions[start]] = 'day';
-                        hasCrossedHigherRank = true;
+                    // Compare points two by two
+                    for (start = 1; start < end; start++) {
+                        if (
+                            time.dateFormat('%d', groupPositions[start]) !==
+                            time.dateFormat('%d', groupPositions[start - 1])
+                        ) {
+                            higherRanks[groupPositions[start]] = 'day';
+                            hasCrossedHigherRank = true;
+                        }
                     }
+
+                    // If the complete array has crossed midnight, we want
+                    // to mark the first positions also as higher rank
+                    if (hasCrossedHigherRank) {
+                        higherRanks[groupPositions[0]] = 'day';
+                    }
+                    info.higherRanks = higherRanks;
                 }
 
-                // If the complete array has crossed midnight, we want to mark
-                // the first positions also as higher rank
-                if (hasCrossedHigherRank) {
-                    higherRanks[groupPositions[0]] = 'day';
-                }
-                info.higherRanks = higherRanks;
+                // Save the info
+                info.segmentStarts = segmentStarts;
+                groupPositions.info = info;
+
+            } else {
+                error(12, false, this.chart);
             }
-
-            // Save the info
-            info.segmentStarts = segmentStarts;
-            groupPositions.info = info;
-
             // Don't show ticks within a gap in the ordinal axis, where the
             // space between two points is greater than a portion of the tick
             // pixel interval


### PR DESCRIPTION
Fixed #13957, added error handler while mixed series data in boost.