### PR TITLE
bugfix/10525-axis-cleared-undefined

### DIFF
--- a/samples/unit-tests/axis/ticks/demo.js
+++ b/samples/unit-tests/axis/ticks/demo.js
@@ -507,6 +507,17 @@ QUnit.test('The tickPositions option', function (assert) {
         'No extra ticks should be inserted when zooming between explicit ' +
             'ticks (#7463)'
     );
+
+    chart.xAxis[0].update({
+        tickPositions: undefined
+    });
+    
+    assert.deepEqual(
+        chart.xAxis[0].tickPositions,
+        [8, 9, 10, 11, 12, 13, 14],
+        'After setting tickPostions to undefined they should be' + 
+            'cleared. (#10525)'
+    );
 });
 
 QUnit.test(
@@ -1103,32 +1114,6 @@ QUnit.test(
         assert.ok(
             chart.yAxis[0].tickPositions.length > 1,
             'Number of ticks on the axis must be greater than one.'
-        );
-    }
-);
-
-QUnit.test(
-    'Axis options should be cleared with undefined, (#10525).',
-    function (assert) {
-        var chart = Highcharts.chart('container', {
-            series: [{
-                data: [1, 2, 3]
-            }],
-            yAxis: {
-                tickPositions: [0, 25, 50, 75, 100]
-            }
-        });
-
-        chart.update({
-            yAxis: {
-                tickPositions: undefined
-            }
-        });
-
-        assert.deepEqual(
-            chart.yAxis[0].tickPositions,
-            [0, 1, 2, 3, 4],
-            'After seting tickPostions to undefined they should be cleared.'
         );
     }
 );

--- a/samples/unit-tests/axis/ticks/demo.js
+++ b/samples/unit-tests/axis/ticks/demo.js
@@ -1106,3 +1106,29 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test(
+    'Axis options should be cleared with undefined, (#10525).',
+    function (assert) {
+        var chart = Highcharts.chart('container', {
+            series: [{
+                data: [1, 2, 3]
+            }],
+            yAxis: {
+                tickPositions: [0, 25, 50, 75, 100]
+            }
+        });
+
+        chart.update({
+            yAxis: {
+                tickPositions: undefined
+            }
+        });
+
+        assert.deepEqual(
+            chart.yAxis[0].tickPositions,
+            [0, 1, 2, 3, 4],
+            'After seting tickPostions to undefined they should be cleared.'
+        );
+    }
+);

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -296,7 +296,9 @@ function cleanRecursively<TNew extends AnyRecord, TOld extends AnyRecord>(
         // Arrays, primitives and DOM nodes are copied directly
         } else if (
             isObject(newer[key]) ||
-            newer[key] !== older[key]
+            newer[key] !== older[key] ||
+            // If the newer key is explicitly undefined, keep it (#10525)
+            (key in newer && !(key in older))
         ) {
             result[key] = newer[key];
         }


### PR DESCRIPTION
Fixed #10525, setting [tickPositions](https://api.highcharts.com/highcharts/xAxis.tickPosition) to `undefined` didn't clear options.