### PR TITLE
Timeline series typos

### DIFF
--- a/docs/advanced-chart-features/annotations-module.md
+++ b/docs/advanced-chart-features/annotations-module.md
@@ -3,7 +3,7 @@ Annotations module
 
 The annotations module allows users to annotate a chart freely with labels and shapes. Without the annotations module, the only way to render shapes or labels in any place on a chart was to use the [Renderer API](https://api.highcharts.com/highcharts/Renderer). The Annotations creates a declarative API for adding shapes and labels to a chart. 
 
-Include the following file ‘modules/annotations.js’ after highcharts.js or highstock.js to enable annotations.
+Include the following file `modules/annotations.js` after highcharts.js or highstock.js to enable annotations.
 
 <iframe style="width: 100%; height: 432px; border: none;" src=https://www.highcharts.com/samples/embed/highcharts/demo/annotations allow="fullscreen"></iframe>
 
@@ -14,14 +14,14 @@ The concept
 
 A single annotation is composed of simple blocks such as labels and shapes. An annotation contains only a simple label pointing to a top left corner of the chart ((0, 0) point in the chart pixel coordinates). Check the example below:
 
-    
+
         annotations: [{
             labels: [{
                 point: { x: 0, y: 0 },
-                text: ‘Label’
+                text: 'Label'
             }]
         }]
-    
+
 
 ![bsFqB4efSMVCqMrAKXy_ZO5QHHBOf4ml8RVgrywyUldMb68b6e1kVMXGHKnWIoPyYLiEjgyJzQULx9pefJW5tRsHLO6KE3ODWyzxw9L1WGw5OxRtmldpVNiyNZ3XKzIaCqf-4nzu](https://lh3.googleusercontent.com/bsFqB4efSMVCqMrAKXy_ZO5QHHBOf4ml8RVgrywyUldMb68b6e1kVMXGHKnWIoPyYLiEjgyJzQULx9pefJW5tRsHLO6KE3ODWyzxw9L1WGw5OxRtmldpVNiyNZ3XKzIaCqf-4nzu)
 
@@ -32,7 +32,7 @@ The point option
 
 In our first annotation, the label was attached to the chart’s pixel coordinates. That means that label will stay at the same place even if the chart is zoomed or panned. The index or the id of the axis need to be specified to attach the label to a point in the chart’s axes coordinates. Check the demo below:
 
-    
+
       annotations: [{
             labels: [{
                 point: {
@@ -53,7 +53,7 @@ In our first annotation, the label was attached to the chart’s pixel coordinat
                     xAxis: 0
                 }
             }],
-    
+
 
 Both annotation configurations are represented on this chart (see below). Try to zoom in and out to see the differences:
 
@@ -74,8 +74,8 @@ The shapes option
 
 Similar to the labels option, the shapes option defines a shape object. The object requires the `type` property such as `rect`, `circle` or `path`.
 
-    
-        
+
+
         annotations: [{
             shapes: [{
                 point: '0',
@@ -88,11 +88,11 @@ Similar to the labels option, the shapes option defines a shape object. The obje
                 height: 20
             }]
         }]
-    
+
 
 The path type allows to define points property that takes an array of points.
 
-    
+
      annotations: [{
             shapes: [{
                 type: 'path',
@@ -105,7 +105,7 @@ The path type allows to define points property that takes an array of points.
                 markerEnd: 'arrow'
             }]
         }]
-    
+
 
 Defining markers for the path
 -----------------------------

--- a/docs/advanced-chart-features/pie-datalabels-alignment.md
+++ b/docs/advanced-chart-features/pie-datalabels-alignment.md
@@ -24,21 +24,21 @@ Alignment method for data labels. Possible values are:
 
 **Demo with connectors**
 
-    
+
     dataLabels: {
         alignTo: 'connectors'
     }
-    
+
 
 <iframe style="width: 100%; height: 450px; border: none;" src=https://www.highcharts.com/samples/embed/highcharts/plotoptions/pie-datalabels-alignto-connectors allow="fullscreen"></iframe>
 
 **Demo with plotEdges**
 
-    
+
     dataLabels: {
         alignTo: 'plotEdges'
     }
-    
+
 
 <iframe style="width: 100%; height: 450px; border: none;" src=https://www.highcharts.com/samples/embed/highcharts/plotoptions/pie-datalabels-alignto-plotedges allow="fullscreen"></iframe>
 
@@ -48,33 +48,33 @@ Specifies the method that is used to generate the connector path. Highcharts pro
 
 **fixedOffset (default):**
 
-    
+
     dataLabels: {
         connectorShape: 'fixedOffset'
     }
-    
+
 
 <iframe width="100%" height="550" style="null" src=https://jsfiddle.net/mushigh/r0qsw9mh/3/embedded/result/ allow="fullscreen"></iframe>
 
 **straight:**
 
-    
+
     dataLabels: {
-        connectorShape: ‘straight’,
+        connectorShape: 'straight',
         crookDistance: '70%'
     }
-    
+
 
 **crookedLine**
 
 This option can be used with the `crookDistance` parameter. It defines how far from the vertical plot edge the connector path should be crooked. Using `crookedLine` makes the most sense (in most cases) when `alignTo` is set.
 
-    
+
     dataLabels: {
         connectorShape: 'crookedLine',
         crookDistance: '70%'
     }
-    
+
 
 <iframe style="width: 100%; height: 450px; border: none;" src=https://www.highcharts.com/samples/embed/highcharts/plotoptions/pie-datalabels-crookdistance allow="fullscreen"></iframe>
 

--- a/docs/chart-and-series-types/packed-bubble.md
+++ b/docs/chart-and-series-types/packed-bubble.md
@@ -12,7 +12,7 @@ The configuration of `packedbubble` differs little from other series types like 
 
 Here is an [example](https://jsfiddle.net/gvaartjes/0yrdsv2a/) of a packed bubble chart in its simplest form:
 
-    
+
     Highcharts.chart('container', {
         chart: {
             type: 'packedbubble'
@@ -29,7 +29,7 @@ In the above example, the series data for Packed Bubble takes a one-dimensional 
 
 Here is an example of how to set the data for a packed bubble with 3 series and different data formats:
 
-    
+
     Highcharts.chart('container', {
         chart: {
             type: 'packedbubble',
@@ -40,10 +40,10 @@ Here is an example of how to set the data for a packed bubble with 3 series and 
                 // name property is used for the datalabel
                 // value property is used for the volume of the bubble
                 value: 12,
-                name: 'Bert’'
+                name: 'Bert'
             }, {
                 value: 5,
-                name: 'John’'
+                name: 'John'
             }, {
                 value: 10,
                 name: 'Sandra'
@@ -82,7 +82,7 @@ Packed Bubble charts with a dataset of either many small or large values need so
 
 Here is an example of setting min and max size for bubbles:
 
-    
+
     Highcharts.chart('container', {
         chart: {
             type: 'packedbubble'

--- a/docs/chart-and-series-types/timeline-series.md
+++ b/docs/chart-and-series-types/timeline-series.md
@@ -36,16 +36,16 @@ The data series has no `x`property set.
         label: 'Event label',
         description: 'Description of this event.'
     }, {
-        name: ‘Another date’,
-        label: ‘Another event label’,
-        description: ‘Description of second event’
+        name: 'Another date',
+        label: 'Another event label',
+        description: 'Description of second event'
     }] 
 
 ### Events tied to a datetime axis
 
-Set for each data point the n `x` property with a timestamp in milliseconds since 1970.
+To place events on a datetime axis, the `x` property can be set with a timestamp in milliseconds since 1970.
 
-Examples of data series:
+Example of data series:
 
     
     data: [{
@@ -56,8 +56,8 @@ Examples of data series:
     }, {
         x: 1526774400000,
         name: 'Event name',
-        label: ‘Another event label’,
-        description: ‘Description of second event’
+        label: 'Another event label',
+        description: 'Description of second event'
     }]
 
 _The demo below illustrates a timeline of space exploration. The demo shows even intervals_

--- a/docs/chart-concepts/3d-charts.md
+++ b/docs/chart-concepts/3d-charts.md
@@ -21,23 +21,23 @@ Loading the 3D module will not alter existing charts unless they are specificall
     chart: {
         ....
         options3d: {
-            enabled: ´boolean value´,
-            alpha: ´numeric value´,
-            beta: ´numeric value´,
-            depth: ´numeric value´,
-            viewDistance: ´numeric value´,
+            enabled: 'boolean value',
+            alpha: 'numeric value',
+            beta: 'numeric value',
+            depth: 'numeric value',
+            viewDistance: 'numeric value',
             frame: {
                 bottom: {
-                    size: ´numeric value´,
-                    color: ´color value´
+                    size: 'numeric value',
+                    color: 'color value'
                 },
                 side: {
-                    size: ´numeric value´,
-                    color: ´color value´
+                    size: 'numeric value',
+                    color: 'color value'
                 },
                 back: {
-                    size: ´numeric value´,
-                    color: ´color value´
+                    size: 'numeric value',
+                    color: 'color value'
                 }
            }
        },
@@ -48,13 +48,13 @@ Loading the 3D module will not alter existing charts unless they are specificall
         ...
         column: {
             ...
-            depth: ´numeric value´,
-            groupZPadding: ´numeric value´,
+            depth: 'numeric value',
+            groupZPadding: 'numeric value',
             ...
         },
         ...
         pie: {
-            depth: ´numeric value´
+            depth: 'numeric value'
         },
         ...
     }
@@ -128,7 +128,7 @@ In addition to x & y coordinates like in a regular [scatter chart](https://highc
 3D Area
 ----------
 
-A 3D chart of type [area](https://highcharts.com/docs/chart-and-series-types/area-chart) is working similar to the column series. It will draw each area series as a 3D plane. By default the depth of an area series is set to 25. 
+A 3D chart of type [area](https://highcharts.com/docs/chart-and-series-types/area-chart) is working similar to the column series. It will draw each area series as a 3D plane. By default the depth of an area series is set to 25.
 
 ### Displaying multiple areas
 

--- a/docs/stock/range-selector.md
+++ b/docs/stock/range-selector.md
@@ -18,11 +18,11 @@ Allowed properties are:
 
 ```js
 rangeSelector: {
-	verticalAlign: ‘top’,
+	verticalAlign: 'top',
 	x: 0,
 	y: 0
 },
-```    
+```
 
 Use the x and y options to customize position. The x and y options offset the selector by pixels from the given alignment.
 
@@ -36,9 +36,9 @@ The option allows to skip adding extra space for range selector. [See a live dem
 ```js
 rangeSelector: {
 	floating: true,
-	y: 250 
+	y: 250
 },
-```   
+```
 
 ![DDz6GfTHnK-F2thKxueqGuU0qLQ-aLHBYUlWqyAOu34_V45k8UXoITv4uNjg6WAQtMHdKPkC7K6ZFpc1QD7siVGBCZi9oirugTMmIreYN1Q-HDZKp2f_ghcM2RpK30z3bnYb23R1](https://lh3.googleusercontent.com/DDz6GfTHnK-F2thKxueqGuU0qLQ-aLHBYUlWqyAOu34_V45k8UXoITv4uNjg6WAQtMHdKPkC7K6ZFpc1QD7siVGBCZi9oirugTMmIreYN1Q-HDZKp2f_ghcM2RpK30z3bnYb23R1) 
 
@@ -56,12 +56,12 @@ For example, we can make them swap places like this:
 ```js
 rangeSelector: {
 	inputPosition: {
-		align: ‘left’,
+		align: 'left',
 		x: 0,
 		y: 0
 	},
 	buttonPosition: {
-		align: ‘right’,
+		align: 'right',
 		x: 0,
 		y: 0
 	},
@@ -99,7 +99,7 @@ rangeSelector: {
 		text: '1m',
 		events: {
 			click: function() {
-				alert(‘Clicked button’);
+				alert('Clicked button');
 			}
 		}
 	}, {

--- a/docs/stock/stock-tools.md
+++ b/docs/stock/stock-tools.md
@@ -19,8 +19,8 @@ To get started quickly it's recommended to use the default toolbar of the Stock 
   ```html
   <script src="https://code.highcharts.com/indicators/indicators.js"></script>
   <script src="https://code.highcharts.com/indicators/rsi.js"></script>
-  <script src="https://code.highcharts.com/indicators/ema.js"></script> 
-  <script src="https://code.highcharts.com/indicators/macd.js"></script> 
+  <script src="https://code.highcharts.com/indicators/ema.js"></script>
+  <script src="https://code.highcharts.com/indicators/macd.js"></script>
   <script src="/ .... other technical indicators ...  "
   ```
 
@@ -68,7 +68,7 @@ _The code snippet below demonstrates how to disable the default toolbar, and tri
 ```js
 Highcharts.stockChart('container', {
     navigation: {
-        bindingsClassName: ‘tools-container’ // informs Stock Tools where to look for HTML elements for adding technical indicators, annotations etc. 
+        bindingsClassName: 'tools-container' // informs Stock Tools where to look for HTML elements for adding technical indicators, annotations etc.
     },
     stockTools: {
         gui: {
@@ -140,13 +140,11 @@ How to implement a custom dialog window, is best explained with an example where
                   chart.annotationsPopupContainer.style.display = 'block';
               }
           },
-          
           closePopup: function() {
               // Hide the popup container, and reset currentAnnotation
               this.chart.annotationsPopupContainer.style.display = 'none';
               this.chart.currentAnnotation = null;
           },
-          
           selectButton: function(event) {
               // Select button
               event.button.classList.add('active');
@@ -154,7 +152,6 @@ How to implement a custom dialog window, is best explained with an example where
               // an annotation.
               this.chart.activeButton = event.button;
           },
-              
           deselectButton: function(event) {
               // Unselect the button
               event.button.classList.remove('active');

--- a/docs/stock/technical-indicator-series.md
+++ b/docs/stock/technical-indicator-series.md
@@ -3,7 +3,7 @@ Technical indicators
 
 Technical Indicators, like annotations, are powerful tools that help to understand charts and make decisions with ease. The mathematical algorithms use the existing data to indicate trends, events, etc. and help to set up boundaries for strategies and to look for patterns.
 
-Technical indicators require the [indicators/indicators.js](https://code.highcharts.com/stock/indicators/indicators.js) main module. The main module includes SMA (Simple Moving Average). Each technical indicator, except the SMA, is a separate module and should be loaded after the main module. 
+Technical indicators require the [indicators/indicators.js](https://code.highcharts.com/stock/indicators/indicators.js) main module. The main module includes SMA (Simple Moving Average). Each technical indicator, except the SMA, is a separate module and should be loaded after the main module.
 
 A full list of supported technical indicators could be divided into two main groups. Overlays use the same scale and are plotted on the same xAxis and yAxis as the main series. The second group (oscillators and other technical indicators) requires additional yAxis because of the different extremes.
 
@@ -39,7 +39,7 @@ A full list of supported technical indicators could be divided into two main gro
 | | [Stochastic](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/stock/indicators/stochastic/) |
 | | [TRIX (Triple exponential average)](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/stock/indicators/trix/) |
 | | [Williams %R](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/stock/indicators/williams-r/) |
-    
+
 
 _For more detailed samples and documentation check the [API.](https://api.highcharts.com/highstock/plotOptions.sma)_
 
@@ -49,23 +49,23 @@ There are no limitations to the number of technical indicators that can be bound
 
 ```js
 series: [{
-  id: ‘main-series’,
+  id: 'main-series',
   data: [ … ]
 }, {
-  type: ‘sma’,
-  linkedTo: ‘main-series’,
+  type: 'sma',
+  linkedTo: 'main-series',
   params: {
     period: 14
   }
 }, {
-  type: ‘sma’,
-  linkedTo: ‘main-series’,
+  type: 'sma',
+  linkedTo: 'main-series',
   params: {
     period: 28
   }
 }, {
-  type: ‘ema’,
-  linkedTo: ‘main-series’,
+  type: 'ema',
+  linkedTo: 'main-series',
   params: {
     period: 7
   }
@@ -86,23 +86,21 @@ All Overlay type technical indicators (the ones listed in the left column of the
 ```js
 yAxis: [{
   // Main series yAxis:
-  height: ‘50%’
-}, {
+  height: '50%'}, {
   // yAxis for Stochastic technical indicator:
-  top: ‘50%’,
-  height: ‘50%’
-}]
+  top: '50%',
+  height: '50%'}]
 ```
 
 2. Bind indicator to this yAxis:
 
 ```js
 series: [{
-  id: ‘main-series’,
+  id: 'main-series',
   data: [ … ]
 }, {
-  type: ‘stochastic’,
-  linkedTo: ‘main-series’,
+  type: 'stochastic',
+  linkedTo: 'main-series',
   yAxis: 1
 }]
 ```
@@ -124,18 +122,18 @@ These indicators require the following parameter `params.volumeSeriesID` to calc
 
 ```js
 series: [{
-  id: ‘main-series’,
+  id: 'main-series',
   data: [ … ]
 }, {
-  id: ‘volume-series’,
+  id: 'volume-series',
   yAxis: 1,
   data: [ … ]
 }, {
-  type: ‘mfi’,
-  linkedTo: ‘main-series’,
+  type: 'mfi',
+  linkedTo: 'main-series',
   yAxis: 2,
   params: {
-    volumeSeriesID: ‘volume-series’
+    volumeSeriesID: 'volume-series'
   }
 }]
 ```


### PR DESCRIPTION
Replaced `´`s with `'`s, rephrased the "Events tied to a datetime axis" section a bit.