### PR TITLE
Fixed #16665, updating dataLabels.useHTML did not work

### DIFF
--- a/samples/unit-tests/series-treemap/datalabels/demo.js
+++ b/samples/unit-tests/series-treemap/datalabels/demo.js
@@ -1128,6 +1128,12 @@ QUnit.test(
         isLabelsWidthCorrect = true;
         points = series.points; // update the reference
 
+        assert.strictEqual(
+            points[0].dataLabel.text.element.nodeName.toLowerCase(),
+            'span',
+            'Data labels should change to HTML'
+        );
+
         for (i = 0; i < points.length; i++) {
             dataLabel = points[i].dataLabel;
             width = dataLabel.options.style.width;
@@ -1142,5 +1148,18 @@ QUnit.test(
             true,
             "Data label(s) text shouldn't be wider than its box (useHTML: true)."
         );
+
+        series.update({
+            dataLabels: {
+                useHTML: false
+            }
+        });
+
+        assert.strictEqual(
+            points[0].dataLabel.text.element.nodeName.toLowerCase(),
+            'text',
+            'Data labels should change to SVG'
+        );
+
     }
 );

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -621,9 +621,15 @@ namespace DataLabel {
 
                     // If the point is outside the plot area, destroy it. #678,
                     // #820
-                    if (dataLabel && (!labelEnabled || !defined(labelText))) {
-                        point.dataLabel =
-                            point.dataLabel && point.dataLabel.destroy();
+                    if (
+                        dataLabel && (
+                            !labelEnabled ||
+                            !defined(labelText) ||
+                            !!dataLabel.div !== !!labelOptions.useHTML
+                        )
+                    ) {
+                        point.dataLabel = dataLabel =
+                            point.dataLabel && point.dataLabel.destroy() as any;
                         if (point.dataLabels) {
                             // Remove point.dataLabels if this was the last one
                             if (point.dataLabels.length === 1) {
@@ -647,11 +653,12 @@ namespace DataLabel {
                                 }
                             }
                         }
+                    }
 
                     // Individual labels are disabled if the are explicitly
                     // disabled in the point options, or if they fall outside
                     // the plot area.
-                    } else if (labelEnabled && defined(labelText)) {
+                    if (labelEnabled && defined(labelText)) {
 
                         if (!dataLabel) {
                             // Create new label element


### PR DESCRIPTION
Fixed #16665, a regression causing updating of `dataLabels.useHTML` not to take effect.