### PR TITLE
Added to context of axis label format/formatter

### DIFF
--- a/samples/highcharts/accessibility/art-grants/demo.js
+++ b/samples/highcharts/accessibility/art-grants/demo.js
@@ -50,9 +50,7 @@ Highcharts.chart('container', {
         min: 0,
         max: 800000,
         labels: {
-            formatter: function () {
-                return '$' + (this.value / 1000) + (this.value ? 'k' : '');
-            }
+            format: '${text}'
         },
         title: {
             text: 'Grant amount'
@@ -67,7 +65,7 @@ Highcharts.chart('container', {
         max: 2400000,
         gridLineWidth: 0,
         labels: {
-            formatter: ctx => '$' + ctx.axis.defaultLabelFormatter.call(ctx),
+            format: '${text}',
             style: {
                 color: '#8F6666'
             }

--- a/samples/highcharts/blog/blog-landing-page/demo.js
+++ b/samples/highcharts/blog/blog-landing-page/demo.js
@@ -206,10 +206,10 @@ const network = Highcharts.chart('network', {
                 info = 'is an airport <b>more than 50</b> direct distinations';
                 break;
             case dirDist10:
-                info = 'is an aiport <b>more than 10</b> direct distinations';
+                info = 'is an airport <b>more than 10</b> direct distinations';
                 break;
             case dirDistLess10:
-                info = 'is an aiport <b>less than 10</b> direct distinations';
+                info = 'is an airport <b>less than 10</b> direct distinations';
                 break;
             default:
              //

--- a/samples/highcharts/xaxis/labels-format-custom/demo.css
+++ b/samples/highcharts/xaxis/labels-format-custom/demo.css
@@ -1,0 +1,6 @@
+#container {
+	height: 400px;
+	min-width: 320px;
+	max-width: 800px;
+	margin: 0 auto;
+}

--- a/samples/highcharts/xaxis/labels-format-custom/demo.details
+++ b/samples/highcharts/xaxis/labels-format-custom/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+...

--- a/samples/highcharts/xaxis/labels-format-custom/demo.html
+++ b/samples/highcharts/xaxis/labels-format-custom/demo.html
@@ -1,0 +1,3 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="container"></div>

--- a/samples/highcharts/xaxis/labels-format-custom/demo.js
+++ b/samples/highcharts/xaxis/labels-format-custom/demo.js
@@ -1,0 +1,23 @@
+Highcharts.chart('container', {
+
+    title: {
+        text: 'Custom number format for Y axis labels'
+    },
+
+    subtitle: {
+        text: 'Add a unit and force two decimals'
+    },
+
+    yAxis: {
+        labels: {
+            format: '${value:.2f}'
+        }
+    },
+
+    series: [{
+        data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4,
+            194.1, 95.6, 54.4],
+        type: 'column'
+    }]
+
+});

--- a/samples/highcharts/xaxis/labels-format-linked/demo.details
+++ b/samples/highcharts/xaxis/labels-format-linked/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+...

--- a/samples/highcharts/xaxis/labels-format-linked/demo.html
+++ b/samples/highcharts/xaxis/labels-format-linked/demo.html
@@ -1,0 +1,3 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="container" style="height: 400px; width: 500px"></div>

--- a/samples/highcharts/xaxis/labels-format-linked/demo.js
+++ b/samples/highcharts/xaxis/labels-format-linked/demo.js
@@ -5,11 +5,11 @@ const categoryLinks = {
 };
 
 // Decorate the tick item with the link
-Highcharts.addEvent(Highcharts.Tick, 'init', e => {
-    const axis = e.target.axis;
+Highcharts.addEvent(Highcharts.Tick, 'labelFormat', ctx => {
+    const axis = ctx.axis;
     if (axis.categories) {
-        const category = axis.categories[e.target.pos];
-        e.target.link = categoryLinks[category];
+        const category = axis.categories[ctx.pos];
+        ctx.link = categoryLinks[category];
     }
 });
 
@@ -23,7 +23,7 @@ Highcharts.chart('container', {
         categories: ['Foo', 'Bar', 'Foobar'],
 
         labels: {
-            format: '<a href="{tick.link}">{text}</a>'
+            format: '<a href="{link}">{text}</a>'
         }
     },
 

--- a/samples/highcharts/xaxis/labels-format-linked/demo.js
+++ b/samples/highcharts/xaxis/labels-format-linked/demo.js
@@ -1,0 +1,33 @@
+const categoryLinks = {
+    Foo: 'http://www.bing.com/search?q=foo',
+    Bar: 'http://www.bing.com/search?q=foo+bar',
+    Foobar: 'http://www.bing.com/serach?q=foobar'
+};
+
+// Decorate the tick item with the link
+Highcharts.addEvent(Highcharts.Tick, 'init', e => {
+    const axis = e.target.axis;
+    if (axis.categories) {
+        const category = axis.categories[e.target.pos];
+        e.target.link = categoryLinks[category];
+    }
+});
+
+Highcharts.chart('container', {
+
+    title: {
+        text: 'Click categories to search'
+    },
+
+    xAxis: {
+        categories: ['Foo', 'Bar', 'Foobar'],
+
+        labels: {
+            format: '<a href="{tick.link}">{text}</a>'
+        }
+    },
+
+    series: [{
+        data: [29.9, 71.5, 106.4]
+    }]
+});

--- a/samples/highcharts/yaxis/labels-format/demo.js
+++ b/samples/highcharts/yaxis/labels-format/demo.js
@@ -2,12 +2,17 @@ Highcharts.chart('container', {
 
     yAxis: {
         labels: {
-            format: '{value} km'
+            format: '${text}' // The $ is literally a dollar unit
+        },
+        title: {
+            text: 'Cost'
         }
     },
 
     series: [{
-        data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]
+        data: [299000, 715000, 1064000, 1292000, 1440000, 1760000, 1356000,
+            1485000, 2164000, 1941000, 956000, 544000],
+        type: 'column'
     }]
 
 });

--- a/test/typescript/highcharts/highcharts.ts
+++ b/test/typescript/highcharts/highcharts.ts
@@ -50,7 +50,10 @@ function test_seriesArea() {
             },
             labels: {
                 formatter: function () {
-                    return this.value / 1000 + 'k';
+                    if (typeof this.value === 'number') {
+                        return this.value / 1000 + 'k';
+                    }
+                    return '';
                 }
             }
         },
@@ -59,7 +62,7 @@ function test_seriesArea() {
         },
         plotOptions: {
             area: {
-                threshold: null,
+                threshold: null as any,
                 pointStart: 1940,
                 marker: {
                     enabled: false,
@@ -224,8 +227,7 @@ function test_seriesColumn() {
         plotOptions: {
             column: {
                 pointPadding: 0.2,
-                borderWidth: 0,
-                dashStyle: 'Dash'
+                borderWidth: 0
             }
         },
         series: [{

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -100,18 +100,20 @@ declare global {
         }
         interface AxisLabelsFormatterCallbackFunction {
             (
-                this: AxisLabelsFormatterContextObject<number>,
-                that?: AxisLabelsFormatterContextObject<string>
+                this: AxisLabelsFormatterContextObject,
+                ctx?: AxisLabelsFormatterContextObject
             ): string;
         }
-        interface AxisLabelsFormatterContextObject<T = number> {
+        interface AxisLabelsFormatterContextObject {
             axis: Axis;
             chart: Chart;
             dateTimeLabelFormat: string;
             isFirst: boolean;
             isLast: boolean;
             pos: number;
-            value: T;
+            text?: string;
+            tick: Tick;
+            value: number|string;
         }
         interface AxisPlotLinePathOptionsObject {
             acrossPanes?: boolean;
@@ -385,7 +387,6 @@ declare global {
             public keepProps?: Array<string>;
             public labelAlign?: AlignValue;
             public labelEdge: Array<null>;
-            public labelFormatter: AxisLabelsFormatterCallbackFunction;
             public labelGroup?: SVGElement;
             public labelOffset?: number;
             public labelRotation?: number;
@@ -459,7 +460,7 @@ declare global {
             public adjustTickAmount(): void;
             public alignToOthers(): (boolean|undefined);
             public autoLabelAlign(rotation: number): AlignValue;
-            public defaultLabelFormatter(): void;
+            public defaultLabelFormatter: AxisLabelsFormatterCallbackFunction;
             public destroy(keepEvents?: boolean): void;
             public drawCrosshair(e?: PointerEvent, point?: Point): void;
             public generateTick(pos: number, i?: number): void;
@@ -601,34 +602,51 @@ declare global {
 /**
  * @callback Highcharts.AxisLabelsFormatterCallbackFunction
  *
- * @param {Highcharts.AxisLabelsFormatterContextObject<number>} this
+ * @param {Highcharts.AxisLabelsFormatterContextObject} this
  *
- * @param {Highcharts.AxisLabelsFormatterContextObject<string>} that
+ * @param {Highcharts.AxisLabelsFormatterContextObject} ctx
  *
  * @return {string}
  */
 
 /**
- * @interface Highcharts.AxisLabelsFormatterContextObject<T>
+ * @interface Highcharts.AxisLabelsFormatterContextObject
  *//**
- * @name Highcharts.AxisLabelsFormatterContextObject<T>#axis
+ * The axis item of the label
+ * @name Highcharts.AxisLabelsFormatterContextObject#axis
  * @type {Highcharts.Axis}
  *//**
- * @name Highcharts.AxisLabelsFormatterContextObject<T>#chart
+ * The chart instance.
+ * @name Highcharts.AxisLabelsFormatterContextObject#chart
  * @type {Highcharts.Chart}
  *//**
- * @name Highcharts.AxisLabelsFormatterContextObject<T>#isFirst
+ * Whether the label belongs to the first tick on the axis.
+ * @name Highcharts.AxisLabelsFormatterContextObject#isFirst
  * @type {boolean}
  *//**
- * @name Highcharts.AxisLabelsFormatterContextObject<T>#isLast
+ * Whether the label belongs to the last tick on the axis.
+ * @name Highcharts.AxisLabelsFormatterContextObject#isLast
  * @type {boolean}
  *//**
- * @name Highcharts.AxisLabelsFormatterContextObject<T>#pos
+ * The position on the axis in terms of axis values. For category axes, a
+ * zero-based index. For datetime axes, the JavaScript time in milliseconds
+ * since 1970.
+ * @name Highcharts.AxisLabelsFormatterContextObject#pos
  * @type {number}
  *//**
+ * The preformatted text as the result of the default formatting. For example
+ * dates will be formatted as strings, and numbers with language-specific comma
+ * separators, thousands separators and numeric symbols like `k` or `M`.
+ * @name Highcharts.AxisLabelsFormatterContextObject#text
+ * @type {string}
+ *//**
+ * The Tick instance.
+ * @name Highcharts.AxisLabelsFormatterContextObject#tick
+ * @type {Highcharts.Tick}
+ *//**
  * This can be either a numeric value or a category string.
- * @name Highcharts.AxisLabelsFormatterContextObject<T>#value
- * @type {T}
+ * @name Highcharts.AxisLabelsFormatterContextObject#value
+ * @type {number|string}
  */
 
 /**
@@ -1607,15 +1625,27 @@ class Axis {
             enabled: true,
 
             /**
-             * A format string for the axis label. See
-             * [format string](https://www.highcharts.com/docs/chart-concepts/labels-and-string-formatting)
-             * for example usage.
+             * A format string for the axis label. The context is available as
+             * format string variables. For example, you can use `{text}` to
+             * insert the default formatted text. The recommended way of adding
+             * units for the label is using `text`, for example `{text} km`.
              *
-             * Note: The default value is not specified due to the dynamic
+             * To add custom numeric or datetime formatting, use `{value}` with
+             * formatting, for example `{value:.1f}` or `{value:%Y-%m-%d}`.
+             *
+             * See
+             * [format string](https://www.highcharts.com/docs/chart-concepts/labels-and-string-formatting)
+             * for more examples of formatting.
+             *
+             * The default value is not specified due to the dynamic
              * nature of the default implementation.
              *
              * @sample {highcharts|highstock} highcharts/yaxis/labels-format/
              *         Add units to Y axis label
+             * @sample {highcharts} highcharts/xaxis/labels-format-linked/
+             *         Linked category names
+             * @sample {highcharts} highcharts/xaxis/labels-format-custom/
+             *         Custom number format
              *
              * @type      {string}
              * @since     3.0
@@ -1625,16 +1655,12 @@ class Axis {
             /**
              * Callback JavaScript function to format the label. The value
              * is given by `this.value`. Additional properties for `this` are
-             * `axis`, `chart`, `isFirst` and `isLast`. The value of the default
-             * label formatter can be retrieved by calling
-             * `this.axis.defaultLabelFormatter.call(this)` within the function.
+             * `axis`, `chart`, `isFirst`, `isLast` and `text` which holds the
+             * value of the default formatter.
              *
-             * Defaults to:
-             * ```js
-             * function() {
-             *     return this.value;
-             * }
-             * ```
+             * Defaults to a built in function returning a formatted string
+             * depending on whether the axis is `category`, `datetime`,
+             * `numeric` or other.
              *
              * @sample {highcharts} highcharts/xaxis/labels-formatter-linked/
              *         Linked category names
@@ -4139,13 +4165,6 @@ class Axis {
         var options = this.options,
             type = options.type;
 
-        axis.labelFormatter = (
-            (options.labels as any).formatter ||
-            // can be overwritten by dynamic format
-            axis.defaultLabelFormatter
-        );
-
-
         /**
          * User's options for this axis without defaults.
          *
@@ -4350,14 +4369,14 @@ class Axis {
      *
      * @function Highcharts.Axis#defaultLabelFormatter
      *
-     * @param {Highcharts.AxisLabelsFormatterContextObject<number>|Highcharts.AxisLabelsFormatterContextObject<string>} this
+     * @param {Highcharts.AxisLabelsFormatterContextObject} this
      * Formatter context of axis label.
      *
      * @return {string}
      * The formatted label content.
      */
     public defaultLabelFormatter(
-        this: Highcharts.AxisLabelsFormatterContextObject<number>
+        this: Highcharts.AxisLabelsFormatterContextObject
     ): string {
         var axis = this.axis,
             value = isNumber(this.value) ? this.value : NaN,
@@ -4370,7 +4389,6 @@ class Axis {
             i = numericSymbols && numericSymbols.length,
             multi,
             ret: (string|undefined),
-            formatOption = axis.options.labels.format,
 
             // make sure the same symbol is added for all labels on a linear
             // axis
@@ -4380,10 +4398,7 @@ class Axis {
         const chart = this.chart;
         const { numberFormatter } = chart;
 
-        if (formatOption) {
-            ret = format(formatOption, this, chart);
-
-        } else if (categories) {
+        if (categories) {
             ret = `${this.value}`;
 
         } else if (dateTimeLabelFormat) { // datetime axis

--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -709,47 +709,6 @@ class GridAxis {
 
         if (gridOptions.enabled) {
             applyGridOptions(axis);
-
-            /*
-            axis.defaultLabelFormatter = function (
-                this: Highcharts.AxisLabelsFormatterContextObject
-            ): string {
-                const {
-                    axis,
-                    value
-                } = this;
-                const tickPos = axis.tickPositions;
-                const series = (
-                    axis.linkedParent || axis
-                ).series[0];
-                const isFirst = value === tickPos[0];
-                const isLast = value === tickPos[tickPos.length - 1];
-                const point: (Point|undefined) =
-                    series && find(series.options.data as any, function (
-                        p: (PointOptions|PointShortOptions)
-                    ): boolean {
-                        return (p as any)[axis.isXAxis ? 'x' : 'y'] === value;
-                    });
-                let pointCopy;
-
-                if (point && series.is('gantt')) {
-                    // For the Gantt set point aliases to the pointCopy
-                    // to do not change the original point
-                    pointCopy = merge(point);
-                    H.seriesTypes.gantt.prototype.pointClass
-                        .setGanttPointAliases(pointCopy as any);
-                }
-                // Make additional properties available for the
-                // formatter
-                this.isFirst = isFirst;
-                this.isLast = isLast;
-                this.point = pointCopy;
-
-                // Call original labelFormatter
-                return Axis.prototype.defaultLabelFormatter.call(this);
-            };
-            */
-
         }
 
         if (gridOptions.columns) {

--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -422,6 +422,45 @@ addEvent(
     }
 );
 
+addEvent(
+    Tick,
+    'labelFormat',
+    (ctx: Highcharts.AxisLabelsFormatterContextObject): void => {
+        const {
+            axis,
+            value
+        } = ctx;
+        if (axis.options.grid?.enabled) {
+            const tickPos = axis.tickPositions;
+            const series = (
+                axis.linkedParent || axis
+            ).series[0];
+            const isFirst = value === tickPos[0];
+            const isLast = value === tickPos[tickPos.length - 1];
+            const point: (Point|undefined) =
+                series && find(series.options.data as any, function (
+                    p: (PointOptions|PointShortOptions)
+                ): boolean {
+                    return (p as any)[axis.isXAxis ? 'x' : 'y'] === value;
+                });
+            let pointCopy;
+
+            if (point && series.is('gantt')) {
+                // For the Gantt set point aliases to the pointCopy
+                // to do not change the original point
+                pointCopy = merge(point);
+                H.seriesTypes.gantt.prototype.pointClass
+                    .setGanttPointAliases(pointCopy as any);
+            }
+            // Make additional properties available for the
+            // formatter
+            ctx.isFirst = isFirst;
+            ctx.isLast = isLast;
+            ctx.point = pointCopy;
+        }
+    }
+);
+
 /* eslint-enable no-invalid-this */
 
 /**
@@ -671,6 +710,7 @@ class GridAxis {
         if (gridOptions.enabled) {
             applyGridOptions(axis);
 
+            /*
             axis.defaultLabelFormatter = function (
                 this: Highcharts.AxisLabelsFormatterContextObject
             ): string {
@@ -708,6 +748,7 @@ class GridAxis {
                 // Call original labelFormatter
                 return Axis.prototype.defaultLabelFormatter.call(this);
             };
+            */
 
         }
 

--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -671,22 +671,16 @@ class GridAxis {
         if (gridOptions.enabled) {
             applyGridOptions(axis);
 
-            /* eslint-disable no-invalid-this */
-
-            // TODO: wrap the axis instead
-            wrap(axis, 'labelFormatter', function (
-                this: Highcharts.AxisLabelsFormatterContextObject,
-                proceed: Function
-            ): void {
+            axis.defaultLabelFormatter = function (
+                this: Highcharts.AxisLabelsFormatterContextObject
+            ): string {
                 const {
                     axis,
                     value
                 } = this;
                 const tickPos = axis.tickPositions;
-                const series: Series = (
-                    axis.isLinked ?
-                        (axis.linkedParent as any) :
-                        axis
+                const series = (
+                    axis.linkedParent || axis
                 ).series[0];
                 const isFirst = value === tickPos[0];
                 const isLast = value === tickPos[tickPos.length - 1];
@@ -702,18 +696,18 @@ class GridAxis {
                     // For the Gantt set point aliases to the pointCopy
                     // to do not change the original point
                     pointCopy = merge(point);
-                    H.seriesTypes.gantt.prototype.pointClass.setGanttPointAliases(pointCopy as any);
+                    H.seriesTypes.gantt.prototype.pointClass
+                        .setGanttPointAliases(pointCopy as any);
                 }
                 // Make additional properties available for the
                 // formatter
                 this.isFirst = isFirst;
                 this.isLast = isLast;
                 this.point = pointCopy;
-                // Call original labelFormatter
-                return proceed.call(this);
-            });
 
-            /* eslint-enable no-invalid-this */
+                // Call original labelFormatter
+                return Axis.prototype.defaultLabelFormatter.call(this);
+            };
 
         }
 


### PR DESCRIPTION
Added `text` to axis label context, making it possible to insert the default formatting inside [labels.format](https://api.highcharts.com/highcharts/xAxis.labels.format).