### PR TITLE
Chart update and events

### DIFF
--- a/samples/unit-tests/chart/chart-update-chart-events/demo.details
+++ b/samples/unit-tests/chart/chart-update-chart-events/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/chart/chart-update-chart-events/demo.html
+++ b/samples/unit-tests/chart/chart-update-chart-events/demo.html
@@ -1,0 +1,11 @@
+<script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+<script src="https://code.highcharts.com/stock/highcharts-3d.js"></script>
+<script src="https://code.highcharts.com/stock/highcharts-more.js"></script>
+<script src="https://code.highcharts.com/stock/modules/exporting.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/chart/chart-update-chart-events/demo.html
+++ b/samples/unit-tests/chart/chart-update-chart-events/demo.html
@@ -1,8 +1,4 @@
-<script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
-<script src="https://code.highcharts.com/stock/highstock.js"></script>
-<script src="https://code.highcharts.com/stock/highcharts-3d.js"></script>
-<script src="https://code.highcharts.com/stock/highcharts-more.js"></script>
-<script src="https://code.highcharts.com/stock/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/highcharts.js"></script>
 
 
 <div id="qunit"></div>

--- a/samples/unit-tests/chart/chart-update-chart-events/demo.js
+++ b/samples/unit-tests/chart/chart-update-chart-events/demo.js
@@ -1,0 +1,52 @@
+QUnit.test('Chart events', assert => {
+    const stack = [];
+    const chart = Highcharts.chart('container', {
+        chart: {
+            events: {
+                redraw: () => stack.push('Redraw.1')
+            },
+            width: 200
+        }
+    });
+
+    assert.deepEqual(
+        stack,
+        [],
+        'No redraw calls initially'
+    );
+
+    chart.setSize(300);
+    assert.deepEqual(
+        stack,
+        [
+            'Redraw.1'
+        ],
+        'The initial event should fire'
+    );
+
+    chart.update({
+        chart: {
+            events: {
+                redraw: () => stack.push('Redraw.2')
+            }
+        }
+    }, false);
+
+    assert.deepEqual(
+        stack,
+        [
+            'Redraw.1'
+        ],
+        'Updated without redraw, no event should fire'
+    );
+
+    chart.redraw();
+    assert.deepEqual(
+        stack,
+        [
+            'Redraw.1',
+            'Redraw.2'
+        ],
+        'Redrew, only the replaced event should fire (#6538)'
+    );
+});

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -527,7 +527,7 @@ class Axis {
             void 0;
 
         // Register event listeners
-        registerEventOptions(axis);
+        registerEventOptions(axis, axis.options);
 
         fireEvent(this, 'afterInit');
     }

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -527,7 +527,7 @@ class Axis {
             void 0;
 
         // Register event listeners
-        registerEventOptions(axis, axis.options);
+        registerEventOptions(axis, options);
 
         fireEvent(this, 'afterInit');
     }

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -29,6 +29,7 @@ import type {
     CSSObject,
     CursorValue
 } from '../Renderer/CSSObject';
+import type { EventCallback } from '../Callback';
 import type {
     LabelsItemsOptions,
     NumberFormatterCallbackFunction,
@@ -58,8 +59,12 @@ const {
     setAnimation
 } = A;
 import Axis from '../Axis/Axis.js';
-import F from '../FormatUtilities.js';
-const { numberFormat } = F;
+import FormatUtilities from '../FormatUtilities.js';
+const { numberFormat } = FormatUtilities;
+import Foundation from '../Foundation.js';
+const {
+    registerEventOptions
+} = Foundation;
 import H from '../Globals.js';
 const {
     charts,
@@ -313,6 +318,7 @@ class Chart {
     public containerWidth?: string;
     public credits?: SVGElement;
     public caption?: SVGElement;
+    public eventOptions: Record<string, EventCallback<Series, Event>> = void 0 as any;
     public hasCartesianSeries?: boolean;
     public hasLoaded?: boolean;
     public hasRendered?: boolean;
@@ -461,8 +467,6 @@ class Chart {
              */
             this.userOptions = userOptions;
 
-            const chartEvents = optionsChart.events;
-
             this.margin = [];
             this.spacing = [];
 
@@ -555,13 +559,7 @@ class Chart {
             H.chartCount++;
 
             // Chart event handlers
-            if (chartEvents) {
-                objectEach(chartEvents, function (event, eventType): void {
-                    if (isFunction(event)) {
-                        addEvent(chart, eventType, event);
-                    }
-                });
-            }
+            registerEventOptions(this, optionsChart);
 
             /**
              * A collection of the X axes in the chart.
@@ -3209,6 +3207,11 @@ class Chart {
 
             if ('alignTicks' in optionsChart) { // #6452
                 updateAllAxes = true;
+            }
+
+            if ('events' in optionsChart) {
+                // Chart event handlers
+                registerEventOptions(this, optionsChart);
             }
 
             objectEach(optionsChart, function (val: any, key: string): void {

--- a/ts/Core/Foundation.ts
+++ b/ts/Core/Foundation.ts
@@ -15,7 +15,18 @@
  *  Imports
  *
  * */
+import type {
+    XAxisOptions
+} from 'Axis/AxisOptions';
+import type {
+    ChartOptions
+} from 'Chart/ChartOptions';
+import type {
+    SeriesOptions
+} from 'Series/SeriesOptions';
+
 import Axis from 'Axis/Axis.js';
+import Chart from 'Chart/Chart.js';
 import Series from 'Series/Series.js';
 
 import U from './Utilities.js';
@@ -35,12 +46,13 @@ const {
 
 /*
  * Register event options. If an event handler is set on the options, it should
- * be subject to Axis.update and Series.update. This is contrary to general
- * handlers that are set directly using addEvent either on the class or on the
- * instance. #6943, #10861.
+ * be subject to Chart.update, Axis.update and Series.update. This is contrary
+ * to general handlers that are set directly using addEvent either on the class
+ * or on the instance. #6538, #6943, #10861.
  */
 const registerEventOptions = (
-    component: Axis|Series
+    component: Axis|Chart|Series,
+    options: XAxisOptions|ChartOptions|SeriesOptions
 ): void => {
 
     // A lookup over those events that are added by _options_ (not
@@ -49,12 +61,12 @@ const registerEventOptions = (
 
     // Register event listeners
     objectEach(
-        component.options.events,
+        options.events,
         function (event: any, eventType: string): void {
             if (isFunction(event)) {
 
-                // If event does not exist, or is changed by Axis.update or
-                // Series.update
+                // If event does not exist, or is changed by the .update()
+                // function
                 if (component.eventOptions[eventType] !== event) {
 
                     // Remove existing if set by option

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2854,7 +2854,7 @@ class Series {
             selected: options.selected === true // false by default
         });
 
-        registerEventOptions(this, this.options);
+        registerEventOptions(this, options);
 
         const events = options.events;
         if (

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2854,7 +2854,7 @@ class Series {
             selected: options.selected === true // false by default
         });
 
-        registerEventOptions(this);
+        registerEventOptions(this, this.options);
 
         const events = options.events;
         if (


### PR DESCRIPTION
Fixed #6538, `chart.update` didn't update events given in `options.chart.events`