### PR TITLE
Fix "code" for District of Columbia

### DIFF
--- a/samples/data/us-counties-unemployment.json
+++ b/samples/data/us-counties-unemployment.json
@@ -1595,7 +1595,7 @@
         "value": 5.2
     },
     {
-        "code": "us-ia-001",
+        "code": "us-dc-001",
         "name": "District of Columbia",
         "value": 5.9
     },


### PR DESCRIPTION
Applied fix to "samples/data/us-counties-unemployment.json" for the District of Columbia "code" value.
* Old incorrect value: 'us-ia-001'
* New corrected value: 'us-dc-001'

Fixes #16477 

**Note:** The example file "samples/maps/demo/us-counties/demo.js" appears to link to a specific version of this file and may need to also be updated to make use of this change.