### PR TITLE
Fixed #16173, word wrap failed inside anchors

### DIFF
--- a/samples/unit-tests/svgrenderer/text/demo.js
+++ b/samples/unit-tests/svgrenderer/text/demo.js
@@ -141,6 +141,15 @@ QUnit.test('Text word wrap with markup', function (assert) {
             'The text node width should be less than 100'
         );
     }
+
+    text.attr({
+        text: '<a href="https://www.highcharts.com">The quick brown fox jumps over the lazy dog</a>'
+    });
+
+    assert.ok(
+        text.getBBox().width <= 100,
+        'Text directly inside anchor should be wrapped (#16173)'
+    );
 });
 
 QUnit.module('whiteSpace: "nowrap"', hooks => {

--- a/ts/Core/Renderer/SVG/TextBuilder.ts
+++ b/ts/Core/Renderer/SVG/TextBuilder.ts
@@ -452,7 +452,7 @@ class TextBuilder {
             } else if (
                 tagName === 'a' &&
                 children &&
-                children.some(child => child.tagName === '#text')
+                children.some((child): boolean => child.tagName === '#text')
             ) {
                 node.children = [{ children, tagName: 'tspan' }];
             }


### PR DESCRIPTION
Fixed #16173, a regression since v9.0.0 causing word wrap and ellipsis to fail with text directly inside anchors.