### PR TITLE
Fixed #15343, treemap and sunburst kbd nav broken.

### DIFF
--- a/ts/Series/Sunburst/SunburstSeries.ts
+++ b/ts/Series/Sunburst/SunburstSeries.ts
@@ -862,6 +862,7 @@ class SunburstSeries extends TreemapSeries {
                 plotX: (shape as any).plotX, // used for data label position
                 plotY: (shape as any).plotY, // used for data label position
                 value: node.val,
+                isInside: visible,
                 isNull: !visible // used for dataLabels & point.draw
             });
             point.dlOptions = getDlOptions({

--- a/ts/Series/Treemap/TreemapSeries.ts
+++ b/ts/Series/Treemap/TreemapSeries.ts
@@ -1061,6 +1061,8 @@ class TreemapSeries extends ScatterSeries {
 
             // Don't bother with calculate styling if the point is not drawn
             if (point.shouldDraw()) {
+                point.isInside = true;
+
                 if (borderRadius) {
                     attribs.r = borderRadius;
                 }


### PR DESCRIPTION
Fixed #15343, regression with treemap and sunburst keyboard navigation.
___
After earlier fix in a11y module that excluded `isInside === false` points from navigation.