### PR TITLE
bugfix/14788-input-type-ie

### DIFF
--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -1082,9 +1082,21 @@ var RangeSelector = /** @class */ (function () {
         // to the right size when focused.
         var input = createElement('input', {
             name: name,
-            className: 'highcharts-range-selector',
-            type: preferredInputType(options.inputDateFormat || '%b %e, %Y')
+            className: 'highcharts-range-selector'
         }, void 0, div);
+        // #14788, setting input.type to an unsupported type throws in IE, so
+        // we need to use setAttribute instead
+        input.setAttribute('type', preferredInputType(options.inputDateFormat || '%b %e, %Y'));
+        if (input.type !== 'text') {
+            // This is the test string modernizr uses
+            input.value = '1)';
+            if (input.value === '1)') {
+                // Some Android browsers pretend to support the type, if it
+                // doesnt reject '1)' then it doesnt actually support the type
+                input.setAttribute('type', 'text');
+            }
+            input.value = '';
+        }
         if (!chart.styledMode) {
             // Styles
             label.css(merge(chartStyle, options.labelStyle));

--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -1084,15 +1084,16 @@ var RangeSelector = /** @class */ (function () {
             name: name,
             className: 'highcharts-range-selector'
         }, void 0, div);
-        // #14788, setting input.type to an unsupported type throws in IE, so
+        // #14788: Setting input.type to an unsupported type throws in IE, so
         // we need to use setAttribute instead
         input.setAttribute('type', preferredInputType(options.inputDateFormat || '%b %e, %Y'));
+        // Some old Android browsers (0.06% usage as of dec 2020) pretend to
+        // support the type by not setting the type attribute back to 'text',
+        // if it doesnt reject the '1)' then it doesnt actually support the
+        // type. May remove this is in the future.
         if (input.type !== 'text') {
-            // This is the test string modernizr uses
-            input.value = '1)';
+            input.value = '1)'; // This is the test string modernizr uses
             if (input.value === '1)') {
-                // Some Android browsers pretend to support the type, if it
-                // doesnt reject '1)' then it doesnt actually support the type
                 input.setAttribute('type', 'text');
             }
             input.value = '';

--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -1087,17 +1087,6 @@ var RangeSelector = /** @class */ (function () {
         // #14788: Setting input.type to an unsupported type throws in IE, so
         // we need to use setAttribute instead
         input.setAttribute('type', preferredInputType(options.inputDateFormat || '%b %e, %Y'));
-        // Some old Android browsers (0.06% usage as of dec 2020) pretend to
-        // support the type by not setting the type attribute back to 'text',
-        // if it doesnt reject the '1)' then it doesnt actually support the
-        // type. May remove this is in the future.
-        if (input.type !== 'text') {
-            input.value = '1)'; // This is the test string modernizr uses
-            if (input.value === '1)') {
-                input.setAttribute('type', 'text');
-            }
-            input.value = '';
-        }
         if (!chart.styledMode) {
             // Styles
             label.css(merge(chartStyle, options.labelStyle));

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -1545,18 +1545,6 @@ class RangeSelector {
         // we need to use setAttribute instead
         input.setAttribute('type', preferredInputType(options.inputDateFormat || '%b %e, %Y'));
 
-        // Some old Android browsers (0.06% usage as of dec 2020) pretend to
-        // support the type by not setting the type attribute back to 'text',
-        // if it doesnt reject the '1)' then it doesnt actually support the
-        // type. May remove this is in the future.
-        if (input.type !== 'text') {
-            input.value = '1)'; // This is the test string modernizr uses
-            if (input.value === '1)') {
-                input.setAttribute('type', 'text');
-            }
-            input.value = '';
-        }
-
         if (!chart.styledMode) {
             // Styles
             label.css(merge(chartStyle, options.labelStyle));

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -1541,16 +1541,17 @@ class RangeSelector {
             className: 'highcharts-range-selector'
         }, void 0, div) as HTMLInputElement;
 
-        // #14788, setting input.type to an unsupported type throws in IE, so
+        // #14788: Setting input.type to an unsupported type throws in IE, so
         // we need to use setAttribute instead
         input.setAttribute('type', preferredInputType(options.inputDateFormat || '%b %e, %Y'));
 
+        // Some old Android browsers (0.06% usage as of dec 2020) pretend to
+        // support the type by not setting the type attribute back to 'text',
+        // if it doesnt reject the '1)' then it doesnt actually support the
+        // type. May remove this is in the future.
         if (input.type !== 'text') {
-            // This is the test string modernizr uses
-            input.value = '1)';
+            input.value = '1)'; // This is the test string modernizr uses
             if (input.value === '1)') {
-                // Some Android browsers pretend to support the type, if it
-                // doesnt reject '1)' then it doesnt actually support the type
                 input.setAttribute('type', 'text');
             }
             input.value = '';

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -1538,9 +1538,23 @@ class RangeSelector {
         // to the right size when focused.
         const input = createElement('input', {
             name: name,
-            className: 'highcharts-range-selector',
-            type: preferredInputType(options.inputDateFormat || '%b %e, %Y')
+            className: 'highcharts-range-selector'
         }, void 0, div) as HTMLInputElement;
+
+        // #14788, setting input.type to an unsupported type throws in IE, so
+        // we need to use setAttribute instead
+        input.setAttribute('type', preferredInputType(options.inputDateFormat || '%b %e, %Y'));
+
+        if (input.type !== 'text') {
+            // This is the test string modernizr uses
+            input.value = '1)';
+            if (input.value === '1)') {
+                // Some Android browsers pretend to support the type, if it
+                // doesnt reject '1)' then it doesnt actually support the type
+                input.setAttribute('type', 'text');
+            }
+            input.value = '';
+        }
 
         if (!chart.styledMode) {
             // Styles


### PR DESCRIPTION
Fixed #14788, range selector date input threw in IE instead of falling back to text.