### PR TITLE
bugfix/16415-sma-index-value 

### DIFF
--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -490,7 +490,7 @@ namespace OrdinalAxis {
 
             // Check if the index is inside position array.
             // If true, read/approximate value for that exact index.
-            if (index >= 0 && index < positions.length) {
+            if (index >= 0 && index < positions.length - 1) {
                 const leftNeighbour = positions[Math.floor(index)],
                     rightNeighbour = positions[Math.ceil(index)],
                     distance = rightNeighbour - leftNeighbour;

--- a/ts/Stock/Indicators/KeltnerChannels/KeltnerChannelsIndicator.ts
+++ b/ts/Stock/Indicators/KeltnerChannels/KeltnerChannelsIndicator.ts
@@ -61,6 +61,12 @@ class KeltnerChannelsIndicator extends SMAIndicator {
      */
     public static defaultOptions: KeltnerChannelsOptions = merge(SMAIndicator.defaultOptions, {
         params: {
+            /**
+             * The point index which indicator calculations will base. For
+             * example using OHLC data, index=2 means the indicator will be
+             * calculated using Low values.
+             */
+            index: 0,
             period: 20,
             /**
              * The ATR period.

--- a/ts/Stock/Indicators/SMA/SMAIndicator.ts
+++ b/ts/Stock/Indicators/SMA/SMAIndicator.ts
@@ -151,7 +151,7 @@ class SMAIndicator extends LineSeries {
              * example using OHLC data, index=2 means the indicator will be
              * calculated using Low values.
              */
-            index: 0,
+            index: 3,
             /**
              * The base period for indicator calculations. This is the number of
              * data points which are taken into account for the indicator


### PR DESCRIPTION
Fixed #16415, changed default SMA `index` parameter, added an `index` to Keltner channels indicator.

 #### Upgrade note
Changed the default SMA `index` parameter from `0` (open) to `3`(close). This also has an impact on the other indicators where SMA is being used, namely  MACD, Price Envelopes and the Linear regression family.