### PR TITLE
fix missing documentation for ToolTip.defaultFormater

### DIFF
--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -294,6 +294,10 @@ class Tooltip {
      * the context here is an object holding point, series, x, y etc.
      *
      * @function Highcharts.Tooltip#defaultFormatter
+     * 
+     * @param {Highcharts.Tooltip} tooltip
+     *
+     * @return {string|Array<string>}
      */
     public defaultFormatter(
         this: Tooltip.FormatterContextObject,


### PR DESCRIPTION
Fixed https://github.com/highcharts/highcharts/issues/16720
A previous change removed parts of the documentation for Highcharts.Tooltip#defaultFormatter leading to an incorrect generation of `.d.ts` files with the 9.3.2 release.

This PR adds that change back in as well as adding a plain `string` as a possible return value.

#### Expected behaviour
signature requires a tooltip parameter and returns a string or string array

#### Actual behaviour
generated signature is: `defaultFormatter(): void;`