### PR TITLE
bugfix/15525-line-dataLabel-drilldown

### DIFF
--- a/samples/unit-tests/datalabels/events/demo.details
+++ b/samples/unit-tests/datalabels/events/demo.details
@@ -1,0 +1,5 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+...

--- a/samples/unit-tests/datalabels/events/demo.html
+++ b/samples/unit-tests/datalabels/events/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 500px;"></div>

--- a/samples/unit-tests/datalabels/events/demo.js
+++ b/samples/unit-tests/datalabels/events/demo.js
@@ -1,0 +1,31 @@
+QUnit.test('Datalabel click', assert => {
+    let clicked = false;
+
+    const chart = Highcharts.chart('container', {
+        series: [{
+            type: 'line',
+            data: [1, 2, 3],
+            dataLabels: {
+                enabled: true
+            },
+            events: {
+                click: () => {
+                    clicked = true;
+                }
+            }
+        }]
+    });
+
+    const controller = new TestController(chart);
+    const label = chart.series[0].points[0].dataLabel;
+    const x = chart.plotLeft + label.x + label.width / 2;
+    const y = chart.plotTop + label.y + label.height / 2;
+
+    controller.moveTo(x, y);
+    controller.click();
+
+    assert.ok(
+        clicked,
+        '#15525: Clicking data label should fire series click event'
+    );
+});

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -6281,21 +6281,27 @@ class Series {
             // The tracker is added to the series group, which is clipped, but
             // is covered by the marker group. So the marker group also needs to
             // capture events.
-            [series.tracker, series.markerGroup].forEach(function (
-                tracker: (SVGElement|undefined)
+            [
+                series.tracker,
+                series.markerGroup,
+                series.dataLabelsGroup
+            ].forEach(function (
+                tracker?: SVGElement
             ): void {
-                (tracker as any).addClass('highcharts-tracker')
-                    .on('mouseover', onMouseOver)
-                    .on('mouseout', function (e: PointerEvent): void {
-                        pointer.onTrackerMouseOut(e);
-                    });
+                if (tracker) {
+                    tracker.addClass('highcharts-tracker')
+                        .on('mouseover', onMouseOver)
+                        .on('mouseout', function (e: PointerEvent): void {
+                            pointer.onTrackerMouseOut(e);
+                        });
 
-                if (options.cursor && !chart.styledMode) {
-                    (tracker as any).css({ cursor: options.cursor });
-                }
+                    if (options.cursor && !chart.styledMode) {
+                        tracker.css({ cursor: options.cursor });
+                    }
 
-                if (hasTouch) {
-                    (tracker as any).on('touchstart', onMouseOver);
+                    if (hasTouch) {
+                        tracker.on('touchstart', onMouseOver);
+                    }
                 }
             });
         }

--- a/ts/Core/Series/SeriesOptions.d.ts
+++ b/ts/Core/Series/SeriesOptions.d.ts
@@ -96,7 +96,7 @@ export interface SeriesOptions {
     colors?: Array<ColorType>;
     connectNulls?: boolean;
     crisp?: (boolean|number);
-    cursor?: (string|CursorValue);
+    cursor?: CursorValue;
     dashStyle?: DashStyleValue;
     data?: Array<(PointOptions|PointShortOptions)>;
     dataSorting?: SeriesDataSortingOptions;


### PR DESCRIPTION
Fixed #15525, clicking data label did not drill down line and area series.