### PR TITLE
bugfix/15811-title-verticalAlign-middle

### DIFF
--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -1266,7 +1266,8 @@ class Chart {
             const title = (this as any)[key],
                 titleOptions: Chart.DescriptionOptionsType = (this as any).options[key],
                 verticalAlign = titleOptions.verticalAlign || 'top',
-                offset = key === 'title' ? -3 :
+                offset = key === 'title' ?
+                    verticalAlign === 'top' ? -3 : 0 :
                     // Floating subtitle (#6574)
                     verticalAlign === 'top' ? titleOffset[0] + 2 : 0;
 


### PR DESCRIPTION
Fixed #15811, setting `title.verticalAlign` to `middle` did not vertically center the title completely.