### PR TITLE
Boost and devicePixelRatio (Retina)

### DIFF
--- a/samples/highcharts/boost/line-devicepixelratio/demo.details
+++ b/samples/highcharts/boost/line-devicepixelratio/demo.details
@@ -1,0 +1,7 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Torstein Hønsi
+ requiresManualTesting: true
+ js_wrap: b
+...

--- a/samples/highcharts/boost/line-devicepixelratio/demo.html
+++ b/samples/highcharts/boost/line-devicepixelratio/demo.html
@@ -1,0 +1,5 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/boost.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
+
+<div id="container" style="height: 400px; max-width: 800px; margin: 0 auto"></div>

--- a/samples/highcharts/boost/line-devicepixelratio/demo.js
+++ b/samples/highcharts/boost/line-devicepixelratio/demo.js
@@ -1,0 +1,66 @@
+function getData(n) {
+    var arr = [],
+        i,
+        a,
+        b,
+        c,
+        spike;
+    for (i = 0; i < n; i = i + 1) {
+        if (i % 100 === 0) {
+            a = 2 * Math.random();
+        }
+        if (i % 1000 === 0) {
+            b = 2 * Math.random();
+        }
+        if (i % 10000 === 0) {
+            c = 2 * Math.random();
+        }
+        if (i % 50000 === 0) {
+            spike = 10;
+        } else {
+            spike = 0;
+        }
+        arr.push([
+            i,
+            2 * Math.sin(i / 100) + a + b + c + spike + Math.random()
+        ]);
+    }
+    return arr;
+}
+var n = 500000,
+    data = getData(n);
+
+
+console.time('line');
+Highcharts.chart('container', {
+
+    chart: {
+        zoomType: 'x',
+        panning: true,
+        panKey: 'shift'
+    },
+
+    boost: {
+        pixelRatio: 0,
+        useGPUTranslations: true
+    },
+
+    title: {
+        text: 'Using <em>window.devicePixelRatio</em>'
+    },
+
+    subtitle: {
+        text: 'Using the Boost module'
+    },
+
+    tooltip: {
+        valueDecimals: 2
+    },
+
+    series: [{
+        data: data,
+        lineWidth: 0.5
+    }]
+
+});
+console.timeEnd('line');

--- a/samples/highcharts/boost/line-export-pixelratio/demo.details
+++ b/samples/highcharts/boost/line-export-pixelratio/demo.details
@@ -1,0 +1,7 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Torstein Hønsi
+ requiresManualTesting: true
+ js_wrap: b
+...

--- a/samples/highcharts/boost/line-export-pixelratio/demo.html
+++ b/samples/highcharts/boost/line-export-pixelratio/demo.html
@@ -1,0 +1,5 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/boost.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
+
+<div id="container" style="height: 400px; max-width: 800px; margin: 0 auto"></div>

--- a/samples/highcharts/boost/line-export-pixelratio/demo.js
+++ b/samples/highcharts/boost/line-export-pixelratio/demo.js
@@ -1,0 +1,73 @@
+function getData(n) {
+    var arr = [],
+        i,
+        a,
+        b,
+        c,
+        spike;
+    for (i = 0; i < n; i = i + 1) {
+        if (i % 100 === 0) {
+            a = 2 * Math.random();
+        }
+        if (i % 1000 === 0) {
+            b = 2 * Math.random();
+        }
+        if (i % 10000 === 0) {
+            c = 2 * Math.random();
+        }
+        if (i % 50000 === 0) {
+            spike = 10;
+        } else {
+            spike = 0;
+        }
+        arr.push([
+            i,
+            2 * Math.sin(i / 100) + a + b + c + spike + Math.random()
+        ]);
+    }
+    return arr;
+}
+var n = 500000,
+    data = getData(n);
+
+
+console.time('line');
+Highcharts.chart('container', {
+
+    chart: {
+        zoomType: 'x',
+        panning: true,
+        panKey: 'shift'
+    },
+
+    exporting: {
+        chartOptions: {
+            boost: {
+                pixelRatio: 2
+            }
+        }
+    },
+
+    boost: {
+        useGPUTranslations: true
+    },
+
+    title: {
+        text: 'Fixed pixel ratio in export'
+    },
+
+    subtitle: {
+        text: 'Using the Boost module'
+    },
+
+    tooltip: {
+        valueDecimals: 2
+    },
+
+    series: [{
+        data: data,
+        lineWidth: 0.5
+    }]
+
+});
+console.timeEnd('line');

--- a/ts/Extensions/Boost/BoostAttach.ts
+++ b/ts/Extensions/Boost/BoostAttach.ts
@@ -18,7 +18,7 @@ import type SVGElement from '../../Core/Renderer/SVG/SVGElement';
 import Chart from '../../Core/Chart/Chart.js';
 import GLRenderer from './WGLRenderer.js';
 import H from '../../Core/Globals.js';
-const { doc } = H;
+const { doc, win } = H;
 import Series from '../../Core/Series/Series.js';
 import U from '../../Core/Utilities.js';
 const {
@@ -77,6 +77,13 @@ function createAndAttachRenderer(
     chart: Chart,
     series: Series
 ): Highcharts.BoostGLRenderer {
+
+    const dpr = (
+        chart.options &&
+        chart.options.boost &&
+        chart.options.boost.pixelRatio
+    ) || win.devicePixelRatio || 1;
+
     let width = chart.chartWidth,
         height = chart.chartHeight,
         target: Highcharts.BoostTargetObject = chart,
@@ -170,8 +177,8 @@ function createAndAttachRenderer(
                 .attr({
                     x: 0,
                     y: 0,
-                    width: width,
-                    height: height
+                    width,
+                    height
                 })
                 .css({
                     pointerEvents: 'none',
@@ -199,8 +206,8 @@ function createAndAttachRenderer(
         }
     }
 
-    (target.canvas as any).width = width;
-    (target.canvas as any).height = height;
+    (target.canvas as any).width = width * dpr;
+    (target.canvas as any).height = height * dpr;
 
     (target.boostClipRect as any).attr(chart.getBoostClipRect(target));
 

--- a/ts/Extensions/Boost/BoostAttach.ts
+++ b/ts/Extensions/Boost/BoostAttach.ts
@@ -78,12 +78,6 @@ function createAndAttachRenderer(
     series: Series
 ): Highcharts.BoostGLRenderer {
 
-    const dpr = (
-        chart.options &&
-        chart.options.boost &&
-        chart.options.boost.pixelRatio
-    ) || win.devicePixelRatio || 1;
-
     let width = chart.chartWidth,
         height = chart.chartHeight,
         target: Highcharts.BoostTargetObject = chart,
@@ -206,8 +200,8 @@ function createAndAttachRenderer(
         }
     }
 
-    (target.canvas as any).width = width * dpr;
-    (target.canvas as any).height = height * dpr;
+    (target.canvas as any).width = width;
+    (target.canvas as any).height = height;
 
     (target.boostClipRect as any).attr(chart.getBoostClipRect(target));
 

--- a/ts/Extensions/Boost/BoostAttach.ts
+++ b/ts/Extensions/Boost/BoostAttach.ts
@@ -18,7 +18,7 @@ import type SVGElement from '../../Core/Renderer/SVG/SVGElement';
 import Chart from '../../Core/Chart/Chart.js';
 import GLRenderer from './WGLRenderer.js';
 import H from '../../Core/Globals.js';
-const { doc, win } = H;
+const { doc } = H;
 import Series from '../../Core/Series/Series.js';
 import U from '../../Core/Utilities.js';
 const {

--- a/ts/Extensions/Boost/BoostOptions.ts
+++ b/ts/Extensions/Boost/BoostOptions.ts
@@ -50,6 +50,7 @@ declare global {
             debug?: BoostDebugOptions;
             enabled?: boolean;
             seriesThreshold?: number;
+            pixelRatio?: number;
             useGPUTranslations?: boolean;
             usePreallocated?: boolean;
         }
@@ -203,6 +204,33 @@ declare global {
  * @type      {boolean}
  * @default   false
  * @apioption boost.debug.timeBufferCopy
+ */
+
+/**
+ * The pixel ratio for the WebGL content. If 0, the `window.devicePixelRatio` is
+ * used. This ensures sharp graphics on high DPI displays like Apple's Retina,
+ * as well as when a page is zoomed.
+ *
+ * The default is left at 1 for now, as this is a new feature that has the
+ * potential to break existing setups. Over time, when it has been battle
+ * tested, the intention is to set it to 0 by default.
+ *
+ * Another use case for this option is to set it to 2 in order to make exported
+ * and upscaled charts render sharp.
+ *
+ * One limitation when using the `pixelRatio` is that the line width of graphs
+ * is scaled down. Since the Boost module currently can only render 1px line
+ * widths, it is scaled down to a thin 0.5 pixels on a Retina display.
+ *
+ * @sample    highcharts/boost/line-devicepixelratio
+ *            Enable the `devicePixelRatio`
+ * @sample    highcharts/boost/line-export-pixelratio
+ *            Sharper graphics in export
+ *
+ * @type      {number}
+ * @since     next
+ * @default   1
+ * @apioption boost.pixelRatio
  */
 
 /**

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -198,10 +198,16 @@ function GLRenderer(
                 timeKDTree: false,
                 showSkipSummary: false
             }
-        },
-        dpr = 1;
+        };
 
     // /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * @private
+     */
+    function getPixelRatio(): number {
+        return settings.pixelRatio || win.devicePixelRatio || 1;
+    }
 
     /**
      * @private
@@ -212,10 +218,9 @@ function GLRenderer(
         // refactor the Boost options to include an object of default options as
         // base for the merge, like other components.
         if (!('pixelRatio' in options)) {
-            options.pixelRatio = void 1;
+            options.pixelRatio = 1;
         }
         merge(true, settings, options);
-        dpr = settings.pixelRatio || win.devicePixelRatio || 1;
     }
 
     /**
@@ -412,7 +417,8 @@ function GLRenderer(
             zoneColors: Array<Color.RGBA>,
             zoneDefColor: (Color.RGBA|undefined) = false as any,
             threshold: number = options.threshold as any,
-            gapSize: number = false as any;
+            gapSize: number = false as any,
+            pixelRatio = getPixelRatio();
 
         if (options.boostData && options.boostData.length > 0) {
             return;
@@ -486,10 +492,10 @@ function GLRenderer(
         ): void {
             pushColor(color);
 
-            if (dpr !== 1 && !settings.useGPUTranslations) {
-                x *= dpr;
-                y *= dpr;
-                pointSize *= dpr;
+            if (pixelRatio !== 1 && !settings.useGPUTranslations) {
+                x *= pixelRatio;
+                y *= pixelRatio;
+                pointSize *= pixelRatio;
             }
 
             if (settings.usePreallocated) {
@@ -498,7 +504,7 @@ function GLRenderer(
             } else {
                 data.push(x);
                 data.push(y);
-                data.push(checkTreshold ? dpr : 0);
+                data.push(checkTreshold ? pixelRatio : 0);
                 data.push(pointSize);
             }
         }
@@ -1166,12 +1172,14 @@ function GLRenderer(
             return;
         }
 
-        shader.setUniform('xAxisTrans', axis.transA * dpr);
+        const pixelRatio = getPixelRatio();
+
+        shader.setUniform('xAxisTrans', axis.transA * pixelRatio);
         shader.setUniform('xAxisMin', axis.min as any);
-        shader.setUniform('xAxisMinPad', axis.minPixelPadding * dpr);
+        shader.setUniform('xAxisMinPad', axis.minPixelPadding * pixelRatio);
         shader.setUniform('xAxisPointRange', axis.pointRange);
-        shader.setUniform('xAxisLen', axis.len * dpr);
-        shader.setUniform('xAxisPos', axis.pos * dpr);
+        shader.setUniform('xAxisLen', axis.len * pixelRatio);
+        shader.setUniform('xAxisPos', axis.pos * pixelRatio);
         shader.setUniform('xAxisCVSCoord', (!axis.horiz) as any);
         shader.setUniform('xAxisIsLog', (!!axis.logarithmic) as any);
         shader.setUniform('xAxisReversed', (!!axis.reversed) as any);
@@ -1187,12 +1195,14 @@ function GLRenderer(
             return;
         }
 
-        shader.setUniform('yAxisTrans', axis.transA * dpr);
+        const pixelRatio = getPixelRatio();
+
+        shader.setUniform('yAxisTrans', axis.transA * pixelRatio);
         shader.setUniform('yAxisMin', axis.min as any);
-        shader.setUniform('yAxisMinPad', axis.minPixelPadding * dpr);
+        shader.setUniform('yAxisMinPad', axis.minPixelPadding * pixelRatio);
         shader.setUniform('yAxisPointRange', axis.pointRange);
-        shader.setUniform('yAxisLen', axis.len * dpr);
-        shader.setUniform('yAxisPos', axis.pos * dpr);
+        shader.setUniform('yAxisLen', axis.len * pixelRatio);
+        shader.setUniform('yAxisPos', axis.pos * pixelRatio);
         shader.setUniform('yAxisCVSCoord', (!axis.horiz) as any);
         shader.setUniform('yAxisIsLog', (!!axis.logarithmic) as any);
         shader.setUniform('yAxisReversed', (!!axis.reversed) as any);
@@ -1216,9 +1226,10 @@ function GLRenderer(
      */
     function render(chart: Chart): (false|undefined) {
 
+        const pixelRatio = getPixelRatio();
         if (chart) {
-            width = chart.chartWidth * dpr;
-            height = chart.chartHeight * dpr;
+            width = chart.chartWidth * pixelRatio;
+            height = chart.chartHeight * pixelRatio;
         } else {
             return false;
         }

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -1395,11 +1395,10 @@ function GLRenderer(
             setThreshold(hasThreshold, translatedThreshold as any);
 
             if (s.drawMode === 'points') {
-                if (options.marker && isNumber(options.marker.radius)) {
-                    shader.setPointSize(options.marker.radius * 2.0);
-                } else {
-                    shader.setPointSize(1);
-                }
+                shader.setPointSize(pick(
+                    options.marker && options.marker.radius,
+                    0.5
+                ) * 2 * pixelRatio);
             }
 
             // If set to true, the toPixels translations in the shader
@@ -1407,7 +1406,12 @@ function GLRenderer(
             shader.setSkipTranslation(s.skipTranslation);
 
             if (s.series.type === 'bubble') {
-                shader.setBubbleUniforms(s.series as any, s.zMin, s.zMax);
+                shader.setBubbleUniforms(
+                    s.series as any,
+                    s.zMin,
+                    s.zMax,
+                    pixelRatio
+                );
             }
 
             shader.setDrawAsCircle(
@@ -1427,11 +1431,11 @@ function GLRenderer(
             }
 
             if (s.hasMarkers && showMarkers) {
-                if (options.marker && isNumber(options.marker.radius)) {
-                    shader.setPointSize(options.marker.radius * 2.0);
-                } else {
-                    shader.setPointSize(10);
-                }
+                shader.setPointSize(pick(
+                    options.marker && options.marker.radius,
+                    5
+                ) * 2 * pixelRatio);
+
                 shader.setDrawAsCircle(true);
                 for (sindex = 0; sindex < s.segments.length; sindex++) {
                     vbuffer.render(

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -492,14 +492,20 @@ function GLRenderer(
         ): void {
             pushColor(color);
 
-            if (pixelRatio !== 1 && !settings.useGPUTranslations) {
+            // Correct for pixel ratio
+            if (
+                pixelRatio !== 1 && (
+                    !settings.useGPUTranslations ||
+                    inst.skipTranslation
+                )
+            ) {
                 x *= pixelRatio;
                 y *= pixelRatio;
                 pointSize *= pixelRatio;
             }
 
             if (settings.usePreallocated) {
-                vbuffer.push(x, y, checkTreshold ? 1 : 0, pointSize || 1);
+                vbuffer.push(x, y, checkTreshold ? 1 : 0, pointSize);
                 vlen += 4;
             } else {
                 data.push(x);
@@ -646,7 +652,7 @@ function GLRenderer(
                     // better color interpolation.
 
                     // If there's stroking, we do an additional rect
-                    if (series.type === 'treemap') {
+                    if (series.is('treemap')) {
                         swidth = swidth || 1;
                         scolor = color(pointAttr.stroke).rgba as any;
 
@@ -662,12 +668,12 @@ function GLRenderer(
                     //     swidth = 0;
                     // }
 
-                    // Fixes issues with inverted heatmaps (see #6981)
-                    // The root cause is that the coordinate system is flipped.
-                    // In other words, instead of [0,0] being top-left, it's
+                    // Fixes issues with inverted heatmaps (see #6981). The root
+                    // cause is that the coordinate system is flipped. In other
+                    // words, instead of [0,0] being top-left, it's
                     // bottom-right. This causes a vertical and horizontal flip
                     // in the resulting image, making it rotated 180 degrees.
-                    if (series.type === 'heatmap' && chart.inverted) {
+                    if (series.is('heatmap') && chart.inverted) {
                         x = xAxis.len - x;
                         y = yAxis.len - y;
                         width = -width;

--- a/ts/Extensions/Boost/WGLShader.ts
+++ b/ts/Extensions/Boost/WGLShader.ts
@@ -38,7 +38,8 @@ declare global {
             setBubbleUniforms(
                 series: BubbleSeries,
                 zCalcMin: number,
-                zCalcMax: number
+                zCalcMax: number,
+                pixelRatio: number
             ): void;
             setColor(color: Array<number>): void;
             setDrawAsCircle(flag?: boolean): void;
@@ -481,7 +482,8 @@ function GLShader(gl: WebGLRenderingContext): (false|Highcharts.BoostGLShader) {
     function setBubbleUniforms(
         series: BubbleSeries,
         zCalcMin: number,
-        zCalcMax: number
+        zCalcMax: number,
+        pixelRatio = 1
     ): void {
         let seriesOptions = series.options,
             zMin = Number.MAX_VALUE,
@@ -515,8 +517,8 @@ function GLShader(gl: WebGLRenderingContext): (false|Highcharts.BoostGLShader) {
             setUniform('bubbleZMin', zMin);
             setUniform('bubbleZMax', zMax);
             setUniform('bubbleZThreshold', series.options.zThreshold as any);
-            setUniform('bubbleMinSize', pxSizes.minPxSize);
-            setUniform('bubbleMaxSize', pxSizes.maxPxSize);
+            setUniform('bubbleMinSize', pxSizes.minPxSize * pixelRatio);
+            setUniform('bubbleMaxSize', pxSizes.maxPxSize * pixelRatio);
         }
     }
 


### PR DESCRIPTION
Added option, `boost.pixelRatio`, providing Retina and device pixel ratio support to the Boost module. 
___

Closes #10096

### Demo
https://jsfiddle.net/highcharts/mbfjL26c/

### Usage
https://github.com/highcharts/highcharts/blob/d5fc68e50dbd5f0f87ef786c2ed01697f0f6c7cb/ts/Extensions/Boost/BoostOptions.ts#L209-L234

### To do
 - [x] Default [is not working](https://github.com/highcharts/highcharts/blob/d5fc68e50dbd5f0f87ef786c2ed01697f0f6c7cb/ts/Extensions/Boost/WGLRenderer.ts#L211-L213). ~~It's time to introduce a DefaultOptions object for the Boost.~~
 - [x] Marker sizes are not scaled up
 - [x] Bubble sizes, probably the same cause
 - [x] Heatmap
 - [x] Treemap