### PR TITLE
bugfix/11494-outside-tooltip-zindex

### DIFF
--- a/js/Core/Tooltip.js
+++ b/js/Core/Tooltip.js
@@ -414,11 +414,11 @@ var Tooltip = /** @class */ (function () {
      * @return {Highcharts.SVGElement}
      */
     Tooltip.prototype.getLabel = function () {
-        var _a, _b;
+        var _a, _b, _c;
         var tooltip = this, renderer = this.chart.renderer, styledMode = this.chart.styledMode, options = this.options, className = ('tooltip' + (defined(options.className) ?
             ' ' + options.className :
             '')), pointerEvents = (((_a = options.style) === null || _a === void 0 ? void 0 : _a.pointerEvents) ||
-            (!this.followPointer && options.stickOnContact ? 'auto' : 'none')), container, set, onMouseEnter = function () {
+            (!this.followPointer && options.stickOnContact ? 'auto' : 'none')), container, onMouseEnter = function () {
             tooltip.inContact = true;
         }, onMouseLeave = function () {
             var series = tooltip.chart.hoverSeries;
@@ -430,6 +430,7 @@ var Tooltip = /** @class */ (function () {
         };
         if (!this.label) {
             if (this.outside) {
+                var chartStyle = (_b = this.chart.options.chart) === null || _b === void 0 ? void 0 : _b.style;
                 /**
                  * Reference to the tooltip's container, when
                  * [Highcharts.Tooltip#outside] is set to true, otherwise
@@ -444,7 +445,7 @@ var Tooltip = /** @class */ (function () {
                     position: 'absolute',
                     top: '1px',
                     pointerEvents: pointerEvents,
-                    zIndex: 3
+                    zIndex: Math.max((((_c = this.options.style) === null || _c === void 0 ? void 0 : _c.zIndex) || 0), ((chartStyle === null || chartStyle === void 0 ? void 0 : chartStyle.zIndex) || 0) + 3)
                 });
                 H.doc.body.appendChild(container);
                 /**
@@ -455,7 +456,7 @@ var Tooltip = /** @class */ (function () {
                  * @name Highcharts.Tooltip#renderer
                  * @type {Highcharts.SVGRenderer|undefined}
                  */
-                this.renderer = renderer = new H.Renderer(container, 0, 0, (_b = this.chart.options.chart) === null || _b === void 0 ? void 0 : _b.style, void 0, void 0, renderer.styledMode);
+                this.renderer = renderer = new H.Renderer(container, 0, 0, chartStyle, void 0, void 0, renderer.styledMode);
             }
             // Create the label
             if (this.split) {

--- a/js/Extensions/ScrollablePlotArea.js
+++ b/js/Extensions/ScrollablePlotArea.js
@@ -261,8 +261,8 @@ Chart.prototype.moveFixedElements = function () {
  * @return {void}
  */
 Chart.prototype.applyFixed = function () {
-    var _a, _b;
-    var fixedRenderer, scrollableWidth, scrollableHeight, firstTime = !this.fixedDiv, scrollableOptions = this.options.chart.scrollablePlotArea;
+    var _a, _b, _c;
+    var fixedRenderer, scrollableWidth, scrollableHeight, firstTime = !this.fixedDiv, chartOptions = this.options.chart, scrollableOptions = chartOptions.scrollablePlotArea;
     // First render
     if (firstTime) {
         this.fixedDiv = createElement('div', {
@@ -271,12 +271,12 @@ Chart.prototype.applyFixed = function () {
             position: 'absolute',
             overflow: 'hidden',
             pointerEvents: 'none',
-            zIndex: 2,
+            zIndex: (((_a = chartOptions.style) === null || _a === void 0 ? void 0 : _a.zIndex) || 0) + 2,
             top: 0
         }, null, true);
-        (_a = this.scrollingContainer) === null || _a === void 0 ? void 0 : _a.parentNode.insertBefore(this.fixedDiv, this.scrollingContainer);
+        (_b = this.scrollingContainer) === null || _b === void 0 ? void 0 : _b.parentNode.insertBefore(this.fixedDiv, this.scrollingContainer);
         this.renderTo.style.overflow = 'visible';
-        this.fixedRenderer = fixedRenderer = new H.Renderer(this.fixedDiv, this.chartWidth, this.chartHeight, (_b = this.options.chart) === null || _b === void 0 ? void 0 : _b.style);
+        this.fixedRenderer = fixedRenderer = new H.Renderer(this.fixedDiv, this.chartWidth, this.chartHeight, (_c = this.options.chart) === null || _c === void 0 ? void 0 : _c.style);
         // Mask
         this.scrollableMask = fixedRenderer
             .path()

--- a/samples/unit-tests/tooltip/outside/demo.js
+++ b/samples/unit-tests/tooltip/outside/demo.js
@@ -30,13 +30,14 @@ QUnit.test('Outside tooltip and styledMode (#11783)', function (assert) {
     );
 });
 
-QUnit.test('Outside tooltip should inherit chart style', function (assert) {
+QUnit.test('Outside tooltip styling', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {
             width: 400,
             height: 400,
             style: {
-                fontFamily: 'Papyrus'
+                fontFamily: 'Papyrus',
+                zIndex: 1334
             }
         },
         tooltip: {
@@ -59,5 +60,24 @@ QUnit.test('Outside tooltip should inherit chart style', function (assert) {
             .parentNode.style.fontFamily,
         'Papyrus',
         'Tooltip container should inherit chart style'
+    );
+
+    assert.strictEqual(
+        chart.tooltip.container.style.zIndex,
+        '1337',
+        '#11494: Tooltip container zIndex should be based on chart.style.zIndex'
+    );
+
+    chart.tooltip.update({
+        style: {
+            zIndex: 1881
+        }
+    });
+    point.onMouseOver();
+
+    assert.strictEqual(
+        chart.tooltip.container.style.zIndex,
+        '1881',
+        '#11494: Setting tooltip.style.zIndex should also work'
     );
 });

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -719,7 +719,6 @@ class Tooltip {
                 (!this.followPointer && options.stickOnContact ? 'auto' : 'none')
             ),
             container: globalThis.HTMLElement,
-            set: Record<string, Function>,
             onMouseEnter = function (): void {
                 tooltip.inContact = true;
             },
@@ -739,6 +738,8 @@ class Tooltip {
         if (!this.label) {
 
             if (this.outside) {
+                const chartStyle = this.chart.options.chart?.style;
+
                 /**
                  * Reference to the tooltip's container, when
                  * [Highcharts.Tooltip#outside] is set to true, otherwise
@@ -754,7 +755,10 @@ class Tooltip {
                     position: 'absolute',
                     top: '1px',
                     pointerEvents,
-                    zIndex: 3
+                    zIndex: Math.max(
+                        (this.options.style?.zIndex || 0) as number,
+                        (chartStyle?.zIndex || 0) as number + 3
+                    )
                 });
 
                 H.doc.body.appendChild(container);
@@ -771,7 +775,7 @@ class Tooltip {
                     container,
                     0,
                     0,
-                    this.chart.options.chart?.style,
+                    chartStyle,
                     void 0,
                     void 0,
                     renderer.styledMode

--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -357,7 +357,8 @@ Chart.prototype.applyFixed = function (): void {
         scrollableWidth,
         scrollableHeight,
         firstTime = !this.fixedDiv,
-        scrollableOptions = (this.options.chart as any).scrollablePlotArea;
+        chartOptions = this.options.chart as any,
+        scrollableOptions = chartOptions.scrollablePlotArea;
 
     // First render
     if (firstTime) {
@@ -370,7 +371,7 @@ Chart.prototype.applyFixed = function (): void {
                 position: 'absolute',
                 overflow: 'hidden',
                 pointerEvents: 'none',
-                zIndex: 2,
+                zIndex: (chartOptions.style?.zIndex || 0) + 2,
                 top: 0
             },
             null as any,


### PR DESCRIPTION
Fixed #11494, setting `z-index` on tooltip with `outside` set to `true` through chart options was not possible.