### PR TITLE
bugfix/14765-global-patterns

### DIFF
--- a/js/Extensions/PatternFill.js
+++ b/js/Extensions/PatternFill.js
@@ -14,6 +14,7 @@
 import A from '../Core/Animation/AnimationUtilities.js';
 var animObject = A.animObject;
 import Chart from '../Core/Chart/Chart.js';
+import H from '../Core/Globals.js';
 import LineSeries from '../Series/Line/LineSeries.js';
 import Point from '../Core/Series/Point.js';
 import SVGRenderer from '../Core/Renderer/SVG/SVGRenderer.js';
@@ -129,7 +130,7 @@ import '../Series/Line/LineSeries.js';
 */
 ''; // detach doclets above
 // Add the predefined patterns
-var patterns = (function () {
+var patterns = H.patterns = (function () {
     var patterns = [], colors = getOptions().colors;
     [
         'M 0 0 L 10 10 M 9 -1 L 11 1 M -1 9 L 1 11',

--- a/samples/unit-tests/color/pattern-fill/demo.js
+++ b/samples/unit-tests/color/pattern-fill/demo.js
@@ -698,3 +698,7 @@ QUnit.test('Destroy and recreate chart', function (assert) {
     const secondChart = Highcharts.chart('container', options);
     testChart(secondChart);
 });
+
+QUnit.test('#14765: Global patterns', assert => {
+    assert.ok(Highcharts.patterns, 'Global patterns should be defined');
+});

--- a/ts/Extensions/PatternFill.ts
+++ b/ts/Extensions/PatternFill.ts
@@ -184,7 +184,7 @@ declare global {
 ''; // detach doclets above
 
 // Add the predefined patterns
-const patterns = ((): Array<PatternFill.PatternOptionsObject> => {
+const patterns = H.patterns = ((): Array<PatternFill.PatternOptionsObject> => {
     const patterns: Array<PatternFill.PatternOptionsObject> = [],
         colors: Array<string> = getOptions().colors as any;
 


### PR DESCRIPTION
Fixed #14765, `Highcharts.patterns` global was missing.