### PR TITLE
bugfix/14803-gantt-documenentation-color

### DIFF
--- a/js/Series/Gantt/GanttSeries.js
+++ b/js/Series/Gantt/GanttSeries.js
@@ -228,7 +228,7 @@ export default GanttSeries;
  * @declare   Highcharts.GanttPointOptionsObject
  * @type      {Array<*>}
  * @extends   series.xrange.data
- * @excluding className, color, colorIndex, connect, dataLabels, events,
+ * @excluding className, connect, dataLabels, events,
  *            partialFill, selected, x, x2
  * @product   gantt
  * @apioption series.gantt.data

--- a/ts/Series/Gantt/GanttSeries.ts
+++ b/ts/Series/Gantt/GanttSeries.ts
@@ -323,7 +323,7 @@ export default GanttSeries;
  * @declare   Highcharts.GanttPointOptionsObject
  * @type      {Array<*>}
  * @extends   series.xrange.data
- * @excluding className, color, colorIndex, connect, dataLabels, events,
+ * @excluding className, connect, dataLabels, events,
  *            partialFill, selected, x, x2
  * @product   gantt
  * @apioption series.gantt.data


### PR DESCRIPTION
Fixed #14803, in gantt series, added `data.color` to the documentation.