### PR TITLE
bugfix/13222-fullscreen-exit-size

### DIFF
--- a/js/Extensions/FullScreen.js
+++ b/js/Extensions/FullScreen.js
@@ -100,7 +100,7 @@ var Fullscreen = /** @class */ (function () {
      * @requires    modules/full-screen
      */
     Fullscreen.prototype.close = function () {
-        var fullscreen = this, chart = fullscreen.chart;
+        var fullscreen = this, chart = fullscreen.chart, optionsChart = chart.options.chart;
         // Don't fire exitFullscreen() when user exited using 'Escape' button.
         if (fullscreen.isOpen &&
             fullscreen.browserProps &&
@@ -110,6 +110,15 @@ var Fullscreen = /** @class */ (function () {
         // Unbind event as it's necessary only before exiting from fullscreen.
         if (fullscreen.unbindFullscreenEvent) {
             fullscreen.unbindFullscreenEvent();
+        }
+        var widthOption = optionsChart && optionsChart.width;
+        var heightOption = optionsChart && optionsChart.height;
+        chart.setSize(fullscreen.origWidth, fullscreen.origHeight, false);
+        fullscreen.origWidth = void 0;
+        fullscreen.origHeight = void 0;
+        if (optionsChart) {
+            optionsChart.width = widthOption;
+            optionsChart.height = heightOption;
         }
         fullscreen.isOpen = false;
         fullscreen.setButtonText();
@@ -128,6 +137,8 @@ var Fullscreen = /** @class */ (function () {
      */
     Fullscreen.prototype.open = function () {
         var fullscreen = this, chart = fullscreen.chart;
+        fullscreen.origWidth = chart.chartWidth;
+        fullscreen.origHeight = chart.chartHeight;
         // Handle exitFullscreen() method when user clicks 'Escape' button.
         if (fullscreen.browserProps) {
             fullscreen.unbindFullscreenEvent = addEvent(chart.container.ownerDocument, // chart's document

--- a/js/Extensions/FullScreen.js
+++ b/js/Extensions/FullScreen.js
@@ -111,15 +111,15 @@ var Fullscreen = /** @class */ (function () {
         if (fullscreen.unbindFullscreenEvent) {
             fullscreen.unbindFullscreenEvent();
         }
-        var widthOption = optionsChart && optionsChart.width;
-        var heightOption = optionsChart && optionsChart.height;
         chart.setSize(fullscreen.origWidth, fullscreen.origHeight, false);
         fullscreen.origWidth = void 0;
         fullscreen.origHeight = void 0;
         if (optionsChart) {
-            optionsChart.width = widthOption;
-            optionsChart.height = heightOption;
+            optionsChart.width = fullscreen.origWidthOption;
+            optionsChart.height = fullscreen.origHeightOption;
         }
+        fullscreen.origWidthOption = void 0;
+        fullscreen.origHeightOption = void 0;
         fullscreen.isOpen = false;
         fullscreen.setButtonText();
     };
@@ -136,7 +136,11 @@ var Fullscreen = /** @class */ (function () {
      * @requires    modules/full-screen
      */
     Fullscreen.prototype.open = function () {
-        var fullscreen = this, chart = fullscreen.chart;
+        var fullscreen = this, chart = fullscreen.chart, optionsChart = chart.options.chart;
+        if (optionsChart) {
+            fullscreen.origWidthOption = optionsChart.width;
+            fullscreen.origHeightOption = optionsChart.height;
+        }
         fullscreen.origWidth = chart.chartWidth;
         fullscreen.origHeight = chart.chartHeight;
         // Handle exitFullscreen() method when user clicks 'Escape' button.
@@ -149,6 +153,7 @@ var Fullscreen = /** @class */ (function () {
                     fullscreen.close();
                 }
                 else {
+                    chart.setSize(null, null, false);
                     fullscreen.isOpen = true;
                     fullscreen.setButtonText();
                 }

--- a/ts/Extensions/FullScreen.ts
+++ b/ts/Extensions/FullScreen.ts
@@ -58,7 +58,9 @@ declare global {
             public isOpen: boolean;
             public open(): void;
             public origHeight?: number;
+            public origHeightOption?: (number|string|null);
             public origWidth?: number;
+            public origWidthOption?: (number|string|null);
             public toggle(): void;
             public unbindFullscreenEvent?: Function;
         }
@@ -158,7 +160,11 @@ class Fullscreen {
     /** @private */
     public origHeight?: number;
     /** @private */
+    public origHeightOption?: (number|string|null);
+    /** @private */
     public origWidth?: number;
+    /** @private */
+    public origWidthOption?: (number|string|null);
 
     /** @private */
     public unbindFullscreenEvent?: Function;
@@ -200,17 +206,16 @@ class Fullscreen {
             fullscreen.unbindFullscreenEvent();
         }
 
-        const widthOption = optionsChart && optionsChart.width;
-        const heightOption = optionsChart && optionsChart.height;
-
         chart.setSize(fullscreen.origWidth, fullscreen.origHeight, false);
         fullscreen.origWidth = void 0;
         fullscreen.origHeight = void 0;
 
         if (optionsChart) {
-            optionsChart.width = widthOption;
-            optionsChart.height = heightOption;
+            optionsChart.width = fullscreen.origWidthOption;
+            optionsChart.height = fullscreen.origHeightOption;
         }
+        fullscreen.origWidthOption = void 0;
+        fullscreen.origHeightOption = void 0;
 
         fullscreen.isOpen = false;
 
@@ -230,8 +235,13 @@ class Fullscreen {
      */
     public open(): void {
         const fullscreen = this,
-            chart = fullscreen.chart;
+            chart = fullscreen.chart,
+            optionsChart = chart.options.chart;
 
+        if (optionsChart) {
+            fullscreen.origWidthOption = optionsChart.width;
+            fullscreen.origHeightOption = optionsChart.height;
+        }
         fullscreen.origWidth = chart.chartWidth;
         fullscreen.origHeight = chart.chartHeight;
 
@@ -246,6 +256,7 @@ class Fullscreen {
                         fullscreen.isOpen = false;
                         fullscreen.close();
                     } else {
+                        chart.setSize(null, null, false);
                         fullscreen.isOpen = true;
                         fullscreen.setButtonText();
                     }

--- a/ts/Extensions/FullScreen.ts
+++ b/ts/Extensions/FullScreen.ts
@@ -57,6 +57,8 @@ declare global {
             public close(): void;
             public isOpen: boolean;
             public open(): void;
+            public origHeight?: number;
+            public origWidth?: number;
             public toggle(): void;
             public unbindFullscreenEvent?: Function;
         }
@@ -154,6 +156,11 @@ class Fullscreen {
     public isOpen: boolean;
 
     /** @private */
+    public origHeight?: number;
+    /** @private */
+    public origWidth?: number;
+
+    /** @private */
     public unbindFullscreenEvent?: Function;
 
     /* *
@@ -174,7 +181,8 @@ class Fullscreen {
      */
     public close(): void {
         const fullscreen = this,
-            chart = fullscreen.chart;
+            chart = fullscreen.chart,
+            optionsChart = chart.options.chart;
 
         // Don't fire exitFullscreen() when user exited using 'Escape' button.
         if (
@@ -190,6 +198,18 @@ class Fullscreen {
         // Unbind event as it's necessary only before exiting from fullscreen.
         if (fullscreen.unbindFullscreenEvent) {
             fullscreen.unbindFullscreenEvent();
+        }
+
+        const widthOption = optionsChart && optionsChart.width;
+        const heightOption = optionsChart && optionsChart.height;
+
+        chart.setSize(fullscreen.origWidth, fullscreen.origHeight, false);
+        fullscreen.origWidth = void 0;
+        fullscreen.origHeight = void 0;
+
+        if (optionsChart) {
+            optionsChart.width = widthOption;
+            optionsChart.height = heightOption;
         }
 
         fullscreen.isOpen = false;
@@ -211,6 +231,9 @@ class Fullscreen {
     public open(): void {
         const fullscreen = this,
             chart = fullscreen.chart;
+
+        fullscreen.origWidth = chart.chartWidth;
+        fullscreen.origHeight = chart.chartHeight;
 
         // Handle exitFullscreen() method when user clicks 'Escape' button.
         if (fullscreen.browserProps) {


### PR DESCRIPTION
Fixed #13222, chart size was wrong after exiting fullscreen.

This also fixes fullscreening of fixed size charts (`options.chart.width`/`height` set).