### PR TITLE
Prevents adding conflicting classNames to SVGElement

### DIFF
--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -633,6 +633,11 @@ class SVGElement {
                 name: string
             ): Array<string> {
                 if ((currentClassName as any).indexOf(name) === -1) {
+                    let split = name.split(/-\d+$/); // see if the `name` is a serialized class that ends in hyphen-number, i.e., `highcharts-color-1`
+                    if (split.length > 1) { // if so the split array will have 2 entries
+                        let regex = new RegExp(split[0] + '-\\d+$'); // remove the corresponding existing className from what will be returned (i.e., remove `highcharts-color-0`)
+                        newClassName[0] = newClassName[0].replace(regex, '');
+                    }
                     newClassName.push(name);
                 }
                 return newClassName;


### PR DESCRIPTION
`SVGElement.prototype.addClass` will currently add a class as long the current className string does not include it exactly. If for example you programmatically change point colors  you will get a className string that includes conflicting classNames. This is true for any "serialized" class ending in hyphen-number.

for example `class="highcharts-point highcharts-color-0 highcharts-color-1"`

if you programmatically try to change that point back to `highcharts-color-0` the `highcharts-color-1` will remain and override it.

this fix checks for the presence of "serialized" classes and will remove any that would be overridden by the new one.

there may be a better way to do it -- this relies on some RegEx sniffing. I left out the typescript typing.