### PR TITLE
bugfix/15436-dynamic-colorAxis

### DIFF
--- a/samples/unit-tests/coloraxis/coloraxis-update/demo.js
+++ b/samples/unit-tests/coloraxis/coloraxis-update/demo.js
@@ -153,6 +153,11 @@ QUnit.test('Adding color axis', function (assert) {
         'Colors should be the same for the second series.'
     );
 
+    assert.notOk(
+        chart.series[0].legendItem,
+        '#15436: Series legendItem should have been destroyed'
+    );
+
     chart.addColorAxis({});
 
     assert.notEqual(

--- a/ts/Core/Axis/ColorAxis.ts
+++ b/ts/Core/Axis/ColorAxis.ts
@@ -1429,13 +1429,22 @@ addEvent(Series, 'bindAxes', function (): void {
 addEvent(Legend, 'afterGetAllItems', function (
     this: Highcharts.Legend,
     e: {
-        allItems: Array<(ColorAxis|ColorAxis.LegendItemObject)>;
+        allItems: Array<(Series|Point|ColorAxis|ColorAxis.LegendItemObject)>;
     }
 ): void {
     var colorAxisItems = [] as Array<(ColorAxis|ColorAxis.LegendItemObject)>,
         colorAxes = this.chart.colorAxis || [],
         options: ColorAxis.Options,
         i;
+
+    const destroyItem = (item: (Series|Point)): void => {
+        const i = e.allItems.indexOf(item);
+        if (i !== -1) {
+            // #15436
+            this.destroyItem(e.allItems[i]);
+            e.allItems.splice(i, 1);
+        }
+    };
 
     colorAxes.forEach(function (colorAxis: ColorAxis): void {
         options = colorAxis.options;
@@ -1459,11 +1468,11 @@ addEvent(Legend, 'afterGetAllItems', function (
                         series.points.forEach(function (
                             point: Point
                         ): void {
-                            erase(e.allItems, point);
+                            destroyItem(point);
                         });
 
                     } else {
-                        erase(e.allItems, series);
+                        destroyItem(series);
                     }
                 }
             });


### PR DESCRIPTION
Fixed #15436, previous legend items remained visible after dynamically adding color axis.

I believe the case of not being able to add a color axis through `update` with `oneToOne=false` is working as intended.