### PR TITLE
bugfix/button-align-update-size

### DIFF
--- a/samples/unit-tests/chart/zoomtype/demo.js
+++ b/samples/unit-tests/chart/zoomtype/demo.js
@@ -70,6 +70,18 @@ QUnit.test('Zoom type', function (assert) {
         6,
         'The zoom button should have Z index 6, below tooltip (#6096)'
     );
+
+    const buttonY = chart.resetZoomButton.translateY - chart.plotTop;
+    chart.update({
+        title: {
+            text: void 0
+        }
+    });
+    assert.strictEqual(
+        chart.resetZoomButton.translateY - chart.plotTop,
+        buttonY,
+        'The zoom button should have been re-aligned'
+    );
 });
 
 QUnit.test('Zooming scatter charts', function (assert) {

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3725,8 +3725,8 @@ class Chart {
 }
 
 addEvent(Chart, 'afterSetChartSize', function (e: { skipAxes: boolean }): void {
-    if (!e.skipAxes && this.resetZoomButton) {
-        this.resetZoomButton.align();
+    if (!e.skipAxes) {
+        this.renderer.align();
     }
 });
 

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -1922,7 +1922,7 @@ class Chart {
                 axis.setAxisSize();
                 axis.setAxisTranslation();
             });
-            this.renderer.alignElements();
+            renderer.alignElements();
         }
 
         fireEvent(chart, 'afterSetChartSize', { skipAxes: skipAxes });

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -1922,6 +1922,7 @@ class Chart {
                 axis.setAxisSize();
                 axis.setAxisTranslation();
             });
+            this.renderer.alignElements();
         }
 
         fireEvent(chart, 'afterSetChartSize', { skipAxes: skipAxes });
@@ -3723,12 +3724,6 @@ class Chart {
     }
 
 }
-
-addEvent(Chart, 'afterSetChartSize', function (e: { skipAxes: boolean }): void {
-    if (!e.skipAxes) {
-        this.renderer.align();
-    }
-});
 
 /* *
  *

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3724,6 +3724,12 @@ class Chart {
 
 }
 
+addEvent(Chart, 'afterSetChartSize', function (e: { skipAxes: boolean }): void {
+    if (!e.skipAxes && this.resetZoomButton) {
+        this.resetZoomButton.align();
+    }
+});
+
 /* *
  *
  *  Class Prototype Properties

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3388,7 +3388,7 @@ class Chart {
                 btnOptions.relativeTo === 'chart' ||
                 btnOptions.relativeTo === 'spacingBox' ?
                     null :
-                    this.scrollablePlotBox || 'plotBox'
+                    'scrollablePlotBox'
             );
 
         /**

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -724,7 +724,12 @@ class SVGElement {
             alignTo = this.alignTo;
         }
 
-        box = pick(box, (renderer as any)[alignTo as any], renderer as any);
+        box = pick(
+            box,
+            (renderer as any)[alignTo as any],
+            alignTo === 'scrollablePlotBox' ? (renderer as any).plotBox : void 0,
+            renderer as any
+        );
 
         // Assign variables
         align = (alignOptions as any).align;

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -139,7 +139,7 @@ declare global {
             public unSubPixelFix?: Function;
             public url: string;
             public width: number;
-            public align(): void;
+            public alignElements(): void;
             public arc(attribs: SVGAttributes): SVGElement;
             public arc(
                 x?: number,
@@ -1578,7 +1578,7 @@ class SVGRenderer {
             duration: pick(animate, true) ? void 0 : 0
         });
 
-        renderer.align();
+        renderer.alignElements();
     }
 
     /**
@@ -2476,14 +2476,13 @@ class SVGRenderer {
      * Re-align all aligned elements.
      *
      * @private
-     * @function Highcharts.SVGRenderer#align
+     * @function Highcharts.SVGRenderer#alignElements
      * @return {void}
      */
-    public align(): void {
-        let i = this.alignedObjects.length;
-        while (i--) {
-            this.alignedObjects[i].align();
-        }
+    public alignElements(): void {
+        this.alignedObjects.forEach((el): void => {
+            el.align();
+        });
     }
 }
 

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -2480,9 +2480,7 @@ class SVGRenderer {
      * @return {void}
      */
     public alignElements(): void {
-        this.alignedObjects.forEach((el): void => {
-            el.align();
-        });
+        this.alignedObjects.forEach((el): SVGElement => el.align());
     }
 }
 

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -139,6 +139,7 @@ declare global {
             public unSubPixelFix?: Function;
             public url: string;
             public width: number;
+            public align(): void;
             public arc(attribs: SVGAttributes): SVGElement;
             public arc(
                 x?: number,
@@ -1559,9 +1560,7 @@ class SVGRenderer {
         height: number,
         animate?: (boolean|Partial<AnimationOptions>)
     ): void {
-        var renderer = this,
-            alignedObjects = renderer.alignedObjects,
-            i = alignedObjects.length;
+        var renderer = this;
 
         renderer.width = width;
         renderer.height = height;
@@ -1579,9 +1578,7 @@ class SVGRenderer {
             duration: pick(animate, true) ? void 0 : 0
         });
 
-        while (i--) {
-            alignedObjects[i].align();
-        }
+        renderer.align();
     }
 
     /**
@@ -2473,6 +2470,20 @@ class SVGRenderer {
             className
         );
 
+    }
+
+    /**
+     * Re-align all aligned elements.
+     *
+     * @private
+     * @function Highcharts.SVGRenderer#align
+     * @return {void}
+     */
+    public align(): void {
+        let i = this.alignedObjects.length;
+        while (i--) {
+            this.alignedObjects[i].align();
+        }
     }
 }
 

--- a/ts/Extensions/Drilldown.ts
+++ b/ts/Extensions/Drilldown.ts
@@ -1673,3 +1673,9 @@ addEvent(H.Chart, 'drillup', function (): void {
         this.resetZoomButton = this.resetZoomButton.destroy();
     }
 });
+
+addEvent(H.Chart, 'afterSetChartSize', function (e: { skipAxes: boolean }): void {
+    if (!e.skipAxes && this.drillUpButton) {
+        this.drillUpButton.align();
+    }
+});

--- a/ts/Extensions/Drilldown.ts
+++ b/ts/Extensions/Drilldown.ts
@@ -872,7 +872,7 @@ Chart.prototype.showDrillUpButton = function (): void {
             buttonOptions.relativeTo === 'chart' ||
             buttonOptions.relativeTo === 'spacingBox' ?
                 null :
-                this.scrollablePlotBox || 'plotBox'
+                'scrollablePlotBox'
         );
 
     if (!this.drillUpButton) {

--- a/ts/Extensions/Drilldown.ts
+++ b/ts/Extensions/Drilldown.ts
@@ -1673,9 +1673,3 @@ addEvent(H.Chart, 'drillup', function (): void {
         this.resetZoomButton = this.resetZoomButton.destroy();
     }
 });
-
-addEvent(H.Chart, 'afterSetChartSize', function (e: { skipAxes: boolean }): void {
-    if (!e.skipAxes && this.drillUpButton) {
-        this.drillUpButton.align();
-    }
-});

--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -58,6 +58,12 @@ declare module '../Core/Chart/ChartLike'{
     }
 }
 
+declare module '../Core/Renderer/SVG/SVGRendererLike' {
+    interface SVGRendererLike {
+        scrollablePlotBox?: BBoxObject;
+    }
+}
+
 /**
  * Options for a scrollable plot area. This feature provides a minimum size for
  * the plot area of the chart. If the size gets smaller than this, typically
@@ -155,7 +161,7 @@ addEvent(Chart, 'afterSetChartSize', function (e: { skipAxes: boolean }): void {
                 scrollableMinWidth - this.chartWidth
             );
             if (scrollablePixelsX) {
-                this.scrollablePlotBox = merge(this.plotBox);
+                this.scrollablePlotBox = this.renderer.scrollablePlotBox = merge(this.plotBox);
                 this.plotBox.width = this.plotWidth += scrollablePixelsX;
                 if (this.inverted) {
                     this.clipBox.height += scrollablePixelsX;
@@ -176,7 +182,7 @@ addEvent(Chart, 'afterSetChartSize', function (e: { skipAxes: boolean }): void {
                 scrollableMinHeight - this.chartHeight
             );
             if (scrollablePixelsY) {
-                this.scrollablePlotBox = merge(this.plotBox);
+                this.scrollablePlotBox = this.renderer.scrollablePlotBox = merge(this.plotBox);
                 this.plotBox.height = this.plotHeight += scrollablePixelsY;
                 if (this.inverted) {
                     this.clipBox.width += scrollablePixelsY;


### PR DESCRIPTION
Fixed reset zoom and drillup button alignment after plot size changes, button alignment did not update when the plot size changed due to hiding or showing elements such as legend or title.