### PR TITLE
bugfix/12548-scatter3d-null-z

### DIFF
--- a/js/Series/Scatter3D/Scatter3DPoint.js
+++ b/js/Series/Scatter3D/Scatter3DPoint.js
@@ -24,6 +24,8 @@ var __extends = (this && this.__extends) || (function () {
     };
 })();
 import ScatterSeries from '../Scatter/ScatterSeries.js';
+import U from '../../Core/Utilities.js';
+var defined = U.defined;
 /* *
  *
  *  Class
@@ -49,7 +51,7 @@ var Scatter3DPoint = /** @class */ (function (_super) {
      * */
     Scatter3DPoint.prototype.applyOptions = function () {
         _super.prototype.applyOptions.apply(this, arguments);
-        if (typeof this.z === 'undefined') {
+        if (!defined(this.z)) {
             this.z = 0;
         }
         return this;

--- a/samples/unit-tests/3d/series-scatter/demo.js
+++ b/samples/unit-tests/3d/series-scatter/demo.js
@@ -108,9 +108,8 @@ QUnit.test('Undefined and null z scatter points (#4507, #12548)', function (asse
         ]
     });
 
-    assert.strictEqual(
-        chart.series[0].points.filter(p => p.graphic).length,
-        5,
+    assert.ok(
+        chart.series[0].points.every(p => p.graphic),
         'All points should have rendered'
     );
 });

--- a/samples/unit-tests/3d/series-scatter/demo.js
+++ b/samples/unit-tests/3d/series-scatter/demo.js
@@ -58,9 +58,8 @@ QUnit.test(
     }
 );
 
-QUnit.test('Render scatter points (#4507)', function (assert) {
-    var UNDEFINED;
-    $('#container').highcharts({
+QUnit.test('Undefined and null z scatter points (#4507, #12548)', function (assert) {
+    const chart = Highcharts.chart('container', {
         chart: {
             options3d: {
                 enabled: true,
@@ -89,7 +88,8 @@ QUnit.test('Render scatter points (#4507)', function (assert) {
                 type: 'scatter',
                 data: [
                     {
-                        y: 100000
+                        y: 100000,
+                        z: null
                     },
                     {
                         y: 20000
@@ -109,9 +109,9 @@ QUnit.test('Render scatter points (#4507)', function (assert) {
     });
 
     assert.strictEqual(
-        $('#container').highcharts().series[0].points[2].graphic !== UNDEFINED,
-        true,
-        'Valid placement'
+        chart.series[0].points.filter(p => p.graphic).length,
+        5,
+        'All points should have rendered'
     );
 });
 

--- a/ts/Series/Scatter3D/Scatter3DPoint.ts
+++ b/ts/Series/Scatter3D/Scatter3DPoint.ts
@@ -21,6 +21,10 @@
 import type Scatter3DPointOptions from './Scatter3DPointOptions';
 import type Scatter3DSeries from './Scatter3DSeries';
 import ScatterSeries from '../Scatter/ScatterSeries.js';
+import U from '../../Core/Utilities.js';
+const {
+    defined
+} = U;
 
 /* *
  *
@@ -48,7 +52,7 @@ class Scatter3DPoint extends ScatterSeries.prototype.pointClass {
 
     public applyOptions(): Scatter3DPoint {
         super.applyOptions.apply(this, arguments);
-        if (typeof this.z === 'undefined') {
+        if (!defined(this.z)) {
             this.z = 0;
         }
 


### PR DESCRIPTION
Fixed #12548, 3d scatter chart rendered no points when the first point had `z` set to `null`.