### PR TITLE
Updated series.line.marker.radius in Highcharts

### DIFF
--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -1240,6 +1240,8 @@ class Series {
              *         Bigger markers
              *
              * @default {highstock} 2
+             * @default {highcharts} 4
+             *
              */
             radius: 4,
 


### PR DESCRIPTION
The docs had the default value for stock charts but not for highcharts - this commit fixed this discrepancy.