### PR TITLE
DeepPartial for Axis options

### DIFF
--- a/samples/unit-tests/axis/update/demo.js
+++ b/samples/unit-tests/axis/update/demo.js
@@ -170,7 +170,7 @@ QUnit.test('Update axis names (#3830)', function (assert) {
 
     assert.strictEqual(
         chart.xAxis[0].labelRotation,
-        undefined,
+        0,
         'Axis labels should not be rotated'
     );
 

--- a/samples/unit-tests/gantt/current-date-indicator/demo.js
+++ b/samples/unit-tests/gantt/current-date-indicator/demo.js
@@ -72,7 +72,7 @@
             clock = TestUtilities.lolexInstall();
 
         try {
-            oldValue = cdi.options.value.getTime();
+            oldValue = cdi.options.value;
 
             // Run lolex ticker
             setTimeout(function () {}, wait);
@@ -81,7 +81,7 @@
 
             axis.redraw();
 
-            newValue = cdi.options.value.getTime();
+            newValue = cdi.options.value;
 
             assert.ok(
                 newValue > oldValue,

--- a/ts/Core/Axis/Axis3D.ts
+++ b/ts/Core/Axis/Axis3D.ts
@@ -147,11 +147,11 @@ class Axis3DAdditions {
             beta = deg2rad * (chart.options.chart as any).options3d.beta,
             positionMode = pick(
                 isTitle && (axis.options.title as any).position3d,
-                (axis.options.labels as any).position3d
+                axis.options.labels.position3d
             ),
             skew = pick(
                 isTitle && (axis.options.title as any).skew3d,
-                (axis.options.labels as any).skew3d
+                axis.options.labels.skew3d
             ),
             frame = chart.chart3d.frame3d,
             plotLeft = chart.plotLeft,

--- a/ts/Core/Axis/ColorAxis.ts
+++ b/ts/Core/Axis/ColorAxis.ts
@@ -90,7 +90,10 @@ declare global {
             labelRight?: number;
         }
         interface Options {
-            colorAxis?: (ColorAxis.Options|Array<ColorAxis.Options>);
+            colorAxis?: (
+                DeepPartial<ColorAxis.Options>|
+                Array<DeepPartial<ColorAxis.Options>>
+            );
         }
         let ColorAxis: ColorAxisClass;
     }
@@ -606,7 +609,10 @@ class ColorAxis extends Axis implements AxisLike {
     /**
      * @private
      */
-    public constructor(chart: Chart, userOptions: ColorAxis.Options) {
+    public constructor(
+        chart: Chart,
+        userOptions: DeepPartial<ColorAxis.Options>
+    ) {
         super(chart, userOptions);
         this.init(chart, userOptions);
     }
@@ -653,7 +659,7 @@ class ColorAxis extends Axis implements AxisLike {
      */
     public init(
         chart: Chart,
-        userOptions: ColorAxis.Options
+        userOptions: DeepPartial<ColorAxis.Options>
     ): void {
         const axis = this;
         const legend = chart.options.legend || {},
@@ -696,7 +702,7 @@ class ColorAxis extends Axis implements AxisLike {
     /**
      * @private
      */
-    public initDataClasses(userOptions: ColorAxis.Options): void {
+    public initDataClasses(userOptions: DeepPartial<ColorAxis.Options>): void {
         const axis = this;
         var chart = axis.chart,
             dataClasses,
@@ -1217,7 +1223,7 @@ class ColorAxis extends Axis implements AxisLike {
      * and call {@link Highcharts.Chart#redraw} after.
      */
     public update(
-        newOptions: ColorAxis.Options,
+        newOptions: DeepPartial<ColorAxis.Options>,
         redraw?: boolean
     ): void {
         const axis = this,

--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -1241,7 +1241,7 @@ class GridAxis {
      */
     public static onInit(
         this: Axis,
-        e: { userOptions?: Highcharts.AxisOptions }
+        e: { userOptions?: DeepPartial<Highcharts.AxisOptions> }
     ): void {
         const axis = this;
         const userOptions = e.userOptions || {};

--- a/ts/Core/Axis/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand.ts
@@ -92,9 +92,6 @@ declare global {
             x?: number;
             y?: number;
         }
-        interface PlotLineOrBandLabelFormatterCallbackFunction {
-            (this: PlotLineOrBand, value?: number, format?: string): string;
-        }
         interface AxisPlotLinesOptions {
             acrossPanes?: boolean;
             className?: string;

--- a/ts/Core/Axis/RadialAxis.ts
+++ b/ts/Core/Axis/RadialAxis.ts
@@ -850,7 +850,7 @@ class RadialAxis {
                     axis.isRadial &&
                     axis.tickPositions &&
                     // undocumented option for now, but working
-                    (axis.options.labels as any).allowOverlap !== true
+                    axis.options.labels.allowOverlap !== true
                 ) {
                     return axis.tickPositions
                         .map(function (

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -277,7 +277,7 @@ class Tick {
 
     public movedLabel?: SVGElement;
 
-    public options?: Highcharts.AxisOptions;
+    public options?: DeepPartial<Highcharts.AxisOptions>;
 
     public parameters: Highcharts.TickParametersObject;
 

--- a/ts/Core/Axis/TreeGridAxis.ts
+++ b/ts/Core/Axis/TreeGridAxis.ts
@@ -143,7 +143,7 @@ namespace TreeGridAxis {
     }
 
     export interface Options extends Highcharts.XAxisOptions {
-        labels?: LabelsOptions;
+        labels: LabelsOptions;
     }
 
     export interface TreeGridNode extends Highcharts.TreeNode {

--- a/ts/Core/Axis/ZAxis.ts
+++ b/ts/Core/Axis/ZAxis.ts
@@ -33,7 +33,10 @@ declare module '../Chart/ChartLike'{
 declare global {
     namespace Highcharts {
         interface Options {
-            zAxis?: (Highcharts.AxisOptions|Array<Highcharts.AxisOptions>);
+            zAxis?: (
+                DeepPartial<Highcharts.AxisOptions>|
+                Array<DeepPartial<Highcharts.AxisOptions>>
+            );
         }
     }
 }
@@ -229,9 +232,9 @@ class ZAxis extends Axis implements AxisLike {
      */
     public setOptions(userOptions: DeepPartial<Highcharts.AxisOptions>): void {
 
-        userOptions = merge<Highcharts.AxisOptions>({
-            offset: 0 as any,
-            lineWidth: 0 as any
+        userOptions = merge<DeepPartial<Highcharts.AxisOptions>>({
+            offset: 0,
+            lineWidth: 0
         }, userOptions);
 
         // #14793, this used to be set on the prototype

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -2323,7 +2323,7 @@ class Chart {
             if (
                 axis.horiz &&
                 axis.visible &&
-                (axis.options.labels as any).enabled &&
+                axis.options.labels.enabled &&
                 axis.series.length
             ) {
                 // 21 is the most common correction for X axis labels

--- a/ts/Core/Chart/GanttChart.ts
+++ b/ts/Core/Chart/GanttChart.ts
@@ -95,8 +95,8 @@ H.ganttChart = function (
 
     // apply X axis options to both single and multi x axes
     options.xAxis = options.xAxis.map(function (
-        xAxisOptions: Highcharts.XAxisOptions,
-        i: number
+        xAxisOptions,
+        i
     ): Highcharts.XAxisOptions {
         if (i === 1) { // Second xAxis
             defaultLinkedTo = 0;
@@ -140,7 +140,7 @@ H.ganttChart = function (
         );
     });
 
-    options.series = null as any;
+    delete options.series;
 
     options = merge(
         true,

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -1110,7 +1110,10 @@ addEvent(Chart, 'update', function (
  * @param {Highcharts.AxisOptions} options
  * @return {Highcharts.AxisOptions}
  */
-function getDefaultAxisOptions(type: string, options: Highcharts.AxisOptions): Highcharts.AxisOptions {
+function getDefaultAxisOptions(
+    type: string,
+    options: Highcharts.AxisOptions
+): DeepPartial<Highcharts.AxisOptions> {
     if (type === 'xAxis') {
         return {
             minPadding: 0,

--- a/ts/Core/Navigator.ts
+++ b/ts/Core/Navigator.ts
@@ -105,8 +105,8 @@ declare global {
             outlineWidth?: number;
             series?: SeriesTypeOptions;
             top?: number;
-            xAxis?: XAxisOptions;
-            yAxis?: YAxisOptions;
+            xAxis?: DeepPartial<XAxisOptions>;
+            yAxis?: DeepPartial<YAxisOptions>;
         }
         interface Options {
             navigator?: NavigatorOptions;
@@ -1884,7 +1884,7 @@ class Navigator {
 
         if (navigator.navigatorEnabled) {
             // an x axis is required for scrollbar also
-            navigator.xAxis = new Axis(chart, merge<Highcharts.XAxisOptions>({
+            navigator.xAxis = new Axis(chart, merge<DeepPartial<Highcharts.XAxisOptions>>({
                 // inherit base xAxis' break and ordinal options
                 breaks: baseXaxis.options.breaks,
                 ordinal: baseXaxis.options.ordinal

--- a/ts/Extensions/DragPanes.ts
+++ b/ts/Extensions/DragPanes.ts
@@ -112,7 +112,7 @@ declare global {
 class AxisResizer {
 
     // Default options for AxisResizer.
-    public static resizerOptions: Highcharts.YAxisOptions = {
+    public static resizerOptions: DeepPartial<Highcharts.YAxisOptions> = {
         /**
          * Minimal size of a resizable axis. Could be set as a percent
          * of plot area or pixel size.
@@ -551,7 +551,7 @@ class AxisResizer {
                                 chart.get(axisInfo)
                         ),
                     axisOptions = axis && axis.options,
-                    optionsToUpdate: Highcharts.YAxisOptions = {},
+                    optionsToUpdate: DeepPartial<Highcharts.YAxisOptions> = {},
                     hDelta = 0,
                     height, top,
                     minLength, maxLength;

--- a/ts/Extensions/ParallelCoordinates.ts
+++ b/ts/Extensions/ParallelCoordinates.ts
@@ -452,7 +452,7 @@ function addFormattedValue(
              * @apioption yAxis.tooltipValueFormat
              */
             yAxisOptions.tooltipValueFormat,
-            (yAxisOptions.labels as any).format
+            yAxisOptions.labels.format
         );
 
         if (labelFormat) {


### PR DESCRIPTION
DeepPartial for Axis options, prevent having to cast `options.label.someThing` to any. Following up this, other options in `AxisOptions` should also be make non-optional.