### PR TITLE
docs/14552/treemap-pointPadding-docs-error

### DIFF
--- a/ts/Series/Treemap/TreemapSeries.ts
+++ b/ts/Series/Treemap/TreemapSeries.ts
@@ -2021,7 +2021,7 @@ export default TreemapSeries;
  *
  * @type      {Array<number|null|*>}
  * @extends   series.heatmap.data
- * @excluding x, y
+ * @excluding x, y, pointPadding
  * @product   highcharts
  * @apioption series.treemap.data
  */


### PR DESCRIPTION
Fixed #14552, removed `pointPadding` API property for treemap.

