### PR TITLE
bugfix/16126-a11y-full-screen-print-error

### DIFF
--- a/ts/Accessibility/Utils/ChartUtilities.ts
+++ b/ts/Accessibility/Utils/ChartUtilities.ts
@@ -21,6 +21,10 @@ import HTMLUtilities from './HTMLUtilities.js';
 const {
     stripHTMLTagsFromString: stripHTMLTags
 } = HTMLUtilities;
+import H from '../../Core/Globals.js';
+const {
+    doc
+} = H;
 import U from '../../Core/Utilities.js';
 const {
     defined,
@@ -270,7 +274,11 @@ function getSeriesA11yElement(
  */
 function unhideChartElementFromAT(chart: Chart, element: DOMElementType): void {
     element.setAttribute('aria-hidden', false);
-    if (element === chart.renderTo || !element.parentNode) {
+    if (
+        element === chart.renderTo ||
+        !element.parentNode ||
+        element.parentNode === doc.body // #16126: Full screen printing
+    ) {
         return;
     }
 
@@ -284,7 +292,7 @@ function unhideChartElementFromAT(chart: Chart, element: DOMElementType): void {
         }
     );
     // Repeat for parent
-    unhideChartElementFromAT(chart, element.parentNode as any);
+    unhideChartElementFromAT(chart, element.parentNode);
 }
 
 


### PR DESCRIPTION
Fixed #16126, printing chart in full screen with accessibility loaded threw.