### PR TITLE
bugfix/15145-dataLabels-percent-stack

### DIFF
--- a/js/Core/Series/DataLabels.js
+++ b/js/Core/Series/DataLabels.js
@@ -430,7 +430,7 @@ Series.prototype.alignDataLabel = function (point, dataLabel, options, alignTo, 
             // If the data label is inside the align box, it is enough
             // that parts of the align box is inside the plot area
             // (#12370)
-            options.inside && alignTo && chart.isInsidePlot(plotX, inverted ?
+            pick(options.inside, !!this.options.stacking) && alignTo && chart.isInsidePlot(plotX, inverted ?
                 alignTo.x + 1 :
                 alignTo.y + alignTo.height - 1, inverted))), setStartPos = function (alignOptions) {
         if (enabledDataSorting && series.xAxis && !justify) {

--- a/js/Core/Series/DataLabels.js
+++ b/js/Core/Series/DataLabels.js
@@ -429,10 +429,13 @@ Series.prototype.alignDataLabel = function (point, dataLabel, options, alignTo, 
             (
             // If the data label is inside the align box, it is enough
             // that parts of the align box is inside the plot area
-            // (#12370)
-            pick(options.inside, !!this.options.stacking) && alignTo && chart.isInsidePlot(plotX, inverted ?
-                alignTo.x + 1 :
-                alignTo.y + alignTo.height - 1, inverted))), setStartPos = function (alignOptions) {
+            // (#12370). When stacking, it is always inside regardless
+            // of the option (#15148).
+            pick(options.inside, !!this.options.stacking) &&
+                alignTo &&
+                chart.isInsidePlot(plotX, inverted ?
+                    alignTo.x + 1 :
+                    alignTo.y + alignTo.height - 1, inverted))), setStartPos = function (alignOptions) {
         if (enabledDataSorting && series.xAxis && !justify) {
             series.setDataLabelStartPos(point, dataLabel, isNew, isInsidePlot, alignOptions);
         }

--- a/samples/unit-tests/datalabels/inside/demo.js
+++ b/samples/unit-tests/datalabels/inside/demo.js
@@ -32,3 +32,35 @@ QUnit.test('Datalabel inside on columnrange(#2711)', function (assert) {
         'Correct positions'
     );
 });
+
+QUnit.test('Implicitly inside percent stacked bar', assert => {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'bar'
+        },
+        yAxis: {
+            min: 0,
+            max: 80
+        },
+        plotOptions: {
+            series: {
+                stacking: 'percent',
+                dataLabels: {
+                    enabled: true
+                }
+            }
+        },
+        series: [{
+            data: [5, 3, 4, 7, 2]
+        }, {
+            data: [2, 2, 3, 2, 1]
+        }, {
+            data: [3, 4, 4, 2, 5]
+        }]
+    });
+
+    assert.ok(
+        chart.series[0].points[4].dataLabel.translateY > 0,
+        '#15145: First series dataLabels should be visible'
+    );
+});

--- a/ts/Core/Series/DataLabels.ts
+++ b/ts/Core/Series/DataLabels.ts
@@ -797,7 +797,7 @@ Series.prototype.alignDataLabel = function (
                     // If the data label is inside the align box, it is enough
                     // that parts of the align box is inside the plot area
                     // (#12370)
-                    options.inside && alignTo && chart.isInsidePlot(
+                    pick(options.inside, !!this.options.stacking) && alignTo && chart.isInsidePlot(
                         plotX,
                         inverted ?
                             alignTo.x + 1 :

--- a/ts/Core/Series/DataLabels.ts
+++ b/ts/Core/Series/DataLabels.ts
@@ -796,8 +796,11 @@ Series.prototype.alignDataLabel = function (
                 (
                     // If the data label is inside the align box, it is enough
                     // that parts of the align box is inside the plot area
-                    // (#12370)
-                    pick(options.inside, !!this.options.stacking) && alignTo && chart.isInsidePlot(
+                    // (#12370). When stacking, it is always inside regardless
+                    // of the option (#15148).
+                    pick(options.inside, !!this.options.stacking) &&
+                    alignTo &&
+                    chart.isInsidePlot(
                         plotX,
                         inverted ?
                             alignTo.x + 1 :


### PR DESCRIPTION
Fixed #15145, some data labels did not show in percent stacked bar or column charts when points were partially outside axis extremes.