### PR TITLE
bugfix/11336-tooltip-small-chart

### DIFF
--- a/samples/unit-tests/legend/legend-height/demo.js
+++ b/samples/unit-tests/legend/legend-height/demo.js
@@ -68,6 +68,12 @@
                 chart.legend.legendHeight < 150,
                 'Legend is less than full height'
             );
+
+            chart.setSize(20, 20);
+            assert.notOk(
+                chart.legend.nav,
+                '#11336: There should be no navigation if there is no space'
+            );
         }
     );
 

--- a/ts/Core/Legend.ts
+++ b/ts/Core/Legend.ts
@@ -1454,7 +1454,10 @@ class Legend {
 
         // Reset the legend height and adjust the clipping rectangle
         pages.length = 0;
-        if (legendHeight > spaceHeight &&
+        if (
+            legendHeight &&
+            spaceHeight > 0 &&
+            legendHeight > spaceHeight &&
             (navOptions as any).enabled !== false
         ) {
 


### PR DESCRIPTION
Fixed #11336, no tooltip showed when hovering very small chart.