### PR TITLE
bugfix/10322-data-parse-dates

### DIFF
--- a/js/Extensions/Data.js
+++ b/js/Extensions/Data.js
@@ -1561,7 +1561,7 @@ var Data = /** @class */ (function () {
      */
     Data.prototype.parseDate = function (val) {
         var parseDate = this.options.parseDate;
-        var ret, key, format, dateFormat = this.options.dateFormat || this.dateFormat, match, timezoneOffset = Data.timezoneOffset;
+        var ret, key, format, dateFormat = this.options.dateFormat || this.dateFormat, match;
         if (parseDate) {
             ret = parseDate(val);
         }
@@ -1593,26 +1593,25 @@ var Data = /** @class */ (function () {
             }
             // Fall back to Date.parse
             if (!match) {
-                if (val.match(/:.+[Z+-]/)) {
+                if (val.match(/:.+(GMT|UTC|[Z+-])/)) {
                     val = val
-                        .replace(/(\d)\s*(?:Z)/, '$1+00:00')
-                        .replace(/\s*(?:GMT|UTC)?([+-])(\d\d)(\d\d)/, '$1$2:$3')
-                        .replace(/\s*(?:GMT|UTC)?([+-])/, '$1');
-                    timezoneOffset = 0;
+                        .replace(/\s*(?:GMT|UTC)?([+-])(\d\d)(\d\d)$/, '$1$2:$3')
+                        .replace(/(?:\s+|GMT|UTC)([+-])/, '$1')
+                        .replace(/(\d)\s*(?:GMT|UTC|Z)$/, '$1+00:00');
                 }
                 match = Date.parse(val);
                 // External tools like Date.js and MooTools extend Date object
-                // and returns a date.
+                // and return a date.
                 if (typeof match === 'object' &&
                     match !== null &&
                     match.getTime) {
                     ret = (match.getTime() -
-                        timezoneOffset *
+                        match.getTimezoneOffset() *
                             60000);
                     // Timestamp
                 }
                 else if (isNumber(match)) {
-                    ret = match - timezoneOffset * 60000;
+                    ret = match - (new Date(match)).getTimezoneOffset() * 60000;
                 }
             }
         }
@@ -1848,12 +1847,6 @@ var Data = /** @class */ (function () {
             this.init(chart.options.data);
         }
     };
-    /* *
-     *
-     *  Static Properties
-     *
-     * */
-    Data.timezoneOffset = (new Date()).getTimezoneOffset();
     return Data;
 }());
 // Register the Data prototype and data function on Highcharts

--- a/js/Extensions/Data.js
+++ b/js/Extensions/Data.js
@@ -472,6 +472,11 @@ var seriesTypes = BaseSeries.seriesTypes;
  * @param {Highcharts.Chart} [chart]
  */
 var Data = /** @class */ (function () {
+    /* *
+     *
+     *  Constructors
+     *
+     * */
     function Data(dataOptions, chartOptions, chart) {
         this.chart = void 0;
         this.chartOptions = void 0;
@@ -539,6 +544,11 @@ var Data = /** @class */ (function () {
         };
         this.init(dataOptions, chartOptions, chart);
     }
+    /* *
+     *
+     *  Functions
+     *
+     * */
     /**
      * Initialize the Data object with the given options
      *
@@ -1550,7 +1560,8 @@ var Data = /** @class */ (function () {
      * @return {number}
      */
     Data.prototype.parseDate = function (val) {
-        var parseDate = this.options.parseDate, ret, key, format, dateFormat = this.options.dateFormat || this.dateFormat, match;
+        var parseDate = this.options.parseDate;
+        var ret, key, format, dateFormat = this.options.dateFormat || this.dateFormat, match, timezoneOffset = Data.timezoneOffset;
         if (parseDate) {
             ret = parseDate(val);
         }
@@ -1582,6 +1593,13 @@ var Data = /** @class */ (function () {
             }
             // Fall back to Date.parse
             if (!match) {
+                if (val.match(/:.+[Z+-]/)) {
+                    val = val
+                        .replace(/(\d)\s*(?:Z)/, '$1+00:00')
+                        .replace(/\s*(?:GMT|UTC)?([+-])(\d\d)(\d\d)/, '$1$2:$3')
+                        .replace(/\s*(?:GMT|UTC)?([+-])/, '$1');
+                    timezoneOffset = 0;
+                }
                 match = Date.parse(val);
                 // External tools like Date.js and MooTools extend Date object
                 // and returns a date.
@@ -1589,12 +1607,12 @@ var Data = /** @class */ (function () {
                     match !== null &&
                     match.getTime) {
                     ret = (match.getTime() -
-                        match.getTimezoneOffset() *
+                        timezoneOffset *
                             60000);
                     // Timestamp
                 }
                 else if (isNumber(match)) {
-                    ret = match - (new Date(match)).getTimezoneOffset() * 60000;
+                    ret = match - timezoneOffset * 60000;
                 }
             }
         }
@@ -1830,6 +1848,12 @@ var Data = /** @class */ (function () {
             this.init(chart.options.data);
         }
     };
+    /* *
+     *
+     *  Static Properties
+     *
+     * */
+    Data.timezoneOffset = (new Date()).getTimezoneOffset();
     return Data;
 }());
 // Register the Data prototype and data function on Highcharts

--- a/samples/unit-tests/data/general/demo.js
+++ b/samples/unit-tests/data/general/demo.js
@@ -1,4 +1,37 @@
 QUnit.test(
+    'Parsing dates with timezone information (#10322)',
+    function (assert) {
+        var data = new Highcharts.Data({}),
+            samples = [
+                '2018-03-13T17:00:00+00:00',
+                '2018-03-13T20:00:00+03:00',
+                '2018-03-13T17:00:00GMT',
+                '2018-03-13T07:00:00GMT-1000',
+                '2018-03-13T08:00:00GMT-09:00',
+                '2018-03-13T17:00:00UTC',
+                '2018-03-13T18:30:00UTC+0130',
+                '2018-03-13T17:30:00UTC+00:30',
+                '2018-03-13T17:00:00Z'
+            ],
+            previousSample;
+
+        samples
+            .map(sample => data.parseDate(sample))
+            .map(sample => (new Date(sample)).toUTCString())
+            .forEach((sample, index) => {
+                if (previousSample) {
+                    assert.strictEqual(
+                        sample,
+                        previousSample,
+                        'Parsed dates should be the same. (Index: ' + index + ')'
+                    );
+                }
+                previousSample = sample;
+            });
+    }
+);
+
+QUnit.test(
     'Data module with decimapPoint and negative numbers (#4749)',
     function (assert) {
         document.body.innerHTML += `<table id="datatable">

--- a/ts/Extensions/Data.ts
+++ b/ts/Extensions/Data.ts
@@ -685,14 +685,6 @@ class Data {
 
     /* *
      *
-     *  Static Properties
-     *
-     * */
-
-    private static timezoneOffset = (new Date()).getTimezoneOffset();
-
-    /* *
-     *
      *  Constructors
      *
      * */
@@ -2183,8 +2175,7 @@ class Data {
             key,
             format,
             dateFormat = this.options.dateFormat || this.dateFormat,
-            match,
-            timezoneOffset = Data.timezoneOffset;
+            match;
 
         if (parseDate) {
             ret = parseDate(val);
@@ -2220,30 +2211,29 @@ class Data {
             }
             // Fall back to Date.parse
             if (!match) {
-                if (val.match(/:.+[Z+-]/)) {
+                if (val.match(/:.+(GMT|UTC|[Z+-])/)) {
                     val = val
-                        .replace(/(\d)\s*(?:Z)/, '$1+00:00')
-                        .replace(/\s*(?:GMT|UTC)?([+-])(\d\d)(\d\d)/, '$1$2:$3')
-                        .replace(/\s*(?:GMT|UTC)?([+-])/, '$1');
-                    timezoneOffset = 0;
+                        .replace(/\s*(?:GMT|UTC)?([+-])(\d\d)(\d\d)$/, '$1$2:$3')
+                        .replace(/(?:\s+|GMT|UTC)([+-])/, '$1')
+                        .replace(/(\d)\s*(?:GMT|UTC|Z)$/, '$1+00:00');
                 }
                 match = Date.parse(val);
                 // External tools like Date.js and MooTools extend Date object
-                // and returns a date.
+                // and return a date.
                 if (
                     typeof match === 'object' &&
                     match !== null &&
-                    (match as any).getTime
+                    (match as Date).getTime
                 ) {
                     ret = (
-                        (match as any).getTime() -
-                        timezoneOffset *
+                        (match as Date).getTime() -
+                        (match as Date).getTimezoneOffset() *
                         60000
                     );
 
                 // Timestamp
                 } else if (isNumber(match)) {
-                    ret = match - timezoneOffset * 60000;
+                    ret = match - (new Date(match)).getTimezoneOffset() * 60000;
                 }
             }
         }

--- a/ts/Extensions/Data.ts
+++ b/ts/Extensions/Data.ts
@@ -682,6 +682,21 @@ const seriesTypes = BaseSeries.seriesTypes as Record<string, any>;
  * @param {Highcharts.Chart} [chart]
  */
 class Data {
+
+    /* *
+     *
+     *  Static Properties
+     *
+     * */
+
+    private static timezoneOffset = (new Date()).getTimezoneOffset();
+
+    /* *
+     *
+     *  Constructors
+     *
+     * */
+
     public constructor(
         dataOptions: Highcharts.DataOptions,
         chartOptions?: Highcharts.Options,
@@ -689,6 +704,12 @@ class Data {
     ) {
         this.init(dataOptions, chartOptions, chart);
     }
+
+    /* *
+     *
+     *  Properties
+     *
+     * */
 
     public alternativeFormat?: string;
     public chart: Chart = void 0 as any;
@@ -701,6 +722,12 @@ class Data {
     public rawColumns: Array<Array<string>> = void 0 as any;
     public options: Highcharts.DataOptions= void 0 as any;
     public valueCount?: Highcharts.DataValueCountObject;
+
+    /* *
+     *
+     *  Functions
+     *
+     * */
 
     /**
      * Initialize the Data object with the given options
@@ -2150,12 +2177,14 @@ class Data {
      * @return {number}
      */
     public parseDate(val: string): number {
-        var parseDate = this.options.parseDate,
-            ret,
+        const parseDate = this.options.parseDate;
+
+        let ret,
             key,
             format,
             dateFormat = this.options.dateFormat || this.dateFormat,
-            match;
+            match,
+            timezoneOffset = Data.timezoneOffset;
 
         if (parseDate) {
             ret = parseDate(val);
@@ -2191,6 +2220,13 @@ class Data {
             }
             // Fall back to Date.parse
             if (!match) {
+                if (val.match(/:.+[Z+-]/)) {
+                    val = val
+                        .replace(/(\d)\s*(?:Z)/, '$1+00:00')
+                        .replace(/\s*(?:GMT|UTC)?([+-])(\d\d)(\d\d)/, '$1$2:$3')
+                        .replace(/\s*(?:GMT|UTC)?([+-])/, '$1');
+                    timezoneOffset = 0;
+                }
                 match = Date.parse(val);
                 // External tools like Date.js and MooTools extend Date object
                 // and returns a date.
@@ -2201,13 +2237,13 @@ class Data {
                 ) {
                     ret = (
                         (match as any).getTime() -
-                        (match as any).getTimezoneOffset() *
+                        timezoneOffset *
                         60000
                     );
 
                 // Timestamp
                 } else if (isNumber(match)) {
-                    ret = match - (new Date(match)).getTimezoneOffset() * 60000;
+                    ret = match - timezoneOffset * 60000;
                 }
             }
         }


### PR DESCRIPTION
Fixed #10322, limit local timezone to timestamps without timezone.