### PR TITLE
Tools: added demos/samples deploy to CI setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,23 @@ jobs:
       - <<: *load_workspace
       - run: ./.circleci/scripts/check_and_trigger_docs_deploy.sh  --bucket=${DOCS_DEPLOY_BUCKET} --token=${CIRCLE_API_TOKEN} <<# parameters.always_deploy >>-f<</ parameters.always_deploy >>
 
+
+  check_for_samples_changes_and_deploy:
+    <<: *defaults
+    description: Checks for changes in samples/ and samples/*/demo and triggers deploy via highcharts-demo-manager
+    parameters:
+      always_deploy:
+        description: "Deploy regardless of finding changes in on last commit"
+        type: boolean
+        default: false
+      include_thumbnails:
+        description: "Include thumbnails in the build"
+        type: boolean
+        default: false
+    steps:
+      - <<: *load_workspace
+      - run: ./.circleci/scripts/check_and_trigger_docs_deploy.sh  --bucket=${DOCS_DEPLOY_BUCKET} --token=${CIRCLE_API_TOKEN} <<# parameters.always_deploy >>-f<</ parameters.always_deploy >> <<# parameters.always_deploy >>--thumbnails<</ parameters.always_deploy >>
+
   generate_release_reference_images:
     <<: *defaults
     description: Generate visual tests reference images
@@ -465,6 +482,17 @@ workflows:
             tags:
               only: /^v\d+(?:\.\d+)+?$/
           context: highcharts-prod
+      - check_for_samples_changes_and_deploy:
+          # On release, make sure everything is up to date and force update thumbnails
+          requires: [generate_release_reference_images]
+          always_deploy: true
+          include_thumbnails: true
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+(?:\.\d+)+?$/
+          context: highcharts-prod
 
   nightly:
     triggers:
@@ -532,6 +560,13 @@ workflows:
       - deploy_to_highcharts_dist:
           requires: [build_dist]
           context: highcharts-staging
+      # Trigger samples/demo updates
+      - check_for_samples_changes_and_deploy:
+          requires: [build_dist]
+          filters:
+            branches:
+              only: [master]
+          context: highcharts-prod
 
   reset_visual_test_references:
     when: << pipeline.parameters.run_reset_tests >>

--- a/.circleci/scripts/check_and_trigger_samples_deploy.sh
+++ b/.circleci/scripts/check_and_trigger_samples_deploy.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -e
+
+# latest commit
+LATEST_COMMIT=$(git rev-parse HEAD)
+BUCKET=""
+TOKEN=""
+FORCE_DEPLOY=false
+THUMBNAILS=false
+
+for i in "$@"
+do
+case $i in
+    -b=*|--bucket=*)
+    BUCKET="${i#*=}"
+    ;;
+      -t=*|--token=*)
+    TOKEN="${i#*=}"
+    ;;
+      -f|--force-deploy)
+    FORCE_DEPLOY=true
+    ;;
+      --thumbnails)
+    THUMBNAILS=true
+    ;;
+    *)
+     # unknown option
+    ;;
+esac
+done
+
+if [[ -z $BUCKET ]]; then
+  echo "Please specify bucket to deploy to using --bucket=<your.bucket> argument."
+  exit 1;
+fi
+
+if [[ -z $TOKEN ]]; then
+  echo "Please specify CirleCI API token to deploy to using --token=<token> argument."
+  exit 1;
+fi
+
+# latest commit where samples were changed, limited to 24 hours
+SAMPLES_COMMIT=$(git log -1 --since=\"24 hours ago\" --format=format:%H --full-diff --name-status samples/)
+DEMOS_COMMIT=$(git log -1 --since=\"24 hours ago\" --format=format:%H --full-diff --name-status samples/\*/demo/\*)q
+
+if [ [ $(echo $SAMPLES_COMMIT | wc -l) -ge 2 ]] || [ "$FORCE_DEPLOY" = true  ]; then
+    echo "Force deployed: ${FORCE_DEPLOY}"
+    echo "Files in samples/ has changed or forcing deploy. Triggering deploy of samples via highcharts-demo-manager to bucket ${BUCKET}"
+    payload="{ \"branch\":\"master\", \"parameters\": { \"deploy_samples\": true, \"target_bucket\": \"${BUCKET}\" }}"
+    echo "$payload"
+
+    # Circle API v2
+    httpUrl="https://circleci.com/api/v2/project/github/highcharts/highcharts-demo-manager/pipeline?circle-token=${TOKEN}&branch=master"
+    rep=$(curl -f -X POST -H "Content-Type: application/json" -d "$payload" "$httpUrl")
+    status="$?"
+    echo "$rep"
+    exit "$status"
+
+else
+     echo "No change in samples/ folder found."
+     exit 0;
+fi
+
+# Handle demos
+if [[ $(echo $DEMOS_COMMIT | wc -l) -ge 2 ]] || [ "$FORCE_DEPLOY" = true  ]; then
+    echo "Force deployed: ${FORCE_DEPLOY}"
+    echo "Found changes in demos"
+    # Check if there are any [A]dded demo files, build thumbnails if that is the case
+	  NEW_FILES=$(echo $DEMOS_COMMIT | egrep -c "^A\s+samples\/.+\/demo\/*\.details")
+    if [[ $NEW_FILES -ge 1 ]]; then
+      THUMBNAILS=true
+    fi
+
+    echo "Files in samples/ has changed or forcing deploy. Triggering deploy of demos via highcharts-demo-manager to bucket ${BUCKET}"
+    payload="{ \"branch\":\"master\", \"parameters\": { \"deploy_demos\": true, \"deploy_thumbnails\": ${THUMBNAILS}, \"target_bucket\": \"${BUCKET}\" }}"
+    echo "$payload"
+
+    # Circle API v2
+    httpUrl="https://circleci.com/api/v2/project/github/highcharts/highcharts-demo-manager/pipeline?circle-token=${TOKEN}&branch=master"
+    rep=$(curl -f -X POST -H "Content-Type: application/json" -d "$payload" "$httpUrl")
+    status="$?"
+    echo "$rep"
+    exit "$status"
+
+else
+     echo "No change in samples/*/demo/ folder found."
+     exit 0;
+fi


### PR DESCRIPTION
Added triggers for building samples and demos via the highcharts-demo-manger CI setup.

Samples and demos should now be updated nightly, if there are changes in the relevant folders. It should also update demo thumbnails if any new demos are added.

I also added a full refresh on release, but this may be redundant (except perhaps in the case of thumbnails being affected by changes in HC).