### PR TITLE
Tools: changed upload path for errors

### DIFF
--- a/tools/gulptasks/dist-upload-errors.js
+++ b/tools/gulptasks/dist-upload-errors.js
@@ -32,7 +32,7 @@ async function uploadErrors() {
     await Promise.all(
         Object.keys(errors)
             .filter(key => key !== 'meta')
-            .map(err => putS3Object(`${errorLocation}/${err}`, null, {
+            .map(err => putS3Object(`${errorLocation}/${err}/index.html`, null, {
                 Bucket: bucket,
                 Body: makeHTML(err, errors[err]),
                 ContentType: 'text/html; charset=utf-8'


### PR DESCRIPTION
Changed the path errors were uploaded to to match the links provided in the console. (These were served via joomla until the new hompage was launched).