### PR TITLE
bugfix/14416-rangeselector-timezone

### DIFF
--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -885,7 +885,7 @@ var RangeSelector = /** @class */ (function () {
     RangeSelector.prototype.defaultInputDateParser = function (inputDate, useUTC, time) {
         var input = inputDate.split(' ').join('T');
         if (input.indexOf('T') === -1) {
-            input += ' 00:00';
+            input += 'T00:00';
         }
         if (useUTC) {
             input += 'Z';

--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -883,16 +883,14 @@ var RangeSelector = /** @class */ (function () {
      * @function Highcharts.RangeSelector#defaultInputDateParser
      */
     RangeSelector.prototype.defaultInputDateParser = function (inputDate, useUTC, time) {
-        var date;
-        if (H.isSafari) {
-            date = Date.parse(inputDate.split(' ').join('T'));
+        var input = inputDate.split(' ').join('T');
+        if (input.indexOf('T') === -1) {
+            input += ' 00:00';
         }
-        else if (useUTC) {
-            date = Date.parse(inputDate + 'Z');
+        if (useUTC) {
+            input += 'Z';
         }
-        else {
-            date = Date.parse(inputDate);
-        }
+        var date = Date.parse(input);
         if (time && useUTC) {
             date += time.getTimezoneOffset(date) * 60 * 1000;
         }
@@ -919,12 +917,14 @@ var RangeSelector = /** @class */ (function () {
             if (value !== input.previousValue) {
                 input.previousValue = value;
                 // If the value isn't parsed directly to a value by the
-                // browser's Date.parse method, like YYYY-MM-DD in IE, try
+                // browser's Date.parse method, like YYYY-MM-DD in IE8, try
                 // parsing it a different way
                 if (!isNumber(value)) {
                     value = inputValue.split('-');
                     value = Date.UTC(pInt(value[0]), pInt(value[1]) - 1, pInt(value[2]));
-                    value += chart.time.getTimezoneOffset(value) * 60 * 1000;
+                    if (chart.time.useUTC) {
+                        value += chart.time.getTimezoneOffset(value) * 60 * 1000;
+                    }
                 }
                 if (isNumber(value)) {
                     // Validate the extremes. If it goes beyound the data min or

--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -919,6 +919,7 @@ var RangeSelector = /** @class */ (function () {
                 if (!isNumber(value)) {
                     value = inputValue.split('-');
                     value = Date.UTC(pInt(value[0]), pInt(value[1]) - 1, pInt(value[2]));
+                    value += (chart.time.timezoneOffset || 0) * 60 * 1000;
                 }
                 if (isNumber(value)) {
                     // Correct for timezone offset (#433)

--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -910,6 +910,7 @@ var RangeSelector = /** @class */ (function () {
                 chart.scroller.xAxis :
                 chartAxis, dataMin = dataAxis.dataMin, dataMax = dataAxis.dataMax;
             value = (options.inputDateParser || defaultInputDateParser)(inputValue, chart.time.useUTC);
+            value += (chart.time.timezoneOffset || 0) * 60 * 1000; // #14416
             if (value !== input.previousValue) {
                 input.previousValue = value;
                 // If the value isn't parsed directly to a value by the

--- a/samples/unit-tests/rangeselector/input-range/demo.js
+++ b/samples/unit-tests/rangeselector/input-range/demo.js
@@ -337,9 +337,9 @@ QUnit.test('Set extremes on inputs blur (#4710)', function (assert) {
 QUnit.test('#13205: Timezone issues', assert => {
     const chart = Highcharts.stockChart('container', {
         rangeSelector: {
-            inputDateFormat: '%Y/%m/%d %H:%M:%S.%L',
+            inputDateFormat: '%Y-%m-%d %H:%M:%S.%L',
             inputBoxWidth: 170,
-            inputEditDateFormat: '%Y/%m/%d %H:%M:%S.%L'
+            inputEditDateFormat: '%Y-%m-%d %H:%M:%S.%L'
         },
         xAxis: {
             tickPixelInterval: 120
@@ -391,9 +391,9 @@ QUnit.test('#13205: Timezone issues', assert => {
 
     const min = chart.xAxis[0].min;
 
-    chart.rangeSelector.minInput.value = '2019/12/23 00:00:00.000';
+    chart.rangeSelector.minInput.value = '2019-12-23 00:00:00.000';
     chart.rangeSelector.minInput.onchange();
-    assert.strictEqual(chart.rangeSelector.minInput.value, '2019/12/23 00:00:00.000', 'The input value should not change');
+    assert.strictEqual(chart.rangeSelector.minInput.value, '2019-12-23 00:00:00.000', 'The input value should not change');
 
     assert.ok(chart.xAxis[0].min > min, 'Extremes should have been updated');
 });

--- a/samples/unit-tests/rangeselector/input-range/demo.js
+++ b/samples/unit-tests/rangeselector/input-range/demo.js
@@ -348,3 +348,24 @@ QUnit.test('Range selector value on change should change properly (#13205)', fun
         'Independently from use UTC being enabled or disabled, the function should return the same values.'
     );
 });
+
+QUnit.test('#14416: Range selector ignored chart.time.timezoneOffset', assert => {
+    const chart = Highcharts.stockChart('container', {
+        time: {
+            timezoneOffset: 420
+        },
+        xAxis: {
+            minRange: 3600 * 1000 // one hour
+        },
+        series: [
+            {
+                pointInterval: 24 * 3600 * 1000,
+                data: [1, 3, 2, 4, 3, 5, 4, 6, 3, 4, 2, 3, 1, 2, 1]
+            }
+        ]
+    });
+
+    chart.rangeSelector.minInput.value = '1970-01-10';
+    chart.rangeSelector.minInput.onchange();
+    assert.strictEqual(chart.rangeSelector.minInput.value, '1970-01-10', 'The input value should not change');
+});

--- a/samples/unit-tests/rangeselector/input-range/demo.js
+++ b/samples/unit-tests/rangeselector/input-range/demo.js
@@ -334,19 +334,68 @@ QUnit.test('Set extremes on inputs blur (#4710)', function (assert) {
     );
 });
 
-QUnit.test('Range selector value on change should change properly (#13205)', function (assert) {
-    const now = new Date(),
-        year = now.getFullYear(),
-        month = (now.getMonth() < 9 ? '0' : '') + (now.getMonth() + 1),
-        day = (now.getDate() < 10 ? '0' : '') + now.getDate(),
-        date = `${year}-${month}-${day}T00:00:00.000`,
-        defaultInputDateParser = Highcharts.RangeSelector.prototype.defaultInputDateParser;
+QUnit.test('#13205: Timezone issues', assert => {
+    const chart = Highcharts.stockChart('container', {
+        rangeSelector: {
+            inputDateFormat: '%Y/%m/%d %H:%M:%S.%L',
+            inputBoxWidth: 170,
+            inputEditDateFormat: '%Y/%m/%d %H:%M:%S.%L'
+        },
+        xAxis: {
+            tickPixelInterval: 120
+        },
+        series: [{
+            name: 0,
+            data: [{
+                y: 50000000,
+                x: 1576886400000
+            }, {
+                y: 50000000,
+                x: 1577491200000
+            }, {
+                y: 50000000,
+                x: 1578096000000
+            }, {
+                y: 50000000,
+                x: 1578700800000
+            }, {
+                y: 26452797.5,
+                x: 1579305600000
+            }, {
+                y: 26477800,
+                x: 1579910400000
+            }, {
+                y: 50000000,
+                x: 1580515200000
+            }, {
+                y: 50000000,
+                x: 1581120000000
+            }, {
+                y: 50000000,
+                x: 1581724800000
+            }, {
+                y: 50000000,
+                x: 1582329600000
+            }, {
+                y: 50000000,
+                x: 1582934400000
+            }, {
+                y: 50000000,
+                x: 1583539200000
+            }, {
+                y: 50000000,
+                x: 1584144000000
+            }]
+        }]
+    });
 
-    assert.strictEqual(
-        0,
-        defaultInputDateParser(date, false) - defaultInputDateParser(date, true),
-        'Independently from use UTC being enabled or disabled, the function should return the same values.'
-    );
+    const min = chart.xAxis[0].min;
+
+    chart.rangeSelector.minInput.value = '2019/12/23 00:00:00.000';
+    chart.rangeSelector.minInput.onchange();
+    assert.strictEqual(chart.rangeSelector.minInput.value, '2019/12/23 00:00:00.000', 'The input value should not change');
+
+    assert.ok(chart.xAxis[0].min > min, 'Extremes should have been updated');
 });
 
 QUnit.test('#14416: Range selector ignored chart.time.timezoneOffset', assert => {
@@ -363,6 +412,16 @@ QUnit.test('#14416: Range selector ignored chart.time.timezoneOffset', assert =>
                 data: [1, 3, 2, 4, 3, 5, 4, 6, 3, 4, 2, 3, 1, 2, 1]
             }
         ]
+    });
+
+    chart.rangeSelector.minInput.value = '1970-01-10';
+    chart.rangeSelector.minInput.onchange();
+    assert.strictEqual(chart.rangeSelector.minInput.value, '1970-01-10', 'The input value should not change');
+
+    chart.update({
+        time: {
+            useUTC: false
+        }
     });
 
     chart.rangeSelector.minInput.value = '1970-01-10';

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -1318,6 +1318,7 @@ class RangeSelector {
                 dataMax = dataAxis.dataMax;
 
             value = (options.inputDateParser || defaultInputDateParser)(inputValue, chart.time.useUTC);
+            value += (chart.time.timezoneOffset || 0) * 60 * 1000; // #14416
 
             if (value !== input.previousValue) {
                 input.previousValue = value;

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -1270,15 +1270,14 @@ class RangeSelector {
      * @function Highcharts.RangeSelector#defaultInputDateParser
      */
     public defaultInputDateParser(inputDate: string, useUTC: boolean, time?: Highcharts.Time): number {
-        let date;
-
-        if (H.isSafari) {
-            date = Date.parse(inputDate.split(' ').join('T'));
-        } else if (useUTC) {
-            date = Date.parse(inputDate + 'Z');
-        } else {
-            date = Date.parse(inputDate);
+        let input = inputDate.split(' ').join('T');
+        if (input.indexOf('T') === -1) {
+            input += ' 00:00';
         }
+        if (useUTC) {
+            input += 'Z';
+        }
+        let date = Date.parse(input);
 
         if (time && useUTC) {
             date += time.getTimezoneOffset(date) * 60 * 1000;
@@ -1329,7 +1328,7 @@ class RangeSelector {
             if (value !== input.previousValue) {
                 input.previousValue = value;
                 // If the value isn't parsed directly to a value by the
-                // browser's Date.parse method, like YYYY-MM-DD in IE, try
+                // browser's Date.parse method, like YYYY-MM-DD in IE8, try
                 // parsing it a different way
                 if (!isNumber(value)) {
                     value = (inputValue as any).split('-');
@@ -1338,7 +1337,9 @@ class RangeSelector {
                         pInt((value as any)[1]) - 1,
                         pInt((value as any)[2])
                     );
-                    value += chart.time.getTimezoneOffset(value) * 60 * 1000;
+                    if (chart.time.useUTC) {
+                        value += chart.time.getTimezoneOffset(value) * 60 * 1000;
+                    }
                 }
 
                 if (isNumber(value)) {

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -1272,7 +1272,7 @@ class RangeSelector {
     public defaultInputDateParser(inputDate: string, useUTC: boolean, time?: Highcharts.Time): number {
         let input = inputDate.split(' ').join('T');
         if (input.indexOf('T') === -1) {
-            input += ' 00:00';
+            input += 'T00:00';
         }
         if (useUTC) {
             input += 'Z';

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -1332,6 +1332,7 @@ class RangeSelector {
                         pInt((value as any)[1]) - 1,
                         pInt((value as any)[2])
                     );
+                    value += (chart.time.timezoneOffset || 0) * 60 * 1000;
                 }
 
                 if (isNumber(value)) {


### PR DESCRIPTION
Fixed #14416, range selector ignored `chart.time.timezoneOffset`.