### PR TITLE
docs/dependency wheel API url fix 

### DIFF
--- a/docs/chart-and-series-types/dependency-wheel.md
+++ b/docs/chart-and-series-types/dependency-wheel.md
@@ -5,7 +5,7 @@ A dependency wheel is a type of flow diagram, where nodes are laid out in a circ
 
 The dependency wheel's use areas are similar to the [Sankey diagram](https://www.highcharts.com/docs/chart-and-series-types/sankey-diagram), but while the Sankey diagram supports multiple columns, and there is a clear direction of flow, the dependency wheel's nodes are laid out on the same level, indicating that the flow is multidirectional.
 
-For more detailed samples and documentation, check the [API](https://api.highcharts.com/highcharts/plotOptions.series.dependencywheel).
+For more detailed samples and documentation, check the [API](https://api.highcharts.com/highcharts/plotOptions.dependencywheel).
 
 <iframe style="width: 100%; height: 600px; border: none;" src=https://www.highcharts.com/samples/embed/highcharts/demo/dependency-wheel allow="fullscreen"></iframe>
 


### PR DESCRIPTION
Dependency wheel API url provided in docs is invalid and results in a 404. 