### PR TITLE
bugfix/15128-series-clip-false-stock

### DIFF
--- a/js/Core/Chart/StockChart.js
+++ b/js/Core/Chart/StockChart.js
@@ -682,7 +682,8 @@ addEvent(Series, 'render', function () {
     if (!(chart.is3d && chart.is3d()) &&
         !chart.polar &&
         this.xAxis &&
-        !this.xAxis.isRadial // Gauge, #6192
+        !this.xAxis.isRadial && // Gauge, #6192
+        this.options.clip !== false // #15128
     ) {
         clipHeight = this.yAxis.len;
         // Include xAxis line width (#8031) but only if the Y axis ends on the

--- a/samples/unit-tests/series/clip/demo.js
+++ b/samples/unit-tests/series/clip/demo.js
@@ -24,6 +24,10 @@ QUnit.test('General series clip tests', assert => {
                     },
                     {
                         data: [400000000, 600000000]
+                    },
+                    {
+                        clip: false,
+                        data: [1, 2, 3]
                     }
                 ]
             },
@@ -32,6 +36,11 @@ QUnit.test('General series clip tests', assert => {
             {
                 duration: 15
             }
+        );
+
+        assert.notOk(
+            chart.series[2].clipBox,
+            '#15128: Series with clip=false should not have stock clipping applied'
         );
 
         setTimeout(() => {

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -1027,7 +1027,8 @@ addEvent(Series, 'render', function (): void {
         !(chart.is3d && chart.is3d()) &&
         !chart.polar &&
         this.xAxis &&
-        !this.xAxis.isRadial // Gauge, #6192
+        !this.xAxis.isRadial && // Gauge, #6192
+        this.options.clip !== false // #15128
     ) {
 
         clipHeight = this.yAxis.len;


### PR DESCRIPTION
Fixed #15128, parts of the series disappeared when redrawing a regular chart with `series.clip` set to `false` and stock loaded.