### PR TITLE
bugfix/missing-series-in-demo

### DIFF
--- a/samples/stock/demo/stock-tools-gui/demo.html
+++ b/samples/stock/demo/stock-tools-gui/demo.html
@@ -14,4 +14,7 @@
 
 <script src="https://code.highcharts.com/modules/stock-tools.js"></script>
 
+<script src="https://code.highcharts.com/stock/modules/heikinashi.js"></script>
+<script src="https://code.highcharts.com/stock/modules/hollowcandlestick.js"></script>
+
 <div id="container" class="chart"></div>


### PR DESCRIPTION
Added missing modules for the new series into the stock tools GUI demo.

After adding the new series `heikinashi` and `hollowcandlestick` they are missing in the stock tools GUI demo.