### PR TITLE
bugfix/15841-Intl-missing

### DIFF
--- a/ts/Core/Time.ts
+++ b/ts/Core/Time.ts
@@ -58,10 +58,10 @@ declare module './Axis/TickPositionsArray'{
  *
  * */
 
-const hasNewSafariBug = (H.isSafari && Intl.DateTimeFormat.prototype.formatRange);
+const hasNewSafariBug = (H.isSafari && Intl && Intl.DateTimeFormat.prototype.formatRange);
 
 // To do: Remove this when we no longer need support for Safari < v14.1
-const hasOldSafariBug = (H.isSafari && !Intl.DateTimeFormat.prototype.formatRange);
+const hasOldSafariBug = (H.isSafari && Intl && !Intl.DateTimeFormat.prototype.formatRange);
 
 /* *
  *


### PR DESCRIPTION
Fixed #15841, charts crashed in some browsers where `Intl` was missing.