### PR TITLE
Refactored events to handle class inheritance

### DIFF
--- a/js/Core/Dynamics.js
+++ b/js/Core/Dynamics.js
@@ -1136,6 +1136,8 @@ extend(LineSeries.prototype, /** @lends Series.prototype */ {
         }
         if (seriesTypes[newType || initialType]) {
             extend(series, seriesTypes[newType || initialType].prototype);
+            // The events are tied to the prototype chain, don't copy
+            delete series.hcEvents;
         }
         else {
             error(17, true, chart, { missingModuleFor: (newType || initialType) });

--- a/js/Core/Dynamics.js
+++ b/js/Core/Dynamics.js
@@ -1131,13 +1131,21 @@ extend(LineSeries.prototype, /** @lends Series.prototype */ {
         // methods and properties from the new type prototype (#2270,
         // #3719).
         series.remove(false, null, false, true);
+        var ownEvents = Object.hasOwnProperty.call(series, 'hcEvents') &&
+            series.hcEvents;
         for (n in initialSeriesProto) { // eslint-disable-line guard-for-in
             series[n] = void 0;
         }
         if (seriesTypes[newType || initialType]) {
             extend(series, seriesTypes[newType || initialType].prototype);
-            // The events are tied to the prototype chain, don't copy
-            delete series.hcEvents;
+            // The events are tied to the prototype chain, don't copy if they're
+            // not the series' own
+            if (ownEvents) {
+                series.hcEvents = ownEvents;
+            }
+            else {
+                delete series.hcEvents;
+            }
         }
         else {
             error(17, true, chart, { missingModuleFor: (newType || initialType) });

--- a/js/Core/Utilities.js
+++ b/js/Core/Utilities.js
@@ -1748,9 +1748,7 @@ var addEvent = H.addEvent = function (el, type, fn, options) {
     };
     events[type].push(eventObject);
     // Order the calls
-    events[type].sort(function (a, b) {
-        return a.order - b.order;
-    });
+    events[type].sort(function (a, b) { return a.order - b.order; });
     // Return a function that can be called to remove this event.
     return function () {
         removeEvent(el, type, fn);
@@ -1921,9 +1919,7 @@ var fireEvent = H.fireEvent = function (el, type, eventArguments, defaultFunctio
         // events are already sorted in the addEvent function.
         if (multilevel) {
             // Order the calls
-            events.sort(function (a, b) {
-                return a.order - b.order;
-            });
+            events.sort(function (a, b) { return a.order - b.order; });
         }
         // Call the collected event handlers
         events.forEach(function (obj) {

--- a/js/Core/Utilities.js
+++ b/js/Core/Utilities.js
@@ -1828,12 +1828,6 @@ var removeEvent = H.removeEvent = function removeEvent(el, type, fn) {
                 removeAllEvents(events);
                 events[type] = [];
             }
-            if (events[type].length === 0) {
-                delete events[type];
-            }
-            if (Object.keys(owner.hcEvents).length === 0) {
-                delete owner.hcEvents;
-            }
         }
         else {
             removeAllEvents(events);

--- a/js/Core/Utilities.js
+++ b/js/Core/Utilities.js
@@ -1709,18 +1709,17 @@ objectEach({
  *         A callback function to remove the added event.
  */
 var addEvent = H.addEvent = function (el, type, fn, options) {
-    if (options === void 0) { options = {}; }
     /* eslint-enable valid-jsdoc */
-    var events, addEventListener = (el.addEventListener || H.addEventListenerPolyfill);
-    // If we're setting events directly on the constructor, use a separate
-    // collection, `protoEvents` to distinguish it from the item events in
-    // `hcEvents`.
-    if (typeof el === 'function' && el.prototype) {
-        events = el.prototype.protoEvents = el.prototype.protoEvents || {};
+    if (options === void 0) { options = {}; }
+    // Add hcEvents to either the prototype (in case we're running addEvent on a
+    // class) or the instance. If hasOwnProperty('hcEvents') is false, it is
+    // inherited down the prototype chain, in which case we need to set the
+    // property on this instance (which may itself be a prototype).
+    var owner = typeof el === 'function' && el.prototype || el;
+    if (!Object.hasOwnProperty.call(owner, 'hcEvents')) {
+        owner.hcEvents = {};
     }
-    else {
-        events = el.hcEvents = el.hcEvents || {};
-    }
+    var events = owner.hcEvents;
     // Allow click events added to points, otherwise they will be prevented by
     // the TouchPointer.pinch function after a pinch zoom operation (#7091).
     if (H.Point && // without H a dependency loop occurs
@@ -1732,6 +1731,7 @@ var addEvent = H.addEvent = function (el, type, fn, options) {
     // Handle DOM events
     // If the browser supports passive events, add it to improve performance
     // on touch events (#11353).
+    var addEventListener = (el.addEventListener || H.addEventListenerPolyfill);
     if (addEventListener) {
         addEventListener.call(el, type, fn, H.supportsPassiveEvents ? {
             passive: options.passive === void 0 ?
@@ -1777,7 +1777,6 @@ var addEvent = H.addEvent = function (el, type, fn, options) {
  */
 var removeEvent = H.removeEvent = function removeEvent(el, type, fn) {
     /* eslint-enable valid-jsdoc */
-    var events;
     /**
      * @private
      * @param {string} type - event type
@@ -1816,29 +1815,33 @@ var removeEvent = H.removeEvent = function removeEvent(el, type, fn) {
             }
         });
     }
-    ['protoEvents', 'hcEvents'].forEach(function (coll, i) {
-        var eventElem = i ? el : el.prototype;
-        var eventCollection = eventElem && eventElem[coll];
-        if (eventCollection) {
-            if (type) {
-                events = (eventCollection[type] || []);
-                if (fn) {
-                    eventCollection[type] = events.filter(function (obj) {
-                        return fn !== obj.fn;
-                    });
-                    removeOneEvent(type, fn);
-                }
-                else {
-                    removeAllEvents(eventCollection);
-                    eventCollection[type] = [];
-                }
+    var owner = typeof el === 'function' && el.prototype || el;
+    if (Object.hasOwnProperty.call(owner, 'hcEvents')) {
+        var events = owner.hcEvents;
+        if (type) {
+            var typeEvents = (events[type] || []);
+            if (fn) {
+                events[type] = typeEvents.filter(function (obj) {
+                    return fn !== obj.fn;
+                });
+                removeOneEvent(type, fn);
             }
             else {
-                removeAllEvents(eventCollection);
-                eventElem[coll] = {};
+                removeAllEvents(events);
+                events[type] = [];
+            }
+            if (events[type].length === 0) {
+                delete events[type];
+            }
+            if (Object.keys(owner.hcEvents).length === 0) {
+                delete owner.hcEvents;
             }
         }
-    });
+        else {
+            removeAllEvents(events);
+            delete owner.hcEvents;
+        }
+    }
 };
 /* eslint-disable valid-jsdoc */
 /**
@@ -1879,7 +1882,7 @@ var fireEvent = H.fireEvent = function (el, type, eventArguments, defaultFunctio
             el.fireEvent(type, e);
         }
     }
-    else {
+    else if (el.hcEvents) {
         if (!eventArguments.target) {
             // We're running a custom event
             extend(eventArguments, {
@@ -1898,28 +1901,38 @@ var fireEvent = H.fireEvent = function (el, type, eventArguments, defaultFunctio
                 type: type
             });
         }
-        var fireInOrder = function (protoEvents, hcEvents) {
-            if (protoEvents === void 0) { protoEvents = []; }
-            if (hcEvents === void 0) { hcEvents = []; }
-            var iA = 0;
-            var iB = 0;
-            var length = protoEvents.length + hcEvents.length;
-            for (i = 0; i < length; i++) {
-                var obj = (!protoEvents[iA] ?
-                    hcEvents[iB++] :
-                    !hcEvents[iB] ?
-                        protoEvents[iA++] :
-                        protoEvents[iA].order <= hcEvents[iB].order ?
-                            protoEvents[iA++] :
-                            hcEvents[iB++]);
-                // If the event handler return false, prevent the default
-                // handler from executing
-                if (obj.fn.call(el, eventArguments) === false) {
-                    eventArguments.preventDefault();
+        var events = [];
+        var object = el;
+        var multilevel = false;
+        // Recurse up the inheritance chain and collect hcEvents set as own
+        // objects on the prototypes.
+        while (object.hcEvents) {
+            if (Object.hasOwnProperty.call(object, 'hcEvents') &&
+                object.hcEvents[type]) {
+                if (events.length) {
+                    multilevel = true;
                 }
+                events.unshift.apply(events, object.hcEvents[type]);
             }
-        };
-        fireInOrder(el.protoEvents && el.protoEvents[type], el.hcEvents && el.hcEvents[type]);
+            object = Object.getPrototypeOf(object);
+        }
+        // For performance reasons, only sort the event handlers in case we are
+        // dealing with multiple levels in the prototype chain. Otherwise, the
+        // events are already sorted in the addEvent function.
+        if (multilevel) {
+            // Order the calls
+            events.sort(function (a, b) {
+                return a.order - b.order;
+            });
+        }
+        // Call the collected event handlers
+        events.forEach(function (obj) {
+            // If the event handler returns false, prevent the default handler
+            // from executing
+            if (obj.fn.call(el, eventArguments) === false) {
+                eventArguments.preventDefault();
+            }
+        });
     }
     // Run the default if not prevented
     if (defaultFunction && !eventArguments.defaultPrevented) {

--- a/js/Extensions/OldiePolyfills.js
+++ b/js/Extensions/OldiePolyfills.js
@@ -106,6 +106,24 @@ if (!Function.prototype.bind) {
         };
     };
 }
+// Adapted from https://johnresig.com/blog/objectgetprototypeof/
+if (!Object.getPrototypeOf) {
+    if (typeof 'test'.__proto__ === 'object') { // eslint-disable-line no-proto
+        Object.getPrototypeOf = function (object) {
+            return object.__proto__; // eslint-disable-line no-proto
+        };
+    }
+    else {
+        Object.getPrototypeOf = function (object) {
+            var proto = object.constructor.prototype;
+            if (proto === object) {
+                return {}.constructor.prototype;
+            }
+            // May break if the constructor has been tampered with
+            return proto;
+        };
+    }
+}
 if (!Object.keys) {
     Object.keys = function (obj) {
         var result = [], prop;

--- a/js/Series/Column3D/Column3DComposition.js
+++ b/js/Series/Column3D/Column3DComposition.js
@@ -246,10 +246,8 @@ wrap(columnProto, 'setVisible', function (proceed, vis) {
     }
     proceed.apply(this, Array.prototype.slice.call(arguments, 1));
 });
-columnProto.handle3dGrouping = true;
-addEvent(LineSeries, 'afterInit', function () {
-    if (this.chart.is3d() &&
-        this.handle3dGrouping) {
+addEvent(ColumnSeries, 'afterInit', function () {
+    if (this.chart.is3d()) {
         var series = this, seriesOptions = this.options, grouping = seriesOptions.grouping, stacking = seriesOptions.stacking, reversedStacks = pick(this.yAxis.options.reversedStacks, true), z = 0;
         // @todo grouping === true ?
         if (!(typeof grouping !== 'undefined' && !grouping)) {

--- a/js/Series/Scatter/ScatterSeries.js
+++ b/js/Series/Scatter/ScatterSeries.js
@@ -224,10 +224,8 @@ extend(ScatterSeries.prototype, {
  *
  * */
 /* eslint-disable no-invalid-this */
-addEvent(LineSeries, 'afterTranslate', function () {
-    if (this instanceof ScatterSeries) {
-        this.applyJitter();
-    }
+addEvent(ScatterSeries, 'afterTranslate', function () {
+    this.applyJitter();
 });
 BaseSeries.registerSeriesType('scatter', ScatterSeries);
 /* *

--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -1,20 +1,24 @@
-QUnit.test("Handles should not be overlapped by xAxis labels (#2908)", function (assert) {
-    var chart = $('#container').highcharts('StockChart', {
-        navigator: {
-            height: 20
-        },
-        series: [{
-            data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]
-        }]
-    }).highcharts();
+QUnit.test(
+    "Handles should not be overlapped by xAxis labels (#2908)",
+    function (assert) {
+        var chart = $('#container').highcharts('StockChart', {
+            navigator: {
+                height: 20
+            },
+            series: [{
+                data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6,
+                    148.5, 216.4, 194.1, 95.6, 54.4]
+            }]
+        }).highcharts();
 
 
-    assert.strictEqual(
-        chart.scroller.handles[0].zIndex >= chart.scroller.xAxis.labelGroup.zIndex,
-        true,
-        "Labels no overlap handles"
-    );
-});
+        assert.ok(
+            chart.scroller.handles[0].zIndex >=
+                chart.scroller.xAxis.labelGroup.zIndex,
+            "Labels no overlap handles"
+        );
+    }
+);
 
 QUnit.test('Navigator (#4053)', function (assert) {
     var chart = new Highcharts.StockChart({
@@ -196,7 +200,8 @@ QUnit.test(
         assert.notEqual(
             secondShadeXBeforeTranslate,
             secondShadeBBox.x,
-            'Second shade should not be in the same position as after mousemove (#12573).'
+            'Second shade should not be in the same position as after ' +
+            'mousemove (#12573).'
         );
 
         assert.deepEqual(
@@ -212,8 +217,8 @@ QUnit.test(
                 chart.plotLeft + firstShadeBBox.width,
                 chart.plotLeft + firstShadeBBox.width + secondShadeBBox.width
             ],
-            'Navigator shades, outline and handles should be properly translated after ' +
-            'yAxis label reserve more space (#12573).'
+            'Navigator shades, outline and handles should be properly ' +
+            'translated after yAxis label reserve more space (#12573).'
         );
 
         chart = Highcharts.stockChart('container', {
@@ -402,101 +407,111 @@ QUnit.test('Missing points using navigator (#5699)', function (assert) {
     }, 0);
 });
 
-QUnit.test('#3961 - Zone zAxis shouldn\'t cause errors in Navigator series.', function (assert) {
-    var chart = $('#container').highcharts('StockChart', {
-        series: [{
-            type: 'bubble',
-            data: [
-                [0, 10, 20],
-                [1, 10, 20]
-            ]
-        }]
-    }).highcharts();
-
-    assert.strictEqual(
-        chart.scroller.handles.length !== 0, // handles are not rendered when we get error in zones
-        true,
-        'No errors in zones for bubble series.'
-    );
-});
-
-QUnit.test('Extremes in navigator with empty series initalized (#5390)', function (assert) {
-
-    var chart = Highcharts.stockChart('container', {
-            series: []
-        }),
-        series = [{
-            data: [{
-                x: 1465102500000,
-                y: 0.0057043973610007015
-            }, {
-                x: 1465251900000,
-                y: 0.020374603343000786
+QUnit.test(
+    '#3961 - Zone zAxis shouldn\'t cause errors in Navigator series.',
+    function (assert) {
+        var chart = $('#container').highcharts('StockChart', {
+            series: [{
+                type: 'bubble',
+                data: [
+                    [0, 10, 20],
+                    [1, 10, 20]
+                ]
             }]
-        }, {
-            data: [{
-                x: 1465102800000,
-                y: 23
-            }, {
-                x: 1465252200000,
-                y: 77
-            }]
-        }, {
-            data: [{
-                x: 1465102800000,
-                y: 1.2800000000000011
-            }, {
-                x: 1465252200000,
-                y: 1.3199999999999932
-            }]
-        }],
-        points = [{
-            data: [{
-                x: 1464951300000,
-                y: 0.04950855198299564
-            }, {
-                x: 1465100700000,
-                y: 0.007108723524993366
-            }]
-        }, {
-            data: [{
-                x: 1464951600000,
-                y: 101
-            }, {
-                x: 1465101000000,
-                y: 18
-            }]
-        }, {
-            data: [{
-                x: 1464951600000,
-                y: 1.5
-            }, {
-                x: 1465101000000,
-                y: 1.2399999999999949
-            }]
-        }];
+        }).highcharts();
 
-    Highcharts.each(series, function (s) {
-        chart.addSeries(s, false);
-    });
-    chart.xAxis[0].setExtremes();
+        assert.notStrictEqual(
+            // handles are not rendered when we get error in zones
+            chart.scroller.handles.length,
+            0,
+            'No errors in zones for bubble series.'
+        );
+    }
+);
 
-    Highcharts.each(points, function (s, index) {
-        if (chart.series[index].options.id !== "highcharts-navigator-series") {
-            Highcharts.each(s.data, function (p) {
-                chart.series[index].addPoint(p, false);
-            });
-        }
-    });
-    chart.xAxis[0].setExtremes();
+QUnit.test(
+    'Extremes in navigator with empty series initalized (#5390)',
+    function (assert) {
 
-    assert.strictEqual(
-        chart.xAxis[1].getExtremes().max,
-        1465251900000,
-        'Correct extremes in navigator'
-    );
+        var chart = Highcharts.stockChart('container', {
+                series: []
+            }),
+            series = [{
+                data: [{
+                    x: 1465102500000,
+                    y: 0.0057043973610007015
+                }, {
+                    x: 1465251900000,
+                    y: 0.020374603343000786
+                }]
+            }, {
+                data: [{
+                    x: 1465102800000,
+                    y: 23
+                }, {
+                    x: 1465252200000,
+                    y: 77
+                }]
+            }, {
+                data: [{
+                    x: 1465102800000,
+                    y: 1.2800000000000011
+                }, {
+                    x: 1465252200000,
+                    y: 1.3199999999999932
+                }]
+            }],
+            points = [{
+                data: [{
+                    x: 1464951300000,
+                    y: 0.04950855198299564
+                }, {
+                    x: 1465100700000,
+                    y: 0.007108723524993366
+                }]
+            }, {
+                data: [{
+                    x: 1464951600000,
+                    y: 101
+                }, {
+                    x: 1465101000000,
+                    y: 18
+                }]
+            }, {
+                data: [{
+                    x: 1464951600000,
+                    y: 1.5
+                }, {
+                    x: 1465101000000,
+                    y: 1.2399999999999949
+                }]
+            }];
 
-});
+        Highcharts.each(series, function (s) {
+            chart.addSeries(s, false);
+        });
+        chart.xAxis[0].setExtremes();
+
+        Highcharts.each(points, function (s, index) {
+            if (
+                chart.series[index].options.id !==
+                "highcharts-navigator-series"
+            ) {
+                Highcharts.each(s.data, function (p) {
+                    chart.series[index].addPoint(p, false);
+                });
+            }
+        });
+        chart.xAxis[0].setExtremes();
+
+        assert.strictEqual(
+            chart.xAxis[1].getExtremes().max,
+            1465251900000,
+            'Correct extremes in navigator'
+        );
+
+    }
+);
 
 QUnit.test('Add point and disabled navigator (#3452)', function (assert) {
 
@@ -616,103 +631,111 @@ QUnit.test('Empty scroller with Axis min set (#5172)', function (assert) {
     );
 });
 
-QUnit.test('Update navigator series on series update (#4923)', function (assert) {
+QUnit.test(
+    'Update navigator series on series update (#4923)',
+    function (assert) {
 
-    var chart = Highcharts.stockChart('container', {
-        series: [{
-            animation: false,
-            data: [
-                { x: 0, y: 0 },
-                { x: 1, y: 1 },
-                { x: 2, y: 2 },
-                { x: 3, y: 3 },
-                { x: 4, y: 4 },
-                { x: 5, y: 5 },
-                { x: 6, y: 6 },
-                { x: 7, y: 7 },
-                { x: 8, y: 8 },
-                { x: 9, y: 9 }
-            ],
-            dataGrouping: {
-                enabled: false
-            }
-        }]
-    });
-
-    var pathWidth = chart.series[1].graph.getBBox().width;
-
-    assert.strictEqual(
-        typeof pathWidth,
-        'number',
-        'Path width is set'
-    );
-    assert.ok(
-        pathWidth > 500,
-        'Path is more than 500px wide'
-    );
-
-    chart.series[0].addPoint([10, 10]);
-    assert.strictEqual(
-        chart.series[1].graph.getBBox().width,
-        pathWidth,
-        'Path width is updated'
-    );
-});
-
-
-QUnit.test('Moving navigator with no series should not break axis (#7411)', function (assert) {
-    var chart = Highcharts.stockChart('container', {
-            chart: {
-                animation: false
-            },
-            navigator: {
-                series: {
-                    visible: false
-                }
-            },
-            rangeSelector: {
-                selected: 4
-            },
+        var chart = Highcharts.stockChart('container', {
             series: [{
                 animation: false,
                 data: [
-                    { x: 1000000, y: 0 },
-                    { x: 100000001, y: 1 },
-                    { x: 1000000002, y: 2 },
-                    { x: 10000000004, y: 4 },
-                    { x: 100000000005, y: 5 },
-                    { x: 1000000000007, y: 7 }
-                ]
+                    { x: 0, y: 0 },
+                    { x: 1, y: 1 },
+                    { x: 2, y: 2 },
+                    { x: 3, y: 3 },
+                    { x: 4, y: 4 },
+                    { x: 5, y: 5 },
+                    { x: 6, y: 6 },
+                    { x: 7, y: 7 },
+                    { x: 8, y: 8 },
+                    { x: 9, y: 9 }
+                ],
+                dataGrouping: {
+                    enabled: false
+                }
             }]
-        }),
-        controller = new TestController(chart),
-        rightHandle = chart.navigator.handles[1],
-        isNum = Highcharts.isNumber;
+        });
 
-    assert.ok(
-        isNum(chart.xAxis[0].userMax),
-        'Axis should have proper extremes before messing with navigator.'
-    );
+        var pathWidth = chart.series[1].graph.getBBox().width;
 
-    // Make the nav do its rendering by simulating mouse click and drag on
-    // right handle.
-    function navRender() {
-        var x = rightHandle.x + rightHandle.translateX + rightHandle.width / 2,
-            y = rightHandle.y + rightHandle.translateY + rightHandle.height / 2;
-        controller.triggerEvent('mousedown', x, y);
-        controller.triggerEvent('mousemove', x, y);
-        controller.triggerEvent('mouseup', x, y);
+        assert.strictEqual(
+            typeof pathWidth,
+            'number',
+            'Path width is set'
+        );
+        assert.ok(
+            pathWidth > 500,
+            'Path is more than 500px wide'
+        );
+
+        chart.series[0].addPoint([10, 10]);
+        assert.strictEqual(
+            chart.series[1].graph.getBBox().width,
+            pathWidth,
+            'Path width is updated'
+        );
     }
+);
 
-    navRender();
-    chart.series[0].hide();
-    navRender();
 
-    assert.ok(
-        isNum(chart.xAxis[0].userMax),
-        'Axis should have proper extremes after messing with navigator.'
-    );
-});
+QUnit.test(
+    'Moving navigator with no series should not break axis (#7411)',
+    function (assert) {
+        var chart = Highcharts.stockChart('container', {
+                chart: {
+                    animation: false
+                },
+                navigator: {
+                    series: {
+                        visible: false
+                    }
+                },
+                rangeSelector: {
+                    selected: 4
+                },
+                series: [{
+                    animation: false,
+                    data: [
+                        { x: 1000000, y: 0 },
+                        { x: 100000001, y: 1 },
+                        { x: 1000000002, y: 2 },
+                        { x: 10000000004, y: 4 },
+                        { x: 100000000005, y: 5 },
+                        { x: 1000000000007, y: 7 }
+                    ]
+                }]
+            }),
+            controller = new TestController(chart),
+            rightHandle = chart.navigator.handles[1],
+            isNum = Highcharts.isNumber;
+
+        assert.ok(
+            isNum(chart.xAxis[0].userMax),
+            'Axis should have proper extremes before messing with navigator.'
+        );
+
+        // Make the nav do its rendering by simulating mouse click and drag on
+        // right handle.
+        function navRender() {
+            var x = rightHandle.x + rightHandle.translateX +
+                    rightHandle.width / 2,
+                y = rightHandle.y + rightHandle.translateY +
+                    rightHandle.height / 2;
+            controller.triggerEvent('mousedown', x, y);
+            controller.triggerEvent('mousemove', x, y);
+            controller.triggerEvent('mouseup', x, y);
+        }
+
+        navRender();
+        chart.series[0].hide();
+        navRender();
+
+        assert.ok(
+            isNum(chart.xAxis[0].userMax),
+            'Axis should have proper extremes after messing with navigator.'
+        );
+    }
+);
 
 QUnit.test(
     'Highcharts events tests',
@@ -733,10 +756,11 @@ QUnit.test(
             }
         });
 
-        assert.strictEqual(
-            chart.series[0].hcEvents.updatedData.length,
-            0,
-            'Update of adaptToUpdatedData should remove all related events (#8038)'
+        assert.ok(
+            !chart.series[0].hcEvents ||
+            !chart.series[0].hcEvents.updatedData ||
+            chart.series[0].hcEvents.updatedData.length === 0,
+            'Update of adaptToUpdatedData should remove all events (#8038)'
         );
 
         assert.strictEqual(
@@ -920,35 +944,38 @@ QUnit.test('stickToMin and stickToMax', function (assert) {
     );
 });
 
-QUnit.test('Update an unrelated dynamically added chart series (#8430)', function (assert) {
-    var chart = Highcharts.stockChart('container', {
-        series: [],
-        navigator: {
-            adaptToUpdatedData: false,
-            series: {
-                id: "navigator",
-                data: []
+QUnit.test(
+    'Update an unrelated dynamically added chart series (#8430)',
+    function (assert) {
+        var chart = Highcharts.stockChart('container', {
+            series: [],
+            navigator: {
+                adaptToUpdatedData: false,
+                series: {
+                    id: "navigator",
+                    data: []
+                }
             }
-        }
-    });
+        });
 
-    chart.addSeries({
-        id: "series1"
-    });
+        chart.addSeries({
+            id: "series1"
+        });
 
-    chart.get("navigator").setData([
-        { x: 0, y: 1 },
-        { x: 1, y: 10 }
-    ]);
+        chart.get("navigator").setData([
+            { x: 0, y: 1 },
+            { x: 1, y: 10 }
+        ]);
 
-    chart.get("series1").update({});
+        chart.get("series1").update({});
 
-    assert.strictEqual(
-        chart.navigator.series[0].points.length,
-        2,
-        'Correct number of points in navigator series (#8430).'
-    );
-});
+        assert.strictEqual(
+            chart.navigator.series[0].points.length,
+            2,
+            'Correct number of points in navigator series (#8430).'
+        );
+    }
+);
 
 QUnit.test('Add a navigator by chart update (#7067)', function (assert) {
     var chart = Highcharts.stockChart('container', {
@@ -1001,7 +1028,8 @@ QUnit.test('Navigator with adding series on chart load.', function (assert) {
             events: {
                 load: function (event) {
                     this.navigator.onMouseUp(event);
-                    const xStr = this.navigator.shades[1].element.getAttribute('x');
+                    const xStr = this.navigator.shades[1].element
+                        .getAttribute('x');
                     assert.notEqual(
                         /^[\-0-9\.]+$/.test(xStr) || xStr === null,
                         false,
@@ -1016,29 +1044,33 @@ QUnit.test('Navigator with adding series on chart load.', function (assert) {
     });
 });
 
-QUnit.test('yAxis in navigator does not match the one in the chart, #14060.', function (assert) {
-    const chart = Highcharts.stockChart('container', {
-        yAxis: {
-            reversed: true
-        },
-        series: [{
-            data: [1, 2, 3]
-        }]
-    });
-
-    assert.ok(
-        chart.navigator.yAxis.reversed,
-        'Navigator should inherit the reversed property from the main axis.'
-    );
-    chart.update({
-        navigator: {
+QUnit.test(
+    'yAxis in navigator does not match the one in the chart, #14060.',
+    function (assert) {
+        const chart = Highcharts.stockChart('container', {
             yAxis: {
-                reversed: false
+                reversed: true
+            },
+            series: [{
+                data: [1, 2, 3]
+            }]
+        });
+
+        assert.ok(
+            chart.navigator.yAxis.reversed,
+            'Navigator should inherit the reversed property from the main axis.'
+        );
+        chart.update({
+            navigator: {
+                yAxis: {
+                    reversed: false
+                }
             }
-        }
-    });
-    assert.notOk(
-        chart.navigator.yAxis.reversed,
-        'Navigator options should have higher priority and the axis should not be reversed anymore.'
-    );
-});
+        });
+        assert.notOk(
+            chart.navigator.yAxis.reversed,
+            'Navigator options should have higher priority and the axis ' +
+            'should not be reversed anymore.'
+        );
+    }
+);

--- a/samples/unit-tests/utilities/events/demo.js
+++ b/samples/unit-tests/utilities/events/demo.js
@@ -600,19 +600,19 @@
 
         const results = [];
 
-        function LineSeries() {}
-        LineSeries.prototype.type = 'line';
+        function Series() {}
+        Series.prototype.type = 'line';
 
-        const ColumnSeries = Highcharts.extendClass(LineSeries, {
+        const ColumnSeries = Highcharts.extendClass(Series, {
             type: 'column'
         });
         const item = new ColumnSeries();
 
 
         addEvent(
-            LineSeries,
+            Series,
             'touch',
-            () => results.push('LineSeries')
+            () => results.push('Series')
         );
         addEvent(
             ColumnSeries,
@@ -629,8 +629,18 @@
         fireEvent(item, 'touch');
         assert.deepEqual(
             results,
-            ['LineSeries', 'ColumnSeries', 'item'],
+            ['Series', 'ColumnSeries', 'item'],
             'All levels of the prototype chain should fire'
+        );
+
+        const line = new Series();
+        results.length = 0;
+        fireEvent(line, 'touch');
+        assert.deepEqual(
+            results,
+            ['Series'],
+            `Only the Series class event should fire on a Series
+            instance`
         );
 
         // Removed
@@ -639,13 +649,13 @@
         fireEvent(item, 'touch');
         assert.deepEqual(
             results,
-            ['LineSeries', 'item'],
+            ['Series', 'item'],
             'Remaining levels of the prototype chain should fire'
         );
 
         // Remove all
         results.length = 0;
-        removeEvent(LineSeries, 'touch');
+        removeEvent(Series, 'touch');
         removeEvent(item, 'touch');
         fireEvent(item, 'touch');
         assert.deepEqual(
@@ -657,15 +667,15 @@
         // Add randomly ordered events spread over the prototype chain
         results.length = 0;
         addEvent(
-            LineSeries,
+            Series,
             'touch',
-            () => results.push('LineSeries.3'),
+            () => results.push('Series.3'),
             { order: 3 }
         );
         addEvent(
-            LineSeries,
+            Series,
             'touch',
-            () => results.push('LineSeries.1'),
+            () => results.push('Series.1'),
             { order: 1 }
         );
 
@@ -701,9 +711,9 @@
             [
                 'item.-1',
                 'ColumnSeries.0',
-                'LineSeries.1',
+                'Series.1',
                 'ColumnSeries.2',
-                'LineSeries.3',
+                'Series.3',
                 'item.4'
             ],
             'Events should fire in order across the prototype chain'

--- a/samples/unit-tests/utilities/events/demo.js
+++ b/samples/unit-tests/utilities/events/demo.js
@@ -166,7 +166,12 @@
     QUnit.test('ObjectEventPreventDefaultExists', function (assert) {
         var o = { clickedCount: 0 },
             f = function (e) {
-                assertEquals(assert, 'preventDefault should exist', typeof e.preventDefault, 'function');
+                assertEquals(
+                    assert,
+                    'preventDefault should exist',
+                    typeof e.preventDefault,
+                    'function'
+                );
             };
 
         // Setup event handler
@@ -180,7 +185,8 @@
     });
 
     /**
-     * Tests that it is possible to prevent the default action by calling preventDefault.
+     * Tests that it is possible to prevent the default action by calling
+     * preventDefault.
      */
     QUnit.test('ObjectEventPreventDefaultByFunction', function (assert) {
         var o = { clickedCount: 0 },
@@ -213,38 +219,47 @@
      * Test that it is possible to prevent the default action from one
      * handler and still not running the default.
      */
-    QUnit.test('ObjectEventPreventDefaultByFunctionMultiple', function (assert) {
-        var o = { clickedCount: 0 },
-            f = function (e) {
-                o.clickedCount += e.inc;
-                e.preventDefault();
-            },
-            g = function (e) {
-                o.clickedCount += e.inc;
-                // e.preventDefault(); Do not prevent the default.
-            },
-            defaultFunction = function (e) {
-                o.clickedCount += e.inc;
-            };
+    QUnit.test(
+        'ObjectEventPreventDefaultByFunctionMultiple',
+        function (assert) {
+            var o = { clickedCount: 0 },
+                f = function (e) {
+                    o.clickedCount += e.inc;
+                    e.preventDefault();
+                },
+                g = function (e) {
+                    o.clickedCount += e.inc;
+                    // e.preventDefault(); Do not prevent the default.
+                },
+                defaultFunction = function (e) {
+                    o.clickedCount += e.inc;
+                };
 
-        // Setup event handler
-        addEvent(o, 'customEvent', f);
-        addEvent(o, 'customEvent', g);
-        assertEquals(assert, 'not yet clicked', 0, o.clickedCount);
+            // Setup event handler
+            addEvent(o, 'customEvent', f);
+            addEvent(o, 'customEvent', g);
+            assertEquals(assert, 'not yet clicked', 0, o.clickedCount);
 
-        // Fire it once
-        fireEvent(o, 'customEvent', { inc: 1 }, defaultFunction);
+            // Fire it once
+            fireEvent(o, 'customEvent', { inc: 1 }, defaultFunction);
 
-        assertEquals(assert, 'now clicked', 2, o.clickedCount);
+            assertEquals(assert, 'now clicked', 2, o.clickedCount);
 
-        // Remove the handler (Most fine-grained)
-        removeEvent(o, 'customEvent', f);
+            // Remove the handler (Most fine-grained)
+            removeEvent(o, 'customEvent', f);
 
-        // Fire it again, should fire 'g' which is not preventing the default
-        fireEvent(o, 'customEvent', { inc: 10 }, defaultFunction);
-        assertEquals(assert, 'clicked again, no change', 22, o.clickedCount); // 2 (from before) + 2 * 10 (handler + default)
-        removeEvent(o, 'customEvent', g);
-    });
+            // Fire it again, should fire 'g' which is not preventing the
+            // default
+            fireEvent(o, 'customEvent', { inc: 10 }, defaultFunction);
+            assertEquals(
+                assert,
+                'clicked again, no change',
+                22, // 2 (from before) + 2 * 10 (handler + default)
+                o.clickedCount
+            );
+            removeEvent(o, 'customEvent', g);
+        }
+    );
 
     /**
      * Test that arguments are passed to the event handler.
@@ -296,55 +311,71 @@
         // Remove the handler (Most fine-grained)
         removeEvent(o, 'customEvent', f);
 
-        // Fire it again, should only run the default function, since the handler is removed
+        // Fire it again, should only run the default function, since the
+        // handler is removed
         fireEvent(o, 'customEvent', { inc: 2 }, defaultFunction);
         assertEquals(assert, 'clicked again, no change', 6, o.clickedCount);
     });
 
     /**
-     * Tests that properties set in the handler is passed on to the default function.
+     * Tests that properties set in the handler is passed on to the default
+     * function.
      */
-    QUnit.test('ObjectEventPropertiesSetInHandlerSuppliedToDefaultFunction', function (assert) {
-        var o = { clickedCount: 0 },
-            f = function (e) {
-                o.clickedCount += e.inc;
-                e.extraInc = 100;
-            },
-            defaultFunction = function (e) {
-                o.clickedCount += e.inc;
-                o.clickedCount += (e.extraInc || 0);
-            };
+    QUnit.test(
+        'ObjectEventPropertiesSetInHandlerSuppliedToDefaultFunction',
+        function (assert) {
+            var o = { clickedCount: 0 },
+                f = function (e) {
+                    o.clickedCount += e.inc;
+                    e.extraInc = 100;
+                },
+                defaultFunction = function (e) {
+                    o.clickedCount += e.inc;
+                    o.clickedCount += (e.extraInc || 0);
+                };
 
-        // Setup event handler
-        addEvent(o, 'customEvent', f);
-        assertEquals(assert, 'not yet clicked', 0, o.clickedCount);
+            // Setup event handler
+            addEvent(o, 'customEvent', f);
+            assertEquals(assert, 'not yet clicked', 0, o.clickedCount);
 
-        // Fire it once
-        fireEvent(o, 'customEvent', { inc: 2 }, defaultFunction);
+            // Fire it once
+            fireEvent(o, 'customEvent', { inc: 2 }, defaultFunction);
 
-        assertEquals(assert, 'now clicked', 104, o.clickedCount);
+            assertEquals(assert, 'now clicked', 104, o.clickedCount);
 
-        // Remove the handler (Most fine-grained)
-        removeEvent(o, 'customEvent', f);
+            // Remove the handler (Most fine-grained)
+            removeEvent(o, 'customEvent', f);
 
-        // Fire it again, should only run the default function, since the handler is removed
-        fireEvent(o, 'customEvent', { inc: 2 }, defaultFunction);
-        assertEquals(assert, 'clicked again, no change', 106, o.clickedCount);
-    });
+            // Fire it again, should only run the default function, since the
+            // handler is removed
+            fireEvent(o, 'customEvent', { inc: 2 }, defaultFunction);
+            assertEquals(
+                assert,
+                'clicked again, no change',
+                106,
+                o.clickedCount
+            );
+        }
+    );
 
     /**
-     * Tests that the default function is executed even when no listeners are registered.
+     * Tests that the default function is executed even when no listeners are
+     * registered.
      */
-    QUnit.test('ObjectEventDefaultFunctionShouldRunWhenNoHandlersAreRegistered', function (assert) {
-        var o = { clickedCount: 0 },
-            defaultFunction = function (e) {
-                o.clickedCount += e.inc;
-            };
+    QUnit.test(
+        'ObjectEventDefaultFunctionShouldRunWhenNoHandlersAreRegistered',
+        function (assert) {
+            var o = { clickedCount: 0 },
+                defaultFunction = function (e) {
+                    o.clickedCount += e.inc;
+                };
 
-        // Fire it, should only run the default function, since there is no handler
-        fireEvent(o, 'customEvent', { inc: 1 }, defaultFunction);
-        assertEquals(assert, 'clicked again, no change', 1, o.clickedCount);
-    });
+            // Fire it, should only run the default function, since there is no
+            // handler
+            fireEvent(o, 'customEvent', { inc: 1 }, defaultFunction);
+            assertEquals(assert, 'clicked again, no change', 1, o.clickedCount);
+        }
+    );
 
     /**
      * Test event add/fire/remove on DOM element.
@@ -373,7 +404,12 @@
 
         // Fire it again, should do nothing, since the handler is removed
         fireEvent(o, 'customEvent', null, null);
-        assertEquals(assert, 'custom clicked again, no change', 1, pInt(o.innerHTML));
+        assertEquals(
+            assert,
+            'custom clicked again, no change',
+            1,
+            pInt(o.innerHTML)
+        );
 
 
         // 2. Test HTML events
@@ -422,7 +458,12 @@
 
         // Fire it again, should do nothing, since the handler is removed
         fireEvent(o, 'customEvent', null, null);
-        assertEquals(assert, 'custom clicked again, no change', 1, pInt(o.innerHTML));
+        assertEquals(
+            assert,
+            'custom clicked again, no change',
+            1,
+            pInt(o.innerHTML)
+        );
 
         // 2. Test HTML events
         // Reset the counter
@@ -471,7 +512,12 @@
 
         // Fire it again, should do nothing, since the handler is removed
         fireEvent(o, 'customEvent', null, null);
-        assertEquals(assert, 'custom clicked again, no change', 1, pInt(o.innerHTML));
+        assertEquals(
+            assert,
+            'custom clicked again, no change',
+            1,
+            pInt(o.innerHTML)
+        );
 
         // 2. Test HTML events
         // Reset the counter
@@ -515,7 +561,7 @@
     });
 
     QUnit.test('Unbinding prototype event', function (assert) {
-        var unbind = Highcharts.addEvent(Highcharts.Chart, 'render', function () {
+        var unbind = addEvent(Highcharts.Chart, 'render', function () {
             assert.ok(false, 'This event should never fire');
         });
         unbind();
@@ -548,5 +594,119 @@
             'Events should be fired in ascending order'
         );
 
+    });
+
+    QUnit.test('Events in extended classes', assert => {
+
+        const results = [];
+
+        function LineSeries() {}
+        LineSeries.prototype.type = 'line';
+
+        const ColumnSeries = Highcharts.extendClass(LineSeries, {
+            type: 'column'
+        });
+        const item = new ColumnSeries();
+
+
+        addEvent(
+            LineSeries,
+            'touch',
+            () => results.push('LineSeries')
+        );
+        addEvent(
+            ColumnSeries,
+            'touch',
+            () => results.push('ColumnSeries')
+        );
+
+        addEvent(
+            item,
+            'touch',
+            () => results.push('item')
+        );
+
+        fireEvent(item, 'touch');
+        assert.deepEqual(
+            results,
+            ['LineSeries', 'ColumnSeries', 'item'],
+            'All levels of the prototype chain should fire'
+        );
+
+        // Removed
+        results.length = 0;
+        removeEvent(ColumnSeries, 'touch');
+        fireEvent(item, 'touch');
+        assert.deepEqual(
+            results,
+            ['LineSeries', 'item'],
+            'Remaining levels of the prototype chain should fire'
+        );
+
+        // Remove all
+        results.length = 0;
+        removeEvent(LineSeries, 'touch');
+        removeEvent(item, 'touch');
+        fireEvent(item, 'touch');
+        assert.deepEqual(
+            results,
+            [],
+            'No events should fire'
+        );
+
+        // Add randomly ordered events spread over the prototype chain
+        results.length = 0;
+        addEvent(
+            LineSeries,
+            'touch',
+            () => results.push('LineSeries.3'),
+            { order: 3 }
+        );
+        addEvent(
+            LineSeries,
+            'touch',
+            () => results.push('LineSeries.1'),
+            { order: 1 }
+        );
+
+        addEvent(
+            ColumnSeries,
+            'touch',
+            () => results.push('ColumnSeries.2'),
+            { order: 2 }
+        );
+        addEvent(
+            ColumnSeries,
+            'touch',
+            () => results.push('ColumnSeries.0'),
+            { order: 0 }
+        );
+
+        addEvent(
+            item,
+            'touch',
+            () => results.push('item.4'),
+            { order: 4 }
+        );
+
+        addEvent(
+            item,
+            'touch',
+            () => results.push('item.-1'),
+            { order: -1 }
+        );
+        fireEvent(item, 'touch');
+        assert.deepEqual(
+            results,
+            [
+                'item.-1',
+                'ColumnSeries.0',
+                'LineSeries.1',
+                'ColumnSeries.2',
+                'LineSeries.3',
+                'item.4'
+            ],
+            'Events should fire in order across the prototype chain'
+        );
     });
 }());

--- a/ts/Core/Dynamics.ts
+++ b/ts/Core/Dynamics.ts
@@ -1613,6 +1613,8 @@ extend(LineSeries.prototype, /** @lends Series.prototype */ {
         }
         if (seriesTypes[newType || initialType]) {
             extend(series, seriesTypes[newType || initialType].prototype);
+            // The events are tied to the prototype chain, don't copy
+            delete series.hcEvents;
         } else {
             error(
                 17,

--- a/ts/Core/Dynamics.ts
+++ b/ts/Core/Dynamics.ts
@@ -1608,13 +1608,20 @@ extend(LineSeries.prototype, /** @lends Series.prototype */ {
         // methods and properties from the new type prototype (#2270,
         // #3719).
         series.remove(false, null as any, false, true);
+        const ownEvents = Object.hasOwnProperty.call(series, 'hcEvents') &&
+            series.hcEvents;
         for (n in initialSeriesProto) { // eslint-disable-line guard-for-in
             (series as any)[n] = void 0;
         }
         if (seriesTypes[newType || initialType]) {
             extend(series, seriesTypes[newType || initialType].prototype);
-            // The events are tied to the prototype chain, don't copy
-            delete series.hcEvents;
+            // The events are tied to the prototype chain, don't copy if they're
+            // not the series' own
+            if (ownEvents) {
+                series.hcEvents = ownEvents;
+            } else {
+                delete series.hcEvents;
+            }
         } else {
             error(
                 17,

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -2375,12 +2375,10 @@ const addEvent = H.addEvent = function<T> (
     events[type].push(eventObject);
 
     // Order the calls
-    events[type].sort(function (
+    events[type].sort((
         a: Highcharts.EventWrapperObject<T>,
         b: Highcharts.EventWrapperObject<T>
-    ): number {
-        return a.order - b.order;
-    });
+    ): number => a.order - b.order);
 
     // Return a function that can be called to remove this event.
     return function (): void {
@@ -2591,12 +2589,10 @@ const fireEvent = H.fireEvent = function<T> (
         // events are already sorted in the addEvent function.
         if (multilevel) {
             // Order the calls
-            events.sort(function (
+            events.sort((
                 a: Highcharts.EventWrapperObject<T>,
                 b: Highcharts.EventWrapperObject<T>
-            ): number {
-                return a.order - b.order;
-            });
+            ): number => a.order - b.order);
         }
 
         // Call the collected event handlers

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -2481,12 +2481,6 @@ const removeEvent = H.removeEvent = function removeEvent<T>(
                 removeAllEvents(events);
                 events[type] = [];
             }
-            if (events[type].length === 0) {
-                delete events[type];
-            }
-            if (Object.keys(owner.hcEvents).length === 0) {
-                delete owner.hcEvents;
-            }
         } else {
             removeAllEvents(events);
             delete owner.hcEvents;

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -2323,19 +2323,17 @@ const addEvent = H.addEvent = function<T> (
     options: Highcharts.EventOptionsObject = {}
 ): Function {
     /* eslint-enable valid-jsdoc */
-    var events: Highcharts.Dictionary<Array<any>>,
-        addEventListener = (
-            (el as any).addEventListener || H.addEventListenerPolyfill
-        );
 
-    // If we're setting events directly on the constructor, use a separate
-    // collection, `protoEvents` to distinguish it from the item events in
-    // `hcEvents`.
-    if (typeof el === 'function' && el.prototype) {
-        events = el.prototype.protoEvents = el.prototype.protoEvents || {};
-    } else {
-        events = (el as any).hcEvents = (el as any).hcEvents || {};
+    // Add hcEvents to either the prototype (in case we're running addEvent on a
+    // class) or the instance. If hasOwnProperty('hcEvents') is false, it is
+    // inherited down the prototype chain, in which case we need to set the
+    // property on this instance (which may itself be a prototype).
+    const owner = typeof el === 'function' && el.prototype || el;
+    if (!Object.hasOwnProperty.call(owner, 'hcEvents')) {
+        owner.hcEvents = {};
     }
+    const events: Highcharts.Dictionary<Array<any>> = owner.hcEvents;
+
 
     // Allow click events added to points, otherwise they will be prevented by
     // the TouchPointer.pinch function after a pinch zoom operation (#7091).
@@ -2350,6 +2348,9 @@ const addEvent = H.addEvent = function<T> (
     // Handle DOM events
     // If the browser supports passive events, add it to improve performance
     // on touch events (#11353).
+    const addEventListener = (
+        (el as any).addEventListener || H.addEventListenerPolyfill
+    );
     if (addEventListener) {
         addEventListener.call(
             el,
@@ -2413,8 +2414,6 @@ const removeEvent = H.removeEvent = function removeEvent<T>(
 ): void {
     /* eslint-enable valid-jsdoc */
 
-    var events;
-
     /**
      * @private
      * @param {string} type - event type
@@ -2464,34 +2463,37 @@ const removeEvent = H.removeEvent = function removeEvent<T>(
         });
     }
 
-    ['protoEvents', 'hcEvents'].forEach(function (coll: string, i): void {
-        const eventElem = i ? el : (el as any).prototype;
-        const eventCollection = eventElem && eventElem[coll];
+    const owner = typeof el === 'function' && el.prototype || el;
+    if (Object.hasOwnProperty.call(owner, 'hcEvents')) {
+        const events = owner.hcEvents;
+        if (type) {
+            const typeEvents = (
+                events[type] || []
+            ) as Highcharts.EventWrapperObject<T>[];
 
-        if (eventCollection) {
-            if (type) {
-                events = (
-                    eventCollection[type] || []
-                ) as Highcharts.EventWrapperObject<T>[];
+            if (fn) {
+                events[type] = typeEvents.filter(
+                    function (obj): boolean {
+                        return fn !== obj.fn;
+                    }
+                );
+                removeOneEvent(type, fn);
 
-                if (fn) {
-                    eventCollection[type] = events.filter(
-                        function (obj): boolean {
-                            return fn !== obj.fn;
-                        }
-                    );
-                    removeOneEvent(type, fn);
-
-                } else {
-                    removeAllEvents(eventCollection);
-                    eventCollection[type] = [];
-                }
             } else {
-                removeAllEvents(eventCollection);
-                eventElem[coll] = {};
+                removeAllEvents(events);
+                events[type] = [];
             }
+            if (events[type].length === 0) {
+                delete events[type];
+            }
+            if (Object.keys(owner.hcEvents).length === 0) {
+                delete owner.hcEvents;
+            }
+        } else {
+            removeAllEvents(events);
+            delete owner.hcEvents;
         }
-    });
+    }
 };
 
 /* eslint-disable valid-jsdoc */
@@ -2543,7 +2545,7 @@ const fireEvent = H.fireEvent = function<T> (
             (el as any).fireEvent(type, e);
         }
 
-    } else {
+    } else if ((el as any).hcEvents) {
 
         if (!(eventArguments as any).target) {
             // We're running a custom event
@@ -2565,37 +2567,47 @@ const fireEvent = H.fireEvent = function<T> (
             });
         }
 
-        const fireInOrder = (
-            protoEvents: Highcharts.EventWrapperObject<any>[] = [],
-            hcEvents: Highcharts.EventWrapperObject<any>[] = []
-        ): void => {
-            let iA = 0;
-            let iB = 0;
-            const length = protoEvents.length + hcEvents.length;
+        const events: Array<Highcharts.EventWrapperObject<any>> = [];
+        let object: any = el;
+        let multilevel = false;
 
-            for (i = 0; i < length; i++) {
-                const obj = (
-                    !protoEvents[iA] ?
-                        hcEvents[iB++] :
-                        !hcEvents[iB] ?
-                            protoEvents[iA++] :
-                            protoEvents[iA].order <= hcEvents[iB].order ?
-                                protoEvents[iA++] :
-                                hcEvents[iB++]
-                );
-
-                // If the event handler return false, prevent the default
-                // handler from executing
-                if (obj.fn.call(el, eventArguments as any) === false) {
-                    (eventArguments as any).preventDefault();
+        // Recurse up the inheritance chain and collect hcEvents set as own
+        // objects on the prototypes.
+        while (object.hcEvents) {
+            if (
+                Object.hasOwnProperty.call(object, 'hcEvents') &&
+                object.hcEvents[type]
+            ) {
+                if (events.length) {
+                    multilevel = true;
                 }
+                events.unshift.apply(events, object.hcEvents[type]);
             }
-        };
+            object = Object.getPrototypeOf(object);
+        }
 
-        fireInOrder(
-            (el as any).protoEvents && (el as any).protoEvents[type],
-            (el as any).hcEvents && (el as any).hcEvents[type]
-        );
+        // For performance reasons, only sort the event handlers in case we are
+        // dealing with multiple levels in the prototype chain. Otherwise, the
+        // events are already sorted in the addEvent function.
+        if (multilevel) {
+            // Order the calls
+            events.sort(function (
+                a: Highcharts.EventWrapperObject<T>,
+                b: Highcharts.EventWrapperObject<T>
+            ): number {
+                return a.order - b.order;
+            });
+        }
+
+        // Call the collected event handlers
+        events.forEach((obj): void => {
+            // If the event handler returns false, prevent the default handler
+            // from executing
+            if (obj.fn.call(el, eventArguments as any) === false) {
+                (eventArguments as any).preventDefault();
+            }
+        });
+
     }
 
     // Run the default if not prevented

--- a/ts/Extensions/OldiePolyfills.ts
+++ b/ts/Extensions/OldiePolyfills.ts
@@ -202,6 +202,24 @@ if (!Function.prototype.bind) {
     };
 }
 
+// Adapted from https://johnresig.com/blog/objectgetprototypeof/
+if (!Object.getPrototypeOf) {
+    if (typeof ('test' as any).__proto__ === 'object') { // eslint-disable-line no-proto
+        Object.getPrototypeOf = function (object): any {
+            return (object as any).__proto__; // eslint-disable-line no-proto
+        };
+    } else {
+        Object.getPrototypeOf = function (object): any {
+            const proto = object.constructor.prototype;
+            if (proto === object) {
+                return {}.constructor.prototype;
+            }
+            // May break if the constructor has been tampered with
+            return proto;
+        };
+    }
+}
+
 if (!Object.keys) {
     Object.keys = function (
         this: Record<string, any>,

--- a/ts/Series/Column3D/Column3DComposition.ts
+++ b/ts/Series/Column3D/Column3DComposition.ts
@@ -71,7 +71,6 @@ declare module '../../Core/Series/PointLike' {
 
 declare module '../../Core/Series/SeriesLike' {
     interface SeriesLike {
-        handle3dGrouping: boolean;
         z: number;
         /** @requires Series/Column3DSeries */
         translate3dShapes(): void;
@@ -405,12 +404,8 @@ wrap(
     }
 );
 
-columnProto.handle3dGrouping = true;
-addEvent(LineSeries, 'afterInit', function (): void {
-    if (
-        this.chart.is3d() &&
-        (this as ColumnSeries).handle3dGrouping
-    ) {
+addEvent(ColumnSeries, 'afterInit', function (): void {
+    if (this.chart.is3d()) {
         var series = this as ColumnSeries,
             seriesOptions: ColumnSeriesOptions = this.options,
             grouping = seriesOptions.grouping,

--- a/ts/Series/Line/LineSeries.ts
+++ b/ts/Series/Line/LineSeries.ts
@@ -6472,7 +6472,7 @@ interface LineSeries extends SeriesLike {
         Highcharts.LegendSymbolMixin['drawLineMarker']|
         Highcharts.LegendSymbolMixin['drawRectangle']
     );
-    hcEvents: Record<string, Array<Highcharts.EventWrapperObject<LineSeries>>>;
+    hcEvents?: Record<string, Array<Highcharts.EventWrapperObject<LineSeries>>>;
     isCartesian: boolean;
     kdAxisArray: Array<string>;
     parallelArrays: Array<string>;

--- a/ts/Series/Scatter/ScatterSeries.ts
+++ b/ts/Series/Scatter/ScatterSeries.ts
@@ -299,12 +299,8 @@ extend(ScatterSeries.prototype, {
 
 /* eslint-disable no-invalid-this */
 
-addEvent(LineSeries, 'afterTranslate', function (
-    this: LineSeries
-): void {
-    if (this instanceof ScatterSeries) {
-        this.applyJitter();
-    }
+addEvent(ScatterSeries, 'afterTranslate', function (): void {
+    this.applyJitter();
 });
 
 /* eslint-enable no-invalid-this */

--- a/ts/Stock/Indicators/BB/BBOptions.d.ts
+++ b/ts/Stock/Indicators/BB/BBOptions.d.ts
@@ -32,4 +32,4 @@ export interface BBParamsOptions extends SMAParamsOptions {
     // for inheritance
 }
 
-export default EMAOptions;
+export default BBOptions;


### PR DESCRIPTION
Fixed #14661, the event system didn't properly work with class inheritance. For example an event set on the inherited `ColumnSeries` class, would also fire on the parent `LineSeries`.

### To do
 - [x] Implement events in the inheritance chain
 - [x] Add unit tests for the new functionality
 - [x] Make use of the new functionality in cases where we currently set an event on the `LineSeries` then do an `instanceof` check within the handler. That should not be needed anymore.
 - [x] IE8 polyfill of `getPrototypeOf`