### PR TITLE
New feature: crop for annotation

### DIFF
--- a/samples/highcharts/annotations/label-crop-overflow/demo.js
+++ b/samples/highcharts/annotations/label-crop-overflow/demo.js
@@ -1,11 +1,15 @@
 Highcharts.chart('container', {
 
+    chart: {
+        plotBorderWidth: 1
+    },
+
     title: {
         text: 'Highcharts Annotations'
     },
 
     subtitle: {
-        text: 'Annotation label crop and overflow options'
+        text: 'Annotation line crop, label crop and overflow options'
     },
 
     xAxis: {
@@ -43,5 +47,37 @@ Highcharts.chart('container', {
         labelOptions: {
             point: '0'
         }
+    }, {
+        crop: false,
+        shapes: [{
+            type: 'path',
+            points: [{
+                x: 2,
+                y: 50,
+                xAxis: 0,
+                yAxis: 0
+            }, {
+                x: 3,
+                y: -10,
+                xAxis: 0,
+                yAxis: 0
+            }]
+        }]
+    }, {
+        //crop: true, // by default lines are cropped
+        shapes: [{
+            type: 'path',
+            points: [{
+                x: 3,
+                y: 50,
+                xAxis: 0,
+                yAxis: 0
+            }, {
+                x: 4,
+                y: -10,
+                xAxis: 0,
+                yAxis: 0
+            }]
+        }]
     }]
 });


### PR DESCRIPTION
Added new option, [annotations.crop](https://api.highcharts.com/highcharts/annotations.crop), allowing to hide annotations outside the plot area. See #15399.