### PR TITLE
bugfix/15646-boost-zone-invisible

### DIFF
--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -417,29 +417,29 @@ function GLRenderer(
             zoneColors = [];
 
             zones.forEach(function (zone, i): void {
-                if (!zoneDefColor && typeof zone.value === 'undefined') {
-                    zoneDefColor = new Color(zone.color).rgba as Color.RGBA;
-                }
                 if (zone.color) {
                     const zoneColor = color(zone.color).rgba as Color.RGBA;
                     zoneColor[0] /= 255.0;
                     zoneColor[1] /= 255.0;
                     zoneColor[2] /= 255.0;
                     zoneColors[i] = zoneColor;
+
+                    if (!zoneDefColor && typeof zone.value === 'undefined') {
+                        zoneDefColor = zoneColor;
+                    }
                 }
             });
 
             if (!zoneDefColor) {
-                const color = (
+                const seriesColor = (
                     (series.pointAttribs && series.pointAttribs().fill) ||
                     series.color
                 );
-                zoneDefColor = new Color(color).rgba as Color.RGBA;
+                zoneDefColor = color(seriesColor).rgba as Color.RGBA;
+                zoneDefColor[0] /= 255.0;
+                zoneDefColor[1] /= 255.0;
+                zoneDefColor[2] /= 255.0;
             }
-
-            zoneDefColor[0] /= 255.0;
-            zoneDefColor[1] /= 255.0;
-            zoneDefColor[2] /= 255.0;
         }
 
         if (chart.inverted) {

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -779,12 +779,12 @@ function GLRenderer(
 
             if (x > xMax && closestRight.x < xMax) {
                 closestRight.x = x;
-                closestRight.y = y as any;
+                closestRight.y = y;
             }
 
             if (x < xMin && closestLeft.x > xMin) {
                 closestLeft.x = x;
-                closestLeft.y = y as any;
+                closestLeft.y = y;
             }
 
             if (y === null && connectNulls) {
@@ -825,7 +825,7 @@ function GLRenderer(
 
                     if (zoneAxis === 'x') {
                         if (typeof zone.value !== 'undefined' && x <= zone.value) {
-                            if (!last || x >= (last.value as any)) {
+                            if (zone.color && (!last || x >= (last.value as any))) {
                                 pcolor = color(zone.color).rgba as any;
                             }
                             return true;
@@ -834,7 +834,7 @@ function GLRenderer(
                     }
 
                     if (typeof zone.value !== 'undefined' && y <= zone.value) {
-                        if (!last || y >= (last.value as any)) {
+                        if (zone.color && (!last || y >= (last.value as any))) {
                             pcolor = color(zone.color).rgba as any;
                         }
                         return true;
@@ -842,9 +842,9 @@ function GLRenderer(
                     return false;
                 });
 
-                (pcolor as any)[0] /= 255.0;
-                (pcolor as any)[1] /= 255.0;
-                (pcolor as any)[2] /= 255.0;
+                pcolor[0] /= 255.0;
+                pcolor[1] /= 255.0;
+                pcolor[2] /= 255.0;
 
             }
 

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -398,6 +398,7 @@ function GLRenderer(
             firstPoint = true,
             zoneAxis = options.zoneAxis || 'y',
             zones = options.zones || false,
+            zoneColors: Array<Color.RGBA>,
             zoneDefColor: (Color.RGBA|undefined) = false as any,
             threshold: number = options.threshold as any,
             gapSize: number = false as any;
@@ -413,12 +414,19 @@ function GLRenderer(
         }
 
         if (zones) {
-            zones.some(function (zone): (boolean) {
-                if (typeof zone.value === 'undefined') {
+            zoneColors = [];
+
+            zones.forEach(function (zone, i): void {
+                if (!zoneDefColor && typeof zone.value === 'undefined') {
                     zoneDefColor = new Color(zone.color).rgba as Color.RGBA;
-                    return true;
                 }
-                return false;
+                if (zone.color) {
+                    const zoneColor = color(zone.color).rgba as Color.RGBA;
+                    zoneColor[0] /= 255.0;
+                    zoneColor[1] /= 255.0;
+                    zoneColor[2] /= 255.0;
+                    zoneColors[i] = zoneColor;
+                }
             });
 
             if (!zoneDefColor) {
@@ -829,8 +837,8 @@ function GLRenderer(
 
                     if (zoneAxis === 'x') {
                         if (typeof zone.value !== 'undefined' && x <= zone.value) {
-                            if (zone.color && (!last || x >= (last.value as any))) {
-                                zoneColor = color(zone.color).rgba as any;
+                            if (zoneColors[i] && (!last || x >= (last.value as any))) {
+                                zoneColor = zoneColors[i];
                             }
                             return true;
                         }
@@ -838,8 +846,8 @@ function GLRenderer(
                     }
 
                     if (typeof zone.value !== 'undefined' && y <= zone.value) {
-                        if (zone.color && (!last || y >= (last.value as any))) {
-                            zoneColor = color(zone.color).rgba as any;
+                        if (zoneColors[i] && (!last || y >= (last.value as any))) {
+                            zoneColor = zoneColors[i];
                         }
                         return true;
                     }
@@ -847,12 +855,6 @@ function GLRenderer(
                 });
 
                 pcolor = zoneColor || zoneDefColor || pcolor;
-
-                if (zoneColor) {
-                    pcolor[0] /= 255.0;
-                    pcolor[1] /= 255.0;
-                    pcolor[2] /= 255.0;
-                }
             }
 
             // Skip translations - temporary floating point fix


### PR DESCRIPTION
Fixed #15646, zones with no color set were invisible in boosted chart.