### PR TITLE
bugfix/15676-stock-scrollablePlotArea-clip

### DIFF
--- a/samples/unit-tests/scrollable-plotarea/options/demo.html
+++ b/samples/unit-tests/scrollable-plotarea/options/demo.html
@@ -1,4 +1,4 @@
-<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 
 <div id="qunit"></div>

--- a/samples/unit-tests/scrollable-plotarea/options/demo.js
+++ b/samples/unit-tests/scrollable-plotarea/options/demo.js
@@ -73,4 +73,9 @@ QUnit.test('fixedRenderer options', function (assert) {
         chart.options.chart.style.fontFamily,
         'fixedRenderer should inherit style from options'
     );
+
+    assert.notOk(
+        chart.series[0].clipBox,
+        '#15676: Stock clipping should not be applied when scrollablePlotArea is enabled'
+    );
 });

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -1145,7 +1145,9 @@ addEvent(Series, 'render', function (): void {
         !chart.polar &&
         this.xAxis &&
         !this.xAxis.isRadial && // Gauge, #6192
-        this.options.clip !== false // #15128
+        this.options.clip !== false && // #15128
+        !chart.scrollablePixelsX && // #15676
+        !chart.scrollablePixelsY
     ) {
 
         clipHeight = this.yAxis.len;


### PR DESCRIPTION
Fixed #15676, clipping was wrong with `scrollablePlotArea` enabled and stock loaded.