### PR TITLE
Fixed #15416, #15413, heatmap kbd nav issues.

### DIFF
--- a/samples/unit-tests/series-heatmap/members/demo.js
+++ b/samples/unit-tests/series-heatmap/members/demo.js
@@ -191,51 +191,19 @@ QUnit.test('Point range after setData(#3758)', function (assert) {
 });
 
 QUnit.test('seriesTypes.heatmap.pointClass.setState', function (assert) {
-    var series = Highcharts.seriesTypes.heatmap,
-        setState = series.prototype.pointClass.prototype.setState,
-        pointAttribs = series.prototype.pointAttribs,
-        noop = Highcharts.noop,
-        point = {
-            graphic: {
-                attr: function (obj) {
-                    var graphic = this,
-                        keys = Object.keys(obj);
-                    keys.forEach(function (key) {
-                        var value = obj[key];
-                        graphic[key] = value;
-                    });
-                },
-                animate: noop,
-                addClass: noop,
-                removeClass: noop
+    const chart = new Highcharts.Chart('container', {
+            chart: {
+                type: 'heatmap'
             },
-            series: {
-                type: 'heatmap',
-                options: {
-                    marker: {
-                        states: {
-                            normal: {},
-                            hover: {},
-                            select: {}
-                        }
-                    },
-                    states: {
-                        hover: {},
-                        select: {}
-                    }
-                },
-                pointAttribs: pointAttribs,
-                zones: [],
-                chart: {
-                    options: {
-                        chart: {
-                            animation: false
-                        }
-                    }
-                }
-            },
-            options: {}
-        };
+
+            series: [{
+                data: [[0, 0, 1]]
+            }]
+        }),
+        point = chart.series[0].points[0],
+        setState = Highcharts.seriesTypes.heatmap.prototype
+            .pointClass.prototype.setState;
+
     setState.call(point, '');
     assert.strictEqual(
         point.graphic.zIndex,

--- a/samples/unit-tests/series-map/members/demo.js
+++ b/samples/unit-tests/series-map/members/demo.js
@@ -22,44 +22,21 @@ QUnit.test(
 );
 
 QUnit.test('seriesTypes.map.pointClass.setState', function (assert) {
-    var series = Highcharts.seriesTypes.map,
-        setState = series.prototype.pointClass.prototype.setState,
-        pointAttribs = series.prototype.pointAttribs,
-        noop = Highcharts.noop,
-        point = {
-            graphic: {
-                attr: function (obj) {
-                    var graphic = this,
-                        keys = Object.keys(obj);
-                    keys.forEach(function (key) {
-                        var value = obj[key];
-                        graphic[key] = value;
-                    });
-                },
-                animate: noop,
-                addClass: noop,
-                removeClass: noop
-            },
-            series: {
-                type: 'map',
-                options: {
-                    states: {
-                        hover: {},
-                        select: {}
-                    }
-                },
-                pointAttribs: pointAttribs,
-                zones: [],
-                chart: {
-                    options: {
-                        chart: {
-                            animation: false
-                        }
-                    }
-                }
-            },
-            options: {}
-        };
+    const chart = Highcharts.mapChart('container', {
+            colorAxis: {},
+            series: [{
+                data: [{
+                    name: 'Test',
+                    value: 1,
+                    path:
+                        'M385,111,392,109,400,111,401,105z'
+                }]
+            }]
+        }),
+        point = chart.series[0].points[0],
+        setState = Highcharts.seriesTypes.map.prototype
+            .pointClass.prototype.setState;
+
     setState.call(point, '');
     assert.strictEqual(
         point.graphic.zIndex,

--- a/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
@@ -17,6 +17,10 @@ import Point from '../../../Core/Series/Point.js';
 import Series from '../../../Core/Series/Series.js';
 import SeriesRegistry from '../../../Core/Series/SeriesRegistry.js';
 const { seriesTypes } = SeriesRegistry;
+import H from '../../../Core/Globals.js';
+const {
+    doc
+} = H;
 import U from '../../../Core/Utilities.js';
 const {
     defined,
@@ -662,6 +666,21 @@ extend(SeriesKeyboardNavigation.prototype, /** @lends Highcharts.SeriesKeyboardN
             setTimeout(function (): void {
                 keyboardNavigation.onDrillupAll();
             }, 10);
+        });
+
+        // Heatmaps et al. alter z-index in setState, causing elements
+        // to lose focus
+        e.addEvent(Point, 'afterSetState', function (): void {
+            const point = this;
+            const pointEl = point.graphic && point.graphic.element;
+            if (
+                chart.highlightedPoint === point &&
+                doc.activeElement !== pointEl &&
+                pointEl &&
+                pointEl.focus
+            ) {
+                pointEl.focus();
+            }
         });
     },
 

--- a/ts/Accessibility/KeyboardNavigation.ts
+++ b/ts/Accessibility/KeyboardNavigation.ts
@@ -246,9 +246,11 @@ KeyboardNavigation.prototype = {
         );
 
         // Init keyboard nav if tabbing into chart
-        if (!this.isClickingChart && !focusComesFromChart && this.modules[0]) {
+        if (!this.exiting && !this.isClickingChart && !focusComesFromChart && this.modules[0]) {
             this.modules[0].init(1);
         }
+
+        this.exiting = false;
     },
 
 
@@ -293,6 +295,9 @@ KeyboardNavigation.prototype = {
 
         // Used for resetting nav state when clicking outside chart
         this.keyboardReset = false;
+
+        // Used for sending focus out of the chart by the modules.
+        this.exiting = false;
 
         // If there is a nav module for the current index, run it.
         // Otherwise, we are outside of the chart in some direction.
@@ -369,8 +374,8 @@ KeyboardNavigation.prototype = {
         this.currentModuleIx = 0; // Reset counter
 
         // Set focus to chart or exit anchor depending on direction
+        this.exiting = true;
         if (direction > 0) {
-            this.exiting = true;
             this.exitAnchor.focus();
         } else {
             this.tabindexContainer.focus();

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1732,7 +1732,7 @@ class Point {
             );
         }
 
-        fireEvent(point, 'afterSetState');
+        fireEvent(point, 'afterSetState', { state });
     }
 
     /**

--- a/ts/Mixins/ColorMapSeries.ts
+++ b/ts/Mixins/ColorMapSeries.ts
@@ -12,7 +12,6 @@
 
 import type ScatterPoint from '../Series/Scatter/ScatterPoint';
 import type ScatterSeries from '../Series/Scatter/ScatterSeries';
-import type { StatesOptionsKey } from '../Core/Series/StatesOptions';
 import type SVGAttributes from '../Core/Renderer/SVG/SVGAttributes';
 import H from '../Core/Globals.js';
 
@@ -30,15 +29,15 @@ declare global {
     namespace Highcharts {
         interface ColorMapPoint extends ScatterPoint {
             dataLabelOnNull: boolean;
+            moveToTopOnHover?: boolean;
             series: ColorMapSeries;
             value: (number|null);
             isValid(): boolean;
-            setState(state?: StatesOptionsKey): void;
         }
         interface ColorMapPointMixin {
             dataLabelOnNull: ColorMapPoint['dataLabelOnNull'];
+            moveToTopOnHover: ColorMapPoint['moveToTopOnHover'];
             isValid: ColorMapPoint['isValid'];
-            setState: ColorMapPoint['setState'];
         }
         interface ColorMapSeries extends ScatterSeries {
             colorProp?: string;
@@ -67,11 +66,24 @@ declare global {
 import Point from '../Core/Series/Point.js';
 import U from '../Core/Utilities.js';
 const {
-    defined
+    defined,
+    addEvent
 } = U;
 
 var noop = H.noop,
     seriesTypes = H.seriesTypes;
+
+
+// Move points to the top of the z-index order when hovered
+addEvent(Point, 'afterSetState', function (e?: Record<string, any>): void {
+    const point = this; // eslint-disable-line no-invalid-this
+    if ((point as Highcharts.ColorMapPoint).moveToTopOnHover && point.graphic) {
+        point.graphic.attr({
+            zIndex: e && e.state === 'hover' ? 1 : 0
+        });
+    }
+});
+
 
 /**
  * Mixin for maps and heatmaps
@@ -81,6 +93,8 @@ var noop = H.noop,
  */
 const colorMapPointMixin = {
     dataLabelOnNull: true,
+    moveToTopOnHover: true,
+
     /* eslint-disable valid-jsdoc */
     /**
      * Color points have a value option that determines whether or not it is
@@ -94,21 +108,6 @@ const colorMapPointMixin = {
             this.value !== Infinity &&
             this.value !== -Infinity
         );
-    },
-
-    /**
-     * @private
-     */
-    setState: function (
-        this: Highcharts.ColorMapPoint,
-        state?: StatesOptionsKey
-    ): void {
-        Point.prototype.setState.call(this, state);
-        if (this.graphic) {
-            this.graphic.attr({
-                zIndex: state === 'hover' ? 1 : 0
-            });
-        }
     }
 
     /* eslint-enable valid-jsdoc */

--- a/ts/Series/Heatmap/HeatmapPoint.ts
+++ b/ts/Series/Heatmap/HeatmapPoint.ts
@@ -239,11 +239,11 @@ class HeatmapPoint extends ScatterPoint {
 
 interface HeatmapPoint {
     dataLabelOnNull: typeof colorMapPointMixin.dataLabelOnNull;
-    setState: typeof colorMapPointMixin.setState;
+    moveToTopOnHover: typeof colorMapPointMixin.moveToTopOnHover;
 }
 extend(HeatmapPoint.prototype, {
     dataLabelOnNull: colorMapPointMixin.dataLabelOnNull,
-    setState: colorMapPointMixin.setState
+    moveToTopOnHover: colorMapPointMixin.moveToTopOnHover
 });
 
 /* *

--- a/ts/Series/Map/MapPoint.ts
+++ b/ts/Series/Map/MapPoint.ts
@@ -156,12 +156,12 @@ class MapPoint extends ScatterSeries.prototype.pointClass {
 interface MapPoint extends ScatterPoint, Highcharts.ColorMapPoint {
     dataLabelOnNull: typeof colorMapPointMixin.dataLabelOnNull;
     isValid: typeof colorMapPointMixin.isValid;
-    setState: typeof colorMapPointMixin.setState;
+    moveToTopOnHover: typeof colorMapPointMixin.moveToTopOnHover;
 }
 extend(MapPoint.prototype, {
     dataLabelOnNull: colorMapPointMixin.dataLabelOnNull,
     isValid: colorMapPointMixin.isValid,
-    setState: colorMapPointMixin.setState
+    moveToTopOnHover: colorMapPointMixin.moveToTopOnHover
 });
 
 /* *


### PR DESCRIPTION
Fixed #15416, #15413, heatmap keyboard navigation not working after mouse interaction, and backwards navigation not working as expected.
___
Two issues at play here, one being that `setState` in colorMap-series alters the z-index of the point, causing elements to lose focus. This is solved now by adding an event listener in the a11y module that reapplies focus after `setState` when relevant. This required some refactoring of how `setState` is handled in colorMap-series.

The other issue was related to the first one, but dealt with the auto-init of the first keyboard nav module when the container receives focus. This should not happen when exiting the chart, but is only an issue in combination with the z-index problem, since the focus is lost when the module inits.