### PR TITLE
bugfix/15491-rangeselector-vertical-center

### DIFF
--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -203,6 +203,7 @@ class AST {
         'orient',
         'padding',
         'paddingLeft',
+        'paddingRight',
         'patternUnits',
         'r',
         'refX',

--- a/ts/Core/Renderer/SVG/SVGLabel.ts
+++ b/ts/Core/Renderer/SVG/SVGLabel.ts
@@ -429,17 +429,24 @@ class SVGLabel extends SVGElement {
         this.width = this.getPaddedWidth();
         this.height = (this.heightSetting || bBox.height || 0) + 2 * padding;
 
+        const metrics = this.renderer.fontMetrics(
+            style && style.fontSize,
+            this.text
+        );
+
         // Update the label-scoped y offset. Math.min because of inline
         // style (#9400)
         this.baselineOffset = padding + Math.min(
-            this.renderer.fontMetrics(
-                style && style.fontSize,
-                this.text
-            ).b,
+            metrics.b,
             // When the height is 0, there is no bBox, so go with the font
             // metrics. Highmaps CSS demos.
             bBox.height || Infinity
         );
+
+        // #15491: Vertical centering
+        if (this.heightSetting) {
+            this.baselineOffset += (this.heightSetting - metrics.h) / 2;
+        }
 
         if (this.needsBox) {
 

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -1403,7 +1403,7 @@ class RangeSelector {
                         this.chart.chartWidth - input.offsetWidth
                     ) + 'px',
                     top: (
-                        translateY - 1 - (input.offsetHeight - dateBox.height) / 2
+                        translateY - (input.offsetHeight - dateBox.height) / 2
                     ) + 'px'
                 });
             }
@@ -1549,7 +1549,8 @@ class RangeSelector {
             .label(text, 0)
             .addClass('highcharts-range-label')
             .attr({
-                padding: text ? 2 : 0
+                padding: text ? 2 : 0,
+                height: text ? options.inputBoxHeight : 0
             })
             .add(inputGroup);
 
@@ -2417,8 +2418,8 @@ class RangeSelector {
         const getAttribs = (text?: string): SVGAttributes => ({
             text: text ? `${text} ▾` : '▾',
             width: 'auto',
-            paddingLeft: 8,
-            paddingRight: 8
+            paddingLeft: pick(options.buttonTheme.paddingLeft, 8),
+            paddingRight: pick(options.buttonTheme.paddingRight, 8)
         } as unknown as SVGAttributes);
 
         if (zoomText) {
@@ -2496,9 +2497,9 @@ class RangeSelector {
             button.attr({
                 text: rangeOptions.text,
                 width: options.buttonTheme.width || 28,
-                paddingLeft: 'unset',
-                paddingRight: 'unset'
-            });
+                paddingLeft: pick(options.buttonTheme.paddingLeft, 'unset'),
+                paddingRight: pick(options.buttonTheme.paddingRight, 'unset')
+            } as SVGAttributes);
 
             if (button.state < 2) {
                 button.setState(0);

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -1913,11 +1913,13 @@ class RangeSelector {
         });
 
         this.zoomText = renderer
-            .text(
-                (lang as any).rangeSelectorZoom,
-                0,
-                15
-            )
+            .label((lang && lang.rangeSelectorZoom) || '', 0)
+            .attr({
+                padding: options.buttonTheme.padding,
+                height: options.buttonTheme.height,
+                paddingLeft: 0,
+                paddingRight: 0
+            })
             .add(this.buttonGroup);
 
         if (!this.chart.styledMode) {
@@ -2410,16 +2412,30 @@ class RangeSelector {
         const {
             buttons,
             buttonOptions,
+            chart,
             dropdown,
             options,
             zoomText
         } = this;
 
+        const userButtonTheme = (
+            chart.userOptions.rangeSelector &&
+            chart.userOptions.rangeSelector.buttonTheme
+        ) || {};
+
         const getAttribs = (text?: string): SVGAttributes => ({
             text: text ? `${text} ▾` : '▾',
             width: 'auto',
-            paddingLeft: pick(options.buttonTheme.paddingLeft, 8),
-            paddingRight: pick(options.buttonTheme.paddingRight, 8)
+            paddingLeft: pick(
+                options.buttonTheme.paddingLeft,
+                userButtonTheme.padding,
+                8
+            ),
+            paddingRight: pick(
+                options.buttonTheme.paddingRight,
+                userButtonTheme.padding,
+                8
+            )
         } as unknown as SVGAttributes);
 
         if (zoomText) {


### PR DESCRIPTION
Fixed #15491, range selector button text vertical centering did not work well and `paddingLeft` and `paddingRight` in `buttonTheme` were not supported.