### PR TITLE
tools/ci-nightly-context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -547,6 +547,7 @@ workflows:
           notify_on_failure: true
       - build_dist:
           requires: [checkout_and_install, "test-Win.IE8"]
+          context: highcharts-staging
       - deploy_code:
           requires: [build_dist]
           context: highcharts-staging
@@ -563,6 +564,7 @@ workflows:
       # Trigger samples/demo updates
       - check_for_samples_changes_and_deploy:
           requires: [build_dist]
+          context: highcharts-staging
           filters:
             branches:
               only: [master]


### PR DESCRIPTION
Added the `highcharts-staging` context to build_dist and check-samples jobs, which should hopefully stop the nightly failing on these steps. ([example](https://app.circleci.com/pipelines/github/highcharts/highcharts/10982/workflows/c40d0ff7-760a-461b-97a2-299a85297329/jobs/74176)).