### PR TITLE
bugfix/13934-xAxis-range-stock-crash

### DIFF
--- a/js/Core/Axis/Axis.js
+++ b/js/Core/Axis/Axis.js
@@ -2098,7 +2098,7 @@ var Axis = /** @class */ (function () {
         var labelOptions = this.options.labels, horiz = this.horiz, tickInterval = this.tickInterval, newTickInterval = tickInterval, slotSize = this.len / (((this.categories ? 1 : 0) +
             this.max -
             this.min) /
-            tickInterval), rotation, rotationOption = labelOptions.rotation, labelMetrics = this.labelMetrics(), step, bestScore = Number.MAX_VALUE, autoRotation, range = Math.abs(this.max - this.min), 
+            tickInterval), rotation, rotationOption = labelOptions.rotation, labelMetrics = this.labelMetrics(), step, bestScore = Number.MAX_VALUE, autoRotation, range = Math.max(this.max - this.min, 0), 
         // Return the multiple of tickInterval that is needed to avoid
         // collision
         getStep = function (spaceNeeded) {

--- a/js/Core/Axis/Axis.js
+++ b/js/Core/Axis/Axis.js
@@ -2098,7 +2098,7 @@ var Axis = /** @class */ (function () {
         var labelOptions = this.options.labels, horiz = this.horiz, tickInterval = this.tickInterval, newTickInterval = tickInterval, slotSize = this.len / (((this.categories ? 1 : 0) +
             this.max -
             this.min) /
-            tickInterval), rotation, rotationOption = labelOptions.rotation, labelMetrics = this.labelMetrics(), step, bestScore = Number.MAX_VALUE, autoRotation, range = this.max - this.min, 
+            tickInterval), rotation, rotationOption = labelOptions.rotation, labelMetrics = this.labelMetrics(), step, bestScore = Number.MAX_VALUE, autoRotation, range = Math.abs(this.max - this.min), 
         // Return the multiple of tickInterval that is needed to avoid
         // collision
         getStep = function (spaceNeeded) {

--- a/samples/unit-tests/axis/extremes/demo.js
+++ b/samples/unit-tests/axis/extremes/demo.js
@@ -677,3 +677,33 @@ QUnit.test('Column zooming and Y axis extremes (#9944)', assert => {
         'The Y axis should adapt to the visible data (#9044)'
     );
 });
+
+QUnit.test('When data grouping disabled and the axis extremes set out of the data range, the chart shouldn\'t crash, #13934.', function (assert) {
+    const chart = Highcharts.stockChart('container', {
+        plotOptions: {
+            series: {
+                dataGrouping: {
+                    enabled: false
+                }
+            }
+        },
+        xAxis: {
+            minRange: 1,
+            min: 1533235200000,
+            max: 1533235200000
+        },
+        series: [{
+            data: [
+                [1563235200000, 0],
+                [1563321600000, 1],
+                [1563408000000, 2],
+                [1563494400000, 3],
+                [1563753600000, 4]
+            ]
+        }]
+    });
+    assert.ok(
+        chart,
+        'The chart exist '
+    );
+});

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -6452,7 +6452,7 @@ class Axis implements AxisComposition, AxisLike {
             step,
             bestScore = Number.MAX_VALUE,
             autoRotation: any,
-            range = (this.max as any) - (this.min as any),
+            range = Math.abs((this.max as any) - (this.min as any)),
             // Return the multiple of tickInterval that is needed to avoid
             // collision
             getStep = function (spaceNeeded: number): number {

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -6452,7 +6452,7 @@ class Axis implements AxisComposition, AxisLike {
             step,
             bestScore = Number.MAX_VALUE,
             autoRotation: any,
-            range = Math.abs((this.max as any) - (this.min as any)),
+            range = Math.max((this.max as any) - (this.min as any), 0),
             // Return the multiple of tickInterval that is needed to avoid
             // collision
             getStep = function (spaceNeeded: number): number {


### PR DESCRIPTION
Fixed #13934, chart crashed when `dataGrouping` was disabled and axis extremes were set outside the data range.