### PR TITLE
Added rangeSelector.buttons.description option for AT. Closes #14437.

### DIFF
--- a/js/Accessibility/Components/RangeSelectorComponent.js
+++ b/js/Accessibility/Components/RangeSelectorComponent.js
@@ -73,14 +73,16 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
      * Called on first render/updates to the chart, including options changes.
      */
     onChartUpdate: function () {
+        var _a;
         var chart = this.chart, component = this, rangeSelector = chart.rangeSelector;
         if (!rangeSelector) {
             return;
         }
-        if (rangeSelector.buttons && rangeSelector.buttons.length) {
-            rangeSelector.buttons.forEach(function (button) {
+        if ((_a = rangeSelector.buttons) === null || _a === void 0 ? void 0 : _a.length) {
+            rangeSelector.buttons.forEach(function (button, ix) {
+                var btnOptions = rangeSelector.buttonOptions[ix];
                 unhideChartElementFromAT(chart, button.element);
-                component.setRangeButtonAttrs(button);
+                component.setRangeButtonAttrs(button, btnOptions);
             });
         }
         // Make sure input boxes are accessible and focusable
@@ -99,10 +101,10 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
      * @private
      * @param {Highcharts.SVGElement} button
      */
-    setRangeButtonAttrs: function (button) {
+    setRangeButtonAttrs: function (button, buttonOptions) {
         var chart = this.chart, label = chart.langFormat('accessibility.rangeSelector.buttonText', {
             chart: chart,
-            buttonText: button.text && button.text.textStr
+            buttonText: buttonOptions.description || buttonOptions.text
         });
         setElAttrs(button.element, {
             tabindex: -1,

--- a/js/Accessibility/Components/RangeSelectorComponent.js
+++ b/js/Accessibility/Components/RangeSelectorComponent.js
@@ -15,7 +15,7 @@ import ChartUtilities from '../Utils/ChartUtilities.js';
 var unhideChartElementFromAT = ChartUtilities.unhideChartElementFromAT;
 import H from '../../Core/Globals.js';
 import HTMLUtilities from '../Utils/HTMLUtilities.js';
-var setElAttrs = HTMLUtilities.setElAttrs;
+var setElAttrs = HTMLUtilities.setElAttrs, setSVGElementTitle = HTMLUtilities.setSVGElementTitle;
 import KeyboardNavigationHandler from '../KeyboardNavigationHandler.js';
 import U from '../../Core/Utilities.js';
 var extend = U.extend;
@@ -102,15 +102,11 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
      * @param {Highcharts.SVGElement} button
      */
     setRangeButtonAttrs: function (button, buttonOptions) {
-        var chart = this.chart, label = chart.langFormat('accessibility.rangeSelector.buttonText', {
-            chart: chart,
-            buttonText: buttonOptions.description || buttonOptions.text
-        });
         setElAttrs(button.element, {
             tabindex: -1,
-            role: 'button',
-            'aria-label': label
+            role: 'button'
         });
+        setSVGElementTitle(button.element, buttonOptions.title || null);
     },
     /**
      * @private

--- a/js/Accessibility/Components/RangeSelectorComponent.js
+++ b/js/Accessibility/Components/RangeSelectorComponent.js
@@ -15,7 +15,7 @@ import ChartUtilities from '../Utils/ChartUtilities.js';
 var unhideChartElementFromAT = ChartUtilities.unhideChartElementFromAT;
 import H from '../../Core/Globals.js';
 import HTMLUtilities from '../Utils/HTMLUtilities.js';
-var setElAttrs = HTMLUtilities.setElAttrs, setSVGElementTitle = HTMLUtilities.setSVGElementTitle;
+var setElAttrs = HTMLUtilities.setElAttrs;
 import KeyboardNavigationHandler from '../KeyboardNavigationHandler.js';
 import U from '../../Core/Utilities.js';
 var extend = U.extend;
@@ -79,10 +79,9 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
             return;
         }
         if ((_a = rangeSelector.buttons) === null || _a === void 0 ? void 0 : _a.length) {
-            rangeSelector.buttons.forEach(function (button, ix) {
-                var btnOptions = rangeSelector.buttonOptions[ix];
+            rangeSelector.buttons.forEach(function (button) {
                 unhideChartElementFromAT(chart, button.element);
-                component.setRangeButtonAttrs(button, btnOptions);
+                component.setRangeButtonAttrs(button);
             });
         }
         // Make sure input boxes are accessible and focusable
@@ -101,12 +100,11 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
      * @private
      * @param {Highcharts.SVGElement} button
      */
-    setRangeButtonAttrs: function (button, buttonOptions) {
+    setRangeButtonAttrs: function (button) {
         setElAttrs(button.element, {
             tabindex: -1,
             role: 'button'
         });
-        setSVGElementTitle(button.element, buttonOptions.title || null);
     },
     /**
      * @private

--- a/js/Accessibility/Options/LangOptions.js
+++ b/js/Accessibility/Options/LangOptions.js
@@ -124,8 +124,7 @@ var langOptions = {
          */
         rangeSelector: {
             minInputLabel: 'Select start date.',
-            maxInputLabel: 'Select end date.',
-            buttonText: 'Select range {buttonText}'
+            maxInputLabel: 'Select end date.'
         },
         /**
          * Accessibility language options for the data table.

--- a/js/Accessibility/Utils/HTMLUtilities.js
+++ b/js/Accessibility/Utils/HTMLUtilities.js
@@ -126,6 +126,27 @@ function setElAttrs(el, attrs) {
     });
 }
 /**
+ * Set title element of an SVG element. Adds a <title> child element
+ * with the content specified. If a <title> element exists, it is
+ * updated. Removes the <title> element if `null` is passed.
+ * @private
+ * @param {Highcharts.HTMLDOMElement|Highcharts.SVGDOMElement} el
+ * @param {string|null} content
+ * @return {void}
+ */
+function setSVGElementTitle(el, content) {
+    var _a;
+    var firstTitle = (_a = el.getElementsByTagNameNS('http://www.w3.org/2000/svg', 'title')) === null || _a === void 0 ? void 0 : _a[0];
+    if (content !== null) {
+        var titleElement = firstTitle || document.createElementNS('http://www.w3.org/2000/svg', 'title');
+        titleElement.textContent = content;
+        el.insertBefore(titleElement, el.firstChild);
+    }
+    else if (firstTitle) {
+        el.removeChild(firstTitle);
+    }
+}
+/**
  * Used for aria-label attributes, painting on a canvas will fail if the
  * text contains tags.
  * @private
@@ -166,6 +187,7 @@ var HTMLUtilities = {
     removeElement: removeElement,
     reverseChildNodes: reverseChildNodes,
     setElAttrs: setElAttrs,
+    setSVGElementTitle: setSVGElementTitle,
     stripHTMLTagsFromString: stripHTMLTagsFromString,
     visuallyHideElement: visuallyHideElement
 };

--- a/js/Accessibility/Utils/HTMLUtilities.js
+++ b/js/Accessibility/Utils/HTMLUtilities.js
@@ -126,27 +126,6 @@ function setElAttrs(el, attrs) {
     });
 }
 /**
- * Set title element of an SVG element. Adds a <title> child element
- * with the content specified. If a <title> element exists, it is
- * updated. Removes the <title> element if `null` is passed.
- * @private
- * @param {Highcharts.HTMLDOMElement|Highcharts.SVGDOMElement} el
- * @param {string|null} content
- * @return {void}
- */
-function setSVGElementTitle(el, content) {
-    var _a;
-    var firstTitle = (_a = el.getElementsByTagNameNS('http://www.w3.org/2000/svg', 'title')) === null || _a === void 0 ? void 0 : _a[0];
-    if (content !== null) {
-        var titleElement = firstTitle || document.createElementNS('http://www.w3.org/2000/svg', 'title');
-        titleElement.textContent = content;
-        el.insertBefore(titleElement, el.firstChild);
-    }
-    else if (firstTitle) {
-        el.removeChild(firstTitle);
-    }
-}
-/**
  * Used for aria-label attributes, painting on a canvas will fail if the
  * text contains tags.
  * @private
@@ -187,7 +166,6 @@ var HTMLUtilities = {
     removeElement: removeElement,
     reverseChildNodes: reverseChildNodes,
     setElAttrs: setElAttrs,
-    setSVGElementTitle: setSVGElementTitle,
     stripHTMLTagsFromString: stripHTMLTagsFromString,
     visuallyHideElement: visuallyHideElement
 };

--- a/js/Core/Renderer/SVG/SVGElement.js
+++ b/js/Core/Renderer/SVG/SVGElement.js
@@ -1956,7 +1956,12 @@ var SVGElement = /** @class */ (function () {
         var titleNode = el.getElementsByTagNameNS(this.SVG_NS, 'title')[0] ||
             doc.createElementNS(this.SVG_NS, 'title');
         // Move to first child
-        el.insertBefore(titleNode, el.firstChild);
+        if (el.insertBefore) {
+            el.insertBefore(titleNode, el.firstChild);
+        }
+        else {
+            el.appendChild(titleNode);
+        }
         // Replace text content and escape markup
         titleNode.textContent =
             // #3276, #3895

--- a/js/Core/Renderer/SVG/SVGElement.js
+++ b/js/Core/Renderer/SVG/SVGElement.js
@@ -1953,7 +1953,7 @@ var SVGElement = /** @class */ (function () {
      */
     SVGElement.prototype.titleSetter = function (value) {
         var el = this.element;
-        var titleNode = el.getElementsByTagNameNS(this.SVG_NS, 'title')[0] ||
+        var titleNode = el.getElementsByTagName('title')[0] ||
             doc.createElementNS(this.SVG_NS, 'title');
         // Move to first child
         if (el.insertBefore) {

--- a/js/Core/Renderer/SVG/SVGElement.js
+++ b/js/Core/Renderer/SVG/SVGElement.js
@@ -1952,21 +1952,18 @@ var SVGElement = /** @class */ (function () {
      * @param {string} value
      */
     SVGElement.prototype.titleSetter = function (value) {
-        var titleNode = this.element.getElementsByTagName('title')[0];
-        if (!titleNode) {
-            titleNode = doc.createElementNS(this.SVG_NS, 'title');
-            this.element.appendChild(titleNode);
-        }
-        // Remove text content if it exists
-        if (titleNode.firstChild) {
-            titleNode.removeChild(titleNode.firstChild);
-        }
-        titleNode.appendChild(doc.createTextNode(
-        // #3276, #3895
-        String(pick(value, ''))
-            .replace(/<[^>]*>/g, '')
-            .replace(/&lt;/g, '<')
-            .replace(/&gt;/g, '>')));
+        var el = this.element;
+        var titleNode = el.getElementsByTagNameNS(this.SVG_NS, 'title')[0] ||
+            doc.createElementNS(this.SVG_NS, 'title');
+        // Move to first child
+        el.insertBefore(titleNode, el.firstChild);
+        // Replace text content and escape markup
+        titleNode.textContent =
+            // #3276, #3895
+            String(pick(value, ''))
+                .replace(/<[^>]*>/g, '')
+                .replace(/&lt;/g, '<')
+                .replace(/&gt;/g, '>');
     };
     /**
      * Bring the element to the front. Alternatively, a new zIndex can be set.

--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -1153,6 +1153,9 @@ var RangeSelector = /** @class */ (function () {
                     'text-align': 'center'
                 })
                     .add(buttonGroup);
+                if (rangeOptions.title) {
+                    buttons[i].attr('title', rangeOptions.title);
+                }
             });
             // first create a wrapper outside the container in order to make
             // the inputs work and make export correct

--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -81,29 +81,30 @@ extend(defaultOptions, {
          *     type: 'month',
          *     count: 1,
          *     text: '1m',
-         *     description: '1 month'
+         *     title: 'View 1 month'
          * }, {
          *     type: 'month',
          *     count: 3,
          *     text: '3m',
-         *     description: '3 months'
+         *     title: 'View 3 months'
          * }, {
          *     type: 'month',
          *     count: 6,
          *     text: '6m',
-         *     description: '6 months'
+         *     title: 'View 6 months'
          * }, {
          *     type: 'ytd',
          *     text: 'YTD',
-         *     description: 'Year to Date'
+         *     title: 'View year to date'
          * }, {
          *     type: 'year',
          *     count: 1,
          *     text: '1y',
-         *     description: '1 year'
+         *     title: 'View 1 year'
          * }, {
          *     type: 'all',
-         *     text: 'All'
+         *     text: 'All',
+         *     title: 'View all'
          * }]
          * ```
          *
@@ -196,11 +197,11 @@ extend(defaultOptions, {
          * @apioption rangeSelector.buttons.text
          */
         /**
-         * Non-abbreviated version of the button range, used by assistive
-         * technology such as screen readers.
+         * Explanation for the button, shown as a tooltip on hover, and used by
+         * assistive technology.
          *
          * @type      {string}
-         * @apioption rangeSelector.buttons.description
+         * @apioption rangeSelector.buttons.title
          */
         /**
          * Defined the time span for the button. Can be one of `millisecond`,
@@ -1437,29 +1438,30 @@ RangeSelector.prototype.defaultButtons = [{
         type: 'month',
         count: 1,
         text: '1m',
-        description: '1 month'
+        title: 'View 1 month'
     }, {
         type: 'month',
         count: 3,
         text: '3m',
-        description: '3 months'
+        title: 'View 3 months'
     }, {
         type: 'month',
         count: 6,
         text: '6m',
-        description: '6 months'
+        title: 'View 6 months'
     }, {
         type: 'ytd',
         text: 'YTD',
-        description: 'Year to Date'
+        title: 'View year to date'
     }, {
         type: 'year',
         count: 1,
         text: '1y',
-        description: '1 year'
+        title: 'View 1 year'
     }, {
         type: 'all',
-        text: 'All'
+        text: 'All',
+        title: 'View all'
     }];
 /**
  * Get the axis min value based on the range option and the current max. For

--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -80,22 +80,27 @@ extend(defaultOptions, {
          * buttons: [{
          *     type: 'month',
          *     count: 1,
-         *     text: '1m'
+         *     text: '1m',
+         *     description: '1 month'
          * }, {
          *     type: 'month',
          *     count: 3,
-         *     text: '3m'
+         *     text: '3m',
+         *     description: '3 months'
          * }, {
          *     type: 'month',
          *     count: 6,
-         *     text: '6m'
+         *     text: '6m',
+         *     description: '6 months'
          * }, {
          *     type: 'ytd',
-         *     text: 'YTD'
+         *     text: 'YTD',
+         *     description: 'Year to Date'
          * }, {
          *     type: 'year',
          *     count: 1,
-         *     text: '1y'
+         *     text: '1y',
+         *     description: '1 year'
          * }, {
          *     type: 'all',
          *     text: 'All'
@@ -189,6 +194,13 @@ extend(defaultOptions, {
          *
          * @type      {string}
          * @apioption rangeSelector.buttons.text
+         */
+        /**
+         * Non-abbreviated version of the button range, used by assistive
+         * technology such as screen readers.
+         *
+         * @type      {string}
+         * @apioption rangeSelector.buttons.description
          */
         /**
          * Defined the time span for the button. Can be one of `millisecond`,
@@ -1424,22 +1436,27 @@ var RangeSelector = /** @class */ (function () {
 RangeSelector.prototype.defaultButtons = [{
         type: 'month',
         count: 1,
-        text: '1m'
+        text: '1m',
+        description: '1 month'
     }, {
         type: 'month',
         count: 3,
-        text: '3m'
+        text: '3m',
+        description: '3 months'
     }, {
         type: 'month',
         count: 6,
-        text: '6m'
+        text: '6m',
+        description: '6 months'
     }, {
         type: 'ytd',
-        text: 'YTD'
+        text: 'YTD',
+        description: 'Year to Date'
     }, {
         type: 'year',
         count: 1,
-        text: '1y'
+        text: '1y',
+        description: '1 year'
     }, {
         type: 'all',
         text: 'All'

--- a/samples/unit-tests/maps/credits-maptext/demo.js
+++ b/samples/unit-tests/maps/credits-maptext/demo.js
@@ -15,7 +15,7 @@ QUnit.test('Credits', function (assert) {
 
     assert.strictEqual(
         chart.credits.element.textContent,
-        Highcharts.getOptions().credits.text + 'Test map creditsTest full map credits',
+        'Test full map credits' + Highcharts.getOptions().credits.text + 'Test map credits',
         'Setting map credits inline'
     );
 
@@ -64,7 +64,7 @@ QUnit.test('Credits', function (assert) {
 
     assert.strictEqual(
         chart.credits.element.textContent,
-        Highcharts.getOptions().credits.text + 'Map credits testMap credits full test',
+        'Map credits full test' + Highcharts.getOptions().credits.text + 'Map credits test',
         'Setting map credits default options'
     );
 
@@ -85,7 +85,7 @@ QUnit.test('Credits', function (assert) {
 
     assert.strictEqual(
         chart.credits.element.textContent,
-        'TestMap credits testMap credits full test',
+        'Map credits full testTestMap credits test',
         'Setting map credits default options as well as inline'
     );
 
@@ -108,7 +108,7 @@ QUnit.test('Credits', function (assert) {
 
     assert.strictEqual(
         chart.credits.element.textContent,
-        'PrecedenceTestPrecedenceMapTextPrecedenceMapTextFull',
+        'PrecedenceMapTextFullPrecedenceTestPrecedenceMapText',
         'Setting map credits default options as well as inline, inline takes precedence'
     );
 

--- a/samples/unit-tests/svgrenderer/text/demo.js
+++ b/samples/unit-tests/svgrenderer/text/demo.js
@@ -321,7 +321,9 @@ QUnit.test('textOverflow: ellipsis.', function (assert) {
             width: width + 'px'
         },
         text1 = ren.text('01234567', 0, 100).css(style).add(),
-        text2 = ren.text('012345678', 0, 120).css(style).add();
+        text2 = ren.text('012345678', 0, 120).css(style).add(),
+        getTextContent = text => text.element.getElementsByTagName('tspan')[0].textContent,
+        text1Content = getTextContent(text1);
 
     assert.strictEqual(
         text1.getBBox().width < width + 2,
@@ -330,13 +332,13 @@ QUnit.test('textOverflow: ellipsis.', function (assert) {
     );
 
     assert.strictEqual(
-        text1.element.childNodes[0].textContent.slice(-1),
+        text1Content.slice(-1),
         '\u2026',
         'Ellipsis was added to text node.'
     );
     assert.strictEqual(
-        text1.element.childNodes[0].textContent,
-        text2.element.childNodes[0].textContent,
+        text1Content,
+        getTextContent(text2),
         'Consistent result between different strings. #6258'
     );
     // TODO 0px does not work, because ellipsis and breaks are not applied
@@ -345,7 +347,7 @@ QUnit.test('textOverflow: ellipsis.', function (assert) {
     text1.destroy();
     text1 = ren.text('01234567', 0, 100).css(style).add();
     assert.strictEqual(
-        text1.element.childNodes[0].textContent,
+        getTextContent(text1),
         '',
         'Width was too small for ellipsis.'
     );
@@ -360,7 +362,7 @@ QUnit.test('textOverflow: ellipsis.', function (assert) {
         rotation: 90
     }).css(style).add();
     assert.strictEqual(
-        text1.element.childNodes[0].textContent.slice(-1),
+        getTextContent(text1).slice(-1),
         '\u2026',
         'Ellipsis was added to text node which has rotation.'
     );

--- a/ts/Accessibility/Components/RangeSelectorComponent.ts
+++ b/ts/Accessibility/Components/RangeSelectorComponent.ts
@@ -24,8 +24,7 @@ const {
 import H from '../../Core/Globals.js';
 import HTMLUtilities from '../Utils/HTMLUtilities.js';
 const {
-    setElAttrs,
-    setSVGElementTitle
+    setElAttrs
 } = HTMLUtilities;
 import KeyboardNavigationHandler from '../KeyboardNavigationHandler.js';
 import U from '../../Core/Utilities.js';
@@ -67,7 +66,7 @@ declare global {
             ): number;
             public onInputNavInit(direction: number): void;
             public onInputNavTerminate(): void;
-            public setRangeButtonAttrs(button: SVGElement, buttonOptions: RangeSelectorButtonsOptions): void;
+            public setRangeButtonAttrs(button: SVGElement): void;
             public setRangeInputAttrs(
                 input: HTMLDOMElement,
                 langKey: string
@@ -161,10 +160,9 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
             return;
         }
         if (rangeSelector.buttons?.length) {
-            rangeSelector.buttons.forEach((button, ix): void => {
-                const btnOptions = rangeSelector.buttonOptions[ix];
+            rangeSelector.buttons.forEach((button): void => {
                 unhideChartElementFromAT(chart, button.element);
-                component.setRangeButtonAttrs(button, btnOptions);
+                component.setRangeButtonAttrs(button);
             });
         }
 
@@ -194,14 +192,12 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
      */
     setRangeButtonAttrs: function (
         this: Highcharts.RangeSelectorComponent,
-        button: Highcharts.SVGElement,
-        buttonOptions: Highcharts.RangeSelectorButtonsOptions
+        button: Highcharts.SVGElement
     ): void {
         setElAttrs(button.element, {
             tabindex: -1,
             role: 'button'
         });
-        setSVGElementTitle(button.element, buttonOptions.title || null);
     },
 
 

--- a/ts/Accessibility/Components/RangeSelectorComponent.ts
+++ b/ts/Accessibility/Components/RangeSelectorComponent.ts
@@ -24,7 +24,8 @@ const {
 import H from '../../Core/Globals.js';
 import HTMLUtilities from '../Utils/HTMLUtilities.js';
 const {
-    setElAttrs
+    setElAttrs,
+    setSVGElementTitle
 } = HTMLUtilities;
 import KeyboardNavigationHandler from '../KeyboardNavigationHandler.js';
 import U from '../../Core/Utilities.js';
@@ -196,20 +197,11 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
         button: Highcharts.SVGElement,
         buttonOptions: Highcharts.RangeSelectorButtonsOptions
     ): void {
-        var chart = this.chart,
-            label = chart.langFormat(
-                'accessibility.rangeSelector.buttonText',
-                {
-                    chart: chart,
-                    buttonText: buttonOptions.description || buttonOptions.text
-                }
-            );
-
         setElAttrs(button.element, {
             tabindex: -1,
-            role: 'button',
-            'aria-label': label
+            role: 'button'
         });
+        setSVGElementTitle(button.element, buttonOptions.title || null);
     },
 
 

--- a/ts/Accessibility/Components/RangeSelectorComponent.ts
+++ b/ts/Accessibility/Components/RangeSelectorComponent.ts
@@ -66,7 +66,7 @@ declare global {
             ): number;
             public onInputNavInit(direction: number): void;
             public onInputNavTerminate(): void;
-            public setRangeButtonAttrs(button: SVGElement): void;
+            public setRangeButtonAttrs(button: SVGElement, buttonOptions: RangeSelectorButtonsOptions): void;
             public setRangeInputAttrs(
                 input: HTMLDOMElement,
                 langKey: string
@@ -152,20 +152,18 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
      * Called on first render/updates to the chart, including options changes.
      */
     onChartUpdate: function (this: Highcharts.RangeSelectorComponent): void {
-        var chart = this.chart,
+        const chart = this.chart,
             component = this,
             rangeSelector = chart.rangeSelector;
 
         if (!rangeSelector) {
             return;
         }
-
-        if (rangeSelector.buttons && rangeSelector.buttons.length) {
-            rangeSelector.buttons.forEach(function (
-                button: Highcharts.SVGElement
-            ): void {
+        if (rangeSelector.buttons?.length) {
+            rangeSelector.buttons.forEach((button, ix): void => {
+                const btnOptions = rangeSelector.buttonOptions[ix];
                 unhideChartElementFromAT(chart, button.element);
-                component.setRangeButtonAttrs(button);
+                component.setRangeButtonAttrs(button, btnOptions);
             });
         }
 
@@ -195,14 +193,15 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
      */
     setRangeButtonAttrs: function (
         this: Highcharts.RangeSelectorComponent,
-        button: Highcharts.SVGElement
+        button: Highcharts.SVGElement,
+        buttonOptions: Highcharts.RangeSelectorButtonsOptions
     ): void {
         var chart = this.chart,
             label = chart.langFormat(
                 'accessibility.rangeSelector.buttonText',
                 {
                     chart: chart,
-                    buttonText: button.text && button.text.textStr
+                    buttonText: buttonOptions.description || buttonOptions.text
                 }
             );
 

--- a/ts/Accessibility/Options/LangOptions.ts
+++ b/ts/Accessibility/Options/LangOptions.ts
@@ -95,7 +95,6 @@ declare global {
             zoom: LangAccessibilityZoomOptions;
         }
         interface LangAccessibilityRangeSelectorOptions {
-            buttonText: string;
             maxInputLabel: string;
             minInputLabel: string;
         }
@@ -300,8 +299,7 @@ var langOptions: Highcharts.LangOptions = {
          */
         rangeSelector: {
             minInputLabel: 'Select start date.',
-            maxInputLabel: 'Select end date.',
-            buttonText: 'Select range {buttonText}'
+            maxInputLabel: 'Select end date.'
         },
 
         /**

--- a/ts/Accessibility/Utils/HTMLUtilities.ts
+++ b/ts/Accessibility/Utils/HTMLUtilities.ts
@@ -168,31 +168,6 @@ function setElAttrs(
 
 
 /**
- * Set title element of an SVG element. Adds a <title> child element
- * with the content specified. If a <title> element exists, it is
- * updated. Removes the <title> element if `null` is passed.
- * @private
- * @param {Highcharts.HTMLDOMElement|Highcharts.SVGDOMElement} el
- * @param {string|null} content
- * @return {void}
- */
-function setSVGElementTitle(
-    el: DOMElementType,
-    content: (string|null)
-): void {
-    const firstTitle = el.getElementsByTagNameNS('http://www.w3.org/2000/svg', 'title')?.[0];
-
-    if (content !== null) {
-        const titleElement = firstTitle || document.createElementNS('http://www.w3.org/2000/svg', 'title');
-        titleElement.textContent = content;
-        el.insertBefore(titleElement, el.firstChild);
-    } else if (firstTitle) {
-        el.removeChild(firstTitle);
-    }
-}
-
-
-/**
  * Used for aria-label attributes, painting on a canvas will fail if the
  * text contains tags.
  * @private
@@ -237,7 +212,6 @@ var HTMLUtilities = {
     removeElement,
     reverseChildNodes,
     setElAttrs,
-    setSVGElementTitle,
     stripHTMLTagsFromString,
     visuallyHideElement
 };

--- a/ts/Accessibility/Utils/HTMLUtilities.ts
+++ b/ts/Accessibility/Utils/HTMLUtilities.ts
@@ -168,6 +168,31 @@ function setElAttrs(
 
 
 /**
+ * Set title element of an SVG element. Adds a <title> child element
+ * with the content specified. If a <title> element exists, it is
+ * updated. Removes the <title> element if `null` is passed.
+ * @private
+ * @param {Highcharts.HTMLDOMElement|Highcharts.SVGDOMElement} el
+ * @param {string|null} content
+ * @return {void}
+ */
+function setSVGElementTitle(
+    el: DOMElementType,
+    content: (string|null)
+): void {
+    const firstTitle = el.getElementsByTagNameNS('http://www.w3.org/2000/svg', 'title')?.[0];
+
+    if (content !== null) {
+        const titleElement = firstTitle || document.createElementNS('http://www.w3.org/2000/svg', 'title');
+        titleElement.textContent = content;
+        el.insertBefore(titleElement, el.firstChild);
+    } else if (firstTitle) {
+        el.removeChild(firstTitle);
+    }
+}
+
+
+/**
  * Used for aria-label attributes, painting on a canvas will fail if the
  * text contains tags.
  * @private
@@ -205,15 +230,16 @@ function visuallyHideElement(element: HTMLDOMElement): void {
 
 
 var HTMLUtilities = {
-    addClass: addClass,
-    escapeStringForHTML: escapeStringForHTML,
-    getElement: getElement,
-    getFakeMouseEvent: getFakeMouseEvent,
-    removeElement: removeElement,
-    reverseChildNodes: reverseChildNodes,
-    setElAttrs: setElAttrs,
-    stripHTMLTagsFromString: stripHTMLTagsFromString,
-    visuallyHideElement: visuallyHideElement
+    addClass,
+    escapeStringForHTML,
+    getElement,
+    getFakeMouseEvent,
+    removeElement,
+    reverseChildNodes,
+    setElAttrs,
+    setSVGElementTitle,
+    stripHTMLTagsFromString,
+    visuallyHideElement
 };
 
 export default HTMLUtilities;

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -2736,7 +2736,11 @@ class SVGElement {
             doc.createElementNS(this.SVG_NS, 'title');
 
         // Move to first child
-        el.insertBefore(titleNode, el.firstChild);
+        if (el.insertBefore) {
+            el.insertBefore(titleNode, el.firstChild);
+        } else {
+            el.appendChild(titleNode);
+        }
 
         // Replace text content and escape markup
         titleNode.textContent =

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -2731,29 +2731,20 @@ class SVGElement {
      * @param {string} value
      */
     public titleSetter(value: string): void {
-        var titleNode: SVGDOMElement = (
-            this.element.getElementsByTagName('title')[0] as any
-        );
+        const el = this.element;
+        const titleNode = el.getElementsByTagNameNS(this.SVG_NS, 'title')[0] ||
+            doc.createElementNS(this.SVG_NS, 'title');
 
-        if (!titleNode) {
-            titleNode = doc.createElementNS(this.SVG_NS, 'title') as any;
-            this.element.appendChild(titleNode);
-        }
+        // Move to first child
+        el.insertBefore(titleNode, el.firstChild);
 
-        // Remove text content if it exists
-        if (titleNode.firstChild) {
-            titleNode.removeChild(titleNode.firstChild);
-        }
-
-        titleNode.appendChild(
-            doc.createTextNode(
+        // Replace text content and escape markup
+        titleNode.textContent =
                 // #3276, #3895
                 String(pick(value, ''))
                     .replace(/<[^>]*>/g, '')
                     .replace(/&lt;/g, '<')
-                    .replace(/&gt;/g, '>')
-            )
-        );
+                    .replace(/&gt;/g, '>');
     }
 
     /**

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -2732,7 +2732,7 @@ class SVGElement {
      */
     public titleSetter(value: string): void {
         const el = this.element;
-        const titleNode = el.getElementsByTagNameNS(this.SVG_NS, 'title')[0] ||
+        const titleNode = el.getElementsByTagName('title')[0] ||
             doc.createElementNS(this.SVG_NS, 'title');
 
         // Move to first child

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -91,7 +91,7 @@ declare global {
             _range?: number;
             count?: number;
             dataGrouping?: DataGroupingOptionsObject;
-            description?: string;
+            title?: string;
             events?: RangeSelectorButtonsEventsOptions;
             offsetMax?: number;
             offsetMin?: number;
@@ -250,29 +250,30 @@ extend(defaultOptions, {
          *     type: 'month',
          *     count: 1,
          *     text: '1m',
-         *     description: '1 month'
+         *     title: 'View 1 month'
          * }, {
          *     type: 'month',
          *     count: 3,
          *     text: '3m',
-         *     description: '3 months'
+         *     title: 'View 3 months'
          * }, {
          *     type: 'month',
          *     count: 6,
          *     text: '6m',
-         *     description: '6 months'
+         *     title: 'View 6 months'
          * }, {
          *     type: 'ytd',
          *     text: 'YTD',
-         *     description: 'Year to Date'
+         *     title: 'View year to date'
          * }, {
          *     type: 'year',
          *     count: 1,
          *     text: '1y',
-         *     description: '1 year'
+         *     title: 'View 1 year'
          * }, {
          *     type: 'all',
-         *     text: 'All'
+         *     text: 'All',
+         *     title: 'View all'
          * }]
          * ```
          *
@@ -373,11 +374,11 @@ extend(defaultOptions, {
          */
 
         /**
-         * Non-abbreviated version of the button range, used by assistive
-         * technology such as screen readers.
+         * Explanation for the button, shown as a tooltip on hover, and used by
+         * assistive technology.
          *
          * @type      {string}
-         * @apioption rangeSelector.buttons.description
+         * @apioption rangeSelector.buttons.title
          */
 
         /**
@@ -2066,29 +2067,30 @@ RangeSelector.prototype.defaultButtons = [{
     type: 'month',
     count: 1,
     text: '1m',
-    description: '1 month'
+    title: 'View 1 month'
 }, {
     type: 'month',
     count: 3,
     text: '3m',
-    description: '3 months'
+    title: 'View 3 months'
 }, {
     type: 'month',
     count: 6,
     text: '6m',
-    description: '6 months'
+    title: 'View 6 months'
 }, {
     type: 'ytd',
     text: 'YTD',
-    description: 'Year to Date'
+    title: 'View year to date'
 }, {
     type: 'year',
     count: 1,
     text: '1y',
-    description: '1 year'
+    title: 'View 1 year'
 }, {
     type: 'all',
-    text: 'All'
+    text: 'All',
+    title: 'View all'
 }];
 
 /**

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -1685,6 +1685,10 @@ class RangeSelector {
                         'text-align': 'center'
                     })
                     .add(buttonGroup);
+
+                if (rangeOptions.title) {
+                    buttons[i].attr('title', rangeOptions.title);
+                }
             });
 
             // first create a wrapper outside the container in order to make

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -91,6 +91,7 @@ declare global {
             _range?: number;
             count?: number;
             dataGrouping?: DataGroupingOptionsObject;
+            description?: string;
             events?: RangeSelectorButtonsEventsOptions;
             offsetMax?: number;
             offsetMin?: number;
@@ -248,22 +249,27 @@ extend(defaultOptions, {
          * buttons: [{
          *     type: 'month',
          *     count: 1,
-         *     text: '1m'
+         *     text: '1m',
+         *     description: '1 month'
          * }, {
          *     type: 'month',
          *     count: 3,
-         *     text: '3m'
+         *     text: '3m',
+         *     description: '3 months'
          * }, {
          *     type: 'month',
          *     count: 6,
-         *     text: '6m'
+         *     text: '6m',
+         *     description: '6 months'
          * }, {
          *     type: 'ytd',
-         *     text: 'YTD'
+         *     text: 'YTD',
+         *     description: 'Year to Date'
          * }, {
          *     type: 'year',
          *     count: 1,
-         *     text: '1y'
+         *     text: '1y',
+         *     description: '1 year'
          * }, {
          *     type: 'all',
          *     text: 'All'
@@ -364,6 +370,14 @@ extend(defaultOptions, {
          *
          * @type      {string}
          * @apioption rangeSelector.buttons.text
+         */
+
+        /**
+         * Non-abbreviated version of the button range, used by assistive
+         * technology such as screen readers.
+         *
+         * @type      {string}
+         * @apioption rangeSelector.buttons.description
          */
 
         /**
@@ -2051,22 +2065,27 @@ interface RangeSelector {
 RangeSelector.prototype.defaultButtons = [{
     type: 'month',
     count: 1,
-    text: '1m'
+    text: '1m',
+    description: '1 month'
 }, {
     type: 'month',
     count: 3,
-    text: '3m'
+    text: '3m',
+    description: '3 months'
 }, {
     type: 'month',
     count: 6,
-    text: '6m'
+    text: '6m',
+    description: '6 months'
 }, {
     type: 'ytd',
-    text: 'YTD'
+    text: 'YTD',
+    description: 'Year to Date'
 }, {
     type: 'year',
     count: 1,
-    text: '1y'
+    text: '1y',
+    description: '1 year'
 }, {
     type: 'all',
     text: 'All'


### PR DESCRIPTION
Added `rangeSelector.buttons.title` option for assistive technology and general accessability, see #14437.
___
It is now possible to define custom accessible labels for each individual range selector button. This is done through the optional `rangeSelector.buttons.description` option. The default buttons have these descriptions added out of the box. Where a description is not supplied, the button text is used, as before.

It is recommended to add the descriptions since many screen readers will announce confusing information when presented with these abbreviations. `1m` can for example be announced as `One minute`.

We might want to consider if these buttons should have a tooltip so that non-AT users can benefit from the abbreviation explanations on hover.

```js
buttons: [{
  type: 'month',
  count: 1,
  text: '1m',
  description: '1 month'
}, {
  // ...
}, {
  type: 'ytd',
  text: 'YTD',
  description: 'Year to Date'
}, {
  type: 'all',
  text: 'All'
 }]
```