### PR TITLE
bugfix/14830-export-waterfall-hidden-stackLabels

### DIFF
--- a/js/Series/Waterfall/WaterfallSeries.js
+++ b/js/Series/Waterfall/WaterfallSeries.js
@@ -161,12 +161,12 @@ var WaterfallSeries = /** @class */ (function (_super) {
                     shapeArgs.y = yAxis.translate(yPos, 0, 1, 0, 1);
                     shapeArgs.height = Math.abs(shapeArgs.y -
                         yAxis.translate(hPos, 0, 1, 0, 1));
-                }
-                dummyStackItem = yAxis.waterfall.dummyStackItem;
-                if (dummyStackItem) {
-                    dummyStackItem.x = i;
-                    dummyStackItem.label = actualStack[i].label;
-                    dummyStackItem.setOffset(series.pointXOffset || 0, series.barW || 0, series.stackedYNeg[i], series.stackedYPos[i]);
+                    dummyStackItem = yAxis.waterfall.dummyStackItem;
+                    if (dummyStackItem) {
+                        dummyStackItem.x = i;
+                        dummyStackItem.label = actualStack[i].label;
+                        dummyStackItem.setOffset(series.pointXOffset || 0, series.barW || 0, series.stackedYNeg[i], series.stackedYPos[i]);
+                    }
                 }
             }
             else {

--- a/samples/unit-tests/series-waterfall/export/demo.details
+++ b/samples/unit-tests/series-waterfall/export/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series-waterfall/export/demo.html
+++ b/samples/unit-tests/series-waterfall/export/demo.html
@@ -1,0 +1,8 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/series-waterfall/export/demo.js
+++ b/samples/unit-tests/series-waterfall/export/demo.js
@@ -1,0 +1,35 @@
+QUnit.test('#14830: getSVG on waterfall chart with stackLabels and hidden series threw', assert => {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'waterfall'
+        },
+        xAxis: {
+            categories: ['assigned', 'total']
+        },
+        yAxis: {
+            stackLabels: {
+                enabled: true
+            }
+        },
+        plotOptions: {
+            series: {
+                stacking: 'normal'
+            }
+        },
+        series: [{
+            data: [{
+                name: 'assigned',
+                y: 2
+            }, {
+                name: 'total',
+                y: 0,
+                isSum: true
+            }]
+        }]
+    });
+
+    chart.series[0].hide();
+    chart.getSVG();
+
+    assert.ok(true, 'It should not throw');
+});

--- a/ts/Series/Waterfall/WaterfallSeries.ts
+++ b/ts/Series/Waterfall/WaterfallSeries.ts
@@ -350,18 +350,18 @@ class WaterfallSeries extends ColumnSeries {
                             1 as any
                         ) as any)
                     );
-                }
 
-                dummyStackItem = yAxis.waterfall.dummyStackItem;
-                if (dummyStackItem) {
-                    dummyStackItem.x = i;
-                    dummyStackItem.label = (actualStack as any)[i].label;
-                    dummyStackItem.setOffset(
-                        series.pointXOffset || 0,
-                        series.barW || 0,
-                        series.stackedYNeg[i],
-                        series.stackedYPos[i]
-                    );
+                    dummyStackItem = yAxis.waterfall.dummyStackItem;
+                    if (dummyStackItem) {
+                        dummyStackItem.x = i;
+                        dummyStackItem.label = actualStack[i].label;
+                        dummyStackItem.setOffset(
+                            series.pointXOffset || 0,
+                            series.barW || 0,
+                            series.stackedYNeg[i],
+                            series.stackedYPos[i]
+                        );
+                    }
                 }
             } else {
                 // up points


### PR DESCRIPTION
Fixed #14830, exporting waterfall chart with stack labels and hidden series threw.