### PR TITLE
docs/class-reference-links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Your issue should:
 
 ## Suggesting Features and Enhancements
 
-Features and enhancements can be suggested on [user voice](https://highcharts.uservoice.com/).
+Features and enhancements can be suggested on [UserVoice](https://highcharts.uservoice.com/).
 
 ## Contributing Code
 
@@ -55,10 +55,10 @@ will be part of the Highcharts source base, which is a commercial product.
 For this reason, submissions may not contain code that prevents or limits commercial usage in closed-source applications.
 To ensure this, submissions must be licensed using one of the following licenses:
 
-* [Apache License 2.0](http://opensource.org/licenses/apache2.0)
-* [BSD Licence](http://www.opensource.org/licenses/BSD-3-Clause)
-* [MIT / X11 License](http://www.opensource.org/licenses/MIT)
-* [Mozilla Public License](http://www.opensource.org/licenses/MPL-2.0)
+* [Apache License 2.0](https://opensource.org/licenses/apache2.0)
+* [BSD Licence](https://opensource.org/licenses/BSD-3-Clause)
+* [MIT / X11 License](https://opensource.org/licenses/MIT)
+* [Mozilla Public License](https://opensource.org/licenses/MPL-2.0)
 
 No other license is permitted for contributions.
 
@@ -95,7 +95,7 @@ We use the following JavaScript style:
 * no `console.*`
 * single quotes
 
-This style is enforced by ESLint, which is ran in a post-commit hook.
+This style is enforced by ESLint, which is run in a post-commit hook.
 
 ### Pull Requests
 

--- a/docs/chart-concepts/labels-and-string-formatting.md
+++ b/docs/chart-concepts/labels-and-string-formatting.md
@@ -39,13 +39,13 @@ Format strings are templates for labels, where variables are inserted. Format st
 *   Thousands separator, no decimal places: `{point.y:,.0f}` [[Demo](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/labels/no-decimal-places)]
 *   Thousands separator, one decimal place: `{point.y:,.1f}` [[Demo, internationalized](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/labels/one-decimal-place)]
 
-**Dates** allow, like numbers, the format to be appended behind a colon. The format conventions allowed are the same as those of [Highcharts.dateFormat()](https://api.highcharts.com/class-reference/Highcharts#dateFormat). For example:
+**Dates** allow, like numbers, the format to be appended behind a colon. The format conventions allowed are the same as those of [Highcharts.dateFormat()](https://api.highcharts.com/class-reference/Highcharts#.dateFormat). For example:
 
 *   Full date: `{value:%Y-%m-%d}` [[Demo](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/labels/full-date)]
 
 ### Formatter callbacks
 
-For full control over string handling and additional scripting capabilities around the labels, you might need to use formatter callbacks. These formatters return HTML (subset). Examples of these are [xAxis.labels.formatter](https://api.highcharts.com/highcharts/xAxis.labels.formatter), [tooltip.formatter](https://api.highcharts.com/highcharts/tooltip.formatter) and [legend.labelFormatter](https://api.highcharts.com/highcharts/legend.labelFormatter). Often times you'll need to call [Highcharts.dateFormat()](https://api.highcharts.com/class-reference/Highcharts#dateFormat) and [Highcharts.numberFormat()](https://api.highcharts.com/class-reference/Highcharts#numberFormat) from the formatters.
+For full control over string handling and additional scripting capabilities around the labels, you might need to use formatter callbacks. These formatters return HTML (subset). Examples of these are [xAxis.labels.formatter](https://api.highcharts.com/highcharts/xAxis.labels.formatter), [tooltip.formatter](https://api.highcharts.com/highcharts/tooltip.formatter) and [legend.labelFormatter](https://api.highcharts.com/highcharts/legend.labelFormatter). Often times you'll need to call [Highcharts.dateFormat()](https://api.highcharts.com/class-reference/Highcharts#.dateFormat) and [Highcharts.numberFormat()](https://api.highcharts.com/class-reference/Highcharts#.numberFormat) from the formatters.
 
 ### Advanced format strings
 

--- a/samples/maps/demo/geojson-multiple-types/readme.md
+++ b/samples/maps/demo/geojson-multiple-types/readme.md
@@ -1,5 +1,5 @@
 # GeoJSON with rivers and cities
 Highmaps accepts [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON) geometry primitives such as Point, LineString and Polygon. The following demo uses GeoJSON map of Australia featuring the provinces, the main cities, and rivers.
 #### Tip
-Use the [Highcharts.geojson function](https://api.highcharts.com/class-reference/Highcharts# geojson) to extract map data from the GeoJSON.
+Use the [Highcharts.geojson function](https://api.highcharts.com/class-reference/Highcharts#.geojson) to extract map data from the GeoJSON.
 Learn more about how to set custom GeoJSON maps [here](https://www.highcharts.com/docs/maps/custom-geojson-maps).

--- a/ts/Accessibility/Options/Options.ts
+++ b/ts/Accessibility/Options/Options.ts
@@ -355,7 +355,7 @@ var options: DeepPartial<Highcharts.Options> = {
              * Date format to use to describe range of datetime axes.
              *
              * For an overview of the replacement codes, see
-             * [dateFormat](/class-reference/Highcharts#dateFormat).
+             * [dateFormat](/class-reference/Highcharts#.dateFormat).
              *
              * @see [point.dateFormat](#accessibility.point.dateFormat)
              *
@@ -419,7 +419,7 @@ var options: DeepPartial<Highcharts.Options> = {
              * Defaults to the same format as in tooltip.
              *
              * For an overview of the replacement codes, see
-             * [dateFormat](/class-reference/Highcharts#dateFormat).
+             * [dateFormat](/class-reference/Highcharts#.dateFormat).
              *
              * @see [dateFormatter](#accessibility.point.dateFormatter)
              *
@@ -433,7 +433,7 @@ var options: DeepPartial<Highcharts.Options> = {
              * points on datetime axes when describing them to screen reader
              * users. Receives one argument, `point`, referring to the point
              * to describe. Should return a date format string compatible with
-             * [dateFormat](/class-reference/Highcharts#dateFormat).
+             * [dateFormat](/class-reference/Highcharts#.dateFormat).
              *
              * @see [dateFormat](#accessibility.point.dateFormat)
              *

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1265,7 +1265,7 @@ class Axis {
          * same axis.
          *
          * For an overview of the replacement codes, see
-         * [dateFormat](/class-reference/Highcharts#dateFormat).
+         * [dateFormat](/class-reference/Highcharts#.dateFormat).
          *
          * Defaults to:
          * ```js

--- a/ts/Core/Options.ts
+++ b/ts/Core/Options.ts
@@ -3969,7 +3969,7 @@ H.defaultOptions = {
          * header will by default be guessed based on the closest data points.
          * This member gives the default string representations used for
          * each unit. For an overview of the replacement codes, see
-         * [dateFormat](/class-reference/Highcharts#dateFormat).
+         * [dateFormat](/class-reference/Highcharts#.dateFormat).
          *
          * @see [xAxis.dateTimeLabelFormats](#xAxis.dateTimeLabelFormats)
          *

--- a/ts/Extensions/CurrentDateIndication.ts
+++ b/ts/Extensions/CurrentDateIndication.ts
@@ -98,7 +98,7 @@ const defaultOptions: Highcharts.CurrentDateIndicatorOptions = {
     label: {
         /**
          * Format of the label. This options is passed as the fist argument to
-         * [dateFormat](/class-reference/Highcharts#dateFormat) function.
+         * [dateFormat](/class-reference/Highcharts#.dateFormat) function.
          *
          * @type      {string}
          * @default   %a, %b %d %Y, %H:%M


### PR DESCRIPTION
Fixed some links in docs to class reference pages and made slight grammatical tweaks to contributing guidelines.

(This may seem so minor as to not even be worth it, but I was clicking links to see the supported format keys in `dateFormat()` and thought that information was removed because after looking in the sidebar I ended up on `dateFormats`.)