### PR TITLE
Maps: Make projection scale more predictable

### DIFF
--- a/samples/maps/demo/topojson-projection/demo.js
+++ b/samples/maps/demo/topojson-projection/demo.js
@@ -1062,7 +1062,7 @@ Highcharts.getJSON(
                 maxZoom: 30,
                 projection: {
                     name: 'Orthographic',
-                    rotation: [60, -30]
+                    rotation: [60, 0]
                 }
             },
 

--- a/samples/unit-tests/maps/projection/demo.js
+++ b/samples/unit-tests/maps/projection/demo.js
@@ -28,12 +28,25 @@ QUnit.module('Projection', function () {
         });
     };
 
+    // Test the scale near the center of the projection to make sure all
+    // projections have comparable zoom levels
+    const testScale = (assert, projection) => {
+        const x1 = projection.forward([-1, 0]),
+            x2 = projection.forward([1, 0]);
+
+        assert.close(
+            x2[0] - x1[0],
+            222638.98158654713,
+            1,
+            'X scale should be similar to that of the WebMercator projection'
+        );
+    };
+
     Object.keys(Projection.registry).forEach(name => {
         QUnit.test(name, function (assert) {
-            testPoints(
-                assert,
-                new Projection({ name })
-            );
+            const basicProjection = new Projection({ name });
+            testPoints(assert, basicProjection);
+            testScale(assert, basicProjection);
             testPoints(
                 assert,
                 new Projection({ name, rotation: [30, 30] })

--- a/ts/Maps/MapView.ts
+++ b/ts/Maps/MapView.ts
@@ -169,13 +169,13 @@ class MapView {
 
                     // ... but don't rotate if we're loading only a part of the
                     // world
-                    (this.minZoom || Infinity) < 25.2
+                    (this.minZoom || Infinity) < 3
                 ) {
 
                     // Empirical ratio where the globe rotates roughly the same
                     // speed as moving the pointer across the center of the
                     // projection
-                    const ratio = 28000 / (this.getScale() * Math.min(
+                    const ratio = 0.0044 / (this.getScale() * Math.min(
                         chart.plotWidth,
                         chart.plotHeight
                     ));

--- a/ts/Maps/Projections/EqualEarth.ts
+++ b/ts/Maps/Projections/EqualEarth.ts
@@ -16,7 +16,8 @@ const A1 = 1.340264,
     A2 = -0.081106,
     A3 = 0.000893,
     A4 = 0.003796,
-    M = Math.sqrt(3) / 2.0;
+    M = Math.sqrt(3) / 2.0,
+    scale = 7403120.656864502;
 
 const EqualEarth: ProjectionDefinition = {
 
@@ -26,7 +27,7 @@ const EqualEarth: ProjectionDefinition = {
             paramLatSq = paramLat * paramLat,
             paramLatPow6 = paramLatSq * paramLatSq * paramLatSq;
 
-        const x = lonLat[0] * d * Math.cos(paramLat) / (
+        const x = lonLat[0] * d * Math.cos(paramLat) * scale / (
             M *
             (
                 A1 +
@@ -34,7 +35,7 @@ const EqualEarth: ProjectionDefinition = {
                 paramLatPow6 * (7 * A3 + 9 * A4 * paramLatSq)
             )
         );
-        const y = paramLat * (
+        const y = paramLat * scale * (
             A1 + A2 * paramLatSq + paramLatPow6 * (A3 + A4 * paramLatSq)
         );
 
@@ -42,11 +43,13 @@ const EqualEarth: ProjectionDefinition = {
     },
 
     inverse: (xy): [number, number] => {
-        const d = 180 / Math.PI,
+        const x = xy[0] / scale,
+            y = xy[1] / scale,
+            d = 180 / Math.PI,
             epsilon = 1e-9,
             iterations = 12;
 
-        let paramLat = xy[1],
+        let paramLat = y,
             paramLatSq, paramLatPow6, fy, fpy, dlat, i;
 
         for (i = 0; i < iterations; ++i) {
@@ -54,7 +57,7 @@ const EqualEarth: ProjectionDefinition = {
             paramLatPow6 = paramLatSq * paramLatSq * paramLatSq;
             fy = paramLat * (
                 A1 + A2 * paramLatSq + paramLatPow6 * (A3 + A4 * paramLatSq)
-            ) - xy[1];
+            ) - y;
             fpy = A1 + 3 * A2 * paramLatSq + paramLatPow6 * (
                 7 * A3 + 9 * A4 * paramLatSq
             );
@@ -66,7 +69,7 @@ const EqualEarth: ProjectionDefinition = {
         paramLatSq = paramLat * paramLat;
         paramLatPow6 = paramLatSq * paramLatSq * paramLatSq;
 
-        const lon = d * M * xy[0] * (
+        const lon = d * M * x * (
             A1 + 3 * A2 * paramLatSq + paramLatPow6 * (
                 7 * A3 + 9 * A4 * paramLatSq
             )

--- a/ts/Maps/Projections/Miller.ts
+++ b/ts/Maps/Projections/Miller.ts
@@ -6,19 +6,20 @@
 
 import type ProjectionDefinition from '../ProjectionDefinition';
 
-const quarterPI = Math.PI / 4;
-const deg2rad = Math.PI / 180;
+const quarterPI = Math.PI / 4,
+    deg2rad = Math.PI / 180,
+    scale = 6378137;
 
 const Miller: ProjectionDefinition = {
 
     forward: (lonLat): [number, number] => [
-        lonLat[0] * deg2rad,
-        1.25 * Math.log(Math.tan(quarterPI + 0.4 * lonLat[1] * deg2rad))
+        lonLat[0] * deg2rad * scale,
+        1.25 * scale * Math.log(Math.tan(quarterPI + 0.4 * lonLat[1] * deg2rad))
     ],
 
     inverse: (xy): [number, number] => [
-        xy[0] / deg2rad,
-        2.5 * (Math.atan(Math.exp(0.8 * xy[1])) - quarterPI) / deg2rad
+        (xy[0] / scale) / deg2rad,
+        2.5 * (Math.atan(Math.exp(0.8 * (xy[1] / scale))) - quarterPI) / deg2rad
     ]
 };
 

--- a/ts/Maps/Projections/Orthographic.ts
+++ b/ts/Maps/Projections/Orthographic.ts
@@ -6,7 +6,8 @@
 
 import type ProjectionDefinition from '../ProjectionDefinition';
 
-const deg2rad = Math.PI / 180;
+const deg2rad = Math.PI / 180,
+    scale = 6378460.826781007;
 
 const Orthographic: ProjectionDefinition = {
 
@@ -20,14 +21,14 @@ const Orthographic: ProjectionDefinition = {
         }
         const lat = latDeg * deg2rad;
         return [
-            Math.cos(lat) * Math.sin(lonDeg * deg2rad),
-            Math.sin(lat)
+            Math.cos(lat) * Math.sin(lonDeg * deg2rad) * scale,
+            Math.sin(lat) * scale
         ];
     },
 
     inverse: (xy): [number, number] => {
-        const x = xy[0],
-            y = xy[1],
+        const x = xy[0] / scale,
+            y = xy[1] / scale,
             z = Math.sqrt(x * x + y * y),
             c = Math.asin(z),
             cSin = Math.sin(c),


### PR DESCRIPTION
Projections are now scaled so that the `mapView.zoom` setting is more predictable between the various projections. The design goal is to be close to WebMercator's zoom of 0 that projects the world on a 256x256 pixel square. Other projections are scaled so that a 2 degrees span from lon/lat [-1, 0] to [1, 0] matches the projected length of the WebMercator projection.