### PR TITLE
bugfix: Sankey chart, overlapping data labels link doesn't work

### DIFF
--- a/js/Extensions/OverlappingDataLabels.js
+++ b/js/Extensions/OverlappingDataLabels.js
@@ -43,7 +43,7 @@ addEvent(Chart, 'render', function collectAndHide() {
         var dlOptions = series.options.dataLabels;
         if (series.visible &&
             !(dlOptions.enabled === false && !series._hasPointLabels)) { // #3866
-            (series.nodes || series.points).forEach(function (point) {
+            ((series.nodes || []).concat(series.points || [])).forEach(function (point) {
                 if (point.visible) {
                     var dataLabels = (isArray(point.dataLabels) ?
                         point.dataLabels :


### PR DESCRIPTION
Bug Fix: #14584 

bug: when series.nodes are present, series.points are ignored

fix: series.nodes and series.points are merged whenever available 