### PR TITLE
bugfix/13490-polar-update-hover

### DIFF
--- a/js/Extensions/Pane.js
+++ b/js/Extensions/Pane.js
@@ -388,6 +388,9 @@ addEvent(Pointer, 'beforeGetHoverData', function (eventArgs) {
                 (!chart.hoverPane || s.xAxis.pane === chart.hoverPane));
         };
     }
+    else {
+        chart.hoverPane = void 0;
+    }
 });
 addEvent(Pointer, 'afterGetHoverData', function (eventArgs) {
     var chart = this.chart;

--- a/samples/unit-tests/polar/update/demo.details
+++ b/samples/unit-tests/polar/update/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/polar/update/demo.html
+++ b/samples/unit-tests/polar/update/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/polar/update/demo.js
+++ b/samples/unit-tests/polar/update/demo.js
@@ -1,0 +1,45 @@
+QUnit.test('#13490: Hovering after disabling polar', assert => {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            polar: true
+        },
+        xAxis: {
+            categories: [
+                'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+            ],
+            tickWidth: 1,
+            tickmarkPlacement: 'on'
+        },
+        series: [{
+            data: [
+                29.9, 71.5, 106.4, 129.2, 144.0, 176.0,
+                135.6, 148.5, 216.4, 194.1, 95.6, 54.4
+            ]
+        }],
+        tooltip: {
+            hideDelay: 0
+        }
+    });
+
+    const point = chart.series[0].points[0];
+
+    const controller = new TestController(chart);
+    controller.moveTo(
+        chart.plotLeft + point.plotX,
+        chart.plotTop + point.plotY
+    );
+
+    chart.update({ chart: { polar: false } }, true, true);
+
+    controller.moveTo(
+        chart.plotLeft + point.plotX,
+        chart.plotTop + point.plotY
+    );
+
+    assert.strictEqual(
+        chart.tooltip.isHidden,
+        false,
+        'First point tooltip should be visible'
+    );
+});

--- a/ts/Extensions/Pane.ts
+++ b/ts/Extensions/Pane.ts
@@ -591,6 +591,8 @@ addEvent(Pointer, 'beforeGetHoverData', function (
                 (!chart.hoverPane || s.xAxis.pane === chart.hoverPane)
             );
         };
+    } else {
+        chart.hoverPane = void 0;
     }
 });
 


### PR DESCRIPTION
Fixed #13490, point hovering effects such as `tooltip` stopped working after disabling `Chart.polar` with `update`.