### PR TITLE
bugfix/15867-multiline-indicator-compare

### DIFF
--- a/samples/unit-tests/series/compare/demo.js
+++ b/samples/unit-tests/series/compare/demo.js
@@ -182,3 +182,41 @@ QUnit.test('Compare with one single value', assert => {
         'The Y axis should have one tick at 0 (#12058)'
     );
 });
+
+QUnit.test('Compare multi line indicators, #15867.', assert => {
+    const chart = Highcharts.stockChart('container', {
+        plotOptions: {
+            series: {
+                compare: 'value'
+            }
+        },
+        series: [{
+            type: 'line',
+            id: 'aapl',
+            name: 'AAPL Stock Price',
+            data: [1, 2, 3, 4, 5]
+        }, {
+            type: 'bb',
+            linkedTo: 'aapl',
+            params: {
+                period: 3
+            }
+        }]
+    });
+
+    assert.strictEqual(
+        chart.yAxis[0].toPixels(0) - chart.plotTop,
+        chart.series[1].points[0].plotMiddle,
+        `The first point of the main line should be located at 0 on yAxis.`
+    );
+    assert.strictEqual(
+        chart.yAxis[0].toPixels(2) - chart.plotTop,
+        chart.series[1].points[0].plotTop,
+        `The first point of the top line should be located at 2 on yAxis.`
+    );
+    assert.strictEqual(
+        chart.yAxis[0].toPixels(-2) - chart.plotTop,
+        chart.series[1].points[0].plotBottom,
+        `The first point of the bottom line should be located at -2 on yAxis.`
+    );
+});

--- a/ts/Mixins/MultipleLines.ts
+++ b/ts/Mixins/MultipleLines.ts
@@ -176,6 +176,7 @@ const multipleLinesMixin: Highcharts.MultipleLinesMixin = {
             pointArrayMap: Array<string> = (indicator.pointArrayMap as any),
             LinesNames = [] as Array<string>,
             value;
+        const modfidyValue = indicator.modifyValue;
 
         LinesNames = indicator.getTranslatedLinesNames();
 
@@ -187,6 +188,12 @@ const multipleLinesMixin: Highcharts.MultipleLinesMixin = {
                 i: number
             ): void {
                 value = (point as any)[propertyName];
+
+                // If the modifier, like for example compare exists,
+                // modified the original value by that method, #15867.
+                if (modfidyValue) {
+                    value = modfidyValue.call(indicator, value);
+                }
 
                 if (value !== null) {
                     (point as any)[LinesNames[i]] = indicator.yAxis.toPixels(


### PR DESCRIPTION
Fixed #15867, comparing an indicator with multiple lines (eg Bollinger Bands) was not possible.