### PR TITLE
Docs: Fixed types of PointLabelObject and TooltipFormatterContextObject.

### DIFF
--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -187,7 +187,7 @@ class Axis {
     public axisTitle?: SVGElement;
     public axisTitleMargin?: number;
     public bottom: number = void 0 as any;
-    public categories: Array<string> = void 0 as any;
+    public categories?: Array<string>;
     public chart: Chart = void 0 as any;
     public closestPointRange: number = void 0 as any;
     public coll: string = void 0 as any;
@@ -420,7 +420,7 @@ class Axis {
          * @type {Array<string>}
          * @readonly
          */
-        axis.categories = (options.categories as any) || axis.hasNames;
+        axis.categories = options.categories || (axis.hasNames ? [] : void 0);
         if (!axis.names) { // Preserve on update (#3830)
             axis.names = [];
             (axis.names as any).keys = {};
@@ -1366,7 +1366,7 @@ class Axis {
      * The X value that the point is given.
      */
     public nameToX(point: Point): number {
-        const explicitCategories = isArray(this.categories),
+        const explicitCategories = isArray(this.options.categories),
             names = explicitCategories ? this.categories : this.names;
 
         let nameX = point.options.x,
@@ -1375,7 +1375,7 @@ class Axis {
         point.series.requireSorting = false;
 
         if (!defined(nameX)) {
-            nameX = this.options.uniqueNames ?
+            nameX = this.options.uniqueNames && names ?
                 (
                     explicitCategories ?
                         names.indexOf(point.name) :
@@ -1385,8 +1385,8 @@ class Axis {
                 point.series.autoIncrement();
         }
         if (nameX === -1) { // Not found in currenct categories
-            if (!explicitCategories) {
-                x = (names as any).length;
+            if (!explicitCategories && names) {
+                x = names.length;
             }
         } else {
             x = nameX;

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1570,7 +1570,7 @@ namespace Point {
         plural: Array<string>;
     }
     export interface PointLabelObject {
-        x?: string;
+        x?: (number|string);
         y?: (number|null);
         color?: ColorType;
         colorIndex?: number;
@@ -1672,7 +1672,7 @@ export default Point;
  *//**
  * The y value of the point.
  * @name Highcharts.PointLabelObject#y
- * @type {number|undefined}
+ * @type {number|null|undefined}
  */
 
 /**

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -236,7 +236,7 @@ class Point {
      */
     public visible: boolean = true;
 
-    public x: (number|null) = void 0 as any;
+    public x: number = void 0 as any;
 
     public y?: (number|null);
 

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1630,7 +1630,7 @@ export default Point;
  */
 
 /**
- * Configuration hash for the data label and tooltip formatters.
+ * Configuration for the data label and tooltip formatters.
  *
  * @interface Highcharts.PointLabelObject
  *//**

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2302,9 +2302,10 @@ class Series {
             // some API data
             point.category = (
                 categories &&
-                typeof (categories as any)[point.x as any] !== 'undefined' ?
-                    (categories as any)[point.x as any] :
-                    point.x
+                point.x !== null &&
+                typeof categories[point.x] !== 'undefined' ?
+                    categories[point.x] :
+                    point.x as any
             );
 
             // Determine auto enabling of markers (#3635, #5099)

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -1600,7 +1600,7 @@ class Series {
             xExtremes = xAxis.getExtremes();
             min = xExtremes.min;
             max = xExtremes.max;
-            updatingNames = xAxis.categories && !xAxis.names.length;
+            updatingNames = !!(xAxis.categories && !xAxis.names.length);
         }
 
         // optionally filter out points outside the plot area
@@ -2300,11 +2300,9 @@ class Series {
             );
 
             // some API data
-            point.category = (
-                categories &&
-                typeof categories[point.x] !== 'undefined' ?
-                    categories[point.x] :
-                    point.x as any
+            point.category = pick(
+                categories && categories[point.x],
+                point.x as any
             );
 
             // Determine auto enabling of markers (#3635, #5099)

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2302,7 +2302,6 @@ class Series {
             // some API data
             point.category = (
                 categories &&
-                point.x !== null &&
                 typeof categories[point.x] !== 'undefined' ?
                     categories[point.x] :
                     point.x as any

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1036,7 +1036,7 @@ class Tooltip {
             options = tooltip.options,
             points: Array<Point> = splat(pointOrPoints),
             point = points[0],
-            pointConfig = [] as Array<Point.PointLabelObject>,
+            pointConfig = [] as Array<Tooltip.FormatterContextObject>,
             formatter = options.formatter || tooltip.defaultFormatter,
             shared = tooltip.shared,
             styledMode = chart.styledMode;
@@ -1078,14 +1078,14 @@ class Tooltip {
                 x: point.category,
                 y: point.y
             } as any;
-            textConfig.points = pointConfig as any;
+            textConfig.points = pointConfig;
 
         // single point tooltip
         } else {
-            textConfig = point.getLabelConfig() as any;
+            textConfig = point.getLabelConfig();
         }
         this.len = pointConfig.length; // #6128
-        const text: (boolean|string) = (formatter as any).call(
+        const text = formatter.call(
             textConfig,
             tooltip
         );
@@ -1100,7 +1100,7 @@ class Tooltip {
         } else {
             // update text
             if (tooltip.split && tooltip.allowShared) { // #13868
-                this.renderSplit(text as any, points);
+                this.renderSplit(text, points);
             } else {
                 let checkX = x;
                 let checkY = y;
@@ -1868,17 +1868,9 @@ namespace Tooltip {
             tooltip: Tooltip
         ): (false|string|Array<string>);
     }
-    export interface FormatterContextObject {
-        color: ColorType;
-        colorIndex?: number;
-        key: number;
-        percentage?: number;
-        point: Point;
+    export interface FormatterContextObject extends Point.PointLabelObject {
         points?: Array<FormatterContextObject>;
-        series: Series;
-        total?: number;
-        x: number;
-        y: number;
+
     }
     export interface PositionerCallbackFunction {
         (
@@ -1921,47 +1913,24 @@ export default Tooltip;
  * @callback Highcharts.TooltipFormatterCallbackFunction
  *
  * @param {Highcharts.TooltipFormatterContextObject} this
- *        Context to format
+ * Context to format
  *
  * @param {Highcharts.Tooltip} tooltip
- *        The tooltip instance
+ * The tooltip instance
  *
  * @return {false|string|Array<(string|null|undefined)>|null|undefined}
- *         Formatted text or false
+ * Formatted text or false
  */
 
 /**
+ * Configuration for the tooltip formatters.
+ *
  * @interface Highcharts.TooltipFormatterContextObject
+ * @extends Highcharts.PointLabelObject
  *//**
- * @name Highcharts.TooltipFormatterContextObject#color
- * @type {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
- *//**
- * @name Highcharts.TooltipFormatterContextObject#colorIndex
- * @type {number|undefined}
- *//**
- * @name Highcharts.TooltipFormatterContextObject#key
- * @type {number}
- *//**
- * @name Highcharts.TooltipFormatterContextObject#percentage
- * @type {number|undefined}
- *//**
- * @name Highcharts.TooltipFormatterContextObject#point
- * @type {Highcharts.Point}
- *//**
+ * Array of points in shared tooltips.
  * @name Highcharts.TooltipFormatterContextObject#points
  * @type {Array<Highcharts.TooltipFormatterContextObject>|undefined}
- *//**
- * @name Highcharts.TooltipFormatterContextObject#series
- * @type {Highcharts.Series}
- *//**
- * @name Highcharts.TooltipFormatterContextObject#total
- * @type {number|undefined}
- *//**
- * @name Highcharts.TooltipFormatterContextObject#x
- * @type {number}
- *//**
- * @name Highcharts.TooltipFormatterContextObject#y
- * @type {number}
  */
 
 /**

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1046,7 +1046,7 @@ class Tooltip {
             return;
         }
 
-        U.clearTimeout(this.hideTimer as any);
+        U.clearTimeout(this.hideTimer);
 
         // A switch saying if this specific tooltip configuration allows shared
         // or split modes

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -602,12 +602,10 @@ function syncTimeout(
  *
  * @function Highcharts.clearTimeout
  *
- * @param {number} id
- *        Id of a timeout.
- *
- * @return {void}
+ * @param {number|undefined} id
+ * Id of a timeout.
  */
-function internalClearTimeout(id: number): void {
+function internalClearTimeout(id: (number|undefined)): void {
     if (defined(id)) {
         clearTimeout(id);
     }

--- a/ts/Extensions/Annotations/MockPoint.ts
+++ b/ts/Extensions/Annotations/MockPoint.ts
@@ -24,7 +24,7 @@ declare module './MockPointOptions' {
 declare global {
     namespace Highcharts {
         interface AnnotationMockLabelOptionsObject {
-            x: (number|null);
+            x: (number|undefined);
             y: (number|null);
             point: MockPoint;
         }
@@ -339,7 +339,7 @@ class MockPoint {
     public target: (Highcharts.AnnotationControllable|null);
     public ttBelow?: boolean = void 0 as any;
     public visible?: boolean;
-    public x: (number|null) = void 0 as any;
+    public x: (number|undefined) = void 0 as any;
     public y: (number|null) = void 0 as any;
 
     /* *
@@ -495,7 +495,7 @@ class MockPoint {
             this.x = options.x;
             this.plotX = xAxis.toPixels(options.x, true);
         } else {
-            this.x = null;
+            this.x = void 0;
             this.plotX = options.x;
         }
 


### PR DESCRIPTION
- Fixed #16565, Synchronized typing of `TooltipFormatterContextObject`with `PointLabelObject`.
- Fixed typing of `PointLabelObject`.
- Fixed parameter type of `Highcharts.clearTimeout`.