### PR TITLE
bugfix/15192-allowedAttributes-typo

### DIFF
--- a/js/Core/Renderer/HTML/AST.js
+++ b/js/Core/Renderer/HTML/AST.js
@@ -318,7 +318,7 @@ var AST = /** @class */ (function () {
      * // Allow a custom, trusted attribute
      * Highcharts.AST.allowedAttributes.push('data-value');
      *
-     * @name Highcharts.AST.allowedTags
+     * @name Highcharts.AST.allowedAttributes
      * @static
      */
     AST.allowedAttributes = [

--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -163,7 +163,7 @@ class AST {
      * // Allow a custom, trusted attribute
      * Highcharts.AST.allowedAttributes.push('data-value');
      *
-     * @name Highcharts.AST.allowedTags
+     * @name Highcharts.AST.allowedAttributes
      * @static
      */
     public static allowedAttributes = [


### PR DESCRIPTION
Fixed #15192, `allowedAttributes` doclet type name was wrong.