### PR TITLE
Tools: fixed `unauthorized` error from demo CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -566,7 +566,6 @@ workflows:
           filters:
             branches:
               only: [master]
-          context: highcharts-prod
 
   reset_visual_test_references:
     when: << pipeline.parameters.run_reset_tests >>

--- a/.circleci/scripts/check_and_trigger_samples_deploy.sh
+++ b/.circleci/scripts/check_and_trigger_samples_deploy.sh
@@ -58,7 +58,6 @@ if [[ $(echo $SAMPLES_COMMIT | wc -l) -ge 2 ]] || [ "$FORCE_DEPLOY" = true ]; th
 
 else
      echo "No change in samples/ folder found."
-     exit 0;
 fi
 
 # Handle demos

--- a/.circleci/scripts/check_and_trigger_samples_deploy.sh
+++ b/.circleci/scripts/check_and_trigger_samples_deploy.sh
@@ -7,6 +7,7 @@ BUCKET=""
 TOKEN=""
 FORCE_DEPLOY=false
 THUMBNAILS=false
+DEPLOYARGS=""
 
 for i in "$@"
 do
@@ -22,6 +23,9 @@ case $i in
     ;;
       --thumbnails)
     THUMBNAILS=true
+    ;;
+      --deployargs=*)
+    DEPLOYARGS="${i#*=}"
     ;;
     *)
      # unknown option
@@ -40,13 +44,13 @@ if [[ -z $TOKEN ]]; then
 fi
 
 # latest commit where samples were changed, limited to 24 hours
-SAMPLES_COMMIT=$(git log -1 -- --since=\"24 hours ago\" --format=format:%H --full-diff --name-status samples/)
-DEMOS_COMMIT=$(git log -1 -- --since=\"24 hours ago\" --format=format:%H --full-diff --name-status samples/\*/demo/\*)q
+SAMPLES_COMMIT=$(git log -1 --since="24 hours ago" --format=format:%H --full-diff --name-status samples/)
+DEMOS_COMMIT=$(git log -1 --since="24 hours ago" --format=format:%H --full-diff --name-status samples/\*/demo/\*)
 
-if [[ $(echo $SAMPLES_COMMIT | wc -l) -ge 2 ]] || [ "$FORCE_DEPLOY" = true ]; then
+if [[ ! -z "$SAMPLES_COMMIT" ]] || [ "$FORCE_DEPLOY" = true ]; then
     echo "Force deployed: ${FORCE_DEPLOY}"
     echo "Files in samples/ has changed or forcing deploy. Triggering deploy of samples via highcharts-demo-manager to bucket ${BUCKET}"
-    payload="{ \"branch\":\"master\", \"parameters\": { \"deploy_samples\": true, \"target_bucket\": \"${BUCKET}\", \"deploy_args\": \"-dryrun\" }}"
+    payload="{ \"branch\":\"master\", \"parameters\": { \"deploy_samples\": true, \"target_bucket\": \"${BUCKET}\", \"deploy_args\": \"${DEPLOYARGS}\" }}"
     echo "$payload"
 
     # Circle API v2
@@ -54,14 +58,12 @@ if [[ $(echo $SAMPLES_COMMIT | wc -l) -ge 2 ]] || [ "$FORCE_DEPLOY" = true ]; th
     rep=$(curl -f -X POST -H "Content-Type: application/json" -d "$payload" "$httpUrl")
     status="$?"
     echo "$rep"
-    exit "$status"
-
 else
      echo "No change in samples/ folder found."
 fi
 
 # Handle demos
-if [[ $(echo $DEMOS_COMMIT | wc -l) -ge 2 ]] || [ "$FORCE_DEPLOY" = true  ]; then
+if [[! -z "$SAMPLES_COMMIT"]] || [ "$FORCE_DEPLOY" = true  ]; then
     echo "Force deployed: ${FORCE_DEPLOY}"
     echo "Found changes in demos"
     # Check if there are any [A]dded demo files, build thumbnails if that is the case
@@ -71,7 +73,7 @@ if [[ $(echo $DEMOS_COMMIT | wc -l) -ge 2 ]] || [ "$FORCE_DEPLOY" = true  ]; the
     fi
 
     echo "Files in samples/ has changed or forcing deploy. Triggering deploy of demos via highcharts-demo-manager to bucket ${BUCKET}"
-    payload="{ \"branch\":\"master\", \"parameters\": { \"deploy_demos\": true, \"deploy_thumbnails\": ${THUMBNAILS}, \"target_bucket\": \"${BUCKET}\", \"deploy_args\": \"-dryrun\" }}"
+    payload="{ \"branch\":\"master\", \"parameters\": { \"deploy_demos\": true, \"deploy_thumbnails\": ${THUMBNAILS}, \"target_bucket\": \"${BUCKET}\", \"deploy_args\": \"${DEPLOYARGS}\" }}"
     echo "$payload"
 
     # Circle API v2
@@ -79,9 +81,8 @@ if [[ $(echo $DEMOS_COMMIT | wc -l) -ge 2 ]] || [ "$FORCE_DEPLOY" = true  ]; the
     rep=$(curl -f -X POST -H "Content-Type: application/json" -d "$payload" "$httpUrl")
     status="$?"
     echo "$rep"
-    exit "$status"
-
 else
      echo "No change in samples/*/demo/ folder found."
-     exit 0;
 fi
+
+exit $status

--- a/.circleci/scripts/check_and_trigger_samples_deploy.sh
+++ b/.circleci/scripts/check_and_trigger_samples_deploy.sh
@@ -40,13 +40,13 @@ if [[ -z $TOKEN ]]; then
 fi
 
 # latest commit where samples were changed, limited to 24 hours
-SAMPLES_COMMIT=$(git log -1 --since=\"24 hours ago\" --format=format:%H --full-diff --name-status samples/)
-DEMOS_COMMIT=$(git log -1 --since=\"24 hours ago\" --format=format:%H --full-diff --name-status samples/\*/demo/\*)q
+SAMPLES_COMMIT=$(git log -1 -- --since=\"24 hours ago\" --format=format:%H --full-diff --name-status samples/)
+DEMOS_COMMIT=$(git log -1 -- --since=\"24 hours ago\" --format=format:%H --full-diff --name-status samples/\*/demo/\*)q
 
-if [ [ $(echo $SAMPLES_COMMIT | wc -l) -ge 2 ]] || [ "$FORCE_DEPLOY" = true  ]; then
+if [[ $(echo $SAMPLES_COMMIT | wc -l) -ge 2 ]] || [ "$FORCE_DEPLOY" = true ]; then
     echo "Force deployed: ${FORCE_DEPLOY}"
     echo "Files in samples/ has changed or forcing deploy. Triggering deploy of samples via highcharts-demo-manager to bucket ${BUCKET}"
-    payload="{ \"branch\":\"master\", \"parameters\": { \"deploy_samples\": true, \"target_bucket\": \"${BUCKET}\" }}"
+    payload="{ \"branch\":\"master\", \"parameters\": { \"deploy_samples\": true, \"target_bucket\": \"${BUCKET}\", \"deploy_args\": \"-dryrun\" }}"
     echo "$payload"
 
     # Circle API v2
@@ -72,7 +72,7 @@ if [[ $(echo $DEMOS_COMMIT | wc -l) -ge 2 ]] || [ "$FORCE_DEPLOY" = true  ]; the
     fi
 
     echo "Files in samples/ has changed or forcing deploy. Triggering deploy of demos via highcharts-demo-manager to bucket ${BUCKET}"
-    payload="{ \"branch\":\"master\", \"parameters\": { \"deploy_demos\": true, \"deploy_thumbnails\": ${THUMBNAILS}, \"target_bucket\": \"${BUCKET}\" }}"
+    payload="{ \"branch\":\"master\", \"parameters\": { \"deploy_demos\": true, \"deploy_thumbnails\": ${THUMBNAILS}, \"target_bucket\": \"${BUCKET}\", \"deploy_args\": \"-dryrun\" }}"
     echo "$payload"
 
     # Circle API v2

--- a/.circleci/scripts/check_and_trigger_samples_deploy.sh
+++ b/.circleci/scripts/check_and_trigger_samples_deploy.sh
@@ -44,8 +44,8 @@ if [[ -z $TOKEN ]]; then
 fi
 
 # latest commit where samples were changed, limited to 24 hours
-SAMPLES_COMMIT=$(git log -1 --since="24 hours ago" --format=format:%H --full-diff --name-status samples/)
-DEMOS_COMMIT=$(git log -1 --since="24 hours ago" --format=format:%H --full-diff --name-status samples/\*/demo/\*)
+SAMPLES_COMMIT=$(git log --since=\""24 hours ago\"" --format=format:%H --full-diff --name-status samples/)
+DEMOS_COMMIT=$(git log --since=\""24 hours ago\"" --format=format:%H --full-diff --name-status samples/\*/demo/\*)
 
 if [[ ! -z "$SAMPLES_COMMIT" ]] || [ "$FORCE_DEPLOY" = true ]; then
     echo "Force deployed: ${FORCE_DEPLOY}"
@@ -63,11 +63,11 @@ else
 fi
 
 # Handle demos
-if [[! -z "$SAMPLES_COMMIT"]] || [ "$FORCE_DEPLOY" = true  ]; then
+if [[ ! -z "$DEMOS_COMMIT" ]] || [ "$FORCE_DEPLOY" = true  ]; then
     echo "Force deployed: ${FORCE_DEPLOY}"
     echo "Found changes in demos"
     # Check if there are any [A]dded demo files, build thumbnails if that is the case
-	  NEW_FILES=$(echo $DEMOS_COMMIT | egrep -c "^A\s+samples\/.+\/demo\/*\.details")
+	  NEW_FILES=$(echo $DEMOS_COMMIT | egrep -c "A\s+samples\/.+\/demo\/*\.details")
     if [[ $NEW_FILES -ge 1 ]]; then
       THUMBNAILS=true
     fi
@@ -84,5 +84,3 @@ if [[! -z "$SAMPLES_COMMIT"]] || [ "$FORCE_DEPLOY" = true  ]; then
 else
      echo "No change in samples/*/demo/ folder found."
 fi
-
-exit $status


### PR DESCRIPTION
Fixed the CI job trying to use a context the nightly bot does not have access to. Also resolved a few problems with the script itself, and added a way to pass arguments to the deployer (`-dryrun` mostly).