### PR TITLE
Tools: removed demos deploy from nightly

### DIFF
--- a/.circleci/scripts/check_and_trigger_samples_deploy.sh
+++ b/.circleci/scripts/check_and_trigger_samples_deploy.sh
@@ -44,8 +44,7 @@ if [[ -z $TOKEN ]]; then
 fi
 
 # latest commit where samples were changed, limited to 24 hours
-SAMPLES_COMMIT=$(git log --since=\""24 hours ago\"" --format=format:%H --full-diff --name-status samples/)
-DEMOS_COMMIT=$(git log --since=\""24 hours ago\"" --format=format:%H --full-diff --name-status samples/\*/demo/\*)
+SAMPLES_COMMIT=$(git log --since=\""24 hours ago\"" --format=format:%H --full-diff --name-status samples | awk '!/\/demo\//'/)
 
 if [[ ! -z "$SAMPLES_COMMIT" ]] || [ "$FORCE_DEPLOY" = true ]; then
     echo "Force deployed: ${FORCE_DEPLOY}"
@@ -60,27 +59,4 @@ if [[ ! -z "$SAMPLES_COMMIT" ]] || [ "$FORCE_DEPLOY" = true ]; then
     echo "$rep"
 else
      echo "No change in samples/ folder found."
-fi
-
-# Handle demos
-if [[ ! -z "$DEMOS_COMMIT" ]] || [ "$FORCE_DEPLOY" = true  ]; then
-    echo "Force deployed: ${FORCE_DEPLOY}"
-    echo "Found changes in demos"
-    # Check if there are any [A]dded demo files, build thumbnails if that is the case
-	  NEW_FILES=$(echo $DEMOS_COMMIT | egrep -c "A\s+samples\/.+\/demo\/*\.details")
-    if [[ $NEW_FILES -ge 1 ]]; then
-      THUMBNAILS=true
-    fi
-
-    echo "Files in samples/ has changed or forcing deploy. Triggering deploy of demos via highcharts-demo-manager to bucket ${BUCKET}"
-    payload="{ \"branch\":\"master\", \"parameters\": { \"deploy_demos\": true, \"deploy_thumbnails\": ${THUMBNAILS}, \"target_bucket\": \"${BUCKET}\", \"deploy_args\": \"${DEPLOYARGS}\" }}"
-    echo "$payload"
-
-    # Circle API v2
-    httpUrl="https://circleci.com/api/v2/project/github/highcharts/highcharts-demo-manager/pipeline?circle-token=${TOKEN}&branch=master"
-    rep=$(curl -f -X POST -H "Content-Type: application/json" -d "$payload" "$httpUrl")
-    status="$?"
-    echo "$rep"
-else
-     echo "No change in samples/*/demo/ folder found."
 fi


### PR DESCRIPTION
This removes the demo deploy from the nightly. Will replace the trigger with a gulp task after tweaking some things on the demo-manager end.