### PR TITLE
Bugfix/15157-stocktools-replace-colors-with-hex

### DIFF
--- a/css/highcharts.scss
+++ b/css/highcharts.scss
@@ -76,8 +76,8 @@ $scrollbar-track-background: $neutral-color-5 !default;
 $scrollbar-track-border: $neutral-color-5 !default;
 
 // Indicators
-$positiveColor: #06b535; // Positive indicator color
-$negativeColor: #f21313; // Negative indicator color
+$positive-color: #06b535; // Positive indicator color
+$negative-color: #f21313; // Negative indicator color
 
 .highcharts-container {
     position: relative;

--- a/css/highcharts.scss
+++ b/css/highcharts.scss
@@ -76,8 +76,8 @@ $scrollbar-track-background: $neutral-color-5 !default;
 $scrollbar-track-border: $neutral-color-5 !default;
 
 // Indicators
-$indicator-positive-line: #06b535; // Positive indicator color
-$indicator-negative-line: #f21313; // Negative indicator color
+$positiveColor: #06b535; // Positive indicator color
+$negativeColor: #f21313; // Negative indicator color
 
 .highcharts-container {
     position: relative;

--- a/samples/unit-tests/indicator-dmi/recalculations/demo.js
+++ b/samples/unit-tests/indicator-dmi/recalculations/demo.js
@@ -1,6 +1,7 @@
 QUnit.test(
     'Testing DMI indicator (values, period and updates), #15140.',
     assert => {
+
         const chart = Highcharts.stockChart('container', {
                 yAxis: [{
                     height: '60%'
@@ -152,13 +153,13 @@ QUnit.test(
 
         assert.strictEqual(
             DMIIndicator.graphplusDILine.element.getAttribute('stroke'),
-            Highcharts.defaultOptions.positiveColor,
+            DMIIndicator.options.plusDILine.styles.lineColor,
             'The +DI line color should be green-ish by default.'
         );
 
         assert.strictEqual(
             DMIIndicator.graphminusDILine.element.getAttribute('stroke'),
-            Highcharts.defaultOptions.negativeColor,
+            DMIIndicator.options.minusDILine.styles.lineColor,
             'The -DI line color should be red-ish by default.'
         );
 

--- a/samples/unit-tests/indicator-dmi/recalculations/demo.js
+++ b/samples/unit-tests/indicator-dmi/recalculations/demo.js
@@ -152,13 +152,13 @@ QUnit.test(
 
         assert.strictEqual(
             DMIIndicator.graphplusDILine.element.getAttribute('stroke'),
-            Highcharts.defaultOptions.colors[2],
+            Highcharts.defaultOptions.positiveColor,
             'The +DI line color should be green-ish by default.'
         );
 
         assert.strictEqual(
             DMIIndicator.graphminusDILine.element.getAttribute('stroke'),
-            Highcharts.defaultOptions.colors[5],
+            Highcharts.defaultOptions.negativeColor,
             'The -DI line color should be red-ish by default.'
         );
 

--- a/tools/gulptasks/palette.js
+++ b/tools/gulptasks/palette.js
@@ -58,7 +58,7 @@ async function task() {
  * the 'gulp palette' task. Palette colors are defined in highcharts.scss.
  */
 /* eslint comma-dangle: 0, max-len: 0 */
-import type ColorString from './Color/ColorString';
+import type ColorString from './ColorString';
 const palette = {
 ${ts}
 };

--- a/tools/gulptasks/palette.js
+++ b/tools/gulptasks/palette.js
@@ -64,7 +64,7 @@ ${ts}
 };
 export default palette;
 `;
-    const tsFilePath = path.join(__dirname, '../../ts/core/Palette.ts');
+    const tsFilePath = path.join(__dirname, '../../ts/core/Color/Palette.ts');
     fs.writeFileSync(tsFilePath, tpl, 'utf8');
 
     log.success(`Wrote palette colors to ${tsFilePath}`);

--- a/ts/Core/Color/Palette.ts
+++ b/ts/Core/Color/Palette.ts
@@ -78,11 +78,11 @@ const palette = {
     /**
      * Positive indicator color
      */
-    indicatorPositiveLine: '#06b535' as ColorString,
+    positiveColor: '#06b535' as ColorString,
     /**
      * Negative indicator color
      */
-    indicatorNegativeLine: '#f21313' as ColorString,
+    negativeColor: '#f21313' as ColorString,
 
 };
 export default palette;

--- a/ts/Extensions/Annotations/Annotations.ts
+++ b/ts/Extensions/Annotations/Annotations.ts
@@ -43,6 +43,7 @@ import H from '../../Core/Globals.js';
 import MockPoint from './MockPoint.js';
 import Pointer from '../../Core/Pointer.js';
 import U from '../../Core/Utilities.js';
+import palette from '../../Core/Color/Palette.js';
 const {
     addEvent,
     defined,
@@ -1106,7 +1107,7 @@ merge<Annotation>(
                      *
                      * @type {Highcharts.ColorString}
                      */
-                    borderColor: 'black',
+                    borderColor: palette.neutralColor100,
 
                     /**
                      * The border radius in pixels for the annotaiton's label.
@@ -1570,9 +1571,9 @@ merge<Annotation>(
                     width: 10,
                     height: 10,
                     style: {
-                        stroke: 'black',
+                        stroke: palette.neutralColor100,
                         'stroke-width': 2,
-                        fill: 'white'
+                        fill: palette.backgroundColor
                     },
                     visible: false,
                     events: {}

--- a/ts/Extensions/Annotations/Types/Fibonacci.ts
+++ b/ts/Extensions/Annotations/Types/Fibonacci.ts
@@ -13,6 +13,7 @@ import Annotation from '../Annotations.js';
 import MockPoint from '../MockPoint.js';
 import Tunnel from './Tunnel.js';
 import U from '../../../Core/Utilities.js';
+import palette from '../../../Core/Color/Palette.js';
 const { merge } = U;
 
 /**
@@ -276,7 +277,7 @@ Fibonacci.prototype.defaultOptions = merge(
             /**
              * The color of line.
              */
-            lineColor: 'grey',
+            lineColor: palette.neutralColor40,
 
             /**
              * An array of colors for the lines.

--- a/ts/Stock/Indicators/AO/AOIndicator.ts
+++ b/ts/Stock/Indicators/AO/AOIndicator.ts
@@ -23,6 +23,7 @@ const {
     }
 } = SeriesRegistry;
 import U from '../../../Core/Utilities.js';
+import palette from '../../../Core/Color/Palette.js';
 const {
     extend,
     merge,
@@ -77,7 +78,7 @@ class AOIndicator extends SMAIndicator {
          * @type  {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
          * @since 7.0.0
          */
-        greaterBarColor: '#06B535',
+        greaterBarColor: palette.positiveColor,
         /**
          * Color of the Awesome oscillator series bar that is lower than the
          * previous one. Note that if a `color` is defined, the `color`
@@ -89,7 +90,7 @@ class AOIndicator extends SMAIndicator {
          * @type  {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
          * @since 7.0.0
          */
-        lowerBarColor: '#F21313',
+        lowerBarColor: palette.negativeColor,
         threshold: 0,
         groupPadding: 0.2,
         pointPadding: 0.2,

--- a/ts/Stock/Indicators/DMI/DMIIndicator.ts
+++ b/ts/Stock/Indicators/DMI/DMIIndicator.ts
@@ -110,7 +110,7 @@ class DMIIndicator extends SMAIndicator {
                  *
                  * @type {Highcharts.ColorString}
                  */
-                lineColor: palette.colors[2] // green-ish
+                lineColor: palette.positiveColor // green-ish
             }
         },
         /**
@@ -130,7 +130,7 @@ class DMIIndicator extends SMAIndicator {
                  *
                  * @type {Highcharts.ColorString}
                  */
-                lineColor: palette.colors[5] // red-ish
+                lineColor: palette.negativeColor // red-ish
             }
         },
         dataGrouping: {

--- a/ts/Stock/Indicators/Supertrend/SupertrendIndicator.ts
+++ b/ts/Stock/Indicators/Supertrend/SupertrendIndicator.ts
@@ -118,7 +118,7 @@ class SupertrendIndicator extends SMAIndicator {
          *
          * @type {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
          */
-        risingTrendColor: palette.indicatorPositiveLine,
+        risingTrendColor: palette.positiveColor,
         /**
          * Color of the Supertrend series line that is above the main series.
          *
@@ -127,7 +127,7 @@ class SupertrendIndicator extends SMAIndicator {
          *
          * @type {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
          */
-        fallingTrendColor: palette.indicatorNegativeLine,
+        fallingTrendColor: palette.negativeColor,
         /**
          * The styles for the Supertrend line that intersect main series.
          *

--- a/ts/Stock/StockToolsBindings.ts
+++ b/ts/Stock/StockToolsBindings.ts
@@ -1838,7 +1838,7 @@ var stockToolsBindings: Record<string, Highcharts.NavigationBindingsOptionsObjec
                                 y: coordsY.value,
                                 controlPoint: {
                                     style: {
-                                        fill: 'red'
+                                        fill: palette.negativeColor
                                     }
                                 }
                             },
@@ -1998,8 +1998,10 @@ var stockToolsBindings: Record<string, Highcharts.NavigationBindingsOptionsObjec
     },
     /**
      * A vertical arrow annotation bindings. Includes `start` event. On click,
-     * finds the closest point and marks it with an arrow. Green arrow when
-     * pointing from above, red when pointing from below the point.
+     * finds the closest point and marks it with an arrow.
+     * palette.PositiveColor is the color of the arrow when
+     * pointing from above, palette.negativeColor
+     * when pointing from below the point.
      *
      * @type    {Highcharts.NavigationBindingsOptionsObject}
      * @product highstock
@@ -2041,7 +2043,7 @@ var stockToolsBindings: Record<string, Highcharts.NavigationBindingsOptionsObjec
                         },
                         connector: {
                             fill: 'none',
-                            stroke: closestPoint.below ? 'red' : 'green'
+                            stroke: closestPoint.below ? palette.negativeColor : palette.positiveColor
                         }
                     },
                     shapeOptions: {

--- a/ts/Stock/StockToolsBindings.ts
+++ b/ts/Stock/StockToolsBindings.ts
@@ -1999,8 +1999,8 @@ var stockToolsBindings: Record<string, Highcharts.NavigationBindingsOptionsObjec
     /**
      * A vertical arrow annotation bindings. Includes `start` event. On click,
      * finds the closest point and marks it with an arrow.
-     * palette.PositiveColor is the color of the arrow when
-     * pointing from above, palette.negativeColor
+     * `${palette.positiveColor}` is the color of the arrow when
+     * pointing from above and `${palette.negativeColor}`
      * when pointing from below the point.
      *
      * @type    {Highcharts.NavigationBindingsOptionsObject}

--- a/ts/Stock/StockToolsBindings.ts
+++ b/ts/Stock/StockToolsBindings.ts
@@ -26,6 +26,7 @@ import H from '../Core/Globals.js';
 import NavigationBindings from '../Extensions/Annotations/NavigationBindings.js';
 import Series from '../Core/Series/Series.js';
 import U from '../Core/Utilities.js';
+import palette from '../Core/Color/Palette.js';
 const {
     correctFloat,
     defined,
@@ -1388,7 +1389,7 @@ var stockToolsBindings: Record<string, Highcharts.NavigationBindingsOptionsObjec
                         },
                         labelOptions: {
                             style: {
-                                color: '#666666'
+                                color: palette.neutralColor60
                             }
                         }
                     },
@@ -1452,7 +1453,7 @@ var stockToolsBindings: Record<string, Highcharts.NavigationBindingsOptionsObjec
                         },
                         labelOptions: {
                             style: {
-                                color: '#666666'
+                                color: palette.neutralColor60
                             }
                         }
                     },
@@ -1511,23 +1512,23 @@ var stockToolsBindings: Record<string, Highcharts.NavigationBindingsOptionsObjec
                             point: { x, y },
                             crosshairX: {
                                 strokeWidth: 1,
-                                stroke: '#000000'
+                                stroke: palette.neutralColor100
                             },
                             crosshairY: {
                                 enabled: false,
                                 strokeWidth: 0,
-                                stroke: '#000000'
+                                stroke: palette.neutralColor100
                             },
                             background: {
                                 width: 0,
                                 height: 0,
                                 strokeWidth: 0,
-                                stroke: '#ffffff'
+                                stroke: palette.backgroundColor
                             }
                         },
                         labelOptions: {
                             style: {
-                                color: '#666666'
+                                color: palette.neutralColor60
                             }
                         }
                     },
@@ -1583,22 +1584,22 @@ var stockToolsBindings: Record<string, Highcharts.NavigationBindingsOptionsObjec
                             crosshairX: {
                                 enabled: false,
                                 strokeWidth: 0,
-                                stroke: '#000000'
+                                stroke: palette.neutralColor100
                             },
                             crosshairY: {
                                 strokeWidth: 1,
-                                stroke: '#000000'
+                                stroke: palette.neutralColor100
                             },
                             background: {
                                 width: 0,
                                 height: 0,
                                 strokeWidth: 0,
-                                stroke: '#ffffff'
+                                stroke: palette.backgroundColor
                             }
                         },
                         labelOptions: {
                             style: {
-                                color: '#666666'
+                                color: palette.neutralColor60
                             }
                         }
                     },
@@ -1658,16 +1659,16 @@ var stockToolsBindings: Record<string, Highcharts.NavigationBindingsOptionsObjec
                             },
                             crosshairX: {
                                 strokeWidth: 1,
-                                stroke: '#000000'
+                                stroke: palette.neutralColor100
                             },
                             crosshairY: {
                                 strokeWidth: 1,
-                                stroke: '#000000'
+                                stroke: palette.neutralColor100
                             }
                         },
                         labelOptions: {
                             style: {
-                                color: '#666666'
+                                color: palette.neutralColor60
                             }
                         }
                     },
@@ -1726,7 +1727,7 @@ var stockToolsBindings: Record<string, Highcharts.NavigationBindingsOptionsObjec
                         },
                         labelOptions: {
                             style: {
-                                color: '#666666'
+                                color: palette.neutralColor60
                             }
                         }
                     },
@@ -1912,7 +1913,7 @@ var stockToolsBindings: Record<string, Highcharts.NavigationBindingsOptionsObjec
                     },
                     labelOptions: {
                         style: {
-                            color: '#666666',
+                            color: palette.neutralColor60,
                             fontSize: '11px'
                         }
                     },
@@ -1977,7 +1978,7 @@ var stockToolsBindings: Record<string, Highcharts.NavigationBindingsOptionsObjec
                     },
                     labelOptions: {
                         style: {
-                            color: '#666666',
+                            color: palette.neutralColor60,
                             fontSize: '11px'
                         }
                     },


### PR DESCRIPTION
Fixed #15157, Replaced the hex, and string colors in the stock tools with the colors defined in the palette.


- [x]     Andrew's pitchfork (control point uses "red")
- [x]     Vertical arrow uses red & green
- [x]     Last price indicator (uses red for the line) - might be fixed by #15137 PR
- [x]     Fibonacci retracements - "grey"
- [x]     Measure uses "black" and "#666666", in StockTools uses "#0" and "#ffffff" (check if defining this is necessary)
- [x]     Elliott-3 and Elliott-5 uses "#666666"
- [x]     Vertical counter and label use "#666666" - check if this config is necessary, if not remove
- [x]     Annotations.ts uses "black" as a border color and control point's border. "white" for control's point fill

- [x]      Rename Palette.indicatorPositiveLine to Palette.positiveColor and Palette.indicatorNegativeLine to Palette.negativeColor.

- [x]     "grey" replace with one of neutralColorXY's (make sure labels and lines are readable and visible).
- [x]     update comments and use this palette in StockTools and SuperTrend technical indicator to replace "red" and "green".
- [x]     "black" replace with neutralColor100
- [x]     "#666666" etc with equivalent neutral colors from Palette
