### PR TITLE
bugfix/15018-split-tooltip-outside-html

### DIFF
--- a/samples/unit-tests/tooltip/split/demo.js
+++ b/samples/unit-tests/tooltip/split/demo.js
@@ -171,7 +171,7 @@ QUnit.test('Split tooltip with empty formats (#8105)', function (assert) {
     );
 });
 
-QUnit.test('Split tooltip with useHTML (#7238)', function (assert) {
+QUnit.test('Split tooltip with useHTML and outside', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {
             width: 600
@@ -183,16 +183,23 @@ QUnit.test('Split tooltip with useHTML (#7238)', function (assert) {
         ],
         tooltip: {
             split: true,
-            useHTML: true
+            useHTML: true,
+            outside: true
         }
     });
 
     chart.series[0].points[0].onMouseOver();
 
     assert.strictEqual(
+        chart.tooltip.tt.renderer,
+        chart.tooltip.renderer,
+        '#15018: Split tooltip should use outside renderer'
+    );
+
+    assert.strictEqual(
         chart.series[0].tt.text.element.tagName,
         'SPAN',
-        'The label is a span'
+        '#7238: The label is a span'
     );
 });
 

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1453,7 +1453,6 @@ class Tooltip {
                 plotLeft,
                 plotTop,
                 pointer,
-                renderer: ren,
                 scrollablePixelsY = 0,
                 scrollingContainer: {
                     scrollLeft,
@@ -1478,6 +1477,7 @@ class Tooltip {
         };
 
         const tooltipLabel = tooltip.getLabel();
+        const ren = this.renderer || chart.renderer;
         const headerTop = Boolean(chart.xAxis[0] && chart.xAxis[0].opposite);
 
         let distributionBoxTop = plotTop + scrollTop;


### PR DESCRIPTION
Fixed #15018, tooltip `split`, `outside` and `useHTML` did not work together.