### PR TITLE
Fixed issues with enablePolling and Google Sheets.

### DIFF
--- a/samples/unit-tests/data/general/demo.js
+++ b/samples/unit-tests/data/general/demo.js
@@ -254,7 +254,7 @@ QUnit.test('Data config on updates and setOptions', function (assert) {
         2,
         'Global data options should be merged with the chart options (#16568).'
     );
-    
+
     // Clear the default options for other tests
     delete Highcharts.defaultOptions.data;
 });
@@ -362,5 +362,34 @@ QUnit.test('Update column names', function (assert) {
         chart.series[0].name,
         'D',
         'Should be able to update series name.'
+    );
+});
+
+
+QUnit.test('Updating with firstRowAsNames and dataGrouping', function (assert) {
+    const chart = Highcharts.chart('container', {
+        plotOptions: {
+            series: {
+                dataGrouping: {
+                    enabled: true
+                }
+            }
+        },
+        data: {
+            columns: [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
+            firstRowAsNames: true
+        }
+    });
+
+    chart.update({
+        data: {
+            dataRefreshRate: 90
+        }
+    });
+
+    assert.strictEqual(
+        chart.options.data.dataRefreshRate,
+        90,
+        'Should be able to update data options despite using columns and having data grouping options.'
     );
 });

--- a/ts/Extensions/Data.ts
+++ b/ts/Extensions/Data.ts
@@ -1960,30 +1960,32 @@ class Data {
      *        Column index
      */
     public parseColumn(
-        column: Array<Highcharts.DataValueType>,
+        column: Array<Highcharts.DataValueType> & { name?: string },
         col: number
     ): void {
-        let rawColumns = this.rawColumns,
+        const rawColumns = this.rawColumns,
             columns = this.columns,
-            row = column.length,
-            val: Highcharts.DataValueType,
-            floatVal,
-            trimVal,
-            trimInsideVal,
             firstRowAsNames = this.firstRowAsNames,
             isXColumn = (this.valueCount as any).xColumns.indexOf(col) !== -1,
-            dateVal,
             backup: Array<Highcharts.DataValueType> = [],
-            diff,
             chartOptions = this.chartOptions,
-            descending,
             columnTypes = this.options.columnTypes || [],
             columnType = columnTypes[col],
             forceCategory = isXColumn && ((
                 chartOptions &&
                 chartOptions.xAxis &&
                 splat(chartOptions.xAxis)[0].type === 'category'
-            ) || columnType === 'string');
+            ) || columnType === 'string'),
+            columnHasName = defined(column.name);
+
+        let row = column.length,
+            val: Highcharts.DataValueType,
+            floatVal,
+            trimVal,
+            trimInsideVal,
+            dateVal,
+            diff,
+            descending;
 
         if (!rawColumns[col]) {
             rawColumns[col] = [];
@@ -2002,7 +2004,10 @@ class Data {
 
             // Disable number or date parsing by setting the X axis type to
             // category
-            if (forceCategory || (row === 0 && firstRowAsNames)) {
+            if (
+                forceCategory ||
+                (row === 0 && firstRowAsNames && !columnHasName)
+            ) {
                 column[row] = '' + trimVal;
 
             } else if (+trimInsideVal === floatVal) { // is numeric


### PR DESCRIPTION
Fixed issues with `data.enablePolling` and Google Sheets.
___
**NOTE: #16869 should be merged first.**

Fixes two issues with live polling and Google Sheets.
1. Starting with `enablePolling: false` and updating to `true` was not possible.
2. If updating the chart to use e.g. CSV data instead, the polling did not immediately stop, therefore overwriting the CSV.