### PR TITLE
Tools: fixed filesize script eating stash and added TS compilation 

### DIFF
--- a/tools/gulptasks/unsorted/filesize.js
+++ b/tools/gulptasks/unsorted/filesize.js
@@ -66,7 +66,7 @@ const filesize = async () => {
         console.log([
             '',
             colors.cyan(name),
-            printRow(colsizes, ['', 'gzipped', 'compiled', 'size']),
+            printRow(colsizes, ['', 'gzipped', 'compiled', 'source']),
             printRow(colsizes, ['New:', current.gzip, current.compiled, current.size]),
             printRow(colsizes, ['HEAD:', head.gzip, head.compiled, head.size]),
             printRow(colsizes, ['Diff:', diff(current.gzip, head.gzip) + 'B', diff(current.compiled, head.compiled) + 'B', diff(current.size, head.size) + 'B']),
@@ -112,7 +112,7 @@ const filesize = async () => {
 
     await compileTypescript();
     await runFileSize(results, 'new');
-    await commandLine(`git add . && git stash -m '${stashName}'`);
+    await commandLine(`git add . && git stash push -m '${stashName}'`);
     await compileTypescript();
     await runFileSize(results, 'head');
 


### PR DESCRIPTION
Fixed `gulp filesize` always popping the latest stash by using a named stash. Also runs `scripts-ts` if `scripts-watch` is not running.  Fixes #16357 and #16358.  