### PR TITLE
bugfix/15560-dumbbell-destruction

### DIFF
--- a/samples/unit-tests/series-dumbbell/connector/demo.js
+++ b/samples/unit-tests/series-dumbbell/connector/demo.js
@@ -61,19 +61,31 @@ QUnit.test('Dumbbell connectors', function (assert) {
         connectorColor: 'blue'
     });
 
-    var point = chart.series[1].points[1],
-        lowerGraphic = point.lowerGraphic,
-        upperGraphic = point.upperGraphic,
-        connector = point.connector,
-        pointGraphics = [lowerGraphic, upperGraphic, connector];
+    const assertDestruction = msg => {
+        var point = chart.series[1].points[0],
+            lowerGraphic = point.lowerGraphic,
+            upperGraphic = point.upperGraphic,
+            connector = point.connector,
+            pointGraphics = [lowerGraphic, upperGraphic, connector];
 
-    point.remove();
+        point.remove();
 
-    pointGraphics.forEach(function (graphic) {
-        assert.strictEqual(
-            graphic.element,
-            undefined,
-            "All point's graphics should be removed."
-        );
+        pointGraphics.forEach(function (graphic) {
+            assert.strictEqual(
+                graphic && graphic.element,
+                undefined,
+                msg
+            );
+        });
+    };
+
+    assertDestruction("All point's graphics should be removed.");
+
+    chart.series[1].update({
+        marker: {
+            enabled: false
+        }
     });
+
+    assertDestruction('#15560: All point graphics should be destroyed when markers are disabled');
 });

--- a/ts/Series/Dumbbell/DumbbellPoint.ts
+++ b/ts/Series/Dumbbell/DumbbellPoint.ts
@@ -113,6 +113,15 @@ class DumbbellPoint extends AreaRangePoint {
 
         point.connector[verb](series.getConnectorAttribs(point));
     }
+
+    public destroy(): void {
+        // #15560
+        if (!this.graphic) {
+            this.graphic = this.connector;
+            this.connector = void 0 as any;
+        }
+        return super.destroy();
+    }
 }
 
 /* *


### PR DESCRIPTION
Fixed #15560, dumbbell connectors remained visible after changing series type when markers were not rendered.