### PR TITLE
bugfix/15528-tick-label-allowOverlap

### DIFF
--- a/samples/unit-tests/series-gauge/update/demo.js
+++ b/samples/unit-tests/series-gauge/update/demo.js
@@ -1,13 +1,25 @@
 QUnit.test('Updating gauge series', assert => {
+    const clock = TestUtilities.lolexInstall();
+
     const chart = Highcharts.chart('container', {
         chart: {
-            type: 'gauge'
+            type: 'gauge',
+            animation: true
         },
         plotOptions: {
             gauge: {
                 dial: {
                     backgroundColor: '#ff0000'
                 }
+            }
+        },
+        yAxis: {
+            min: 0,
+            max: 200,
+            tickPixelInterval: 30,
+            labels: {
+                allowOverlap: false,
+                format: 'Really long tick label'
             }
         },
         series: [
@@ -29,9 +41,18 @@ QUnit.test('Updating gauge series', assert => {
         }
     });
 
+    clock.tick(600);
+
     assert.strictEqual(
         chart.series[0].points[0].graphic.element.getAttribute('fill'),
-        '#0000ff',
+        'rgb(0,0,255)',
         'The dial should be blue after update'
     );
+
+    assert.ok(
+        Object.values(chart.yAxis[0].ticks).some(t => t.label.opacity === 0),
+        '#15528: Some tick labels should still be hidden after update'
+    );
+
+    TestUtilities.lolexUninstall(clock);
 });

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -926,23 +926,30 @@ class Tick {
             horiz = axis.horiz,
             pos = tick.pos,
             tickmarkOffset = pick(tick.tickmarkOffset, axis.tickmarkOffset),
-            xy = tick.getPosition(horiz as any, pos, tickmarkOffset, old),
+            xy = tick.getPosition(!!horiz, pos, tickmarkOffset, old),
             x = xy.x,
             y = xy.y,
-            reverseCrisp = ((horiz && x === (axis.pos as any) + axis.len) ||
+            reverseCrisp = ((horiz && x === axis.pos + axis.len) ||
                 (!horiz && y === axis.pos)) ? -1 : 1; // #1480, #1687
 
+        old = !!old;
+
+        const labelOpacity = pick(
+            opacity,
+            tick.label && tick.label.newOpacity, // #15528
+            1
+        );
         opacity = pick(opacity, 1);
         this.isActive = true;
 
         // Create the grid line
-        this.renderGridLine(old as any, opacity as any, reverseCrisp);
+        this.renderGridLine(old, opacity, reverseCrisp);
 
         // create the tick mark
-        this.renderMark(xy, opacity as any, reverseCrisp);
+        this.renderMark(xy, opacity, reverseCrisp);
 
         // the label is created on init - now move it into place
-        this.renderLabel(xy, old as any, opacity as any, index as any);
+        this.renderLabel(xy, old, labelOpacity, index);
 
         tick.isNew = false;
 

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -544,7 +544,7 @@ class Tick {
      * @fires Highcharts.Tick#event:afterGetPosition
      */
     public getPosition(
-        horiz: boolean,
+        horiz: boolean|undefined,
         tickPos: number,
         tickmarkOffset: number,
         old?: boolean
@@ -926,13 +926,11 @@ class Tick {
             horiz = axis.horiz,
             pos = tick.pos,
             tickmarkOffset = pick(tick.tickmarkOffset, axis.tickmarkOffset),
-            xy = tick.getPosition(!!horiz, pos, tickmarkOffset, old),
+            xy = tick.getPosition(horiz, pos, tickmarkOffset, old),
             x = xy.x,
             y = xy.y,
             reverseCrisp = ((horiz && x === axis.pos + axis.len) ||
                 (!horiz && y === axis.pos)) ? -1 : 1; // #1480, #1687
-
-        old = !!old;
 
         const labelOpacity = pick(
             opacity,
@@ -966,7 +964,7 @@ class Tick {
      * @return {void}
      */
     public renderGridLine(
-        old: boolean,
+        old: boolean|undefined,
         opacity: number,
         reverseCrisp: number
     ): void {
@@ -1123,7 +1121,7 @@ class Tick {
      */
     public renderLabel(
         xy: Highcharts.TickPositionObject,
-        old: boolean,
+        old: boolean|undefined,
         opacity: number,
         index: number
     ): void {


### PR DESCRIPTION
Fixed #15528, `allowOverlap` set to `false` stopped working for axis tick labels after `update`.