### PR TITLE
bugfix/14966-accessibility-null-points

### DIFF
--- a/js/Core/Series/Point.js
+++ b/js/Core/Series/Point.js
@@ -1136,7 +1136,8 @@ var Point = /** @class */ (function () {
             markerAttribs = series.markerAttribs(point, state);
         }
         // Apply hover styles to the existing point
-        if (point.graphic) {
+        // Prevent from dummy null points (#14966)
+        if (point.graphic && !point.hasDummyGraphic) {
             if (previousState) {
                 point.graphic.removeClass('highcharts-point-' + previousState);
             }

--- a/samples/unit-tests/accessibility/null-points/demo.js
+++ b/samples/unit-tests/accessibility/null-points/demo.js
@@ -55,3 +55,32 @@ QUnit.test('Dynamic null points', function (assert) {
         'Point should have a new dummy marker graphic after update to null point.'
     );
 });
+
+// Issue #14966
+QUnit.test('Updating null point', assert => {
+    const chart = Highcharts.chart('container', {
+        series: [{
+            data: [{
+                x: 1,
+                y: 20
+            }, {
+                x: 2,
+                y: null
+            }, {
+                x: 3,
+                y: 20
+            }, {
+                x: 4,
+                y: 30
+            }]
+        }]
+    });
+
+    chart.series[0].points[1].select(true, true);
+
+    assert.notStrictEqual(
+        chart.series[0].points[1].graphic.y,
+        NaN,
+        'Point graphic y shouldn\'t be NaN.'
+    );
+});

--- a/samples/unit-tests/accessibility/null-points/demo.js
+++ b/samples/unit-tests/accessibility/null-points/demo.js
@@ -54,33 +54,12 @@ QUnit.test('Dynamic null points', function (assert) {
         'rect',
         'Point should have a new dummy marker graphic after update to null point.'
     );
-});
 
-// Issue #14966
-QUnit.test('Updating null point', assert => {
-    const chart = Highcharts.chart('container', {
-        series: [{
-            data: [{
-                x: 1,
-                y: 20
-            }, {
-                x: 2,
-                y: null
-            }, {
-                x: 3,
-                y: 20
-            }, {
-                x: 4,
-                y: 30
-            }]
-        }]
-    });
-
-    chart.series[0].points[1].select(true, true);
+    nullPoint.select(true, true);
 
     assert.notStrictEqual(
-        chart.series[0].points[1].graphic.y,
-        NaN,
+        nullPoint.graphic.attr('y'),
+        "NaN",
         'Point graphic y shouldn\'t be NaN.'
     );
 });

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1562,7 +1562,8 @@ class Point {
         }
 
         // Apply hover styles to the existing point
-        if (point.graphic) {
+        // Prevent from dummy null points (#14966)
+        if (point.graphic && !point.hasDummyGraphic) {
 
             if (previousState) {
                 point.graphic.removeClass('highcharts-point-' + previousState);


### PR DESCRIPTION
Fixed #14966, selected null points generated: "Error: attribute y: Expected length, "NaN"".