### PR TITLE
bugfix/16112-polar-axis-array-setOptions

### DIFF
--- a/samples/unit-tests/series-solidgauge/solidgauge/demo.js
+++ b/samples/unit-tests/series-solidgauge/solidgauge/demo.js
@@ -210,10 +210,22 @@ QUnit.test('Solid gauge null point (#10630)', function (assert) {
 });
 
 QUnit.test('Solid gauge updates', function (assert) {
+    Highcharts.setOptions({
+        yAxis: {
+            labels: {
+                style: {
+                    color: 'red'
+                }
+            }
+        }
+    });
+
     var chart = Highcharts.chart('container', {
             chart: {
                 type: 'solidgauge'
             },
+
+            yAxis: [{}],
 
             series: [
                 {
@@ -223,6 +235,12 @@ QUnit.test('Solid gauge updates', function (assert) {
             ]
         }),
         point = chart.series[0].points[0];
+
+    assert.strictEqual(
+        chart.yAxis[0].options.labels.style.color,
+        'red',
+        '#16112: Axis options set by setOptions should be picked up'
+    );
 
     chart.series[0].update({
         linecap: 'round',

--- a/ts/Core/Axis/RadialAxis.ts
+++ b/ts/Core/Axis/RadialAxis.ts
@@ -30,6 +30,8 @@ import type Tick from './Tick';
 import type { YAxisOptions } from './AxisOptions';
 
 import AxisDefaults from './AxisDefaults.js';
+import D from '../DefaultOptions.js';
+const { defaultOptions } = D;
 import H from '../Globals.js';
 const { noop } = H;
 import U from '../Utilities.js';
@@ -1448,6 +1450,7 @@ namespace RadialAxis {
         const options = this.options = merge<Options>(
             (this.constructor as typeof Axis).defaultOptions,
             this.defaultPolarOptions,
+            (defaultOptions as any)[this.coll], // #16112
             userOptions
         );
 


### PR DESCRIPTION
Fixed #16112, axis options set by `setOptions` were not picked up by polar chart when chart axis options were set as an array.