### PR TITLE
bugfix/15022-vertical-panning-extremes

### DIFF
--- a/js/Core/Chart/Chart.js
+++ b/js/Core/Chart/Chart.js
@@ -2581,9 +2581,9 @@ var Chart = /** @class */ (function () {
                     halfPointRange * pointRangeDirection, flipped = panMax < panMin, newMin = flipped ? panMax : panMin, newMax = flipped ? panMin : panMax, hasVerticalPanning = axis.hasVerticalPanning(), paddedMin, paddedMax, spill, panningState = axis.panningState;
                 // General calculations of panning state.
                 // This is related to using vertical panning. (#11315).
-                axis.series.forEach(function (series) {
-                    if (hasVerticalPanning &&
-                        !isX && (!panningState || panningState.isDirty)) {
+                if (hasVerticalPanning &&
+                    !isX && (!panningState || panningState.isDirty)) {
+                    axis.series.forEach(function (series) {
                         var processedData = series.getProcessedData(true), dataExtremes = series.getExtremes(processedData.yData, true);
                         if (!panningState) {
                             panningState = {
@@ -2596,8 +2596,8 @@ var Chart = /** @class */ (function () {
                             panningState.startMin = Math.min(pick(series.options.threshold, Infinity), dataExtremes.dataMin, panningState.startMin);
                             panningState.startMax = Math.max(pick(series.options.threshold, -Infinity), dataExtremes.dataMax, panningState.startMax);
                         }
-                    }
-                });
+                    });
+                }
                 paddedMin = Math.min(pick(panningState === null || panningState === void 0 ? void 0 : panningState.startMin, extremes.dataMin), halfPointRange ?
                     extremes.min :
                     axis.toValue(axis.toPixels(extremes.min) -

--- a/samples/unit-tests/chart/panning/demo.js
+++ b/samples/unit-tests/chart/panning/demo.js
@@ -168,6 +168,8 @@ QUnit.test('Zoom and pan key', function (assert) {
                         95.6,
                         54.4
                     ]
+                }, {
+                    data: [20, 300]
                 }
             ]
         }),
@@ -225,6 +227,17 @@ QUnit.test('Zoom and pan key', function (assert) {
         xExtremes.max - xExtremes.min,
         0.00001, // Roundoff error in Firefox
         'Has preserved range'
+    );
+
+    assert.strictEqual(
+        chart.yAxis[0].panningState.startMin,
+        20,
+        '#15022: panningState should have the correct startMin'
+    );
+    assert.strictEqual(
+        chart.yAxis[0].panningState.startMax,
+        300,
+        '#15022: panningState should have the correct startMax'
     );
 });
 

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3610,13 +3610,13 @@ class Chart {
 
                 // General calculations of panning state.
                 // This is related to using vertical panning. (#11315).
-                axis.series.forEach(function (series): void {
-                    if (
-                        hasVerticalPanning &&
-                        !isX && (
-                            !panningState || panningState.isDirty
-                        )
-                    ) {
+                if (
+                    hasVerticalPanning &&
+                    !isX && (
+                        !panningState || panningState.isDirty
+                    )
+                ) {
+                    axis.series.forEach(function (series): void {
                         const processedData = series.getProcessedData(true),
                             dataExtremes = series.getExtremes(
                                 processedData.yData, true
@@ -3644,8 +3644,8 @@ class Chart {
                                 panningState.startMax
                             );
                         }
-                    }
-                });
+                    });
+                }
 
                 paddedMin = Math.min(
                     pick(panningState?.startMin, extremes.dataMin),


### PR DESCRIPTION
Fixed #15022, vertical panning was limited to the first series extremes after zooming in.