### PR TITLE
bugfix/15400-stock-clip-load-setSize

### DIFF
--- a/samples/unit-tests/series/clip/demo.js
+++ b/samples/unit-tests/series/clip/demo.js
@@ -128,8 +128,26 @@ QUnit.test('General series clip tests', assert => {
 
 QUnit.test('Each series should have their own clip-path, (#14549).', assert => {
     const chart = Highcharts.stockChart('container', {
-
+        chart: {
+            height: 300,
+            events: {
+                load() {
+                    this.setSize(null, 400, false);
+                }
+            }
+        },
+        series: [{
+            data: [1, 2, 3]
+        }]
     });
+
+    assert.strictEqual(
+        chart.series[0].clipBox.height,
+        chart.clipBox.height,
+        '#15400: clipBox should have been updated by setSize in load event'
+    );
+
+    chart.series[0].remove();
 
     chart.addAxis({
         id: 'line',

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -1167,7 +1167,7 @@ addEvent(Series, 'render', function (): void {
         // First render, initial clip box. clipBox also needs to be updated if
         // the series is rendered again before starting animating, in
         // compliance with a responsive rule (#13858).
-        if (!chart.hasRendered || (!this.clipBox && this.isDirty && !this.isDirtyData)) {
+        if (!chart.hasLoaded || (!this.clipBox && this.isDirty && !this.isDirtyData)) {
             this.clipBox = this.clipBox || merge(chart.clipBox);
             this.clipBox.width = this.xAxis.len;
             this.clipBox.height = clipHeight;


### PR DESCRIPTION
Fixed #15400, clipping was wrong after calling `setSize` in `load` event with stock loaded.