### PR TITLE
bugfix/15692-gantt-axis-month-year

### DIFF
--- a/samples/unit-tests/gantt/grid-axis/demo.js
+++ b/samples/unit-tests/gantt/grid-axis/demo.js
@@ -1848,6 +1848,24 @@ QUnit.test(
             chart.xAxis[1].tickPositions,
             'The secondary axis should have longer range ticks'
         );
+
+        chart.update({
+            series: [{
+                data: [{
+                    start: Date.UTC(2019, 7, 2),
+                    end: Date.UTC(2019, 11, 1)
+                }]
+            }]
+        }, true, true);
+        chart.setSize(400);
+
+        const axis = chart.xAxis[1];
+
+        assert.strictEqual(
+            axis.ticks[axis.tickPositions[0]].label.textStr,
+            '2019',
+            '#15692: Primary axis should show years'
+        );
     }
 );
 

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -439,6 +439,9 @@ class Tick {
                     text: ''
                 });
             };
+        } else {
+            // #15692
+            tick.shortenLabel = void 0;
         }
 
         // Call only after first render


### PR DESCRIPTION
Fixed #15692, gantt chart grid axis did not update from months to years when resizing down.