### PR TITLE
Tools: moved XML prettifying on reference SVGs

### DIFF
--- a/test/karma-imagecapture-reporter.js
+++ b/test/karma-imagecapture-reporter.js
@@ -28,25 +28,6 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
     } = config;
 
     /**
-     * Basic pretty-print SVG, each tag on a new line.
-     * @param  {String} svg The SVG
-     * @return {String}     Pretty SVG
-     */
-    function prettyXML(svg) {
-        svg = svg
-            .replace(/>/g, '>\n')
-
-            // Don't introduce newlines inside tspans or links, it will make the text
-            // render differently
-            .replace(/<tspan([^>]*)>\n/g, '<tspan$1>')
-            .replace(/<\/tspan>\n/g, '</tspan>')
-            .replace(/<a([^>]*)>\n/g, '<a$1>')
-            .replace(/<\/a>\n/g, '</a>');
-
-        return svg;
-    }
-
-    /**
      * Create an animated gif of the reference and the candidata image, in order to
      * see the differences.
      * @param  {String} filename
@@ -158,7 +139,7 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
         try {
             if (/\.svg$/.test(filename)) {
                 pendingFileWritings++;
-                fs.writeFile(filename, prettyXML(data), err => {
+                fs.writeFile(filename, data, err => {
                     if (err) {
                         throw err;
                     }

--- a/test/karma-imagecapture-reporter.js
+++ b/test/karma-imagecapture-reporter.js
@@ -27,6 +27,24 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
         referenceRun = false
     } = config;
 
+    /**
+     * Basic pretty-print SVG, each tag on a new line.
+     * @param  {String} svg The SVG
+     * @return {String}     Pretty SVG
+     */
+    function prettyXML(svg) {
+        svg = svg
+            .replace(/>/g, '>\n')
+
+            // Don't introduce newlines inside tspans or links, it will make the text
+            // render differently
+            .replace(/<tspan([^>]*)>\n/g, '<tspan$1>')
+            .replace(/<\/tspan>\n/g, '</tspan>')
+            .replace(/<a([^>]*)>\n/g, '<a$1>')
+            .replace(/<\/a>\n/g, '</a>');
+
+        return svg;
+    }
 
     /**
      * Create an animated gif of the reference and the candidata image, in order to
@@ -140,7 +158,7 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
         try {
             if (/\.svg$/.test(filename)) {
                 pendingFileWritings++;
-                fs.writeFile(filename, data, err => {
+                fs.writeFile(filename, prettyXML(data), err => {
                     if (err) {
                         throw err;
                     }

--- a/test/karma-imagecapture-reporter.js
+++ b/test/karma-imagecapture-reporter.js
@@ -27,24 +27,6 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
         referenceRun = false
     } = config;
 
-    /**
-     * Basic pretty-print SVG, each tag on a new line.
-     * @param  {String} svg The SVG
-     * @return {String}     Pretty SVG
-     */
-    function prettyXML(svg) {
-        svg = svg
-            .replace(/>/g, '>\n')
-
-            // Don't introduce newlines inside tspans or links, it will make the text
-            // render differently
-            .replace(/<tspan([^>]*)>\n/g, '<tspan$1>')
-            .replace(/<\/tspan>\n/g, '</tspan>')
-            .replace(/<a([^>]*)>\n/g, '<a$1>')
-            .replace(/<\/a>\n/g, '</a>');
-
-        return svg;
-    }
 
     /**
      * Create an animated gif of the reference and the candidata image, in order to
@@ -158,7 +140,7 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
         try {
             if (/\.svg$/.test(filename)) {
                 pendingFileWritings++;
-                fs.writeFile(filename, prettyXML(data), err => {
+                fs.writeFile(filename, data, err => {
                     if (err) {
                         throw err;
                     }

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -415,6 +415,25 @@ Highcharts.prepareShot = function (chart) {
 };
 
 /**
+* Basic pretty-print SVG, each tag on a new line.
+* @param  {String} svg The SVG
+* @return {String}     Pretty SVG
+*/
+function prettyXML(svg) {
+    svg = svg
+        .replace(/>/g, '>\n')
+
+        // Don't introduce newlines inside tspans or links, it will make the text
+        // render differently
+        .replace(/<tspan([^>]*)>\n/g, '<tspan$1>')
+        .replace(/<\/tspan>\n/g, '</tspan>')
+        .replace(/<a([^>]*)>\n/g, '<a$1>')
+        .replace(/<\/a>\n/g, '</a>');
+
+    return svg;
+}
+
+/**
  * Get the SVG of a chart, or the first SVG in the page
  * @param  {Object} chart The chart
  * @return {String}       The SVG
@@ -445,7 +464,8 @@ function getSVG(chart) {
             svg = document.getElementsByTagName('svg')[0].outerHTML;
         }
     }
-    return svg;
+
+    return prettyXML(svg);
 }
 
 /**


### PR DESCRIPTION
@TorsteinHonsi Issue with visual tests seems to be that we inserted a newline inside `title` elements, which is interpreted as a whitespace on render.

It is probably best to run the test on the raw SVG and move the pretty printing to the visual test application (which also needs to be updated as the file diff is broken without newlines).