### PR TITLE
bugfix/15543-seriesthreshold-default-value

### DIFF
--- a/ts/Extensions/Boost/BoostOptions.ts
+++ b/ts/Extensions/Boost/BoostOptions.ts
@@ -113,7 +113,7 @@ declare global {
  * amount of series.
  *
  * @type      {number|null}
- * @default   null
+ * @default   50
  * @apioption boost.seriesThreshold
  */
 


### PR DESCRIPTION
Fixed #15543, setting a proper default value for seriesThreshold in docs