### PR TITLE
bugfix/16492-getbaseseriesmin-empty-xdata

### DIFF
--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -1307,3 +1307,47 @@ QUnit.test('Initiation chart without data but with set range, #15864.', function
         the navigator shouldn't stick to min.`
     );
 });
+
+
+QUnit.test('Navigator, testing method: getBaseSeriesMin', function (assert) {
+    const method = Highcharts.Navigator.prototype.getBaseSeriesMin;
+
+    const mocks = [
+        // Regular case, simple series
+        {
+            baseSeries: [
+                { xData: [-5, 0, 5] }
+            ]
+        },
+        // Two series, one without xData
+        {
+            baseSeries: [
+                { xData: [-5, 0, 5] },
+                { }
+            ]
+        },
+        // Two series, one without empty xData
+        {
+            baseSeries: [
+                { xData: [-5, 0, 5] },
+                { xData: [] }
+            ]
+        },
+        // One series, undefiend in xData
+        {
+            baseSeries: [
+                { xData: [-5, undefined, 5] }
+            ]
+        }
+    ];
+
+    mocks.forEach(mock => {
+        const result = method.call(mock, 0);
+
+        assert.strictEqual(
+            result,
+            -5,
+            `With config: ${JSON.stringify(mock)}, the min should not be a NaN`
+        );
+    });
+});

--- a/ts/Core/Navigator.ts
+++ b/ts/Core/Navigator.ts
@@ -2463,7 +2463,11 @@ class Navigator {
         return this.baseSeries.reduce(
             function (min: number, series: Series): number {
                 // (#10193)
-                return Math.min(min, series.xData ? series.xData[0] : min);
+                return Math.min(
+                    min,
+                    series.xData && series.xData.length ?
+                        series.xData[0] : min
+                );
             },
             currentSeriesMin
         );


### PR DESCRIPTION
Fixed #16492, Navigator did not stick to the max when adding a point and an additional, empty series was existing on the chart.