### PR TITLE
bugfix/15133-drilldown-labels-fadein

### DIFF
--- a/samples/unit-tests/drilldown/animation/demo.details
+++ b/samples/unit-tests/drilldown/animation/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/drilldown/animation/demo.html
+++ b/samples/unit-tests/drilldown/animation/demo.html
@@ -1,0 +1,8 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/drilldown.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/sinonjs/lolex/lolex.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container" style="width: 600px; margin: 0 auto"></div>

--- a/samples/unit-tests/drilldown/animation/demo.js
+++ b/samples/unit-tests/drilldown/animation/demo.js
@@ -1,0 +1,74 @@
+QUnit.test(
+    'Drilldown animations',
+    assert => {
+        const clock = TestUtilities.lolexInstall();
+
+        try {
+            const done = assert.async();
+            const chart = Highcharts.chart('container', {
+                chart: {
+                    type: 'column'
+                },
+                plotOptions: {
+                    series: {
+                        dataLabels: {
+                            enabled: true
+                        }
+                    }
+                },
+                series: [{
+                    data: [{
+                        y: 62.74,
+                        drilldown: 'drilldown'
+                    }, {
+                        y: 10.57
+                    }]
+                }],
+                drilldown: {
+                    animation: {
+                        duration: 100
+                    },
+                    series: [{
+                        id: 'drilldown',
+                        data: [15]
+                    }]
+                }
+            });
+
+            chart.series[0].points[0].doDrilldown();
+
+            setTimeout(function () {
+                assert.equal(
+                    chart.series[0].dataLabelsGroup.attr('visibility'),
+                    'hidden',
+                    `Data Labels' group should be hidden
+                    during the drilldown animation (#15133).`
+                );
+            }, 40);
+
+            setTimeout(function () {
+                const dataLabelsGroup = chart.series[0].dataLabelsGroup;
+
+                assert.equal(
+                    dataLabelsGroup.attr('visibility'),
+                    'inherit',
+                    `Data Labels' group should be visible
+                    after the drilldown animation (#15133).`
+                );
+
+                assert.notEqual(
+                    dataLabelsGroup.attr('opacity'),
+                    1,
+                    `Data Labels' group' opacity should be animating
+                    after the drilldown animation (#15133).`
+                );
+
+                done();
+            }, 140);
+
+            TestUtilities.lolexRunAndUninstall(clock);
+        } finally {
+            TestUtilities.lolexUninstall(clock);
+        }
+    }
+);

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -90,6 +90,9 @@ Highcharts.setOptions({
     },
     tooltip: {
         animation: false
+    },
+    drilldown: {
+        animation: false
     }
 });
 // Save default functions from the default options, as they are not stringified

--- a/ts/Extensions/Drilldown.ts
+++ b/ts/Extensions/Drilldown.ts
@@ -1407,7 +1407,6 @@ if (PieSeries) {
                 (this.chart.drilldownLevels as any)[
                     (this.chart.drilldownLevels as any).length - 1
                 ],
-                dataLabelsGroup = this.dataLabelsGroup,
                 animationOptions =
                     (this.chart.options.drilldown as any).animation;
 

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -529,7 +529,11 @@ class MapSeries extends ScatterSeries {
                     scaleX: 1,
                     scaleY: 1,
                     opacity: 1
-                });
+                }, (this.chart.options.drilldown as any).animation);
+
+                if (chart.drilldown) {
+                    chart.drilldown.fadeInGroup(this.dataLabelsGroup);
+                }
             }
         }
 


### PR DESCRIPTION
Fixed #15133, Data Labels were missing the fade-in effect upon drilling down.
___
tl;dr:
\*whew\* quite a tricky issue 😅 
Click on a point to drill down. Observe data labels:
| Current | PR |
|---|---|
| [Pie drilldown](https://jsfiddle.net/BlackLabel/8ecyqda9/1/) | [Pie drilldown](https://jsfiddle.net/BlackLabel/8ecyqda9/2/) |
| [Column drilldown](https://jsfiddle.net/BlackLabel/Ldwc2z4q/1/) | [Column drilldown](https://jsfiddle.net/BlackLabel/Ldwc2z4q/2/) |
| [Maps drilldown v6](https://jsfiddle.net/BlackLabel/fzx1w26t/1/) and [Maps drilldown v9](https://jsfiddle.net/BlackLabel/fzx1w26t/2/) | [Maps drilldown](https://jsfiddle.net/BlackLabel/fzx1w26t/4/) |

A bit longer description:
I have tested three possible solutions:
- set the opacity for each label separately (this is the current implementation in Column drilldown) then fade in - as can be observed above, it's not working. I did not debug this further, because I decided it's not optimal anyway. Better hide the group:
- set the opacity for the group, then fade in. This is broken as [Ken Havard described](https://github.com/highcharts/highcharts/issues/15133#issuecomment-779257583): due to hovering a shape, during the animation, the `setState()` is called. `setState()` operates on the group's opacity. We could add events, refactor a little `setState()` etc. to get the desired result, but that may pollute the code and I really wanted to understand why `drillUp` works fine. And that leads to the third solution:
- hide the group (using `visibility` attr), then fade in using `setTimeout`. Personally, I don't like `setTimeout`s, so it can be further refactored (for example use `complete` callback after drilling up/down animation. Not a big deal, but the current solution starts fading in ~50ms before the animation ends). While mentioning refactoring:

A few ideas on how we could improve Drilldown's codebase:
- make Drilldown a class then use it later as a composition. We already have an object: `chart.drilldown` that holds the `update()` method. Now I have added an extra one (+`chart` property)
- replace `syncTimeout` with a sync code. I think `animation.defer` could be a way to help syncing shapes animation and data labels animation. I'm not sure how tricky it can be..


___
TESTS NOTE:
Perhaps I'm using `lolex` incorrectly, but when I tried to add this test to existing ones it broke other tests in the same `demo.js` - like enabling animation for all of them. That's the reason for creating a separate test for animations.