### PR TITLE
bugfix/15607-random-zero-stackLabels

### DIFF
--- a/ts/Extensions/OverlappingDataLabels.ts
+++ b/ts/Extensions/OverlappingDataLabels.ts
@@ -69,7 +69,12 @@ addEvent(Chart, 'render', function collectAndHide(): void {
                 objectEach(stack, function (
                     stackItem: Highcharts.StackItem
                 ): void {
-                    labels.push(stackItem.label);
+                    if (
+                        stackItem.label &&
+                        stackItem.label.visibility !== 'hidden' // #15607
+                    ) {
+                        labels.push(stackItem.label);
+                    }
                 });
             });
         }
@@ -311,7 +316,6 @@ function hideOrShow(label: SVGElement, chart: Chart): boolean {
                     if (!chart.styledMode) {
                         label.css({ pointerEvents: newOpacity ? 'auto' : 'none' });
                     }
-                    label.visibility = newOpacity ? 'inherit' : 'hidden';
                 };
 
                 isLabelAffected = true;


### PR DESCRIPTION
Fixed #15607, random stack labels with the value 0 showed when zooming in.