### PR TITLE
bugfix/14143-14434-stickOnContact-useHTML-outside

### DIFF
--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1119,6 +1119,14 @@ class Pointer {
         const chart = charts[pick(Pointer.hoverChartIndex, -1)];
         const tooltip = this.chart.tooltip;
 
+        // #14434: tooltip.options.outside
+        if (tooltip && tooltip.shouldStickOnContact() && this.inClass(
+            e.relatedTarget as any,
+            'highcharts-tooltip-container'
+        )) {
+            return;
+        }
+
         e = this.normalize(e);
 
         // #4886, MS Touch end fires mouseleave but with no related target

--- a/ts/Core/Renderer/SVG/SVGLabel.ts
+++ b/ts/Core/Renderer/SVG/SVGLabel.ts
@@ -316,6 +316,8 @@ class SVGLabel extends SVGElement {
                     e.relatedTarget instanceof Element &&
                     (
                         // #14110
+                        label.element === e.relatedTarget ||
+                        span.element === e.relatedTarget ||
                         label.element.compareDocumentPosition(e.relatedTarget) & Node.DOCUMENT_POSITION_CONTAINED_BY ||
                         span.element.compareDocumentPosition(e.relatedTarget) & Node.DOCUMENT_POSITION_CONTAINED_BY
                     )

--- a/ts/Core/Renderer/SVG/SVGLabel.ts
+++ b/ts/Core/Renderer/SVG/SVGLabel.ts
@@ -291,52 +291,6 @@ class SVGLabel extends SVGElement {
         this.heightSetting = value;
     }
 
-    // Event handling. In case of useHTML, we need to make sure that events
-    // are captured on the span as well, and that mouseenter/mouseleave
-    // between the SVG group and the HTML span are not treated as real
-    // enter/leave events. #13310.
-    public on(
-        eventType: string,
-        handler: Function
-    ): this {
-        const label = this;
-        const text = label.text;
-        const span: SVGElement|undefined =
-            text && text.element.tagName === 'SPAN' ? text : void 0;
-
-        let selectiveHandler: Function|undefined;
-
-        if (span) {
-            selectiveHandler = function (e: MouseEvent): void {
-                if (
-                    (
-                        eventType === 'mouseenter' ||
-                        eventType === 'mouseleave'
-                    ) &&
-                    e.relatedTarget instanceof Element &&
-                    (
-                        // #14110
-                        label.element === e.relatedTarget ||
-                        span.element === e.relatedTarget ||
-                        label.element.compareDocumentPosition(e.relatedTarget) & Node.DOCUMENT_POSITION_CONTAINED_BY ||
-                        span.element.compareDocumentPosition(e.relatedTarget) & Node.DOCUMENT_POSITION_CONTAINED_BY
-                    )
-                ) {
-                    return;
-                }
-                handler.call(label.element, e);
-            };
-            span.on(eventType, selectiveHandler);
-        }
-        SVGElement.prototype.on.call(
-            label,
-            eventType,
-            selectiveHandler || handler
-        );
-
-        return label;
-    }
-
     /*
      * After the text element is added, get the desired size of the border
      * box and add it before the text in the DOM.

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -37,6 +37,7 @@ import palette from './Color/Palette.js';
 import RendererRegistry from './Renderer/RendererRegistry.js';
 import U from './Utilities.js';
 const {
+    addEvent,
     clamp,
     css,
     defined,
@@ -523,12 +524,18 @@ class Tooltip {
             onMouseEnter = function (): void {
                 tooltip.inContact = true;
             },
-            onMouseLeave = function (): void {
+            onMouseLeave = function (e: MouseEvent): void {
                 const series = tooltip.chart.hoverSeries;
 
-                tooltip.inContact = false;
+                // #14143, #13310: tooltip.options.useHTML
+                tooltip.inContact = tooltip.shouldStickOnContact() &&
+                    tooltip.chart.pointer.inClass(
+                        e.relatedTarget as any,
+                        'highcharts-tooltip'
+                    );
 
                 if (
+                    !tooltip.inContact &&
                     series &&
                     series.onMouseOut
                 ) {
@@ -564,6 +571,9 @@ class Tooltip {
                         (chartStyle && chartStyle.zIndex || 0) + 3
                     )
                 });
+
+                addEvent(container, 'mouseenter', onMouseEnter);
+                addEvent(container, 'mouseleave', onMouseLeave);
 
                 H.doc.body.appendChild(container);
 

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -37,7 +37,6 @@ import palette from './Color/Palette.js';
 import RendererRegistry from './Renderer/RendererRegistry.js';
 import U from './Utilities.js';
 const {
-    addEvent,
     clamp,
     css,
     defined,
@@ -524,18 +523,12 @@ class Tooltip {
             onMouseEnter = function (): void {
                 tooltip.inContact = true;
             },
-            onMouseLeave = function (e: MouseEvent): void {
+            onMouseLeave = function (): void {
                 const series = tooltip.chart.hoverSeries;
 
-                // #14143: tooltip.options.useHTML
-                tooltip.inContact = tooltip.shouldStickOnContact() &&
-                    tooltip.chart.pointer.inClass(
-                        e.relatedTarget as any,
-                        'highcharts-tooltip'
-                    );
+                tooltip.inContact = false;
 
                 if (
-                    !tooltip.inContact &&
                     series &&
                     series.onMouseOut
                 ) {
@@ -571,9 +564,6 @@ class Tooltip {
                         (chartStyle && chartStyle.zIndex || 0) + 3
                     )
                 });
-
-                addEvent(container, 'mouseenter', onMouseEnter);
-                addEvent(container, 'mouseleave', onMouseLeave);
 
                 H.doc.body.appendChild(container);
 


### PR DESCRIPTION
Fixed #14143, #14434, #13310, tooltip with `stickOnContact` and `useHTML` or `outside` enabled did not work properly.

Replaces #14473.
Closes #14434.
Closes #13310.