### PR TITLE
bugfix/16568-data-options-merging

### DIFF
--- a/samples/unit-tests/data/general/demo.js
+++ b/samples/unit-tests/data/general/demo.js
@@ -205,7 +205,13 @@ QUnit.test('Combination charts and column mapping', function (assert) {
     );
 });
 
-QUnit.test('Data config on updates', function (assert) {
+QUnit.test('Data config on updates and setOptions', function (assert) {
+    Highcharts.setOptions({
+        data: {
+            endRow: 2
+        }
+    });
+
     var chart = Highcharts.chart('container', {
             data: {
                 csv: [
@@ -241,6 +247,12 @@ QUnit.test('Data config on updates', function (assert) {
         chart.series.length,
         oldDataLength,
         'Switching back switchRowsAndColumns should restore number of series (#11095).'
+    );
+
+    assert.strictEqual(
+        chart.series.length,
+        2,
+        'Global data options should be merged with the chart options (#16568).'
     );
 });
 

--- a/samples/unit-tests/data/general/demo.js
+++ b/samples/unit-tests/data/general/demo.js
@@ -1,3 +1,5 @@
+const defaultOptions = { ...Highcharts.defaultOptions };
+
 QUnit.test(
     'Parsing dates with timezone information (#10322)',
     function (assert) {
@@ -254,6 +256,11 @@ QUnit.test('Data config on updates and setOptions', function (assert) {
         2,
         'Global data options should be merged with the chart options (#16568).'
     );
+    
+    // Back to default options after test.
+    Highcharts.setOptions({
+        data: null
+    });
 });
 
 QUnit.test(

--- a/samples/unit-tests/data/general/demo.js
+++ b/samples/unit-tests/data/general/demo.js
@@ -1,5 +1,3 @@
-const defaultOptions = { ...Highcharts.defaultOptions };
-
 QUnit.test(
     'Parsing dates with timezone information (#10322)',
     function (assert) {
@@ -257,10 +255,8 @@ QUnit.test('Data config on updates and setOptions', function (assert) {
         'Global data options should be merged with the chart options (#16568).'
     );
     
-    // Back to default options after test.
-    Highcharts.setOptions({
-        data: null
-    });
+    // Clear the default options for other tests
+    delete Highcharts.defaultOptions.data;
 });
 
 QUnit.test(

--- a/ts/Extensions/Data.ts
+++ b/ts/Extensions/Data.ts
@@ -30,6 +30,8 @@ import Point from '../Core/Series/Point.js';
 import SeriesRegistry from '../Core/Series/SeriesRegistry.js';
 const { seriesTypes } = SeriesRegistry;
 import U from '../Core/Utilities.js';
+import D from '../Core/DefaultOptions.js';
+const { getOptions } = D;
 const {
     addEvent,
     defined,
@@ -2599,8 +2601,12 @@ addEvent(
         let chart = this, // eslint-disable-line no-invalid-this
             userOptions: Partial<Options> = (e.args[0] || {}),
             callback = e.args[1];
+        const defaultDataOptions = getOptions().data;
 
-        if (userOptions && userOptions.data && !chart.hasDataDef) {
+        if (
+            (defaultDataOptions || userOptions && userOptions.data) &&
+            !chart.hasDataDef
+        ) {
             chart.hasDataDef = true;
             /**
              * The data parser for this chart.
@@ -2608,7 +2614,10 @@ addEvent(
              * @name Highcharts.Chart#data
              * @type {Highcharts.Data|undefined}
              */
-            chart.data = new G.Data(extend(userOptions.data, {
+
+            const dataOptions = merge(defaultDataOptions, userOptions.data);
+
+            chart.data = new G.Data(extend(dataOptions, {
 
                 afterComplete: function (
                     dataOptions?: Partial<Options>


### PR DESCRIPTION
Fixed #16568, setting `data` options with `Highcharts.setOptions` did not work.

~~Fixed #16568, merging global data options with the chart options.~~