### PR TITLE
bugfix/14906-split-tooltip-followPointer

### DIFF
--- a/samples/unit-tests/tooltip/split/demo.js
+++ b/samples/unit-tests/tooltip/split/demo.js
@@ -184,7 +184,8 @@ QUnit.test('Split tooltip with useHTML and outside', function (assert) {
         tooltip: {
             split: true,
             useHTML: true,
-            outside: true
+            outside: true,
+            followPointer: true
         }
     });
 
@@ -194,6 +195,11 @@ QUnit.test('Split tooltip with useHTML and outside', function (assert) {
         chart.tooltip.tt.renderer,
         chart.tooltip.renderer,
         '#15018: Split tooltip should use outside renderer'
+    );
+
+    assert.notOk(
+        chart.tooltip.followPointer,
+        '#14906: followPointer should be false with split tooltip'
     );
 
     assert.strictEqual(

--- a/ts/Core/Options.ts
+++ b/ts/Core/Options.ts
@@ -3558,6 +3558,8 @@ H.defaultOptions = {
          * and wordcloud series by override in the `plotOptions`
          * for those series types.
          *
+         * Does not apply if [split](#tooltip.split) is `true`.
+         *
          * For touch moves to behave the same way, [followTouchMove](
          * #tooltip.followTouchMove) must be `true` also.
          *

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1886,7 +1886,9 @@ class Pointer {
         hoverPoint = hoverData.hoverPoint;
         points = hoverData.hoverPoints;
         hoverSeries = hoverData.hoverSeries;
-        followPointer = hoverSeries && hoverSeries.tooltipOptions.followPointer;
+        followPointer = hoverSeries &&
+            hoverSeries.tooltipOptions.followPointer &&
+            !hoverSeries.tooltipOptions.split;
         useSharedTooltip = (
             shared &&
             hoverSeries &&

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1328,8 +1328,7 @@ class Tooltip {
         U.clearTimeout(this.hideTimer as any);
 
         // get the reference point coordinates (pie charts use tooltipPos)
-        tooltip.followPointer = splat(point)[0].series.tooltipOptions
-            .followPointer;
+        tooltip.followPointer = !tooltip.split && splat(point)[0].series.tooltipOptions.followPointer;
         anchor = tooltip.getAnchor(point as any, mouseEvent);
         x = anchor[0];
         y = anchor[1];


### PR DESCRIPTION
Fixed #14906, split tooltip flickered with `followPointer` enabled.