### PR TITLE
feature/15225-offset-direction

### DIFF
--- a/samples/highcharts/plotoptions/sankey-node-column/demo.js
+++ b/samples/highcharts/plotoptions/sankey-node-column/demo.js
@@ -18,7 +18,9 @@ Highcharts.chart('container', {
         ],
         nodes: [{
             id: 'US',
-            offset: 130
+            //offset: 130 // deprecated
+            offsetHorizontal: -50,
+            offsetVertical: 130
         }, {
             id: 'EU',
             column: 2

--- a/ts/Series/Sankey/SankeyPointOptions.d.ts
+++ b/ts/Series/Sankey/SankeyPointOptions.d.ts
@@ -30,6 +30,8 @@ export interface SankeyPointOptions extends ColumnPointOptions, Highcharts.Nodes
     height?: number;
     level?: number;
     offset?: (number|string);
+    offsetHorizontal?: (number|string);
+    offsetVertical?: (number|string);
     to?: string;
     width?: number;
 }

--- a/ts/Series/Sankey/SankeySeries.ts
+++ b/ts/Series/Sankey/SankeySeries.ts
@@ -468,11 +468,16 @@ class SankeySeries extends ColumnSeries {
                 nodePadding = series.nodePadding;
 
             for (let i = 0; i < column.length; i++) {
-                const sum = column[i].getSum();
-                const height = Math.max(
-                    sum * factor,
-                    series.options.minLinkWidth as any
-                );
+                const sum = column[i].getSum(),
+                    height = Math.max(
+                        sum * factor,
+                        series.options.minLinkWidth as any
+                    ),
+                    directionOffset = node.options[chart.inverted ?
+                        'offsetHorizontal' :
+                        'offsetVertical'
+                    ],
+                    optionOffset = node.options.offset || 0;
 
                 if (sum) {
                     totalNodeOffset = height + nodePadding;
@@ -482,9 +487,15 @@ class SankeySeries extends ColumnSeries {
                 }
                 if (column[i] === node) {
                     return {
-                        relativeTop: offset + relativeLength(
-                            node.options.offset || 0,
-                            totalNodeOffset
+                        relativeTop: offset + (defined(directionOffset) ?
+                            // directionOffset is a percent of the node height
+                            relativeLength(
+                                directionOffset,
+                                height
+                            ) : relativeLength(
+                                optionOffset,
+                                totalNodeOffset
+                            )
                         )
                     };
                 }
@@ -914,14 +925,13 @@ class SankeySeries extends ColumnSeries {
             toY = getY(toNode, 'linksTo'),
             nodeLeft = fromNode.nodeX,
             nodeW = this.nodeWidth,
-            right = (toNode.column as any) * this.colDistance,
+            right = toNode.nodeX,
             outgoing = point.outgoing,
             straight = right > nodeLeft + nodeW;
 
         if (chart.inverted) {
             fromY = (chart.plotSizeY as any) - fromY;
             toY = (chart.plotSizeY || 0) - toY;
-            right = (chart.plotSizeX as any) - right;
             nodeW = -nodeW;
             linkHeight = -linkHeight;
             straight = nodeLeft > right;
@@ -1060,6 +1070,7 @@ class SankeySeries extends ColumnSeries {
                 Math.round(sum * translationFactor),
                 this.options.minLinkWidth as any
             ),
+            nodeWidth = Math.round(this.nodeWidth),
             crisp = Math.round(options.borderWidth as any) % 2 / 2,
             nodeOffset = column.offset(node, translationFactor),
             fromNodeTop = Math.floor(pick(
@@ -1072,11 +1083,11 @@ class SankeySeries extends ColumnSeries {
             left = Math.floor(
                 this.colDistance * (node.column as any) +
                 (options.borderWidth as any) / 2
-            ) + crisp,
+            ) + relativeLength(node.options.offsetHorizontal || 0, nodeWidth) +
+            crisp,
             nodeLeft = chart.inverted ?
                 (chart.plotSizeX as any) - left :
-                left,
-            nodeWidth = Math.round(this.nodeWidth);
+                left;
 
         node.sum = sum;
         // If node sum is 0, don't render the rect #12453
@@ -1258,16 +1269,50 @@ export default SankeySeries;
  * @type {string}
  * @product highcharts
  *//**
+ * This option is deprecated, use
+ * {@link Highcharts.SankeyNodeObject#offsetHorizontal} and
+ * {@link Highcharts.SankeyNodeObject#offsetVertical}  instead.
+ *
  * The vertical offset of a node in terms of weight. Positive values shift the
  * node downwards, negative shift it upwards.
+ *
+ * If a percantage string is given, the node is offset by the percentage of the
+ * node size plus `nodePadding`.
  *
  * @see {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/plotoptions/sankey-node-column/|Highcharts-Demo:}
  *         Specified node offset
  *
+ * @deprecated
  * @name Highcharts.SankeyNodeObject#offset
- * @type {number}
+ * @type {number|string}
  * @default 0
  * @since 6.0.5
+ *//**
+ * The horizontal offset of a node. Positive values shift the node right,
+ * negative shift it left.
+ *
+ * If a percantage string is given, the node is offset by the percentage of the
+ * node size.
+ *
+ * @see {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/plotoptions/sankey-node-column/|Highcharts-Demo:}
+ *         Specified node offset
+ *
+ * @name Highcharts.SankeyNodeObject#offsetHorizontal
+ * @type {number|string}
+ * @since next
+ *//**
+ * The vertical offset of a node. Positive values shift the node down,
+ * negative shift it up.
+ *
+ * If a percantage string is given, the node is offset by the percentage of the
+ * node size.
+ *
+ * @see {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/plotoptions/sankey-node-column/|Highcharts-Demo:}
+ *         Specified node offset
+ *
+ * @name Highcharts.SankeyNodeObject#offsetVertical
+ * @type {number|string}
+ * @since next
  */
 
 /**
@@ -1408,6 +1453,10 @@ export default SankeySeries;
  */
 
 /**
+ * This option is deprecated, use
+ * [offsetHorizontal](#series.sankey.nodes.offsetHorizontal) and
+ * [offsetVertical](#series.sankey.nodes.offsetVertical) instead.
+ *
  * In a horizontal layout, the vertical offset of a node in terms of weight.
  * Positive values shift the node downwards, negative shift it upwards. In a
  * vertical layout, like organization chart, the offset is horizontal.
@@ -1415,14 +1464,44 @@ export default SankeySeries;
  * If a percantage string is given, the node is offset by the percentage of the
  * node size plus `nodePadding`.
  *
- * @sample highcharts/plotoptions/sankey-node-column/
- *         Specified node offset
- *
+ * @deprecated
  * @type      {number|string}
  * @default   0
  * @since     6.0.5
  * @product   highcharts
  * @apioption series.sankey.nodes.offset
+ */
+
+/**
+ * The horizontal offset of a node. Positive values shift the node right,
+ * negative shift it left.
+ *
+ * If a percantage string is given, the node is offset by the percentage of the
+ * node size.
+ *
+ * @sample highcharts/plotoptions/sankey-node-column/
+ *         Specified node offset
+ *
+ * @type      {number|string}
+ * @since     next
+ * @product   highcharts
+ * @apioption series.sankey.nodes.offsetHorizontal
+ */
+
+/**
+ * The vertical offset of a node. Positive values shift the node down,
+ * negative shift it up.
+ *
+ * If a percantage string is given, the node is offset by the percentage of the
+ * node size.
+ *
+ * @sample highcharts/plotoptions/sankey-node-column/
+ *         Specified node offset
+ *
+ * @type      {number|string}
+ * @since     next
+ * @product   highcharts
+ * @apioption series.sankey.nodes.offsetVertical
  */
 
 /**

--- a/ts/Series/Sankey/SankeySeries.ts
+++ b/ts/Series/Sankey/SankeySeries.ts
@@ -1271,7 +1271,7 @@ export default SankeySeries;
  *//**
  * This option is deprecated, use
  * {@link Highcharts.SankeyNodeObject#offsetHorizontal} and
- * {@link Highcharts.SankeyNodeObject#offsetVertical}  instead.
+ * {@link Highcharts.SankeyNodeObject#offsetVertical} instead.
  *
  * The vertical offset of a node in terms of weight. Positive values shift the
  * node downwards, negative shift it upwards.


### PR DESCRIPTION
Added new offset options for nodes in Sankey and Organization chart, [`nodes.offsetHorizontal`](https://api.highcharts.com/highcharts/series.sankey.nodes.offsetHorizontal) and [`nodes.offsetVertical`](https://api.highcharts.com/highcharts/series.sankey.nodes.offsetVertical). See [#15225](https://github.com/highcharts/highcharts/issues/15225).

Closes #15225.