### PR TITLE
bugfix/8742-stackLabels-dataLabels

### DIFF
--- a/js/Extensions/Stacking.js
+++ b/js/Extensions/Stacking.js
@@ -150,7 +150,7 @@ var StackItem = /** @class */ (function () {
             }
         }
         // Rank it higher than data labels (#8742)
-        this.label.labelrank = chart.inverted ? chart.plotWidth : chart.plotHeight;
+        this.label.labelrank = chart.plotSizeY;
     };
     /**
      * Sets the offset that the stack has from the x value and repositions the

--- a/js/Extensions/Stacking.js
+++ b/js/Extensions/Stacking.js
@@ -150,7 +150,7 @@ var StackItem = /** @class */ (function () {
             }
         }
         // Rank it higher than data labels (#8742)
-        this.label.labelrank = chart.plotHeight;
+        this.label.labelrank = chart.inverted ? chart.plotWidth : chart.plotHeight;
     };
     /**
      * Sets the offset that the stack has from the x value and repositions the

--- a/samples/unit-tests/axis/stacklabels/demo.js
+++ b/samples/unit-tests/axis/stacklabels/demo.js
@@ -625,3 +625,43 @@ QUnit.test(
         }
     }
 );
+
+QUnit.test('#8742: Some stackLabels did not render with dataLabels enabled', assert => {
+    [
+        'column',
+        'bar'
+    ].forEach(type => {
+        const chart = Highcharts.chart('container', {
+            chart: {
+                type
+            },
+            yAxis: {
+                stackLabels: {
+                    enabled: true
+                }
+            },
+            plotOptions: {
+                [type]: {
+                    stacking: 'normal',
+                    dataLabels: {
+                        enabled: true,
+                        inside: false
+                    }
+                }
+            },
+            series: [{
+                data: [0, 99, 454, 297, 409]
+            }, {
+                data: [51, 150, 155, 106, 97]
+            }, {
+                data: [19, 107, 184, 138, 150]
+            }]
+        });
+
+        const stack = chart.yAxis[0].stacking.stacks[`${type},,,`];
+        assert.ok(
+            Object.values(stack).every(item => item.label.visibility !== 'hidden'),
+            `${type}: All stackLabels should be visible`
+        );
+    });
+});

--- a/ts/Extensions/Stacking.ts
+++ b/ts/Extensions/Stacking.ts
@@ -373,7 +373,7 @@ class StackItem {
         }
 
         // Rank it higher than data labels (#8742)
-        this.label.labelrank = chart.plotHeight;
+        this.label.labelrank = chart.inverted ? chart.plotWidth : chart.plotHeight;
     }
 
     /**

--- a/ts/Extensions/Stacking.ts
+++ b/ts/Extensions/Stacking.ts
@@ -373,7 +373,7 @@ class StackItem {
         }
 
         // Rank it higher than data labels (#8742)
-        this.label.labelrank = chart.inverted ? chart.plotWidth : chart.plotHeight;
+        this.label.labelrank = chart.plotSizeY;
     }
 
     /**


### PR DESCRIPTION
Fixed #8742, some `stackLabels` did not render with `dataLabels` enabled.