### PR TITLE
Support pgUp/pgDown in legend keyboard navigation.

### DIFF
--- a/ts/Accessibility/AccessibilityComponent.ts
+++ b/ts/Accessibility/AccessibilityComponent.ts
@@ -152,7 +152,11 @@ AccessibilityComponent.prototype = {
             enter: 13,
             space: 32,
             esc: 27,
-            tab: 9
+            tab: 9,
+            pageUp: 33,
+            pageDown: 34,
+            end: 35,
+            home: 36
         };
     },
 

--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -96,6 +96,7 @@ declare global {
                 keyboardNavigationHandler: KeyboardNavigationHandler
             ): number;
             public onKbdNavigationInit(direction: number): void;
+            public highlightAdjacentLegendPage(direction: number): void;
             public proxyLegendItem(item: LegendItem): void;
             public proxyLegendItems(): void;
             public recreateProxies(): boolean;
@@ -294,6 +295,31 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
     /**
      * @private
      */
+    highlightAdjacentLegendPage: function (this: Highcharts.LegendComponent, direction: number): void {
+        const chart = this.chart;
+        const legend = chart.legend;
+        const curPageIx = legend.currentPage || 1;
+        const newPageIx = curPageIx + direction;
+        const pages = legend.pages || [];
+
+        if (newPageIx > 0 && newPageIx <= pages.length) {
+            const len = legend.allItems.length;
+            for (let i = 0; i < len; ++i) {
+                if ((legend.allItems[i].pageIx as number) + 1 === newPageIx) {
+                    const res = chart.highlightLegendItem(i);
+                    if (res) {
+                        this.highlightedLegendItemIx = i;
+                    }
+                    return;
+                }
+            }
+        }
+    },
+
+
+    /**
+     * @private
+     */
     updateProxyPositionForItem: function (
         this: Highcharts.LegendComponent,
         item: LegendItem
@@ -457,6 +483,17 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
                             return this.response.success;
                         }
                         return component.onKbdClick(this);
+                    }
+                ],
+                [
+                    [keys.pageDown, keys.pageUp],
+                    function (
+                        this: Highcharts.KeyboardNavigationHandler,
+                        keyCode: number
+                    ): number {
+                        const direction = keyCode === keys.pageDown ? 1 : -1;
+                        component.highlightAdjacentLegendPage(direction);
+                        return this.response.success;
                     }
                 ]
             ],


### PR DESCRIPTION
Support `pageUp`/`pageDown` in legend keyboard navigation for scrolling between legend pages.