### PR TITLE
bugfix/16011-annotation-labels-shapes-update

### DIFF
--- a/samples/unit-tests/annotations/annotations-dynamic/demo.js
+++ b/samples/unit-tests/annotations/annotations-dynamic/demo.js
@@ -105,6 +105,13 @@ QUnit.test("Annotation's dynamic methods", function (assert) {
                     xAxis: 0,
                     yAxis: 0
                 }
+            }, {
+                point: {
+                    x: 3,
+                    y: 125000,
+                    xAxis: 0,
+                    yAxis: 0
+                }
             }
         ]
     };
@@ -129,6 +136,11 @@ QUnit.test("Annotation's dynamic methods", function (assert) {
         thirdAnnotation.labels[0].options.format,
         'custom format',
         'Correct annotations text after update (annotations.labels)'
+    );
+    assert.strictEqual(
+        thirdAnnotation.labels.length,
+        2,
+        '#16011: Labels should not disappear on update'
     );
 
     thirdAnnotation.update({
@@ -214,6 +226,14 @@ QUnit.test("Annotation's dynamic methods", function (assert) {
                 { xAxis: 0, yAxis: 0, x: 3, y: 100000 },
                 { xAxis: 0, yAxis: 0, x: 1, y: 100000 }
             ]
+        }, {
+            type: 'path',
+            points: [
+                { xAxis: 0, yAxis: 0, x: 1, y: 150000 },
+                { xAxis: 0, yAxis: 0, x: 3, y: 150000 },
+                { xAxis: 0, yAxis: 0, x: 3, y: 100000 },
+                { xAxis: 0, yAxis: 0, x: 1, y: 100000 }
+            ]
         }]
     });
 
@@ -225,6 +245,14 @@ QUnit.test("Annotation's dynamic methods", function (assert) {
     assert.ok(
         thirdAnnotation.labels[0].graphic.hasClass('highcharts-no-tooltip'),
         '#14403: Annotation label should have no-tooltip class'
+    );
+
+    rect.update({});
+
+    assert.strictEqual(
+        rect.shapes.length,
+        2,
+        '#16011: Shapes should not disappear on update'
     );
 });
 

--- a/samples/unit-tests/svgrenderer/label/demo.js
+++ b/samples/unit-tests/svgrenderer/label/demo.js
@@ -476,6 +476,19 @@ QUnit.test('Labels with useHTML', assert => {
         '200px',
         'The span width should adapt to shorter text (#10009)'
     );
+
+    const g = ren.g('parent')
+        .attr({
+            visibility: 'hidden'
+        })
+        .add();
+    ren.label('Foo', 0, 0, void 0, 0, 0, true).add(g);
+
+    assert.strictEqual(
+        g.div.style.visibility,
+        'hidden',
+        'Visibility should be set on parent group div'
+    );
 });
 
 QUnit.test('Change of label alignment after add (#4652)', function (assert) {

--- a/ts/Core/Renderer/HTML/HTMLRenderer.ts
+++ b/ts/Core/Renderer/HTML/HTMLRenderer.ts
@@ -121,11 +121,6 @@ class HTMLRenderer extends SVGRenderer {
                         }
                     };
                 });
-                // Handle visibility set on the parent group before adding
-                // setters
-                gWrapper.attr({
-                    visibility: gWrapper.visibility
-                });
                 gWrapper.addedSetters = true;
             };
 
@@ -273,7 +268,8 @@ class HTMLRenderer extends SVGRenderer {
                                     opacity: parentGroup.opacity, // #5075
                                     cursor: parentGroupStyles.cursor, // #6794
                                     pointerEvents:
-                                        parentGroupStyles.pointerEvents // #5595
+                                        parentGroupStyles.pointerEvents, // #5595
+                                    visibility: parentGroup.visibility
 
                                 // the top group is appended to container
                                 },

--- a/ts/Core/Renderer/HTML/HTMLRenderer.ts
+++ b/ts/Core/Renderer/HTML/HTMLRenderer.ts
@@ -121,6 +121,11 @@ class HTMLRenderer extends SVGRenderer {
                         }
                     };
                 });
+                // Handle visibility set on the parent group before adding
+                // setters
+                gWrapper.attr({
+                    visibility: gWrapper.visibility
+                });
                 gWrapper.addedSetters = true;
             };
 

--- a/ts/Extensions/Annotations/Annotations.ts
+++ b/ts/Extensions/Annotations/Annotations.ts
@@ -499,14 +499,18 @@ class Annotation implements EventEmitterMixin.Type, ControllableMixin.Type {
 
         (['labels', 'shapes'] as Array<('labels'|'shapes')>).forEach(function (name: ('labels'|'shapes')): void {
             if (baseOptions[name]) {
-                mergedOptions[name] = splat(newOptions[name]).map(
-                    function (
-                        basicOptions: (Highcharts.AnnotationsLabelsOptions|Highcharts.AnnotationsShapesOptions),
-                        i: number
-                    ): (Highcharts.AnnotationsLabelsOptions|Highcharts.AnnotationsShapesOptions) {
-                        return merge(baseOptions[name][i], basicOptions);
-                    }
-                ) as any;
+                if (newOptions[name]) {
+                    mergedOptions[name] = splat(newOptions[name]).map(
+                        function (
+                            basicOptions: (Highcharts.AnnotationsLabelsOptions|Highcharts.AnnotationsShapesOptions),
+                            i: number
+                        ): (Highcharts.AnnotationsLabelsOptions|Highcharts.AnnotationsShapesOptions) {
+                            return merge(baseOptions[name][i], basicOptions);
+                        }
+                    ) as any;
+                } else {
+                    mergedOptions[name] = baseOptions[name] as any;
+                }
             }
         });
 


### PR DESCRIPTION
Fixed #16011, some labels/shapes disappeared when updating annotation with multiple labels/shapes and not passing in any labels/shapes.