### PR TITLE
bugfix/14742-scrolling-navigator-range

### DIFF
--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -1197,15 +1197,28 @@ QUnit.test('Navigator dafault dataLabels enabled, #13847.', function (assert) {
 });
 
 QUnit.test('Scrolling when the range is set, #14742.', function (assert) {
-    const chart = Highcharts.stockChart('container', {
-        xAxis: {
-            range: 15
-        },
-        series: [{
-            // 16 points -> range is 15
-            data: [7, 6, 9, 14, 8, 8, 5, 6, 4, 1, 3, 9, 4, 6, 7, 4]
-        }]
-    });
+    let cursor = 8;
+    const chunk = 3,
+        originalData = [7, 6, 9, 14, 8, 8, 5, 6, 4, 1, 3, 9, 4, 6, 7, 4],
+        chart = Highcharts.stockChart('container', {
+            xAxis: {
+                range: 15
+            },
+            series: [{
+                // 16 points -> range is 15
+                data: originalData
+            }]
+        });
+
+    function addPoints() {
+        const data = originalData.slice(cursor, cursor + chunk);
+        cursor += chunk;
+        for (let i = 0; i < data.length; i++) {
+            chart.series[0].addPoint(data[i], false, true);
+        }
+
+        chart.redraw();
+    }
 
     assert.strictEqual(
         chart.xAxis[0].min,
@@ -1241,5 +1254,20 @@ QUnit.test('Scrolling when the range is set, #14742.', function (assert) {
         chart.xAxis[0].min,
         0,
         `When all button enabled, adding point should not change the extremes.`
+    );
+
+    chart.xAxis[0].setExtremes(2, 5);
+    addPoints();
+
+    assert.strictEqual(
+        chart.xAxis[0].min,
+        chart.series[0].data[0].x,
+        `After changing the extremes and adding shifted points,
+        min should stay at the begging of the data.`
+    );
+    assert.ok(
+        chart.xAxis[0].max > chart.xAxis[0].min,
+        `After changing the extremes and adding shifted points,
+        the range should not equal zero.`
     );
 });

--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -1195,3 +1195,51 @@ QUnit.test('Navigator dafault dataLabels enabled, #13847.', function (assert) {
         'DataLabels in Navigator should be enabled, if specified in options (wrapped with array).'
     );
 });
+
+QUnit.test('Scrolling when the range is set, #14742.', function (assert) {
+    const chart = Highcharts.stockChart('container', {
+        xAxis: {
+            range: 15
+        },
+        series: [{
+            // 16 points -> range is 15
+            data: [7, 6, 9, 14, 8, 8, 5, 6, 4, 1, 3, 9, 4, 6, 7, 4]
+        }]
+    });
+
+    assert.strictEqual(
+        chart.xAxis[0].min,
+        0,
+        `Initially, for that number of points,
+        the navigator should be placed on the left.`
+    );
+
+    chart.series[0].addPoint(3);
+    assert.strictEqual(
+        chart.xAxis[0].min,
+        1,
+        `After adding the point, the number of sections between ticks
+        is greater than the range so the extremes should have changed.`
+    );
+
+    chart.series[0].addPoint(5);
+    assert.strictEqual(
+        chart.xAxis[0].min,
+        2,
+        `Adding another point should result in changing the extremes.`
+    );
+
+    chart.rangeSelector.clickButton(5); // all
+    assert.strictEqual(
+        chart.xAxis[0].min,
+        0,
+        `After selecting all, extremes should return to the initial one.`
+    );
+
+    chart.series[0].addPoint(5);
+    assert.strictEqual(
+        chart.xAxis[0].min,
+        0,
+        `When all button enabled, adding point should not change the extremes.`
+    );
+});

--- a/samples/unit-tests/series/addpoint-highstock/demo.js
+++ b/samples/unit-tests/series/addpoint-highstock/demo.js
@@ -143,15 +143,13 @@ QUnit.test('Add point with shift', function (assert) {
     maxBefore = chart.xAxis[0].max;
 
     add100();
-    assert.strictEqual(
-        chart.xAxis[0].min > minBefore,
-        true,
+    assert.ok(
+        chart.xAxis[0].min >= minBefore,
         'Stick left, data shifted'
     );
 
-    assert.strictEqual(
-        chart.xAxis[0].max > maxBefore,
-        true,
+    assert.ok(
+        chart.xAxis[0].max >= maxBefore,
         'Stick left, data shifted'
     );
 });

--- a/ts/Core/Navigator.ts
+++ b/ts/Core/Navigator.ts
@@ -218,6 +218,10 @@ declare global {
                 addEvent: boolean,
                 redraw?: boolean
             ): void;
+            public shouldStickToMin(
+                baseSeries: Series,
+                navigator: Navigator
+            ): boolean|undefined;
         }
     }
 }
@@ -2527,8 +2531,7 @@ class Navigator {
     public updatedDataHandler(this: Series): void {
         const navigator = this.chart.navigator as Highcharts.Navigator,
             baseSeries = this,
-            navigatorSeries = this.navigatorSeries,
-            xDataMin = navigator.getBaseSeriesMin((baseSeries.xData as any)[0]);
+            navigatorSeries = this.navigatorSeries;
 
         // If the scrollbar is scrolled all the way to the right, keep right as
         // new data  comes in.
@@ -2536,12 +2539,7 @@ class Navigator {
             Math.round(navigator.zoomedMin) === 0 :
             Math.round(navigator.zoomedMax) >= Math.round(navigator.size);
 
-        // Detect whether the zoomed area should stick to the minimum or
-        // maximum. If the current axis minimum falls outside the new updated
-        // dataset, we must adjust.
-        navigator.stickToMin = isNumber(baseSeries.xAxis.min) &&
-            ((baseSeries.xAxis.min as any) <= xDataMin) &&
-            (!this.chart.fixedRange || !navigator.stickToMax);
+        navigator.stickToMin = navigator.shouldStickToMin(baseSeries, navigator);
 
         // Set the navigator series data to the new data of the base series
         if (navigatorSeries && !navigator.hasNavigatorData) {
@@ -2553,6 +2551,36 @@ class Navigator {
                 false
             ); // #5414
         }
+    }
+
+    /**
+     * Detect if the zoomed area should stick to the minimum or maximum, #14742.
+     *
+     * @private
+     * @function Highcharts.Navigator#shouldStickToMin
+     */
+    public shouldStickToMin(baseSeries: Series, navigator: Navigator): boolean|undefined {
+        const xDataMin = navigator.getBaseSeriesMin((baseSeries.xData as any)[0]),
+            xAxis = baseSeries.xAxis,
+            max = xAxis.max,
+            min = xAxis.min,
+            range = xAxis.options.range;
+
+        let stickToMin: boolean = true;
+
+        if (isNumber(max) && isNumber(min)) {
+            // If range declared, stick to the minimum only if the range
+            // is smaller than the data set range.
+            if (range) {
+                stickToMin = max - xDataMin < range && (!this.chart.fixedRange);
+            } else {
+                // If the current axis minimum falls outside the new
+                // updated dataset, we must adjust.
+                stickToMin = min <= xDataMin && (!this.chart.fixedRange);
+            }
+        }
+
+        return stickToMin;
     }
 
     /**

--- a/ts/Core/Navigator.ts
+++ b/ts/Core/Navigator.ts
@@ -2554,7 +2554,7 @@ class Navigator {
     }
 
     /**
-     * Detect if the zoomed area should stick to the minimum or maximum, #14742.
+     * Detect if the zoomed area should stick to the minimum, #14742.
      *
      * @private
      * @function Highcharts.Navigator#shouldStickToMin
@@ -2571,12 +2571,12 @@ class Navigator {
         if (isNumber(max) && isNumber(min)) {
             // If range declared, stick to the minimum only if the range
             // is smaller than the data set range.
-            if (range) {
+            if (range && max - xDataMin > 0) {
                 stickToMin = max - xDataMin < range && (!this.chart.fixedRange);
             } else {
                 // If the current axis minimum falls outside the new
                 // updated dataset, we must adjust.
-                stickToMin = min <= xDataMin && (!this.chart.fixedRange);
+                stickToMin = min <= xDataMin;
             }
         }
 

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -950,6 +950,12 @@ class RangeSelector {
                 return;
             }
         } else if (type === 'all' && baseAxis) {
+            // If the navigator exist and the axis range is declared reset that
+            // range and from now on only use the range set by a user, #14742.
+            if (chart.navigator) {
+                chart.navigator.baseSeries[0].xAxis.options.range = void 0 as any;
+            }
+
             newMin = dataMin;
             newMax = dataMax as any;
         }

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -952,7 +952,7 @@ class RangeSelector {
         } else if (type === 'all' && baseAxis) {
             // If the navigator exist and the axis range is declared reset that
             // range and from now on only use the range set by a user, #14742.
-            if (chart.navigator) {
+            if (chart.navigator && chart.navigator.baseSeries[0]) {
                 chart.navigator.baseSeries[0].xAxis.options.range = void 0 as any;
             }
 


### PR DESCRIPTION
Fixed #14742, the axis `range` property was ignored when there were fewer data points.