### PR TITLE
bugfix/15864-navigator-rangeSelector-regresion 

### DIFF
--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -1300,8 +1300,9 @@ QUnit.test('Initiation chart without data but with set range, #15864.', function
             pointInterval: 36e7
         }]
     });
-    assert.ok(
-        chart.xAxis[0].max !== 0,
+    assert.notStrictEqual(
+        chart.xAxis[0].max,
+        0,
         `After adding series to the chart that has set the range,
         the navigator shouldn't stick to min.`
     );

--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -1289,3 +1289,20 @@ QUnit.test('Scrolling when the range is set, #14742.', function (assert) {
         the range should not equal zero.`
     );
 });
+
+
+QUnit.test('Initiation chart without data but with set range, #15864.', function (assert) {
+    const chart = Highcharts.stockChart('container', {
+        rangeSelector: {
+            selected: 1
+        },
+        series: [{
+            pointInterval: 36e7
+        }]
+    });
+    assert.ok(
+        chart.xAxis[0].max !== 0,
+        `After adding series to the chart that has set the range,
+        the navigator shouldn't stick to min.`
+    );
+});

--- a/ts/Core/Navigator.ts
+++ b/ts/Core/Navigator.ts
@@ -2599,6 +2599,8 @@ class Navigator {
                 // updated dataset, we must adjust.
                 stickToMin = min <= xDataMin;
             }
+        } else {
+            stickToMin = false; // #15864
         }
 
         return stickToMin;


### PR DESCRIPTION
Fixed #15864, a regression in the navigator. When `rangeSelector.selected` was set, the navigator had the wrong position after adding a series to an empty chart.