### PR TITLE
bugfix/13981-marker-cluster-empty-data

### DIFF
--- a/js/Extensions/MarkerClusters.js
+++ b/js/Extensions/MarkerClusters.js
@@ -1291,7 +1291,8 @@ Scatter.prototype.generatePoints = function () {
         clusterOptions.enabled &&
         series.xData &&
         series.yData &&
-        !chart.polar) {
+        !chart.polar &&
+        series.data.length) {
         type = clusterOptions.layoutAlgorithm.type;
         layoutAlgOptions = clusterOptions.layoutAlgorithm;
         // Get processed algorithm properties.

--- a/js/Extensions/MarkerClusters.js
+++ b/js/Extensions/MarkerClusters.js
@@ -1290,9 +1290,10 @@ Scatter.prototype.generatePoints = function () {
     if (clusterOptions &&
         clusterOptions.enabled &&
         series.xData &&
+        series.xData.length &&
         series.yData &&
-        !chart.polar &&
-        series.data.length) {
+        series.yData.length &&
+        !chart.polar) {
         type = clusterOptions.layoutAlgorithm.type;
         layoutAlgOptions = clusterOptions.layoutAlgorithm;
         // Get processed algorithm properties.

--- a/samples/unit-tests/series/marker-clusters/demo.js
+++ b/samples/unit-tests/series/marker-clusters/demo.js
@@ -360,6 +360,22 @@ QUnit.test('General marker-clusters', function (assert) {
         'Parent point should be hidden before animation.'
     );
 
+    // (#13981)
+    chart = Highcharts.chart('container', {
+        series: [{
+            cluster: {
+                enabled: true
+            },
+            type: 'scatter',
+            data: []
+        }]
+    });
+
+    assert.ok(
+        !chart.series[0].markerClusterInfo,
+        'Marker clusters should not be generated when a series has empty data (#13981).'
+    );
+
     // (#13302)
     var done = assert.async(),
         url = location.host.substr(0, 12) === 'localhost:98' ?

--- a/ts/Extensions/MarkerClusters.ts
+++ b/ts/Extensions/MarkerClusters.ts
@@ -2096,7 +2096,8 @@ Scatter.prototype.generatePoints = function (
         clusterOptions.enabled &&
         series.xData &&
         series.yData &&
-        !chart.polar
+        !chart.polar &&
+        series.data.length
     ) {
         type = clusterOptions.layoutAlgorithm.type;
         layoutAlgOptions = clusterOptions.layoutAlgorithm;

--- a/ts/Extensions/MarkerClusters.ts
+++ b/ts/Extensions/MarkerClusters.ts
@@ -2095,9 +2095,10 @@ Scatter.prototype.generatePoints = function (
         clusterOptions &&
         clusterOptions.enabled &&
         series.xData &&
+        series.xData.length &&
         series.yData &&
-        !chart.polar &&
-        series.data.length
+        series.yData.length &&
+        !chart.polar
     ) {
         type = clusterOptions.layoutAlgorithm.type;
         layoutAlgOptions = clusterOptions.layoutAlgorithm;


### PR DESCRIPTION
Fixed #13981, no map displayed when using marker clusters and empty data array.

~~Fixed issue with marker clusters empty data array, see #13981.~~