### PR TITLE
Fixed issue with data module updates with firstRowAsNames enabled.

### DIFF
--- a/samples/unit-tests/data/general/demo.js
+++ b/samples/unit-tests/data/general/demo.js
@@ -296,7 +296,7 @@ QUnit.test(
         });
 
         assert.strictEqual(
-            chart.data.columns[2][1],
+            chart.data.columns[2][0],
             null,
             'Empty point should be parsed to null instead of undefined.'
         );
@@ -325,5 +325,27 @@ QUnit.test('Updating with firstRowAsNames', function (assert) {
         chart.series[0].points.length,
         numPoints,
         'Updating data options should not remove data rows.'
+    );
+});
+
+
+QUnit.test('Update column names', function (assert) {
+    const chart = Highcharts.chart('container', {
+        data: {
+            columns: [['A', 1, 2, 3, 4, 5, 6], ['B', 2, 4, 8, 3, 6, 6]],
+            firstRowAsNames: true
+        }
+    });
+
+    chart.update({
+        data: {
+            columns: [['C', 1, 2, 3, 4, 5, 6], ['D', 2, 4, 8, 3, 6, 6]]
+        }
+    });
+
+    assert.strictEqual(
+        chart.series[0].name,
+        'D',
+        'Should be able to update series name.'
     );
 });

--- a/samples/unit-tests/data/general/demo.js
+++ b/samples/unit-tests/data/general/demo.js
@@ -296,7 +296,7 @@ QUnit.test(
         });
 
         assert.strictEqual(
-            chart.data.columns[2][0],
+            chart.data.columns[2][1],
             null,
             'Empty point should be parsed to null instead of undefined.'
         );
@@ -304,3 +304,26 @@ QUnit.test(
         document.body.removeChild(table);
     }
 );
+
+
+QUnit.test('Updating with firstRowAsNames', function (assert) {
+    const chart = Highcharts.chart('container', {
+            data: {
+                columns: [['A', 1, 2, 3, 4, 5, 6], ['B', 2, 4, 8, 3, 6, 6]],
+                firstRowAsNames: true
+            }
+        }),
+        numPoints = chart.series[0].points.length;
+
+    chart.update({
+        data: {
+            googleSpreadsheetKey: 'placeholder'
+        }
+    });
+
+    assert.strictEqual(
+        chart.series[0].points.length,
+        numPoints,
+        'Updating data options should not remove data rows.'
+    );
+});

--- a/ts/Extensions/Data.ts
+++ b/ts/Extensions/Data.ts
@@ -2376,22 +2376,15 @@ class Data {
 
             // Get the names and shift the top row
             if (this.firstRowAsNames) {
-                // We can't modify the original array as further updates
-                // would keep removing first row.
-                const columnsCopy = [];
                 for (i = 0; i < (columns as any).length; i++) {
-                    const curColumn = (columns as any)[i];
-                    const shifted = curColumn.slice(1);
-                    shifted.name = curColumn[0];
-                    extend(shifted, {
-                        isDatetime: curColumn.isDatetime,
-                        isNumeric: curColumn.isNumeric,
-                        mixed: curColumn.mixed,
-                        unsorted: curColumn.unsorted
-                    });
-                    columnsCopy.push(shifted);
+                    const curCol = (columns as any)[i];
+                    if (!defined(curCol.name)) {
+                        curCol.name = pick(
+                            curCol.shift(),
+                            ''
+                        ).toString();
+                    }
                 }
-                columns = columnsCopy;
             }
 
             // Use the next columns for series

--- a/ts/Extensions/Data.ts
+++ b/ts/Extensions/Data.ts
@@ -2376,9 +2376,22 @@ class Data {
 
             // Get the names and shift the top row
             if (this.firstRowAsNames) {
+                // We can't modify the original array as further updates
+                // would keep removing first row.
+                const columnsCopy = [];
                 for (i = 0; i < (columns as any).length; i++) {
-                    (columns as any)[i].name = (columns as any)[i].shift();
+                    const curColumn = (columns as any)[i];
+                    const shifted = curColumn.slice(1);
+                    shifted.name = curColumn[0];
+                    extend(shifted, {
+                        isDatetime: curColumn.isDatetime,
+                        isNumeric: curColumn.isNumeric,
+                        mixed: curColumn.mixed,
+                        unsorted: curColumn.unsorted
+                    });
+                    columnsCopy.push(shifted);
                 }
+                columns = columnsCopy;
             }
 
             // Use the next columns for series


### PR DESCRIPTION
Fixed issue with data module updates with `firstRowAsNames` enabled.
___
Pragmatic fix for this issue, which happens both with using `data.columns` and any other options that parse something and then set `data.columns`, such as the Google Sheet link.

The `data.complete()` function modifies the `data.columns` prop when removing the first row as names. This means that when the chart data options are updated (`data.update` runs), the `data.columns` prop already has the first row removed. Since `firstRowAsNames` is still true, the first row is removed again, and data rows are lost.

Pragmatic fix: Work on a copy of the columns array in `data.complete()` when using firstRowAsNames, and avoid modifying `data.columns`.

Not a huge fan of this fix for two reasons:
1. It slightly breaks backwards compatibility, because `data.columns` will now also include the column headers, and will no longer have the `.name` prop. We can of course re-add the `.name` prop purely for compatibility, but it will still include the column headers so chances are a rewrite will be needed by the users that modify this array in some cases.
2. We are using custom props on the column arrays that have to be copied over, and if we add more of these and forget to do this we will introduce bugs (`column.isNumeric`, `column.unsorted`, etc). It seems overkill to write logic to copy over all non-array elements, but that is a solution of course.

Suggestions for a better fix appreciated, but it seems to work at least.