### PR TITLE
Migrated outdated types of Globals.

### DIFF
--- a/ts/Accessibility/A11yI18n.ts
+++ b/ts/Accessibility/A11yI18n.ts
@@ -26,7 +26,7 @@ declare module '../Core/Chart/ChartLike' {
         /** @requires modules/accessibility */
         langFormat(
             langKey: string,
-            context: Record<string, any>,
+            context: AnyRecord,
             time?: Highcharts.Time
         ): string;
     }
@@ -50,7 +50,7 @@ declare global {
         /** @requires modules/accessibility */
         function i18nFormat(
             formatString: string,
-            context: Record<string, any>,
+            context: AnyRecord,
             chart: Chart
         ): string;
     }
@@ -92,7 +92,7 @@ function stringTrim(str: string): string {
  */
 function formatExtendedStatement(
     statement: string,
-    ctx: Record<string, any>
+    ctx: AnyRecord
 ): string {
     var eachStart = statement.indexOf('#each('),
         pluralStart = statement.indexOf('#plural('),
@@ -254,7 +254,7 @@ function formatExtendedStatement(
  */
 H.i18nFormat = function (
     formatString: string,
-    context: Record<string, any>,
+    context: AnyRecord,
     chart: Chart
 ): string {
     var getFirstBracketStatement = function (
@@ -343,7 +343,7 @@ H.i18nFormat = function (
  */
 H.Chart.prototype.langFormat = function (
     langKey: string,
-    context: Record<string, any>
+    context: AnyRecord
 ): string {
     var keys = langKey.split('.'),
         formatString: string = this.options.lang as any,

--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -216,7 +216,7 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
                 this.chart.highlightLegendItem(component.highlightedLegendItemIx);
             }
         });
-        this.addEvent(Legend, 'afterPositionItem', function (e: Record<string, any>): void {
+        this.addEvent(Legend, 'afterPositionItem', function (e: AnyRecord): void {
             if (this.chart === component.chart && this.chart.renderer) {
                 component.updateProxyPositionForItem(e.item);
             }

--- a/ts/Accessibility/HighContrastMode.ts
+++ b/ts/Accessibility/HighContrastMode.ts
@@ -89,7 +89,7 @@ var whcm = {
         chart.highContrastModeActive = true;
 
         // Apply theme to chart
-        var theme: Record<string, any> = (
+        var theme: AnyRecord = (
             chart.options.accessibility.highContrastTheme
         );
         chart.update(theme, false);

--- a/ts/Accessibility/Options/Options.ts
+++ b/ts/Accessibility/Options/Options.ts
@@ -79,10 +79,10 @@ declare global {
         }
         interface AccessibilityOptions {
             announceNewData: AccessibilityAnnounceNewDataOptions;
-            customComponents?: Record<string, any>;
+            customComponents?: AnyRecord;
             description?: string;
             enabled: boolean;
-            highContrastTheme: Record<string, any>;
+            highContrastTheme: AnyRecord;
             keyboardNavigation: AccessibilityKeyboardNavigationOptions;
             landmarkVerbosity: string;
             linkedDescription: (string|HTMLDOMElement);

--- a/ts/Core/Animation/AnimationUtilities.ts
+++ b/ts/Core/Animation/AnimationUtilities.ts
@@ -129,7 +129,7 @@ const animObject = H.animObject = function animObject(
  */
 const getDeferredAnimation = H.getDeferredAnimation = function (
     chart: Chart,
-    animation: (false|DeepPartial<AnimationOptions>),
+    animation: (false|Partial<AnimationOptions>),
     series?: Series
 ): Partial<AnimationOptions> {
 

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -6209,9 +6209,9 @@ class Axis {
             evt = {
                 newMin: newMin,
                 newMax: newMax
-            } as Record<string, any>;
+            } as AnyRecord;
 
-        fireEvent(this, 'zoom', evt, function (e: Record<string, any>): void {
+        fireEvent(this, 'zoom', evt, function (e: AnyRecord): void {
 
             // Use e.newMin and e.newMax - event handlers may have altered them
             var newMin = e.newMin,
@@ -6397,7 +6397,7 @@ class Axis {
             evt = { align: 'center' as AlignValue };
 
         fireEvent(this, 'autoLabelAlign', evt, function (
-            e: Record<string, any>
+            e: AnyRecord
         ): void {
 
             if (angle > 15 && angle < 165) {

--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -72,6 +72,9 @@ declare global {
  * @private
  */
 declare module './Types' {
+    interface AxisLike {
+        rightWall?: SVGElement;
+    }
     interface AxisComposition {
         grid?: GridAxis['grid'];
     }

--- a/ts/Core/Axis/NavigatorAxis.ts
+++ b/ts/Core/Axis/NavigatorAxis.ts
@@ -182,7 +182,7 @@ class NavigatorAxis {
         // For Stock charts, override selection zooming with some special
         // features because X axis zooming is already allowed by the Navigator
         // and Range selector.
-        addEvent(AxisClass, 'zoom', function (e: Record<string, any>): void {
+        addEvent(AxisClass, 'zoom', function (e: AnyRecord): void {
             const axis = this as NavigatorAxis;
             const chart = axis.chart;
             const chartOptions = chart.options;

--- a/ts/Core/Axis/StackingAxis.ts
+++ b/ts/Core/Axis/StackingAxis.ts
@@ -170,8 +170,8 @@ class StackingAxisAdditions {
         const chart = axis.chart;
         const renderer = chart.renderer;
         const stacks = stacking.stacks;
-        const stackLabelsAnim = axis.options.stackLabels.animation;
-        const animationConfig = getDeferredAnimation(chart, stackLabelsAnim);
+        const stackLabelsAnim = axis.options.stackLabels && axis.options.stackLabels.animation;
+        const animationConfig = getDeferredAnimation(chart, stackLabelsAnim || false);
         const stackTotalGroup = stacking.stackTotalGroup = (
             stacking.stackTotalGroup ||
             renderer

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -46,7 +46,7 @@ declare global {
         }
         interface TickParametersObject {
             category?: string;
-            options?: Record<string, any>;
+            options?: AnyRecord;
             tickmarkOffset?: number;
         }
         interface TickPositionObject extends PositionObject {
@@ -335,7 +335,7 @@ class Tick {
             dateTimeLabelFormat,
             dateTimeLabelFormats,
             i,
-            list: Record<string, any>;
+            list: AnyRecord;
 
         // Set the datetime label format. If a higher rank is set for this
         // position, use that. If not, use the general format.

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -128,6 +128,7 @@ declare global {
             index?: number;
         }
         interface ChartOptions {
+            forExport?: boolean;
             renderer?: string;
             skipClone?: boolean;
         }
@@ -363,7 +364,7 @@ class Chart {
             // Override (by copy of user options) or clear tooltip options
             // in chart.options.plotOptions (#6218)
             objectEach(options.plotOptions, function (
-                typeOptions: Record<string, any>,
+                typeOptions: AnyRecord,
                 type: string
             ): void {
                 if (isObject(typeOptions)) { // #8766
@@ -3162,10 +3163,7 @@ class Chart {
         // options.mapNavigation => chart.mapNavigation
         // options.navigator => chart.navigator
         // options.scrollbar => chart.scrollbar
-        objectEach(options, function (
-            val: Record<string, any>,
-            key: string
-        ): void {
+        objectEach(options, function (val, key): void {
             if ((chart as any)[key] &&
                 typeof (chart as any)[key].update === 'function'
             ) {
@@ -3178,7 +3176,7 @@ class Chart {
             // Else, just merge the options. For nodes like loading, noData,
             // plotOptions
             } else if (
-                key !== 'color' &&
+                key !== 'colors' &&
                 chart.collectionsWithUpdate.indexOf(key) === -1
             ) {
                 merge(true, (chart.options as any)[key], (options as any)[key]);

--- a/ts/Core/Chart/Chart3D.ts
+++ b/ts/Core/Chart/Chart3D.ts
@@ -15,6 +15,7 @@
 import type ColorType from '../Color/ColorType';
 import type Position3DObject from '../Renderer/Position3DObject';
 import type SeriesOptions from '../Series/SeriesOptions';
+import type SVGElement from '../Renderer/SVG/SVGElement';
 import Axis from '../Axis/Axis.js';
 import Axis3D from '../Axis/Axis3D.js';
 import Chart from './Chart.js';
@@ -48,6 +49,7 @@ declare module '../Animation/FxLike' {
 declare module '../Chart/ChartLike'{
     interface ChartLike {
         chart3d?: Chart3D['chart3d'];
+        frameShapes?: Record<string, SVGElement>;
         is3d(): boolean;
     }
 }

--- a/ts/Core/Chart/MapChart.ts
+++ b/ts/Core/Chart/MapChart.ts
@@ -132,7 +132,7 @@ namespace MapChart {
      * @name Highcharts.maps
      * @type {Record<string,*>}
      */
-    export const maps: Record<string, any> = {};
+    export const maps: AnyRecord = {};
 
     /**
      * The factory function for creating new map charts. Creates a new {@link

--- a/ts/Core/Globals.ts
+++ b/ts/Core/Globals.ts
@@ -16,9 +16,7 @@
  *
  * */
 
-import type Chart from './Chart/Chart';
-import type { SeriesTypeRegistry } from './Series/SeriesType';
-import type SizeObject from './Renderer/SizeObject';
+import type GlobalsType from './GlobalsType';
 
 /* *
  *
@@ -27,9 +25,9 @@ import type SizeObject from './Renderer/SizeObject';
  * */
 
 declare global {
-    type GlobalSVGElement = SVGElement;
+    type AnyRecord = Record<string, any>;
     interface CallableFunction {
-        apply<TScope, TArguments extends any[], TReturn>(
+        apply<TScope, TArguments extends Array<unknown>, TReturn>(
             this: (this: TScope, ...args: TArguments) => TReturn,
             thisArg: TScope,
             args?: (TArguments|IArguments)
@@ -48,26 +46,14 @@ declare global {
          * @param o The object to change its prototype.
          * @param proto The value of the new prototype or null.
          */
-        setPrototypeOf?(o: any, proto: object | null): any;
+        setPrototypeOf?<T>(o: T, proto: object | null): T;
     }
-}
-
-declare module './Chart/ChartLike' {
-    interface ChartLike {
-        frameShapes?: any; // @todo highcharts 3d
-        isBoosting?: any; // @todo boost module
-    }
-}
-
-declare module './Series/PointLike' {
-    interface PointLike {
-        startR?: any; // @todo solid-gauge
-        tooltipDateKeys?: any; // @todo xrange
-    }
-}
-
-declare interface HighchartsObjectConstructor extends ObjectConstructor {
-    keys<T extends object>(obj: T): keyof T;
+    /**
+     * @private
+     * @deprecated
+     * @todo: Rename UMD argument `win` to `window`
+     */
+    const win: Window|undefined;
 }
 
 /* *
@@ -81,7 +67,7 @@ declare interface HighchartsObjectConstructor extends ObjectConstructor {
  * @deprecated
  * @todo Rename UMD argument `win` to `window`; move code to `Globals.win`
  */
-const WINDOW = (
+const w = (
     typeof win !== 'undefined' ?
         win :
         typeof window !== 'undefined' ?
@@ -103,32 +89,21 @@ namespace Globals {
 
     /* *
      *
-     *  Aliases
-     *
-     * */
-
-    export const Obj = Object as unknown as HighchartsObjectConstructor;
-
-    export const SVG_NS = 'http://www.w3.org/2000/svg';
-
-    /* *
-     *
      *  Constants
      *
      * */
 
-    export const
+    export const SVG_NS = 'http://www.w3.org/2000/svg',
         product = 'Highcharts',
         version = '@product.version@',
-        win = WINDOW,
+        win = w,
         doc = win.document,
-        nav = win.navigator,
         svg = (
             doc &&
             doc.createElementNS &&
             !!(doc.createElementNS(SVG_NS, 'svg') as SVGSVGElement).createSVGRect
         ),
-        userAgent = (nav && nav.userAgent) || '',
+        userAgent = (win.navigator && win.navigator.userAgent) || '',
         isChrome = userAgent.indexOf('Chrome') !== -1,
         isFirefox = userAgent.indexOf('Firefox') !== -1,
         isMS = /(edge|msie|trident)/i.test(userAgent) && !win.opera,
@@ -141,7 +116,7 @@ namespace Globals {
             parseInt(userAgent.split('Firefox/')[1], 10) < 4 // issue #38
         ),
         hasTouch = !!win.TouchEvent,
-        marginNames: ReadonlyArray<string> = [
+        marginNames: GlobalsType['marginNames'] = [
             'plotTop',
             'marginRight',
             'marginBottom',
@@ -178,7 +153,7 @@ namespace Globals {
      * @name Highcharts.charts
      * @type {Array<Highcharts.Chart|undefined>}
      */
-    export const charts: Array<(Chart|undefined)> = [];
+    export const charts: GlobalsType['charts'] = [];
 
     /**
      * A hook for defining additional date format specifiers. New
@@ -193,19 +168,19 @@ namespace Globals {
      * @name Highcharts.dateFormats
      * @type {Record<string, Highcharts.TimeFormatCallbackFunction>}
      */
-    export const dateFormats: Record<string, Highcharts.TimeFormatCallbackFunction> = {};
+    export const dateFormats: GlobalsType['dateFormats'] = {};
 
     /**
      * @private
      * @deprecated
      * @todo Use only `Core/Series/SeriesRegistry.seriesTypes`
      */
-    export const seriesTypes = {} as SeriesTypeRegistry;
+    export const seriesTypes = {} as GlobalsType['seriesTypes'];
 
     /**
      * @private
      */
-    export const symbolSizes: Record<string, SizeObject> = {};
+    export const symbolSizes: GlobalsType['symbolSizes'] = {};
 
     /* *
      *
@@ -227,102 +202,10 @@ namespace Globals {
 
 }
 
-export default Globals as unknown as (typeof Globals&typeof Highcharts);
-
 /* *
  *
- *  API Declarations
+ *  Default Export
  *
  * */
 
-/**
- * Reference to the global SVGElement class as a workaround for a name conflict
- * in the Highcharts namespace.
- *
- * @global
- * @typedef {global.SVGElement} GlobalSVGElement
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGElement
- */
-
-''; // detach doclets above
-
-/* *
- *
- *  Deprecated API
- *
- * */
-
-/**
- * Internal types
- * @private
- */
-declare global {
-    /**
-     * @private
-     * @deprecated
-     * @todo: Rename UMD argument `win` to `window`
-     */
-    const win: Window|undefined;
-    /**
-     * [[include:README.md]]
-     * @deprecated
-     */
-    namespace Highcharts {
-        interface Axis {
-            rightWall?: any; // @todo
-            beforePadding?: Function; // @todo
-        }
-        interface XAxisOptions {
-            stackLabels?: any; // @todo
-        }
-        interface ChartOptions {
-            forExport?: any; // @todo
-        }
-        interface Options {
-            toolbar?: any; // @todo stock-tools
-        }
-    }
-    interface Document {
-        /** @deprecated */
-        exitFullscreen: () => Promise<void>;
-        /** @deprecated */
-        mozCancelFullScreen: Function;
-        /** @deprecated */
-        msExitFullscreen: Function;
-        /** @deprecated */
-        msHidden: boolean;
-        /** @deprecated */
-        webkitExitFullscreen: Function;
-        /** @deprecated */
-        webkitHidden: boolean;
-    }
-    interface Element {
-        /** @deprecated */
-        currentStyle?: ElementCSSInlineStyle;
-        /** @deprecated */
-        mozRequestFullScreen: Function;
-        /** @deprecated */
-        msMatchesSelector: Element['matches'];
-        /** @deprecated */
-        msRequestFullscreen: Function;
-        /** @deprecated */
-        webkitMatchesSelector: Element['matches'];
-        /** @deprecated */
-        webkitRequestFullScreen: Function;
-    }
-    interface PointerEvent {
-        /** @deprecated */
-        readonly toElement: Element;
-    }
-    interface Window {
-        /** @deprecated */
-        createObjectURL?: (typeof URL)['createObjectURL'];
-        /** @deprecated */
-        opera?: unknown;
-        /** @deprecated */
-        webkitAudioContext?: typeof AudioContext;
-        /** @deprecated */
-        webkitURL?: typeof URL;
-    }
-}
+export default Globals as unknown as GlobalsType;

--- a/ts/Core/Globals.ts
+++ b/ts/Core/Globals.ts
@@ -16,7 +16,7 @@
  *
  * */
 
-import type GlobalsType from './GlobalsType';
+import type GlobalsLike from './GlobalsLike';
 
 /* *
  *
@@ -116,7 +116,7 @@ namespace Globals {
             parseInt(userAgent.split('Firefox/')[1], 10) < 4 // issue #38
         ),
         hasTouch = !!win.TouchEvent,
-        marginNames: GlobalsType['marginNames'] = [
+        marginNames: GlobalsLike['marginNames'] = [
             'plotTop',
             'marginRight',
             'marginBottom',
@@ -153,7 +153,7 @@ namespace Globals {
      * @name Highcharts.charts
      * @type {Array<Highcharts.Chart|undefined>}
      */
-    export const charts: GlobalsType['charts'] = [];
+    export const charts: GlobalsLike['charts'] = [];
 
     /**
      * A hook for defining additional date format specifiers. New
@@ -168,19 +168,19 @@ namespace Globals {
      * @name Highcharts.dateFormats
      * @type {Record<string, Highcharts.TimeFormatCallbackFunction>}
      */
-    export const dateFormats: GlobalsType['dateFormats'] = {};
+    export const dateFormats: GlobalsLike['dateFormats'] = {};
 
     /**
      * @private
      * @deprecated
      * @todo Use only `Core/Series/SeriesRegistry.seriesTypes`
      */
-    export const seriesTypes = {} as GlobalsType['seriesTypes'];
+    export const seriesTypes = {} as GlobalsLike['seriesTypes'];
 
     /**
      * @private
      */
-    export const symbolSizes: GlobalsType['symbolSizes'] = {};
+    export const symbolSizes: GlobalsLike['symbolSizes'] = {};
 
     /* *
      *
@@ -208,4 +208,4 @@ namespace Globals {
  *
  * */
 
-export default Globals as unknown as GlobalsType;
+export default Globals as unknown as GlobalsLike;

--- a/ts/Core/GlobalsLike.d.ts
+++ b/ts/Core/GlobalsLike.d.ts
@@ -90,10 +90,10 @@ export type InternalNamespace = typeof Highcharts;
 /**
  * Helper interface to add property types to `Globals`.
  *
- * Use the `declare module 'GlobalsType'` pattern to overload the interface in
+ * Use the `declare module 'GlobalsLike'` pattern to overload the interface in
  * this definition file.
  */
-export interface GlobalsType extends InternalNamespace {
+export interface GlobalsLike extends InternalNamespace {
     readonly Obj: ObjectConstructor;
     readonly SVG_NS: string;
     readonly charts: Array<(Chart|undefined)>;
@@ -123,4 +123,4 @@ export interface GlobalsType extends InternalNamespace {
     readonly win: (Window&typeof globalThis);
 }
 
-export default GlobalsType;
+export default GlobalsLike;

--- a/ts/Core/GlobalsType.d.ts
+++ b/ts/Core/GlobalsType.d.ts
@@ -1,0 +1,126 @@
+/* *
+ *
+ *  (c) 2010-2021 Torstein Honsi
+ *
+ *  License: www.highcharts.com/license
+ *
+ *  !!!!!!! SOURCE GETS TRANSPILED BY TYPESCRIPT. EDIT TS FILE ONLY. !!!!!!!
+ *
+ * */
+
+/* *
+ *
+ *  Imports
+ *
+ * */
+
+import type Chart from './Chart/Chart';
+import type { SeriesTypeRegistry } from './Series/SeriesType';
+import type SizeObject from './Renderer/SizeObject';
+
+/* *
+ *
+ *  Declarations
+ *
+ * */
+
+/**
+ * Deprecated API
+ * @private
+ */
+declare global {
+    /**
+     * [[include:README.md]]
+     * @deprecated
+     * @todo remove
+     */
+    namespace Highcharts {
+        // @todo remove
+    }
+    interface Document {
+        /** @deprecated */
+        exitFullscreen: () => Promise<void>;
+        /** @deprecated */
+        mozCancelFullScreen: Function;
+        /** @deprecated */
+        msExitFullscreen: Function;
+        /** @deprecated */
+        msHidden: boolean;
+        /** @deprecated */
+        webkitExitFullscreen: Function;
+        /** @deprecated */
+        webkitHidden: boolean;
+    }
+    interface Element {
+        /** @deprecated */
+        currentStyle?: ElementCSSInlineStyle;
+        /** @deprecated */
+        mozRequestFullScreen: Function;
+        /** @deprecated */
+        msMatchesSelector: Element['matches'];
+        /** @deprecated */
+        msRequestFullscreen: Function;
+        /** @deprecated */
+        webkitMatchesSelector: Element['matches'];
+        /** @deprecated */
+        webkitRequestFullScreen: Function;
+    }
+    interface PointerEvent {
+        /** @deprecated */
+        readonly toElement: Element;
+    }
+    interface Window {
+        /** @deprecated */
+        createObjectURL?: (typeof URL)['createObjectURL'];
+        /** @deprecated */
+        opera?: unknown;
+        /** @deprecated */
+        webkitAudioContext?: typeof AudioContext;
+        /** @deprecated */
+        webkitURL?: typeof URL;
+    }
+}
+
+/**
+ * @deprecated
+ * @todo remove
+ */
+export type InternalNamespace = typeof Highcharts;
+
+/**
+ * Helper interface to add property types to `Globals`.
+ *
+ * Use the `declare module 'GlobalsType'` pattern to overload the interface in
+ * this definition file.
+ */
+export interface GlobalsType extends InternalNamespace {
+    readonly Obj: ObjectConstructor;
+    readonly SVG_NS: string;
+    readonly charts: Array<(Chart|undefined)>;
+    readonly dateFormats: Record<string, Highcharts.TimeFormatCallbackFunction>;
+    readonly deg2rad: number;
+    readonly doc: Document;
+    readonly hasBidiBug: boolean;
+    readonly hasTouch: boolean;
+    readonly isChrome: boolean;
+    readonly isFirefox: boolean;
+    readonly isMS: boolean;
+    readonly isSafari: boolean;
+    readonly isTouchDevice: boolean;
+    readonly isWebKit: boolean;
+    readonly marginNames: ReadonlyArray<string>;
+    readonly nav: Navigator;
+    readonly noop: (this: unknown, ...args: Array<unknown>) => unknown;
+    readonly product: string;
+    readonly seriesTypes: SeriesTypeRegistry;
+    readonly supportsPassiveEvents: boolean;
+    readonly svg: boolean;
+    readonly symbolSizes: Record<string, SizeObject>;
+    theme?: Highcharts.Options;
+    readonly userAgent: string;
+    readonly version: string;
+    // eslint-disable-next-line node/no-unsupported-features/es-builtins
+    readonly win: (Window&typeof globalThis);
+}
+
+export default GlobalsType;

--- a/ts/Core/Legend.ts
+++ b/ts/Core/Legend.ts
@@ -1117,7 +1117,7 @@ class Legend {
      */
     public proximatePositions(): void {
         var chart = this.chart,
-            boxes = [] as Array<Record<string, any>>,
+            boxes = [] as Array<AnyRecord>,
             alignLeft = this.options.align === 'left';
 
         this.allItems.forEach(function (item): void {

--- a/ts/Core/Navigator.ts
+++ b/ts/Core/Navigator.ts
@@ -2184,7 +2184,7 @@ class Navigator {
                         opacity: 1
                     }
                 }
-            } as Record<string, any>,
+            } as AnyRecord,
             // Remove navigator series that are no longer in the baseSeries
             navigatorSeries = navigator.series =
                 (navigator.series || []).filter(function (navSeries): boolean {
@@ -2221,7 +2221,7 @@ class Navigator {
                         {
                             color: base.color,
                             visible: base.visible
-                        } as Record<string, any>,
+                        } as AnyRecord,
                         !isArray(chartNavigatorSeriesOptions) ?
                             chartNavigatorSeriesOptions :
                             (defaultOptions.navigator as any).series

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -86,6 +86,11 @@ declare module '../CSSObject' {
  * @private
  */
 declare global {
+    /**
+     * @internal
+     * @deprecated
+     */
+    type GlobalSVGElement = SVGElement;
     interface Element {
         gradient?: string;
         parentNode: (Node&ParentNode);
@@ -232,6 +237,16 @@ declare global {
         }
     }
 }
+
+/**
+ * Reference to the global SVGElement class as a workaround for a name conflict
+ * in the Highcharts namespace.
+ *
+ * @global
+ * @typedef {global.SVGElement} GlobalSVGElement
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/SVGElement
+ */
 
 /**
  * The horizontal alignment of an element.
@@ -441,7 +456,7 @@ class SVGElement {
     public oldShadowOptions?: ShadowOptionsObject;
     public onAdd?: Function;
     public opacity = 1; // Default base for animation
-    public options?: Record<string, any>;
+    public options?: AnyRecord;
     public parentInverted?: boolean;
     public parentGroup?: SVGElement;
     public pathArray?: SVGPath;
@@ -513,8 +528,8 @@ class SVGElement {
      */
     private _defaultGetter(key: string): (number|string) {
         var ret = pick(
-            (this as Record<string, any>)[key + 'Value'], // align getter
-            (this as Record<string, any>)[key],
+            (this as AnyRecord)[key + 'Value'], // align getter
+            (this as AnyRecord)[key],
             this.element ? this.element.getAttribute(key) : null,
             0
         );
@@ -1051,8 +1066,8 @@ class SVGElement {
         // used as a getter: first argument is a string, second is undefined
         if (typeof hash === 'string') {
             ret = (
-                (this as Record<string, any>)[hash + 'Getter'] ||
-                (this as Record<string, any>)._defaultGetter
+                (this as AnyRecord)[hash + 'Getter'] ||
+                (this as AnyRecord)._defaultGetter
             ).call(
                 this,
                 hash,
@@ -1092,8 +1107,8 @@ class SVGElement {
 
                 if (!skipAttr) {
                     setter = (
-                        (this as Record<string, any>)[key + 'Setter'] ||
-                        (this as Record<string, any>)._defaultSetter
+                        (this as AnyRecord)[key + 'Setter'] ||
+                        (this as AnyRecord)._defaultSetter
                     );
                     setter.call(this, val, key, element);
 
@@ -1562,15 +1577,15 @@ class SVGElement {
 
             // Destroy child elements of a group
             if (
-                (wrapper as Record<string, any>)[key] &&
-                (wrapper as Record<string, any>)[key].parentGroup === wrapper &&
-                (wrapper as Record<string, any>)[key].destroy
+                (wrapper as AnyRecord)[key] &&
+                (wrapper as AnyRecord)[key].parentGroup === wrapper &&
+                (wrapper as AnyRecord)[key].destroy
             ) {
-                (wrapper as Record<string, any>)[key].destroy();
+                (wrapper as AnyRecord)[key].destroy();
             }
 
             // Delete all properties
-            delete (wrapper as Record<string, any>)[key];
+            delete (wrapper as AnyRecord)[key];
         });
 
         return;
@@ -1672,9 +1687,9 @@ class SVGElement {
         // Check for cache before resetting. Resetting causes disturbance in the
         // DOM, causing flickering in some cases in Edge/IE (#6747). Also
         // possible performance gain.
-        if ((this as Record<string, any>)[key] !== value) {
+        if ((this as AnyRecord)[key] !== value) {
             element.setAttribute(key, value);
-            (this as Record<string, any>)[key] = value;
+            (this as AnyRecord)[key] = value;
         }
 
     }
@@ -2122,7 +2137,7 @@ class SVGElement {
             };
         } else {
             // simplest possible event model for internal use
-            (element as Record<string, any>)['on' + eventType] = handler;
+            (element as AnyRecord)['on' + eventType] = handler;
         }
         return this;
     }
@@ -2251,7 +2266,7 @@ class SVGElement {
      */
     public setTextPath(
         path: SVGElement,
-        textPathOptions: Record<string, any>
+        textPathOptions: AnyRecord
     ): SVGElement {
         var elem = this.element,
             textNode = this.text ? this.text.element : elem,
@@ -2389,8 +2404,8 @@ class SVGElement {
             }
 
             // Disable some functions
-            this.updateTransform = noop as any;
-            this.applyTextOutline = noop as any;
+            this.updateTransform = noop;
+            this.applyTextOutline = noop;
 
         } else if (textPathWrapper) {
             // Reset to prototype
@@ -2575,7 +2590,7 @@ class SVGElement {
         key: string,
         element: SVGDOMElement
     ): void {
-        (this as Record<string, any>)[key] = value;
+        (this as AnyRecord)[key] = value;
         // Only apply the stroke attribute if the stroke width is defined and
         // larger than 0
         if (this.stroke && this['stroke-width']) {
@@ -2661,7 +2676,7 @@ class SVGElement {
      * The attributes to set.
      */
     public symbolAttr(hash: SVGAttributes): void {
-        var wrapper = this as Record<string, any>;
+        var wrapper = this as AnyRecord;
 
         [
             'x',
@@ -2900,10 +2915,10 @@ class SVGElement {
         // attribute instead (#2881, #3909)
         if (value === 'inherit') {
             element.removeAttribute(key);
-        } else if ((this as Record<string, any>)[key] !== value) { // #6747
+        } else if ((this as AnyRecord)[key] !== value) { // #6747
             element.setAttribute(key, value);
         }
-        (this as Record<string, any>)[key] = value;
+        (this as AnyRecord)[key] = value;
     }
 
     /**
@@ -3059,7 +3074,7 @@ SVGElement.prototype.verticalAlignSetter = function (
     value: (number|string|null),
     key: string
 ): void {
-    (this as Record<string, any>)[key] = value;
+    (this as AnyRecord)[key] = value;
     this.doTransform = true;
 };
 

--- a/ts/Core/Renderer/SVG/SVGElement3D.ts
+++ b/ts/Core/Renderer/SVG/SVGElement3D.ts
@@ -109,13 +109,13 @@ namespace SVGElement3D {
             this: SVGElement,
             prop: string,
             val: any,
-            values?: Record<string, any>,
+            values?: AnyRecord,
             verb?: string,
             duration?: any,
             complete?: any
         ): SVGElement {
             var elem3d = this,
-                newAttr = {} as Record<string, any>,
+                newAttr = {} as AnyRecord,
                 optionsToApply = [null, null, (verb || 'attr'), duration, complete],
                 hasZIndexes = values && values.zIndexes;
 
@@ -152,7 +152,7 @@ namespace SVGElement3D {
         processParts: function (
             this: SVGElement,
             props: any,
-            partsProps: Record<string, any>,
+            partsProps: AnyRecord,
             verb: string,
             duration?: any,
             complete?: any

--- a/ts/Core/Responsive.ts
+++ b/ts/Core/Responsive.ts
@@ -328,24 +328,21 @@ Chart.prototype.currentOptions = function (
 ): Highcharts.Options {
 
     var chart = this,
-        ret = {} as Record<string, any>;
+        ret = {};
 
     /**
      * Recurse over a set of options and its current values,
      * and store the current values in the ret object.
      */
     function getCurrent(
-        options: Highcharts.Options,
-        curr: Record<string, any>,
-        ret: Record<string, any>,
+        options: AnyRecord,
+        curr: AnyRecord,
+        ret: AnyRecord,
         depth: number
     ): void {
         var i;
 
-        objectEach(options, function (
-            val: Record<string, any>,
-            key: string
-        ): void {
+        objectEach(options, function (val, key): void {
             if (
                 !depth &&
                 chart.collectionsWithUpdate.indexOf(key) > -1 &&

--- a/ts/Core/Series/DataLabels.ts
+++ b/ts/Core/Series/DataLabels.ts
@@ -1653,7 +1653,7 @@ if (seriesTypes.pie) {
         }, this);
     };
 
-    seriesTypes.pie.prototype.alignDataLabel = noop as any;
+    seriesTypes.pie.prototype.alignDataLabel = noop;
 
     /**
      * Verify whether the data labels are allowed to draw, or we should run more

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -704,7 +704,7 @@ class Point {
      *
      * @fires Highcharts.Point#event:*
      */
-    public firePointEvent<T extends Record<string, any>|Event>(
+    public firePointEvent<T extends AnyRecord|Event>(
         eventType: string,
         eventArgs?: T,
         defaultFunction?: (
@@ -957,7 +957,7 @@ class Point {
     public optionsToObject(
         options: (PointOptions|PointShortOptions)
     ): this['options'] {
-        var ret = {} as Record<string, any>,
+        var ret = {} as AnyRecord,
             series = this.series,
             keys = series.options.keys,
             pointArrayMap = keys || series.pointArrayMap || ['y'],

--- a/ts/Core/Series/PointOptions.d.ts
+++ b/ts/Core/Series/PointOptions.d.ts
@@ -80,7 +80,7 @@ export interface PointOptions {
     className?: string;
     color?: ColorType;
     colorIndex?: number;
-    custom?: Record<string, any>;
+    custom?: AnyRecord;
     drilldown?: string;
     events?: PointEventsOptions;
     id?: string;
@@ -126,7 +126,7 @@ export interface PointStateNormalOptions extends StateNormalOptions {
     opacity?: number;
 }
 
-export interface PointStatesOptions<T extends { options: Record<string, any> }> extends StatesOptions {
+export interface PointStatesOptions<T extends { options: AnyRecord }> extends StatesOptions {
     hover?: PointStateHoverOptions&StateGenericOptions<T>;
     inactive?: PointStateInactiveOptions&StateGenericOptions<T>;
     normal?: PointStateNormalOptions&StateGenericOptions<T>;

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -3355,7 +3355,7 @@ class Series {
     public getCyclic(
         prop: string,
         value?: any,
-        defaults?: Record<string, any>
+        defaults?: AnyRecord
     ): void {
         var i,
             chart = this.chart,
@@ -6711,6 +6711,8 @@ class Series {
 
             if (casting) {
                 // Modern browsers including IE11
+                // @todo slow, consider alternatives mentioned:
+                // https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf
                 if (Object.setPrototypeOf) {
                     Object.setPrototypeOf(
                         series,

--- a/ts/Core/Series/SeriesOptions.d.ts
+++ b/ts/Core/Series/SeriesOptions.d.ts
@@ -174,7 +174,7 @@ export interface SeriesStateSelectOptions extends StateSelectOptions {
     // nothing here yet
 }
 
-export interface SeriesStatesOptions<T extends { options: Record<string, any> }> extends StatesOptions {
+export interface SeriesStatesOptions<T extends { options: AnyRecord }> extends StatesOptions {
     hover?: SeriesStateHoverOptions&StateGenericOptions<T>;
     inactive?: SeriesStateInactiveOptions&StateGenericOptions<T>;
     normal?: SeriesStateNormalOptions&StateGenericOptions<T>;

--- a/ts/Core/Series/SeriesType.d.ts
+++ b/ts/Core/Series/SeriesType.d.ts
@@ -47,8 +47,8 @@ export type SeriesType = SeriesTypeRegistry[keyof SeriesTypeRegistry]['prototype
 /**
  * Helper interface to add series types to `SeriesOptionsType` and `SeriesType`.
  *
- * Use the `declare module 'Types'` pattern to overload the interface in this
- * definition file.
+ * Use the `declare module 'SeriesType'` pattern to overload the interface in
+ * this definition file.
  */
 export interface SeriesTypeRegistry {
     [key: string]: typeof Series;

--- a/ts/Core/Series/StatesOptions.d.ts
+++ b/ts/Core/Series/StatesOptions.d.ts
@@ -25,7 +25,7 @@ import type DashStyleValue from '../Renderer/DashStyleValue';
 
 export interface StateClassWithOptions {}
 
-export type StateGenericOptions<T extends { options: Record<string, any> }> = (
+export type StateGenericOptions<T extends { options: AnyRecord }> = (
     DeepPartial<Omit<T['options'], ('states'|'data')>>
 );
 

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1647,10 +1647,10 @@ class Tooltip {
         }
         // Create the individual labels for header and points, ignore footer
         let boxes = labels.slice(0, points.length + 1).reduce(function (
-            boxes: Array<Record<string, any>>,
+            boxes: Array<AnyRecord>,
             str: (boolean|string),
             i: number
-        ): Array<Record<string, any>> {
+        ): Array<AnyRecord> {
             if (str !== false && str !== '') {
                 const point: (Point|Highcharts.TooltipPositionerPointObject) = (
                     points[i - 1] ||
@@ -1726,7 +1726,7 @@ class Tooltip {
 
         // If overflow left then align all labels to the right
         if (!positioner && boxes.some((box): boolean => box.x < bounds.left)) {
-            boxes = boxes.map((box): Record<string, any> => {
+            boxes = boxes.map((box): AnyRecord => {
                 const { x, y } = defaultPositioner(
                     box.anchorX,
                     box.anchorY,
@@ -1746,7 +1746,7 @@ class Tooltip {
 
         // Distribute and put in place
         H.distribute(boxes as any, adjustedPlotHeight);
-        boxes.forEach(function (box: Record<string, any>): void {
+        boxes.forEach(function (box: AnyRecord): void {
             const { anchorX, anchorY, pos, x } = box;
             // Put the label in place
             box.tt.attr({
@@ -1901,11 +1901,11 @@ class Tooltip {
             e = {
                 isFooter: isFooter,
                 labelConfig: labelConfig
-            } as Record<string, any>;
+            } as AnyRecord;
 
         fireEvent(this, 'headerFormatter', e, function (
             this: Highcharts.Tooltip,
-            e: Record<string, any>
+            e: AnyRecord
         ): void {
 
             // Guess the best date format based on the closest point distance

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -60,7 +60,7 @@ declare global {
             params: Record<string, string>;
         }
         interface EventCallbackFunction<T> {
-            (this: T, eventArguments: (Record<string, any>|Event)): (boolean|void);
+            (this: T, eventArguments: (AnyRecord|Event)): (boolean|void);
         }
         interface EventOptionsObject {
             order?: number;
@@ -286,7 +286,7 @@ declare global {
 
 /**
  * Generic dictionary in TypeScript notation.
- * Use the native `Record<string, any>` instead.
+ * Use the native `AnyRecord` instead.
  *
  * @deprecated
  * @interface Highcharts.Dictionary<T>
@@ -668,11 +668,11 @@ function clamp(value: number, min: number, max: number): number {
  * computing (#9197).
  * @private
  */
-function cleanRecursively<TNew extends Record<string, any>, TOld extends Record<string, any>>(
+function cleanRecursively<TNew extends AnyRecord, TOld extends AnyRecord>(
     newer: TNew,
     older: TOld
 ): TNew & TOld {
-    var result: Record<string, any> = {};
+    var result: AnyRecord = {};
 
     objectEach(newer, function (_val: unknown, key: (number|string)): void {
         var ob;
@@ -2375,7 +2375,7 @@ function removeEvent<T>(
 function fireEvent<T>(
     el: T,
     type: string,
-    eventArguments?: (Record<string, any>|Event),
+    eventArguments?: (AnyRecord|Event),
     defaultFunction?: (Highcharts.EventCallbackFunction<T>|Function)
 ): void {
     /* eslint-enable valid-jsdoc */

--- a/ts/Extensions/Ajax.ts
+++ b/ts/Extensions/Ajax.ts
@@ -32,7 +32,7 @@ declare global {
             (response: (string|JSONType)): void;
         }
         interface AjaxSettingsObject {
-            data: (string|Record<string, any>);
+            data: (string|AnyRecord);
             dataType: string;
             error: AjaxErrorCallbackFunction;
             headers: Record<string, string>;

--- a/ts/Extensions/Annotations/Controllables/ControllableLabel.ts
+++ b/ts/Extensions/Annotations/Controllables/ControllableLabel.ts
@@ -287,11 +287,11 @@ class ControllableLabel implements ControllableMixin.Type {
     public translate(dx: number, dy: number): void {
         var chart = this.annotation.chart,
             // Annotation.options
-            labelOptions: Record<string, any> = this.annotation.userOptions,
+            labelOptions: AnyRecord = this.annotation.userOptions,
             // Chart.options.annotations
             annotationIndex = chart.annotations.indexOf(this.annotation),
             chartAnnotations = chart.options.annotations,
-            chartOptions: Record<string, any> = chartAnnotations[annotationIndex],
+            chartOptions: AnyRecord = chartAnnotations[annotationIndex],
             temp;
 
         if (chart.inverted) {

--- a/ts/Extensions/Boost/BoostInit.ts
+++ b/ts/Extensions/Boost/BoostInit.ts
@@ -30,6 +30,7 @@ const {
 declare module '../../Core/Chart/ChartLike'{
     interface ChartLike {
         didBoost?: boolean;
+        isBoosting?: boolean;
         markerGroup?: Series['markerGroup'];
     }
 }

--- a/ts/Extensions/DataGrouping.ts
+++ b/ts/Extensions/DataGrouping.ts
@@ -890,7 +890,7 @@ addEvent(Point, 'update', function (): (boolean|undefined) {
 // range.
 addEvent(Tooltip, 'headerFormatter', function (
     this: Highcharts.Tooltip,
-    e: Record<string, any>
+    e: AnyRecord
 ): void {
     var tooltip = this,
         chart = this.chart,

--- a/ts/Extensions/DragPanes.ts
+++ b/ts/Extensions/DragPanes.ts
@@ -502,7 +502,7 @@ class AxisResizer {
             prevAxes: Array<(number|string)> =
                 [resizer.axis as any].concat((axes as any).prev),
             // prev and next configs
-            axesConfigs: Array<Record<string, any>> = [],
+            axesConfigs: Array<AnyRecord> = [],
             stopDrag = false,
             plotTop = chart.plotTop,
             plotHeight = chart.plotHeight,
@@ -644,7 +644,7 @@ class AxisResizer {
         if (!stopDrag) {
             // Now update axes:
             axesConfigs.forEach(function (
-                config: Record<string, any>
+                config: AnyRecord
             ): void {
                 config.axis.update(config.options, false);
             });

--- a/ts/Extensions/Drilldown.ts
+++ b/ts/Extensions/Drilldown.ts
@@ -809,7 +809,7 @@ Chart.prototype.addSingleSeriesAsDrilldown = function (
 
     // Run fancy cross-animation on supported and equal types
     if (oldSeries.type === newSeries.type) {
-        newSeries.animate = newSeries.animateDrilldown || (noop as any);
+        newSeries.animate = (newSeries.animateDrilldown || noop);
         newSeries.options.animation = true;
     }
 };

--- a/ts/Extensions/ExportData.ts
+++ b/ts/Extensions/ExportData.ts
@@ -530,7 +530,7 @@ Chart.prototype.getDataRows = function (
         ),
         xAxis: Highcharts.Axis,
         xAxes = this.xAxis,
-        rows: Record<string, (Array<any>&Record<string, any>)> =
+        rows: Record<string, (Array<any>&AnyRecord)> =
             {},
         rowArr = [],
         dataRows,
@@ -808,8 +808,8 @@ Chart.prototype.getDataRows = function (
 
         // Sort it by X values
         rowArr.sort(function ( // eslint-disable-line no-loop-func
-            a: Record<string, any>,
-            b: Record<string, any>
+            a: AnyRecord,
+            b: AnyRecord
         ): number {
             return a.xValues[xAxisIndex] - b.xValues[xAxisIndex];
         });
@@ -825,7 +825,7 @@ Chart.prototype.getDataRows = function (
 
         // Add the category column
         rowArr.forEach(function ( // eslint-disable-line no-loop-func
-            row: Record<string, any>
+            row: AnyRecord
         ): void {
             var category = row.name;
 

--- a/ts/Extensions/Exporting.ts
+++ b/ts/Extensions/Exporting.ts
@@ -2144,7 +2144,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         if (onclick) {
             callback = function (
                 this: SVGElement,
-                e: (Event|Record<string, any>)
+                e: (Event|AnyRecord)
             ): void {
                 if (e) {
                     e.stopPropagation();
@@ -2155,7 +2155,7 @@ extend(Chart.prototype, /** @lends Highcharts.Chart.prototype */ {
         } else if (menuItems) {
             callback = function (
                 this: SVGElement,
-                e: (Event|Record<string, any>)
+                e: (Event|AnyRecord)
             ): void {
                 // consistent with onclick call (#3495)
                 if (e) {

--- a/ts/Extensions/GeoJSON.ts
+++ b/ts/Extensions/GeoJSON.ts
@@ -78,19 +78,19 @@ declare global {
         interface GeoJSON {
             copyright?: string;
             copyrightShort?: string;
-            crs?: Record<string, any>;
+            crs?: AnyRecord;
             features: Array<GeoJSONFeature>;
             'hc-transform'?: Record<string, GeoJSONTransform>;
             title?: string;
             type?: string;
             version?: string;
         }
-        interface GeoJSONFeature extends Record<string, any> {
+        interface GeoJSONFeature extends AnyRecord {
             type: string;
         }
         interface GeoJSONTransform {
             crs?: string;
-            hitZone?: Record<string, any>;
+            hitZone?: AnyRecord;
             jsonmarginX?: number;
             jsonmarginY?: number;
             jsonres?: number;

--- a/ts/Extensions/Oldie/Oldie.ts
+++ b/ts/Extensions/Oldie/Oldie.ts
@@ -99,7 +99,7 @@ declare global {
             measureSpanWidth(text: string, style: CSSObject): number;
         }
         /** @requires highcharts/modules/oldies */
-        interface VMLAttributes extends Record<string, any> {
+        interface VMLAttributes extends AnyRecord {
             d?: VMLPathArray;
             end?: number;
             innerR?: number;

--- a/ts/Extensions/OldiePolyfills.ts
+++ b/ts/Extensions/OldiePolyfills.ts
@@ -222,7 +222,7 @@ if (!Object.getPrototypeOf) {
 
 if (!Object.keys) {
     Object.keys = function (
-        this: Record<string, any>,
+        this: AnyRecord,
         obj: object
     ): Array<string> {
         var result = [] as Array<string>,

--- a/ts/Extensions/Polar.ts
+++ b/ts/Extensions/Polar.ts
@@ -478,7 +478,7 @@ addEvent(Series, 'afterTranslate', function (): void {
                         }
 
                         this.group.clip(this.clipCircle);
-                        this.setClip = H.noop as any;
+                        this.setClip = H.noop;
                     }
                 })
             );

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -1941,7 +1941,7 @@ class RangeSelector {
                     rangeOptions.text,
                     0,
                     0,
-                    (e: (Event|Record<string, any>)): void => {
+                    (e: (Event|AnyRecord)): void => {
 
                         // extract events from button object and call
                         var buttonEvents = (

--- a/ts/Extensions/Sonification/ChartSonify.ts
+++ b/ts/Extensions/Sonification/ChartSonify.ts
@@ -1126,11 +1126,11 @@ function getSeriesInstrumentOptions(
         return options.instruments;
     }
 
-    const defaultInstrOpts: Record<string, any> =
+    const defaultInstrOpts: AnyRecord =
         series.chart.options.sonification?.defaultInstrumentOptions || {};
-    const seriesInstrOpts: Array<Record<string, any>> =
+    const seriesInstrOpts: Array<AnyRecord> =
         series.options.sonification?.instruments || [{}];
-    const removeNullsFromObject = (obj: Record<string, any>): void => {
+    const removeNullsFromObject = (obj: AnyRecord): void => {
         objectEach(obj, (val: any, key: string): void => {
             if (val === null) {
                 delete obj[key];
@@ -1222,7 +1222,7 @@ function getChartSonifyOptions(
     chart: Highcharts.SonifyableChart,
     options?: Highcharts.SonifyChartOptionsObject
 ): Highcharts.SonifyChartOptionsObject {
-    const chartOpts: Record<string, any> = chart.options.sonification || {};
+    const chartOpts: AnyRecord = chart.options.sonification || {};
 
     return merge(
         {

--- a/ts/Extensions/Stacking.ts
+++ b/ts/Extensions/Stacking.ts
@@ -111,11 +111,14 @@ declare global {
             total: number;
             x: number;
         }
+        interface XAxisOptions {
+            stackLabels?: YAxisStackLabelsOptions;
+        }
         interface YAxisOptions {
             stackLabels?: YAxisStackLabelsOptions;
         }
         interface YAxisStackLabelsOptions {
-            animation?: (boolean|Partial<AnimationOptions>);
+            animation?: (false|Partial<AnimationOptions>);
             align?: AlignValue;
             allowOverlap?: boolean;
             backgroundColor?: ColorType;

--- a/ts/Extensions/Themes/DarkBlue.ts
+++ b/ts/Extensions/Themes/DarkBlue.ts
@@ -91,11 +91,6 @@ Highcharts.theme = {
             color: '#F0F0F0'
         }
     },
-    toolbar: {
-        itemStyle: {
-            color: 'silver'
-        }
-    },
     plotOptions: {
         line: {
             dataLabels: {

--- a/ts/Extensions/Themes/DarkGreen.ts
+++ b/ts/Extensions/Themes/DarkGreen.ts
@@ -92,11 +92,6 @@ Highcharts.theme = {
             color: '#F0F0F0'
         }
     },
-    toolbar: {
-        itemStyle: {
-            color: 'silver'
-        }
-    },
     plotOptions: {
         line: {
             dataLabels: {

--- a/ts/Extensions/Themes/Gray.ts
+++ b/ts/Extensions/Themes/Gray.ts
@@ -122,8 +122,6 @@ H.theme = {
             color: '#FFF'
         }
     },
-
-
     plotOptions: {
         series: {
             dataLabels: {
@@ -153,13 +151,6 @@ H.theme = {
             lineColor: 'white'
         }
     } as SeriesTypePlotOptions,
-
-    toolbar: {
-        itemStyle: {
-            color: '#CCC'
-        }
-    },
-
     navigation: {
         buttonOptions: {
             symbolStroke: '#DDDDDD',
@@ -175,7 +166,6 @@ H.theme = {
             }
         }
     },
-
     // scroll charts
     rangeSelector: {
         buttonTheme: {
@@ -228,7 +218,6 @@ H.theme = {
             color: 'silver'
         }
     },
-
     navigator: {
         handles: {
             backgroundColor: '#666',
@@ -241,7 +230,6 @@ H.theme = {
             lineColor: '#A6C7ED'
         }
     },
-
     scrollbar: {
         barBackgroundColor: {
             linearGradient: { x1: 0, y1: 0, x2: 0, y2: 1 },

--- a/ts/Maps/MapNavigation.ts
+++ b/ts/Maps/MapNavigation.ts
@@ -165,7 +165,7 @@ MapNavigation.prototype.update = function (
         selectStates: SVGAttributes|undefined,
         outerHandler = function (
             this: SVGElement,
-            e: (Event|Record<string, any>)
+            e: (Event|AnyRecord)
         ): void {
             this.handler.call(chart, e);
             stopEvent(e as any); // Stop default click event (#4444)

--- a/ts/Mixins/TreeSeries.ts
+++ b/ts/Mixins/TreeSeries.ts
@@ -189,7 +189,7 @@ const getColor = function getColor(
         chartOptionsChart: Highcharts.ChartOptions =
             series.chart.options.chart as any,
         point,
-        level: Record<string, any>,
+        level: AnyRecord,
         colorByPoint,
         colorIndexByPoint,
         color,

--- a/ts/Series/AreaRange/AreaRangeSeries.ts
+++ b/ts/Series/AreaRange/AreaRangeSeries.ts
@@ -307,7 +307,7 @@ class AreaRangeSeries extends AreaSeries {
      * path to both lower and higher values of the range.
      * @private
      */
-    public getGraphPath(points: Array<AreaRangePoint>): SVGPath {
+    public getGraphPath(points: Array<AreaPoint>): SVGPath {
 
         var highPoints = [],
             highAreaPoints: Array<AreaPoint> = [],
@@ -315,8 +315,8 @@ class AreaRangeSeries extends AreaSeries {
             getGraphPath = areaProto.getGraphPath,
             point: any,
             pointShim: any,
-            linePath: SVGPath & Record<string, any>,
-            lowerPath: SVGPath & Record<string, any>,
+            linePath: SVGPath & AnyRecord,
+            lowerPath: SVGPath & AnyRecord,
             options = this.options,
             polar = this.chart.polar,
             connectEnds = polar && options.connectEnds !== false,
@@ -638,8 +638,6 @@ class AreaRangeSeries extends AreaSeries {
         }
     }
 
-    public setStackedPoints = noop;
-
     /* eslint-enable valid-jsdoc */
 }
 
@@ -659,7 +657,8 @@ extend(AreaRangeSeries.prototype, {
     pointArrayMap: ['low', 'high'],
     pointValKey: 'low',
     deferTranslatePolar: true,
-    pointClass: AreaRangePoint
+    pointClass: AreaRangePoint,
+    setStackedPoints: noop
 });
 
 

--- a/ts/Series/BoxPlot/BoxPlotSeries.ts
+++ b/ts/Series/BoxPlot/BoxPlotSeries.ts
@@ -619,8 +619,8 @@ extend(BoxPlotSeries.prototype, {
     // defines the top of the tracker
     pointValKey: 'high',
     // Disable data labels for box plot
-    drawDataLabels: noop as any,
-    setStackedPoints: noop as any // #3890
+    drawDataLabels: noop,
+    setStackedPoints: noop // #3890
 });
 
 /* *

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -56,6 +56,12 @@ import './BubbleLegend.js';
  *
  * */
 
+declare module '../../Core/Axis/Types' {
+    interface AxisLike {
+        beforePadding?(): void;
+    }
+}
+
 declare module '../../Core/Series/SeriesLike' {
     interface SeriesLike {
         bubblePadding?: BubbleSeries['bubblePadding'];
@@ -595,9 +601,9 @@ interface BubbleSeries {
 }
 extend(BubbleSeries.prototype, {
     alignDataLabel: ColumnSeries.prototype.alignDataLabel,
-    applyZones: noop as any,
+    applyZones: noop,
     bubblePadding: true,
-    buildKDTree: noop as any,
+    buildKDTree: noop,
     directTouch: true,
     isBubble: true,
     pointArrayMap: ['y', 'z'],

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -1317,7 +1317,7 @@ extend(ColumnSeries.prototype, {
      */
     drawLegendSymbol: LegendSymbolMixin.drawRectangle,
 
-    getSymbol: noop as any,
+    getSymbol: noop,
 
     // use separate negative stacks, unlike area stacks where a negative
     // point is substracted from previous (#1910)

--- a/ts/Series/ColumnRange/ColumnRangeSeries.ts
+++ b/ts/Series/ColumnRange/ColumnRangeSeries.ts
@@ -271,8 +271,8 @@ interface ColumnRangeSeries {
 extend(ColumnRangeSeries.prototype, {
     directTouch: true,
     trackerGroups: ['group', 'dataLabelsGroup'],
-    drawGraph: noop as any,
-    getSymbol: noop as any,
+    drawGraph: noop,
+    getSymbol: noop,
     polarArc: function (this: ColumnRangeSeries): void {
         return (columnProto as any).polarArc.apply(this, arguments);
     },

--- a/ts/Series/Flags/FlagsSeries.ts
+++ b/ts/Series/Flags/FlagsSeries.ts
@@ -671,7 +671,7 @@ extend(FlagsSeries.prototype, {
      * @private
      * @function Highcharts.seriesTypes.flags#buildKDTree
      */
-    buildKDTree: noop as any,
+    buildKDTree: noop,
 
     forceCrop: true,
 
@@ -691,7 +691,7 @@ extend(FlagsSeries.prototype, {
      * @private
      * @function Highcharts.seriesTypes.flags#invertGroups
      */
-    invertGroups: noop as any,
+    invertGroups: noop,
 
     // Flags series group should not be invertible (#14063).
     invertible: false,

--- a/ts/Series/Funnel/FunnelSeries.ts
+++ b/ts/Series/Funnel/FunnelSeries.ts
@@ -573,7 +573,7 @@ class FunnelSeries extends PieSeries {
             };
 
             // Slice is a noop on funnel points
-            point.slice = noop as any;
+            point.slice = noop;
 
             // Mimicking pie data label placement logic
             point.half = half;
@@ -612,7 +612,7 @@ interface FunnelSeries {
     getX(y: number, half: boolean, point: FunnelPoint): number; // added during translate
 }
 extend(FunnelSeries.prototype, {
-    animate: noop as any
+    animate: noop
 });
 
 /* *

--- a/ts/Series/Funnel3D/Funnel3DSeries.ts
+++ b/ts/Series/Funnel3D/Funnel3DSeries.ts
@@ -463,7 +463,7 @@ interface Funnel3DSeries {
 }
 extend(Funnel3DSeries.prototype, {
     pointClass: Funnel3DPoint,
-    translate3dShapes: noop as any
+    translate3dShapes: noop
 });
 
 /* *

--- a/ts/Series/Gauge/GaugeSeries.ts
+++ b/ts/Series/Gauge/GaugeSeries.ts
@@ -633,7 +633,7 @@ extend(GaugeSeries.prototype, {
     // and this will be used on the axes
     angular: true,
     directTouch: true, // #5063
-    drawGraph: noop as any,
+    drawGraph: noop,
     drawTracker: ColumnSeries.prototype.drawTracker,
     fixedBox: true,
     forceDL: true,

--- a/ts/Series/Heatmap/HeatmapSeries.ts
+++ b/ts/Series/Heatmap/HeatmapSeries.ts
@@ -735,7 +735,7 @@ extend(HeatmapSeries.prototype, {
      * @ignore
      * @deprecated
      */
-    getBox: noop as any,
+    getBox: noop,
 
     getExtremesFromAll: true,
 

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -420,7 +420,7 @@ class MapSeries extends ScatterSeries {
 
     public mapData?: unknown;
 
-    public mapMap?: Record<string, any>;
+    public mapMap?: AnyRecord;
 
     public mapTitle?: string;
 
@@ -1029,7 +1029,7 @@ class MapSeries extends ScatterSeries {
             joinBy = this.joinBy,
             pointArrayMap = options.keys || this.pointArrayMap,
             dataUsed: Array<MapPointOptions> = [],
-            mapMap: Record<string, any> = {},
+            mapMap: AnyRecord = {},
             mapPoint,
             mapTransforms = this.chart.mapTransforms,
             props,
@@ -1346,10 +1346,10 @@ extend(MapSeries.prototype, {
 
     // We need the points' bounding boxes in order to draw the data labels,
     // so we skip it now and call it from drawPoints instead.
-    drawDataLabels: noop as any,
+    drawDataLabels: noop,
 
     // No graph for the map series
-    drawGraph: noop as any,
+    drawGraph: noop,
 
     drawLegendSymbol: LegendSymbolMixin.drawRectangle,
 
@@ -1368,7 +1368,7 @@ extend(MapSeries.prototype, {
     // X axis and Y axis must have same translation slope
     preserveAspectRatio: true,
 
-    searchPoint: noop as any,
+    searchPoint: noop,
 
     trackerGroups: colorMapSeriesMixin.trackerGroups,
 

--- a/ts/Series/Networkgraph/Networkgraph.ts
+++ b/ts/Series/Networkgraph/Networkgraph.ts
@@ -716,7 +716,7 @@ extend(NetworkgraphSeries.prototype, {
     drawTracker: seriesTypes.column.prototype.drawTracker,
     // Animation is run in `series.simulation`.
     animate: null as any,
-    buildKDTree: H.noop as any,
+    buildKDTree: H.noop,
     /**
      * Create a single node that holds information on incoming and outgoing
      * links.

--- a/ts/Series/PackedBubble/PackedBubbleSeries.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeries.ts
@@ -1539,7 +1539,7 @@ extend(PackedBubbleSeries.prototype, {
     requireSorting: false,
 
     // solving #12287
-    searchPoint: H.noop as any,
+    searchPoint: H.noop,
 
     trackerGroups: ['group', 'dataLabelsGroup', 'parentNodesGroup']
 

--- a/ts/Series/Pie/PiePoint.ts
+++ b/ts/Series/Pie/PiePoint.ts
@@ -85,6 +85,8 @@ class PiePoint extends Point {
 
     public slicedTranslation?: PiePoint.TranslationAttributes;
 
+    public startR?: number;
+
     /* *
      *
      *  Functions
@@ -164,7 +166,7 @@ class PiePoint extends Point {
 
         // add event listener for select
         toggleSlice = function (
-            e: (Record<string, any>|Event)
+            e: (AnyRecord|Event)
         ): void {
             point.slice(e.type === 'select');
         };

--- a/ts/Series/Pie/PieSeries.ts
+++ b/ts/Series/Pie/PieSeries.ts
@@ -1207,7 +1207,7 @@ extend(PieSeries.prototype, {
 
     getCenter: CenteredSeriesMixin.getCenter,
 
-    getSymbol: noop as any,
+    getSymbol: noop,
 
     isCartesian: false,
 
@@ -1219,7 +1219,7 @@ extend(PieSeries.prototype, {
 
     requireSorting: false,
 
-    searchPoint: noop as any,
+    searchPoint: noop,
 
     trackerGroups: ['group', 'dataLabelsGroup']
 });

--- a/ts/Series/Polygon/PolygonSeries.ts
+++ b/ts/Series/Polygon/PolygonSeries.ts
@@ -126,7 +126,7 @@ extend(PolygonSeries.prototype, {
     type: 'polygon',
     drawLegendSymbol: LegendSymbolMixin.drawRectangle,
     drawTracker: Series.prototype.drawTracker,
-    setStackedPoints: noop as any // No stacking points on polygons (#5310)
+    setStackedPoints: noop // No stacking points on polygons (#5310)
 });
 
 /* *

--- a/ts/Series/Sankey/SankeySeries.ts
+++ b/ts/Series/Sankey/SankeySeries.ts
@@ -691,12 +691,12 @@ class SankeySeries extends ColumnSeries {
             stateOptions = (
                 levelOptions.states && levelOptions.states[state || '']
             ) || {},
-            values: Record<string, any> = [
+            values: AnyRecord = [
                 'colorByPoint', 'borderColor', 'borderWidth', 'linkOpacity'
             ].reduce(function (
-                obj: Record<string, any>,
+                obj: AnyRecord,
                 key: string
-            ): Record<string, any> {
+            ): AnyRecord {
                 obj[key] = pick(
                     stateOptions[key],
                     (options as any)[key],
@@ -1166,7 +1166,7 @@ extend(SankeySeries.prototype, {
     orderNodes: true,
     pointArrayMap: ['from', 'to'],
     pointClass: SankeyPoint,
-    searchPoint: H.noop as any,
+    searchPoint: H.noop,
     setData: NodesMixin.setData
 });
 

--- a/ts/Series/SolidGauge/SolidGaugePoint.d.ts
+++ b/ts/Series/SolidGauge/SolidGaugePoint.d.ts
@@ -27,6 +27,7 @@ import type GaugePoint from '../Gauge/GaugePoint';
 declare class SolidGaugePoint extends GaugePoint {
     options: SolidGaugePointOptions;
     series: SolidGaugeSeries;
+    startR?: number;
 }
 
 /* *

--- a/ts/Series/SolidGauge/SolidGaugeSeries.ts
+++ b/ts/Series/SolidGauge/SolidGaugeSeries.ts
@@ -243,9 +243,7 @@ class SolidGaugeSeries extends GaugeSeries {
         );
 
 
-        series.points.forEach(function (
-            point: SolidGaugePoint
-        ): void {
+        series.points.forEach(function (point): void {
             // #10630 null point should not be draw
             if (!point.isNull) { // condition like in pie chart
                 var graphic = point.graphic,

--- a/ts/Series/Treemap/TreemapSeries.ts
+++ b/ts/Series/Treemap/TreemapSeries.ts
@@ -1881,12 +1881,12 @@ interface TreemapSeries extends Highcharts.TreeSeries {
     };
 }
 extend(TreemapSeries.prototype, {
-    buildKDTree: noop as any,
+    buildKDTree: noop,
     colorKey: 'colorValue', // Point color option key
     directTouch: true,
     drawLegendSymbol: LegendSymbolMixin.drawRectangle,
     getExtremesFromAll: true,
-    getSymbol: noop as any,
+    getSymbol: noop,
     optionalAxis: 'colorAxis',
     parallelArrays: ['x', 'y', 'value', 'colorValue'],
     pointArrayMap: ['value'],

--- a/ts/Series/Vector/VectorSeries.ts
+++ b/ts/Series/Vector/VectorSeries.ts
@@ -335,19 +335,19 @@ extend(VectorSeries.prototype, {
      * @ignore
      * @deprecated
      */
-    drawGraph: H.noop as any,
+    drawGraph: H.noop,
 
     /**
      * @ignore
      * @deprecated
      */
-    getSymbol: H.noop as any,
+    getSymbol: H.noop,
 
     /**
      * @ignore
      * @deprecated
      */
-    markerAttribs: H.noop as any,
+    markerAttribs: H.noop,
 
     parallelArrays: ['x', 'y', 'length', 'direction'],
 

--- a/ts/Series/Windbarb/WindbarbSeries.ts
+++ b/ts/Series/Windbarb/WindbarbSeries.ts
@@ -461,7 +461,7 @@ extend(WindbarbSeries.prototype, {
     trackerGroups: ['markerGroup'],
     getPlotBox: OnSeriesMixin.getPlotBox,
     // Don't invert the marker group (#4960)
-    invertGroups: noop as any
+    invertGroups: noop
 });
 
 WindbarbSeries.prototype.pointClass = WindbarbPoint;

--- a/ts/Series/Wordcloud/WordcloudSeries.ts
+++ b/ts/Series/Wordcloud/WordcloudSeries.ts
@@ -502,10 +502,10 @@ interface WordcloudSeries {
 
 extend(WordcloudSeries.prototype, {
     animate: Series.prototype.animate,
-    animateDrilldown: noop as any,
-    animateDrillupFrom: noop as any,
+    animateDrilldown: noop,
+    animateDrillupFrom: noop,
     pointClass: WordcloudPoint,
-    setClip: noop as any,
+    setClip: noop,
 
     // Strategies used for deciding rotation and initial position of a word. To
     // implement a custom strategy, have a look at the function random for

--- a/ts/Series/XRange/XRangePoint.ts
+++ b/ts/Series/XRange/XRangePoint.ts
@@ -31,12 +31,27 @@ const {
     }
 } = SeriesRegistry;
 import XRangeSeries from './XRangeSeries.js';
+import U from '../../Core/Utilities.js';
+const { extend } = U;
 
 /* *
  *
  *  Declarations
  *
  * */
+
+declare module '../../Core/Series/PointLike' {
+    interface PointLike {
+        tooltipDateKeys?: Array<string>;
+    }
+}
+
+/* *
+ *
+ *  Class
+ *
+ * */
+
 class XRangePoint extends ColumnSeries.prototype.pointClass {
 
     /* *
@@ -62,7 +77,7 @@ class XRangePoint extends ColumnSeries.prototype.pointClass {
     public static getColorByCategory(
         series: Series,
         point: Point
-    ): Record<string, any> {
+    ): AnyRecord {
         var colors = series.options.colors || series.chart.options.colors,
             colorCount = colors ?
                 colors.length :
@@ -176,8 +191,6 @@ class XRangePoint extends ColumnSeries.prototype.pointClass {
         return cfg;
     }
 
-    public tooltipDateKeys = ['x', 'x2']
-
     /**
      * @private
      * @function Highcharts.Point#isValid
@@ -208,6 +221,7 @@ declare namespace XRangePoint {
  * Prototype Properties
  *
  * */
+
 interface XRangePoint {
     clipRectArgs?: RectangleObject;
     len?: number;
@@ -219,6 +233,10 @@ interface XRangePoint {
     yCategory?: string;
 
 }
+extend(XRangePoint.prototype, {
+    tooltipDateKeys: ['x', 'x2']
+});
+
 
 /* *
  *

--- a/ts/Series/XRange/XRangeSeries.ts
+++ b/ts/Series/XRange/XRangeSeries.ts
@@ -718,8 +718,8 @@ extend(XRangeSeries.prototype, {
     animate: Series.prototype.animate,
     cropShoulder: 1,
     getExtremesFromAll: true,
-    autoIncrement: H.noop as any,
-    buildKDTree: H.noop as any,
+    autoIncrement: H.noop,
+    buildKDTree: H.noop,
     pointClass: XRangePoint
 });
 

--- a/ts/Stock/Indicators/AO/AOIndicator.ts
+++ b/ts/Stock/Indicators/AO/AOIndicator.ts
@@ -244,7 +244,7 @@ extend(AOIndicator.prototype, {
     nameComponents: (false as any),
 
     // Columns support:
-    markerAttribs: (noop as any),
+    markerAttribs: noop,
     getColumnMetrics: ColumnSeries.prototype.getColumnMetrics,
     crispCol: ColumnSeries.prototype.crispCol,
     translate: ColumnSeries.prototype.translate,

--- a/ts/Stock/Indicators/IKH/IKHIndicator.ts
+++ b/ts/Stock/Indicators/IKH/IKHIndicator.ts
@@ -36,7 +36,7 @@ const {
     seriesTypes: { sma: SMAIndicator }
 } = SeriesRegistry;
 import U from '../../../Core/Utilities.js';
-const { defined, extend, isArray, merge, objectEach } = U;
+const { defined, extend, isArray, isNumber, merge, objectEach } = U;
 
 declare module '../../../Core/Series/SeriesLike' {
     interface SeriesLike {
@@ -440,20 +440,21 @@ class IKHIndicator extends SMAIndicator {
             point: IKHPoint
         ): void {
             indicator.pointArrayMap.forEach(function (
-                value: keyof IKHPoint
+                key: keyof IKHPoint
             ): void {
-                if (defined(point[value])) {
-                    (point as any)['plot' + value] = indicator.yAxis.toPixels(
-                        point[value],
+                const pointValue = point[key];
+                if (isNumber(pointValue)) {
+                    (point as any)['plot' + key] = indicator.yAxis.toPixels(
+                        pointValue,
                         true
                     );
 
                     // Add extra parameters for support tooltip in moved
                     // lines
-                    point.plotY = (point as any)['plot' + value];
+                    point.plotY = (point as any)['plot' + key];
                     point.tooltipPos = [
                         point.plotX,
-                        (point as any)['plot' + value]
+                        (point as any)['plot' + key]
                     ];
                     point.isNull = false;
                 }

--- a/ts/Stock/Indicators/MACD/MACDIndicator.ts
+++ b/ts/Stock/Indicators/MACD/MACDIndicator.ts
@@ -501,7 +501,7 @@ extend(MACDIndicator.prototype, {
     parallelArrays: ['x', 'y', 'signal', 'MACD'],
     pointValKey: 'y',
     // Columns support:
-    markerAttribs: (noop as any),
+    markerAttribs: noop,
     getColumnMetrics: H.seriesTypes.column.prototype.getColumnMetrics,
     crispCol: H.seriesTypes.column.prototype.crispCol,
     drawPoints: H.seriesTypes.column.prototype.drawPoints

--- a/ts/Stock/Indicators/Supertrend/SupertrendOptions.d.ts
+++ b/ts/Stock/Indicators/Supertrend/SupertrendOptions.d.ts
@@ -68,7 +68,7 @@ export interface SupertrendGroupedPointsObject {
 }
 
 export interface SupertrendLineObject {
-    [index: string]: (Record<string, any>|undefined);
+    [index: string]: (AnyRecord|undefined);
 }
 
 export default SupertrendOptions;

--- a/ts/Stock/Indicators/VBP/VBPIndicator.ts
+++ b/ts/Stock/Indicators/VBP/VBPIndicator.ts
@@ -793,8 +793,8 @@ extend(VBPIndicator.prototype, {
         eventName: 'afterSetExtremes'
     },
     calculateOn: 'render',
-    markerAttribs: (noop as any),
-    drawGraph: (noop as any),
+    markerAttribs: noop,
+    drawGraph: noop,
     getColumnMetrics: columnPrototype.getColumnMetrics,
     crispCol: columnPrototype.crispCol
 });


### PR DESCRIPTION
- Added `AnyRecord` type to prepare `any` linting.
- Added `GlobalsLike` interface to allow type additions to `Globals`.
- Moved / Removed some `any` types of internal namespace.
- Fixed some typing in classes.