### PR TITLE
bugfix/16036-vbp-indicator-volumeDivision-graphic

### DIFF
--- a/samples/unit-tests/indicator-volume-by-price/recalculations/demo.js
+++ b/samples/unit-tests/indicator-volume-by-price/recalculations/demo.js
@@ -195,6 +195,13 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
         'volumeDataArray is correct after point remove on the base and the volume series.'
     );
 
+    const negativeGraphic = indicator.points[0].negativeGraphic;
+    indicator.points[0].destroy();
+    assert.notOk(
+        negativeGraphic.element,
+        '#16036: negativeGraphic should have been destroyed'
+    );
+
     indicator.remove();
     assert.ok(
         chart.series.indexOf(indicator) === -1,

--- a/ts/Stock/Indicators/VBP/VBPIndicator.ts
+++ b/ts/Stock/Indicators/VBP/VBPIndicator.ts
@@ -25,7 +25,7 @@ import type {
     VBPOptions,
     VBPParamsOptions
 } from './VBPOptions';
-import VBPPoint from './VBPPoint';
+import VBPPoint from './VBPPoint.js';
 
 import A from '../../../Core/Animation/AnimationUtilities.js';
 const { animObject } = A;
@@ -798,6 +798,7 @@ extend(VBPIndicator.prototype, {
         eventName: 'afterSetExtremes'
     },
     calculateOn: 'render',
+    pointClass: VBPPoint,
     markerAttribs: noop as any,
     drawGraph: noop,
     getColumnMetrics: columnPrototype.getColumnMetrics,


### PR DESCRIPTION
Fixed #16036, VBP indicator graphic did not update correctly with `volumeDivision` enabled.