### PR TITLE
bugfix/14305-chart-update-mutate

### DIFF
--- a/js/Core/Chart/Chart.js
+++ b/js/Core/Chart/Chart.js
@@ -2223,7 +2223,7 @@ var Chart = /** @class */ (function () {
             chart.setResponsive(false, true);
         }
         options = cleanRecursively(options, chart.options);
-        merge(true, chart.userOptions, options);
+        chart.userOptions = merge(chart.userOptions, options);
         // If the top-level chart option is present, some special updates are
         // required
         optionsChart = options.chart;

--- a/samples/unit-tests/chart/chart-update/demo.js
+++ b/samples/unit-tests/chart/chart-update/demo.js
@@ -394,6 +394,18 @@
                 JSON.stringify(options, null, '  '),
                 'Options should not be mutated after chart.update'
             );
+
+            chart.update({
+                title: {
+                    text: 'Ohai'
+                }
+            });
+
+            assert.strictEqual(
+                cfg,
+                JSON.stringify(options, null, '  '),
+                '#14305: Options should not be mutated after actually changing something with chart.update'
+            );
         }
     );
 }());

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3080,7 +3080,7 @@ class Chart {
 
         options = cleanRecursively(options, chart.options);
 
-        merge(true, chart.userOptions, options);
+        chart.userOptions = merge(chart.userOptions, options);
 
         // If the top-level chart option is present, some special updates are
         // required


### PR DESCRIPTION
Fixed #14305, original chart options got mutated on `update`.