### PR TITLE
bugfix/15983-update-remove-event

### DIFF
--- a/samples/unit-tests/axis/events/demo.js
+++ b/samples/unit-tests/axis/events/demo.js
@@ -94,4 +94,16 @@ QUnit.test('Axis events', function (assert) {
     );
 
     unbindClass();
+
+    chart.xAxis[0].update({
+        events: {
+            afterSetExtremes: void 0
+        }
+    });
+    chart.xAxis[0].setExtremes(3, 7);
+    assert.deepEqual(
+        [calls.afterSetExtremesOptions, calls.afterSetExtremesOptionsUpdated],
+        [2, 1],
+        'Event handler should be removed after updating to undefined (#15983)'
+    );
 });

--- a/ts/Core/Foundation.ts
+++ b/ts/Core/Foundation.ts
@@ -63,21 +63,21 @@ const registerEventOptions = (
     objectEach(
         options.events,
         function (event: any, eventType: string): void {
-            if (isFunction(event)) {
+            // If event does not exist, or is changed by the .update()
+            // function
+            if (component.eventOptions[eventType] !== event) {
 
-                // If event does not exist, or is changed by the .update()
-                // function
-                if (component.eventOptions[eventType] !== event) {
+                // Remove existing if set by option
+                if (component.eventOptions[eventType]) {
+                    removeEvent(
+                        component,
+                        eventType,
+                        component.eventOptions[eventType]
+                    );
+                    delete component.eventOptions[eventType];
+                }
 
-                    // Remove existing if set by option
-                    if (isFunction(component.eventOptions[eventType])) {
-                        removeEvent(
-                            component,
-                            eventType,
-                            component.eventOptions[eventType]
-                        );
-                    }
-
+                if (isFunction(event)) {
                     component.eventOptions[eventType] = event;
                     addEvent(component, eventType, event);
                 }


### PR DESCRIPTION
Fixed #15983, event did not get removed when updating it to `undefined`.