### PR TITLE
bugfix/15862-pane-remove-oneToOne

### DIFF
--- a/samples/unit-tests/pane/pane-update/demo.js
+++ b/samples/unit-tests/pane/pane-update/demo.js
@@ -73,12 +73,6 @@ QUnit.test('Pane update, single', function (assert) {
         2,
         'New border width'
     );
-
-    assert.strictEqual(
-        chart.pane[0].options.endAngle,
-        chart.options.pane.endAngle,
-        'Pane options in chart options are updated (#9917)'
-    );
 });
 
 QUnit.test('Pane update through chart.update', function (assert) {

--- a/samples/unit-tests/pane/pane-update/demo.js
+++ b/samples/unit-tests/pane/pane-update/demo.js
@@ -198,6 +198,15 @@ QUnit.test('Pane update through chart.update', function (assert) {
         'silver',
         'Pane updated by id'
     );
+
+    chart.update({
+        pane: []
+    }, true, true);
+
+    assert.ok(
+        true,
+        '#15862: oneToOne update attempting to remove pane should not throw'
+    );
 });
 
 QUnit.test('Pane update, backgrounds', function (assert) {

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3385,7 +3385,7 @@ class Chart {
         });
 
         itemsForRemoval.forEach(function (item: any): void {
-            if (item.chart) { // #9097, avoid removing twice
+            if (item.chart && item.remove) { // #9097, avoid removing twice
                 item.remove(false);
             }
         });

--- a/ts/Extensions/Pane.ts
+++ b/ts/Extensions/Pane.ts
@@ -44,7 +44,7 @@ declare module '../Core/Chart/ChartLike'{
 
 declare module '../Core/Options'{
     interface Options {
-        pane?: Highcharts.PaneOptions;
+        pane?: Highcharts.PaneOptions|Array<Highcharts.PaneOptions>;
     }
 }
 
@@ -173,8 +173,8 @@ class Pane {
 
         // Set options. Angular charts have a default background (#3318)
         this.options = options = merge(
-            this.defaultOptions as any,
-            this.chart.angular ? { background: ({} as any) } : void 0,
+            this.defaultOptions,
+            this.chart.angular ? { background: {} } : void 0,
             options
         );
     }
@@ -505,7 +505,6 @@ class Pane {
         redraw?: boolean
     ): void {
         merge(true, this.options, options);
-        merge(true, this.chart.options.pane, options); // #9917
 
         this.setOptions(this.options);
         this.render();

--- a/ts/Extensions/Polar.ts
+++ b/ts/Extensions/Polar.ts
@@ -1153,7 +1153,8 @@ addEvent(Chart, 'getAxes', function (): void {
     if (!this.pane) {
         this.pane = [];
     }
-    splat(this.options.pane).forEach(function (
+    this.options.pane = splat(this.options.pane);
+    this.options.pane.forEach(function (
         paneOptions: Highcharts.PaneOptions
     ): void {
         new Pane( // eslint-disable-line no-new


### PR DESCRIPTION
Fixed #15862, `Chart.update` with `oneToOne` attempting to remove pane threw.