### PR TITLE
bugfix/14244-tooltipPos-multiple-xAxis

### DIFF
--- a/js/Series/Column/ColumnSeries.js
+++ b/js/Series/Column/ColumnSeries.js
@@ -338,7 +338,7 @@ var ColumnSeries = /** @class */ (function (_super) {
                     barH
                 ] :
                 [
-                    barX + barW / 2,
+                    xAxis.left - chart.plotLeft + barX + barW / 2,
                     clamp(plotY + yAxis.pos -
                         chart.plotTop, yAxis.pos - chart.plotTop, yAxis.len + yAxis.pos - chart.plotTop),
                     barH

--- a/samples/unit-tests/tooltip/position/demo.js
+++ b/samples/unit-tests/tooltip/position/demo.js
@@ -178,3 +178,46 @@ QUnit.test('Wrong tooltip pos for column (#424)', function (assert) {
         'Tooltip position should be correct when bar chart xAxis has top and height set with numeric values (#12589).'
     );
 });
+
+QUnit.test('#14244: Tooltip position with multiple xAxis', assert => {
+    const chart = Highcharts.chart('container', {
+        xAxis: [{
+            width: '50%'
+        }, {
+            left: '50%',
+            width: '50%',
+            offset: 0
+        }],
+        plotOptions: {
+            series: {
+                grouping: false
+            }
+        },
+        series: [{
+            type: 'column',
+            xAxis: 0,
+            data: [{
+                y: 120000
+            }, {
+                y: 569000
+            }, {
+                y: 231000
+            }]
+        }, {
+            type: 'column',
+            xAxis: 1,
+            data: [{
+                y: 10000
+            }, {
+                y: 500000
+            }, {
+                y: 201000
+            }]
+        }]
+    });
+
+    const point = chart.series[1].points[0];
+    const axis = point.series.xAxis;
+
+    assert.ok(axis.left - chart.plotLeft < point.tooltipPos[0], 'Tooltip x position should be within correct xAxis');
+});

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -899,7 +899,7 @@ class ColumnSeries extends LineSeries {
                     barH
                 ] :
                 [
-                    barX + barW / 2,
+                    xAxis.left - chart.plotLeft + barX + barW / 2,
                     clamp(
                         plotY + (yAxis.pos as any) -
                         chart.plotTop,


### PR DESCRIPTION
Fixed #14244, tooltip in column-based series with multiple `xAxis` had wrong position.