### PR TITLE
bugfix/14267-tilemap-square-error

### DIFF
--- a/samples/unit-tests/series-tilemap/coloraxis/demo.js
+++ b/samples/unit-tests/series-tilemap/coloraxis/demo.js
@@ -35,6 +35,11 @@ QUnit.test('Tilemap and ColorAxis', function (assert) {
         'ColorAxis.max should be the same as max value in points (#11644)'
     );
 
+    // Square shape: no errors should be visible in the console, #14267
+    chart.series[0].update({
+        tileShape: 'square'
+    });
+
     chart.series[0].update({
         tileShape: 'circle'
     });

--- a/ts/Series/Heatmap/HeatmapPoint.ts
+++ b/ts/Series/Heatmap/HeatmapPoint.ts
@@ -32,9 +32,9 @@ const {
     }
 } = SeriesRegistry;
 import U from '../../Core/Utilities.js';
-import BBoxObject from '../../Core/Renderer/BBoxObject';
 const {
     clamp,
+    defined,
     extend,
     pick
 } = U;
@@ -144,9 +144,12 @@ class HeatmapPoint extends ScatterPoint {
                 ), -yAxis.len, 2 * yAxis.len)
             };
 
+        const dimensions: [['width', 'x'], ['height', 'y']] =
+            [['width', 'x'], ['height', 'y']];
+
         // Handle marker's fixed width, and height values including border
         // and pointPadding while calculating cell attributes.
-        [['width', 'x'], ['height', 'y']].forEach(function (dimension): void {
+        dimensions.forEach(function (dimension): void {
             const prop = dimension[0],
                 direction = dimension[1];
 
@@ -160,21 +163,15 @@ class HeatmapPoint extends ScatterPoint {
                     markerOptions.lineWidth || 0,
                 plotPos = Math.abs(
                     cellAttr[start] + cellAttr[end]
-                ) / 2;
+                ) / 2,
+                widthOrHeight = markerOptions && markerOptions[prop];
 
+            if (defined(widthOrHeight) && widthOrHeight < side) {
+                const halfCellSize = widthOrHeight / 2 + borderWidth / 2;
 
-            if (
-                markerOptions &&
-                (markerOptions as any)[prop] &&
-                (markerOptions as any)[prop] < side
-            ) {
-                cellAttr[start] = plotPos - (
-                    (markerOptions as any)[prop] / 2) -
-                    (borderWidth / 2);
+                cellAttr[start] = plotPos - halfCellSize;
 
-                cellAttr[end] = plotPos + (
-                    (markerOptions as any)[prop] / 2) +
-                    (borderWidth / 2);
+                cellAttr[end] = plotPos + halfCellSize;
             }
 
             // Handle pointPadding

--- a/ts/Series/Heatmap/HeatmapPoint.ts
+++ b/ts/Series/Heatmap/HeatmapPoint.ts
@@ -164,6 +164,7 @@ class HeatmapPoint extends ScatterPoint {
 
 
             if (
+                markerOptions &&
                 (markerOptions as any)[prop] &&
                 (markerOptions as any)[prop] < side
             ) {


### PR DESCRIPTION
Fixed #14267, tilemap [tileShape](https://api.highcharts.com/highmaps/series.tilemap.tileShape) `square` was throwing an error into the console.