### PR TITLE
bugfix/8862-scrollablePlotArea-update-yAxis

### DIFF
--- a/js/Extensions/ScrollablePlotArea.js
+++ b/js/Extensions/ScrollablePlotArea.js
@@ -19,6 +19,7 @@ WIP on vertical scrollable plot area (#9378). To do:
 'use strict';
 import A from '../Core/Animation/AnimationUtilities.js';
 var stop = A.stop;
+import Axis from '../Core/Axis/Axis.js';
 import Chart from '../Core/Chart/Chart.js';
 import H from '../Core/Globals.js';
 import U from '../Core/Utilities.js';
@@ -261,6 +262,7 @@ Chart.prototype.moveFixedElements = function () {
  * @return {void}
  */
 Chart.prototype.applyFixed = function () {
+    var _this = this;
     var _a, _b, _c;
     var fixedRenderer, scrollableWidth, scrollableHeight, firstTime = !this.fixedDiv, chartOptions = this.options.chart, scrollableOptions = chartOptions.scrollablePlotArea;
     // First render
@@ -289,12 +291,18 @@ Chart.prototype.applyFixed = function () {
             .add();
         addEvent(this, 'afterShowResetZoom', this.moveFixedElements);
         addEvent(this, 'afterLayOutTitles', this.moveFixedElements);
+        addEvent(Axis, 'afterInit', function () {
+            _this.scrollableDirty = true;
+        });
     }
     else {
         // Set the size of the fixed renderer to the visible width
         this.fixedRenderer.setSize(this.chartWidth, this.chartHeight);
     }
-    this.moveFixedElements();
+    if (this.scrollableDirty || firstTime) {
+        this.scrollableDirty = false;
+        this.moveFixedElements();
+    }
     // Increase the size of the scrollable renderer and background
     scrollableWidth = this.chartWidth + (this.scrollablePixelsX || 0);
     scrollableHeight = this.chartHeight + (this.scrollablePixelsY || 0);

--- a/js/Extensions/ScrollablePlotArea.js
+++ b/js/Extensions/ScrollablePlotArea.js
@@ -287,7 +287,6 @@ Chart.prototype.applyFixed = function () {
         })
             .addClass('highcharts-scrollable-mask')
             .add();
-        this.moveFixedElements();
         addEvent(this, 'afterShowResetZoom', this.moveFixedElements);
         addEvent(this, 'afterLayOutTitles', this.moveFixedElements);
     }
@@ -295,6 +294,7 @@ Chart.prototype.applyFixed = function () {
         // Set the size of the fixed renderer to the visible width
         this.fixedRenderer.setSize(this.chartWidth, this.chartHeight);
     }
+    this.moveFixedElements();
     // Increase the size of the scrollable renderer and background
     scrollableWidth = this.chartWidth + (this.scrollablePixelsX || 0);
     scrollableHeight = this.chartHeight + (this.scrollablePixelsY || 0);

--- a/js/Extensions/ScrollablePlotArea.js
+++ b/js/Extensions/ScrollablePlotArea.js
@@ -21,6 +21,7 @@ import A from '../Core/Animation/AnimationUtilities.js';
 var stop = A.stop;
 import Axis from '../Core/Axis/Axis.js';
 import Chart from '../Core/Chart/Chart.js';
+import Series from '../Core/Series/Series.js';
 import H from '../Core/Globals.js';
 import U from '../Core/Utilities.js';
 var addEvent = U.addEvent, createElement = U.createElement, pick = U.pick;
@@ -292,6 +293,9 @@ Chart.prototype.applyFixed = function () {
         addEvent(this, 'afterShowResetZoom', this.moveFixedElements);
         addEvent(this, 'afterLayOutTitles', this.moveFixedElements);
         addEvent(Axis, 'afterInit', function () {
+            _this.scrollableDirty = true;
+        });
+        addEvent(Series, 'show', function () {
             _this.scrollableDirty = true;
         });
     }

--- a/samples/unit-tests/scrollable-plotarea/dynamics/demo.js
+++ b/samples/unit-tests/scrollable-plotarea/dynamics/demo.js
@@ -6,17 +6,28 @@ QUnit.test('Test dynamic behaviour of Scrollable PlotArea', function (assert) {
                 minWidth: 2000,
                 scrollPositionX: 1
             }
-        }
+        },
+        series: [{
+            data: [1, 2, 3]
+        }]
     });
 
     chart.setTitle({ text: 'New title' });
 
-    assert.equal(
-        chart.title.element.parentNode.parentNode.classList.contains(
-            'highcharts-fixed'
-        ),
-        true,
+    assert.ok(
+        chart.fixedRenderer.box.contains(chart.title.element),
         'Title should be outside the scrollable plot area (#11966)'
+    );
+
+    chart.update({
+        yAxis: {
+            lineWidth: 1
+        }
+    });
+
+    assert.ok(
+        chart.fixedRenderer.box.contains(chart.yAxis[0].axisGroup.element),
+        'Y-axis should be outside the scrollable plot area (#8862)'
     );
 });
 

--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -27,6 +27,7 @@ import type {
 import type SVGPath from '../Core/Renderer/SVG/SVGPath';
 import A from '../Core/Animation/AnimationUtilities.js';
 const { stop } = A;
+import Axis from '../Core/Axis/Axis.js';
 import Chart from '../Core/Chart/Chart.js';
 import H from '../Core/Globals.js';
 import U from '../Core/Utilities.js';
@@ -43,6 +44,7 @@ declare module '../Core/Chart/ChartLike'{
         innerContainer?: HTMLDOMElement;
         scrollingContainer?: HTMLDOMElement;
         scrollingParent?: HTMLDOMElement;
+        scrollableDirty?: boolean;
         scrollableMask?: Highcharts.SVGElement;
         scrollablePixelsX?: number;
         scrollablePixelsY?: number;
@@ -402,6 +404,9 @@ Chart.prototype.applyFixed = function (): void {
 
         addEvent(this, 'afterShowResetZoom', this.moveFixedElements);
         addEvent(this, 'afterLayOutTitles', this.moveFixedElements);
+        addEvent(Axis, 'afterInit', (): void => {
+            this.scrollableDirty = true;
+        });
 
     } else {
 
@@ -412,7 +417,10 @@ Chart.prototype.applyFixed = function (): void {
         );
     }
 
-    this.moveFixedElements();
+    if (this.scrollableDirty || firstTime) {
+        this.scrollableDirty = false;
+        this.moveFixedElements();
+    }
 
     // Increase the size of the scrollable renderer and background
     scrollableWidth = this.chartWidth + (this.scrollablePixelsX || 0);

--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -400,8 +400,6 @@ Chart.prototype.applyFixed = function (): void {
             .addClass('highcharts-scrollable-mask')
             .add();
 
-        this.moveFixedElements();
-
         addEvent(this, 'afterShowResetZoom', this.moveFixedElements);
         addEvent(this, 'afterLayOutTitles', this.moveFixedElements);
 
@@ -413,6 +411,8 @@ Chart.prototype.applyFixed = function (): void {
             this.chartHeight
         );
     }
+
+    this.moveFixedElements();
 
     // Increase the size of the scrollable renderer and background
     scrollableWidth = this.chartWidth + (this.scrollablePixelsX || 0);

--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -29,6 +29,7 @@ import A from '../Core/Animation/AnimationUtilities.js';
 const { stop } = A;
 import Axis from '../Core/Axis/Axis.js';
 import Chart from '../Core/Chart/Chart.js';
+import Series from '../Core/Series/Series.js';
 import H from '../Core/Globals.js';
 import U from '../Core/Utilities.js';
 const {
@@ -405,6 +406,9 @@ Chart.prototype.applyFixed = function (): void {
         addEvent(this, 'afterShowResetZoom', this.moveFixedElements);
         addEvent(this, 'afterLayOutTitles', this.moveFixedElements);
         addEvent(Axis, 'afterInit', (): void => {
+            this.scrollableDirty = true;
+        });
+        addEvent(Series, 'show', (): void => {
             this.scrollableDirty = true;
         });
 


### PR DESCRIPTION
Fixed #8862, #12112, y-axis did not stay fixed after `update` when using `scrollablePlotArea`.

Closes #12112.