### PR TITLE
bugfix/12961-negative-tickinterval

### DIFF
--- a/samples/unit-tests/axis/ticks/demo.js
+++ b/samples/unit-tests/axis/ticks/demo.js
@@ -104,6 +104,15 @@ QUnit.test(
             1,
             'Actual tick interval is as option'
         );
+
+        chart.xAxis[0].update({
+            tickInterval: -1
+        });
+
+        assert.ok(
+            true,
+            'No errors should occur when tickInterval has a negative value.'
+        );
     }
 );
 QUnit.test('Prevent dense ticks(#4477)', function (assert) {

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1611,7 +1611,10 @@ class Axis {
             minPadding = options.minPadding,
             length,
             linkedParentExtremes,
-            tickIntervalOption = options.tickInterval,
+            // Only non-negative tickInterval is valid, #12961
+            tickIntervalOption =
+                isNumber(options.tickInterval) && options.tickInterval >= 0 ?
+                    options.tickInterval : void 0,
             threshold = isNumber(axis.threshold) ? axis.threshold : null,
             thresholdMin,
             thresholdMax,


### PR DESCRIPTION
Fixed #12961, the chart crashed when `axis.tickInterval` was negative.