### PR TITLE
bugfix/15060-rangeselector-text-input-width

### DIFF
--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -1375,14 +1375,15 @@ class RangeSelector {
         if (input && dateBox && this.inputGroup) {
             const isTextInput = input.type === 'text';
             const { translateX, translateY } = this.inputGroup;
+            const { inputBoxWidth } = this.options;
 
             css(input, {
-                width: isTextInput ? ((dateBox.width - 2) + 'px') : 'auto',
+                width: isTextInput ? ((dateBox.width + (inputBoxWidth ? -2 : 20)) + 'px') : 'auto',
                 height: isTextInput ? ((dateBox.height - 2) + 'px') : 'auto',
                 border: '2px solid silver'
             });
 
-            if (isTextInput) {
+            if (isTextInput && inputBoxWidth) {
                 css(input, {
                     left: (translateX + dateBox.x) + 'px',
                     top: translateY + 'px'
@@ -1401,7 +1402,7 @@ class RangeSelector {
                         this.chart.chartWidth - input.offsetWidth
                     ) + 'px',
                     top: (
-                        translateY - (input.offsetHeight - dateBox.height) / 2
+                        translateY - 1 - (input.offsetHeight - dateBox.height) / 2
                     ) + 'px'
                 });
             }


### PR DESCRIPTION
Fixed #15060, range selector text input was too short when `inputBoxWidth` was not set, especially in IE.