### PR TITLE
bugfix/15534-area-null-empty-update

### DIFF
--- a/samples/unit-tests/series-area/update/demo.js
+++ b/samples/unit-tests/series-area/update/demo.js
@@ -3,7 +3,8 @@ QUnit.test('Updating series stacked property', assert => {
         chart: {
             type: 'area',
             width: 600,
-            height: 350
+            height: 350,
+            animation: true
         },
         xAxis: {
             categories: [
@@ -79,5 +80,14 @@ QUnit.test('Updating series stacked property', assert => {
         chart.series[0].areaPath.length,
         0,
         'Path should be empty when there is no data'
+    );
+
+    chart.series[1].update({
+        data: []
+    });
+
+    assert.ok(
+        true,
+        '#15534: Updating from data containing nulls to no data should not throw'
     );
 });

--- a/ts/Core/Animation/Fx.ts
+++ b/ts/Core/Animation/Fx.ts
@@ -440,7 +440,7 @@ class Fx {
 
         // For sideways animation, find out how much we need to shift to get the
         // start path Xs to match the end path Xs.
-        if (startX && endX) {
+        if (startX && endX && endX.length) {
             for (i = 0; i < startX.length; i++) {
                 // Moving left, new points coming in on right
                 if (startX[i] === endX[0]) {


### PR DESCRIPTION
Fixed #15534, updating area series containing null data to no data threw.