### PR TITLE
Fixed #16329, unable to deep-merge treemap levels

### DIFF
--- a/samples/highcharts/demo/treemap-large-dataset/demo.js
+++ b/samples/highcharts/demo/treemap-large-dataset/demo.js
@@ -18,7 +18,7 @@ Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/sam
         };
 
     for (region in data) {
-        if (data.hasOwnProperty(region)) {
+        if (Object.hasOwnProperty.call(data, region)) {
             regionVal = 0;
             regionP = {
                 id: 'id_' + regionI,
@@ -27,7 +27,7 @@ Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/sam
             };
             countryI = 0;
             for (country in data[region]) {
-                if (data[region].hasOwnProperty(country)) {
+                if (Object.hasOwnProperty.call(data[region], country)) {
                     countryP = {
                         id: regionP.id + '_' + countryI,
                         name: country,
@@ -36,7 +36,9 @@ Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/sam
                     points.push(countryP);
                     causeI = 0;
                     for (cause in data[region][country]) {
-                        if (data[region][country].hasOwnProperty(cause)) {
+                        if (Object.hasOwnProperty.call(
+                            data[region][country], cause
+                        )) {
                             causeP = {
                                 id: countryP.id + '_' + causeI,
                                 name: causeName[cause],
@@ -65,13 +67,20 @@ Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/sam
             dataLabels: {
                 enabled: false
             },
-            levelIsConstant: false,
             levels: [{
                 level: 1,
                 dataLabels: {
                     enabled: true
                 },
-                borderWidth: 3
+                borderWidth: 3,
+                levelIsConstant: false
+            }, {
+                level: 1,
+                dataLabels: {
+                    style: {
+                        fontSize: '14px'
+                    }
+                }
             }],
             data: points
         }],

--- a/ts/Mixins/TreeSeries.ts
+++ b/ts/Mixins/TreeSeries.ts
@@ -305,7 +305,7 @@ const getLevelOptions = function getLevelOptions<T extends Highcharts.TreeSeries
                     // Calculate which level these options apply to.
                     level = item.level + (levelIsConstant ? 0 : from - 1);
                     if (isObject(obj[level])) {
-                        extend(obj[level], options);
+                        merge(true, obj[level], options); // #16329
                     } else {
                         obj[level] = options;
                     }


### PR DESCRIPTION
Fixed #16329, unable to merge deep options of different levels in treemaps and sunburst.