### PR TITLE
bugfix/14977-macd-index-param

### DIFF
--- a/js/Stock/Indicators/MACD/MACDIndicator.js
+++ b/js/Stock/Indicators/MACD/MACDIndicator.js
@@ -195,10 +195,12 @@ var MACDIndicator = /** @class */ (function (_super) {
         }
         // Calculating the short and long EMA used when calculating the MACD
         shortEMA = SeriesRegistry.seriesTypes.ema.prototype.getValues(series, {
-            period: params.shortPeriod
+            period: params.shortPeriod,
+            index: params.index
         });
         longEMA = SeriesRegistry.seriesTypes.ema.prototype.getValues(series, {
-            period: params.longPeriod
+            period: params.longPeriod,
+            index: params.index
         });
         shortEMA = shortEMA.values;
         longEMA = longEMA.values;

--- a/samples/unit-tests/indicator-macd/recalculations/demo.js
+++ b/samples/unit-tests/indicator-macd/recalculations/demo.js
@@ -488,3 +488,26 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
     chart.series[1].remove();
     assert.ok(true, 'No error when removing MACD without lines (#8848).');
 });
+
+QUnit.test('#14977: Index param', assert => {
+    const xData = [...Array(50).keys()];
+    const yData = xData.map(() => {
+        const y = Math.random();
+        return [y, y * 2, y, y * 2];
+    });
+
+    const getValues = index =>
+        Highcharts.seriesTypes.macd.prototype.getValues({
+            xData,
+            yData
+        }, Highcharts.merge(
+            Highcharts.getOptions().plotOptions.macd.params,
+            { index }
+        )).values;
+
+    assert.notStrictEqual(
+        getValues(0)[0][3],
+        getValues(1)[0][3],
+        'getValues should return different values when passed different index param'
+    );
+});

--- a/ts/Stock/Indicators/MACD/MACDIndicator.ts
+++ b/ts/Stock/Indicators/MACD/MACDIndicator.ts
@@ -398,14 +398,16 @@ class MACDIndicator extends SMAIndicator {
         shortEMA = (SeriesRegistry.seriesTypes.ema.prototype.getValues(
             series,
             {
-                period: params.shortPeriod
+                period: params.shortPeriod,
+                index: params.index
             }
         ) as any);
 
         longEMA = (SeriesRegistry.seriesTypes.ema.prototype.getValues(
             series,
             {
-                period: params.longPeriod
+                period: params.longPeriod,
+                index: params.index
             }
         ) as any);
 


### PR DESCRIPTION
Fixed #14977, MACD indicator `index` param did not work.