### PR TITLE
bugfix/14973-patternfill-base-pushState

### DIFF
--- a/js/Core/Chart/Chart.js
+++ b/js/Core/Chart/Chart.js
@@ -1847,6 +1847,7 @@ var Chart = /** @class */ (function () {
             }
         });
         chart.render();
+        chart.pointer.getChartPosition(); // #14973
         // Fire the load event if there are no external images
         if (!chart.renderer.imgCount && !chart.hasLoaded) {
             chart.onload();

--- a/js/Core/Pointer.js
+++ b/js/Core/Pointer.js
@@ -513,14 +513,15 @@ var Pointer = /** @class */ (function () {
             scaleX: 1,
             scaleY: 1
         };
+        var offsetWidth = container.offsetWidth;
+        var offsetHeight = container.offsetHeight;
         // #13342 - tooltip was not visible in Chrome, when chart
         // updates height.
-        if (container.offsetWidth > 2 && // #13342
-            container.offsetHeight > 2 && // #13342
-            container.getBoundingClientRect) {
-            var bb = container.getBoundingClientRect();
-            this.chartPosition.scaleX = bb.width / container.offsetWidth;
-            this.chartPosition.scaleY = bb.height / container.offsetHeight;
+        if (offsetWidth > 2 && // #13342
+            offsetHeight > 2 // #13342
+        ) {
+            this.chartPosition.scaleX = pos.width / offsetWidth;
+            this.chartPosition.scaleY = pos.height / offsetHeight;
         }
         return this.chartPosition;
     };

--- a/js/Core/Utilities.js
+++ b/js/Core/Utilities.js
@@ -1572,12 +1572,14 @@ function keys(obj) {
 function offset(el) {
     var docElem = doc.documentElement, box = (el.parentElement || el.parentNode) ?
         el.getBoundingClientRect() :
-        { top: 0, left: 0 };
+        { top: 0, left: 0, width: 0, height: 0 };
     return {
         top: box.top + (win.pageYOffset || docElem.scrollTop) -
             (docElem.clientTop || 0),
         left: box.left + (win.pageXOffset || docElem.scrollLeft) -
-            (docElem.clientLeft || 0)
+            (docElem.clientLeft || 0),
+        width: box.width,
+        height: box.height
     };
 }
 /* eslint-disable valid-jsdoc */

--- a/samples/unit-tests/stock-tools/bindings/demo.js
+++ b/samples/unit-tests/stock-tools/bindings/demo.js
@@ -52,6 +52,7 @@ QUnit.test('Bindings general tests', function (assert) {
     if (qunitContainer) {
         qunitContainer.style.display = 'none';
     }
+    delete chart.pointer.chartPosition;
 
     // Shorthand for selecting a button
     function selectButton(name) {

--- a/samples/unit-tests/tooltip/split/demo.js
+++ b/samples/unit-tests/tooltip/split/demo.js
@@ -360,6 +360,8 @@ QUnit.test('Split tooltip, horizontal scrollable plot area', assert => {
         });
         let bBox;
 
+        delete chart.pointer.chartPosition;
+
         // Open tooltip
         chart.series[0].points[8].onMouseOver();
 

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -2615,6 +2615,7 @@ class Chart {
         });
 
         chart.render();
+        chart.pointer.getChartPosition(); // #14973
 
         // Fire the load event if there are no external images
         if (!chart.renderer.imgCount && !chart.hasLoaded) {

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -818,16 +818,17 @@ class Pointer {
             scaleY: 1
         };
 
+        const offsetWidth = container.offsetWidth;
+        const offsetHeight = container.offsetHeight;
+
         // #13342 - tooltip was not visible in Chrome, when chart
         // updates height.
         if (
-            container.offsetWidth > 2 && // #13342
-            container.offsetHeight > 2 && // #13342
-            container.getBoundingClientRect
+            offsetWidth > 2 && // #13342
+            offsetHeight > 2 // #13342
         ) {
-            const bb = container.getBoundingClientRect();
-            this.chartPosition.scaleX = bb.width / container.offsetWidth;
-            this.chartPosition.scaleY = bb.height / container.offsetHeight;
+            this.chartPosition.scaleX = pos.width / offsetWidth;
+            this.chartPosition.scaleY = pos.height / offsetHeight;
         }
 
         return this.chartPosition;

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -82,8 +82,10 @@ declare global {
             ): void;
         }
         interface OffsetObject {
+            height: number;
             left: number;
             top: number;
+            width: number;
         }
         interface Timer {
             (gotoEnd?: boolean): boolean;
@@ -1998,13 +2000,15 @@ function offset(el: Element): Highcharts.OffsetObject {
     var docElem = doc.documentElement,
         box = (el.parentElement || el.parentNode) ?
             el.getBoundingClientRect() :
-            { top: 0, left: 0 };
+            { top: 0, left: 0, width: 0, height: 0 };
 
     return {
         top: box.top + (win.pageYOffset || docElem.scrollTop) -
             (docElem.clientTop || 0),
         left: box.left + (win.pageXOffset || docElem.scrollLeft) -
-            (docElem.clientLeft || 0)
+            (docElem.clientLeft || 0),
+        width: box.width,
+        height: box.height
     };
 }
 

--- a/ts/Extensions/Oldie/Oldie.ts
+++ b/ts/Extensions/Oldie/Oldie.ts
@@ -452,7 +452,7 @@ if (!svg) {
      */
     Pointer.prototype.normalize = function<T extends PointerEvent> (
         e: (T|MouseEvent|PointerEvent|TouchEvent),
-        chartPosition?: Highcharts.OffsetObject
+        chartPosition?: Highcharts.ChartPositionObject
     ): T {
 
         e = e || win.event;


### PR DESCRIPTION
Fixed #14973, pattern fill failed to render when `<base>` tag was present and `window.location` was manipulated via `history.pushState`.

The pattern disappearing on `redraw` gets fixed by #14874.

Threw in some unrelated optimizations in `getChartPosition`.