### PR TITLE
Increased timeouts in local tests.

### DIFF
--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -661,6 +661,10 @@ module.exports = function (config) {
         };
         options.browserDisconnectTimeout = 30 * 60 * 1000;
         options.browserNoActivityTimeout = 30 * 60 * 1000;
+    } else {
+        // Local tests
+        options.browserDisconnectTimeout = 30 * 1000;
+        options.browserNoActivityTimeout = 30 * 1000;
     }
 
     config.set(options);


### PR DESCRIPTION
Empirically, the longest tests took around 15s (the slowest tests are related to panning, we can improve that too - probably `mousemove`  event is fired continuously).

Sometimes 20s could fail, so 30s sounds safe.

I don't see any noticeable time increase in tests (for me, still tests need less than 5mins). When running tests and observing CPU monitor, CPU usage jumped to 250%+ on one core (?!) and timeout error showed up in the console.