### PR TITLE
bugfix/15377-inactive-state-zero-opacity

### DIFF
--- a/samples/unit-tests/series-pie/datalabel/demo.js
+++ b/samples/unit-tests/series-pie/datalabel/demo.js
@@ -7,6 +7,11 @@ QUnit.test('Pie data labels general tests', function (assert) {
                 {
                     animation: false,
                     type: 'pie',
+                    states: {
+                        inactive: {
+                            opacity: 0
+                        }
+                    },
                     data: [
                         {
                             name: 'Firefox',
@@ -49,6 +54,14 @@ QUnit.test('Pie data labels general tests', function (assert) {
         point.dataLabel.translateY - dataLabelOldY,
         offsetY,
         'A point dataLabel y option should be used in calculations (#12985).'
+    );
+
+    chart.series[0].points[0].onMouseOver();
+
+    assert.strictEqual(
+        chart.series[0].points[1].dataLabel.opacity,
+        0,
+        '#15377: Inactive point should have 0 opacity'
     );
 });
 

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1582,7 +1582,7 @@ class Point {
 
                 // Some inactive points (e.g. slices in pie) should apply
                 // oppacity also for it's labels
-                if (series.options.inactiveOtherPoints && pointAttribs.opacity) {
+                if (series.options.inactiveOtherPoints && isNumber(pointAttribs.opacity)) {
                     (point.dataLabels || []).forEach(function (
                         label: SVGElement
                     ): void {


### PR DESCRIPTION
Fixed #15377, inactive state with 0 opacity applied due to `inactiveOtherSeries` being `true` did not work for data labels and connectors.