### PR TITLE
Support for fluid RangeSelector inputs

### DIFF
--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -413,6 +413,13 @@ extend(defaultOptions, {
             y: 0
         },
         /**
+         * The space in pixels between the labels and the date input boxes in
+         * the range selector.
+         *
+         * @since next
+         */
+        inputSpacing: 5,
+        /**
          * The index of the button to appear pre-selected.
          *
          * @type      {number}
@@ -654,7 +661,7 @@ var RangeSelector = /** @class */ (function () {
         }
         else {
             // Existing axis object. Set extremes after render time.
-            baseAxis.setExtremes(newMin, newMax, pick(redraw, 1), null, // auto animation
+            baseAxis.setExtremes(newMin, newMax, pick(redraw, true), void 0, // auto animation
             {
                 trigger: 'rangeSelectorButton',
                 rangeSelectorButton: rangeOptions
@@ -792,7 +799,7 @@ var RangeSelector = /** @class */ (function () {
                 button.setState(state);
                 // Reset (#9209)
                 if (state === 0 && selected === i) {
-                    rangeSelector.setSelected(null);
+                    rangeSelector.setSelected();
                 }
             }
         });
@@ -860,7 +867,7 @@ var RangeSelector = /** @class */ (function () {
      * @return {void}
      */
     RangeSelector.prototype.setInputValue = function (name, inputTime) {
-        var options = this.options, time = this.chart.time, input = name === 'min' ? this.minInput : this.maxInput;
+        var options = this.options, time = this.chart.time, input = name === 'min' ? this.minInput : this.maxInput, dateBox = name === 'min' ? this.minDateBox : this.maxDateBox;
         if (input) {
             var hcTimeAttr = input.getAttribute('data-hc-time');
             var updatedTime = defined(hcTimeAttr) ? Number(hcTimeAttr) : void 0;
@@ -873,9 +880,11 @@ var RangeSelector = /** @class */ (function () {
                 updatedTime = inputTime;
             }
             input.value = time.dateFormat(this.inputTypeFormats[input.type] || options.inputEditDateFormat, updatedTime);
-            this[name + 'DateBox'].attr({
-                text: time.dateFormat(options.inputDateFormat, updatedTime)
-            });
+            if (dateBox) {
+                dateBox.attr({
+                    text: time.dateFormat(options.inputDateFormat, updatedTime)
+                });
+            }
         }
     };
     /**
@@ -912,29 +921,32 @@ var RangeSelector = /** @class */ (function () {
      * @return {void}
      */
     RangeSelector.prototype.showInput = function (name) {
-        var dateBox = this[name + 'DateBox'], input = this[name + 'Input'], isTextInput = input.type === 'text';
-        var _a = this.inputGroup, translateX = _a.translateX, translateY = _a.translateY;
-        css(input, {
-            width: isTextInput ? ((dateBox.width - 2) + 'px') : 'auto',
-            height: isTextInput ? ((dateBox.height - 2) + 'px') : 'auto',
-            border: '2px solid silver'
-        });
-        if (isTextInput) {
+        var dateBox = name === 'min' ? this.minDateBox : this.maxDateBox;
+        var input = name === 'min' ? this.minInput : this.maxInput;
+        if (input && dateBox && this.inputGroup) {
+            var isTextInput = input.type === 'text';
+            var _a = this.inputGroup, translateX = _a.translateX, translateY = _a.translateY;
             css(input, {
-                left: (translateX + dateBox.x) + 'px',
-                top: translateY + 'px'
+                width: isTextInput ? ((dateBox.width - 2) + 'px') : 'auto',
+                height: isTextInput ? ((dateBox.height - 2) + 'px') : 'auto',
+                border: '2px solid silver'
             });
-            // Inputs of types date, time or datetime-local should be centered on
-            // top of the dateBox
-        }
-        else {
-            css(input, {
-                left: Math.min(Math.round(dateBox.x +
-                    translateX -
-                    (input.offsetWidth - dateBox.width) / 2), this.chart.chartWidth - input.offsetWidth) + 'px',
-                top: (translateY - (input.offsetHeight - dateBox.height) / 2) +
-                    'px'
-            });
+            if (isTextInput) {
+                css(input, {
+                    left: (translateX + dateBox.x) + 'px',
+                    top: translateY + 'px'
+                });
+                // Inputs of types date, time or datetime-local should be centered
+                // on top of the dateBox
+            }
+            else {
+                css(input, {
+                    left: Math.min(Math.round(dateBox.x +
+                        translateX -
+                        (input.offsetWidth - dateBox.width) / 2), this.chart.chartWidth - input.offsetWidth) + 'px',
+                    top: (translateY - (input.offsetHeight - dateBox.height) / 2) + 'px'
+                });
+            }
         }
     };
     /**
@@ -944,12 +956,15 @@ var RangeSelector = /** @class */ (function () {
      * @return {void}
      */
     RangeSelector.prototype.hideInput = function (name) {
-        css(this[name + 'Input'], {
-            top: '-9999em',
-            border: 0,
-            width: '1px',
-            height: '1px'
-        });
+        var input = name === 'min' ? this.minInput : this.maxInput;
+        if (input) {
+            css(input, {
+                top: '-9999em',
+                border: 0,
+                width: '1px',
+                height: '1px'
+            });
+        }
     };
     /**
      * @private
@@ -991,11 +1006,11 @@ var RangeSelector = /** @class */ (function () {
      * @private
      * @function Highcharts.RangeSelector#drawInput
      * @param {string} name
-     * @return {void}
+     * @return {RangeSelectorInputElements}
      */
     RangeSelector.prototype.drawInput = function (name) {
         var _a = this, chart = _a.chart, div = _a.div, inputGroup = _a.inputGroup;
-        var rangeSelector = this, chartStyle = chart.renderer.style || {}, renderer = chart.renderer, options = chart.options.rangeSelector, lang = defaultOptions.lang, isMin = name === 'min', input, label, dateBox;
+        var rangeSelector = this, chartStyle = chart.renderer.style || {}, renderer = chart.renderer, options = chart.options.rangeSelector, lang = defaultOptions.lang, isMin = name === 'min';
         /**
          * @private
          */
@@ -1032,18 +1047,17 @@ var RangeSelector = /** @class */ (function () {
             }
         }
         // Create the text label
-        this[name + 'Label'] = label = renderer
-            .label(lang[isMin ? 'rangeSelectorFrom' : 'rangeSelectorTo'], this.inputGroup.offset)
+        var label = renderer
+            .label(lang[isMin ? 'rangeSelectorFrom' : 'rangeSelectorTo'], 0)
             .addClass('highcharts-range-label')
             .attr({
             padding: 2
         })
             .add(inputGroup);
-        inputGroup.offset += label.width + 5;
         // Create an SVG label that shows updated date ranges and and records
         // click events that bring in the HTML input.
-        this[name + 'DateBox'] = dateBox = renderer
-            .label('', inputGroup.offset)
+        var dateBox = renderer
+            .label('', 0)
             .addClass('highcharts-range-input')
             .attr({
             padding: 2,
@@ -1064,10 +1078,9 @@ var RangeSelector = /** @class */ (function () {
             });
         }
         dateBox.add(inputGroup);
-        inputGroup.offset += dateBox.width + (isMin ? 10 : 0);
         // Create the HTML input element. This is rendered as 1x1 pixel then set
         // to the right size when focused.
-        this[name + 'Input'] = input = createElement('input', {
+        var input = createElement('input', {
             name: name,
             className: 'highcharts-range-selector',
             type: preferredInputType(options.inputDateFormat || '%b %e, %Y')
@@ -1130,6 +1143,7 @@ var RangeSelector = /** @class */ (function () {
         input.onkeyup = function () {
             keyDown = false;
         };
+        return { dateBox: dateBox, input: input, label: label };
     };
     /**
      * Get the position of the range selector buttons and inputs. This can be
@@ -1215,9 +1229,14 @@ var RangeSelector = /** @class */ (function () {
                 container.parentNode.insertBefore(this.div, container);
                 // Create the group to keep the inputs
                 this.inputGroup = renderer.g('input-group').add(this.group);
-                this.inputGroup.offset = 0;
-                this.drawInput('min');
-                this.drawInput('max');
+                var minElems = this.drawInput('min');
+                this.minDateBox = minElems.dateBox;
+                this.minLabel = minElems.label;
+                this.minInput = minElems.input;
+                var maxElems = this.drawInput('max');
+                this.maxDateBox = maxElems.dateBox;
+                this.maxLabel = maxElems.label;
+                this.maxInput = maxElems.input;
             }
         }
         if (inputEnabled) {
@@ -1229,6 +1248,26 @@ var RangeSelector = /** @class */ (function () {
                 var minRange = chart.xAxis[0].minRange || 0;
                 this.setInputExtremes('min', unionExtremes.dataMin, Math.min(unionExtremes.dataMax, this.getInputValue('max')) - minRange);
                 this.setInputExtremes('max', Math.max(unionExtremes.dataMin, this.getInputValue('min')) + minRange, unionExtremes.dataMax);
+            }
+            // Reflow
+            if (this.inputGroup) {
+                var x_1 = 0;
+                [
+                    this.minLabel,
+                    this.minDateBox,
+                    this.maxLabel,
+                    this.maxDateBox
+                ].forEach(function (label, i) {
+                    if (label) {
+                        label.attr({ x: x_1 });
+                        x_1 += label.width + options.inputSpacing;
+                        // For version <= 8 compliance
+                        // @todo remove this if we change the design
+                        if (i % 2) {
+                            x_1 += options.inputSpacing;
+                        }
+                    }
+                });
             }
         }
         this.alignElements();

--- a/samples/unit-tests/rangeselector/members/demo.js
+++ b/samples/unit-tests/rangeselector/members/demo.js
@@ -135,12 +135,12 @@ QUnit.test('RangeSelector.updateButtonStates, visual output', assert => {
     );
     assert.strictEqual(
         chart.rangeSelector.selected,
-        null,
+        undefined,
         'The selected property should be updated'
     );
     assert.strictEqual(
         chart.rangeSelector.options.selected,
-        null,
+        undefined,
         'The selected option should be updated'
     );
 
@@ -154,12 +154,12 @@ QUnit.test('RangeSelector.updateButtonStates, visual output', assert => {
     );
     assert.strictEqual(
         chart.rangeSelector.selected,
-        null,
+        undefined,
         'The selected property should remain after redraw (#9209)'
     );
     assert.strictEqual(
         chart.rangeSelector.options.selected,
-        null,
+        undefined,
         'The selected option should remain after redraw (#9209)'
     );
 });

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -28,6 +28,7 @@ const { defaultOptions } = O;
 import palette from '../Core/Color/Palette.js';
 import SVGElement from '../Core/Renderer/SVG/SVGElement.js';
 import U from '../Core/Utilities.js';
+import SVGLabel from '../Core/Renderer/SVG/SVGLabel';
 const {
     addEvent,
     createElement,
@@ -94,6 +95,11 @@ declare global {
             text: string;
             type?: RangeSelectorButtonTypeValue;
         }
+        interface RangeSelectorInputElements {
+            dateBox: SVGElement;
+            input: HTMLInputElement;
+            label: SVGElement;
+        }
         interface RangeSelectorOptions {
             allButtonsEnabled: boolean;
             buttonPosition: RangeSelectorPositionOptions;
@@ -105,12 +111,13 @@ declare global {
             height?: number;
             inputBoxBorderColor: ColorString;
             inputBoxHeight: number;
-            inputBoxWidth: number;
+            inputBoxWidth?: number;
             inputDateFormat: string;
             inputDateParser?: RangeSelectorParseCallbackFunction;
             inputEditDateFormat: string;
             inputEnabled: boolean;
             inputPosition: RangeSelectorPositionOptions;
+            inputSpacing: number;
             inputStyle: CSSObject;
             labelStyle: CSSObject;
             selected?: number;
@@ -150,7 +157,7 @@ declare global {
                 rangeOptions: RangeSelectorButtonsOptions
             ): void;
             public destroy(): void;
-            public drawInput(name: ('min'|'max')): void;
+            public drawInput(name: ('min'|'max')): RangeSelectorInputElements;
             public getHeight(): number;
             public getInputValue(name: string): number;
             public getPosition(): Dictionary<number>;
@@ -604,6 +611,14 @@ extend(defaultOptions, {
         },
 
         /**
+         * The space in pixels between the labels and the date input boxes in
+         * the range selector.
+         *
+         * @since next
+         */
+        inputSpacing: 5,
+
+        /**
          * The index of the button to appear pre-selected.
          *
          * @type      {number}
@@ -761,8 +776,12 @@ class RangeSelector {
     public group?: SVGElement;
     public inputGroup?: SVGElement;
     public isActive?: boolean;
+    public maxDateBox?: SVGElement;
     public maxInput?: HTMLInputElement;
+    public maxLabel?: SVGElement;
+    public minDateBox?: SVGElement;
     public minInput?: HTMLInputElement;
+    public minLabel?: SVGElement;
     public options: Highcharts.RangeSelectorOptions = void 0 as any;
     public rendered?: boolean;
     public selected?: number;
@@ -927,8 +946,8 @@ class RangeSelector {
             baseAxis.setExtremes(
                 newMin,
                 newMax,
-                pick(redraw, 1 as any),
-                null as any, // auto animation
+                pick(redraw, true),
+                void 0, // auto animation
                 {
                     trigger: 'rangeSelectorButton',
                     rangeSelectorButton: rangeOptions
@@ -1150,7 +1169,7 @@ class RangeSelector {
 
                 // Reset (#9209)
                 if (state === 0 && selected === i) {
-                    rangeSelector.setSelected(null as any);
+                    rangeSelector.setSelected();
                 }
             }
         });
@@ -1234,7 +1253,8 @@ class RangeSelector {
     ): void {
         var options = this.options,
             time = this.chart.time,
-            input = name === 'min' ? this.minInput : this.maxInput;
+            input = name === 'min' ? this.minInput : this.maxInput,
+            dateBox = name === 'min' ? this.minDateBox : this.maxDateBox;
 
         if (input) {
             const hcTimeAttr = input.getAttribute('data-hc-time');
@@ -1253,12 +1273,14 @@ class RangeSelector {
                 this.inputTypeFormats[input.type] || options.inputEditDateFormat,
                 updatedTime
             );
-            (this as any)[name + 'DateBox'].attr({
-                text: time.dateFormat(
-                    options.inputDateFormat,
-                    updatedTime
-                )
-            });
+            if (dateBox) {
+                dateBox.attr({
+                    text: time.dateFormat(
+                        options.inputDateFormat,
+                        updatedTime
+                    )
+                });
+            }
         }
     }
 
@@ -1301,39 +1323,43 @@ class RangeSelector {
      * @param {string} name
      * @return {void}
      */
-    public showInput(name: string): void {
-        var dateBox = (this as any)[name + 'DateBox'],
-            input = (this as any)[name + 'Input'],
-            isTextInput = input.type === 'text';
-        const { translateX, translateY } = this.inputGroup as any;
+    public showInput(name: ('min'|'max')): void {
+        const dateBox = name === 'min' ? this.minDateBox : this.maxDateBox;
+        const input = name === 'min' ? this.minInput : this.maxInput;
 
-        css(input, {
-            width: isTextInput ? ((dateBox.width - 2) + 'px') : 'auto',
-            height: isTextInput ? ((dateBox.height - 2) + 'px') : 'auto',
-            border: '2px solid silver'
-        });
+        if (input && dateBox && this.inputGroup) {
+            const isTextInput = input.type === 'text';
+            const { translateX, translateY } = this.inputGroup;
 
-        if (isTextInput) {
             css(input, {
-                left: (translateX + dateBox.x) + 'px',
-                top: translateY + 'px'
+                width: isTextInput ? ((dateBox.width - 2) + 'px') : 'auto',
+                height: isTextInput ? ((dateBox.height - 2) + 'px') : 'auto',
+                border: '2px solid silver'
             });
 
-        // Inputs of types date, time or datetime-local should be centered on
-        // top of the dateBox
-        } else {
-            css(input, {
-                left: Math.min(
-                    Math.round(
-                        dateBox.x +
-                        translateX -
-                        (input.offsetWidth - dateBox.width) / 2
-                    ),
-                    this.chart.chartWidth - input.offsetWidth
-                ) + 'px',
-                top: (translateY - (input.offsetHeight - dateBox.height) / 2) +
-                    'px'
-            });
+            if (isTextInput) {
+                css(input, {
+                    left: (translateX + dateBox.x) + 'px',
+                    top: translateY + 'px'
+                });
+
+            // Inputs of types date, time or datetime-local should be centered
+            // on top of the dateBox
+            } else {
+                css(input, {
+                    left: Math.min(
+                        Math.round(
+                            dateBox.x +
+                            translateX -
+                            (input.offsetWidth - dateBox.width) / 2
+                        ),
+                        this.chart.chartWidth - input.offsetWidth
+                    ) + 'px',
+                    top: (
+                        translateY - (input.offsetHeight - dateBox.height) / 2
+                    ) + 'px'
+                });
+            }
         }
     }
 
@@ -1343,13 +1369,16 @@ class RangeSelector {
      * @param {string} name
      * @return {void}
      */
-    public hideInput(name: string): void {
-        css((this as any)[name + 'Input'], {
-            top: '-9999em',
-            border: 0,
-            width: '1px',
-            height: '1px'
-        });
+    public hideInput(name: ('min'|'max')): void {
+        const input = name === 'min' ? this.minInput : this.maxInput;
+        if (input) {
+            css(input, {
+                top: '-9999em',
+                border: 0,
+                width: '1px',
+                height: '1px'
+            });
+        }
     }
 
     /**
@@ -1399,9 +1428,9 @@ class RangeSelector {
      * @private
      * @function Highcharts.RangeSelector#drawInput
      * @param {string} name
-     * @return {void}
+     * @return {RangeSelectorInputElements}
      */
-    public drawInput(name: ('min'|'max')): void {
+    public drawInput(name: ('min'|'max')): Highcharts.RangeSelectorInputElements {
         const {
             chart,
             div,
@@ -1414,10 +1443,7 @@ class RangeSelector {
             options =
                chart.options.rangeSelector as Highcharts.RangeSelectorOptions,
             lang = defaultOptions.lang,
-            isMin = name === 'min',
-            input: HTMLInputElement,
-            label,
-            dateBox;
+            isMin = name === 'min';
 
         /**
          * @private
@@ -1469,22 +1495,21 @@ class RangeSelector {
         }
 
         // Create the text label
-        (this as any)[name + 'Label'] = label = renderer
+        const label = renderer
             .label(
                 (lang as any)[isMin ? 'rangeSelectorFrom' : 'rangeSelectorTo'],
-                (this.inputGroup as any).offset
+                0
             )
             .addClass('highcharts-range-label')
             .attr({
                 padding: 2
             })
             .add(inputGroup);
-        (inputGroup as any).offset += label.width + 5;
 
         // Create an SVG label that shows updated date ranges and and records
         // click events that bring in the HTML input.
-        (this as any)[name + 'DateBox'] = dateBox = renderer
-            .label('', (inputGroup as any).offset)
+        const dateBox = renderer
+            .label('', 0)
             .addClass('highcharts-range-input')
             .attr({
                 padding: 2,
@@ -1508,16 +1533,14 @@ class RangeSelector {
 
         dateBox.add(inputGroup);
 
-        (inputGroup as any).offset += dateBox.width + (isMin ? 10 : 0);
-
 
         // Create the HTML input element. This is rendered as 1x1 pixel then set
         // to the right size when focused.
-        (this as any)[name + 'Input'] = input = createElement('input', {
+        const input = createElement('input', {
             name: name,
             className: 'highcharts-range-selector',
             type: preferredInputType(options.inputDateFormat || '%b %e, %Y')
-        }, void 0, div) as any;
+        }, void 0, div) as HTMLInputElement;
 
         if (!chart.styledMode) {
             // Styles
@@ -1587,6 +1610,8 @@ class RangeSelector {
         input.onkeyup = (): void => {
             keyDown = false;
         };
+
+        return { dateBox, input, label };
     }
 
     /**
@@ -1607,8 +1632,8 @@ class RangeSelector {
                 0; // set offset only for varticalAlign top
 
         return {
-            buttonTop: top + (options.buttonPosition as any).y,
-            inputTop: top + (options.inputPosition as any).y - 10
+            buttonTop: top + options.buttonPosition.y,
+            inputTop: top + options.inputPosition.y - 10
         };
     }
     /**
@@ -1708,10 +1733,16 @@ class RangeSelector {
 
                 // Create the group to keep the inputs
                 this.inputGroup = renderer.g('input-group').add(this.group);
-                this.inputGroup.offset = 0;
 
-                this.drawInput('min');
-                this.drawInput('max');
+                const minElems = this.drawInput('min');
+                this.minDateBox = minElems.dateBox;
+                this.minLabel = minElems.label;
+                this.minInput = minElems.input;
+
+                const maxElems = this.drawInput('max');
+                this.maxDateBox = maxElems.dateBox;
+                this.maxLabel = maxElems.label;
+                this.maxInput = maxElems.input;
             }
         }
 
@@ -1737,6 +1768,28 @@ class RangeSelector {
                     Math.max(unionExtremes.dataMin, this.getInputValue('min')) + minRange,
                     unionExtremes.dataMax
                 );
+            }
+
+            // Reflow
+            if (this.inputGroup) {
+                let x = 0;
+                [
+                    this.minLabel,
+                    this.minDateBox,
+                    this.maxLabel,
+                    this.maxDateBox
+                ].forEach((label, i): void => {
+                    if (label) {
+                        label.attr({ x });
+                        x += label.width + options.inputSpacing;
+
+                        // For version <= 8 compliance
+                        // @todo remove this if we change the design
+                        if (i % 2) {
+                            x += options.inputSpacing;
+                        }
+                    }
+                });
             }
         }
 

--- a/ts/Stock/Indicators/ROC/ROCOptions.d.ts
+++ b/ts/Stock/Indicators/ROC/ROCOptions.d.ts
@@ -31,4 +31,4 @@ export interface ROCParamsOptions extends SMAParamsOptions {
     // for inheritance
 }
 
-export default EMAOptions;
+export default ROCOptions;


### PR DESCRIPTION
Also applied some stricter typing.

With this PR, we will be able to achieve a more fluid and frameless layout of the range selector inputs:

![Skjermbilde 2020-12-02 kl  11 31 53](https://user-images.githubusercontent.com/227836/100861414-12c98b80-3492-11eb-8ece-c96cf15bb24f.png)


```js
Highcharts.setOptions({
    lang: {
        rangeSelectorFrom: '',
        rangeSelectorTo: '→'
    },
    rangeSelector: {
        inputBoxBorderColor: 'none',
        inputBoxWidth: void 0,
        inputSpacing: 0,
        inputStyle: {
            color: '#6685c2' // palette.highlightColor60 (or 80 better?)
        }
    }
});
```

https://jsfiddle.net/highcharts/umyb4h3w/