### PR TITLE
bugfix/14280-closePopup-event

### DIFF
--- a/js/Extensions/Annotations/NavigationBindings.js
+++ b/js/Extensions/Annotations/NavigationBindings.js
@@ -263,7 +263,6 @@ var NavigationBindings = /** @class */ (function () {
             // TO DO: Polyfill for IE11?
             !closestPolyfill(clickEvent.target, '.' + PREFIX + 'popup')) {
             fireEvent(navigation, 'closePopup');
-            navigation.deselectAnnotation();
         }
         if (!selectedButton || !selectedButton.start) {
             return;
@@ -714,7 +713,6 @@ function selectableAnnotation(annotationType) {
         }
         else {
             // Deselect current:
-            navigation.deselectAnnotation();
             fireEvent(navigation, 'closePopup');
         }
         // Let bubble event to chart.click:
@@ -1038,5 +1036,8 @@ setOptions({
             }
         }
     }
+});
+addEvent(NavigationBindings, 'closePopup', function () {
+    this.deselectAnnotation();
 });
 export default NavigationBindings;

--- a/js/Extensions/Annotations/Popup.js
+++ b/js/Extensions/Annotations/Popup.js
@@ -14,7 +14,7 @@ var isFirefox = H.isFirefox;
 import NavigationBindings from './NavigationBindings.js';
 import Pointer from '../../Core/Pointer.js';
 import U from '../../Core/Utilities.js';
-var addEvent = U.addEvent, createElement = U.createElement, defined = U.defined, getOptions = U.getOptions, isArray = U.isArray, isObject = U.isObject, isString = U.isString, objectEach = U.objectEach, pick = U.pick, stableSort = U.stableSort, wrap = U.wrap;
+var addEvent = U.addEvent, createElement = U.createElement, defined = U.defined, fireEvent = U.fireEvent, getOptions = U.getOptions, isArray = U.isArray, isObject = U.isObject, isString = U.isString, objectEach = U.objectEach, pick = U.pick, stableSort = U.stableSort, wrap = U.wrap;
 var indexFilter = /\d/g, PREFIX = 'highcharts-', DIV = 'div', INPUT = 'input', LABEL = 'label', BUTTON = 'button', SELECT = 'select', OPTION = 'option', SPAN = 'span', UL = 'ul', LI = 'li', H3 = 'h3';
 /* eslint-disable no-invalid-this, valid-jsdoc */
 // onContainerMouseDown blocks internal popup events, due to e.preventDefault.
@@ -27,8 +27,8 @@ wrap(Pointer.prototype, 'onContainerMouseDown', function (proceed, e) {
         proceed.apply(this, Array.prototype.slice.call(arguments, 1));
     }
 });
-H.Popup = function (parentDiv, iconsURL) {
-    this.init(parentDiv, iconsURL);
+H.Popup = function (parentDiv, iconsURL, chart) {
+    this.init(parentDiv, iconsURL, chart);
 };
 H.Popup.prototype = {
     /**
@@ -39,7 +39,8 @@ H.Popup.prototype = {
      * @param {string} iconsURL
      * Icon URL
      */
-    init: function (parentDiv, iconsURL) {
+    init: function (parentDiv, iconsURL, chart) {
+        this.chart = chart;
         // create popup div
         this.container = createElement(DIV, {
             className: PREFIX + 'popup'
@@ -63,7 +64,7 @@ H.Popup.prototype = {
             this.iconsURL + 'close.svg)';
         ['click', 'touchstart'].forEach(function (eventName) {
             addEvent(closeBtn, eventName, function () {
-                _self.closePopup();
+                fireEvent(_self.chart.navigationBindings, 'closePopup');
             });
         });
     },
@@ -725,7 +726,7 @@ addEvent(NavigationBindings, 'showPopup', function (config) {
         this.popup = new H.Popup(this.chart.container, (this.chart.options.navigation.iconsURL ||
             (this.chart.options.stockTools &&
                 this.chart.options.stockTools.gui.iconsURL) ||
-            'https://code.highcharts.com/@product.version@/gfx/stock-icons/'));
+            'https://code.highcharts.com/@product.version@/gfx/stock-icons/'), this.chart);
     }
     this.popup.showForm(config.formType, this.chart, config.options, config.onSubmit);
 });

--- a/samples/unit-tests/stock-tools/popup/demo.js
+++ b/samples/unit-tests/stock-tools/popup/demo.js
@@ -56,7 +56,7 @@ QUnit.test('Touch event test on popup', function (assert) {
         testController = new TestController(chart);
 
     // show toolbar
-    testController.triggerEvent('click', 100, 100, {}, true);
+    testController.triggerEvent('click', 100, 100);
 
     var rangeSelector = chart.rangeSelector,
         inputGroup = rangeSelector.inputGroup;
@@ -66,8 +66,7 @@ QUnit.test('Touch event test on popup', function (assert) {
         inputGroup.translateX + rangeSelector.minDateBox.x + 80,
         chart.plotTop + inputGroup.translateY,
         undefined,
-        undefined,
-        true
+        undefined
     );
 
     assert.strictEqual(
@@ -78,6 +77,32 @@ QUnit.test('Touch event test on popup', function (assert) {
         'Edit popup is displayed by touch event.'
     );
 
+    let fired = false;
+    // adding event to check, if closePopup event was fired, when closing popup
+    Highcharts.addEvent(chart.navigationBindings, 'closePopup', () => {
+        fired = true;
+    });
+
+    // closing popup
+
+
+    const closeButton = chart.container.getElementsByClassName('highcharts-popup-close')[0];
+    // css are not loaded in karma, so it is mandatory to set the position of the button manually
+    closeButton.style.position = 'absolute';
+    closeButton.style.top = 0;
+    closeButton.style.height = 40;
+    closeButton.style.width = 40;
+    closeButton.style.right = 0;
+    const { left, top } = Highcharts.offset(closeButton);
+
+    const offsetOfContainer = Highcharts.offset(chart.container);
+    testController.triggerEvent('click', left - offsetOfContainer.left + 20, top - offsetOfContainer.top + 20, {}, true);
+
+    assert.equal(
+        fired,
+        true,
+        'Event "closePopup" should be fired when closing popup'
+    );
     // REMOVE CSS STYLES
     style.parentNode.removeChild(style);
 });

--- a/ts/Extensions/Annotations/NavigationBindings.ts
+++ b/ts/Extensions/Annotations/NavigationBindings.ts
@@ -536,7 +536,6 @@ class NavigationBindings {
             !closestPolyfill(clickEvent.target as any, '.' + PREFIX + 'popup')
         ) {
             fireEvent(navigation, 'closePopup');
-            navigation.deselectAnnotation();
         }
 
         if (!selectedButton || !selectedButton.start) {
@@ -1085,7 +1084,6 @@ function selectableAnnotation(annotationType: typeof Annotation): void {
             );
         } else {
             // Deselect current:
-            navigation.deselectAnnotation();
             fireEvent(navigation, 'closePopup');
         }
         // Let bubble event to chart.click:
@@ -1487,6 +1485,10 @@ setOptions({
             }
         }
     }
+});
+
+addEvent(NavigationBindings, 'closePopup', function (this: NavigationBindings): void {
+    this.deselectAnnotation();
 });
 
 export default NavigationBindings;

--- a/ts/Extensions/Annotations/Popup.ts
+++ b/ts/Extensions/Annotations/Popup.ts
@@ -27,6 +27,7 @@ const {
     addEvent,
     createElement,
     defined,
+    fireEvent,
     getOptions,
     isArray,
     isObject,
@@ -44,7 +45,7 @@ const {
 declare global {
     namespace Highcharts {
         class Popup {
-            public constructor(parentDiv: HTMLDOMElement, iconsURL: string);
+            public constructor(parentDiv: HTMLDOMElement, iconsURL: string, chart: Chart);
             public annotations: PopupAnnotationsObject;
             public container: HTMLDOMElement;
             public iconsURL: string;
@@ -66,7 +67,7 @@ declare global {
             public deselectAll(): void;
             public getFields(parentDiv: HTMLDOMElement, type: string): PopupFieldsObject;
             public getLangpack(): Record<string, string>;
-            public init(parentDiv: HTMLDOMElement, iconsURL: string): void;
+            public init(parentDiv: HTMLDOMElement, iconsURL: string, chart: Chart): void;
             public showForm(
                 type: string,
                 chart: AnnotationChart,
@@ -180,8 +181,8 @@ wrap(Pointer.prototype, 'onContainerMouseDown', function (this: Pointer, proceed
     }
 });
 
-H.Popup = function (this: Highcharts.Popup, parentDiv: HTMLDOMElement, iconsURL: string): void {
-    this.init(parentDiv, iconsURL);
+H.Popup = function (this: Highcharts.Popup, parentDiv: HTMLDOMElement, iconsURL: string, chart: Chart): void {
+    this.init(parentDiv, iconsURL, chart);
 } as any;
 
 H.Popup.prototype = {
@@ -193,7 +194,8 @@ H.Popup.prototype = {
      * @param {string} iconsURL
      * Icon URL
      */
-    init: function (parentDiv: HTMLDOMElement, iconsURL: string): void {
+    init: function (parentDiv: HTMLDOMElement, iconsURL: string, chart: Chart): void {
+        this.chart = chart;
 
         // create popup div
         this.container = createElement(DIV, {
@@ -224,7 +226,8 @@ H.Popup.prototype = {
 
         ['click', 'touchstart'].forEach(function (eventName: string): void {
             addEvent(closeBtn, eventName, function (): void {
-                _self.closePopup();
+
+                fireEvent(_self.chart.navigationBindings, 'closePopup');
             });
         });
     },
@@ -1295,7 +1298,7 @@ addEvent(NavigationBindings, 'showPopup', function (
                     this.chart.options.stockTools.gui.iconsURL
                 ) ||
                 'https://code.highcharts.com/@product.version@/gfx/stock-icons/'
-            )
+            ), this.chart
         );
     }
 


### PR DESCRIPTION
Fixed #14280, Stock Tools GUI popup - clicking on the 'x' button didn't call the `closePopup` event