### PR TITLE
bugfix/13961-half-hour-timezone-ticks

### DIFF
--- a/js/Core/Time.js
+++ b/js/Core/Time.js
@@ -221,7 +221,8 @@ var Time = /** @class */ (function () {
             // time
             if (unit === 'Milliseconds' ||
                 unit === 'Seconds' ||
-                (unit === 'Minutes' && this.getTimezoneOffset(date) % 3600000 === 0)) {
+                (unit === 'Minutes' && this.getTimezoneOffset(date) % 3600000 === 0) // #13961
+            ) {
                 return date['setUTC' + unit](value);
             }
             // Higher order time units need to take the time zone into

--- a/js/Core/Time.js
+++ b/js/Core/Time.js
@@ -221,7 +221,7 @@ var Time = /** @class */ (function () {
             // time
             if (unit === 'Milliseconds' ||
                 unit === 'Seconds' ||
-                unit === 'Minutes') {
+                (unit === 'Minutes' && this.getTimezoneOffset(date) % 3600000 === 0)) {
                 return date['setUTC' + unit](value);
             }
             // Higher order time units need to take the time zone into

--- a/samples/unit-tests/time/timeticks/demo.js
+++ b/samples/unit-tests/time/timeticks/demo.js
@@ -471,4 +471,33 @@
                 new Date().getTimezoneOffset()
         );
     });
+
+    QUnit.test('#13961: Missing ticks for half-hour timezones', assert => {
+        const utc = new Highcharts.Time();
+        const india = new Highcharts.Time({
+            timezoneOffset: -330
+        });
+
+        [2, 5, 10, 15].forEach(count =>
+            assert.strictEqual(
+                utc.getTimeTicks(
+                    {
+                        unitRange: 60000,
+                        count
+                    },
+                    1595801085000,
+                    1595802945000
+                ).length,
+                india.getTimeTicks(
+                    {
+                        unitRange: 60000,
+                        count
+                    },
+                    1595801085000,
+                    1595802945000
+                ).length,
+                'Tick count should match'
+            )
+        );
+    });
 }());

--- a/ts/Core/Time.ts
+++ b/ts/Core/Time.ts
@@ -347,7 +347,7 @@ class Time {
             if (
                 unit === 'Milliseconds' ||
                 unit === 'Seconds' ||
-                unit === 'Minutes'
+                (unit === 'Minutes' && this.getTimezoneOffset(date) % 3600000 === 0)
             ) {
                 return (date as any)['setUTC' + unit](value);
             }

--- a/ts/Core/Time.ts
+++ b/ts/Core/Time.ts
@@ -347,7 +347,7 @@ class Time {
             if (
                 unit === 'Milliseconds' ||
                 unit === 'Seconds' ||
-                (unit === 'Minutes' && this.getTimezoneOffset(date) % 3600000 === 0)
+                (unit === 'Minutes' && this.getTimezoneOffset(date) % 3600000 === 0) // #13961
             ) {
                 return (date as any)['setUTC' + unit](value);
             }


### PR DESCRIPTION
Fixed #13961, `datetime` axis had missing ticks when `Chart.time` had half-hour `timezone` or `timezoneOffset` set.