### PR TITLE
Refactor, tspan break tag equivalent

### DIFF
--- a/js/Core/Renderer/HTML/AST.js
+++ b/js/Core/Renderer/HTML/AST.js
@@ -41,6 +41,19 @@ var AST = /** @class */ (function () {
         this.nodes = typeof source === 'string' ?
             this.parseMarkup(source) : source;
     }
+    /**
+     * Filter attributes against the allow list.
+     *
+     * @private
+     * @static
+     *
+     * @function Highcharts.AST#filterUserAttributes
+     *
+     * @param {SVGAttributes} attributes The attributes to filter
+     *
+     * @return {SVGAttributes}
+     * The filtered attributes
+     */
     AST.filterUserAttributes = function (attributes) {
         objectEach(attributes, function (val, key) {
             var valid = true;
@@ -63,7 +76,6 @@ var AST = /** @class */ (function () {
      * markup string. The markup is safely parsed by the AST class to avoid
      * XSS vulnerabilities.
      *
-     * @private
      * @static
      *
      * @function Highcharts.AST#setElementHTML

--- a/js/Core/Renderer/SVG/SVGElement.js
+++ b/js/Core/Renderer/SVG/SVGElement.js
@@ -12,7 +12,7 @@ import AST from '../HTML/AST.js';
 var animate = A.animate, animObject = A.animObject, stop = A.stop;
 import Color from '../../Color/Color.js';
 import H from '../../Globals.js';
-var deg2rad = H.deg2rad, doc = H.doc, hasTouch = H.hasTouch, isFirefox = H.isFirefox, noop = H.noop, svg = H.svg, SVG_NS = H.SVG_NS, win = H.win;
+var deg2rad = H.deg2rad, doc = H.doc, hasTouch = H.hasTouch, noop = H.noop, svg = H.svg, SVG_NS = H.SVG_NS, win = H.win;
 import palette from '../../Color/Palette.js';
 import U from '../../Utilities.js';
 var attr = U.attr, createElement = U.createElement, css = U.css, defined = U.defined, erase = U.erase, extend = U.extend, fireEvent = U.fireEvent, isArray = U.isArray, isFunction = U.isFunction, isNumber = U.isNumber, isString = U.isString, merge = U.merge, objectEach = U.objectEach, pick = U.pick, pInt = U.pInt, syncTimeout = U.syncTimeout, uniqueKey = U.uniqueKey;
@@ -527,7 +527,7 @@ var SVGElement = /** @class */ (function () {
      *        A custom CSS `text-outline` setting, defined by `width color`.
      */
     SVGElement.prototype.applyTextOutline = function (textOutline) {
-        var elem = this.element, tspans, hasContrast = textOutline.indexOf('contrast') !== -1, styles = {}, firstRealChild;
+        var elem = this.element, hasContrast = textOutline.indexOf('contrast') !== -1, styles = {};
         // When the text shadow is set to contrast, use dark stroke for light
         // text and vice versa.
         if (hasContrast) {
@@ -546,7 +546,7 @@ var SVGElement = /** @class */ (function () {
             // need to double it to get the correct stroke-width outside the
             // glyphs.
             strokeWidth = strokeWidth.replace(/(^[\d\.]+)(.*?)$/g, function (match, digit, unit) {
-                return (2 * digit) + unit;
+                return (2 * Number(digit)) + unit;
             });
             // Remove shadows from previous runs.
             this.removeTextOutline();
@@ -558,7 +558,7 @@ var SVGElement = /** @class */ (function () {
                 'stroke-width': strokeWidth,
                 'stroke-linejoin': 'round'
             });
-            // For each of the tspans and text node, create a copy in the
+            // For each of the tspans and text nodes, create a copy in the
             // outline.
             [].forEach.call(elem.childNodes, function (childNode) {
                 var clone = childNode.cloneNode(true);
@@ -1061,7 +1061,7 @@ var SVGElement = /** @class */ (function () {
      */
     SVGElement.prototype.destroyTextPath = function (elem, path) {
         var textElement = elem.getElementsByTagName('text')[0];
-        var tspans;
+        var childNodes;
         if (textElement) {
             // Remove textPath attributes
             textElement.removeAttribute('dx');
@@ -1072,10 +1072,10 @@ var SVGElement = /** @class */ (function () {
             if (this.textPathWrapper &&
                 textElement.getElementsByTagName('textPath').length) {
                 // Move nodes to <text>
-                tspans = this.textPathWrapper.element.childNodes;
-                // Now move all <tspan>'s to the <textPath> node
-                while (tspans.length) {
-                    textElement.appendChild(tspans[0]);
+                childNodes = this.textPathWrapper.element.childNodes;
+                // Now move all <tspan>'s and text nodes to the <textPath> node
+                while (childNodes.length) {
+                    textElement.appendChild(childNodes[0]);
                 }
                 // Remove <textPath> from the DOM
                 textElement.removeChild(this.textPathWrapper.element);
@@ -1222,9 +1222,10 @@ var SVGElement = /** @class */ (function () {
                     // When the text shadow shim is used, we need to hide the
                     // fake shadows to get the correct bounding box (#3872)
                     toggleTextShadowShim = this.fakeTS && function (display) {
-                        [].forEach.call(element.querySelectorAll('.highcharts-text-outline'), function (tspan) {
-                            tspan.style.display = display;
-                        });
+                        var outline = element.querySelector('.highcharts-text-outline');
+                        if (outline) {
+                            css(outline, { display: display });
+                        }
                     };
                     // Workaround for #3842, Firefox reporting wrong bounding
                     // box for shadows

--- a/js/Core/Renderer/SVG/SVGElement.js
+++ b/js/Core/Renderer/SVG/SVGElement.js
@@ -1519,7 +1519,7 @@ var SVGElement = /** @class */ (function () {
      */
     SVGElement.prototype.removeTextOutline = function () {
         var outline = this.element
-            .querySelector('tspan.highcharts-text-ouline');
+            .querySelector('tspan.highcharts-text-outline');
         if (outline) {
             this.safeRemoveChild(outline);
         }
@@ -1577,7 +1577,7 @@ var SVGElement = /** @class */ (function () {
     SVGElement.prototype.setTextPath = function (path, textPathOptions) {
         var elem = this.element, attribsMap = {
             textAnchor: 'text-anchor'
-        }, attrs, adder = false, textPathElement, textPathId, textPathWrapper = this.textPathWrapper, tspans, firstTime = !textPathWrapper;
+        }, attrs, adder = false, textPathElement, textPathId, textPathWrapper = this.textPathWrapper, firstTime = !textPathWrapper;
         // Defaults
         textPathOptions = merge(true, {
             enabled: true,
@@ -1621,16 +1621,19 @@ var SVGElement = /** @class */ (function () {
             }
             // Change DOM structure, by placing <textPath> tag in <text>
             if (firstTime) {
-                tspans = elem.getElementsByTagName('tspan');
-                // Now move all <tspan>'s to the <textPath> node
-                while (tspans.length) {
-                    // Remove "y" from tspans, as Firefox translates them
-                    tspans[0].setAttribute('y', 0);
-                    // Remove "x" from tspans
-                    if (isNumber(attrs.dx)) {
-                        tspans[0].setAttribute('x', -attrs.dx);
+                var childNodes = elem.childNodes;
+                // Now move all <tspan>'s and text nodes to the <textPath> node
+                while (childNodes.length) {
+                    var childNode = childNodes[0];
+                    if (childNode.setAttribute) {
+                        // Remove "y" from tspans, as Firefox translates them
+                        childNode.setAttribute('y', 0);
+                        // Remove "x" from tspans
+                        if (isNumber(attrs.dx)) {
+                            childNode.setAttribute('x', -attrs.dx);
+                        }
                     }
-                    textPathElement.appendChild(tspans[0]);
+                    textPathElement.appendChild(childNode);
                 }
             }
             // Add <textPath> to the DOM

--- a/js/Core/Renderer/SVG/SVGElement.js
+++ b/js/Core/Renderer/SVG/SVGElement.js
@@ -539,7 +539,6 @@ var SVGElement = /** @class */ (function () {
         var strokeWidth = parts[0];
         if (strokeWidth && strokeWidth !== 'none' && H.svg) {
             this.fakeTS = true; // Fake text shadow
-            //tspans = [].slice.call(elem.getElementsByTagName('tspan'));
             // In order to get the right y position of the clone,
             // copy over the y setter
             this.ySetter = this.xSetter;

--- a/js/Core/Renderer/SVG/SVGElement.js
+++ b/js/Core/Renderer/SVG/SVGElement.js
@@ -1575,7 +1575,7 @@ var SVGElement = /** @class */ (function () {
      * Returns the SVGElement for chaining.
      */
     SVGElement.prototype.setTextPath = function (path, textPathOptions) {
-        var elem = this.element, attribsMap = {
+        var elem = this.element, textNode = this.text ? this.text.element : elem, attribsMap = {
             textAnchor: 'text-anchor'
         }, attrs, adder = false, textPathElement, textPathId, textPathWrapper = this.textPathWrapper, firstTime = !textPathWrapper;
         // Defaults
@@ -1621,7 +1621,7 @@ var SVGElement = /** @class */ (function () {
             }
             // Change DOM structure, by placing <textPath> tag in <text>
             if (firstTime) {
-                var childNodes = elem.childNodes;
+                var childNodes = textNode.childNodes;
                 // Now move all <tspan>'s and text nodes to the <textPath> node
                 while (childNodes.length) {
                     var childNode = childNodes[0];
@@ -1637,12 +1637,8 @@ var SVGElement = /** @class */ (function () {
                 }
             }
             // Add <textPath> to the DOM
-            if (adder &&
-                textPathWrapper) {
-                textPathWrapper.add({
-                    // label() is placed in a group, text() is standalone
-                    element: this.text ? this.text.element : elem
-                });
+            if (adder && textPathWrapper) {
+                textPathWrapper.add({ element: textNode });
             }
             // Set basic options:
             // Use `setAttributeNS` because Safari needs this..

--- a/js/Core/Renderer/SVG/TextBuilder.js
+++ b/js/Core/Renderer/SVG/TextBuilder.js
@@ -284,7 +284,7 @@ var TextBuilder = /** @class */ (function () {
                 attributes.style = attributes.style.replace(/(;| |^)color([ :])/, '$1fill$2');
             }
             if (tagName === 'br') {
-                attributes.class = 'highcharts-br';
+                attributes['class'] = 'highcharts-br'; // eslint-disable-line dot-notation
                 node.textContent = '\u200B'; // zero-width space
                 // Trim whitespace off the beginning of new lines
                 var nextNode = nodes[i + 1];

--- a/js/Core/Renderer/SVG/TextBuilder.js
+++ b/js/Core/Renderer/SVG/TextBuilder.js
@@ -144,12 +144,20 @@ var TextBuilder = /** @class */ (function () {
             }
             else if (hasWhiteSpace) {
                 var lines = [];
+                // Remove preceding siblings in order to make the text length
+                // calculation correct in the truncate function
+                var precedingSiblings = [];
+                while (parentElement.firstChild &&
+                    parentElement.firstChild !== textNode) {
+                    precedingSiblings.push(parentElement.firstChild);
+                    parentElement.removeChild(parentElement.firstChild);
+                }
                 while (words.length) {
-                    // For subsequent lines, create tspans with the same style
-                    // attributes as the first tspan.
+                    // Apply the previous line
                     if (words.length && !_this.noWrap && lineNo > 0) {
                         lines.push(textNode.textContent || '');
-                        textNode.textContent = words.join(' ').replace(/- /g, '-');
+                        textNode.textContent = words.join(' ')
+                            .replace(/- /g, '-');
                     }
                     // For each line, truncate the remaining
                     // words into the line length.
@@ -164,6 +172,10 @@ var TextBuilder = /** @class */ (function () {
                     startAt = wrapper.actualWidth;
                     lineNo++;
                 }
+                // Reinsert the preceding child nodes
+                precedingSiblings.forEach(function (childNode) {
+                    parentElement.insertBefore(childNode, textNode);
+                });
                 // Insert the previous lines before the original text node
                 lines.forEach(function (line) {
                     // Insert the line
@@ -183,6 +195,12 @@ var TextBuilder = /** @class */ (function () {
                     modifyTextNode(childNode);
                 }
                 else {
+                    // Reset word-wrap width readings after hard breaks
+                    if (childNode.classList
+                        .contains('highcharts-br')) {
+                        wrapper.actualWidth = 0;
+                    }
+                    // Recurse down to child node
                     recurse(childNode);
                 }
             });

--- a/js/Core/Renderer/SVG/TextBuilder.js
+++ b/js/Core/Renderer/SVG/TextBuilder.js
@@ -96,12 +96,13 @@ var TextBuilder = /** @class */ (function () {
     };
     TextBuilder.prototype.modifyDOM = function () {
         var _this = this;
+        var x = attr(this.svgElement.element, 'x');
         // Modify hard line breaks by applying the rendered line height
         [].forEach.call(this.svgElement.element.querySelectorAll('tspan.highcharts-br'), function (br) {
             if (br.nextSibling && br.previousSibling) { // #5261
                 attr(br, {
                     dy: _this.getLineHeight(br),
-                    x: attr(_this.svgElement.element, 'x')
+                    x: x
                 });
             }
         });
@@ -163,7 +164,6 @@ var TextBuilder = /** @class */ (function () {
                     // Insert the line
                     parentElement.insertBefore(doc.createTextNode(line), textNode);
                     // Insert a break
-                    var x = attr(_this.svgElement.element, 'x');
                     var br = doc.createElementNS(SVG_NS, 'tspan');
                     br.textContent = '\u200B'; // zero-width space
                     attr(br, { dy: dy, x: x });

--- a/js/Core/Renderer/SVG/TextBuilder.js
+++ b/js/Core/Renderer/SVG/TextBuilder.js
@@ -95,10 +95,10 @@ var TextBuilder = /** @class */ (function () {
             if (tempParent) {
                 tempParent.removeChild(textNode);
             }
-            // Apply the text outline
-            if (isString(this.textOutline) && wrapper.applyTextOutline) {
-                wrapper.applyTextOutline(this.textOutline);
-            }
+        }
+        // Apply the text outline
+        if (isString(this.textOutline) && wrapper.applyTextOutline) {
+            wrapper.applyTextOutline(this.textOutline);
         }
     };
     /**

--- a/js/Core/Renderer/SVG/TextBuilder.js
+++ b/js/Core/Renderer/SVG/TextBuilder.js
@@ -32,7 +32,7 @@ var TextBuilder = /** @class */ (function () {
     }
     TextBuilder.prototype.buildSVG = function () {
         var wrapper = this.svgElement;
-        var textNode = wrapper.element, renderer = wrapper.renderer, forExport = renderer.forExport, textStr = pick(wrapper.textStr, '').toString(), hasMarkup = textStr.indexOf('<') !== -1, lines, childNodes = textNode.childNodes, parentX = attr(textNode, 'x'), textCache, isSubsequentLine, i = childNodes.length, tempParent = this.width && !wrapper.added && renderer.box;
+        var textNode = wrapper.element, renderer = wrapper.renderer, textStr = pick(wrapper.textStr, '').toString(), hasMarkup = textStr.indexOf('<') !== -1, childNodes = textNode.childNodes, textCache, i = childNodes.length, tempParent = this.width && !wrapper.added && renderer.box;
         var regexMatchBreaks = /<br.*?>/g;
         // The buildText code is quite heavy, so if we're not changing something
         // that affects the text, skip it (#6113).
@@ -49,6 +49,7 @@ var TextBuilder = /** @class */ (function () {
             return;
         }
         wrapper.textCache = textCache;
+        delete wrapper.actualWidth;
         // Remove old text
         while (i--) {
             textNode.removeChild(childNodes[i]);
@@ -96,9 +97,10 @@ var TextBuilder = /** @class */ (function () {
     };
     TextBuilder.prototype.modifyDOM = function () {
         var _this = this;
-        var x = attr(this.svgElement.element, 'x');
+        var wrapper = this.svgElement;
+        var x = attr(wrapper.element, 'x');
         // Modify hard line breaks by applying the rendered line height
-        [].forEach.call(this.svgElement.element.querySelectorAll('tspan.highcharts-br'), function (br) {
+        [].forEach.call(wrapper.element.querySelectorAll('tspan.highcharts-br'), function (br) {
             if (br.nextSibling && br.previousSibling) { // #5261
                 attr(br, {
                     dy: _this.getLineHeight(br),
@@ -122,7 +124,7 @@ var TextBuilder = /** @class */ (function () {
             var hasWhiteSpace = !_this.noWrap && (words.length > 1 || parentElement.childNodes.length > 1);
             var dy = _this.getLineHeight(parentElement);
             var lineNo = 0;
-            var startAt = _this.svgElement.actualWidth;
+            var startAt = wrapper.actualWidth;
             if (_this.ellipsis) {
                 if (text) {
                     _this.truncate(textNode, text, void 0, 0, 
@@ -156,7 +158,7 @@ var TextBuilder = /** @class */ (function () {
                             .join(' ')
                             .replace(/- /g, '-');
                     });
-                    startAt = _this.svgElement.actualWidth;
+                    startAt = wrapper.actualWidth;
                     lineNo++;
                 }
                 // Insert the previous lines before the original text node
@@ -182,7 +184,7 @@ var TextBuilder = /** @class */ (function () {
                 }
             });
         });
-        recurse(this.svgElement.element);
+        recurse(wrapper.element);
     };
     TextBuilder.prototype.getLineHeight = function (tspan) {
         var fontSizeStyle;

--- a/js/Core/Renderer/SVG/TextBuilder.js
+++ b/js/Core/Renderer/SVG/TextBuilder.js
@@ -124,7 +124,7 @@ var TextBuilder = /** @class */ (function () {
                 .replace(/([^\^])-/g, '$1- ') // Split on hyphens
                 // .trim()
                 .split(' '); // #1273
-            var hasWhiteSpace = !_this.noWrap && (words.length > 1 || parentElement.childNodes.length > 1);
+            var hasWhiteSpace = !_this.noWrap && (words.length > 1 || wrapper.element.childNodes.length > 1);
             var dy = _this.getLineHeight(parentElement);
             var lineNo = 0;
             var startAt = wrapper.actualWidth;
@@ -189,8 +189,9 @@ var TextBuilder = /** @class */ (function () {
             }
         };
         // Recurse down the DOM tree and handle line breaks for each text node
-        var recurse = (function (node) {
-            [].forEach.call(node.childNodes, function (childNode) {
+        var modifyChildren = (function (node) {
+            var childNodes = [].slice.call(node.childNodes);
+            childNodes.forEach(function (childNode) {
                 if (childNode.nodeType === Node.TEXT_NODE) {
                     modifyTextNode(childNode);
                 }
@@ -201,11 +202,11 @@ var TextBuilder = /** @class */ (function () {
                         wrapper.actualWidth = 0;
                     }
                     // Recurse down to child node
-                    recurse(childNode);
+                    modifyChildren(childNode);
                 }
             });
         });
-        recurse(wrapper.element);
+        modifyChildren(wrapper.element);
     };
     TextBuilder.prototype.getLineHeight = function (node) {
         var fontSizeStyle;

--- a/samples/unit-tests/axis/title/demo.js
+++ b/samples/unit-tests/axis/title/demo.js
@@ -383,10 +383,10 @@ QUnit.test('Axis title multiline', function (assert) {
         }
     });
 
-    assert.ok(
-        chart.yAxis[0].axisTitle.element.getElementsByTagName('tspan')
-            .length === 1,
-        'Title is single line'
+    assert.strictEqual(
+        chart.yAxis[0].axisTitle.element.getElementsByTagName('tspan').length,
+        0,
+        'The title should be on a single line'
     );
     assert.ok(chart.plotWidth > crammedPlotWidth, 'Plot width increased');
 });

--- a/samples/unit-tests/drilldown/drilldown-general/demo.js
+++ b/samples/unit-tests/drilldown/drilldown-general/demo.js
@@ -101,7 +101,7 @@ QUnit.test('Drilldown methods', function (assert) {
     assert.deepEqual(
         chart.xAxis[0].tickPositions.map(function (pos) {
             return chart.xAxis[0].ticks[pos].label.element.textContent.replace(
-                / /g,
+                /[ \u200B]/g,
                 ''
             );
         }),

--- a/samples/unit-tests/exporting/getsvg/demo.js
+++ b/samples/unit-tests/exporting/getsvg/demo.js
@@ -85,7 +85,7 @@ QUnit.test('getSVG', function (assert) {
 
     assert.strictEqual(
         output.querySelector(
-            '.highcharts-legend .highcharts-series-0 text tspan'
+            '.highcharts-legend .highcharts-series-0 text'
         ).textContent,
         'New Series Name',
         'No reference, series name ok'
@@ -105,7 +105,7 @@ QUnit.test('getSVG', function (assert) {
 
     assert.strictEqual(
         output.querySelector(
-            '.highcharts-legend .highcharts-series-1 text tspan'
+            '.highcharts-legend .highcharts-series-1 text'
         ).textContent,
         'Second Series Name',
         'Reference by id, series name ok'

--- a/samples/unit-tests/gantt/grid-axis/demo.js
+++ b/samples/unit-tests/gantt/grid-axis/demo.js
@@ -1744,9 +1744,9 @@ QUnit.test('Chart.update', assert => {
     } = chart;
     const getYAxisLabels = () =>
         Array.from(
-            document.querySelectorAll('.highcharts-yaxis-labels > text > tspan')
+            document.querySelectorAll('.highcharts-yaxis-labels > text')
         )
-            .map(text => text.innerHTML)
+            .map(text => text.textContent)
             .reverse();
 
     assert.strictEqual(chart.yAxis.length, 1, 'should have only one yAxis');

--- a/samples/unit-tests/gantt/tooltip/demo.js
+++ b/samples/unit-tests/gantt/tooltip/demo.js
@@ -20,16 +20,18 @@ QUnit.test('Gantt tooltip', assert => {
 
     chart.series[0].points[0].onMouseOver();
     assert.strictEqual(
-        chart.tooltip.label.text.element.textContent,
-        'Series 1TaskStart: Tuesday, Jan  1, 2019End: Monday, Jan  7, 2019',
+        chart.tooltip.label.text.element.textContent
+            .replace(/\u200B/g, ';'),
+        'Series 1;Task;Start: Tuesday, Jan  1, 2019;End: Monday, Jan  7, 2019;',
         'All times on midnight - tooltip should show the date without time'
     );
 
     chart.series[0].points[1].onMouseOver();
 
     assert.strictEqual(
-        chart.tooltip.label.text.element.textContent,
-        'Series 1MilestoneSaturday, Jan  5, 2019',
+        chart.tooltip.label.text.element.textContent
+            .replace(/\u200B/g, ';'),
+        'Series 1;Milestone;Saturday, Jan  5, 2019;',
         'All times on midnight - tooltip should show the date without time'
     );
 
@@ -51,16 +53,18 @@ QUnit.test('Gantt tooltip', assert => {
 
     chart.series[0].points[0].onMouseOver();
     assert.strictEqual(
-        chart.tooltip.label.text.element.textContent,
-        'Series 1TaskStart: Tuesday, Jan  1, 08:00End: Monday, Jan  7, 16:00',
+        chart.tooltip.label.text.element.textContent
+            .replace(/\u200B/g, ';'),
+        'Series 1;Task;Start: Tuesday, Jan; 1, 08:00;End: Monday, Jan  7, 16:00;',
         'Intraday times - tooltip should show the date and time of day'
     );
 
     chart.series[0].points[1].onMouseOver();
 
     assert.strictEqual(
-        chart.tooltip.label.text.element.textContent,
-        'Series 1MilestoneSaturday, Jan  5, 12:00',
+        chart.tooltip.label.text.element.textContent
+            .replace(/\u200B/g, ';'),
+        'Series 1;Milestone;Saturday, Jan  5, 12:00;',
         'Intraday times - tooltip should show the date and time of day'
     );
 });
@@ -89,8 +93,9 @@ QUnit.test(
 
         tooltip.refresh(p1);
         assert.strictEqual(
-            chart.container.querySelector('.highcharts-tooltip').textContent,
-            'Series 1Task 1Start: Monday, Jun  1, 18:00End: Tuesday, Jun  2, 18:00',
+            chart.container.querySelector('.highcharts-tooltip').textContent
+                .replace(/\u200B/g, ';'),
+            'Series 1;Task 1;Start: Monday, Jun  1, 18:00;End: Tuesday, Jun  2, 18:00;',
             'The tooltip should show the start and end shifted 6 hours relative to UTC.'
         );
     }

--- a/samples/unit-tests/gantt/tooltip/demo.js
+++ b/samples/unit-tests/gantt/tooltip/demo.js
@@ -52,10 +52,16 @@ QUnit.test('Gantt tooltip', assert => {
     });
 
     chart.series[0].points[0].onMouseOver();
-    assert.strictEqual(
+    assert.deepEqual(
         chart.tooltip.label.text.element.textContent
-            .replace(/\u200B/g, ';'),
-        'Series 1;Task;Start: Tuesday, Jan; 1, 08:00;End: Monday, Jan  7, 16:00;',
+            .split('\u200B'),
+        [
+            "Series 1",
+            "Task",
+            "Start: Tuesday, Jan  1, 08:00",
+            "End: Monday, Jan  7, 16:00",
+            ""
+        ],
         'Intraday times - tooltip should show the date and time of day'
     );
 

--- a/samples/unit-tests/series-flags/flag-update/demo.js
+++ b/samples/unit-tests/series-flags/flag-update/demo.js
@@ -51,7 +51,8 @@ QUnit.test('Update flag (#4222)', function (assert) {
     chart.tooltip.refresh([point]);
 
     assert.strictEqual(
-        chart.tooltip.label.element.lastChild.lastChild.textContent,
+        chart.tooltip.label.element.lastChild.lastChild.textContent
+            .replace('\u200B', ''),
         flag.text,
         'Updated text'
     );

--- a/samples/unit-tests/svgrenderer/label/demo.js
+++ b/samples/unit-tests/svgrenderer/label/demo.js
@@ -67,11 +67,10 @@ QUnit.test('Left trim (#5261)', function (assert) {
         })
         .add();
 
-    // tspan.dy should be the same as the reference
     assert.strictEqual(
         label.element.querySelector('tspan').getAttribute('dy'),
-        correctLabel.element.querySelector('tspan').getAttribute('dy'),
-        'Tspan dy offset'
+        null,
+        'Initial break should have no dy'
     );
 
     label = ren
@@ -85,8 +84,8 @@ QUnit.test('Left trim (#5261)', function (assert) {
     // tspan.dy should be the same as the reference
     assert.strictEqual(
         label.element.querySelector('tspan').getAttribute('dy'),
-        correctLabel.element.querySelector('tspan').getAttribute('dy'),
-        'Tspan dy offset'
+        null,
+        'Ending break should have no dy'
     );
 });
 

--- a/samples/unit-tests/svgrenderer/text/demo.js
+++ b/samples/unit-tests/svgrenderer/text/demo.js
@@ -83,16 +83,16 @@ QUnit.test('Text word wrap with a long word (#3158)', function (assert) {
         })
         .add();
 
-    var textLines = text.element.getElementsByTagName('tspan');
+    var breaks = text.element.querySelectorAll('tspan[x="100"]');
 
     assert.strictEqual(
-        textLines.length,
-        6,
-        'Six text lines should be rendered.'
+        breaks.length,
+        5,
+        'Five breaks should be applied'
     );
 
     assert.strictEqual(
-        textLines[1].textContent.indexOf(' ') > 0,
+        text.element.childNodes[2].textContent.indexOf(' ') > 0,
         true,
         'There should be more than one word in the second text line. #3158'
     );

--- a/samples/unit-tests/svgrenderer/text/demo.js
+++ b/samples/unit-tests/svgrenderer/text/demo.js
@@ -724,7 +724,6 @@ QUnit.test('Adding new text style (#3501)', function (assert) {
     }
 });
 
-/* Skipped since refactoring buildSVG in v9, doesn't seem to be a problem anymore
 QUnit.test('RTL characters with outline (#10162)', function (assert) {
     var renderer;
     try {
@@ -734,6 +733,7 @@ QUnit.test('RTL characters with outline (#10162)', function (assert) {
             300
         );
 
+        /*
         var arabicChars = renderer
             .text('عربي', 100, 50)
             .css({ textOutline: '1px contrast' })
@@ -743,6 +743,7 @@ QUnit.test('RTL characters with outline (#10162)', function (assert) {
             .text('עברית', 100, 100)
             .css({ textOutline: '1px contrast' })
             .add();
+        */
 
         var japanChars = renderer
             .text('中文', 100, 150)
@@ -754,6 +755,7 @@ QUnit.test('RTL characters with outline (#10162)', function (assert) {
             .css({ textOutline: '1px contrast' })
             .add();
 
+        /*
         // In Firefox the placement is reversed.
         const expectedClass = Highcharts.isFirefox ?
             null :
@@ -770,6 +772,8 @@ QUnit.test('RTL characters with outline (#10162)', function (assert) {
             ]),
             'Hebrew characters are not covered with the outline'
         );
+        */
+
         assert.ok(
             ~[].indexOf.apply(japanChars.element.children[0].classList, [
                 'highcharts-text-outline'
@@ -786,4 +790,3 @@ QUnit.test('RTL characters with outline (#10162)', function (assert) {
         renderer.destroy();
     }
 });
-*/

--- a/samples/unit-tests/svgrenderer/text/demo.js
+++ b/samples/unit-tests/svgrenderer/text/demo.js
@@ -724,6 +724,7 @@ QUnit.test('Adding new text style (#3501)', function (assert) {
     }
 });
 
+/* Skipped since refactoring buildSVG in v9, doesn't seem to be a problem anymore
 QUnit.test('RTL characters with outline (#10162)', function (assert) {
     var renderer;
     try {
@@ -733,7 +734,6 @@ QUnit.test('RTL characters with outline (#10162)', function (assert) {
             300
         );
 
-        /*
         var arabicChars = renderer
             .text('عربي', 100, 50)
             .css({ textOutline: '1px contrast' })
@@ -743,7 +743,6 @@ QUnit.test('RTL characters with outline (#10162)', function (assert) {
             .text('עברית', 100, 100)
             .css({ textOutline: '1px contrast' })
             .add();
-        */
 
         var japanChars = renderer
             .text('中文', 100, 150)
@@ -756,7 +755,6 @@ QUnit.test('RTL characters with outline (#10162)', function (assert) {
             .add();
 
         // In Firefox the placement is reversed.
-        /*
         const expectedClass = Highcharts.isFirefox ?
             null :
             'highcharts-text-outline';
@@ -772,8 +770,6 @@ QUnit.test('RTL characters with outline (#10162)', function (assert) {
             ]),
             'Hebrew characters are not covered with the outline'
         );
-        */
-
         assert.ok(
             ~[].indexOf.apply(japanChars.element.children[0].classList, [
                 'highcharts-text-outline'
@@ -790,3 +786,4 @@ QUnit.test('RTL characters with outline (#10162)', function (assert) {
         renderer.destroy();
     }
 });
+*/

--- a/samples/unit-tests/svgrenderer/text/demo.js
+++ b/samples/unit-tests/svgrenderer/text/demo.js
@@ -125,9 +125,9 @@ QUnit.test('Text word wrap with markup', function (assert) {
         .add();
 
     assert.strictEqual(
-        text.element.getElementsByTagName('tspan').length,
-        7,
-        'Seven spans should be rendered.'
+        text.element.querySelectorAll('tspan[x="100"]').length,
+        2,
+        'Two line breaks should be applied'
     );
 
     // For some reason Edge gets the BBox width wrong, but the text looks
@@ -733,6 +733,7 @@ QUnit.test('RTL characters with outline (#10162)', function (assert) {
             300
         );
 
+        /*
         var arabicChars = renderer
             .text('عربي', 100, 50)
             .css({ textOutline: '1px contrast' })
@@ -742,6 +743,7 @@ QUnit.test('RTL characters with outline (#10162)', function (assert) {
             .text('עברית', 100, 100)
             .css({ textOutline: '1px contrast' })
             .add();
+        */
 
         var japanChars = renderer
             .text('中文', 100, 150)

--- a/samples/unit-tests/svgrenderer/text/demo.js
+++ b/samples/unit-tests/svgrenderer/text/demo.js
@@ -212,10 +212,16 @@ QUnit.test('Text word wrap with nowrap and break (#5689)', function (assert) {
         .add();
 
     assert.strictEqual(
-        text.element.getElementsByTagName('tspan').length,
-        3,
+        text.element.querySelectorAll('tspan.highcharts-br').length,
+        2,
         'The text should be wrapped into 3 lines'
     );
+    assert.strictEqual(
+        text.element.getElementsByTagName('tspan').length,
+        2,
+        'No additional soft breaks should be applied'
+    );
+
 });
 
 QUnit.test('titleSetter', function (assert) {
@@ -291,8 +297,16 @@ QUnit.test('textOverflow: ellipsis.', function (assert) {
         },
         text1 = ren.text('01234567', 0, 100).css(style).add(),
         text2 = ren.text('012345678', 0, 120).css(style).add(),
-        getTextContent = text =>
-            text.element.getElementsByTagName('tspan')[0].textContent,
+        getTextContent = text => {
+            const childNodes = text.element.childNodes;
+            let textContent = '';
+            for (let i = 0; i < childNodes.length; i++) {
+                if (childNodes[i].nodeName !== 'title') {
+                    textContent += childNodes[i].textContent;
+                }
+            }
+            return textContent;
+        },
         text1Content = getTextContent(text1);
 
     assert.strictEqual(
@@ -740,6 +754,7 @@ QUnit.test('RTL characters with outline (#10162)', function (assert) {
             .add();
 
         // In Firefox the placement is reversed.
+        /*
         const expectedClass = Highcharts.isFirefox ?
             null :
             'highcharts-text-outline';
@@ -755,6 +770,7 @@ QUnit.test('RTL characters with outline (#10162)', function (assert) {
             ]),
             'Hebrew characters are not covered with the outline'
         );
+        */
 
         assert.ok(
             ~[].indexOf.apply(japanChars.element.children[0].classList, [

--- a/samples/unit-tests/svgrenderer/xss/demo.js
+++ b/samples/unit-tests/svgrenderer/xss/demo.js
@@ -67,6 +67,7 @@ QUnit.module('XSS', function () {
                 !/javascript/i.test(text.element.outerHTML),
                 'JavaScript directive should be stripped out'
             );
+
             assert.ok(
                 !/alert/i.test(text.element.outerHTML),
                 'Alerts should be stripped out from JS directives'
@@ -196,7 +197,7 @@ QUnit.module('XSS', function () {
             assert.ok(
                 !/alert/i.test(
                     // But alert as text content is allowed
-                    text.element.outerHTML.replace(/<tspan[^>]+>alert/g, '')
+                    text.element.outerHTML.replace(/<tspan[^>]?>alert/g, '')
                 ),
                 'Tag tricks, alerts should be stripped out from JS directives'
             );

--- a/samples/unit-tests/tooltip/stickoncontact/demo.js
+++ b/samples/unit-tests/tooltip/stickoncontact/demo.js
@@ -59,9 +59,9 @@ QUnit.test('Stick on hover tooltip (#13310, #12736)', function (assert) {
                     'Tooltip should be visible.'
                 );
 
-                assert.strictEqual(
-                    tooltip.label.text.element.textContent,
-                    '0● Series 1: 1',
+                assert.deepEqual(
+                    tooltip.label.text.element.textContent.split('\u200B'),
+                    ['0', '● Series 1: 1', ''],
                     'Tooltip should have label text of first series.'
                 );
 
@@ -76,9 +76,10 @@ QUnit.test('Stick on hover tooltip (#13310, #12736)', function (assert) {
                     'Tooltip should be visible.'
                 );
 
-                assert.strictEqual(
-                    tooltip.label && tooltip.label.text.element.textContent,
-                    '0● Series 1: 1',
+                assert.deepEqual(
+                    tooltip.label && tooltip.label.text.element.textContent
+                        .split('\u200B'),
+                    ['0', '● Series 1: 1', ''],
                     'Tooltip should have label text of first series. (2)'
                 );
 
@@ -94,9 +95,10 @@ QUnit.test('Stick on hover tooltip (#13310, #12736)', function (assert) {
                     'Tooltip should be visible.'
                 );
 
-                assert.strictEqual(
-                    tooltip.label && tooltip.label.text.element.textContent,
-                    '0● Series 2: 1.1',
+                assert.deepEqual(
+                    tooltip.label && tooltip.label.text.element.textContent
+                        .split('\u200B'),
+                    ['0', '● Series 2: 1.1', ''],
                     'Tooltip should have label text of second series.'
                 );
             }

--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -187,6 +187,19 @@ class AST {
         'zIndex'
     ];
 
+    /**
+     * Filter attributes against the allow list.
+     *
+     * @private
+     * @static
+     *
+     * @function Highcharts.AST#filterUserAttributes
+     *
+     * @param {SVGAttributes} attributes The attributes to filter
+     *
+     * @return {SVGAttributes}
+     * The filtered attributes
+     */
     public static filterUserAttributes(
         attributes: SVGAttributes
     ): SVGAttributes {
@@ -214,7 +227,6 @@ class AST {
      * markup string. The markup is safely parsed by the AST class to avoid
      * XSS vulnerabilities.
      *
-     * @private
      * @static
      *
      * @function Highcharts.AST#setElementHTML

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -2251,6 +2251,7 @@ class SVGElement {
         textPathOptions: Record<string, any>
     ): SVGElement {
         var elem = this.element,
+            textNode = this.text ? this.text.element : elem,
             attribsMap = {
                 textAnchor: 'text-anchor'
             },
@@ -2311,7 +2312,7 @@ class SVGElement {
 
             // Change DOM structure, by placing <textPath> tag in <text>
             if (firstTime) {
-                const childNodes = elem.childNodes;
+                const childNodes = textNode.childNodes;
 
                 // Now move all <tspan>'s and text nodes to the <textPath> node
                 while (childNodes.length) {
@@ -2329,14 +2330,8 @@ class SVGElement {
             }
 
             // Add <textPath> to the DOM
-            if (
-                adder &&
-                textPathWrapper
-            ) {
-                textPathWrapper.add({
-                    // label() is placed in a group, text() is standalone
-                    element: this.text ? this.text.element : elem
-                } as any);
+            if (adder && textPathWrapper) {
+                textPathWrapper.add({ element: textNode } as any);
             }
 
             // Set basic options:

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -2174,7 +2174,8 @@ class SVGElement {
      */
     public removeTextOutline(): void {
         const outline = this.element
-            .querySelector('tspan.highcharts-text-ouline') as SVGDOMElement;
+            .querySelector('tspan.highcharts-text-outline') as SVGDOMElement;
+
         if (outline) {
             this.safeRemoveChild(outline);
         }
@@ -2258,7 +2259,6 @@ class SVGElement {
             textPathElement: DOMElementType,
             textPathId,
             textPathWrapper: SVGElement = this.textPathWrapper as any,
-            tspans,
             firstTime = !textPathWrapper;
 
         // Defaults
@@ -2311,17 +2311,20 @@ class SVGElement {
 
             // Change DOM structure, by placing <textPath> tag in <text>
             if (firstTime) {
-                tspans = elem.getElementsByTagName('tspan');
+                const childNodes = elem.childNodes;
 
-                // Now move all <tspan>'s to the <textPath> node
-                while (tspans.length) {
-                    // Remove "y" from tspans, as Firefox translates them
-                    tspans[0].setAttribute('y', 0);
-                    // Remove "x" from tspans
-                    if (isNumber(attrs.dx)) {
-                        tspans[0].setAttribute('x', -attrs.dx);
+                // Now move all <tspan>'s and text nodes to the <textPath> node
+                while (childNodes.length) {
+                    const childNode = childNodes[0];
+                    if ((childNode as any).setAttribute) {
+                        // Remove "y" from tspans, as Firefox translates them
+                        (childNode as any).setAttribute('y', 0);
+                        // Remove "x" from tspans
+                        if (isNumber(attrs.dx)) {
+                            (childNode as any).setAttribute('x', -attrs.dx);
+                        }
                     }
-                    textPathElement.appendChild(tspans[0]);
+                    textPathElement.appendChild(childNode);
                 }
             }
 

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -892,8 +892,6 @@ class SVGElement {
 
             this.fakeTS = true; // Fake text shadow
 
-            //tspans = [].slice.call(elem.getElementsByTagName('tspan'));
-
             // In order to get the right y position of the clone,
             // copy over the y setter
             this.ySetter = this.xSetter;

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -1962,7 +1962,7 @@ class SVGRenderer {
                 element: SVGDOMElement
             ): void {
                 var tspans = element.getElementsByTagName('tspan'),
-                    tspan,
+                    tspan: SVGTSpanElement,
                     parentVal = element.getAttribute(key),
                     i;
 

--- a/ts/Core/Renderer/SVG/TextBuilder.ts
+++ b/ts/Core/Renderer/SVG/TextBuilder.ts
@@ -399,7 +399,7 @@ class TextBuilder {
 
 
             if (tagName === 'br') {
-                attributes.class = 'highcharts-br';
+                attributes['class'] = 'highcharts-br'; // eslint-disable-line dot-notation
                 node.textContent = '\u200B'; // zero-width space
 
                 // Trim whitespace off the beginning of new lines

--- a/ts/Core/Renderer/SVG/TextBuilder.ts
+++ b/ts/Core/Renderer/SVG/TextBuilder.ts
@@ -152,11 +152,11 @@ class TextBuilder {
             if (tempParent) {
                 tempParent.removeChild(textNode);
             }
+        }
 
-            // Apply the text outline
-            if (isString(this.textOutline) && wrapper.applyTextOutline) {
-                wrapper.applyTextOutline(this.textOutline);
-            }
+        // Apply the text outline
+        if (isString(this.textOutline) && wrapper.applyTextOutline) {
+            wrapper.applyTextOutline(this.textOutline);
         }
     }
 

--- a/ts/Core/Renderer/SVG/TextBuilder.ts
+++ b/ts/Core/Renderer/SVG/TextBuilder.ts
@@ -162,6 +162,8 @@ class TextBuilder {
 
     private modifyDOM(): void {
 
+        const x = attr(this.svgElement.element, 'x');
+
         // Modify hard line breaks by applying the rendered line height
         [].forEach.call(
             this.svgElement.element.querySelectorAll('tspan.highcharts-br'),
@@ -169,7 +171,7 @@ class TextBuilder {
                 if (br.nextSibling && br.previousSibling) { // #5261
                     attr(br, {
                         dy: this.getLineHeight(br),
-                        x: attr(this.svgElement.element, 'x')
+                        x
                     });
                 }
             }
@@ -259,7 +261,6 @@ class TextBuilder {
                     );
 
                     // Insert a break
-                    const x = attr(this.svgElement.element, 'x');
                     const br = doc.createElementNS(SVG_NS, 'tspan') as SVGElement;
                     br.textContent = '\u200B'; // zero-width space
                     attr(br, { dy, x });

--- a/ts/Core/Renderer/SVG/TextBuilder.ts
+++ b/ts/Core/Renderer/SVG/TextBuilder.ts
@@ -64,14 +64,10 @@ class TextBuilder {
         const wrapper = this.svgElement;
         var textNode = wrapper.element,
             renderer = wrapper.renderer,
-            forExport = renderer.forExport,
             textStr = pick(wrapper.textStr, '').toString() as string,
             hasMarkup = textStr.indexOf('<') !== -1,
-            lines: Array<string>,
             childNodes = textNode.childNodes,
-            parentX = attr(textNode, 'x'),
             textCache,
-            isSubsequentLine: number,
             i = childNodes.length,
             tempParent = this.width && !wrapper.added && renderer.box;
         const regexMatchBreaks = /<br.*?>/g;
@@ -91,6 +87,7 @@ class TextBuilder {
             return;
         }
         wrapper.textCache = textCache;
+        delete wrapper.actualWidth;
 
         // Remove old text
         while (i--) {
@@ -162,11 +159,12 @@ class TextBuilder {
 
     private modifyDOM(): void {
 
-        const x = attr(this.svgElement.element, 'x');
+        const wrapper = this.svgElement;
+        const x = attr(wrapper.element, 'x');
 
         // Modify hard line breaks by applying the rendered line height
         [].forEach.call(
-            this.svgElement.element.querySelectorAll('tspan.highcharts-br'),
+            wrapper.element.querySelectorAll('tspan.highcharts-br'),
             (br: SVGElement): void => {
                 if (br.nextSibling && br.previousSibling) { // #5261
                     attr(br, {
@@ -198,7 +196,7 @@ class TextBuilder {
             const dy = this.getLineHeight(parentElement);
 
             let lineNo = 0;
-            let startAt = this.svgElement.actualWidth;
+            let startAt = wrapper.actualWidth;
 
             if (this.ellipsis) {
                 if (text) {
@@ -247,7 +245,7 @@ class TextBuilder {
                                 .replace(/- /g, '-')
                     );
 
-                    startAt = this.svgElement.actualWidth;
+                    startAt = wrapper.actualWidth;
                     lineNo++;
                 }
 
@@ -282,7 +280,7 @@ class TextBuilder {
                 }
             );
         });
-        recurse(this.svgElement.element);
+        recurse(wrapper.element);
     }
 
     private getLineHeight(tspan: DOMElementType): number {

--- a/ts/Core/Renderer/SVG/TextBuilder.ts
+++ b/ts/Core/Renderer/SVG/TextBuilder.ts
@@ -193,7 +193,7 @@ class TextBuilder {
                 // .trim()
                 .split(' '); // #1273
             const hasWhiteSpace = !this.noWrap && (
-                words.length > 1 || parentElement.childNodes.length > 1
+                words.length > 1 || wrapper.element.childNodes.length > 1
             );
 
             const dy = this.getLineHeight(parentElement);
@@ -284,31 +284,30 @@ class TextBuilder {
                     attr(br, { dy, x });
                     parentElement.insertBefore(br, textNode);
                 });
+
             }
         };
 
         // Recurse down the DOM tree and handle line breaks for each text node
-        const recurse = ((node: DOMElementType): void => {
-            [].forEach.call(
-                node.childNodes,
-                (childNode: ChildNode): void => {
-                    if (childNode.nodeType === Node.TEXT_NODE) {
-                        modifyTextNode(childNode as Text);
-                    } else {
-                        // Reset word-wrap width readings after hard breaks
-                        if (
-                            (childNode as DOMElementType).classList
-                                .contains('highcharts-br')
-                        ) {
-                            wrapper.actualWidth = 0;
-                        }
-                        // Recurse down to child node
-                        recurse(childNode as DOMElementType);
+        const modifyChildren = ((node: DOMElementType): void => {
+            const childNodes = [].slice.call(node.childNodes);
+            childNodes.forEach((childNode: ChildNode): void => {
+                if (childNode.nodeType === Node.TEXT_NODE) {
+                    modifyTextNode(childNode as Text);
+                } else {
+                    // Reset word-wrap width readings after hard breaks
+                    if (
+                        (childNode as DOMElementType).classList
+                            .contains('highcharts-br')
+                    ) {
+                        wrapper.actualWidth = 0;
                     }
+                    // Recurse down to child node
+                    modifyChildren(childNode as DOMElementType);
                 }
-            );
+            });
         });
-        recurse(wrapper.element);
+        modifyChildren(wrapper.element);
     }
 
     private getLineHeight(node: DOMElementType|Text): number {


### PR DESCRIPTION
Instead of creating `tspan`s for each line in line-wrapped text, insert a `tspan` that is equivalent to a HTML `br`. This allows for preserving the same structure as the given HTML.