### PR TITLE
bugfix/16896-hovering-map

### DIFF
--- a/samples/unit-tests/maps/mapbubble-linewidth/demo.js
+++ b/samples/unit-tests/maps/mapbubble-linewidth/demo.js
@@ -1,38 +1,37 @@
 QUnit.test('MapBubble', function (assert) {
     const chart = Highcharts.mapChart('container', {
-            series: [
-                {
-                    mapData: Highcharts.maps['countries/gb/gb-all']
-                },
-                {
-                    type: 'mapbubble',
-                    lineWidth: 2,
-                    data: [
-                        {
-                            lat: 51.507222,
-                            lon: -0.1275,
-                            z: 3
-                        },
-                        {
-                            lat: 52.483056,
-                            lon: -1.893611,
-                            z: 4
-                        },
-                        {
-                            x: 1600,
-                            y: -3500,
-                            z: 3
-                        },
-                        {
-                            x: 2800,
-                            y: -3800,
-                            z: 1
-                        }
-                    ]
-                }
-            ]
-        }),
-        controller = new TestController(chart);
+        series: [
+            {
+                mapData: Highcharts.maps['countries/gb/gb-all']
+            },
+            {
+                type: 'mapbubble',
+                lineWidth: 2,
+                data: [
+                    {
+                        lat: 51.507222,
+                        lon: -0.1275,
+                        z: 3
+                    },
+                    {
+                        lat: 52.483056,
+                        lon: -1.893611,
+                        z: 4
+                    },
+                    {
+                        x: 1600,
+                        y: -3500,
+                        z: 3
+                    },
+                    {
+                        x: 2800,
+                        y: -3800,
+                        z: 1
+                    }
+                ]
+            }
+        ]
+    });
 
     assert.strictEqual(
         chart.series[1].graph['stroke-width'],
@@ -46,7 +45,7 @@ QUnit.test('MapBubble', function (assert) {
         }
     });
     // Hover over the chart.
-    controller.mouseMove(200, 200);
+    chart.pointer.runPointActions({ chartX: 200, chartY: 200 });
     assert.ok(
         true,
         `When hovering over mapbubble series with shared tooltip,

--- a/samples/unit-tests/maps/mapbubble-linewidth/demo.js
+++ b/samples/unit-tests/maps/mapbubble-linewidth/demo.js
@@ -1,41 +1,55 @@
-// This should maybe be a visual test
-QUnit.test('MapBubble with LineWidth', function (assert) {
-    var chart = Highcharts.mapChart('container', {
-        series: [
-            {
-                mapData: Highcharts.maps['countries/gb/gb-all']
-            },
-            {
-                type: 'mapbubble',
-                lineWidth: 2,
-                data: [
-                    {
-                        lat: 51.507222,
-                        lon: -0.1275,
-                        z: 3
-                    },
-                    {
-                        lat: 52.483056,
-                        lon: -1.893611,
-                        z: 4
-                    },
-                    {
-                        x: 1600,
-                        y: -3500,
-                        z: 3
-                    },
-                    {
-                        x: 2800,
-                        y: -3800,
-                        z: 1
-                    }
-                ]
-            }
-        ]
-    });
+QUnit.test('MapBubble', function (assert) {
+    const chart = Highcharts.mapChart('container', {
+            series: [
+                {
+                    mapData: Highcharts.maps['countries/gb/gb-all']
+                },
+                {
+                    type: 'mapbubble',
+                    lineWidth: 2,
+                    data: [
+                        {
+                            lat: 51.507222,
+                            lon: -0.1275,
+                            z: 3
+                        },
+                        {
+                            lat: 52.483056,
+                            lon: -1.893611,
+                            z: 4
+                        },
+                        {
+                            x: 1600,
+                            y: -3500,
+                            z: 3
+                        },
+                        {
+                            x: 2800,
+                            y: -3800,
+                            z: 1
+                        }
+                    ]
+                }
+            ]
+        }),
+        controller = new TestController(chart);
+
     assert.strictEqual(
         chart.series[1].graph['stroke-width'],
         2,
-        'Points have stroke width'
+        'MapBubble with linewidth- points should have stroke width.'
+    );
+
+    chart.update({
+        tooltip: {
+            shared: true
+        }
+    });
+    // Hover over the chart.
+    controller.mouseMove(200, 200);
+    assert.ok(
+        true,
+        `When hovering over mapbubble series with shared tooltip,
+        there should be no errors in the console.`
     );
 });

--- a/ts/Series/MapBubble/MapBubbleSeries.ts
+++ b/ts/Series/MapBubble/MapBubbleSeries.ts
@@ -17,6 +17,7 @@
  * */
 
 import type MapBubbleSeriesOptions from './MapBubbleSeriesOptions';
+import type PointerEvent from '../../Core/PointerEvent';
 
 import BubbleSeries from '../Bubble/BubbleSeries.js';
 import MapBubblePoint from './MapBubblePoint.js';
@@ -38,6 +39,7 @@ const {
 import '../../Core/DefaultOptions.js';
 import '../Bubble/BubbleSeries.js';
 import '../Map/MapSeries.js';
+import Point from '../../Core/Series/Point';
 
 /* *
  *
@@ -210,6 +212,16 @@ class MapBubbleSeries extends BubbleSeries {
     public options: MapBubbleSeriesOptions = void 0 as any;
 
     public points: Array<MapBubblePoint> = void 0 as any;
+
+    public searchPoint(
+        e: PointerEvent,
+        compareX?: boolean
+    ): (Point|undefined) {
+        return this.searchKDTree({
+            clientX: e.chartX - this.chart.plotLeft,
+            plotY: e.chartY - this.chart.plotTop
+        }, compareX, e);
+    }
 
     translate(): void {
         MapPointSeries.prototype.translate.call(this);

--- a/ts/Series/MapBubble/MapBubbleSeries.ts
+++ b/ts/Series/MapBubble/MapBubbleSeries.ts
@@ -262,8 +262,6 @@ extend(MapBubbleSeries.prototype, {
 
     processData: MapSeries.prototype.processData,
 
-    searchPoint: noop as any, // #16896
-
     setData: MapSeries.prototype.setData,
 
     setOptions: MapSeries.prototype.setOptions,

--- a/ts/Series/MapBubble/MapBubbleSeries.ts
+++ b/ts/Series/MapBubble/MapBubbleSeries.ts
@@ -22,6 +22,8 @@ import BubbleSeries from '../Bubble/BubbleSeries.js';
 import MapBubblePoint from './MapBubblePoint.js';
 import MapSeries from '../Map/MapSeries.js';
 import SeriesRegistry from '../../Core/Series/SeriesRegistry.js';
+import H from '../../Core/Globals.js';
+const { noop } = H;
 const {
     seriesTypes: {
         mappoint: MapPointSeries
@@ -247,6 +249,8 @@ extend(MapBubbleSeries.prototype, {
     pointClass: MapBubblePoint,
 
     processData: MapSeries.prototype.processData,
+
+    searchPoint: noop as any, // #16896
 
     setData: MapSeries.prototype.setData,
 


### PR DESCRIPTION
 Fixed #16896, hovering over `mapbubble` with shared tooltip caused an error.