### PR TITLE
bugfix/13683-legend-nav-pages

### DIFF
--- a/samples/unit-tests/legend/navigation/demo.details
+++ b/samples/unit-tests/legend/navigation/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+... 

--- a/samples/unit-tests/legend/navigation/demo.html
+++ b/samples/unit-tests/legend/navigation/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div> 

--- a/samples/unit-tests/legend/navigation/demo.js
+++ b/samples/unit-tests/legend/navigation/demo.js
@@ -1,0 +1,23 @@
+QUnit.test(
+    'Pages and navigation of legend',
+    function (assert) {
+        var chart = Highcharts.chart('container', {
+            chart: {
+                width: 250
+            },
+            legend: {
+                maxHeight: 47,
+                itemStyle: {
+                    fontSize: '11px'
+                }
+            },
+            series: [{}, {}, {}, {}, {}, {}, {}, {}]
+        });
+
+        assert.strictEqual(
+            chart.legend.pages.length,
+            4,
+            'There should be enough pages to fully fit all elements (#13683)'
+        );
+    }
+);

--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -1368,10 +1368,14 @@ class Legend {
                     allItems[i - 1].pageIx = len - 1;
                 }
 
+                // add the last page if needed (#2617, #13683)
                 if (
+                    // check the last item
                     i === allItems.length - 1 &&
+                    // if adding next page is needed
                     y + h - pages[len - 1] > clipHeight &&
-                    y !== lastY // #2617
+                    // and will fully fit inside a new page
+                    h <= clipHeight
                 ) {
                     pages.push(y);
                     item.pageIx = len;


### PR DESCRIPTION
Fixed #13683, the last row of items in a paginated legend was not fully visible in edge cases.