### PR TITLE
Docs: updated links for descriptionformatter a11y options

### DIFF
--- a/ts/Accessibility/Options/LangOptions.ts
+++ b/ts/Accessibility/Options/LangOptions.ts
@@ -187,10 +187,10 @@ const langOptions: Highcharts.LangOptions = {
      * [Highcharts Accessibility](https://www.highcharts.com/docs/chart-concepts/accessibility).
      *
      * For more dynamic control over the accessibility functionality, see
-     * [accessibility.pointDescriptionFormatter](#accessibility.pointDescriptionFormatter),
-     * [accessibility.seriesDescriptionFormatter](#accessibility.seriesDescriptionFormatter),
+     * [accessibility.point.descriptionFormatter](#accessibility.point.descriptionFormatter),
+     * [accessibility.series.descriptionFormatter](#accessibility.series.descriptionFormatter),
      * and
-     * [accessibility.screenReaderSectionFormatter](#accessibility.screenReaderSectionFormatter).
+     * [accessibility.screenReaderSection.beforeChartFormatter](#accessibility.screenReaderSection.beforeChartFormatter).
      *
      * @since        6.0.6
      * @optionparent lang.accessibility

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -732,7 +732,7 @@ class Series {
 
         /**
          * Same as
-         * [accessibility.pointDescriptionFormatter](#accessibility.pointDescriptionFormatter),
+         * [accessibility.series.descriptionFormatter](#accessibility.series.descriptionFormatter),
          * but for an individual series. Overrides the chart wide configuration.
          *
          * @type      {Function}


### PR DESCRIPTION
Fixed broken links to `accessibility.pointDescriptionFormatter`. See: https://api.highcharts.com/highcharts/lang.accessibility