### PR TITLE
bugfix/14495-cross-hair-bg-colour-overwritten

### DIFF
--- a/js/Extensions/PriceIndication.js
+++ b/js/Extensions/PriceIndication.js
@@ -73,6 +73,7 @@ var addEvent = U.addEvent, isArray = U.isArray, merge = U.merge;
  */
 /* eslint-disable no-invalid-this */
 addEvent(LineSeries, 'afterRender', function () {
+    var _a, _b;
     var serie = this, seriesOptions = serie.options, pointRange = seriesOptions.pointRange, lastVisiblePrice = seriesOptions.lastVisiblePrice, lastPrice = seriesOptions.lastPrice;
     if ((lastVisiblePrice || lastPrice) &&
         seriesOptions.id !== 'highcharts-navigator-series') {
@@ -97,6 +98,8 @@ addEvent(LineSeries, 'afterRender', function () {
             lastVisiblePrice.enabled &&
             pLength > 0) {
             crop = (points[pLength - 1].x === x) || pointRange === null ? 1 : 2;
+            // #14495 To reset color for labels without lastVisiblePrice.
+            var crossHairColor = (_b = (_a = yAxis.crosshair) === null || _a === void 0 ? void 0 : _a.label) === null || _b === void 0 ? void 0 : _b.backgroundColor;
             yAxis.crosshair = yAxis.options.crosshair = merge({
                 color: 'transparent'
             }, seriesOptions.lastVisiblePrice);
@@ -117,6 +120,10 @@ addEvent(LineSeries, 'afterRender', function () {
                 }
             }
             serie.crossLabel = yAxis.crossLabel;
+            // #14495 Reset backgroundColor for labels without lastVisiblePrice.
+            if (yAxis.options.crosshair.label) {
+                yAxis.options.crosshair.label.backgroundColor = crossHairColor;
+            }
         }
         // Restore crosshair:
         yAxis.crosshair = origOptions;

--- a/js/Extensions/PriceIndication.js
+++ b/js/Extensions/PriceIndication.js
@@ -73,7 +73,6 @@ var addEvent = U.addEvent, isArray = U.isArray, merge = U.merge;
  */
 /* eslint-disable no-invalid-this */
 addEvent(LineSeries, 'afterRender', function () {
-    var _a, _b;
     var serie = this, seriesOptions = serie.options, pointRange = seriesOptions.pointRange, lastVisiblePrice = seriesOptions.lastVisiblePrice, lastPrice = seriesOptions.lastPrice;
     if ((lastVisiblePrice || lastPrice) &&
         seriesOptions.id !== 'highcharts-navigator-series') {
@@ -98,8 +97,6 @@ addEvent(LineSeries, 'afterRender', function () {
             lastVisiblePrice.enabled &&
             pLength > 0) {
             crop = (points[pLength - 1].x === x) || pointRange === null ? 1 : 2;
-            // #14495 To reset color for labels without lastVisiblePrice.
-            var crossHairColor = (_b = (_a = yAxis.crosshair) === null || _a === void 0 ? void 0 : _a.label) === null || _b === void 0 ? void 0 : _b.backgroundColor;
             yAxis.crosshair = yAxis.options.crosshair = merge({
                 color: 'transparent'
             }, seriesOptions.lastVisiblePrice);
@@ -120,13 +117,9 @@ addEvent(LineSeries, 'afterRender', function () {
                 }
             }
             serie.crossLabel = yAxis.crossLabel;
-            // #14495 Reset backgroundColor for labels without lastVisiblePrice.
-            if (yAxis.options.crosshair.label) {
-                yAxis.options.crosshair.label.backgroundColor = crossHairColor;
-            }
         }
         // Restore crosshair:
-        yAxis.crosshair = origOptions;
+        yAxis.crosshair = yAxis.options.crosshair = origOptions;
         yAxis.cross = origGraphic;
         yAxis.crossLabel = origLabel;
     }

--- a/samples/unit-tests/indicator-current-price/recalculations/demo.js
+++ b/samples/unit-tests/indicator-current-price/recalculations/demo.js
@@ -37,3 +37,33 @@ QUnit.test('Test current and last price indicator.', function (assert) {
         'The last visible price is correct.'
     );
 });
+
+QUnit.test('Test label background colors with lastVisiblePrice in use.', function (assert) {
+
+    var chart = Highcharts.chart('container', {
+        series: [{
+            data: [1],
+            lastVisiblePrice: {
+                enabled: true,
+                label: {
+                    enabled: true,
+                    backgroundColor: "orange"
+                }
+            }
+        }],
+        yAxis: {
+            crosshair: {
+                color: 'green',
+                label: {
+                    enabled: true,
+                    backgroundColor: "blue"
+                }
+            }
+        }
+    });
+
+    var actualColor = chart.series[0].yAxis.crosshair.label.backgroundColor;
+
+    assert.strictEqual(actualColor, 'blue', 'Crosshair label must not be overwritten.');
+
+});

--- a/ts/Extensions/PriceIndication.ts
+++ b/ts/Extensions/PriceIndication.ts
@@ -171,6 +171,9 @@ addEvent(LineSeries, 'afterRender', function (): void {
 
             crop = (points[pLength - 1].x === x) || pointRange === null ? 1 : 2;
 
+            // #14495 To reset color for labels without lastVisiblePrice.
+            var crossHairColor = yAxis.crosshair?.label?.backgroundColor;
+
             yAxis.crosshair = yAxis.options.crosshair = merge({
                 color: 'transparent'
             }, seriesOptions.lastVisiblePrice);
@@ -197,6 +200,10 @@ addEvent(LineSeries, 'afterRender', function (): void {
 
             serie.crossLabel = yAxis.crossLabel;
 
+            // #14495 Reset backgroundColor for labels without lastVisiblePrice.
+            if (yAxis.options.crosshair.label) {
+                yAxis.options.crosshair.label.backgroundColor = crossHairColor;
+            }
         }
 
         // Restore crosshair:

--- a/ts/Extensions/PriceIndication.ts
+++ b/ts/Extensions/PriceIndication.ts
@@ -171,9 +171,6 @@ addEvent(LineSeries, 'afterRender', function (): void {
 
             crop = (points[pLength - 1].x === x) || pointRange === null ? 1 : 2;
 
-            // #14495 To reset color for labels without lastVisiblePrice.
-            var crossHairColor = yAxis.crosshair?.label?.backgroundColor;
-
             yAxis.crosshair = yAxis.options.crosshair = merge({
                 color: 'transparent'
             }, seriesOptions.lastVisiblePrice);
@@ -199,15 +196,10 @@ addEvent(LineSeries, 'afterRender', function (): void {
             }
 
             serie.crossLabel = yAxis.crossLabel;
-
-            // #14495 Reset backgroundColor for labels without lastVisiblePrice.
-            if (yAxis.options.crosshair.label) {
-                yAxis.options.crosshair.label.backgroundColor = crossHairColor;
-            }
         }
 
         // Restore crosshair:
-        yAxis.crosshair = origOptions;
+        yAxis.crosshair = yAxis.options.crosshair = origOptions;
         yAxis.cross = origGraphic;
         yAxis.crossLabel = origLabel;
 


### PR DESCRIPTION
Fixed #14495, the `lastVisiblePrice` label in price-indicator module overwrote the `backgroudColor` property of the crosshair label

~~Fixed background color not overwritten by lastVisiblePrice label background color.~~