### PR TITLE
bugfix/16390-fixed-multiple-line-indicator-demo

### DIFF
--- a/docs/stock/custom-technical-indicators.md
+++ b/docs/stock/custom-technical-indicators.md
@@ -224,7 +224,8 @@ var multipleLinesMixin = Highcharts._modules['Mixins/MultipleLines.js'];
 
 Highcharts.seriesType(
   'linearregressionzones',
-  'sma', {
+  'sma',
+  {
     color: '#00ff00',
     params: {
       zoneDistance: 5
@@ -261,9 +262,10 @@ Highcharts.seriesType(
         lineColor: '#ff0000'
       }
     }
-  }, {
-    getValues: function(series) {
-      return this.getLinearRegressionZones(series.xData, series.yData);
+  },
+  {
+    getValues: function (series) {
+        return this.getLinearRegressionZones(series.xData, series.yData);
     },
     getLinearRegressionZones: getLinearRegressionZones,
 
@@ -273,14 +275,28 @@ Highcharts.seriesType(
     nameSuffixes: ['%'],
     parallelArrays: ['x', 'y', 'y1', 'y2', 'y3', 'y4'],
     pointArrayMap: ['y1', 'y2', 'y', 'y3', 'y4'],
-    pointValKey: 'y',
-
-    drawGraph: multipleLinesMixin.drawGraph,
-    getTranslatedLinesNames: multipleLinesMixin.getTranslatedLinesNames,
-    translate: multipleLinesMixin.translate,
-    toYData: multipleLinesMixin.toYData
+    pointValKey: 'y'
   }
 );
+
+/* eslint-disable no-underscore-dangle */
+var multipleLinesMixin = Highcharts._modules['Mixins/MultipleLines.js'];
+
+if (multipleLinesMixin) {
+  Highcharts.extend(
+    Highcharts.seriesTypes.linearregressionzones.prototype,
+    {
+      drawGraph: multipleLinesMixin.drawGraph,
+      getTranslatedLinesNames: multipleLinesMixin.getTranslatedLinesNames,
+      translate: multipleLinesMixin.translate,
+      toYData: multipleLinesMixin.toYData
+    }
+  );
+} else { // Highcharts v9.2.3+
+  Highcharts._modules['Stock/Indicators/MultipleLinesComposition.js'].compose(
+    Highcharts.seriesTypes.linearregressionzones
+  );
+}
 ```
 
 A live demo of the above multiline indicator can be found [here](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/stock/indicators/custom-regression-multiple-lines/).

--- a/docs/stock/custom-technical-indicators.md
+++ b/docs/stock/custom-technical-indicators.md
@@ -279,7 +279,6 @@ Highcharts.seriesType(
   }
 );
 
-/* eslint-disable no-underscore-dangle */
 var multipleLinesMixin = Highcharts._modules['Mixins/MultipleLines.js'];
 
 if (multipleLinesMixin) {

--- a/samples/stock/indicators/custom-regression-multiple-lines/demo.js
+++ b/samples/stock/indicators/custom-regression-multiple-lines/demo.js
@@ -107,11 +107,19 @@ Highcharts.seriesType(
         pointValKey: 'y'
     }
 );
+
 /* eslint-disable no-underscore-dangle */
-if (Highcharts._modules['Mixins/MultipleLines.js']) {
+var multipleLinesMixin = Highcharts._modules['Mixins/MultipleLines.js'];
+
+if (multipleLinesMixin) {
     Highcharts.extend(
-        Highcharts.seriesTypes.linearregressionzones,
-        Highcharts._modules['Mixins/MultipleLines.js']
+        Highcharts.seriesTypes.linearregressionzones.prototype,
+        {
+            drawGraph: multipleLinesMixin.drawGraph,
+            getTranslatedLinesNames: multipleLinesMixin.getTranslatedLinesNames,
+            translate: multipleLinesMixin.translate,
+            toYData: multipleLinesMixin.toYData
+        }
     );
 } else { // Highcharts v9.2.3+
     Highcharts._modules['Stock/Indicators/MultipleLinesComposition.js'].compose(


### PR DESCRIPTION
Fixed #16390, a regression in a documentation article and demo. Multiple lines indicator didn't work after changes related to migrating MultipleLines mixin to composition.

Internal note: the demo wasn't working because, when extending the `linearregressionzones` **prorotype***, some options were being overwritten by the default MultipleLinex mixin's options. Should be extended with only the four prototype methods.