### PR TITLE
Improvements to series keyboard navigation.

### DIFF
--- a/ts/Accessibility/AccessibilityComponent.ts
+++ b/ts/Accessibility/AccessibilityComponent.ts
@@ -152,7 +152,11 @@ AccessibilityComponent.prototype = {
             enter: 13,
             space: 32,
             esc: 27,
-            tab: 9
+            tab: 9,
+            pageUp: 33,
+            pageDown: 34,
+            end: 35,
+            home: 36
         };
     },
 

--- a/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
@@ -81,10 +81,6 @@ declare global {
             public getKeyboardNavigationHandler(): KeyboardNavigationHandler;
             public init(): void;
             public onDrillupAll(): void;
-            public onHandlerInit(
-                handler: KeyboardNavigationHandler,
-                initDirection: number
-            ): number;
             public onHandlerTerminate(): void;
             public onKbdSideways(
                 handler: KeyboardNavigationHandler,
@@ -766,14 +762,35 @@ extend(SeriesKeyboardNavigation.prototype, /** @lends Highcharts.SeriesKeyboardN
                             point.firePointEvent('click');
                         }
                         return this.response.success;
+                    }],
+
+                [[keys.home],
+                    function (this: Highcharts.KeyboardNavigationHandler): number {
+                        highlightFirstValidPointInChart(chart);
+                        return this.response.success;
+                    }],
+
+                [[keys.end],
+                    function (this: Highcharts.KeyboardNavigationHandler): number {
+                        highlightLastValidPointInChart(chart);
+                        return this.response.success;
+                    }],
+
+                [[keys.pageDown, keys.pageUp],
+                    function (
+                        this: Highcharts.KeyboardNavigationHandler,
+                        keyCode: number
+                    ): number {
+                        chart.highlightAdjacentSeries(keyCode === keys.pageDown);
+                        return this.response.success;
                     }]
             ],
 
             init: function (
-                this: Highcharts.KeyboardNavigationHandler,
-                dir: number
+                this: Highcharts.KeyboardNavigationHandler
             ): number {
-                return keyboardNavigation.onHandlerInit(this, dir);
+                highlightFirstValidPointInChart(chart);
+                return this.response.success;
             },
 
             terminate: function (): void {
@@ -839,30 +856,6 @@ extend(SeriesKeyboardNavigation.prototype, /** @lends Highcharts.SeriesKeyboardN
             'highlightAdjacentSeries';
 
         chart[highlightMethod](isNext);
-
-        return handler.response.success;
-    },
-
-
-    /**
-     * @private
-     * @param {Highcharts.KeyboardNavigationHandler} handler
-     * @param {number} initDirection
-     * @return {number}
-     * response
-     */
-    onHandlerInit: function (
-        this: Highcharts.SeriesKeyboardNavigation,
-        handler: Highcharts.KeyboardNavigationHandler,
-        initDirection: number
-    ): number {
-        const chart = this.chart;
-
-        if (initDirection > 0) {
-            highlightFirstValidPointInChart(chart);
-        } else {
-            highlightLastValidPointInChart(chart);
-        }
 
         return handler.response.success;
     },


### PR DESCRIPTION
Improvements to series keyboard navigation, now supporting `End`/`Home`/`PgUp`/`PgDown` keys.
___
We no longer go to last point when tabbing backwards into the chart, as this was shown in user testing to be confusing for some users.

Instead we now support these additional keyboard shortcuts:
- `Home`: Go to first point in chart
- `End`: Go to last point in chart
- `PageUp`: Go to next series
- `PageDown`: Go to previous series