### PR TITLE
Docs: Fixed samples and tags

### DIFF
--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -343,9 +343,9 @@ extend(LegendComponent.prototype, /** @lends Highcharts.LegendComponent */ {
 
 
     /**
-     * @private
      * Returns false if legend a11y is disabled and proxies were not created,
      * true otherwise.
+     * @private
      */
     recreateProxies: function (this: Highcharts.LegendComponent): boolean {
         this.removeProxies();

--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -575,9 +575,9 @@ namespace AxisDefaults {
          * In Highcharts Stock, `endOnTick` is always `false` when the navigator
          * is enabled, to prevent jumpy scrolling.
          *
-         * @sample {highcharts} highcharts/chart/reflow-true/
-         *         True by default
          * @sample {highcharts} highcharts/yaxis/endontick/
+         *         True by default
+         * @sample {highcharts} highcharts/yaxis/endontick-false/
          *         False
          * @sample {highstock} stock/demo/basic-line/
          *         True by default
@@ -2393,9 +2393,9 @@ namespace AxisDefaults {
          * @see [type](#chart.panning.type)
          *
          *
-         * @sample {highcharts} highcharts/chart/reflow-true/
-         *         True by default
          * @sample {highcharts} highcharts/yaxis/endontick/
+         *         True by default
+         * @sample {highcharts} highcharts/yaxis/endontick-false/
          *         False
          * @sample {highstock} stock/demo/basic-line/
          *         True by default

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -603,9 +603,8 @@ namespace OrdinalAxis {
     }
 
     /**
-     * @private
-     *
      * Extending the Chart.pan method for ordinal axes
+     * @private
      */
     function onChartPan(this: Chart, e: Event): void {
         const chart = this,

--- a/ts/Series/HLC/HLCSeries.ts
+++ b/ts/Series/HLC/HLCSeries.ts
@@ -263,10 +263,9 @@ class HLCSeries extends ColumnSeries {
 
 
     /**
+     * Draw single point
      * @private
-     * draw single point
      */
-
     public drawSinglePoint(point: HLCPoint): void {
 
         const series = point.series,


### PR DESCRIPTION
- Fixed #15915, sample links for endOnTick option.
- Fixed tag-order in doclets.