### PR TITLE
bugfix/empty-area-svg-error

### DIFF
--- a/samples/unit-tests/series-area/update/demo.js
+++ b/samples/unit-tests/series-area/update/demo.js
@@ -70,4 +70,14 @@ QUnit.test('Updating series stacked property', assert => {
         chart.series[0].areaPath.slice(-1)[0].includes("Z"),
         'The last index of the path array contains the closure'
     );
+
+    chart.series[0].update({
+        data: []
+    });
+
+    assert.strictEqual(
+        chart.series[0].areaPath.length,
+        0,
+        'Path should be empty when there is no data'
+    );
 });

--- a/ts/Series/Area/AreaSeries.ts
+++ b/ts/Series/Area/AreaSeries.ts
@@ -450,7 +450,9 @@ class AreaSeries extends LineSeries {
         }
 
         areaPath = topPath.concat(bottomPath);
-        areaPath.push(['Z']);
+        if (areaPath.length) {
+            areaPath.push(['Z']);
+        }
         // TODO: don't set leftCliff and rightCliff when connectNulls?
         graphPath = getGraphPath
             .call(this, graphPoints, false, connectNulls);


### PR DESCRIPTION
Fixed a regression, area series with empty data caused SVG error.