### PR TITLE
bugfix/15845-selection-marker-export

### DIFF
--- a/ts/Core/Globals.ts
+++ b/ts/Core/Globals.ts
@@ -223,7 +223,7 @@ namespace Globals {
      *
      * */
 
-    export let chartCount: 0;
+    export let chartCount = 0;
 
     /**
      * Theme options that should get applied to the chart. In module mode it


### PR DESCRIPTION
Fixed #15845, selection marker showed without mousedown after export.