### PR TITLE
bugfix/14729-ROCOptions-wrong-export

### DIFF
--- a/ts/Stock/Indicators/ROC/ROCOptions.d.ts
+++ b/ts/Stock/Indicators/ROC/ROCOptions.d.ts
@@ -31,4 +31,4 @@ export interface ROCParamsOptions extends SMAParamsOptions {
     // for inheritance
 }
 
-export default EMAOptions;
+export default ROCOptions;


### PR DESCRIPTION
Fixed #14729, wrong export from ROCOptions.