### PR TITLE
Fix getTimeTicks: ensure min value of 1 for setUTCDate

### DIFF
--- a/js/Core/Time.js
+++ b/js/Core/Time.js
@@ -565,11 +565,11 @@ var Time = /** @class */ (function () {
             if (interval === timeUnits.week) {
                 // get start of current week, independent of count
                 minDay = time.get('Day', minDate);
-                time.set('Date', minDate, (time.get('Date', minDate) -
+                time.set('Date', minDate, Math.max(1, (time.get('Date', minDate) -
                     minDay + startOfWeek +
                     // We don't want to skip days that are before
                     // startOfWeek (#7051)
-                    (minDay < startOfWeek ? -7 : 0)));
+                    (minDay < startOfWeek ? -7 : 0))));
             }
             // Get basics for variable time spans
             minYear = time.get('FullYear', minDate);


### PR DESCRIPTION
Same as https://github.com/highcharts/highcharts/pull/9344, but for a different branch of the `getTimeTicks` function.

See http://jsfiddle.net/xjrop93q/ for a reproduction scenario. The chart width must be less than about 1200px for the error behavior to occur:
<img width="361" alt="image" src="https://user-images.githubusercontent.com/734581/100494836-dc180c00-3145-11eb-8d45-816be420ab42.png">