### PR TITLE
bugfix/15869-boost-multiple-types

### DIFF
--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -1340,6 +1340,10 @@ function GLRenderer(
                 cbuffer = GLVertexBuffer(gl, shader); // eslint-disable-line new-cap
                 cbuffer.build(s.colorData, 'aColor', 4);
                 cbuffer.bind();
+            } else {
+                // #15869, a buffer with fewer points might already be bound by
+                // a different series/chart causing out of range errors
+                gl.disableVertexAttribArray(1);
             }
 
             // Set series specific uniforms


### PR DESCRIPTION
Fixed #15869, boosted rendering sometimes crashed with multiple different chart types.