### PR TITLE
docs/15034-rangeselector-enabled

### DIFF
--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -237,7 +237,7 @@ extend(defaultOptions, {
          * @sample {highstock} stock/rangeselector/enabled/
          *         Disable the range selector
          *
-         * @type {boolean}
+         * @type {boolean|undefined}
          * @default {highstock} true
          */
         enabled: void 0,

--- a/js/Extensions/RangeSelector.js
+++ b/js/Extensions/RangeSelector.js
@@ -237,6 +237,7 @@ extend(defaultOptions, {
          * @sample {highstock} stock/rangeselector/enabled/
          *         Disable the range selector
          *
+         * @type {boolean}
          * @default {highstock} true
          */
         enabled: void 0,

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -428,7 +428,7 @@ extend(defaultOptions, {
          * @sample {highstock} stock/rangeselector/enabled/
          *         Disable the range selector
          *
-         * @type {boolean}
+         * @type {boolean|undefined}
          * @default {highstock} true
          */
         enabled: void 0,

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -428,6 +428,7 @@ extend(defaultOptions, {
          * @sample {highstock} stock/rangeselector/enabled/
          *         Disable the range selector
          *
+         * @type {boolean}
          * @default {highstock} true
          */
         enabled: void 0,


### PR DESCRIPTION
Fixed #15034, `rangeSelector.enabled` missed doclet type.