### PR TITLE
Whitelist <abbr title=""> tag for chart titles and subtitles

### DIFF
--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -143,6 +143,7 @@ class AST {
         'text-align',
         'textAnchor',
         'textLength',
+        'title',
         'type',
         'valign',
         'width',
@@ -190,6 +191,7 @@ class AST {
      */
     public static allowedTags = [
         'a',
+        'abbr',
         'b',
         'br',
         'button',


### PR DESCRIPTION
The AST introduced in Highcharts v9 filters out HTML abbreviation tags such as 

```html
<abbr title="">
```

To my knowledge, there is no XSS vulnerability introduced by `<abbr title="">` or `<span title="">` tags and they are valuable for chart Titles and Subtitles.

```js
title: {
  text: `Most Popular <abbr title="Hypertext Markup Language">HTML</abbr> Tags`,
  useHTML: true
}
```

You can work around this currently by adding them back:

```js
Highcharts.AST.allowedTags.push("abbr");
Highcharts.AST.allowedAttributes.push("title");
```

But I don't see any reason why they should be filtered out in the first place.