### PR TITLE
bugfix/16319-rangeSelector-all-data-grouping 

### DIFF
--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1590,6 +1590,19 @@ class Axis {
     }
 
     /**
+     * @private
+     * @function Highcharts.Axis#hasExtemesChanged
+     *
+     * @return {boolean}
+     */
+    public hasExtemesChanged(): boolean {
+        const axis = this;
+
+        return axis.min !== (axis.old && axis.old.min) ||
+            axis.max !== (axis.old && axis.old.max);
+    }
+
+    /**
      * Set the tick positions to round values and optionally extend the extremes
      * to the nearest tick.
      *
@@ -1840,18 +1853,17 @@ class Axis {
         // This is in turn needed in order to find tick positions in ordinal
         // axes.
         if (isXAxis && !secondPass) {
+            const hasExtemesChanged = axis.hasExtemesChanged();
+
             // First process all series assigned to that axis.
             axis.series.forEach(function (series): void {
                 // Allows filtering out points outside the plot area.
                 series.forceCrop = series.forceCropping && series.forceCropping();
 
-                series.processData(
-                    axis.min !== (axis.old && axis.old.min) ||
-                    axis.max !== (axis.old && axis.old.max)
-                );
+                series.processData(hasExtemesChanged);
             });
             // Then apply grouping if needed.
-            fireEvent(this, 'postProcessData');
+            fireEvent(this, 'postProcessData', { hasExtemesChanged });
         }
 
         // set the translation factor used in translate function

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1590,19 +1590,6 @@ class Axis {
     }
 
     /**
-     * @private
-     * @function Highcharts.Axis#hasExtemesChanged
-     *
-     * @return {boolean}
-     */
-    public hasExtemesChanged(): boolean {
-        const axis = this;
-
-        return axis.min !== (axis.old && axis.old.min) ||
-            axis.max !== (axis.old && axis.old.max);
-    }
-
-    /**
      * Set the tick positions to round values and optionally extend the extremes
      * to the nearest tick.
      *
@@ -1853,16 +1840,19 @@ class Axis {
         // This is in turn needed in order to find tick positions in ordinal
         // axes.
         if (isXAxis && !secondPass) {
-            const hasExtemesChanged = axis.hasExtemesChanged();
+            const hasExtemesChanged = axis.min !== (axis.old && axis.old.min) ||
+                axis.max !== (axis.old && axis.old.max);
 
             // First process all series assigned to that axis.
             axis.series.forEach(function (series): void {
                 // Allows filtering out points outside the plot area.
                 series.forceCrop = series.forceCropping && series.forceCropping();
-
                 series.processData(hasExtemesChanged);
             });
+
             // Then apply grouping if needed.
+            // The hasExtemesChanged helps to decide if the data grouping should
+            // be skipped in the further calculations #16319.
             fireEvent(this, 'postProcessData', { hasExtemesChanged });
         }
 

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -1238,7 +1238,7 @@ namespace OrdinalAxis {
                 });
 
                 // Apply grouping if needed.
-                axis.applyGrouping.call(fakeAxis);
+                axis.applyGrouping.call(fakeAxis, false);
 
                 // Force to use the ordinal when points are evenly spaced
                 // (e.g. weeks), #3825.

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -1238,7 +1238,12 @@ namespace OrdinalAxis {
                 });
 
                 // Apply grouping if needed.
-                axis.applyGrouping.call(fakeAxis, false);
+                axis.applyGrouping.call(
+                    fakeAxis,
+                    {
+                        hasExtemesChanged: false
+                    }
+                );
 
                 // Force to use the ordinal when points are evenly spaced
                 // (e.g. weeks), #3825.


### PR DESCRIPTION
Fixed #16319, grouped positions were not calculated correctly after clicking the All button multiple times.