### PR TITLE
Updated package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "highcharts",
       "version": "9.3.2",
       "license": "SEE LICENSE IN <license.txt>",
       "dependencies": {


### PR DESCRIPTION
Fresh clone of the repo, using:
```
> node -v
v16.13.0
> npm -v
8.3.0
```

Updates the package-lock with a minor change