### PR TITLE
bugfix/16169-centerInCategory-reverses-stack 

### DIFF
--- a/samples/unit-tests/series/stacking/demo.js
+++ b/samples/unit-tests/series/stacking/demo.js
@@ -699,4 +699,46 @@ QUnit.test('Date objects as X values, column', function (assert) {
             'Series 3 - Point should start from value=1 (#4024)'
         );
     });
+
+    QUnit.test(
+        'The centerInCategory, reversedStacks order of stacks, #16169.',
+        function (assert) {
+            const chart = Highcharts.chart('container', {
+                    chart: {
+                        type: "column"
+                    },
+                    plotOptions: {
+                        column: {
+                            stacking: "normal",
+                            centerInCategory: true
+                        }
+                    },
+                    yAxis: {
+                        reversedStacks: false,
+                        stackLabels: {
+                            enabled: true
+                        }
+                    },
+                    series: [{
+                        data: [5],
+                        id: 0
+                    }, {
+                        data: [2],
+                        id: 1
+                    }, {
+                        data: [4],
+                        stack: "1"
+                    }, {
+                        data: [1],
+                        stack: "1"
+                    }]
+                }),
+                series = chart.series;
+
+            assert.ok(
+                series[0].points[0].barX < series[2].points[0].barX,
+                `Enabling centerInCategory and setting reversedStacks to false
+                should not affect the stack order.`
+            );
+        });
 }());

--- a/samples/unit-tests/series/stacking/demo.js
+++ b/samples/unit-tests/series/stacking/demo.js
@@ -705,11 +705,11 @@ QUnit.test('Date objects as X values, column', function (assert) {
         function (assert) {
             const chart = Highcharts.chart('container', {
                     chart: {
-                        type: "column"
+                        type: 'column'
                     },
                     plotOptions: {
                         column: {
-                            stacking: "normal",
+                            stacking: 'normal',
                             centerInCategory: true
                         }
                     },
@@ -720,17 +720,15 @@ QUnit.test('Date objects as X values, column', function (assert) {
                         }
                     },
                     series: [{
-                        data: [5],
-                        id: 0
+                        data: [5]
                     }, {
-                        data: [2],
-                        id: 1
+                        data: [2]
                     }, {
                         data: [4],
-                        stack: "1"
+                        stack: '1'
                     }, {
                         data: [1],
-                        stack: "1"
+                        stack: '1'
                     }]
                 }),
                 series = chart.series;

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -823,7 +823,7 @@ class ColumnSeries extends Series {
                                     indexInCategory = totalInCategory;
                                 }
                                 if (stackItem.hasValidPoints) {
-                                    reversedStacks ?
+                                    reversedStacks ? // #16169
                                         totalInCategory++ : totalInCategory--;
                                 }
 

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -793,8 +793,9 @@ class ColumnSeries extends Series {
     ): number {
         const stacking = this.options.stacking;
         if (!point.isNull && metrics.columnCount > 1) {
-            let indexInCategory = 0;
-            let totalInCategory = 0;
+            const reversedStacks = this.yAxis.options.reversedStacks;
+            let indexInCategory = 0,
+                totalInCategory = reversedStacks ? 0 : -metrics.columnCount;
 
             // Loop over all the stacks on the Y axis. When stacking is enabled,
             // these are real point stacks. When stacking is not enabled, but
@@ -822,7 +823,8 @@ class ColumnSeries extends Series {
                                     indexInCategory = totalInCategory;
                                 }
                                 if (stackItem.hasValidPoints) {
-                                    totalInCategory++;
+                                    reversedStacks ?
+                                        totalInCategory++ : totalInCategory--;
                                 }
 
                             // If `stacking` is not enabled, look for the index


### PR DESCRIPTION
Fixed #16169, stack order was affected when `centerInCategory` enabled and `reversedStacks` set to false.