### PR TITLE
bugfix/15654-inverted-shadow-offset

### DIFF
--- a/samples/unit-tests/svgrenderer/shadows/demo.js
+++ b/samples/unit-tests/svgrenderer/shadows/demo.js
@@ -68,6 +68,9 @@ QUnit.test('Series shadows', function (assert) {
     );
 
     chart = Highcharts.chart('container', {
+        chart: {
+            inverted: true
+        },
         series: [
             {
                 shadow: true,
@@ -79,7 +82,7 @@ QUnit.test('Series shadows', function (assert) {
     attributes = [
         'stroke="red"',
         'stroke-opacity="0.3"',
-        'transform="translate(5, 10)'
+        'transform="translate(10, 5)'
     ];
 
     chart.series[0].update({

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -2099,8 +2099,8 @@ class SVGElement implements SVGElementLike {
             oldShadowOptions = this.oldShadowOptions,
             defaultShadowOptions: ShadowOptionsObject = {
                 color: palette.neutralColor100,
-                offsetX: 1,
-                offsetY: 1,
+                offsetX: this.parentInverted ? -1 : 1,
+                offsetY: this.parentInverted ? -1 : 1,
                 opacity: 0.15,
                 width: 3
             };
@@ -2144,7 +2144,7 @@ class SVGElement implements SVGElementLike {
         } else if (!this.shadows) {
             shadowElementOpacity = options.opacity / options.width;
             transform = this.parentInverted ?
-                'translate(-1,-1)' :
+                `translate(${options.offsetY}, ${options.offsetX})` :
                 `translate(${options.offsetX}, ${options.offsetY})`;
             for (i = 1; i <= options.width; i++) {
                 shadow = element.cloneNode(false) as any;


### PR DESCRIPTION
Fixed #15654, shadow offset did not get applied on inverted charts.