### PR TITLE
bugfix/15922-heatmap-border-dataLabels-useHTML

### DIFF
--- a/samples/unit-tests/series-heatmap/datalabel/demo.js
+++ b/samples/unit-tests/series-heatmap/datalabel/demo.js
@@ -11,7 +11,13 @@ QUnit.test('Check last point visible (#5254)', function (assert) {
         series: [
             {
                 data: [
-                    [0, 0, 10],
+                    {
+                        x: 0,
+                        y: 0,
+                        value: 10,
+                        borderColor: 'red',
+                        borderWidth: 1
+                    },
                     [0, 1, 19],
                     [1, 0, 8],
                     [1, 1, 24]
@@ -19,7 +25,8 @@ QUnit.test('Check last point visible (#5254)', function (assert) {
                 dataLabels: {
                     enabled: true,
                     verticalAlign: 'bottom',
-                    align: 'left'
+                    align: 'left',
+                    useHTML: true
                 },
                 borderColor: 'white',
                 borderWidth: 2
@@ -31,6 +38,21 @@ QUnit.test('Check last point visible (#5254)', function (assert) {
     var leftX = point.dataLabel.translateX;
     var bottomY = point.dataLabel.translateY;
     assert.strictEqual(typeof leftX, 'number', 'All well so far');
+
+    assert.ok(
+        point.dataLabel.width > 0 && point.dataLabel.height > 0,
+        '#15922: useHTML dataLabel should be visible'
+    );
+    assert.strictEqual(
+        point.graphic.stroke,
+        'red',
+        '#15922: Point borderColor should work'
+    );
+    assert.strictEqual(
+        point.graphic['stroke-width'],
+        1,
+        '#15922: Point borderWidth should work'
+    );
 
     chart.series[0].update({
         dataLabels: {

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -107,8 +107,11 @@ class BubbleSeries extends ScatterSeries {
         dataLabels: {
             formatter: function (
                 this: Point.PointLabelObject
-            ): (number|null|undefined) { // #2945
-                return (this.point as BubblePoint).z;
+            ): string { // #2945
+                const { numberFormatter } = this.point.series.chart;
+                const { z } = (this.point as BubblePoint);
+
+                return isNumber(z) ? numberFormatter(z, -1) : '';
             },
             inside: true,
             verticalAlign: 'middle'

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -108,7 +108,7 @@ class BubbleSeries extends ScatterSeries {
             formatter: function (
                 this: Point.PointLabelObject
             ): string { // #2945
-                const { numberFormatter } = this.point.series.chart;
+                const { numberFormatter } = this.series.chart;
                 const { z } = (this.point as BubblePoint);
 
                 return isNumber(z) ? numberFormatter(z, -1) : '';

--- a/ts/Series/Heatmap/HeatmapPointOptions.d.ts
+++ b/ts/Series/Heatmap/HeatmapPointOptions.d.ts
@@ -23,6 +23,7 @@ import type ScatterPointOptions from '../Scatter/ScatterPointOptions';
  * */
 
 export interface HeatmapPointOptions extends ScatterPointOptions {
+    borderWidth?: number;
     pointPadding?: number;
     value?: (number|null);
 }

--- a/ts/Series/Heatmap/HeatmapSeries.ts
+++ b/ts/Series/Heatmap/HeatmapSeries.ts
@@ -195,7 +195,7 @@ class HeatmapSeries extends ScatterSeries {
 
         dataLabels: {
             formatter: function (): string { // #2945
-                const { numberFormatter } = this.point.series.chart;
+                const { numberFormatter } = this.series.chart;
                 const { value } = this.point as HeatmapPoint;
 
                 return isNumber(value) ? numberFormatter(value, -1) : '';

--- a/ts/Series/Heatmap/HeatmapSeries.ts
+++ b/ts/Series/Heatmap/HeatmapSeries.ts
@@ -194,8 +194,11 @@ class HeatmapSeries extends ScatterSeries {
         nullColor: palette.neutralColor3,
 
         dataLabels: {
-            formatter: function (): (number|null) { // #2945
-                return (this.point as HeatmapPoint).value;
+            formatter: function (): string { // #2945
+                const { numberFormatter } = this.point.series.chart;
+                const { value } = this.point as HeatmapPoint;
+
+                return isNumber(value) ? numberFormatter(value, -1) : '';
             },
             inside: true,
             verticalAlign: 'middle',
@@ -578,10 +581,12 @@ class HeatmapSeries extends ScatterSeries {
             brightness,
             // Get old properties in order to keep backward compatibility
             borderColor =
+                (point && point.options.borderColor) ||
                 seriesOptions.borderColor ||
                 heatmapPlotOptions.borderColor ||
                 seriesPlotOptions.borderColor,
             borderWidth =
+                (point && point.options.borderWidth) ||
                 seriesOptions.borderWidth ||
                 heatmapPlotOptions.borderWidth ||
                 seriesPlotOptions.borderWidth ||

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -154,8 +154,11 @@ class MapSeries extends ScatterSeries {
 
         dataLabels: {
             crop: false,
-            formatter: function (): (number|null) { // #2945
-                return (this.point as MapPoint).value;
+            formatter: function (): string { // #2945
+                const { numberFormatter } = this.point.series.chart;
+                const { value } = this.point as MapPoint;
+
+                return isNumber(value) ? numberFormatter(value, -1) : '';
             },
             inside: true, // for the color
             overflow: false as any,

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -155,7 +155,7 @@ class MapSeries extends ScatterSeries {
         dataLabels: {
             crop: false,
             formatter: function (): string { // #2945
-                const { numberFormatter } = this.point.series.chart;
+                const { numberFormatter } = this.series.chart;
                 const { value } = this.point as MapPoint;
 
                 return isNumber(value) ? numberFormatter(value, -1) : '';

--- a/ts/Series/PackedBubble/PackedBubbleSeries.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeries.ts
@@ -207,8 +207,11 @@ class PackedBubbleSeries extends BubbleSeries implements Highcharts.DragNodesSer
                     Point.PointLabelObject|
                     PackedBubbleDataLabelFormatterObject
                 )
-            ): (number|null) {
-                return (this.point as any).value;
+            ): string {
+                const { numberFormatter } = this.point.series.chart;
+                const { value } = this.point as PackedBubblePoint;
+
+                return isNumber(value) ? numberFormatter(value, -1) : '';
             },
 
             /**

--- a/ts/Series/PackedBubble/PackedBubbleSeries.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeries.ts
@@ -208,7 +208,7 @@ class PackedBubbleSeries extends BubbleSeries implements Highcharts.DragNodesSer
                     PackedBubbleDataLabelFormatterObject
                 )
             ): string {
-                const { numberFormatter } = this.point.series.chart;
+                const { numberFormatter } = this.series.chart;
                 const { value } = this.point as PackedBubblePoint;
 
                 return isNumber(value) ? numberFormatter(value, -1) : '';


### PR DESCRIPTION
Fixed #15922, heatmap data labels with `useHTML` enabled and default formatter did not work, per-point `borderColor` and `borderWidth` did not work.