### PR TITLE
Tools/ci update aws orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,7 +228,7 @@ jobs:
       - aws-s3/sync:
           from: "/home/circleci/repo/tmp/latest/"
           to: 's3://${HIGHCHARTS_VISUAL_TESTS_BUCKET}/visualtests/reference/latest/' # delete existing latest references in S3 location
-          overwrite: true
+          arguments: '--delete'
       - run:
           name: "Upload test results"
           command: "npx gulp dist-testresults --tag ${CIRCLE_TAG} --bucket ${HIGHCHARTS_VISUAL_TESTS_BUCKET}"


### PR DESCRIPTION
Fixes a step in the `generate_release_reference_images` CI job failing because of an unsupported Python version. Solved by upgrading to the latest AWS-S3 orb, which uses v2 of the AWS CLI, which has Python embedded. Also had to replace the `overwrite` parameter (with the more aptly named `--delete` argument), as it was deprecated.