### PR TITLE
bugfix/16800-breadcrumbs-not-showing-names

### DIFF
--- a/ts/Extensions/Breadcrumbs.ts
+++ b/ts/Extensions/Breadcrumbs.ts
@@ -45,7 +45,8 @@ const {
     fireEvent,
     merge,
     pick,
-    defined
+    defined,
+    isString
 } = U;
 
 /* *
@@ -485,7 +486,16 @@ class Breadcrumbs {
                     chart
                 ) || '';
 
-        if (returnText === '← ' && defined(defaultText)) {
+        if (
+            (
+                (
+                    isString(returnText) &&
+                    !returnText.length
+                ) ||
+                returnText === '← '
+            ) &&
+            defined(defaultText)
+        ) {
             returnText = !breadcrumbsOptions.showFullPath ?
                 '← ' + defaultText :
                 defaultText;

--- a/ts/Extensions/Drilldown.ts
+++ b/ts/Extensions/Drilldown.ts
@@ -932,7 +932,9 @@ const createBreadcrumbsList = function (chart: Chart): Array<Breadcrumbs.Breadcr
             if (level.levelNumber + 1 > lastBreadcrumb.level) {
                 list.push({
                     level: level.levelNumber + 1,
-                    levelOptions: level.pointOptions
+                    levelOptions: merge({
+                        name: level.lowerSeries.name
+                    }, level.pointOptions)
                 });
             }
         });


### PR DESCRIPTION
Fixed #16800, breadcrumbs were not showing proper button names.