### PR TITLE
TS: Improved ES6 pattern and types of Globals

### DIFF
--- a/ts/Core/Globals.ts
+++ b/ts/Core/Globals.ts
@@ -10,9 +10,47 @@
 
 'use strict';
 
+/* *
+ *
+ *  Imports
+ *
+ * */
+
 import type Chart from './Chart/Chart';
 import type { SeriesTypeRegistry } from './Series/SeriesType';
 import type SizeObject from './Renderer/SizeObject';
+
+/* *
+ *
+ *  Declarations
+ *
+ * */
+
+declare global {
+    type GlobalSVGElement = SVGElement;
+    interface CallableFunction {
+        apply<TScope, TArguments extends any[], TReturn>(
+            this: (this: TScope, ...args: TArguments) => TReturn,
+            thisArg: TScope,
+            args?: (TArguments|IArguments)
+        ): TReturn;
+    }
+    interface Element {
+        setAttribute(
+            qualifiedName: string,
+            value: (boolean|number|string)
+        ): void;
+    }
+    interface ObjectConstructor {
+        /**
+         * Sets the prototype of a specified object o to object proto or null.
+         * Returns the object o.
+         * @param o The object to change its prototype.
+         * @param proto The value of the new prototype or null.
+         */
+        setPrototypeOf?(o: any, proto: object | null): any;
+    }
+}
 
 declare module './Chart/ChartLike' {
     interface ChartLike {
@@ -28,13 +66,207 @@ declare module './Series/PointLike' {
     }
 }
 
+declare interface HighchartsObjectConstructor extends ObjectConstructor {
+    keys<T extends object>(obj: T): keyof T;
+}
+
+/* *
+ *
+ *  Constants
+ *
+ * */
+
+/**
+ * @private
+ * @deprecated
+ * @todo Rename UMD argument `win` to `window`; move code to `Globals.win`
+ */
+const WINDOW = (
+    typeof win !== 'undefined' ?
+        win :
+        typeof window !== 'undefined' ?
+            window :
+            {}
+// eslint-disable-next-line node/no-unsupported-features/es-builtins
+) as (Window&typeof globalThis);
+
+/* *
+ *
+ *  Namespace
+ *
+ * */
+
+/**
+ * Shared Highcharts properties.
+ */
+namespace Globals {
+
+    /* *
+     *
+     *  Aliases
+     *
+     * */
+
+    export const Obj = Object as unknown as HighchartsObjectConstructor;
+
+    export const SVG_NS = 'http://www.w3.org/2000/svg';
+
+    /* *
+     *
+     *  Constants
+     *
+     * */
+
+    export const
+        product = 'Highcharts',
+        version = '@product.version@',
+        win = WINDOW,
+        doc = win.document,
+        nav = win.navigator,
+        svg = (
+            doc &&
+            doc.createElementNS &&
+            !!(doc.createElementNS(SVG_NS, 'svg') as SVGSVGElement).createSVGRect
+        ),
+        userAgent = (nav && nav.userAgent) || '',
+        isChrome = userAgent.indexOf('Chrome') !== -1,
+        isFirefox = userAgent.indexOf('Firefox') !== -1,
+        isMS = /(edge|msie|trident)/i.test(userAgent) && !win.opera,
+        isSafari = !isChrome && userAgent.indexOf('Safari') !== -1,
+        isTouchDevice = /(Mobile|Android|Windows Phone)/.test(userAgent),
+        isWebKit = userAgent.indexOf('AppleWebKit') !== -1,
+        deg2rad = Math.PI * 2 / 360,
+        hasBidiBug = (
+            isFirefox &&
+            parseInt(userAgent.split('Firefox/')[1], 10) < 4 // issue #38
+        ),
+        hasTouch = !!win.TouchEvent,
+        marginNames: ReadonlyArray<string> = [
+            'plotTop',
+            'marginRight',
+            'marginBottom',
+            'plotLeft'
+        ],
+        noop = function (): void {},
+        supportsPassiveEvents = (function (): boolean {
+            // Checks whether the browser supports passive events, (#11353).
+            let supportsPassive = false;
+
+            // Object.defineProperty doesn't work on IE as well as passive
+            // events - instead of using polyfill, we can exclude IE totally.
+            if (!isMS) {
+                const opts = Object.defineProperty({}, 'passive', {
+                    get: function (): void {
+                        supportsPassive = true;
+                    }
+                });
+
+                if (win.addEventListener && win.removeEventListener) {
+                    win.addEventListener('testPassive', noop, opts);
+                    win.removeEventListener('testPassive', noop, opts);
+                }
+            }
+
+            return supportsPassive;
+        }());
+
+    /**
+     * An array containing the current chart objects in the page. A chart's
+     * position in the array is preserved throughout the page's lifetime. When
+     * a chart is destroyed, the array item becomes `undefined`.
+     *
+     * @name Highcharts.charts
+     * @type {Array<Highcharts.Chart|undefined>}
+     */
+    export const charts: Array<(Chart|undefined)> = [];
+
+    /**
+     * A hook for defining additional date format specifiers. New
+     * specifiers are defined as key-value pairs by using the
+     * specifier as key, and a function which takes the timestamp as
+     * value. This function returns the formatted portion of the
+     * date.
+     *
+     * @sample highcharts/global/dateformats/
+     *         Adding support for week number
+     *
+     * @name Highcharts.dateFormats
+     * @type {Record<string, Highcharts.TimeFormatCallbackFunction>}
+     */
+    export const dateFormats: Record<string, Highcharts.TimeFormatCallbackFunction> = {};
+
+    /**
+     * @private
+     * @deprecated
+     * @todo Use only `Core/Series/SeriesRegistry.seriesTypes`
+     */
+    export const seriesTypes = {} as SeriesTypeRegistry;
+
+    /**
+     * @private
+     */
+    export const symbolSizes: Record<string, SizeObject> = {};
+
+    /* *
+     *
+     *  Properties
+     *
+     * */
+
+    export let chartCount: 0;
+
+    /**
+     * Theme options that should get applied to the chart. In module mode it
+     * might not be possible to change this property because of read-only
+     * restrictions, instead use {@link Highcharts.setOptions}.
+     *
+     * @name Highcharts.theme
+     * @type {Highcharts.Options}
+     */
+    export let theme: (Highcharts.Options|undefined);
+
+}
+
+export default Globals as unknown as (typeof Globals&typeof Highcharts);
+
+/* *
+ *
+ *  API Declarations
+ *
+ * */
+
+/**
+ * Reference to the global SVGElement class as a workaround for a name conflict
+ * in the Highcharts namespace.
+ *
+ * @global
+ * @typedef {global.SVGElement} GlobalSVGElement
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGElement
+ */
+
+''; // detach doclets above
+
+/* *
+ *
+ *  Deprecated API
+ *
+ * */
+
 /**
  * Internal types
  * @private
  */
 declare global {
     /**
+     * @private
+     * @deprecated
+     * @todo: Rename UMD argument `win` to `window`
+     */
+    const win: Window|undefined;
+    /**
      * [[include:README.md]]
+     * @deprecated
      */
     namespace Highcharts {
         interface Axis {
@@ -50,38 +282,6 @@ declare global {
         interface Options {
             toolbar?: any; // @todo stock-tools
         }
-        const SVG_NS: string;
-        const charts: Array<Chart|undefined>;
-        const dateFormats: Record<string, TimeFormatCallbackFunction>;
-        const deg2rad: number;
-        const doc: Document;
-        const hasBidiBug: boolean;
-        const hasTouch: boolean;
-        const isChrome: boolean;
-        const isFirefox: boolean;
-        const isMS: boolean;
-        const isSafari: boolean;
-        const isTouchDevice: boolean;
-        const isWebKit: boolean;
-        const marginNames: Array<string>;
-        const noop: () => void;
-        const product: string;
-        const supportsPassiveEvents: boolean;
-        const symbolSizes: Record<string, SizeObject>;
-        const win: GlobalWindow;
-        const svg: boolean;
-        const version: string;
-        let theme: (Options|undefined);
-    }
-    type GlobalWindow = typeof window;
-    type GlobalHTMLElement = HTMLElement;
-    type GlobalSVGElement = SVGElement;
-    interface CallableFunction {
-        apply<TScope, TArguments extends any[], TReturn>(
-            this: (this: TScope, ...args: TArguments) => TReturn,
-            thisArg: TScope,
-            args?: (TArguments|IArguments)
-        ): TReturn;
     }
     interface Document {
         /** @deprecated */
@@ -90,9 +290,11 @@ declare global {
         mozCancelFullScreen: Function;
         /** @deprecated */
         msExitFullscreen: Function;
+        /** @deprecated */
         msHidden: boolean;
         /** @deprecated */
         webkitExitFullscreen: Function;
+        /** @deprecated */
         webkitHidden: boolean;
     }
     interface Element {
@@ -100,40 +302,20 @@ declare global {
         currentStyle?: ElementCSSInlineStyle;
         /** @deprecated */
         mozRequestFullScreen: Function;
+        /** @deprecated */
         msMatchesSelector: Element['matches'];
         /** @deprecated */
         msRequestFullscreen: Function;
+        /** @deprecated */
         webkitMatchesSelector: Element['matches'];
         /** @deprecated */
         webkitRequestFullScreen: Function;
-        setAttribute(
-            qualifiedName: string,
-            value: (boolean|number|string)
-        ): void;
-    }/*
-    interface Highcharts {
-        /**
-         * @deprecated
-         * /
-        [key: string]: any;
-    }*/
-    interface ObjectConstructor {
-        /**
-         * Sets the prototype of a specified object o to object proto or null.
-         * Returns the object o.
-         * @param o The object to change its prototype.
-         * @param proto The value of the new prototype or null.
-         */
-        setPrototypeOf?(o: any, proto: object | null): any;
-    }
-    interface OscillatorNode extends AudioNode {
     }
     interface PointerEvent {
         /** @deprecated */
         readonly toElement: Element;
     }
     interface Window {
-        TouchEvent?: typeof TouchEvent;
         /** @deprecated */
         createObjectURL?: (typeof URL)['createObjectURL'];
         /** @deprecated */
@@ -143,123 +325,4 @@ declare global {
         /** @deprecated */
         webkitURL?: typeof URL;
     }
-    const win: GlobalWindow|undefined; // @todo: UMD variable named `window`
 }
-
-/* globals Image, window */
-
-/**
- * Reference to the global SVGElement class as a workaround for a name conflict
- * in the Highcharts namespace.
- *
- * @global
- * @typedef {global.SVGElement} GlobalSVGElement
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGElement
- */
-
-// glob is a temporary fix to allow our es-modules to work.
-var glob = ( // @todo UMD variable named `window`, and glob named `win`
-        typeof win !== 'undefined' ?
-            win :
-            typeof window !== 'undefined' ?
-                window :
-                {} as GlobalWindow
-    ),
-    doc = glob.document,
-    SVG_NS = 'http://www.w3.org/2000/svg',
-    userAgent = (glob.navigator && glob.navigator.userAgent) || '',
-    svg = (
-        doc &&
-        doc.createElementNS &&
-        !!(doc.createElementNS(SVG_NS, 'svg') as SVGSVGElement).createSVGRect
-    ),
-    isMS = /(edge|msie|trident)/i.test(userAgent) && !glob.opera,
-    isFirefox = userAgent.indexOf('Firefox') !== -1,
-    isChrome = userAgent.indexOf('Chrome') !== -1,
-    hasBidiBug = (
-        isFirefox &&
-        parseInt(userAgent.split('Firefox/')[1], 10) < 4 // issue #38
-    ),
-    noop = function (): void {},
-    // Checks whether the browser supports passive events, (#11353).
-    checkPassiveEvents = function (): boolean {
-        let supportsPassive = false;
-
-        // Object.defineProperty doesn't work on IE as well as passive events -
-        // instead of using polyfill, we can exclude IE totally.
-        if (!isMS) {
-            const opts = Object.defineProperty({}, 'passive', {
-                get: function (): void {
-                    supportsPassive = true;
-                }
-            });
-
-            if (glob.addEventListener && glob.removeEventListener) {
-                glob.addEventListener('testPassive', noop, opts);
-                glob.removeEventListener('testPassive', noop, opts);
-            }
-        }
-
-        return supportsPassive;
-    };
-
-var H: typeof Highcharts = {
-    product: 'Highcharts',
-    version: '@product.version@',
-    deg2rad: Math.PI * 2 / 360,
-    doc,
-    hasBidiBug: hasBidiBug,
-    hasTouch: !!glob.TouchEvent,
-    isMS,
-    isWebKit: userAgent.indexOf('AppleWebKit') !== -1,
-    isFirefox,
-    isChrome,
-    isSafari: !isChrome && userAgent.indexOf('Safari') !== -1,
-    isTouchDevice: /(Mobile|Android|Windows Phone)/.test(userAgent),
-    SVG_NS,
-    chartCount: 0,
-    seriesTypes: {} as SeriesTypeRegistry,
-    supportsPassiveEvents: checkPassiveEvents(),
-    symbolSizes: {},
-    svg,
-    win: glob,
-    marginNames: ['plotTop', 'marginRight', 'marginBottom', 'plotLeft'],
-    noop,
-
-    /**
-     * Theme options that should get applied to the chart. In module mode it
-     * might not be possible to change this property because of read-only
-     * restrictions, instead use {@link Highcharts.setOptions}.
-     *
-     * @name Highcharts.theme
-     * @type {Highcharts.Options}
-     */
-
-    /**
-     * An array containing the current chart objects in the page. A chart's
-     * position in the array is preserved throughout the page's lifetime. When
-     * a chart is destroyed, the array item becomes `undefined`.
-     *
-     * @name Highcharts.charts
-     * @type {Array<Highcharts.Chart|undefined>}
-     */
-    charts: [],
-
-    /**
-     * A hook for defining additional date format specifiers. New
-     * specifiers are defined as key-value pairs by using the
-     * specifier as key, and a function which takes the timestamp as
-     * value. This function returns the formatted portion of the
-     * date.
-     *
-     * @sample highcharts/global/dateformats/
-     *         Adding support for week number
-     *
-     * @name Highcharts.dateFormats
-     * @type {Highcharts.Dictionary<Highcharts.TimeFormatCallbackFunction>}
-     */
-    dateFormats: {}
-} as unknown as typeof Highcharts;
-
-export default H;

--- a/ts/Core/Series/SeriesRegistry.ts
+++ b/ts/Core/Series/SeriesRegistry.ts
@@ -75,7 +75,11 @@ namespace SeriesRegistry {
     /** @internal */
     export let series: typeof Series;
 
-    export const seriesTypes = {} as SeriesTypeRegistry;
+    /**
+     * @internal
+     * @todo Move `Globals.seriesTypes` code to her.
+     */
+    export const seriesTypes = H.seriesTypes;
 
     /* *
      *
@@ -212,7 +216,6 @@ namespace SeriesRegistry {
  * */
 
 H.seriesType = SeriesRegistry.seriesType;
-H.seriesTypes = SeriesRegistry.seriesTypes;
 
 /* *
  *

--- a/ts/Extensions/Data.ts
+++ b/ts/Extensions/Data.ts
@@ -101,7 +101,7 @@ declare global {
             startColumn?: number;
             startRow?: number;
             switchRowsAndColumns?: boolean;
-            table?: (string|GlobalHTMLElement);
+            table?: (string|HTMLElement);
         }
         interface DataParseDateCallbackFunction {
             (dateValue: string): number;


### PR DESCRIPTION
- Added internal custom H.Obj.keys type reference, returning `keyof object` for usage on objects without indexer.
- Migrated shared properties to ES6 namespace Globals (= window.Highcharts in masters).
- Clarified todo's of UMD workaround.
- Simplified assignment of SeriesRegistry.
- Deprecated custom browser properties, as TypeScript tends to remove them gradually from the internal type definitions.
- Removed outdated global types