### PR TITLE
bugfix/14023-numberFormat-returns-wrong-value

### DIFF
--- a/js/Core/Utilities.js
+++ b/js/Core/Utilities.js
@@ -1281,7 +1281,7 @@ var timeUnits = H.timeUnits = {
 var numberFormat = H.numberFormat = function numberFormat(number, decimals, decimalPoint, thousandsSep) {
     number = +number || 0;
     decimals = +decimals;
-    var lang = H.defaultOptions.lang, origDec = (number.toString().split('.')[1] || '').split('e')[0].length, strinteger, thousands, ret, roundedNumber, exponent = number.toString().split('e'), fractionDigits;
+    var lang = H.defaultOptions.lang, origDec = (number.toString().split('.')[1] || '').split('e')[0].length, strinteger, thousands, ret, roundedNumber, exponent = number.toString().split('e'), fractionDigits, firstDecimals = decimals;
     if (decimals === -1) {
         // Preserve decimals. Not huge numbers (#3793).
         decimals = Math.min(origDec, 20);
@@ -1329,10 +1329,15 @@ var numberFormat = H.numberFormat = function numberFormat(number, decimals, deci
     // Add the leftover after grouping into thousands. For example, in the
     // number 42 000 000, this line adds 42.
     ret += thousands ? strinteger.substr(0, thousands) + thousandsSep : '';
-    // Add the remaining thousands groups, joined by the thousands separator
-    ret += strinteger
-        .substr(thousands)
-        .replace(/(\d{3})(?=\d)/g, '$1' + thousandsSep);
+    if (+exponent[1] < 0 && !firstDecimals) {
+        ret = '0';
+    }
+    else {
+        // Add the remaining thousands groups, joined by the thousands separator
+        ret += strinteger
+            .substr(thousands)
+            .replace(/(\d{3})(?=\d)/g, '$1' + thousandsSep);
+    }
     // Add the decimal point and the decimal component
     if (decimals) {
         // Get the decimal component

--- a/samples/unit-tests/utilities/utilities/demo.js
+++ b/samples/unit-tests/utilities/utilities/demo.js
@@ -284,6 +284,11 @@
                 numberFormat(6.26e-7, i)
             );
         }
+        assert.strictEqual(
+            '0',
+            Highcharts.numberFormat(4.9E-07, 0),
+            'For small numbers and when decimals argument declared as zero, the formatter should return zero, #14023.'
+        );
     });
 
 

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -1830,7 +1830,8 @@ const numberFormat = H.numberFormat = function numberFormat(
         ret,
         roundedNumber,
         exponent = number.toString().split('e'),
-        fractionDigits;
+        fractionDigits,
+        firstDecimals = decimals;
 
     if (decimals === -1) {
         // Preserve decimals. Not huge numbers (#3793).
@@ -1885,10 +1886,14 @@ const numberFormat = H.numberFormat = function numberFormat(
     // number 42 000 000, this line adds 42.
     ret += thousands ? strinteger.substr(0, thousands) + thousandsSep : '';
 
-    // Add the remaining thousands groups, joined by the thousands separator
-    ret += strinteger
-        .substr(thousands)
-        .replace(/(\d{3})(?=\d)/g, '$1' + thousandsSep);
+    if (+exponent[1] < 0 && !firstDecimals) {
+        ret = '0';
+    } else {
+        // Add the remaining thousands groups, joined by the thousands separator
+        ret += strinteger
+            .substr(thousands)
+            .replace(/(\d{3})(?=\d)/g, '$1' + thousandsSep);
+    }
 
     // Add the decimal point and the decimal component
     if (decimals) {


### PR DESCRIPTION
Fixed #14023, for small numbers and decimals argument set to zero, the `numberFormater` returned wrong values.