### PR TITLE
Fixed doclet

### DIFF
--- a/ts/Series/Lollipop/LollipopSeries.ts
+++ b/ts/Series/Lollipop/LollipopSeries.ts
@@ -179,7 +179,7 @@ export default LollipopSeries;
  * The `lollipop` series. If the [type](#series.lollipop.type) option is
  * not specified, it is inherited from [chart.type](#chart.type).
  *
- * @extends   series,plotOptions.lollipop,
+ * @extends   series,plotOptions.lollipop
  * @excluding boostThreshold, boostBlending
  * @product   highcharts highstock
  * @requires  highcharts-more


### PR DESCRIPTION
Just a typo in doclets. The current one creates in `tree.json`: `extends: series,plotOptions.lollipop,`, which splitting by comma will cause searching for `""` (an empty string) as a parent.