### PR TITLE
bugfix/16231-export-styledMode

### DIFF
--- a/samples/unit-tests/exporting/styled-mode/demo.js
+++ b/samples/unit-tests/exporting/styled-mode/demo.js
@@ -38,5 +38,11 @@ QUnit.test(
             0,
             "Exported chart CSS 'url' values does not have any unnecessary '&quot;' strings."
         );
+
+        assert.notStrictEqual(
+            svg.indexOf('style="'),
+            -1,
+            '#16231: Styles should have been inlined'
+        );
     }
 );

--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -1331,8 +1331,7 @@ namespace Exporting {
     function inlineStyles(
         this: ChartComposition
     ): void {
-        const renderer = this.renderer,
-            blacklist = inlineBlacklist,
+        const blacklist = inlineBlacklist,
             whitelist = inlineWhitelist, // For IE
             defaultStyles: Record<string, CSSObject> = {};
         let dummySVG: SVGElement;
@@ -1382,7 +1381,7 @@ namespace Exporting {
 
                 // Check against whitelist & blacklist
                 blacklisted = whitelisted = false;
-                if (whitelist) {
+                if (whitelist.length) {
                     // Styled mode in IE has a whitelist instead.
                     // Exclude all props not in this list.
                     i = whitelist.length;
@@ -1397,10 +1396,10 @@ namespace Exporting {
                     blacklisted = true;
                 }
 
-                i = (blacklist as any).length;
+                i = blacklist.length;
                 while (i-- && !blacklisted) {
                     blacklisted = (
-                        (blacklist as any)[i].test(prop) ||
+                        blacklist[i].test(prop) ||
                         typeof val === 'function'
                     );
                 }
@@ -1434,12 +1433,12 @@ namespace Exporting {
 
             if (
                 node.nodeType === 1 &&
-                (unstyledElements as any).indexOf(node.nodeName) === -1
+                unstyledElements.indexOf(node.nodeName) === -1
             ) {
                 styles = win.getComputedStyle(node, null) as any;
                 parentStyles = node.nodeName === 'svg' ?
                     {} :
-                    win.getComputedStyle(node.parentNode as any, null) as any;
+                    win.getComputedStyle(node.parentNode, null) as any;
 
                 // Get default styles from the browser so that we don't have to
                 // add these

--- a/ts/Extensions/OfflineExporting/OfflineExporting.ts
+++ b/ts/Extensions/OfflineExporting/OfflineExporting.ts
@@ -480,7 +480,7 @@ namespace OfflineExporting {
         // renderer for inline styles that we want to pass through. There
         // are so many styles by default in IE that we don't want to
         // blacklist them all.
-        if (H.isMS && chart.styledMode) {
+        if (H.isMS && chart.styledMode && !Exporting.inlineWhitelist.length) {
             Exporting.inlineWhitelist.push(
                 /^blockSize/,
                 /^border/,


### PR DESCRIPTION
Fixed #16231, a regresssion in v9.2 causing exporting not to work with `styledMode` enabled.