### PR TITLE
bugfix/11712-update-node

### DIFF
--- a/samples/unit-tests/series-sankey/sankey/demo.js
+++ b/samples/unit-tests/series-sankey/sankey/demo.js
@@ -219,6 +219,23 @@ QUnit.test('Sankey nodeFormat, nodeFormatter', function (assert) {
         -1,
         'Tooltip ok'
     );
+
+    series.nodes[0].update({
+        color: 'red'
+    });
+
+    // After update, nodes should still use nodeFormat etc
+    assert.strictEqual(
+        series.nodes[0].dataLabel.text.textStr,
+        'Nodez',
+        'Explicit nodeFormat'
+    );
+    series.nodes[0].onMouseOver();
+    assert.notEqual(
+        chart.tooltip.label.text.textStr.indexOf('Nodez'),
+        -1,
+        'Tooltip ok'
+    );
 });
 
 QUnit.test('Sankey column option', function (assert) {
@@ -864,5 +881,88 @@ QUnit.test('#14584: Sankey overlapping datalabels', assert => {
     assert.ok(
         chart.series[0].points.some(p => p.dataLabel.attr('opacity') === 0),
         'Some of the point datalabels should be hidden'
+    );
+});
+
+QUnit.test('Sankey and point updates', assert => {
+    const linkConfig = { from: 'A', to: 'B', weight: 1 },
+        chart = Highcharts.chart('container', {
+            series: [{
+                data: [Highcharts.merge(linkConfig)], // use a shallow copy
+                type: 'sankey',
+                nodes: [{
+                    id: 'A',
+                    color: 'red'
+                }]
+            }]
+        }),
+        series = chart.series[0];
+
+    // Test 1:
+    // Uodate a node that exists in a config
+    series.nodes[0].update({
+        color: 'black'
+    });
+
+    assert.strictEqual(
+        series.nodes[0].graphic.attr('fill'),
+        'black',
+        'After an update, node defined in options should use new color.'
+    );
+
+    assert.deepEqual(
+        series.options.nodes[0].color,
+        'black',
+        `After an update,
+        node defined in options should have correct color in options.`
+    );
+
+    assert.deepEqual(
+        series.options.data[0],
+        linkConfig,
+        `Updating a node defined in options
+        should not replace a link config (#11712).`
+    );
+
+    // Test 2:
+    // Uodate a node that DOES NOT exist in a config
+    series.nodes[1].update({
+        color: 'green'
+    });
+
+    assert.strictEqual(
+        series.options.nodes.length,
+        2,
+        `Updating a node without options,
+        should create a new entry in options.`
+    );
+
+    assert.strictEqual(
+        series.nodes[1].graphic.attr('fill'),
+        'green',
+        'After an update, node without config should use new color.'
+    );
+
+    assert.deepEqual(
+        series.options.nodes[1].color,
+        'green',
+        `After an update,
+        node without config should have correct color in options.`
+    );
+
+    assert.deepEqual(
+        series.options.data[0],
+        linkConfig,
+        `Updating a node without config
+        should not replace a link config (#11712).`
+    );
+
+    assert.strictEqual(
+        series.options.data.length,
+        1,
+        `
+        Udpating a node with higher index than available in series.options.data
+        should not add any elements to the series.options.data
+        `
     );
 });

--- a/ts/Extensions/Annotations/MockPoint.ts
+++ b/ts/Extensions/Annotations/MockPoint.ts
@@ -73,7 +73,7 @@ declare global {
                 cy: (number|undefined),
                 dx: number,
                 dy: number
-            ): void
+            ): void;
         }
         interface AnnotationMockSeries {
             chart: AnnotationChart;

--- a/ts/Series/DataModifyComposition.ts
+++ b/ts/Series/DataModifyComposition.ts
@@ -113,7 +113,7 @@ namespace DataModifyComposition {
             mode: 'compare'|'cumulative',
             modeState?: boolean|null|'percent'|'value',
             redraw?: boolean
-        ): void
+        ): void;
     }
 
     export declare class PointComposition extends Point {

--- a/ts/Series/DependencyWheel/DependencyWheelSeries.ts
+++ b/ts/Series/DependencyWheel/DependencyWheelSeries.ts
@@ -152,7 +152,6 @@ class DependencyWheelSeries extends SankeySeries {
             this,
             id
         ) as DependencyWheelPoint;
-        node.index = this.nodes.length - 1;
 
         /**
          * Return the sum of incoming and outgoing links.

--- a/ts/Series/Networkgraph/Layouts.ts
+++ b/ts/Series/Networkgraph/Layouts.ts
@@ -144,7 +144,7 @@ declare global {
             public updateSimulation(enable?: boolean): void;
             public removeElementFromCollection<T>(
                 element: T, collection: Array<T>
-            ): void
+            ): void;
             public repulsiveForces(): void;
             public resetSimulation(): void;
             public restartSimulation(): void;


### PR DESCRIPTION
Fixed #11712, in node-based series types like dependency wheel and network graph, calling `node.update()` in the `afterAnimate` event would throw errors.
___
Prioritized because TreeGraph series also needs this `node.update()` to be working (e.g. to hide/show children nodes).

Two issues under the hood:
- wrong `node.index` for all Node-based series (except the DependencyWheel)
- updating a node used to update `series.options.data` instead of `series.options.nodes`. Solved this via 'wrapping' `Point.update()` in `Node.update()` composition: let `point.update()` do their job, then replace configs with correct ones

Perhaps there's a different approach to solve this? I'm open to suggestions!