### PR TITLE
bugfix/14053-plotband-add-update-redraw

### DIFF
--- a/js/Core/Axis/Axis.js
+++ b/js/Core/Axis/Axis.js
@@ -2763,12 +2763,12 @@ var Axis = /** @class */ (function () {
             }
             // custom plot lines and bands
             if (!axis._addedPlotLB) { // only first time
+                axis._addedPlotLB = true;
                 (options.plotLines || [])
                     .concat(options.plotBands || [])
                     .forEach(function (plotLineOptions) {
                     axis.addPlotBandOrLine(plotLineOptions);
                 });
-                axis._addedPlotLB = true;
             }
         } // end if hasData
         // Remove inactive ticks

--- a/js/Core/Axis/PlotLineOrBand.js
+++ b/js/Core/Axis/PlotLineOrBand.js
@@ -952,11 +952,20 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
      * @return {Highcharts.PlotLineOrBand|undefined}
      */
     addPlotBandOrLine: function (options, coll) {
+        var _this = this;
         var obj = new H.PlotLineOrBand(this, options), userOptions = this.userOptions;
         if (this.visible) {
             obj = obj.render();
         }
         if (obj) { // #2189
+            if (!this._addedPlotLB) {
+                this._addedPlotLB = true;
+                (userOptions.plotLines || [])
+                    .concat(userOptions.plotBands || [])
+                    .forEach(function (plotLineOptions) {
+                    _this.addPlotBandOrLine(plotLineOptions);
+                });
+            }
             // Add it to the user options for exporting and Axis.update
             if (coll) {
                 // Workaround Microsoft/TypeScript issue #32693
@@ -965,7 +974,6 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
                 userOptions[coll] = updatedOptions;
             }
             this.plotLinesAndBands.push(obj);
-            this._addedPlotLB = true;
         }
         return obj;
     },

--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
@@ -680,70 +680,80 @@ QUnit.test(
     }
 );
 
-QUnit.test(
-    '#14310: Visibility of dynamically added plotbands',
-    function (assert) {
-        var chart = Highcharts.chart('container', {
-            chart: {
-                zoomType: 'xy'
-            },
-            xAxis: {
-                tickInterval: 24 * 3600 * 1000,
-                type: 'datetime',
-                visible: false
-            },
-            series: [
-                {
-                    data: [
-                        29.9,
-                        71.5,
-                        106.4,
-                        129.2,
-                        144.0,
-                        176.0,
-                        135.6,
-                        148.5,
-                        216.4,
-                        100,
-                        110,
-                        120,
-                        101,
-                        115,
-                        128,
-                        99,
-                        80,
-                        132
-                    ],
-                    pointStart: Date.UTC(2010, 0, 1),
-                    pointInterval: 24 * 3600 * 1000
-                }
-            ]
-        });
-
-        chart.xAxis[0].addPlotBand({
-            color: '#FCFFC5',
-            from: Date.UTC(2010, 0, 2),
-            to: Date.UTC(2010, 0, 4)
-        });
-
-        assert.ok(
-            !chart.xAxis[0].plotLinesAndBands[0].svgElem,
-            'plotBand should not render when axis is not visible'
-        );
-
-        chart.update({
-            xAxis: {
-                visible: true
+QUnit.test('Dynamically added plotbands', function (assert) {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            zoomType: 'xy'
+        },
+        xAxis: {
+            tickInterval: 24 * 3600 * 1000,
+            type: 'datetime',
+            visible: false
+        },
+        series: [
+            {
+                data: [
+                    29.9,
+                    71.5,
+                    106.4,
+                    129.2,
+                    144.0,
+                    176.0,
+                    135.6,
+                    148.5,
+                    216.4,
+                    100,
+                    110,
+                    120,
+                    101,
+                    115,
+                    128,
+                    99,
+                    80,
+                    132
+                ],
+                pointStart: Date.UTC(2010, 0, 1),
+                pointInterval: 24 * 3600 * 1000
             }
-        });
+        ]
+    });
 
-        assert.ok(
-            !!chart.xAxis[0].plotLinesAndBands[0].svgElem,
-            'plotBand should render when axis ' +
-                'visibility gets dynamically updated'
-        );
-    }
-);
+    chart.xAxis[0].addPlotBand({
+        color: '#FCFFC5',
+        from: Date.UTC(2010, 0, 2),
+        to: Date.UTC(2010, 0, 4)
+    });
+
+    assert.ok(
+        !chart.xAxis[0].plotLinesAndBands[0].svgElem,
+        '#14310: plotBand should not render when axis is not visible'
+    );
+
+    chart.update({
+        xAxis: {
+            visible: true
+        }
+    });
+
+    assert.ok(
+        !!chart.xAxis[0].plotLinesAndBands[0].svgElem,
+        '#14310: plotBand should render when axis visibility gets dynamically updated'
+    );
+
+    chart.xAxis[0].update({}, false);
+    chart.xAxis[0].addPlotBand({
+        color: '#FCFFC5',
+        from: Date.UTC(2010, 0, 4),
+        to: Date.UTC(2010, 0, 5)
+    });
+    chart.redraw();
+
+    assert.strictEqual(
+        chart.xAxis[0].plotLinesAndBands.length,
+        2,
+        '#14053: plotBands from before update with redraw=false should also be added'
+    );
+});
 
 QUnit.test('#14254: plotBands.acrossPanes', function (assert) {
     var chart = Highcharts.stockChart('container', {

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -7442,6 +7442,7 @@ class Axis {
 
             // custom plot lines and bands
             if (!axis._addedPlotLB) { // only first time
+                axis._addedPlotLB = true;
                 (options.plotLines || [])
                     .concat((options.plotBands as any) || [])
                     .forEach(
@@ -7449,7 +7450,6 @@ class Axis {
                             axis.addPlotBandOrLine(plotLineOptions);
                         }
                     );
-                axis._addedPlotLB = true;
             }
 
         } // end if hasData

--- a/ts/Core/Axis/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand.ts
@@ -1303,6 +1303,17 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
         }
 
         if (obj) { // #2189
+            if (!this._addedPlotLB) {
+                this._addedPlotLB = true;
+                (userOptions.plotLines || [])
+                    .concat((userOptions.plotBands as any) || [])
+                    .forEach(
+                        (plotLineOptions: any): void => {
+                            this.addPlotBandOrLine(plotLineOptions);
+                        }
+                    );
+            }
+
             // Add it to the user options for exporting and Axis.update
             if (coll) {
                 // Workaround Microsoft/TypeScript issue #32693
@@ -1311,7 +1322,6 @@ extend(Axis.prototype, /** @lends Highcharts.Axis.prototype */ {
                 userOptions[coll] = updatedOptions;
             }
             this.plotLinesAndBands.push(obj);
-            this._addedPlotLB = true;
         }
 
         return obj;


### PR DESCRIPTION
Fixed #14053, plot bands added before `update` with `redraw` set to `false` were not added when dynamically adding plot bands between the `update` and a `redraw`.