### PR TITLE
bugfix/15420-zones-clip-leak

### DIFF
--- a/samples/unit-tests/series/zones/demo.js
+++ b/samples/unit-tests/series/zones/demo.js
@@ -284,9 +284,17 @@ QUnit.test('Adding and removing zones', function (assert) {
         ]
     });
 
+    const clips = chart.series[0].clips;
+
     chart.series[0].update({
         zones: []
     });
+
+    assert.strictEqual(
+        chart.series[0].clips,
+        clips,
+        '#15420: Clips array should have been preserved'
+    );
 
     assert.strictEqual(
         chart.series[0].graph.attr('visibility'),
@@ -317,6 +325,14 @@ QUnit.test('Adding and removing zones', function (assert) {
         chart.series[0].graph.attr('visibility'),
         'hidden',
         'Series line is hidden after adding zones back (#10569).'
+    );
+
+    const clip = chart.series[0].clips[0];
+    chart.series[0].destroy();
+
+    assert.notOk(
+        clip.element,
+        '#15420: Clip should have been destroyed'
     );
 });
 

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -5385,7 +5385,10 @@ class Series {
                 point.destroy();
             }
         }
-        series.points = null as any;
+
+        if (series.clips) {
+            series.clips.forEach((clip): void => clip.destroy());
+        }
 
         // Clear the animation timeout if we are destroying the series
         // during initial animation
@@ -5407,7 +5410,7 @@ class Series {
 
         // remove from hoverSeries
         if (chart.hoverSeries === series) {
-            chart.hoverSeries = null as any;
+            chart.hoverSeries = void 0;
         }
         erase(chart.series, series);
         chart.orderSeries();
@@ -6647,6 +6650,7 @@ class Series {
                 'cropped',
                 '_hasPointMarkers',
                 '_hasPointLabels',
+                'clips', // #15420
 
                 // Networkgraph (#14397)
                 'nodes',


### PR DESCRIPTION
Fixed #15420, series with `zones` or `negativeColor` enabled leaked memory on `update`.