### PR TITLE
bugfix/16153-chart-update-style-fontFamily-reset

### DIFF
--- a/samples/unit-tests/chart/chart-update/demo.js
+++ b/samples/unit-tests/chart/chart-update/demo.js
@@ -146,6 +146,11 @@
         var chart = Highcharts.chart(
             $('<div>').appendTo('#container')[0],
             Highcharts.merge(getConfig(), {
+                chart: {
+                    style: {
+                        fontFamily: 'ProximaNova, Arial, \'Helvetica Neue\', Helvetica, sans-serif'
+                    }
+                },
                 title: {
                     text: 'Colors update'
                 }
@@ -157,6 +162,20 @@
         });
 
         assert.strictEqual(chart.series[0].color, '#68266f', 'Color updated');
+
+        chart.update({
+            chart: {
+                style: {
+                    color: 'red'
+                }
+            }
+        });
+
+        assert.strictEqual(
+            chart.renderer.style.fontFamily,
+            'ProximaNova, Arial, \'Helvetica Neue\', Helvetica, sans-serif',
+            '#16153: fontFamily should not reset when updating chart.style'
+        );
     });
 
     QUnit.test('Loading update', function (assert) {

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3206,8 +3206,8 @@ class Chart {
                 }
             });
 
-            if (!chart.styledMode && 'style' in optionsChart) {
-                chart.renderer.setStyle(optionsChart.style as any);
+            if (!chart.styledMode && optionsChart.style) {
+                chart.renderer.setStyle(chart.options.chart.style || {});
             }
         }
 


### PR DESCRIPTION
Fixed #16153, `fontFamily` reset when updating `chart.style`.