### PR TITLE
bugfix/13572-incorrect-path-rendering-for-area

### DIFF
--- a/js/Core/Animation/Fx.js
+++ b/js/Core/Animation/Fx.js
@@ -295,7 +295,7 @@ var Fx = /** @class */ (function () {
                 // causing the middle two points to be sliced out, since an area
                 // path starts at left, follows the upper path then turns and
                 // follows the bottom back.
-                var segmentToAdd = arr[arr.length / positionFactor - 1].slice();
+                var segmentToAdd = arr[Math.floor(arr.length / positionFactor) - 1].slice();
                 // Disable the first control point of curve segments
                 if (segmentToAdd[0] === 'C') {
                     segmentToAdd[1] = segmentToAdd[5];
@@ -305,7 +305,7 @@ var Fx = /** @class */ (function () {
                     arr.push(segmentToAdd);
                 }
                 else {
-                    var lowerSegmentToAdd = arr[arr.length / positionFactor].slice();
+                    var lowerSegmentToAdd = arr[Math.floor(arr.length / positionFactor)].slice();
                     arr.splice(arr.length / 2, 0, segmentToAdd, lowerSegmentToAdd);
                 }
             }

--- a/js/Core/Animation/Fx.js
+++ b/js/Core/Animation/Fx.js
@@ -276,7 +276,8 @@ var Fx = /** @class */ (function () {
                 // For areas, the bottom path goes back again to the left, so we
                 // need to append a copy of the last point.
                 if (isArea) {
-                    arr.push(arr[arr.length - 1]);
+                    var z = arr.pop();
+                    arr.push(arr[arr.length - 1], z); // append point and the Z
                 }
             }
         }

--- a/js/Series/Area/AreaSeries.js
+++ b/js/Series/Area/AreaSeries.js
@@ -203,6 +203,7 @@ var AreaSeries = /** @class */ (function (_super) {
             bottomPath[0] = ['L', firstBottomPoint[1], firstBottomPoint[2]];
         }
         areaPath = topPath.concat(bottomPath);
+        areaPath.push(['Z']);
         // TODO: don't set leftCliff and rightCliff when connectNulls?
         graphPath = getGraphPath
             .call(this, graphPoints, false, connectNulls);

--- a/samples/unit-tests/series-area/update/demo.js
+++ b/samples/unit-tests/series-area/update/demo.js
@@ -64,4 +64,10 @@ QUnit.test('Updating series stacked property', assert => {
         chart.series[0].graph.element.getAttribute('d'),
         'The graph should be back to the initial'
     );
+
+    // Issue #13572
+    assert.ok(
+        chart.series[0].areaPath.slice(-1)[0].includes("Z"),
+        'The last index of the path array contains the closure'
+    );
 });

--- a/ts/Core/Animation/Fx.ts
+++ b/ts/Core/Animation/Fx.ts
@@ -416,7 +416,9 @@ class Fx {
                 // For areas, the bottom path goes back again to the left, so we
                 // need to append a copy of the last point.
                 if (isArea) {
-                    arr.push(arr[arr.length - 1]);
+                    const z: any = arr.pop();
+
+                    arr.push(arr[arr.length - 1], z); // append point and the Z
                 }
             }
         }

--- a/ts/Core/Animation/Fx.ts
+++ b/ts/Core/Animation/Fx.ts
@@ -440,7 +440,7 @@ class Fx {
                 // causing the middle two points to be sliced out, since an area
                 // path starts at left, follows the upper path then turns and
                 // follows the bottom back.
-                const segmentToAdd = arr[arr.length / positionFactor - 1].slice();
+                const segmentToAdd = arr[Math.floor(arr.length / positionFactor) - 1].slice();
 
                 // Disable the first control point of curve segments
                 if (segmentToAdd[0] === 'C') {
@@ -453,7 +453,7 @@ class Fx {
 
                 } else {
 
-                    const lowerSegmentToAdd = arr[arr.length / positionFactor].slice();
+                    const lowerSegmentToAdd = arr[Math.floor(arr.length / positionFactor)].slice();
                     arr.splice(
                         arr.length / 2,
                         0,

--- a/ts/Series/Area/AreaSeries.ts
+++ b/ts/Series/Area/AreaSeries.ts
@@ -446,6 +446,7 @@ class AreaSeries extends Series {
         }
 
         areaPath = topPath.concat(bottomPath);
+        areaPath.push(['Z']);
         // TODO: don't set leftCliff and rightCliff when connectNulls?
         graphPath = getGraphPath
             .call(this, graphPoints, false, connectNulls);


### PR DESCRIPTION
Fixed #13572, area series fill was not closed, making it hard to add a stroke for the area itself.