### PR TITLE
bugfix/10464-boost-halo-axis-pos

### DIFF
--- a/ts/Extensions/Boost/BoostInit.ts
+++ b/ts/Extensions/Boost/BoostInit.ts
@@ -476,6 +476,9 @@ function init(): void {
                     (xAxis && xAxis.pos !== prevX) ||
                     (yAxis && yAxis.pos !== prevY)
                 ) {
+                    // #10464: Keep the marker group position in sync with the
+                    // position of the hovered series axes since there is only
+                    // one shared marker group when boosting.
                     chart.markerGroup.translate(xAxis.pos, yAxis.pos);
 
                     prevX = xAxis.pos;

--- a/ts/Extensions/Boost/BoostInit.ts
+++ b/ts/Extensions/Boost/BoostInit.ts
@@ -462,6 +462,27 @@ function init(): void {
         //         shouldForceChartSeriesBoosting(chart);
         // });
 
+        let prevX = -1;
+        let prevY = -1;
+
+        addEvent(chart.pointer, 'afterGetHoverData', (): void => {
+            const series = chart.hoverSeries;
+
+            if (chart.markerGroup && series) {
+                const xAxis = chart.inverted ? series.yAxis : series.xAxis;
+                const yAxis = chart.inverted ? series.xAxis : series.yAxis;
+
+                if (
+                    (xAxis && xAxis.pos !== prevX) ||
+                    (yAxis && yAxis.pos !== prevY)
+                ) {
+                    chart.markerGroup.translate(xAxis.pos, yAxis.pos);
+
+                    prevX = xAxis.pos;
+                    prevY = yAxis.pos;
+                }
+            }
+        });
     });
 
     /* eslint-enable no-invalid-this */


### PR DESCRIPTION
Fixed #10464, halo position was wrong when using boost with multiple axes.