### PR TITLE
Fixing CSP warnings

### DIFF
--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -299,9 +299,6 @@ module.exports = function (config) {
 
         // These ones fail
         exclude: argv.oldie ? [] : [
-            // The configuration currently loads classic mode only. Styled mode
-            // needs to be a separate instance.
-            'samples/unit-tests/series-pie/styled-mode/demo.js',
             // Themes alter the whole default options structure. Set up a
             // separate test suite? Or perhaps somehow decouple the options so
             // they are not mutated for later tests?

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -515,20 +515,18 @@ function getSVG(chart) {
         if (chart.styledMode) {
             svg = svg.replace(
                 '</defs>',
-                `
-                <style>
-                * {
-                    fill: rgba(0, 0, 0, 0.1);
-                    stroke: black;
-                    stroke-width: 1px;
-                }
-                text, tspan {
-                    fill: blue;
-                    stroke: none;
-                }
-                </style>
-                </defs>
-                `
+                '<style>' +
+                '* {' +
+                '   fill: rgba(0, 0, 0, 0.1);' +
+                '   stroke: black;' +
+                '   stroke-width: 1px;' +
+                '}' +
+                'text, tspan {' +
+                '    fill: blue;' +
+                '    stroke: none;' +
+                '}' +
+                '</style>' +
+                '</defs>'
             );
         }
 

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -514,9 +514,21 @@ function getSVG(chart) {
 
         if (chart.styledMode) {
             svg = svg.replace(
-                '</style>',
-                '* { fill: rgba(0, 0, 0, 0.1); stroke: black; stroke-width: 1px; } '
-                + 'text, tspan { fill: blue; stroke: none; } </style>'
+                '</defs>',
+                `
+                <style>
+                * {
+                    fill: rgba(0, 0, 0, 0.1);
+                    stroke: black;
+                    stroke-width: 1px;
+                }
+                text, tspan {
+                    fill: blue;
+                    stroke: none;
+                }
+                </style>
+                </defs>
+                `
             );
         }
 

--- a/ts/Core/Chart/Chart3D.ts
+++ b/ts/Core/Chart/Chart3D.ts
@@ -1833,19 +1833,7 @@ namespace Chart3D {
      */
     function onAfterGetContainer(this: Chart): void {
         if (this.styledMode) {
-            this.renderer.definition({
-                tagName: 'style',
-                textContent:
-                    '.highcharts-3d-top{' +
-                        'filter: url(#highcharts-brighter)' +
-                    '}\n' +
-                    '.highcharts-3d-side{' +
-                        'filter: url(#highcharts-darker)' +
-                    '}\n'
-            });
-
-            // Add add definitions used by brighter and darker faces of the
-            // cuboids.
+            // Add definitions used by brighter and darker faces of the cuboids.
             [{
                 name: 'darker',
                 slope: 0.6

--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -498,8 +498,8 @@ class AST {
 
         markup = markup
             .trim()
-            // The style attribute throws a warning when CSP (#6884), so use an
-            // alias and pick it up below
+            // The style attribute throws a warning when parsing when CSP is
+            // enabled (#6884), so use an alias and pick it up below
             .replace(/ style="/g, ' data-style="');
 
         let doc;

--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -496,7 +496,11 @@ class AST {
 
         const nodes: Array<AST.Node> = [];
 
-        markup = markup.trim();
+        markup = markup
+            .trim()
+            // The style attribute throws a warning when CSP (#6884), so use an
+            // alias and pick it up below
+            .replace(/ style="/g, ' data-style="');
 
         let doc;
         if (hasValidDOMParser) {
@@ -531,7 +535,11 @@ class AST {
             if (parsedAttributes) {
                 const attributes: HTMLAttributes&SVGAttributes = {};
                 [].forEach.call(parsedAttributes, (attrib: Attribute): void => {
-                    attributes[attrib.name] = attrib.value;
+                    attributes[
+                        attrib.name as string === 'data-style' ?
+                            'style' :
+                            attrib.name
+                    ] = attrib.value;
                 });
                 astNode.attributes = attributes;
             }

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -1076,9 +1076,9 @@ class SVGElement implements SVGElementLike {
 
         // Filter out existing styles to increase performance (#2640)
         if (oldStyles) {
-            objectEach(styles, function (style, n): void {
-                if (oldStyles && oldStyles[n] !== style) {
-                    (newStyles as any)[n] = style;
+            objectEach(styles, function (value, n: keyof CSSObject): void {
+                if (oldStyles && oldStyles[n] !== value) {
+                    newStyles[n] = value;
                     hasNew = true;
                 }
             });

--- a/ts/Core/Renderer/SVG/SVGElement3D.ts
+++ b/ts/Core/Renderer/SVG/SVGElement3D.ts
@@ -68,10 +68,20 @@ SVGElement3D.base = {
 
         // build parts
         (elem3d.parts as any).forEach(function (part: string): void {
-            elem3d[part] = renderer.path((paths as any)[part]).attr({
+            const attribs: SVGAttributes = {
                 'class': 'highcharts-3d-' + part,
                 zIndex: zIndexes[part] || 0
-            }).add(elem3d);
+            };
+            if (renderer.styledMode) {
+                if (part === 'top') {
+                    attribs.filter = 'url(#highcharts-brighter)';
+                } else if (part === 'side') {
+                    attribs.filter = 'url(#highcharts-darker)';
+                }
+            }
+            elem3d[part] = renderer.path((paths as any)[part])
+                .attr(attribs)
+                .add(elem3d);
         });
 
         elem3d.attr({
@@ -221,11 +231,12 @@ SVGElement3D.cuboid = merge(SVGElement3D.base, {
                 zIndex: paths.zIndexes.group
             });
 
-            // If sides that are forced to render changed, recalculate
-            // colors.
+            // If sides that are forced to render changed, recalculate colors.
             if (forcedSides !== this.forcedSides) {
                 this.forcedSides = forcedSides;
-                SVGElement3D.cuboid.fillSetter.call(this, this.fill);
+                if (!this.renderer.styledMode) {
+                    SVGElement3D.cuboid.fillSetter.call(this, this.fill);
+                }
             }
         } else {
             SVGElement.prototype.animate.call(this, args, duration, complete);

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -703,7 +703,12 @@ class SVGRenderer implements SVGRendererLike {
             // (reference to options.rangeSelector.buttonTheme)
             normalState = theme ? merge(theme) : {};
 
-        const userNormalStyle = normalState && normalState.style || {};
+        const normalStyle = merge({
+            color: Palette.neutralColor80,
+            cursor: 'pointer',
+            fontWeight: 'normal'
+        }, normalState.style);
+        delete normalState.style;
 
         // Remove stylable attributes
         normalState = AST.filterUserAttributes(normalState);
@@ -712,8 +717,7 @@ class SVGRenderer implements SVGRendererLike {
         label.attr(merge({ padding: 8, r: 2 }, normalState));
 
         // Presentational
-        let normalStyle: any,
-            hoverStyle: any,
+        let hoverStyle: any,
             pressedStyle: any,
             disabledStyle: any;
 
@@ -723,17 +727,8 @@ class SVGRenderer implements SVGRendererLike {
             normalState = merge({
                 fill: Palette.neutralColor3,
                 stroke: Palette.neutralColor20,
-                'stroke-width': 1,
-                style: {
-                    color: Palette.neutralColor80,
-                    cursor: 'pointer',
-                    fontWeight: 'normal'
-                }
-            }, {
-                style: userNormalStyle
+                'stroke-width': 1
             }, normalState);
-            normalStyle = normalState.style;
-            delete normalState.style;
 
             // Hover state
             hoverState = merge(normalState, {

--- a/ts/Core/Renderer/SVG/TextBuilder.ts
+++ b/ts/Core/Renderer/SVG/TextBuilder.ts
@@ -34,6 +34,7 @@ const {
 import U from '../../Utilities.js';
 const {
     attr,
+    extend,
     isString,
     objectEach,
     pick
@@ -414,34 +415,29 @@ class TextBuilder {
     ): void {
 
         const modifyChild = (node: AST.Node, i: number): void => {
-            const { attributes = {}, children, tagName } = node,
+            const { attributes = {}, children, style = {}, tagName } = node,
                 styledMode = this.renderer.styledMode;
 
             // Apply styling to text tags
             if (tagName === 'b' || tagName === 'strong') {
                 if (styledMode) {
-                    attributes['class'] = 'highcharts-strong'; // eslint-disable-line dot-notation
+                    // eslint-disable-next-line dot-notation
+                    attributes['class'] = 'highcharts-strong';
                 } else {
-                    attributes.style = (
-                        'font-weight:bold;' + (attributes.style || '')
-                    );
+                    style.fontWeight = 'bold';
                 }
             } else if (tagName === 'i' || tagName === 'em') {
                 if (styledMode) {
-                    attributes['class'] = 'highcharts-emphasized'; // eslint-disable-line dot-notation
+                    // eslint-disable-next-line dot-notation
+                    attributes['class'] = 'highcharts-emphasized';
                 } else {
-                    attributes.style = (
-                        'font-style:italic;' + (attributes.style || '')
-                    );
+                    style.fontStyle = 'italic';
                 }
             }
 
-            // Modify attributes
-            if (isString(attributes.style)) {
-                attributes.style = attributes.style.replace(
-                    /(;| |^)color([ :])/,
-                    '$1fill$2'
-                );
+            // Modify styling
+            if (style && style.color) {
+                style.fill = style.color;
             }
 
             // Handle breaks
@@ -471,7 +467,7 @@ class TextBuilder {
             if (tagName !== '#text' && tagName !== 'a') {
                 node.tagName = 'tspan';
             }
-            node.attributes = attributes;
+            extend(node, { attributes, style });
 
             // Recurse
             if (children) {

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -714,21 +714,22 @@ function css(
     if (isString(styles)) {
         styles = styles
             .split(';')
-            .reduce((styles, line: string): CSSObject => {
-                const pair = line.split(':'),
+            .reduce((styles, line): CSSObject => {
+                const pair = line.split(':').map((s): string => s.trim()),
                     key = pair[0].replace(
                         /-([a-z])/g,
                         (g): string => g[1].toUpperCase()
                     );
 
-                (styles as any)[key] = pair[1];
+                if (pair[1]) {
+                    (styles as any)[key] = pair[1];
+                }
                 return styles;
             }, {} as CSSObject);
     }
     if (H.isMS && !H.svg) { // #2686
-        if (styles && typeof styles.opacity !== 'undefined') {
-            styles.filter =
-                'alpha(opacity=' + (styles.opacity as any * 100) + ')';
+        if (styles && defined(styles.opacity)) {
+            styles.filter = `alpha(opacity=${styles.opacity * 100})`;
         }
     }
     extend(el.style, styles as any);

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -530,13 +530,7 @@ function attr(
 
         // Set the value
         if (defined(value)) {
-            // The style attribute can't be set when CSP disallows it. Parse it
-            // into style properties instead (#6884).
-            if (key === 'style' && isString(value)) {
-                css(elem, value);
-            } else {
-                elem.setAttribute(key, value);
-            }
+            elem.setAttribute(key, value);
 
         // Get the value
         } else if (isGetter) {
@@ -714,24 +708,8 @@ function pick<T>(): T|undefined {
  */
 function css(
     el: DOMElementType,
-    styles: CSSObject|string
+    styles: CSSObject
 ): void {
-    if (isString(styles)) {
-        styles = styles
-            .split(';')
-            .reduce((styles, line): CSSObject => {
-                const pair = line.split(':').map((s): string => s.trim()),
-                    key = pair[0].replace(
-                        /-([a-z])/g,
-                        (g): string => g[1].toUpperCase()
-                    );
-
-                if (pair[1]) {
-                    (styles as any)[key] = pair[1];
-                }
-                return styles;
-            }, {} as CSSObject);
-    }
     if (H.isMS && !H.svg) { // #2686
         if (styles && defined(styles.opacity)) {
             styles.filter = `alpha(opacity=${styles.opacity * 100})`;

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -700,9 +700,8 @@ function pick<T>(): T|undefined {
  * @param {Highcharts.HTMLDOMElement|Highcharts.SVGDOMElement} el
  *        An HTML DOM element.
  *
- * @param {Highcharts.CSSObject|string} styles
- *        Style object with camel case property names. Alternatively a style
- *        string like given in HTML or SVG style attribute.
+ * @param {Highcharts.CSSObject} styles
+ *        Style object with camel case property names.
  *
  * @return {void}
  */

--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -872,7 +872,7 @@ namespace Exporting {
                             } as any;
                             css(element, extend({
                                 cursor: 'pointer'
-                            }, navOptions.menuItemStyle as any));
+                            } as CSSObject, navOptions.menuItemStyle || {}));
                         }
                     }
 


### PR DESCRIPTION
Fixed #6884, console errors related to style attributes because of Content Security Policy.

### To do
 - [x] Go over new code and look for optimization
 - [x] Check Firefox `scrollablePlotArea` case again
 - [x] Check legacy browsers manually