### PR TITLE
Fix HTML parsing in Phantom

### DIFF
--- a/js/Core/Renderer/HTML/AST.js
+++ b/js/Core/Renderer/HTML/AST.js
@@ -29,6 +29,12 @@ var attr = U.attr, createElement = U.createElement, discardElement = U.discardEl
 * @type {string|undefined}
 */
 ''; // detach doclets above
+// In IE8, DOMParser is undefined. IE9 and batik are only able to parse XML.
+var hasValidDOMParser = false;
+try {
+    hasValidDOMParser = Boolean(new DOMParser().parseFromString('', 'text/html'));
+}
+catch (e) { } // eslint-disable-line no-empty
 /**
  * Represents an AST
  * @private
@@ -175,17 +181,13 @@ var AST = /** @class */ (function () {
         var nodes = [];
         var doc;
         var body;
-        if (
-        // IE9 is only able to parse XML
-        /MSIE 9.0/.test(navigator.userAgent) ||
-            // IE8-
-            typeof DOMParser === 'undefined') {
+        if (hasValidDOMParser) {
+            doc = new DOMParser().parseFromString(markup, 'text/html');
+        }
+        else {
             body = createElement('div');
             body.innerHTML = markup;
             doc = { body: body };
-        }
-        else {
-            doc = new DOMParser().parseFromString(markup, 'text/html');
         }
         var appendChildNodes = function (node, addTo) {
             var tagName = node.nodeName.toLowerCase();

--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -57,6 +57,14 @@ declare global {
     }
 }
 
+// In IE8, DOMParser is undefined. IE9 and batik are only able to parse XML.
+let hasValidDOMParser = false;
+try {
+    hasValidDOMParser = Boolean(
+        new DOMParser().parseFromString('', 'text/html')
+    );
+} catch (e) { } // eslint-disable-line no-empty
+
 /**
  * Represents an AST
  * @private
@@ -365,19 +373,15 @@ class AST {
         }
 
         const nodes: Highcharts.ASTNode[] = [];
+
         let doc;
         let body;
-        if (
-            // IE9 is only able to parse XML
-            /MSIE 9.0/.test(navigator.userAgent) ||
-            // IE8-
-            typeof DOMParser === 'undefined'
-        ) {
+        if (hasValidDOMParser) {
+            doc = new DOMParser().parseFromString(markup, 'text/html');
+        } else {
             body = createElement('div');
             body.innerHTML = markup;
             doc = { body };
-        } else {
-            doc = new DOMParser().parseFromString(markup, 'text/html');
         }
 
         const appendChildNodes = (


### PR DESCRIPTION
Fixed #15037, a regression causing failure with text parsing in PhantomJS.

___

The feature check was too narrow, used browser sniffing instead of feature sniffing.

@cvasseng Can you verify that this works in PhantomJS without the `DOMParser` polyfill?