### PR TITLE
Fixed #14837, more intuitive legend item a11y labels.

### DIFF
--- a/js/Accessibility/Components/LegendComponent.js
+++ b/js/Accessibility/Components/LegendComponent.js
@@ -64,7 +64,7 @@ H.Chart.prototype.highlightLegendItem = function (ix) {
 addEvent(Legend, 'afterColorizeItem', function (e) {
     var chart = this.chart, a11yOptions = chart.options.accessibility, legendItem = e.item;
     if (a11yOptions.enabled && legendItem && legendItem.a11yProxyElement) {
-        legendItem.a11yProxyElement.setAttribute('aria-pressed', e.visible ? 'false' : 'true');
+        legendItem.a11yProxyElement.setAttribute('aria-pressed', e.visible ? 'true' : 'false');
     }
 });
 /**
@@ -197,7 +197,7 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
             itemName: stripHTMLTags(item.name)
         }), attribs = {
             tabindex: -1,
-            'aria-pressed': !item.visible,
+            'aria-pressed': item.visible,
             'aria-label': itemLabel
         }, 
         // Considers useHTML

--- a/js/Accessibility/Options/LangOptions.js
+++ b/js/Accessibility/Options/LangOptions.js
@@ -105,7 +105,7 @@ var langOptions = {
          */
         legend: {
             legendLabel: 'Toggle series visibility',
-            legendItem: 'Hide {itemName}'
+            legendItem: 'Show {itemName}'
         },
         /**
          * Chart and map zoom accessibility language options.

--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -177,7 +177,7 @@ addEvent(Legend, 'afterColorizeItem', function (
 
     if (a11yOptions.enabled && legendItem && legendItem.a11yProxyElement) {
         legendItem.a11yProxyElement.setAttribute(
-            'aria-pressed', e.visible ? 'false' : 'true'
+            'aria-pressed', e.visible ? 'true' : 'false'
         );
     }
 });
@@ -365,7 +365,7 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
             ),
             attribs = {
                 tabindex: -1,
-                'aria-pressed': !item.visible,
+                'aria-pressed': item.visible,
                 'aria-label': itemLabel
             },
             // Considers useHTML

--- a/ts/Accessibility/Options/LangOptions.ts
+++ b/ts/Accessibility/Options/LangOptions.ts
@@ -279,7 +279,7 @@ var langOptions: Highcharts.LangOptions = {
          */
         legend: {
             legendLabel: 'Toggle series visibility',
-            legendItem: 'Hide {itemName}'
+            legendItem: 'Show {itemName}'
         },
 
         /**


### PR DESCRIPTION
More intuitive legend item labels for assistive technology. Closes #14837.
___
Legend item buttons are now pressed by default, with the text `"Show series"` rather than `"Hide series"`. This is more intuitive for Narrator users in particular, where a pressed button is read as `"ON"`, and an unselected button is read as `"OFF"`.

Note that this breaks backwards compatibility for configurations of the [lang.accessibility.legend.legendItem](https://api.highcharts.com/highcharts/lang.accessibility.legend.legendItem) API option, since the logic is now reversed.