### PR TITLE
tools/increase-comparison-time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,7 +244,7 @@ jobs:
       - run:
           name: Wait for file size comparison and comment on PR
           command: while [ ! -f ./tmp/filesizes/comparison.md ]; do sleep 1; done && npx gulp pr-comment-sizes --pr ${CIRCLE_PULL_REQUEST##*/} --user circleci-mu
-          no_output_timeout: 2m #wait for max 2 minutes
+          no_output_timeout: 5m #wait for max 2 minutes
 
   nightly_visual_diff:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,13 +217,11 @@ jobs:
       - generate_references_command:
           browsercount: 2
       - run: git checkout ${CIRCLE_BRANCH}  && git log --oneline -5 && npm i && npx gulp scripts
-      # Running these in the background to save a few minutes
       - run:
           name: File size comparison
           command: |
             npx gulp write-file-sizes --filename ${CIRCLE_PULL_REQUEST##*/}.json &&
             npx gulp compare-size-and-comment --master ./tmp/filesizes/master.json --proposed ./tmp/filesizes/${CIRCLE_PULL_REQUEST##*/}.json --pr ${CIRCLE_PULL_REQUEST##*/} --user circleci-mu
-          background: true
       # we are forcing success on the below test runs to avoid failing the PR build
       - run: npx karma start test/karma-conf.js --tests highcharts/*/* --single-run --browsercount 2 --visualcompare || true
       - run: npx karma start test/karma-conf.js --tests stock/*/* --single-run --browsercount 2 --visualcompare || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,9 @@ jobs:
       # Running these in the background to save a few minutes
       - run:
           name: File size comparison
-          command: (npx gulp write-file-sizes --filename ${CIRCLE_PULL_REQUEST##*/}.json && npx gulp write-size-table --master ./tmp/filesizes/master.json --proposed ./tmp/filesizes/${CIRCLE_PULL_REQUEST##*/}.json) || touch ./tmp/filesizes/comparsion.md
+          command: |
+            npx gulp write-file-sizes --filename ${CIRCLE_PULL_REQUEST##*/}.json &&
+            npx gulp compare-size-and-comment --master ./tmp/filesizes/master.json --proposed ./tmp/filesizes/${CIRCLE_PULL_REQUEST##*/}.json --pr ${CIRCLE_PULL_REQUEST##*/} --user circleci-mu
           background: true
       # we are forcing success on the below test runs to avoid failing the PR build
       - run: npx karma start test/karma-conf.js --tests highcharts/*/* --single-run --browsercount 2 --visualcompare || true
@@ -241,10 +243,6 @@ jobs:
           path: ../visual-test-results
       - store_artifacts:
           path: ../visual-test-results
-      - run:
-          name: Wait for file size comparison and comment on PR
-          command: while [ ! -f ./tmp/filesizes/comparison.md ]; do sleep 1; done && npx gulp pr-comment-sizes --pr ${CIRCLE_PULL_REQUEST##*/} --user circleci-mu
-          no_output_timeout: 5m #wait for max 2 minutes
 
   nightly_visual_diff:
     <<: *defaults

--- a/tools/gulptasks/pr-size-table.js
+++ b/tools/gulptasks/pr-size-table.js
@@ -91,16 +91,12 @@ async function writeFileSizes() {
  * @return {void}
  */
 async function writeTable() {
-    try {
-        const { master, proposed } = argv;
-        if (master && proposed) {
-            fs.writeFileSync('./tmp/filesizes/comparison.md', makeTable(master, proposed));
-        } else {
-            log.failure('Please provide all required arguments');
-        }
-    } catch (error) {
-        log.failure(error);
+    const { master, proposed } = argv;
+    if (master && proposed) {
+        // eslint-disable-next-line node/no-unsupported-features/node-builtins
+        return fs.promises.writeFile('./tmp/filesizes/comparison.md', makeTable(master, proposed));
     }
+    throw new Error('Please provide all required arguments');
 }
 
 /**
@@ -140,3 +136,4 @@ comment.flags = {
 gulp.task('write-size-table', writeTable);
 gulp.task('write-file-sizes', writeFileSizes);
 gulp.task('pr-comment-sizes', comment);
+gulp.task('compare-size-and-comment', gulp.series(writeTable, comment));


### PR DESCRIPTION
Fixed `visual_comparison_with_master` failing on the last step. It seems our visual tests are finishing faster, which caused the script that waited for the background job to time out. Removed the waiting step by combining the two gulp tasks.