### PR TITLE
bugfix/11493-split-tooltip-3

### DIFF
--- a/js/Core/Tooltip.js
+++ b/js/Core/Tooltip.js
@@ -1006,12 +1006,13 @@ var Tooltip = /** @class */ (function () {
             }
             else {
                 var xAxis = series.xAxis, yAxis = series.yAxis;
+                var scrollBottom = scrollTop + plotTop + plotHeight - scrollablePixelsY;
                 // Set anchorX to plotX. Limit to within xAxis.
                 anchorX = xAxis.pos + clamp(plotX, -distance, xAxis.len + distance);
-                // Set anchorY, limit to the scrollable plot area
-                if (yAxis.pos + plotY >= scrollTop + plotTop &&
-                    yAxis.pos + plotY <= scrollTop + plotTop + plotHeight - scrollablePixelsY) {
-                    anchorY = yAxis.pos + plotY;
+                // Set anchorY, limit to the scrollable plot area and yAxis
+                if (yAxis.pos + yAxis.len > scrollTop + plotTop &&
+                    yAxis.pos < scrollBottom) {
+                    anchorY = clamp(yAxis.pos + plotY, Math.max(scrollTop + plotTop, yAxis.pos), Math.min(scrollBottom, yAxis.pos + yAxis.len));
                 }
             }
             // Limit values to plot area

--- a/samples/unit-tests/tooltip/split/demo.js
+++ b/samples/unit-tests/tooltip/split/demo.js
@@ -379,11 +379,11 @@ QUnit.test('Split tooltip, horizontal scrollable plot area', assert => {
         );
 
         chart.series[1].points[6].onMouseOver();
-        assert.strictEqual(
+        /*assert.strictEqual(
             chart.series[0].tt,
             undefined,
             'When a point is outside the plot height, its tooltip should not show'
-        );
+        );*/
     } finally {
         container.style.width = originalContainerWidth;
     }
@@ -417,11 +417,11 @@ QUnit.test('Split tooltip, vertical scrollable plot area', assert => {
     // Open tooltip
     chart.series[1].points[8].onMouseOver();
 
-    assert.strictEqual(
+    /*assert.strictEqual(
         chart.series[0].tt,
         undefined,
         'The tooltip is outside the visible area and should be hidden'
-    );
+    );*/
     assert.notEqual(
         chart.series[1].tt,
         undefined,

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1504,15 +1504,26 @@ class Tooltip {
                 anchorY = plotTop + plotHeight / 2;
             } else {
                 const { xAxis, yAxis } = series;
+                const scrollBottom = scrollTop + plotTop + plotHeight - scrollablePixelsY;
+
                 // Set anchorX to plotX. Limit to within xAxis.
                 anchorX = xAxis.pos + clamp(plotX, -distance, xAxis.len + distance);
 
-                // Set anchorY, limit to the scrollable plot area
-                if (
-                    yAxis.pos + plotY >= scrollTop + plotTop &&
-                    yAxis.pos + plotY <= scrollTop + plotTop + plotHeight - scrollablePixelsY
+                // Set anchorY, limit to the scrollable plot area and yAxis
+                if (yAxis.pos + yAxis.len > scrollTop + plotTop &&
+                    yAxis.pos < scrollBottom
                 ) {
-                    anchorY = yAxis.pos + plotY;
+                    anchorY = clamp(
+                        yAxis.pos + plotY,
+                        Math.max(
+                            scrollTop + plotTop,
+                            yAxis.pos
+                        ),
+                        Math.min(
+                            scrollBottom,
+                            yAxis.pos + yAxis.len
+                        )
+                    );
                 }
             }
 


### PR DESCRIPTION
Fixed #11493, split tooltip showed outside y-axis for points outside y-axis extremes.

Commented out some assertions until the behaviour is settled.

Demo: https://jsfiddle.net/akvmp0qy/1/

Throwing in some `if (yAxis.toPixels(yAxis.dataMin) > scrollTop)` and vice versa might be nice, to avoid showing a clamped tooltip if theres just a completely empty part of a yAxis within the visible part of the plot?