### PR TITLE
Docs: Added Point.plotX/Y to API docs.

### DIFF
--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2188,8 +2188,10 @@ class Series {
             }
 
             /**
-             * This is the translated X value for the point. Depending
-             * on the series type this value might not be defined.
+             * The translated X value for the point in terms of pixels. Relative
+             * to the X axis position if the series has one, otherwise relative
+             * to the plot area. Depending on the series type this value might
+             * not be defined.
              * @name Highcharts.Point#plotX
              * @type {number|undefined}
              */
@@ -2287,8 +2289,10 @@ class Series {
                 );
                 if (typeof translated !== 'undefined') {
                     /**
-                     * This is the translated Y value for the point. Depending
-                     * on the series type this value might not be defined.
+                     * The translated Y value for the point in terms of pixels.
+                     * Relative to the Y axis position if the series has one,
+                     * otherwise relative to the plot area. Depending on the
+                     * series type this value might not be defined.
                      * @name Highcharts.Point#plotY
                      * @type {number|undefined}
                      */

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -115,6 +115,13 @@ declare module '../Renderer/SVG/SVGElementLike' {
     }
 }
 
+declare module './PointLike' {
+    interface PointLike {
+        plotX?: number;
+        plotY?: number;
+    }
+}
+
 declare module './SeriesLike' {
     interface SeriesLike {
         _hasPointMarkers?: boolean;
@@ -2180,8 +2187,14 @@ class Series {
                 point.isNull = true;
             }
 
-            // Get the plotX translation
+            /**
+             * This is the translated X value for the point. Depending
+             * on the series type this value might not be defined.
+             * @name Highcharts.Point#plotX
+             * @type {number|undefined}
+             */
             point.plotX = plotX = correctFloat( // #5236
+                // Get the plotX translation
                 limitedRange((xAxis.translate as any)( // #3923
                     xValue,
                     0,
@@ -2273,6 +2286,12 @@ class Series {
                     yValue, false, true, false, true
                 );
                 if (typeof translated !== 'undefined') {
+                    /**
+                     * This is the translated Y value for the point. Depending
+                     * on the series type this value might not be defined.
+                     * @name Highcharts.Point#plotY
+                     * @type {number|undefined}
+                     */
                     point.plotY = limitedRange(translated);
                 }
             }

--- a/ts/Series/Line/LinePoint.d.ts
+++ b/ts/Series/Line/LinePoint.d.ts
@@ -38,8 +38,6 @@ declare module '../../Core/Series/PointLike' {
         low?: number;
         negative?: boolean;
         options: PointOptions;
-        plotX?: number;
-        plotY?: number;
         stackTotal?: number;
         stackY?: (number|null);
         yBottom?: number;


### PR DESCRIPTION
Fixed #16822, Added doclets for `Point.plotX` and `Point.plotY` to make both properties visible in API documentation and TypeScript definitions.