### PR TITLE
Fixed #15229, avoid duplicate a11y region labels.

### DIFF
--- a/ts/Accessibility/Components/InfoRegionsComponent.ts
+++ b/ts/Accessibility/Components/InfoRegionsComponent.ts
@@ -53,7 +53,6 @@ const {
 import HTMLUtilities from '../Utils/HTMLUtilities.js';
 const {
     addClass,
-    escapeStringForHTML,
     getElement,
     getHeadingTagNameForElement,
     setElAttrs,
@@ -466,7 +465,7 @@ extend(InfoRegionsComponent.prototype, /** @lends Highcharts.InfoRegionsComponen
                 'accessibility.screenReaderSection.' + regionKey + 'RegionLabel'
             ),
             chart = this.chart,
-            labelText = chart.langFormat(labelLangKey, { chart: chart }),
+            labelText = chart.langFormat(labelLangKey, { chart: chart, chartTitle: getChartTitle(chart) }),
             sectionId = 'highcharts-screen-reader-region-' + regionKey + '-' +
                 chart.index;
 

--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -44,6 +44,10 @@ const {
     removeElement,
     stripHTMLTagsFromString: stripHTMLTags
 } = HTMLUtilities;
+import ChartUtils from '../Utils/ChartUtilities.js';
+const {
+    getChartTitle
+} = ChartUtils;
 
 type LegendItem = (BubbleLegendItem|Series|Point);
 
@@ -363,7 +367,8 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
         const legendLabel = chart.langFormat(
             'accessibility.legend.legendLabel' + (legendTitle ? '' : 'NoTitle'), {
                 chart,
-                legendTitle
+                legendTitle,
+                chartTitle: getChartTitle(chart)
             }
         );
 

--- a/ts/Accessibility/Components/MenuComponent.ts
+++ b/ts/Accessibility/Components/MenuComponent.ts
@@ -20,7 +20,6 @@ import type {
 import type SVGElement from '../../Core/Renderer/SVG/SVGElement';
 
 import Chart from '../../Core/Chart/Chart.js';
-import H from '../../Core/Globals.js';
 import U from '../../Core/Utilities.js';
 const {
     extend
@@ -30,7 +29,10 @@ import AccessibilityComponent from '../AccessibilityComponent.js';
 import KeyboardNavigationHandler from '../KeyboardNavigationHandler.js';
 
 import ChartUtilities from '../Utils/ChartUtilities.js';
-const unhideChartElementFromAT = ChartUtilities.unhideChartElementFromAT;
+const {
+    getChartTitle,
+    unhideChartElementFromAT
+} = ChartUtilities;
 
 import HTMLUtilities from '../Utils/HTMLUtilities.js';
 const removeElement = HTMLUtilities.removeElement,
@@ -326,7 +328,7 @@ extend(MenuComponent.prototype, /** @lends Highcharts.MenuComponent */ {
                 a11yOptions.landmarkVerbosity === 'all' ? {
                     'aria-label': chart.langFormat(
                         'accessibility.exporting.exportRegionLabel',
-                        { chart: chart }
+                        { chart: chart, chartTitle: getChartTitle(chart) }
                     ),
                     'role': 'region'
                 } : {}

--- a/ts/Accessibility/Options/LangOptions.ts
+++ b/ts/Accessibility/Options/LangOptions.ts
@@ -255,7 +255,7 @@ const langOptions: DeepPartial<LangOptions> = {
          * @since 8.0.0
          */
         screenReaderSection: {
-            beforeRegionLabel: 'Chart screen reader information.',
+            beforeRegionLabel: 'Chart screen reader information, {chartTitle}.',
             afterRegionLabel: '',
 
             /**
@@ -295,7 +295,7 @@ const langOptions: DeepPartial<LangOptions> = {
          * @since 8.0.0
          */
         legend: {
-            legendLabelNoTitle: 'Toggle series visibility',
+            legendLabelNoTitle: 'Toggle series visibility, {chartTitle}',
             legendLabel: 'Chart legend: {legendTitle}',
             legendItem: 'Show {itemName}'
         },
@@ -450,7 +450,7 @@ const langOptions: DeepPartial<LangOptions> = {
         exporting: {
             chartMenuLabel: 'Chart menu',
             menuButtonLabel: 'View chart menu',
-            exportRegionLabel: 'Chart menu'
+            exportRegionLabel: 'Chart menu, {chartTitle}'
         },
 
         /**


### PR DESCRIPTION
Fixed #15229, avoid duplicate a11y region labels.
___
We now add the chart title to these by default.