### PR TITLE
docs/14710-column-pointwidth

### DIFF
--- a/js/Accessibility/Components/RangeSelectorComponent.js
+++ b/js/Accessibility/Components/RangeSelectorComponent.js
@@ -121,8 +121,8 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
         }
     },
     /**
-     * @private
      * Hide buttons from AT when showing dropdown, and vice versa.
+     * @private
      */
     updateSelectorVisibility: function () {
         var chart = this.chart;
@@ -142,8 +142,8 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
         }
     },
     /**
-     * @private
      * Set accessibility related attributes on dropdown element.
+     * @private
      */
     setDropdownAttrs: function () {
         var _a;

--- a/js/Series/Column/ColumnSeries.js
+++ b/js/Series/Column/ColumnSeries.js
@@ -751,10 +751,10 @@ var ColumnSeries = /** @class */ (function (_super) {
         pointPadding: 0.1,
         /**
          * A pixel value specifying a fixed width for each column or bar point.
-         * When `null`, the width is calculated from the `pointPadding` and
-         * `groupPadding`. The width effects the dimension that is not based on
-         * the point value. For column series it is the hoizontal length and for
-         * bar series it is the vertical length.
+         * When set to `undefined`, the width is calculated from the
+         * `pointPadding` and `groupPadding`. The width effects the dimension
+         * that is not based on the point value. For column series it is the
+         * hoizontal length and for bar series it is the vertical length.
          *
          * @see [maxPointWidth](#plotOptions.column.maxPointWidth)
          *
@@ -762,7 +762,7 @@ var ColumnSeries = /** @class */ (function (_super) {
          *         20px wide columns regardless of chart width or the amount of
          *         data points
          *
-         * @type      {number|null}
+         * @type      {number}
          * @since     1.2.5
          * @product   highcharts highstock gantt
          * @apioption plotOptions.column.pointWidth

--- a/js/Series/Column/ColumnSeries.js
+++ b/js/Series/Column/ColumnSeries.js
@@ -762,7 +762,7 @@ var ColumnSeries = /** @class */ (function (_super) {
          *         20px wide columns regardless of chart width or the amount of
          *         data points
          *
-         * @type      {number}
+         * @type      {number|null}
          * @since     1.2.5
          * @product   highcharts highstock gantt
          * @apioption plotOptions.column.pointWidth

--- a/ts/Accessibility/Components/RangeSelectorComponent.ts
+++ b/ts/Accessibility/Components/RangeSelectorComponent.ts
@@ -218,8 +218,8 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
 
 
     /**
-     * @private
      * Hide buttons from AT when showing dropdown, and vice versa.
+     * @private
      */
     updateSelectorVisibility: function (this: Highcharts.RangeSelectorComponent): void {
         const chart = this.chart;
@@ -241,8 +241,8 @@ extend(RangeSelectorComponent.prototype, /** @lends Highcharts.RangeSelectorComp
 
 
     /**
-     * @private
      * Set accessibility related attributes on dropdown element.
+     * @private
      */
     setDropdownAttrs: function (this: Highcharts.RangeSelectorComponent): void {
         const chart = this.chart;

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -237,10 +237,10 @@ class ColumnSeries extends Series {
 
         /**
          * A pixel value specifying a fixed width for each column or bar point.
-         * When `null`, the width is calculated from the `pointPadding` and
-         * `groupPadding`. The width effects the dimension that is not based on
-         * the point value. For column series it is the hoizontal length and for
-         * bar series it is the vertical length.
+         * When set to `undefined`, the width is calculated from the
+         * `pointPadding` and `groupPadding`. The width effects the dimension
+         * that is not based on the point value. For column series it is the
+         * hoizontal length and for bar series it is the vertical length.
          *
          * @see [maxPointWidth](#plotOptions.column.maxPointWidth)
          *
@@ -248,7 +248,7 @@ class ColumnSeries extends Series {
          *         20px wide columns regardless of chart width or the amount of
          *         data points
          *
-         * @type      {number|null}
+         * @type      {number}
          * @since     1.2.5
          * @product   highcharts highstock gantt
          * @apioption plotOptions.column.pointWidth

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -248,7 +248,7 @@ class ColumnSeries extends Series {
          *         20px wide columns regardless of chart width or the amount of
          *         data points
          *
-         * @type      {number}
+         * @type      {number|null}
          * @since     1.2.5
          * @product   highcharts highstock gantt
          * @apioption plotOptions.column.pointWidth


### PR DESCRIPTION
Fixed #14710, added `undefined` as the valid type/value for default behavior  of `column.pointWidth` and inherited series options.