### PR TITLE
bugfix/8795-zoom-setData-hover

### DIFF
--- a/js/Core/Pointer.js
+++ b/js/Core/Pointer.js
@@ -439,7 +439,7 @@ var Pointer = /** @class */ (function () {
             var noSharedTooltip = s.noSharedTooltip && shared, compareX = (!noSharedTooltip &&
                 s.options.findNearestPointBy.indexOf('y') < 0), point = s.searchPoint(e, compareX);
             if ( // Check that we actually found a point on the series.
-            isObject(point, true) &&
+            isObject(point, true) && point.series &&
                 // Use the new point if it is closer.
                 (!isObject(closest, true) ||
                     (sort(closest, point) > 0))) {

--- a/samples/unit-tests/series/setdata/demo.js
+++ b/samples/unit-tests/series/setdata/demo.js
@@ -622,3 +622,29 @@ QUnit.test(
         assert.deepEqual(iterator, 1, "Just one 'updatedData' call");
     }
 );
+
+QUnit.test('#8795: Hovering after zooming in and using setData with redraw set to false threw', assert => {
+    const data = () => {
+        const ret = [];
+        for (let i = 0; i < 500; i++) {
+            ret[i] = Math.random();
+        }
+        return ret;
+    };
+
+    const chart = Highcharts.chart('container', {
+        chart: {
+            zoomType: 'x'
+        },
+        series: [{
+            data: data()
+        }]
+    });
+
+    const controller = new TestController(chart);
+    controller.pan([200, 150], [250, 150]);
+    chart.series[0].setData(data(), false);
+    controller.moveTo(150, 150);
+
+    assert.ok(true, 'It should not throw');
+});

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -721,7 +721,7 @@ class Pointer {
                 );
 
             if (// Check that we actually found a point on the series.
-                isObject(point, true) &&
+                isObject(point, true) && point.series &&
                 // Use the new point if it is closer.
                 (!isObject(closest, true) ||
                 (sort(closest as any, point as any) > 0))


### PR DESCRIPTION
Fixed #8795, hovering the chart after zooming in and using `setData` with `redraw` set to `false` threw.