### PR TITLE
Map projection clipBounds

### DIFF
--- a/samples/highcharts/studies/projection/demo.js
+++ b/samples/highcharts/studies/projection/demo.js
@@ -85,7 +85,8 @@ const drawMap = projectionKey => {
         },
         lcc: {
             name: 'LambertConformalConic',
-            parallels: [-30, -40]
+            parallels: [30, 40],
+            clipBounds: { x1: -250, y1: -250, x2: 250, y2: 250 }
         },
         miller: {
             name: 'Miller'

--- a/ts/Maps/MapViewOptionsDefault.ts
+++ b/ts/Maps/MapViewOptionsDefault.ts
@@ -17,7 +17,6 @@
  * */
 
 import type MapViewOptions from './MapViewOptions';
-import D from '../Core/DefaultOptions.js';
 
 /**
  * The `mapView` options control the initial view of the chart, and how

--- a/ts/Maps/Projection.ts
+++ b/ts/Maps/Projection.ts
@@ -587,9 +587,12 @@ export default class Projection {
                                     lastValidLonLat,
                                     lonLat
                                 );
-                                greatCircle.forEach((lonLat): void =>
-                                    pushToPath(postclip.forward(lonLat)));
-
+                                greatCircle.forEach((lonLat): void => {
+                                    const p = postclip.forward(lonLat);
+                                    if (!isNaN(p[0])) {
+                                        pushToPath(p);
+                                    }
+                                });
                             // For lines, just jump over the gap
                             } else {
                                 movedTo = false;
@@ -628,6 +631,7 @@ export default class Projection {
             }
 
         }
+
         return path;
     }
 }

--- a/ts/Maps/ProjectionOptions.d.ts
+++ b/ts/Maps/ProjectionOptions.d.ts
@@ -8,11 +8,14 @@
  *
  * */
 
+import type { MapBounds } from './MapViewOptions';
+
 export type ProjectionRotationOption = (
     [number, number]|[number, number, number]
 );
 
 export interface ProjectionOptions {
+    clipBounds?: MapBounds;
     name?: string;
     parallels?: number[];
     rotation?: ProjectionRotationOption;


### PR DESCRIPTION
Needed to prevent an LCC projection of the world from going into infinity (and the continents imploding into a singularity). Not documented yet, awaiting merging of the Map Inset PR.