### PR TITLE
bugfix/14444-clip-path-boost-inverted

### DIFF
--- a/js/Extensions/Boost/BoostOverrides.js
+++ b/js/Extensions/Boost/BoostOverrides.js
@@ -61,10 +61,13 @@ Chart.prototype.getBoostClipRect = function (target) {
     };
     if (target === this) {
         var verticalAxes = this.inverted ? this.xAxis : this.yAxis; // #14444
-        verticalAxes.forEach(function (axis) {
-            clipBox.y = Math.min(axis.pos, clipBox.y);
-            clipBox.height = Math.min(axis.pos - this.plotTop + axis.len, clipBox.height);
-        }, this);
+        if (verticalAxes.length <= 1) {
+            clipBox.y = Math.min(verticalAxes[0].pos, clipBox.y);
+            clipBox.height = verticalAxes[0].pos - this.plotTop + verticalAxes[0].len;
+        }
+        else {
+            clipBox.height = this.plotHeight;
+        }
     }
     return clipBox;
 };

--- a/js/Extensions/Boost/BoostOverrides.js
+++ b/js/Extensions/Boost/BoostOverrides.js
@@ -60,16 +60,11 @@ Chart.prototype.getBoostClipRect = function (target) {
         height: this.plotHeight
     };
     if (target === this) {
-        if (!this.inverted) {
-            this.yAxis.forEach(function (yAxis) {
-                clipBox.y = Math.min(yAxis.pos, clipBox.y);
-                clipBox.height = Math.max(yAxis.pos - this.plotTop + yAxis.len, clipBox.height);
-            }, this);
-        }
-        else { // #14444
-            clipBox.height = this.plotHeight;
-            clipBox.y = this.plotTop;
-        }
+        var verticalAxes = this.inverted ? this.xAxis : this.yAxis; // #14444
+        verticalAxes.forEach(function (axis) {
+            clipBox.y = Math.min(axis.pos, clipBox.y);
+            clipBox.height = Math.min(axis.pos - this.plotTop + axis.len, clipBox.height);
+        }, this);
     }
     return clipBox;
 };

--- a/js/Extensions/Boost/BoostOverrides.js
+++ b/js/Extensions/Boost/BoostOverrides.js
@@ -60,10 +60,16 @@ Chart.prototype.getBoostClipRect = function (target) {
         height: this.plotHeight
     };
     if (target === this) {
-        this.yAxis.forEach(function (yAxis) {
-            clipBox.y = Math.min(yAxis.pos, clipBox.y);
-            clipBox.height = Math.max(yAxis.pos - this.plotTop + yAxis.len, clipBox.height);
-        }, this);
+        if (!this.inverted) {
+            this.yAxis.forEach(function (yAxis) {
+                clipBox.y = Math.min(yAxis.pos, clipBox.y);
+                clipBox.height = Math.max(yAxis.pos - this.plotTop + yAxis.len, clipBox.height);
+            }, this);
+        }
+        else { // #14444
+            clipBox.height = this.plotHeight;
+            clipBox.y = this.plotTop;
+        }
     }
     return clipBox;
 };

--- a/samples/unit-tests/boost/general/demo.js
+++ b/samples/unit-tests/boost/general/demo.js
@@ -237,3 +237,48 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
         });
     }
 );
+
+QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
+    'The boost clip-path should have the same size as the chart area, #14444.',
+    function (assert) {
+        function generataSeries() {
+            const series = Array.from(Array(100)).map(function () {
+                return {
+                    data: Array.from(Array(10)).map(() => Math.round(Math.random() * 10))
+                };
+            });
+            return series;
+        }
+
+        const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'line',
+                zoomType: 'xy',
+                inverted: true
+            },
+            boost: {
+                enabled: true
+            },
+            legend: {
+                enabled: false
+            },
+            plotOptions: {
+                bar: {
+                    stacking: 'normal'
+                }
+            },
+            series: generataSeries()
+        });
+
+        assert.strictEqual(
+            chart.boostClipRect.getBBox().height,
+            chart.plotHeight,
+            'Height of the plot area and clip-path should be the same.'
+        );
+        assert.strictEqual(
+            chart.boostClipRect.getBBox().width,
+            chart.plotWidth,
+            'Width of the plot area and clip-path should be the same.'
+        );
+    }
+);

--- a/samples/unit-tests/boost/general/demo.js
+++ b/samples/unit-tests/boost/general/demo.js
@@ -280,5 +280,28 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
             chart.plotWidth,
             'Width of the plot area and clip-path should be the same.'
         );
+        chart.update({
+            xAxis: [{
+                max: 10,
+                height: '50%'
+            }, {
+                height: '50%',
+                max: 10,
+                linkedTo: 0
+            }],
+            yAxis: [{
+                max: 10,
+                height: '50%'
+            }, {
+                max: 10,
+                height: '50%',
+                linkedTo: 0
+            }]
+        });
+        assert.strictEqual(
+            chart.boostClipRect.attr('height'),
+            chart.yAxis[0].height,
+            'After setting the axis position manually, the boost clip-path shouldn\'t be bigger than the axis size.'
+        );
     }
 );

--- a/samples/unit-tests/boost/general/demo.js
+++ b/samples/unit-tests/boost/general/demo.js
@@ -271,12 +271,12 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
         });
 
         assert.strictEqual(
-            chart.boostClipRect.getBBox().height,
+            chart.boostClipRect.attr('height'),
             chart.plotHeight,
             'Height of the plot area and clip-path should be the same.'
         );
         assert.strictEqual(
-            chart.boostClipRect.getBBox().width,
+            chart.boostClipRect.attr('width'),
             chart.plotWidth,
             'Width of the plot area and clip-path should be the same.'
         );

--- a/ts/Extensions/Boost/BoostOverrides.ts
+++ b/ts/Extensions/Boost/BoostOverrides.ts
@@ -138,19 +138,14 @@ Chart.prototype.getBoostClipRect = function (
     };
 
     if (target === this) {
-        if (!this.inverted) {
-            this.yAxis.forEach(function (yAxis: Highcharts.Axis): void {
-                clipBox.y = Math.min(yAxis.pos, clipBox.y);
-                clipBox.height = Math.max(
-                    yAxis.pos - this.plotTop + yAxis.len,
-                    clipBox.height
-                );
-            }, this);
-        } else { // #14444
-            clipBox.height = this.plotHeight;
-            clipBox.y = this.plotTop;
-        }
-
+        const verticalAxes = this.inverted ? this.xAxis : this.yAxis; // #14444
+        verticalAxes.forEach(function (axis): void {
+            clipBox.y = Math.min(axis.pos, clipBox.y);
+            clipBox.height = Math.min(
+                axis.pos - this.plotTop + axis.len,
+                clipBox.height
+            );
+        }, this);
     }
 
     return clipBox;

--- a/ts/Extensions/Boost/BoostOverrides.ts
+++ b/ts/Extensions/Boost/BoostOverrides.ts
@@ -138,13 +138,19 @@ Chart.prototype.getBoostClipRect = function (
     };
 
     if (target === this) {
-        this.yAxis.forEach(function (yAxis: Highcharts.Axis): void {
-            clipBox.y = Math.min(yAxis.pos, clipBox.y);
-            clipBox.height = Math.max(
-                yAxis.pos - this.plotTop + yAxis.len,
-                clipBox.height
-            );
-        }, this);
+        if (!this.inverted) {
+            this.yAxis.forEach(function (yAxis: Highcharts.Axis): void {
+                clipBox.y = Math.min(yAxis.pos, clipBox.y);
+                clipBox.height = Math.max(
+                    yAxis.pos - this.plotTop + yAxis.len,
+                    clipBox.height
+                );
+            }, this);
+        } else { // #14444
+            clipBox.height = this.plotHeight;
+            clipBox.y = this.plotTop;
+        }
+
     }
 
     return clipBox;

--- a/ts/Extensions/Boost/BoostOverrides.ts
+++ b/ts/Extensions/Boost/BoostOverrides.ts
@@ -139,13 +139,12 @@ Chart.prototype.getBoostClipRect = function (
 
     if (target === this) {
         const verticalAxes = this.inverted ? this.xAxis : this.yAxis; // #14444
-        verticalAxes.forEach(function (axis): void {
-            clipBox.y = Math.min(axis.pos, clipBox.y);
-            clipBox.height = Math.min(
-                axis.pos - this.plotTop + axis.len,
-                clipBox.height
-            );
-        }, this);
+        if (verticalAxes.length <= 1) {
+            clipBox.y = Math.min(verticalAxes[0].pos, clipBox.y);
+            clipBox.height = verticalAxes[0].pos - this.plotTop + verticalAxes[0].len;
+        } else {
+            clipBox.height = this.plotHeight;
+        }
     }
 
     return clipBox;


### PR DESCRIPTION
Fixed #14444, boosted inverted chart had wrong clip-path.

Last changes are a compromise solution because they fixed the issue with inverted charts however the issue with multiple panes is still open and the chart so far it looks the same as before this fix.