### PR TITLE
bugfix/15392-boost-empty-data-turbo

### DIFF
--- a/ts/Extensions/Boost/BoostOverrides.ts
+++ b/ts/Extensions/Boost/BoostOverrides.ts
@@ -425,9 +425,11 @@ wrap(Series.prototype, 'processData', function (
         // Enter or exit boost mode
         if (this.isSeriesBoosting) {
             // Force turbo-mode:
-            firstPoint = this.getFirstValidPoint(this.options.data as any);
-            if (!isNumber(firstPoint) && !isArray(firstPoint)) {
-                error(12, false, this.chart);
+            if (this.options.data && this.options.data.length) {
+                firstPoint = this.getFirstValidPoint(this.options.data);
+                if (!isNumber(firstPoint) && !isArray(firstPoint)) {
+                    error(12, false, this.chart);
+                }
             }
             this.enterBoost();
         } else if (this.exitBoost) {


### PR DESCRIPTION
Fixed #15392, boosted chart with empty data showed turbo warning.