### PR TITLE
bugfix/getTimeTicks-negative-values

### DIFF
--- a/js/Core/Time.js
+++ b/js/Core/Time.js
@@ -566,11 +566,11 @@ var Time = /** @class */ (function () {
             if (interval === timeUnits.week) {
                 // get start of current week, independent of count
                 minDay = time.get('Day', minDate);
-                time.set('Date', minDate, Math.max(1, (time.get('Date', minDate) -
+                time.set('Date', minDate, time.get('Date', minDate) -
                     minDay + startOfWeek +
                     // We don't want to skip days that are before
                     // startOfWeek (#7051)
-                    (minDay < startOfWeek ? -7 : 0))));
+                    (minDay < startOfWeek ? -7 : 0));
             }
             // Get basics for variable time spans
             minYear = time.get('FullYear', minDate);
@@ -594,6 +594,10 @@ var Time = /** @class */ (function () {
             }
             // Iterate and add tick positions at appropriate values
             var t = minDate.getTime();
+            // Don't allow negative ticks.
+            if (t < 0) {
+                t = 1;
+            }
             i = 1;
             while (t < max) {
                 tickPositions.push(t);

--- a/js/Core/Time.js
+++ b/js/Core/Time.js
@@ -566,11 +566,11 @@ var Time = /** @class */ (function () {
             if (interval === timeUnits.week) {
                 // get start of current week, independent of count
                 minDay = time.get('Day', minDate);
-                time.set('Date', minDate, (time.get('Date', minDate) -
+                time.set('Date', minDate, Math.max(1, (time.get('Date', minDate) -
                     minDay + startOfWeek +
                     // We don't want to skip days that are before
                     // startOfWeek (#7051)
-                    (minDay < startOfWeek ? -7 : 0)));
+                    (minDay < startOfWeek ? -7 : 0))));
             }
             // Get basics for variable time spans
             minYear = time.get('FullYear', minDate);

--- a/samples/unit-tests/axis/type-datetime/demo.js
+++ b/samples/unit-tests/axis/type-datetime/demo.js
@@ -48,3 +48,20 @@ QUnit.test('Single point padding (#2846)', function (assert) {
         'The point width should be larger than about 1 pixel.'
     );
 });
+
+QUnit.test('The getTimeTicks should not return negative values.', function (assert) {
+    var chart = Highcharts.chart('container', {
+        yAxis: {
+            type: "datetime"
+        },
+        series: [{
+            type: 'column',
+            data: [6048000000, 41280000, 33180000, 0]
+        }]
+    });
+
+    assert.ok(
+        chart.yAxis[0].tickPositions[0] >= 0,
+        'The first tick on the datetime axis should not be negative.'
+    );
+});

--- a/samples/unit-tests/series/datagroup/demo.js
+++ b/samples/unit-tests/series/datagroup/demo.js
@@ -29,7 +29,7 @@ QUnit.test('Point dataGroup', function (assert) {
 
     assert.strictEqual(
         chart.series[0].points[0].dataGroup.length,
-        3,
-        'First group includes 3 points'
+        7,
+        'First group includes 7 points'
     );
 });

--- a/samples/unit-tests/series/datagroup/demo.js
+++ b/samples/unit-tests/series/datagroup/demo.js
@@ -29,7 +29,7 @@ QUnit.test('Point dataGroup', function (assert) {
 
     assert.strictEqual(
         chart.series[0].points[0].dataGroup.length,
-        7,
-        'First group includes 7 points'
+        3,
+        'First group includes 3 points'
     );
 });

--- a/ts/Core/Time.ts
+++ b/ts/Core/Time.ts
@@ -833,12 +833,15 @@ class Time {
                 time.set(
                     'Date',
                     minDate,
-                    (
-                        time.get('Date', minDate) -
-                        minDay + startOfWeek +
-                        // We don't want to skip days that are before
-                        // startOfWeek (#7051)
-                        (minDay < startOfWeek ? -7 : 0)
+                    Math.max(
+                        1,
+                        (
+                            time.get('Date', minDate) -
+                            minDay + startOfWeek +
+                            // We don't want to skip days that are before
+                            // startOfWeek (#7051)
+                            (minDay < startOfWeek ? -7 : 0)
+                        )
                     )
                 );
             }

--- a/ts/Core/Time.ts
+++ b/ts/Core/Time.ts
@@ -833,16 +833,11 @@ class Time {
                 time.set(
                     'Date',
                     minDate,
-                    Math.max(
-                        1,
-                        (
-                            time.get('Date', minDate) -
-                            minDay + startOfWeek +
-                            // We don't want to skip days that are before
-                            // startOfWeek (#7051)
-                            (minDay < startOfWeek ? -7 : 0)
-                        )
-                    )
+                    time.get('Date', minDate) -
+                        minDay + startOfWeek +
+                        // We don't want to skip days that are before
+                        // startOfWeek (#7051)
+                        (minDay < startOfWeek ? -7 : 0)
                 );
             }
 
@@ -875,6 +870,10 @@ class Time {
 
             // Iterate and add tick positions at appropriate values
             var t = minDate.getTime();
+            // Don't allow negative ticks.
+            if (t < 0) {
+                t = 1;
+            }
 
             i = 1;
             while (t < (max as any)) {


### PR DESCRIPTION
Fixed, getTimeTicks returned negative values.
Replacement for the #14694 PR.