### PR TITLE
tools/bust-ci-cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,13 +87,13 @@ jobs:
      - run: node --version && npm --version
      - restore_cache:
          keys:
-           - npm-deps-{{ .Environment.HIGHCHARTS_CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package.json" }}
-           - npm-deps-{{ .Environment.HIGHCHARTS_CACHE_VERSION }}-{{ .Branch }}
+           - npm-deps-v1-{{ .Environment.HIGHCHARTS_CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package.json" }}
+           - npm-deps-v1-{{ .Environment.HIGHCHARTS_CACHE_VERSION }}-{{ .Branch }}
      - run: npm install --quiet
      - save_cache:
          paths:
            - /home/circleci/repo/highcharts/node_modules
-         key: npm-deps-{{ .Environment.HIGHCHARTS_CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package.json" }}
+         key: npm-deps-v1-{{ .Environment.HIGHCHARTS_CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package.json" }}
      - run: npm run gulp scripts
      - run: git diff --name-only --exit-code || (echo "Untracked files found. Did you forget to commit any transpiled files? Failing build now as this likely will trigger errors later in the build.." && exit 1)
      - <<: *persist_workspace


### PR DESCRIPTION
This should fix the failing `checkout_and_install` caused by node v14 entering LTS recently and there being node-sass bindings for v12 cached before this.