### PR TITLE
Fixed regressions related to chart.update and axis redraw

### DIFF
--- a/js/Core/Axis/Axis.js
+++ b/js/Core/Axis/Axis.js
@@ -733,7 +733,7 @@ var Axis = /** @class */ (function () {
      */
     Axis.prototype.translate = function (val, backwards, cvsCoord, old, handleLog, pointPlacement) {
         var axis = this.linkedParent || this, // #1417
-        sign = 1, cvsOffset = 0, localA = old ? axis.oldTransA : axis.transA, localMin = old ? axis.oldMin : axis.min, returnValue = 0, minPixelPadding = axis.minPixelPadding, doPostTranslate = (axis.isOrdinal ||
+        sign = 1, cvsOffset = 0, localA = old && axis.old ? axis.old.transA : axis.transA, localMin = old && axis.old ? axis.old.min : axis.min, returnValue = 0, minPixelPadding = axis.minPixelPadding, doPostTranslate = (axis.isOrdinal ||
             axis.brokenAxis && axis.brokenAxis.hasBreaks ||
             (axis.logarithmic && handleLog)) && axis.lin2val;
         if (!localA) {
@@ -1435,7 +1435,8 @@ var Axis = /** @class */ (function () {
         // axes.
         if (isXAxis && !secondPass) {
             axis.series.forEach(function (series) {
-                series.processData(axis.min !== axis.oldMin || axis.max !== axis.oldMax);
+                var _a, _b;
+                series.processData(axis.min !== ((_a = axis.old) === null || _a === void 0 ? void 0 : _a.min) || axis.max !== ((_b = axis.old) === null || _b === void 0 ? void 0 : _b.max));
             });
         }
         // set the translation factor used in translate function
@@ -1765,6 +1766,7 @@ var Axis = /** @class */ (function () {
      * @fires Highcharts.Axis#event:afterSetScale
      */
     Axis.prototype.setScale = function () {
+        var _a, _b, _c, _d, _e;
         var axis = this, isDirtyAxisLength, isDirtyData = false, isXAxisDirty = false;
         axis.series.forEach(function (series) {
             var _a;
@@ -1773,20 +1775,17 @@ var Axis = /** @class */ (function () {
             // well:
             isXAxisDirty = isXAxisDirty || ((_a = series.xAxis) === null || _a === void 0 ? void 0 : _a.isDirty) || false;
         });
-        axis.oldMin = axis.min;
-        axis.oldMax = axis.max;
-        axis.oldAxisLength = axis.len;
         // set the new axisLength
         axis.setAxisSize();
-        isDirtyAxisLength = axis.len !== axis.oldAxisLength;
+        isDirtyAxisLength = axis.len !== ((_a = axis.old) === null || _a === void 0 ? void 0 : _a.len);
         // do we really need to go through all this?
         if (isDirtyAxisLength ||
             isDirtyData ||
             isXAxisDirty ||
             axis.isLinked ||
             axis.forceRedraw ||
-            axis.userMin !== axis.oldUserMin ||
-            axis.userMax !== axis.oldUserMax ||
+            axis.userMin !== ((_b = axis.old) === null || _b === void 0 ? void 0 : _b.userMin) ||
+            axis.userMax !== ((_c = axis.old) === null || _c === void 0 ? void 0 : _c.userMax) ||
             axis.alignToOthers()) {
             if (axis.stacking) {
                 axis.stacking.resetStacks();
@@ -1796,17 +1795,13 @@ var Axis = /** @class */ (function () {
             axis.getSeriesExtremes();
             // get fixed positions based on tickInterval
             axis.setTickInterval();
-            // record old values to decide whether a rescale is necessary later
-            // on (#540)
-            axis.oldUserMin = axis.userMin;
-            axis.oldUserMax = axis.userMax;
             // Mark as dirty if it is not already set to dirty and extremes have
             // changed. #595.
             if (!axis.isDirty) {
                 axis.isDirty =
                     isDirtyAxisLength ||
-                        axis.min !== axis.oldMin ||
-                        axis.max !== axis.oldMax;
+                        axis.min !== ((_d = axis.old) === null || _d === void 0 ? void 0 : _d.min) ||
+                        axis.max !== ((_e = axis.old) === null || _e === void 0 ? void 0 : _e.max);
             }
         }
         else if (axis.stacking) {
@@ -2639,7 +2634,7 @@ var Axis = /** @class */ (function () {
      */
     Axis.prototype.renderMinorTick = function (pos) {
         var axis = this;
-        var slideInTicks = axis.chart.hasRendered && isNumber(axis.oldTransA);
+        var slideInTicks = axis.chart.hasRendered && axis.old;
         var minorTicks = axis.minorTicks;
         if (!minorTicks[pos]) {
             minorTicks[pos] = new Tick(axis, pos, 'minor');
@@ -2667,7 +2662,7 @@ var Axis = /** @class */ (function () {
         var axis = this;
         var isLinked = axis.isLinked;
         var ticks = axis.ticks;
-        var slideInTicks = axis.chart.hasRendered && isNumber(axis.oldTransA);
+        var slideInTicks = axis.chart.hasRendered && axis.old;
         // Linked axes need an extra check to find out if
         if (!isLinked ||
             (pos >= axis.min && pos <= axis.max) || ((_a = axis.grid) === null || _a === void 0 ? void 0 : _a.isColumn)) {
@@ -2821,7 +2816,15 @@ var Axis = /** @class */ (function () {
             axis.stacking.renderStackTotals();
         }
         // End stacked totals
-        axis.oldTransA = axis.transA;
+        // Record old scaling for updating/animation
+        axis.old = {
+            len: axis.len,
+            max: axis.max,
+            min: axis.min,
+            transA: axis.transA,
+            userMax: axis.userMax,
+            userMin: axis.userMin
+        };
         axis.isDirty = false;
         fireEvent(this, 'afterRender');
     };

--- a/js/Core/Axis/Axis.js
+++ b/js/Core/Axis/Axis.js
@@ -1187,12 +1187,9 @@ var Axis = /** @class */ (function () {
      * @private
      * @function Highcharts.Axis#setAxisTranslation
      *
-     * @param {boolean} [saveOld]
-     * TO-DO: parameter description
-     *
      * @fires Highcharts.Axis#event:afterSetAxisTranslation
      */
-    Axis.prototype.setAxisTranslation = function (saveOld) {
+    Axis.prototype.setAxisTranslation = function () {
         var axis = this, range = axis.max - axis.min, pointRange = axis.axisPointRange || 0, closestPointRange, minPointOffset = 0, pointRangePadding = 0, linkedParent = axis.linkedParent, ordinalCorrection, hasCategories = !!axis.categories, transA = axis.transA, isXAxis = axis.isXAxis;
         // Adjust translation for padding. Y axis with categories need to go
         // through the same (#1784).
@@ -1252,9 +1249,6 @@ var Axis = /** @class */ (function () {
             }
         }
         // Secondary values
-        if (saveOld) {
-            axis.oldTransA = transA;
-        }
         axis.translationSlope = axis.transA = transA =
             axis.staticScale ||
                 axis.len / ((range + pointRangePadding) || 1);
@@ -1445,7 +1439,7 @@ var Axis = /** @class */ (function () {
             });
         }
         // set the translation factor used in translate function
-        axis.setAxisTranslation(true);
+        axis.setAxisTranslation();
         // hook for ordinal axes and radial axes
         fireEvent(this, 'initialAxisTranslation');
         // In column-like charts, don't cramp in more ticks than there are
@@ -2645,7 +2639,7 @@ var Axis = /** @class */ (function () {
      */
     Axis.prototype.renderMinorTick = function (pos) {
         var axis = this;
-        var slideInTicks = axis.chart.hasRendered && isNumber(axis.oldMin);
+        var slideInTicks = axis.chart.hasRendered && isNumber(axis.oldTransA);
         var minorTicks = axis.minorTicks;
         if (!minorTicks[pos]) {
             minorTicks[pos] = new Tick(axis, pos, 'minor');
@@ -2673,7 +2667,7 @@ var Axis = /** @class */ (function () {
         var axis = this;
         var isLinked = axis.isLinked;
         var ticks = axis.ticks;
-        var slideInTicks = axis.chart.hasRendered && isNumber(axis.oldMin);
+        var slideInTicks = axis.chart.hasRendered && isNumber(axis.oldTransA);
         // Linked axes need an extra check to find out if
         if (!isLinked ||
             (pos >= axis.min && pos <= axis.max) || ((_a = axis.grid) === null || _a === void 0 ? void 0 : _a.isColumn)) {
@@ -2827,6 +2821,7 @@ var Axis = /** @class */ (function () {
             axis.stacking.renderStackTotals();
         }
         // End stacked totals
+        axis.oldTransA = axis.transA;
         axis.isDirty = false;
         fireEvent(this, 'afterRender');
     };

--- a/js/Core/Axis/BrokenAxis.js
+++ b/js/Core/Axis/BrokenAxis.js
@@ -203,8 +203,8 @@ var BrokenAxisAdditions = /** @class */ (function () {
                 }
                 Axis.prototype.setExtremes.call(this, newMin, newMax, redraw, animation, eventArguments);
             };
-            axis.setAxisTranslation = function (saveOld) {
-                Axis.prototype.setAxisTranslation.call(this, saveOld);
+            axis.setAxisTranslation = function () {
+                Axis.prototype.setAxisTranslation.call(this);
                 brokenAxis.unitLength = null;
                 if (brokenAxis.hasBreaks) {
                     var breaks = axis.options.breaks || [], 

--- a/js/Core/Axis/TreeGridAxis.js
+++ b/js/Core/Axis/TreeGridAxis.js
@@ -529,7 +529,7 @@ var TreeGridAxis;
             fireEvent(axis, 'foundExtremes');
             // setAxisTranslation modifies the min and max according to
             // axis breaks.
-            axis.setAxisTranslation(true);
+            axis.setAxisTranslation();
             axis.tickmarkOffset = 0.5;
             axis.tickInterval = 1;
             axis.tickPositions = axis.treeGrid.mapOfPosToGridNode ?

--- a/js/Core/Chart/Chart.js
+++ b/js/Core/Chart/Chart.js
@@ -563,13 +563,8 @@ var Chart = /** @class */ (function () {
         if (hasCartesianSeries) {
             // set axes scales
             axes.forEach(function (axis) {
-                // Don't do setScale again if we're only resizing. Regression
-                // #13507. But we need it after chart.update (responsive), as
-                // axis is initialized again (#12137).
-                if (!chart.isResizing || !isNumber(axis.min)) {
-                    axis.updateNames();
-                    axis.setScale();
-                }
+                axis.updateNames();
+                axis.setScale();
             });
         }
         chart.getMargins(); // #3098

--- a/samples/unit-tests/chart/chart-update-axis/demo.js
+++ b/samples/unit-tests/chart/chart-update-axis/demo.js
@@ -171,3 +171,63 @@ QUnit.test('Updating unidentified axes by index (#6019)', function (assert) {
         'Updated titles'
     );
 });
+
+QUnit.test('Stacking consistent after update', assert => {
+    const options = {
+        chart: {
+            width: 250,
+            type: "column"
+        },
+        yAxis: {
+            title: {
+                text: 'test 1'
+            }
+        },
+        plotOptions: {
+            series: {
+                stacking: "normal",
+                animation: false
+            }
+        },
+        series: [{
+            data: [500]
+        }, {
+            data: [300]
+        }],
+        legend: {
+            enabled: false
+        }
+    };
+
+    const chart = Highcharts.chart('container', options);
+
+    const getPositions = () => [
+        chart.series[0].points[0].graphic.getBBox().y,
+        chart.series[0].points[0].graphic.getBBox().height,
+        chart.series[1].points[0].graphic.getBBox().y,
+        chart.series[1].points[0].graphic.getBBox().height
+    ];
+    const originalPositions = getPositions();
+    chart.update({
+        chart: {
+            width: 200
+        },
+        yAxis: {
+            title: {
+                text: 'test 2'
+            }
+        },
+        series: [{
+            data: [500]
+        }, {
+            data: [300]
+        }]
+    }, undefined, undefined, false);
+
+    assert.deepEqual(
+        getPositions(),
+        originalPositions,
+        'Horizontal bar positions should not change after update (#14130)'
+    );
+
+});

--- a/samples/unit-tests/chart/setsize/demo.js
+++ b/samples/unit-tests/chart/setsize/demo.js
@@ -544,3 +544,49 @@ QUnit.test('Succession of setSize and other dynamics', assert => {
         done();
     }, 2);
 });
+
+QUnit.test('Succession of setSize and adders', assert => {
+    var chart = Highcharts.chart('container', {
+
+    });
+    chart.setSize(undefined, undefined);
+
+    chart.addAxis({
+        id: 'xaxis1'
+    });
+
+
+    chart.addAxis({
+        id: 'yaxis1'
+    });
+
+    chart.addSeries({
+        type: 'column',
+        yAxis: 'yaxis1',
+        data: [1, 2, 3, 4]
+    }, false);
+
+
+    chart.addAxis({
+        id: 'yaxis2'
+    });
+
+    chart.addSeries({
+        type: 'column',
+        yAxis: 'yaxis2',
+        data: [1, 2, 3, 4]
+    }, false);
+
+    chart.redraw();
+
+    const colHeight = chart.series[0].points[0].graphic.getBBox().height;
+    assert.ok(
+        typeof colHeight === 'number' && colHeight > 0,
+        'The column height should be a positive number'
+    );
+    assert.strictEqual(
+        colHeight,
+        chart.series[1].points[0].graphic.getBBox().height,
+        'The two first columns should be equal height (#13995)'
+    );
+});

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -375,12 +375,14 @@ declare global {
             public minRange?: (null|number);
             public names: Array<string>;
             public offset: number;
-            public oldAxisLength?: number;
-            public oldMax: (null|number);
-            public oldMin: (null|number);
-            public oldTransA?: number;
-            public oldUserMax?: number;
-            public oldUserMin?: number;
+            public old?: {
+                len: number;
+                max: number|null;
+                min: number|null;
+                transA: number;
+                userMax?: number;
+                userMin?: number;
+            }
             public opposite?: boolean;
             public options: AxisOptions;
             public overlap: boolean;
@@ -4531,8 +4533,8 @@ class Axis implements AxisComposition, AxisLike {
         var axis: Highcharts.Axis = this.linkedParent || this as any, // #1417
             sign = 1,
             cvsOffset = 0,
-            localA = old ? axis.oldTransA : axis.transA,
-            localMin = old ? axis.oldMin : axis.min,
+            localA = old && axis.old ? axis.old.transA : axis.transA,
+            localMin = old && axis.old ? axis.old.min : axis.min,
             returnValue = 0,
             minPixelPadding = axis.minPixelPadding,
             doPostTranslate = (
@@ -5525,7 +5527,7 @@ class Axis implements AxisComposition, AxisLike {
         if (isXAxis && !secondPass) {
             axis.series.forEach(function (series: Highcharts.Series): void {
                 series.processData(
-                    axis.min !== axis.oldMin || axis.max !== axis.oldMax
+                    axis.min !== axis.old?.min || axis.max !== axis.old?.max
                 );
             });
         }
@@ -6003,13 +6005,9 @@ class Axis implements AxisComposition, AxisLike {
             isXAxisDirty = isXAxisDirty || series.xAxis?.isDirty || false;
         });
 
-        axis.oldMin = axis.min;
-        axis.oldMax = axis.max;
-        axis.oldAxisLength = axis.len;
-
         // set the new axisLength
         axis.setAxisSize();
-        isDirtyAxisLength = axis.len !== axis.oldAxisLength;
+        isDirtyAxisLength = axis.len !== axis.old?.len;
 
         // do we really need to go through all this?
         if (
@@ -6018,8 +6016,8 @@ class Axis implements AxisComposition, AxisLike {
             isXAxisDirty ||
             axis.isLinked ||
             axis.forceRedraw ||
-            axis.userMin !== axis.oldUserMin ||
-            axis.userMax !== axis.oldUserMax ||
+            axis.userMin !== axis.old?.userMin ||
+            axis.userMax !== axis.old?.userMax ||
             axis.alignToOthers()
         ) {
 
@@ -6035,18 +6033,13 @@ class Axis implements AxisComposition, AxisLike {
             // get fixed positions based on tickInterval
             axis.setTickInterval();
 
-            // record old values to decide whether a rescale is necessary later
-            // on (#540)
-            axis.oldUserMin = axis.userMin;
-            axis.oldUserMax = axis.userMax;
-
             // Mark as dirty if it is not already set to dirty and extremes have
             // changed. #595.
             if (!axis.isDirty) {
                 axis.isDirty =
                     isDirtyAxisLength ||
-                    axis.min !== axis.oldMin ||
-                    axis.max !== axis.oldMax;
+                    axis.min !== axis.old?.min ||
+                    axis.max !== axis.old?.max;
             }
         } else if (axis.stacking) {
             axis.stacking.cleanStacks();
@@ -7231,7 +7224,7 @@ class Axis implements AxisComposition, AxisLike {
      */
     public renderMinorTick(pos: number): void {
         const axis: Highcharts.Axis = this as any;
-        const slideInTicks = axis.chart.hasRendered && isNumber(axis.oldTransA);
+        const slideInTicks = axis.chart.hasRendered && axis.old;
         const minorTicks = axis.minorTicks;
 
         if (!minorTicks[pos]) {
@@ -7262,7 +7255,7 @@ class Axis implements AxisComposition, AxisLike {
         const axis: Highcharts.Axis = this as any;
         const isLinked = axis.isLinked;
         const ticks = axis.ticks;
-        const slideInTicks = axis.chart.hasRendered && isNumber(axis.oldTransA);
+        const slideInTicks = axis.chart.hasRendered && axis.old;
 
         // Linked axes need an extra check to find out if
         if (!isLinked ||
@@ -7486,7 +7479,15 @@ class Axis implements AxisComposition, AxisLike {
         }
         // End stacked totals
 
-        axis.oldTransA = axis.transA;
+        // Record old scaling for updating/animation
+        axis.old = {
+            len: axis.len,
+            max: axis.max,
+            min: axis.min,
+            transA: axis.transA,
+            userMax: axis.userMax,
+            userMin: axis.userMin
+        };
         axis.isDirty = false;
 
         fireEvent(this, 'afterRender');

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -465,7 +465,7 @@ declare global {
             public renderTick(pos: number, i: number): void;
             public renderUnsquish(): void;
             public setAxisSize(): void;
-            public setAxisTranslation(saveOld?: boolean): void;
+            public setAxisTranslation(): void;
             public setExtremes(
                 newMin?: number,
                 newMax?: number,
@@ -5172,12 +5172,9 @@ class Axis implements AxisComposition, AxisLike {
      * @private
      * @function Highcharts.Axis#setAxisTranslation
      *
-     * @param {boolean} [saveOld]
-     * TO-DO: parameter description
-     *
      * @fires Highcharts.Axis#event:afterSetAxisTranslation
      */
-    public setAxisTranslation(saveOld?: boolean): void {
+    public setAxisTranslation(): void {
         var axis = this,
             range = (axis.max as any) - (axis.min as any),
             pointRange = axis.axisPointRange || 0,
@@ -5272,9 +5269,6 @@ class Axis implements AxisComposition, AxisLike {
         }
 
         // Secondary values
-        if (saveOld) {
-            axis.oldTransA = transA;
-        }
         axis.translationSlope = axis.transA = transA =
             axis.staticScale ||
             axis.len / ((range + pointRangePadding) || 1);
@@ -5537,7 +5531,7 @@ class Axis implements AxisComposition, AxisLike {
         }
 
         // set the translation factor used in translate function
-        axis.setAxisTranslation(true);
+        axis.setAxisTranslation();
 
         // hook for ordinal axes and radial axes
         fireEvent(this, 'initialAxisTranslation');
@@ -7237,7 +7231,7 @@ class Axis implements AxisComposition, AxisLike {
      */
     public renderMinorTick(pos: number): void {
         const axis: Highcharts.Axis = this as any;
-        const slideInTicks = axis.chart.hasRendered && isNumber(axis.oldMin);
+        const slideInTicks = axis.chart.hasRendered && isNumber(axis.oldTransA);
         const minorTicks = axis.minorTicks;
 
         if (!minorTicks[pos]) {
@@ -7268,7 +7262,7 @@ class Axis implements AxisComposition, AxisLike {
         const axis: Highcharts.Axis = this as any;
         const isLinked = axis.isLinked;
         const ticks = axis.ticks;
-        const slideInTicks = axis.chart.hasRendered && isNumber(axis.oldMin);
+        const slideInTicks = axis.chart.hasRendered && isNumber(axis.oldTransA);
 
         // Linked axes need an extra check to find out if
         if (!isLinked ||
@@ -7492,6 +7486,7 @@ class Axis implements AxisComposition, AxisLike {
         }
         // End stacked totals
 
+        axis.oldTransA = axis.transA;
         axis.isDirty = false;
 
         fireEvent(this, 'afterRender');

--- a/ts/Core/Axis/BrokenAxis.ts
+++ b/ts/Core/Axis/BrokenAxis.ts
@@ -334,8 +334,8 @@ class BrokenAxisAdditions {
                 );
             };
 
-            axis.setAxisTranslation = function (saveOld?: boolean): void {
-                Axis.prototype.setAxisTranslation.call(this, saveOld);
+            axis.setAxisTranslation = function (): void {
+                Axis.prototype.setAxisTranslation.call(this);
 
                 brokenAxis.unitLength = null as any;
                 if (brokenAxis.hasBreaks) {

--- a/ts/Core/Axis/TreeGridAxis.ts
+++ b/ts/Core/Axis/TreeGridAxis.ts
@@ -807,7 +807,7 @@ namespace TreeGridAxis {
 
             // setAxisTranslation modifies the min and max according to
             // axis breaks.
-            axis.setAxisTranslation(true);
+            axis.setAxisTranslation();
 
             axis.tickmarkOffset = 0.5;
             axis.tickInterval = 1;

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -833,13 +833,8 @@ class Chart {
         if (hasCartesianSeries) {
             // set axes scales
             axes.forEach(function (axis: Highcharts.Axis): void {
-                // Don't do setScale again if we're only resizing. Regression
-                // #13507. But we need it after chart.update (responsive), as
-                // axis is initialized again (#12137).
-                if (!chart.isResizing || !isNumber(axis.min)) {
-                    axis.updateNames();
-                    axis.setScale();
-                }
+                axis.updateNames();
+                axis.setScale();
             });
         }
 


### PR DESCRIPTION
Fixed regressions with `chart.update` and `chart.setSize`, causing side effects like stacks not updating and series not
showing after adding dynamically. See #13995 and #14130.