### PR TITLE
bugfix/14858-callout-anchor-line

### DIFF
--- a/js/Core/Renderer/SVG/SVGRenderer.js
+++ b/js/Core/Renderer/SVG/SVGRenderer.js
@@ -2288,7 +2288,7 @@ SVGRenderer.prototype.symbols = {
             ['C', x, y, x, y, x + r, y] // top-left corner
         ];
         // Anchor on right side
-        if (anchorX && anchorX > w) {
+        if (x + anchorX >= w) {
             // Chevron
             if (anchorY > y + safeDistance &&
                 anchorY < y + h - safeDistance) {
@@ -2300,7 +2300,7 @@ SVGRenderer.prototype.symbols = {
             }
             // Anchor on left side
         }
-        else if (anchorX && anchorX < 0) {
+        else if (x + anchorX <= 0) {
             // Chevron
             if (anchorY > y + safeDistance &&
                 anchorY < y + h - safeDistance) {
@@ -2313,37 +2313,17 @@ SVGRenderer.prototype.symbols = {
         }
         else if ( // replace bottom
         anchorY &&
-            anchorY > h) {
-            // Chevron
-            if (anchorX > x + safeDistance &&
-                anchorX < x + w - safeDistance) {
-                path.splice(5, 1, ['L', anchorX + halfDistance, y + h], ['L', anchorX, y + h + arrowLength], ['L', anchorX - halfDistance, y + h], ['L', x + r, y + h]);
-                // Simple connector left corner
-            }
-            else if (anchorX <= x + safeDistance) {
-                path.splice(5, 1, ['L', x + r, y + h], ['L', anchorX, anchorY], ['L', x + r, y + h]);
-                // Simple connector right corner
-            }
-            else {
-                path.splice(5, 1, ['L', anchorX, anchorY], ['L', x + w - r, y + h], ['L', x + r, y + h]);
-            }
+            anchorY > h &&
+            anchorX > x + safeDistance &&
+            anchorX < x + w - safeDistance) {
+            path.splice(5, 1, ['L', anchorX + halfDistance, y + h], ['L', anchorX, y + h + arrowLength], ['L', anchorX - halfDistance, y + h], ['L', x + r, y + h]);
         }
         else if ( // replace top
         anchorY &&
-            anchorY < 0) {
-            // Chevron
-            if (anchorX > x + safeDistance &&
-                anchorX < x + w - safeDistance) {
-                path.splice(1, 1, ['L', anchorX - halfDistance, y], ['L', anchorX, y - arrowLength], ['L', anchorX + halfDistance, y], ['L', w - r, y]);
-                // Simple connector left corner
-            }
-            else if (anchorX <= x + safeDistance) {
-                path.splice(1, 1, ['L', anchorX, anchorY], ['L', x + r, y], ['L', w - r, y]);
-                // Simple connector right corner
-            }
-            else {
-                path.splice(1, 1, ['L', w - r, y], ['L', anchorX, anchorY], ['L', w - r, y]);
-            }
+            anchorY < 0 &&
+            anchorX > x + safeDistance &&
+            anchorX < x + w - safeDistance) {
+            path.splice(1, 1, ['L', anchorX - halfDistance, y], ['L', anchorX, y - arrowLength], ['L', anchorX + halfDistance, y], ['L', w - r, y]);
         }
         return path;
     }

--- a/js/Core/Renderer/SVG/SVGRenderer.js
+++ b/js/Core/Renderer/SVG/SVGRenderer.js
@@ -2334,15 +2334,15 @@ SVGRenderer.prototype.symbols = {
             // Chevron
             if (anchorX > x + safeDistance &&
                 anchorX < x + w - safeDistance) {
-                path.splice(1, 1, ['L', anchorX - halfDistance, y], ['L', anchorX, y - arrowLength], ['L', anchorX + halfDistance, y], ['L', x + w - r, y]);
+                path.splice(1, 1, ['L', anchorX - halfDistance, y], ['L', anchorX, y - arrowLength], ['L', anchorX + halfDistance, y], ['L', w - r, y]);
                 // Simple connector left corner
             }
             else if (anchorX <= x + safeDistance) {
-                path.splice(1, 1, ['L', anchorX, anchorY], ['L', x + r, y], ['L', x + w - r, y]);
+                path.splice(1, 1, ['L', anchorX, anchorY], ['L', x + r, y], ['L', w - r, y]);
                 // Simple connector right corner
             }
             else {
-                path.splice(1, 1, ['L', x + w - r, y], ['L', anchorX, anchorY], ['L', x + w - r, y]);
+                path.splice(1, 1, ['L', w - r, y], ['L', anchorX, anchorY], ['L', w - r, y]);
             }
         }
         return path;

--- a/js/Core/Renderer/SVG/SVGRenderer.js
+++ b/js/Core/Renderer/SVG/SVGRenderer.js
@@ -2313,17 +2313,37 @@ SVGRenderer.prototype.symbols = {
         }
         else if ( // replace bottom
         anchorY &&
-            anchorY > h &&
-            anchorX > x + safeDistance &&
-            anchorX < x + w - safeDistance) {
-            path.splice(5, 1, ['L', anchorX + halfDistance, y + h], ['L', anchorX, y + h + arrowLength], ['L', anchorX - halfDistance, y + h], ['L', x + r, y + h]);
+            anchorY > h) {
+            // Chevron
+            if (anchorX > x + safeDistance &&
+                anchorX < x + w - safeDistance) {
+                path.splice(5, 1, ['L', anchorX + halfDistance, y + h], ['L', anchorX, y + h + arrowLength], ['L', anchorX - halfDistance, y + h], ['L', x + r, y + h]);
+                // Simple connector left corner
+            }
+            else if (anchorX <= x + safeDistance) {
+                path.splice(5, 1, ['L', x + r, y + h], ['L', anchorX, anchorY], ['L', x + r, y + h]);
+                // Simple connector right corner
+            }
+            else {
+                path.splice(5, 1, ['L', anchorX, anchorY], ['L', x + w - r, y + h], ['L', x + r, y + h]);
+            }
         }
         else if ( // replace top
         anchorY &&
-            anchorY < 0 &&
-            anchorX > x + safeDistance &&
-            anchorX < x + w - safeDistance) {
-            path.splice(1, 1, ['L', anchorX - halfDistance, y], ['L', anchorX, y - arrowLength], ['L', anchorX + halfDistance, y], ['L', w - r, y]);
+            anchorY < 0) {
+            // Chevron
+            if (anchorX > x + safeDistance &&
+                anchorX < x + w - safeDistance) {
+                path.splice(1, 1, ['L', anchorX - halfDistance, y], ['L', anchorX, y - arrowLength], ['L', anchorX + halfDistance, y], ['L', x + w - r, y]);
+                // Simple connector left corner
+            }
+            else if (anchorX <= x + safeDistance) {
+                path.splice(1, 1, ['L', anchorX, anchorY], ['L', x + r, y], ['L', x + w - r, y]);
+                // Simple connector right corner
+            }
+            else {
+                path.splice(1, 1, ['L', x + w - r, y], ['L', anchorX, anchorY], ['L', x + w - r, y]);
+            }
         }
         return path;
     }

--- a/js/Core/Renderer/SVG/SVGRenderer.js
+++ b/js/Core/Renderer/SVG/SVGRenderer.js
@@ -2275,7 +2275,7 @@ SVGRenderer.prototype.symbols = {
      * rectangles in VML
      */
     callout: function (x, y, w, h, options) {
-        var arrowLength = 6, halfDistance = 6, r = Math.min((options && options.r) || 0, w, h), safeDistance = r + halfDistance, anchorX = options && options.anchorX || 0, anchorY = options && options.anchorY || 0, path;
+        var arrowLength = 6, halfDistance = 6, r = Math.min((options && options.r) || 0, w, h), safeDistance = r + halfDistance, anchorX = options && options.anchorX, anchorY = options && options.anchorY || 0, path;
         path = [
             ['M', x + r, y],
             ['L', x + w - r, y],
@@ -2287,6 +2287,9 @@ SVGRenderer.prototype.symbols = {
             ['L', x, y + r],
             ['C', x, y, x, y, x + r, y] // top-left corner
         ];
+        if (!isNumber(anchorX)) {
+            return path;
+        }
         // Anchor on right side
         if (x + anchorX >= w) {
             // Chevron

--- a/samples/unit-tests/svgrenderer/label/demo.js
+++ b/samples/unit-tests/svgrenderer/label/demo.js
@@ -560,3 +560,32 @@ QUnit.test('Label padding', assert => {
         );
     });
 });
+
+QUnit.test('#14858: Callout missing line when anchorX within width and no room for chevron', assert => {
+    const ren = new Highcharts.Renderer(
+        document.getElementById('container'),
+        600,
+        400
+    );
+
+    [
+        ['left', 101, 100],
+        ['right', 99, 100],
+        ['left', 101, 20],
+        ['right', 99, 20]
+    ].forEach(([align, anchorX, anchorY]) => {
+        const label = ren
+            .label('Some text', 100, 50, 'callout', anchorX, anchorY)
+            .attr({
+                align,
+                'stroke-width': 2,
+                stroke: 'black'
+            })
+            .add();
+
+        assert.ok(
+            label.box.pathArray.length > 9,
+            'Anchor line should have rendered'
+        );
+    });
+});

--- a/samples/unit-tests/svgrenderer/label/demo.js
+++ b/samples/unit-tests/svgrenderer/label/demo.js
@@ -569,16 +569,20 @@ QUnit.test('#14858: Callout missing line when anchorX within width and no room f
     );
 
     [
-        ['left', 101, 100],
-        ['right', 99, 100],
-        ['left', 101, 20],
-        ['right', 99, 20]
-    ].forEach(([align, anchorX, anchorY]) => {
+        [1, 'left', 100],
+        [1, 'right', 100],
+        [1, 'left', 20],
+        [1, 'right', 20],
+        [2, 'left', 100],
+        [2, 'right', 100],
+        [2, 'left', 20],
+        [2, 'right', 20]
+    ].forEach(([strokeWidth, align, anchorY]) => {
         const label = ren
-            .label('Some text', 100, 50, 'callout', anchorX, anchorY)
+            .label('Some text', 100, 50, 'callout', 100, anchorY)
             .attr({
                 align,
-                'stroke-width': 2,
+                'stroke-width': strokeWidth,
                 stroke: 'black'
             })
             .add();

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -3366,7 +3366,7 @@ SVGRenderer.prototype.symbols = {
                     ['L', anchorX - halfDistance, y],
                     ['L', anchorX, y - arrowLength],
                     ['L', anchorX + halfDistance, y],
-                    ['L', x + w - r, y]
+                    ['L', w - r, y]
                 );
             // Simple connector left corner
             } else if (anchorX <= x + safeDistance) {
@@ -3375,16 +3375,16 @@ SVGRenderer.prototype.symbols = {
                     1,
                     ['L', anchorX, anchorY],
                     ['L', x + r, y],
-                    ['L', x + w - r, y]
+                    ['L', w - r, y]
                 );
             // Simple connector right corner
             } else {
                 path.splice(
                     1,
                     1,
-                    ['L', x + w - r, y],
+                    ['L', w - r, y],
                     ['L', anchorX, anchorY],
-                    ['L', x + w - r, y]
+                    ['L', w - r, y]
                 );
             }
         }

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -3244,7 +3244,7 @@ SVGRenderer.prototype.symbols = {
             halfDistance = 6,
             r = Math.min((options && options.r) || 0, w, h),
             safeDistance = r + halfDistance,
-            anchorX = options && options.anchorX || 0,
+            anchorX = options && options.anchorX,
             anchorY = options && options.anchorY || 0,
             path: SVGPath;
 
@@ -3259,6 +3259,10 @@ SVGRenderer.prototype.symbols = {
             ['L', x, y + r], // left side
             ['C', x, y, x, y, x + r, y] // top-left corner
         ];
+
+        if (!isNumber(anchorX)) {
+            return path;
+        }
 
         // Anchor on right side
         if (x + anchorX >= w) {

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -3261,7 +3261,7 @@ SVGRenderer.prototype.symbols = {
         ];
 
         // Anchor on right side
-        if (anchorX && anchorX > w) {
+        if (x + anchorX >= w) {
 
             // Chevron
             if (
@@ -3290,7 +3290,7 @@ SVGRenderer.prototype.symbols = {
             }
 
         // Anchor on left side
-        } else if (anchorX && anchorX < 0) {
+        } else if (x + anchorX <= 0) {
 
             // Chevron
             if (
@@ -3320,73 +3320,33 @@ SVGRenderer.prototype.symbols = {
 
         } else if ( // replace bottom
             anchorY &&
-            anchorY > h
+            anchorY > h &&
+            anchorX > x + safeDistance &&
+            anchorX < x + w - safeDistance
         ) {
-            // Chevron
-            if (anchorX > x + safeDistance &&
-                anchorX < x + w - safeDistance) {
-                path.splice(
-                    5,
-                    1,
-                    ['L', anchorX + halfDistance, y + h],
-                    ['L', anchorX, y + h + arrowLength],
-                    ['L', anchorX - halfDistance, y + h],
-                    ['L', x + r, y + h]
-                );
-            // Simple connector left corner
-            } else if (anchorX <= x + safeDistance) {
-                path.splice(
-                    5,
-                    1,
-                    ['L', x + r, y + h],
-                    ['L', anchorX, anchorY],
-                    ['L', x + r, y + h]
-                );
-            // Simple connector right corner
-            } else {
-                path.splice(
-                    5,
-                    1,
-                    ['L', anchorX, anchorY],
-                    ['L', x + w - r, y + h],
-                    ['L', x + r, y + h]
-                );
-            }
+            path.splice(
+                5,
+                1,
+                ['L', anchorX + halfDistance, y + h],
+                ['L', anchorX, y + h + arrowLength],
+                ['L', anchorX - halfDistance, y + h],
+                ['L', x + r, y + h]
+            );
 
         } else if ( // replace top
             anchorY &&
-            anchorY < 0
+            anchorY < 0 &&
+            anchorX > x + safeDistance &&
+            anchorX < x + w - safeDistance
         ) {
-            // Chevron
-            if (anchorX > x + safeDistance &&
-                anchorX < x + w - safeDistance) {
-                path.splice(
-                    1,
-                    1,
-                    ['L', anchorX - halfDistance, y],
-                    ['L', anchorX, y - arrowLength],
-                    ['L', anchorX + halfDistance, y],
-                    ['L', w - r, y]
-                );
-            // Simple connector left corner
-            } else if (anchorX <= x + safeDistance) {
-                path.splice(
-                    1,
-                    1,
-                    ['L', anchorX, anchorY],
-                    ['L', x + r, y],
-                    ['L', w - r, y]
-                );
-            // Simple connector right corner
-            } else {
-                path.splice(
-                    1,
-                    1,
-                    ['L', w - r, y],
-                    ['L', anchorX, anchorY],
-                    ['L', w - r, y]
-                );
-            }
+            path.splice(
+                1,
+                1,
+                ['L', anchorX - halfDistance, y],
+                ['L', anchorX, y - arrowLength],
+                ['L', anchorX + halfDistance, y],
+                ['L', w - r, y]
+            );
         }
 
         return path;

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -3320,33 +3320,73 @@ SVGRenderer.prototype.symbols = {
 
         } else if ( // replace bottom
             anchorY &&
-            anchorY > h &&
-            anchorX > x + safeDistance &&
-            anchorX < x + w - safeDistance
+            anchorY > h
         ) {
-            path.splice(
-                5,
-                1,
-                ['L', anchorX + halfDistance, y + h],
-                ['L', anchorX, y + h + arrowLength],
-                ['L', anchorX - halfDistance, y + h],
-                ['L', x + r, y + h]
-            );
+            // Chevron
+            if (anchorX > x + safeDistance &&
+                anchorX < x + w - safeDistance) {
+                path.splice(
+                    5,
+                    1,
+                    ['L', anchorX + halfDistance, y + h],
+                    ['L', anchorX, y + h + arrowLength],
+                    ['L', anchorX - halfDistance, y + h],
+                    ['L', x + r, y + h]
+                );
+            // Simple connector left corner
+            } else if (anchorX <= x + safeDistance) {
+                path.splice(
+                    5,
+                    1,
+                    ['L', x + r, y + h],
+                    ['L', anchorX, anchorY],
+                    ['L', x + r, y + h]
+                );
+            // Simple connector right corner
+            } else {
+                path.splice(
+                    5,
+                    1,
+                    ['L', anchorX, anchorY],
+                    ['L', x + w - r, y + h],
+                    ['L', x + r, y + h]
+                );
+            }
 
         } else if ( // replace top
             anchorY &&
-            anchorY < 0 &&
-            anchorX > x + safeDistance &&
-            anchorX < x + w - safeDistance
+            anchorY < 0
         ) {
-            path.splice(
-                1,
-                1,
-                ['L', anchorX - halfDistance, y],
-                ['L', anchorX, y - arrowLength],
-                ['L', anchorX + halfDistance, y],
-                ['L', w - r, y]
-            );
+            // Chevron
+            if (anchorX > x + safeDistance &&
+                anchorX < x + w - safeDistance) {
+                path.splice(
+                    1,
+                    1,
+                    ['L', anchorX - halfDistance, y],
+                    ['L', anchorX, y - arrowLength],
+                    ['L', anchorX + halfDistance, y],
+                    ['L', x + w - r, y]
+                );
+            // Simple connector left corner
+            } else if (anchorX <= x + safeDistance) {
+                path.splice(
+                    1,
+                    1,
+                    ['L', anchorX, anchorY],
+                    ['L', x + r, y],
+                    ['L', x + w - r, y]
+                );
+            // Simple connector right corner
+            } else {
+                path.splice(
+                    1,
+                    1,
+                    ['L', x + w - r, y],
+                    ['L', anchorX, anchorY],
+                    ['L', x + w - r, y]
+                );
+            }
         }
 
         return path;


### PR DESCRIPTION
Fixed #14858, left and right-aligned callout labels with the anchor above or below sometimes missed anchor lines when there was no room for a chevron.