### PR TITLE
bugfix/15445-stock-options-mutate

### DIFF
--- a/samples/unit-tests/axis/overscroll/demo.js
+++ b/samples/unit-tests/axis/overscroll/demo.js
@@ -84,7 +84,7 @@ Highcharts.each([true, false], function (ordinal) {
                 xAxis.max - xAxis.min,
                 xAxis.series[0].options.data.length -
                     1 +
-                    options.xAxis[0].overscroll,
+                    xAxis.options.overscroll,
                 'Correct range with ALL'
             );
         }
@@ -168,7 +168,7 @@ Highcharts.each([true, false], function (ordinal) {
 
             assert.strictEqual(
                 xAxis.max - xAxis.min,
-                xAxis.dataMax + options.xAxis[0].overscroll,
+                xAxis.dataMax + xAxis.options.overscroll,
                 'Correct range with ALL'
             );
         }

--- a/samples/unit-tests/chart/chart-update/demo.js
+++ b/samples/unit-tests/chart/chart-update/demo.js
@@ -367,45 +367,49 @@
         );
     });
 
-    QUnit.test(
-        'Options for chart.update should not be mutated',
-        function (assert) {
-            var options = {
-                legend: {
-                    enabled: false
-                },
-                title: {
-                    text: 'Hello Bello'
-                },
-                series: [
-                    {
-                        data: [1, 4, 3, 5]
-                    }
-                ]
-            };
-            var chart = Highcharts.chart('container', options);
-
-            var cfg = JSON.stringify(options, null, '  ');
-
-            chart.update(options);
-
-            assert.strictEqual(
-                cfg,
-                JSON.stringify(options, null, '  '),
-                'Options should not be mutated after chart.update'
-            );
-
-            chart.update({
-                title: {
-                    text: 'Ohai'
+    QUnit.test('Chart options mutation', function (assert) {
+        var options = {
+            legend: {
+                enabled: false
+            },
+            title: {
+                text: 'Hello Bello'
+            },
+            series: [
+                {
+                    data: [1, 4, 3, 5]
                 }
-            });
+            ]
+        };
 
-            assert.strictEqual(
-                cfg,
-                JSON.stringify(options, null, '  '),
-                '#14305: Options should not be mutated after actually changing something with chart.update'
-            );
-        }
-    );
+        var cfg = JSON.stringify(options, null, '  ');
+
+        var chart = Highcharts.stockChart('container', options);
+
+        assert.strictEqual(
+            JSON.stringify(options, null, '  '),
+            cfg,
+            '#15445: Options should not be mutated after chart creation'
+        );
+
+        chart.update(options);
+
+        assert.strictEqual(
+            JSON.stringify(options, null, '  '),
+            cfg,
+            'Options should not be mutated after chart.update'
+        );
+
+        chart.update({
+            title: {
+                text: 'Ohai'
+            }
+        });
+
+        assert.strictEqual(
+            JSON.stringify(options, null, '  '),
+            cfg,
+            '#14305: Options should not be mutated after actually changing something with chart.update'
+        );
+    });
 }());

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -347,17 +347,13 @@ class Chart {
     ): void {
 
         // Handle regular options
-        var options: Highcharts.Options,
-            // skip merging data points to increase performance
-            seriesOptions = userOptions.series,
-            userPlotOptions =
-                userOptions.plotOptions || {} as SeriesTypePlotOptions;
+        const userPlotOptions =
+            userOptions.plotOptions || {} as SeriesTypePlotOptions;
 
         // Fire the event with a default function
         fireEvent(this, 'init', { args: arguments }, function (): void {
 
-            userOptions.series = null as any;
-            options = merge(defaultOptions, userOptions); // do the merge
+            const options = merge(defaultOptions, userOptions); // do the merge
 
             const optionsChart = options.chart;
 
@@ -382,9 +378,6 @@ class Chart {
                 userOptions.chart.forExport &&
                 (userOptions.tooltip as any).userOptions
             ) || userOptions.tooltip;
-
-            // set back the series data
-            options.series = userOptions.series = seriesOptions;
 
             /**
              * The original options given to the constructor or a chart factory

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -163,9 +163,9 @@ class StockChart extends Chart {
         userOptions: Partial<Highcharts.Options>,
         callback?: Chart.CallbackFunction
     ): void {
-        // to increase performance, don't merge the data
-        var seriesOptions = userOptions.series,
-            defaultOptions = getOptions(),
+        const defaultOptions = getOptions(),
+            xAxisOptions = userOptions.xAxis,
+            yAxisOptions = userOptions.yAxis,
             // Always disable startOnTick:true on the main axis when the
             // navigator is enabled (#1090)
             navigatorEnabled = pick(
@@ -174,36 +174,10 @@ class StockChart extends Chart {
                 true
             );
 
-        // apply X axis options to both single and multi y axes
-        userOptions.xAxis = splat(userOptions.xAxis || {}).map(function (
-            xAxisOptions: Highcharts.XAxisOptions,
-            i: number
-        ): Highcharts.XAxisOptions {
-            return merge(
-                getDefaultAxisOptions('xAxis', xAxisOptions),
-                defaultOptions.xAxis, // #3802
-                defaultOptions.xAxis && (defaultOptions.xAxis as any)[i], // #7690
-                xAxisOptions, // user options
-                getForcedAxisOptions('xAxis', userOptions)
-            );
-        });
+        // Avoid doing these twice
+        userOptions.xAxis = userOptions.yAxis = void 0;
 
-        // apply Y axis options to both single and multi y axes
-        userOptions.yAxis = splat(userOptions.yAxis || {}).map(function (
-            yAxisOptions: Highcharts.YAxisOptions,
-            i: number
-        ): Highcharts.YAxisOptions {
-            return merge(
-                getDefaultAxisOptions('yAxis', yAxisOptions),
-                defaultOptions.yAxis, // #3802
-                defaultOptions.yAxis && (defaultOptions.yAxis as any)[i], // #7690
-                yAxisOptions // user options
-            );
-        });
-
-        userOptions.series = void 0;
-
-        userOptions = merge(
+        const options = merge(
             {
                 chart: {
                     panning: {
@@ -246,9 +220,37 @@ class StockChart extends Chart {
             }
         );
 
-        userOptions.series = seriesOptions;
+        userOptions.xAxis = xAxisOptions;
+        userOptions.yAxis = yAxisOptions;
 
-        super.init(userOptions, callback);
+        // apply X axis options to both single and multi y axes
+        options.xAxis = splat(userOptions.xAxis || {}).map(function (
+            xAxisOptions: Highcharts.XAxisOptions,
+            i: number
+        ): Highcharts.XAxisOptions {
+            return merge(
+                getDefaultAxisOptions('xAxis', xAxisOptions),
+                defaultOptions.xAxis, // #3802
+                defaultOptions.xAxis && (defaultOptions.xAxis as any)[i], // #7690
+                xAxisOptions, // user options
+                getForcedAxisOptions('xAxis', userOptions)
+            );
+        });
+
+        // apply Y axis options to both single and multi y axes
+        options.yAxis = splat(userOptions.yAxis || {}).map(function (
+            yAxisOptions: Highcharts.YAxisOptions,
+            i: number
+        ): Highcharts.YAxisOptions {
+            return merge(
+                getDefaultAxisOptions('yAxis', yAxisOptions),
+                defaultOptions.yAxis, // #3802
+                defaultOptions.yAxis && (defaultOptions.yAxis as any)[i], // #7690
+                yAxisOptions // user options
+            );
+        });
+
+        super.init(options, callback);
     }
 
     /**


### PR DESCRIPTION
Fixed #15445, options got mutated when creating stock chart.

I also got rid of the series hoop jumping in `Chart` since `merge` is just going to do `copy.series = original.series`, which is the same thing, so I dont see where the performance gain was supposed to come from.