### PR TITLE
Typesafe Utilities.extend

### DIFF
--- a/ts/Accessibility/Components/MenuComponent.ts
+++ b/ts/Accessibility/Components/MenuComponent.ts
@@ -384,7 +384,7 @@ extend(MenuComponent.prototype, /** @lends Highcharts.MenuComponent */ {
      */
     getKeyboardNavigation: function (
         this: Highcharts.MenuComponent
-    ): Highcharts.KeyboardNavigation {
+    ): Highcharts.KeyboardNavigationHandler {
         var keys = this.keyCodes,
             chart = this.chart,
             component = this;

--- a/ts/Accessibility/Components/SeriesComponent/NewDataAnnouncer.ts
+++ b/ts/Accessibility/Components/SeriesComponent/NewDataAnnouncer.ts
@@ -56,7 +56,7 @@ declare global {
                 dirtySeries: Array<Series>,
                 newSeries?: Series,
                 newPoint?: Point
-            ): string;
+            ): string|null;
             public destroy(): void;
             public init(): void;
             public onPointAdded(point: Point): void;

--- a/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
@@ -727,9 +727,8 @@ extend(SeriesKeyboardNavigation.prototype, /** @lends Highcharts.SeriesKeyboardN
                     ): number {
                         const point = chart.highlightedPoint;
                         if (point) {
-                            fireEvent(point.series, 'click', extend(event, {
-                                point
-                            }));
+                            (event as any).point = point;
+                            fireEvent(point.series, 'click', event);
                             point.firePointEvent('click');
                         }
                         return this.response.success;

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -7717,7 +7717,7 @@ class Axis {
             pos,
             categorized,
             graphic = this.cross,
-            crossOptions,
+            crossOptions: Highcharts.AxisPlotLinesOptions,
             chart = this.chart;
 
         fireEvent(this, 'drawCrosshair', { e: e, point: point });

--- a/ts/Core/Axis/ColorAxis.ts
+++ b/ts/Core/Axis/ColorAxis.ts
@@ -108,8 +108,8 @@ type ColorAxisClass = typeof ColorAxis;
 
 ''; // detach doclet above
 
-extend(Series.prototype, colorSeriesMixin);
-extend(Point.prototype, colorPointMixin);
+extend(Series.prototype, colorSeriesMixin as any);
+extend(Point.prototype, colorPointMixin as any);
 
 Chart.prototype.collectionsWithUpdate.push('colorAxis');
 Chart.prototype.collectionsWithInit.colorAxis = [Chart.prototype.addColorAxis];

--- a/ts/Core/Axis/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand.ts
@@ -100,6 +100,7 @@ declare global {
             events?: any;
             id?: string;
             label?: AxisPlotLinesLabelOptions;
+            translatedValue?: number;
             value?: number;
             width?: number;
             zIndex?: number;

--- a/ts/Core/Axis/RadialAxis.ts
+++ b/ts/Core/Axis/RadialAxis.ts
@@ -392,7 +392,7 @@ class RadialAxis {
 
                 // In case when the innerSize is set in a polar chart, the axis'
                 // center cannot be a reference to pane's center
-                center = this.center = extend([], this.pane.center);
+                center = this.center = this.pane.center.slice();
 
                 // The sector is used in Axis.translate to compute the
                 // translation of reversed axis points (#2570)

--- a/ts/Core/Axis/SolidGaugeAxis.ts
+++ b/ts/Core/Axis/SolidGaugeAxis.ts
@@ -203,7 +203,7 @@ namespace SolidGaugeAxis {
      * @private
      */
     export function init(axis: RadialAxis): void {
-        extend(axis, methods);
+        extend<SolidGaugeAxis|RadialAxis>(axis, methods);
     }
 
 }

--- a/ts/Core/Axis/TimeTicksInfoObject.d.ts
+++ b/ts/Core/Axis/TimeTicksInfoObject.d.ts
@@ -15,7 +15,7 @@
  * */
 
 export interface TimeTicksInfoObject extends Highcharts.TimeNormalizedObject {
-    higherRanks: Array<string>;
+    higherRanks: Record<string, string>;
     totalRange: number;
 }
 

--- a/ts/Core/Navigator.ts
+++ b/ts/Core/Navigator.ts
@@ -535,7 +535,7 @@ extend(defaultOptions, {
             /**
              * @ignore-option
              */
-            compare: void 0,
+            compare: null as any,
 
             /**
              * Unless data is explicitly defined, the data is borrowed from the
@@ -597,7 +597,7 @@ extend(defaultOptions, {
              *
              * @type {Highcharts.ColorString|null}
              */
-            lineColor: void 0, // #4602
+            lineColor: null as any, // #4602
 
             marker: {
                 enabled: false

--- a/ts/Core/Navigator.ts
+++ b/ts/Core/Navigator.ts
@@ -70,6 +70,7 @@ declare module './Series/SeriesLike' {
 
 declare module './Series/SeriesOptions' {
     interface SeriesOptions {
+        fillOpacity?: number;
         navigatorOptions?: SeriesOptions;
         showInNavigator?: boolean;
     }
@@ -534,7 +535,7 @@ extend(defaultOptions, {
             /**
              * @ignore-option
              */
-            compare: null,
+            compare: void 0,
 
             /**
              * Unless data is explicitly defined, the data is borrowed from the
@@ -596,7 +597,7 @@ extend(defaultOptions, {
              *
              * @type {Highcharts.ColorString|null}
              */
-            lineColor: null, // #4602
+            lineColor: void 0, // #4602
 
             marker: {
                 enabled: false

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1530,10 +1530,12 @@ class Pointer {
 
             // Set the marker
             if (!selectionMarker) {
+                // @todo It's a mock object, so maybe we need a separate
+                // interface
                 self.selectionMarker = selectionMarker = extend({
                     destroy: noop,
                     touch: true
-                }, chart.plotBox) as any;
+                }, chart.plotBox as any) as any;
             }
 
             self.pinchTranslate(

--- a/ts/Core/PointerEvent.d.ts
+++ b/ts/Core/PointerEvent.d.ts
@@ -31,6 +31,8 @@ export interface PointerEvent extends globalThis.PointerEvent {
     chartY: number;
     point?: Point;
     touches?: Array<Touch>;
+    xAxis?: Array<Highcharts.PointerAxisCoordinateObject>;
+    yAxis?: Array<Highcharts.PointerAxisCoordinateObject>;
 }
 
 /* *

--- a/ts/Core/Renderer/CSSObject.d.ts
+++ b/ts/Core/Renderer/CSSObject.d.ts
@@ -96,6 +96,7 @@ export interface CSSObject {
     'touch-action'?: string;
     transform?: string;
     transformOrigin?: string;
+    transition?: string;
     userSelect?: string;
     visibility?: 'hidden'|'inherit'|'visible';
     whiteSpace?: string;

--- a/ts/Core/Renderer/HTML/HTMLElement.ts
+++ b/ts/Core/Renderer/HTML/HTMLElement.ts
@@ -81,7 +81,7 @@ interface HTMLElement extends SVGElement {
     element: HTMLDOMElement;
     parentGroup?: HTMLElement;
     renderer: HTMLRenderer;
-    style: CSSObject & CSSStyleDeclaration;
+    style: CSSObject;
     xCorr: number;
     yCorr: number;
     afterSetters(): void;

--- a/ts/Core/Renderer/HTML/HTMLRenderer.ts
+++ b/ts/Core/Renderer/HTML/HTMLRenderer.ts
@@ -45,7 +45,7 @@ interface HTMLRenderer extends SVGRenderer {
 /* eslint-disable valid-jsdoc */
 
 // Extend SvgRenderer for useHTML option.
-extend(SVGRenderer.prototype, /** @lends SVGRenderer.prototype */ {
+extend<SVGRenderer|HTMLRenderer>(SVGRenderer.prototype, /** @lends SVGRenderer.prototype */ {
 
     /**
      * Create HTML text node. This is used by the VML renderer as well as the

--- a/ts/Core/Renderer/SVG/SVGAttributes.d.ts
+++ b/ts/Core/Renderer/SVG/SVGAttributes.d.ts
@@ -31,6 +31,7 @@ import type SVGPath from './SVGPath';
 export interface SVGAttributes {
     // [key: string]: any;
     align?: 'left'|'center'|'right';
+    'alignment-baseline'?: string;
     alphaCorrection?: number;
     anchorX?: number;
     anchorY?: number;

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -105,6 +105,7 @@ declare global {
             [key: string]: any;
             public element: DOMElementType;
             public hasBoxWidthChanged: boolean;
+            // public height?: number;
             public parentGroup?: SVGElement;
             public pathArray?: SVGPath;
             public r?: number;
@@ -114,6 +115,7 @@ declare global {
             public oldShadowOptions?: ShadowOptionsObject;
             public styles?: CSSObject;
             public textStr?: string;
+            // public width?: number;
             public x?: number;
             public y?: number;
             public add(parent?: SVGElement): SVGElement;

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -866,7 +866,7 @@ class SVGRenderer {
      * The style settings mixed with defaults.
      */
     public getStyle(style: CSSObject): CSSObject {
-        this.style = extend({
+        this.style = extend<CSSObject>({
 
             fontFamily: '"Lucida Grande", "Lucida Sans Unicode", ' +
                 'Arial, Helvetica, sans-serif',

--- a/ts/Core/Series/DataLabels.ts
+++ b/ts/Core/Series/DataLabels.ts
@@ -837,7 +837,7 @@ Series.prototype.alignDataLabel = function (
         }, alignTo);
 
         // Add the text size for alignment calculation
-        extend(options, {
+        extend<DataLabelOptions|BBoxObject>(options, {
             width: bBox.width,
             height: bBox.height
         });
@@ -887,7 +887,7 @@ Series.prototype.alignDataLabel = function (
 
         } else {
             setStartPos(alignTo); // data sorting
-            dataLabel.align(options as any, null as any, alignTo);
+            dataLabel.align(options, void 0, alignTo);
             alignAttr = dataLabel.alignAttr;
         }
 

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -499,7 +499,7 @@ class Point {
         graphicalProps.plural.forEach(function (plural: any): void {
             (point as any)[plural].forEach(function (item: any): void {
                 if (item.element) {
-                    item.animate(extend(
+                    item.animate(extend<SVGAttributes>(
                         { x: point.startXPos },
                         (item.startYPos ? {
                             x: item.startXPos,

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2770,10 +2770,10 @@ class Series {
 
     public init(
         chart: Chart,
-        options: DeepPartial<SeriesTypeOptions>
+        userOptions: DeepPartial<SeriesTypeOptions>
     ): void {
 
-        fireEvent(this, 'init', { options: options });
+        fireEvent(this, 'init', { options: userOptions });
 
         var series = this,
             events,
@@ -2814,13 +2814,14 @@ class Series {
          * @name Highcharts.Series#options
          * @type {Highcharts.SeriesOptionsType}
          */
-        series.options = options = series.setOptions(options);
+        series.options = series.setOptions(userOptions);
+        const options = series.options;
+
         series.linkedSeries = [];
         // bind the axes
         series.bindAxes();
 
-        // set some variables
-        extend(series, {
+        extend<Series>(series, {
             /**
              * The series name as given in the options. Defaults to
              * "Series {n}".
@@ -3191,7 +3192,7 @@ class Series {
     public setDataSortingOptions(): void {
         var options = this.options;
 
-        extend(this, {
+        extend<Series>(this, {
             requireSorting: false,
             sorted: false,
             enabledDataSorting: true,
@@ -6730,7 +6731,10 @@ class Series {
 
                     // Reinsert all methods and properties from the new type
                     // prototype (#2270, #3719).
-                    extend(series, seriesTypes[newType || initialType].prototype);
+                    extend<Series>(
+                        series,
+                        seriesTypes[newType || initialType].prototype
+                    );
 
                     // The events are tied to the prototype chain, don't copy if
                     // they're not the series' own

--- a/ts/Core/Time.ts
+++ b/ts/Core/Time.ts
@@ -941,10 +941,13 @@ class Time {
 
 
         // record information on the chosen unit - for dynamic label formatter
-        tickPositions.info = extend(normalizedInterval, {
-            higherRanks: higherRanks,
-            totalRange: interval * count
-        }) as TimeTicksInfoObject;
+        tickPositions.info = extend<Highcharts.TimeNormalizedObject|TimeTicksInfoObject>(
+            normalizedInterval,
+            {
+                higherRanks,
+                totalRange: interval * count
+            }
+        ) as TimeTicksInfoObject;
 
         return tickPositions;
     }

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -1008,13 +1008,13 @@ function internalClearTimeout(id: number): void {
  * @param {T|undefined} a
  *        The object to be extended.
  *
- * @param {object} b
+ * @param {Partial<T>} b
  *        The object to add to the first one.
  *
  * @return {T}
  *         Object a, the original object.
  */
-function extend<T extends object>(a: (T|undefined), b: object): T {
+function extend<T extends object>(a: (T|undefined), b: Partial<T>): T {
     /* eslint-enable valid-jsdoc */
     var n;
 
@@ -1094,7 +1094,7 @@ function css(
                 'alpha(opacity=' + (styles.opacity as any * 100) + ')';
         }
     }
-    extend(el.style, styles);
+    extend(el.style, styles as any);
 }
 
 /**

--- a/ts/Extensions/Annotations/Annotations.ts
+++ b/ts/Extensions/Annotations/Annotations.ts
@@ -20,6 +20,7 @@ import type BBoxObject from '../../Core/Renderer/BBoxObject';
 import type ColorString from '../../Core/Color/ColorString';
 import type ColorType from '../../Core/Color/ColorType';
 import type CSSObject from '../../Core/Renderer/CSSObject';
+import type DashStyleValue from '../../Core/Renderer/DashStyleValue';
 import type { DataLabelOverflowValue } from '../../Core/Series/DataLabelOptions';
 import type Point from '../../Core/Series/Point';
 import type Series from '../../Core/Series/Series';
@@ -142,8 +143,12 @@ declare global {
             y: number;
         }
         interface AnnotationsLabelsOptions extends AnnotationsLabelOptions {
+            color?: ColorType;
+            dashStyle?: DashStyleValue;
+            // formatter: FormatterCallbackFunction<T>;
             point?: (string|AnnotationMockPointOptionsObject);
             itemType?: string;
+            vertical?: VerticalAlignValue;
         }
         interface AnnotationsOptions extends AnnotationControllableOptionsObject {
             animation: Partial<AnimationOptions>;

--- a/ts/Extensions/Annotations/Controllables/ControllableLabel.ts
+++ b/ts/Extensions/Annotations/Controllables/ControllableLabel.ts
@@ -438,6 +438,8 @@ class ControllableLabel implements ControllableMixin.Type {
                 point.series.visible &&
                 MockPoint.prototype.isInsidePlot.call(point);
 
+        const { width = 0, height = 0 } = item;
+
         if (showItem) {
 
             if (itemOptions.distance) {
@@ -446,8 +448,8 @@ class ControllableLabel implements ControllableMixin.Type {
                         chart: chart,
                         distance: pick(itemOptions.distance, 16)
                     },
-                    item.width,
-                    item.height,
+                    width,
+                    height,
                     {
                         plotX: anchorRelativePosition.x,
                         plotY: anchorRelativePosition.y,
@@ -467,10 +469,12 @@ class ControllableLabel implements ControllableMixin.Type {
                 };
 
                 itemPosition = ControllableLabel.alignedPosition(
-                    extend(itemOptions, {
-                        width: item.width,
-                        height: item.height
-                    }),
+                    extend<Highcharts.AnnotationsLabelOptions|BBoxObject>(
+                        itemOptions, {
+                            width,
+                            height
+                        }
+                    ),
                     alignTo
                 );
 
@@ -498,8 +502,8 @@ class ControllableLabel implements ControllableMixin.Type {
                         itemPosRelativeY
                     ) &&
                     chart.isInsidePlot(
-                        itemPosRelativeX + item.width,
-                        itemPosRelativeY + item.height
+                        itemPosRelativeX + width,
+                        itemPosRelativeY + height
                     );
             }
         }

--- a/ts/Extensions/Annotations/Types/Measure.ts
+++ b/ts/Extensions/Annotations/Types/Measure.ts
@@ -523,13 +523,13 @@ class Measure extends Annotation {
                         Measure.calculations.defaultFormatter.call(this);
 
         } else {
-            (this.initLabel as any)(extend({
+            this.initLabel(extend<Partial<Highcharts.AnnotationsLabelsOptions>>({
                 shape: 'rect',
                 backgroundColor: 'none',
                 color: 'black',
                 borderWidth: 0,
-                dashStyle: 'dash',
-                overflow: 'none',
+                dashStyle: 'Dash',
+                overflow: 'allow',
                 align: 'left',
                 vertical: 'top',
                 crop: true,
@@ -548,10 +548,10 @@ class Measure extends Annotation {
                         y: (inverted ? -left + 10 : top) +
                             yAxis.toPixels(annotation.yAxisMin)
                     };
-                },
+                } as any,
                 text: (formatter && formatter.call(this)) ||
                     Measure.calculations.defaultFormatter.call(this)
-            }, typeOptions.label));
+            }, typeOptions.label as any), void 0 as any);
         }
     }
 
@@ -575,7 +575,7 @@ class Measure extends Annotation {
             return;
         }
 
-        this.initShape(extend({
+        this.initShape(extend<Partial<Highcharts.AnnotationsShapeOptions>>({
             type: 'path',
             points: this.shapePointsOptions()
         }, this.options.typeOptions.background), false as any);
@@ -653,11 +653,11 @@ class Measure extends Annotation {
             crosshairOptionsX = merge(defaultOptions, options.crosshairX);
             crosshairOptionsY = merge(defaultOptions, options.crosshairY);
 
-            this.initShape(extend({
+            this.initShape(extend<Partial<Highcharts.AnnotationsShapeOptions>>({
                 d: pathH
             }, crosshairOptionsX), false as any);
 
-            this.initShape(extend({
+            this.initShape(extend<Partial<Highcharts.AnnotationsShapeOptions>>({
                 d: pathV
             }, crosshairOptionsY), false as any);
 

--- a/ts/Extensions/Data.ts
+++ b/ts/Extensions/Data.ts
@@ -60,7 +60,7 @@ declare global {
             (csv: string): string;
         }
         interface DataCompleteCallbackFunction {
-            (chartOptions: Options): void;
+            (chartOptions: Partial<Options>): void;
         }
         interface DataDateFormatCallbackFunction {
             (match: ReturnType<string['match']>): number;
@@ -126,7 +126,7 @@ declare global {
         class Data {
             public constructor(
                 dataOptions: DataOptions,
-                chartOptions?: Options,
+                chartOptions?: Partial<Options>,
                 chart?: Chart
             );
             public alternativeFormat?: string;
@@ -2361,7 +2361,7 @@ class Data {
             j: number,
             r: number,
             seriesIndex,
-            chartOptions: Highcharts.Options,
+            chartOptions: Partial<Highcharts.Options>,
             allSeriesBuilders = [],
             builder,
             freeIndexes,
@@ -2596,7 +2596,7 @@ addEvent(
         }
     ): void {
         var chart = this, // eslint-disable-line no-invalid-this
-            userOptions = (e.args[0] || {}),
+            userOptions: Partial<Highcharts.Options> = (e.args[0] || {}),
             callback = e.args[1];
 
         if (userOptions && userOptions.data && !chart.hasDataDef) {
@@ -2610,7 +2610,7 @@ addEvent(
             chart.data = new H.Data(extend(userOptions.data, {
 
                 afterComplete: function (
-                    dataOptions: Highcharts.Options
+                    dataOptions?: Highcharts.Options
                 ): void {
                     var i, series;
 

--- a/ts/Extensions/GeoJSON.ts
+++ b/ts/Extensions/GeoJSON.ts
@@ -61,11 +61,15 @@ declare module '../Core/Chart/ChartLike'{
 declare global {
     namespace Highcharts {
         interface MapCoordinateObject {
+            name?: string;
+            properties?: object;
             x: number;
             y: (number|null);
         }
         interface MapPathObject {
+            name?: string;
             path: SVGPath;
+            properties?: object;
         }
         interface MapLatLonObject {
             lat: number;
@@ -631,7 +635,7 @@ H.geojson = function (
                  * @name Highcharts.Point#properties
                  * @type {*}
                  */
-                properties: properties
+                properties
             }));
         }
 

--- a/ts/Extensions/Oldie/Oldie.ts
+++ b/ts/Extensions/Oldie/Oldie.ts
@@ -1466,7 +1466,7 @@ if (!svg) {
                         left = rect.left,
                         right = left + rect.width,
                         bottom = top + rect.height,
-                        ret = {
+                        ret: CSSObject = {
                             clip: 'rect(' +
                                 Math.round(inverted ? left : top) + 'px,' +
                                 Math.round(inverted ? bottom : right) + 'px,' +
@@ -2087,8 +2087,8 @@ if (!svg) {
     ): void {
         this.init.apply(this, arguments as any);
     } as any;
-    extend(VMLRenderer.prototype, SVGRenderer.prototype);
-    extend(VMLRenderer.prototype, VMLRendererExtension);
+    extend(VMLRenderer.prototype, SVGRenderer.prototype as any);
+    extend(VMLRenderer.prototype, VMLRendererExtension as any);
 
     // general renderer
     H.Renderer = VMLRenderer as any;

--- a/ts/Extensions/Pane.ts
+++ b/ts/Extensions/Pane.ts
@@ -13,6 +13,7 @@
 import type ColorType from '../Core/Color/ColorType';
 import type RadialAxis from '../Core/Axis/RadialAxis';
 import type Series from '../Core/Series/Series';
+import type SVGAttributes from '../Core/Renderer/SVG/SVGAttributes';
 import type SVGElement from '../Core/Renderer/SVG/SVGElement';
 import Chart from '../Core/Chart/Chart.js';
 import H from '../Core/Globals.js';
@@ -238,7 +239,7 @@ class Pane {
         i: number
     ): void {
         var method = 'animate',
-            attribs = {
+            attribs: SVGAttributes = {
                 'class':
                     'highcharts-pane ' + (backgroundOptions.className || '')
             };

--- a/ts/Extensions/ParallelCoordinates.ts
+++ b/ts/Extensions/ParallelCoordinates.ts
@@ -460,7 +460,7 @@ function addFormattedValue(
                 labelFormat,
                 extend(
                     this,
-                    { value: this.y }
+                    { value: this.y } as any
                 ),
                 chart
             );

--- a/ts/Extensions/Sonification/Sonification.ts
+++ b/ts/Extensions/Sonification/Sonification.ts
@@ -191,7 +191,7 @@ merge(
 Point.prototype.sonify = pointSonifyFunctions.pointSonify;
 Point.prototype.cancelSonify = pointSonifyFunctions.pointCancelSonify;
 Series.prototype.sonify = chartSonifyFunctions.seriesSonify;
-extend(Chart.prototype, {
+extend<Chart|Highcharts.SonifyableChart>(Chart.prototype, {
     sonify: chartSonifyFunctions.chartSonify,
     pauseSonify: chartSonifyFunctions.pause,
     resumeSonify: chartSonifyFunctions.resume,

--- a/ts/Gantt/Pathfinder.ts
+++ b/ts/Gantt/Pathfinder.ts
@@ -932,7 +932,9 @@ class Pathfinder {
      * @return {boolean}
      *         Returns true for X, false for Y, and undefined for autocalculate.
      */
-    public getAlgorithmStartDirection(markerOptions: Highcharts.ConnectorsMarkerOptions): (boolean|undefined) {
+    public getAlgorithmStartDirection(
+        markerOptions: Highcharts.ConnectorsMarkerOptions
+    ): (boolean|undefined) {
         var xCenter = markerOptions.align !== 'left' &&
                         markerOptions.align !== 'right',
             yCenter = markerOptions.verticalAlign !== 'top' &&

--- a/ts/Gantt/PathfinderAlgorithms.ts
+++ b/ts/Gantt/PathfinderAlgorithms.ts
@@ -243,7 +243,7 @@ function straight(
  *         renderer, as well as an array of new obstacles making up this
  *         path.
  */
-const simpleConnect = extend(function (
+const simpleConnect = function (
     start: PositionObject,
     end: PositionObject,
     options: any
@@ -384,9 +384,8 @@ const simpleConnect = extend(function (
         path: pathFromSegments(segments),
         obstacles: segments
     };
-}, {
-    requiresObstacles: true
-});
+};
+simpleConnect.requiresObstacles = true;
 
 /**
  * Find a path from a starting coordinate to an ending coordinate, taking
@@ -418,7 +417,7 @@ const simpleConnect = extend(function (
  *         renderer, as well as an array of new obstacles making up this
  *         path.
  */
-const fastAvoid = extend(function (
+const fastAvoid = function (
     start: PositionObject,
     end: PositionObject,
     options: any
@@ -898,9 +897,8 @@ const fastAvoid = extend(function (
         path: pathFromSegments(segments),
         obstacles: segments
     };
-}, {
-    requiresObstacles: true
-});
+};
+fastAvoid.requiresObstacles = true;
 
 // Define the available pathfinding algorithms.
 // Algorithms take up to 3 arguments: starting point, ending point, and an

--- a/ts/Maps/MapNavigation.ts
+++ b/ts/Maps/MapNavigation.ts
@@ -317,7 +317,7 @@ MapNavigation.prototype.updateEvents = function (
 };
 
 // Add events to the Chart object itself
-extend(Chart.prototype, /** @lends Chart.prototype */ {
+extend<Chart|Highcharts.MapNavigationChart>(Chart.prototype, /** @lends Chart.prototype */ {
 
     /**
      * Fit an inner box to an outer. If the inner box overflows left or right,

--- a/ts/Maps/MapPointer.ts
+++ b/ts/Maps/MapPointer.ts
@@ -48,7 +48,7 @@ declare global {
 /* eslint-disable no-invalid-this */
 
 // Extend the Pointer
-extend(Pointer.prototype, {
+extend<Pointer|Highcharts.MapPointer>(Pointer.prototype, {
 
     // The event handler for the doubleclick event
     onContainerDblClick: function (

--- a/ts/Mixins/TreeSeries.ts
+++ b/ts/Mixins/TreeSeries.ts
@@ -36,9 +36,13 @@ declare global {
         }
         interface TreeNodeObject {
             children: Array<TreeNodeObject>;
+            childrenTotal?: number;
             i: number;
             id: string;
+            isLeaf?: boolean;
+            levelDynamic?: number;
             level: number;
+            name?: string;
             val: number;
             visible: boolean;
         }
@@ -75,10 +79,12 @@ declare global {
         interface TreeValuesOptionsObject<T extends TreeSeries = TreeSeries> {
             before?: TreeValuesBeforeCallbackFunction<T>;
             idRoot: string;
+            index?: number;
             levelIsConstant?: boolean;
             mapIdToNode: Record<string, TreeNodeObject>;
             points: T['points'];
             series: T;
+            siblings?: number;
             visible?: boolean;
         }
     }
@@ -118,14 +124,13 @@ const setTreeValues = function setTreeValues<T extends Highcharts.TreeSeries>(
         children: Array<Highcharts.TreeNodeObject> = [],
         value;
 
-    extend(tree, {
-        levelDynamic: tree.level - (levelIsConstant ? 0 : nodeRoot.level),
-        name: pick(point && point.name, ''),
-        visible: (
-            idRoot === tree.id ||
-            (isBoolean(options.visible) ? options.visible : false)
-        )
-    });
+    tree.levelDynamic = tree.level - (levelIsConstant ? 0 : nodeRoot.level);
+    tree.name = pick(point && point.name, '');
+    tree.visible = (
+        idRoot === tree.id ||
+        (isBoolean(options.visible) ? options.visible : false)
+    );
+
     if (isFn(before)) {
         tree = before(tree, options);
     }
@@ -134,7 +139,7 @@ const setTreeValues = function setTreeValues<T extends Highcharts.TreeSeries>(
         child: Highcharts.TreeNodeObject,
         i: number
     ): void {
-        var newOptions = extend<Highcharts.TreeValuesOptionsObject>(
+        var newOptions = extend<Highcharts.TreeValuesOptionsObject<T>>(
             {} as any, options
         );
 
@@ -152,12 +157,11 @@ const setTreeValues = function setTreeValues<T extends Highcharts.TreeSeries>(
     tree.visible = childrenTotal > 0 || tree.visible;
     // Set the values
     value = pick(optionsPoint.value, childrenTotal);
-    extend(tree, {
-        children: children,
-        childrenTotal: childrenTotal,
-        isLeaf: tree.visible && !childrenTotal,
-        val: value
-    });
+    tree.children = children;
+    tree.childrenTotal = childrenTotal;
+    tree.isLeaf = tree.visible && !childrenTotal;
+    tree.val = value;
+
     return tree;
 };
 

--- a/ts/Series/ColumnRange/ColumnRangeSeries.ts
+++ b/ts/Series/ColumnRange/ColumnRangeSeries.ts
@@ -273,8 +273,8 @@ extend(ColumnRangeSeries.prototype, {
     trackerGroups: ['group', 'dataLabelsGroup'],
     drawGraph: noop,
     getSymbol: noop,
-    polarArc: function (this: ColumnRangeSeries): void {
-        return (columnProto as any).polarArc.apply(this, arguments);
+    polarArc: function (this: ColumnRangeSeries): SVGAttributes {
+        return columnProto.polarArc.apply(this, arguments);
     },
     pointClass: ColumnRangePoint
 });

--- a/ts/Series/Dumbbell/DumbbellPoint.ts
+++ b/ts/Series/Dumbbell/DumbbellPoint.ts
@@ -79,7 +79,7 @@ class DumbbellPoint extends AreaRangePoint {
             ),
             verb = 'attr',
             upperGraphicColor,
-            origProps;
+            origProps: Partial<DumbbellPoint>;
 
         this.pointSetState.apply(this, arguments);
 

--- a/ts/Series/Funnel3D/Funnel3DSeries.ts
+++ b/ts/Series/Funnel3D/Funnel3DSeries.ts
@@ -257,12 +257,12 @@ class Funnel3DSeries extends ColumnSeries {
         extend(this.xAxis.options, {
             gridLineWidth: 0,
             lineWidth: 0,
-            title: null,
+            title: void 0,
             tickPositions: []
         });
         extend(this.yAxis.options, {
             gridLineWidth: 0,
-            title: null,
+            title: void 0,
             labels: {
                 enabled: false
             }

--- a/ts/Series/Gauge/GaugeSeries.ts
+++ b/ts/Series/Gauge/GaugeSeries.ts
@@ -622,6 +622,7 @@ class GaugeSeries extends Series {
 interface GaugeSeries {
     angular: boolean;
     directTouch: boolean;
+    drawGraph(): void;
     fixedBox: boolean;
     forceDL: boolean;
     noSharedTooltip: boolean;

--- a/ts/Series/Heatmap/HeatmapSeries.ts
+++ b/ts/Series/Heatmap/HeatmapSeries.ts
@@ -730,17 +730,9 @@ extend(HeatmapSeries.prototype, {
      */
     drawLegendSymbol: LegendSymbolMixin.drawRectangle,
 
-    /**
-     * @ignore
-     * @deprecated
-     */
-    getBox: noop,
-
     getExtremesFromAll: true,
 
     getSymbol: Series.prototype.getSymbol,
-
-    hasPointSpecificOptions: true,
 
     parallelArrays: colorMapSeriesMixin.parallelArrays,
 

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -1368,7 +1368,7 @@ extend(MapSeries.prototype, {
     // X axis and Y axis must have same translation slope
     preserveAspectRatio: true,
 
-    searchPoint: noop,
+    searchPoint: noop as any,
 
     trackerGroups: colorMapSeriesMixin.trackerGroups,
 

--- a/ts/Series/Networkgraph/Networkgraph.ts
+++ b/ts/Series/Networkgraph/Networkgraph.ts
@@ -663,6 +663,7 @@ interface NetworkgraphSeries {
     data: Array<NetworkgraphPoint>;
     destroy(): void;
     directTouch: boolean;
+    drawGraph: void;
     forces: Array<string>;
     hasDraggableNodes: boolean;
     isCartesian: boolean;
@@ -706,7 +707,7 @@ extend(NetworkgraphSeries.prototype, {
      */
     forces: ['barycenter', 'repulsive', 'attractive'],
     hasDraggableNodes: true,
-    drawGraph: null as any,
+    drawGraph: void 0,
     isCartesian: false,
     requireSorting: false,
     directTouch: true,
@@ -715,7 +716,7 @@ extend(NetworkgraphSeries.prototype, {
     trackerGroups: ['group', 'markerGroup', 'dataLabelsGroup'],
     drawTracker: seriesTypes.column.prototype.drawTracker,
     // Animation is run in `series.simulation`.
-    animate: null as any,
+    animate: void 0,
     buildKDTree: H.noop,
     /**
      * Create a single node that holds information on incoming and outgoing

--- a/ts/Series/PackedBubble/PackedBubbleSeries.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeries.ts
@@ -1399,7 +1399,7 @@ class PackedBubbleSeries extends BubbleSeries implements Highcharts.DragNodesSer
             data = series.data,
             index = series.index,
             point,
-            radius,
+            radius: number|undefined,
             positions,
             i,
             useSimulation = series.options.useSimulation;
@@ -1431,7 +1431,7 @@ class PackedBubbleSeries extends BubbleSeries implements Highcharts.DragNodesSer
                 // update the series points with the val from positions
                 // array
                 point = data[positions[i][4] as any];
-                radius = positions[i][2];
+                radius = pick(positions[i][2], void 0);
 
                 if (!useSimulation) {
                     point.plotX = (
@@ -1443,12 +1443,14 @@ class PackedBubbleSeries extends BubbleSeries implements Highcharts.DragNodesSer
                         chart.diffY
                     );
                 }
-                point.marker = extend(point.marker, {
-                    radius: radius,
-                    width: 2 * (radius as any),
-                    height: 2 * (radius as any)
-                });
-                point.radius = radius as any;
+                if (isNumber(radius)) {
+                    point.marker = extend(point.marker, {
+                        radius,
+                        width: 2 * radius,
+                        height: 2 * radius
+                    });
+                    point.radius = radius;
+                }
             }
         }
 
@@ -1539,7 +1541,7 @@ extend(PackedBubbleSeries.prototype, {
     requireSorting: false,
 
     // solving #12287
-    searchPoint: H.noop,
+    searchPoint: H.noop as any,
 
     trackerGroups: ['group', 'dataLabelsGroup', 'parentNodesGroup']
 

--- a/ts/Series/Pie/PieSeries.ts
+++ b/ts/Series/Pie/PieSeries.ts
@@ -1190,6 +1190,7 @@ class PieSeries extends Series {
  * */
 
 interface PieSeries {
+    drawGraph: undefined;
     getCenter: typeof CenteredSeriesMixin['getCenter'];
     pointClass: typeof PiePoint;
 }
@@ -1199,7 +1200,7 @@ extend(PieSeries.prototype, {
 
     directTouch: true,
 
-    drawGraph: null as any,
+    drawGraph: void 0,
 
     drawLegendSymbol: LegendSymbolMixin.drawRectangle,
 
@@ -1219,7 +1220,7 @@ extend(PieSeries.prototype, {
 
     requireSorting: false,
 
-    searchPoint: noop,
+    searchPoint: noop as any,
 
     trackerGroups: ['group', 'dataLabelsGroup']
 });

--- a/ts/Series/Pie3D/Pie3DSeries.ts
+++ b/ts/Series/Pie3D/Pie3DSeries.ts
@@ -265,7 +265,7 @@ class Pie3DSeries extends PieSeries {
 interface Pie3DSeries {
     pointClass: typeof Pie3DPoint;
 }
-extend(Pie3DSeries, {
+extend(Pie3DSeries.prototype, {
     pointClass: Pie3DPoint
 });
 

--- a/ts/Series/Sankey/SankeySeries.ts
+++ b/ts/Series/Sankey/SankeySeries.ts
@@ -1158,7 +1158,7 @@ extend(SankeySeries.prototype, {
     animate: Series.prototype.animate,
     // Create a single node that holds information on incoming and outgoing
     // links.
-    createNode: NodesMixin.createNode,
+    createNode: NodesMixin.createNode as any,
     destroy: NodesMixin.destroy,
     forceDL: true,
     invertible: true,
@@ -1166,7 +1166,7 @@ extend(SankeySeries.prototype, {
     orderNodes: true,
     pointArrayMap: ['from', 'to'],
     pointClass: SankeyPoint,
-    searchPoint: H.noop,
+    searchPoint: H.noop as any,
     setData: NodesMixin.setData
 });
 

--- a/ts/Series/Sunburst/SunburstSeries.ts
+++ b/ts/Series/Sunburst/SunburstSeries.ts
@@ -1129,7 +1129,7 @@ interface SunburstSeries {
 }
 extend(SunburstSeries.prototype, {
     drawDataLabels: noop, // drawDataLabels is called in drawPoints
-    pointAttribs: ColumnSeries.prototype.pointAttribs,
+    pointAttribs: ColumnSeries.prototype.pointAttribs as any,
     pointClass: SunburstPoint,
     utils: SunburstUtilities
 });

--- a/ts/Series/Tilemap/TilemapSeries.ts
+++ b/ts/Series/Tilemap/TilemapSeries.ts
@@ -335,7 +335,7 @@ extend(TilemapSeries.prototype, { // Prototype functions
     // TODO: Consider standarizing heatmap and tilemap into more
     // consistent form.
     markerAttribs: ScatterSeries.prototype.markerAttribs,
-    pointAttribs: ColumnSeries.prototype.pointAttribs,
+    pointAttribs: ColumnSeries.prototype.pointAttribs as any,
     pointClass: TilemapPoint
 });
 

--- a/ts/Series/Treemap/TreemapComposition.ts
+++ b/ts/Series/Treemap/TreemapComposition.ts
@@ -49,13 +49,13 @@ addEvent(Series, 'afterBindAxes', function (): void {
                 gridLineWidth: 0,
                 lineWidth: 0,
                 min: 0,
-                dataMin: 0,
+                // dataMin: 0,
                 minPadding: 0,
                 max: TreemapUtilities.AXIS_MAX,
-                dataMax: TreemapUtilities.AXIS_MAX,
+                // dataMax: TreemapUtilities.AXIS_MAX,
                 maxPadding: 0,
                 startOnTick: false,
-                title: null,
+                title: void 0,
                 tickPositions: []
             };
 

--- a/ts/Series/Treemap/TreemapSeries.ts
+++ b/ts/Series/Treemap/TreemapSeries.ts
@@ -1084,7 +1084,10 @@ class TreemapSeries extends ScatterSeries {
                 // the fill attribute.
                 if (series.colorAttribs && styledMode) {
                     // Heatmap is loaded
-                    extend(css, series.colorAttribs(point as any));
+                    extend<CSSObject|SVGAttributes>(
+                        css,
+                        series.colorAttribs(point as any)
+                    );
                 }
 
                 if (!(series as any)[groupKey]) {

--- a/ts/Series/Vector/VectorSeries.ts
+++ b/ts/Series/Vector/VectorSeries.ts
@@ -347,7 +347,7 @@ extend(VectorSeries.prototype, {
      * @ignore
      * @deprecated
      */
-    markerAttribs: H.noop,
+    markerAttribs: H.noop as any,
 
     parallelArrays: ['x', 'y', 'length', 'direction'],
 

--- a/ts/Series/Waterfall/WaterfallSeries.ts
+++ b/ts/Series/Waterfall/WaterfallSeries.ts
@@ -938,7 +938,7 @@ class WaterfallSeries extends ColumnSeries {
 }
 
 interface WaterfallSeries {
-    getZonesGraph: typeof LineSeries.prototype.getZonesGraphs;
+    getZonesGraphs: typeof LineSeries.prototype.getZonesGraphs;
     pointClass: typeof WaterfallPoint;
     pointValKey: string;
     showLine: boolean;

--- a/ts/Series/Wordcloud/WordcloudSeries.ts
+++ b/ts/Series/Wordcloud/WordcloudSeries.ts
@@ -207,7 +207,7 @@ class WordcloudSeries extends ColumnSeries {
             lineWidth: 0,
             maxPadding: 0,
             startOnTick: false,
-            title: null,
+            title: void 0,
             tickPositions: []
         };
 
@@ -364,7 +364,9 @@ class WordcloudSeries extends ColumnSeries {
                         x: placement.x,
                         y: placement.y,
                         text: point.name,
-                        rotation: placement.rotation
+                        rotation: isNumber(placement.rotation) ?
+                            placement.rotation :
+                            void 0
                     }
                 ),
                 polygon = getPolygon(
@@ -552,7 +554,7 @@ extend(WordcloudSeries.prototype, {
         isPolygonsColliding: isPolygonsColliding,
         rotate2DToOrigin: rotate2DToOrigin,
         rotate2DToPoint: rotate2DToPoint
-    }
+    } as any
 });
 
 /* *

--- a/ts/Series/XRange/XRangeSeries.ts
+++ b/ts/Series/XRange/XRangeSeries.ts
@@ -718,7 +718,7 @@ extend(XRangeSeries.prototype, {
     animate: Series.prototype.animate,
     cropShoulder: 1,
     getExtremesFromAll: true,
-    autoIncrement: H.noop,
+    autoIncrement: H.noop as any,
     buildKDTree: H.noop,
     pointClass: XRangePoint
 });

--- a/ts/Stock/Indicators/AO/AOIndicator.ts
+++ b/ts/Stock/Indicators/AO/AOIndicator.ts
@@ -244,7 +244,7 @@ extend(AOIndicator.prototype, {
     nameComponents: (false as any),
 
     // Columns support:
-    markerAttribs: noop,
+    markerAttribs: noop as any,
     getColumnMetrics: ColumnSeries.prototype.getColumnMetrics,
     crispCol: ColumnSeries.prototype.crispCol,
     translate: ColumnSeries.prototype.translate,

--- a/ts/Stock/Indicators/MACD/MACDIndicator.ts
+++ b/ts/Stock/Indicators/MACD/MACDIndicator.ts
@@ -501,7 +501,7 @@ extend(MACDIndicator.prototype, {
     parallelArrays: ['x', 'y', 'signal', 'MACD'],
     pointValKey: 'y',
     // Columns support:
-    markerAttribs: noop,
+    markerAttribs: noop as any,
     getColumnMetrics: H.seriesTypes.column.prototype.getColumnMetrics,
     crispCol: H.seriesTypes.column.prototype.crispCol,
     drawPoints: H.seriesTypes.column.prototype.drawPoints

--- a/ts/Stock/Indicators/PSAR/PSARIndicator.ts
+++ b/ts/Stock/Indicators/PSAR/PSARIndicator.ts
@@ -389,7 +389,7 @@ interface PSARIndicator {
 }
 
 extend(PSARIndicator.prototype, {
-    nameComponents: false
+    nameComponents: void 0
 });
 
 /* *

--- a/ts/Stock/Indicators/SMA/SMAComposition.ts
+++ b/ts/Stock/Indicators/SMA/SMAComposition.ts
@@ -50,7 +50,7 @@ addEvent(Series, 'init', function (
     ) {
         extend(series, {
             pointValKey: ohlcProto.pointValKey,
-            keys: (ohlcProto as any).keys, // @todo potentially nonsense
+            // keys: ohlcProto.keys, // @todo potentially nonsense
             pointArrayMap: ohlcProto.pointArrayMap,
             toYData: ohlcProto.toYData
         });

--- a/ts/Stock/Indicators/VBP/VBPIndicator.ts
+++ b/ts/Stock/Indicators/VBP/VBPIndicator.ts
@@ -793,7 +793,7 @@ extend(VBPIndicator.prototype, {
         eventName: 'afterSetExtremes'
     },
     calculateOn: 'render',
-    markerAttribs: noop,
+    markerAttribs: noop as any,
     drawGraph: noop,
     getColumnMetrics: columnPrototype.getColumnMetrics,
     crispCol: columnPrototype.crispCol

--- a/ts/Stock/StockToolsBindings.ts
+++ b/ts/Stock/StockToolsBindings.ts
@@ -540,7 +540,7 @@ bindingsUtils.updateNthPoint = function (
 };
 
 // Extends NavigationBindigs to support indicators and resizers:
-extend(NavigationBindings.prototype, {
+extend<NavigationBindings|Highcharts.StockToolsNavigationBindings>(NavigationBindings.prototype, {
     /* eslint-disable valid-jsdoc */
     /**
      * Get current positions for all yAxes. If new axis does not have position,


### PR DESCRIPTION
As a general rule, the second argument of `extend` should be a subset/partial of the first. Exceptions are when two objects are merged to create a third type, in which case we can use an explicit type.

With this PR some new `any` casts are added. Previously these were inferred any's. It is better with explicit any's that we can systematically refactor out, than implicit any's that allowed us to extend typed objects with anything.