### PR TITLE
Fixed #16873, windows high contrast mode not detected in other browsers

### DIFF
--- a/ts/Accessibility/HighContrastMode.ts
+++ b/ts/Accessibility/HighContrastMode.ts
@@ -84,8 +84,7 @@ function isHighContrastModeActive(): boolean {
         return bi === 'none';
     }
 
-    // Not used for other browsers
-    return false;
+    return win.matchMedia && win.matchMedia('(forced-colors: active)').matches;
 }
 
 /**


### PR DESCRIPTION
Fixed #16873, windows high contrast mode not detected in other browsers

Latest browsers will use the standard https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors instead of -ms-high-contrast