### PR TITLE
bugfix/14433-dependency-wheel-datalabels

### DIFF
--- a/js/Series/DependencyWheelSeries.js
+++ b/js/Series/DependencyWheelSeries.js
@@ -259,7 +259,10 @@ BaseSeries.seriesType('dependencywheel', 'sankey',
         var renderer = this.series.chart.renderer, shapeArgs = this.shapeArgs, upperHalf = this.angle < 0 || this.angle > Math.PI, start = shapeArgs.start, end = shapeArgs.end;
         if (!this.dataLabelPath) {
             this.dataLabelPath = renderer
-                .arc({ open: true })
+                .arc({
+                open: true,
+                longArc: Math.abs(Math.abs(start) - Math.abs(end)) < Math.PI ? 0 : 1
+            })
                 // Add it inside the data label group so it gets destroyed
                 // with the label
                 .add(label);

--- a/ts/Series/DependencyWheelSeries.ts
+++ b/ts/Series/DependencyWheelSeries.ts
@@ -429,8 +429,10 @@ BaseSeries.seriesType<typeof Highcharts.DependencyWheelSeries>(
 
             if (!this.dataLabelPath) {
                 this.dataLabelPath = renderer
-                    .arc({ open: true })
-
+                    .arc({
+                        open: true,
+                        longArc: Math.abs(Math.abs(start) - Math.abs(end)) < Math.PI ? 0 : 1
+                    })
                     // Add it inside the data label group so it gets destroyed
                     // with the label
                     .add(label);


### PR DESCRIPTION
Fixed #14433, dependency wheel data labels had wrong position for items covering more than 180 degrees of the wheel.