### PR TITLE
bugfix/15424-fibonacci-lineColor

### DIFF
--- a/samples/unit-tests/annotations/annotations-dynamic/demo.html
+++ b/samples/unit-tests/annotations/annotations-dynamic/demo.html
@@ -1,5 +1,5 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
-<script src="https://code.highcharts.com/modules/annotations.js"></script>
+<script src="https://code.highcharts.com/modules/annotations-advanced.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/annotations/annotations-dynamic/demo.js
+++ b/samples/unit-tests/annotations/annotations-dynamic/demo.js
@@ -174,6 +174,31 @@ QUnit.test("Annotation's dynamic methods", function (assert) {
         2,
         'Annotation with id=number, should be removed without errors (#10648)'
     );
+
+    const fib = chart.addAnnotation({
+        type: 'fibonacci',
+        typeOptions: {
+            lineColor: 'blue',
+            lineColors: ['blue', 'green', 'red'],
+            points: [{}, {}]
+        }
+    });
+
+    assert.strictEqual(
+        fib.shapes[0].graphic.stroke,
+        'blue',
+        '#15424: First line should be blue (lineColors[0])'
+    );
+    assert.strictEqual(
+        fib.shapes[3].graphic.stroke,
+        'red',
+        '#15424: Third line should be red (lineColors[2])'
+    );
+    assert.strictEqual(
+        fib.shapes[5].graphic.stroke,
+        'blue',
+        '#15424: Fourth line should be blue (lineColor)'
+    );
 });
 
 QUnit.test(

--- a/ts/Extensions/Annotations/Types/Fibonacci.ts
+++ b/ts/Extensions/Annotations/Types/Fibonacci.ts
@@ -190,15 +190,22 @@ class Fibonacci extends Tunnel {
 
     public addShapes(): void {
         Fibonacci.levels.forEach(function (this: Highcharts.AnnotationFibonacci, _level: number, i: number): void {
+            const {
+                backgroundColors,
+                lineColor,
+                lineColors
+            } = this.options.typeOptions;
+
             this.initShape({
                 type: 'path',
-                d: createPathDGenerator(i)
+                d: createPathDGenerator(i),
+                stroke: lineColors[i] || lineColor
             }, false as any);
 
             if (i > 0) {
                 (this.initShape as any)({
                     type: 'path',
-                    fill: this.options.typeOptions.backgroundColors[i - 1],
+                    fill: backgroundColors[i - 1],
                     strokeWidth: 0,
                     d: createPathDGenerator(i, true)
                 });


### PR DESCRIPTION
Fixed #15424, fibonacci annotation `lineColor` and `lineColors` options did not work.