### PR TITLE
Bugfix/15508-stock-tools-measure-x-annotation

### DIFF
--- a/samples/unit-tests/annotations/annotations-measure/demo.js
+++ b/samples/unit-tests/annotations/annotations-measure/demo.js
@@ -52,7 +52,30 @@ QUnit.test('#13664 - annotation measure on yAxis', function (assert) {
     assert.close(
         chart.annotations[0].shapesGroup.getBBox().x,
         chart.annotations[0].labels[0].graphic.anchorX,
-        5,
+        0.5,
         "Annotation's label's X position should be close to the X position of the annotation."
+    );
+
+    chart.update({
+        chart: {
+            spacingTop: 100
+        },
+        title: {
+            text: ''
+        }
+    });
+
+    assert.close(
+        chart.annotations[0].shapesGroup.getBBox().y,
+        chart.annotations[0].labels[0].graphic.anchorY,
+        0.5,
+        "Annotation's label's Y position should be close to the Y position of the annotation after updates."
+    );
+
+    assert.close(
+        chart.annotations[0].shapesGroup.getBBox().x,
+        chart.annotations[0].labels[0].graphic.anchorX,
+        0.5,
+        "Annotation's label's X position should be close to the X position of the annotation after updates."
     );
 });

--- a/samples/unit-tests/annotations/annotations-measure/demo.js
+++ b/samples/unit-tests/annotations/annotations-measure/demo.js
@@ -47,14 +47,16 @@ QUnit.test('#13664 - annotation measure on yAxis', function (assert) {
         bbox.y,
         chart.annotations[0].labels[0].graphic.anchorY,
         0.5,
-        "Annotation's label's Y position should be close to the Y position of the annotation."
+        `Annotation's label's Y position should be
+        close to the Y position of the annotation.`
     );
 
     assert.close(
         bbox.x,
         chart.annotations[0].labels[0].graphic.anchorX,
         0.5,
-        "Annotation's label's X position should be close to the X position of the annotation."
+        `Annotation's label's X position should
+        be close to the X position of the annotation.`
     );
 
     chart.update({
@@ -72,13 +74,15 @@ QUnit.test('#13664 - annotation measure on yAxis', function (assert) {
         bbox.y,
         chart.annotations[0].labels[0].graphic.anchorY,
         0.5,
-        "Annotation's label's Y position should be close to the Y position of the annotation after updates."
+        `Annotation's label's Y position should be close
+        to the Y position of the annotation after updates.`
     );
 
     assert.close(
         bbox.x,
         chart.annotations[0].labels[0].graphic.anchorX,
         0.5,
-        "Annotation's label's X position should be close to the X position of the annotation after updates."
+        `Annotation's label's X position should be close
+        to the X position of the annotation after updates.`
     );
 });

--- a/samples/unit-tests/annotations/annotations-measure/demo.js
+++ b/samples/unit-tests/annotations/annotations-measure/demo.js
@@ -29,37 +29,30 @@ QUnit.test('#13664 - annotation measure on yAxis', function (assert) {
             }
         ],
 
-        series: [
-            {
-                data: [1, 2, 3, 2, 3, 4, 5, 6, 7, 8, 3, 2, 4, 4, 4, 4, 3]
-            },
-            {
-                yAxis: 1,
-                data: [
-                    1,
-                    2,
-                    3,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8,
-                    3,
-                    2,
-                    4,
-                    4,
-                    4,
-                    4,
-                    3
-                ].reverse()
-            }
-        ]
+        series: [{
+            data: [1, 2, 3, 2, 3, 4, 5, 6, 7, 8, 3, 2, 4, 4, 4, 4, 3]
+        }, {
+            yAxis: 1,
+            data: [6, 7, 8, 3, 2, 4, 4, 4, 4, 3, 3, 2, 4, 4, 4, 4, 3]
+        }]
     });
 
     assert.ok(
         chart.annotations[0].shapesGroup.getBBox().y === chart.yAxis[1].top,
         'Annotation measure should be visible on vary yaxis (#13664).'
+    );
+
+    assert.close(
+        chart.annotations[0].shapesGroup.getBBox().y,
+        chart.annotations[0].labels[0].graphic.anchorY,
+        0.5,
+        "Annotation's label's Y position should be close to the Y position of the annotation."
+    );
+
+    assert.close(
+        chart.annotations[0].shapesGroup.getBBox().x,
+        chart.annotations[0].labels[0].graphic.anchorX,
+        5,
+        "Annotation's label's X position should be close to the X position of the annotation."
     );
 });

--- a/samples/unit-tests/annotations/annotations-measure/demo.js
+++ b/samples/unit-tests/annotations/annotations-measure/demo.js
@@ -37,20 +37,21 @@ QUnit.test('#13664 - annotation measure on yAxis', function (assert) {
         }]
     });
 
+    let bbox = chart.annotations[0].shapesGroup.getBBox();
     assert.ok(
-        chart.annotations[0].shapesGroup.getBBox().y === chart.yAxis[1].top,
+        bbox.y === chart.yAxis[1].top,
         'Annotation measure should be visible on vary yaxis (#13664).'
     );
 
     assert.close(
-        chart.annotations[0].shapesGroup.getBBox().y,
+        bbox.y,
         chart.annotations[0].labels[0].graphic.anchorY,
         0.5,
         "Annotation's label's Y position should be close to the Y position of the annotation."
     );
 
     assert.close(
-        chart.annotations[0].shapesGroup.getBBox().x,
+        bbox.x,
         chart.annotations[0].labels[0].graphic.anchorX,
         0.5,
         "Annotation's label's X position should be close to the X position of the annotation."
@@ -65,15 +66,17 @@ QUnit.test('#13664 - annotation measure on yAxis', function (assert) {
         }
     });
 
+    bbox = chart.annotations[0].shapesGroup.getBBox();
+
     assert.close(
-        chart.annotations[0].shapesGroup.getBBox().y,
+        bbox.y,
         chart.annotations[0].labels[0].graphic.anchorY,
         0.5,
         "Annotation's label's Y position should be close to the Y position of the annotation after updates."
     );
 
     assert.close(
-        chart.annotations[0].shapesGroup.getBBox().x,
+        bbox.x,
         chart.annotations[0].labels[0].graphic.anchorX,
         0.5,
         "Annotation's label's X position should be close to the X position of the annotation after updates."

--- a/ts/Extensions/Annotations/Annotations.ts
+++ b/ts/Extensions/Annotations/Annotations.ts
@@ -165,6 +165,8 @@ declare global {
             point?: (string|MockPointOptions);
             itemType?: string;
             vertical?: VerticalAlignValue;
+            xAxis?: number;
+            yAxis?: number;
         }
         interface AnnotationsOptions extends AnnotationControllableOptionsObject { // @todo AnnotationOptions.d.ts
             animation: Partial<AnimationOptions>;

--- a/ts/Extensions/Annotations/Annotations.ts
+++ b/ts/Extensions/Annotations/Annotations.ts
@@ -165,8 +165,8 @@ declare global {
             point?: (string|MockPointOptions);
             itemType?: string;
             vertical?: VerticalAlignValue;
-            xAxis?: number;
-            yAxis?: number;
+            xAxis?: number|string;
+            yAxis?: number|string;
         }
         interface AnnotationsOptions extends AnnotationControllableOptionsObject { // @todo AnnotationOptions.d.ts
             animation: Partial<AnimationOptions>;

--- a/ts/Extensions/Annotations/Types/Measure.ts
+++ b/ts/Extensions/Annotations/Types/Measure.ts
@@ -19,7 +19,8 @@ import U from '../../../Core/Utilities.js';
 const {
     extend,
     isNumber,
-    merge
+    merge,
+    pick
 } = U;
 
 /* eslint-disable no-invalid-this, valid-jsdoc */
@@ -505,6 +506,8 @@ class Measure extends Annotation {
                 y: 0,
                 verticalAlign: 'top',
                 crop: true,
+                xAxis: 0,
+                yAxis: 0,
                 point: function (target: any): ExtendedPositionObject {
                     const annotation: Measure = target.annotation;
                     const options = target.options;
@@ -512,9 +515,9 @@ class Measure extends Annotation {
                     return {
                         x: annotation.xAxisMin,
                         y: annotation.yAxisMin,
-                        xAxis: options.xAxis,
-                        yAxis: options.yAxis
-                    };
+                        xAxis: pick(typeOptions.xAxis, options.xAxis),
+                        yAxis: pick(typeOptions.yAxis, options.yAxis)
+                      };
                 } as any,
                 text: (formatter && formatter.call(this)) ||
                     Measure.calculations.defaultFormatter.call(this)

--- a/ts/Extensions/Annotations/Types/Measure.ts
+++ b/ts/Extensions/Annotations/Types/Measure.ts
@@ -24,11 +24,6 @@ const {
 } = U;
 
 /* eslint-disable no-invalid-this, valid-jsdoc */
-interface ExtendedPositionObject extends PositionObject{
-    yAxis: number;
-    xAxis: number;
-}
-
 class Measure extends Annotation {
 
     /* *
@@ -509,7 +504,7 @@ class Measure extends Annotation {
                 crop: true,
                 xAxis: 0,
                 yAxis: 0,
-                point: function (target: any): ExtendedPositionObject {
+                point: function (target: any): MockPointOptions {
                     const annotation: Measure = target.annotation,
                         options = target.options;
 

--- a/ts/Extensions/Annotations/Types/Measure.ts
+++ b/ts/Extensions/Annotations/Types/Measure.ts
@@ -23,6 +23,10 @@ const {
 } = U;
 
 /* eslint-disable no-invalid-this, valid-jsdoc */
+interface ExtendedPositionObject extends PositionObject{
+    yAxis: number;
+    xAxis: number;
+}
 
 class Measure extends Annotation {
 
@@ -498,22 +502,18 @@ class Measure extends Annotation {
                 dashStyle: 'Dash',
                 overflow: 'allow',
                 align: 'left',
-                vertical: 'top',
+                y: 0,
+                verticalAlign: 'top',
                 crop: true,
-                point: function (target: any): PositionObject {
-                    const annotation: Measure = target.annotation,
-                        chart = annotation.chart,
-                        inverted = chart.inverted,
-                        xAxis = chart.xAxis[typeOptions.xAxis],
-                        yAxis = chart.yAxis[typeOptions.yAxis],
-                        top = chart.plotTop,
-                        left = chart.plotLeft;
+                point: function (target: any): ExtendedPositionObject {
+                    const annotation: Measure = target.annotation;
+                    const options = target.options;
 
                     return {
-                        x: (inverted ? top : 10) +
-                            xAxis.toPixels(annotation.xAxisMin, !inverted),
-                        y: (inverted ? -left + 10 : top) +
-                            yAxis.toPixels(annotation.yAxisMin)
+                        x: annotation.xAxisMin,
+                        y: annotation.yAxisMin,
+                        xAxis: options.xAxis,
+                        yAxis: options.yAxis
                     };
                 } as any,
                 text: (formatter && formatter.call(this)) ||

--- a/ts/Extensions/Annotations/Types/Measure.ts
+++ b/ts/Extensions/Annotations/Types/Measure.ts
@@ -504,13 +504,14 @@ class Measure extends Annotation {
                 overflow: 'allow',
                 align: 'left',
                 y: 0,
+                x: 0,
                 verticalAlign: 'top',
                 crop: true,
                 xAxis: 0,
                 yAxis: 0,
                 point: function (target: any): ExtendedPositionObject {
-                    const annotation: Measure = target.annotation;
-                    const options = target.options;
+                    const annotation: Measure = target.annotation,
+                        options = target.options;
 
                     return {
                         x: annotation.xAxisMin,

--- a/ts/Extensions/Annotations/Types/Measure.ts
+++ b/ts/Extensions/Annotations/Types/Measure.ts
@@ -517,7 +517,7 @@ class Measure extends Annotation {
                         y: annotation.yAxisMin,
                         xAxis: pick(typeOptions.xAxis, options.xAxis),
                         yAxis: pick(typeOptions.yAxis, options.yAxis)
-                      };
+                    };
                 } as any,
                 text: (formatter && formatter.call(this)) ||
                     Measure.calculations.defaultFormatter.call(this)


### PR DESCRIPTION
Fixed #15508, the measure annotation's label wasn't correctly rendered inside the annotation.