### PR TITLE
bugfix/16474-pie-3d-click

### DIFF
--- a/samples/unit-tests/3d/series-pie/demo.js
+++ b/samples/unit-tests/3d/series-pie/demo.js
@@ -483,3 +483,47 @@ QUnit.test('#13804: Inactive tab animation threw', assert => {
 
     Highcharts.SVGElement.prototype.animate = animate;
 });
+
+QUnit.test('Pie 3d interations (clicks, hovers etc.)', assert => {
+    let clicks = 0;
+
+    const chart = new Highcharts.chart('container', {
+            chart: {
+                type: 'pie',
+                options3d: {
+                    enabled: true,
+                    alpha: 90
+                }
+            },
+            plotOptions: {
+                pie: {
+                    cursor: 'pointer',
+                    depth: 35,
+                    events: {
+                        click: () => clicks++
+                    }
+                }
+            },
+            series: [{
+                type: 'pie',
+                data: [5, 2, 3]
+            }]
+        }),
+        controller = new TestController(chart);
+
+    controller.moveTo(
+        chart.plotLeft + chart.series[0].center[0] - 20,
+        chart.plotTop + chart.series[0].center[1] + 5
+    );
+
+    controller.click(
+        chart.plotLeft + chart.series[0].center[0] - 20,
+        chart.plotTop + chart.series[0].center[1] + 5
+    );
+
+    assert.strictEqual(
+        clicks,
+        1,
+        'Clicking on a side of a 3d slice should fire click event (#16474).'
+    );
+});

--- a/ts/Series/Pie3D/Pie3DSeries.ts
+++ b/ts/Series/Pie3D/Pie3DSeries.ts
@@ -260,6 +260,27 @@ class Pie3DSeries extends PieSeries {
         });
     }
 
+    /**
+     * @private
+     */
+    public drawTracker(): void {
+        super.drawTracker.apply(this, arguments);
+
+        // Do not do this if the chart is not 3D
+        if (!this.chart.is3d()) {
+            return;
+        }
+
+        this.points.forEach(function (point): void {
+            if (point.graphic) {
+                ['out', 'inn', 'side1', 'side2'].forEach((face): void => {
+                    if (point.graphic) {
+                        point.graphic[face].element.point = point;
+                    }
+                });
+            }
+        });
+    }
     /* eslint-enable valid-jsdoc */
 
 }


### PR DESCRIPTION
Fixed #16474, added missing click event callback on sides of the 3D pie slices.