### PR TITLE
bugfix/timeline-duplicate-events

### DIFF
--- a/js/Core/Series/CartesianSeries.js
+++ b/js/Core/Series/CartesianSeries.js
@@ -5008,7 +5008,7 @@ void 0,
             // remove all events
             removeEvent(series);
         }
-        else if (series.eventsToUnbind.length) {
+        if (series.eventsToUnbind.length) {
             // remove only internal events for proper update
             // #12355 - solves problem with multiple destroy events
             series.eventsToUnbind.forEach(function (unbind) {

--- a/js/Extensions/Exporting.js
+++ b/js/Extensions/Exporting.js
@@ -1924,8 +1924,6 @@ Chart.prototype.renderExporting = function () {
         });
         chart.isDirtyExporting = false;
     }
-    // Destroy the export elements at chart destroy
-    addEvent(chart, 'destroy', chart.destroyExport);
 };
 /* eslint-disable no-invalid-this */
 // Add update methods to handle chart.update and chart.exporting.update and
@@ -1967,6 +1965,8 @@ addEvent(Chart, 'init', function () {
 Chart.prototype.callbacks.push(function (chart) {
     chart.renderExporting();
     addEvent(chart, 'redraw', chart.renderExporting);
+    // Destroy the export elements at chart destroy
+    addEvent(chart, 'destroy', chart.destroyExport);
     // Uncomment this to see a button directly below the chart, for quick
     // testing of export
     /*

--- a/js/Series/PackedBubbleSeries.js
+++ b/js/Series/PackedBubbleSeries.js
@@ -563,13 +563,13 @@ BaseSeries.seriesType('packedbubble', 'bubble',
     init: function () {
         Series.prototype.init.apply(this, arguments);
         // When one series is modified, the others need to be recomputed
-        addEvent(this, 'updatedData', function () {
+        this.eventsToUnbind.push(addEvent(this, 'updatedData', function () {
             this.chart.series.forEach(function (s) {
                 if (s.type === this.type) {
                     s.isDirty = true;
                 }
             }, this);
-        });
+        }));
         return this;
     },
     render: function () {

--- a/js/Series/TimelineSeries.js
+++ b/js/Series/TimelineSeries.js
@@ -221,7 +221,7 @@ BaseSeries.seriesType('timeline', 'line',
     init: function () {
         var series = this;
         Series.prototype.init.apply(series, arguments);
-        addEvent(series, 'afterTranslate', function () {
+        series.eventsToUnbind.push(addEvent(series, 'afterTranslate', function () {
             var lastPlotX, closestPointRangePx = Number.MAX_VALUE;
             series.points.forEach(function (point) {
                 // Set the isInside parameter basing also on the real point
@@ -238,15 +238,15 @@ BaseSeries.seriesType('timeline', 'line',
                 }
             });
             series.closestPointRangePx = closestPointRangePx;
-        });
+        }));
         // Distribute data labels before rendering them. Distribution is
         // based on the 'dataLabels.distance' and 'dataLabels.alternate'
         // property.
-        addEvent(series, 'drawDataLabels', function () {
+        series.eventsToUnbind.push(addEvent(series, 'drawDataLabels', function () {
             // Distribute data labels basing on defined algorithm.
             series.distributeDL(); // @todo use this scope for series
-        });
-        addEvent(series, 'afterDrawDataLabels', function () {
+        }));
+        series.eventsToUnbind.push(addEvent(series, 'afterDrawDataLabels', function () {
             var dataLabel; // @todo use this scope for series
             // Draw or align connector for each point.
             series.points.forEach(function (point) {
@@ -273,8 +273,8 @@ BaseSeries.seriesType('timeline', 'line',
                     return point.drawConnector();
                 }
             });
-        });
-        addEvent(series.chart, 'afterHideOverlappingLabel', function () {
+        }));
+        series.eventsToUnbind.push(addEvent(series.chart, 'afterHideOverlappingLabel', function () {
             series.points.forEach(function (p) {
                 if (p.connector &&
                     p.dataLabel &&
@@ -282,7 +282,7 @@ BaseSeries.seriesType('timeline', 'line',
                     p.alignConnector();
                 }
             });
-        });
+        }));
     },
     alignDataLabel: function (point, dataLabel, options, alignTo) {
         var series = this, isInverted = series.chart.inverted, visiblePoints = series.visibilityMap.filter(function (point) {

--- a/samples/unit-tests/series/seriestypes/demo.html
+++ b/samples/unit-tests/series/seriestypes/demo.html
@@ -1,4 +1,4 @@
-<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 <script src="https://code.highcharts.com/highcharts-3d.js"></script>
 <script src="https://code.highcharts.com/modules/map.js"></script>
@@ -8,6 +8,8 @@
 <script src="https://code.highcharts.com/modules/histogram-bellcurve.js"></script>
 <script src="https://code.highcharts.com/modules/sunburst.js"></script>
 <script src="https://code.highcharts.com/modules/solid-gauge.js"></script>
+<script src="https://code.highcharts.com/modules/timeline.js"></script>
+<script src="https://code.highcharts.com/modules/networkgraph.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/series/seriestypes/demo.js
+++ b/samples/unit-tests/series/seriestypes/demo.js
@@ -73,8 +73,8 @@ QUnit.test('#13277: Event listener memory leak', assert => {
                 data: []
             });
 
-            assert.ok(before === eventCount(chart.series[0]), `No leakage into series.hcEvents for ${type} series`);
-            assert.ok(beforeChart === eventCount(chart), `No leakage into chart.hcEvents for ${type} series`);
+            assert.strictEqual(eventCount(chart.series[0]), before, `${type} update() should not leak into series.hcEvents`);
+            assert.strictEqual(eventCount(chart), beforeChart, `${type} update() should not leak into chart.hcEvents`);
         }
     });
 });

--- a/samples/unit-tests/series/seriestypes/demo.js
+++ b/samples/unit-tests/series/seriestypes/demo.js
@@ -40,3 +40,41 @@ Object.keys(Highcharts.seriesTypes).forEach(function (type) {
         });
     }
 });
+
+QUnit.test('#13277: Event listener memory leak', assert => {
+    Object.keys(Highcharts.seriesTypes).forEach(type => {
+        if (
+            !('linkedTo' in Highcharts.defaultOptions.plotOptions[type]) &&
+            type !== 'scatter3d' &&
+            type !== 'map' && type !== 'mapline' // Transform error on redraw
+        ) {
+            const chart = Highcharts.chart('container', {
+                chart: {
+                    type: type
+                },
+                series: [{
+                    name: 'Test series'
+                }]
+            });
+
+            const eventCount = el => {
+                let count = 0;
+                //eslint-disable-next-line
+                for (const t in el.hcEvents) {
+                    count += el.hcEvents[t].length;
+                }
+                return count;
+            };
+
+            const before = eventCount(chart.series[0]);
+            const beforeChart = eventCount(chart);
+
+            chart.series[0].update({
+                data: []
+            });
+
+            assert.ok(before === eventCount(chart.series[0]), `No leakage into series.hcEvents for ${type} series`);
+            assert.ok(beforeChart === eventCount(chart), `No leakage into chart.hcEvents for ${type} series`);
+        }
+    });
+});

--- a/ts/Core/Series/CartesianSeries.ts
+++ b/ts/Core/Series/CartesianSeries.ts
@@ -6544,7 +6544,9 @@ const CartesianSeries = BaseSeries.seriesType<typeof Highcharts.LineSeries>(
             if (!keepEventsForUpdate) {
                 // remove all events
                 removeEvent(series);
-            } else if (series.eventsToUnbind.length) {
+            }
+
+            if (series.eventsToUnbind.length) {
                 // remove only internal events for proper update
                 // #12355 - solves problem with multiple destroy events
                 series.eventsToUnbind.forEach(function (

--- a/ts/Extensions/Exporting.ts
+++ b/ts/Extensions/Exporting.ts
@@ -2651,9 +2651,6 @@ Chart.prototype.renderExporting = function (): void {
 
         chart.isDirtyExporting = false;
     }
-
-    // Destroy the export elements at chart destroy
-    addEvent(chart, 'destroy', chart.destroyExport);
 };
 
 /* eslint-disable no-invalid-this */
@@ -2717,6 +2714,8 @@ Chart.prototype.callbacks.push(function (chart: Chart): void {
     chart.renderExporting();
 
     addEvent(chart, 'redraw', chart.renderExporting);
+    // Destroy the export elements at chart destroy
+    addEvent(chart, 'destroy', chart.destroyExport);
 
 
     // Uncomment this to see a button directly below the chart, for quick

--- a/ts/Series/PackedBubbleSeries.ts
+++ b/ts/Series/PackedBubbleSeries.ts
@@ -941,7 +941,7 @@ BaseSeries.seriesType<typeof Highcharts.PackedBubbleSeries>(
             Series.prototype.init.apply(this, arguments as any);
 
             // When one series is modified, the others need to be recomputed
-            addEvent(this, 'updatedData', function (
+            this.eventsToUnbind.push(addEvent(this, 'updatedData', function (
                 this: Highcharts.PackedBubbleSeries
             ): void {
                 this.chart.series.forEach(function (
@@ -951,7 +951,7 @@ BaseSeries.seriesType<typeof Highcharts.PackedBubbleSeries>(
                         s.isDirty = true;
                     }
                 }, this);
-            });
+            }));
 
             return this;
         },

--- a/ts/Series/TimelineSeries.ts
+++ b/ts/Series/TimelineSeries.ts
@@ -374,7 +374,7 @@ BaseSeries.seriesType<typeof Highcharts.TimelineSeries>('timeline', 'line',
 
             Series.prototype.init.apply(series, arguments);
 
-            addEvent(series, 'afterTranslate', function (): void {
+            series.eventsToUnbind.push(addEvent(series, 'afterTranslate', function (): void {
                 var lastPlotX: (number|undefined),
                     closestPointRangePx = Number.MAX_VALUE;
 
@@ -399,17 +399,17 @@ BaseSeries.seriesType<typeof Highcharts.TimelineSeries>('timeline', 'line',
                     }
                 });
                 series.closestPointRangePx = closestPointRangePx;
-            });
+            }));
 
             // Distribute data labels before rendering them. Distribution is
             // based on the 'dataLabels.distance' and 'dataLabels.alternate'
             // property.
-            addEvent(series, 'drawDataLabels', function (): void {
+            series.eventsToUnbind.push(addEvent(series, 'drawDataLabels', function (): void {
                 // Distribute data labels basing on defined algorithm.
                 series.distributeDL(); // @todo use this scope for series
-            });
+            }));
 
-            addEvent(series, 'afterDrawDataLabels', function (): void {
+            series.eventsToUnbind.push(addEvent(series, 'afterDrawDataLabels', function (): void {
                 var dataLabel; // @todo use this scope for series
 
                 // Draw or align connector for each point.
@@ -448,8 +448,9 @@ BaseSeries.seriesType<typeof Highcharts.TimelineSeries>('timeline', 'line',
                         return point.drawConnector();
                     }
                 });
-            });
-            addEvent(
+            }));
+
+            series.eventsToUnbind.push(addEvent(
                 series.chart,
                 'afterHideOverlappingLabel',
                 function (): void {
@@ -465,7 +466,7 @@ BaseSeries.seriesType<typeof Highcharts.TimelineSeries>('timeline', 'line',
                         }
                     });
                 }
-            );
+            ));
         },
         alignDataLabel: function (
             this: Highcharts.TimelineSeries,


### PR DESCRIPTION
Fixed #13277, event listener leakage in several series and export module.

The same internal listeners were being re-added on every `update()`/`redraw()` and never removed.