### PR TITLE
bugfix/13283-hexcolor-treated-as-comment)

### DIFF
--- a/js/Extensions/Data.js
+++ b/js/Extensions/Data.js
@@ -830,6 +830,7 @@ var Data = /** @class */ (function () {
             /**
              * Count hex values that are not comments (#13283)
              * @private
+             * @return {number}
              */
             function countHexValues() {
                 var hexValuesCount = 0;

--- a/js/Extensions/Data.js
+++ b/js/Extensions/Data.js
@@ -774,7 +774,7 @@ var Data = /** @class */ (function () {
          * @private
          */
         function parseRow(columnStr, rowNumber, noAdd, callbacks) {
-            var i = 0, c = '', cl = '', cn = '', token = '', actualColumn = 0, column = 0, remainingHexColors = countHexValues(); // (#13283)
+            var i = 0, c = '', cl = '', cn = '', token = '', actualColumn = 0, column = 0;
             /**
              * @private
              */
@@ -827,27 +827,6 @@ var Data = /** @class */ (function () {
                 ++column;
                 ++actualColumn;
             }
-            /**
-             * Count hex values that are not comments (#13283)
-             * @private
-             * @return {number}
-             */
-            function countHexValues() {
-                var hexValuesCount = 0;
-                var potentialHexValues = columnStr.split(itemDelimiter)
-                    .filter(function (item) {
-                    return item.indexOf('#') === 0;
-                });
-                potentialHexValues.forEach(function (pH) {
-                    pH = pH.substring(1);
-                    var a = parseInt(pH, 16);
-                    if ((a.toString(16) === pH.toLowerCase()) ||
-                        (pH === '000')) { // Black values
-                        hexValuesCount++;
-                    }
-                });
-                return hexValuesCount;
-            }
             if (!columnStr.trim().length) {
                 return;
             }
@@ -856,15 +835,6 @@ var Data = /** @class */ (function () {
             }
             for (; i < columnStr.length; i++) {
                 read(i);
-                // If there are hexvalues remaining (#13283)
-                if (c === '#' && remainingHexColors) {
-                    remainingHexColors--;
-                }
-                else if (c === '#') {
-                    // The rest of the row is a comment
-                    push();
-                    return;
-                }
                 if (c === '"') {
                     read(++i);
                     while (i < columnStr.length) {

--- a/js/Extensions/Data.js
+++ b/js/Extensions/Data.js
@@ -774,7 +774,7 @@ var Data = /** @class */ (function () {
          * @private
          */
         function parseRow(columnStr, rowNumber, noAdd, callbacks) {
-            var i = 0, c = '', cl = '', cn = '', token = '', actualColumn = 0, column = 0;
+            var i = 0, c = '', cl = '', cn = '', token = '', actualColumn = 0, column = 0, remainingHexColors = countHexValues(); // (#13283)
             /**
              * @private
              */
@@ -827,6 +827,26 @@ var Data = /** @class */ (function () {
                 ++column;
                 ++actualColumn;
             }
+            /**
+             * Count hex values that are not comments (#13283)
+             * @private
+             */
+            function countHexValues() {
+                var hexValuesCount = 0;
+                var potentialHexValues = columnStr.split(itemDelimiter)
+                    .filter(function (item) {
+                    return item.indexOf('#') === 0;
+                });
+                potentialHexValues.forEach(function (pH) {
+                    pH = pH.substring(1);
+                    var a = parseInt(pH, 16);
+                    if ((a.toString(16) === pH.toLowerCase()) ||
+                        (pH === '000')) { // Black values
+                        hexValuesCount++;
+                    }
+                });
+                return hexValuesCount;
+            }
             if (!columnStr.trim().length) {
                 return;
             }
@@ -835,8 +855,11 @@ var Data = /** @class */ (function () {
             }
             for (; i < columnStr.length; i++) {
                 read(i);
-                // Quoted string
-                if (c === '#') {
+                // If there are hexvalues remaining (#13283)
+                if (c === '#' && remainingHexColors) {
+                    remainingHexColors--;
+                }
+                else if (c === '#') {
                     // The rest of the row is a comment
                     push();
                     return;

--- a/samples/unit-tests/data/csv/demo.js
+++ b/samples/unit-tests/data/csv/demo.js
@@ -643,34 +643,6 @@ QUnit.test('startRow, endRow, startColumn, endColumn', function (assert) {
     });
 });
 
-QUnit.test('Comments in CSV', function (assert) {
-    var data = [
-        '# -------',
-        '# Comment',
-        '# ----',
-        'Apples,Pears',
-        '1,2# Inline comment',
-        '3,4',
-        '5,6'
-    ].join('\n');
-
-    Highcharts.data({
-        csv: data,
-        parsed: function () {
-            assert.strictEqual(
-                this.columns[0].join(','),
-                'Apples,1,3,5',
-                'First column ok'
-            );
-            assert.strictEqual(
-                this.columns[1].join(','),
-                'Pears,2,4,6',
-                'Second column ok'
-            );
-        }
-    });
-});
-
 // Highcharts 4.0.4, Issue #3437
 // Data module fails with numeric data in first column
 QUnit.test('Data module numeric x (#3437)', function (assert) {

--- a/samples/unit-tests/data/csv/demo.js
+++ b/samples/unit-tests/data/csv/demo.js
@@ -713,3 +713,27 @@ QUnit.test('Dot date format', function (assert) {
         }
     });
 });
+
+QUnit.test(
+    'Hex values are not treated as comments (#13283).',
+    function (assert) {
+        var chart = Highcharts.chart('container', {
+            chart: {
+                type: 'bar'
+            },
+            data: {
+                csv:
+                    'x;y;color\n' +
+                    '0;1;#F0F\n',
+
+                itemDelimiter: ';',
+                seriesMapping: [{
+                    color: 2
+                }]
+            }
+        });
+
+        var actualColor = chart.series[0].data[0].options.color;
+        assert.strictEqual(actualColor, '#F0F', 'Color must be a hex value');
+    }
+);

--- a/samples/unit-tests/data/csv/demo.js
+++ b/samples/unit-tests/data/csv/demo.js
@@ -689,23 +689,23 @@ QUnit.test('Dot date format', function (assert) {
 QUnit.test(
     'Hex values are not treated as comments (#13283).',
     function (assert) {
-        var chart = Highcharts.chart('container', {
-            chart: {
-                type: 'bar'
-            },
-            data: {
-                csv:
-                    'x;y;color\n' +
-                    '0;1;#F0F\n',
+        Highcharts.data({
+            csv:
+                'x;y;color\n' +
+                '0;1;#F0F\n',
 
-                itemDelimiter: ';',
-                seriesMapping: [{
-                    color: 2
-                }]
+            itemDelimiter: ';',
+            seriesMapping: [{
+                color: 2
+            }],
+
+            parsed: function () {
+                assert.strictEqual(
+                    this.columns[2][1],
+                    '#F0F',
+                    'Color should be a hex value.'
+                );
             }
         });
-
-        var actualColor = chart.series[0].data[0].options.color;
-        assert.strictEqual(actualColor, '#F0F', 'Color must be a hex value');
     }
 );

--- a/ts/Extensions/Data.ts
+++ b/ts/Extensions/Data.ts
@@ -1112,6 +1112,7 @@ class Data {
             /**
              * Count hex values that are not comments (#13283)
              * @private
+             * @return {number}
              */
             function countHexValues(): number {
                 var hexValuesCount: number = 0;

--- a/ts/Extensions/Data.ts
+++ b/ts/Extensions/Data.ts
@@ -1049,7 +1049,8 @@ class Data {
                 cn = '',
                 token = '',
                 actualColumn = 0,
-                column = 0;
+                column = 0,
+                remainingHexColors = countHexValues(); // (#13283)
 
             /**
              * @private
@@ -1108,6 +1109,31 @@ class Data {
                 ++actualColumn;
             }
 
+            /**
+             * Count hex values that are not comments (#13283)
+             * @private
+             */
+            function countHexValues(): number {
+                var hexValuesCount: number = 0;
+                var potentialHexValues = columnStr.split(itemDelimiter)
+                    .filter(function (item: string): boolean {
+                        return item.indexOf('#') === 0;
+                    });
+
+                potentialHexValues.forEach(function (
+                    pH: string
+                ): void {
+                    pH = pH.substring(1);
+                    var a: number = parseInt(pH, 16);
+                    if ((a.toString(16) === pH.toLowerCase()) ||
+                        (pH === '000')) { // Black values
+                        hexValuesCount++;
+                    }
+                });
+
+                return hexValuesCount;
+            }
+
             if (!columnStr.trim().length) {
                 return;
             }
@@ -1119,8 +1145,10 @@ class Data {
             for (; i < columnStr.length; i++) {
                 read(i);
 
-                // Quoted string
-                if (c === '#') {
+                // If there are hexvalues remaining (#13283)
+                if (c === '#' && remainingHexColors) {
+                    remainingHexColors--;
+                } else if (c === '#') {
                     // The rest of the row is a comment
                     push();
                     return;

--- a/ts/Extensions/Data.ts
+++ b/ts/Extensions/Data.ts
@@ -1049,8 +1049,7 @@ class Data {
                 cn = '',
                 token = '',
                 actualColumn = 0,
-                column = 0,
-                remainingHexColors = countHexValues(); // (#13283)
+                column = 0;
 
             /**
              * @private
@@ -1109,32 +1108,6 @@ class Data {
                 ++actualColumn;
             }
 
-            /**
-             * Count hex values that are not comments (#13283)
-             * @private
-             * @return {number}
-             */
-            function countHexValues(): number {
-                var hexValuesCount: number = 0;
-                var potentialHexValues = columnStr.split(itemDelimiter)
-                    .filter(function (item: string): boolean {
-                        return item.indexOf('#') === 0;
-                    });
-
-                potentialHexValues.forEach(function (
-                    pH: string
-                ): void {
-                    pH = pH.substring(1);
-                    var a: number = parseInt(pH, 16);
-                    if ((a.toString(16) === pH.toLowerCase()) ||
-                        (pH === '000')) { // Black values
-                        hexValuesCount++;
-                    }
-                });
-
-                return hexValuesCount;
-            }
-
             if (!columnStr.trim().length) {
                 return;
             }
@@ -1145,15 +1118,6 @@ class Data {
 
             for (; i < columnStr.length; i++) {
                 read(i);
-
-                // If there are hexvalues remaining (#13283)
-                if (c === '#' && remainingHexColors) {
-                    remainingHexColors--;
-                } else if (c === '#') {
-                    // The rest of the row is a comment
-                    push();
-                    return;
-                }
 
                 if (c === '"') {
                     read(++i);


### PR DESCRIPTION
Fixed #13283, an issue with the data module's CSV parser. Hex colors (and any other strings following a hash) were treated as a comment and ignored.

~~Fixed #13283, Hex color ignored as a comment.~~