### PR TITLE
bugfix/5430-state-marker-zone-color

### DIFF
--- a/samples/unit-tests/series/marker/demo.js
+++ b/samples/unit-tests/series/marker/demo.js
@@ -176,6 +176,11 @@ QUnit.test('Marker size and position', function (assert) {
         Math.floor(series.stateMarkerGraphic.attr('y')),
         'Correct image y-position (#7273)'
     );
+
+    assert.ok(
+        series.stateMarkerGraphic.attr('class'),
+        '#5430: State marker should have class set'
+    );
 });
 
 QUnit.test('visibility', assert => {

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1680,6 +1680,8 @@ class Point {
                     state && point.isInside ? 'show' : 'hide'
                 ](); // #2450
                 (stateMarkerGraphic.element as any).point = point; // #4310
+
+                stateMarkerGraphic.addClass(point.getClassName(), true);
             }
         }
 


### PR DESCRIPTION
Fixed #5430, marker shown on hover with disabled markers missed CSS class.