### PR TITLE
Stock Tools: corrected "langKey" for crooked5 annotation

### DIFF
--- a/ts/Stock/StockToolsBindings.ts
+++ b/ts/Stock/StockToolsBindings.ts
@@ -1312,7 +1312,7 @@ const stockToolsBindings: Record<string, Highcharts.NavigationBindingsOptionsObj
      *
      * @type    {Highcharts.NavigationBindingsOptionsObject}
      * @product highstock
-     * @default {"className": "highcharts-crooked3", "start": function() {}, "steps": [function() {}, function() {}, function() {}, function() {}], "annotationsOptions": {}}
+     * @default {"className": "highcharts-crooked5", "start": function() {}, "steps": [function() {}, function() {}, function() {}, function() {}], "annotationsOptions": {}}
      */
     crooked5: {
         /** @ignore-option */
@@ -1337,7 +1337,7 @@ const stockToolsBindings: Record<string, Highcharts.NavigationBindingsOptionsObj
                 navigation = this.chart.options.navigation,
                 options = merge(
                     {
-                        langKey: 'crookedLine',
+                        langKey: 'crooked5',
                         type: 'crookedLine',
                         typeOptions: {
                             xAxis: coordsX.axis.options.index,


### PR DESCRIPTION
Fixed #16318, corrected the `langKey` property in Stock Tools gui for the Crooked Line 5 annotation.