### PR TITLE
bugfix/13170-boost-scatter-cull-y

### DIFF
--- a/js/Extensions/Boost/WGLRenderer.js
+++ b/js/Extensions/Boost/WGLRenderer.js
@@ -464,10 +464,10 @@ function GLRenderer(postRenderCallback) {
                 beginSegment();
                 continue;
             }
-            if (nx && nx >= xMin && nx <= xMax) {
+            if (nx && nx >= xMin && nx <= xMax && series.type !== 'scatter') {
                 nextInside = true;
             }
-            if (px && px >= xMin && px <= xMax) {
+            if (px && px >= xMin && px <= xMax && series.type !== 'scatter') {
                 prevInside = true;
             }
             if (isRange) {

--- a/js/Extensions/Boost/WGLRenderer.js
+++ b/js/Extensions/Boost/WGLRenderer.js
@@ -464,10 +464,10 @@ function GLRenderer(postRenderCallback) {
                 beginSegment();
                 continue;
             }
-            if (nx && nx >= xMin && nx <= xMax && series.type !== 'scatter') {
+            if (nx && nx >= xMin && nx <= xMax && !series.is('scatter')) {
                 nextInside = true;
             }
-            if (px && px >= xMin && px <= xMax && series.type !== 'scatter') {
+            if (px && px >= xMin && px <= xMax && !series.is('scatter')) {
                 prevInside = true;
             }
             if (isRange) {

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -748,11 +748,11 @@ function GLRenderer(
                 continue;
             }
 
-            if (nx && nx >= xMin && nx <= xMax && series.type !== 'scatter') {
+            if (nx && nx >= xMin && nx <= xMax && !series.is('scatter')) {
                 nextInside = true;
             }
 
-            if (px && px >= xMin && px <= xMax && series.type !== 'scatter') {
+            if (px && px >= xMin && px <= xMax && !series.is('scatter')) {
                 prevInside = true;
             }
 

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -748,11 +748,11 @@ function GLRenderer(
                 continue;
             }
 
-            if (nx && nx >= xMin && nx <= xMax) {
+            if (nx && nx >= xMin && nx <= xMax && series.type !== 'scatter') {
                 nextInside = true;
             }
 
-            if (px && px >= xMin && px <= xMax) {
+            if (px && px >= xMin && px <= xMax && series.type !== 'scatter') {
                 prevInside = true;
             }
 


### PR DESCRIPTION
Fixed #13170, some of the points below a zoomed-in boosted scatter chart were not culled properly and displayed along the bottom of the plot area.