### PR TITLE
bugfix/15946-marker-symbol-update-animate

### DIFF
--- a/samples/unit-tests/series/update/demo.js
+++ b/samples/unit-tests/series/update/demo.js
@@ -126,7 +126,19 @@ QUnit.test('Series.update', function (assert) {
     assert.strictEqual(
         chart.series[0].points[0].graphic.symbolName,
         'square',
-        'The symbol name should update for all markers (#10870'
+        'The symbol name should update for all markers (#10870)'
+    );
+
+    const graphic = chart.series[0].points[0].graphic;
+    chart.series[0].update({
+        marker: {
+            symbol: 'square'
+        }
+    });
+    assert.strictEqual(
+        chart.series[0].points[0].graphic,
+        graphic,
+        'Graphic should not be destroyed if symbol didnt change (#15946)'
     );
 
     // Color

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -6760,7 +6760,8 @@ class Series {
                 if (
                     marker && (
                         marker.enabled === false ||
-                        'symbol' in marker // #10870
+                        (oldOptions.marker && oldOptions.marker.symbol) !==
+                            marker.symbol // #10870, #15946
                     )
                 ) {
                     kinds.graphic = 1;


### PR DESCRIPTION
Fixed #15946, unchanged markers set in options did not animate when updating data through `update`.