### PR TITLE
Removed duplicate entry in docs sidebar

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -33,7 +33,6 @@ module.exports = {
             'stock/understanding-highcharts-stock',
             'stock/stock-tools',
             'stock/candlestick-chart',
-            'stock/custom-technical-indicators',
             'stock/data-grouping',
             'stock/depth-chart',
             'stock/flag-series',


### PR DESCRIPTION
`stock/custom-technical-indicators` appears twice in the the stock category.