### PR TITLE
bugfix/16759-rangeSelector-overwrite-dataGrouping

### DIFF
--- a/samples/unit-tests/series/datagrouping/demo.js
+++ b/samples/unit-tests/series/datagrouping/demo.js
@@ -1018,24 +1018,23 @@ QUnit.test('The dataGrouping enabling/disabling.', function (assert) {
     });
 });
 
-QUnit.test('The dataGrouping with selected range.', function (assert) {
+QUnit.test('The dataGrouping with selected range.', (assert) => {
     const chart = Highcharts.stockChart('container', {
         rangeSelector: {
             selected: 0,
             buttons: [{
-                type: "all",
-                text: "All",
+                type: 'all',
+                text: 'All',
                 dataGrouping: {
                     forced: true,
                     units: [
-                        ["millisecond", [3]]
+                        ['millisecond', [3]]
                     ]
                 }
             }]
         },
-        
         series: [{
-            data: [1,2,3,4,5,6,7,8,9],
+            data: [1, 2, 3, 4, 5, 6, 7, 8, 9],
             dataGrouping: {
                 approximation: () => 3
             }
@@ -1045,6 +1044,7 @@ QUnit.test('The dataGrouping with selected range.', function (assert) {
     assert.strictEqual(
         chart.series[0].points[0].y,
         3,
-        `When range is selected dataGrouping should work properly (#16759)`
+        `When the scope is set in the dataGrouping options
+         it should workas well as without it (#16759)`
     );
 });

--- a/samples/unit-tests/series/datagrouping/demo.js
+++ b/samples/unit-tests/series/datagrouping/demo.js
@@ -734,29 +734,50 @@ QUnit.test('Data grouping, custom name in tooltip', function (assert) {
     );
 });
 
-QUnit.test('DataGrouping and update', function (assert) {
+QUnit.test('DataGrouping with selected range and update', function (assert) {
     const chart = Highcharts.stockChart('container', {
+        rangeSelector: {
+            selected: 0,
+            buttons: [{
+                type: 'all',
+                text: 'All',
+                dataGrouping: {
+                    forced: true,
+                    units: [
+                        ['millisecond', [3]]
+                    ]
+                }
+            }]
+        },
         series: [
             {
                 id: 'usdeur',
                 dataGrouping: {
-                    forced: true
+                    forced: true,
+                    approximation: () => 3
                 },
-                data: [1, 2, 3]
+                data: [1, 2, 3, 4, 5, 6]
             }
         ]
     });
+
+    assert.strictEqual(
+        chart.series[0].points[0].y,
+        3,
+        `When the scope is set in the dataGrouping options
+        it should work as well as without it (#16759)`
+    );
 
     chart.update(
         {
             series: [
                 {
                     id: 'usdeur',
-                    data: [3, 2, 1]
+                    data: [6, 5, 4, 3, 2, 1]
                 },
                 {
                     id: 'eurusd',
-                    data: [1, 2, 3]
+                    data: [1, 2, 3, 4, 5, 6]
                 }
             ]
         },
@@ -1016,35 +1037,4 @@ QUnit.test('The dataGrouping enabling/disabling.', function (assert) {
             the series.${prop} property should be deleted.`
         );
     });
-});
-
-QUnit.test('The dataGrouping with selected range.', (assert) => {
-    const chart = Highcharts.stockChart('container', {
-        rangeSelector: {
-            selected: 0,
-            buttons: [{
-                type: 'all',
-                text: 'All',
-                dataGrouping: {
-                    forced: true,
-                    units: [
-                        ['millisecond', [3]]
-                    ]
-                }
-            }]
-        },
-        series: [{
-            data: [1, 2, 3, 4, 5, 6, 7, 8, 9],
-            dataGrouping: {
-                approximation: () => 3
-            }
-        }]
-    })
-
-    assert.strictEqual(
-        chart.series[0].points[0].y,
-        3,
-        `When the scope is set in the dataGrouping options
-         it should workas well as without it (#16759)`
-    );
 });

--- a/samples/unit-tests/series/datagrouping/demo.js
+++ b/samples/unit-tests/series/datagrouping/demo.js
@@ -1017,3 +1017,34 @@ QUnit.test('The dataGrouping enabling/disabling.', function (assert) {
         );
     });
 });
+
+QUnit.test('The dataGrouping with selected range.', function (assert) {
+    const chart = Highcharts.stockChart('container', {
+        rangeSelector: {
+            selected: 0,
+            buttons: [{
+                type: "all",
+                text: "All",
+                dataGrouping: {
+                    forced: true,
+                    units: [
+                        ["millisecond", [3]]
+                    ]
+                }
+            }]
+        },
+        
+        series: [{
+            data: [1,2,3,4,5,6,7,8,9],
+            dataGrouping: {
+                approximation: () => 3
+            }
+        }]
+    })
+
+    assert.strictEqual(
+        chart.series[0].points[0].y,
+        3,
+        `When range is selected dataGrouping should work properly (#16759)`
+    );
+});

--- a/ts/Extensions/DataGrouping.ts
+++ b/ts/Extensions/DataGrouping.ts
@@ -1229,16 +1229,14 @@ Axis.prototype.setDataGrouping = function (
         }
 
     // Axis not yet instanciated, alter series options
-    } else if (dataGrouping) {
+    } else {
         (this as any).chart.options.series.forEach(function (
             seriesOptions: any
         ): void {
+            // Merging dataGrouping options with already defined options #16759
             seriesOptions.dataGrouping = typeof dataGrouping === 'boolean' ?
                 dataGrouping :
-                merge(
-                    dataGrouping,
-                    seriesOptions.dataGrouping
-                );
+                merge(dataGrouping, seriesOptions.dataGrouping);
         });
     }
 

--- a/ts/Extensions/DataGrouping.ts
+++ b/ts/Extensions/DataGrouping.ts
@@ -1229,12 +1229,17 @@ Axis.prototype.setDataGrouping = function (
         }
 
     // Axis not yet instanciated, alter series options
-    } else {
+    } else if (dataGrouping) {
         (this as any).chart.options.series.forEach(function (
             seriesOptions: any
         ): void {
-            seriesOptions.dataGrouping = dataGrouping;
-        }, false);
+            seriesOptions.dataGrouping = typeof dataGrouping === 'boolean' ?
+                dataGrouping :
+                merge(
+                    dataGrouping,
+                    seriesOptions.dataGrouping
+                );
+        });
     }
 
     // Clear ordinal slope, so we won't accidentaly use the old one (#7827)


### PR DESCRIPTION
Fixed #16759, range selector buttons overwrote series data grouping options when selected by default.