### PR TITLE
bugfix/16245-floor-ceiling-minRange

### DIFF
--- a/samples/unit-tests/axis/floor-ceiling/demo.js
+++ b/samples/unit-tests/axis/floor-ceiling/demo.js
@@ -19,6 +19,12 @@ QUnit.test('Floor and ceiling', function (assert) {
         'Lower data should be preserved'
     );
 
+    assert.strictEqual(
+        axis.minRange,
+        null,
+        '#16245: automatic minRange should not be set when ceiling is set'
+    );
+
     chart.series[0].setData([1, 2, 3, 4, 5, 6, 7, 8]);
 
     assert.deepEqual([axis.min, axis.max], [0, 5], 'Axis should be capped');

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1235,7 +1235,12 @@ class Axis {
             !log
         ) {
 
-            if (defined(options.min) || defined(options.max)) {
+            if (
+                defined(options.min) ||
+                defined(options.max) ||
+                defined(options.floor) ||
+                defined(options.ceiling)
+            ) {
                 axis.minRange = null; // don't do this again
 
             } else {


### PR DESCRIPTION
Fixed #16245, automatic `minRange` did not consider `floor`/`ceiling`.