### PR TITLE
A11y proxy refactoring

### DIFF
--- a/samples/unit-tests/accessibility/accessibility-exporting/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-exporting/demo.js
@@ -1,28 +1,47 @@
-QUnit.test('Exporting region has ARIA markup', function (assert) {
+QUnit.test('Exporting button and menu HTML/ARIA markup', function (assert) {
     var chart = Highcharts.chart('container', {
-            series: [
-                {
-                    data: [1, 2, 3, 4, 5, 6]
-                }
-            ],
-            yAxis: {
-                plotBands: [
-                    {
-                        from: 0,
-                        to: 1,
-                        color: 'red'
-                    }
-                ]
-            }
+            series: [{
+                data: [1, 2, 3, 4, 5, 6]
+            }]
         }),
-        exportGroup = chart.accessibility.components.chartMenu.exportProxyGroup;
+        exportProxy = chart.accessibility.components.chartMenu
+            .exportButtonProxy;
 
     assert.ok(
-        exportGroup.getAttribute('aria-label'),
-        'There is aria label on the exporting group'
+        exportProxy.buttonElement.getAttribute('aria-label'),
+        'There is aria label on the exporting button'
     );
+
+    assert.strictEqual(
+        exportProxy.buttonElement.getAttribute('aria-expanded'),
+        'false',
+        'Exporting button should have aria-expanded on it'
+    );
+
+    exportProxy.click();
+
+    assert.strictEqual(
+        exportProxy.buttonElement.getAttribute('aria-expanded'),
+        'true',
+        'Exporting button should update aria-expanded on click'
+    );
+
+    const innerMenu = chart.exportContextMenu.firstChild;
+
+    assert.strictEqual(
+        innerMenu.tagName.toLowerCase(),
+        'ul',
+        'Context menu should be a <ul> element'
+    );
+
+    assert.strictEqual(
+        innerMenu.getAttribute('role'),
+        'list',
+        'Context menu needs a role="list" attribute for webkit accessibility'
+    );
+
     assert.ok(
-        exportGroup.firstChild.getAttribute('aria-label'),
-        'There is aria label on the exporting group child'
+        innerMenu.getAttribute('aria-label'),
+        'Context menu should have aria-label'
     );
 });

--- a/samples/unit-tests/accessibility/series-showhide/demo.js
+++ b/samples/unit-tests/accessibility/series-showhide/demo.js
@@ -48,7 +48,7 @@ QUnit.test(
         });
 
         assert.notStrictEqual(
-            chart.series[0].a11yProxyElement.getAttribute('aria-label').indexOf('Bean'),
+            chart.series[0].a11yProxyElement.buttonElement.getAttribute('aria-label').indexOf('Bean'),
             -1,
             '#15902: Proxy button aria-label should have been updated'
         );
@@ -56,14 +56,15 @@ QUnit.test(
         const added = chart.addSeries({ data: [1, 2, 3] });
 
         assert.ok(
-            added.a11yProxyElement,
+            added.a11yProxyElement.buttonElement,
             '#15902: New legend item should have proxy button'
         );
 
         added.remove();
 
         assert.strictEqual(
-            chart.accessibility.components.legend.proxyElementsList.length,
+            chart.accessibility.proxyProvider.groups
+                .legend.proxyElements.length,
             2,
             '#15902: Proxy items should be recreated after removing legend item'
         );

--- a/samples/unit-tests/exporting/getsvg/demo.js
+++ b/samples/unit-tests/exporting/getsvg/demo.js
@@ -1,5 +1,9 @@
 QUnit.test('getSVG', function (assert) {
     var chart = Highcharts.chart('container', {
+        accessibility: {
+            enabled: false // Adds DOM elements to container
+        },
+
         credits: {
             enabled: false
         },

--- a/samples/unit-tests/series-column/axis-multiple/demo.js
+++ b/samples/unit-tests/series-column/axis-multiple/demo.js
@@ -6,6 +6,9 @@ QUnit.test('Wrong datalabel position (#3648)', function (assert) {
             type: 'column',
             inverted: true
         },
+        accessibility: {
+            enabled: false // A11y module adds DOM elements => different childNodes in container
+        },
         yAxis: [
             {
                 width: 200,

--- a/ts/Accessibility/AccessibilityComponent.ts
+++ b/ts/Accessibility/AccessibilityComponent.ts
@@ -12,35 +12,29 @@
 
 'use strict';
 
-import type BBoxObject from '../Core/Renderer/BBoxObject';
 import type {
-    DOMElementType,
-    HTMLDOMElement
+    HTMLDOMElement,
+    DOMElementType
 } from '../Core/Renderer/DOMElementType';
-import type HTMLAttributes from '../Core/Renderer/HTML/HTMLAttributes';
 import type HTMLElement from '../Core/Renderer/HTML/HTMLElement';
-import type SVGAttributes from '../Core/Renderer/SVG/SVGAttributes';
 import type SVGElement from '../Core/Renderer/SVG/SVGElement';
-import ChartUtilities from './Utils/ChartUtilities.js';
-const { unhideChartElementFromAT } = ChartUtilities;
+import type ProxyProvider from './ProxyProvider';
 import DOMElementProvider from './Utils/DOMElementProvider.js';
 import EventProvider from './Utils/EventProvider.js';
-import type ProxyProvider from './ProxyProvider';
-import H from '../Core/Globals.js';
-const {
-    doc,
-    win
-} = H;
+
 import HTMLUtilities from './Utils/HTMLUtilities.js';
 const {
-    removeElement,
     getFakeMouseEvent
 } = HTMLUtilities;
+
+import ChartUtilities from './Utils/ChartUtilities.js';
+const {
+    fireEventOnWrappedOrUnwrappedElement
+} = ChartUtilities;
+
 import U from '../Core/Utilities.js';
 const {
-    extend,
-    fireEvent,
-    merge
+    extend
 } = U;
 
 /**
@@ -58,22 +52,9 @@ declare global {
             public proxyProvider: ProxyProvider;
             public addEvent: EventProvider['addEvent'];
             public createElement: DOMElementProvider['createElement'];
-            public addProxyGroup(attrs?: HTMLAttributes): HTMLDOMElement;
             public destroy(): void;
             public destroyBase(): void;
-            public cloneMouseEvent(e: MouseEvent): MouseEvent;
-            public cloneTouchEvent(e: TouchEvent): TouchEvent;
-            public createOrUpdateProxyContainer(): void;
-            public createProxyButton(
-                svgElement: SVGElement,
-                parentGroup: HTMLDOMElement,
-                attributes?: SVGAttributes,
-                posElement?: SVGElement,
-                preClickEvent?: Function
-            ): HTMLDOMElement;
-            public createProxyContainerElement(): HTMLDOMElement;
-            public fakeClickEvent(element: DOMElementType): void;
-            public getElementPosition(element: SVGElement): BBoxObject;
+            public fakeClickEvent(el: (HTMLElement|SVGElement|DOMElementType)): void;
             public getKeyboardNavigation(): (
                 KeyboardNavigationHandler|Array<KeyboardNavigationHandler>
             );
@@ -84,22 +65,6 @@ declare global {
             ): void;
             public onChartRender(): void;
             public onChartUpdate(): void;
-            public proxyMouseEventsForButton(
-                source: (SVGElement|HTMLElement|DOMElementType),
-                button: HTMLDOMElement
-            ): void;
-            public fireEventOnWrappedOrUnwrappedElement(
-                el: (SVGElement|HTMLElement|DOMElementType),
-                eventObject: Event
-            ): void;
-            public setProxyButtonStyle(button: HTMLDOMElement): void;
-            public updateProxyButtonPosition(
-                proxy: HTMLDOMElement,
-                posElement: SVGElement
-            ): void;
-        }
-        interface AccessibilityChart {
-            a11yProxyContainer?: HTMLDOMElement;
         }
     }
 }
@@ -218,367 +183,12 @@ AccessibilityComponent.prototype = {
 
 
     /**
-     * Fire an event on an element that is either wrapped by Highcharts,
-     * or a DOM element
-     * @private
-     * @param {Highcharts.HTMLElement|Highcharts.HTMLDOMElement|
-     *  Highcharts.SVGDOMElement|Highcharts.SVGElement} el
-     * @param {Event} eventObject
+     * Fire a fake click event on an element. It is useful to have this on
+     * AccessibilityComponent for users of custom components.
      */
-    fireEventOnWrappedOrUnwrappedElement: function (
-        el: (HTMLElement|SVGElement|DOMElementType),
-        eventObject: Event
-    ): void {
-        const type = eventObject.type;
-
-        if (doc.createEvent && ((el as any).dispatchEvent || (el as any).fireEvent)) {
-            if ((el as any).dispatchEvent) {
-                (el as any).dispatchEvent(eventObject);
-            } else {
-                (el as any).fireEvent(type, eventObject);
-            }
-        } else {
-            fireEvent(el, type, eventObject);
-        }
-    },
-
-
-    /**
-     * Utility function to attempt to fake a click event on an element.
-     * @private
-     * @param {Highcharts.HTMLDOMElement|Highcharts.SVGDOMElement} element
-     */
-    fakeClickEvent: function (element: DOMElementType): void {
-        if (element) {
-            const fakeEventObject = getFakeMouseEvent('click');
-            this.fireEventOnWrappedOrUnwrappedElement(element, fakeEventObject);
-        }
-    },
-
-
-    /**
-     * Add a new proxy group to the proxy container. Creates the proxy container
-     * if it does not exist.
-     * @private
-     * @param {Highcharts.HTMLAttributes} [attrs]
-     * The attributes to set on the new group div.
-     * @return {Highcharts.HTMLDOMElement}
-     * The new proxy group element.
-     */
-    addProxyGroup: function (
-        this: Highcharts.AccessibilityComponent,
-        attrs?: HTMLAttributes
-    ): HTMLDOMElement {
-        this.createOrUpdateProxyContainer();
-
-        const groupDiv = this.createElement('div');
-
-        Object.keys(attrs || {}).forEach(function (prop: string): void {
-            if ((attrs as any)[prop] !== null) {
-                groupDiv.setAttribute(prop, (attrs as any)[prop]);
-            }
-        });
-        (this.chart as any).a11yProxyContainer.appendChild(groupDiv);
-
-        return groupDiv;
-    },
-
-
-    /**
-     * Creates and updates DOM position of proxy container
-     * @private
-     */
-    createOrUpdateProxyContainer: function (
-        this: Highcharts.AccessibilityComponent
-    ): void {
-        const chart = this.chart,
-            rendererSVGEl = chart.renderer.box;
-
-        chart.a11yProxyContainer = chart.a11yProxyContainer ||
-            this.createProxyContainerElement();
-
-        if (rendererSVGEl.nextSibling !== chart.a11yProxyContainer) {
-            chart.container.insertBefore(
-                chart.a11yProxyContainer,
-                rendererSVGEl.nextSibling
-            );
-        }
-    },
-
-
-    /**
-     * @private
-     * @return {Highcharts.HTMLDOMElement} element
-     */
-    createProxyContainerElement: function (): HTMLDOMElement {
-        const pc = doc.createElement('div');
-        pc.className = 'highcharts-a11y-proxy-container';
-        return pc;
-    },
-
-
-    /**
-     * Create an invisible proxy HTML button in the same position as an SVG
-     * element
-     * @private
-     * @param {Highcharts.SVGElement} svgElement
-     * The wrapped svg el to proxy.
-     * @param {Highcharts.HTMLDOMElement} parentGroup
-     * The proxy group element in the proxy container to add this button to.
-     * @param {Highcharts.SVGAttributes} [attributes]
-     * Additional attributes to set.
-     * @param {Highcharts.SVGElement} [posElement]
-     * Element to use for positioning instead of svgElement.
-     * @param {Function} [preClickEvent]
-     * Function to call before click event fires.
-     *
-     * @return {Highcharts.HTMLDOMElement} The proxy button.
-     */
-    createProxyButton: function (
-        this: Highcharts.AccessibilityComponent,
-        svgElement: SVGElement,
-        parentGroup: HTMLDOMElement,
-        attributes?: SVGAttributes,
-        posElement?: SVGElement,
-        preClickEvent?: Function
-    ): HTMLDOMElement {
-        const svgEl = svgElement.element,
-            proxy = this.createElement('button'),
-            attrs = merge({
-                'aria-label': svgEl.getAttribute('aria-label')
-            }, attributes);
-
-        Object.keys(attrs).forEach(function (prop: string): void {
-            if ((attrs as any)[prop] !== null) {
-                proxy.setAttribute(prop, (attrs as any)[prop]);
-            }
-        });
-
-        proxy.className = 'highcharts-a11y-proxy-button';
-
-        if (svgElement.hasClass('highcharts-no-tooltip')) {
-            proxy.className += ' highcharts-no-tooltip';
-        }
-
-        if (preClickEvent) {
-            this.addEvent(proxy, 'click', preClickEvent);
-        }
-
-        this.setProxyButtonStyle(proxy);
-        this.updateProxyButtonPosition(proxy, posElement || svgElement);
-        this.proxyMouseEventsForButton(svgEl, proxy);
-
-        // Add to chart div and unhide from screen readers
-        parentGroup.appendChild(proxy);
-        if (!attrs['aria-hidden']) {
-            unhideChartElementFromAT(this.chart as any, proxy);
-        }
-
-        return proxy;
-    },
-
-
-    /**
-     * Get the position relative to chart container for a wrapped SVG element.
-     * @private
-     * @param {Highcharts.SVGElement} element
-     * The element to calculate position for.
-     * @return {Highcharts.BBoxObject}
-     * Object with x and y props for the position.
-     */
-    getElementPosition: function (
-        this: Highcharts.AccessibilityComponent,
-        element: SVGElement
-    ): BBoxObject {
-        const el = element.element,
-            div: HTMLDOMElement = (this.chart as any).renderTo;
-
-        if (div && el && el.getBoundingClientRect) {
-            const rectEl = el.getBoundingClientRect(),
-                rectDiv = div.getBoundingClientRect();
-
-            return {
-                x: rectEl.left - rectDiv.left,
-                y: rectEl.top - rectDiv.top,
-                width: rectEl.right - rectEl.left,
-                height: rectEl.bottom - rectEl.top
-            };
-        }
-
-        return { x: 0, y: 0, width: 1, height: 1 };
-    },
-
-
-    /**
-     * @private
-     * @param {Highcharts.HTMLElement} button The proxy element.
-     */
-    setProxyButtonStyle: function (button: HTMLDOMElement): void {
-        merge(true, button.style, {
-            borderWidth: '0',
-            backgroundColor: 'transparent',
-            cursor: 'pointer',
-            outline: 'none',
-            opacity: '0.001',
-            filter: 'alpha(opacity=1)',
-            zIndex: '999',
-            overflow: 'hidden',
-            padding: '0',
-            margin: '0',
-            display: 'block',
-            position: 'absolute'
-        });
-        (button.style as any)['-ms-filter'] =
-            'progid:DXImageTransform.Microsoft.Alpha(Opacity=1)';
-    },
-
-
-    /**
-     * @private
-     * @param {Highcharts.HTMLElement} proxy The proxy to update position of.
-     * @param {Highcharts.SVGElement} posElement The element to overlay and take position from.
-     */
-    updateProxyButtonPosition: function (
-        proxy: HTMLDOMElement,
-        posElement: SVGElement
-    ): void {
-        const bBox = this.getElementPosition(posElement);
-        merge(true, proxy.style, {
-            width: (bBox.width || 1) + 'px',
-            height: (bBox.height || 1) + 'px',
-            left: (Math.round(bBox.x) || 0) + 'px',
-            top: (Math.round(bBox.y) || 0) + 'px'
-        });
-    },
-
-
-    /**
-     * @private
-     * @param {Highcharts.HTMLElement|Highcharts.HTMLDOMElement|
-     *  Highcharts.SVGDOMElement|Highcharts.SVGElement} source
-     * @param {Highcharts.HTMLElement} button
-     */
-    proxyMouseEventsForButton: function (
-        this: Highcharts.AccessibilityComponent,
-        source: (
-            HTMLElement|SVGElement|DOMElementType
-        ),
-        button: HTMLDOMElement
-    ): void {
-        const component = this;
-
-        [
-            'click', 'touchstart', 'touchend', 'touchcancel', 'touchmove',
-            'mouseover', 'mouseenter', 'mouseleave', 'mouseout'
-        ].forEach(function (evtType: string): void {
-            const isTouchEvent = evtType.indexOf('touch') === 0;
-
-            component.addEvent(button, evtType, function (e: MouseEvent | TouchEvent): void {
-                const clonedEvent = isTouchEvent ?
-                    component.cloneTouchEvent(e as TouchEvent) :
-                    component.cloneMouseEvent(e as MouseEvent);
-
-                if (source) {
-                    component.fireEventOnWrappedOrUnwrappedElement(source, clonedEvent);
-                }
-
-                e.stopPropagation();
-
-                // #9682, #15318: Touch scrolling didnt work when touching a
-                // component
-                if (evtType !== 'touchstart' && evtType !== 'touchmove' && evtType !== 'touchend') {
-                    e.preventDefault();
-                }
-            }, { passive: false });
-        });
-    },
-
-
-    /**
-     * Utility function to clone a mouse event for re-dispatching.
-     * @private
-     * @param {global.MouseEvent} e The event to clone.
-     * @return {global.MouseEvent} The cloned event
-     */
-    cloneMouseEvent: function (e: MouseEvent): MouseEvent {
-        if (typeof win.MouseEvent === 'function') {
-            return new win.MouseEvent(e.type, e);
-        }
-
-        // No MouseEvent support, try using initMouseEvent
-        if (doc.createEvent) {
-            const evt = doc.createEvent('MouseEvent');
-            if (evt.initMouseEvent) {
-                evt.initMouseEvent(
-                    e.type,
-                    e.bubbles, // #10561, #12161
-                    e.cancelable,
-                    e.view || win,
-                    e.detail,
-                    e.screenX,
-                    e.screenY,
-                    e.clientX,
-                    e.clientY,
-                    e.ctrlKey,
-                    e.altKey,
-                    e.shiftKey,
-                    e.metaKey,
-                    e.button,
-                    e.relatedTarget
-                );
-                return evt;
-            }
-        }
-
-        return getFakeMouseEvent(e.type);
-    },
-
-
-    /**
-     * Utility function to clone a touch event for re-dispatching.
-     * @private
-     * @param {global.TouchEvent} e The event to clone.
-     * @return {global.TouchEvent} The cloned event
-     */
-    cloneTouchEvent: function (e: TouchEvent): TouchEvent {
-        const touchListToTouchArray = (l: TouchList): Touch[] => {
-            const touchArray = [];
-            for (let i = 0; i < l.length; ++i) {
-                const item = l.item(i);
-                if (item) {
-                    touchArray.push(item);
-                }
-            }
-            return touchArray;
-        };
-
-        if (typeof win.TouchEvent === 'function') {
-            const newEvent = new win.TouchEvent(e.type, {
-                touches: touchListToTouchArray(e.touches),
-                targetTouches: touchListToTouchArray(e.targetTouches),
-                changedTouches: touchListToTouchArray(e.changedTouches),
-                ctrlKey: e.ctrlKey,
-                shiftKey: e.shiftKey,
-                altKey: e.altKey,
-                metaKey: e.metaKey,
-                bubbles: e.bubbles,
-                cancelable: e.cancelable,
-                composed: e.composed,
-                detail: e.detail,
-                view: e.view
-            });
-            if (e.defaultPrevented) {
-                newEvent.preventDefault();
-            }
-            return newEvent;
-        }
-
-        // Fallback to mouse event
-        const fakeEvt = this.cloneMouseEvent(e as unknown as MouseEvent);
-        fakeEvt.touches = e.touches;
-        fakeEvt.changedTouches = e.changedTouches;
-        fakeEvt.targetTouches = e.targetTouches;
-        return fakeEvt;
+    fakeClickEvent(el: (HTMLElement|SVGElement|DOMElementType)): void {
+        const fakeEvent = getFakeMouseEvent('click');
+        fireEventOnWrappedOrUnwrappedElement(el, fakeEvent);
     },
 
 
@@ -587,7 +197,6 @@ AccessibilityComponent.prototype = {
      * @private
      */
     destroyBase: function (): void {
-        removeElement(this.chart.a11yProxyContainer);
         this.domElementProvider.destroyCreatedElements();
         this.eventProvider.removeAddedEvents();
     }

--- a/ts/Accessibility/AccessibilityComponent.ts
+++ b/ts/Accessibility/AccessibilityComponent.ts
@@ -25,6 +25,7 @@ import ChartUtilities from './Utils/ChartUtilities.js';
 const { unhideChartElementFromAT } = ChartUtilities;
 import DOMElementProvider from './Utils/DOMElementProvider.js';
 import EventProvider from './Utils/EventProvider.js';
+import type ProxyProvider from './ProxyProvider';
 import H from '../Core/Globals.js';
 const {
     doc,
@@ -54,6 +55,7 @@ declare global {
             public domElementProvider: DOMElementProvider;
             public eventProvider: EventProvider;
             public keyCodes: Record<string, number>;
+            public proxyProvider: ProxyProvider;
             public addEvent: EventProvider['addEvent'];
             public createElement: DOMElementProvider['createElement'];
             public addProxyGroup(attrs?: HTMLAttributes): HTMLDOMElement;
@@ -76,7 +78,10 @@ declare global {
                 KeyboardNavigationHandler|Array<KeyboardNavigationHandler>
             );
             public init(): void;
-            public initBase(chart: AccessibilityChart): void;
+            public initBase(
+                chart: AccessibilityChart,
+                proxyProvider: ProxyProvider
+            ): void;
             public onChartRender(): void;
             public onChartUpdate(): void;
             public proxyMouseEventsForButton(
@@ -159,17 +164,19 @@ AccessibilityComponent.prototype = {
     /**
      * Initialize the class
      * @private
-     * @param {Highcharts.Chart} chart
-     *        Chart object
+     * @param {Highcharts.Chart} chart The chart object
+     * @param {Highcharts.ProxyProvider} proxyProvider The proxy provider of the accessibility module
      */
     initBase: function (
         this: Highcharts.AccessibilityComponent,
-        chart: Highcharts.AccessibilityChart
+        chart: Highcharts.AccessibilityChart,
+        proxyProvider: ProxyProvider
     ): void {
         this.chart = chart;
 
         this.eventProvider = new EventProvider();
         this.domElementProvider = new DOMElementProvider();
+        this.proxyProvider = proxyProvider;
 
         // Key code enum for common keys
         this.keyCodes = {

--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -158,11 +158,9 @@ Chart.prototype.highlightLegendItem = function (ix: number): boolean {
         scrollLegendToItem(this.legend, ix);
 
         const legendItemProp = itemToHighlight.legendItem;
-        if (legendItemProp && legendItemProp.element) {
-            this.setFocusToElement(
-                legendItemProp as SVGElement,
-                itemToHighlight.a11yProxyElement && itemToHighlight.a11yProxyElement.buttonElement
-            );
+        const proxyBtn = itemToHighlight.a11yProxyElement && itemToHighlight.a11yProxyElement.buttonElement;
+        if (legendItemProp && legendItemProp.element && proxyBtn) {
+            this.setFocusToElement(legendItemProp as SVGElement, proxyBtn);
         }
 
         if (itemToHighlight.legendGroup) {

--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -13,10 +13,10 @@
 'use strict';
 
 import type BubbleLegendItem from '../../Series/Bubble/BubbleLegendItem';
-import type { HTMLDOMElement } from '../../Core/Renderer/DOMElementType';
 import type Point from '../../Core/Series/Point';
 import type Series from '../../Core/Series/Series';
 import type SVGElement from '../../Core/Renderer/SVG/SVGElement';
+import type ProxyElement from '../ProxyElement';
 
 import A from '../../Core/Animation/AnimationUtilities.js';
 const {
@@ -29,7 +29,6 @@ import U from '../../Core/Utilities.js';
 const {
     addEvent,
     extend,
-    find,
     fireEvent,
     isNumber,
     pick,
@@ -41,7 +40,6 @@ import KeyboardNavigationHandler from '../KeyboardNavigationHandler.js';
 
 import HTMLUtilities from '../Utils/HTMLUtilities.js';
 const {
-    removeElement,
     stripHTMLTagsFromString: stripHTMLTags
 } = HTMLUtilities;
 
@@ -57,13 +55,13 @@ declare module '../../Core/Chart/ChartLike'{
 
 declare module '../../Core/Series/PointLike' {
     interface PointLike {
-        a11yProxyElement?: HTMLDOMElement;
+        a11yProxyElement?: ProxyElement;
     }
 }
 
 declare module '../../Core/Series/SeriesLike' {
     interface SeriesLike {
-        a11yProxyElement?: HTMLDOMElement;
+        a11yProxyElement?: ProxyElement;
     }
 }
 
@@ -76,12 +74,7 @@ declare global {
         class LegendComponent extends AccessibilityComponent {
             public constructor();
             public highlightedLegendItemIx: number;
-            public legendProxyButtonClicked?: boolean;
-            public legendProxyGroup: HTMLDOMElement;
-            public legendListContainer?: HTMLDOMElement;
-            public proxyElementsList: Array<A11yLegendProxyButtonReference>;
             public addLegendProxyGroup(): void;
-            public addLegendListContainer(): void;
             public getKeyboardNavigation(): KeyboardNavigationHandler;
             public init(): void;
             public onChartRender(): void;
@@ -100,16 +93,10 @@ declare global {
             public shouldHaveLegendNavigation(): (boolean);
             public updateLegendItemProxyVisibility(): void;
             public updateLegendTitle(): void;
-            public updateProxiesPositions(): void;
             public updateProxyPositionForItem(item: LegendItem): void;
         }
-        interface A11yLegendProxyButtonReference {
-            item: LegendItem;
-            element: HTMLDOMElement;
-            posElement: SVGElement;
-        }
         interface LegendItemObject {
-            a11yProxyElement?: HTMLDOMElement;
+            a11yProxyElement?: ProxyElement;
         }
     }
 }
@@ -158,23 +145,29 @@ function shouldDoLegendA11y(chart: Chart): boolean {
  * @return {boolean}
  */
 Chart.prototype.highlightLegendItem = function (ix: number): boolean {
-    const items = this.legend.allItems,
-        oldIx = this.accessibility &&
+    const items = this.legend.allItems;
+    const oldIx = this.accessibility &&
             this.accessibility.components.legend.highlightedLegendItemIx;
+    const itemToHighlight = items[ix];
 
-    if (items[ix]) {
+    if (itemToHighlight) {
         if (isNumber(oldIx) && items[oldIx]) {
             fireEvent((items[oldIx].legendGroup as any).element, 'mouseout');
         }
 
         scrollLegendToItem(this.legend, ix);
 
-        this.setFocusToElement(
-            items[ix].legendItem as any,
-            items[ix].a11yProxyElement
-        );
+        const legendItemProp = itemToHighlight.legendItem;
+        if (legendItemProp && legendItemProp.element) {
+            this.setFocusToElement(
+                legendItemProp as SVGElement,
+                itemToHighlight.a11yProxyElement && itemToHighlight.a11yProxyElement.buttonElement
+            );
+        }
 
-        fireEvent((items[ix].legendGroup as any).element, 'mouseover');
+        if (itemToHighlight.legendGroup) {
+            fireEvent(itemToHighlight.legendGroup.element, 'mouseover');
+        }
         return true;
     }
     return false;
@@ -192,7 +185,7 @@ addEvent(Legend, 'afterColorizeItem', function (
         legendItem = e.item;
 
     if (a11yOptions.enabled && legendItem && legendItem.a11yProxyElement) {
-        legendItem.a11yProxyElement.setAttribute(
+        legendItem.a11yProxyElement.buttonElement.setAttribute(
             'aria-pressed', e.visible ? 'true' : 'false'
         );
     }
@@ -217,16 +210,17 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
      */
     init: function (this: Highcharts.LegendComponent): void {
         const component = this;
-        this.proxyElementsList = [];
         this.recreateProxies();
 
         // Note: Chart could create legend dynamically, so events can not be
         // tied to the component's chart's current legend.
         this.addEvent(Legend, 'afterScroll', function (): void {
             if (this.chart === component.chart) {
-                component.updateProxiesPositions();
+                component.proxyProvider.updateGroupProxyElementPositions('legend');
                 component.updateLegendItemProxyVisibility();
-                this.chart.highlightLegendItem(component.highlightedLegendItemIx);
+                if (component.highlightedLegendItemIx > -1) {
+                    this.chart.highlightLegendItem(component.highlightedLegendItemIx);
+                }
             }
         });
         this.addEvent(Legend, 'afterPositionItem', function (e: AnyRecord): void {
@@ -241,7 +235,7 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
                 component.recreateProxies()
             ) {
                 syncTimeout(
-                    (): void => component.updateProxiesPositions(),
+                    (): void => component.proxyProvider.updateGroupProxyElementPositions('legend'),
                     animObject(
                         pick(this.chart.renderer.globalAnimation, true)
                     ).duration
@@ -263,22 +257,27 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
             clipHeight = legend.clipHeight || 0;
 
         items.forEach(function (item: LegendItem): void {
-            const itemPage = item.pageIx || 0,
-                y = item._legendItemPos ? item._legendItemPos[1] : 0,
-                h = item.legendItem ? Math.round(item.legendItem.getBBox().height) : 0,
-                hide = y + h - legend.pages[itemPage] > clipHeight || itemPage !== curPage - 1;
-
             if (item.a11yProxyElement) {
-                item.a11yProxyElement.style.visibility = hide ?
-                    'hidden' : 'visible';
+                const hasPages = legend.pages && legend.pages.length;
+                const elStyle = item.a11yProxyElement.element.style;
+
+                if (hasPages) {
+                    const itemPage = item.pageIx || 0;
+                    const y = item._legendItemPos ? item._legendItemPos[1] : 0;
+                    const h = item.legendItem ? Math.round(item.legendItem.getBBox().height) : 0;
+                    const hide = y + h - legend.pages[itemPage] > clipHeight || itemPage !== curPage - 1;
+
+                    elStyle.visibility = hide ? 'hidden' : 'visible';
+                } else {
+                    elStyle.visibility = 'visible';
+                }
             }
         });
     },
 
 
     /**
-     * The legend needs updates on every render, in order to update positioning
-     * of the proxy overlays.
+     * @private
      */
     onChartRender: function (this: Highcharts.LegendComponent): void {
         if (!shouldDoLegendA11y(this.chart)) {
@@ -290,48 +289,29 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
     /**
      * @private
      */
-    onChartUpdate: function (this: Highcharts.LegendComponent): void {
-        this.updateLegendTitle();
-    },
-
-
-    /**
-     * @private
-     */
-    updateProxiesPositions: function (this: Highcharts.LegendComponent): void {
-        for (const { element, posElement } of this.proxyElementsList) {
-            this.updateProxyButtonPosition(element, posElement);
-        }
-    },
-
-
-    /**
-     * @private
-     */
     updateProxyPositionForItem: function (
         this: Highcharts.LegendComponent,
         item: LegendItem
     ): void {
-        const proxyRef = find(this.proxyElementsList,
-            (ref: Highcharts.A11yLegendProxyButtonReference): boolean => ref.item === item);
-
-        if (proxyRef) {
-            this.updateProxyButtonPosition(proxyRef.element, proxyRef.posElement);
+        if (item.a11yProxyElement) {
+            item.a11yProxyElement.refreshPosition();
         }
     },
 
 
     /**
      * @private
+     * Returns false if legend a11y is disabled and proxies were not created,
+     * true otherwise.
      */
     recreateProxies: function (this: Highcharts.LegendComponent): boolean {
         this.removeProxies();
 
         if (shouldDoLegendA11y(this.chart)) {
             this.addLegendProxyGroup();
-            this.addLegendListContainer();
             this.proxyLegendItems();
             this.updateLegendItemProxyVisibility();
+            this.updateLegendTitle();
             return true;
         }
         return false;
@@ -342,8 +322,7 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
      * @private
      */
     removeProxies: function (this: Highcharts.LegendComponent): void {
-        removeElement(this.legendProxyGroup);
-        this.proxyElementsList = [];
+        this.proxyProvider.removeGroup('legend');
     },
 
 
@@ -367,23 +346,8 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
             }
         );
 
-        if (this.legendProxyGroup) {
-            this.legendProxyGroup.setAttribute('aria-label', legendLabel);
-        }
-    },
-
-
-    /**
-     * @private
-     */
-    addLegendProxyGroup: function (this: Highcharts.LegendComponent): void {
-        const a11yOptions = this.chart.options.accessibility,
-            groupRole = a11yOptions.landmarkVerbosity === 'all' ?
-                'region' : null;
-
-        this.legendProxyGroup = this.addProxyGroup({
-            'aria-label': '_placeholder_', // Filled in by updateLegendTitle
-            role: groupRole as any
+        this.proxyProvider.updateGroupAttrs('legend', {
+            'aria-label': legendLabel
         });
     },
 
@@ -391,12 +355,14 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
     /**
      * @private
      */
-    addLegendListContainer: function (this: Highcharts.LegendComponent): void {
-        if (this.legendProxyGroup) {
-            const container = this.legendListContainer = this.createElement('ul');
-            container.style.listStyle = 'none';
-            this.legendProxyGroup.appendChild(container);
-        }
+    addLegendProxyGroup: function (this: Highcharts.LegendComponent): void {
+        const a11yOptions = this.chart.options.accessibility;
+        const groupRole = a11yOptions.landmarkVerbosity === 'all' ? 'region' : null;
+
+        this.proxyProvider.addGroup('legend', 'ul', {
+            'aria-label': '_placeholder_', // Filled by updateLegendTitle, to keep up to date without recreating group
+            role: groupRole as string
+        });
     },
 
 
@@ -426,42 +392,30 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
         this: Highcharts.LegendComponent,
         item: LegendItem
     ): void {
-        if (!item.legendItem || !item.legendGroup || !this.legendListContainer) {
+        if (!item.legendItem || !item.legendGroup) {
             return;
         }
 
         const itemLabel = this.chart.langFormat(
-                'accessibility.legend.legendItem',
-                {
-                    chart: this.chart,
-                    itemName: stripHTMLTags((item as any).name),
-                    item
-                }
-            ),
-            attribs = {
-                tabindex: -1,
-                'aria-pressed': item.visible,
-                'aria-label': itemLabel
-            },
-            // Considers useHTML
-            proxyPositioningElement = item.legendGroup.div ?
-                item.legendItem : item.legendGroup;
-
-        const listItem = this.createElement('li');
-        this.legendListContainer.appendChild(listItem);
-
-        item.a11yProxyElement = this.createProxyButton(
-            item.legendItem as any,
-            listItem,
-            attribs,
-            proxyPositioningElement as any
+            'accessibility.legend.legendItem',
+            {
+                chart: this.chart,
+                itemName: stripHTMLTags((item as any).name),
+                item
+            }
         );
+        const attribs = {
+            tabindex: -1,
+            'aria-pressed': item.visible,
+            'aria-label': itemLabel
+        };
+        // Considers useHTML
+        const proxyPositioningElement = item.legendGroup.div ? item.legendItem : item.legendGroup;
 
-        this.proxyElementsList.push({
-            item: item,
-            element: item.a11yProxyElement,
-            posElement: proxyPositioningElement as any
-        });
+        item.a11yProxyElement = this.proxyProvider.addProxyElement('legend', {
+            click: item.legendItem as SVGElement,
+            visual: proxyPositioningElement.element
+        }, attribs);
     },
 
 
@@ -510,6 +464,7 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
             },
 
             terminate: function (): void {
+                component.highlightedLegendItemIx = -1;
                 chart.legend.allItems.forEach(
                     (item): unknown => item.setState('', true));
             }
@@ -560,8 +515,7 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
     /**
      * @private
      * @param {Highcharts.KeyboardNavigationHandler} keyboardNavigationHandler
-     * @return {number}
-     * Response code
+     * @return {number} Response code
      */
     onKbdClick: function (
         this: Highcharts.LegendComponent,
@@ -572,7 +526,7 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
         ];
 
         if (legendItem && legendItem.a11yProxyElement) {
-            fireEvent(legendItem.a11yProxyElement, 'click');
+            legendItem.a11yProxyElement.click();
         }
 
         return keyboardNavigationHandler.response.success;

--- a/ts/Accessibility/Components/MenuComponent.ts
+++ b/ts/Accessibility/Components/MenuComponent.ts
@@ -13,14 +13,11 @@
 'use strict';
 
 import type Exporting from '../../Extensions/Exporting/Exporting';
-import type {
-    HTMLDOMElement,
-    SVGDOMElement
-} from '../../Core/Renderer/DOMElementType';
+import type { SVGDOMElement } from '../../Core/Renderer/DOMElementType';
 import type SVGElement from '../../Core/Renderer/SVG/SVGElement';
+import type ProxyElement from '../ProxyElement';
 
 import Chart from '../../Core/Chart/Chart.js';
-import H from '../../Core/Globals.js';
 import U from '../../Core/Utilities.js';
 const {
     extend
@@ -30,11 +27,16 @@ import AccessibilityComponent from '../AccessibilityComponent.js';
 import KeyboardNavigationHandler from '../KeyboardNavigationHandler.js';
 
 import ChartUtilities from '../Utils/ChartUtilities.js';
-const unhideChartElementFromAT = ChartUtilities.unhideChartElementFromAT;
+const {
+    getChartTitle,
+    unhideChartElementFromAT
+} = ChartUtilities;
 
 import HTMLUtilities from '../Utils/HTMLUtilities.js';
-const removeElement = HTMLUtilities.removeElement,
-    getFakeMouseEvent = HTMLUtilities.getFakeMouseEvent;
+const {
+    getFakeMouseEvent,
+    setElAttrs
+} = HTMLUtilities;
 
 declare module '../../Core/Chart/ChartLike' {
     interface ChartLike {
@@ -57,9 +59,10 @@ declare global {
     namespace Highcharts {
         class MenuComponent extends AccessibilityComponent {
             public constructor();
-            public exportButtonProxy?: HTMLDOMElement;
-            public exportProxyGroup?: HTMLDOMElement;
+            public exportButtonProxy?: ProxyElement;
             public addAccessibleContextMenuAttribs(): void;
+            public proxyMenuButton(): void;
+            public createProxyGroup(): void;
             public getKeyboardNavigation(): KeyboardNavigationHandler;
             public onChartRender(): void;
             public onKbdClick(
@@ -154,11 +157,10 @@ Chart.prototype.hideExportMenu = function (): void {
 Chart.prototype.highlightExportItem = function (
     ix: number
 ): boolean {
-    let listItem = this.exportDivElements && this.exportDivElements[ix],
-        curHighlighted =
+    const listItem = this.exportDivElements && this.exportDivElements[ix];
+    const curHighlighted =
             this.exportDivElements &&
-            this.exportDivElements[this.highlightedExportItemIx as any],
-        hasSVGFocusSupport;
+            this.exportDivElements[this.highlightedExportItemIx as any];
 
     if (
         listItem &&
@@ -166,7 +168,7 @@ Chart.prototype.highlightExportItem = function (
         !(listItem.children && listItem.children.length)
     ) {
         // Test if we have focus support for SVG elements
-        hasSVGFocusSupport = !!(
+        const hasSVGFocusSupport = !!(
             this.renderTo.getElementsByTagName('g')[0] || {}
         ).focus;
 
@@ -197,11 +199,9 @@ Chart.prototype.highlightExportItem = function (
  * @return {boolean}
  */
 Chart.prototype.highlightLastExportItem = function (): boolean {
-    let chart = this,
-        i;
-
+    const chart = this;
     if (chart.exportDivElements) {
-        i = chart.exportDivElements.length;
+        let i = chart.exportDivElements.length;
         while (i--) {
             if (chart.highlightExportItem(i)) {
                 return true;
@@ -257,6 +257,8 @@ extend(MenuComponent.prototype, /** @lends Highcharts.MenuComponent */ {
         this.addEvent(chart, 'exportMenuHidden', function (): void {
             component.onMenuHidden();
         });
+
+        this.createProxyGroup();
     },
 
 
@@ -300,9 +302,8 @@ extend(MenuComponent.prototype, /** @lends Highcharts.MenuComponent */ {
         this: Highcharts.MenuComponent,
         stateStr: string
     ): void {
-        const button = this.exportButtonProxy;
-        if (button) {
-            button.setAttribute('aria-expanded', stateStr);
+        if (this.exportButtonProxy) {
+            this.exportButtonProxy.buttonElement.setAttribute('aria-expanded', stateStr);
         }
     },
 
@@ -312,38 +313,49 @@ extend(MenuComponent.prototype, /** @lends Highcharts.MenuComponent */ {
      * proxy overlay.
      */
     onChartRender: function (this: Highcharts.MenuComponent): void {
-        const chart = this.chart,
-            a11yOptions = chart.options.accessibility;
+        this.proxyProvider.clearGroup('chartMenu');
+        this.proxyMenuButton();
+    },
 
-        // Always start with a clean slate
-        removeElement(this.exportProxyGroup);
 
-        // Set screen reader properties on export menu
-        if (exportingShouldHaveA11y(chart)) {
-            // Proxy button and group
-            this.exportProxyGroup = this.addProxyGroup(
-                // Wrap in a region div if verbosity is high
-                a11yOptions.landmarkVerbosity === 'all' ? {
-                    'aria-label': chart.langFormat(
-                        'accessibility.exporting.exportRegionLabel',
-                        { chart: chart }
-                    ),
-                    'role': 'region'
-                } : {}
-            );
+    /**
+     * @private
+     */
+    proxyMenuButton: function (
+        this: Highcharts.MenuComponent
+    ): void {
+        const chart = this.chart;
+        const proxyProvider = this.proxyProvider;
+        const buttonEl = getExportMenuButtonElement(chart);
 
-            const button: SVGElement = getExportMenuButtonElement(this.chart) as any;
-            this.exportButtonProxy = this.createProxyButton(
-                button,
-                this.exportProxyGroup,
+        if (exportingShouldHaveA11y(chart) && buttonEl) {
+            this.exportButtonProxy = proxyProvider.addProxyElement(
+                'chartMenu',
+                { click: buttonEl },
                 {
                     'aria-label': chart.langFormat(
                         'accessibility.exporting.menuButtonLabel',
-                        { chart: chart }
+                        {
+                            chart: chart,
+                            chartTitle: getChartTitle(chart)
+                        }
                     ),
                     'aria-expanded': false
                 }
             );
+        }
+    },
+
+
+    /**
+     * @private
+     */
+    createProxyGroup: function (
+        this: Highcharts.MenuComponent
+    ): void {
+        const chart = this.chart;
+        if (chart && this.proxyProvider) {
+            this.proxyProvider.addGroup('chartMenu', 'div');
         }
     },
 
@@ -374,13 +386,13 @@ extend(MenuComponent.prototype, /** @lends Highcharts.MenuComponent */ {
             // Set accessibility properties on parent div
             const parentDiv = (exportList[0] && exportList[0].parentNode);
             if (parentDiv) {
-                parentDiv.removeAttribute('aria-hidden');
-                parentDiv.setAttribute(
-                    'aria-label',
-                    chart.langFormat(
+                setElAttrs(parentDiv, {
+                    'aria-hidden': null,
+                    'aria-label': chart.langFormat(
                         'accessibility.exporting.chartMenuLabel', { chart: chart }
-                    )
-                );
+                    ),
+                    role: 'list' // Needed for webkit/VO
+                });
             }
         }
     },
@@ -441,11 +453,10 @@ extend(MenuComponent.prototype, /** @lends Highcharts.MenuComponent */ {
 
             // Focus export menu button
             init: function (): void {
-                const exportBtn = component.exportButtonProxy,
-                    exportGroup = chart.exportingGroup;
-
-                if (exportGroup && exportBtn) {
-                    chart.setFocusToElement(exportGroup, exportBtn);
+                const proxy = component.exportButtonProxy;
+                const svgEl = component.chart.exportingGroup;
+                if (proxy && svgEl) {
+                    chart.setFocusToElement(svgEl, proxy.buttonElement);
                 }
             },
 
@@ -460,20 +471,19 @@ extend(MenuComponent.prototype, /** @lends Highcharts.MenuComponent */ {
     /**
      * @private
      * @param {Highcharts.KeyboardNavigationHandler} keyboardNavigationHandler
-     * @return {number}
-     * Response code
+     * @return {number} Response code
      */
     onKbdPrevious: function (
         this: Highcharts.MenuComponent,
         keyboardNavigationHandler: Highcharts.KeyboardNavigationHandler
     ): number {
-        let chart = this.chart,
-            a11yOptions = chart.options.accessibility,
-            response = keyboardNavigationHandler.response,
-            i = chart.highlightedExportItemIx || 0;
+        const chart = this.chart;
+        const a11yOptions = chart.options.accessibility;
+        const response = keyboardNavigationHandler.response;
 
         // Try to highlight prev item in list. Highlighting e.g.
         // separators will fail.
+        let i = chart.highlightedExportItemIx || 0;
         while (i--) {
             if (chart.highlightExportItem(i)) {
                 return response.success;
@@ -492,21 +502,23 @@ extend(MenuComponent.prototype, /** @lends Highcharts.MenuComponent */ {
     /**
      * @private
      * @param {Highcharts.KeyboardNavigationHandler} keyboardNavigationHandler
-     * @return {number}
-     * Response code
+     * @return {number} Response code
      */
     onKbdNext: function (
         this: Highcharts.MenuComponent,
         keyboardNavigationHandler: Highcharts.KeyboardNavigationHandler
     ): number {
-        let chart = this.chart,
-            a11yOptions = chart.options.accessibility,
-            response = keyboardNavigationHandler.response,
-            i = (chart.highlightedExportItemIx || 0) + 1;
+        const chart = this.chart;
+        const a11yOptions = chart.options.accessibility;
+        const response = keyboardNavigationHandler.response;
 
         // Try to highlight next item in list. Highlighting e.g.
         // separators will fail.
-        for (;i < (chart.exportDivElements as any).length; ++i) {
+        for (
+            let i = (chart.highlightedExportItemIx || 0) + 1;
+            i < (chart.exportDivElements as any).length;
+            ++i
+        ) {
             if (chart.highlightExportItem(i)) {
                 return response.success;
             }
@@ -524,18 +536,17 @@ extend(MenuComponent.prototype, /** @lends Highcharts.MenuComponent */ {
     /**
      * @private
      * @param {Highcharts.KeyboardNavigationHandler} keyboardNavigationHandler
-     * @return {number}
-     * Response code
+     * @return {number} Response code
      */
     onKbdClick: function (
         this: Highcharts.MenuComponent,
         keyboardNavigationHandler: Highcharts.KeyboardNavigationHandler
     ): number {
-        const chart = this.chart,
-            curHighlightedItem = (chart.exportDivElements as any)[
-                chart.highlightedExportItemIx as any
-            ],
-            exportButtonElement: SVGDOMElement = (getExportMenuButtonElement(chart) as any).element;
+        const chart = this.chart;
+        const curHighlightedItem = (chart.exportDivElements as any)[
+            chart.highlightedExportItemIx as any
+        ];
+        const exportButtonElement: SVGDOMElement = (getExportMenuButtonElement(chart) as any).element;
 
         if (this.isExportMenuShown) {
             this.fakeClickEvent(curHighlightedItem);

--- a/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
@@ -675,9 +675,19 @@ extend(SeriesKeyboardNavigation.prototype, /** @lends Highcharts.SeriesKeyboardN
         e.addEvent(Point, 'afterSetState', function (): void {
             const point = this;
             const pointEl = point.graphic && point.graphic.element;
+            const focusedElement = doc.activeElement;
+            // VO brings focus with it to container, causing series nav to run.
+            // If then navigating with virtual cursor, it is possible to leave
+            // keyboard nav module state on the data points and still activate
+            // proxy buttons.
+            const focusedElClassName = focusedElement && focusedElement.getAttribute('class');
+            const isProxyFocused = focusedElClassName &&
+                focusedElClassName.indexOf('highcharts-a11y-proxy-button') > -1;
+
             if (
                 chart.highlightedPoint === point &&
-                doc.activeElement !== pointEl &&
+                focusedElement !== pointEl &&
+                !isProxyFocused &&
                 pointEl &&
                 pointEl.focus
             ) {

--- a/ts/Accessibility/Components/ZoomComponent.ts
+++ b/ts/Accessibility/Components/ZoomComponent.ts
@@ -14,15 +14,15 @@
 
 import type Chart from '../../Core/Chart/Chart';
 import type {
-    DOMElementType,
-    HTMLDOMElement
+    DOMElementType, SVGDOMElement
 } from '../../Core/Renderer/DOMElementType';
 import type SVGElement from '../../Core/Renderer/SVG/SVGElement';
+import type ProxyElement from '../ProxyElement';
 
 import AccessibilityComponent from '../AccessibilityComponent.js';
-import Axis from '../../Core/Axis/Axis.js';
 import ChartUtilities from '../Utils/ChartUtilities.js';
 const {
+    fireEventOnWrappedOrUnwrappedElement,
     unhideChartElementFromAT
 } = ChartUtilities;
 import H from '../../Core/Globals.js';
@@ -31,7 +31,7 @@ const {
 } = H;
 import HTMLUtilities from '../Utils/HTMLUtilities.js';
 const {
-    removeElement,
+    getFakeMouseEvent,
     setElAttrs
 } = HTMLUtilities;
 import KeyboardNavigationHandler from '../KeyboardNavigationHandler.js';
@@ -54,14 +54,17 @@ declare global {
     namespace Highcharts {
         class ZoomComponent extends AccessibilityComponent {
             public constructor();
-            public drillUpProxyButton?: HTMLDOMElement;
-            public drillUpProxyGroup?: HTMLDOMElement;
+            public drillUpProxyButton?: ProxyElement;
+            public resetZoomProxyButton?: ProxyElement;
             public focusedMapNavButtonIx: number;
-            public resetZoomProxyButton?: HTMLDOMElement;
-            public resetZoomProxyGroup?: HTMLDOMElement;
             getKeyboardNavigation(): Array<KeyboardNavigationHandler>;
             getMapZoomNavigation(): KeyboardNavigationHandler;
             init(): void;
+            createZoomProxyButton(
+                buttonEl: SVGElement,
+                buttonProp: ('drillUpProxyButton'|'resetZoomProxyButton'),
+                label: string
+            ): void;
             onChartRender(): void;
             onChartUpdate(): void;
             onMapKbdArrow(
@@ -76,12 +79,6 @@ declare global {
                 keyboardNavigationHandler: KeyboardNavigationHandler,
                 event: Event
             ): number;
-            recreateProxyButtonAndGroup(
-                buttonEl: SVGElement,
-                buttonProp: ('drillUpProxyButton'|'resetZoomProxyButton'),
-                groupProp: ('drillUpProxyGroup'|'resetZoomProxyGroup'),
-                label: string
-            ): void;
             setMapNavButtonAttrs(
                 button: DOMElementType,
                 labelFormatKey: string
@@ -127,12 +124,12 @@ function chartHasMapZoom(
     direction: number,
     granularity?: number
 ): void {
-    let gran = granularity || 3,
-        extremes = this.getExtremes(),
-        step = (extremes.max - extremes.min) / gran * direction,
-        newMax = extremes.max + step,
-        newMin = extremes.min + step,
-        size = newMax - newMin;
+    const gran = granularity || 3;
+    const extremes = this.getExtremes();
+    const step = (extremes.max - extremes.min) / gran * direction;
+    let newMax = extremes.max + step;
+    let newMin = extremes.min + step;
+    const size = newMax - newMin;
 
     if (direction < 0 && newMin < extremes.dataMin) {
         newMin = extremes.dataMin;
@@ -162,6 +159,9 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
     init: function (this: Highcharts.ZoomComponent): void {
         const component = this,
             chart = this.chart;
+
+        this.proxyProvider.addGroup('zoom', 'div');
+
         [
             'afterShowResetZoom', 'afterDrilldown', 'drillupall'
         ].forEach(function (eventType: string): void {
@@ -235,13 +235,12 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
         const chart = this.chart;
 
         // Always start with a clean slate
-        removeElement(this.drillUpProxyGroup);
-        removeElement(this.resetZoomProxyGroup);
+        this.proxyProvider.clearGroup('zoom');
 
         if (chart.resetZoomButton) {
-            this.recreateProxyButtonAndGroup(
+            this.createZoomProxyButton(
                 chart.resetZoomButton, 'resetZoomProxyButton',
-                'resetZoomProxyGroup', chart.langFormat(
+                chart.langFormat(
                     'accessibility.zoom.resetZoomButton',
                     { chart: chart }
                 )
@@ -249,9 +248,9 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
         }
 
         if (chart.drillUpButton) {
-            this.recreateProxyButtonAndGroup(
+            this.createZoomProxyButton(
                 chart.drillUpButton, 'drillUpProxyButton',
-                'drillUpProxyGroup', chart.langFormat(
+                chart.langFormat(
                     'accessibility.drillUpButton',
                     {
                         chart: chart,
@@ -267,23 +266,20 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
      * @private
      * @param {Highcharts.SVGElement} buttonEl
      * @param {string} buttonProp
-     * @param {string} groupProp
      * @param {string} label
      */
-    recreateProxyButtonAndGroup: function (
+    createZoomProxyButton: function (
         this: Highcharts.ZoomComponent,
         buttonEl: SVGElement,
         buttonProp: ('drillUpProxyButton'|'resetZoomProxyButton'),
-        groupProp: ('drillUpProxyGroup'|'resetZoomProxyGroup'),
         label: string
     ): void {
-        removeElement(this[groupProp]);
-        this[groupProp] = this.addProxyGroup();
-        this[buttonProp] = this.createProxyButton(
-            buttonEl,
-            this[groupProp] as any,
-            { 'aria-label': label, tabindex: -1 }
-        );
+        this[buttonProp] = this.proxyProvider.addProxyElement('zoom', {
+            click: buttonEl
+        }, {
+            'aria-label': label,
+            tabindex: -1
+        });
     },
 
 
@@ -376,11 +372,10 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
         keyboardNavigationHandler: Highcharts.KeyboardNavigationHandler,
         event: KeyboardEvent
     ): number {
-        let button: (SVGElement|undefined),
-            chart: Highcharts.MapNavigationChart = this.chart as any,
-            response = keyboardNavigationHandler.response,
-            isBackwards = event.shiftKey,
-            isMoveOutOfRange = isBackwards && !this.focusedMapNavButtonIx ||
+        const chart: Highcharts.MapNavigationChart = this.chart as Highcharts.MapNavigationChart;
+        const response = keyboardNavigationHandler.response;
+        const isBackwards = event.shiftKey;
+        const isMoveOutOfRange = isBackwards && !this.focusedMapNavButtonIx ||
                 !isBackwards && this.focusedMapNavButtonIx;
 
         // Deselect old
@@ -393,7 +388,7 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
 
         // Select other button
         this.focusedMapNavButtonIx += isBackwards ? -1 : 1;
-        button = chart.mapNavButtons[this.focusedMapNavButtonIx];
+        const button = chart.mapNavButtons[this.focusedMapNavButtonIx];
         chart.setFocusToElement(button.box, button.element);
         button.setState(2);
 
@@ -410,10 +405,9 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
         this: Highcharts.ZoomComponent,
         keyboardNavigationHandler: Highcharts.KeyboardNavigationHandler
     ): number {
-        this.fakeClickEvent(
-            (this.chart as any).mapNavButtons[this.focusedMapNavButtonIx]
-                .element
-        );
+        const fakeEvent = getFakeMouseEvent('click');
+        const el: SVGDOMElement = (this.chart as any).mapNavButtons[this.focusedMapNavButtonIx].element;
+        fireEventOnWrappedOrUnwrappedElement(el, fakeEvent);
         return keyboardNavigationHandler.response.success;
     },
 
@@ -487,7 +481,7 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
                 const hasButton = (
                     (chart as any)[buttonProp] &&
                     (chart as any)[buttonProp].box &&
-                    (component as any)[proxyProp]
+                    (component as any)[proxyProp].buttonElement
                 );
                 return hasButton;
             },
@@ -495,7 +489,7 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
             init: function (): void {
                 chart.setFocusToElement(
                     (chart as any)[buttonProp].box,
-                    (component as any)[proxyProp]
+                    (component as any)[proxyProp].buttonElement
                 );
             }
         });

--- a/ts/Accessibility/Components/ZoomComponent.ts
+++ b/ts/Accessibility/Components/ZoomComponent.ts
@@ -22,7 +22,6 @@ import type ProxyElement from '../ProxyElement';
 import AccessibilityComponent from '../AccessibilityComponent.js';
 import ChartUtilities from '../Utils/ChartUtilities.js';
 const {
-    fireEventOnWrappedOrUnwrappedElement,
     unhideChartElementFromAT
 } = ChartUtilities;
 import H from '../../Core/Globals.js';
@@ -31,7 +30,6 @@ const {
 } = H;
 import HTMLUtilities from '../Utils/HTMLUtilities.js';
 const {
-    getFakeMouseEvent,
     setElAttrs
 } = HTMLUtilities;
 import KeyboardNavigationHandler from '../KeyboardNavigationHandler.js';
@@ -405,9 +403,8 @@ extend(ZoomComponent.prototype, /** @lends Highcharts.ZoomComponent */ {
         this: Highcharts.ZoomComponent,
         keyboardNavigationHandler: Highcharts.KeyboardNavigationHandler
     ): number {
-        const fakeEvent = getFakeMouseEvent('click');
         const el: SVGDOMElement = (this.chart as any).mapNavButtons[this.focusedMapNavButtonIx].element;
-        fireEventOnWrappedOrUnwrappedElement(el, fakeEvent);
+        this.fakeClickEvent(el);
         return keyboardNavigationHandler.response.success;
     },
 

--- a/ts/Accessibility/KeyboardNavigation.ts
+++ b/ts/Accessibility/KeyboardNavigation.ts
@@ -161,7 +161,6 @@ KeyboardNavigation.prototype = {
         this.modules = [];
         this.currentModuleIx = 0;
 
-        // Run an update to get all modules
         this.update();
 
         ep.addEvent(this.tabindexContainer, 'keydown',
@@ -187,11 +186,6 @@ KeyboardNavigation.prototype = {
         ep.addEvent(chart.renderTo, 'mouseout', (): void => {
             this.pointerIsOverChart = false;
         });
-
-        // Init first module
-        if (this.modules.length) {
-            this.modules[0].init(1);
-        }
     },
 
 

--- a/ts/Accessibility/Options/LangOptions.ts
+++ b/ts/Accessibility/Options/LangOptions.ts
@@ -449,8 +449,7 @@ const langOptions: DeepPartial<LangOptions> = {
          */
         exporting: {
             chartMenuLabel: 'Chart menu',
-            menuButtonLabel: 'View chart menu',
-            exportRegionLabel: 'Chart menu'
+            menuButtonLabel: 'View chart menu, {chartTitle}'
         },
 
         /**

--- a/ts/Accessibility/ProxyElement.ts
+++ b/ts/Accessibility/ProxyElement.ts
@@ -1,0 +1,293 @@
+/* *
+ *
+ *  (c) 2009-2021 Øystein Moseng
+ *
+ *  Proxy elements are used to shadow SVG elements in HTML for assistive
+ *  technology, such as screen readers or voice input software.
+ *
+ *  The ProxyElement class represents such an element, and deals with
+ *  overlay positioning and mirroring events for the target.
+ *
+ *  License: www.highcharts.com/license
+ *
+ *  !!!!!!! SOURCE GETS TRANSPILED BY TYPESCRIPT. EDIT TS FILE ONLY. !!!!!!!
+ *
+ * */
+
+'use strict';
+
+import type BBoxObject from '../Core/Renderer/BBoxObject';
+import type {
+    DOMElementType,
+    HTMLDOMElement,
+    SVGDOMElement
+} from '../Core/Renderer/DOMElementType';
+import type HTMLAttributes from '../Core/Renderer/HTML/HTMLAttributes';
+import type HTMLElement from '../Core/Renderer/HTML/HTMLElement';
+import type SVGElement from '../Core/Renderer/SVG/SVGElement';
+import EventProvider from './Utils/EventProvider.js';
+import H from '../Core/Globals.js';
+const {
+    doc
+} = H;
+import HTMLUtilities from './Utils/HTMLUtilities.js';
+const {
+    cloneMouseEvent,
+    cloneTouchEvent,
+    getFakeMouseEvent,
+    removeElement,
+    setElAttrs
+} = HTMLUtilities;
+import U from '../Core/Utilities.js';
+const {
+    fireEvent,
+    merge
+} = U;
+
+
+/* eslint-disable valid-jsdoc */
+
+export interface ProxyTarget {
+    click: DOMElementType|SVGElement|HTMLElement;
+    visual?: DOMElementType;
+}
+export type ProxyGroupTypes = 'div'|'ul';
+
+
+/**
+ * Represents a proxy element that overlays a target and relays events
+ * to its target.
+ *
+ * @private
+ * @class
+ */
+class ProxyElement {
+    // The entire proxy HTML element. Note: May not refer to the
+    // button element directly, see below.
+    public element: HTMLDOMElement;
+
+    // The proxy button element, may be same as element, depending
+    // on group type.
+    public buttonElement: HTMLButtonElement;
+
+    private eventProvider: Highcharts.EventProvider;
+
+    constructor(
+        private chart: Highcharts.AccessibilityChart,
+        public target: ProxyTarget,
+        public groupType: ProxyGroupTypes,
+        attributes?: HTMLAttributes
+    ) {
+        this.eventProvider = new EventProvider();
+
+        const wrapperEl = groupType === 'ul' ? doc.createElement('li') : null;
+        const btnEl = this.buttonElement = doc.createElement('button');
+        this.hideButtonVisually(btnEl);
+
+        if (wrapperEl) {
+            wrapperEl.appendChild(btnEl);
+            this.element = wrapperEl;
+        } else {
+            this.element = btnEl;
+        }
+
+        this.updateTarget(target, attributes);
+    }
+
+
+    /**
+     * Fake a click event on the target.
+     */
+    public click(): void {
+        const pos = this.getTargetPosition();
+        pos.x += pos.width / 2;
+        pos.y += pos.height / 2;
+        const fakeEventObject = getFakeMouseEvent('click', pos);
+        this.fireEventOnWrappedOrUnwrappedElement(this.target.click, fakeEventObject);
+    }
+
+
+    /**
+     * Update the target to be proxied.
+     * The position and events are updated to match the new target.
+     * @param target The new target definition
+     * @param attributes New HTML attributes to apply to the button. Set an attribute to null to remove.
+     */
+    public updateTarget(target: ProxyTarget, attributes?: HTMLAttributes): void {
+        this.target = target;
+        this.updateCSSClassName();
+
+        setElAttrs(this.buttonElement, merge({
+            'aria-label': this.getTargetAttr(target.click, 'aria-label')
+        }, attributes));
+
+        this.eventProvider.removeAddedEvents();
+        this.addProxyEventsToButton(this.buttonElement, target.click);
+        this.refreshPosition();
+    }
+
+
+    /**
+     * Refresh the position of the proxy element to match the current target
+     */
+    public refreshPosition(): void {
+        const bBox = this.getTargetPosition();
+        merge(true, this.buttonElement.style, {
+            width: (bBox.width || 1) + 'px',
+            height: (bBox.height || 1) + 'px',
+            left: (Math.round(bBox.x) || 0) + 'px',
+            top: (Math.round(bBox.y) || 0) + 'px'
+        });
+    }
+
+
+    /**
+     * Remove button from DOM, and clear events.
+     */
+    public remove(): void {
+        this.eventProvider.removeAddedEvents();
+        removeElement(this.element);
+    }
+
+
+    // -------------------------- private ------------------------------------
+
+
+    /**
+     * Update the CSS class name to match target
+     */
+    private updateCSSClassName(): void {
+        const stringHasNoTooltip = (s: string): boolean => s.indexOf('highcharts-no-tooltip') > -1;
+        const legend = this.chart.legend;
+        const groupDiv = legend.group && legend.group.div;
+        const noTooltipOnGroup = stringHasNoTooltip(groupDiv && groupDiv.className || '');
+        const targetClassName = this.getTargetAttr(this.target.click, 'className') as string || '';
+        const noTooltipOnTarget = stringHasNoTooltip(targetClassName);
+
+        this.buttonElement.className = noTooltipOnGroup || noTooltipOnTarget ?
+            'highcharts-a11y-proxy-button highcharts-no-tooltip' :
+            'highcharts-a11y-proxy-button';
+    }
+
+
+    /**
+     * Mirror events for a proxy button to a target
+     */
+    private addProxyEventsToButton(
+        button: HTMLDOMElement,
+        target: DOMElementType|SVGElement|HTMLElement
+    ): void {
+        [
+            'click', 'touchstart', 'touchend', 'touchcancel', 'touchmove',
+            'mouseover', 'mouseenter', 'mouseleave', 'mouseout'
+        ].forEach((evtType: string): void => {
+            const isTouchEvent = evtType.indexOf('touch') === 0;
+
+            this.eventProvider.addEvent(button, evtType, (e: MouseEvent | TouchEvent): void => {
+                const clonedEvent = isTouchEvent ?
+                    cloneTouchEvent(e as TouchEvent) :
+                    cloneMouseEvent(e as MouseEvent);
+
+                if (target) {
+                    this.fireEventOnWrappedOrUnwrappedElement(target, clonedEvent);
+                }
+
+                e.stopPropagation();
+
+                // #9682, #15318: Touch scrolling didnt work when touching proxy
+                if (!isTouchEvent) {
+                    e.preventDefault();
+                }
+            }, { passive: false });
+        });
+    }
+
+
+    /**
+     * Fire an event on an element that is either wrapped by Highcharts,
+     * or a DOM element
+     */
+    private fireEventOnWrappedOrUnwrappedElement(
+        el: (HTMLElement|SVGElement|DOMElementType),
+        eventObject: Event
+    ): void {
+        const type = eventObject.type;
+        const hcEvents = (el as SVGElement).hcEvents;
+
+        if (doc.createEvent && ((el as Element).dispatchEvent || (el as SVGElement).fireEvent)) {
+            if (el.dispatchEvent) {
+                el.dispatchEvent(eventObject);
+            } else {
+                (el as SVGElement).fireEvent(type, eventObject);
+            }
+        } else if (hcEvents && hcEvents[type]) {
+            fireEvent(el, type, eventObject);
+        } else if ((el as SVGElement).element) {
+            this.fireEventOnWrappedOrUnwrappedElement((el as SVGElement).element, eventObject);
+        }
+    }
+
+
+    /**
+     * Set visually hidden style on a proxy button
+     */
+    private hideButtonVisually(button: HTMLDOMElement): void {
+        merge(true, button.style, {
+            borderWidth: '0',
+            backgroundColor: 'transparent',
+            cursor: 'pointer',
+            outline: 'none',
+            opacity: '0.001',
+            filter: 'alpha(opacity=1)',
+            zIndex: '999',
+            overflow: 'hidden',
+            padding: '0',
+            margin: '0',
+            display: 'block',
+            position: 'absolute'
+        });
+        (button.style as any)['-ms-filter'] =
+            'progid:DXImageTransform.Microsoft.Alpha(Opacity=1)';
+    }
+
+
+    /**
+     * Get the position relative to chart container for the target
+     */
+    private getTargetPosition(): BBoxObject {
+        const clickTarget = this.target.click;
+        // We accept both DOM elements and wrapped elements as click targets.
+        const clickTargetElement = (clickTarget as SVGElement).element ?
+            (clickTarget as SVGElement).element :
+            clickTarget as SVGDOMElement;
+        const posElement = this.target.visual || clickTargetElement;
+        const chartDiv: HTMLDOMElement = this.chart.renderTo;
+
+        if (chartDiv && posElement && posElement.getBoundingClientRect) {
+            const rectEl = posElement.getBoundingClientRect(),
+                rectDiv = chartDiv.getBoundingClientRect();
+
+            return {
+                x: rectEl.left - rectDiv.left,
+                y: rectEl.top - rectDiv.top,
+                width: rectEl.right - rectEl.left,
+                height: rectEl.bottom - rectEl.top
+            };
+        }
+
+        return { x: 0, y: 0, width: 1, height: 1 };
+    }
+
+
+    /**
+     * Get an attribute value of a target
+     */
+    private getTargetAttr(target: SVGElement|HTMLElement|DOMElementType, key: string): unknown {
+        if ((target as SVGElement).element) {
+            return (target as SVGElement).element.getAttribute(key);
+        }
+        return target.getAttribute(key);
+    }
+}
+
+export default ProxyElement;

--- a/ts/Accessibility/ProxyElement.ts
+++ b/ts/Accessibility/ProxyElement.ts
@@ -30,6 +30,10 @@ import H from '../Core/Globals.js';
 const {
     doc
 } = H;
+import ChartUtilities from './Utils/ChartUtilities.js';
+const {
+    fireEventOnWrappedOrUnwrappedElement
+} = ChartUtilities;
 import HTMLUtilities from './Utils/HTMLUtilities.js';
 const {
     cloneMouseEvent,
@@ -40,7 +44,6 @@ const {
 } = HTMLUtilities;
 import U from '../Core/Utilities.js';
 const {
-    fireEvent,
     merge
 } = U;
 
@@ -103,7 +106,7 @@ class ProxyElement {
         pos.x += pos.width / 2;
         pos.y += pos.height / 2;
         const fakeEventObject = getFakeMouseEvent('click', pos);
-        this.fireEventOnWrappedOrUnwrappedElement(this.target.click, fakeEventObject);
+        fireEventOnWrappedOrUnwrappedElement(this.target.click, fakeEventObject);
     }
 
 
@@ -189,7 +192,7 @@ class ProxyElement {
                     cloneMouseEvent(e as MouseEvent);
 
                 if (target) {
-                    this.fireEventOnWrappedOrUnwrappedElement(target, clonedEvent);
+                    fireEventOnWrappedOrUnwrappedElement(target, clonedEvent);
                 }
 
                 e.stopPropagation();
@@ -200,31 +203,6 @@ class ProxyElement {
                 }
             }, { passive: false });
         });
-    }
-
-
-    /**
-     * Fire an event on an element that is either wrapped by Highcharts,
-     * or a DOM element
-     */
-    private fireEventOnWrappedOrUnwrappedElement(
-        el: (HTMLElement|SVGElement|DOMElementType),
-        eventObject: Event
-    ): void {
-        const type = eventObject.type;
-        const hcEvents = (el as SVGElement).hcEvents;
-
-        if (doc.createEvent && ((el as Element).dispatchEvent || (el as SVGElement).fireEvent)) {
-            if (el.dispatchEvent) {
-                el.dispatchEvent(eventObject);
-            } else {
-                (el as SVGElement).fireEvent(type, eventObject);
-            }
-        } else if (hcEvents && hcEvents[type]) {
-            fireEvent(el, type, eventObject);
-        } else if ((el as SVGElement).element) {
-            this.fireEventOnWrappedOrUnwrappedElement((el as SVGElement).element, eventObject);
-        }
     }
 
 

--- a/ts/Accessibility/ProxyElement.ts
+++ b/ts/Accessibility/ProxyElement.ts
@@ -161,7 +161,7 @@ class ProxyElement {
         const legend = this.chart.legend;
         const groupDiv = legend.group && legend.group.div;
         const noTooltipOnGroup = stringHasNoTooltip(groupDiv && groupDiv.className || '');
-        const targetClassName = this.getTargetAttr(this.target.click, 'className') as string || '';
+        const targetClassName = this.getTargetAttr(this.target.click, 'class') as string || '';
         const noTooltipOnTarget = stringHasNoTooltip(targetClassName);
 
         this.buttonElement.className = noTooltipOnGroup || noTooltipOnTarget ?

--- a/ts/Accessibility/ProxyProvider.ts
+++ b/ts/Accessibility/ProxyProvider.ts
@@ -1,0 +1,271 @@
+/* *
+ *
+ *  (c) 2009-2021 Øystein Moseng
+ *
+ *  Proxy elements are used to shadow SVG elements in HTML for assistive
+ *  technology, such as screen readers or voice input software.
+ *
+ *  The ProxyProvider keeps track of all proxy elements of the a11y module,
+ *  and updating their order and positioning.
+ *
+ *  License: www.highcharts.com/license
+ *
+ *  !!!!!!! SOURCE GETS TRANSPILED BY TYPESCRIPT. EDIT TS FILE ONLY. !!!!!!!
+ *
+ * */
+
+'use strict';
+
+import type {
+    HTMLDOMElement
+} from '../Core/Renderer/DOMElementType';
+import type HTMLAttributes from '../Core/Renderer/HTML/HTMLAttributes';
+import DOMElementProvider from './Utils/DOMElementProvider.js';
+import ProxyElement from './ProxyElement.js';
+import type { ProxyTarget, ProxyGroupTypes } from './ProxyElement';
+import HTMLUtilities from './Utils/HTMLUtilities.js';
+const {
+    removeElement,
+    removeChildNodes,
+    setElAttrs
+} = HTMLUtilities;
+import ChartUtilities from './Utils/ChartUtilities.js';
+const {
+    unhideChartElementFromAT
+} = ChartUtilities;
+import U from '../Core/Utilities.js';
+const {
+    merge
+} = U;
+
+
+/* eslint-disable valid-jsdoc */
+
+interface ProxyGroup {
+    container: HTMLDOMElement;
+    type: ProxyGroupTypes;
+    proxyElements: ProxyElement[];
+}
+
+/**
+ * Keeps track of all proxy elements and proxy groups.
+ *
+ * @private
+ * @class
+ */
+class ProxyProvider {
+    private beforeChartProxyPosContainer: HTMLDOMElement;
+    private afterChartProxyPosContainer: HTMLDOMElement;
+    private domElementProvider: Highcharts.DOMElementProvider;
+    private groups: Record<string, ProxyGroup|undefined>;
+    private groupOrder: string[];
+
+    constructor(private chart: Highcharts.AccessibilityChart) {
+        this.domElementProvider = new DOMElementProvider();
+        this.groups = {};
+        this.groupOrder = [];
+
+        this.beforeChartProxyPosContainer = this.createProxyPosContainer('before');
+        this.afterChartProxyPosContainer = this.createProxyPosContainer('after');
+
+        this.update();
+    }
+
+
+    /**
+     * Add a new proxy element to a group, proxying a target control.
+     */
+    public addProxyElement(
+        groupKey: string,
+        target: ProxyTarget,
+        attributes?: HTMLAttributes
+    ): ProxyElement {
+        const group = this.groups[groupKey];
+        if (!group) {
+            throw new Error('ProxyProvider.addProxyElement: Invalid group key ' + groupKey);
+        }
+
+        const proxy = new ProxyElement(this.chart, target, group.type, attributes);
+
+        group.container.appendChild(proxy.element);
+        group.proxyElements.push(proxy);
+
+        return proxy;
+    }
+
+
+    /**
+     * Create a group that will contain proxy elements. The group order is
+     * automatically updated according to the last group order keys.
+     */
+    public addGroup(groupKey: string, groupType: ProxyGroupTypes, attributes: HTMLAttributes): void {
+        if (this.groups[groupKey]) {
+            return;
+        }
+
+        const groupEl = this.domElementProvider.createElement(groupType);
+
+        groupEl.className = 'highcharts-a11y-proxy-group-' + groupKey.replace(/\W/g, '-');
+
+        this.groups[groupKey] = {
+            container: groupEl,
+            type: groupType,
+            proxyElements: []
+        };
+
+        setElAttrs(groupEl, merge(attributes, { 'aria-hidden': false }));
+        if (groupType === 'ul') {
+            groupEl.style.listStyle = 'none';
+            groupEl.setAttribute('role', 'list'); // Needed for safari/VO with list-style: none
+        }
+
+        this.updateGroupOrder(this.groupOrder);
+    }
+
+
+    /**
+     * Update HTML attributes of a group.
+     */
+    public updateGroupAttrs(groupKey: string, attributes: HTMLAttributes): void {
+        const group = this.groups[groupKey];
+        if (!group) {
+            throw new Error('ProxyProvider.updateGroupAttrs: Invalid group key ' + groupKey);
+        }
+        setElAttrs(group.container, attributes);
+    }
+
+
+    /**
+     * Reorder the proxy groups.
+     *
+     * The group key "series" refers to the chart's data points / <svg> element.
+     * This is so that the keyboardNavigation.order option can be used to
+     * determine the proxy group order.
+     */
+    public updateGroupOrder(groupKeys: string[]): void {
+        // Store so that we can update order when a new group is created
+        this.groupOrder = groupKeys.slice();
+
+        const seriesIx = groupKeys.indexOf('series');
+        const beforeKeys = seriesIx > -1 ? groupKeys.slice(0, seriesIx) : groupKeys;
+        const afterKeys = seriesIx > -1 ? groupKeys.slice(seriesIx + 1) : [];
+
+        ['before', 'after'].forEach((pos): void => {
+            const posContainer = this[
+                pos === 'before' ?
+                    'beforeChartProxyPosContainer' :
+                    'afterChartProxyPosContainer'
+            ];
+            const keys = pos === 'before' ? beforeKeys : afterKeys;
+
+            removeChildNodes(posContainer);
+
+            keys.forEach((groupKey): void => {
+                const group = this.groups[groupKey];
+                if (group) {
+                    posContainer.appendChild(group.container);
+                }
+            });
+        });
+    }
+
+
+    /**
+     * Remove all proxy elements in a group
+     */
+    public clearGroup(groupKey: string): void {
+        const group = this.groups[groupKey];
+        if (!group) {
+            throw new Error('ProxyProvider.clearGroup: Invalid group key ' + groupKey);
+        }
+        removeChildNodes(group.container);
+    }
+
+
+    /**
+     * Remove a group from the DOM and from the proxy provider's group list.
+     * All child elements are removed.
+     * If the group does not exist, nothing happens.
+     */
+    public removeGroup(groupKey: string): void {
+        const group = this.groups[groupKey];
+        if (group) {
+            removeElement(group.container);
+            delete this.groups[groupKey];
+        }
+    }
+
+
+    /**
+     * Update the position and order of all proxy groups and elements
+     */
+    public update(): void {
+        this.updatePosContainerPositions();
+        this.updateGroupOrder(this.groupOrder);
+        this.updateProxyElementPositions();
+    }
+
+
+    /**
+     * Update all proxy element positions
+     */
+    public updateProxyElementPositions(): void {
+        Object.keys(this.groups).forEach(this.updateGroupProxyElementPositions.bind(this));
+    }
+
+
+    /**
+     * Update a group's proxy elements' positions.
+     * If the group does not exist, nothing happens.
+     */
+    public updateGroupProxyElementPositions(groupKey: string): void {
+        const group = this.groups[groupKey];
+        if (group) {
+            group.proxyElements.forEach((el): void => el.refreshPosition());
+        }
+    }
+
+
+    /**
+     * Remove all added elements
+     */
+    public destroy(): void {
+        this.domElementProvider.destroyCreatedElements();
+    }
+
+
+    // -------------------------- private ------------------------------------
+
+
+    /**
+     * Create and return a pos container element (the overall containers for
+     * the proxy groups).
+     */
+    private createProxyPosContainer(classNamePostfix?: string): HTMLDivElement {
+        const el = this.domElementProvider.createElement('div');
+        el.className = 'highcharts-a11y-proxy-container' + (classNamePostfix ? '-' + classNamePostfix : '');
+        return el;
+    }
+
+
+    /**
+     * Update the DOM positions of the before/after proxy
+     * positioning containers for the groups.
+     */
+    private updatePosContainerPositions(): void {
+        const chart = this.chart;
+        const rendererSVGEl = chart.renderer.box;
+        chart.container.insertBefore(
+            this.afterChartProxyPosContainer,
+            rendererSVGEl.nextSibling
+        );
+        chart.container.insertBefore(
+            this.beforeChartProxyPosContainer,
+            rendererSVGEl
+        );
+        unhideChartElementFromAT(this.chart, this.afterChartProxyPosContainer);
+        unhideChartElementFromAT(this.chart, this.beforeChartProxyPosContainer);
+    }
+}
+
+export default ProxyProvider;

--- a/ts/Accessibility/Utils/ChartUtilities.ts
+++ b/ts/Accessibility/Utils/ChartUtilities.ts
@@ -17,10 +17,17 @@ import type Chart from '../../Core/Chart/Chart';
 import type { DOMElementType } from '../../Core/Renderer/DOMElementType';
 import type Point from '../../Core/Series/Point';
 import type Series from '../../Core/Series/Series';
+import type HTMLElement from '../../Core/Renderer/HTML/HTMLElement';
+import type SVGElement from '../../Core/Renderer/SVG/SVGElement';
+
 import HTMLUtilities from './HTMLUtilities.js';
 const {
     stripHTMLTagsFromString: stripHTMLTags
 } = HTMLUtilities;
+import H from '../../Core/Globals.js';
+const {
+    doc
+} = H;
 import U from '../../Core/Utilities.js';
 const {
     defined,
@@ -36,6 +43,10 @@ const {
 declare global {
     namespace Highcharts {
         interface A11yChartUtilities {
+            fireEventOnWrappedOrUnwrappedElement(
+                el: (HTMLElement|SVGElement|DOMElementType),
+                eventObject: Event
+            ): void;
             getChartTitle(chart: Chart): string;
             getAxisDescription(axis: Axis): string;
             getAxisRangeDescription(axis: Axis): string;
@@ -62,6 +73,32 @@ declare global {
 }
 
 /* eslint-disable valid-jsdoc */
+
+
+/**
+ * Fire an event on an element that is either wrapped by Highcharts,
+ * or a DOM element
+ */
+function fireEventOnWrappedOrUnwrappedElement(
+    el: (HTMLElement|SVGElement|DOMElementType),
+    eventObject: Event
+): void {
+    const type = eventObject.type;
+    const hcEvents = (el as SVGElement).hcEvents;
+
+    if (doc.createEvent && ((el as Element).dispatchEvent || (el as SVGElement).fireEvent)) {
+        if (el.dispatchEvent) {
+            el.dispatchEvent(eventObject);
+        } else {
+            (el as SVGElement).fireEvent(type, eventObject);
+        }
+    } else if (hcEvents && hcEvents[type]) {
+        fireEvent(el, type, eventObject);
+    } else if ((el as SVGElement).element) {
+        fireEventOnWrappedOrUnwrappedElement((el as SVGElement).element, eventObject);
+    }
+}
+
 
 /**
  * @return {string}
@@ -405,6 +442,7 @@ function scrollToPoint(point: Point): void {
 
 
 const ChartUtilities: Highcharts.A11yChartUtilities = {
+    fireEventOnWrappedOrUnwrappedElement,
     getChartTitle,
     getAxisDescription,
     getAxisRangeDescription,

--- a/ts/Accessibility/Utils/HTMLUtilities.ts
+++ b/ts/Accessibility/Utils/HTMLUtilities.ts
@@ -27,6 +27,10 @@ const {
     merge
 } = U;
 
+type Nullable<T> = {
+    [P in keyof T]: T[P] | null;
+};
+
 /* eslint-disable valid-jsdoc */
 
 /**
@@ -323,7 +327,7 @@ function reverseChildNodes(node: DOMElementType): void {
  */
 function setElAttrs(
     el: DOMElementType,
-    attrs: (HTMLAttributes|SVGAttributes)
+    attrs: Nullable<(HTMLAttributes|SVGAttributes)>
 ): void {
     Object.keys(attrs).forEach(function (attr: string): void {
         const val = (attrs as any)[attr];


### PR DESCRIPTION
Fixed issue #15876, DOM order not following keyboardNavigation.order.
___
Pretty comprehensive rewrite of the proxy element logic. Now the a11y module has one central ProxyProvider that keeps track of the various groups, and can reorder them in the DOM properly (ref #15876). Previously the logic was disjointed, as each component kept track of its own group.

Fixed several edge case bugs/glitches in the process, and the new solution should be more robust in general, and easier to debug since critical logic is gathered in one place.