### PR TITLE
bugfix/14505-axis-minRange-NaN

### DIFF
--- a/js/Core/Axis/Axis.js
+++ b/js/Core/Axis/Axis.js
@@ -1004,7 +1004,7 @@ var Axis = /** @class */ (function () {
      * @function Highcharts.Axis#adjustForMinRange
      */
     Axis.prototype.adjustForMinRange = function () {
-        var axis = this, options = axis.options, min = axis.min, max = axis.max, log = axis.logarithmic, zoomOffset, spaceAvailable, closestDataRange, i, distance, xData, loopLength, minArgs, maxArgs, minRange;
+        var axis = this, options = axis.options, min = axis.min, max = axis.max, log = axis.logarithmic, zoomOffset, spaceAvailable, closestDataRange = 0, i, distance, xData, loopLength, minArgs, maxArgs, minRange;
         // Set the automatic minimum range based on the closest point distance
         if (axis.isXAxis &&
             typeof axis.minRange === 'undefined' &&
@@ -1022,8 +1022,7 @@ var Axis = /** @class */ (function () {
                     if (xData.length > 1) {
                         for (i = loopLength; i > 0; i--) {
                             distance = xData[i] - xData[i - 1];
-                            if (typeof closestDataRange === 'undefined' ||
-                                distance < closestDataRange) {
+                            if (!closestDataRange || distance < closestDataRange) {
                                 closestDataRange = distance;
                             }
                         }

--- a/js/Core/Axis/Axis.js
+++ b/js/Core/Axis/Axis.js
@@ -1019,11 +1019,13 @@ var Axis = /** @class */ (function () {
                 axis.series.forEach(function (series) {
                     xData = series.xData;
                     loopLength = series.xIncrement ? 1 : xData.length - 1;
-                    for (i = loopLength; i > 0; i--) {
-                        distance = xData[i] - xData[i - 1];
-                        if (typeof closestDataRange === 'undefined' ||
-                            distance < closestDataRange) {
-                            closestDataRange = distance;
+                    if (xData.length > 1) {
+                        for (i = loopLength; i > 0; i--) {
+                            distance = xData[i] - xData[i - 1];
+                            if (typeof closestDataRange === 'undefined' ||
+                                distance < closestDataRange) {
+                                closestDataRange = distance;
+                            }
                         }
                     }
                 });

--- a/samples/unit-tests/axis/minrange/demo.js
+++ b/samples/unit-tests/axis/minrange/demo.js
@@ -18,3 +18,25 @@ QUnit.test('minRange with log axis', function (assert) {
         'Axis label makes sense'
     );
 });
+
+QUnit.test('#14505: minRange NaN with single point series', assert => {
+    [
+        [{
+            data: [1]
+        }, {
+            data: [1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3]
+        }, {
+            data: [4, 8, 5, 8, 5, 7, 6, 4, 5, 3, 3, 2]
+        }], [{
+            data: [1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3]
+        }, {
+            data: [4, 8, 5, 8, 5, 7, 6, 4, 5, 3, 3, 2]
+        }, {
+            data: [1]
+        }]
+    ].forEach(series => {
+        const chart = Highcharts.chart('container', { series });
+
+        assert.ok(Highcharts.isNumber(chart.xAxis[0].minRange), 'minRange should be a finite number');
+    });
+});

--- a/samples/unit-tests/axis/minrange/demo.js
+++ b/samples/unit-tests/axis/minrange/demo.js
@@ -33,6 +33,8 @@ QUnit.test('#14505: minRange NaN with single point series', assert => {
             data: [4, 8, 5, 8, 5, 7, 6, 4, 5, 3, 3, 2]
         }, {
             data: [1]
+        }], [{
+            data: [1]
         }]
     ].forEach(series => {
         const chart = Highcharts.chart('container', { series });

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -4972,13 +4972,16 @@ class Axis {
                 axis.series.forEach(function (series): void {
                     xData = series.xData as any;
                     loopLength = series.xIncrement ? 1 : xData.length - 1;
-                    for (i = loopLength; i > 0; i--) {
-                        distance = xData[i] - xData[i - 1];
-                        if (
-                            typeof closestDataRange === 'undefined' ||
-                            distance < closestDataRange
-                        ) {
-                            closestDataRange = distance;
+
+                    if (xData.length > 1) {
+                        for (i = loopLength; i > 0; i--) {
+                            distance = xData[i] - xData[i - 1];
+                            if (
+                                typeof closestDataRange === 'undefined' ||
+                                distance < closestDataRange
+                            ) {
+                                closestDataRange = distance;
+                            }
                         }
                     }
                 });

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -4945,7 +4945,7 @@ class Axis {
             log = axis.logarithmic,
             zoomOffset,
             spaceAvailable: boolean,
-            closestDataRange: (number|undefined),
+            closestDataRange = 0,
             i,
             distance,
             xData,
@@ -4976,17 +4976,14 @@ class Axis {
                     if (xData.length > 1) {
                         for (i = loopLength; i > 0; i--) {
                             distance = xData[i] - xData[i - 1];
-                            if (
-                                typeof closestDataRange === 'undefined' ||
-                                distance < closestDataRange
-                            ) {
+                            if (!closestDataRange || distance < closestDataRange) {
                                 closestDataRange = distance;
                             }
                         }
                     }
                 });
                 axis.minRange = Math.min(
-                    (closestDataRange as any) * 5,
+                    closestDataRange * 5,
                     (axis.dataMax as any) - (axis.dataMin as any)
                 );
             }


### PR DESCRIPTION
Fixed #14505, when one of the chart series had a single point, the navigator handles could be dragged beyond the default `xAxis.minRange`. The computed `minRange` was `NaN`.

~~Fixed #14505, `axis.minRange` was `NaN` when the first series had only a single point.~~