### PR TITLE
bugfix/12061-zones-stroke-width-animation

### DIFF
--- a/js/Core/Series/Series.js
+++ b/js/Core/Series/Series.js
@@ -3091,7 +3091,7 @@ var Series = /** @class */ (function () {
                     // Animate the graph stroke-width.
                     graph.animate(attribs, stateAnimation);
                     while (series['zone-graph-' + i]) {
-                        series['zone-graph-' + i].attr(attribs);
+                        series['zone-graph-' + i].animate(attribs, stateAnimation);
                         i = i + 1;
                     }
                 }

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -7011,7 +7011,10 @@ class Series {
                         stateAnimation
                     );
                     while ((series as any)['zone-graph-' + i]) {
-                        (series as any)['zone-graph-' + i].attr(attribs);
+                        (series as any)['zone-graph-' + i].animate(
+                            attribs,
+                            stateAnimation
+                        );
                         i = i + 1;
                     }
                 }


### PR DESCRIPTION
Fixed #12061, `stroke-width` animation did not work when using zones.