### PR TITLE
bugfix/9738-groupAll-ohlc

### DIFF
--- a/js/Extensions/DataGrouping.js
+++ b/js/Extensions/DataGrouping.js
@@ -136,6 +136,7 @@ var approximations = H.approximations = {
     }
 };
 var groupData = function (xData, yData, groupPositions, approximation) {
+    var _a;
     var series = this, data = series.data, dataOptions = series.options && series.options.data, groupedXData = [], groupedYData = [], groupMap = [], dataLength = xData.length, pointX, pointY, groupedY, 
     // when grouping the fake extended axis for panning,
     // we don't need to consider y
@@ -224,7 +225,7 @@ var groupData = function (xData, yData, groupPositions, approximation) {
         // for each raw data point, push it to an array that contains all values
         // for this specific group
         if (pointArrayMap) {
-            var index = series.cropStart + i, point = (data && data[index]) ||
+            var index = ((_a = series.options.dataGrouping) === null || _a === void 0 ? void 0 : _a.groupAll) ? i : series.cropStart + i, point = (data && data[index]) ||
                 series.pointClass.prototype.applyOptions.apply({
                     series: series
                 }, [dataOptions[index]]), val;

--- a/samples/unit-tests/series/datagrouping/demo.js
+++ b/samples/unit-tests/series/datagrouping/demo.js
@@ -33,6 +33,42 @@ QUnit.test('General dataGrouping options', function (assert) {
             {
                 type: 'scatter',
                 data: [[1, 1]]
+            },
+            {
+                type: 'ohlc',
+                dataGrouping: {
+                    groupAll: true
+                },
+                data: [
+                    [1, 2, 1, 2],
+                    [2, 4, 2, 4],
+                    [1, 2, 1, 2],
+                    [1, 2, 1, 2],
+                    [1, 2, 1, 2],
+                    [1, 2, 1, 2],
+                    [1, 2, 1, 2],
+                    [1, 2, 1, 2],
+                    [1, 2, 1, 2],
+                    [1, 2, 1, 2]
+                ]
+            },
+            {
+                type: 'ohlc',
+                dataGrouping: {
+                    groupAll: false
+                },
+                data: [
+                    [1, 2, 1, 2],
+                    [2, 4, 2, 4],
+                    [1, 2, 1, 2],
+                    [1, 2, 1, 2],
+                    [1, 2, 1, 2],
+                    [1, 2, 1, 2],
+                    [1, 2, 1, 2],
+                    [1, 2, 1, 2],
+                    [1, 2, 1, 2],
+                    [1, 2, 1, 2]
+                ]
             }
         ]
     });
@@ -52,6 +88,17 @@ QUnit.test('General dataGrouping options', function (assert) {
         chart.series[1].points[0].y,
         4,
         'Only visible points are used to calculate gorups (#5344)'
+    );
+
+    assert.strictEqual(
+        chart.series[3].points[0].open,
+        1,
+        'All OHLC points are used (#9738)'
+    );
+    assert.strictEqual(
+        chart.series[4].points[0].open,
+        2,
+        'Only visible OHLC points are used (#9738)'
     );
 });
 

--- a/ts/Extensions/DataGrouping.ts
+++ b/ts/Extensions/DataGrouping.ts
@@ -469,7 +469,7 @@ const groupData = function (
         // for this specific group
         if (pointArrayMap) {
 
-            var index = (series.cropStart as any) + i,
+            var index = series.options.dataGrouping?.groupAll ? i : (series.cropStart as any) + i,
                 point = (data && data[index]) ||
                     series.pointClass.prototype.applyOptions.apply({
                         series: series


### PR DESCRIPTION
Fixed #9738, `groupAll` did not work correctly with OHLC-based series.