### PR TITLE
bugfix/14771-inverted-area-tooltip-position

### DIFF
--- a/js/Core/Tooltip.js
+++ b/js/Core/Tooltip.js
@@ -289,7 +289,7 @@ var Tooltip = /** @class */ (function () {
      * @return {Array<number>}
      */
     Tooltip.prototype.getAnchor = function (points, mouseEvent) {
-        var ret, chart = this.chart, pointer = chart.pointer, inverted = chart.inverted, plotTop = chart.plotTop, plotLeft = chart.plotLeft, plotX = 0, plotY = 0, yAxis, xAxis;
+        var ret, chart = this.chart, pointer = chart.pointer, inverted = chart.inverted, plotTop = chart.plotTop, plotLeft = chart.plotLeft, plotX = 0, plotY = 0, yAxis, xAxis, plotWidth;
         points = splat(points);
         // When tooltip follows mouse, relate the position to the mouse
         if (this.followPointer && mouseEvent) {
@@ -319,8 +319,12 @@ var Tooltip = /** @class */ (function () {
             });
             plotX /= points.length;
             plotY /= points.length;
+            // Calculate plot width if axis width is adjusted (#14771).
+            yAxis = points[0].series.yAxis;
+            plotWidth = !this.shared && yAxis && chart.plotWidth !== yAxis.width ?
+                yAxis.width + yAxis.left - plotLeft : chart.plotWidth;
             ret = [
-                inverted ? chart.plotWidth - plotY : plotX,
+                inverted ? plotWidth - plotY : plotX,
                 this.shared && !inverted && points.length > 1 && mouseEvent ?
                     // place shared tooltip next to the mouse (#424)
                     mouseEvent.chartY - plotTop :

--- a/samples/unit-tests/tooltip/position/demo.js
+++ b/samples/unit-tests/tooltip/position/demo.js
@@ -197,8 +197,8 @@ QUnit.test('Wrong tooltip pos for column (#424)', function (assert) {
     );
 });
 
-QUnit.test('#14244: Tooltip position with multiple xAxis', assert => {
-    const chart = Highcharts.chart('container', {
+QUnit.test('Tooltip position with multiple axes.', assert => {
+    let chart = Highcharts.chart('container', {
         xAxis: [
             {
                 width: '50%'
@@ -253,6 +253,43 @@ QUnit.test('#14244: Tooltip position with multiple xAxis', assert => {
 
     assert.ok(
         axis.left - chart.plotLeft < point.tooltipPos[0],
-        'Tooltip x position should be within correct xAxis'
+        'Tooltip x position should be within correct xAxis (#14244).'
+    );
+
+    chart = Highcharts.chart('container', {
+        chart: {
+            type: 'area',
+            inverted: true
+        },
+        yAxis: [{
+            width: '45%'
+        }, {
+            width: '45%',
+            left: '55%',
+            offset: 0
+        }],
+        tooltip: {
+            shared: false
+        },
+        series: [{
+            data: [1, -4, 3, -5],
+            yAxis: 0
+        }, {
+            data: [2, -2, 1, -3],
+            yAxis: 0
+        }, {
+            data: [1, -4, 3, -5],
+            yAxis: 1
+        }]
+    });
+
+    const point1 = chart.series[0].points[1];
+
+    point1.onMouseOver();
+    assert.close(
+        chart.tooltip.now.anchorX,
+        chart.series[0].yAxis.width + chart.plotLeft - point1.plotY,
+        0.5,
+        'Tooltip position on inverted area chart with adjusted width should be correct (#14771).'
     );
 });

--- a/samples/unit-tests/tooltip/position/demo.js
+++ b/samples/unit-tests/tooltip/position/demo.js
@@ -198,7 +198,7 @@ QUnit.test('Wrong tooltip pos for column (#424)', function (assert) {
 });
 
 QUnit.test('Tooltip position with multiple axes.', assert => {
-    let chart = Highcharts.chart('container', {
+    const chart = Highcharts.chart('container', {
         xAxis: [
             {
                 width: '50%'
@@ -255,10 +255,11 @@ QUnit.test('Tooltip position with multiple axes.', assert => {
         axis.left - chart.plotLeft < point.tooltipPos[0],
         'Tooltip x position should be within correct xAxis (#14244).'
     );
+});
 
-    chart = Highcharts.chart('container', {
+QUnit.test('Tooltip position with inverted multiple axes', assert => {
+    const chart = Highcharts.chart('container', {
         chart: {
-            type: 'area',
             inverted: true
         },
         yAxis: [{
@@ -290,6 +291,6 @@ QUnit.test('Tooltip position with multiple axes.', assert => {
         chart.tooltip.now.anchorX,
         chart.series[0].yAxis.width + chart.plotLeft - point1.plotY,
         0.5,
-        'Tooltip position on inverted area chart with adjusted width should be correct (#14771).'
+        'Tooltip position on inverted chart with multiple axes should appear at point (#14771).'
     );
 });

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -546,7 +546,8 @@ class Tooltip {
             plotX = 0,
             plotY = 0,
             yAxis,
-            xAxis;
+            xAxis,
+            plotWidth;
 
         points = splat(points);
 
@@ -582,8 +583,13 @@ class Tooltip {
             plotX /= points.length;
             plotY /= points.length;
 
+            // Calculate plot width if axis width is adjusted (#14771).
+            yAxis = points[0].series.yAxis;
+            plotWidth = !this.shared && yAxis && chart.plotWidth !== yAxis.width ?
+                yAxis.width + yAxis.left - plotLeft : chart.plotWidth;
+
             ret = [
-                inverted ? chart.plotWidth - plotY : plotX,
+                inverted ? plotWidth - plotY : plotX,
                 this.shared && !inverted && points.length > 1 && mouseEvent ?
                     // place shared tooltip next to the mouse (#424)
                     mouseEvent.chartY - plotTop :

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -537,7 +537,7 @@ class Tooltip {
         points: (Point|Array<Point>),
         mouseEvent?: PointerEvent
     ): Array<number> {
-        var ret,
+        var ret: number[],
             chart = this.chart,
             pointer = chart.pointer,
             inverted = chart.inverted,
@@ -545,9 +545,8 @@ class Tooltip {
             plotLeft = chart.plotLeft,
             plotX = 0,
             plotY = 0,
-            yAxis,
-            xAxis,
-            plotWidth;
+            yAxis: Highcharts.Axis|undefined,
+            xAxis: Highcharts.Axis|undefined;
 
         points = splat(points);
 
@@ -566,38 +565,50 @@ class Tooltip {
         } else if (points[0].tooltipPos) {
             ret = points[0].tooltipPos;
 
-        // When shared, use the average position
+        // Calculate the average position and adjust for axis positions
         } else {
             points.forEach(function (point): void {
                 yAxis = point.series.yAxis;
                 xAxis = point.series.xAxis;
-                plotX += (point.plotX as any) +
-                    (!inverted && xAxis ? xAxis.left - plotLeft : 0);
+                plotX += point.plotX || 0;
                 plotY += (
                     point.plotLow ?
-                        ((point.plotLow as any) + point.plotHigh) / 2 :
-                        (point.plotY as any)
-                ) + (!inverted && yAxis ? yAxis.top - plotTop : 0); // #1151
+                        (point.plotLow + (point.plotHigh || 0)) / 2 :
+                        (point.plotY || 0)
+                );
+
+                // Adjust position for positioned axes (top/left settings)
+                if (xAxis && yAxis) {
+                    if (!inverted) { // #1151
+                        plotX += xAxis.pos - plotLeft;
+                        plotY += yAxis.pos - plotTop;
+                    } else { // #14771
+                        plotX += plotTop + chart.plotHeight - xAxis.len - xAxis.pos;
+                        plotY += plotLeft + chart.plotWidth - yAxis.len - yAxis.pos;
+                    }
+                }
             });
 
             plotX /= points.length;
             plotY /= points.length;
 
-            // Calculate plot width if axis width is adjusted (#14771).
-            yAxis = points[0].series.yAxis;
-            plotWidth = !this.shared && yAxis && chart.plotWidth !== yAxis.width ?
-                yAxis.width + yAxis.left - plotLeft : chart.plotWidth;
-
+            // Use the average position for multiple points
             ret = [
-                inverted ? plotWidth - plotY : plotX,
-                this.shared && !inverted && points.length > 1 && mouseEvent ?
-                    // place shared tooltip next to the mouse (#424)
-                    mouseEvent.chartY - plotTop :
-                    inverted ? chart.plotHeight - plotX : plotY
+                inverted ? chart.plotWidth - plotY : plotX,
+                inverted ? chart.plotHeight - plotX : plotY
             ];
-        }
 
+            // When shared, place the tooltip next to the mouse (#424)
+            if (this.shared && points.length > 1 && mouseEvent) {
+                if (inverted) {
+                    ret[0] = mouseEvent.chartX - plotLeft;
+                } else {
+                    ret[1] = mouseEvent.chartY - plotTop;
+                }
+            }
+        }
         return ret.map(Math.round);
+
     }
 
     /**


### PR DESCRIPTION
Fixed #14771, incorrect tooltip position on inverted chart with adjusted axis width.