### PR TITLE
bugfix/16104-category-update-warning

### DIFF
--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -4018,7 +4018,8 @@ class Series {
             processedYData: (
                 Array<(number|null)>|Array<Array<(number|null)>>
             ) = (series.yData as any),
-            throwOnUnsorted = series.requireSorting;
+            throwOnUnsorted = series.requireSorting,
+            updatingNames = false;
         const dataLength = (processedXData as any).length;
 
         if (xAxis) {
@@ -4026,6 +4027,7 @@ class Series {
             xExtremes = xAxis.getExtremes();
             min = xExtremes.min;
             max = xExtremes.max;
+            updatingNames = xAxis.categories && !xAxis.names.length;
         }
 
         // optionally filter out points outside the plot area
@@ -4088,8 +4090,10 @@ class Series {
 
             // Unsorted data is not supported by the line tooltip, as well
             // as data grouping and navigation in Stock charts (#725) and
-            // width calculation of columns (#1900)
-            } else if (distance < 0 && throwOnUnsorted) {
+            // width calculation of columns (#1900).
+            // Avoid warning during the premature processing pass in
+            // updateNames (#16104).
+            } else if (distance < 0 && throwOnUnsorted && !updatingNames) {
                 error(15, false, series.chart);
                 throwOnUnsorted = false; // Only once
             }


### PR DESCRIPTION
Fixed #16104, chart warned about unsorted data when updating category names.