### PR TITLE
Bugfix/13847-datalabels-in-navigator

### DIFF
--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -1144,3 +1144,74 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test('Navigator dafault dataLabels enabled, #13847.', function (assert) {
+    const chart = Highcharts.stockChart('container', {
+        navigator: {
+            enabled: true
+        },
+        plotOptions: {
+            series: {
+                cursor: 'pointer',
+                dataLabels: [{
+                    enabled: true,
+                    format: 'T2'
+                }]
+            }
+        },
+        series: [{
+            data: [{
+                y: 1624060740000,
+                x: 1624060740000,
+                today: 1593414458227
+            }, {
+                y: 1655510340000,
+                x: 1655510340000,
+                today: 1593414458227
+            }, {
+                y: 1607731140000,
+                x: 1607731140000,
+                today: 1594125209741
+            }]
+        }]
+    });
+
+    assert.equal(
+        chart.navigator.series[0].options.dataLabels[0].enabled,
+        false,
+        'DataLabels in Navigator should be disabled in default.'
+    );
+    // The problem was connected with merge Utils function,
+    // that doesn't handle merging objects with different structures.
+    chart.update({
+        navigator: {
+            series: {
+                dataLabels: {
+                    enabled: true
+                }
+            }
+        }
+    });
+
+    assert.equal(
+        chart.navigator.series[0].options.dataLabels[0].enabled,
+        true,
+        'DataLabels in Navigator should be enabled, if specified in options.'
+    );
+
+    chart.update({
+        navigator: {
+            series: {
+                dataLabels: [{
+                    enabled: true
+                }]
+            }
+        }
+    });
+
+    assert.equal(
+        chart.navigator.series[0].options.dataLabels[0].enabled,
+        true,
+        'DataLabels in Navigator should be enabled, if specified in options (wrapped with array).'
+    );
+});

--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -1147,16 +1147,12 @@ QUnit.test(
 
 QUnit.test('Navigator dafault dataLabels enabled, #13847.', function (assert) {
     const chart = Highcharts.stockChart('container', {
-        plotOptions: {
-            series: {
-                dataLabels: [{
-                    enabled: true,
-                    format: 'T2'
-                }]
-            }
-        },
         series: [{
-            data: [1, 2, 3]
+            data: [1, 2, 3],
+            dataLabels: [{
+                enabled: true,
+                format: 'T2'
+            }]
         }]
     });
 
@@ -1187,7 +1183,7 @@ QUnit.test('Navigator dafault dataLabels enabled, #13847.', function (assert) {
         navigator: {
             series: {
                 dataLabels: [{
-                    enabled: true
+                    enabled: false
                 }]
             }
         }
@@ -1195,7 +1191,7 @@ QUnit.test('Navigator dafault dataLabels enabled, #13847.', function (assert) {
 
     assert.equal(
         chart.navigator.series[0].options.dataLabels[0].enabled,
-        true,
+        false,
         'DataLabels in Navigator should be enabled, if specified in options (wrapped with array).'
     );
 });

--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -1147,12 +1147,8 @@ QUnit.test(
 
 QUnit.test('Navigator dafault dataLabels enabled, #13847.', function (assert) {
     const chart = Highcharts.stockChart('container', {
-        navigator: {
-            enabled: true
-        },
         plotOptions: {
             series: {
-                cursor: 'pointer',
                 dataLabels: [{
                     enabled: true,
                     format: 'T2'
@@ -1160,19 +1156,7 @@ QUnit.test('Navigator dafault dataLabels enabled, #13847.', function (assert) {
             }
         },
         series: [{
-            data: [{
-                y: 1624060740000,
-                x: 1624060740000,
-                today: 1593414458227
-            }, {
-                y: 1655510340000,
-                x: 1655510340000,
-                today: 1593414458227
-            }, {
-                y: 1607731140000,
-                x: 1607731140000,
-                today: 1594125209741
-            }]
+            data: [1, 2, 3]
         }]
     });
 

--- a/ts/Core/Navigator.ts
+++ b/ts/Core/Navigator.ts
@@ -2241,6 +2241,8 @@ class Navigator {
 
                 baseOptions = base.options || {};
                 baseNavigatorOptions = baseOptions.navigatorOptions || {};
+
+                userNavOptions.dataLabels = splat(userNavOptions.dataLabels);
                 mergedNavSeriesOptions = merge(
                     baseOptions,
                     navSeriesMixin,

--- a/ts/Core/Navigator.ts
+++ b/ts/Core/Navigator.ts
@@ -2242,6 +2242,8 @@ class Navigator {
                 baseOptions = base.options || {};
                 baseNavigatorOptions = baseOptions.navigatorOptions || {};
 
+                // The dataLabels options are not merged correctly
+                // if the settings are and array, #13847.
                 userNavOptions.dataLabels = splat(userNavOptions.dataLabels);
                 mergedNavSeriesOptions = merge(
                     baseOptions,

--- a/ts/Core/Navigator.ts
+++ b/ts/Core/Navigator.ts
@@ -2243,7 +2243,7 @@ class Navigator {
                 baseNavigatorOptions = baseOptions.navigatorOptions || {};
 
                 // The dataLabels options are not merged correctly
-                // if the settings are and array, #13847.
+                // if the settings are an array, #13847.
                 userNavOptions.dataLabels = splat(userNavOptions.dataLabels);
                 mergedNavSeriesOptions = merge(
                     baseOptions,


### PR DESCRIPTION
Fixed #13847, DataLabels in navigator should be disabled in the default configuration.