### PR TITLE
bugfix/15401-invalid-attribute-tableValues

### DIFF
--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -217,6 +217,7 @@ class AST {
         'stroke-linecap',
         'stroke-width',
         'style',
+        'tableValues',
         'result',
         'rowspan',
         'summary',


### PR DESCRIPTION
Fixed #15401, `tableValues` invalid attribute console warning.