### PR TITLE
bugfix/15975-zoom-minRange-adjust

### DIFF
--- a/samples/unit-tests/axis/minrange/demo.js
+++ b/samples/unit-tests/axis/minrange/demo.js
@@ -72,3 +72,37 @@ QUnit.test('#14505: minRange NaN with single point series', assert => {
         );
     });
 });
+
+QUnit.test('adjustForMinRange', assert => {
+    const chart = Highcharts.chart('container', {
+        series: [{
+            data: [
+                { x: 0, y: 4 },
+                { x: 1, y: 3 },
+                { x: 2, y: 5 },
+                { x: 3, y: 6 },
+                { x: 4, y: 2 },
+                { x: 5, y: 3 }
+            ]
+        }, {
+            data: [
+                { x: 6, y: 4 },
+                { x: 7, y: 23 },
+                { x: 8, y: 5 },
+                { x: 9, y: 6 },
+                { x: 10, y: 2 },
+                { x: 11, y: 3 }
+            ]
+        }]
+    });
+
+    chart.xAxis[0].setExtremes(4, 7);
+    const adjusted = [chart.xAxis[0].min, chart.xAxis[0].max];
+    chart.series[0].hide();
+
+    assert.deepEqual(
+        [chart.xAxis[0].min, chart.xAxis[0].max],
+        adjusted,
+        '#15975: Zoomed extremes should not re-adjust after hiding series'
+    );
+});

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1304,11 +1304,19 @@ class Axis {
                 minArgs[1] = pick(options.min, max - (minRange as any));
                 min = arrayMax(minArgs);
             }
-        }
 
-        // Record modified extremes
-        axis.min = min;
-        axis.max = max;
+            // Record modified extremes
+            axis.min = min;
+            axis.max = max;
+
+            // #15975: Adjust user extremes as well to avoid re-adjusting when
+            // the range between user extremes is smaller than minRange but the
+            // extremes have already been adjusted
+            if (isNumber(axis.userMin) && isNumber(axis.userMax)) {
+                axis.userMin = min;
+                axis.userMax = max;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Fixed #15975, extremes changed when hiding series after attempting to zoom in further than `minRange`.