### PR TITLE
bugfix/15867 multiline indicator compare

### DIFF
--- a/samples/stock/members/axis-setcumulative/demo.details
+++ b/samples/stock/members/axis-setcumulative/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Stock Demo
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+...

--- a/samples/stock/members/axis-setcumulative/demo.html
+++ b/samples/stock/members/axis-setcumulative/demo.html
@@ -1,0 +1,8 @@
+<div id="container" style="height: 400px; min-width: 600px"></div>
+
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+<script src="https://code.highcharts.com/stock/modules/data.js"></script>
+<script src="https://code.highcharts.com/stock/modules/exporting.js"></script>
+
+<button class="disable-cumulative">Disable Cumulative Sum</button>
+<button class="enable-cumulative">Enable Cumulative Sum</button>

--- a/samples/stock/members/axis-setcumulative/demo.js
+++ b/samples/stock/members/axis-setcumulative/demo.js
@@ -1,0 +1,32 @@
+Highcharts.stockChart('container', {
+
+    rangeSelector: {
+        selected: 4
+    },
+
+    tooltip: {
+        pointFormat: '<span style="color:{series.color}">{series.name}</span>: <b>{point.y}</b> ({point.cumulativeSum})<br/>',
+        changeDecimals: 2,
+        valueDecimals: 2
+    },
+
+    series: [{
+        data: [5, 3, 5, 5, 5, 5]
+    }, {
+        data: [1, 2, 3, 4, 5, 6]
+    }, {
+        data: [6, 5, 4, 3, 2, 1]
+    }]
+
+}, function (chart) {
+    // Buttons behaviour
+    document.querySelector('button.enable-cumulative')
+        .addEventListener('click', function () {
+            chart.yAxis[0].setCumulative(true);
+        });
+
+    document.querySelector('button.disable-cumulative')
+        .addEventListener('click', function () {
+            chart.yAxis[0].setCumulative(false);
+        });
+});

--- a/samples/stock/plotoptions/series-cumulative-sum/demo.details
+++ b/samples/stock/plotoptions/series-cumulative-sum/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Stock Demo
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+...

--- a/samples/stock/plotoptions/series-cumulative-sum/demo.html
+++ b/samples/stock/plotoptions/series-cumulative-sum/demo.html
@@ -1,0 +1,5 @@
+<div id="container" style="height: 400px; min-width: 600px"></div>
+
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+<script src="https://code.highcharts.com/stock/modules/data.js"></script>
+<script src="https://code.highcharts.com/stock/modules/exporting.js"></script>

--- a/samples/stock/plotoptions/series-cumulative-sum/demo.js
+++ b/samples/stock/plotoptions/series-cumulative-sum/demo.js
@@ -1,0 +1,42 @@
+var day = 1000 * 60 * 60 * 24;
+
+// Create the chart
+Highcharts.stockChart('container', {
+
+    title: {
+        text: 'Cumulative Sum'
+    },
+
+    subtitle: {
+        text: 'Displays the sum of all the previous values and the current value (only within visible range)'
+    },
+
+    plotOptions: {
+        series: {
+            cumulative: true,
+            pointStart: Date.UTC(2021, 0, 1),
+            pointInterval: day
+        }
+    },
+
+    rangeSelector: {
+        enabled: false
+    },
+
+    tooltip: {
+        pointFormat: '<span style="color:{series.color}">{series.name}</span>: <b>{point.y}</b> ({point.cumulativeSum})<br/>',
+        changeDecimals: 2,
+        valueDecimals: 2
+    },
+
+    xAxis: {
+        minRange: day * 3,
+        max: Date.UTC(2021, 0, 6)
+    },
+
+    series: [{
+        data: [1, 2, 5, 10, 20, 50, 100, -100, 100, -100]
+    }, {
+        data: [100, -50, -15, 15, -50, -20, -30, 100, -100, 100]
+    }]
+});

--- a/samples/unit-tests/series/cumulative/demo.details
+++ b/samples/unit-tests/series/cumulative/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/series/cumulative/demo.html
+++ b/samples/unit-tests/series/cumulative/demo.html
@@ -1,0 +1,8 @@
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+<script src="https://code.highcharts.com/stock/indicators/indicators-all.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/series/cumulative/demo.js
+++ b/samples/unit-tests/series/cumulative/demo.js
@@ -1,0 +1,85 @@
+QUnit.test('Stock: general tests for the Cumulative Sum', function (assert) {
+    const chart = Highcharts.chart('container', {
+
+            plotOptions: {
+                series: {
+                    cumulative: true
+                }
+            },
+
+            series: [{
+                data: [0]
+            }]
+
+        }),
+        dataArr1 = [1, 4, 5, 6],
+        dataArr2 = [4, 5, 1, -3];
+
+    assert.deepEqual(
+        Highcharts.Series.prototype.getCumulativeExtremes([1, 2, 3, 4, 5, 0]),
+        [1, 15],
+        'Data min and max should be calculated correctly.'
+    );
+
+    assert.deepEqual(
+        chart.yAxis[0].tickPositions,
+        [0],
+        'The Y axis should have one tick at 0.'
+    );
+
+    chart.series[0].setData(dataArr1, false);
+
+    chart.addSeries({
+        data: dataArr2
+    });
+
+    assert.strictEqual(
+        chart.yAxis[0].dataMax,
+        Math.max(
+            dataArr1.reduce((a, b) => a + b),
+            dataArr2.reduce((a, b) => a + b)
+        ),
+        `The yAxis dataMax should be equal to the highest sum
+        of each series' summed points.`
+    );
+
+    chart.update({
+        plotOptions: {
+            series: {
+                cumulative: false
+            }
+        }
+    });
+
+    assert.notEqual(
+        chart.series[0].points[2].plotY,
+        chart.series[1].points[2].plotY,
+        'The points should not overlap when cumulative is disabled.'
+    );
+
+    chart.yAxis[0].setCumulative(true);
+
+    assert.strictEqual(
+        chart.series[0].points[2].plotY,
+        chart.series[1].points[2].plotY,
+        'The points should have the same sum value and overlap (sum to 10).'
+    );
+
+    chart.yAxis[0].setCumulative(false);
+
+    assert.strictEqual(
+        chart.plotTop + chart.series[0].points[1].plotY,
+        chart.yAxis[0].toPixels(chart.series[0].points[1].y),
+        'Cumulative disabled - point should not be summed.'
+    );
+
+    chart.series[0].setCumulative(true);
+
+    assert.strictEqual(
+        chart.series[0].points[1].plotY,
+        chart.series[1].points[1].plotY,
+        `The two first points should be summed only in the first series.
+        1 + 4 should be equal to 5 (second point of the second series).`
+    );
+
+});

--- a/ts/Core/Series/DataExtremesObject.d.ts
+++ b/ts/Core/Series/DataExtremesObject.d.ts
@@ -15,6 +15,7 @@
  * */
 
 export interface DataExtremesObject {
+    activeYData?: Array<number>;
     dataMin?: number;
     dataMax?: number;
 }

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -4685,7 +4685,7 @@ class Series {
                 ) as any) :
                 null as any;
 
-            // general hook, used for Highcharts Stock compare and cumulative
+            // General hook, used for Highcharts Stock compare and cumulative
             if (series.modifyValue) {
                 yValue = series.modifyValue(yValue, i);
             }

--- a/ts/Mixins/MultipleLines.ts
+++ b/ts/Mixins/MultipleLines.ts
@@ -176,6 +176,7 @@ const multipleLinesMixin: Highcharts.MultipleLinesMixin = {
             pointArrayMap: Array<string> = (indicator.pointArrayMap as any),
             LinesNames = [] as Array<string>,
             value;
+        const modfidyValue = indicator.modifyValue;
 
         LinesNames = indicator.getTranslatedLinesNames();
 
@@ -187,6 +188,12 @@ const multipleLinesMixin: Highcharts.MultipleLinesMixin = {
                 i: number
             ): void {
                 value = (point as any)[propertyName];
+
+                // If the modifier, like for example compare exists,
+                // modified the original value by that method, #15867.
+                if (modfidyValue) {
+                    value = modfidyValue.call(indicator, value);
+                }
 
                 if (value !== null) {
                     (point as any)[LinesNames[i]] = indicator.yAxis.toPixels(


### PR DESCRIPTION
Fixed #15867, comparing the indicator with multiple lines (eg Bollinger Bands) was not possible.