### PR TITLE
bugfix/15235-ast-whitespace

### DIFF
--- a/samples/unit-tests/svgrenderer/label/demo.js
+++ b/samples/unit-tests/svgrenderer/label/demo.js
@@ -92,6 +92,20 @@ QUnit.test('Left trim (#5261)', function (assert) {
         null,
         'Ending break should have no dy'
     );
+
+    label = ren
+        .label('<span>Hello</span> <span>World</span>', 100, 50)
+        .attr({
+            'stroke-width': 1,
+            stroke: 'blue'
+        })
+        .add();
+
+    assert.strictEqual(
+        label.text.element.childNodes.length,
+        3,
+        '#15235: Whitespace between spans should not be removed'
+    );
 });
 
 QUnit.test('Image labels should have no fill (#4324)', function (assert) {

--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -428,6 +428,8 @@ class AST {
 
         const nodes: Array<AST.Node> = [];
 
+        markup = markup.trim();
+
         let doc;
         let body;
         if (hasValidDOMParser) {
@@ -451,8 +453,8 @@ class AST {
             if (tagName === '#text') {
                 const textContent = node.textContent || '';
 
-                // Whitespace text node, don't append it to the AST
-                if (/^[\s]*$/.test(textContent)) {
+                // Leading whitespace text node, don't append it to the AST
+                if (nodes.length === 0 && /^[\s]*$/.test(textContent)) {
                     return;
                 }
 


### PR DESCRIPTION
Fixed #15235, whitespace between html elements got removed.