### PR TITLE
bugfix/15790-axis-offset-type

### DIFF
--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -1374,6 +1374,7 @@ namespace AxisDefaults {
          * @sample {highstock} stock/xaxis/offset/
          *         Y axis offset by 70 px
          *
+         * @type {number}
          */
         offset: void 0,
 


### PR DESCRIPTION
Fixed #15790, axis `offset` doclet type was wrong.