### PR TITLE
bugfix/16479-resetZoomButton-drillup 

### DIFF
--- a/samples/unit-tests/drilldown/resetzoom/demo.js
+++ b/samples/unit-tests/drilldown/resetzoom/demo.js
@@ -435,11 +435,25 @@ QUnit.test('Drilldown and reset zoom should not crash the chart, #8095.', functi
         'Buttons should not overlap.'
     );
 
-    //chart.drillUp();
     Highcharts.fireEvent(chart.breadcrumbs, 'up', { newLevel: 1 });
     chart.series[0].points[0].doDrilldown();
 
     assert.ok(
         'No errors in the console.'
+    );
+
+    // Reset chart to initial state.
+    Highcharts.fireEvent(chart.resetZoomButton.element, 'click');
+    chart.drillUp();
+
+    // Zoom in basic level.
+    controller.pan([100, 200], [300, 200]);
+
+    chart.series[0].points[0].doDrilldown();
+    chart.drillUp();
+    assert.strictEqual(
+        typeof chart.resetZoomButton,
+        'object',
+        'Reset zoom button should be visible again.'
     );
 });

--- a/ts/Extensions/Drilldown.ts
+++ b/ts/Extensions/Drilldown.ts
@@ -1033,8 +1033,6 @@ Chart.prototype.drillUp = function (): void {
                     level.seriesOptions
             });
 
-            this.resetZoomButton && this.resetZoomButton.destroy(); // #8095
-
             if ((newSeries as any).type === oldSeries.type) {
                 (newSeries as any).drilldownLevel = level;
                 (newSeries as any).options.animation =
@@ -1067,7 +1065,6 @@ Chart.prototype.drillUp = function (): void {
             // it to the chart and show it.
             if (level.resetZoomButton) {
                 chart.resetZoomButton = level.resetZoomButton;
-                chart.resetZoomButton.show();
             }
         }
     }
@@ -1791,5 +1788,11 @@ addEvent(Point, 'afterSetState', function (): void {
 addEvent(Chart, 'drillup', function (): void {
     if (this.resetZoomButton) {
         this.resetZoomButton = this.resetZoomButton.destroy();
+    }
+});
+
+addEvent(Chart, 'drillupall', function (): void {
+    if (this.resetZoomButton) {
+        this.showResetZoom();
     }
 });


### PR DESCRIPTION
Fixed #16479, `resetZoomButton` was not visible after drilling up to a level with zoom.