### PR TITLE
bugfix/16080-sankey-self-ref-redraw

### DIFF
--- a/samples/unit-tests/series-sankey/sankey/demo.js
+++ b/samples/unit-tests/series-sankey/sankey/demo.js
@@ -528,6 +528,18 @@ QUnit.test('Sankey and circular data', function (assert) {
         'The link should have a complex, circular structure, ' +
             'not direct (#12882)'
     );
+
+    chart.series[0].setData([
+        ['a', 'a', 1]
+    ]);
+    chart.series[0].redraw();
+
+    const shapeArgs = chart.series[0].nodes[0].shapeArgs;
+    assert.deepEqual(
+        [shapeArgs.x, shapeArgs.y],
+        [0, 0],
+        '#16080: Node should still be in top left corner after redraw'
+    );
 });
 
 QUnit.test('Sankey and minimum line width', function (assert) {

--- a/ts/Series/Sankey/SankeySeries.ts
+++ b/ts/Series/Sankey/SankeySeries.ts
@@ -528,9 +528,7 @@ class SankeySeries extends ColumnSeries {
 
         this.nodes.forEach(function (node: SankeyPoint): void {
             let fromColumn = -1,
-                fromNode,
-                i,
-                point;
+                fromNode;
 
             if (!defined(node.options.column)) {
                 // No links to this node, place it left
@@ -540,8 +538,8 @@ class SankeySeries extends ColumnSeries {
                 // There are incoming links, place it to the right of the
                 // highest order column that links to this one.
                 } else {
-                    for (i = 0; i < node.linksTo.length; i++) {
-                        point = node.linksTo[0];
+                    for (let i = 0; i < node.linksTo.length; i++) {
+                        const point = node.linksTo[i];
                         if (
                             (point.fromNode.column as any) > fromColumn &&
                             point.fromNode !== node // #16080
@@ -558,7 +556,7 @@ class SankeySeries extends ColumnSeries {
                         (fromNode.options as any).layout === 'hanging'
                     ) {
                         node.hangsFrom = fromNode;
-                        i = -1; // Reuse existing variable i
+                        let i = -1;
                         find(
                             fromNode.linksFrom,
                             function (

--- a/ts/Series/Sankey/SankeySeries.ts
+++ b/ts/Series/Sankey/SankeySeries.ts
@@ -542,7 +542,10 @@ class SankeySeries extends ColumnSeries {
                 } else {
                     for (i = 0; i < node.linksTo.length; i++) {
                         point = node.linksTo[0];
-                        if ((point.fromNode.column as any) > fromColumn) {
+                        if (
+                            (point.fromNode.column as any) > fromColumn &&
+                            point.fromNode !== node // #16080
+                        ) {
                             fromNode = point.fromNode;
                             fromColumn = (fromNode.column as any);
                         }


### PR DESCRIPTION
Fixed #16080, #13705, sankey chart with self-referential points broke on `redraw`.

Closes #13705.