### PR TITLE
bugfix/15009-venn-point-className

### DIFF
--- a/js/Series/Venn/VennPoint.js
+++ b/js/Series/Venn/VennPoint.js
@@ -57,7 +57,7 @@ var VennPoint = /** @class */ (function (_super) {
     return VennPoint;
 }(ScatterSeries.prototype.pointClass));
 extend(VennPoint.prototype, {
-    draw: DrawPointMixin.draw
+    draw: DrawPointMixin.drawPoint
 });
 /* *
  *

--- a/samples/unit-tests/series-venn/integration/demo.js
+++ b/samples/unit-tests/series-venn/integration/demo.js
@@ -149,6 +149,11 @@ QUnit.test(
             ]
         });
 
+        assert.ok(
+            chart.series[0].points[0].graphic.attr('class'),
+            '#15009: CSS class should be set'
+        );
+
         assert.strictEqual(
             chart.series[0].points[2].graphic.opacity,
             0.75,

--- a/ts/Series/Venn/VennPoint.ts
+++ b/ts/Series/Venn/VennPoint.ts
@@ -71,10 +71,10 @@ class VennPoint extends ScatterSeries.prototype.pointClass implements Highcharts
  * */
 
 interface VennPoint {
-    draw: typeof DrawPointMixin.draw;
+    draw: typeof DrawPointMixin.drawPoint;
 }
 extend(VennPoint.prototype, {
-    draw: DrawPointMixin.draw
+    draw: DrawPointMixin.drawPoint
 });
 
 /* *

--- a/ts/Series/Venn/VennSeries.ts
+++ b/ts/Series/Venn/VennSeries.ts
@@ -83,7 +83,7 @@ const {
 declare global {
     namespace Highcharts {
         class VennPoint extends ScatterPoint implements DrawPoint {
-            public draw: typeof DrawPointMixin.draw;
+            public draw: typeof DrawPointMixin.drawPoint;
             public isValid: () => boolean;
             public options: VennPointOptions;
             public series: VennSeries;


### PR DESCRIPTION
Fixed #15009, setting `className` on points in venn series did not work.