### PR TITLE
bugfix/16316-annotation-measue-with-ordinal 

### DIFF
--- a/test/cypress/integration/Highcharts/stock-tools.spec.js
+++ b/test/cypress/integration/Highcharts/stock-tools.spec.js
@@ -181,3 +181,36 @@ describe('An indicator on indicator, #15696.', () => {
             .should('not.contain', 'SMA (14)')
     });
 });
+
+describe('Measure annotation, #15696.', () => {
+    beforeEach(() => {
+        cy.viewport(1000, 800);
+    });
+
+    before(() => {
+        cy.visit('/stock/demo/stock-tools-gui');
+    });
+    it('#15725: Should use the same axis for all points in multi-step annotation', () => {
+        cy.get('.highcharts-range-selector-group')
+            .contains('3m')
+            .click()
+
+        cy.get('.highcharts-measure-xy')
+            .children()
+            .eq(1)
+            .click();
+        cy.get('.highcharts-measure-y')
+            .click();
+
+        cy.get('.highcharts-container')
+            .click(250, 200, { force: true })
+            .click(350, 100, { force: true })
+
+        cy.chart().then(chart =>
+            assert.ok(
+                chart.annotations[0].startXMax,
+                'The startXMax property should be calculated.'
+            )
+        );
+    });
+});

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -490,7 +490,7 @@ namespace OrdinalAxis {
 
             // Check if the index is inside position array.
             // If true, read/approximate value for that exact index.
-            if (index >= 0 && index < positions.length) {
+            if (index >= 0 && index < positions.length - 1) {
                 const leftNeighbour = positions[Math.floor(index)],
                     rightNeighbour = positions[Math.ceil(index)],
                     distance = rightNeighbour - leftNeighbour;


### PR DESCRIPTION
Fixed #16316, the position of measure annotation was not calculated properly on the ordinal axis.