### PR TITLE
A11y adjustments for new range selector features.

### DIFF
--- a/js/Accessibility/Components/RangeSelectorComponent.js
+++ b/js/Accessibility/Components/RangeSelectorComponent.js
@@ -101,9 +101,10 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
         if (!rangeSelector) {
             return;
         }
+        this.updateSelectorVisibility();
+        this.setDropdownAttrs();
         if ((_a = rangeSelector.buttons) === null || _a === void 0 ? void 0 : _a.length) {
             rangeSelector.buttons.forEach(function (button) {
-                unhideChartElementFromAT(chart, button.element);
                 component.setRangeButtonAttrs(button);
             });
         }
@@ -117,6 +118,41 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
                         'InputLabel');
                 }
             });
+        }
+    },
+    /**
+     * @private
+     * Hide buttons from AT when showing dropdown, and vice versa.
+     */
+    updateSelectorVisibility: function () {
+        var chart = this.chart;
+        var rangeSelector = chart.rangeSelector;
+        var dropdown = rangeSelector === null || rangeSelector === void 0 ? void 0 : rangeSelector.dropdown;
+        var buttons = (rangeSelector === null || rangeSelector === void 0 ? void 0 : rangeSelector.buttons) || [];
+        var hideFromAT = function (el) { return el.setAttribute('aria-hidden', true); };
+        if ((rangeSelector === null || rangeSelector === void 0 ? void 0 : rangeSelector.hasVisibleDropdown) && dropdown) {
+            unhideChartElementFromAT(chart, dropdown);
+            buttons.forEach(function (btn) { return hideFromAT(btn.element); });
+        }
+        else {
+            if (dropdown) {
+                hideFromAT(dropdown);
+            }
+            buttons.forEach(function (btn) { return unhideChartElementFromAT(chart, btn.element); });
+        }
+    },
+    /**
+     * @private
+     * Set accessibility related attributes on dropdown element.
+     */
+    setDropdownAttrs: function () {
+        var _a;
+        var chart = this.chart;
+        var dropdown = (_a = chart.rangeSelector) === null || _a === void 0 ? void 0 : _a.dropdown;
+        if (dropdown) {
+            var label = chart.langFormat('accessibility.rangeSelector.dropdownLabel', { rangeTitle: chart.options.lang.rangeSelectorZoom });
+            dropdown.setAttribute('aria-label', label);
+            dropdown.setAttribute('tabindex', -1);
         }
     },
     /**
@@ -136,42 +172,7 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
         var chart = this.chart;
         setElAttrs(input, {
             tabindex: -1,
-            role: 'textbox',
             'aria-label': chart.langFormat(langKey, { chart: chart })
-        });
-    },
-    /**
-     * Get navigation for the range selector buttons.
-     * @private
-     * @return {Highcharts.KeyboardNavigationHandler} The module object.
-     */
-    getRangeSelectorButtonNavigation: function () {
-        var chart = this.chart, keys = this.keyCodes, component = this;
-        return new KeyboardNavigationHandler(chart, {
-            keyCodeMap: [
-                [
-                    [keys.left, keys.right, keys.up, keys.down],
-                    function (keyCode) {
-                        return component.onButtonNavKbdArrowKey(this, keyCode);
-                    }
-                ],
-                [
-                    [keys.enter, keys.space],
-                    function () {
-                        return component.onButtonNavKbdClick(this);
-                    }
-                ]
-            ],
-            validate: function () {
-                var hasRangeSelector = chart.rangeSelector &&
-                    chart.rangeSelector.buttons &&
-                    chart.rangeSelector.buttons.length;
-                return hasRangeSelector;
-            },
-            init: function (direction) {
-                var lastButtonIx = (chart.rangeSelector.buttons.length - 1);
-                chart.highlightRangeSelectorButton(direction > 0 ? 0 : lastButtonIx);
-            }
         });
     },
     /**
@@ -216,60 +217,63 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
         }
     },
     /**
-     * Get navigation for the range selector input boxes.
      * @private
-     * @return {Highcharts.KeyboardNavigationHandler}
-     *         The module object.
      */
-    getRangeSelectorInputNavigation: function () {
-        var chart = this.chart, keys = this.keyCodes, component = this;
-        return new KeyboardNavigationHandler(chart, {
-            keyCodeMap: [
-                [
-                    [
-                        keys.tab, keys.up, keys.down
-                    ],
-                    function (keyCode, e) {
-                        var direction = (keyCode === keys.tab && e.shiftKey ||
-                            keyCode === keys.up) ? -1 : 1;
-                        return component.onInputKbdMove(this, direction);
-                    }
-                ]
-            ],
-            validate: function () {
-                return shouldRunInputNavigation(chart);
-            },
-            init: function (direction) {
-                component.onInputNavInit(direction);
-            },
-            terminate: function () {
-                component.onInputNavTerminate();
-            }
-        });
-    },
-    /**
-     * @private
-     * @param {Highcharts.KeyboardNavigationHandler} keyboardNavigationHandler
-     * @param {number} direction
-     * @return {number} Response code
-     */
-    onInputKbdMove: function (keyboardNavigationHandler, direction) {
-        var chart = this.chart, response = keyboardNavigationHandler.response, newIx = chart.highlightedInputRangeIx =
-            chart.highlightedInputRangeIx + direction, newIxOutOfRange = newIx > 1 || newIx < 0;
+    onInputKbdMove: function (direction) {
+        var _a, _b;
+        var chart = this.chart;
+        var rangeSel = chart.rangeSelector;
+        var newIx = chart.highlightedInputRangeIx = (chart.highlightedInputRangeIx || 0) + direction;
+        var newIxOutOfRange = newIx > 1 || newIx < 0;
         if (newIxOutOfRange) {
-            return response[direction > 0 ? 'next' : 'prev'];
+            (_a = chart.accessibility) === null || _a === void 0 ? void 0 : _a.keyboardNavigation.tabindexContainer.focus();
+            (_b = chart.accessibility) === null || _b === void 0 ? void 0 : _b.keyboardNavigation[direction < 0 ? 'prev' : 'next']();
         }
-        chart.rangeSelector[newIx ? 'maxInput' : 'minInput'].focus();
-        return response.success;
+        else if (rangeSel) {
+            var svgEl = rangeSel[newIx ? 'maxDateBox' : 'minDateBox'];
+            var inputEl = rangeSel[newIx ? 'maxInput' : 'minInput'];
+            if (svgEl && inputEl) {
+                chart.setFocusToElement(svgEl, inputEl);
+            }
+        }
     },
     /**
      * @private
      * @param {number} direction
      */
     onInputNavInit: function (direction) {
-        var chart = this.chart, buttonIxToHighlight = direction > 0 ? 0 : 1;
+        var _this = this;
+        var component = this;
+        var chart = this.chart;
+        var buttonIxToHighlight = direction > 0 ? 0 : 1;
+        var rangeSel = chart.rangeSelector;
+        var svgEl = rangeSel === null || rangeSel === void 0 ? void 0 : rangeSel[buttonIxToHighlight ? 'maxDateBox' : 'minDateBox'];
+        var minInput = rangeSel === null || rangeSel === void 0 ? void 0 : rangeSel.minInput;
+        var maxInput = rangeSel === null || rangeSel === void 0 ? void 0 : rangeSel.maxInput;
+        var inputEl = buttonIxToHighlight ? maxInput : minInput;
         chart.highlightedInputRangeIx = buttonIxToHighlight;
-        chart.rangeSelector[buttonIxToHighlight ? 'maxInput' : 'minInput'].focus();
+        if (svgEl && minInput && maxInput) {
+            chart.setFocusToElement(svgEl, inputEl);
+            // Tab-press with the input focused does not propagate to chart
+            // automatically, so we manually catch and handle it when relevant.
+            if (this.removeInputKeydownHandler) {
+                this.removeInputKeydownHandler();
+            }
+            var keydownHandler = function (e) {
+                var isTab = (e.which || e.keyCode) === _this.keyCodes.tab;
+                if (isTab) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    component.onInputKbdMove(e.shiftKey ? -1 : 1);
+                }
+            };
+            var minRemover_1 = addEvent(minInput, 'keydown', keydownHandler);
+            var maxRemover_1 = addEvent(maxInput, 'keydown', keydownHandler);
+            this.removeInputKeydownHandler = function () {
+                minRemover_1();
+                maxRemover_1();
+            };
+        }
     },
     /**
      * @private
@@ -282,6 +286,105 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
         if (rangeSel.minInput) {
             rangeSel.hideInput('min');
         }
+        if (this.removeInputKeydownHandler) {
+            this.removeInputKeydownHandler();
+            delete this.removeInputKeydownHandler;
+        }
+    },
+    /**
+     * @private
+     */
+    initDropdownNav: function () {
+        var _this = this;
+        var chart = this.chart;
+        var rangeSelector = chart.rangeSelector;
+        var dropdown = rangeSelector === null || rangeSelector === void 0 ? void 0 : rangeSelector.dropdown;
+        if (rangeSelector && dropdown) {
+            chart.setFocusToElement(rangeSelector.buttonGroup, dropdown);
+            if (this.removeDropdownKeydownHandler) {
+                this.removeDropdownKeydownHandler();
+            }
+            // Tab-press with dropdown focused does not propagate to chart
+            // automatically, so we manually catch and handle it when relevant.
+            this.removeDropdownKeydownHandler = addEvent(dropdown, 'keydown', function (e) {
+                var _a, _b;
+                var isTab = (e.which || e.keyCode) === _this.keyCodes.tab;
+                if (isTab) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    (_a = chart.accessibility) === null || _a === void 0 ? void 0 : _a.keyboardNavigation.tabindexContainer.focus();
+                    (_b = chart.accessibility) === null || _b === void 0 ? void 0 : _b.keyboardNavigation[e.shiftKey ? 'prev' : 'next']();
+                }
+            });
+        }
+    },
+    /**
+     * Get navigation for the range selector buttons.
+     * @private
+     * @return {Highcharts.KeyboardNavigationHandler} The module object.
+     */
+    getRangeSelectorButtonNavigation: function () {
+        var chart = this.chart;
+        var keys = this.keyCodes;
+        var component = this;
+        return new KeyboardNavigationHandler(chart, {
+            keyCodeMap: [
+                [
+                    [keys.left, keys.right, keys.up, keys.down],
+                    function (keyCode) {
+                        return component.onButtonNavKbdArrowKey(this, keyCode);
+                    }
+                ],
+                [
+                    [keys.enter, keys.space],
+                    function () {
+                        return component.onButtonNavKbdClick(this);
+                    }
+                ]
+            ],
+            validate: function () {
+                var _a, _b;
+                return !!((_b = (_a = chart.rangeSelector) === null || _a === void 0 ? void 0 : _a.buttons) === null || _b === void 0 ? void 0 : _b.length);
+            },
+            init: function (direction) {
+                var rangeSelector = chart.rangeSelector;
+                if (rangeSelector === null || rangeSelector === void 0 ? void 0 : rangeSelector.hasVisibleDropdown) {
+                    component.initDropdownNav();
+                }
+                else if (rangeSelector) {
+                    var lastButtonIx = rangeSelector.buttons.length - 1;
+                    chart.highlightRangeSelectorButton(direction > 0 ? 0 : lastButtonIx);
+                }
+            },
+            terminate: function () {
+                if (component.removeDropdownKeydownHandler) {
+                    component.removeDropdownKeydownHandler();
+                    delete component.removeDropdownKeydownHandler;
+                }
+            }
+        });
+    },
+    /**
+     * Get navigation for the range selector input boxes.
+     * @private
+     * @return {Highcharts.KeyboardNavigationHandler}
+     *         The module object.
+     */
+    getRangeSelectorInputNavigation: function () {
+        var chart = this.chart;
+        var component = this;
+        return new KeyboardNavigationHandler(chart, {
+            keyCodeMap: [],
+            validate: function () {
+                return shouldRunInputNavigation(chart);
+            },
+            init: function (direction) {
+                component.onInputNavInit(direction);
+            },
+            terminate: function () {
+                component.onInputNavTerminate();
+            }
+        });
     },
     /**
      * Get keyboard navigation handlers for this component.
@@ -299,6 +402,12 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
      */
     destroy: function () {
         var _a;
+        if (this.removeDropdownKeydownHandler) {
+            this.removeDropdownKeydownHandler();
+        }
+        if (this.removeInputKeydownHandler) {
+            this.removeInputKeydownHandler();
+        }
         (_a = this.announcer) === null || _a === void 0 ? void 0 : _a.destroy();
     }
 });

--- a/js/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.js
+++ b/js/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.js
@@ -97,6 +97,7 @@ function isSkipPoint(point) {
     return point.isNull &&
         a11yOptions.keyboardNavigation.seriesNavigation.skipNullPoints ||
         point.visible === false ||
+        point.isInside === false ||
         isSkipSeries(point.series);
 }
 /**

--- a/js/Accessibility/FocusBorder.js
+++ b/js/Accessibility/FocusBorder.js
@@ -150,19 +150,30 @@ extend(SVGElement.prototype, {
         }
         var isLabel = this instanceof SVGLabel;
         if (this.element.nodeName === 'text' || isLabel) {
-            var isRotated = !!this.rotation, correction = !isLabel ? getTextAnchorCorrection(this) :
+            var isRotated = !!this.rotation;
+            var correction = !isLabel ? getTextAnchorCorrection(this) :
                 {
                     x: isRotated ? 1 : 0,
                     y: 0
                 };
-            borderPosX = +this.attr('x') - (bb.width * correction.x) - pad;
-            borderPosY = +this.attr('y') - (bb.height * correction.y) - pad;
+            var attrX = +this.attr('x');
+            var attrY = +this.attr('y');
+            if (!isNaN(attrX)) {
+                borderPosX = attrX - (bb.width * correction.x) - pad;
+            }
+            if (!isNaN(attrY)) {
+                borderPosY = attrY - (bb.height * correction.y) - pad;
+            }
             if (isLabel && isRotated) {
                 var temp = borderWidth;
                 borderWidth = borderHeight;
                 borderHeight = temp;
-                borderPosX = +this.attr('x') - (bb.height * correction.x) - pad;
-                borderPosY = +this.attr('y') - (bb.width * correction.y) - pad;
+                if (!isNaN(attrX)) {
+                    borderPosX = attrX - (bb.height * correction.x) - pad;
+                }
+                if (!isNaN(attrY)) {
+                    borderPosY = attrY - (bb.width * correction.y) - pad;
+                }
             }
         }
         this.focusBorder = this.renderer.rect(borderPosX, borderPosY, borderWidth, borderHeight, parseInt((style && style.borderRadius || 0).toString(), 10))

--- a/js/Accessibility/Options/LangOptions.js
+++ b/js/Accessibility/Options/LangOptions.js
@@ -123,6 +123,7 @@ var langOptions = {
          * @since 8.0.0
          */
         rangeSelector: {
+            dropdownLabel: '{rangeTitle}',
             minInputLabel: 'Select start date.',
             maxInputLabel: 'Select end date.',
             clickButtonAnnouncement: 'Viewing {axisRangeDescription}'

--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -1365,7 +1365,7 @@ var RangeSelector = /** @class */ (function () {
         }, void 0, dropdown);
         this.buttonOptions.forEach(function (rangeOptions, i) {
             createElement('option', {
-                textContent: rangeOptions.text
+                textContent: rangeOptions.title || rangeOptions.text
             }, void 0, dropdown);
             buttons[i] = renderer
                 .button(rangeOptions.text, 0, 0, function (e) {
@@ -1796,6 +1796,7 @@ var RangeSelector = /** @class */ (function () {
                 width: bBox.width + 'px',
                 height: bBox.height + 'px'
             });
+            this.hasVisibleDropdown = true;
         }
     };
     /**
@@ -1811,6 +1812,7 @@ var RangeSelector = /** @class */ (function () {
                 width: '1px',
                 height: '1px'
             });
+            this.hasVisibleDropdown = false;
         }
     };
     /**

--- a/samples/stock/rangeselector/dropdown/demo.html
+++ b/samples/stock/rangeselector/dropdown/demo.html
@@ -23,3 +23,4 @@
 <script src="https://code.highcharts.com/stock/modules/data.js"></script>
 <script src="https://code.highcharts.com/stock/highcharts-more.js"></script>
 <script src="https://code.highcharts.com/stock/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/stock/modules/accessibility.js"></script>

--- a/ts/Accessibility/Components/RangeSelectorComponent.ts
+++ b/ts/Accessibility/Components/RangeSelectorComponent.ts
@@ -59,6 +59,7 @@ declare global {
             public getRangeSelectorButtonNavigation(
             ): KeyboardNavigationHandler;
             public getRangeSelectorInputNavigation(): KeyboardNavigationHandler;
+            public initDropdownNav(): void;
             public onAfterBtnClick(): void;
             public onButtonNavKbdArrowKey(
                 keyboardNavigationHandler: KeyboardNavigationHandler,
@@ -66,17 +67,18 @@ declare global {
             ): number;
             public onButtonNavKbdClick(keyboardNavigationHandler: KeyboardNavigationHandler): number;
             public onChartUpdate(): void;
-            public onInputKbdMove(
-                keyboardNavigationHandler: KeyboardNavigationHandler,
-                direction: number
-            ): number;
+            public onInputKbdMove(direction: number): void;
             public onInputNavInit(direction: number): void;
             public onInputNavTerminate(): void;
+            public removeDropdownKeydownHandler?: Function;
+            public removeInputKeydownHandler?: Function;
+            public setDropdownAttrs(): void;
             public setRangeButtonAttrs(button: SVGElement): void;
             public setRangeInputAttrs(
                 input: HTMLDOMElement,
                 langKey: string
             ): void;
+            public updateSelectorVisibility(): void;
         }
     }
 }
@@ -185,9 +187,12 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
         if (!rangeSelector) {
             return;
         }
+
+        this.updateSelectorVisibility();
+        this.setDropdownAttrs();
+
         if (rangeSelector.buttons?.length) {
             rangeSelector.buttons.forEach((button): void => {
-                unhideChartElementFromAT(chart, button.element);
                 component.setRangeButtonAttrs(button);
             });
         }
@@ -208,6 +213,46 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
                     );
                 }
             });
+        }
+    },
+
+
+    /**
+     * @private
+     * Hide buttons from AT when showing dropdown, and vice versa.
+     */
+    updateSelectorVisibility: function (this: Highcharts.RangeSelectorComponent): void {
+        const chart = this.chart;
+        const rangeSelector = chart.rangeSelector;
+        const dropdown = rangeSelector?.dropdown;
+        const buttons = rangeSelector?.buttons || [];
+        const hideFromAT = (el: Element): void => el.setAttribute('aria-hidden', true);
+
+        if (rangeSelector?.hasVisibleDropdown && dropdown) {
+            unhideChartElementFromAT(chart, dropdown);
+            buttons.forEach((btn): void => hideFromAT(btn.element));
+        } else {
+            if (dropdown) {
+                hideFromAT(dropdown);
+            }
+            buttons.forEach((btn): void => unhideChartElementFromAT(chart, btn.element));
+        }
+    },
+
+
+    /**
+     * @private
+     * Set accessibility related attributes on dropdown element.
+     */
+    setDropdownAttrs: function (this: Highcharts.RangeSelectorComponent): void {
+        const chart = this.chart;
+        const dropdown = chart.rangeSelector?.dropdown;
+        if (dropdown) {
+            const label = chart.langFormat('accessibility.rangeSelector.dropdownLabel',
+                { rangeTitle: chart.options.lang.rangeSelectorZoom }
+            );
+            dropdown.setAttribute('aria-label', label);
+            dropdown.setAttribute('tabindex', -1);
         }
     },
 
@@ -239,60 +284,7 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
 
         setElAttrs(input, {
             tabindex: -1,
-            role: 'textbox',
             'aria-label': chart.langFormat(langKey, { chart: chart })
-        });
-    },
-
-
-    /**
-     * Get navigation for the range selector buttons.
-     * @private
-     * @return {Highcharts.KeyboardNavigationHandler} The module object.
-     */
-    getRangeSelectorButtonNavigation: function (
-        this: Highcharts.RangeSelectorComponent
-    ): Highcharts.KeyboardNavigationHandler {
-        var chart = this.chart,
-            keys = this.keyCodes,
-            component = this;
-
-        return new (KeyboardNavigationHandler as any)(chart, {
-            keyCodeMap: [
-                [
-                    [keys.left, keys.right, keys.up, keys.down],
-                    function (
-                        this: Highcharts.KeyboardNavigationHandler,
-                        keyCode: number
-                    ): number {
-                        return component.onButtonNavKbdArrowKey(this, keyCode);
-                    }
-                ],
-                [
-                    [keys.enter, keys.space],
-                    function (
-                        this: Highcharts.KeyboardNavigationHandler
-                    ): number {
-                        return component.onButtonNavKbdClick(this);
-                    }
-                ]
-            ],
-
-            validate: function (): (number|undefined) {
-                var hasRangeSelector = chart.rangeSelector &&
-                    chart.rangeSelector.buttons &&
-                    chart.rangeSelector.buttons.length;
-                return hasRangeSelector;
-            },
-
-            init: function (direction: number): void {
-                var lastButtonIx = (
-                    (chart.rangeSelector as any).buttons.length - 1
-                );
-                chart.highlightRangeSelectorButton(
-                    direction > 0 ? 0 : lastButtonIx
-                );
-            }
         });
     },
 
@@ -377,76 +369,29 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
 
 
     /**
-     * Get navigation for the range selector input boxes.
      * @private
-     * @return {Highcharts.KeyboardNavigationHandler}
-     *         The module object.
-     */
-    getRangeSelectorInputNavigation: function (
-        this: Highcharts.RangeSelectorComponent
-    ): Highcharts.KeyboardNavigationHandler {
-        var chart = this.chart,
-            keys = this.keyCodes,
-            component = this;
-
-        return new (KeyboardNavigationHandler as any)(chart, {
-            keyCodeMap: [
-                [
-                    [
-                        keys.tab, keys.up, keys.down
-                    ], function (
-                        this: Highcharts.KeyboardNavigationHandler,
-                        keyCode: number,
-                        e: KeyboardEvent
-                    ): number {
-                        var direction = (
-                            keyCode === keys.tab && e.shiftKey ||
-                            keyCode === keys.up
-                        ) ? -1 : 1;
-
-                        return component.onInputKbdMove(this, direction);
-                    }
-                ]
-            ],
-
-            validate: function (): boolean {
-                return shouldRunInputNavigation(chart);
-            },
-
-            init: function (direction: number): void {
-                component.onInputNavInit(direction);
-            },
-
-            terminate: function (): void {
-                component.onInputNavTerminate();
-            }
-        });
-    },
-
-
-    /**
-     * @private
-     * @param {Highcharts.KeyboardNavigationHandler} keyboardNavigationHandler
-     * @param {number} direction
-     * @return {number} Response code
      */
     onInputKbdMove: function (
         this: Highcharts.RangeSelectorComponent,
-        keyboardNavigationHandler: Highcharts.KeyboardNavigationHandler,
         direction: number
-    ): number {
-        var chart = this.chart,
-            response = keyboardNavigationHandler.response,
-            newIx = chart.highlightedInputRangeIx =
-                (chart.highlightedInputRangeIx as any) + direction,
-            newIxOutOfRange = newIx > 1 || newIx < 0;
+    ): void {
+        const chart = this.chart;
+        const rangeSel = chart.rangeSelector;
+        const newIx = chart.highlightedInputRangeIx = (chart.highlightedInputRangeIx || 0) + direction;
+        const newIxOutOfRange = newIx > 1 || newIx < 0;
 
         if (newIxOutOfRange) {
-            return response[direction > 0 ? 'next' : 'prev'];
+            chart.accessibility?.keyboardNavigation.tabindexContainer.focus();
+            chart.accessibility?.keyboardNavigation[
+                direction < 0 ? 'prev' : 'next'
+            ]();
+        } else if (rangeSel) {
+            const svgEl = rangeSel[newIx ? 'maxDateBox' : 'minDateBox'];
+            const inputEl = rangeSel[newIx ? 'maxInput' : 'minInput'];
+            if (svgEl && inputEl) {
+                chart.setFocusToElement(svgEl, inputEl);
+            }
         }
-
-        (chart.rangeSelector as any)[newIx ? 'maxInput' : 'minInput'].focus();
-        return response.success;
     },
 
 
@@ -458,13 +403,40 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
         this: Highcharts.RangeSelectorComponent,
         direction: number
     ): void {
-        var chart = this.chart,
-            buttonIxToHighlight = direction > 0 ? 0 : 1;
+        const component = this;
+        const chart = this.chart;
+        const buttonIxToHighlight = direction > 0 ? 0 : 1;
+        const rangeSel = chart.rangeSelector;
+        const svgEl = rangeSel?.[buttonIxToHighlight ? 'maxDateBox' : 'minDateBox'];
+        const minInput = rangeSel?.minInput;
+        const maxInput = rangeSel?.maxInput;
+        const inputEl = buttonIxToHighlight ? maxInput : minInput;
 
         chart.highlightedInputRangeIx = buttonIxToHighlight;
-        (chart.rangeSelector as any)[
-            buttonIxToHighlight ? 'maxInput' : 'minInput'
-        ].focus();
+        if (svgEl && minInput && maxInput) {
+            chart.setFocusToElement(svgEl, inputEl);
+
+            // Tab-press with the input focused does not propagate to chart
+            // automatically, so we manually catch and handle it when relevant.
+            if (this.removeInputKeydownHandler) {
+                this.removeInputKeydownHandler();
+            }
+            const keydownHandler = (e: KeyboardEvent): void => {
+                const isTab = (e.which || e.keyCode) === this.keyCodes.tab;
+                if (isTab) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    component.onInputKbdMove(e.shiftKey ? -1 : 1);
+                }
+            };
+            const minRemover = addEvent(minInput, 'keydown', keydownHandler);
+            const maxRemover = addEvent(maxInput, 'keydown', keydownHandler);
+
+            this.removeInputKeydownHandler = (): void => {
+                minRemover();
+                maxRemover();
+            };
+        }
     },
 
 
@@ -484,6 +456,131 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
         if (rangeSel.minInput) {
             rangeSel.hideInput('min');
         }
+
+        if (this.removeInputKeydownHandler) {
+            this.removeInputKeydownHandler();
+            delete this.removeInputKeydownHandler;
+        }
+    },
+
+
+    /**
+     * @private
+     */
+    initDropdownNav: function (this: Highcharts.RangeSelectorComponent): void {
+        const chart = this.chart;
+        const rangeSelector = chart.rangeSelector;
+        const dropdown = rangeSelector?.dropdown;
+
+        if (rangeSelector && dropdown) {
+            chart.setFocusToElement(rangeSelector.buttonGroup as any, dropdown);
+            if (this.removeDropdownKeydownHandler) {
+                this.removeDropdownKeydownHandler();
+            }
+            // Tab-press with dropdown focused does not propagate to chart
+            // automatically, so we manually catch and handle it when relevant.
+            this.removeDropdownKeydownHandler = addEvent(dropdown, 'keydown',
+                (e: KeyboardEvent): void => {
+                    const isTab = (e.which || e.keyCode) === this.keyCodes.tab;
+                    if (isTab) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        chart.accessibility?.keyboardNavigation.tabindexContainer.focus();
+                        chart.accessibility?.keyboardNavigation[
+                            e.shiftKey ? 'prev' : 'next'
+                        ]();
+                    }
+                });
+        }
+    },
+
+
+    /**
+     * Get navigation for the range selector buttons.
+     * @private
+     * @return {Highcharts.KeyboardNavigationHandler} The module object.
+     */
+    getRangeSelectorButtonNavigation: function (
+        this: Highcharts.RangeSelectorComponent
+    ): Highcharts.KeyboardNavigationHandler {
+        const chart = this.chart;
+        const keys = this.keyCodes;
+        const component = this;
+
+        return new (KeyboardNavigationHandler as any)(chart, {
+            keyCodeMap: [
+                [
+                    [keys.left, keys.right, keys.up, keys.down],
+                    function (
+                        this: Highcharts.KeyboardNavigationHandler,
+                        keyCode: number
+                    ): number {
+                        return component.onButtonNavKbdArrowKey(this, keyCode);
+                    }
+                ],
+                [
+                    [keys.enter, keys.space],
+                    function (
+                        this: Highcharts.KeyboardNavigationHandler
+                    ): number {
+                        return component.onButtonNavKbdClick(this);
+                    }
+                ]
+            ],
+
+            validate: function (): boolean {
+                return !!chart.rangeSelector?.buttons?.length;
+            },
+
+            init: function (direction: number): void {
+                const rangeSelector = chart.rangeSelector;
+                if (rangeSelector?.hasVisibleDropdown) {
+                    component.initDropdownNav();
+                } else if (rangeSelector) {
+                    const lastButtonIx = rangeSelector.buttons.length - 1;
+                    chart.highlightRangeSelectorButton(
+                        direction > 0 ? 0 : lastButtonIx
+                    );
+                }
+            },
+
+            terminate: function (): void {
+                if (component.removeDropdownKeydownHandler) {
+                    component.removeDropdownKeydownHandler();
+                    delete component.removeDropdownKeydownHandler;
+                }
+            }
+        });
+    },
+
+
+    /**
+     * Get navigation for the range selector input boxes.
+     * @private
+     * @return {Highcharts.KeyboardNavigationHandler}
+     *         The module object.
+     */
+    getRangeSelectorInputNavigation: function (
+        this: Highcharts.RangeSelectorComponent
+    ): Highcharts.KeyboardNavigationHandler {
+        const chart = this.chart;
+        const component = this;
+
+        return new (KeyboardNavigationHandler as any)(chart, {
+            keyCodeMap: [],
+
+            validate: function (): boolean {
+                return shouldRunInputNavigation(chart);
+            },
+
+            init: function (direction: number): void {
+                component.onInputNavInit(direction);
+            },
+
+            terminate: function (): void {
+                component.onInputNavTerminate();
+            }
+        });
     },
 
 
@@ -506,6 +603,12 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
      * Remove component traces
      */
     destroy: function (this: Highcharts.RangeSelectorComponent): void {
+        if (this.removeDropdownKeydownHandler) {
+            this.removeDropdownKeydownHandler();
+        }
+        if (this.removeInputKeydownHandler) {
+            this.removeInputKeydownHandler();
+        }
         this.announcer?.destroy();
     }
 });

--- a/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
@@ -206,6 +206,7 @@ function isSkipPoint(
     return point.isNull &&
         a11yOptions.keyboardNavigation.seriesNavigation.skipNullPoints ||
         point.visible === false ||
+        point.isInside === false ||
         isSkipSeries(point.series);
 }
 

--- a/ts/Accessibility/FocusBorder.ts
+++ b/ts/Accessibility/FocusBorder.ts
@@ -225,22 +225,32 @@ extend(SVGElement.prototype, {
 
         const isLabel = this instanceof SVGLabel;
         if (this.element.nodeName === 'text' || isLabel) {
-            const isRotated = !!this.rotation,
-                correction = !isLabel ? getTextAnchorCorrection(this) :
-                    {
-                        x: isRotated ? 1 : 0,
-                        y: 0
-                    };
+            const isRotated = !!this.rotation;
+            const correction = !isLabel ? getTextAnchorCorrection(this) :
+                {
+                    x: isRotated ? 1 : 0,
+                    y: 0
+                };
+            const attrX = +this.attr('x');
+            const attrY = +this.attr('y');
 
-            borderPosX = +this.attr('x') - (bb.width * correction.x) - pad;
-            borderPosY = +this.attr('y') - (bb.height * correction.y) - pad;
+            if (!isNaN(attrX)) {
+                borderPosX = attrX - (bb.width * correction.x) - pad;
+            }
+            if (!isNaN(attrY)) {
+                borderPosY = attrY - (bb.height * correction.y) - pad;
+            }
 
             if (isLabel && isRotated) {
                 const temp = borderWidth;
                 borderWidth = borderHeight;
                 borderHeight = temp;
-                borderPosX = +this.attr('x') - (bb.height * correction.x) - pad;
-                borderPosY = +this.attr('y') - (bb.width * correction.y) - pad;
+                if (!isNaN(attrX)) {
+                    borderPosX = attrX - (bb.height * correction.x) - pad;
+                }
+                if (!isNaN(attrY)) {
+                    borderPosY = attrY - (bb.width * correction.y) - pad;
+                }
             }
         }
 

--- a/ts/Accessibility/Options/LangOptions.ts
+++ b/ts/Accessibility/Options/LangOptions.ts
@@ -95,6 +95,7 @@ declare global {
             zoom: LangAccessibilityZoomOptions;
         }
         interface LangAccessibilityRangeSelectorOptions {
+            dropdownLabel: string;
             maxInputLabel: string;
             minInputLabel: string;
             clickButtonAnnouncement: string;
@@ -299,6 +300,7 @@ var langOptions: Highcharts.LangOptions = {
          * @since 8.0.0
          */
         rangeSelector: {
+            dropdownLabel: '{rangeTitle}',
             minInputLabel: 'Select start date.',
             maxInputLabel: 'Select end date.',
             clickButtonAnnouncement: 'Viewing {axisRangeDescription}'

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -73,6 +73,11 @@ declare global {
         interface Options {
             rangeSelector?: DeepPartial<RangeSelectorOptions>;
         }
+        interface LangOptions {
+            rangeSelectorFrom?: string;
+            rangeSelectorTo?: string;
+            rangeSelectorZoom?: string;
+        }
         interface RangeSelectorClickCallbackFunction {
             (e: Event): (boolean|undefined);
         }
@@ -145,9 +150,12 @@ declare global {
             public forcedDataGrouping?: boolean;
             public frozenStates?: boolean;
             public group?: SVGElement;
+            public hasVisibleDropdown?: boolean;
             public inputGroup?: SVGElement;
             public isActive?: boolean;
+            public maxDateBox?: SVGElement;
             public maxInput?: HTMLInputElement;
+            public minDateBox?: SVGElement;
             public minInput?: HTMLInputElement;
             public options: RangeSelectorOptions;
             public rendered?: boolean;
@@ -795,6 +803,7 @@ class RangeSelector {
     public forcedDataGrouping?: boolean;
     public frozenStates?: boolean;
     public group?: SVGElement;
+    public hasVisibleDropdown?: boolean;
     public initialButtonGroupWidth = 0;
     public inputGroup?: SVGElement;
     public isActive?: boolean;
@@ -1918,7 +1927,7 @@ class RangeSelector {
             i: number
         ): void => {
             createElement('option', {
-                textContent: rangeOptions.text
+                textContent: rangeOptions.title || rangeOptions.text
             }, void 0, dropdown);
 
             buttons[i] = renderer
@@ -2531,6 +2540,7 @@ class RangeSelector {
                 width: bBox.width + 'px',
                 height: bBox.height + 'px'
             });
+            this.hasVisibleDropdown = true;
         }
     }
 
@@ -2548,6 +2558,7 @@ class RangeSelector {
                 width: '1px',
                 height: '1px'
             });
+            this.hasVisibleDropdown = false;
         }
     }
 


### PR DESCRIPTION
A11y adjustments for new range selector features.
___
Follow up to #14586 and #14717, ensuring screen reader and keyboard navigation is on track with changes. Native datepickers are still surprisingly sub-optimal with screen readers, but not much we can do except wait for browsers and screen reader vendors to fix.

Also changes the dropdown options to `button.title` content if available, as it is easier to understand than the abbreviations.