### PR TITLE
Fixed regression in offline PDF

### DIFF
--- a/js/Extensions/OfflineExporting.js
+++ b/js/Extensions/OfflineExporting.js
@@ -224,6 +224,15 @@ function downloadSVGLocal(svg, options, failCallback, successCallback) {
                 i++;
             }
         }
+        // Workaround for #15135, zero width spaces, which Highcharts uses to
+        // break lines, are not correctly rendered in PDF. Replace it with a
+        // regular space and offset by some pixels to compensate.
+        [].forEach.call(svgElement.querySelectorAll('tspan'), function (tspan) {
+            if (tspan.textContent === '\u200B') {
+                tspan.textContent = ' ';
+                tspan.setAttribute('dx', -5);
+            }
+        });
         win.svg2pdf(svgElement, pdf, { removeInvalid: true });
         return pdf.output('datauristring');
     }

--- a/samples/highcharts/css/exporting-offline/test-notes.md
+++ b/samples/highcharts/css/exporting-offline/test-notes.md
@@ -1,2 +1,2 @@
 * Check that exporting works
-* Check that View in full screen works (must open the sample in its own tab)
+* Check that View in full screen works

--- a/ts/Extensions/OfflineExporting.ts
+++ b/ts/Extensions/OfflineExporting.ts
@@ -395,6 +395,19 @@ function downloadSVGLocal(
             }
         }
 
+        // Workaround for #15135, zero width spaces, which Highcharts uses to
+        // break lines, are not correctly rendered in PDF. Replace it with a
+        // regular space and offset by some pixels to compensate.
+        [].forEach.call(
+            svgElement.querySelectorAll('tspan'),
+            (tspan: SVGDOMElement): void => {
+                if (tspan.textContent === '\u200B') {
+                    tspan.textContent = ' ';
+                    tspan.setAttribute('dx', -5);
+                }
+            }
+        );
+
         win.svg2pdf(svgElement, pdf, { removeInvalid: true });
         return pdf.output('datauristring');
     }


### PR DESCRIPTION
Fixed #15135, a regression causing newline to render as garbled text in offline PDF exports.