### PR TITLE
bugfix/4406-addSeries-animation-clip

### DIFF
--- a/samples/unit-tests/series/clip/demo.js
+++ b/samples/unit-tests/series/clip/demo.js
@@ -84,6 +84,33 @@ QUnit.test('General series clip tests', assert => {
             '#15435: Shared clip should have been updated'
         );
 
+        chart.addSeries({
+            data: [3, 3, 3],
+            animation: true
+        });
+
+        assert.ok(
+            chart.series[4].sharedClipKey.includes('temporary'),
+            `Clippath should only exist until the animation is finished
+            (#4406).`
+        );
+
+        assert.strictEqual(
+            chart.sharedClips[chart.series[4].sharedClipKey].attr('width'),
+            0,
+            `Clippath's width immediately after addSeries should be 0
+            (series hasn't started animation yet) (#4406).`
+        );
+
+        setTimeout(() => {
+            assert.ok(
+                chart.sharedClips[chart.series[4].sharedClipKey]
+                    .attr('width') > 0,
+                `Clippath's width after addSeries should increase
+                (series is being animated) (#4406).`
+            );
+        }, 20);
+
         setTimeout(() => {
             chart.update(
                 {

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -2712,7 +2712,10 @@ class Chart {
                     fireEvent(chart, 'afterAddSeries', { series: series });
 
                     if (redraw) {
+                        // For series animation after addSeries(), (#4406)
+                        series.useTemporaryClip = true;
                         chart.redraw(animation);
+                        delete series.useTemporaryClip;
                     }
                 }
             );


### PR DESCRIPTION
Fixed #4406, series animation didn't work when adding a new series using the `chart.addSeries()` method.