### PR TITLE
bugfix/15117-turbo-pointStart-2d-array-data

### DIFF
--- a/samples/unit-tests/point/point-update/demo.js
+++ b/samples/unit-tests/point/point-update/demo.js
@@ -331,6 +331,41 @@ QUnit.test(
             '[object Array],[object Array],[object Object]',
             'Points are mixed'
         );
+
+        chart.series[0].update({
+            pointStart: 5,
+            pointInterval: 2
+        });
+        chart.series[0].setData([[1], [2], [3]], true, false, false);
+
+        assert.deepEqual(
+            chart.series[0].xData,
+            [5, 7, 9],
+            '#15117: pointStart/pointInterval should work with turboed 2d array data'
+        );
+        assert.deepEqual(
+            chart.series[0].yData,
+            [1, 2, 3],
+            '#15117: pointStart/pointInterval should work with turboed 2d array data'
+        );
+
+        const map = Highcharts.seriesTypes.line.prototype.pointArrayMap;
+        Highcharts.seriesTypes.line.prototype.pointArrayMap = ['y'];
+
+        chart.series[0].setData([[2], [4], [6]], true, false, false);
+
+        assert.deepEqual(
+            chart.series[0].xData,
+            [5, 7, 9],
+            '#15117: pointStart/pointInterval should work with turboed pointArrayMap series'
+        );
+        assert.deepEqual(
+            chart.series[0].yData,
+            [[2], [4], [6]],
+            '#15117: pointStart/pointInterval should work with turboed pointArrayMap series'
+        );
+
+        Highcharts.seriesTypes.line.prototype.pointArrayMap = map;
     }
 );
 

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -3823,11 +3823,18 @@ class Series {
                 // Assume all points are arrays when first point is
                 } else if (isArray(firstPoint)) {
                     if (valueCount) { // [x, low, high] or [x, o, h, l, c]
-                        for (i = 0; i < dataLength; i++) {
-                            pt = data[i];
-                            (xData as any)[i] = (pt as any)[0];
-                            (yData as any)[i] =
-                                (pt as any).slice(1, valueCount + 1);
+                        if (firstPoint.length === valueCount) {
+                            for (i = 0; i < dataLength; i++) {
+                                (xData as any)[i] = this.autoIncrement();
+                                (yData as any)[i] = data[i];
+                            }
+                        } else {
+                            for (i = 0; i < dataLength; i++) {
+                                pt = data[i];
+                                (xData as any)[i] = (pt as any)[0];
+                                (yData as any)[i] =
+                                    (pt as any).slice(1, valueCount + 1);
+                            }
                         }
                     } else { // [x, y]
                         if (keys) {
@@ -3838,10 +3845,21 @@ class Series {
                             indexOfY = indexOfY >= 0 ? indexOfY : 1;
                         }
 
-                        for (i = 0; i < dataLength; i++) {
-                            pt = data[i];
-                            (xData as any)[i] = (pt as any)[indexOfX];
-                            (yData as any)[i] = (pt as any)[indexOfY];
+                        if (firstPoint.length === 1) {
+                            indexOfY = 0;
+                        }
+
+                        if (indexOfX === indexOfY) {
+                            for (i = 0; i < dataLength; i++) {
+                                (xData as any)[i] = this.autoIncrement();
+                                (yData as any)[i] = (data[i] as any)[indexOfY];
+                            }
+                        } else {
+                            for (i = 0; i < dataLength; i++) {
+                                pt = data[i];
+                                (xData as any)[i] = (pt as any)[indexOfX];
+                                (yData as any)[i] = (pt as any)[indexOfY];
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
Fixed #15117, `pointStart` and `pointInterval` did not work with turboed 2d array data.