### PR TITLE
Docs: Add correct @since jsdoc notation in ScrollablePlotArea

### DIFF
--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -511,6 +511,7 @@ addEvent(Series, 'show', function (): void {
  * area will become scrollable.
  *
  * @type      {number}
+ * @since     7.1.2
  * @apioption chart.scrollablePlotArea.minHeight
  */
 
@@ -519,6 +520,7 @@ addEvent(Series, 'show', function (): void {
  * area will become scrollable.
  *
  * @type      {number}
+ * @since     6.1.0
  * @apioption chart.scrollablePlotArea.minWidth
  */
 
@@ -528,6 +530,7 @@ addEvent(Series, 'show', function (): void {
  * Typically we would use 1 if the chart has right aligned Y axes.
  *
  * @type      {number}
+ * @since     6.1.0
  * @apioption chart.scrollablePlotArea.scrollPositionX
  */
 
@@ -536,6 +539,7 @@ addEvent(Series, 'show', function (): void {
  * 1, where 0 aligns the plot area to the top and 1 aligns it to the bottom.
  *
  * @type      {number}
+ * @since     7.1.2
  * @apioption chart.scrollablePlotArea.scrollPositionY
  */
 


### PR DESCRIPTION
Some of these were using the default for the file, which generated the wrong since strings in the documentation for those properties.  I chased this for too long before realizing the docs were wrong.