### PR TITLE
Fixed #14260, series color affected by marker.fillColor in Boost

### DIFF
--- a/js/Extensions/Boost/WGLRenderer.js
+++ b/js/Extensions/Boost/WGLRenderer.js
@@ -831,7 +831,9 @@ function GLRenderer(postRenderCallback) {
             }
             else {
                 fillColor =
-                    (s.series.pointAttribs && s.series.pointAttribs().fill) ||
+                    (s.drawMode === 'points' && // #14260
+                        s.series.pointAttribs &&
+                        s.series.pointAttribs().fill) ||
                         s.series.color;
                 if (options.colorByPoint) {
                     fillColor = s.series.chart.options.colors[si];

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -1254,7 +1254,11 @@ function GLRenderer(
 
             } else {
                 fillColor =
-                    (s.series.pointAttribs && s.series.pointAttribs().fill) ||
+                    (
+                        s.drawMode === 'points' && // #14260
+                        s.series.pointAttribs &&
+                        s.series.pointAttribs().fill
+                    ) ||
                     s.series.color;
 
                 if (options.colorByPoint) {


### PR DESCRIPTION
Fixed #14260, series graph color was affected by `marker.fillColor` in Boost