### PR TITLE
bugfix/15260-networkgraph-className

### DIFF
--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.js
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.js
@@ -29,7 +29,11 @@ QUnit.test('Network Graph', function (assert) {
         },
         keys: ['from', 'to'],
         data: [
-            ['A', 'B'],
+            {
+                from: 'A',
+                to: 'B',
+                className: 'test'
+            },
             ['A', 'C'],
             ['A', 'D'],
 
@@ -52,6 +56,12 @@ QUnit.test('Network Graph', function (assert) {
         chart.series[0].points.length,
         7,
         'Series successfully added'
+    );
+
+    assert.notStrictEqual(
+        chart.series[0].points[0].graphic.attr('class').indexOf('test'),
+        -1,
+        '#15260: Point className should have been added'
     );
 
     assert.strictEqual(

--- a/ts/Series/Networkgraph/Networkgraph.ts
+++ b/ts/Series/Networkgraph/Networkgraph.ts
@@ -1242,6 +1242,7 @@ extend(NetworkgraphPoint.prototype, {
                 .path(
                     this.getLinkPath()
                 )
+                .addClass(this.getClassName(), true)
                 .add(this.series.group);
 
             if (!this.series.chart.styledMode) {


### PR DESCRIPTION
Fixed #15260, networkgraph point `className` option did not work.