### PR TITLE
bugfix/14637-line-pointPlacement-between

### DIFF
--- a/js/Series/Line/LineSeries.js
+++ b/js/Series/Line/LineSeries.js
@@ -2691,7 +2691,7 @@ var LineSeries = /** @class */ (function () {
             factor = axis.reversed ? -0.5 : 0.5; // #11955
         }
         return isNumber(factor) ?
-            factor * pick(pointRange, axis.pointRange) :
+            factor * (pointRange || axis.pointRange) :
             0;
     };
     /**

--- a/samples/unit-tests/axis/pointplacement/demo.js
+++ b/samples/unit-tests/axis/pointplacement/demo.js
@@ -52,3 +52,26 @@ QUnit.test('Axis pointPlacement', assert => {
         'All points are between appropriate ticks when the chart is inverted.'
     );
 });
+
+QUnit.test('#14637: Line series pointPlacement="between"', assert => {
+    const chart = Highcharts.chart('container', {
+        plotOptions: {
+            series: {
+                pointPlacement: 'between'
+            }
+        },
+        series: [{
+            type: 'column',
+            data: [5, 3, 4, 7, 2]
+        }, {
+            type: "line",
+            data: [3, 5, 6, 2, 9]
+        }]
+    });
+
+    assert.strictEqual(
+        Math.floor(chart.series[1].points[0].plotX),
+        Math.floor(chart.xAxis[0].toPixels(0.5, true)),
+        'Points should be placed between ticks'
+    );
+});

--- a/ts/Series/Line/LineSeries.ts
+++ b/ts/Series/Line/LineSeries.ts
@@ -6432,7 +6432,7 @@ class LineSeries {
         }
 
         return isNumber(factor) ?
-            factor * pick(pointRange, axis.pointRange) :
+            factor * (pointRange || axis.pointRange) :
             0;
     }
 


### PR DESCRIPTION
Fixed #14637, setting `pointPlacement` to `between` placed line series points on ticks instead of between them.