### PR TITLE
bugfix/13716-initialize-responsive-rules

### DIFF
--- a/js/Core/Chart/Chart.js
+++ b/js/Core/Chart/Chart.js
@@ -1668,10 +1668,6 @@ var Chart = /** @class */ (function () {
         chart.renderLabels();
         // Credits
         chart.addCredits();
-        // Handle responsiveness
-        if (chart.setResponsive) {
-            chart.setResponsive();
-        }
         // Handle scaling
         chart.updateContainerScaling();
         // Set flag
@@ -1869,6 +1865,12 @@ var Chart = /** @class */ (function () {
                 chart.pointer = new Pointer(chart, options);
             }
         }
+        // Handle responsiveness. Has to fire after extensions are loaded
+        addEvent(chart, 'load', function () {
+            if (chart.setResponsive) {
+                chart.setResponsive(true);
+            }
+        });
         chart.render();
         // Fire the load event if there are no external images
         if (!chart.renderer.imgCount && !chart.hasLoaded) {

--- a/samples/unit-tests/responsive/responsive/demo.js
+++ b/samples/unit-tests/responsive/responsive/demo.js
@@ -332,6 +332,83 @@ QUnit.test(
     }
 );
 
+QUnit.test('Annotations applied on init', function (assert) {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            animation: false
+        },
+
+        series: [
+            {
+                data: [1, 4, 3],
+                animation: false,
+                yAxis: 0
+            }
+        ],
+
+        yAxis: [
+            {
+                min: 0,
+                max: 10
+            },
+            {
+                opposite: true,
+                min: -10,
+                max: 10
+            }
+        ],
+
+        responsive: {
+            rules: [
+                {
+                    condition: {
+                        minWidth: 100
+                    },
+                    chartOptions: {
+                        plotOptions: {
+                            series: {
+                                color: 'red'
+                            }
+                        },
+                        series: [
+                            {
+                                yAxis: 1
+                            }
+                        ],
+                        annotations: [
+                            {
+                                labels: [
+                                    {
+                                        point: {
+                                            xAxis: 0,
+                                            yAxis: 0,
+                                            x: 1,
+                                            y: 1
+                                        },
+                                        text: 'Label v2'
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    });
+
+    assert.strictEqual(
+        chart.annotations.length,
+        1,
+        'Annotations should be applied to chart from responsive rule'
+    );
+    assert.strictEqual(
+        chart.options.annotations[0].labels[0].text,
+        'Label v2',
+        'Annotation options should be set'
+    );
+
+});
+
 QUnit.test('Revert axis properties', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -2357,11 +2357,6 @@ class Chart {
         // Credits
         chart.addCredits();
 
-        // Handle responsiveness
-        if (chart.setResponsive) {
-            chart.setResponsive();
-        }
-
         // Handle scaling
         chart.updateContainerScaling();
 
@@ -2608,6 +2603,13 @@ class Chart {
                 chart.pointer = new Pointer(chart, options);
             }
         }
+
+        // Handle responsiveness. Has to fire after extensions are loaded
+        addEvent(chart, 'load', function (): void {
+            if (chart.setResponsive) {
+                chart.setResponsive(true);
+            }
+        });
 
         chart.render();
 


### PR DESCRIPTION
Fixed #13716, annotations added in responsive rules did not work.

This was due to `setResponsive` being called before callbacks were added.