### PR TITLE
Refactor series.update, use setPrototypeOf to cast series type

### DIFF
--- a/js/Core/Dynamics.js
+++ b/js/Core/Dynamics.js
@@ -589,7 +589,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
             }
         });
         itemsForRemoval.forEach(function (item) {
-            if (item.remove) {
+            if (item.chart) { // #9097, avoid removing twice
                 item.remove(false);
             }
         });
@@ -1000,7 +1000,6 @@ extend(LineSeries.prototype, /** @lends Series.prototype */ {
         function remove() {
             // Destroy elements
             series.destroy(keepEvents);
-            series.remove = null; // Prevent from doing again (#9097)
             // Redraw
             chart.isDirtyLegend = chart.isDirtyBox = true;
             chart.linkSeries();
@@ -1127,24 +1126,35 @@ extend(LineSeries.prototype, /** @lends Series.prototype */ {
             preserve[prop] = series[prop];
             delete series[prop];
         });
-        // Destroy the series and delete all properties. Reinsert all
-        // methods and properties from the new type prototype (#2270,
-        // #3719).
-        series.remove(false, null, false, true);
-        var ownEvents = Object.hasOwnProperty.call(series, 'hcEvents') &&
-            series.hcEvents;
-        for (n in initialSeriesProto) { // eslint-disable-line guard-for-in
-            series[n] = void 0;
-        }
         if (seriesTypes[newType || initialType]) {
-            extend(series, seriesTypes[newType || initialType].prototype);
-            // The events are tied to the prototype chain, don't copy if they're
-            // not the series' own
-            if (ownEvents) {
-                series.hcEvents = ownEvents;
-            }
-            else {
-                delete series.hcEvents;
+            var casting = newType !== series.type;
+            // Destroy the series and delete all properties, it will be
+            // reinserted within the `init` call below
+            series.remove(false, false, false, true);
+            if (casting) {
+                // Modern browsers including IE11
+                if (Object.setPrototypeOf) {
+                    Object.setPrototypeOf(series, seriesTypes[newType || initialType].prototype);
+                    // Legacy (IE < 11)
+                }
+                else {
+                    var ownEvents = Object.hasOwnProperty.call(series, 'hcEvents') &&
+                        series.hcEvents;
+                    for (n in initialSeriesProto) { // eslint-disable-line guard-for-in
+                        series[n] = void 0;
+                    }
+                    // Reinsert all methods and properties from the new type
+                    // prototype (#2270, #3719).
+                    extend(series, seriesTypes[newType || initialType].prototype);
+                    // The events are tied to the prototype chain, don't copy if
+                    // they're not the series' own
+                    if (ownEvents) {
+                        series.hcEvents = ownEvents;
+                    }
+                    else {
+                        delete series.hcEvents;
+                    }
+                }
             }
         }
         else {

--- a/samples/unit-tests/series/update/demo.js
+++ b/samples/unit-tests/series/update/demo.js
@@ -155,6 +155,14 @@ QUnit.test('Series.update', function (assert) {
         type: 'column'
     });
     assert.strictEqual(chart.series[0].type, 'column', 'Column type');
+
+    if (Object.setPrototypeOf) {
+        assert.ok(
+            chart.series[0] instanceof Highcharts.seriesTypes.column,
+            'The series should be an instance of the ColumnSeries'
+        );
+    }
+
     assert.strictEqual(
         chart.series[0].points[0].graphic.element.nodeName,
         'rect',
@@ -171,12 +179,27 @@ QUnit.test('Series.update', function (assert) {
         'square',
         'Line point'
     );
+    if (Object.setPrototypeOf) {
+        assert.ok(
+            chart.series[0] instanceof Highcharts.seriesTypes.line,
+            'The series should be an instance of the LineSeries'
+        );
+        assert.notOk(
+            chart.series[0] instanceof Highcharts.seriesTypes.column,
+            'The series should not be an instance of the ColumnSeries'
+        );
+    }
 
     // Type spline
     chart.series[0].update({
         type: 'spline'
     });
     assert.strictEqual(chart.series[0].type, 'spline', 'Spline type');
+    assert.ok(
+        chart.series[0] instanceof Highcharts.seriesTypes.spline,
+        'The series should be an instance of the SplineSeries'
+    );
+
     assert.strictEqual(
         chart.series[0].graph.element.getAttribute('d').indexOf('C') !== -1, // has curved path
         true,
@@ -188,6 +211,11 @@ QUnit.test('Series.update', function (assert) {
         type: 'area'
     });
     assert.strictEqual(chart.series[0].type, 'area', 'Area type');
+    assert.ok(
+        chart.series[0] instanceof Highcharts.seriesTypes.area,
+        'The series should be an instance of the AreaSeries'
+    );
+
     assert.strictEqual(
         chart.series[0].area.element.nodeName,
         'path',
@@ -199,6 +227,11 @@ QUnit.test('Series.update', function (assert) {
         type: 'areaspline'
     });
     assert.strictEqual(chart.series[0].type, 'areaspline', 'Areaspline type');
+    assert.ok(
+        chart.series[0] instanceof Highcharts.seriesTypes.areaspline,
+        'The series should be an instance of the AreaSpline'
+    );
+
     assert.strictEqual(
         chart.series[0].graph.element.getAttribute('d').indexOf('C') !== -1, // has curved path
         true,
@@ -215,6 +248,11 @@ QUnit.test('Series.update', function (assert) {
         type: 'scatter'
     });
     assert.strictEqual(chart.series[0].type, 'scatter', 'Scatter type');
+    assert.ok(
+        chart.series[0] instanceof Highcharts.seriesTypes.scatter,
+        'The series should be an instance of the ScatterSeries'
+    );
+
     assert.strictEqual(
         typeof chart.series[0].graph,
         'undefined',
@@ -226,6 +264,11 @@ QUnit.test('Series.update', function (assert) {
         type: 'pie'
     });
     assert.strictEqual(chart.series[0].type, 'pie', 'Pie type');
+    assert.ok(
+        chart.series[0] instanceof Highcharts.seriesTypes.pie,
+        'The series should be an instance of the PieSeries'
+    );
+
     assert.strictEqual(
         typeof chart.series[0].graph,
         'undefined',

--- a/ts/Core/Dynamics.ts
+++ b/ts/Core/Dynamics.ts
@@ -899,7 +899,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         });
 
         itemsForRemoval.forEach(function (item: any): void {
-            if (item.remove) {
+            if (item.chart) { // #9097, avoid removing twice
                 item.remove(false);
             }
         });
@@ -1426,7 +1426,6 @@ extend(LineSeries.prototype, /** @lends Series.prototype */ {
 
             // Destroy elements
             series.destroy(keepEvents);
-            (series as any).remove = null; // Prevent from doing again (#9097)
 
             // Redraw
             chart.isDirtyLegend = chart.isDirtyBox = true;
@@ -1604,23 +1603,43 @@ extend(LineSeries.prototype, /** @lends Series.prototype */ {
             delete (series as any)[prop];
         });
 
-        // Destroy the series and delete all properties. Reinsert all
-        // methods and properties from the new type prototype (#2270,
-        // #3719).
-        series.remove(false, null as any, false, true);
-        const ownEvents = Object.hasOwnProperty.call(series, 'hcEvents') &&
-            series.hcEvents;
-        for (n in initialSeriesProto) { // eslint-disable-line guard-for-in
-            (series as any)[n] = void 0;
-        }
         if (seriesTypes[newType || initialType]) {
-            extend(series, seriesTypes[newType || initialType].prototype);
-            // The events are tied to the prototype chain, don't copy if they're
-            // not the series' own
-            if (ownEvents) {
-                series.hcEvents = ownEvents;
-            } else {
-                delete series.hcEvents;
+
+            const casting = newType !== series.type;
+
+            // Destroy the series and delete all properties, it will be
+            // reinserted within the `init` call below
+            series.remove(false, false, false, true);
+
+            if (casting) {
+                // Modern browsers including IE11
+                if (Object.setPrototypeOf) {
+                    Object.setPrototypeOf(
+                        series,
+                        seriesTypes[newType || initialType].prototype
+                    );
+
+                // Legacy (IE < 11)
+                } else {
+
+                    const ownEvents = Object.hasOwnProperty.call(series, 'hcEvents') &&
+                        series.hcEvents;
+                    for (n in initialSeriesProto) { // eslint-disable-line guard-for-in
+                        (series as any)[n] = void 0;
+                    }
+
+                    // Reinsert all methods and properties from the new type
+                    // prototype (#2270, #3719).
+                    extend(series, seriesTypes[newType || initialType].prototype);
+
+                    // The events are tied to the prototype chain, don't copy if
+                    // they're not the series' own
+                    if (ownEvents) {
+                        series.hcEvents = ownEvents;
+                    } else {
+                        delete series.hcEvents;
+                    }
+                }
             }
         } else {
             error(
@@ -1637,6 +1656,7 @@ extend(LineSeries.prototype, /** @lends Series.prototype */ {
         });
 
         series.init(chart, options);
+
 
         // Remove particular elements of the points. Check `series.options`
         // because we need to consider the options being set on plotOptions as

--- a/ts/Core/Globals.ts
+++ b/ts/Core/Globals.ts
@@ -110,6 +110,15 @@ declare global {
             value: (boolean|number|string)
         ): void;
     }
+    interface ObjectConstructor {
+        /**
+         * Sets the prototype of a specified object o to object proto or null.
+         * Returns the object o.
+         * @param o The object to change its prototype.
+         * @param proto The value of the new prototype or null.
+         */
+        setPrototypeOf?(o: any, proto: object | null): any;
+    }
     interface OscillatorNode extends AudioNode {
     }
     interface PointerEvent {


### PR DESCRIPTION
The `Object.setPrototypeOf` function is supported by IE11 and all modern browsers. This ensures that when running `Series.update({ type })`, the series is a true instance of the new type, instead of an imitation with copied-over members like currently.