### PR TITLE
bugfix/6765-dataGrouping-order 

### DIFF
--- a/samples/unit-tests/series/datagrouping/demo.js
+++ b/samples/unit-tests/series/datagrouping/demo.js
@@ -955,3 +955,35 @@ QUnit.test('Panning with dataGrouping and ordinal axis, #3825.', function (asser
         the ordinal positions should be recalculated- allows panning.`
     );
 });
+
+QUnit.test('Grouping each series when the only one requires that, #6765.', function (assert) {
+    const chart = Highcharts.stockChart('container', {
+        chart: {
+            width: 400
+        },
+        plotOptions: {
+            series: {
+                dataGrouping: {
+                    groupPixelWidth: 50,
+                    units: [
+                        ['millisecond', [2]]
+                    ]
+                }
+            }
+        },
+        series: [{
+            data: [0, 5, 3, 4]
+        }, {
+            data: [2, 2, 3, 5, 6, 7, 2, 4, 5, 4, 6, 7, 5, 6]
+        }
+        ]
+    });
+
+    assert.strictEqual(
+        chart.series[0].processedXData.length,
+        2,
+        `Even if the first series doesn't require grouping,
+        It should be grouped the same as the second one is.
+        Thus only two grouped points should be visible.`
+    );
+});

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1836,7 +1836,7 @@ class Axis {
             // First process all series assigned to that axis.
             axis.series.forEach(function (series): void {
                 // Allows filtering out points outside the plot area.
-                series.forceCrop = series.forceCropping();
+                series.forceCrop = series.forceCropping && series.forceCropping();
 
                 series.processData(
                     axis.min !== (axis.old && axis.old.min) ||

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1833,12 +1833,24 @@ class Axis {
         // This is in turn needed in order to find tick positions in ordinal
         // axes.
         if (isXAxis && !secondPass) {
+            // First process all series assigned to that axis.
             axis.series.forEach(function (series): void {
+                const chart = series.chart,
+                    options = series.options,
+                    dataGroupingOptions = options.dataGrouping,
+                    groupingEnabled = series.allowDG !== false && dataGroupingOptions &&
+                        pick(dataGroupingOptions.enabled, chart.options.isStock);
+
+                // Allows filtering out points outside the plot area.
+                series.forceCrop = groupingEnabled; // #334
+
                 series.processData(
                     axis.min !== (axis.old && axis.old.min) ||
                     axis.max !== (axis.old && axis.old.max)
                 );
             });
+            // Then apply grouping if needed.
+            fireEvent(this, 'afterProcessData');
         }
 
         // set the translation factor used in translate function

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1844,7 +1844,7 @@ class Axis {
                 );
             });
             // Then apply grouping if needed.
-            fireEvent(this, 'afterProcessData');
+            fireEvent(this, 'postProcessData');
         }
 
         // set the translation factor used in translate function

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1835,14 +1835,8 @@ class Axis {
         if (isXAxis && !secondPass) {
             // First process all series assigned to that axis.
             axis.series.forEach(function (series): void {
-                const chart = series.chart,
-                    options = series.options,
-                    dataGroupingOptions = options.dataGrouping,
-                    groupingEnabled = series.allowDG !== false && dataGroupingOptions &&
-                        pick(dataGroupingOptions.enabled, chart.options.isStock);
-
                 // Allows filtering out points outside the plot area.
-                series.forceCrop = groupingEnabled; // #334
+                series.forceCrop = series.forceCropping();
 
                 series.processData(
                     axis.min !== (axis.old && axis.old.min) ||

--- a/ts/Core/Axis/BreakObject.d.ts
+++ b/ts/Core/Axis/BreakObject.d.ts
@@ -32,4 +32,4 @@ export interface AxisBreakObject {
  *
  * */
 
-export default BreakObject;
+export default AxisBreakBorderObject;

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -117,6 +117,7 @@ declare module '../Series/SeriesLike' {
     interface SeriesLike {
         clipBox?: BBoxObject;
         compareValue?: number;
+        forceCropping(): boolean|undefined;
         modifyValue?(value?: number, point?: Point): (number|undefined);
         setCompare(compare?: string): void;
         initCompare(compare?: string): void;
@@ -994,6 +995,23 @@ Series.prototype.initCompare = function (compare?: string): void {
     if (this.chart.hasRendered) {
         this.isDirty = true;
     }
+};
+
+/**
+ * Based on the data grouping options decides whether
+ * the data should be cropped while processing.
+ *
+ * @ignore
+ * @function Highcharts.Series#forceCropping
+ */
+Series.prototype.forceCropping = function (this: Series): (boolean|undefined) {
+    const chart = this.chart,
+        options = this.options,
+        dataGroupingOptions = options.dataGrouping,
+        groupingEnabled = this.allowDG !== false && dataGroupingOptions &&
+            pick(dataGroupingOptions.enabled, chart.options.isStock);
+
+    return groupingEnabled;
 };
 
 /**

--- a/ts/Extensions/Boost/BoostOverrides.ts
+++ b/ts/Extensions/Boost/BoostOverrides.ts
@@ -392,12 +392,16 @@ wrap(Series.prototype, 'processData', function (
     /**
      * Used twice in this function, first on this.options.data, the second
      * time it runs the check again after processedXData is built.
+     * If the data is going to be grouped, the series shouldn't be boosted.
      * @private
-     * @todo Check what happens with data grouping
      */
     function getSeriesBoosting(
         data?: Array<(PointOptions|PointShortOptions)>
     ): boolean {
+        // Check if will be grouped.
+        if (series.forceCrop) {
+            return false;
+        }
         return series.chart.isChartSeriesBoosting() || (
             (data ? data.length : 0) >=
             (series.options.boostThreshold || Number.MAX_VALUE)

--- a/ts/Extensions/DataGrouping.ts
+++ b/ts/Extensions/DataGrouping.ts
@@ -1024,13 +1024,13 @@ seriesProto.generatePoints = function (): void {
 
 // When all series are processed, calculate the group pixel width and then
 // if this value is different than zero apply groupings.
-addEvent(Axis, 'afterProcessData', function (): void {
+addEvent(Axis, 'postProcessData', function (): void {
     const axis = this,
         series = axis.series;
 
     series.forEach(function (series): void {
         // Reset the groupPixelWidth, then calculate if needed.
-        series.groupPixelWidth = null as any; // #2110
+        series.groupPixelWidth = void 0; // #2110
 
         series.groupPixelWidth = axis.getGroupPixelWidth && axis.getGroupPixelWidth();
 

--- a/ts/Extensions/DataGrouping.ts
+++ b/ts/Extensions/DataGrouping.ts
@@ -72,6 +72,7 @@ declare module '../Core/Series/SeriesLike' {
         hasGroupedData?: boolean;
         hasProcessed?: boolean;
         preventGraphAnimation?: boolean;
+        applyGrouping(): void;
         destroyGroupedData(): void;
         generatePoints(): void;
         getDGApproximation(): string;
@@ -346,6 +347,180 @@ H.approximations = {
             return null;
         }
         // else, return is undefined
+    }
+};
+
+const applyGrouping = function (this: Series): void {
+    let series = this,
+        chart = series.chart,
+        options = series.options,
+        dataGroupingOptions = options.dataGrouping,
+        groupingEnabled = series.allowDG !== false && dataGroupingOptions &&
+            pick(dataGroupingOptions.enabled, chart.options.isStock),
+        visible = (
+            series.visible || !chart.options.chart.ignoreHiddenSeries
+        ),
+        hasGroupedData,
+        skip,
+        lastDataGrouping = this.currentDataGrouping,
+        currentDataGrouping,
+        croppedData,
+        revertRequireSorting = false;
+
+    // Data needs to be sorted for dataGrouping
+    if (groupingEnabled && !series.requireSorting) {
+        series.requireSorting = revertRequireSorting = true;
+    }
+
+    // Skip if processData returns false or if grouping is disabled (in that
+    // order)
+    skip = skipDataGrouping(series) || !groupingEnabled;
+
+    // Revert original requireSorting value if changed
+    if (revertRequireSorting) {
+        series.requireSorting = false;
+    }
+
+    if (!skip) {
+        series.destroyGroupedData();
+
+        let i,
+            processedXData = (dataGroupingOptions as any).groupAll ?
+                series.xData :
+                series.processedXData,
+            processedYData = (dataGroupingOptions as any).groupAll ?
+                series.yData :
+                series.processedYData,
+            plotSizeX = chart.plotSizeX,
+            xAxis = series.xAxis,
+            ordinal = xAxis.options.ordinal,
+            groupPixelWidth = series.groupPixelWidth;
+
+        // Execute grouping if the amount of points is greater than the limit
+        // defined in groupPixelWidth
+        if (
+            groupPixelWidth &&
+            processedXData &&
+            processedXData.length
+        ) {
+            hasGroupedData = true;
+
+            // Force recreation of point instances in series.translate, #5699
+            series.isDirty = true;
+            series.points = null as any; // #6709
+
+            let extremes = xAxis.getExtremes(),
+                xMin = extremes.min,
+                xMax = extremes.max,
+                groupIntervalFactor = (
+                    ordinal &&
+                    xAxis.ordinal &&
+                    xAxis.ordinal.getGroupIntervalFactor(xMin, xMax, series)
+                ) || 1,
+                interval =
+                    (groupPixelWidth * (xMax - xMin) / (plotSizeX as any)) *
+                    groupIntervalFactor,
+                groupPositions = xAxis.getTimeTicks(
+                    DateTimeAxis.AdditionsClass.prototype.normalizeTimeTickInterval(
+                        interval,
+                        (dataGroupingOptions as any).units ||
+                        defaultDataGroupingUnits
+                    ),
+                    // Processed data may extend beyond axis (#4907)
+                    Math.min(xMin, processedXData[0]),
+                    Math.max(
+                        xMax,
+                        processedXData[processedXData.length - 1]
+                    ),
+                    xAxis.options.startOfWeek,
+                    processedXData,
+                    series.closestPointRange
+                ),
+                groupedData = seriesProto.groupData.apply(
+                    series,
+                    [
+                        processedXData,
+                        processedYData as any,
+                        groupPositions,
+                        (dataGroupingOptions as any).approximation
+                    ]
+                ),
+                groupedXData = groupedData.groupedXData,
+                groupedYData = groupedData.groupedYData,
+                gapSize = 0;
+
+            // The smoothed option is deprecated, instead,
+            // there is a fallback to the new anchoring mechanism. #12455.
+            if (dataGroupingOptions && dataGroupingOptions.smoothed && groupedXData.length) {
+                dataGroupingOptions.firstAnchor = 'firstPoint';
+                dataGroupingOptions.anchor = 'middle';
+                dataGroupingOptions.lastAnchor = 'lastPoint';
+
+                error(32, false, chart, { 'dataGrouping.smoothed': 'use dataGrouping.anchor' });
+            }
+
+            anchorPoints(series, groupedXData, xMax);
+
+            // Record what data grouping values were used
+            for (i = 1; i < groupPositions.length; i++) {
+                // The grouped gapSize needs to be the largest distance between
+                // the group to capture varying group sizes like months or DST
+                // crossing (#10000). Also check that the gap is not at the
+                // start of a segment.
+                if (!(groupPositions.info as any).segmentStarts ||
+                    (groupPositions.info as any).segmentStarts.indexOf(i) === -1
+                ) {
+                    gapSize = Math.max(
+                        groupPositions[i] - groupPositions[i - 1],
+                        gapSize
+                    );
+                }
+            }
+            currentDataGrouping = groupPositions.info;
+            (currentDataGrouping as any).gapSize = gapSize;
+            series.closestPointRange = (groupPositions.info as any).totalRange;
+            series.groupMap = groupedData.groupMap;
+
+            if (visible) {
+                adjustExtremes(xAxis, groupedXData);
+            }
+
+            // We calculated all group positions but we should render
+            // only the ones within the visible range
+            if ((dataGroupingOptions as any).groupAll) {
+                croppedData = series.cropData(
+                    groupedXData,
+                    groupedYData as any,
+                    xAxis.min as any,
+                    xAxis.max as any,
+                    1 // Ordinal xAxis will remove left-most points otherwise
+                );
+                groupedXData = croppedData.xData;
+                groupedYData = croppedData.yData;
+                series.cropStart = croppedData.start; // #15005
+            }
+            // Set series props
+            series.processedXData = groupedXData;
+            series.processedYData = groupedYData as any;
+        } else {
+            series.groupMap = null as any;
+        }
+        series.hasGroupedData = hasGroupedData;
+        series.currentDataGrouping = currentDataGrouping;
+
+        series.preventGraphAnimation =
+            (lastDataGrouping && lastDataGrouping.totalRange) !==
+            (currentDataGrouping && currentDataGrouping.totalRange);
+    }
+};
+
+const skipDataGrouping = function (series: Series): void|false {
+    if (series.isCartesian &&
+        !series.isDirty &&
+        !series.xAxis.isDirty &&
+        !series.yAxis.isDirty
+    ) {
+        return false;
     }
 };
 
@@ -804,180 +979,15 @@ seriesProto.getDGApproximation = function (): string {
  */
 seriesProto.groupData = groupData;
 
-// Extend the basic processData method, that crops the data to the current zoom
-// range, with data grouping logic.
-seriesProto.processData = function (): any {
-    let series = this,
-        chart = series.chart,
-        options = series.options,
-        dataGroupingOptions = options.dataGrouping,
-        groupingEnabled = series.allowDG !== false && dataGroupingOptions &&
-            pick(dataGroupingOptions.enabled, chart.options.isStock),
-        visible = (
-            series.visible || !chart.options.chart.ignoreHiddenSeries
-        ),
-        hasGroupedData,
-        skip,
-        lastDataGrouping = this.currentDataGrouping,
-        currentDataGrouping,
-        croppedData,
-        revertRequireSorting = false;
-
-    // Run base method
-    series.forceCrop = groupingEnabled; // #334
-    series.groupPixelWidth = null as any; // #2110
-    series.hasProcessed = true; // #2692
-
-    // Data needs to be sorted for dataGrouping
-    if (groupingEnabled && !series.requireSorting) {
-        series.requireSorting = revertRequireSorting = true;
-    }
-
-    // Skip if processData returns false or if grouping is disabled (in that
-    // order)
-    skip = (
-        baseProcessData.apply(series, arguments as any) === false ||
-        !groupingEnabled
-    );
-
-    // Revert original requireSorting value if changed
-    if (revertRequireSorting) {
-        series.requireSorting = false;
-    }
-
-    if (!skip) {
-        series.destroyGroupedData();
-
-        let i,
-            processedXData = (dataGroupingOptions as any).groupAll ?
-                series.xData :
-                series.processedXData,
-            processedYData = (dataGroupingOptions as any).groupAll ?
-                series.yData :
-                series.processedYData,
-            plotSizeX = chart.plotSizeX,
-            xAxis = series.xAxis,
-            ordinal = xAxis.options.ordinal,
-            groupPixelWidth = series.groupPixelWidth =
-                xAxis.getGroupPixelWidth && xAxis.getGroupPixelWidth();
-
-        // Execute grouping if the amount of points is greater than the limit
-        // defined in groupPixelWidth
-        if (
-            groupPixelWidth &&
-            processedXData &&
-            processedXData.length
-        ) {
-            hasGroupedData = true;
-
-            // Force recreation of point instances in series.translate, #5699
-            series.isDirty = true;
-            series.points = null as any; // #6709
-
-            let extremes = xAxis.getExtremes(),
-                xMin = extremes.min,
-                xMax = extremes.max,
-                groupIntervalFactor = (
-                    ordinal &&
-                    xAxis.ordinal &&
-                    xAxis.ordinal.getGroupIntervalFactor(xMin, xMax, series)
-                ) || 1,
-                interval =
-                    (groupPixelWidth * (xMax - xMin) / (plotSizeX as any)) *
-                    groupIntervalFactor,
-                groupPositions = xAxis.getTimeTicks(
-                    DateTimeAxis.AdditionsClass.prototype.normalizeTimeTickInterval(
-                        interval,
-                        (dataGroupingOptions as any).units ||
-                        defaultDataGroupingUnits
-                    ),
-                    // Processed data may extend beyond axis (#4907)
-                    Math.min(xMin, processedXData[0]),
-                    Math.max(
-                        xMax,
-                        processedXData[processedXData.length - 1]
-                    ),
-                    xAxis.options.startOfWeek,
-                    processedXData,
-                    series.closestPointRange
-                ),
-                groupedData = seriesProto.groupData.apply(
-                    series,
-                    [
-                        processedXData,
-                        processedYData as any,
-                        groupPositions,
-                        (dataGroupingOptions as any).approximation
-                    ]
-                ),
-                groupedXData = groupedData.groupedXData,
-                groupedYData = groupedData.groupedYData,
-                gapSize = 0;
-
-            // The smoothed option is deprecated, instead,
-            // there is a fallback to the new anchoring mechanism. #12455.
-            if (dataGroupingOptions && dataGroupingOptions.smoothed && groupedXData.length) {
-                dataGroupingOptions.firstAnchor = 'firstPoint';
-                dataGroupingOptions.anchor = 'middle';
-                dataGroupingOptions.lastAnchor = 'lastPoint';
-
-                error(32, false, chart, { 'dataGrouping.smoothed': 'use dataGrouping.anchor' });
-            }
-
-            anchorPoints(series, groupedXData, xMax);
-
-            // Record what data grouping values were used
-            for (i = 1; i < groupPositions.length; i++) {
-                // The grouped gapSize needs to be the largest distance between
-                // the group to capture varying group sizes like months or DST
-                // crossing (#10000). Also check that the gap is not at the
-                // start of a segment.
-                if (!(groupPositions.info as any).segmentStarts ||
-                    (groupPositions.info as any).segmentStarts.indexOf(i) === -1
-                ) {
-                    gapSize = Math.max(
-                        groupPositions[i] - groupPositions[i - 1],
-                        gapSize
-                    );
-                }
-            }
-            currentDataGrouping = groupPositions.info;
-            (currentDataGrouping as any).gapSize = gapSize;
-            series.closestPointRange = (groupPositions.info as any).totalRange;
-            series.groupMap = groupedData.groupMap;
-
-            if (visible) {
-                adjustExtremes(xAxis, groupedXData);
-            }
-
-            // We calculated all group positions but we should render
-            // only the ones within the visible range
-            if ((dataGroupingOptions as any).groupAll) {
-                croppedData = series.cropData(
-                    groupedXData,
-                    groupedYData as any,
-                    xAxis.min as any,
-                    xAxis.max as any,
-                    1 // Ordinal xAxis will remove left-most points otherwise
-                );
-                groupedXData = croppedData.xData;
-                groupedYData = croppedData.yData;
-                series.cropStart = croppedData.start; // #15005
-            }
-            // Set series props
-            series.processedXData = groupedXData;
-            series.processedYData = groupedYData as any;
-        } else {
-            series.groupMap = null as any;
-        }
-        series.hasGroupedData = hasGroupedData;
-        series.currentDataGrouping = currentDataGrouping;
-
-        series.preventGraphAnimation =
-            (lastDataGrouping && lastDataGrouping.totalRange) !==
-            (currentDataGrouping && currentDataGrouping.totalRange);
-    }
-};
+/**
+ * For the processed data, calculate the grouped data if needed.
+ *
+ * @private
+ * @function Highcharts.Series#applyGrouping
+ *
+ * @return {void}
+ */
+seriesProto.applyGrouping = applyGrouping;
 
 // Destroy the grouped data points. #622, #740
 seriesProto.destroyGroupedData = function (): void {
@@ -1011,6 +1021,26 @@ seriesProto.generatePoints = function (): void {
     this.destroyGroupedData(); // #622
     this.groupedData = this.hasGroupedData ? this.points : null;
 };
+
+// When all series are processed, calculate the group pixel width and then
+// if this value is different than zero apply groupings.
+addEvent(Axis, 'afterProcessData', function (): void {
+    const axis = this,
+        series = axis.series;
+
+    series.forEach(function (series): void {
+        // Reset the groupPixelWidth, then calculate if needed.
+        series.groupPixelWidth = null as any; // #2110
+
+        series.groupPixelWidth = axis.getGroupPixelWidth && axis.getGroupPixelWidth();
+
+        if (series.groupPixelWidth) {
+            series.hasProcessed = true; // #2692
+
+            series.applyGrouping();
+        }
+    });
+});
 
 // Override point prototype to throw a warning when trying to update grouped
 // points.
@@ -1192,7 +1222,7 @@ Axis.prototype.getGroupPixelWidth = function (): number {
     while (i--) {
         dgOptions = series[i].options.dataGrouping;
 
-        if (dgOptions && series[i].hasProcessed) { // #2692
+        if (dgOptions) { // #2692
 
             dataLength = (series[i].processedXData || series[i].data).length;
 


### PR DESCRIPTION
Fixed #6765, changed how and when the `dataGrouping` should be fired for multiple series when one of them doesn't require grouping.

Todo
- [x] Tests