### PR TITLE
bugfix/14876-minPointLength-negative-zero

### DIFF
--- a/js/Series/Column/ColumnSeries.js
+++ b/js/Series/Column/ColumnSeries.js
@@ -346,8 +346,9 @@ var ColumnSeries = /** @class */ (function (_super) {
                     // and if there's room for it (#7311)
                     (yAxis.min || 0) < threshold &&
                     // if all points are the same value (i.e zero) not draw
-                    // as negative points (#10646)
-                    dataMin !== dataMax) {
+                    // as negative points (#10646), but only if there's room
+                    // for it (#14876)
+                    (dataMin !== dataMax || (yAxis.max || 0) <= threshold)) {
                     up = !up;
                 }
                 // If stacked...

--- a/samples/unit-tests/series-column/minpointlength/demo.js
+++ b/samples/unit-tests/series-column/minpointlength/demo.js
@@ -47,4 +47,14 @@ QUnit.test('All zero values', function (assert) {
         true,
         'Zero values are draw as positive columns (#10646)'
     );
+
+    chart.addSeries({
+        data: [-1, -2]
+    });
+
+    assert.strictEqual(
+        Math.round(chart.series[0].points[0].shapeArgs.y),
+        0,
+        'Zero values should only be drawn as positive when there is room for it (#14876)'
+    );
 });

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -916,8 +916,9 @@ class ColumnSeries extends LineSeries {
                     // and if there's room for it (#7311)
                     (yAxis.min || 0) < threshold &&
                     // if all points are the same value (i.e zero) not draw
-                    // as negative points (#10646)
-                    dataMin !== dataMax
+                    // as negative points (#10646), but only if there's room
+                    // for it (#14876)
+                    (dataMin !== dataMax || (yAxis.max || 0) <= threshold)
                 ) {
                     up = !up;
                 }


### PR DESCRIPTION
Fixed #14876, `minPointLength` columns did not show for series with only zero values when combined with series with only negative values.