### PR TITLE
bugfix/13840-3d-column-scroll-corner

### DIFF
--- a/ts/Series/Column3D/Column3DComposition.ts
+++ b/ts/Series/Column3D/Column3DComposition.ts
@@ -223,7 +223,8 @@ columnProto.translate3dShapes = function (): void {
                 ) {
                     // Set args to 0 if column is outside the chart.
                     for (const key in shapeArgs) { // eslint-disable-line guard-for-in
-                        (shapeArgs as any)[key] = 0;
+                        // #13840
+                        (shapeArgs as any)[key] = key === 'y' ? -9999 : 0;
                     }
                     // #7103 outside3dPlot flag is set on Points which are
                     // currently outside of plot.
@@ -320,7 +321,11 @@ wrap(columnProto, 'animate', function (
                         (point.shapeArgs as any).y = point.shapey; // #2968
                         // null value do not have a graphic
                         if (point.graphic) {
-                            point.graphic.animate(
+                            point.graphic[
+                                point.outside3dPlot ?
+                                    'attr' :
+                                    'animate'
+                            ](
                                 point.shapeArgs as any,
                                 series.options.animation
                             );


### PR DESCRIPTION
Fixed #13840, 3d column chart with scrollbar showed points outside plot in upper left corner.

_Behaviour when clicking the scrollbar might need some work._