### PR TITLE
bugfix/scrollablePlotArea-tooltip-getValidPoints

### DIFF
--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -639,15 +639,15 @@ class Chart {
             plotBox,
             plotLeft,
             plotTop,
-            scrollablePlotBox,
-            scrollingContainer: {
-                scrollLeft,
-                scrollTop
-            } = {
-                scrollLeft: 0,
-                scrollTop: 0
-            }
+            scrollablePlotBox
         } = this;
+
+        let scrollLeft = 0,
+            scrollTop = 0;
+
+        if (options.visiblePlotOnly && this.scrollingContainer) {
+            ({ scrollLeft, scrollTop } = this.scrollingContainer);
+        }
 
         const series = options.series;
         const box = (options.visiblePlotOnly && scrollablePlotBox) || plotBox;


### PR DESCRIPTION
Fixed a `scrollablePlotArea` regression, tooltip did not show sometimes.

Repro:
1. Open https://www.highcharts.com/samples/highcharts/chart/scrollable-plotarea
2. Scroll left