### PR TITLE
Fixed #15480 and #16052, point markers appear on redraw.

### DIFF
--- a/samples/unit-tests/accessibility/forced-markers/demo.js
+++ b/samples/unit-tests/accessibility/forced-markers/demo.js
@@ -115,6 +115,13 @@ QUnit.test('Markers enabled, point marker off', function (assert) {
     assert.strictEqual(hasVisibleMarker(pointA), true, 'Series marker visible');
     assert.strictEqual(hasMarker(pointB), true, 'Point marker exists');
     assert.strictEqual(hasVisibleMarker(pointB), false, 'Point marker hidden');
+
+    // Force redraw
+    chart.update({
+        yAxis: { visible: false }
+    });
+    assert.strictEqual(hasMarker(pointB), true, 'Point marker exists after update');
+    assert.strictEqual(hasVisibleMarker(pointB), false, 'Point marker hidden after update');
 });
 
 QUnit.test('Markers disabled, point marker off', function (assert) {

--- a/ts/Accessibility/Components/SeriesComponent/ForcedMarkers.ts
+++ b/ts/Accessibility/Components/SeriesComponent/ForcedMarkers.ts
@@ -175,7 +175,7 @@ function handleForcePointMarkers(series: Series): void {
             if (pointOptions.marker.enabled && !isStillForcedMarker) {
                 unforcePointMarkerOptions(pointOptions);
                 point.hasForcedA11yMarker = false;
-            } else {
+            } else if (pointOptions.marker.enabled === false) {
                 forceZeroOpacityMarkerOptions(pointOptions);
                 point.hasForcedA11yMarker = true;
             }

--- a/ts/Accessibility/Components/SeriesComponent/ForcedMarkers.ts
+++ b/ts/Accessibility/Components/SeriesComponent/ForcedMarkers.ts
@@ -136,10 +136,10 @@ function forceZeroOpacityMarkerOptions(
 /**
  * @private
  */
-function getPointMarkerOpacity(pointOptions: PointOptions): number {
+function getPointMarkerOpacity(pointOptions: PointOptions): number|undefined {
     return (pointOptions.marker as any).states &&
         (pointOptions.marker as any).states.normal &&
-        (pointOptions.marker as any).states.normal.opacity || 1;
+        (pointOptions.marker as any).states.normal.opacity;
 }
 
 
@@ -150,7 +150,7 @@ function unforcePointMarkerOptions(pointOptions: PointOptions): void {
     merge(true, pointOptions.marker, {
         states: {
             normal: {
-                opacity: getPointMarkerOpacity(pointOptions)
+                opacity: getPointMarkerOpacity(pointOptions) || 1
             }
         }
     });
@@ -166,10 +166,13 @@ function handleForcePointMarkers(series: Series): void {
     while (i--) {
         const point = series.points[i];
         const pointOptions = point.options;
+        const hadForcedMarker = point.hasForcedA11yMarker;
         delete point.hasForcedA11yMarker;
 
         if (pointOptions.marker) {
-            if (pointOptions.marker.enabled) {
+            const isStillForcedMarker = hadForcedMarker && getPointMarkerOpacity(pointOptions) === 0;
+
+            if (pointOptions.marker.enabled && !isStillForcedMarker) {
                 unforcePointMarkerOptions(pointOptions);
                 point.hasForcedA11yMarker = false;
             } else {


### PR DESCRIPTION
Fixed #15480 and #16052, disabled point markers sometimes appeared on redraw with accessibility module loaded.

