### PR TITLE
Fix creating tickPositions with [ NaN, NaN ] and therefore calling axisFormatter

### DIFF
--- a/js/Core/Axis/Axis.js
+++ b/js/Core/Axis/Axis.js
@@ -1696,7 +1696,7 @@ var Axis = /** @class */ (function () {
     Axis.prototype.getTickAmount = function () {
         var axis = this, options = this.options, tickAmount = options.tickAmount, tickPixelInterval = options.tickPixelInterval;
         if (!defined(options.tickInterval) &&
-            !tickAmount && this.len < tickPixelInterval &&
+            tickAmount == 0 && this.len < tickPixelInterval &&
             !this.isRadial &&
             !axis.logarithmic &&
             options.startOnTick &&

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -5902,7 +5902,7 @@ class Axis {
 
         if (
             !defined(options.tickInterval) &&
-            !tickAmount && this.len < tickPixelInterval &&
+            tickAmount == 0 && this.len < tickPixelInterval &&
             !this.isRadial &&
             !axis.logarithmic &&
             options.startOnTick &&


### PR DESCRIPTION
Consider the following scenario: There is a series with x / y values; however all y values are "null" because there is no data yet. There are two cases now:

1) this.len >= tickPixelInterval => tickAmount stays at undefined =>tickPositions is an empty array => axisFormatter is not called
2) this.len < tickPixelInterval => tickAmount is set to 2 => tickAmount is set to 5 at then end => tickPositions is [NaN, NaN] in the end => axisFormatter is called with garbage

This change fixes this issue by only setting tickAmount to 2 if tickAmount was only 0 not undefined.