### PR TITLE
bugfix/#15432-mutated-zone-default-color

### DIFF
--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -816,7 +816,7 @@ function GLRenderer(
 
             // Note: Boost requires that zones are sorted!
             if (zones) {
-                pcolor = (zoneDefColor as any).rgba;
+                pcolor = (zoneDefColor as any).rgba.slice();
                 zones.some(function ( // eslint-disable-line no-loop-func
                     zone: SeriesZonesOptions,
                     i: number


### PR DESCRIPTION
Fixed #15432, boost zone default color is cloned instead of mutated.

The **zoneDefColor** rgba array is mutated for each point in the series:
```
(pcolor as any)[0] /= 255.0;
(pcolor as any)[1] /= 255.0;
(pcolor as any)[2] /= 255.0;
```
So the first point that uses **zoneDefColor** will have the right color and everything after will have rgb = [0, 0, 0] (black).
https://jsfiddle.net/5tcpuedx/