### PR TITLE
bugfix/15843-tooltip-shared-stickOnContact

### DIFF
--- a/samples/unit-tests/tooltip/shared/demo.js
+++ b/samples/unit-tests/tooltip/shared/demo.js
@@ -212,14 +212,15 @@ QUnit.test(
     }
 );
 
-QUnit.test('Shared tooltip with pointPlacement (#5832)', function (assert) {
+QUnit.test('Shared tooltip with pointPlacement and stickOnContact', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {
             type: 'column'
         },
 
         tooltip: {
-            shared: true
+            shared: true,
+            stickOnContact: true
         },
         plotOptions: {
             column: {
@@ -268,5 +269,13 @@ QUnit.test('Shared tooltip with pointPlacement (#5832)', function (assert) {
         target: chart.container
     });
 
-    assert.strictEqual(chart.hoverPoints.length, 5, 'All series present');
+    assert.strictEqual(chart.hoverPoints.length, 5, '#5832: All series present');
+
+    const heightBefore = chart.tooltip.tracker.attr('height');
+    chart.series[1].points[0].onMouseOver();
+    assert.strictEqual(
+        chart.tooltip.tracker.attr('height'),
+        heightBefore,
+        '#15843: Tracker height should be the same after hovering another point in the same stack'
+    );
 });

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1913,9 +1913,9 @@ class Tooltip {
 
         const chart = tooltip.chart;
         const label = tooltip.label;
-        const point = chart.hoverPoint;
+        const points = tooltip.shared ? chart.hoverPoints : chart.hoverPoint;
 
-        if (!label || !point) {
+        if (!label || !points) {
             return;
         }
 
@@ -1927,7 +1927,7 @@ class Tooltip {
         };
 
         // Combine anchor and tooltip
-        const anchorPos = this.getAnchor(point);
+        const anchorPos = this.getAnchor(points);
         const labelBBox = label.getBBox();
 
         anchorPos[0] += chart.plotLeft - label.translateX;


### PR DESCRIPTION
Fixed #15843, shared tooltip with `stickOnContact` enabled did not always update position.