### PR TITLE
Migration: Chart renderer

### DIFF
--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -51,6 +51,7 @@ import type {
 import type { HTMLDOMElement } from '../Renderer/DOMElementType';
 import type SVGAttributes from '../Renderer/SVG/SVGAttributes';
 import type SVGElement from '../Renderer/SVG/SVGElement';
+import type SVGRenderer from '../Renderer/SVG/SVGRenderer.js';
 
 import A from '../Animation/AnimationUtilities.js';
 const {
@@ -84,7 +85,6 @@ import Pointer from '../Pointer.js';
 import RendererRegistry from '../Renderer/RendererRegistry.js';
 import SeriesRegistry from '../Series/SeriesRegistry.js';
 const { seriesTypes } = SeriesRegistry;
-import SVGRenderer from '../Renderer/SVG/SVGRenderer.js';
 import Time from '../Time.js';
 import U from '../Utilities.js';
 import AST from '../Renderer/HTML/AST.js';
@@ -151,7 +151,7 @@ declare module './ChartLike' {
 declare module './ChartOptions' {
     interface ChartOptions {
         forExport?: boolean;
-        renderer?: string;
+        renderer?: (string|typeof SVGRenderer);
         skipClone?: boolean;
     }
 }
@@ -1593,7 +1593,9 @@ class Chart {
         chart._cursor = container.style.cursor as CursorValue;
 
         // Initialize the renderer
-        const Renderer = RendererRegistry.getRendererType(optionsChart.renderer);
+        const Renderer = typeof optionsChart.renderer === 'function' ?
+            optionsChart.renderer :
+            RendererRegistry.getRendererType(optionsChart.renderer);
 
         /**
          * The renderer instance of the chart. Each chart instance has only one

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -51,7 +51,6 @@ import type {
 import type { HTMLDOMElement } from '../Renderer/DOMElementType';
 import type SVGAttributes from '../Renderer/SVG/SVGAttributes';
 import type SVGElement from '../Renderer/SVG/SVGElement';
-import type SVGRenderer from '../Renderer/SVG/SVGRenderer.js';
 
 import A from '../Animation/AnimationUtilities.js';
 const {
@@ -71,6 +70,7 @@ const {
     charts,
     doc,
     marginNames,
+    svg,
     win
 } = H;
 import Legend from '../Legend.js';
@@ -85,6 +85,7 @@ import Pointer from '../Pointer.js';
 import RendererRegistry from '../Renderer/RendererRegistry.js';
 import SeriesRegistry from '../Series/SeriesRegistry.js';
 const { seriesTypes } = SeriesRegistry;
+import SVGRenderer from '../Renderer/SVG/SVGRenderer.js';
 import Time from '../Time.js';
 import U from '../Utilities.js';
 import AST from '../Renderer/HTML/AST.js';
@@ -151,7 +152,7 @@ declare module './ChartLike' {
 declare module './ChartOptions' {
     interface ChartOptions {
         forExport?: boolean;
-        renderer?: (string|typeof SVGRenderer);
+        renderer?: string;
         skipClone?: boolean;
     }
 }
@@ -1593,9 +1594,9 @@ class Chart {
         chart._cursor = container.style.cursor as CursorValue;
 
         // Initialize the renderer
-        const Renderer = typeof optionsChart.renderer === 'function' ?
-            optionsChart.renderer :
-            RendererRegistry.getRendererType(optionsChart.renderer);
+        const Renderer = optionsChart.renderer || !svg ?
+            RendererRegistry.getRendererType(optionsChart.renderer) :
+            SVGRenderer;
 
         /**
          * The renderer instance of the chart. Each chart instance has only one

--- a/ts/Core/Chart/ChartDefaults.ts
+++ b/ts/Core/Chart/ChartDefaults.ts
@@ -33,22 +33,6 @@ import Palette from '../Color/Palette.js';
  */
 const ChartDefaults: ChartOptions = {
 
-    /* eslint-disable max-len */
-    /**
-     * Class or constructor for the SVGRenderer instance to create. This option
-     * is used mainly in module-based chart solutions.
-     *
-     * @example
-     * import SVGRenderer from 'highcharts/es-modules/Core/Renderer/SVG/SVGRenderer.js';
-     * import Chart from 'highcharts/es-modules/Core/Chart/Chart.js';
-     * const chart = new Chart('container', { chart: { renderer: SVGRenderer } });
-     *
-     * @type      {Function}
-     * @since     next
-     * @apioption chart.renderer
-     */
-    /* eslint-enable max-len */
-
     /**
      * Default `mapData` for all series. If set to a string, it functions
      * as an index into the `Highcharts.maps` array. Otherwise it is

--- a/ts/Core/Chart/ChartDefaults.ts
+++ b/ts/Core/Chart/ChartDefaults.ts
@@ -33,6 +33,22 @@ import Palette from '../Color/Palette.js';
  */
 const ChartDefaults: ChartOptions = {
 
+    /* eslint-disable max-len */
+    /**
+     * Class or constructor for the SVGRenderer instance to create. This option
+     * is used mainly in module-based chart solutions.
+     *
+     * @example
+     * import SVGRenderer from 'highcharts/es-modules/Core/Renderer/SVG/SVGRenderer.js';
+     * import Chart from 'highcharts/es-modules/Core/Chart/Chart.js';
+     * const chart = new Chart('container', { chart: { renderer: SVGRenderer } });
+     *
+     * @type      {Function}
+     * @since     next
+     * @apioption chart.renderer
+     */
+    /* eslint-enable max-len */
+
     /**
      * Default `mapData` for all series. If set to a string, it functions
      * as an index into the `Highcharts.maps` array. Otherwise it is


### PR DESCRIPTION
SVGRenderer will be the default fallback and imported mandatory together with Chart.

~Extended `chart.renderer` option with the class constructor type of `SVGRenderer`.~

~Without something like this, `Chart` class will never become full ESM compatible (async) as it expects registered renderers to be available during construction.~

~An alternative could be a fourth argument in the constructor taking the renderer class.~