### PR TITLE
bugfix/15973-wordcloud-focus-border-firefox

### DIFF
--- a/samples/unit-tests/accessibility/accessibility-options/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-options/demo.js
@@ -351,9 +351,7 @@ QUnit.test('Focus border in wordcloud', function (assert) {
         focusBorderY = chart.focusElement.focusBorder.attr('y'),
         focusBorderHeight = chart.focusElement.focusBorder.attr('height'),
         focusElementX = chart.focusElement.attr('x'),
-        focusElementY = chart.focusElement.attr('y'),
-        focusElementHeight = point.graphic.getBBox().height,
-        H = Highcharts;
+        focusElementY = chart.focusElement.attr('y');
 
     assert.strictEqual(
         focusBorderX + focusBorderWidth / 2,
@@ -361,10 +359,9 @@ QUnit.test('Focus border in wordcloud', function (assert) {
         'should be correctly applied for text elements horizontally, #11397'
     );
 
-    // Correct baseline position on Firefox.
     assert.strictEqual(
         focusBorderY + focusBorderHeight / 2,
-        H.isFirefox ? focusElementY - focusElementHeight * 0.25 : focusElementY,
+        focusElementY,
         'should be correctly applied for text elements vertically, #11397'
     );
 });

--- a/ts/Accessibility/FocusBorder.ts
+++ b/ts/Accessibility/FocusBorder.ts
@@ -211,8 +211,7 @@ extend(SVGElement.prototype, {
                 posYCorrection = 0;
 
             if (text.attr('text-anchor') === 'middle') {
-                posXCorrection = H.isFirefox && text.rotation ? 0.25 : 0.5;
-                posYCorrection = H.isFirefox && !text.rotation ? 0.75 : 0.5;
+                posXCorrection = posYCorrection = 0.5;
             } else if (!text.rotation) {
                 posYCorrection = 0.75;
             } else {

--- a/ts/Core/Renderer/SVG/SVGAttributes.d.ts
+++ b/ts/Core/Renderer/SVG/SVGAttributes.d.ts
@@ -52,6 +52,7 @@ export interface SVGAttributes {
     dashstyle?: DashStyleValue;
     depth?: number;
     display?: ''|'block'|'none';
+    'dominant-baseline'?: string;
     dx?: number;
     dy?: number;
     end?: number;

--- a/ts/Series/Wordcloud/WordcloudSeries.ts
+++ b/ts/Series/Wordcloud/WordcloudSeries.ts
@@ -361,6 +361,7 @@ class WordcloudSeries extends ColumnSeries {
                     {
                         align: 'center',
                         'alignment-baseline': 'middle',
+                        'dominant-baseline': 'middle', // #15973: Firefox
                         x: placement.x,
                         y: placement.y,
                         text: point.name,


### PR DESCRIPTION
Fixed #15973, word cloud focus border position for rotated points was wrong in Firefox.