### PR TITLE
bugfix/16238-reset-datagrouping

### DIFF
--- a/docs/doc-config.js
+++ b/docs/doc-config.js
@@ -6,7 +6,9 @@ module.exports = {
      * Refer to doc by relative path without extension, i.e.: 'maps/drilldown'
      */
     unlisted: [
-        'export-module/legacy-export-servers'
+        'export-module/legacy-export-servers',
+        'stock/compare',
+        'stock/cumulative-sum'
     ],
     /* List of old paths that should be redirected */
     redirects: [

--- a/samples/unit-tests/series/datagrouping/demo.js
+++ b/samples/unit-tests/series/datagrouping/demo.js
@@ -986,3 +986,45 @@ QUnit.test('Grouping each series when the only one requires that, #6765.', funct
         Thus only two grouped points should be visible.`
     );
 });
+
+QUnit.test(
+    'When grouping gets off, the properties should be deleted #16238.',
+    assert => {
+        const chart = Highcharts.stockChart('container', {
+
+            series: [{
+                data: [2, 2, 3, 5, 6, 7, 2, 4, 5, 4, 6, 7, 5, 6],
+                dataGrouping: {
+                    groupPixelWidth: 50,
+                    units: [
+                        ['millisecond', [2]]
+                    ]
+                }
+            }]
+        }),
+        series = chart.series[0],
+        mapArray = [
+            'groupMap',
+            'hasGroupedData', 
+            'currentDataGrouping'
+        ];
+
+        mapArray.forEach(prop => {
+            assert.ok(
+                series[prop],
+                `When the dataGrouping is enabled,
+                the series.${prop} property should be defined.`
+            );
+        });
+
+        // Set extremes to turn the dataGrouping off
+        chart.xAxis[0].setExtremes(0, 5);
+
+        mapArray.forEach(prop => {
+            assert.notOk(
+                series[prop],
+                `When the dataGrouping gets disabled,
+                the series.${prop} property should be deleted.`
+            );
+        });
+});

--- a/samples/unit-tests/series/datagrouping/demo.js
+++ b/samples/unit-tests/series/datagrouping/demo.js
@@ -955,7 +955,7 @@ QUnit.test('Panning with dataGrouping and ordinal axis, #3825.', function (asser
     );
 });
 
-QUnit.test('Grouping each series when the only one requires that, #6765.', function (assert) {
+QUnit.test('The dataGrouping enabling/disabling.', function (assert) {
     const chart = Highcharts.stockChart('container', {
         chart: {
             width: 400
@@ -978,6 +978,7 @@ QUnit.test('Grouping each series when the only one requires that, #6765.', funct
         ]
     });
 
+    // Grouping each series when the only one requires that, #6765.
     assert.strictEqual(
         chart.series[0].processedXData.length,
         2,
@@ -985,46 +986,34 @@ QUnit.test('Grouping each series when the only one requires that, #6765.', funct
         It should be grouped the same as the second one is.
         Thus only two grouped points should be visible.`
     );
-});
+    
+    chart.series[0].remove();
 
-QUnit.test(
-    'When grouping gets off, the properties should be deleted #16238.',
-    assert => {
-        const chart = Highcharts.stockChart('container', {
-
-            series: [{
-                data: [2, 2, 3, 5, 6, 7, 2, 4, 5, 4, 6, 7, 5, 6],
-                dataGrouping: {
-                    groupPixelWidth: 50,
-                    units: [
-                        ['millisecond', [2]]
-                    ]
-                }
-            }]
-        }),
-        series = chart.series[0],
+    const series = chart.series[0],
         mapArray = [
             'groupMap',
             'hasGroupedData', 
             'currentDataGrouping'
         ];
 
-        mapArray.forEach(prop => {
-            assert.ok(
-                series[prop],
-                `When the dataGrouping is enabled,
-                the series.${prop} property should be defined.`
-            );
-        });
+    // When the dataGrouping is enabled, the properties should exist.
+    mapArray.forEach(prop => {
+        assert.ok(
+            series[prop],
+            `When the dataGrouping is enabled,
+            the series.${prop} property should be defined.`
+        );
+    });
 
-        // Set extremes to turn the dataGrouping off
-        chart.xAxis[0].setExtremes(0, 5);
+    // Set extremes to turn the dataGrouping off
+    chart.xAxis[0].setExtremes(0, 5);
 
-        mapArray.forEach(prop => {
-            assert.notOk(
-                series[prop],
-                `When the dataGrouping gets disabled,
-                the series.${prop} property should be deleted.`
-            );
-        });
+    // When the dataGrouping gets off, the properties should be deleted, #16238.
+    mapArray.forEach(prop => {
+        assert.notOk(
+            series[prop],
+            `When the dataGrouping gets disabled,
+            the series.${prop} property should be deleted.`
+        );
+    });
 });

--- a/ts/Extensions/DataGrouping.ts
+++ b/ts/Extensions/DataGrouping.ts
@@ -1064,9 +1064,11 @@ Axis.prototype.applyGrouping = function (this: Axis): void {
 
         if (series.groupPixelWidth) {
             series.hasProcessed = true; // #2692
-
-            series.applyGrouping();
         }
+
+        // Fire independing on series.groupPixelWidth to always set a proper
+        // dataGrouping state, (#16238)
+        series.applyGrouping();
     });
 };
 


### PR DESCRIPTION
Fixed #16238, a regression causing data grouping information not to reset when zooming in, both in the tooltip and in internal properties.