### PR TITLE
bugfix/15265-firevents-ignores-dom-params

### DIFF
--- a/samples/unit-tests/utilities/events/demo.js
+++ b/samples/unit-tests/utilities/events/demo.js
@@ -669,4 +669,29 @@
             'Events should fire in order across the prototype chain'
         );
     });
+
+    QUnit.test('FireEvent on dom element keeps params', assert => {
+        const container = document.getElementById('container');
+        const value = 'test';
+
+        Highcharts.addEvent(container, 'testEvent', function (e) {
+            e.test = value;
+        });
+
+        Highcharts.fireEvent(container, 'testEvent', { a: 'test' }, function (e) {
+            console.log(e.test);
+            assert.equal(e.test, value);
+        });
+
+        const obj = {};
+
+        Highcharts.addEvent(obj, 'testEvent2', function (e) {
+            e.test = value;
+        });
+
+        Highcharts.fireEvent(obj, 'testEvent2', { a: 'testt2' }, function (e) {
+            console.log(e.test);
+            assert.equal(e.test, value);
+        });
+    });
 }());

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -2390,12 +2390,12 @@ function fireEvent<T>(
         e = doc.createEvent('Events');
         e.initEvent(type, true, true);
 
-        extend(e, eventArguments);
+        eventArguments = extend(e, eventArguments);
 
         if ((el as any).dispatchEvent) {
-            (el as any).dispatchEvent(e);
+            (el as any).dispatchEvent(eventArguments);
         } else {
-            (el as any).fireEvent(type, e);
+            (el as any).fireEvent(type, eventArguments);
         }
 
     } else if ((el as any).hcEvents) {


### PR DESCRIPTION
Fixed #15265, fireEvent ignored extended params on DOM element.