### PR TITLE
bugfix/15656-wheel

### DIFF
--- a/ts/Maps/MapPointer.ts
+++ b/ts/Maps/MapPointer.ts
@@ -14,6 +14,7 @@ import type PointerEvent from '../Core/PointerEvent';
 import Pointer from '../Core/Pointer.js';
 import U from '../Core/Utilities.js';
 const {
+    defined,
     extend,
     pick,
     wrap
@@ -96,7 +97,9 @@ extend<Pointer|Highcharts.MapPointer>(Pointer.prototype, {
         e = this.normalize(e);
 
         // Firefox uses e.deltaY or e.detail, WebKit and IE uses wheelDelta
-        const delta = e.deltaY || e.detail || -((e.wheelDelta as any) / 120);
+        // try wheelDelta first #15656
+        const delta = (defined(e.wheelDelta) && -(e.wheelDelta as any) / 120) ||
+            e.deltaY || e.detail;
 
         // Wheel zooming on trackpads have different behaviours in Firefox vs
         // WebKit. In Firefox the delta increments in steps by 1, so it is not


### PR DESCRIPTION
Fixed #15656, resolved broken mouse scroll on some browsers.

--------
Looks like `e.deltaY` is problematic as it is not in the same units - in different browser+OS combinations are giving drastically different values. If `e.wheelDelta` will be prioritized then other possible options (`e.deltaY` and `e.detail`) will be used mostly be some old or probably some future browsers (`e.wheelDelta` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent)).

Tested manually on Win and Mac in Chrome, Edge, Firefox and Safari (Mac). The broken browsers are now fixed and some other browsers are slightly changed (smaller jumps on scroll and IMHO better zoom, so an overall improvement).