### PR TITLE
bugfix/15362-cleaning-indicators-params-docs

### DIFF
--- a/ts/Extensions/Annotations/Popup.ts
+++ b/ts/Extensions/Annotations/Popup.ts
@@ -1110,26 +1110,28 @@ H.Popup.prototype = {
                 // create name like params.styles.fontSize
                 parentFullName = parentNode + '.' + fieldName;
 
-                if (isObject(value)) {
-                    addParamInputs.call(
-                        _self,
-                        chart,
-                        parentFullName,
-                        value as any,
-                        type,
-                        parentDiv
-                    );
-                } else if (
-                // skip volume field which is created by addFormFields
-                    parentFullName !== 'params.volumeSeriesID'
-                ) {
-                    addInput.call(
-                        _self,
-                        parentFullName,
-                        type,
-                        parentDiv,
-                        [value, 'text'] as any // all inputs are text type
-                    );
+                if (value !== void 0) { // skip if field is unnecessary, #15362
+                    if (isObject(value)) {
+                        addParamInputs.call(
+                            _self,
+                            chart,
+                            parentFullName,
+                            value as any,
+                            type,
+                            parentDiv
+                        );
+                    } else if (
+                    // skip volume field which is created by addFormFields
+                        parentFullName !== 'params.volumeSeriesID'
+                    ) {
+                        addInput.call(
+                            _self,
+                            parentFullName,
+                            type,
+                            parentDiv,
+                            [value, 'text'] as any // all inputs are text type
+                        );
+                    }
                 }
             });
         },

--- a/ts/Stock/Indicators/AD/ADIndicator.ts
+++ b/ts/Stock/Indicators/AD/ADIndicator.ts
@@ -66,7 +66,11 @@ class ADIndicator extends SMAIndicator {
      * @optionparent plotOptions.ad
      */
     public static defaultOptions: ADOptions = merge(SMAIndicator.defaultOptions, {
+        /**
+         * @excluding index
+         */
         params: {
+            index: void 0, // unused index, do not inherit (#15362)
             /**
              * The id of volume series which is mandatory.
              * For example using OHLC data, volumeSeriesID='volume' means

--- a/ts/Stock/Indicators/AO/AOIndicator.ts
+++ b/ts/Stock/Indicators/AO/AOIndicator.ts
@@ -66,6 +66,11 @@ class AOIndicator extends SMAIndicator {
      */
     public static defaultOptions: AOOptions =
     merge(SMAIndicator.defaultOptions, {
+        params: {
+            // Index and period are unchangeable, do not inherit (#15362)
+            index: void 0,
+            period: void 0
+        },
         /**
          * Color of the Awesome oscillator series bar that is greater than the
          * previous one. Note that if a `color` is defined, the `color`

--- a/ts/Stock/Indicators/APO/APOIndicator.ts
+++ b/ts/Stock/Indicators/APO/APOIndicator.ts
@@ -72,6 +72,7 @@ class APOIndicator extends EMAIndicator {
          * @excluding period
          */
         params: {
+            period: void 0, // unchangeable period, do not inherit (#15362)
             /**
              * Periods for Absolute Price Oscillator calculations.
              *

--- a/ts/Stock/Indicators/ATR/ATRIndicator.ts
+++ b/ts/Stock/Indicators/ATR/ATRIndicator.ts
@@ -115,8 +115,11 @@ class ATRIndicator extends SMAIndicator {
      * @optionparent plotOptions.atr
      */
     public static defaultOptions: ATROptions = merge(SMAIndicator.defaultOptions, {
+        /**
+         * @excluding index
+         */
         params: {
-            period: 14
+            index: void 0 // unused index, do not inherit (#15362)
         }
     } as ATROptions);
 

--- a/ts/Stock/Indicators/Aroon/AroonIndicator.ts
+++ b/ts/Stock/Indicators/Aroon/AroonIndicator.ts
@@ -96,12 +96,10 @@ class AroonIndicator extends SMAIndicator implements Highcharts.MultipleLinesInd
         /**
          * Paramters used in calculation of aroon series points.
          *
-         * @excluding periods, index
+         * @excluding index
          */
         params: {
-            /**
-             * Period for Aroon indicator
-             */
+            index: void 0, // unchangeable index, do not inherit (#15362)
             period: 25
         },
         marker: {

--- a/ts/Stock/Indicators/AroonOscillator/AroonOscillatorIndicator.ts
+++ b/ts/Stock/Indicators/AroonOscillator/AroonOscillatorIndicator.ts
@@ -69,20 +69,6 @@ class AroonOscillatorIndicator extends AroonIndicator implements Highcharts.Mult
      * @optionparent plotOptions.aroonoscillator
      */
     public static defaultOptions: AroonOscillatorOptions = merge(AroonIndicator.defaultOptions, {
-        /**
-         * Paramters used in calculation of aroon oscillator series points.
-         *
-         * @excluding periods, index
-         */
-        params: {
-            /**
-             * Period for Aroon Oscillator
-             *
-             * @since   7.0.0
-             * @product highstock
-             */
-            period: 25
-        },
         tooltip: {
             pointFormat: '<span style="color:{point.color}">\u25CF</span><b> {series.name}</b>: {point.y}'
         }

--- a/ts/Stock/Indicators/CCI/CCIIndicator.ts
+++ b/ts/Stock/Indicators/CCI/CCIIndicator.ts
@@ -92,8 +92,11 @@ class CCIIndicator extends SMAIndicator {
      * @optionparent plotOptions.cci
      */
     public static defaultOptions: CCIOptions = merge(SMAIndicator.defaultOptions, {
+        /**
+         * @excluding index
+         */
         params: {
-            period: 14
+            index: void 0 // unused index, do not inherit (#15362)
         }
     } as CCIOptions);
 

--- a/ts/Stock/Indicators/CMF/CMFIndicator.ts
+++ b/ts/Stock/Indicators/CMF/CMFIndicator.ts
@@ -57,8 +57,11 @@ class CMFIndicator extends SMAIndicator {
      * @optionparent plotOptions.cmf
      */
     public static defaultOptions: CMFOptions = merge(SMAIndicator.defaultOptions, {
+        /**
+         * @excluding index
+         */
         params: {
-            period: 14,
+            index: void 0, // unused index, do not inherit (#15362)
             /**
              * The id of another series to use its data as volume data for the
              * indiator calculation.

--- a/ts/Stock/Indicators/Chaikin/ChaikinIndicator.ts
+++ b/ts/Stock/Indicators/Chaikin/ChaikinIndicator.ts
@@ -84,6 +84,12 @@ class ChaikinIndicator extends EMAIndicator {
              */
             volumeSeriesID: 'volume',
             /**
+             * Parameter used indirectly for calculating the `AD` indicator.
+             * Decides about the number of data points that are taken
+             * into account for the indicator calculations.
+             */
+            period: 9,
+            /**
              * Periods for Chaikin Oscillator calculations.
              *
              * @type    {Array<number>}

--- a/ts/Stock/Indicators/Chaikin/ChaikinIndicator.ts
+++ b/ts/Stock/Indicators/Chaikin/ChaikinIndicator.ts
@@ -73,9 +73,10 @@ class ChaikinIndicator extends EMAIndicator {
          * Paramters used in calculation of Chaikin Oscillator
          * series points.
          *
-         * @excluding index, period
+         * @excluding index
          */
         params: {
+            index: void 0, // unused index, do not inherit (#15362)
             /**
              * The id of volume series which is mandatory.
              * For example using OHLC data, volumeSeriesID='volume' means

--- a/ts/Stock/Indicators/DEMA/DEMAIndicator.ts
+++ b/ts/Stock/Indicators/DEMA/DEMAIndicator.ts
@@ -224,10 +224,10 @@ SeriesRegistry.registerSeriesType('dema', DEMAIndicator);
 export default DEMAIndicator;
 
 /**
- * A `DEMA` series. If the [type](#series.ema.type) option is not
+ * A `DEMA` series. If the [type](#series.dema.type) option is not
  * specified, it is inherited from [chart.type](#chart.type).
  *
- * @extends   series,plotOptions.ema
+ * @extends   series,plotOptions.dema
  * @since     7.0.0
  * @product   highstock
  * @excluding allAreas, colorAxis, compare, compareBase, dataParser, dataURL,

--- a/ts/Stock/Indicators/DMI/DMIIndicator.ts
+++ b/ts/Stock/Indicators/DMI/DMIIndicator.ts
@@ -79,8 +79,7 @@ class DMIIndicator extends SMAIndicator {
          * @excluding index
          */
         params: {
-            index: void 0, // DMI has unchangeable index
-            period: 14
+            index: void 0 // unused index, do not inherit (#15362)
         },
         marker: {
             enabled: false

--- a/ts/Stock/Indicators/DPO/DPOIndicator.ts
+++ b/ts/Stock/Indicators/DPO/DPOIndicator.ts
@@ -92,6 +92,7 @@ class DPOIndicator extends SMAIndicator {
          * points.
          */
         params: {
+            index: 0,
             /**
              * Period for Detrended Price Oscillator
              */

--- a/ts/Stock/Indicators/IKH/IKHIndicator.ts
+++ b/ts/Stock/Indicators/IKH/IKHIndicator.ts
@@ -204,7 +204,11 @@ class IKHIndicator extends SMAIndicator {
     public static defaultOptions: IKHOptions = merge(
         SMAIndicator.defaultOptions,
         {
+            /**
+             * @excluding index
+             */
             params: {
+                index: void 0, // unused index, do not inherit (#15362)
                 period: 26,
                 /**
                  * The base period for Tenkan calculations.

--- a/ts/Stock/Indicators/KeltnerChannels/KeltnerChannelsIndicator.ts
+++ b/ts/Stock/Indicators/KeltnerChannels/KeltnerChannelsIndicator.ts
@@ -248,7 +248,7 @@ export default KeltnerChannelsIndicator;
  * A Keltner Channels indicator. If the [type](#series.keltnerchannels.type)
  * option is not specified, it is inherited from[chart.type](#chart.type).
  *
- * @extends      series,plotOptions.sma
+ * @extends      series,plotOptions.keltnerchannels
  * @since        7.0.0
  * @product      highstock
  * @excluding    allAreas, colorAxis, compare, compareBase, dataParser, dataURL,

--- a/ts/Stock/Indicators/LinearRegression/LinearRegression.ts
+++ b/ts/Stock/Indicators/LinearRegression/LinearRegression.ts
@@ -82,6 +82,9 @@ class LinearRegressionIndicator extends SMAIndicator {
                  * computing the slope and the intercept. This may enchance the
                  * legiblitity of the indicator's values.
                  *
+                 * Default value is the closest distance between two data
+                 * points.
+                 *
                  * In `v9.0.2`, the default value has been changed
                  * from `undefined` to `null`.
                  *

--- a/ts/Stock/Indicators/LinearRegression/LinearRegression.ts
+++ b/ts/Stock/Indicators/LinearRegression/LinearRegression.ts
@@ -82,8 +82,8 @@ class LinearRegressionIndicator extends SMAIndicator {
                  * computing the slope and the intercept. This may enchance the
                  * legiblitity of the indicator's values.
                  *
-                 * Default value is the closest distance between two data
-                 * points.
+                 * In `v9.0.2`, the default value has been changed
+                 * from `undefined` to `null`.
                  *
                  * @sample {highstock} stock/plotoptions/linear-regression-xaxisunit
                  *         xAxisUnit set to 1 minute
@@ -105,7 +105,7 @@ class LinearRegressionIndicator extends SMAIndicator {
                  * // indicator's point will be `2.3148148148148148e-8` which is
                  * // harder to interpert for a human.
                  *
-                 * @type    {number}
+                 * @type    {null|number}
                  * @product highstock
                  */
                 xAxisUnit: null

--- a/ts/Stock/Indicators/LinearRegression/LinearRegression.ts
+++ b/ts/Stock/Indicators/LinearRegression/LinearRegression.ts
@@ -108,7 +108,7 @@ class LinearRegressionIndicator extends SMAIndicator {
                  * @type    {number}
                  * @product highstock
                  */
-                xAxisUnit: void 0
+                xAxisUnit: null
             },
             tooltip: {
                 valueDecimals: 4

--- a/ts/Stock/Indicators/LinearRegression/LinearRegressionOptions.d.ts
+++ b/ts/Stock/Indicators/LinearRegression/LinearRegressionOptions.d.ts
@@ -29,7 +29,7 @@ export interface LinearRegressionOptions extends SMAOptions {
 }
 
 export interface LinearRegressionParamsOptions extends SMAParamsOptions {
-    xAxisUnit?: number;
+    xAxisUnit?: null|number;
 }
 
 export interface RegressionLineParametersObject {

--- a/ts/Stock/Indicators/LinearRegressionAngle/LinearRegressionAngle.ts
+++ b/ts/Stock/Indicators/LinearRegressionAngle/LinearRegressionAngle.ts
@@ -19,7 +19,6 @@ import type LinearRegressionAnglePoint from './LinearRegressionAnglePoint';
 import SeriesRegistry from '../../../Core/Series/SeriesRegistry.js';
 const {
     seriesTypes: {
-        sma: SMAIndicator,
         linearRegression: LinearRegressionIndicator
     }
 } = SeriesRegistry;
@@ -61,7 +60,7 @@ class LinearRegressionAngleIndicator extends LinearRegressionIndicator {
      * @optionparent plotOptions.linearregressionangle
      */
     public static defaultOptions: LinearRegressionParamsOptions = merge(
-        SMAIndicator.defaultOptions, {
+        LinearRegressionIndicator.defaultOptions, {
             tooltip: { // add a degree symbol
                 pointFormat: '<span style="color:{point.color}">\u25CF</span>' +
                 '{series.name}: <b>{point.y}°</b><br/>'

--- a/ts/Stock/Indicators/LinearRegressionIntercept/LinearRegressionIntercept.ts
+++ b/ts/Stock/Indicators/LinearRegressionIntercept/LinearRegressionIntercept.ts
@@ -19,13 +19,11 @@ import type LinearRegressionInterceptPoint from './LinearRegressionInterceptPoin
 import SeriesRegistry from '../../../Core/Series/SeriesRegistry.js';
 const {
     seriesTypes: {
-        sma: SMAIndicator,
         linearRegression: LinearRegressionIndicator
     }
 } = SeriesRegistry;
 import U from '../../../Core/Utilities.js';
 const {
-    isArray,
     extend,
     merge
 } = U;

--- a/ts/Stock/Indicators/LinearRegressionSlopes/LinearRegressionSlopes.ts
+++ b/ts/Stock/Indicators/LinearRegressionSlopes/LinearRegressionSlopes.ts
@@ -19,13 +19,11 @@ import type LinearRegressionSlopesPoint from './LinearRegressionSlopesPoint';
 import SeriesRegistry from '../../../Core/Series/SeriesRegistry.js';
 const {
     seriesTypes: {
-        sma: SMAIndicator,
         linearRegression: LinearRegressionIndicator
     }
 } = SeriesRegistry;
 import U from '../../../Core/Utilities.js';
 const {
-    isArray,
     extend,
     merge
 } = U;

--- a/ts/Stock/Indicators/MACD/MACDIndicator.ts
+++ b/ts/Stock/Indicators/MACD/MACDIndicator.ts
@@ -28,7 +28,6 @@ import SeriesRegistry from '../../../Core/Series/SeriesRegistry.js';
 const {
     seriesTypes: {
         sma: SMAIndicator,
-        ema: EMAIndicator,
         column: ColumnSeries
     }
 } = SeriesRegistry;

--- a/ts/Stock/Indicators/MFI/MFIIndicator.ts
+++ b/ts/Stock/Indicators/MFI/MFIIndicator.ts
@@ -93,7 +93,7 @@ class MFIIndicator extends SMAIndicator {
          * @excluding index
          */
         params: {
-            period: 14,
+            index: void 0, // unchangeable index, do not inherit (#15362)
             /**
              * The id of volume series which is mandatory.
              * For example using OHLC data, volumeSeriesID='volume' means

--- a/ts/Stock/Indicators/Momentum/MomentumIndicator.ts
+++ b/ts/Stock/Indicators/Momentum/MomentumIndicator.ts
@@ -67,11 +67,8 @@ class MomentumIndicator extends SMAIndicator {
      * @requires     stock/indicators/momentum
      * @optionparent plotOptions.momentum
      */
-    public static defaultOptions: MomentumOptions = merge(SMAIndicator.defaultOptions, {
-        params: {
-            period: 14
-        }
-    } as MomentumOptions);
+    public static defaultOptions: MomentumOptions =
+    merge(SMAIndicator.defaultOptions, {} as MomentumOptions);
 
     public data: Array<MomentumPoint> = void 0 as any;
     public options: MomentumOptions = void 0 as any;

--- a/ts/Stock/Indicators/Momentum/MomentumIndicator.ts
+++ b/ts/Stock/Indicators/Momentum/MomentumIndicator.ts
@@ -28,16 +28,14 @@ const {
 /* eslint-disable require-jsdoc */
 
 function populateAverage(
-    points: Array<number>,
     xVal: Array<number>,
     yVal: Array<Array<number>>,
     i: number,
-    period: number
+    period: number,
+    index: number
 ): [number, number] {
-    var mmY: number = yVal[i - 1][3] - yVal[i - period - 1][3],
+    var mmY: number = yVal[i - 1][index] - yVal[i - period - 1][index],
         mmX: number = xVal[i - 1];
-
-    points.shift(); // remove point until range < period
 
     return [mmX, mmY];
 }
@@ -68,7 +66,11 @@ class MomentumIndicator extends SMAIndicator {
      * @optionparent plotOptions.momentum
      */
     public static defaultOptions: MomentumOptions =
-    merge(SMAIndicator.defaultOptions, {} as MomentumOptions);
+    merge(SMAIndicator.defaultOptions, {
+        params: {
+            index: 3
+        }
+    } as MomentumOptions);
 
     public data: Array<MomentumPoint> = void 0 as any;
     public options: MomentumOptions = void 0 as any;
@@ -79,17 +81,15 @@ class MomentumIndicator extends SMAIndicator {
         params: MomentumOptions
     ): (IndicatorValuesObject<TLinkedSeries>|undefined) {
         var period: number = params.period,
+            index: number = params.index as any,
             xVal: Array<number> = (series.xData as any),
             yVal: Array<Array<number>> = (series.yData as any),
             yValLen: number = yVal ? yVal.length : 0,
-            xValue: number = xVal[0],
             yValue: (Array<number>|number) = yVal[0],
             MM: Array<Array<number>> = [],
             xData: Array<number> = [],
             yData: Array<number> = [],
-            index: any,
             i: number,
-            points: Array<Array<number>>,
             MMPoint: [number, number];
 
         if (xVal.length <= period) {
@@ -98,29 +98,20 @@ class MomentumIndicator extends SMAIndicator {
 
         // Switch index for OHLC / Candlestick / Arearange
         if (isArray(yVal[0])) {
-            yValue = (yVal[0][3] as any);
+            yValue = (yVal[0][index] as any);
         } else {
             return;
         }
-        // Starting point
-        points = [
-            [xValue, (yValue as any)]
-        ];
-
 
         // Calculate value one-by-one for each period in visible data
         for (i = (period + 1); i < yValLen; i++) {
-            MMPoint = (populateAverage as any)(
-                points, xVal, yVal, i, period, index
-            );
+            MMPoint = populateAverage(xVal, yVal, i, period, index);
             MM.push(MMPoint);
             xData.push(MMPoint[0]);
             yData.push(MMPoint[1]);
         }
 
-        MMPoint = (populateAverage as any)(
-            points, xVal, yVal, i, period, index
-        );
+        MMPoint = populateAverage(xVal, yVal, i, period, index);
         MM.push(MMPoint);
         xData.push(MMPoint[0]);
         yData.push(MMPoint[1]);

--- a/ts/Stock/Indicators/OBV/OBVIndicator.ts
+++ b/ts/Stock/Indicators/OBV/OBVIndicator.ts
@@ -73,8 +73,9 @@ class OBVIndicator extends SMAIndicator {
          * @excluding index, period
          */
         params: {
-            index: void 0 as any,
-            period: void 0 as any,
+            // Index and period are unchangeable, do not inherit (#15362)
+            index: void 0,
+            period: void 0,
             /**
              * The id of another series to use its data as volume data for the
              * indiator calculation.

--- a/ts/Stock/Indicators/PC/PCIndicator.ts
+++ b/ts/Stock/Indicators/PC/PCIndicator.ts
@@ -71,6 +71,7 @@ class PCIndicator extends SMAIndicator implements Highcharts.MultipleLinesIndica
          * @excluding index
          */
         params: {
+            index: void 0, // unchangeable index, do not inherit (#15362)
             period: 20
         },
         lineWidth: 1,

--- a/ts/Stock/Indicators/PPO/PPOIndicator.ts
+++ b/ts/Stock/Indicators/PPO/PPOIndicator.ts
@@ -74,6 +74,7 @@ class PPOIndicator extends EMAIndicator {
          * @excluding period
          */
         params: {
+            period: void 0, // unchangeable period, do not inherit (#15362)
             /**
              * Periods for Percentage Price Oscillator calculations.
              *

--- a/ts/Stock/Indicators/PSAR/PSARIndicator.ts
+++ b/ts/Stock/Indicators/PSAR/PSARIndicator.ts
@@ -189,6 +189,7 @@ class PSARIndicator extends SMAIndicator {
          * @excluding period
          */
         params: {
+            period: void 0, // unchangeable period, do not inherit (#15362)
             /**
              * The initial value for acceleration factor.
              * Acceleration factor is starting with this value

--- a/ts/Stock/Indicators/PivotPoints/PivotPointsIndicator.ts
+++ b/ts/Stock/Indicators/PivotPoints/PivotPointsIndicator.ts
@@ -68,6 +68,7 @@ class PivotPointsIndicator extends SMAIndicator {
          * @excluding index
          */
         params: {
+            index: void 0, // unchangeable index, do not inherit (#15362)
             period: 28,
             /**
              * Algorithm used to calculate ressistance and support lines based

--- a/ts/Stock/Indicators/RSI/RSIIndicator.ts
+++ b/ts/Stock/Indicators/RSI/RSIIndicator.ts
@@ -63,7 +63,6 @@ class RSIIndicator extends SMAIndicator {
      */
     public static defaultOptions: RSIOptions = merge(SMAIndicator.defaultOptions, {
         params: {
-            period: 14,
             decimals: 4,
             index: 3
         }

--- a/ts/Stock/Indicators/Stochastic/StochasticIndicator.ts
+++ b/ts/Stock/Indicators/Stochastic/StochasticIndicator.ts
@@ -63,6 +63,9 @@ class StochasticIndicator extends SMAIndicator implements Highcharts.MultipleLin
          * @excluding index, period
          */
         params: {
+            // Index and period are unchangeable, do not inherit (#15362)
+            index: void 0,
+            period: void 0,
             /**
              * Periods for Stochastic oscillator: [%K, %D].
              *

--- a/ts/Stock/Indicators/Supertrend/SupertrendIndicator.ts
+++ b/ts/Stock/Indicators/Supertrend/SupertrendIndicator.ts
@@ -99,6 +99,7 @@ class SupertrendIndicator extends SMAIndicator {
          * @excluding index
          */
         params: {
+            index: void 0, // unchangeable index, do not inherit (#15362)
             /**
              * Multiplier for Supertrend Indicator.
              */

--- a/ts/Stock/Indicators/TEMA/TEMAIndicator.ts
+++ b/ts/Stock/Indicators/TEMA/TEMAIndicator.ts
@@ -296,10 +296,10 @@ export default TEMAIndicator;
 
 
 /**
- * A `TEMA` series. If the [type](#series.ema.type) option is not
+ * A `TEMA` series. If the [type](#series.tema.type) option is not
  * specified, it is inherited from [chart.type](#chart.type).
  *
- * @extends   series,plotOptions.ema
+ * @extends   series,plotOptions.tema
  * @since     7.0.0
  * @product   highstock
  * @excluding allAreas, colorAxis, compare, compareBase, dataParser, dataURL,

--- a/ts/Stock/Indicators/TRIX/TRIXIndicator.ts
+++ b/ts/Stock/Indicators/TRIX/TRIXIndicator.ts
@@ -10,8 +10,7 @@
 
 import type TEMAIndicatorType from '../TEMA/TEMAIndicator';
 import type {
-    TRIXOptions,
-    TRIXParamsOptions
+    TRIXOptions
 } from './TRIXOptions';
 import type TRIXPoint from './TRIXPoint';
 
@@ -119,10 +118,10 @@ SeriesRegistry.registerSeriesType('trix', TRIXIndicator);
 export default TRIXIndicator;
 
 /**
- * A `TRIX` series. If the [type](#series.tema.type) option is not specified, it
+ * A `TRIX` series. If the [type](#series.trix.type) option is not specified, it
  * is inherited from [chart.type](#chart.type).
  *
- * @extends   series,plotOptions.tema
+ * @extends   series,plotOptions.trix
  * @since     7.0.0
  * @product   highstock
  * @excluding allAreas, colorAxis, compare, compareBase, dataParser, dataURL,

--- a/ts/Stock/Indicators/TrendLine/TrendLineIndicator.ts
+++ b/ts/Stock/Indicators/TrendLine/TrendLineIndicator.ts
@@ -65,6 +65,7 @@ class TrendLineIndicator extends SMAIndicator {
          * @excluding period
          */
         params: {
+            period: void 0, // unchangeable period, do not inherit (#15362)
             /**
              * The point index which indicator calculations will base. For
              * example using OHLC data, index=2 means the indicator will be

--- a/ts/Stock/Indicators/VBP/VBPIndicator.ts
+++ b/ts/Stock/Indicators/VBP/VBPIndicator.ts
@@ -782,6 +782,7 @@ namespace VBPIndicator {
 
 interface VBPIndicator {
     nameBase: string;
+    nameComponents: Array<string>;
     calculateOn: string;
     pointClass: typeof VBPPoint;
 
@@ -791,6 +792,7 @@ interface VBPIndicator {
 
 extend(VBPIndicator.prototype, {
     nameBase: 'Volume by Price',
+    nameComponents: ['ranges'],
     bindTo: {
         series: false,
         eventName: 'afterSetExtremes'

--- a/ts/Stock/Indicators/VBP/VBPIndicator.ts
+++ b/ts/Stock/Indicators/VBP/VBPIndicator.ts
@@ -115,6 +115,9 @@ class VBPIndicator extends SMAIndicator {
          * @excluding index, period
          */
         params: {
+            // Index and period are unchangeable, do not inherit (#15362)
+            index: void 0,
+            period: void 0,
             /**
              * The number of price zones.
              */

--- a/ts/Stock/Indicators/VWAP/VWAPIndicator.ts
+++ b/ts/Stock/Indicators/VWAP/VWAPIndicator.ts
@@ -71,6 +71,7 @@ class VWAPIndicator extends SMAIndicator {
          * @excluding index
          */
         params: {
+            index: void 0, // unchangeable index, do not inherit (#15362)
             period: 30,
             /**
              * The id of volume series which is mandatory. For example using

--- a/ts/Stock/Indicators/WilliamsR/WilliamsRIndicator.ts
+++ b/ts/Stock/Indicators/WilliamsR/WilliamsRIndicator.ts
@@ -66,6 +66,7 @@ class WilliamsRIndicator extends SMAIndicator {
          * @excluding index
          */
         params: {
+            index: void 0, // unchangeable index, do not inherit (#15362)
             /**
              * Period for Williams %R oscillator
              */

--- a/ts/Stock/Indicators/Zigzag/ZigzagIndicator.ts
+++ b/ts/Stock/Indicators/Zigzag/ZigzagIndicator.ts
@@ -67,6 +67,9 @@ class ZigzagIndicator extends SMAIndicator {
          * @excluding index, period
          */
         params: {
+            // Index and period are unchangeable, do not inherit (#15362)
+            index: void 0,
+            period: void 0,
             /**
              * The point index which indicator calculations will base - low
              * value.


### PR DESCRIPTION
Fixed #15362, corrected API and Stock Tools popup list of indicators' params.

#### Upgrade note
The default value of [linearregression.params.xAxisUnit](https://api.highcharts.com/highstock/plotOptions.linearregression.params.xAxisUnit) has been changed from `undefined` to `null`.