### PR TITLE
bugfix/15685-boost-scatter-ghost

### DIFF
--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -1255,10 +1255,7 @@ function GLRenderer(
 
             if (
                 s.segments.length === 0 ||
-                (
-                    (s as any).segmentslength &&
-                    s.segments[0].from === s.segments[0].to
-                )
+                s.segments[0].from === s.segments[0].to
             ) {
                 return;
             }


### PR DESCRIPTION
Fixed #15685, boosted scatter chart with empty first series rendered ghost points.