### PR TITLE
bugfix/16275-number-precision-float

### DIFF
--- a/samples/unit-tests/axis/ticks/demo.js
+++ b/samples/unit-tests/axis/ticks/demo.js
@@ -1090,3 +1090,19 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test(
+    'Checking if ticks are displayed when the numbers are very high. (#16275).',
+    function (assert) {
+        var chart = Highcharts.chart('container', {
+            series: [{
+                data: [238863224762451, 238863224762452, 238863224762453]
+            }]
+        });
+
+        assert.ok(
+            chart.yAxis[0].tickPositions.length > 1,
+            'Number of ticks on the axis must be greater than one.'
+        );
+    }
+);

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1053,18 +1053,21 @@ class Axis {
         min: number,
         max: number
     ): Array<number> {
-        const roundedMin = correctFloat(Math.floor(min / tickInterval) * tickInterval),
-            roundedMax = correctFloat(Math.ceil(max / tickInterval) * tickInterval),
-            tickPositions = [];
+        const tickPositions = [];
 
         let pos,
             lastPos,
-            precision;
+            precision,
+            roundedMin = correctFloat(Math.floor(min / tickInterval) * tickInterval),
+            roundedMax = correctFloat(Math.ceil(max / tickInterval) * tickInterval);
 
         // When the precision is higher than what we filter out in
         // correctFloat, skip it (#6183).
+        // Comment TODO (#16275)
         if (correctFloat(roundedMin + tickInterval) === roundedMin) {
             precision = 20;
+            roundedMin = correctFloat(Math.floor(min / tickInterval) * tickInterval, precision);
+            roundedMax = correctFloat(Math.ceil(max / tickInterval) * tickInterval, precision);
         }
 
         // For single points, add a tick regardless of the relative position


### PR DESCRIPTION
Fixed #16275, ticks on the axis weren't displayed when their value was too high.