### PR TITLE
Samples: tweaked end date for stock/lazy-loading demo

### DIFF
--- a/samples/stock/demo/lazy-loading/demo.js
+++ b/samples/stock/demo/lazy-loading/demo.js
@@ -19,10 +19,7 @@ fetch(dataURL)
     .then(data => {
 
         // Add a null value for the end date
-        data = [].concat(
-            data,
-            [[Date.UTC(2011, 9, 14, 19, 59), null, null, null, null]]
-        );
+        data.push([Date.UTC(2011, 9, 14, 18), null, null, null, null]);
 
         // create the chart
         Highcharts.stockChart('container', {


### PR DESCRIPTION
Changed the final date by 1h 59min to make it look better if the viewer were to select "1h" on the rangeselector without navigating. [Fiddle](https://jsfiddle.net/goransle/tj749wns/)