### PR TITLE
enhancement/15804-popup-custom-indicator-axis

### DIFF
--- a/test/cypress/integration/Highcharts/stock-tools.spec.js
+++ b/test/cypress/integration/Highcharts/stock-tools.spec.js
@@ -34,3 +34,52 @@ describe('Stock Tools', () => {
         );
     });
 });
+
+describe('Adding custom indicator on a separate axis through indicator popup, #15804.', () => {
+    beforeEach(() => {
+        cy.viewport(1000, 500);
+    });
+
+    before(() => {
+        cy.visit('/stock/demo/stock-tools-gui');
+    });
+
+    it('#15730: Should close popup after hiding annotation', () => {
+        // Add custom indicator which should use another axis.
+        cy.window().then((win) => {
+            const H = win.Highcharts,
+                bindingsUtils = H._modules['Extensions/Annotations/NavigationBindings.js'].prototype.utils;
+            
+            H.seriesType(
+                'customIndicatorBasedOnRSI',
+                'rsi', {
+                name: 'Custom Indicator',
+                color: 'red'
+                }, {
+
+                }
+            );
+            bindingsUtils.indicatorsWithAxes.push('customIndicatorBasedOnRSI');
+        });
+
+        cy.get('.highcharts-indicators')
+            .click();
+
+        cy.get('.highcharts-indicator-list')
+            .contains('CUSTOMINDICATORBASEDONRSI')
+            .click();
+
+        cy.get('.highcharts-popup-rhs-col')
+            .children('.highcharts-popup button')
+            .eq(0)
+            .click(); // Add indicator.
+        cy.chart().should(chart =>
+            assert.strictEqual(
+                chart.yAxis.length,
+                4,
+                `After adding a custom indicator that is based on other oscillators,
+                another axis should be added.`
+            )
+        );
+    });
+});

--- a/ts/Stock/StockToolsBindings.ts
+++ b/ts/Stock/StockToolsBindings.ts
@@ -278,7 +278,7 @@ bindingsUtils.indicatorsWithAxes = [
     'linearRegressionIntercept',
     'linearRegressionAngle',
     'klinger'
-]
+];
 
 bindingsUtils.manageIndicators = function (
     this: Highcharts.StockToolsNavigationBindings,

--- a/ts/Stock/StockToolsBindings.ts
+++ b/ts/Stock/StockToolsBindings.ts
@@ -102,6 +102,8 @@ declare global {
             enabled: boolean;
         }
         interface StockToolsNavigationBindingsUtilsObject extends NavigationBindingUtils {
+            indicatorsWithAxes: Array<string>;
+
             addFlagFromForm(this: NavigationBindings, type: string): Function;
             attractToPoint(e: Event, chart: Chart): NavigationBindingsAttractionObject|void;
             isNotNavigatorYAxis(axis: AxisType): boolean;
@@ -247,6 +249,37 @@ bindingsUtils.addFlagFromForm = function (
     };
 };
 
+bindingsUtils.indicatorsWithAxes = [
+    'ad',
+    'atr',
+    'cci',
+    'cmf',
+    'disparityindex',
+    'cmo',
+    'dmi',
+    'macd',
+    'mfi',
+    'roc',
+    'rsi',
+    'ao',
+    'aroon',
+    'aroonoscillator',
+    'trix',
+    'apo',
+    'dpo',
+    'ppo',
+    'natr',
+    'obv',
+    'williamsr',
+    'stochastic',
+    'slowstochastic',
+    'linearRegression',
+    'linearRegressionSlope',
+    'linearRegressionIntercept',
+    'linearRegressionAngle',
+    'klinger'
+]
+
 bindingsUtils.manageIndicators = function (
     this: Highcharts.StockToolsNavigationBindings,
     data: Highcharts.StockToolsFieldsObject
@@ -266,36 +299,7 @@ bindingsUtils.manageIndicators = function (
             'vbp',
             'vwap'
         ],
-        indicatorsWithAxes = [
-            'ad',
-            'atr',
-            'cci',
-            'cmf',
-            'disparityindex',
-            'cmo',
-            'dmi',
-            'macd',
-            'mfi',
-            'roc',
-            'rsi',
-            'ao',
-            'aroon',
-            'aroonoscillator',
-            'trix',
-            'apo',
-            'dpo',
-            'ppo',
-            'natr',
-            'obv',
-            'williamsr',
-            'stochastic',
-            'slowstochastic',
-            'linearRegression',
-            'linearRegressionSlope',
-            'linearRegressionIntercept',
-            'linearRegressionAngle',
-            'klinger'
-        ],
+        indicatorsWithAxes = bindingsUtils.indicatorsWithAxes,
         yAxis,
         parentSeries,
         defaultOptions,


### PR DESCRIPTION
Added support for creating a custom indicator on an additional axis through the Stock Tools popup. See #15804.