### PR TITLE
bugfix/11930-yAxis-remove-options

### DIFF
--- a/js/Core/Axis/Axis.js
+++ b/js/Core/Axis/Axis.js
@@ -3138,8 +3138,20 @@ var Axis = /** @class */ (function () {
         // Remove the axis
         erase(chart.axes, this);
         erase(chart[key], this);
-        if (isArray(chart.options[key])) {
-            chart.options[key].splice(this.options.index, 1);
+        var options = chart.options[key];
+        if (isArray(options) && defined(this.options.index)) {
+            var option = options[this.options.index];
+            if (option && option.index === this.options.index) {
+                options.splice(this.options.index, 1);
+            }
+            else {
+                for (var i_1 = 0; i_1 < options.length; i_1++) {
+                    if (options[i_1].index === this.options.index) {
+                        options.splice(i_1, 1);
+                        break;
+                    }
+                }
+            }
         }
         else { // color axis, #6488
             delete chart.options[key];

--- a/js/Core/Axis/Axis.js
+++ b/js/Core/Axis/Axis.js
@@ -3138,16 +3138,22 @@ var Axis = /** @class */ (function () {
         // Remove the axis
         erase(chart.axes, this);
         erase(chart[key], this);
-        var options = chart.options[key];
-        if (isArray(options) && defined(this.options.index)) {
-            var option = options[this.options.index];
-            if (option && option.index === this.options.index) {
-                options.splice(this.options.index, 1);
+        var chartAxisOptions = chart.options[key];
+        if (isArray(chartAxisOptions) && defined(this.options.index)) {
+            var chartAxisOption = chartAxisOptions[this.options.index];
+            // #11930: Some axes such as NavigatorAxis do not get added to
+            // chart.options, so there might be a mismatch between
+            // Axis.options.index and the index of the axis in the chart
+            // options array for axes added after the navigator axis.
+            if (chartAxisOption && chartAxisOption.index === this.options.index) {
+                chartAxisOptions.splice(this.options.index, 1);
             }
             else {
-                for (var i_1 = 0; i_1 < options.length; i_1++) {
-                    if (options[i_1].index === this.options.index) {
-                        options.splice(i_1, 1);
+                // Find the correct axis in chart.options if the index
+                // doesnt match
+                for (var i_1 = 0; i_1 < chartAxisOptions.length; i_1++) {
+                    if (chartAxisOptions[i_1].index === this.options.index) {
+                        chartAxisOptions.splice(i_1, 1);
                         break;
                     }
                 }

--- a/samples/unit-tests/axis/update/demo.js
+++ b/samples/unit-tests/axis/update/demo.js
@@ -128,6 +128,13 @@ QUnit.test('General yAxis updates', function (assert) {
         chart.yAxis.length - 1,
         'Last index should be less than yAxis array length (#8075) - part II'
     );
+
+    chart.yAxis[2].remove();
+    assert.strictEqual(
+        chart.options.yAxis.length,
+        1,
+        '#11930: Both the dynamically added axes should be removed from chart.options'
+    );
 });
 
 QUnit.test('Updates after new Axis', function (assert) {

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -7927,8 +7927,20 @@ class Axis {
         erase(chart.axes, this);
         erase((chart as any)[key], this);
 
-        if (isArray((chart.options as any)[key])) {
-            (chart.options as any)[key].splice(this.options.index, 1);
+        const options: Highcharts.AxisOptions[] = (chart.options as any)[key];
+
+        if (isArray(options) && defined(this.options.index)) {
+            const option = options[this.options.index];
+            if (option && option.index === this.options.index) {
+                options.splice(this.options.index, 1);
+            } else {
+                for (let i = 0; i < options.length; i++) {
+                    if (options[i].index === this.options.index) {
+                        options.splice(i, 1);
+                        break;
+                    }
+                }
+            }
         } else { // color axis, #6488
             delete (chart.options as any)[key];
         }

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -7927,16 +7927,23 @@ class Axis {
         erase(chart.axes, this);
         erase((chart as any)[key], this);
 
-        const options: Highcharts.AxisOptions[] = (chart.options as any)[key];
+        const chartAxisOptions: Highcharts.AxisOptions[] = (chart.options as any)[key];
 
-        if (isArray(options) && defined(this.options.index)) {
-            const option = options[this.options.index];
-            if (option && option.index === this.options.index) {
-                options.splice(this.options.index, 1);
+        if (isArray(chartAxisOptions) && defined(this.options.index)) {
+            const chartAxisOption = chartAxisOptions[this.options.index];
+
+            // #11930: Some axes such as NavigatorAxis do not get added to
+            // chart.options, so there might be a mismatch between
+            // Axis.options.index and the index of the axis in the chart
+            // options array for axes added after the navigator axis.
+            if (chartAxisOption && chartAxisOption.index === this.options.index) {
+                chartAxisOptions.splice(this.options.index, 1);
             } else {
-                for (let i = 0; i < options.length; i++) {
-                    if (options[i].index === this.options.index) {
-                        options.splice(i, 1);
+                // Find the correct axis in chart.options if the index
+                // doesnt match
+                for (let i = 0; i < chartAxisOptions.length; i++) {
+                    if (chartAxisOptions[i].index === this.options.index) {
+                        chartAxisOptions.splice(i, 1);
                         break;
                     }
                 }


### PR DESCRIPTION
Fixed #11930, removing dynamically added y-axes did not work correctly with `navigator` enabled, causing the removed axis to show in exported charts.