### PR TITLE
Stricter typing of options.lang

### DIFF
--- a/ts/Accessibility/HighContrastTheme.ts
+++ b/ts/Accessibility/HighContrastTheme.ts
@@ -21,7 +21,7 @@ declare module '../Core/Series/DataLabelOptions' {
     }
 }
 
-const theme: Options = {
+const theme: DeepPartial<Options> = {
     chart: {
         backgroundColor: 'window'
     },

--- a/ts/Accessibility/Options/LangOptions.ts
+++ b/ts/Accessibility/Options/LangOptions.ts
@@ -192,7 +192,7 @@ declare global {
     }
 }
 
-const langOptions: Partial<LangOptions> = {
+const langOptions: DeepPartial<LangOptions> = {
 
     /**
      * Configure the accessibility strings in the chart. Requires the

--- a/ts/Accessibility/Options/LangOptions.ts
+++ b/ts/Accessibility/Options/LangOptions.ts
@@ -192,7 +192,7 @@ declare global {
     }
 }
 
-const langOptions: LangOptions = {
+const langOptions: Partial<LangOptions> = {
 
     /**
      * Configure the accessibility strings in the chart. Requires the

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -591,8 +591,8 @@ class Axis {
             categories = axis.categories,
             dateTimeLabelFormat = this.dateTimeLabelFormat,
             lang = defaultOptions.lang,
-            numericSymbols = (lang as any).numericSymbols,
-            numSymMagnitude = (lang as any).numericSymbolMagnitude || 1000,
+            numericSymbols = lang.numericSymbols,
+            numSymMagnitude = lang.numericSymbolMagnitude || 1000,
             // make sure the same symbol is added for all labels on a linear
             // axis
             numericSymbolDetector = axis.logarithmic ?

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3022,7 +3022,7 @@ class Chart {
         // Update text
         AST.setElementHTML(
             loadingSpan,
-            pick(str, (options.lang as any).loading, '')
+            pick(str, options.lang.loading, '')
         );
 
         if (!chart.styledMode) {
@@ -3501,7 +3501,7 @@ class Chart {
         fireEvent(this, 'beforeShowResetZoom', null as any, function (): void {
             chart.resetZoomButton = chart.renderer
                 .button(
-                    (lang as any).resetZoom,
+                    lang.resetZoom,
                     null as any,
                     null as any,
                     zoomOut,
@@ -3510,7 +3510,7 @@ class Chart {
                 )
                 .attr({
                     align: btnOptions.position.align,
-                    title: (lang as any).resetZoomTitle
+                    title: lang.resetZoomTitle
                 })
                 .addClass('highcharts-reset-zoom')
                 .add()

--- a/ts/Core/DefaultOptions.ts
+++ b/ts/Core/DefaultOptions.ts
@@ -47,18 +47,18 @@ declare module './Chart/ChartOptions'{
 
 declare module './LangOptions'{
     export interface LangOptions {
-        decimalPoint?: string;
+        decimalPoint: string;
         invalidDate?: string;
-        loading?: string;
-        months?: Array<string>;
+        loading: string;
+        months: Array<string>;
         numericSymbolMagnitude?: number;
-        numericSymbols?: Array<string>;
-        resetZoom?: string;
-        resetZoomTitle?: string;
-        shortMonths?: Array<string>;
+        numericSymbols: Array<string>;
+        resetZoom: string;
+        resetZoomTitle: string;
+        shortMonths: Array<string>;
         shortWeekdays?: Array<string>;
-        thousandsSep?: string;
-        weekdays?: Array<string>;
+        thousandsSep: string;
+        weekdays: Array<string>;
         zoomIn?: string;
         zoomOut?: string;
     }
@@ -2931,7 +2931,7 @@ function getOptions(): Options {
  *         Updated options.
  */
 function setOptions(
-    options: Partial<Options>
+    options: DeepPartial<Options>
 ): Options {
 
     // Copy in the default options

--- a/ts/Core/FormatUtilities.ts
+++ b/ts/Core/FormatUtilities.ts
@@ -155,8 +155,8 @@ function format(str: string, ctx: any, chart?: Chart): string {
                         val = numberFormatter(
                             val,
                             decimals,
-                            (lang as any).decimalPoint,
-                            segment.indexOf(',') > -1 ? (lang as any).thousandsSep : ''
+                            lang.decimalPoint,
+                            segment.indexOf(',') > -1 ? lang.thousandsSep : ''
                         );
                     }
                 } else {
@@ -264,8 +264,8 @@ function numberFormat(
     const thousands = strinteger.length > 3 ? strinteger.length % 3 : 0;
 
     // Language
-    decimalPoint = pick(decimalPoint, (lang as any).decimalPoint);
-    thousandsSep = pick(thousandsSep, (lang as any).thousandsSep);
+    decimalPoint = pick(decimalPoint, lang.decimalPoint);
+    thousandsSep = pick(thousandsSep, lang.thousandsSep);
 
     // Start building the return
     ret = number < 0 ? '-' : '';

--- a/ts/Core/Options.d.ts
+++ b/ts/Core/Options.d.ts
@@ -29,7 +29,7 @@ import type { SymbolKey } from './Renderer/SVG/SymbolType';
 
 export interface Options {
     colors?: Array<ColorString>;
-    lang?: LangOptions;
+    lang: LangOptions;
     loading?: LoadingOptions;
     plotOptions?: SeriesTypePlotOptions;
     symbols?: Array<SymbolKey>;

--- a/ts/Core/Time.ts
+++ b/ts/Core/Time.ts
@@ -518,9 +518,9 @@ class Time {
 
                     // Month
                     // Short month, like 'Jan'
-                    b: (lang as any).shortMonths[month],
+                    b: lang.shortMonths[month],
                     // Long month, like 'January'
-                    B: (lang as any).months[month],
+                    B: lang.months[month],
                     // Two digit month number, 01 through 12
                     m: pad(month + 1),
                     // Month number, 1 through 12 (#8150)

--- a/ts/Extensions/Drilldown.ts
+++ b/ts/Extensions/Drilldown.ts
@@ -879,7 +879,7 @@ Chart.prototype.getDrilldownBackText = function (): (string|undefined) {
     if (drilldownLevels && drilldownLevels.length > 0) { // #3352, async loading
         lastLevel = drilldownLevels[drilldownLevels.length - 1];
         (lastLevel as any).series = lastLevel.seriesOptions;
-        return format((this.options.lang as any).drillUpText, lastLevel);
+        return format(this.options.lang.drillUpText || '', lastLevel);
     }
 };
 

--- a/ts/Extensions/ExportData.ts
+++ b/ts/Extensions/ExportData.ts
@@ -528,7 +528,7 @@ Chart.prototype.getDataRows = function (
         i: number,
         x,
         xTitle: string,
-        langOptions: LangOptions = this.options.lang as any,
+        langOptions = this.options.lang,
         exportDataOptions: Highcharts.ExportDataOptions = langOptions.exportData as any,
         categoryHeader = exportDataOptions.categoryHeader as any,
         categoryDatetimeHeader = exportDataOptions.categoryDatetimeHeader,

--- a/ts/Extensions/NoDataToDisplay.ts
+++ b/ts/Extensions/NoDataToDisplay.ts
@@ -198,7 +198,7 @@ defaultOptions.noData = {
 chartPrototype.showNoData = function (str?: string): void {
     const chart = this,
         options = chart.options,
-        text = str || (options && (options.lang as any).noData),
+        text = str || (options && options.lang.noData) || '',
         noDataOptions: Highcharts.NoDataOptions =
             options && (options.noData || {});
 

--- a/ts/Extensions/RangeSelector.ts
+++ b/ts/Extensions/RangeSelector.ts
@@ -1570,9 +1570,9 @@ class RangeSelector {
         }
 
         // Create the text label
-        const text: string = (lang as any)[
+        const text = lang[
             isMin ? 'rangeSelectorFrom' : 'rangeSelectorTo'
-        ];
+        ] || '';
         const label = renderer
             .label(text, 0)
             .addClass('highcharts-range-label')


### PR DESCRIPTION
So we can skip any-casting whenever accessing language strings that we know are defined.