### PR TITLE
bugfix/16670-indicator-series-update

### DIFF
--- a/samples/unit-tests/indicator-sma/recalculations/demo.js
+++ b/samples/unit-tests/indicator-sma/recalculations/demo.js
@@ -175,7 +175,10 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
         false
     );
 
-    assert.ok('#16670: Update without redraw should not throw errors.');
+    assert.ok(
+        true,
+        '#16670: Update without redraw should not throw errors.'
+    );
 
     chart.redraw();
 

--- a/samples/unit-tests/indicator-sma/recalculations/demo.js
+++ b/samples/unit-tests/indicator-sma/recalculations/demo.js
@@ -149,23 +149,35 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
     chart.xAxis[0].setExtremes(0, 30);
     const yBefore = chart.series[1].points[0].y;
 
-    chart.series[0].update({
-        type: 'ohlc',
-        data: [
-            [20, 30, 10, 125],
-            [20, 30, 10, 123],
-            [20, 30, 10, 121],
-            [20, 30, 10, 125],
-            [20, 30, 10, 126],
-            [20, 30, 10, 123],
-            [20, 30, 10, 127],
-            [20, 30, 10, 122],
-            [20, 30, 10, 122],
-            [20, 30, 10, 123],
-            [20, 30, 10, 125],
-            [20, 30, 10, 126]
-        ]
-    });
+    chart.series[1].update(
+        { name: 'TEST', dataGrouping: { } },
+        false
+    );
+
+    chart.series[0].update(
+        {
+            type: 'ohlc',
+            data: [
+                [20, 30, 10, 125],
+                [20, 30, 10, 123],
+                [20, 30, 10, 121],
+                [20, 30, 10, 125],
+                [20, 30, 10, 126],
+                [20, 30, 10, 123],
+                [20, 30, 10, 127],
+                [20, 30, 10, 122],
+                [20, 30, 10, 122],
+                [20, 30, 10, 123],
+                [20, 30, 10, 125],
+                [20, 30, 10, 126]
+            ]
+        },
+        false
+    );
+
+    assert.ok('#16670: Update without redraw should not throw errors.');
+
+    chart.redraw();
 
     assert.notStrictEqual(
         chart.series[1].points[0].y,

--- a/ts/Stock/Indicators/SMA/SMAIndicator.ts
+++ b/ts/Stock/Indicators/SMA/SMAIndicator.ts
@@ -379,15 +379,12 @@ class SMAIndicator extends LineSeries {
         let indicator = this,
             oldData = indicator.points || [],
             oldDataLength = (indicator.xData || []).length,
-            processedData: IndicatorValuesObject<typeof LineSeries.prototype> = (
-                indicator.getValues(
-                    indicator.linkedParent,
-                    indicator.options.params as any
-                ) || {
-                    values: [],
-                    xData: [],
-                    yData: []
-                }),
+            emptySet: IndicatorValuesObject<typeof LineSeries.prototype> = {
+                values: [],
+                xData: [],
+                yData: []
+            },
+            processedData: IndicatorValuesObject<typeof LineSeries.prototype>,
             croppedDataValues = [],
             overwriteData = true,
             oldFirstPointIndex,
@@ -396,6 +393,19 @@ class SMAIndicator extends LineSeries {
             min,
             max,
             i;
+
+        // Updating an indicator with redraw=false may destroy data.
+        // If there will be a following update for the parent series,
+        // we will try to access Series object without any properties
+        // (except for prototyped ones). This is what happens
+        // for example when using Axis.setDataGrouping(). See #16670
+        processedData = indicator.linkedParent.options ?
+            (
+                indicator.getValues(
+                    indicator.linkedParent,
+                    indicator.options.params as any
+                ) || emptySet
+            ) : emptySet;
 
         // We need to update points to reflect changes in all,
         // x and y's, values. However, do it only for non-grouped


### PR DESCRIPTION
Fixed #16670, Range Selector's buttons with `dataGrouping` setting caused error after adding an indicator using the Stock Tools GUI.