### PR TITLE
bugfix/14434-stickOnContact-outside

### DIFF
--- a/js/Core/Pointer.js
+++ b/js/Core/Pointer.js
@@ -836,6 +836,13 @@ var Pointer = /** @class */ (function () {
     Pointer.prototype.onContainerMouseLeave = function (e) {
         var chart = charts[pick(H.hoverChartIndex, -1)];
         var tooltip = this.chart.tooltip;
+        if (tooltip && tooltip.container) { // #14434
+            var rect = tooltip.container.getBoundingClientRect();
+            if (e.clientX >= rect.left && e.clientX <= rect.right &&
+                e.clientY >= rect.top && e.clientY <= rect.bottom) {
+                return;
+            }
+        }
         e = this.normalize(e);
         // #4886, MS Touch end fires mouseleave but with no related target
         if (chart &&

--- a/js/Core/Tooltip.js
+++ b/js/Core/Tooltip.js
@@ -270,6 +270,7 @@ var Tooltip = /** @class */ (function () {
         if (this.renderer) {
             this.renderer = this.renderer.destroy();
             discardElement(this.container);
+            this.container = void 0;
         }
         U.clearTimeout(this.hideTimer);
         U.clearTimeout(this.tooltipTimeout);

--- a/samples/unit-tests/tooltip/outside/demo.js
+++ b/samples/unit-tests/tooltip/outside/demo.js
@@ -59,3 +59,31 @@ QUnit.test('Outside tooltip should inherit chart style', function (assert) {
         'Tooltip container should inherit chart style'
     );
 });
+
+QUnit.test('Outside tooltip update', assert => {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            width: 400,
+            height: 400,
+            style: {
+                fontFamily: 'Papyrus'
+            }
+        },
+        tooltip: {
+            outside: true
+        },
+        series: [{
+            data: [1, 3, 2, 4]
+        }]
+    });
+
+    chart.series[0].points[0].onMouseOver();
+
+    chart.update({
+        tooltip: {
+            outside: false
+        }
+    });
+
+    assert.strictEqual(chart.tooltip.container, undefined, 'Container should be undefined after updating outside to false');
+});

--- a/samples/unit-tests/tooltip/stickoncontact/demo.js
+++ b/samples/unit-tests/tooltip/stickoncontact/demo.js
@@ -126,3 +126,32 @@ QUnit.test('Do not stick on hover tooltip following pointer (#12885)', function 
         );
     });
 });
+
+QUnit.test('#14434: stickOnContact and outside', assert => {
+    const chart = Highcharts.chart('container', {
+        tooltip: {
+            stickOnContact: true,
+            outside: true,
+            hideDelay: 0
+        },
+        series: [{
+            data: [1, 2, 3, 4, 5]
+        }, {
+            data: [3, 4, 5, 6, 7]
+        }]
+    });
+
+    const point = chart.series[0].points[0];
+    const pos = {
+        x: chart.plotLeft + point.plotX,
+        y: chart.plotTop + point.plotY
+    };
+
+    const controller = new TestController(chart);
+    controller.moveTo(pos.x, pos.y);
+
+    const rect = chart.tooltip.container.getBoundingClientRect();
+    chart.pointer.onContainerMouseLeave({ clientX: rect.x, clientY: rect.y });
+
+    assert.strictEqual(!chart.tooltip.isHidden, true, 'Tooltip should still be visible');
+});

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1233,6 +1233,14 @@ class Pointer {
         const chart = charts[pick(H.hoverChartIndex, -1)];
         const tooltip = this.chart.tooltip;
 
+        if (tooltip && tooltip.container) { // #14434
+            const rect = tooltip.container.getBoundingClientRect();
+            if (e.clientX >= rect.left && e.clientX <= rect.right &&
+                e.clientY >= rect.top && e.clientY <= rect.bottom) {
+                return;
+            }
+        }
+
         e = this.normalize(e);
 
         // #4886, MS Touch end fires mouseleave but with no related target

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -503,6 +503,7 @@ class Tooltip {
         if (this.renderer) {
             this.renderer = this.renderer.destroy() as any;
             discardElement(this.container as any);
+            this.container = void 0 as any;
         }
         U.clearTimeout(this.hideTimer as any);
         U.clearTimeout(this.tooltipTimeout as any);


### PR DESCRIPTION
Fixed #14434, `tooltip.outside` broke `tooltip.stickOnContact`.