### PR TITLE
Fixed #15447, wordcloud kbd nav issues.

### DIFF
--- a/ts/Accessibility/Components/ContainerComponent.ts
+++ b/ts/Accessibility/Components/ContainerComponent.ts
@@ -14,6 +14,7 @@ import type {
     SVGDOMElement
 } from '../../Core/Renderer/DOMElementType';
 import AccessibilityComponent from '../AccessibilityComponent.js';
+import KeyboardNavigationHandler from '../KeyboardNavigationHandler.js';
 import ChartUtilities from '../Utils/ChartUtilities.js';
 const {
     unhideChartElementFromAT,
@@ -189,6 +190,29 @@ extend(ContainerComponent.prototype, /** @lends Highcharts.ContainerComponent */
         }
     },
 
+    /**
+     * Empty handler to just set focus on chart
+     * @return {Highcharts.KeyboardNavigationHandler}
+     */
+    getKeyboardNavigation: function (
+        this: Highcharts.ContainerComponent
+    ): Highcharts.KeyboardNavigationHandler {
+        const chart = this.chart;
+        return new (KeyboardNavigationHandler as any)(chart, {
+            keyCodeMap: [],
+
+            validate: function (): (boolean) {
+                return true;
+            },
+
+            init: function (): void {
+                const a11y = chart.accessibility;
+                if (a11y) {
+                    a11y.keyboardNavigation.tabindexContainer.focus();
+                }
+            }
+        });
+    },
 
     /**
      * Accessibility disabled/chart destroyed.

--- a/ts/Accessibility/Options/Options.ts
+++ b/ts/Accessibility/Options/Options.ts
@@ -707,8 +707,11 @@ var options: DeepPartial<Highcharts.Options> = {
             /**
              * Order of tab navigation in the chart. Determines which elements
              * are tabbed to first. Available elements are: `series`, `zoom`,
-             * `rangeSelector`, `chartMenu`, `legend`. In addition, any custom
-             * components can be added here.
+             * `rangeSelector`, `chartMenu`, `legend` and `container`. In
+             * addition, any custom components can be added here. Adding
+             * `container` first in order will make the keyboard focus stop on
+             * the chart container first, requiring the user to tab again to
+             * enter the chart.
              *
              * @type  {Array<string>}
              * @since 7.1.0

--- a/ts/Series/Wordcloud/WordcloudSeries.ts
+++ b/ts/Series/Wordcloud/WordcloudSeries.ts
@@ -414,6 +414,7 @@ class WordcloudSeries extends ColumnSeries {
                 field = WordcloudUtils.updateFieldBoundaries(field, rectangle);
                 placed.push(point);
                 point.isNull = false;
+                point.isInside = true; // #15447
             } else {
                 point.isNull = true;
             }


### PR DESCRIPTION
Fixed #15447, wordcloud keyboard navigation, and added support for making the chart container a separate tab-stop.
___
Added support for using the `container` component in keyboard navigation, to make the container itself a tab-stop. This is done by adding `container` in the [`keyboardNavigation.order`](https://api.highcharts.com/highcharts/accessibility.keyboardNavigation.order) list.