### PR TITLE
bugfix/zAxis-double-update

### DIFF
--- a/samples/unit-tests/3d/zaxis-update/demo.js
+++ b/samples/unit-tests/3d/zaxis-update/demo.js
@@ -68,6 +68,10 @@ QUnit.test('zAxis update through chart.update() (#6566)', function (assert) {
         ]
     });
 
+    let updates = 0;
+
+    Highcharts.addEvent(Highcharts.Axis, 'afterInit', () => updates++);
+
     chart.update({
         zAxis: {
             min: 0,
@@ -89,5 +93,11 @@ QUnit.test('zAxis update through chart.update() (#6566)', function (assert) {
         chart.zAxis[0].isZAxis,
         true,
         '#14793: isZAxis should still be true after update'
+    );
+
+    assert.strictEqual(
+        updates,
+        1,
+        'zAxis should only have updated once'
     );
 });

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3871,7 +3871,6 @@ extend(Chart.prototype, {
     collectionsWithUpdate: [
         'xAxis',
         'yAxis',
-        'zAxis',
         'series'
     ],
 


### PR DESCRIPTION
Fixed 3d bug, z-axis updated twice on `Chart.update`.