### PR TITLE
bugfix/12100-indicators-menu-scrollable-refectoring

### DIFF
--- a/samples/stock/stocktools/scrollable-popup/demo.css
+++ b/samples/stock/stocktools/scrollable-popup/demo.css
@@ -1,0 +1,3 @@
+.scrollable{
+    height: 1000px;
+}

--- a/samples/stock/stocktools/scrollable-popup/demo.details
+++ b/samples/stock/stocktools/scrollable-popup/demo.details
@@ -1,0 +1,7 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Karol Kolodziej
+ requiresManualTesting: true
+ js_wrap: b
+...

--- a/samples/stock/stocktools/scrollable-popup/demo.html
+++ b/samples/stock/stocktools/scrollable-popup/demo.html
@@ -1,0 +1,12 @@
+<link rel="stylesheet" type="text/css" href="https://code.highcharts.com/css/stocktools/gui.css">
+<link rel="stylesheet" type="text/css" href="https://code.highcharts.com/css/annotations/popup.css">
+
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+<script src="https://code.highcharts.com/maps/modules/map.js"></script>
+<script src="https://code.highcharts.com/stock/indicators/indicators-all.js"></script>
+<script src="https://code.highcharts.com/modules/annotations-advanced.js"></script>
+<script src="https://code.highcharts.com/modules/stock-tools.js"></script>
+
+<div class="scrollable">
+    <div id="container"></div> 
+</div>

--- a/samples/stock/stocktools/scrollable-popup/demo.js
+++ b/samples/stock/stocktools/scrollable-popup/demo.js
@@ -1,0 +1,15 @@
+Highcharts.stockChart('container', {
+    mapNavigation: {
+        enabled: true
+    },
+    stockTools: {
+        gui: {
+            enabled: true,
+            buttons: ['indicators']
+        }
+    },
+    series: [{
+        type: 'line',
+        data: Array.from({ length: 50 }, () => Math.random() * 10)
+    }]
+});

--- a/samples/stock/stocktools/scrollable-popup/test-notes.md
+++ b/samples/stock/stocktools/scrollable-popup/test-notes.md
@@ -1,0 +1,4 @@
+1. Click the stock tools indicator button.
+2. Scroll inside the popup. The list should be scrollable and the chart should not change its extremes.
+3. After closing the popup and scrolling inside the plot area, extremes should change.
+4. Move the pointer to the blank space under the chart and make sure that the main div is scrollable and the chart is not changing the extremes, #5011.

--- a/ts/Extensions/Annotations/Popup.ts
+++ b/ts/Extensions/Annotations/Popup.ts
@@ -1233,7 +1233,7 @@ H.Popup.prototype = {
             return createElement(
                 DIV,
                 {
-                    className: PREFIX + 'tab-item-content'
+                    className: PREFIX + 'tab-item-content ' + PREFIX + 'no-mousewheel'// #12100
                 },
                 null as any,
                 popupDiv

--- a/ts/Maps/MapNavigation.ts
+++ b/ts/Maps/MapNavigation.ts
@@ -296,10 +296,14 @@ MapNavigation.prototype.updateEvents = function (
             typeof doc.onmousewheel === 'undefined' ?
                 'DOMMouseScroll' : 'mousewheel',
             function (e: PointerEvent): boolean {
-                chart.pointer.onContainerMouseWheel(e);
-                // Issue #5011, returning false from non-jQuery event does
-                // not prevent default
-                stopEvent(e as Event);
+                // Prevent scrolling when the pointer is over the element
+                // with that class, for example anotation popup #12100.
+                if (!chart.pointer.inClass(e.target as any, 'highcharts-no-mousewheel')) {
+                    chart.pointer.onContainerMouseWheel(e);
+                    // Issue #5011, returning false from non-jQuery event does
+                    // not prevent default
+                    stopEvent(e as Event);
+                }
                 return false;
             }
         );


### PR DESCRIPTION
Fixed #12100, unable to scroll using mousewheel inside Stock Tools popups when `mapNavigation` was enabled.