### PR TITLE
Fixed #12169, allow Blob offline export in Firefox.

### DIFF
--- a/ts/Extensions/OfflineExporting/OfflineExporting.ts
+++ b/ts/Extensions/OfflineExporting/OfflineExporting.ts
@@ -833,10 +833,9 @@ namespace OfflineExporting {
 
         try {
             // Safari requires data URI since it doesn't allow navigation to
-            // blob URLs. Firefox has an issue with Blobs and internal
-            // references, leading to gradients not working using Blobs (#4550).
-            // foreignObjects also dont work well in Blobs in Chrome (#14780).
-            if (!webKit && !H.isFirefox && svg.indexOf('<foreignObject') === -1) {
+            // blob URLs. ForeignObjects also dont work well in Blobs in Chrome
+            // (#14780).
+            if (!webKit && svg.indexOf('<foreignObject') === -1) {
                 return domurl.createObjectURL(new win.Blob([svg], {
                     type: 'image/svg+xml;charset-utf-16'
                 }));


### PR DESCRIPTION
Fixed #12169, allow Blob offline export in Firefox.
___
Removes old workaround for #4550. Tested and verified that it is no longer needed. The Safari workaround appears to still be necessary.