### PR TITLE
Fixed #14460, kbd click not firing series.click event.

### DIFF
--- a/js/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.js
+++ b/js/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.js
@@ -16,7 +16,7 @@ import Chart from '../../../Core/Chart/Chart.js';
 import LineSeries from '../../../Series/Line/LineSeries.js';
 import Point from '../../../Core/Series/Point.js';
 import U from '../../../Core/Utilities.js';
-var defined = U.defined, extend = U.extend;
+var defined = U.defined, extend = U.extend, fireEvent = U.fireEvent;
 import KeyboardNavigationHandler from '../../KeyboardNavigationHandler.js';
 import EventProvider from '../../Utils/EventProvider.js';
 import ChartUtilities from '../../Utils/ChartUtilities.js';
@@ -453,9 +453,13 @@ extend(SeriesKeyboardNavigation.prototype, /** @lends Highcharts.SeriesKeyboardN
                 [inverted ? [keys.left, keys.right] : [keys.up, keys.down], function (keyCode) {
                         return keyboardNavigation.onKbdVertical(this, keyCode);
                     }],
-                [[keys.enter, keys.space], function () {
-                        if (chart.highlightedPoint) {
-                            chart.highlightedPoint.firePointEvent('click');
+                [[keys.enter, keys.space], function (keyCode, event) {
+                        var point = chart.highlightedPoint;
+                        if (point) {
+                            fireEvent(point.series, 'click', extend(event, {
+                                point: point
+                            }));
+                            point.firePointEvent('click');
                         }
                         return this.response.success;
                     }]

--- a/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
@@ -22,7 +22,8 @@ import Point from '../../../Core/Series/Point.js';
 import U from '../../../Core/Utilities.js';
 const {
     defined,
-    extend
+    extend,
+    fireEvent
 } = U;
 
 declare module '../../../Core/Chart/ChartLike'{
@@ -719,10 +720,16 @@ extend(SeriesKeyboardNavigation.prototype, /** @lends Highcharts.SeriesKeyboardN
 
                 [[keys.enter, keys.space],
                     function (
-                        this: Highcharts.KeyboardNavigationHandler
+                        this: Highcharts.KeyboardNavigationHandler,
+                        keyCode: number,
+                        event: KeyboardEvent
                     ): number {
-                        if (chart.highlightedPoint) {
-                            chart.highlightedPoint.firePointEvent('click');
+                        const point = chart.highlightedPoint;
+                        if (point) {
+                            fireEvent(point.series, 'click', extend(event, {
+                                point
+                            }));
+                            point.firePointEvent('click');
                         }
                         return this.response.success;
                     }]


### PR DESCRIPTION
Fixed #14460, keyboard enter/space press not firing `series.click` event.
____
`series.point.click` works as before, but now `series.click` is also fired - similarly to the behavior with mouse/touch.