### PR TITLE
bugfix/16596-drag-column-category

### DIFF
--- a/samples/unit-tests/dragdrop/dynamic/demo.js
+++ b/samples/unit-tests/dragdrop/dynamic/demo.js
@@ -189,6 +189,32 @@ QUnit.test('Dragdrop enabled in dynamic chart', function (assert) {
     controller.mouseUp();
 
     assert.ok(true, '#15537: Destroying point while dragging should not throw');
+
+    // Clear chart.dragHandles for the next test
+    chart.hideDragHandles();
+
+    chart.series[0].update({
+        type: 'column',
+        data: [1, 2, 3, 5],
+        pointPadding: 0,
+        groupPadding: 0
+    }, false);
+
+    chart.xAxis[0].update({
+        type: 'category'
+    });
+
+    chart.series[0].points[0].showDragHandles();
+
+    assert.ok(
+        // dragHandles.undefined element is created in the showDragHandles
+        // method after the changes made in #16596 after the function's return.
+        // The return should be skipped and the dragHandles.undefined element
+        // should be created.
+        chart.dragHandles && chart.dragHandles.undefined,
+        `DragHandles should be visible - dragging should work on the first
+        column in a categorized xAxis, (#16596)`
+    );
 });
 
 QUnit.test('Dragdrop and logarithmic axes', function (assert) {

--- a/ts/Extensions/DraggablePoints.ts
+++ b/ts/Extensions/DraggablePoints.ts
@@ -2504,7 +2504,9 @@ Point.prototype.showDragHandles = function (): void {
             // Find position and path of handle
             pos = positioner(point);
             handleAttrs.d = path = pathFormatter(point);
-            if (!path || pos.x < 0 || pos.y < 0) {
+            // Correct left edge value depending on the xAxis' type, #16596
+            const minEdge = point.series.xAxis.categories ? -0.5 : 0;
+            if (!path || pos.x < minEdge || pos.y < 0) {
                 return;
             }
 


### PR DESCRIPTION
Fixed #16596, the first column point of categorized x-axis wasn't draggable.