### PR TITLE
bugfix/15640-legend-state-keyboard-nav

### DIFF
--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -25,7 +25,8 @@ const {
     addEvent,
     extend,
     find,
-    fireEvent
+    fireEvent,
+    isNumber
 } = U;
 
 import AccessibilityComponent from '../AccessibilityComponent.js';
@@ -149,10 +150,11 @@ function shouldDoLegendA11y(chart: Chart): boolean {
  */
 H.Chart.prototype.highlightLegendItem = function (ix: number): boolean {
     const items = this.legend.allItems,
-        oldIx: number = this.highlightedLegendItemIx as any;
+        oldIx = this.accessibility &&
+            this.accessibility.components.legend.highlightedLegendItemIx;
 
     if (items[ix]) {
-        if (items[oldIx]) {
+        if (isNumber(oldIx) && items[oldIx]) {
             fireEvent((items[oldIx].legendGroup as any).element, 'mouseout');
         }
 


### PR DESCRIPTION
Fixed #15640, legend items lost disabled state on keyboard navigation.