### PR TITLE
bugfix/9612-zoom-pan-pointPlacement

### DIFF
--- a/samples/unit-tests/axis/pointplacement/demo.js
+++ b/samples/unit-tests/axis/pointplacement/demo.js
@@ -1,26 +1,54 @@
 QUnit.test('Axis pointPlacement', assert => {
     var chart = Highcharts.chart('container', {
         chart: {
-            width: 600
+            width: 600,
+            zoomType: 'x',
+            panning: true,
+            panKey: 'shift'
         },
         xAxis: {
             categories: ['Apples', 'Pears', 'Bananas', 'Oranges']
         },
         series: [
             {
-                data: [1, 4, 3, 5],
+                data: [
+                    [1541688900000, 1],
+                    [1541689200000, 1],
+                    [1541692800000, 4],
+                    [1541696400000, 1],
+                    [1541898000000, 1],
+                    [1542009600000, 1],
+                    [1542013200000, 1],
+                    [1542016800000, 1],
+                    [1542020400000, 1],
+                    [1542038400000, 1]
+                ],
                 type: 'column',
                 pointPlacement: 'on'
             }
         ]
     });
 
-    assert.strictEqual(chart.xAxis[0].toPixels(0, true), 0, 'No padded ticks');
+    const axis = chart.xAxis[0];
+    const controller = new TestController(chart);
+
+    assert.strictEqual(axis.toPixels(1541688900000, true), 0, 'No padded ticks');
 
     assert.strictEqual(
-        chart.xAxis[0].toPixels(3, true),
+        axis.toPixels(1542038400000, true),
         chart.plotWidth,
         'No padded ticks'
+    );
+
+    controller.pan([200, 60], [400, 60], void 0, true);
+
+    const rangeBefore = axis.max - axis.min;
+    controller.pan([200, 60], [400, 60], { shiftKey: true }, true);
+    assert.close(
+        rangeBefore,
+        axis.max - axis.min,
+        1,
+        '#9612: Axis range should not change when panning'
     );
 
     chart = Highcharts.chart('container', {

--- a/samples/unit-tests/axis/pointplacement/demo.js
+++ b/samples/unit-tests/axis/pointplacement/demo.js
@@ -40,10 +40,10 @@ QUnit.test('Axis pointPlacement', assert => {
         'No padded ticks'
     );
 
-    controller.pan([200, 60], [400, 60], void 0, true);
+    controller.pan([200, 60], [400, 60]);
 
     const rangeBefore = axis.max - axis.min;
-    controller.pan([200, 60], [400, 60], { shiftKey: true }, true);
+    controller.pan([200, 60], [400, 60], { shiftKey: true });
     assert.close(
         rangeBefore,
         axis.max - axis.min,

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3678,7 +3678,7 @@ class Chart {
                     mousePos = e[horiz ? 'chartX' : 'chartY'],
                     mouseDown = horiz ? 'mouseDownX' : 'mouseDownY',
                     startPos = (chart as any)[mouseDown],
-                    halfPointRange = (axis.pointRange || 0) / 2,
+                    halfPointRange = axis.minPointOffset || 0,
                     pointRangeDirection =
                         (axis.reversed && !chart.inverted) ||
                         (!axis.reversed && chart.inverted) ?
@@ -3691,7 +3691,11 @@ class Chart {
                         axis.toValue(
                             startPos + axis.len - mousePos, true
                         ) -
-                        halfPointRange * pointRangeDirection,
+                        (
+                            (halfPointRange * pointRangeDirection) ||
+                            (axis.isXAxis && axis.pointRangePadding) ||
+                            0
+                        ),
                     flipped = panMax < panMin,
                     hasVerticalPanning = axis.hasVerticalPanning();
 


### PR DESCRIPTION
Fixed #9612, panning after zooming sometimes broke with `pointPlacement` set to `on` or `between`.