### PR TITLE
Fixed #16893, findNearestPointBy not working well with Boost

### DIFF
--- a/ts/Extensions/Boost/BoostInit.ts
+++ b/ts/Extensions/Boost/BoostInit.ts
@@ -287,7 +287,7 @@ function init(): void {
 
                             }
                             // Add points and reset
-                            if (clientX !== lastClientX) {
+                            if (!compareX || clientX !== lastClientX) {
                                 // maxI is number too:
                                 if (typeof minI !== 'undefined') {
                                     plotY =


### PR DESCRIPTION
Fixed #16893, `series.findNearestPointBy` set to `xy` was not working well with Boost.

Demo with the fix applied: https://jsfiddle.net/highcharts/k4bxoht5/