### PR TITLE
bugfix/16045-resetzoom-tooltip-opacity

### DIFF
--- a/samples/unit-tests/pointer/touch/demo.js
+++ b/samples/unit-tests/pointer/touch/demo.js
@@ -166,6 +166,8 @@ QUnit.test('followPointer and followTouchMove', function (assert) {
             target: points[0].graphic.element
         });
 
+        chart.pointer.res = false;
+
         chart.pointer.onContainerTouchMove({
             type: 'touchmove',
             touches: [

--- a/samples/unit-tests/svgrenderer/animate/demo.js
+++ b/samples/unit-tests/svgrenderer/animate/demo.js
@@ -774,6 +774,23 @@ QUnit.test('Complete callback', function (assert) {
             );
         }, 150);
 
+        let completeCalled = false;
+
+        circle.animate(
+            { opacity: 0 },
+            {
+                duration: 0,
+                complete: () => {
+                    completeCalled = true;
+                }
+            }
+        );
+
+        assert.ok(
+            completeCalled,
+            '#16045: complete callback in options should be called when duration=0'
+        );
+
         // Run and reset animation
         TestUtilities.lolexRunAndUninstall(clock);
     } finally {

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -547,7 +547,7 @@ class SVGElement implements SVGElementLike {
                 }
             }, deferTime);
         } else {
-            this.attr(params, void 0, complete);
+            this.attr(params, void 0, complete || animOptions.complete);
             // Call the end step synchronously
             objectEach(params, function (val: any, prop: string): void {
                 if (animOptions.step) {


### PR DESCRIPTION
Fixed #16045, tooltip with opacity was not fully hidden when hovering over a reset zoom button.

This is a continuation of https://github.com/highcharts/highcharts/pull/16054 (old PR can be closed)