### PR TITLE
bugfix/2667-area-series-legend-symbol

### DIFF
--- a/samples/unit-tests/legend/legend-symbol-opacity/demo.css
+++ b/samples/unit-tests/legend/legend-symbol-opacity/demo.css
@@ -1,0 +1,10 @@
+@import "https://code.highcharts.com/css/highcharts.css";
+
+#container {
+    max-width: 800px;
+    margin: 1em auto;
+}
+
+g.highcharts-series {
+    transition: opacity 0ms;
+}

--- a/samples/unit-tests/legend/legend-symbol-opacity/demo.details
+++ b/samples/unit-tests/legend/legend-symbol-opacity/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/legend/legend-symbol-opacity/demo.html
+++ b/samples/unit-tests/legend/legend-symbol-opacity/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/legend/legend-symbol-opacity/demo.js
+++ b/samples/unit-tests/legend/legend-symbol-opacity/demo.js
@@ -1,0 +1,18 @@
+QUnit.test('Legend symbol transparency', function (assert) {
+    Highcharts.chart('container', {
+        chart: {
+            type: 'area'
+        },
+        series: [
+            {
+                data: [1, 3, 2, 4],
+                fillOpacity: 0.5
+            },
+            {
+                data: [4, 4, 7, 1],
+                opacity: 0.3
+            }
+        ]
+    });
+    assert.equal(true, true, '');
+});

--- a/samples/unit-tests/legend/legend-symbol-opacity/demo.js
+++ b/samples/unit-tests/legend/legend-symbol-opacity/demo.js
@@ -1,5 +1,5 @@
 QUnit.test('Legend symbol transparency', function (assert) {
-    Highcharts.chart('container', {
+    const chart = Highcharts.chart('container', {
         chart: {
             type: 'area'
         },
@@ -7,12 +7,15 @@ QUnit.test('Legend symbol transparency', function (assert) {
             {
                 data: [1, 3, 2, 4],
                 fillOpacity: 0.5
-            },
-            {
-                data: [4, 4, 7, 1],
-                opacity: 0.3
             }
         ]
     });
-    assert.equal(true, true, '');
+
+    assert.equal(
+        chart.legend.allItems[0].legendSymbol.element.getAttribute(
+            'fill-opacity'
+        ),
+        0.5,
+        'The legend symbol of the first element should be the same as the fillOpacity.'
+    );
 });

--- a/ts/Core/Legend/LegendSymbol.ts
+++ b/ts/Core/Legend/LegendSymbol.ts
@@ -24,6 +24,7 @@ import type SVGAttributes from '../Renderer/SVG/SVGAttributes';
 
 import U from '../Utilities.js';
 const {
+    defined,
     merge,
     pick
 } = U;
@@ -175,7 +176,17 @@ namespace LegendSymbol {
         const options = legend.options,
             symbolHeight = legend.symbolHeight,
             square = options.squareSymbol,
-            symbolWidth = square ? symbolHeight : legend.symbolWidth;
+            symbolWidth = square ? symbolHeight : legend.symbolWidth,
+            attributes = this.chart.styledMode ? {
+                zIndex: 3
+            } : {
+                zIndex: 3,
+                'fill-opacity': pick(
+                    this.options.fillOpacity,
+                    this.options.opacity,
+                    1
+                )
+            };
 
         item.legendSymbol = this.chart.renderer.rect(
             square ? (legend.symbolWidth - symbolHeight) / 2 : 0,
@@ -185,12 +196,8 @@ namespace LegendSymbol {
             pick(legend.options.symbolRadius, symbolHeight / 2)
         )
             .addClass('highcharts-point')
-            .attr({
-                zIndex: 3
-            }).add(item.legendGroup);
-
+            .attr(attributes).add(item.legendGroup);
     }
-
 }
 
 /* *

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -1985,7 +1985,9 @@ const seriesDefaults: SeriesOptions = {
     cropThreshold: 300,
 
     /**
-     * Opacity of a series parts: line, fill (e.g. area) and dataLabels.
+     * Opacity of a series parts: line, fill (e.g. area) and dataLabels. Applied
+     * also to the legend symbol. If you want to apply the opacity only to
+     * legend symbol, use `fillOpacity` instead
      *
      * @see [states.inactive.opacity](#plotOptions.series.states.inactive.opacity)
      *


### PR DESCRIPTION
Fixed #2667, legend item of area series didn't apply the opacity property.