### PR TITLE
bugfix/15909-pie-dataLabel-useHTML-visible

### DIFF
--- a/samples/unit-tests/series-pie/datalabel/demo.js
+++ b/samples/unit-tests/series-pie/datalabel/demo.js
@@ -464,7 +464,7 @@ QUnit.test(
                         data: [
                             ['Firefox', 44.2],
                             ['IE7', 26.6],
-                            ['IE6', 20],
+                            { name: 'IE6', y: 20, visible: false },
                             ['Chrome', 3.1],
                             ['Other', 5.4]
                         ]
@@ -473,6 +473,11 @@ QUnit.test(
             }),
             points = chart.series[0].points,
             offset = Highcharts.offset(chart.container);
+
+        assert.ok(
+            true,
+            '#15909: Hidden point with useHTML dataLabels should not throw'
+        );
 
         Highcharts.fireEvent(points[0].dataLabel.div, 'mouseover', {
             which: 1,

--- a/ts/Core/Renderer/HTML/HTMLRenderer.ts
+++ b/ts/Core/Renderer/HTML/HTMLRenderer.ts
@@ -301,7 +301,7 @@ class HTMLRenderer extends SVGRenderer {
                                     if (parents[0].div) { // #6418
                                         wrapper.on.apply({
                                             element: parents[0].div,
-                                            onEvents: wrapper.onEvents
+                                            onEvents: parentGroup.onEvents
                                         }, arguments);
                                     }
                                     return parentGroup;


### PR DESCRIPTION
Fixed #15909, pie point with `visible` set to `false` and `useHTML` data labels threw.