### PR TITLE
bugfix/15952-annotation-control-point-afterUpdate

### DIFF
--- a/samples/unit-tests/annotations/annotations-events/demo.html
+++ b/samples/unit-tests/annotations/annotations-events/demo.html
@@ -1,5 +1,5 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
-<script src="https://code.highcharts.com/modules/annotations.js"></script>
+<script src="https://code.highcharts.com/modules/annotations-advanced.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/annotations/annotations-events/demo.js
+++ b/samples/unit-tests/annotations/annotations-events/demo.js
@@ -2,6 +2,7 @@ QUnit.test('Annotations events - general', function (assert) {
     var addEventCalled = 0,
         afterUpdateEventCalled = 0,
         removeEventCalled = 0,
+        circleAfterUpdateCalled = 0,
         popupOptions,
         getShapes = function () {
             return [
@@ -43,6 +44,7 @@ QUnit.test('Annotations events - general', function (assert) {
                     }
                 },
                 {
+                    type: 'basicAnnotation',
                     shapes: [
                         {
                             type: 'circle',
@@ -54,7 +56,12 @@ QUnit.test('Annotations events - general', function (assert) {
                             },
                             r: 10
                         }
-                    ]
+                    ],
+                    events: {
+                        afterUpdate: function () {
+                            circleAfterUpdateCalled++;
+                        }
+                    }
                 }
             ],
             navigation: {
@@ -85,6 +92,17 @@ QUnit.test('Annotations events - general', function (assert) {
         annotation = chart.annotations[0],
         point = chart.series[0].points[2],
         controller = new TestController(chart);
+
+    const controlPoint = chart.annotations[1].shapes[0].controlPoints[0];
+
+    Highcharts.fireEvent(controlPoint.graphic.element, 'mousedown');
+    Highcharts.fireEvent(controlPoint.graphic.element, 'mouseup');
+
+    assert.strictEqual(
+        circleAfterUpdateCalled,
+        1,
+        '#15952: afterUpdate event should fire when clicking control point'
+    );
 
     assert.strictEqual(
         addEventCalled,
@@ -178,7 +196,7 @@ QUnit.test('Annotations events - general', function (assert) {
                     strokeWidth: [1, 'number']
                 }
             ],
-            type: 'circle'
+            type: 'basicAnnotation'
         },
         "Annotations' popup should get correct config for fields (#11716)"
     );

--- a/ts/Extensions/Annotations/Mixins/EventEmitterMixin.ts
+++ b/ts/Extensions/Annotations/Mixins/EventEmitterMixin.ts
@@ -220,7 +220,10 @@ const eventEmitterMixin: Highcharts.AnnotationEventEmitterMixin = {
                 emitter.hasDragged = false;
                 emitter.chart.hasDraggedAnnotation = false;
                 // ControlPoints vs Annotation:
-                fireEvent(pick(emitter.target, emitter), 'afterUpdate');
+                fireEvent(pick(
+                    emitter.target && emitter.target.annotation, // #15952
+                    emitter
+                ), 'afterUpdate');
                 emitter.onMouseUp(e);
             },
             H.isTouchDevice ? { passive: false } : void 0


### PR DESCRIPTION
Fixed #15952, annotation `afterUpdate` event did not fire when using control point.