### PR TITLE
Allow removing a11y info sections by setting format to null.

### DIFF
--- a/samples/unit-tests/accessibility/descriptions-added/demo.js
+++ b/samples/unit-tests/accessibility/descriptions-added/demo.js
@@ -88,7 +88,7 @@ QUnit.test('No information region', function (assert) {
     var chart = Highcharts.chart('container', {
         accessibility: {
             screenReaderSection: {
-                beforeChartFormat: null
+                beforeChartFormat: ''
             }
         },
         series: [{ data: [1, 2, 3] }]
@@ -108,7 +108,7 @@ QUnit.test('No information region', function (assert) {
     chart.update({
         accessibility: {
             screenReaderSection: {
-                afterChartFormat: null
+                afterChartFormat: ''
             }
         }
     });

--- a/samples/unit-tests/accessibility/descriptions-added/demo.js
+++ b/samples/unit-tests/accessibility/descriptions-added/demo.js
@@ -83,3 +83,39 @@ QUnit.test('Accessible pie', function (assert) {
         'There be screen reader region'
     );
 });
+
+QUnit.test('No information region', function (assert) {
+    var chart = Highcharts.chart('container', {
+        accessibility: {
+            screenReaderSection: {
+                beforeChartFormat: null
+            }
+        },
+        series: [{ data: [1, 2, 3] }]
+    });
+
+    assert.notOk(
+        chart.accessibility.components.infoRegions
+            .screenReaderSections.before.element,
+        'There is no before screen reader region'
+    );
+    assert.ok(
+        chart.accessibility.components.infoRegions
+            .screenReaderSections.after.element,
+        'There is an after screen reader region'
+    );
+
+    chart.update({
+        accessibility: {
+            screenReaderSection: {
+                afterChartFormat: null
+            }
+        }
+    });
+
+    assert.notOk(
+        chart.accessibility.components.infoRegions
+            .screenReaderSections.after.element,
+        'There is no after screen reader region after update'
+    );
+});

--- a/samples/unit-tests/accessibility/descriptions-added/demo.js
+++ b/samples/unit-tests/accessibility/descriptions-added/demo.js
@@ -119,3 +119,41 @@ QUnit.test('No information region', function (assert) {
         'There is no after screen reader region after update'
     );
 });
+
+
+QUnit.test('Proxy region', function (assert) {
+    var chart = Highcharts.chart('container', {
+        series: [{ data: [1, 2, 3] }]
+    });
+
+    function testProxyRegions(msgAdd) {
+        assert.ok(
+            chart.accessibility.proxyProvider.beforeChartProxyPosContainer,
+            'There is a before proxy region' + msgAdd
+        );
+        assert.ok(
+            chart.accessibility.proxyProvider.afterChartProxyPosContainer,
+            'There is an after proxy region' + msgAdd
+        );
+        assert.strictEqual(
+            chart.container.querySelectorAll('.highcharts-a11y-proxy-container-before').length, 1,
+            'The is only one before proxy region' + msgAdd
+        );
+        assert.strictEqual(
+            chart.container.querySelectorAll('.highcharts-a11y-proxy-container-after').length, 1,
+            'The is only one after proxy region' + msgAdd
+        );
+    }
+
+    testProxyRegions();
+
+    chart.update({
+        accessibility: {
+            screenReaderSection: {
+                afterChartFormat: 'Anything'
+            }
+        }
+    });
+
+    testProxyRegions(' after update');
+});

--- a/ts/Accessibility/Accessibility.ts
+++ b/ts/Accessibility/Accessibility.ts
@@ -299,6 +299,11 @@ Accessibility.prototype = {
             components[componentName].destroyBase();
         });
 
+        // Destroy proxy provider
+        if (this.proxyProvider) {
+            this.proxyProvider.destroy();
+        }
+
         // Kill keyboard nav
         if (this.keyboardNavigation) {
             this.keyboardNavigation.destroy();

--- a/ts/Accessibility/Components/InfoRegionsComponent.ts
+++ b/ts/Accessibility/Components/InfoRegionsComponent.ts
@@ -509,7 +509,7 @@ extend(InfoRegionsComponent.prototype, /** @lends Highcharts.InfoRegionsComponen
         const chart = this.chart;
         const format = chart.options.accessibility.screenReaderSection.beforeChartFormat;
 
-        if (format === null) {
+        if (!format) {
             return '';
         }
 
@@ -562,7 +562,7 @@ extend(InfoRegionsComponent.prototype, /** @lends Highcharts.InfoRegionsComponen
         const chart = this.chart;
         const format = chart.options.accessibility.screenReaderSection.afterChartFormat;
 
-        if (format === null) {
+        if (!format) {
             return '';
         }
 

--- a/ts/Accessibility/Components/InfoRegionsComponent.ts
+++ b/ts/Accessibility/Components/InfoRegionsComponent.ts
@@ -429,29 +429,36 @@ extend(InfoRegionsComponent.prototype, /** @lends Highcharts.InfoRegionsComponen
         this: Highcharts.InfoRegionsComponent,
         regionKey: string
     ): void {
-        const chart = this.chart,
-            region = this.screenReaderSections[regionKey],
-            content = region.buildContent(chart),
-            sectionDiv = region.element = (
-                region.element || this.createElement('div')
-            ),
-            hiddenDiv: HTMLDOMElement = (
-                (sectionDiv.firstChild as any) || this.createElement('div')
-            );
+        const chart = this.chart;
+        const region = this.screenReaderSections[regionKey];
+        const content = region.buildContent(chart);
+        const sectionDiv = region.element = (
+            region.element || this.createElement('div')
+        );
+        const hiddenDiv: HTMLDOMElement = (
+            (sectionDiv.firstChild as any) || this.createElement('div')
+        );
 
-        this.setScreenReaderSectionAttribs(sectionDiv, regionKey);
-        AST.setElementHTML(hiddenDiv, content);
-        sectionDiv.appendChild(hiddenDiv);
-        region.insertIntoDOM(sectionDiv, chart);
+        if (content) {
+            this.setScreenReaderSectionAttribs(sectionDiv, regionKey);
+            AST.setElementHTML(hiddenDiv, content);
+            sectionDiv.appendChild(hiddenDiv);
+            region.insertIntoDOM(sectionDiv, chart);
 
-        if (chart.styledMode) {
-            addClass(hiddenDiv, 'highcharts-visually-hidden');
+            if (chart.styledMode) {
+                addClass(hiddenDiv, 'highcharts-visually-hidden');
+            } else {
+                visuallyHideElement(hiddenDiv);
+            }
+            unhideChartElementFromAT(chart, hiddenDiv);
+            if (region.afterInserted) {
+                region.afterInserted();
+            }
         } else {
-            visuallyHideElement(hiddenDiv);
-        }
-        unhideChartElementFromAT(chart, hiddenDiv);
-        if (region.afterInserted) {
-            region.afterInserted();
+            if (sectionDiv.parentNode) {
+                sectionDiv.parentNode.removeChild(sectionDiv);
+            }
+            delete region.element;
         }
     },
 
@@ -499,10 +506,14 @@ extend(InfoRegionsComponent.prototype, /** @lends Highcharts.InfoRegionsComponen
     defaultBeforeChartFormatter: function (
         this: Highcharts.InfoRegionsComponent
     ): string {
-        const chart = this.chart,
-            format = chart.options.accessibility
-                .screenReaderSection.beforeChartFormat,
-            axesDesc = this.getAxesDescription(),
+        const chart = this.chart;
+        const format = chart.options.accessibility.screenReaderSection.beforeChartFormat;
+
+        if (format === null) {
+            return '';
+        }
+
+        const axesDesc = this.getAxesDescription(),
             shouldHaveSonifyBtn = (
                 chart.sonify &&
                 chart.options.sonification &&
@@ -548,13 +559,15 @@ extend(InfoRegionsComponent.prototype, /** @lends Highcharts.InfoRegionsComponen
     defaultAfterChartFormatter: function (
         this: Highcharts.InfoRegionsComponent
     ): string {
-        const chart = this.chart,
-            format = chart.options.accessibility
-                .screenReaderSection.afterChartFormat,
-            context = {
-                endOfChartMarker: this.getEndOfChartMarkerText()
-            },
-            formattedString = H.i18nFormat(format, context, chart);
+        const chart = this.chart;
+        const format = chart.options.accessibility.screenReaderSection.afterChartFormat;
+
+        if (format === null) {
+            return '';
+        }
+
+        const context = { endOfChartMarker: this.getEndOfChartMarkerText() };
+        const formattedString = H.i18nFormat(format, context, chart);
 
         return stripEmptyHTMLTags(formattedString);
     },

--- a/ts/Accessibility/Options/Options.ts
+++ b/ts/Accessibility/Options/Options.ts
@@ -341,6 +341,8 @@ const Options: DeepPartial<OptionsType> = {
              * corresponds to the heading level below the previous heading in
              * the DOM.
              *
+             * Set to `null` or empty string to remove the region altogether.
+             *
              * @since 8.0.0
              */
             beforeChartFormat:

--- a/ts/Accessibility/Options/Options.ts
+++ b/ts/Accessibility/Options/Options.ts
@@ -341,7 +341,7 @@ const Options: DeepPartial<OptionsType> = {
              * corresponds to the heading level below the previous heading in
              * the DOM.
              *
-             * Set to `null` or empty string to remove the region altogether.
+             * Set to empty string to remove the region altogether.
              *
              * @since 8.0.0
              */


### PR DESCRIPTION
Allow removing accessibility information sections by setting section formats to `null`.
___
This allows for a cleaner DOM in cases where one or more of these sections are not needed.

See [accessibility.screenReaderSection.beforeChartFormat](https://api.highcharts.com/highcharts/accessibility.screenReaderSection.beforeChartFormat).