### PR TITLE
bugfix/14138-misplaced-tooltip-column

### DIFF
--- a/js/Series/ColumnSeries.js
+++ b/js/Series/ColumnSeries.js
@@ -687,8 +687,12 @@ var ColumnSeries = BaseSeries.seriesType('column', 'line',
                     xAxis.len + xAxis.pos - chart.plotTop - (plotX || 0) - seriesXOffset - barW / 2,
                     barH
                 ] :
-                [barX + barW / 2, clamp(plotY + yAxis.pos -
-                        chart.plotTop, yAxis.pos - chart.plotTop, yAxis.len + yAxis.pos - chart.plotTop), barH];
+                [
+                    barX + barW / 2,
+                    clamp(plotY + yAxis.pos -
+                        chart.plotTop, yAxis.pos - chart.plotTop, yAxis.len + yAxis.pos - chart.plotTop),
+                    barH
+                ];
             // Register shape type and arguments to be used in drawPoints
             // Allow shapeType defined on pointClass level
             point.shapeType =

--- a/js/Series/ColumnSeries.js
+++ b/js/Series/ColumnSeries.js
@@ -683,12 +683,12 @@ var ColumnSeries = BaseSeries.seriesType('column', 'line',
             // #3648)
             point.tooltipPos = chart.inverted ?
                 [
-                    yAxis.len + yAxis.pos - chart.plotLeft - plotY,
+                    clamp(yAxis.len + yAxis.pos - chart.plotLeft - plotY, yAxis.pos - chart.plotLeft, yAxis.len + yAxis.pos - chart.plotLeft),
                     xAxis.len + xAxis.pos - chart.plotTop - (plotX || 0) - seriesXOffset - barW / 2,
                     barH
                 ] :
-                [barX + barW / 2, plotY + yAxis.pos -
-                        chart.plotTop, barH];
+                [barX + barW / 2, clamp(plotY + yAxis.pos -
+                        chart.plotTop, yAxis.pos - chart.plotTop, yAxis.len + yAxis.pos - chart.plotTop), barH];
             // Register shape type and arguments to be used in drawPoints
             // Allow shapeType defined on pointClass level
             point.shapeType =

--- a/samples/unit-tests/series-column/tooltip/demo.js
+++ b/samples/unit-tests/series-column/tooltip/demo.js
@@ -53,3 +53,47 @@ QUnit.test("Shared tooltip should compare point.distX, not point.dist to find ab
         "Proper hovered point."
     );
 });
+
+
+QUnit.test("Tooltip should stay inside plotArea even when columns are outside axis extremes.", function (assert) {
+    var chart = new Highcharts.chart('container', {
+        chart: {
+            type: 'column',
+            marginTop: 150
+        },
+        plotOptions: {
+            series: {
+                stacking: true
+            }
+        },
+        tooltip: {
+            outside: true
+        },
+        series: [{
+            data: [100]
+        }, {
+            data: [-100]
+        }],
+        yAxis: [{
+            min: -20,
+            max: 20,
+            startOnTick: false,
+            endOnTick: false
+        }]
+    });
+
+    var point = chart.series[0].data[0],
+        controller = new TestController(chart);
+
+    controller.mouseOver(
+        chart.plotLeft + point.plotX + 4,
+        chart.plotTop
+    );
+
+    assert.strictEqual(
+        point.tooltipPos[1] >= 0,
+        true,
+        "Tooltip inside plotArea."
+    );
+
+});

--- a/samples/unit-tests/series-column/tooltip/demo.js
+++ b/samples/unit-tests/series-column/tooltip/demo.js
@@ -93,7 +93,7 @@ QUnit.test("Tooltip should stay inside plotArea even when columns are outside ax
     assert.strictEqual(
         point.tooltipPos[1] >= 0,
         true,
-        "Tooltip inside plotArea."
+        "Tooltip should be inside plotArea (#14138)."
     );
 
 });

--- a/ts/Series/ColumnSeries.ts
+++ b/ts/Series/ColumnSeries.ts
@@ -966,12 +966,20 @@ const ColumnSeries = BaseSeries.seriesType<typeof Highcharts.ColumnSeries>(
                 // #3648)
                 point.tooltipPos = chart.inverted ?
                     [
-                        yAxis.len + yAxis.pos - chart.plotLeft - plotY,
+                        clamp(
+                            yAxis.len + yAxis.pos - chart.plotLeft - plotY,
+                            yAxis.pos - chart.plotLeft,
+                            yAxis.len + yAxis.pos - chart.plotLeft
+                        ),
                         xAxis.len + xAxis.pos - chart.plotTop - (plotX || 0) - seriesXOffset - barW / 2,
                         barH
                     ] :
-                    [barX + barW / 2, plotY + (yAxis.pos as any) -
-                    chart.plotTop, barH];
+                    [barX + barW / 2, clamp(
+                        plotY + (yAxis.pos as any) -
+                        chart.plotTop,
+                        yAxis.pos - chart.plotTop,
+                        yAxis.len + yAxis.pos - chart.plotTop
+                    ), barH];
 
                 // Register shape type and arguments to be used in drawPoints
                 // Allow shapeType defined on pointClass level

--- a/ts/Series/ColumnSeries.ts
+++ b/ts/Series/ColumnSeries.ts
@@ -974,12 +974,16 @@ const ColumnSeries = BaseSeries.seriesType<typeof Highcharts.ColumnSeries>(
                         xAxis.len + xAxis.pos - chart.plotTop - (plotX || 0) - seriesXOffset - barW / 2,
                         barH
                     ] :
-                    [barX + barW / 2, clamp(
-                        plotY + (yAxis.pos as any) -
-                        chart.plotTop,
-                        yAxis.pos - chart.plotTop,
-                        yAxis.len + yAxis.pos - chart.plotTop
-                    ), barH];
+                    [
+                        barX + barW / 2,
+                        clamp(
+                            plotY + (yAxis.pos as any) -
+                            chart.plotTop,
+                            yAxis.pos - chart.plotTop,
+                            yAxis.len + yAxis.pos - chart.plotTop
+                        ),
+                        barH
+                    ];
 
                 // Register shape type and arguments to be used in drawPoints
                 // Allow shapeType defined on pointClass level


### PR DESCRIPTION
Fixed #14138, tooltip was displayed outside plotArea for columns when they were exceeding yAxis extremes.