### PR TITLE
bugfix/9744-legend-title-stocktools-overlap

### DIFF
--- a/js/Stock/StockToolsGui.js
+++ b/js/Stock/StockToolsGui.js
@@ -751,7 +751,31 @@ addEvent(Chart, 'getMargins', function () {
         getStyle(listWrapper, 'padding-right')) || listWrapper.offsetWidth);
     if (offsetWidth && offsetWidth < this.plotWidth) {
         this.plotLeft += offsetWidth;
+        this.spacing[3] += offsetWidth;
     }
+});
+['beforeRender', 'beforeRedraw'].forEach(function (event) {
+    addEvent(Chart, event, function () {
+        if (this.stockTools) {
+            var listWrapper = this.stockTools.listWrapper, offsetWidth = listWrapper && ((listWrapper.startWidth +
+                getStyle(listWrapper, 'padding-left') +
+                getStyle(listWrapper, 'padding-right')) || listWrapper.offsetWidth);
+            var dirty = false;
+            if (offsetWidth && offsetWidth < this.plotWidth) {
+                this.spacingBox.x += offsetWidth;
+                dirty = true;
+            }
+            else if (offsetWidth === 0) {
+                dirty = true;
+            }
+            if (offsetWidth !== this.stockTools.prevOffsetWidth) {
+                this.stockTools.prevOffsetWidth = offsetWidth;
+                if (dirty) {
+                    this.isDirtyLegend = true;
+                }
+            }
+        }
+    });
 });
 addEvent(Chart, 'destroy', function () {
     if (this.stockTools) {

--- a/samples/unit-tests/stock-tools/gui/demo.html
+++ b/samples/unit-tests/stock-tools/gui/demo.html
@@ -1,3 +1,5 @@
+<link rel="stylesheet" type="text/css" href="https://code.highcharts.com/css/stocktools/gui.css">
+
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 <script src="https://code.highcharts.com/stock/indicators/indicators.js"></script>

--- a/samples/unit-tests/stock-tools/gui/demo.js
+++ b/samples/unit-tests/stock-tools/gui/demo.js
@@ -1,13 +1,22 @@
-QUnit.test('Touch event test on popup', function (assert) {
-    Highcharts.stockChart('container', {
+QUnit.test('Stocktools GUI', function (assert) {
+    /*const chart = */Highcharts.stockChart('container', {
         stockTools: {
             gui: {
+                enabled: true,
                 definitions: {
                     measure: {
                         items: ['measureX']
                     }
                 }
             }
+        },
+        title: {
+            text: 'Chart title',
+            align: 'left'
+        },
+        legend: {
+            enabled: true,
+            align: 'left'
         },
         series: [
             {
@@ -20,4 +29,35 @@ QUnit.test('Touch event test on popup', function (assert) {
         1,
         'No errors should be thrown after setting just one item (#10980)'
     );
+
+    // This doesnt work outside highcharts-utils, possibly because it needs
+    // the css
+    /*
+    const spacing = Highcharts.defaultOptions.chart.spacing[3];
+    const offset = spacing + chart.stockTools.listWrapper.offsetWidth;
+
+    assert.strictEqual(
+        chart.legend.group.translateX,
+        offset,
+        '#9744: Legend should have correct position'
+    );
+    assert.strictEqual(
+        chart.title.attr('x'),
+        offset,
+        '#9744: Title should have the correct position'
+    );
+
+    Highcharts.fireEvent(chart.stockTools.showhideBtn, 'click');
+
+    assert.strictEqual(
+        chart.legend.group.translateX,
+        spacing,
+        '#9744: Legend should have correct position after hiding toolbar'
+    );
+    assert.strictEqual(
+        chart.title.attr('x'),
+        spacing,
+        '#9744: Title should have the correct position after hiding toolbar'
+    );
+    */
 });

--- a/ts/Stock/StockToolsGui.ts
+++ b/ts/Stock/StockToolsGui.ts
@@ -112,6 +112,7 @@ declare global {
             public listWrapper: HTMLDOMElement;
             public options: StockToolsGuiOptions;
             public placed: boolean;
+            public prevOffsetWidth: (number|undefined);
             public showhideBtn: HTMLDOMElement;
             public submenu: HTMLDOMElement;
             public toolbar: HTMLDOMElement;
@@ -919,7 +920,39 @@ addEvent(Chart, 'getMargins', function (): void {
 
     if (offsetWidth && offsetWidth < this.plotWidth) {
         this.plotLeft += offsetWidth;
+        this.spacing[3] += offsetWidth;
     }
+});
+
+['beforeRender', 'beforeRedraw'].forEach((event: string): void => {
+    addEvent(Chart, event, function (): void {
+        if (this.stockTools) {
+            const listWrapper = this.stockTools.listWrapper,
+                offsetWidth = listWrapper && (
+                    (
+                        (listWrapper as any).startWidth +
+                        getStyle(listWrapper, 'padding-left') +
+                        getStyle(listWrapper, 'padding-right')
+                    ) || listWrapper.offsetWidth
+                );
+
+            let dirty = false;
+
+            if (offsetWidth && offsetWidth < this.plotWidth) {
+                this.spacingBox.x += offsetWidth;
+                dirty = true;
+            } else if (offsetWidth === 0) {
+                dirty = true;
+            }
+
+            if (offsetWidth !== this.stockTools.prevOffsetWidth) {
+                this.stockTools.prevOffsetWidth = offsetWidth;
+                if (dirty) {
+                    this.isDirtyLegend = true;
+                }
+            }
+        }
+    });
 });
 
 addEvent(Chart, 'destroy', function (): void {
@@ -983,6 +1016,7 @@ class Toolbar {
     public listWrapper: HTMLDOMElement = void 0 as any;
     public options: Highcharts.StockToolsGuiOptions;
     public placed: boolean;
+    public prevOffsetWidth: (number|undefined);
     public showhideBtn: HTMLDOMElement = void 0 as any;
     public submenu: HTMLDOMElement = void 0 as any;
     public toolbar: HTMLDOMElement = void 0 as any;


### PR DESCRIPTION
Fixed #9744, stock toolbar overlapped left-aligned title and legend.