### PR TITLE
bugfix/15986-exit-anchor-chart-update

### DIFF
--- a/samples/unit-tests/accessibility/accessibility-options/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-options/demo.js
@@ -249,6 +249,12 @@ QUnit.test('Chart description', function (assert) {
             -1,
         'Chart description included in screen reader region'
     );
+
+    chart.update({});
+    assert.ok(
+        document.querySelector('.highcharts-exit-anchor'),
+        '#15986: There should still be an exit anchor after updating'
+    );
 });
 
 QUnit.test('Landmark verbosity', function (assert) {

--- a/ts/Accessibility/Components/InfoRegionsComponent.ts
+++ b/ts/Accessibility/Components/InfoRegionsComponent.ts
@@ -350,6 +350,12 @@ extend(InfoRegionsComponent.prototype, /** @lends Highcharts.InfoRegionsComponen
                     chart.renderTo.insertBefore(
                         el, chart.container.nextSibling
                     );
+                },
+                afterInserted: function (): void {
+                    if (component.chart.accessibility) {
+                        component.chart.accessibility
+                            .keyboardNavigation.updateExitAnchor(); // #15986
+                    }
                 }
             }
         };


### PR DESCRIPTION
Fixed #15986, exit anchor disappeared on `Chart.update`.