### PR TITLE
bugfix/15203-symbol-hover-state 

### DIFF
--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -2127,7 +2127,7 @@ const seriesDefaults: SeriesOptions = {
              * @deprecated
              *
              * @extends   plotOptions.series.marker
-             * @excluding states
+             * @excluding states, symbol
              * @product   highcharts highstock
              */
             marker: {


### PR DESCRIPTION
Fixed #15203, removed marker symbol property from series hover API.