### PR TITLE
Fixed missing import after merge.

### DIFF
--- a/js/Accessibility/Components/LegendComponent.js
+++ b/js/Accessibility/Components/LegendComponent.js
@@ -17,7 +17,7 @@ var addEvent = U.addEvent, extend = U.extend, find = U.find, fireEvent = U.fireE
 import AccessibilityComponent from '../AccessibilityComponent.js';
 import KeyboardNavigationHandler from '../KeyboardNavigationHandler.js';
 import HTMLUtilities from '../Utils/HTMLUtilities.js';
-var removeElement = HTMLUtilities.removeElement;
+var removeElement = HTMLUtilities.removeElement, stripHTMLTags = HTMLUtilities.stripHTMLTagsFromString;
 /* eslint-disable no-invalid-this, valid-jsdoc */
 /**
  * @private

--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -30,7 +30,10 @@ import AccessibilityComponent from '../AccessibilityComponent.js';
 import KeyboardNavigationHandler from '../KeyboardNavigationHandler.js';
 
 import HTMLUtilities from '../Utils/HTMLUtilities.js';
-const removeElement = HTMLUtilities.removeElement;
+const {
+    removeElement,
+    stripHTMLTagsFromString: stripHTMLTags
+} = HTMLUtilities;
 
 type LegendItem = (Highcharts.BubbleLegend|Series|Point);
 


### PR DESCRIPTION
Fixed missing import after merge.
___
The `stripHTMLTagsFromString` call is needed here - not for security, but to avoid html code being part of the label in case of HTML titles.