### PR TITLE
bugfix/14868-gantt-drilldown-labels-postion

### DIFF
--- a/js/Core/Axis/GridAxis.js
+++ b/js/Core/Axis/GridAxis.js
@@ -611,34 +611,37 @@ var GridAxis = /** @class */ (function () {
         var options = axis.options;
         var gridOptions = options.grid || {};
         var userLabels = axis.userOptions.labels || {};
-        if (axis.horiz) {
-            if (gridOptions.enabled === true) {
-                axis.series.forEach(function (series) {
-                    series.options.pointRange = 0;
-                });
-            }
-            // Lower level time ticks, like hours or minutes, represent
-            // points in time and not ranges. These should be aligned
-            // left in the grid cell by default. The same applies to
-            // years of higher order.
-            if (tickInfo &&
-                options.dateTimeLabelFormats &&
-                options.labels &&
-                !defined(userLabels.align) &&
-                (options.dateTimeLabelFormats[tickInfo.unitName].range === false ||
-                    tickInfo.count > 1 // years
-                )) {
-                options.labels.align = 'left';
-                if (!defined(userLabels.x)) {
-                    options.labels.x = 3;
+        // Fire this only for the Gantt type chart, #14868.
+        if (axis.userOptions.grid && axis.userOptions.grid.enabled) {
+            if (axis.horiz) {
+                if (gridOptions.enabled === true) {
+                    axis.series.forEach(function (series) {
+                        series.options.pointRange = 0;
+                    });
+                }
+                // Lower level time ticks, like hours or minutes, represent
+                // points in time and not ranges. These should be aligned
+                // left in the grid cell by default. The same applies to
+                // years of higher order.
+                if (tickInfo &&
+                    options.dateTimeLabelFormats &&
+                    options.labels &&
+                    !defined(userLabels.align) &&
+                    (options.dateTimeLabelFormats[tickInfo.unitName].range === false ||
+                        tickInfo.count > 1 // years
+                    )) {
+                    options.labels.align = 'left';
+                    if (!defined(userLabels.x)) {
+                        options.labels.x = 3;
+                    }
                 }
             }
-        }
-        else {
-            // Don't trim ticks which not in min/max range but
-            // they are still in the min/max plus tickInterval.
-            if (this.options.type !== 'treegrid' && ((_a = axis.grid) === null || _a === void 0 ? void 0 : _a.columns)) {
-                this.minPointOffset = this.tickInterval;
+            else {
+                // Don't trim ticks which not in min/max range but
+                // they are still in the min/max plus tickInterval.
+                if (this.options.type !== 'treegrid' && ((_a = axis.grid) === null || _a === void 0 ? void 0 : _a.columns)) {
+                    this.minPointOffset = this.tickInterval;
+                }
             }
         }
     };

--- a/js/Core/Axis/GridAxis.js
+++ b/js/Core/Axis/GridAxis.js
@@ -612,13 +612,11 @@ var GridAxis = /** @class */ (function () {
         var gridOptions = options.grid || {};
         var userLabels = axis.userOptions.labels || {};
         // Fire this only for the Gantt type chart, #14868.
-        if (axis.options.grid && axis.options.grid.enabled) {
+        if (gridOptions.enabled) {
             if (axis.horiz) {
-                if (gridOptions.enabled === true) {
-                    axis.series.forEach(function (series) {
-                        series.options.pointRange = 0;
-                    });
-                }
+                axis.series.forEach(function (series) {
+                    series.options.pointRange = 0;
+                });
                 // Lower level time ticks, like hours or minutes, represent
                 // points in time and not ranges. These should be aligned
                 // left in the grid cell by default. The same applies to

--- a/js/Core/Axis/GridAxis.js
+++ b/js/Core/Axis/GridAxis.js
@@ -612,7 +612,7 @@ var GridAxis = /** @class */ (function () {
         var gridOptions = options.grid || {};
         var userLabels = axis.userOptions.labels || {};
         // Fire this only for the Gantt type chart, #14868.
-        if (axis.userOptions.grid && axis.userOptions.grid.enabled) {
+        if (axis.options.grid && axis.options.grid.enabled) {
             if (axis.horiz) {
                 if (gridOptions.enabled === true) {
                     axis.series.forEach(function (series) {

--- a/samples/unit-tests/gantt/grid-axis/demo.js
+++ b/samples/unit-tests/gantt/grid-axis/demo.js
@@ -2070,3 +2070,46 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test(
+    'Grid axis code should not interfere with non-Gantt type charts, 14868.',
+    assert => {
+        const chart = Highcharts.chart('container', {
+            chart: {
+                zoomType: 'x'
+            },
+            xAxis: {
+                type: 'datetime'
+            },
+            series: [{
+                type: 'xrange',
+                data: [{
+                    x: Date.UTC(2014, 11, 8),
+                    x2: Date.UTC(2014, 11, 9),
+                    y: 0
+                }, {
+                    x: Date.UTC(2014, 11, 9),
+                    x2: Date.UTC(2014, 11, 19),
+                    y: 1
+                }, {
+                    x: Date.UTC(2014, 11, 10),
+                    x2: Date.UTC(2014, 11, 23),
+                    y: 2
+                }]
+            }]
+        });
+
+        assert.notOk(
+            chart.xAxis[0].options.labels.align,
+            'Label align options should not be defined.'
+        );
+        chart.xAxis[0].setExtremes(
+            Date.UTC(2014, 11, 8),
+            Date.UTC(2014, 11, 10)
+        );
+        assert.notOk(
+            chart.xAxis[0].options.labels.align,
+            'Label align options should still not be defined.'
+        );
+    }
+);

--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -911,7 +911,7 @@ class GridAxis {
         const userLabels = axis.userOptions.labels || {};
 
         // Fire this only for the Gantt type chart, #14868.
-        if (axis.userOptions.grid && axis.userOptions.grid.enabled) {
+        if (axis.options.grid && axis.options.grid.enabled) {
             if (axis.horiz) {
                 if (gridOptions.enabled === true) {
                     axis.series.forEach(function (series): void {

--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -911,13 +911,11 @@ class GridAxis {
         const userLabels = axis.userOptions.labels || {};
 
         // Fire this only for the Gantt type chart, #14868.
-        if (axis.options.grid && axis.options.grid.enabled) {
+        if (gridOptions.enabled) {
             if (axis.horiz) {
-                if (gridOptions.enabled === true) {
-                    axis.series.forEach(function (series): void {
-                        series.options.pointRange = 0;
-                    });
-                }
+                axis.series.forEach(function (series): void {
+                    series.options.pointRange = 0;
+                });
 
                 // Lower level time ticks, like hours or minutes, represent
                 // points in time and not ranges. These should be aligned

--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -910,38 +910,41 @@ class GridAxis {
         const gridOptions = options.grid || {};
         const userLabels = axis.userOptions.labels || {};
 
-        if (axis.horiz) {
-            if (gridOptions.enabled === true) {
-                axis.series.forEach(function (series): void {
-                    series.options.pointRange = 0;
-                });
-            }
-
-            // Lower level time ticks, like hours or minutes, represent
-            // points in time and not ranges. These should be aligned
-            // left in the grid cell by default. The same applies to
-            // years of higher order.
-            if (
-                tickInfo &&
-                options.dateTimeLabelFormats &&
-                options.labels &&
-                !defined(userLabels.align) &&
-                (
-                    (options.dateTimeLabelFormats[tickInfo.unitName] as any).range === false ||
-                    tickInfo.count > 1 // years
-                )
-            ) {
-                options.labels.align = 'left';
-
-                if (!defined(userLabels.x)) {
-                    options.labels.x = 3;
+        // Fire this only for the Gantt type chart, #14868.
+        if (axis.userOptions.grid && axis.userOptions.grid.enabled) {
+            if (axis.horiz) {
+                if (gridOptions.enabled === true) {
+                    axis.series.forEach(function (series): void {
+                        series.options.pointRange = 0;
+                    });
                 }
-            }
-        } else {
-            // Don't trim ticks which not in min/max range but
-            // they are still in the min/max plus tickInterval.
-            if (this.options.type !== 'treegrid' && axis.grid?.columns) {
-                this.minPointOffset = this.tickInterval;
+
+                // Lower level time ticks, like hours or minutes, represent
+                // points in time and not ranges. These should be aligned
+                // left in the grid cell by default. The same applies to
+                // years of higher order.
+                if (
+                    tickInfo &&
+                    options.dateTimeLabelFormats &&
+                    options.labels &&
+                    !defined(userLabels.align) &&
+                    (
+                        (options.dateTimeLabelFormats[tickInfo.unitName] as any).range === false ||
+                        tickInfo.count > 1 // years
+                    )
+                ) {
+                    options.labels.align = 'left';
+
+                    if (!defined(userLabels.x)) {
+                        options.labels.x = 3;
+                    }
+                }
+            } else {
+                // Don't trim ticks which not in min/max range but
+                // they are still in the min/max plus tickInterval.
+                if (this.options.type !== 'treegrid' && axis.grid?.columns) {
+                    this.minPointOffset = this.tickInterval;
+                }
             }
         }
     }


### PR DESCRIPTION
Fixed #14868, axis labels were positioned incorrectly in non-Gantt charts when the Gantt package was imported.