### PR TITLE
bugfix/15757-heatmap-borderRadius

### DIFF
--- a/samples/unit-tests/series-heatmap/marker/demo.js
+++ b/samples/unit-tests/series-heatmap/marker/demo.js
@@ -113,6 +113,7 @@ QUnit.test('General marker tests', function (assert) {
 
     // Test marker states
     heatmap.update({
+        borderRadius: 5,
         marker: {
             states: {
                 hover: {
@@ -124,6 +125,11 @@ QUnit.test('General marker tests', function (assert) {
             }
         }
     });
+
+    assert.ok(
+        heatmap.points[0].graphic.pathArray.length > 5,
+        '#15757: Corners should be rounded'
+    );
 
     resetState(point);
 

--- a/ts/Series/Heatmap/HeatmapSeries.ts
+++ b/ts/Series/Heatmap/HeatmapSeries.ts
@@ -119,7 +119,12 @@ class HeatmapSeries extends ScatterSeries {
         animation: false,
 
         /**
-         * The border width for each heat map item.
+         * The border radius for each heatmap item.
+         */
+        borderRadius: 0,
+
+        /**
+         * The border width for each heatmap item.
          */
         borderWidth: 0,
 
@@ -424,6 +429,12 @@ class HeatmapSeries extends ScatterSeries {
                     (point.graphic as any)[
                         this.chart.styledMode ? 'css' : 'animate'
                     ](this.colorAttribs(point));
+
+                    if (this.options.borderRadius) {
+                        point.graphic.attr({
+                            r: this.options.borderRadius
+                        });
+                    }
 
                     if (point.value === null) { // #15708
                         point.graphic.addClass('highcharts-null-point');

--- a/ts/Series/Treemap/TreemapSeries.ts
+++ b/ts/Series/Treemap/TreemapSeries.ts
@@ -144,6 +144,12 @@ class TreemapSeries extends ScatterSeries {
         allowTraversingTree: false,
 
         animationLimit: 250,
+
+        /**
+         * The border radius for each treemap item.
+         */
+        borderRadius: 0,
+
         /**
          * When the series contains less points than the crop threshold, all
          * points are drawn, event if the points fall outside the visible plot


### PR DESCRIPTION
Fixed #15757, heatmap `borderRadius` did not work.