### PR TITLE
bugfix/14147-xRange-center-toolTipPosition

### DIFF
--- a/js/Series/XRangeSeries.js
+++ b/js/Series/XRangeSeries.js
@@ -251,7 +251,8 @@ BaseSeries.seriesType('xrange', 'column'
      * @param {Highcharts.Point} point
      */
     translatePoint: function (point) {
-        var series = this, xAxis = series.xAxis, yAxis = series.yAxis, metrics = series.columnMetrics, options = series.options, minPointLength = options.minPointLength || 0, plotX = point.plotX, posX = pick(point.x2, point.x + (point.len || 0)), plotX2 = xAxis.translate(posX, 0, 0, 0, 1), length = Math.abs(plotX2 - plotX), widthDifference, shapeArgs, partialFill, inverted = this.chart.inverted, borderWidth = pick(options.borderWidth, 1), crisper = borderWidth % 2 / 2, yOffset = metrics.offset, pointHeight = Math.round(metrics.width), dlLeft, dlRight, dlWidth, clipRectWidth, tooltipYOffset;
+        var _a, _b;
+        var series = this, xAxis = series.xAxis, yAxis = series.yAxis, metrics = series.columnMetrics, options = series.options, minPointLength = options.minPointLength || 0, oldColWidth = ((_a = point.shapeArgs) === null || _a === void 0 ? void 0 : _a.width) / 2, seriesXOffset = series.pointXOffset = metrics.offset, plotX = point.plotX, posX = pick(point.x2, point.x + (point.len || 0)), plotX2 = xAxis.translate(posX, 0, 0, 0, 1), length = Math.abs(plotX2 - plotX), widthDifference, shapeArgs, partialFill, inverted = this.chart.inverted, borderWidth = pick(options.borderWidth, 1), crisper = borderWidth % 2 / 2, yOffset = metrics.offset, pointHeight = Math.round(metrics.width), dlLeft, dlRight, dlWidth, clipRectWidth, tooltipYOffset;
         if (minPointLength) {
             widthDifference = minPointLength - length;
             if (widthDifference < 0) {
@@ -280,6 +281,16 @@ BaseSeries.seriesType('xrange', 'column'
             height: pointHeight,
             r: series.options.borderRadius
         };
+        // Move tooltip to default position
+        if (!inverted) {
+            point.tooltipPos[0] -= oldColWidth +
+                seriesXOffset -
+                ((_b = point.shapeArgs) === null || _b === void 0 ? void 0 : _b.width) / 2;
+        }
+        else {
+            point.tooltipPos[1] += seriesXOffset +
+                oldColWidth;
+        }
         // Align data labels inside the shape and inside the plot area
         dlLeft = point.shapeArgs.x;
         dlRight = dlLeft + point.shapeArgs.width;
@@ -302,9 +313,13 @@ BaseSeries.seriesType('xrange', 'column'
         var yIndex = !inverted ? 1 : 0;
         tooltipYOffset = series.columnMetrics ?
             series.columnMetrics.offset : -metrics.width / 2;
-        // Limit position by the correct axis size (#9727)
-        tooltipPos[xIndex] = clamp(tooltipPos[xIndex] + ((!inverted ? 1 : -1) * (xAxis.reversed ? -1 : 1) *
-            (length / 2)), 0, xAxis.len - 1);
+        // Centering tooltip position (#14147)
+        if (!inverted) {
+            tooltipPos[xIndex] += (xAxis.reversed ? -1 : 0) * point.shapeArgs.width;
+        }
+        else {
+            tooltipPos[xIndex] += point.shapeArgs.width / 2;
+        }
         tooltipPos[yIndex] = clamp(tooltipPos[yIndex] + ((inverted ? -1 : 1) * tooltipYOffset), 0, yAxis.len - 1);
         // Add a partShapeArgs to the point, based on the shapeArgs property
         partialFill = point.partialFill;

--- a/samples/unit-tests/series-xrange/xrange/demo.js
+++ b/samples/unit-tests/series-xrange/xrange/demo.js
@@ -542,3 +542,196 @@ QUnit.test('#13811: partialFill application order', function (assert) {
         'Series.partialFill should still work'
     );
 });
+
+QUnit.test('XRange series and tooltip position', assert => {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'xrange'
+        },
+        yAxis: {
+            categories: ["First", "Second"]
+        },
+        series: [{
+            data: [{
+                x: 0,
+                x2: 5,
+                y: 0
+            }, {
+                x: 5,
+                x2: 10,
+                y: 1
+            }]
+        }, {
+            data: [{
+                x: 5,
+                x2: 10,
+                y: 0
+            }, {
+                x: 0,
+                x2: 5,
+                y: 1
+            }]
+        }]
+    });
+
+    chart.tooltip.refresh(chart.series[0].points[0]);
+
+    var labelBox = chart.tooltip.label.element.getBoundingClientRect();
+    var pointGraphicBox = chart.series[0].points[0].graphic.element.getBoundingClientRect();
+
+    //Precision up to 2 pixels
+    assert.close(
+        labelBox.left + labelBox.width / 2,
+        pointGraphicBox.left + pointGraphicBox.width / 2,
+        2,
+        'No inverted chart, no reversed xAxis, no reversed yAxis'
+    );
+
+    chart.update({
+        yAxis: {
+            reversed: true
+        }
+    });
+
+    chart.tooltip.refresh(chart.series[0].points[0]);
+
+    labelBox = chart.tooltip.label.element.getBoundingClientRect();
+    pointGraphicBox = chart.series[0].points[0].graphic.element.getBoundingClientRect();
+
+    //Precision up to 2 pixels
+    assert.close(
+        labelBox.left + labelBox.width / 2,
+        pointGraphicBox.left + pointGraphicBox.width / 2,
+        2,
+        'No inverted chart, no reversed xAxis, reversed yAxis'
+    );
+
+    chart.update({
+        xAxis: {
+            reversed: true
+        }
+    });
+
+    chart.tooltip.refresh(chart.series[0].points[0]);
+
+    labelBox = chart.tooltip.label.element.getBoundingClientRect();
+    pointGraphicBox = chart.series[0].points[0].graphic.element.getBoundingClientRect();
+
+    //Precision up to 2 pixels
+    assert.close(
+        labelBox.left + labelBox.width / 2,
+        pointGraphicBox.left + pointGraphicBox.width / 2,
+        2,
+        'No inverted chart, reversed xAxis, no reversed yAxis'
+    );
+
+    chart.update({
+        xAxis: {
+            reversed: true
+        },
+        yAxis: {
+            reversed: true
+        }
+    });
+
+    chart.tooltip.refresh(chart.series[0].points[0]);
+
+    labelBox = chart.tooltip.label.element.getBoundingClientRect();
+    pointGraphicBox = chart.series[0].points[0].graphic.element.getBoundingClientRect();
+
+    //Precision up to 2 pixels
+    assert.close(
+        labelBox.left + labelBox.width / 2,
+        pointGraphicBox.left + pointGraphicBox.width / 2,
+        2,
+        'No inverted chart, reversed xAxis, reversed yAxis'
+    );
+
+    chart.update({
+        chart: {
+            inverted: true
+        },
+        xAxis: {
+            reversed: true
+        },
+        yAxis: {
+            reversed: true
+        }
+    });
+
+    chart.tooltip.refresh(chart.series[0].points[0]);
+
+    labelBox = chart.tooltip.label.element.getBoundingClientRect();
+    pointGraphicBox = chart.series[0].points[0].graphic.element.getBoundingClientRect();
+
+    //Precision up to 2 pixels
+    assert.close(
+        labelBox.top + labelBox.height / 2,
+        pointGraphicBox.top + pointGraphicBox.height / 2,
+        2.001,
+        'Inverted chart, reversed xAxis, reversed yAxis'
+    );
+
+    chart.update({
+        chart: {
+            inverted: true
+        }
+    });
+
+    chart.tooltip.refresh(chart.series[0].points[0]);
+
+    labelBox = chart.tooltip.label.element.getBoundingClientRect();
+    pointGraphicBox = chart.series[0].points[0].graphic.element.getBoundingClientRect();
+
+    //Precision up to 2 pixels
+    assert.close(
+        labelBox.top + labelBox.height / 2,
+        pointGraphicBox.top + pointGraphicBox.height / 2,
+        2.001,
+        'Inverted chart, no reversed xAxis, no reversed yAxis'
+    );
+
+    chart.update({
+        chart: {
+            inverted: true
+        },
+        xAxis: {
+            reversed: true
+        }
+    });
+
+    chart.tooltip.refresh(chart.series[0].points[0]);
+
+    labelBox = chart.tooltip.label.element.getBoundingClientRect();
+    pointGraphicBox = chart.series[0].points[0].graphic.element.getBoundingClientRect();
+
+    //Precision up to 2 pixels
+    assert.close(
+        labelBox.top + labelBox.height / 2,
+        pointGraphicBox.top + pointGraphicBox.height / 2,
+        2.001,
+        'Inverted chart, reversed xAxis, no reversed yAxis'
+    );
+
+    chart.update({
+        chart: {
+            inverted: true
+        },
+        yAxis: {
+            reversed: true
+        }
+    });
+
+    chart.tooltip.refresh(chart.series[0].points[0]);
+
+    labelBox = chart.tooltip.label.element.getBoundingClientRect();
+    pointGraphicBox = chart.series[0].points[0].graphic.element.getBoundingClientRect();
+
+    //Precision up to 2 pixels
+    assert.close(
+        labelBox.top + labelBox.height / 2,
+        pointGraphicBox.top + pointGraphicBox.height / 2,
+        2.001,
+        'Inverted chart, no reversed xAxis, reversed yAxis'
+    );
+});

--- a/ts/Series/XRangeSeries.ts
+++ b/ts/Series/XRangeSeries.ts
@@ -430,6 +430,8 @@ BaseSeries.seriesType<typeof Highcharts.XRangeSeries>('xrange', 'column'
                     series.columnMetrics as any,
                 options = series.options,
                 minPointLength = options.minPointLength || 0,
+                oldColWidth = point.shapeArgs?.width / 2,
+                seriesXOffset = series.pointXOffset = metrics.offset,
                 plotX = point.plotX,
                 posX = pick(point.x2, (point.x as any) + (point.len || 0)),
                 plotX2 = xAxis.translate(
@@ -501,6 +503,16 @@ BaseSeries.seriesType<typeof Highcharts.XRangeSeries>('xrange', 'column'
                 r: series.options.borderRadius
             };
 
+            // Move tooltip to default position
+            if (!inverted) {
+                (point.tooltipPos as any)[0] -= oldColWidth +
+                seriesXOffset -
+                point.shapeArgs?.width / 2;
+            } else {
+                (point.tooltipPos as any)[1] += seriesXOffset +
+                oldColWidth;
+            }
+
             // Align data labels inside the shape and inside the plot area
             dlLeft = point.shapeArgs.x;
             dlRight = dlLeft + point.shapeArgs.width;
@@ -526,15 +538,12 @@ BaseSeries.seriesType<typeof Highcharts.XRangeSeries>('xrange', 'column'
             tooltipYOffset = series.columnMetrics ?
                 series.columnMetrics.offset : -metrics.width / 2;
 
-            // Limit position by the correct axis size (#9727)
-            tooltipPos[xIndex] = clamp(
-                tooltipPos[xIndex] + (
-                    (!inverted ? 1 : -1) * (xAxis.reversed ? -1 : 1) *
-                    (length / 2)
-                ),
-                0,
-                xAxis.len - 1
-            );
+            // Centering tooltip position (#14147)
+            if (!inverted) {
+                tooltipPos[xIndex] += (xAxis.reversed ? -1 : 0) * point.shapeArgs.width;
+            } else {
+                tooltipPos[xIndex] += point.shapeArgs.width / 2;
+            }
             tooltipPos[yIndex] = clamp(
                 tooltipPos[yIndex] + (
                     (inverted ? -1 : 1) * tooltipYOffset


### PR DESCRIPTION
Fixed #14147, in xrange/gantt series, the tooltip wasn't centered above the point if there were more than one series in the chart.

~~Fixed #14147 tooltip wasn't centered.~~