### PR TITLE
bugfix/13473-scrollbar-threshold

### DIFF
--- a/js/Core/Axis/ScrollbarAxis.js
+++ b/js/Core/Axis/ScrollbarAxis.js
@@ -38,9 +38,9 @@ var ScrollbarAxis = /** @class */ (function () {
                 axisMin: axisMin,
                 axisMax: axisMax,
                 scrollMin: defined(axis.dataMin) ?
-                    Math.min(axisMin, axis.min, Math.min(pick(axis.threshold, Infinity), axis.dataMin)) : axisMin,
+                    Math.min(axisMin, axis.min, axis.dataMin, pick(axis.threshold, Infinity)) : axisMin,
                 scrollMax: defined(axis.dataMax) ?
-                    Math.max(axisMax, axis.max, Math.max(pick(axis.threshold, -Infinity), axis.dataMax)) : axisMax
+                    Math.max(axisMax, axis.max, axis.dataMax, pick(axis.threshold, -Infinity)) : axisMax
             };
         };
         // Wrap axis initialization and create scrollbar if enabled:

--- a/js/Core/Axis/ScrollbarAxis.js
+++ b/js/Core/Axis/ScrollbarAxis.js
@@ -43,8 +43,10 @@ var ScrollbarAxis = /** @class */ (function () {
                 axis.scrollbar = new ScrollbarClass(axis.chart.renderer, axis.options.scrollbar, axis.chart);
                 addEvent(axis.scrollbar, 'changed', function (e) {
                     var axisMin = pick(axis.options && axis.options.min, axis.min), axisMax = pick(axis.options && axis.options.max, axis.max), unitedMin = defined(axis.dataMin) ?
-                        Math.min(axisMin, axis.min, axis.dataMin) : axisMin, unitedMax = defined(axis.dataMax) ?
-                        Math.max(axisMax, axis.max, axis.dataMax) : axisMax, range = unitedMax - unitedMin, to, from;
+                        Math.min(axisMin, axis.min, axis.dataMin > axis.threshold ?
+                            axis.threshold : axis.dataMin) : axisMin, unitedMax = defined(axis.dataMax) ?
+                        Math.max(axisMax, axis.max, axis.dataMax < axis.threshold ?
+                            axis.threshold : axis.dataMax) : axisMax, range = unitedMax - unitedMin, to, from;
                     // #12834, scroll when show/hide series, wrong extremes
                     if (!defined(axisMin) || !defined(axisMax)) {
                         return;
@@ -78,8 +80,10 @@ var ScrollbarAxis = /** @class */ (function () {
         });
         // Wrap rendering axis, and update scrollbar if one is created:
         addEvent(AxisClass, 'afterRender', function () {
-            var axis = this, scrollMin = Math.min(pick(axis.options.min, axis.min), axis.min, pick(axis.dataMin, axis.min) // #6930
-            ), scrollMax = Math.max(pick(axis.options.max, axis.max), axis.max, pick(axis.dataMax, axis.max) // #6930
+            var axis = this, scrollMin = Math.min(pick(axis.options.min, axis.min), axis.min, pick(axis.dataMin > axis.threshold ?
+                axis.threshold : axis.dataMin, axis.min) // #6930
+            ), scrollMax = Math.max(pick(axis.options.max, axis.max), axis.max, pick(axis.dataMax < axis.threshold ?
+                axis.threshold : axis.dataMax, axis.max) // #6930
             ), scrollbar = axis.scrollbar, offset = axis.axisTitleMargin + (axis.titleOffset || 0), scrollbarsOffsets = axis.chart.scrollbarsOffsets, axisMargin = axis.options.margin || 0, offsetsIndex, from, to;
             if (scrollbar) {
                 if (axis.horiz) {

--- a/js/Core/Axis/ScrollbarAxis.js
+++ b/js/Core/Axis/ScrollbarAxis.js
@@ -31,6 +31,18 @@ var ScrollbarAxis = /** @class */ (function () {
      * Scrollbar class to use.
      */
     ScrollbarAxis.compose = function (AxisClass, ScrollbarClass) {
+        var getExtremes = function (axis) {
+            var axisMin = pick(axis.options && axis.options.min, axis.min);
+            var axisMax = pick(axis.options && axis.options.max, axis.max);
+            return {
+                axisMin: axisMin,
+                axisMax: axisMax,
+                scrollMin: defined(axis.dataMin) ?
+                    Math.min(axisMin, axis.min, Math.min(pick(axis.threshold, Infinity), axis.dataMin)) : axisMin,
+                scrollMax: defined(axis.dataMax) ?
+                    Math.max(axisMax, axis.max, Math.max(pick(axis.threshold, -Infinity), axis.dataMax)) : axisMax
+            };
+        };
         // Wrap axis initialization and create scrollbar if enabled:
         addEvent(AxisClass, 'afterInit', function () {
             var axis = this;
@@ -42,11 +54,7 @@ var ScrollbarAxis = /** @class */ (function () {
                 axis.options.startOnTick = axis.options.endOnTick = false;
                 axis.scrollbar = new ScrollbarClass(axis.chart.renderer, axis.options.scrollbar, axis.chart);
                 addEvent(axis.scrollbar, 'changed', function (e) {
-                    var axisMin = pick(axis.options && axis.options.min, axis.min), axisMax = pick(axis.options && axis.options.max, axis.max), unitedMin = defined(axis.dataMin) ?
-                        Math.min(axisMin, axis.min, axis.dataMin > axis.threshold ?
-                            axis.threshold : axis.dataMin) : axisMin, unitedMax = defined(axis.dataMax) ?
-                        Math.max(axisMax, axis.max, axis.dataMax < axis.threshold ?
-                            axis.threshold : axis.dataMax) : axisMax, range = unitedMax - unitedMin, to, from;
+                    var _a = getExtremes(axis), axisMin = _a.axisMin, axisMax = _a.axisMax, unitedMin = _a.scrollMin, unitedMax = _a.scrollMax, range = unitedMax - unitedMin, to, from;
                     // #12834, scroll when show/hide series, wrong extremes
                     if (!defined(axisMin) || !defined(axisMax)) {
                         return;
@@ -80,11 +88,7 @@ var ScrollbarAxis = /** @class */ (function () {
         });
         // Wrap rendering axis, and update scrollbar if one is created:
         addEvent(AxisClass, 'afterRender', function () {
-            var axis = this, scrollMin = Math.min(pick(axis.options.min, axis.min), axis.min, pick(axis.dataMin > axis.threshold ?
-                axis.threshold : axis.dataMin, axis.min) // #6930
-            ), scrollMax = Math.max(pick(axis.options.max, axis.max), axis.max, pick(axis.dataMax < axis.threshold ?
-                axis.threshold : axis.dataMax, axis.max) // #6930
-            ), scrollbar = axis.scrollbar, offset = axis.axisTitleMargin + (axis.titleOffset || 0), scrollbarsOffsets = axis.chart.scrollbarsOffsets, axisMargin = axis.options.margin || 0, offsetsIndex, from, to;
+            var axis = this, _a = getExtremes(axis), scrollMin = _a.scrollMin, scrollMax = _a.scrollMax, scrollbar = axis.scrollbar, offset = axis.axisTitleMargin + (axis.titleOffset || 0), scrollbarsOffsets = axis.chart.scrollbarsOffsets, axisMargin = axis.options.margin || 0, offsetsIndex, from, to;
             if (scrollbar) {
                 if (axis.horiz) {
                     // Reserve space for labels/title

--- a/samples/unit-tests/scrollbar/extremes/demo.js
+++ b/samples/unit-tests/scrollbar/extremes/demo.js
@@ -339,3 +339,34 @@ QUnit.test('Toggle chart.scrollbar', assert => {
         "xAxis's tick should equal min and max values (#13184)."
     );
 });
+
+QUnit.test('#13473: Threshold', assert => {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'column'
+        },
+        yAxis: {
+            max: 200,
+            scrollbar: {
+                enabled: true
+            }
+        },
+        series: [{
+            data: [100, 200, 500]
+        }]
+    });
+
+    const scrollbar = chart.yAxis[0].scrollbar;
+    scrollbar.buttonToMinClick({
+        trigger: 'scrollbar'
+    });
+    scrollbar.buttonToMaxClick({
+        trigger: 'scrollbar'
+    });
+
+    assert.strictEqual(
+        chart.yAxis[0].min,
+        0,
+        'It should be possible to scroll back down to the threshold after scrolling up'
+    );
+});

--- a/ts/Core/Axis/ScrollbarAxis.ts
+++ b/ts/Core/Axis/ScrollbarAxis.ts
@@ -67,13 +67,15 @@ class ScrollbarAxis {
                     Math.min(
                         axisMin,
                         axis.min as any,
-                        Math.min(pick(axis.threshold, Infinity), axis.dataMin)
+                        axis.dataMin,
+                        pick(axis.threshold, Infinity)
                     ) : axisMin,
                 scrollMax: defined(axis.dataMax) ?
                     Math.max(
                         axisMax,
                         axis.max as any,
-                        Math.max(pick(axis.threshold, -Infinity), axis.dataMax)
+                        axis.dataMax,
+                        pick(axis.threshold, -Infinity)
                     ) : axisMax
             };
         };

--- a/ts/Core/Axis/ScrollbarAxis.ts
+++ b/ts/Core/Axis/ScrollbarAxis.ts
@@ -51,6 +51,32 @@ class ScrollbarAxis {
      * Scrollbar class to use.
      */
     public static compose(AxisClass: typeof Axis, ScrollbarClass: typeof Scrollbar): void {
+        const getExtremes = (axis: ScrollbarAxis): Record<string, number> => {
+            const axisMin = pick(
+                axis.options && axis.options.min,
+                axis.min as any
+            );
+            const axisMax = pick(
+                axis.options && axis.options.max,
+                axis.max as any
+            );
+            return {
+                axisMin,
+                axisMax,
+                scrollMin: defined(axis.dataMin) ?
+                    Math.min(
+                        axisMin,
+                        axis.min as any,
+                        Math.min(pick(axis.threshold, Infinity), axis.dataMin)
+                    ) : axisMin,
+                scrollMax: defined(axis.dataMax) ?
+                    Math.max(
+                        axisMax,
+                        axis.max as any,
+                        Math.max(pick(axis.threshold, -Infinity), axis.dataMax)
+                    ) : axisMax
+            };
+        };
 
         // Wrap axis initialization and create scrollbar if enabled:
         addEvent(AxisClass, 'afterInit', function (): void {
@@ -75,28 +101,12 @@ class ScrollbarAxis {
                     this: Highcharts.Scrollbar,
                     e: Highcharts.ScrollbarChangedEventObject
                 ): void {
-                    var axisMin = pick(
-                            axis.options && axis.options.min,
-                            axis.min as any
-                        ),
-                        axisMax = pick(
-                            axis.options && axis.options.max,
-                            axis.max as any
-                        ),
-                        unitedMin = defined(axis.dataMin as any) ?
-                            Math.min(
-                                axisMin,
-                                axis.min as any,
-                                (axis.dataMin as any) > (axis.threshold as any) ?
-                                    axis.threshold : (axis.dataMin as any)
-                            ) : axisMin,
-                        unitedMax = defined(axis.dataMax as any) ?
-                            Math.max(
-                                axisMax,
-                                axis.max as any,
-                                (axis.dataMax as any) < (axis.threshold as any) ?
-                                    axis.threshold : (axis.dataMax as any)
-                            ) : axisMax,
+                    var {
+                            axisMin,
+                            axisMax,
+                            scrollMin: unitedMin,
+                            scrollMax: unitedMax
+                        } = getExtremes(axis),
                         range = unitedMax - unitedMin,
                         to,
                         from;
@@ -149,24 +159,10 @@ class ScrollbarAxis {
         // Wrap rendering axis, and update scrollbar if one is created:
         addEvent(AxisClass, 'afterRender', function (): void {
             var axis = this as ScrollbarAxis,
-                scrollMin = Math.min(
-                    pick(axis.options.min, axis.min as any),
-                    axis.min as any,
-                    pick(
-                        (axis.dataMin as any) > (axis.threshold as any) ?
-                            axis.threshold : axis.dataMin,
-                        axis.min as any
-                    ) // #6930
-                ),
-                scrollMax = Math.max(
-                    pick(axis.options.max, axis.max as any),
-                    axis.max as any,
-                    pick(
-                        (axis.dataMax as any) < (axis.threshold as any) ?
-                            axis.threshold : axis.dataMax,
-                        axis.max as any
-                    ) // #6930
-                ),
+                {
+                    scrollMin,
+                    scrollMax
+                } = getExtremes(axis),
                 scrollbar = axis.scrollbar,
                 offset = (axis.axisTitleMargin as any) + (axis.titleOffset || 0),
                 scrollbarsOffsets = axis.chart.scrollbarsOffsets,

--- a/ts/Core/Axis/ScrollbarAxis.ts
+++ b/ts/Core/Axis/ScrollbarAxis.ts
@@ -87,13 +87,15 @@ class ScrollbarAxis {
                             Math.min(
                                 axisMin,
                                 axis.min as any,
-                                axis.dataMin as any
+                                (axis.dataMin as any) > (axis.threshold as any) ?
+                                    axis.threshold : (axis.dataMin as any)
                             ) : axisMin,
                         unitedMax = defined(axis.dataMax as any) ?
                             Math.max(
                                 axisMax,
                                 axis.max as any,
-                                axis.dataMax as any
+                                (axis.dataMax as any) < (axis.threshold as any) ?
+                                    axis.threshold : (axis.dataMax as any)
                             ) : axisMax,
                         range = unitedMax - unitedMin,
                         to,
@@ -150,12 +152,20 @@ class ScrollbarAxis {
                 scrollMin = Math.min(
                     pick(axis.options.min, axis.min as any),
                     axis.min as any,
-                    pick(axis.dataMin, axis.min as any) // #6930
+                    pick(
+                        (axis.dataMin as any) > (axis.threshold as any) ?
+                            axis.threshold : axis.dataMin,
+                        axis.min as any
+                    ) // #6930
                 ),
                 scrollMax = Math.max(
                     pick(axis.options.max, axis.max as any),
                     axis.max as any,
-                    pick(axis.dataMax, axis.max as any) // #6930
+                    pick(
+                        (axis.dataMax as any) < (axis.threshold as any) ?
+                            axis.threshold : axis.dataMax,
+                        axis.max as any
+                    ) // #6930
                 ),
                 scrollbar = axis.scrollbar,
                 offset = (axis.axisTitleMargin as any) + (axis.titleOffset || 0),


### PR DESCRIPTION
Fixed #13473, it was not possible to scroll back down to the `threshold` after scrolling up with `yAxis.scrollbar` enabled and no explicit `yAxis.min` set.