### PR TITLE
Range selector inputs design upgrade

### DIFF
--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -343,7 +343,8 @@ extend(defaultOptions, {
          * @sample {highstock} stock/rangeselector/styling/
          *         Styling the buttons and inputs
          *
-         * @since     1.3.7
+         * @type   {number|undefined}
+         * @since  1.3.7
          */
         inputBoxWidth: void 0,
         /**

--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -326,7 +326,7 @@ extend(defaultOptions, {
          * @type      {Highcharts.ColorString}
          * @since     1.3.7
          */
-        inputBoxBorderColor: palette.neutralColor20,
+        inputBoxBorderColor: 'none',
         /**
          * The pixel height of the date input boxes.
          *
@@ -337,14 +337,15 @@ extend(defaultOptions, {
          */
         inputBoxHeight: 17,
         /**
-         * The pixel width of the date input boxes.
+         * The pixel width of the date input boxes. When `undefined`, the width
+         * is fitted to the renderred content.
          *
          * @sample {highstock} stock/rangeselector/styling/
          *         Styling the buttons and inputs
          *
          * @since     1.3.7
          */
-        inputBoxWidth: 90,
+        inputBoxWidth: void 0,
         /**
          * The date format in the input boxes when not selected for editing.
          * Defaults to `%b %e, %Y`.
@@ -475,7 +476,10 @@ extend(defaultOptions, {
          * @type      {Highcharts.CSSObject}
          * @apioption rangeSelector.inputStyle
          */
-        inputStyle: {},
+        inputStyle: {
+            /** @ignore */
+            color: palette.highlightColor80
+        },
         /**
          * CSS styles for the labels - the Zoom, From and To texts.
          *
@@ -493,7 +497,7 @@ extend(defaultOptions, {
         }
     }
 });
-defaultOptions.lang = merge(defaultOptions.lang, 
+extend(defaultOptions.lang, 
 /**
  * Language object. The language object is global and it can't be set
  * on each chart initialization. Instead, use `Highcharts.setOptions` to
@@ -526,17 +530,18 @@ defaultOptions.lang = merge(defaultOptions.lang,
     rangeSelectorZoom: 'Zoom',
     /**
      * The text for the label for the "from" input box in the range
-     * selector.
+     * selector. Since v9.0, this string is empty as the label is not
+     * rendered by default.
      *
      * @product highstock gantt
      */
-    rangeSelectorFrom: 'From',
+    rangeSelectorFrom: '',
     /**
      * The text for the label for the "to" input box in the range selector.
      *
      * @product highstock gantt
      */
-    rangeSelectorTo: 'To'
+    rangeSelectorTo: '→'
 });
 /* eslint-disable no-invalid-this, valid-jsdoc */
 /**

--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -479,7 +479,9 @@ extend(defaultOptions, {
          */
         inputStyle: {
             /** @ignore */
-            color: palette.highlightColor80
+            color: palette.highlightColor80,
+            /** @ignore */
+            cursor: 'pointer'
         },
         /**
          * CSS styles for the labels - the Zoom, From and To texts.
@@ -1075,11 +1077,12 @@ var RangeSelector = /** @class */ (function () {
             }
         }
         // Create the text label
+        var text = lang[isMin ? 'rangeSelectorFrom' : 'rangeSelectorTo'];
         var label = renderer
-            .label(lang[isMin ? 'rangeSelectorFrom' : 'rangeSelectorTo'], 0)
+            .label(text, 0)
             .addClass('highcharts-range-label')
             .attr({
-            padding: 2
+            padding: text ? 2 : 0
         })
             .add(inputGroup);
         // Create an SVG label that shows updated date ranges and and records
@@ -1289,15 +1292,10 @@ var RangeSelector = /** @class */ (function () {
                     this.minDateBox,
                     this.maxLabel,
                     this.maxDateBox
-                ].forEach(function (label, i) {
-                    if (label) {
+                ].forEach(function (label) {
+                    if (label && label.width) {
                         label.attr({ x: x_1 });
                         x_1 += label.width + options.inputSpacing;
-                        // For version <= 8 compliance
-                        // @todo remove this if we change the design
-                        if (i % 2) {
-                            x_1 += options.inputSpacing;
-                        }
                     }
                 });
             }

--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -338,7 +338,7 @@ extend(defaultOptions, {
         inputBoxHeight: 17,
         /**
          * The pixel width of the date input boxes. When `undefined`, the width
-         * is fitted to the renderred content.
+         * is fitted to the rendered content.
          *
          * @sample {highstock} stock/rangeselector/styling/
          *         Styling the buttons and inputs

--- a/samples/stock/rangeselector/styling/demo.js
+++ b/samples/stock/rangeselector/styling/demo.js
@@ -1,3 +1,11 @@
+Highcharts.setOptions({
+    lang: {
+        // Pre-v9 legacy settings
+        rangeSelectorFrom: 'From',
+        rangeSelectorTo: 'To'
+    }
+});
+
 Highcharts.stockChart('container', {
 
     rangeSelector: {

--- a/samples/unit-tests/rangeselector/input-range/demo.js
+++ b/samples/unit-tests/rangeselector/input-range/demo.js
@@ -406,7 +406,7 @@ QUnit.test('Set extremes on inputs blur (#4710)', function (assert) {
 
     newMin = chart.xAxis[0].min;
 
-    assert.strictEqual(min === newMin, false, 'Extremes should be updated');
+    assert.notStrictEqual(min, newMin, 'Extremes should be updated');
 });
 
 QUnit.test('#13205, #14544: Timezone issues', assert => {

--- a/samples/unit-tests/rangeselector/input-range/demo.js
+++ b/samples/unit-tests/rangeselector/input-range/demo.js
@@ -387,7 +387,17 @@ QUnit.test('Set extremes on inputs blur (#4710)', function (assert) {
         newMin,
         test = new TestController(chart);
 
-    test.triggerEvent('click', 400, 20, {}, true);
+    const chartOffset = Highcharts.offset(chart.container);
+    const minDateBoxOffset = Highcharts.offset(
+        chart.rangeSelector.minDateBox.element
+    );
+    test.triggerEvent(
+        'click',
+        minDateBoxOffset.left - chartOffset.left + 10,
+        minDateBoxOffset.top - chartOffset.top + 10,
+        {},
+        true
+    );
 
     document.activeElement.value = '2007-09-13';
 
@@ -396,7 +406,7 @@ QUnit.test('Set extremes on inputs blur (#4710)', function (assert) {
 
     newMin = chart.xAxis[0].min;
 
-    assert.strictEqual(min === newMin, false, 'Extremes are updated.');
+    assert.strictEqual(min === newMin, false, 'Extremes should be updated');
 });
 
 QUnit.test('#13205, #14544: Timezone issues', assert => {

--- a/samples/unit-tests/stock-tools/popup/demo.js
+++ b/samples/unit-tests/stock-tools/popup/demo.js
@@ -63,7 +63,7 @@ QUnit.test('Touch event test on popup', function (assert) {
 
     // click on the first button
     testController.touchStart(
-        inputGroup.translateX + rangeSelector.minDateBox.x + 80,
+        chart.plotWidth - 120,
         chart.plotTop + inputGroup.translateY,
         undefined,
         undefined,
@@ -75,7 +75,7 @@ QUnit.test('Touch event test on popup', function (assert) {
             'highcharts-annotation-toolbar'
         ),
         -1,
-        'Edit popup is displayed by touch event.'
+        'Edit popup should be displayed by touch event'
     );
 
     // REMOVE CSS STYLES

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -543,7 +543,8 @@ extend(defaultOptions, {
          * @sample {highstock} stock/rangeselector/styling/
          *         Styling the buttons and inputs
          *
-         * @since     1.3.7
+         * @type   {number|undefined}
+         * @since  1.3.7
          */
         inputBoxWidth: void 0,
 

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -538,7 +538,7 @@ extend(defaultOptions, {
 
         /**
          * The pixel width of the date input boxes. When `undefined`, the width
-         * is fitted to the renderred content.
+         * is fitted to the rendered content.
          *
          * @sample {highstock} stock/rangeselector/styling/
          *         Styling the buttons and inputs

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -694,7 +694,9 @@ extend(defaultOptions, {
          */
         inputStyle: {
             /** @ignore */
-            color: palette.highlightColor80
+            color: palette.highlightColor80,
+            /** @ignore */
+            cursor: 'pointer'
         },
 
         /**
@@ -1536,14 +1538,14 @@ class RangeSelector {
         }
 
         // Create the text label
+        const text: string = (lang as any)[
+            isMin ? 'rangeSelectorFrom' : 'rangeSelectorTo'
+        ];
         const label = renderer
-            .label(
-                (lang as any)[isMin ? 'rangeSelectorFrom' : 'rangeSelectorTo'],
-                0
-            )
+            .label(text, 0)
             .addClass('highcharts-range-label')
             .attr({
-                padding: 2
+                padding: text ? 2 : 0
             })
             .add(inputGroup);
 
@@ -1823,16 +1825,10 @@ class RangeSelector {
                     this.minDateBox,
                     this.maxLabel,
                     this.maxDateBox
-                ].forEach((label, i): void => {
-                    if (label) {
+                ].forEach((label): void => {
+                    if (label && label.width) {
                         label.attr({ x });
                         x += label.width + options.inputSpacing;
-
-                        // For version <= 8 compliance
-                        // @todo remove this if we change the design
-                        if (i % 2) {
-                            x += options.inputSpacing;
-                        }
                     }
                 });
             }

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -524,7 +524,7 @@ extend(defaultOptions, {
          * @type      {Highcharts.ColorString}
          * @since     1.3.7
          */
-        inputBoxBorderColor: palette.neutralColor20,
+        inputBoxBorderColor: 'none',
 
         /**
          * The pixel height of the date input boxes.
@@ -537,14 +537,15 @@ extend(defaultOptions, {
         inputBoxHeight: 17,
 
         /**
-         * The pixel width of the date input boxes.
+         * The pixel width of the date input boxes. When `undefined`, the width
+         * is fitted to the renderred content.
          *
          * @sample {highstock} stock/rangeselector/styling/
          *         Styling the buttons and inputs
          *
          * @since     1.3.7
          */
-        inputBoxWidth: 90,
+        inputBoxWidth: void 0,
 
         /**
          * The date format in the input boxes when not selected for editing.
@@ -690,7 +691,10 @@ extend(defaultOptions, {
          * @type      {Highcharts.CSSObject}
          * @apioption rangeSelector.inputStyle
          */
-        inputStyle: {},
+        inputStyle: {
+            /** @ignore */
+            color: palette.highlightColor80
+        },
 
         /**
          * CSS styles for the labels - the Zoom, From and To texts.
@@ -710,8 +714,7 @@ extend(defaultOptions, {
     } as Highcharts.RangeSelectorOptions
 });
 
-defaultOptions.lang = merge(
-
+extend(
     defaultOptions.lang,
 
     /**
@@ -748,18 +751,19 @@ defaultOptions.lang = merge(
 
         /**
          * The text for the label for the "from" input box in the range
-         * selector.
+         * selector. Since v9.0, this string is empty as the label is not
+         * rendered by default.
          *
          * @product highstock gantt
          */
-        rangeSelectorFrom: 'From',
+        rangeSelectorFrom: '',
 
         /**
          * The text for the label for the "to" input box in the range selector.
          *
          * @product highstock gantt
          */
-        rangeSelectorTo: 'To'
+        rangeSelectorTo: '→'
     }
 );
 


### PR DESCRIPTION
New graphic design for the range selector date inputs. Simplified visual appearance and flexible width based on the rendered content.

#### Upgrade note
The range selector date input fields have a new visual appearance. See [this fiddle](https://jsfiddle.net/highcharts/vto4af69/) on how to revert to the old design.