### PR TITLE
bugfix/16397-indicator-recalculation 

### DIFF
--- a/samples/unit-tests/indicator-volume-by-price/recalculations/demo.js
+++ b/samples/unit-tests/indicator-volume-by-price/recalculations/demo.js
@@ -238,6 +238,27 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
         'volumeDataArray is correct after point remove on the base and the volume series.'
     );
 
+    chart.series[0].points[14].update({
+        open: 60,
+        high: 90,
+        low: 55,
+        close: 80
+    });
+    const yData = chart.series[2].yData.slice();
+    chart.series[0].points[14].update({
+        open: 60,
+        high: 150,
+        low: 55,
+        close: 140
+    });
+
+    assert.notDeepEqual(
+        yData,
+        chart.series[2].yData,
+        `After multiple updates on the base series' point,
+        the indicator should recalculate its values, #16397.`
+    );
+
     const negativeGraphic = indicator.points[0].negativeGraphic;
     indicator.points[0].destroy();
     assert.notOk(

--- a/ts/Stock/Indicators/SMA/SMAIndicator.ts
+++ b/ts/Stock/Indicators/SMA/SMAIndicator.ts
@@ -326,7 +326,7 @@ class SMAIndicator extends LineSeries {
                 }
 
                 // Most indicators are being calculated on chart's init.
-                if (indicator.calculateOn === 'init') {
+                if (!indicator.calculateOnExtremesChange) {
                     if (!indicator.processedYData) {
                         indicator.recalculateValues();
                     }
@@ -335,7 +335,7 @@ class SMAIndicator extends LineSeries {
                     // values after other chart's events (render).
                     const unbinder = addEvent(
                         indicator.chart,
-                        indicator.calculateOn,
+                        'render',
                         function (): void {
                             indicator.recalculateValues();
                             // Call this just once.
@@ -505,7 +505,6 @@ class SMAIndicator extends LineSeries {
 
 interface SMAIndicator extends IndicatorLike {
     calculateOnExtremesChange: boolean;
-    calculateOn: string;
     hasDerivedData: boolean;
     nameComponents: Array<string>;
     nameSuffixes: Array<string>;
@@ -514,7 +513,6 @@ interface SMAIndicator extends IndicatorLike {
 }
 extend(SMAIndicator.prototype, {
     calculateOnExtremesChange: false,
-    calculateOn: 'init',
     hasDerivedData: true,
     nameComponents: ['period'],
     nameSuffixes: [], // e.g. Zig Zag uses extra '%'' in the legend name

--- a/ts/Stock/Indicators/SMA/SMAIndicator.ts
+++ b/ts/Stock/Indicators/SMA/SMAIndicator.ts
@@ -49,12 +49,6 @@ import './SMAComposition.js';
  *  Declarations
  *
  * */
-
-interface BindToObject {
-    eventName: string;
-    series: boolean;
-}
-
 declare module '../../../Core/Series/SeriesOptions' {
     interface SeriesOptions {
         useOhlcData?: boolean;
@@ -304,35 +298,50 @@ class SMAIndicator extends LineSeries {
 
             if (indicator.linkedParent) {
                 if (!hasEvents) {
+                    // No matter which indicator,
+                    // always recalculate after updating the data.
                     indicator.dataEventsToUnbind.push(
-                        addEvent<AxisType|SeriesType>(
-                            indicator.bindTo.series ?
-                                indicator.linkedParent :
-                                indicator.linkedParent.xAxis,
-                            indicator.bindTo.eventName,
+                        addEvent<SeriesType>(
+                            indicator.linkedParent,
+                            'updatedData',
                             function (): void {
                                 indicator.recalculateValues();
                             }
                         )
                     );
+
+                    // Some indicators (like VBP) requires an additional
+                    // event (afterSetExtremes) to properly show the data.
+                    if (indicator.calculateOnExtremesChagne) {
+                        indicator.dataEventsToUnbind.push(
+                            addEvent<AxisType>(
+                                indicator.linkedParent.xAxis,
+                                'afterSetExtremes',
+                                function (): void {
+                                    indicator.recalculateValues();
+                                }
+                            )
+                        );
+                    }
                 }
 
+                // Most indicators are being calculated on chart's init.
                 if (indicator.calculateOn === 'init') {
                     if (!indicator.processedYData) {
                         indicator.recalculateValues();
                     }
-                } else {
-                    if (!hasEvents) {
-                        const unbinder = addEvent(
-                            indicator.chart,
-                            indicator.calculateOn,
-                            function (): void {
-                                indicator.recalculateValues();
-                                // Call this just once, on init
-                                unbinder();
-                            }
-                        );
-                    }
+                } else if (!hasEvents) {
+                    // Some indicators (like VBP) has to recalculate their
+                    // values after other chart's events (render).
+                    const unbinder = addEvent(
+                        indicator.chart,
+                        indicator.calculateOn,
+                        function (): void {
+                            indicator.recalculateValues();
+                            // Call this just once.
+                            unbinder();
+                        }
+                    );
                 }
             } else {
                 return error(
@@ -451,7 +460,7 @@ class SMAIndicator extends LineSeries {
 
         // Removal of processedXData property is required because on
         // first translate processedXData array is empty
-        if (indicator.bindTo.series === false) {
+        if (indicator.calculateOnExtremesChagne) {
             delete indicator.processedXData;
 
             indicator.isDirty = true;
@@ -495,7 +504,7 @@ class SMAIndicator extends LineSeries {
  * */
 
 interface SMAIndicator extends IndicatorLike {
-    bindTo: BindToObject;
+    calculateOnExtremesChagne: boolean;
     calculateOn: string;
     hasDerivedData: boolean;
     nameComponents: Array<string>;
@@ -504,10 +513,7 @@ interface SMAIndicator extends IndicatorLike {
     useCommonDataGrouping: boolean;
 }
 extend(SMAIndicator.prototype, {
-    bindTo: {
-        series: true,
-        eventName: 'updatedData'
-    },
+    calculateOnExtremesChagne: false,
     calculateOn: 'init',
     hasDerivedData: true,
     nameComponents: ['period'],

--- a/ts/Stock/Indicators/SMA/SMAIndicator.ts
+++ b/ts/Stock/Indicators/SMA/SMAIndicator.ts
@@ -312,7 +312,7 @@ class SMAIndicator extends LineSeries {
 
                     // Some indicators (like VBP) requires an additional
                     // event (afterSetExtremes) to properly show the data.
-                    if (indicator.calculateOnExtremesChagne) {
+                    if (indicator.calculateOnExtremesChange) {
                         indicator.dataEventsToUnbind.push(
                             addEvent<AxisType>(
                                 indicator.linkedParent.xAxis,
@@ -460,7 +460,7 @@ class SMAIndicator extends LineSeries {
 
         // Removal of processedXData property is required because on
         // first translate processedXData array is empty
-        if (indicator.calculateOnExtremesChagne) {
+        if (indicator.calculateOnExtremesChange) {
             delete indicator.processedXData;
 
             indicator.isDirty = true;
@@ -504,7 +504,7 @@ class SMAIndicator extends LineSeries {
  * */
 
 interface SMAIndicator extends IndicatorLike {
-    calculateOnExtremesChagne: boolean;
+    calculateOnExtremesChange: boolean;
     calculateOn: string;
     hasDerivedData: boolean;
     nameComponents: Array<string>;
@@ -513,7 +513,7 @@ interface SMAIndicator extends IndicatorLike {
     useCommonDataGrouping: boolean;
 }
 extend(SMAIndicator.prototype, {
-    calculateOnExtremesChagne: false,
+    calculateOnExtremesChange: false,
     calculateOn: 'init',
     hasDerivedData: true,
     nameComponents: ['period'],

--- a/ts/Stock/Indicators/SMA/SMAIndicator.ts
+++ b/ts/Stock/Indicators/SMA/SMAIndicator.ts
@@ -312,7 +312,7 @@ class SMAIndicator extends LineSeries {
 
                     // Some indicators (like VBP) requires an additional
                     // event (afterSetExtremes) to properly show the data.
-                    if (indicator.calculateOnExtremesChange) {
+                    if (indicator.useAdditionalEvents) {
                         indicator.dataEventsToUnbind.push(
                             addEvent<AxisType>(
                                 indicator.linkedParent.xAxis,
@@ -326,7 +326,7 @@ class SMAIndicator extends LineSeries {
                 }
 
                 // Most indicators are being calculated on chart's init.
-                if (!indicator.calculateOnExtremesChange) {
+                if (!indicator.useAdditionalEvents) {
                     if (!indicator.processedYData) {
                         indicator.recalculateValues();
                     }
@@ -460,7 +460,7 @@ class SMAIndicator extends LineSeries {
 
         // Removal of processedXData property is required because on
         // first translate processedXData array is empty
-        if (indicator.calculateOnExtremesChange) {
+        if (indicator.useAdditionalEvents) {
             delete indicator.processedXData;
 
             indicator.isDirty = true;
@@ -504,7 +504,7 @@ class SMAIndicator extends LineSeries {
  * */
 
 interface SMAIndicator extends IndicatorLike {
-    calculateOnExtremesChange: boolean;
+    useAdditionalEvents: boolean;
     hasDerivedData: boolean;
     nameComponents: Array<string>;
     nameSuffixes: Array<string>;
@@ -512,7 +512,7 @@ interface SMAIndicator extends IndicatorLike {
     useCommonDataGrouping: boolean;
 }
 extend(SMAIndicator.prototype, {
-    calculateOnExtremesChange: false,
+    useAdditionalEvents: false,
     hasDerivedData: true,
     nameComponents: ['period'],
     nameSuffixes: [], // e.g. Zig Zag uses extra '%'' in the legend name

--- a/ts/Stock/Indicators/SMA/SMAIndicator.ts
+++ b/ts/Stock/Indicators/SMA/SMAIndicator.ts
@@ -306,7 +306,7 @@ class SMAIndicator extends LineSeries {
                     // No matter which indicator,
                     // always recalculate after updating the data.
                     indicator.dataEventsToUnbind.push(
-                        addEvent<SeriesType>(
+                        addEvent(
                             indicator.linkedParent,
                             'updatedData',
                             function (): void {
@@ -319,7 +319,7 @@ class SMAIndicator extends LineSeries {
                     // event (afterSetExtremes) to properly show the data.
                     if (indicator.calculateOn.xAxis) {
                         indicator.dataEventsToUnbind.push(
-                            addEvent<AxisType>(
+                            addEvent(
                                 indicator.linkedParent.xAxis,
                                 indicator.calculateOn.xAxis,
                                 function (): void {

--- a/ts/Stock/Indicators/VBP/VBPIndicator.ts
+++ b/ts/Stock/Indicators/VBP/VBPIndicator.ts
@@ -828,7 +828,10 @@ interface VBPIndicator {
 extend(VBPIndicator.prototype, {
     nameBase: 'Volume by Price',
     nameComponents: ['ranges'],
-    useAdditionalEvents: true,
+    calculateOn: {
+        chart: 'render',
+        xAxis: 'afterSetExtremes'
+    },
     pointClass: VBPPoint,
     markerAttribs: noop as any,
     drawGraph: noop,

--- a/ts/Stock/Indicators/VBP/VBPIndicator.ts
+++ b/ts/Stock/Indicators/VBP/VBPIndicator.ts
@@ -829,7 +829,7 @@ interface VBPIndicator {
 extend(VBPIndicator.prototype, {
     nameBase: 'Volume by Price',
     nameComponents: ['ranges'],
-    calculateOnExtremesChagne: true,
+    calculateOnExtremesChange: true,
     calculateOn: 'render',
     pointClass: VBPPoint,
     markerAttribs: noop as any,

--- a/ts/Stock/Indicators/VBP/VBPIndicator.ts
+++ b/ts/Stock/Indicators/VBP/VBPIndicator.ts
@@ -819,7 +819,6 @@ namespace VBPIndicator {
 interface VBPIndicator {
     nameBase: string;
     nameComponents: Array<string>;
-    calculateOn: string;
     pointClass: typeof VBPPoint;
 
     crispCol: ColumnSeries['crispCol'];
@@ -830,7 +829,6 @@ extend(VBPIndicator.prototype, {
     nameBase: 'Volume by Price',
     nameComponents: ['ranges'],
     calculateOnExtremesChange: true,
-    calculateOn: 'render',
     pointClass: VBPPoint,
     markerAttribs: noop as any,
     drawGraph: noop,

--- a/ts/Stock/Indicators/VBP/VBPIndicator.ts
+++ b/ts/Stock/Indicators/VBP/VBPIndicator.ts
@@ -828,7 +828,7 @@ interface VBPIndicator {
 extend(VBPIndicator.prototype, {
     nameBase: 'Volume by Price',
     nameComponents: ['ranges'],
-    calculateOnExtremesChange: true,
+    useAdditionalEvents: true,
     pointClass: VBPPoint,
     markerAttribs: noop as any,
     drawGraph: noop,

--- a/ts/Stock/Indicators/VBP/VBPIndicator.ts
+++ b/ts/Stock/Indicators/VBP/VBPIndicator.ts
@@ -829,10 +829,7 @@ interface VBPIndicator {
 extend(VBPIndicator.prototype, {
     nameBase: 'Volume by Price',
     nameComponents: ['ranges'],
-    bindTo: {
-        series: false,
-        eventName: 'afterSetExtremes'
-    },
+    calculateOnExtremesChagne: true,
     calculateOn: 'render',
     pointClass: VBPPoint,
     markerAttribs: noop as any,


### PR DESCRIPTION
Fixed #16397, the VBP indicator was not recalculated after adding the point.

- [x] tests
- [x] ~braking change message (after reviewers approve the PR)~ no need for that, we modified internal properties
- [ ] adjust documentation (after reviewers approve the PR) #16409 