### PR TITLE
Fixed #16731, correct TS type for PlotAreasplineOptions.compare.

### DIFF
--- a/ts/Series/DataModifyComposition.ts
+++ b/ts/Series/DataModifyComposition.ts
@@ -738,6 +738,7 @@ export default DataModifyComposition;
  * @type      {string}
  * @since     1.0.1
  * @product   highstock
+ * @validvalue ["percent", "value"]
  * @apioption plotOptions.series.compare
  */
 


### PR DESCRIPTION
Fixed #16731, this changes TS declaration from:

```ts
export interface PlotAreasplineOptions {
    /**
     * (Highstock) Compare the values of the series against the first non-null,
     * non- zero value in the visible range. The y axis will show percentage or
     * absolute change depending on whether `compare` is set to `"percent"` or
     * `"value"`. When this is applied to multiple series, it allows comparing
     * the development of the series against each other. Adds a `change` field
     * to every point object.
     */
    compare?: string;
```

to:

```ts
export type OptionsCompareValue = ("percent"|"value");

export interface PlotAreasplineOptions {

    /**
     * (Highstock) Compare the values of the series against the first non-null,
     * non- zero value in the visible range. The y axis will show percentage or
     * absolute change depending on whether `compare` is set to `"percent"` or
     * `"value"`. When this is applied to multiple series, it allows comparing
     * the development of the series against each other. Adds a `change` field
     * to every point object.
     */
    compare?: OptionsCompareValue;
```