### PR TITLE
bugfix/15742-gantt-shorten-right-tick

### DIFF
--- a/samples/unit-tests/gantt/grid-axis/demo.js
+++ b/samples/unit-tests/gantt/grid-axis/demo.js
@@ -2145,3 +2145,26 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test('slotWidth', assert => {
+    const chart = Highcharts.ganttChart("container", {
+        chart: {
+            width: 600
+        },
+        series: [{
+            data: [
+                {
+                    start: Date.UTC(2017, 8, 1),
+                    end: Date.UTC(2017, 11, 4)
+                }
+            ]
+        }]
+    });
+
+    const axis = chart.xAxis[1];
+
+    assert.ok(
+        axis.ticks[axis.tickPositions[3]].slotWidth < 30,
+        '#15742: Rightmost tick slotWidth should be much smaller than the other ticks'
+    );
+});

--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -302,7 +302,7 @@ addEvent(
                 column.setAxisSize();
                 column.setAxisTranslation();
             });
-        } as any);
+        });
     }
 );
 
@@ -326,7 +326,7 @@ addEvent(
             options = axis.options,
             gridOptions = options.grid || {},
             labelOpts = axis.options.labels,
-            align = (labelOpts as any).align,
+            align = labelOpts.align,
             // verticalAlign is currently not supported for axis.labels.
             verticalAlign = 'middle', // labelOpts.verticalAlign,
             side = GridAxis.Side[axis.side],
@@ -336,7 +336,7 @@ addEvent(
             nextTickPos = (
                 isNumber(tickPositions[e.index + 1]) ?
                     tickPositions[e.index + 1] - tickmarkOffset :
-                    (axis.max as any) + tickmarkOffset
+                    (axis.max || 0) + tickmarkOffset
             ),
             tickSize = axis.tickSize('tick'),
             tickWidth = tickSize ? tickSize[0] : 0,
@@ -361,10 +361,10 @@ addEvent(
             } else {
                 bottom = axis.top + axis.len - (axis.translate(
                     reversed ? nextTickPos : tickPos
-                ) as any);
+                ) || 0);
                 top = axis.top + axis.len - (axis.translate(
                     reversed ? tickPos : nextTickPos
-                ) as any);
+                ) || 0);
             }
 
             // Calculate left and right positions of the cell.
@@ -377,10 +377,13 @@ addEvent(
             } else {
                 left = Math.round(axis.left + (axis.translate(
                     reversed ? nextTickPos : tickPos
-                ) as any)) - crispCorr;
-                right = Math.round(axis.left + (axis.translate(
-                    reversed ? tickPos : nextTickPos
-                ) as any)) - crispCorr;
+                ) || 0)) - crispCorr;
+                right = Math.min( // #15742
+                    Math.round(axis.left + (axis.translate(
+                        reversed ? tickPos : nextTickPos
+                    ) || 0)) - crispCorr,
+                    axis.left + axis.len
+                );
             }
 
             tick.slotWidth = right - left;
@@ -403,14 +406,14 @@ addEvent(
             );
 
             lblMetrics = chart.renderer.fontMetrics(
-                (labelOpts as any).style.fontSize,
-                (label as any).element
+                labelOpts.style.fontSize,
+                label && label.element
             );
-            labelHeight = (label as any).getBBox().height;
+            labelHeight = label ? label.getBBox().height : 0;
 
             // Adjustment to y position to align the label correctly.
             // Would be better to have a setter or similar for this.
-            if (!(labelOpts as any).useHTML) {
+            if (!labelOpts.useHTML) {
                 lines = Math.round(labelHeight / lblMetrics.h);
                 e.pos.y += (
                     // Center the label
@@ -428,7 +431,7 @@ addEvent(
                 );
             }
 
-            e.pos.x += (axis.horiz && (labelOpts as any).x || 0);
+            e.pos.x += (axis.horiz && labelOpts.x) || 0;
         }
     }
 );


### PR DESCRIPTION
Fixed #15742, rightmost gantt chart grid axis tick labels did not get shortened correctly.