### PR TITLE
bugfix/9047-boost-primcount-zero

### DIFF
--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -1376,13 +1376,11 @@ function GLRenderer(
             // If the line width is < 0, skip rendering of the lines. See #7833.
             if (lineWidth > 0 || s.drawMode !== 'line_strip') {
                 for (sindex = 0; sindex < s.segments.length; sindex++) {
-                    // if (s.segments[sindex].from < s.segments[sindex].to) {
                     vbuffer.render(
                         s.segments[sindex].from,
                         s.segments[sindex].to,
                         s.drawMode
                     );
-                    // }
                 }
             }
 
@@ -1394,13 +1392,11 @@ function GLRenderer(
                 }
                 shader.setDrawAsCircle(true);
                 for (sindex = 0; sindex < s.segments.length; sindex++) {
-                    // if (s.segments[sindex].from < s.segments[sindex].to) {
                     vbuffer.render(
                         s.segments[sindex].from,
                         s.segments[sindex].to,
                         'POINTS'
                     );
-                    // }
                 }
             }
         });

--- a/ts/Extensions/Boost/WGLVBuffer.ts
+++ b/ts/Extensions/Boost/WGLVBuffer.ts
@@ -173,6 +173,10 @@ function GLVertexBuffer(
             to = length;
         }
 
+        if (from >= to) {
+            return false;
+        }
+
         drawMode = drawMode || 'points';
 
         gl.drawArrays(


### PR DESCRIPTION
Fixed #9047, boosted series with null points showed warnings in some browsers.