### PR TITLE
Bugfix/16255 ordinal visible click

### DIFF
--- a/samples/unit-tests/axis/ordinal/demo.js
+++ b/samples/unit-tests/axis/ordinal/demo.js
@@ -9,25 +9,26 @@ QUnit.test('Ordinal general tests.', function (assert) {
             xAxis: {
                 min: 1458054620689
             },
-            series: [
-                {
-                    type: 'column',
-                    data: [
-                        [1451577600000, 305899579],
-                        [1454256000000, 303016703],
-                        [1456761600000, 308008429],
-                        [1459440000000, 328699625],
-                        [1462032000000, 350010305],
-                        [1464710400000, 365809905],
-                        [1467302400000, 364839585],
-                        [1469980800000, 386193804],
-                        [1472659200000, 387630083],
-                        [1475251200000, 405138911]
-                    ]
-                }
-            ]
+            series: [{
+                type: 'column',
+                data: [
+                    [1451577600000, 305899579],
+                    [1454256000000, 303016703],
+                    [1456761600000, 308008429],
+                    [1459440000000, 328699625],
+                    [1462032000000, 350010305],
+                    [1464710400000, 365809905],
+                    [1467302400000, 364839585],
+                    [1469980800000, 386193804],
+                    [1472659200000, 387630083],
+                    [1475251200000, 405138911]
+                ]
+            }, {
+                visible: false
+            }]
         }),
-        tickPositions = chart.xAxis[0].tickPositions;
+        tickPositions = chart.xAxis[0].tickPositions,
+        controller = new TestController(chart);
 
     assert.ok(
         tickPositions[0] >= chart.xAxis[0].min,
@@ -53,6 +54,10 @@ QUnit.test('Ordinal general tests.', function (assert) {
         'Last tick should be smaller than axis max when ' +
             'ordinal is enabled (#12716).'
     );
+
+    controller.click(100, 100);
+
+    assert.ok(true, 'Click shoult not throw #16255');
 });
 
 QUnit.test(

--- a/samples/unit-tests/axis/ordinal/demo.js
+++ b/samples/unit-tests/axis/ordinal/demo.js
@@ -23,7 +23,17 @@ QUnit.test('Ordinal general tests.', function (assert) {
                     [1472659200000, 387630083],
                     [1475251200000, 405138911]
                 ]
-            }, {
+            },
+            {
+                data: [1, 2, 3, 4, [420, 44]],
+                dataGrouping: {
+                    forced: true,
+                    units: [['millisecond', [1, 42]]]
+                }
+            },
+            {
+                type: 'column',
+                data: [1, 2, 3],
                 visible: false
             }]
         }),
@@ -55,9 +65,12 @@ QUnit.test('Ordinal general tests.', function (assert) {
             'ordinal is enabled (#12716).'
     );
 
+    chart.xAxis[0].setExtremes(0, 5);
+    chart.xAxis[0].setExtremes(0, 500);
+
     controller.click(100, 100);
 
-    assert.ok(true, 'Click shoult not throw #16255');
+    assert.ok(true, 'Click should not throw #16255');
 });
 
 QUnit.test(

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -1357,6 +1357,7 @@ namespace OrdinalAxis {
             if (axis.series.length > 1) {
                 axis.series.forEach(function (series): void {
                     if (
+                        series.points &&
                         defined(series.points[0]) &&
                         defined(series.points[0].plotX) &&
                         series.points[0].plotX < firstPointX


### PR DESCRIPTION
Fixed #16255, error after setting new extremes in a chart with ordinal axis and invisible series.

~~Fixed #16255, click throw error after new extremes when oridinal and invisible series.~~