### PR TITLE
bugfix/16791-safari-exporting

### DIFF
--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -1472,7 +1472,7 @@ namespace Exporting {
                 }
 
                 // Loop through all styles and add them inline if they are ok
-                if (G.isFirefox || G.isMS) {
+                if (G.isFirefox || G.isMS || G.isSafari) {
                     // Some browsers put lots of styles on the prototype
                     for (const p in styles) { // eslint-disable-line guard-for-in
                         filterStyles((styles as any)[p], p);

--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -1472,13 +1472,17 @@ namespace Exporting {
                 }
 
                 // Loop through all styles and add them inline if they are ok
-                if (G.isFirefox || G.isMS || G.isSafari) {
-                    // Some browsers put lots of styles on the prototype
-                    for (const p in styles) { // eslint-disable-line guard-for-in
+                for (const p in styles) {
+                    if (
+                        // Some browsers put lots of styles on the prototype...
+                        G.isFirefox ||
+                        G.isMS ||
+                        G.isSafari || // #16902
+                        // ... Chrome puts them on the instance
+                        Object.hasOwnProperty.call(styles, p)
+                    ) {
                         filterStyles((styles as any)[p], p);
                     }
-                } else {
-                    objectEach(styles, filterStyles as any);
                 }
 
                 // Apply styles


### PR DESCRIPTION
Fixed #16791, exporting a chart in styled mode on Safari v15 produced a black image.
___
Test case: https://jsfiddle.net/BlackLabel/fr2ajxt8/4/ (compare results in console in Safari v15+ and Chrome v97+)