### PR TITLE
Removed nightly trigger for demo deploy from ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -600,13 +600,6 @@ workflows:
       - deploy_to_highcharts_dist:
           requires: [build_dist]
           context: highcharts-staging
-      # Trigger samples/demo updates
-      - check_for_samples_changes_and_deploy:
-          requires: [build_dist]
-          context: highcharts-staging
-          filters:
-            branches:
-              only: [master]
 
   reset_visual_test_references:
     when: << pipeline.parameters.run_reset_tests >>


### PR DESCRIPTION
Removed the `check_for_samples_changes_and_deploy` job from the nightly workflow, as it seems the scheduled workflows are a bit more limited when it comes to CI credentials. This functionality is being moved to [highcharts/highcharts-demo-manager](/highcharts/highcharts-demo-manager).