### PR TITLE
docs/misplaced-indicators-docs

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -108,8 +108,7 @@ module.exports = {
             'chart-and-series-types/waterfall-series',
             'chart-and-series-types/wind-barbs-series',
             'chart-and-series-types/word-cloud-series',
-            'chart-and-series-types/x-range-series',
-            'stock/technical-indicator-series'
+            'chart-and-series-types/x-range-series'
 
         ],
         'Advanced chart features': [


### PR DESCRIPTION
On the website, the indicators should be only under the "Stock" category, not mixed with a typical chart series.

Recent related PRs:
https://github.com/highcharts/highcharts/pull/15113
https://github.com/highcharts/highcharts/pull/15119
Sorry for the confusion!