### PR TITLE
Map projection clipping

### DIFF
--- a/samples/maps/mapview/projection-explorer/demo.html
+++ b/samples/maps/mapview/projection-explorer/demo.html
@@ -10,7 +10,7 @@
 <hr>
 
 <div id="projection-buttons" class="buttons">
-    <h4 class="mt-4">Flat projections</h4>
+    <h4 class="mt-4">Cylindrical and conic projections</h4>
     <div class="btn-group">
         <button id="equalearth" class="btn btn-outline-secondary">Equal Earth</button>
         <button id="miller" class="btn btn-outline-secondary">Miller</button>

--- a/samples/maps/mapview/projection-explorer/demo.js
+++ b/samples/maps/mapview/projection-explorer/demo.js
@@ -298,7 +298,7 @@
         });
     };
 
-    drawMap('equalearth');
+    drawMap('webmerc');
 
     enableInputs();
 })();

--- a/samples/maps/mapview/projection-explorer/demo.js
+++ b/samples/maps/mapview/projection-explorer/demo.js
@@ -142,8 +142,7 @@
 
             chart = Highcharts.mapChart('container', {
                 chart: {
-                    map: topology,
-                    plotBorderWidth: 1
+                    map: topology
                 },
 
                 title: {

--- a/samples/maps/mapview/projection-explorer/demo.js
+++ b/samples/maps/mapview/projection-explorer/demo.js
@@ -142,7 +142,8 @@
 
             chart = Highcharts.mapChart('container', {
                 chart: {
-                    map: topology
+                    map: topology,
+                    plotBorderWidth: 1
                 },
 
                 title: {

--- a/samples/maps/mapview/projection-explorer/demo.js
+++ b/samples/maps/mapview/projection-explorer/demo.js
@@ -10,6 +10,10 @@
         'https://code.highcharts.com/mapdata/custom/world.topo.json'
     ).then(response => response.json());
 
+    const antarctica = await fetch(
+        'https://code.highcharts.com/mapdata/custom/antarctica.topo.json'
+    ).then(response => response.json());
+
     const data = getRandomData(topology);
 
     // Get the graticule, the grid of meridians an parallels.
@@ -210,6 +214,12 @@
                         format: '{point.name}'
                     },
                     clip: false
+                }, {
+                    mapData: antarctica,
+                    allAreas: true,
+                    name: 'Antarctica',
+                    clip: false,
+                    opacity: 0.75
                 }, {
                     type: 'mapline',
                     data: [{

--- a/samples/maps/mapview/projection-explorer/demo.js
+++ b/samples/maps/mapview/projection-explorer/demo.js
@@ -297,7 +297,7 @@
         });
     };
 
-    drawMap('webmerc');
+    drawMap('equalearth');
 
     enableInputs();
 })();

--- a/ts/Maps/MapView.ts
+++ b/ts/Maps/MapView.ts
@@ -662,7 +662,6 @@ class MapView {
                             projection: {
                                 rotation: [-lon, -lat]
                             },
-                            center: [lon, lat],
                             zoom: this.zoom
                         }, true, false);
 

--- a/ts/Maps/MapViewOptions.d.ts
+++ b/ts/Maps/MapViewOptions.d.ts
@@ -38,6 +38,8 @@ export type MapViewPaddingType = (
     [number|string, number|string, number|string, number|string]
 );
 
+export type ProjectedXYArray = [number, number] & { outside?: boolean };
+
 export interface ProjectedXY {
     x: number;
     y: number;

--- a/ts/Maps/Projection.ts
+++ b/ts/Maps/Projection.ts
@@ -15,7 +15,8 @@ import type {
 } from './GeoJSON';
 import type {
     LonLatArray,
-    MapBounds
+    MapBounds,
+    ProjectedXYArray
 } from './MapViewOptions';
 import type { ProjectionDefinition, Projector } from './ProjectionDefinition';
 import type {
@@ -181,13 +182,13 @@ export default class Projection {
         }
 
         if (rotator && def) {
-            this.forward = (lonLat): [number, number] =>
+            this.forward = (lonLat): LonLatArray =>
                 def.forward(rotator.forward(lonLat));
-            this.inverse = (xy): [number, number] =>
+            this.inverse = (xy): ProjectedXYArray =>
                 rotator.inverse(def.inverse(xy));
         } else if (def) {
-            this.forward = (lonLat): [number, number] => def.forward(lonLat);
-            this.inverse = (xy): [number, number] => def.inverse(xy);
+            this.forward = (lonLat): LonLatArray => def.forward(lonLat);
+            this.inverse = (xy): ProjectedXYArray => def.inverse(xy);
         } else if (rotator) {
             this.forward = rotator.forward;
             this.inverse = rotator.inverse;
@@ -197,6 +198,92 @@ export default class Projection {
         this.bounds = projectedBounds === 'world' ?
             def && def.bounds :
             projectedBounds;
+    }
+
+    public lineIntersectsBounds(line: ProjectedXYArray[]): ProjectedXYArray {
+        const { x1, x2, y1, y2 } = this.bounds || {};
+
+        const getIntersect = (
+            line: ProjectedXYArray[],
+            dim: 0|1,
+            val?: number
+        ): ProjectedXYArray|undefined => {
+            const [p1, p2] = line,
+                otherDim = dim ? 0 : 1;
+            // Check if points are on either side of the line
+            if (typeof val === 'number' && p1[dim] >= val !== p2[dim] >= val) {
+                const fraction = ((val - p1[dim]) / (p2[dim] - p1[dim])),
+                    crossingVal = p1[otherDim] +
+                        fraction * (p2[otherDim] - p1[otherDim]);
+                return dim ? [crossingVal, val] : [val, crossingVal];
+            }
+        };
+
+        let intersection: ProjectedXYArray|undefined,
+            ret = line[0];
+
+        if ((intersection = getIntersect(line, 0, x1))) {
+            ret = intersection;
+
+            // Assuming line[1] was originally outside, replace it with the
+            // intersection point so that the horizontal intersection will
+            // be correct.
+            line[1] = intersection;
+        } else if ((intersection = getIntersect(line, 0, x2))) {
+            ret = intersection;
+            line[1] = intersection;
+        }
+
+        if ((intersection = getIntersect(line, 1, y1))) {
+            ret = intersection;
+        } else if ((intersection = getIntersect(line, 1, y2))) {
+            ret = intersection;
+        }
+
+        return ret;
+    }
+
+    // Get the intermediate points along the perimeter of the bounds, in
+    // practice the corners
+    public getBoundsPerimeter(
+        p1: ProjectedXYArray,
+        p2: ProjectedXYArray
+    ): ProjectedXYArray[] {
+        const corners: ProjectedXYArray[] = [];
+
+        // If they're on the same side, no interpolation
+        if (p1[0] === p2[0] || p1[1] === p2[1]) {
+            return corners;
+        }
+
+        let addCorner = false;
+
+        if (this.bounds) {
+            const { x1, x2, y1, y2 } = this.bounds,
+                sides = [x1, y2, x2, y1, x1, y2, x2];
+            sides.forEach((val, side): void => {
+                const dim = side % 2;
+                if (addCorner) {
+                    corners.push(
+                        dim === 0 ?
+                            [val, sides[side - 1]] :
+                            [sides[side - 1], val]
+                    );
+                }
+                if (Math.abs(p1[dim] - val) < 0.5) {
+                    addCorner = true;
+                }
+                if (Math.abs(p2[dim] - val) < 0.5) {
+                    addCorner = false;
+                }
+            });
+        }
+        // Going the long way around the perimeter, try the other way around
+        if (corners.length > 2) {
+            return this.getBoundsPerimeter(p2, p1);
+        }
+
+        return corners;
     }
 
     /*
@@ -267,13 +354,13 @@ export default class Projection {
 
     // Project a lonlat coordinate position to xy. Dynamically overridden when
     // projection is set.
-    public forward(lonLat: [number, number]): [number, number] {
+    public forward(lonLat: LonLatArray): ProjectedXYArray {
         return lonLat;
     }
 
-    // Project an xy chart coordinate position to lonlat. Dynamically overridden
-    // when projection is set.
-    public inverse(xy: [number, number]): [number, number] {
+    // Unproject an xy chart coordinate position to lonlat. Dynamically
+    // overridden when projection is set.
+    public inverse(xy: ProjectedXYArray): LonLatArray {
         return xy;
     }
 
@@ -315,8 +402,7 @@ export default class Projection {
             ) {
 
                 // Interpolate to the intersection latitude
-                const fraction = (antimeridian - previousLonLat[0]) /
-                    (lonLat[0] - previousLonLat[0]);
+                const fraction = -lon1 / (lon2 - lon1);
                 const lat = previousLonLat[1] +
                     fraction * (lonLat[1] - previousLonLat[1]);
 
@@ -532,10 +618,12 @@ export default class Projection {
                     return;
                 }
 
-                let movedTo = false;
-                let firstValidLonLat: LonLatArray|undefined;
-                let lastValidLonLat: LonLatArray|undefined;
-                let gap = false;
+                let movedTo = false,
+                    firstValidLonLat: LonLatArray|undefined,
+                    lastValidLonLat: LonLatArray|undefined,
+                    lastValidPoint: ProjectedXYArray|undefined,
+                    lastInvalidPoint: ProjectedXYArray|undefined;
+
                 const pushToPath = (point: [number, number]): void => {
                     if (!movedTo) {
                         path.push(['M', point[0], point[1]]);
@@ -546,19 +634,10 @@ export default class Projection {
                 };
 
                 for (let i = 0; i < poly.length; i++) {
-                    const lonLat = poly[i];
+                    const lonLat = poly[i],
+                        point = postclip.forward(lonLat);
 
-                    const point = postclip.forward(lonLat);
-
-                    const valid = (
-                        /*
-                        !isNaN(point[0]) &&
-                        !isNaN(point[1]) &&
-                        */
-                        !point.outside
-                    );
-
-                    if (valid) {
+                    if (!point.outside) {
 
                         // In order to be able to interpolate if the first or
                         // last point is invalid (on the far side of the globe
@@ -566,13 +645,18 @@ export default class Projection {
                         // first valid point to the end of the polygon.
                         if (isPolygon && !firstValidLonLat) {
                             firstValidLonLat = lonLat;
+                            // To get the intersection right we need the last
+                            // invalid point too.
+                            if (poly[i - 1]) {
+                                poly.push(poly[i - 1]);
+                            }
                             poly.push(lonLat);
                         }
 
                         // When entering the first valid point after a gap of
                         // invalid points, typically on the far side of the
                         // globe in an orthographic projection.
-                        if (gap && lastValidLonLat) {
+                        if (lastInvalidPoint && lastValidLonLat) {
 
                             // For areas, in an orthographic projection, the
                             // great circle between two visible points will be
@@ -582,17 +666,34 @@ export default class Projection {
                             // rewrite this to use the small circle related to
                             // the current lon0 and lat0.
                             if (isPolygon && hasGeoProjection) {
-                                const greatCircle = Projection.greatCircle(
-                                    lastValidLonLat,
-                                    lonLat
-                                );
-                                greatCircle.forEach((lonLat): void => {
-                                    const p = postclip.forward(lonLat);
-                                    // if (!isNaN(p[0])) {
-                                    if (!p.outside) {
-                                        pushToPath(p);
+
+                                if (this.bounds) {
+                                    const intersection = this
+                                        .lineIntersectsBounds([
+                                            point, lastInvalidPoint
+                                        ]);
+                                    if (lastValidPoint) {
+                                        // Push the intermediate points
+                                        this.getBoundsPerimeter(
+                                            lastValidPoint,
+                                            intersection
+                                        ).forEach(pushToPath);
                                     }
-                                });
+                                    pushToPath(intersection);
+                                    // perimeter.forEach()
+                                } else {
+                                    const greatCircle = Projection.greatCircle(
+                                        lastValidLonLat,
+                                        lonLat
+                                    );
+                                    greatCircle.forEach((lonLat): void => {
+                                        const p = postclip.forward(lonLat);
+                                        // if (!isNaN(p[0])) {
+                                        if (!p.outside) {
+                                            pushToPath(p);
+                                        }
+                                    });
+                                }
                             // For lines, just jump over the gap
                             } else {
                                 movedTo = false;
@@ -602,9 +703,16 @@ export default class Projection {
                         pushToPath(point);
 
                         lastValidLonLat = lonLat;
-                        gap = false;
+                        lastValidPoint = point;
+                        lastInvalidPoint = void 0;
                     } else {
-                        gap = true;
+                        if (lastValidPoint && !lastInvalidPoint) {
+                            lastValidPoint = this.lineIntersectsBounds([
+                                lastValidPoint, point
+                            ]);
+                            pushToPath(lastValidPoint);
+                        }
+                        lastInvalidPoint = point;
                     }
                 }
             });

--- a/ts/Maps/Projection.ts
+++ b/ts/Maps/Projection.ts
@@ -552,15 +552,7 @@ export default class Projection {
 
                     const valid = (
                         !isNaN(point[0]) &&
-                        !isNaN(point[1]) &&
-                        (
-                            !hasGeoProjection ||
-                            // Limited projections like Web Mercator
-                            (
-                                lonLat[1] <= this.maxLatitude &&
-                                lonLat[1] >= -this.maxLatitude
-                            )
-                        )
+                        !isNaN(point[1])
                     );
 
                     if (valid) {

--- a/ts/Maps/Projection.ts
+++ b/ts/Maps/Projection.ts
@@ -551,8 +551,11 @@ export default class Projection {
                     const point = postclip.forward(lonLat);
 
                     const valid = (
+                        /*
                         !isNaN(point[0]) &&
-                        !isNaN(point[1])
+                        !isNaN(point[1]) &&
+                        */
+                        !point.outside
                     );
 
                     if (valid) {
@@ -585,7 +588,8 @@ export default class Projection {
                                 );
                                 greatCircle.forEach((lonLat): void => {
                                     const p = postclip.forward(lonLat);
-                                    if (!isNaN(p[0])) {
+                                    // if (!isNaN(p[0])) {
+                                    if (!p.outside) {
                                         pushToPath(p);
                                     }
                                 });

--- a/ts/Maps/Projection.ts
+++ b/ts/Maps/Projection.ts
@@ -565,7 +565,7 @@ export default class Projection {
         // pre-projected.
         const hasGeoProjection = this.hasGeoProjection;
 
-        // @todo better test for when to do this
+        // @todo better test for when to do this (use clipAngle = 90?)
         const projectingToPlane = this.options.name !== 'Orthographic';
         // We need to rotate in a separate step before applying antimeridian
         // clipping
@@ -657,11 +657,13 @@ export default class Projection {
                         // invalid points, typically on the far side of the
                         // globe in an orthographic projection.
                         if (lastInvalidPoint) {
-
-                            const intersection = this.bounds && this
-                                .lineIntersectsBounds([
-                                    point, lastInvalidPoint
-                                ]);
+                            const intersection = (
+                                this.bounds &&
+                                projectingToPlane &&
+                                this.lineIntersectsBounds(
+                                    [point, lastInvalidPoint]
+                                )
+                            );
 
                             if (isPolygon && hasGeoProjection) {
 

--- a/ts/Maps/ProjectionDefinition.d.ts
+++ b/ts/Maps/ProjectionDefinition.d.ts
@@ -8,23 +8,31 @@
  *
  * */
 
-import type { MapBounds } from './MapViewOptions';
+import type {
+    LonLatArray,
+    MapBounds,
+    ProjectedXYArray
+} from './MapViewOptions';
 import type ProjectionOptions from './ProjectionOptions';
 
-export interface ProjectionFunction {
-    (coords: [number, number]): [number, number];
+export interface ProjectionForwardFunction {
+    (coords: LonLatArray): ProjectedXYArray;
+}
+
+export interface ProjectionInverseFunction {
+    (xy: ProjectedXYArray): LonLatArray;
 }
 
 export interface Projector {
-    forward: ProjectionFunction;
-    inverse: ProjectionFunction;
+    forward: ProjectionForwardFunction;
+    inverse: ProjectionInverseFunction;
 }
 
 export declare class ProjectionDefinition {
     constructor(options: ProjectionOptions);
     bounds?: MapBounds;
-    forward: ProjectionFunction;
-    inverse: ProjectionFunction;
+    forward: ProjectionForwardFunction;
+    inverse: ProjectionInverseFunction;
     maxLatitude?: number;
 }
 

--- a/ts/Maps/Projections/EqualEarth.ts
+++ b/ts/Maps/Projections/EqualEarth.ts
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type { LonLatArray } from '../MapViewOptions';
+import type { LonLatArray, ProjectedXYArray } from '../MapViewOptions';
 import type ProjectionDefinition from '../ProjectionDefinition';
 
 const A1 = 1.340264,
@@ -29,7 +29,7 @@ export default class EqualEarth implements ProjectionDefinition {
         y2: 97.52595454902263
     };
 
-    forward(lonLat: LonLatArray): [number, number] {
+    forward(lonLat: LonLatArray): ProjectedXYArray {
         const d = Math.PI / 180,
             paramLat = Math.asin(M * Math.sin(lonLat[1] * d)),
             paramLatSq = paramLat * paramLat,
@@ -50,7 +50,7 @@ export default class EqualEarth implements ProjectionDefinition {
         return [x, y];
     }
 
-    inverse(xy: [number, number]): LonLatArray {
+    inverse(xy: ProjectedXYArray): LonLatArray {
         const x = xy[0] / scale,
             y = xy[1] / scale,
             d = 180 / Math.PI,

--- a/ts/Maps/Projections/LambertConformalConic.ts
+++ b/ts/Maps/Projections/LambertConformalConic.ts
@@ -3,7 +3,11 @@
  * */
 
 'use strict';
-import type { LonLatArray, MapBounds } from '../MapViewOptions';
+import type {
+    LonLatArray,
+    MapBounds,
+    ProjectedXYArray
+} from '../MapViewOptions';
 import type ProjectionDefinition from '../ProjectionDefinition';
 import type ProjectionOptions from '../ProjectionOptions';
 
@@ -47,7 +51,7 @@ export default class LambertConformalConic implements ProjectionDefinition {
 
     }
 
-    forward(lonLat: LonLatArray): [number, number] {
+    forward(lonLat: LonLatArray): ProjectedXYArray {
         const lon = lonLat[0] * deg2rad,
             { c, n, projectedBounds } = this;
         let lat = lonLat[1] * deg2rad;
@@ -62,7 +66,8 @@ export default class LambertConformalConic implements ProjectionDefinition {
         }
         const r = c / Math.pow(tany(lat), n),
             x = r * Math.sin(n * lon) * scale,
-            y = (c - r * Math.cos(n * lon)) * scale;
+            y = (c - r * Math.cos(n * lon)) * scale,
+            xy: ProjectedXYArray = [x, y];
 
         if (
             projectedBounds && (
@@ -72,14 +77,12 @@ export default class LambertConformalConic implements ProjectionDefinition {
                 y > projectedBounds.y2
             )
         ) {
-            return [NaN, NaN];
+            xy.outside = true;
         }
-        return [
-            x, y
-        ];
+        return xy;
     }
 
-    inverse(xy: [number, number]): LonLatArray {
+    inverse(xy: ProjectedXYArray): LonLatArray {
         const x = xy[0] / scale,
             y = xy[1] / scale,
             { c, n } = this,

--- a/ts/Maps/Projections/Miller.ts
+++ b/ts/Maps/Projections/Miller.ts
@@ -3,7 +3,7 @@
  * */
 
 'use strict';
-import type { LonLatArray } from '../MapViewOptions';
+import type { LonLatArray, ProjectedXYArray } from '../MapViewOptions';
 import type ProjectionDefinition from '../ProjectionDefinition';
 
 const quarterPI = Math.PI / 4,
@@ -19,7 +19,7 @@ export default class Miller implements ProjectionDefinition {
         y2: 146.91480769173063
     };
 
-    forward(lonLat: LonLatArray): [number, number] {
+    forward(lonLat: LonLatArray): ProjectedXYArray {
         return [
             lonLat[0] * deg2rad * scale,
             1.25 * scale * Math.log(
@@ -28,7 +28,7 @@ export default class Miller implements ProjectionDefinition {
         ];
     }
 
-    inverse(xy: [number, number]): LonLatArray {
+    inverse(xy: ProjectedXYArray): LonLatArray {
         return [
             (xy[0] / scale) / deg2rad,
             2.5 * (Math.atan(

--- a/ts/Maps/Projections/Orthographic.ts
+++ b/ts/Maps/Projections/Orthographic.ts
@@ -3,7 +3,7 @@
  * */
 
 'use strict';
-import type { LonLatArray } from '../MapViewOptions';
+import type { LonLatArray, ProjectedXYArray } from '../MapViewOptions';
 import type ProjectionDefinition from '../ProjectionDefinition';
 
 const deg2rad = Math.PI / 180,
@@ -18,22 +18,23 @@ export default class Orthographic implements ProjectionDefinition {
         y2: scale
     };
 
-    forward(lonLat: LonLatArray): [number, number] {
+    forward(lonLat: LonLatArray): ProjectedXYArray {
 
         const lonDeg = lonLat[0],
             latDeg = lonLat[1];
 
-        if (lonDeg < -90 || lonDeg > 90) {
-            return [NaN, NaN];
-        }
         const lat = latDeg * deg2rad;
-        return [
+        const xy: ProjectedXYArray = [
             Math.cos(lat) * Math.sin(lonDeg * deg2rad) * scale,
             Math.sin(lat) * scale
         ];
+        if (lonDeg < -90 || lonDeg > 90) {
+            xy.outside = true;
+        }
+        return xy;
     }
 
-    inverse(xy: [number, number]): LonLatArray {
+    inverse(xy: ProjectedXYArray): LonLatArray {
         const x = xy[0] / scale,
             y = xy[1] / scale,
             z = Math.sqrt(x * x + y * y),

--- a/ts/Maps/Projections/WebMercator.ts
+++ b/ts/Maps/Projections/WebMercator.ts
@@ -4,7 +4,7 @@
 
 'use strict';
 
-import type { LonLatArray } from '../MapViewOptions';
+import type { LonLatArray, ProjectedXYArray } from '../MapViewOptions';
 import type ProjectionDefinition from '../ProjectionDefinition';
 
 const maxLatitude = 85.0511287798, // The latitude that defines a square
@@ -20,21 +20,23 @@ export default class WebMercator implements ProjectionDefinition {
         y2: 200.3750834278071
     };
 
-    forward(lonLat: LonLatArray): [number, number] {
-
-        if (Math.abs(lonLat[1]) > maxLatitude) {
-            return [NaN, NaN];
-        }
+    forward(lonLat: LonLatArray): ProjectedXYArray {
 
         const sinLat = Math.sin(lonLat[1] * deg2rad);
 
-        return [
+        const xy: ProjectedXYArray = [
             r * lonLat[0] * deg2rad,
             r * Math.log((1 + sinLat) / (1 - sinLat)) / 2
         ];
+
+        if (Math.abs(lonLat[1]) > maxLatitude) {
+            xy.outside = true;
+        }
+
+        return xy;
     }
 
-    inverse(xy: [number, number]): LonLatArray {
+    inverse(xy: ProjectedXYArray): LonLatArray {
         return [
             xy[0] / (r * deg2rad),
             (2 * Math.atan(Math.exp(xy[1] / r)) - (Math.PI / 2)) / deg2rad

--- a/ts/Series/MapPoint/MapPointSeries.ts
+++ b/ts/Series/MapPoint/MapPointSeries.ts
@@ -139,8 +139,10 @@ class MapPointSeries extends ScatterSeries {
                     );
                 if (coordinates) {
                     const xy = forward(coordinates);
-                    x = xy[0];
-                    y = xy[1];
+                    if (!(xy as any).outside) {
+                        x = xy[0];
+                        y = xy[1];
+                    }
 
                 // Map bubbles getting geometry from shape
                 } else if (p.bounds) {

--- a/ts/Series/MapPoint/MapPointSeries.ts
+++ b/ts/Series/MapPoint/MapPointSeries.ts
@@ -16,6 +16,7 @@
  *
  * */
 
+import type MapChart from '../../Core/Chart/MapChart';
 import type MapPointSeriesOptions from './MapPointSeriesOptions';
 import H from '../../Core/Globals.js';
 const { noop } = H;
@@ -94,6 +95,7 @@ class MapPointSeries extends ScatterSeries {
      *  Properties
      *
      * */
+    public chart: MapChart = void 0 as any;
 
     public data: Array<MapPointPoint> = void 0 as any;
 
@@ -139,7 +141,7 @@ class MapPointSeries extends ScatterSeries {
                     );
                 if (coordinates) {
                     const xy = forward(coordinates);
-                    if (!(xy as any).outside) {
+                    if (!xy.outside) {
                         x = xy[0];
                         y = xy[1];
                     }


### PR DESCRIPTION
Clipping to the given (or projection default) `projectionBounds`.

### To do
 - [x] Correct clipping in both ends of lines (meridians in the WebMercator projection).
 - [x] Regression with great circle path interpolation.