### PR TITLE
bugfix/14063-flags-series-invertible

### DIFF
--- a/js/Core/Series/Series.js
+++ b/js/Core/Series/Series.js
@@ -2366,7 +2366,7 @@ var Series = /** @class */ (function () {
         }
         // SVGRenderer needs to know this before drawing elements (#1089,
         // #1795)
-        group.inverted = series.isCartesian || series.invertable ?
+        group.inverted = pick(series.invertible, series.isCartesian) ?
             inverted : false;
         // Draw the graph if any
         if (series.drawGraph) {

--- a/js/Series/Flags/FlagsSeries.js
+++ b/js/Series/Flags/FlagsSeries.js
@@ -512,6 +512,8 @@ extend(FlagsSeries.prototype, {
      * @function Highcharts.seriesTypes.flags#invertGroups
      */
     invertGroups: noop,
+    // Flags series group should not be invertible (#14063).
+    invertible: false,
     noSharedTooltip: true,
     pointClass: FlagsPoint,
     sorted: false,

--- a/js/Series/Sankey/SankeySeries.js
+++ b/js/Series/Sankey/SankeySeries.js
@@ -828,7 +828,7 @@ extend(SankeySeries.prototype, {
     createNode: NodesMixin.createNode,
     destroy: NodesMixin.destroy,
     forceDL: true,
-    invertable: true,
+    invertible: true,
     isCartesian: false,
     orderNodes: true,
     pointArrayMap: ['from', 'to'],

--- a/samples/unit-tests/series-flags/general/demo.js
+++ b/samples/unit-tests/series-flags/general/demo.js
@@ -165,3 +165,43 @@ QUnit.test('Flags visibility', function (assert) {
         'Flag with box position value equal to 0 is visible.'
     );
 });
+
+QUnit.test('Scrolling inverted chart with a flag series.', function (assert) {
+    var chart = Highcharts.chart('container', {
+            chart: {
+                inverted: true
+            },
+
+            xAxis: {
+                scrollbar: {
+                    enabled: true
+                },
+                min: 2,
+                max: 3
+            },
+
+            series: [{
+                data: [1, 2, 3, 4, 5]
+            }, {
+                type: 'flags',
+                data: [{
+                    x: 3,
+                    text: '3',
+                    title: '3'
+                }]
+            }]
+        }),
+        controller = new TestController(chart),
+        scrollbar = chart.xAxis[0].scrollbar;
+
+    controller.pan(
+        [scrollbar.x + 3, scrollbar.y + scrollbar.scrollbarTop + 3],
+        [scrollbar.x + 3, scrollbar.y + scrollbar.scrollbarTop + 10]
+    );
+
+    assert.equal(
+        chart.series[1].group.inverted,
+        false,
+        'The flag series should be invertible (#14063).'
+    );
+});

--- a/samples/unit-tests/series-flags/general/demo.js
+++ b/samples/unit-tests/series-flags/general/demo.js
@@ -166,51 +166,38 @@ QUnit.test('Flags visibility', function (assert) {
     );
 });
 
-// The flag series should be invertible (#14063).
+// The flag series should not be invertible (#14063).
 QUnit.test('Scrolling inverted chart with a flag series.', function (assert) {
     var chart = Highcharts.chart('container', {
-            chart: {
-                inverted: true
-            },
+        chart: {
+            inverted: true
+        },
 
-            xAxis: {
-                scrollbar: {
-                    enabled: true
-                },
-                min: 2,
-                max: 3
+        xAxis: {
+            scrollbar: {
+                enabled: true
             },
+            min: 2,
+            max: 3
+        },
 
-            series: [{
-                data: [1, 2, 3, 4, 5]
-            }, {
-                type: 'flags',
-                data: [{
-                    x: 3,
-                    text: '3',
-                    title: '3'
-                }]
+        series: [{
+            data: [1, 2, 3, 4, 5]
+        }, {
+            type: 'flags',
+            data: [{
+                x: 3,
+                text: '3',
+                title: '3'
             }]
-        }),
-        controller = new TestController(chart),
-        scrollbar = chart.xAxis[0].scrollbar,
-        containsNaN = false;
+        }]
+    });
 
-    // Move scrollbar 7px down
-    controller.pan(
-        [scrollbar.x + 3, scrollbar.y + scrollbar.scrollbarTop + 3],
-        [scrollbar.x + 3, scrollbar.y + scrollbar.scrollbarTop + 10]
-    );
-
-    chart.container.querySelectorAll('.highcharts-flags-series')
-        .forEach(function (group) {
-            containsNaN =
-                containsNaN ||
-                group.getAttribute('transform').includes('NaN');
-        });
+    chart.xAxis[0].setExtremes(3, 4);
 
     assert.equal(
-        containsNaN,
+        [...chart.container.querySelectorAll('.highcharts-flags-series')]
+            .some(group =>  group.getAttribute('transform').includes('NaN')),
         false,
         'The flag series\' DOM elements should not contain NaN attributes values (#14063).'
     );

--- a/samples/unit-tests/series-flags/general/demo.js
+++ b/samples/unit-tests/series-flags/general/demo.js
@@ -166,6 +166,7 @@ QUnit.test('Flags visibility', function (assert) {
     );
 });
 
+// The flag series should be invertible (#14063).
 QUnit.test('Scrolling inverted chart with a flag series.', function (assert) {
     var chart = Highcharts.chart('container', {
             chart: {
@@ -192,16 +193,25 @@ QUnit.test('Scrolling inverted chart with a flag series.', function (assert) {
             }]
         }),
         controller = new TestController(chart),
-        scrollbar = chart.xAxis[0].scrollbar;
+        scrollbar = chart.xAxis[0].scrollbar,
+        containsNaN = false;
 
+    // Move scrollbar 7px down
     controller.pan(
         [scrollbar.x + 3, scrollbar.y + scrollbar.scrollbarTop + 3],
         [scrollbar.x + 3, scrollbar.y + scrollbar.scrollbarTop + 10]
     );
 
+    chart.container.querySelectorAll('.highcharts-flags-series')
+        .forEach(function (group) {
+            containsNaN =
+                containsNaN ||
+                group.getAttribute('transform').includes('NaN');
+        });
+
     assert.equal(
-        chart.series[1].group.inverted,
+        containsNaN,
         false,
-        'The flag series should be invertible (#14063).'
+        'The flag series\' DOM elements should not contain NaN attributes values (#14063).'
     );
 });

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -105,6 +105,7 @@ declare module '../Chart/ChartLike'{
 declare module './SeriesLike' {
     interface SeriesLike {
         _hasPointMarkers?: boolean;
+        invertible?: boolean;
         pointArrayMap?: Array<string>;
         pointValKey?: string;
     }
@@ -5981,7 +5982,7 @@ class Series {
 
         // SVGRenderer needs to know this before drawing elements (#1089,
         // #1795)
-        group.inverted = series.isCartesian || series.invertable ?
+        group.inverted = pick(series.invertible, series.isCartesian) ?
             inverted : false;
 
         // Draw the graph if any

--- a/ts/Series/Flags/FlagsSeries.ts
+++ b/ts/Series/Flags/FlagsSeries.ts
@@ -693,6 +693,9 @@ extend(FlagsSeries.prototype, {
      */
     invertGroups: noop as any,
 
+    // Flags series group should not be invertible (#14063).
+    invertible: false,
+
     noSharedTooltip: true,
 
     pointClass: FlagsPoint,

--- a/ts/Series/Sankey/SankeySeries.ts
+++ b/ts/Series/Sankey/SankeySeries.ts
@@ -59,18 +59,6 @@ const {
 
 /* *
  *
- *  Declarations
- *
- * */
-
-declare module '../../Core/Series/SeriesLike' {
-    interface SeriesLike {
-        invertable?: boolean;
-    }
-}
-
-/* *
- *
  *  Class
  *
  * */
@@ -1155,7 +1143,7 @@ interface SankeySeries extends Highcharts.NodesSeries {
     destroy: Highcharts.NodesMixin['destroy'];
     forceDL: boolean;
     init(chart: Chart, options: SankeySeriesOptions): void;
-    invertable: boolean;
+    invertible: boolean;
     isCartesian: boolean;
     orderNodes: boolean;
     pointArrayMap: Array<string>;
@@ -1170,7 +1158,7 @@ extend(SankeySeries.prototype, {
     createNode: NodesMixin.createNode,
     destroy: NodesMixin.destroy,
     forceDL: true,
-    invertable: true,
+    invertible: true,
     isCartesian: false,
     orderNodes: true,
     pointArrayMap: ['from', 'to'],


### PR DESCRIPTION
Fixed #14063, an error was thrown when scrolling an inverted chart with a flag series.

To do:
- [x] test