### PR TITLE
bugfix/15708-heatmap-null-point-class

### DIFF
--- a/samples/unit-tests/series-heatmap/marker/demo.js
+++ b/samples/unit-tests/series-heatmap/marker/demo.js
@@ -20,7 +20,7 @@ QUnit.test('General marker tests', function (assert) {
         series: [
             {
                 data: [
-                    [0, 0, 1],
+                    [0, 0, null],
                     [0, 1, 1.1],
                     [0, 2, 1.2],
                     [1, 0, 2],
@@ -205,5 +205,10 @@ QUnit.test('General marker tests', function (assert) {
         point.graphic.element.tagName === 'image' && point.hasImage,
         true,
         "The image should set as a point's marker."
+    );
+
+    assert.ok(
+        heatmap.points[0].graphic.hasClass('highcharts-null-point'),
+        '#15708: Null points should have null-point class'
     );
 });

--- a/ts/Series/Heatmap/HeatmapSeries.ts
+++ b/ts/Series/Heatmap/HeatmapSeries.ts
@@ -420,10 +420,15 @@ class HeatmapSeries extends ScatterSeries {
         if (seriesMarkerOptions.enabled || this._hasPointMarkers) {
             Series.prototype.drawPoints.call(this);
             this.points.forEach((point): void => {
-                point.graphic &&
-                (point.graphic as any)[
-                    this.chart.styledMode ? 'css' : 'animate'
-                ](this.colorAttribs(point));
+                if (point.graphic) {
+                    (point.graphic as any)[
+                        this.chart.styledMode ? 'css' : 'animate'
+                    ](this.colorAttribs(point));
+
+                    if (point.value === null) { // #15708
+                        point.graphic.addClass('highcharts-null-point');
+                    }
+                }
             });
         }
     }


### PR DESCRIPTION
Fixed #15708, heatmap null points missed `highcharts-null-point` class.