### PR TITLE
bugfix/16055-panning-mobile-extendedOrdinalPositions 

### DIFF
--- a/samples/unit-tests/axis/ordinal/demo.js
+++ b/samples/unit-tests/axis/ordinal/demo.js
@@ -257,6 +257,16 @@ QUnit.test('Panning ordinal axis on mobile devices- lin2val calculation, #13238'
         `After panning 20px, the axis extremes should not be reset
         but changed respectively.`
     );
+
+    const extendedOrdinalPositionsLength =
+        chart.xAxis[0].ordinal.extendedOrdinalPositions.length;
+    chart.series[0].addPoint([1585666260000 + 36e7, 1171.11]);
+    assert.notStrictEqual(
+        extendedOrdinalPositionsLength,
+        chart.xAxis[0].ordinal.extendedOrdinalPositions.length,
+        `After adding the point, the extendedOrdinalPositions array
+        should be recalculated, #16055.`
+    );
 });
 
 QUnit.test('findIndexOf', assert => {

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -1288,8 +1288,10 @@ namespace OrdinalAxis {
     function onSeriesUpdatedData(this: Series): void {
         const xAxis = this.xAxis as Composition;
         // Destroy the extended ordinal index on updated data
+        // and destroy extendedOrdinalPositions, #16055.
         if (xAxis && xAxis.options.ordinal) {
             delete xAxis.ordinal.index;
+            delete xAxis.ordinal.extendedOrdinalPositions;
         }
     }
 


### PR DESCRIPTION
Fixed #16055, after adding a point to an ordinal axis, panning was impossible.