### PR TITLE
bugfix/15160-touch-inactive-state

### DIFF
--- a/ts/Accessibility/AccessibilityComponent.ts
+++ b/ts/Accessibility/AccessibilityComponent.ts
@@ -471,7 +471,13 @@ AccessibilityComponent.prototype = {
                 }
 
                 e.stopPropagation();
-                e.preventDefault();
+
+                // #9682, #15318: Touch scrolling didnt work when touching a
+                // component, the touchend after dragging will have
+                // cancelable=false
+                if (evtType !== 'touchstart' && evtType !== 'touchmove' && e.cancelable !== false) {
+                    e.preventDefault();
+                }
             }, { passive: false });
         });
     },

--- a/ts/Accessibility/AccessibilityComponent.ts
+++ b/ts/Accessibility/AccessibilityComponent.ts
@@ -473,9 +473,8 @@ AccessibilityComponent.prototype = {
                 e.stopPropagation();
 
                 // #9682, #15318: Touch scrolling didnt work when touching a
-                // component, the touchend after dragging will have
-                // cancelable=false
-                if (evtType !== 'touchstart' && evtType !== 'touchmove' && e.cancelable !== false) {
+                // component
+                if (evtType !== 'touchstart' && evtType !== 'touchmove' && evtType !== 'touchend') {
                     e.preventDefault();
                 }
             }, { passive: false });

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1268,11 +1268,6 @@ class Pointer {
         ) {
             this.reset();
         }
-
-        // #15160
-        if (H.hasTouch) {
-            this.chart.series.forEach((series: Series): void => series.setState());
-        }
     }
 
     /**
@@ -1838,6 +1833,11 @@ class Pointer {
             });
 
             pointer.hoverX = chart.hoverPoints = chart.hoverPoint = null as any;
+        }
+
+        // #15160
+        if (H.hasTouch) {
+            this.chart.series.forEach((series: Series): void => series.setState());
         }
     }
 

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -253,8 +253,6 @@ class Pointer {
         this.chart = chart;
         this.hasDragged = false;
         this.options = options;
-        this.unbindContainerMouseLeave = function (): void {};
-        this.unbindContainerMouseEnter = function (): void {};
         this.init(chart, options);
     }
 
@@ -300,9 +298,7 @@ class Pointer {
 
     public tooltipTimeout?: number;
 
-    public unbindContainerMouseLeave: Function;
-
-    public unbindContainerMouseEnter: Function;
+    public eventsToUnbind: Array<Function> = [];
 
     public unDocMouseMove?: Function;
 
@@ -378,11 +374,8 @@ class Pointer {
     public destroy(): void {
         var pointer = this;
 
-        if (typeof pointer.unDocMouseMove !== 'undefined') {
-            pointer.unDocMouseMove();
-        }
-
-        this.unbindContainerMouseLeave();
+        this.eventsToUnbind.forEach((unbind): void => unbind());
+        this.eventsToUnbind = [];
 
         if (!H.chartCount) {
             if (H.unbindDocumentMouseUp) {
@@ -1275,6 +1268,11 @@ class Pointer {
         ) {
             this.reset();
         }
+
+        // #15160
+        if (H.hasTouch) {
+            this.chart.series.forEach((series: Series): void => series.setState());
+        }
     }
 
     /**
@@ -1986,6 +1984,7 @@ class Pointer {
                     }
                 }
             );
+            pointer.eventsToUnbind.push(pointer.unDocMouseMove);
         }
 
         // Issues related to crosshair #4927, #5269 #5066, #5658
@@ -2062,16 +2061,16 @@ class Pointer {
         container.onmousedown = this.onContainerMouseDown.bind(this);
         container.onmousemove = this.onContainerMouseMove.bind(this);
         container.onclick = this.onContainerClick.bind(this);
-        this.unbindContainerMouseEnter = addEvent(
+        this.eventsToUnbind.push(addEvent(
             container,
             'mouseenter',
             this.onContainerMouseEnter.bind(this)
-        );
-        this.unbindContainerMouseLeave = addEvent(
+        ));
+        this.eventsToUnbind.push(addEvent(
             container,
             'mouseleave',
             this.onContainerMouseLeave.bind(this)
-        );
+        ));
         if (!H.unbindDocumentMouseUp) {
             H.unbindDocumentMouseUp = addEvent(
                 ownerDoc,
@@ -2084,25 +2083,25 @@ class Pointer {
         // scrolling parent elements
         let parent = this.chart.renderTo.parentElement;
         while (parent && parent.tagName !== 'BODY') {
-            addEvent(parent, 'scroll', (): void => {
+            this.eventsToUnbind.push(addEvent(parent, 'scroll', (): void => {
                 delete this.chartPosition;
-            });
+            }));
             parent = parent.parentElement;
         }
 
         if (H.hasTouch) {
-            addEvent(
+            this.eventsToUnbind.push(addEvent(
                 container,
                 'touchstart',
                 this.onContainerTouchStart.bind(this),
                 { passive: false }
-            );
-            addEvent(
+            ));
+            this.eventsToUnbind.push(addEvent(
                 container,
                 'touchmove',
                 this.onContainerTouchMove.bind(this),
                 { passive: false }
-            );
+            ));
             if (!H.unbindDocumentTouchEnd) {
                 H.unbindDocumentTouchEnd = addEvent(
                     ownerDoc,

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1834,11 +1834,6 @@ class Pointer {
 
             pointer.hoverX = chart.hoverPoints = chart.hoverPoint = null as any;
         }
-
-        // #15160
-        if (H.hasTouch) {
-            this.chart.series.forEach((series: Series): void => series.setState());
-        }
     }
 
     /**

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -2123,10 +2123,6 @@ class SVGElement {
                 }
 
                 touchEventFired = true;
-                if (e.cancelable !== false) {
-                    // prevent other events from being fired. #9682
-                    e.preventDefault();
-                }
             };
 
             element.onclick = function (e: Event): void {


### PR DESCRIPTION
Fixed #15160, inactive state was not always cleared on touch devices when clicking outside the chart.