### PR TITLE
bugfix/16042-xrange-gaps

### DIFF
--- a/ts/Series/XRange/XRangeSeries.ts
+++ b/ts/Series/XRange/XRangeSeries.ts
@@ -391,10 +391,13 @@ class XRangeSeries extends ColumnSeries {
             );
         }
 
+        const x = Math.floor(Math.min(plotX, plotX2)) + crisper;
+        const x2 = Math.floor(Math.max(plotX, plotX2)) + crisper;
+
         const shapeArgs = {
-            x: Math.floor(Math.min(plotX, plotX2)) + crisper,
+            x,
             y: Math.floor((point.plotY as any) + yOffset) + crisper,
-            width: Math.round(Math.abs(plotX2 - plotX)),
+            width: x2 - x,
             height: pointHeight,
             r: series.options.borderRadius
         };


### PR DESCRIPTION
Fixed #16042, 1px gaps showed between some xrange points when there was no gaps in the data.