### PR TITLE
Fixed #16261, legend label misaligned

### DIFF
--- a/samples/unit-tests/svgrenderer/text/demo.js
+++ b/samples/unit-tests/svgrenderer/text/demo.js
@@ -528,6 +528,31 @@ QUnit.test('HTML', function (assert) {
             'The style width should be removed when setting to undefined'
         );
 
+        document.getElementById('container').style.position = 'relative';
+        text = renderer
+            .text(
+                'LooooooooooooooooooooooooooooooooooooongText',
+                0,
+                10,
+                true
+            )
+            .css({
+                width: '50px',
+                textOverflow: 'ellipsis'
+            })
+            .add();
+        assert.ok(
+            text.getBBox().width <= 50,
+            'When potentially overflowing, the box should be restrained'
+        );
+
+        text.css({ width: '600px' });
+        assert.ok(
+            text.getBBox().width < 500,
+            'When not overflowing, the bounding box should not extend to the CSS width (#16261)'
+        );
+
+
         renderer = new Highcharts.SVGRenderer(
             document.getElementById('container'),
             500,

--- a/ts/Core/Renderer/HTML/HTMLElement.ts
+++ b/ts/Core/Renderer/HTML/HTMLElement.ts
@@ -299,36 +299,39 @@ class HTMLElement extends SVGElement {
                     wrapper.textAlign
                 ].join(',');
 
-            let baseline;
+            let baseline,
+                hasBoxWidthChanged = false;
 
             // Update textWidth. Use the memoized textPxLength if possible, to
             // avoid the getTextPxLength function using elem.offsetWidth.
             // Calling offsetWidth affects rendering time as it forces layout
             // (#7656).
-            if (
-                textWidth !== wrapper.oldTextWidth &&
-                (
-                    (textWidth > wrapper.oldTextWidth) ||
-                    getTextPxLength() > textWidth
-                ) && (
-                    // Only set the width if the text is able to word-wrap, or
-                    // text-overflow is ellipsis (#9537)
-                    /[ \-]/.test(elem.textContent || elem.innerText) ||
-                    elem.style.textOverflow === 'ellipsis'
-                )
-            ) { // #983, #1254
-                css(elem, {
-                    width: (getTextPxLength() > textWidth) || rotation ?
-                        textWidth + 'px' :
-                        'auto', // #16261
-                    display: 'block',
-                    whiteSpace: whiteSpace || 'normal' // #3331
-                });
-                wrapper.oldTextWidth = textWidth;
-                wrapper.hasBoxWidthChanged = true; // #8159
-            } else {
-                wrapper.hasBoxWidthChanged = false; // #8159
+            if (textWidth !== wrapper.oldTextWidth) { // #983, #1254
+                const textPxLength = getTextPxLength();
+                if (
+                    (
+                        (textWidth > wrapper.oldTextWidth) ||
+                        textPxLength > textWidth
+                    ) && (
+                        // Only set the width if the text is able to word-wrap,
+                        // or text-overflow is ellipsis (#9537)
+                        /[ \-]/.test(elem.textContent || elem.innerText) ||
+                        elem.style.textOverflow === 'ellipsis'
+                    )
+                ) {
+                    css(elem, {
+                        width: (textPxLength > textWidth) || rotation ?
+                            textWidth + 'px' :
+                            'auto', // #16261
+                        display: 'block',
+                        whiteSpace: whiteSpace || 'normal' // #3331
+                    });
+                    wrapper.oldTextWidth = textWidth;
+                    hasBoxWidthChanged = true; // #8159
+                }
             }
+            wrapper.hasBoxWidthChanged = hasBoxWidthChanged; // #8159
+
 
             // Do the calculations and DOM access only if properties changed
             if (currentTextTransform !== wrapper.cTT) {

--- a/ts/Core/Renderer/HTML/HTMLElement.ts
+++ b/ts/Core/Renderer/HTML/HTMLElement.ts
@@ -252,6 +252,9 @@ class HTMLElement extends SVGElement {
 
         /** @private */
         function getTextPxLength(): number {
+            if (wrapper.textPxLength) {
+                return wrapper.textPxLength;
+            }
             // Reset multiline/ellipsis in order to read width (#4928,
             // #5417)
             css(elem, {
@@ -305,8 +308,8 @@ class HTMLElement extends SVGElement {
             if (
                 textWidth !== wrapper.oldTextWidth &&
                 (
-                    ((textWidth as any) > wrapper.oldTextWidth) ||
-                    (wrapper.textPxLength || getTextPxLength()) > (textWidth as any)
+                    (textWidth > wrapper.oldTextWidth) ||
+                    getTextPxLength() > textWidth
                 ) && (
                     // Only set the width if the text is able to word-wrap, or
                     // text-overflow is ellipsis (#9537)
@@ -315,7 +318,9 @@ class HTMLElement extends SVGElement {
                 )
             ) { // #983, #1254
                 css(elem, {
-                    width: textWidth + 'px',
+                    width: (getTextPxLength() > textWidth) || rotation ?
+                        textWidth + 'px' :
+                        'auto', // #16261
                     display: 'block',
                     whiteSpace: whiteSpace || 'normal' // #3331
                 });


### PR DESCRIPTION
Fixed #16261, legend label with `useHTML` misaligned after resizing the chart.

Closes #12154

