### PR TITLE
bugfix/15706-lastVisiblePrice-color-styledMode

### DIFF
--- a/samples/unit-tests/indicator-current-price/recalculations/demo.js
+++ b/samples/unit-tests/indicator-current-price/recalculations/demo.js
@@ -14,6 +14,14 @@ QUnit.test('Test current and last price indicator.', function (assert) {
                         enabled: true
                     }
                 }
+            }, {
+                data: [0],
+                lastVisiblePrice: {
+                    enabled: true,
+                    label: {
+                        enabled: true
+                    }
+                }
             }
         ]
     });
@@ -36,6 +44,11 @@ QUnit.test('Test current and last price indicator.', function (assert) {
         chart.series[0].lastVisiblePrice.y,
         15,
         'The last visible price is correct.'
+    );
+
+    assert.ok(
+        chart.series[1].crossLabel.hasClass('highcharts-color-1'),
+        '#15706: Second lastVisiblePrice label should have correct color class'
     );
 });
 

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -783,9 +783,10 @@ addEvent(Axis, 'afterDrawCrosshair', function (
                 options.shape || 'callout'
             )
             .addClass(
-                'highcharts-crosshair-label' + (
-                    this.series[0] &&
-                    ' highcharts-color-' + this.series[0].colorIndex
+                'highcharts-crosshair-label highcharts-color-' + (
+                    point ?
+                        point.series.colorIndex :
+                        this.series[0] && this.series[0].colorIndex
                 )
             )
             .attr({


### PR DESCRIPTION
Fixed #15706, `lastVisiblePrice` label color class did not always match the series color class.