### PR TITLE
bugfix/14372-patternfill-opacity 

### DIFF
--- a/js/Series/VennSeries.js
+++ b/js/Series/VennSeries.js
@@ -868,9 +868,10 @@ var vennSeries = {
         // Return resulting values for the attributes.
         return {
             'fill': color(options.color)
-                .setOpacity(options.opacity)
                 .brighten(options.brightness)
                 .get(),
+            // Set opacity directly to the SVG element, not to pattern #14372.
+            opacity: options.opacity,
             'stroke': options.borderColor,
             'stroke-width': options.borderWidth,
             'dashstyle': options.borderDashStyle

--- a/samples/unit-tests/series-venn/integration/demo.js
+++ b/samples/unit-tests/series-venn/integration/demo.js
@@ -98,3 +98,53 @@ QUnit.module('Options', () => {
         });
     });
 });
+
+QUnit.test('The inactive state should be set to the patterns the same as for colors, #14372.', function (assert) {
+    const chart =  Highcharts.chart('container', {
+        series: [{
+            type: 'venn',
+            data: [{
+                sets: ['A'],
+                value: 2
+            }, {
+                sets: ['B'],
+                value: 2
+            }, {
+                sets: ['A', 'B'],
+                value: 1,
+                name: 'A&B',
+                color: {
+                    pattern: {
+                        path: {
+                            d: 'M 0 0 L 10 10 M 9 -1 L 11 1 M -1 9 L 1 11',
+                            strokeWidth: 3
+                        },
+                        width: 10,
+                        height: 10
+                    }
+                }
+            }]
+        }]
+    });
+
+    assert.strictEqual(
+        chart.series[0].points[2].graphic.opacity,
+        0.75,
+        'In normal state the pattern opacity should be equal to 0.75.'
+    );
+    chart.series[0].points[2].setState('inactive');
+
+    assert.strictEqual(
+        chart.series[0].points[2].graphic.opacity,
+        0.075,
+        'In inactive state the pattern opacity should be equal to 0.075.'
+    );
+    chart.series[0].points[2].setState('hover');
+
+    assert.strictEqual(
+        chart.series[0].points[2].graphic.opacity,
+        1,
+        'In hover state the pattern opacity should be equal to 1.'
+    );
+
+});

--- a/ts/Series/VennSeries.ts
+++ b/ts/Series/VennSeries.ts
@@ -1342,9 +1342,10 @@ var vennSeries = {
         // Return resulting values for the attributes.
         return {
             'fill': color(options.color)
-                .setOpacity(options.opacity as any)
                 .brighten(options.brightness as any)
                 .get(),
+            // Set opacity directly to the SVG element, not to pattern #14372.
+            opacity: options.opacity,
             'stroke': options.borderColor,
             'stroke-width': options.borderWidth,
             'dashstyle': options.borderDashStyle


### PR DESCRIPTION
Fixed #14372, unable to set opacity in the pattern.

Works with the `Venn` series, however, the animation is missing... is it acceptable or should I find another solution?
Demo: https://jsfiddle.net/BlackLabel/y6ne1a8x/