### PR TITLE
bugfix/14209-Histogram-update-with-empty-array

### DIFF
--- a/js/Series/Histogram/HistogramSeries.js
+++ b/js/Series/Histogram/HistogramSeries.js
@@ -160,6 +160,7 @@ var HistogramSeries = /** @class */ (function (_super) {
     HistogramSeries.prototype.setDerivedData = function () {
         var yData = this.baseSeries.yData;
         if (!yData.length) {
+            this.setData([]);
             return;
         }
         var data = this.derivedData(yData, this.binsNumber(), this.options.binWidth);

--- a/samples/unit-tests/series-histogram/members/demo.js
+++ b/samples/unit-tests/series-histogram/members/demo.js
@@ -1,14 +1,20 @@
 QUnit.test('setDerivedData', assert => {
-    const { setDerivedData } = Highcharts.seriesTypes.histogram.prototype;
-    const ctx = {
-        baseSeries: {
-            yData: []
-        }
-    };
-
     /**
      * setDerivedData should work properly with an empty yData. #11388.
      */
-    setDerivedData.call(ctx);
-    assert.ok(true, 'Should not error when called with empty yData.');
+    const chart = Highcharts.chart('container', {
+        series: [{
+            type: 'histogram',
+            baseSeries: 1
+        }, {
+            data: [1, 2, 2, 3, 3, 3, 4, 4, 5, 5, 6]
+        }]
+    });
+
+    chart.series[0].setData([]);
+
+    assert.ok(
+        true,
+        'Should not error when called with empty yData.'
+    );
 });

--- a/ts/Series/Histogram/HistogramSeries.ts
+++ b/ts/Series/Histogram/HistogramSeries.ts
@@ -288,6 +288,7 @@ class HistogramSeries extends ColumnSeries {
         var yData = (this.baseSeries as any).yData;
 
         if (!yData.length) {
+            this.setData([]);
             return;
         }
 


### PR DESCRIPTION
Fixed #14209, histogram after `setData` with empty array wasn't updated.