### PR TITLE
bugfix/14746-datetime-null-local

### DIFF
--- a/js/Core/Time.js
+++ b/js/Core/Time.js
@@ -578,7 +578,7 @@ var Time = /** @class */ (function () {
             // Redefine min to the floored/rounded minimum time (#7432)
             min = minDate.getTime();
             // Handle local timezone offset
-            if (time.variableTimezone || !time.useUTC) {
+            if ((time.variableTimezone || !time.useUTC) && defined(max)) {
                 // Detect whether we need to take the DST crossover into
                 // consideration. If we're crossing over DST, the day length may
                 // be 23h or 25h and we need to compute the exact clock time for

--- a/samples/unit-tests/time/get-set/demo.js
+++ b/samples/unit-tests/time/get-set/demo.js
@@ -312,3 +312,13 @@ QUnit.test('useUTC = false (variableTimezone)', assert => {
         'Time should be intact when useUTC = false'
     );
 });
+
+QUnit.test('#14746: Undefined max getTimeTicks threw', assert => {
+    const time = new Highcharts.Time({
+        useUTC: false
+    });
+
+    time.getTimeTicks({}, 0, undefined);
+
+    assert.ok(true, 'It should not throw');
+});

--- a/samples/unit-tests/time/get-set/demo.js
+++ b/samples/unit-tests/time/get-set/demo.js
@@ -312,13 +312,3 @@ QUnit.test('useUTC = false (variableTimezone)', assert => {
         'Time should be intact when useUTC = false'
     );
 });
-
-QUnit.test('#14746: Undefined max getTimeTicks threw', assert => {
-    const time = new Highcharts.Time({
-        useUTC: false
-    });
-
-    time.getTimeTicks({}, 0, undefined);
-
-    assert.ok(true, 'It should not throw');
-});

--- a/samples/unit-tests/time/timeticks/demo.js
+++ b/samples/unit-tests/time/timeticks/demo.js
@@ -500,4 +500,14 @@
             )
         );
     });
+
+    QUnit.test('#14746: Undefined max getTimeTicks threw', assert => {
+        const time = new Highcharts.Time({
+            useUTC: false
+        });
+
+        time.getTimeTicks({}, 0, undefined);
+
+        assert.ok(true, 'It should not throw');
+    });
 }());

--- a/ts/Core/Time.ts
+++ b/ts/Core/Time.ts
@@ -835,10 +835,10 @@ class Time {
                     minDate,
                     (
                         time.get('Date', minDate) -
-                        minDay + (startOfWeek as any) +
+                        minDay + startOfWeek +
                         // We don't want to skip days that are before
                         // startOfWeek (#7051)
-                        (minDay < (startOfWeek as any) ? -7 : 0)
+                        (minDay < startOfWeek ? -7 : 0)
                     )
                 );
             }
@@ -854,8 +854,7 @@ class Time {
             min = minDate.getTime();
 
             // Handle local timezone offset
-            if (time.variableTimezone || !time.useUTC) {
-
+            if ((time.variableTimezone || !time.useUTC) && defined(max)) {
                 // Detect whether we need to take the DST crossover into
                 // consideration. If we're crossing over DST, the day length may
                 // be 23h or 25h and we need to compute the exact clock time for
@@ -863,11 +862,11 @@ class Time {
                 // so first we find out if it is needed (#4951).
                 variableDayLength = (
                     // Long range, assume we're crossing over.
-                    (max as any) - min > 4 * timeUnits.month ||
+                    max - min > 4 * timeUnits.month ||
                     // Short range, check if min and max are in different time
                     // zones.
                     time.getTimezoneOffset(min) !==
-                    time.getTimezoneOffset(max as any)
+                    time.getTimezoneOffset(max)
                 );
             }
 


### PR DESCRIPTION
Fixed #14746, column chart with null data, datetime axis and `useUTC` set to `false` threw.