### PR TITLE
bugfix/14315-column-empty-extremes

### DIFF
--- a/js/Series/Line/LineSeries.js
+++ b/js/Series/Line/LineSeries.js
@@ -1488,7 +1488,7 @@ var LineSeries = /** @class */ (function () {
             // Set the the plotY value, reset it for redraws
             // #3201
             point.plotY = void 0;
-            if (typeof yValue === 'number' && yValue !== Infinity) {
+            if (isNumber(yValue)) {
                 var translated = yAxis.translate(yValue, false, true, false, true);
                 if (typeof translated !== 'undefined') {
                     point.plotY = limitedRange(translated);

--- a/js/Series/Line/LineSeries.js
+++ b/js/Series/Line/LineSeries.js
@@ -1487,9 +1487,13 @@ var LineSeries = /** @class */ (function () {
             }
             // Set the the plotY value, reset it for redraws
             // #3201
-            point.plotY = ((typeof yValue === 'number' && yValue !== Infinity) ?
-                limitedRange(yAxis.translate(yValue, 0, 1, 0, 1)) :
-                void 0);
+            point.plotY = void 0;
+            if (typeof yValue === 'number' && yValue !== Infinity) {
+                var translated = yAxis.translate(yValue, false, true, false, true);
+                if (typeof translated !== 'undefined') {
+                    point.plotY = limitedRange(translated);
+                }
+            }
             point.isInside = this.isPointInside(point);
             // Set client related positions for mouse tracking
             point.clientX = dynamicallyPlaced ?

--- a/samples/unit-tests/series-column/data/demo.js
+++ b/samples/unit-tests/series-column/data/demo.js
@@ -14,3 +14,22 @@ QUnit.test('Zero column visible (#5146)', function (assert) {
         'No height'
     );
 });
+
+QUnit.test('#14315: Setting extremes that contained no data threw', assert => {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'column',
+            animation: false
+        },
+        series: [{
+            data: [
+                49.9, 71.5, 106.4, 129.2, 144.0, 176.0,
+                135.6, 148.5, 216.4, 194.1, 95.6, 54.4
+            ]
+        }]
+    });
+
+    chart.xAxis[0].setExtremes(-10, -5);
+
+    assert.ok(true, 'Setting extremes should not throw');
+});

--- a/ts/Series/Line/LineSeries.ts
+++ b/ts/Series/Line/LineSeries.ts
@@ -4665,7 +4665,7 @@ class LineSeries {
             // Set the the plotY value, reset it for redraws
             // #3201
             point.plotY = void 0;
-            if (typeof yValue === 'number' && yValue !== Infinity) {
+            if (isNumber(yValue)) {
                 const translated = yAxis.translate(
                     yValue, false, true, false, true
                 );

--- a/ts/Series/Line/LineSeries.ts
+++ b/ts/Series/Line/LineSeries.ts
@@ -4664,13 +4664,15 @@ class LineSeries {
 
             // Set the the plotY value, reset it for redraws
             // #3201
-            point.plotY = (
-                (typeof yValue === 'number' && yValue !== Infinity) ?
-                    limitedRange(yAxis.translate(
-                        yValue, 0 as any, 1 as any, 0 as any, 1 as any
-                    ) as any) :
-                    void 0
-            );
+            point.plotY = void 0;
+            if (typeof yValue === 'number' && yValue !== Infinity) {
+                const translated = yAxis.translate(
+                    yValue, false, true, false, true
+                );
+                if (typeof translated !== 'undefined') {
+                    point.plotY = limitedRange(translated);
+                }
+            }
 
             point.isInside = this.isPointInside(point);
 


### PR DESCRIPTION
Fixed #14315, setting X axis extremes outside the chart series' data range threw.

This regression happened because `clamp(undefined, -1e5, 1e5)` returns `-1e5` while `Math.min(Math.max(-1e5, undefined), 1e5)` returns `NaN` and `ColumnSeries.drawPoints` uses `isNumber(plotY)` to determine if it should draw.