### PR TITLE
bugfix/12116-boost-stacked-rangeselector

### DIFF
--- a/ts/Extensions/Boost/BoostInit.ts
+++ b/ts/Extensions/Boost/BoostInit.ts
@@ -225,6 +225,10 @@ function init(): void {
                     chartDestroyed = typeof chart.index === 'undefined',
                     isYInside = true;
 
+                if (typeof d === 'undefined') {
+                    return true;
+                }
+
                 if (!chartDestroyed) {
                     if (useRaw) {
                         x = (d as any)[0];

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -656,6 +656,10 @@ function GLRenderer(
         while (i < sdata.length - 1) {
             d = sdata[++i];
 
+            if (typeof d === 'undefined') {
+                continue;
+            }
+
             // px = x = y = z = nx = low = false;
             // chartDestroyed = typeof chart.index === 'undefined';
             // nextInside = prevInside = pcolor = isXInside = isYInside = false;


### PR DESCRIPTION
Fixed #12116, boosted stacked chart with range selector enabled and a partial range selected threw.