### PR TITLE
bugfix/indicator-chaikin

### DIFF
--- a/js/Stock/Indicators/Chaikin/ChaikinIndicator.js
+++ b/js/Stock/Indicators/Chaikin/ChaikinIndicator.js
@@ -24,6 +24,8 @@ import SeriesRegistry from '../../../Core/Series/SeriesRegistry.js';
 var _a = SeriesRegistry.seriesTypes, AD = _a.ad, EMAIndicator = _a.ema;
 import U from '../../../Core/Utilities.js';
 var correctFloat = U.correctFloat, extend = U.extend, merge = U.merge, error = U.error;
+// @todo fix direct dependency quirk
+import '../AD/ADIndicator.js';
 /* *
  *
  *  Class

--- a/ts/Stock/Indicators/Chaikin/ChaikinIndicator.ts
+++ b/ts/Stock/Indicators/Chaikin/ChaikinIndicator.ts
@@ -32,6 +32,9 @@ const {
     error
 } = U;
 
+// @todo fix direct dependency quirk
+import '../AD/ADIndicator.js';
+
 /* *
  *
  *  Class


### PR DESCRIPTION
Chaikin indicator requires a direct import of AD indicator to work with all demos.