### PR TITLE
bugfix/15179-crisp-subpixel-radius

### DIFF
--- a/samples/unit-tests/series/marker/demo.js
+++ b/samples/unit-tests/series/marker/demo.js
@@ -72,6 +72,7 @@ QUnit.test('Marker size and position', function (assert) {
                 data: [1, 2, 3],
                 animation: false,
                 marker: {
+                    radius: 2.5,
                     animation: false,
                     states: {
                         hover: {
@@ -82,6 +83,18 @@ QUnit.test('Marker size and position', function (assert) {
             }
         ]
     }).series[0];
+
+    assert.strictEqual(
+        series.points[0].graphic.x % 1,
+        0,
+        '#15179: Position should be a whole number because of crisping'
+    );
+
+    series.update({
+        marker: {
+            radius: 4
+        }
+    });
 
     // Default size
     assert.strictEqual(

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -5218,7 +5218,7 @@ class Series {
         attribs = {
             // Math.floor for #1843:
             x: seriesOptions.crisp ?
-                Math.floor(point.plotX as any) - radius :
+                Math.floor(point.plotX as any - radius) :
                 (point.plotX as any) - radius,
             y: (point.plotY as any) - radius
         };


### PR DESCRIPTION
Fixed #15179, crisping did not work correctly for subpixel radius markers.