### PR TITLE
bugfix/16062-useHTML-line-break-align

### DIFF
--- a/samples/unit-tests/svgrenderer/text/demo.js
+++ b/samples/unit-tests/svgrenderer/text/demo.js
@@ -527,6 +527,26 @@ QUnit.test('HTML', function (assert) {
             '',
             'The style width should be removed when setting to undefined'
         );
+
+        renderer = new Highcharts.SVGRenderer(
+            document.getElementById('container'),
+            500,
+            500,
+            void 0,
+            true
+        );
+
+        text = renderer.text('Line<br>break', 0, 10, true)
+            .add()
+            .attr({
+                x: 10
+            });
+
+        assert.strictEqual(
+            text.element.querySelector('tspan').getAttribute('x'),
+            '10',
+            '#16062: tspan breaks should have correct x when exporting useHTML=true text with allowHTML=false'
+        );
     } finally {
         renderer.destroy();
     }

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -1631,7 +1631,7 @@ class SVGRenderer implements SVGRendererLike {
 
         const wrapper = renderer.createElement('text').attr(attribs);
 
-        if (!useHTML) {
+        if (!useHTML || (renderer.forExport && !renderer.allowHTML)) {
             wrapper.xSetter = function (
                 value: string,
                 key: string,


### PR DESCRIPTION
Fixed #16062, lines after the first line break in text with `useHTML` set to `true` were misaligned in exported charts when `exporting.allowHTML` was set to `false`.