### PR TITLE
bugfix/15524-annotation-drag-update

### DIFF
--- a/samples/highcharts/accessibility/accessible-annotations/demo.js
+++ b/samples/highcharts/accessibility/accessible-annotations/demo.js
@@ -93,7 +93,8 @@ Highcharts.chart('container', {
             point: {
                 x: 0, y: 0
             },
-            x: -10,
+            align: 'left',
+            x: 10,
             y: 10,
             style: {
                 width: 150

--- a/samples/unit-tests/annotations/annotations-dynamic/demo.js
+++ b/samples/unit-tests/annotations/annotations-dynamic/demo.js
@@ -60,6 +60,11 @@ QUnit.test("Annotation's dynamic methods", function (assert) {
         'Annotation options are correctly added to chart options'
     );
 
+    chart.annotations[0].labels[0].update({});
+    chart.annotations[0].labels[0].translate(0, 0);
+
+    assert.ok('#15524: Translating updated label should not throw');
+
     chart.removeAnnotation('1');
 
     assert.strictEqual(

--- a/samples/unit-tests/annotations/annotations-labels-positioning/demo.js
+++ b/samples/unit-tests/annotations/annotations-labels-positioning/demo.js
@@ -41,6 +41,11 @@ QUnit.test('Positioning labels according to real points', function (assert) {
                                     y: 0
                                 };
                             }
+                        },
+                        {
+                            point: 'id5',
+                            text: 'Really long label',
+                            x: -10
                         }
                     ],
 
@@ -99,6 +104,13 @@ QUnit.test('Positioning labels according to real points', function (assert) {
 
     assert.strictEqual(label4.x, x4, 'x position - positioner');
     assert.strictEqual(label4.y, y4, 'y position - positioner');
+
+    const label5 = chart.annotations[0].labels[4].graphic;
+
+    assert.ok(
+        Math.round(label5.x + label5.width) <= chart.plotLeft + chart.plotWidth,
+        '#15524: Label should be within the plot'
+    );
 });
 
 QUnit.test(

--- a/ts/Extensions/Annotations/Controllables/ControllableLabel.ts
+++ b/ts/Extensions/Annotations/Controllables/ControllableLabel.ts
@@ -184,7 +184,7 @@ class ControllableLabel implements ControllableMixin.Type {
             if (align === 'right') {
                 options.align = 'left';
             } else {
-                options.x = -off;
+                options.x = (options.x || 0) - off;
             }
         }
 
@@ -194,7 +194,7 @@ class ControllableLabel implements ControllableMixin.Type {
             if (align === 'left') {
                 options.align = 'right';
             } else {
-                options.x = chart.plotWidth - off;
+                options.x = (options.x || 0) + chart.plotWidth - off;
             }
         }
 
@@ -204,7 +204,7 @@ class ControllableLabel implements ControllableMixin.Type {
             if (verticalAlign === 'bottom') {
                 options.verticalAlign = 'top';
             } else {
-                options.y = -off;
+                options.y = (options.y || 0) - off;
             }
         }
 
@@ -214,7 +214,7 @@ class ControllableLabel implements ControllableMixin.Type {
             if (verticalAlign === 'top') {
                 options.verticalAlign = 'bottom';
             } else {
-                options.y = chart.plotHeight - off;
+                options.y = (options.y || 0) + chart.plotHeight - off;
             }
         }
 

--- a/ts/Extensions/Annotations/Mixins/ControllableMixin.ts
+++ b/ts/Extensions/Annotations/Mixins/ControllableMixin.ts
@@ -601,7 +601,7 @@ var controllableMixin: Highcharts.AnnotationControllableMixin = {
             parentGroup = this.graphic.parentGroup;
 
         this.destroy();
-        (this as any).constructor(annotation, options);
+        this.constructor(annotation, options, this.index);
         this.render(parentGroup);
         this.redraw();
     }


### PR DESCRIPTION
Fixed #15524, dragging annotation after updating label threw and `labels.overflow` set to `justify` did not work correctly.