### PR TITLE
Mention how to load ES modules

### DIFF
--- a/docs/getting-started/install-from-npm.md
+++ b/docs/getting-started/install-from-npm.md
@@ -15,7 +15,8 @@ require('highcharts/modules/exporting')(Highcharts);
 // Create the chart
 Highcharts.chart('container', { /*Highcharts options*/ });
 ```
-    
+
+For other ways to load Highcharts (ECMAScript modules etc.) please see [the README](https://github.com/highcharts/highcharts#load-highcharts-from-the-cdn-as-ecmascript-modules).
 
 Load Highcharts Stock or Highcharts Maps
 --------------------------


### PR DESCRIPTION
The current instructions for loading Highcharts seem a bit outdated (`var`, `require`). Might be worth inlining more modern loading methods there? This PR simply links to the GitHub README that details them.