### PR TITLE
bugfix/15261-candlestick-api-documentation 

### DIFF
--- a/ts/Series/Candlestick/CandlestickSeries.ts
+++ b/ts/Series/Candlestick/CandlestickSeries.ts
@@ -384,7 +384,7 @@ export default CandlestickSeries;
  *
  * @type      {*}
  * @extends   series,plotOptions.candlestick
- * @excluding dataParser, dataURL
+ * @excluding dataParser, dataURL, marker
  * @product   highstock
  * @apioption series.candlestick
  */


### PR DESCRIPTION
Fixed #15261, removed the marker from candlestick API docs.