### PR TITLE
bugfix/14148-waterfall-reversed-stacking-connectors

### DIFF
--- a/js/Series/Waterfall/WaterfallSeries.js
+++ b/js/Series/Waterfall/WaterfallSeries.js
@@ -355,10 +355,9 @@ var WaterfallSeries = /** @class */ (function (_super) {
                     yPos
                 ]);
             }
-            if (!stacking &&
+            if (prevArgs &&
                 path.length &&
-                prevArgs &&
-                ((prevPoint.y < 0 && !reversedYAxis) ||
+                ((!stacking && prevPoint.y < 0 && !reversedYAxis) ||
                     (prevPoint.y > 0 && reversedYAxis))) {
                 path[path.length - 2][2] += prevArgs.height;
                 path[path.length - 1][2] += prevArgs.height;

--- a/samples/unit-tests/series-waterfall/stacking/demo.html
+++ b/samples/unit-tests/series-waterfall/stacking/demo.html
@@ -1,4 +1,7 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
 <div id="container"></div>

--- a/samples/unit-tests/series-waterfall/stacking/demo.js
+++ b/samples/unit-tests/series-waterfall/stacking/demo.js
@@ -1,28 +1,53 @@
-QUnit.test('Waterfall should render stacks. (#6020)', function (assert) {
-    var chart = new Highcharts.Chart({
-            chart: {
-                type: 'waterfall',
-                renderTo: 'container'
-            },
-            plotOptions: {
-                series: {
-                    stacking: 'normal'
-                }
-            },
-            series: [
-                {
-                    data: [5561.52, 5561.52, 5561.52, 5561.52]
-                },
-                {
-                    data: [11178.45, 11178.45, 11178.45, 11178.45]
-                }
-            ]
-        }),
-        UNDEFINED;
+QUnit.test('Waterfall stacking', function (assert) {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'waterfall'
+        },
+        yAxis: {
+            reversed: true
+        },
+        plotOptions: {
+            series: {
+                stacking: 'normal',
+                lineWidth: 1
+            }
+        },
+        series: [{
+            data: [10, 10, 30, {
+                isIntermediateSum: true
+            }, 20, {
+                isIntermediateSum: true
+            }, 10, {
+                isSum: true
+            }]
+        }, {
+            data: [-20, -10, -20, {
+                isIntermediateSum: true
+            }, 10, {
+                isIntermediateSum: true
+            }, -20, {
+                isSum: true
+            }]
+        }, {
+            data: [-20, 10, 10, {
+                isIntermediateSum: true
+            }, 30, {
+                isIntermediateSum: true
+            }, -10, {
+                isSum: true
+            }]
+        }]
+    });
 
-    assert.strictEqual(
-        chart.series[0].points[0].graphic !== UNDEFINED,
-        true,
-        'First points correctly rendered.'
+    assert.notStrictEqual(
+        chart.series[0].points[0].graphic,
+        void 0,
+        '#6020: First points correctly rendered.'
+    );
+
+    const paths = chart.series.map(s => JSON.stringify(s.getCrispPath()));
+    assert.ok(
+        paths.every(p => p === paths[0]),
+        '#14148: All series should draw the same connector line'
     );
 });

--- a/ts/Series/Waterfall/WaterfallSeries.ts
+++ b/ts/Series/Waterfall/WaterfallSeries.ts
@@ -693,11 +693,10 @@ class WaterfallSeries extends ColumnSeries {
             }
 
             if (
-                !stacking &&
-                path.length &&
                 prevArgs &&
+                path.length &&
                 (
-                    (prevPoint.y < 0 && !reversedYAxis) ||
+                    (!stacking && prevPoint.y < 0 && !reversedYAxis) ||
                     (prevPoint.y > 0 && reversedYAxis)
                 )
             ) {


### PR DESCRIPTION
Fixed #14148, `waterfall` chart with reversed `yAxis` rendered wrong stacking connectors.