### PR TITLE
docs/15851-multiple-lines-indicator-docs

### DIFF
--- a/docs/stock/custom-technical-indicators.md
+++ b/docs/stock/custom-technical-indicators.md
@@ -170,5 +170,120 @@ Highcharts.seriesType(
 **Module**
 The indicator is available as a [indicators/trendline.js](http://code.highcharts.com/stock/indicators/trendline.js) main module.
 
+### 3. Indicator with multiple lines
+Highcharts Stock offers many already implemented ready-to-use indicators. Some of them are drawn using multiple lines (e.g. Bollinger Bands). In this section, you will learn how to build a custom indicator consisting of 5 lines.
+
+Let's assume we would like to build an indicator with a linear regression main line from the previous example, but this time with the four additional range lines that help to visualize the difference between the main series line and our regression line. For that, we'll add 4 additional lines that will be treated as zones. Those lines' values will be multiplied accordingly by 90%, 95%, 105%, and 110% of the regression line values (step ratio would be possible to change in `series.params`).
+
+Of course, the data from the previous example has to be modified:
+```js
+// ...
+
+var zoneDistance = this.options.params.zoneDistance / 100;
+
+// ...
+
+// Calculate linear regression:
+for (i = 0; i < n; i++) {
+  x = xData[i];
+  y = alpha * x + beta;
+
+  // Prepare arrays required for getValues() method
+  linearData[i] = [x, y * (1 - 2 * zoneDistance), y * (1 - zoneDistance), y, y * (1 + zoneDistance), y * (1 + 2 * zoneDistance)];
+  linearXData[i] = x;
+  linearYData[i] = [y * (1 - 2 * zoneDistance), y * (1 - zoneDistance), y, y * (1 + zoneDistance), y * (1 + 2 * zoneDistance)];
+}
+
+return {
+  xData: linearXData,
+  yData: linearYData,
+  values: linearData
+};
+```
+
+To draw an indicator with multiple lines, we can use the Highcharts MultipleLines mixin that can be accessed after we add any of the Highcharts indicators implementing multiple lines, e.g. Bollinger Bands:
+```html
+<script type="text/javascript" src="https://code.highcharts.com/stock/indicators/bollinger-bands.js"></script>
+```
+
+Now, when having access to the MultipleLines mixin, we can prepare Highcharts to draw multiple lines by overwriting the default series prototype methods. We can also name each additional line and define its own styles. Inside the `Highcharts.seriesType` method we can define the following properties (* - required):
+
+*   `params`* - indicator's parameters. In our case, we set the default difference between the lines to `5%`. This can be changed in the indicator's series options.
+*   `closeRangeBottomLine`*, `highRangeBottomLine`*, `closeRangeTopLine`*, `highRangeTopLine`* - separate default styles for each additional line. This can be changed in the indicator's series options.
+*   `linesApiNames`* - an array containing the names of the additional lines.
+*   `nameBase` - the name of the indicator displayed in the legend.
+*   `nameComponents` - an array containing the names of the properties that values should be displayed in parenthesis in the legend next to the indicator's name.
+*   `pointArrayMap`* - an array containing the keys of the points' values.
+*   `pointValKey`* - default value for [pointValKey](https://api.highcharts.com/highstock/series.ohlc.pointValKey)
+*   `drawGraph`*, `getTranslatedLinesNames`*, `translate`*, `toYData`* - overwrite the Highcharts core methods responsible for drawing multiple lines.
+
+Here is how the seriesType method's arguments should look like:
+
+```js
+var multipleLinesMixin = Highcharts._modules['Mixins/MultipleLines.js'];
+
+Highcharts.seriesType(
+  'linearregressionzones',
+  'sma', {
+    color: '#00ff00',
+    params: {
+      zoneDistance: 5
+    },
+    tooltip: {
+      pointFormat: '<span style="color:{point.color}">\u25CF</span> {series.name}:<br/>' +
+        '110%: <b>{point.y4}</b><br/>' +
+        '105%: <b>{point.y3}</b><br/>' +
+        '100%: <b>{point.y}</b><br/>' +
+        '95%: <b>{point.y2}</b><br/>' +
+        '90%: <b>{point.y1}</b>'
+    },
+    closeRangeBottomLine: {
+      styles: {
+        lineWidth: 1,
+        lineColor: '#ffa500'
+      }
+    },
+    highRangeBottomLine: {
+      styles: {
+        lineWidth: 1,
+        lineColor: '#ff0000'
+      }
+    },
+    closeRangeTopLine: {
+      styles: {
+        lineWidth: 1,
+        lineColor: '#ffa500'
+      }
+    },
+    highRangeTopLine: {
+      styles: {
+        lineWidth: 1,
+        lineColor: '#ff0000'
+      }
+    }
+  }, {
+    getValues: function(series) {
+      return this.getLinearRegressionZones(series.xData, series.yData);
+    },
+    getLinearRegressionZones: getLinearRegressionZones,
+
+    linesApiNames: ['highRangeBottomLine', 'closeRangeBottomLine', 'closeRangeTopLine', 'highRangeTopLine'],
+    nameBase: 'Linear regression zones',
+    nameComponents: ['zoneDistance'],
+    nameSuffixes: ['%'],
+    parallelArrays: ['x', 'y', 'y1', 'y2', 'y3', 'y4'],
+    pointArrayMap: ['y1', 'y2', 'y', 'y3', 'y4'],
+    pointValKey: 'y',
+
+    drawGraph: multipleLinesMixin.drawGraph,
+    getTranslatedLinesNames: multipleLinesMixin.getTranslatedLinesNames,
+    translate: multipleLinesMixin.translate,
+    toYData: multipleLinesMixin.toYData
+  }
+);
+```
+
+A live demo of the above multiline indicator can be found [here](https://jsfiddle.net/BlackLabel/6ueky3x2).
+
 _For more detailed samples and documentation check the [API](https://api.highcharts.com/highstock/series.trendline)._
 

--- a/docs/stock/custom-technical-indicators.md
+++ b/docs/stock/custom-technical-indicators.md
@@ -283,7 +283,7 @@ Highcharts.seriesType(
 );
 ```
 
-A live demo of the above multiline indicator can be found [here](https://jsfiddle.net/BlackLabel/6ueky3x2).
+A live demo of the above multiline indicator can be found [here](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/stock/indicators/custom-regression-multiple-lines/).
 
 _For more detailed samples and documentation check the [API](https://api.highcharts.com/highstock/series.trendline)._
 

--- a/samples/stock/indicators/custom-regression-multiple-lines/demo.details
+++ b/samples/stock/indicators/custom-regression-multiple-lines/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Stock Demo
+ authors:
+   - Rafal Sebestjanski
+ js_wrap: b
+...

--- a/samples/stock/indicators/custom-regression-multiple-lines/demo.html
+++ b/samples/stock/indicators/custom-regression-multiple-lines/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+<script src="https://code.highcharts.com/stock/modules/data.js"></script>
+<script src="https://code.highcharts.com/stock/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/stock/indicators/indicators.js"></script>
+<script src="https://code.highcharts.com/stock/indicators/bollinger-bands.js"></script>
+
+<div id="container" style="height: 400px; min-width: 310px"></div>

--- a/samples/stock/indicators/custom-regression-multiple-lines/demo.js
+++ b/samples/stock/indicators/custom-regression-multiple-lines/demo.js
@@ -1,0 +1,149 @@
+function getLinearRegressionZones(xData, yData) {
+    var sumX = 0,
+        sumY = 0,
+        sumXY = 0,
+        sumX2 = 0,
+        linearData = [],
+        linearXData = [],
+        linearYData = [],
+        n = xData.length,
+        alpha, beta, i, x, y,
+        zoneDistance = this.options.params.zoneDistance / 100,
+        y1, y1, y3, y4;
+
+    // Get sums:
+    for (i = 0; i < n; i++) {
+        x = xData[i];
+        y = yData[i];
+        sumX += x;
+        sumY += y;
+        sumXY += x * y;
+        sumX2 += x * x;
+    }
+
+    // Get slope and offset:
+    alpha = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
+    if (isNaN(alpha)) {
+        alpha = 0;
+    }
+    beta = (sumY - alpha * sumX) / n;
+
+    // Calculate linear regression:
+    for (i = 0; i < n; i++) {
+        x = xData[i];
+        y = alpha * x + beta;
+
+        y1 = y * (1 - 2 * zoneDistance);
+        y2 = y * (1 - zoneDistance);
+        y3 = y * (1 + zoneDistance);
+        y4 = y * (1 + 2 * zoneDistance);
+
+        // Prepare arrays required for getValues() method
+        linearData[i] = [x, y1, y2, y, y3, y4];
+        linearXData[i] = x;
+        linearYData[i] = [y1, y2, y, y3, y4];
+    }
+
+    return {
+        xData: linearXData,
+        yData: linearYData,
+        values: linearData
+    };
+}
+
+var multipleLinesMixin = Highcharts._modules['Mixins/MultipleLines.js'];
+
+Highcharts.seriesType(
+    'linearregressionzones',
+    'sma',
+    {
+        color: '#00ff00',
+        params: {
+            zoneDistance: 3
+        },
+        tooltip: {
+            pointFormat: '<span style="color:{point.color}">\u25CF</span> {series.name}:<br/>' +
+                '110%: <b>{point.y4}</b><br/>' +
+                '105%: <b>{point.y3}</b><br/>' +
+                '100%: <b>{point.y}</b><br/>' +
+                '95%: <b>{point.y2}</b><br/>' +
+                '90%: <b>{point.y1}</b>'
+        },
+        closeRangeBottomLine: {
+            styles: {
+                lineWidth: 1,
+                lineColor: '#ffa500'
+            }
+        },
+        highRangeBottomLine: {
+            styles: {
+                lineWidth: 1,
+                lineColor: '#ff0000'
+            }
+        },
+        closeRangeTopLine: {
+            styles: {
+                lineWidth: 1,
+                lineColor: '#ffa500'
+            }
+        },
+        highRangeTopLine: {
+            styles: {
+                lineWidth: 1,
+                lineColor: '#ff0000'
+            }
+        }
+    },
+    {
+        getValues: function (series) {
+            return this.getLinearRegressionZones(series.xData, series.yData);
+        },
+        getLinearRegressionZones: getLinearRegressionZones,
+
+        linesApiNames: ['highRangeBottomLine', 'closeRangeBottomLine', 'closeRangeTopLine', 'highRangeTopLine'],
+        nameBase: 'Linear regression zones',
+        nameComponents: ['zoneDistance'],
+        nameSuffixes: ['%'],
+        parallelArrays: ['x', 'y', 'y1', 'y2', 'y3', 'y4'],
+        pointArrayMap: ['y1', 'y2', 'y', 'y3', 'y4'],
+        pointValKey: 'y',
+
+        drawGraph: multipleLinesMixin.drawGraph,
+        getTranslatedLinesNames: multipleLinesMixin.getTranslatedLinesNames,
+        translate: multipleLinesMixin.translate,
+        toYData: multipleLinesMixin.toYData
+    }
+);
+
+Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-c.json', function (data) {
+    Highcharts.stockChart('container', {
+
+        rangeSelector: {
+            selected: 2
+        },
+
+        title: {
+            text: 'AAPL Stock Price with Linear Regression zones'
+        },
+
+        legend: {
+            enabled: true
+        },
+
+        plotOptions: {
+            series: {
+                showInLegend: true
+            }
+        },
+
+        series: [{
+            id: 'aapl',
+            name: 'AAPL Stock Price',
+            data: data
+        }, {
+            type: 'linearregressionzones',
+            linkedTo: 'aapl'
+        }]
+
+    });
+});


### PR DESCRIPTION
Docs #15851, added an additional section about custom multiple lines indicator to the general documentation article.

https://www.highcharts.com/docs/stock/custom-technical-indicators