### PR TITLE
samples/stock-tools-gui-css

### DIFF
--- a/samples/stock/demo/stock-tools-gui/demo.css
+++ b/samples/stock/demo/stock-tools-gui/demo.css
@@ -1,9 +1,4 @@
 #container {
 	max-height: 800px;
-	height: 75vh;
-}
-
-/* Conflict with Bootstrap, not needed after v7.0.1 */
-.highcharts-bindings-wrapper * {
-	box-sizing: content-box;
+	min-height: 75vh;
 }


### PR DESCRIPTION
Slight modification to css of the `stock-tools-gui` demo, that will mainly result in a nicer thumbnail on the website. Also removed a style that was noted to be outdated.