### PR TITLE
bugfix/15593-stocktools-overflow

### DIFF
--- a/css/stocktools/gui.scss
+++ b/css/stocktools/gui.scss
@@ -41,6 +41,7 @@ $button-hover-color: #e6ebf5;
   height: 100%;
   position: absolute;
   z-index: 10;
+  top: 0px;
 }
 
 .highcharts-stocktools-popup {

--- a/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
+++ b/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
@@ -185,6 +185,10 @@ function (assert) {
         controller = new TestController(chart),
         button = chart.stockTools.listWrapper.childNodes[0].childNodes[0];
 
+    document.getElementsByClassName(
+        'highcharts-stocktools-wrapper'
+    )[0].style.display = 'none';
+
     // Show croshair with the label.
     controller.moveTo(200, 200);
     assert.strictEqual(

--- a/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
+++ b/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
@@ -185,9 +185,7 @@ function (assert) {
         controller = new TestController(chart),
         button = chart.stockTools.listWrapper.childNodes[0].childNodes[0];
 
-    document.getElementsByClassName(
-        'highcharts-stocktools-wrapper'
-    )[0].style.display = 'none';
+    chart.stockTools.wrapper.style.display = 'none';
 
     // Show croshair with the label.
     controller.moveTo(200, 200);

--- a/samples/unit-tests/stock-tools/bindings/demo.js
+++ b/samples/unit-tests/stock-tools/bindings/demo.js
@@ -42,9 +42,7 @@ QUnit.test('Bindings general tests', function (assert) {
     // CSS Styles are not loaded, so hide left bar. If we don't hide the bar,
     // chart will be rendered outside the visible page and events will not be
     // fired (TestController issue)
-    document.getElementsByClassName(
-        'highcharts-stocktools-wrapper'
-    )[0].style.display = 'none';
+    chart.stockTools.wrapper.style.display = 'none';
 
     // Number of tests is so high that events are not triggered on a chart,
     // temporary hide it:

--- a/ts/Stock/StockToolsGui.ts
+++ b/ts/Stock/StockToolsGui.ts
@@ -1415,7 +1415,7 @@ class Toolbar {
             className: PREFIX + 'stocktools-wrapper ' +
                 guiOptions.className + ' ' + bindingsClassName
         });
-        container.insertBefore(wrapper, container.childNodes[0]);
+        container.appendChild(wrapper);
 
         // Mimic event behaviour of being outside chart.container
         [

--- a/ts/Stock/StockToolsGui.ts
+++ b/ts/Stock/StockToolsGui.ts
@@ -1408,18 +1408,28 @@ class Toolbar {
             navigation = chart.options.navigation,
             bindingsClassName = navigation && navigation.bindingsClassName,
             listWrapper,
-            toolbar,
-            wrapper;
-
-        // #15593
-        css(container.parentNode, { position: 'relative' });
+            toolbar;
 
         // create main container
-        stockToolbar.wrapper = wrapper = createElement(DIV, {
+        const wrapper = stockToolbar.wrapper = createElement(DIV, {
             className: PREFIX + 'stocktools-wrapper ' +
                 guiOptions.className + ' ' + bindingsClassName
         });
-        container.parentNode.insertBefore(wrapper, container);
+        container.insertBefore(wrapper, container.childNodes[0]);
+
+        // Mimic event behaviour of being outside chart.container
+        [
+            'mousemove',
+            'click',
+            'touchstart'
+        ].forEach((eventType): void => {
+            addEvent(wrapper, eventType, (e): void =>
+                e.stopPropagation()
+            );
+        });
+        addEvent(wrapper, 'mouseover', (e: MouseEvent): void =>
+            chart.pointer.onContainerMouseLeave(e)
+        );
 
         // toolbar
         stockToolbar.toolbar = toolbar = createElement(UL, {

--- a/ts/Stock/StockToolsGui.ts
+++ b/ts/Stock/StockToolsGui.ts
@@ -1130,7 +1130,7 @@ class Toolbar {
         // create submenu container
         this.submenu = submenuWrapper = createElement(UL, {
             className: PREFIX + 'submenu-wrapper'
-        }, null as any, buttonWrapper);
+        }, void 0, buttonWrapper);
 
         // create submenu buttons and select the first one
         this.addSubmenuItems(buttonWrapper, button);
@@ -1218,7 +1218,7 @@ class Toolbar {
 
             _self.eventsToUnbind.push(
                 addEvent(
-                    (submenuBtn as any).mainButton,
+                    submenuBtn.mainButton,
                     'click',
                     function (): void {
                         (_self.switchSymbol as any)(this, buttonWrapper, true);
@@ -1299,12 +1299,12 @@ class Toolbar {
         buttonWrapper = createElement(LI, {
             className: pick(classMapping[btnName], '') + ' ' + userClassName,
             title: lang[btnName] || btnName
-        }, null as any, target);
+        }, void 0, target);
 
         // single button
         mainButton = createElement(SPAN, {
             className: PREFIX + 'menu-item-btn'
-        }, null as any, buttonWrapper);
+        }, void 0, buttonWrapper);
 
         // submenu
         if (items && items.length) {
@@ -1313,12 +1313,12 @@ class Toolbar {
             submenuArrow = createElement(SPAN, {
                 className: PREFIX + 'submenu-item-arrow ' +
                     PREFIX + 'arrow-right'
-            }, null as any, buttonWrapper);
+            }, void 0, buttonWrapper);
 
-            (submenuArrow.style as any)['background-image'] = 'url(' +
+            submenuArrow.style.backgroundImage = 'url(' +
                 this.iconsURL + 'arrow-bottom.svg)';
         } else {
-            (mainButton.style as any)['background-image'] = 'url(' +
+            mainButton.style.backgroundImage = 'url(' +
                 this.iconsURL + btnOptions.symbol + ')';
         }
 
@@ -1343,16 +1343,16 @@ class Toolbar {
 
         stockToolbar.arrowUp = createElement(DIV, {
             className: PREFIX + 'arrow-up'
-        }, null as any, stockToolbar.arrowWrapper);
+        }, void 0, stockToolbar.arrowWrapper);
 
-        (stockToolbar.arrowUp.style as any)['background-image'] =
+        stockToolbar.arrowUp.style.backgroundImage =
             'url(' + this.iconsURL + 'arrow-right.svg)';
 
         stockToolbar.arrowDown = createElement(DIV, {
             className: PREFIX + 'arrow-down'
-        }, null as any, stockToolbar.arrowWrapper);
+        }, void 0, stockToolbar.arrowWrapper);
 
-        (stockToolbar.arrowDown.style as any)['background-image'] =
+        stockToolbar.arrowDown.style.backgroundImage =
             'url(' + this.iconsURL + 'arrow-right.svg)';
 
         wrapper.insertBefore(
@@ -1379,7 +1379,7 @@ class Toolbar {
             addEvent(_self.arrowUp, 'click', function (): void {
                 if (targetY > 0) {
                     targetY -= step;
-                    (toolbar.style as any)['margin-top'] = -targetY + 'px';
+                    toolbar.style.marginTop = -targetY + 'px';
                 }
             })
         );
@@ -1391,7 +1391,7 @@ class Toolbar {
                     toolbar.offsetHeight + step
                 ) {
                     targetY += step;
-                    (toolbar.style as any)['margin-top'] = -targetY + 'px';
+                    toolbar.style.marginTop = -targetY + 'px';
                 }
             })
         );
@@ -1411,12 +1411,15 @@ class Toolbar {
             toolbar,
             wrapper;
 
+        // #15593
+        css(container.parentNode, { position: 'relative' });
+
         // create main container
         stockToolbar.wrapper = wrapper = createElement(DIV, {
             className: PREFIX + 'stocktools-wrapper ' +
                 guiOptions.className + ' ' + bindingsClassName
         });
-        (container.parentNode as any).insertBefore(wrapper, container);
+        container.parentNode.insertBefore(wrapper, container);
 
         // toolbar
         stockToolbar.toolbar = toolbar = createElement(UL, {
@@ -1473,9 +1476,9 @@ class Toolbar {
         // Show hide toolbar
         this.showhideBtn = showhideBtn = createElement(DIV, {
             className: PREFIX + 'toggle-toolbar ' + PREFIX + 'arrow-left'
-        }, null as any, wrapper);
+        }, void 0, wrapper);
 
-        (showhideBtn.style as any)['background-image'] =
+        showhideBtn.style.backgroundImage =
             'url(' + this.iconsURL + 'arrow-right.svg)';
 
         if (!visible) {
@@ -1524,9 +1527,9 @@ class Toolbar {
         redraw?: boolean
     ): void {
         const buttonWrapper = button.parentNode,
-            buttonWrapperClass = (buttonWrapper as any).classList.value,
+            buttonWrapperClass = buttonWrapper.classList.value,
             // main button in first level og GUI
-            mainNavButton = (buttonWrapper as any).parentNode.parentNode;
+            mainNavButton = buttonWrapper.parentNode.parentNode;
 
         // if the button is disabled, don't do anything
         if (buttonWrapperClass.indexOf('highcharts-disabled-btn') > -1) {
@@ -1540,9 +1543,9 @@ class Toolbar {
 
         // set icon
         mainNavButton
-            .querySelectorAll('.' + PREFIX + 'menu-item-btn')[0]
-            .style['background-image'] =
-            (button.style as any)['background-image'];
+            .querySelectorAll<HTMLElement>('.' + PREFIX + 'menu-item-btn')[0]
+            .style.backgroundImage =
+            button.style.backgroundImage;
 
         // set active class
         if (redraw) {
@@ -1569,7 +1572,7 @@ class Toolbar {
      *
      */
     public unselectAllButtons(button: HTMLDOMElement): void {
-        const activeButtons = (button.parentNode as any)
+        const activeButtons = button.parentNode
             .querySelectorAll('.' + activeClass);
 
         [].forEach.call(activeButtons, function (
@@ -1693,16 +1696,16 @@ extend(Chart.prototype, {
         options?: Highcharts.StockToolsOptions
     ): void {
         const chartOptions: Highcharts.Options = this.options,
-            lang: Highcharts.LangOptions = chartOptions.lang as any,
+            lang = chartOptions.lang,
             guiOptions = merge(
                 chartOptions.stockTools && chartOptions.stockTools.gui,
                 options && options.gui
             ),
-            langOptions = lang.stockTools && lang.stockTools.gui;
+            langOptions = lang && lang.stockTools && lang.stockTools.gui;
 
         this.stockTools = new Toolbar(guiOptions, langOptions, this);
 
-        if ((this.stockTools as any).guiEnabled) {
+        if (this.stockTools.guiEnabled) {
             this.isDirtyBox = true;
         }
     }
@@ -1721,8 +1724,8 @@ addEvent(NavigationBindings, 'selectButton', function (
         gui.unselectAllButtons(event.button);
 
         // If clicked on a submenu, select state for it's parent
-        if ((button.parentNode as any).className.indexOf(className) >= 0) {
-            button = (button.parentNode as any).parentNode;
+        if (button.parentNode.className.indexOf(className) >= 0) {
+            button = button.parentNode.parentNode;
         }
         // Set active class on the current button
         gui.selectButton(button);
@@ -1738,8 +1741,8 @@ addEvent(NavigationBindings, 'deselectButton', function (
 
     if (gui && gui.guiEnabled) {
         // If deselecting a button from a submenu, select state for it's parent
-        if ((button.parentNode as any).className.indexOf(className) >= 0) {
-            button = (button.parentNode as any).parentNode;
+        if (button.parentNode.className.indexOf(className) >= 0) {
+            button = button.parentNode.parentNode;
         }
         gui.selectButton(button);
     }
@@ -1765,5 +1768,5 @@ addEvent(H.Chart, 'render', function (): void {
     }
 });
 
-H.Toolbar = Toolbar as any;
+H.Toolbar = Toolbar;
 export default H.Toolbar;


### PR DESCRIPTION
Fixed #15593, Stock Tools overflowed the chart container when the class `chart` was not set on the container.