### PR TITLE
bugfix/16150-columnpyramid-inverted-yAxis-width

### DIFF
--- a/samples/unit-tests/series-columnpyramid/basic/demo.js
+++ b/samples/unit-tests/series-columnpyramid/basic/demo.js
@@ -54,3 +54,51 @@ QUnit.test('Column pyramid series - 0 dataLabel #12514', function (assert) {
         'Label should be translated and had different position translate attributes than starting values #12514'
     );
 });
+
+QUnit.test(
+    "Column pyramid series inverted - yAxis width #16150",
+    function (assert) {
+        const chart = Highcharts.chart("container", {
+            chart: {
+                type: "columnpyramid",
+                inverted: true,
+                width: 600,
+                animation: false,
+                height: 600
+            },
+            yAxis: {
+                width: "40%"
+            },
+
+            series: [
+                {
+                    data: [5, 4, 2]
+                }
+            ]
+        });
+
+        var roundPath = function (dArray) {
+            return dArray.map(item =>
+                Highcharts.map(item, function (value) {
+                    var number = Math.round(value);
+                    return Highcharts.isNumber(number) ? number : value;
+                })
+            );
+        };
+
+        const validPath = [
+            ["M", 370, 37],
+            ["L", 370, 37],
+            ["L", 335, 223],
+            ["L", 406, 223],
+            ["Z"]
+        ];
+
+        const testedPath = roundPath(chart.series[0].points[0].shapeArgs.d);
+        assert.deepEqual(
+            testedPath,
+            validPath,
+            "testedPath should be equal to validPath, #16150"
+        );
+    }
+);

--- a/samples/unit-tests/series-columnpyramid/basic/demo.js
+++ b/samples/unit-tests/series-columnpyramid/basic/demo.js
@@ -56,49 +56,37 @@ QUnit.test('Column pyramid series - 0 dataLabel #12514', function (assert) {
 });
 
 QUnit.test(
-    "Column pyramid series inverted - yAxis width #16150",
-    function (assert) {
-        const chart = Highcharts.chart("container", {
+    'The columnpyramid series inverted with yAxis.width, #16150',
+    assert => {
+        const chart = Highcharts.chart('container', {
             chart: {
-                type: "columnpyramid",
-                inverted: true,
-                width: 600,
-                animation: false,
-                height: 600
+                type: 'columnpyramid',
+                inverted: true
             },
             yAxis: {
-                width: "40%"
+                width: '40%'
             },
-
-            series: [
-                {
-                    data: [5, 4, 2]
-                }
-            ]
+            series: [{
+                data: [5, 4, 2]
+            }]
         });
 
-        var roundPath = function (dArray) {
-            return dArray.map(item =>
-                Highcharts.map(item, function (value) {
-                    var number = Math.round(value);
-                    return Highcharts.isNumber(number) ? number : value;
-                })
-            );
-        };
+        const [, x1, y1] = chart.series[0].points[0].shapeArgs.d[0],
+            [, x2, y2] = chart.series[0].points[0].shapeArgs.d[1];
 
-        const validPath = [
-            ["M", 370, 37],
-            ["L", 370, 37],
-            ["L", 335, 223],
-            ["L", 406, 223],
-            ["Z"]
-        ];
-
-        const testedPath = roundPath(chart.series[0].points[0].shapeArgs.d);
-        assert.deepEqual(
-            testedPath,
-            validPath,
-            "testedPath should be equal to validPath, #16150"
+        assert.close(
+            x1,
+            x2,
+            0.5,
+            `The pyramid shape should be correct (the point has always 4
+            coordinates, 2 of them should be the same to get triangle), #16150.`
+        );
+        assert.close(
+            y1,
+            y2,
+            0.5,
+            `The pyramid shape should be correct (the point has always 4
+            coordinates, 2 of them should be the same to get triangle), #16150.`
         );
     }
 );

--- a/samples/unit-tests/series-columnpyramid/basic/demo.js
+++ b/samples/unit-tests/series-columnpyramid/basic/demo.js
@@ -1,20 +1,40 @@
-QUnit.test('Column pyramid series', function (assert) {
-    var chart = Highcharts.chart('container', {
+QUnit.test('Column pyramid series', assert => {
+    const chart = Highcharts.chart('container', {
         chart: {
-            renderTo: 'container',
-            type: 'columnpyramid'
+            type: 'columnpyramid',
+            inverted: true
         },
-        series: [
-            {
-                data: [10, 20, 5]
-            }
-        ]
+        yAxis: {
+            width: '40%'
+        },
+        series: [{
+            data: [10, 20, 5]
+        }]
     });
 
     assert.ok(
         chart.series[0].points[1].graphic.d &&
             chart.series[0].points[1].graphic !== 'rect',
         'Shapes are paths - pyramids'
+    );
+
+    const [, x1, y1] = chart.series[0].points[0].shapeArgs.d[0],
+        [, x2, y2] = chart.series[0].points[0].shapeArgs.d[1];
+
+    assert.close(
+        x1,
+        x2,
+        0.5,
+        `The pyramid shape should be correct (the point has always 4
+        coordinates, 2 of them should be the same to get triangle), #16150.`
+    );
+
+    assert.close(
+        y1,
+        y2,
+        0.5,
+        `The pyramid shape should be correct (the point has always 4
+        coordinates, 2 of them should be the same to get triangle), #16150.`
     );
 });
 
@@ -54,39 +74,3 @@ QUnit.test('Column pyramid series - 0 dataLabel #12514', function (assert) {
         'Label should be translated and had different position translate attributes than starting values #12514'
     );
 });
-
-QUnit.test(
-    'The columnpyramid series inverted with yAxis.width, #16150',
-    assert => {
-        const chart = Highcharts.chart('container', {
-            chart: {
-                type: 'columnpyramid',
-                inverted: true
-            },
-            yAxis: {
-                width: '40%'
-            },
-            series: [{
-                data: [5, 4, 2]
-            }]
-        });
-
-        const [, x1, y1] = chart.series[0].points[0].shapeArgs.d[0],
-            [, x2, y2] = chart.series[0].points[0].shapeArgs.d[1];
-
-        assert.close(
-            x1,
-            x2,
-            0.5,
-            `The pyramid shape should be correct (the point has always 4
-            coordinates, 2 of them should be the same to get triangle), #16150.`
-        );
-        assert.close(
-            y1,
-            y2,
-            0.5,
-            `The pyramid shape should be correct (the point has always 4
-            coordinates, 2 of them should be the same to get triangle), #16150.`
-        );
-    }
-);

--- a/ts/Series/ColumnPyramid/ColumnPyramidSeries.ts
+++ b/ts/Series/ColumnPyramid/ColumnPyramidSeries.ts
@@ -206,10 +206,10 @@ class ColumnPyramidSeries extends ColumnSeries {
 
             /*
                     /\
-                    /  \
+                   /  \
             x1,y1,------ x2,y1
-                    /      \
-                ----------
+                /      \
+               ----------
             x4,y2        x3,y2
             */
 
@@ -229,8 +229,8 @@ class ColumnPyramidSeries extends ColumnSeries {
             // inverted chart
             if (chart.inverted) {
                 invBarPos = yAxis.width - barY;
-                stackHeight = (topPointY -
-                (yAxis.width - (translatedThreshold as any)));
+                stackHeight =
+                    topPointY - (yAxis.width - (translatedThreshold as any));
 
                 // proportion tanges
                 topXwidth = (barW *

--- a/ts/Series/ColumnPyramid/ColumnPyramidSeries.ts
+++ b/ts/Series/ColumnPyramid/ColumnPyramidSeries.ts
@@ -228,9 +228,9 @@ class ColumnPyramidSeries extends ColumnSeries {
 
             // inverted chart
             if (chart.inverted) {
-                invBarPos = chart.plotWidth - barY;
+                invBarPos = yAxis.width - barY;
                 stackHeight = (topPointY -
-                (chart.plotWidth - (translatedThreshold as any)));
+                (yAxis.width - (translatedThreshold as any)));
 
                 // proportion tanges
                 topXwidth = (barW *


### PR DESCRIPTION
Fixed #16150, pyramid shape was incorrect for inverted charts when `yAxis.width` set.