### PR TITLE
docs/16379-missing-module-api

### DIFF
--- a/ts/Extensions/OfflineExporting/OfflineExporting.ts
+++ b/ts/Extensions/OfflineExporting/OfflineExporting.ts
@@ -415,6 +415,7 @@ namespace OfflineExporting {
      * @return {void}
      *
      * @requires modules/exporting
+     * @requires modules/offline-exporting
      */
     function exportChartLocal(
         this: Chart,


### PR DESCRIPTION
Fixed #16379, the offline-exporting module was missing in the API.