### PR TITLE
bugfix/16448-anotations-events-api

### DIFF
--- a/ts/Extensions/Annotations/Annotations.ts
+++ b/ts/Extensions/Annotations/Annotations.ts
@@ -1695,6 +1695,14 @@ merge<Annotation>(
                  */
 
                 /**
+                 * Fires when the annotation is clicked.
+                 *
+                 * @type      {Highcharts.EventCallbackFunction<Highcharts.Annotation>}
+                 * @since     7.1.0
+                 * @apioption annotations.events.click
+                 */
+
+                /**
                  * Event callback when annotation is removed from the chart.
                  *
                  * @type      {Highcharts.EventCallbackFunction<Highcharts.Annotation>}


### PR DESCRIPTION
Added the existing `annotations.click` callback option to the API. See #16448.