### PR TITLE
Fixed #6173, CSP errors on tooltip drop shadow in styled mode

### DIFF
--- a/ts/Core/Renderer/SVG/SVGAttributes.d.ts
+++ b/ts/Core/Renderer/SVG/SVGAttributes.d.ts
@@ -57,6 +57,7 @@ export interface SVGAttributes {
     end?: number;
     fill?: ColorType;
     'fill-opacity'?: number;
+    filter?: string;
     gradientUnits?: 'userSpaceOnUse';
     height?: number;
     href?: string;

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -439,12 +439,6 @@ class Tooltip {
                 }]
             }]
         });
-        chart.renderer.definition({
-            tagName: 'style',
-            textContent: '.highcharts-tooltip-' + chart.index + '{' +
-                'filter:url(#drop-shadow-' + chart.index + ')' +
-            '}'
-        });
     }
 
     /**
@@ -848,10 +842,12 @@ class Tooltip {
                 }
             }
 
-            if (styledMode) {
+            if (styledMode && options.shadow) {
                 // Apply the drop-shadow filter
                 this.applyFilter();
-                this.label.addClass('highcharts-tooltip-' + this.chart.index);
+                this.label.attr({
+                    filter: 'url(#drop-shadow-' + this.chart.index + ')'
+                });
             }
 
             // Split tooltip use updateTooltipContainer to position the tooltip


### PR DESCRIPTION
Fixed #6173, CSP errors on tooltip drop shadow, even in styled mode.

Set tooltip shadow filter as attribute instead of inline style.