### PR TITLE
bugfix/15162-scss-subtitle-font-size

### DIFF
--- a/css/highcharts.scss
+++ b/css/highcharts.scss
@@ -137,6 +137,7 @@ $indicator-negative-line: #f21313; // Negative indicator color
 }
 .highcharts-subtitle {
     fill: $neutral-color-60;
+    font-size: $subtitle-font-size;
 }
 
 /* Axes */


### PR DESCRIPTION
Fixed #15162, in styled mode, the font-size of the subtitle was not used like defined in Sass file. 