### PR TITLE
bugfix/14549-clip-path-added-axis

### DIFF
--- a/js/Core/Chart/StockChart.js
+++ b/js/Core/Chart/StockChart.js
@@ -685,9 +685,9 @@ addEvent(LineSeries, 'render', function () {
             }
         }
         // First render, initial clip box
-        if (!this.clipBox && !chart.hasRendered) {
-            this.clipBox = merge(chart.clipBox);
-            this.clipBox.width = this.xAxis.len;
+        if (!this.clipBox) {
+            this.clipBox = merge({}, chart.clipBox);
+            this.clipBox.width = chart.chartWidth;
             this.clipBox.height = clipHeight;
             // On redrawing, resizing etc, update the clip rectangle
         }

--- a/js/Core/Chart/StockChart.js
+++ b/js/Core/Chart/StockChart.js
@@ -685,9 +685,9 @@ addEvent(LineSeries, 'render', function () {
             }
         }
         // First render, initial clip box
-        if (!this.clipBox) {
-            this.clipBox = merge({}, chart.clipBox);
-            this.clipBox.width = chart.chartWidth;
+        if (!this.clipBox && this.isDirty && !this.isDirtyData) {
+            this.clipBox = merge(chart.clipBox);
+            this.clipBox.width = this.xAxis.len;
             this.clipBox.height = clipHeight;
             // On redrawing, resizing etc, update the clip rectangle
         }

--- a/samples/unit-tests/axis/offset/demo.js
+++ b/samples/unit-tests/axis/offset/demo.js
@@ -33,7 +33,7 @@ QUnit.test('Axis offsets - test series clips.(#4371)', function (assert) {
         };
 
     assert.strictEqual(
-        chart.chartWidth === parseInt(clip.width, 10) &&
+        chart.plotWidth === parseInt(clip.width, 10) &&
             chart.plotHeight === parseInt(clip.height, 10),
         true,
         'CLip path has proper width and height'

--- a/samples/unit-tests/axis/offset/demo.js
+++ b/samples/unit-tests/axis/offset/demo.js
@@ -33,7 +33,7 @@ QUnit.test('Axis offsets - test series clips.(#4371)', function (assert) {
         };
 
     assert.strictEqual(
-        chart.plotWidth === parseInt(clip.width, 10) &&
+        chart.chartWidth === parseInt(clip.width, 10) &&
             chart.plotHeight === parseInt(clip.height, 10),
         true,
         'CLip path has proper width and height'

--- a/samples/unit-tests/series/clip/demo.js
+++ b/samples/unit-tests/series/clip/demo.js
@@ -63,7 +63,7 @@ QUnit.test('General series clip tests', assert => {
                         )[0]
                         .getAttribute('width')
                 ),
-                chart.clipBox.width,
+                chart.chartWidth,
                 "Correct clippath's width after updating chart (#13751)."
             );
 
@@ -74,4 +74,44 @@ QUnit.test('General series clip tests', assert => {
     } finally {
         TestUtilities.lolexUninstall(clock);
     }
+});
+
+QUnit.test('Each series should have their own clip-path, (#14549).', assert => {
+    const chart = Highcharts.stockChart('container', {
+
+    });
+
+    chart.addAxis({
+        id: 'line',
+        height: '60%',
+        min: 4,
+        max: 6
+    }, false, false);
+
+    chart.addAxis({
+        id: 'column',
+        top: '65%',
+        height: '35%',
+        offset: 0
+    }, false, false);
+
+    chart.addSeries({
+        type: 'line',
+        data: [5, 7, 5, 2, 3, 7],
+        yAxis: 'line'
+    }, false, false);
+
+    chart.addSeries({
+        type: 'column',
+        data: [23, 45, 37, 22, 39, 65],
+        yAxis: 'column'
+    }, false, false);
+
+    chart.redraw(false);
+
+    assert.ok(
+        chart.series[0].clipBox.height + chart.series[1].clipBox.height <=
+        chart.plotHeight,
+        "The sum of the series clip-paths should not be bigger than the plot height."
+    );
 });

--- a/samples/unit-tests/series/clip/demo.js
+++ b/samples/unit-tests/series/clip/demo.js
@@ -63,7 +63,7 @@ QUnit.test('General series clip tests', assert => {
                         )[0]
                         .getAttribute('width')
                 ),
-                chart.chartWidth,
+                chart.clipBox.width,
                 "Correct clippath's width after updating chart (#13751)."
             );
 

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -1037,9 +1037,9 @@ addEvent(LineSeries, 'render', function (): void {
         }
 
         // First render, initial clip box
-        if (!this.clipBox) {
-            this.clipBox = merge({}, chart.clipBox);
-            this.clipBox.width = chart.chartWidth;
+        if (!this.clipBox && this.isDirty && !this.isDirtyData) {
+            this.clipBox = merge(chart.clipBox);
+            this.clipBox.width = this.xAxis.len;
             this.clipBox.height = clipHeight;
 
         // On redrawing, resizing etc, update the clip rectangle

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -1037,9 +1037,9 @@ addEvent(LineSeries, 'render', function (): void {
         }
 
         // First render, initial clip box
-        if (!this.clipBox && !chart.hasRendered) {
-            this.clipBox = merge(chart.clipBox);
-            this.clipBox.width = this.xAxis.len;
+        if (!this.clipBox) {
+            this.clipBox = merge({}, chart.clipBox);
+            this.clipBox.width = chart.chartWidth;
             this.clipBox.height = clipHeight;
 
         // On redrawing, resizing etc, update the clip rectangle


### PR DESCRIPTION
Fixed #14549, incorrect clip-path for added axis.

~~This change improves #13751. It applies the max available clip-path width to make sure that none of the series points is going to be cut.  An extra part of the series clip-path is then trimmed by the `plotArea`.~~

The previous approach procured to many visual differences. Latest commit is about to refix the issue introduced in #13751.
