### PR TITLE
bugfix/14440-adjustForMissingColumns

### DIFF
--- a/js/Series/ColumnRangeSeries.js
+++ b/js/Series/ColumnRangeSeries.js
@@ -147,6 +147,9 @@ BaseSeries.seriesType('columnrange', 'arearange', merge(defaultOptions.plotOptio
     pointAttribs: function () {
         return columnProto.pointAttribs.apply(this, arguments);
     },
+    adjustForMissingColumns: function () {
+        return columnProto.adjustForMissingColumns.apply(this, arguments);
+    },
     animate: function () {
         return columnProto.animate.apply(this, arguments);
     },

--- a/samples/unit-tests/series-columnrange/columnrange/demo.details
+++ b/samples/unit-tests/series-columnrange/columnrange/demo.details
@@ -1,0 +1,5 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+...

--- a/samples/unit-tests/series-columnrange/columnrange/demo.html
+++ b/samples/unit-tests/series-columnrange/columnrange/demo.html
@@ -1,0 +1,8 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+
+<div id="container" style="width: 600px; margin: 0 auto;"></div>

--- a/samples/unit-tests/series-columnrange/columnrange/demo.js
+++ b/samples/unit-tests/series-columnrange/columnrange/demo.js
@@ -1,0 +1,18 @@
+QUnit.test('#14440: Missing adjustForMissingColumns', assert => {
+    Highcharts.chart('container', {
+        chart: {
+            type: 'column'
+        },
+        plotOptions: {
+            columnrange: {
+                centerInCategory: true
+            }
+        },
+        series: [{
+            type: 'columnrange',
+            data: [{ high: 2, low: 1, x: 0 }]
+        }]
+    });
+
+    assert.ok(true, 'Enabling centerInCategory should not throw');
+});

--- a/ts/Series/ColumnRangeSeries.ts
+++ b/ts/Series/ColumnRangeSeries.ts
@@ -38,6 +38,7 @@ declare global {
             public shapeType: ColumnPoint['shapeType'];
         }
         class ColumnRangeSeries extends AreaRangeSeries {
+            public adjustForMissingColumns: ColumnSeries['adjustForMissingColumns'];
             public animate: ColumnSeries['animate'];
             public crispCol: ColumnSeries['crispCol'];
             public data: Array<ColumnRangePoint>;
@@ -254,6 +255,9 @@ BaseSeries.seriesType<typeof Highcharts.ColumnRangeSeries>('columnrange', 'arear
         this: Highcharts.ColumnRangeSeries
     ): SVGAttributes {
         return columnProto.pointAttribs.apply(this, arguments as any);
+    },
+    adjustForMissingColumns: function (this: Highcharts.ColumnRangeSeries): number {
+        return columnProto.adjustForMissingColumns.apply(this, arguments);
     },
     animate: function (this: Highcharts.ColumnRangeSeries): void {
         return columnProto.animate.apply(this, arguments as any);


### PR DESCRIPTION
Fixed #14440, `ColumnRangeSeries` missed `adjustForMissingColumns`.