### PR TITLE
bugfix/16673-treeGrid-destroy-icon

### DIFF
--- a/samples/unit-tests/gantt/treegrid/demo.js
+++ b/samples/unit-tests/gantt/treegrid/demo.js
@@ -516,4 +516,11 @@ QUnit.test('series.data[].collapsed', assert => {
         false,
         'This point should be expanded #13838'
     );
+
+    chart.series[0].setData([], true, true, false);
+    assert.notOk(
+        document.querySelector('.highcharts-label-icon'),
+        `After updating data,
+        the unnecessary label icons should be removed, 16673.`
+    );
 });

--- a/ts/Core/Axis/TreeGridTick.ts
+++ b/ts/Core/Axis/TreeGridTick.ts
@@ -467,6 +467,18 @@ namespace TreeGridTick {
         }
 
         /**
+         * Destroy remaining labelIcon if exist.
+         *
+         * @private
+         * @function Highcharts.Tick#destroy
+         */
+        public destroy(): void {
+            if (this.labelIcon) {
+                this.labelIcon.destroy();
+            }
+        }
+
+        /**
          * Expand the grid cell. Used when axis is of type treegrid.
          *
          * @see gantt/treegrid-axis/collapsed-dynamically/demo.js


### PR DESCRIPTION
Fixed #16673, label icons in TreeGrid were not destroyed after an update.