### PR TITLE
bugfix/12031-tooltip-distance-scale

### DIFF
--- a/js/Core/Tooltip.js
+++ b/js/Core/Tooltip.js
@@ -584,8 +584,9 @@ var Tooltip = /** @class */ (function () {
          */
         firstDimension = function (dim, outerSize, innerSize, scaledInnerSize, // #11329
         point, min, max) {
-            var scaledDist = dim === 'y' ?
-                scaleY(distance) : scaleX(distance), scaleDiff = (innerSize - scaledInnerSize) / 2, roomLeft = scaledInnerSize < point - distance, roomRight = point + distance + scaledInnerSize < outerSize, alignedLeft = point - scaledDist - innerSize + scaleDiff, alignedRight = point + scaledDist - scaleDiff;
+            var scaledDist = outside ?
+                (dim === 'y' ? scaleY(distance) : scaleX(distance)) :
+                distance, scaleDiff = (innerSize - scaledInnerSize) / 2, roomLeft = scaledInnerSize < point - distance, roomRight = point + distance + scaledInnerSize < outerSize, alignedLeft = point - scaledDist - innerSize + scaleDiff, alignedRight = point + scaledDist - scaleDiff;
             if (preferFarSide && roomRight) {
                 ret[dim] = alignedRight;
             }

--- a/samples/unit-tests/tooltip/position/demo.js
+++ b/samples/unit-tests/tooltip/position/demo.js
@@ -29,6 +29,9 @@ QUnit.test(
                 {
                     type: 'column',
                     data: [2, 3, 5, 2, 5, 2]
+                }, {
+                    type: 'line',
+                    data: [1, 2, 3]
                 }
             ]
         });
@@ -64,6 +67,21 @@ QUnit.test(
             x,
             'The tooltip should move with its point'
         );
+
+        chart.tooltip.refresh(chart.series[1].points[0]);
+        const distanceBefore = chart.tooltip.now.x - chart.tooltip.now.anchorX;
+
+        chart.renderTo.style.transform = 'scale(1.5)';
+        chart.reflow();
+
+        chart.tooltip.refresh(chart.series[1].points[0]);
+        assert.strictEqual(
+            chart.tooltip.now.x - chart.tooltip.now.anchorX,
+            distanceBefore,
+            '#12031: Distance should be the same before and after scaling'
+        );
+
+        chart.renderTo.style.transform = '';
     }
 );
 // Highcharts v4.0.3, Issue #424

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -958,8 +958,9 @@ class Tooltip {
                 min: number,
                 max: number
             ): (boolean|undefined) {
-                const scaledDist = dim === 'y' ?
-                        scaleY(distance) : scaleX(distance),
+                const scaledDist = outside ?
+                        (dim === 'y' ? scaleY(distance) : scaleX(distance)) :
+                        distance,
                     scaleDiff = (innerSize - scaledInnerSize) / 2,
                     roomLeft = scaledInnerSize < point - distance,
                     roomRight = point + distance + scaledInnerSize < outerSize,


### PR DESCRIPTION
Fixed #12031, tooltip `distance` did not scale correctly with `outside` set to `false`.