### PR TITLE
bugfix/15435-stock-clip-update

### DIFF
--- a/samples/unit-tests/series/clip/demo.js
+++ b/samples/unit-tests/series/clip/demo.js
@@ -5,12 +5,17 @@ QUnit.test('General series clip tests', assert => {
         const chart = Highcharts.chart('container', {
                 series: [{
                     data: [10, 20]
+                }, {
+                    data: [1, 2, 3],
+                    yAxis: 1
                 }],
-                yAxis: {
+                yAxis: [{
                     labels: {
                         format: '{value}'
                     }
-                },
+                }, {
+                    opposite: true
+                }],
                 plotOptions: {
                     series: {
                         animation: false
@@ -49,7 +54,8 @@ QUnit.test('General series clip tests', assert => {
                     {
                         clip: false,
                         data: [1, 2, 3]
-                    }
+                    },
+                    {}
                 ]
             },
             true,
@@ -62,6 +68,20 @@ QUnit.test('General series clip tests', assert => {
         assert.notOk(
             chart.series[2].clipBox,
             '#15128: Series with clip=false should not have stock clipping applied'
+        );
+
+        const widthBefore = chart[chart.series[3].sharedClipKey].attr('width');
+
+        chart.update({
+            yAxis: [{}, {
+                visible: false
+            }],
+            series: [{}, {}, {}, {}]
+        }, true, true);
+
+        assert.ok(
+            chart[chart.series[3].sharedClipKey].attr('width') > widthBefore,
+            '#15435: Shared clip should have been updated'
         );
 
         setTimeout(() => {

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -1165,19 +1165,28 @@ addEvent(Series, 'render', function (): void {
             this.clipBox = this.clipBox || merge(chart.clipBox);
             this.clipBox.width = this.xAxis.len;
             this.clipBox.height = clipHeight;
+        }
 
-        // On redrawing, resizing etc, update the clip rectangle
-        } else if ((chart as any)[this.sharedClipKey as any]) {
+        // #15435: this.sharedClipKey might not have been set yet, for example
+        // when updating the series, so we need to use this function instead
+        const sharedClipKey = this.getSharedClipKey();
+
+        // On redrawing, resizing etc, update the clip rectangle.
+        //
+        // #15435: Update it even when we are creating/updating clipBox, since
+        // there could be series updating and pane size changes happening at
+        // the same time and we dont destroy shared clips in stock.
+        if ((chart as any)[sharedClipKey]) {
             // animate in case resize is done during initial animation
-            (chart as any)[this.sharedClipKey as any].animate({
+            (chart as any)[sharedClipKey].animate({
                 width: this.xAxis.len,
                 height: clipHeight
             });
 
             // also change markers clip animation for consistency
             // (marker clip rects should exist only on chart init)
-            if ((chart as any)[this.sharedClipKey + 'm']) {
-                (chart as any)[this.sharedClipKey + 'm'].animate({
+            if ((chart as any)[sharedClipKey + 'm']) {
+                (chart as any)[sharedClipKey + 'm'].animate({
                     width: this.xAxis.len
                 });
             }

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -24,6 +24,10 @@ import type PointerEvent from '../PointerEvent';
 import type { SeriesTypePlotOptions } from '../Series/SeriesType';
 import type SVGElement from '../Renderer/SVG/SVGElement';
 import type SVGPath from '../Renderer/SVG/SVGPath';
+import A from '../Animation/AnimationUtilities.js';
+const {
+    animObject
+} = A;
 import Axis from '../Axis/Axis.js';
 import Chart from '../Chart/Chart.js';
 import palette from '../../Core/Color/Palette.js';
@@ -1168,10 +1172,12 @@ addEvent(Series, 'render', function (): void {
         }
 
         if (chart.hasRendered) {
+            const animation = animObject(this.options.animation);
+
             // #15435: this.sharedClipKey might not have been set yet, for
             // example when updating the series, so we need to use this
             // function instead
-            const sharedClipKey = this.getSharedClipKey();
+            const sharedClipKey = this.getSharedClipKey(animation);
 
             // On redrawing, resizing etc, update the clip rectangle.
             //

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -1161,7 +1161,7 @@ addEvent(Series, 'render', function (): void {
         // First render, initial clip box. clipBox also needs to be updated if
         // the series is rendered again before starting animating, in
         // compliance with a responsive rule (#13858).
-        if (!chart.hasLoaded || (!this.clipBox && this.isDirty && !this.isDirtyData)) {
+        if (!chart.hasRendered || (!this.clipBox && this.isDirty && !this.isDirtyData)) {
             this.clipBox = this.clipBox || merge(chart.clipBox);
             this.clipBox.width = this.xAxis.len;
             this.clipBox.height = clipHeight;
@@ -1176,7 +1176,7 @@ addEvent(Series, 'render', function (): void {
         // #15435: Update it even when we are creating/updating clipBox, since
         // there could be series updating and pane size changes happening at
         // the same time and we dont destroy shared clips in stock.
-        if ((chart as any)[sharedClipKey]) {
+        if (chart.hasRendered && (chart as any)[sharedClipKey]) {
             // animate in case resize is done during initial animation
             (chart as any)[sharedClipKey].animate({
                 width: this.xAxis.len,

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -1167,28 +1167,32 @@ addEvent(Series, 'render', function (): void {
             this.clipBox.height = clipHeight;
         }
 
-        // #15435: this.sharedClipKey might not have been set yet, for example
-        // when updating the series, so we need to use this function instead
-        const sharedClipKey = this.getSharedClipKey();
+        if (chart.hasRendered) {
+            // #15435: this.sharedClipKey might not have been set yet, for
+            // example when updating the series, so we need to use this
+            // function instead
+            const sharedClipKey = this.getSharedClipKey();
 
-        // On redrawing, resizing etc, update the clip rectangle.
-        //
-        // #15435: Update it even when we are creating/updating clipBox, since
-        // there could be series updating and pane size changes happening at
-        // the same time and we dont destroy shared clips in stock.
-        if (chart.hasRendered && (chart as any)[sharedClipKey]) {
-            // animate in case resize is done during initial animation
-            (chart as any)[sharedClipKey].animate({
-                width: this.xAxis.len,
-                height: clipHeight
-            });
-
-            // also change markers clip animation for consistency
-            // (marker clip rects should exist only on chart init)
-            if ((chart as any)[sharedClipKey + 'm']) {
-                (chart as any)[sharedClipKey + 'm'].animate({
-                    width: this.xAxis.len
+            // On redrawing, resizing etc, update the clip rectangle.
+            //
+            // #15435: Update it even when we are creating/updating clipBox,
+            // since there could be series updating and pane size changes
+            // happening at the same time and we dont destroy shared clips in
+            // stock.
+            if ((chart as any)[sharedClipKey]) {
+                // animate in case resize is done during initial animation
+                (chart as any)[sharedClipKey].animate({
+                    width: this.xAxis.len,
+                    height: clipHeight
                 });
+
+                // also change markers clip animation for consistency
+                // (marker clip rects should exist only on chart init)
+                if ((chart as any)[sharedClipKey + 'm']) {
+                    (chart as any)[sharedClipKey + 'm'].animate({
+                        width: this.xAxis.len
+                    });
+                }
             }
         }
     }

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -4858,24 +4858,26 @@ class Series {
      * @private
      * @function Highcharts.Series#getSharedClipKey
      */
-    public getSharedClipKey(): string {
+    public getSharedClipKey(animation?: AnimationOptions): string {
         if (this.sharedClipKey) {
             return this.sharedClipKey;
         }
 
-        const animation = animObject(this.options.animation);
-
-        this.sharedClipKey = [
+        const sharedClipKey = [
             '_sharedClip',
-            animation.duration,
-            animation.easing,
-            animation.defer,
+            animation && animation.duration,
+            animation && animation.easing,
+            animation && animation.defer,
             this.getClipBox(animation).height,
             this.options.xAxis,
             this.options.yAxis
         ].join(',');
 
-        return this.sharedClipKey;
+        if (this.options.clip !== false || animation) {
+            this.sharedClipKey = sharedClipKey;
+        }
+
+        return sharedClipKey;
     }
 
     /**
@@ -4886,14 +4888,14 @@ class Series {
      * @private
      * @function Highcharts.Series#setClip
      */
-    public setClip(animation?: (boolean|AnimationOptions)): void {
+    public setClip(animation?: AnimationOptions): void {
         var chart = this.chart,
             options = this.options,
             renderer = chart.renderer,
             inverted = chart.inverted,
             seriesClipBox = this.clipBox,
             clipBox = this.getClipBox(animation),
-            sharedClipKey = this.getSharedClipKey(), // #4526
+            sharedClipKey = this.getSharedClipKey(animation), // #4526
             clipRect = (chart as any)[sharedClipKey],
             markerClipRect = (chart as any)[sharedClipKey + 'm'];
 
@@ -4946,7 +4948,6 @@ class Series {
                 animation || seriesClipBox ? clipRect : chart.clipRect
             );
             (this.markerGroup as any).clip(markerClipRect);
-            this.sharedClipKey = sharedClipKey;
         }
 
         // Remove the shared clipping rectangle when all series are shown

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -4853,6 +4853,32 @@ class Series {
     }
 
     /**
+     * Get the shared clip key, creating it if it doesnt exist.
+     *
+     * @private
+     * @function Highcharts.Series#getSharedClipKey
+     */
+    public getSharedClipKey(): string {
+        if (this.sharedClipKey) {
+            return this.sharedClipKey;
+        }
+
+        const animation = animObject(this.options.animation);
+
+        this.sharedClipKey = [
+            '_sharedClip',
+            animation.duration,
+            animation.easing,
+            animation.defer,
+            this.getClipBox(animation).height,
+            this.options.xAxis,
+            this.options.yAxis
+        ].join(',');
+
+        return this.sharedClipKey;
+    }
+
+    /**
      * Set the clipping for the series. For animated series it is called
      * twice, first to initiate animating the clip then the second time
      * without the animation to set the final clip.
@@ -4867,17 +4893,7 @@ class Series {
             inverted = chart.inverted,
             seriesClipBox = this.clipBox,
             clipBox = this.getClipBox(animation),
-            sharedClipKey =
-                this.sharedClipKey ||
-                [
-                    '_sharedClip',
-                    animation && (animation as any).duration,
-                    animation && (animation as any).easing,
-                    animation && (animation as any).defer,
-                    clipBox.height,
-                    options.xAxis,
-                    options.yAxis
-                ].join(','), // #4526
+            sharedClipKey = this.getSharedClipKey(), // #4526
             clipRect = (chart as any)[sharedClipKey],
             markerClipRect = (chart as any)[sharedClipKey + 'm'];
 


### PR DESCRIPTION
Fixed #15435, clipping was sometimes wrong after `update` with stock loaded.