### PR TITLE
MapView translation functions

### DIFF
--- a/docs/maps/mapview-and-projection.md
+++ b/docs/maps/mapview-and-projection.md
@@ -23,3 +23,12 @@ Insets are small maps that are inset in parts of the main map. Highcharts Maps t
 
 <iframe style="width: 100%; height: 470px; border: none;" src='https://www.highcharts.com/samples/embed/maps/mapview/insets-extended' allow="fullscreen"></iframe>
 
+### Coordinate systems
+A map view operates with three different coordinate systems:
+
+* The geographic coordinates
+* The projected plane on which the geographic coordinates are projected, and
+* The pixel positions within the plot area, onto which the projected plane is scaled and translated.
+
+The [MapView class](https://api.highcharts.com/class-reference/Highcharts.MapView) contains conversion functions between these coordiate systems. In addition to that, all pointer events are extended with `lon` and `lat` properties, allowing longitude and latitude to be read directly from for example a click event.
+

--- a/samples/maps/chart/events-click-getcoordinates/demo.js
+++ b/samples/maps/chart/events-click-getcoordinates/demo.js
@@ -27,7 +27,7 @@ function showMap(mapKey) {
 
                     series.addPoint(
                         supportsLatLon ?
-                            this.fromPointToLatLon(pos) :
+                            this.mapView.projectedUnitsToLonLat(pos) :
                             pos
                     );
                 }
@@ -73,7 +73,8 @@ function showMap(mapKey) {
                             var newLatLon;
                             if (supportsLatLon) {
                                 newLatLon = this.series.chart
-                                    .fromPointToLatLon(this);
+                                    .mapView
+                                    .projectedUnitsToLonLat(this);
                                 this.lat = newLatLon.lat;
                                 this.lon = newLatLon.lon;
                             }

--- a/samples/maps/chart/events-click-getcoordinates/demo.js
+++ b/samples/maps/chart/events-click-getcoordinates/demo.js
@@ -16,20 +16,26 @@ function showMap(mapKey) {
             events: {
                 click: function (e) {
                     const series = this.get(
-                            document
-                                .querySelector('input[name=series]:checked')
-                                .value
-                        ),
-                        pos = this.mapView.pixelsToProjectedUnits({
+                        document
+                            .querySelector('input[name=series]:checked')
+                            .value
+                    );
+
+                    let p = { lon: e.lon, lat: e.lat };
+
+                    // @todo Legacy, remove after launching v10
+                    if (p.lon === undefined || p.lat === undefined) {
+                        const pos = this.mapView.pixelsToProjectedUnits({
                             x: Math.round(e.chartX - this.plotLeft),
                             y: Math.round(e.chartY - this.plotTop)
                         });
 
-                    series.addPoint(
-                        supportsLatLon ?
-                            this.mapView.projectedUnitsToLonLat(pos) :
-                            pos
-                    );
+                        p = supportsLatLon ?
+                            this.fromPointToLatLon(pos) :
+                            pos;
+                    }
+
+                    series.addPoint(p);
                 }
             },
             animation: false
@@ -73,8 +79,7 @@ function showMap(mapKey) {
                             var newLatLon;
                             if (supportsLatLon) {
                                 newLatLon = this.series.chart
-                                    .mapView
-                                    .projectedUnitsToLonLat(this);
+                                    .fromPointToLatLon(this);
                                 this.lat = newLatLon.lat;
                                 this.lon = newLatLon.lon;
                             }

--- a/samples/maps/chart/events-click/demo.js
+++ b/samples/maps/chart/events-click/demo.js
@@ -11,14 +11,10 @@
         // `this` is either Series or Chart
         const chart = this.chart || this;
 
-        // Get position in pre-projected units
-        const pos = chart.mapView.pixelsToProjectedUnits({
+        const p = chart.mapView.pixelsToLonLat({
             x: Math.round(e.chartX - chart.plotLeft),
             y: Math.round(e.chartY - chart.plotTop)
         });
-
-        // Convert to lonLat
-        const p = chart.mapView.projectedUnitsToLonLat(pos);
         p.name = '[N' + p.lat.toFixed(2) + ', E' + p.lon.toFixed(2) + ']';
 
         // Add point

--- a/samples/maps/chart/events-click/demo.js
+++ b/samples/maps/chart/events-click/demo.js
@@ -17,8 +17,8 @@
             y: Math.round(e.chartY - chart.plotTop)
         });
 
-        // Convert to latLon
-        const p = chart.fromPointToLatLon(pos);
+        // Convert to lonLat
+        const p = chart.mapView.projectedUnitsToLonLat(pos);
         p.name = '[N' + p.lat.toFixed(2) + ', E' + p.lon.toFixed(2) + ']';
 
         // Add point

--- a/samples/maps/chart/events-click/demo.js
+++ b/samples/maps/chart/events-click/demo.js
@@ -11,10 +11,20 @@
         // `this` is either Series or Chart
         const chart = this.chart || this;
 
-        const p = chart.mapView.pixelsToLonLat({
-            x: Math.round(e.chartX - chart.plotLeft),
-            y: Math.round(e.chartY - chart.plotTop)
-        });
+        let p = { lon: e.lon, lat: e.lat };
+
+        // @todo Legacy, remove after launching v10
+        if (p.lon === undefined || p.lat === 'undefined') {
+            // Get position in pre-projected units
+            const pos = chart.mapView.pixelsToProjectedUnits({
+                x: Math.round(e.chartX - chart.plotLeft),
+                y: Math.round(e.chartY - chart.plotTop)
+            });
+
+            // Convert to latLon
+            p = chart.fromPointToLatLon(pos);
+        }
+
         p.name = '[N' + p.lat.toFixed(2) + ', E' + p.lon.toFixed(2) + ']';
 
         // Add point

--- a/samples/maps/chart/zoomtype-xy/demo.css
+++ b/samples/maps/chart/zoomtype-xy/demo.css
@@ -1,0 +1,12 @@
+#container {
+    height: 500px;
+    min-width: 310px;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.loading {
+    margin-top: 10em;
+    text-align: center;
+    color: gray;
+}

--- a/samples/maps/chart/zoomtype-xy/demo.details
+++ b/samples/maps/chart/zoomtype-xy/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+...

--- a/samples/maps/chart/zoomtype-xy/demo.html
+++ b/samples/maps/chart/zoomtype-xy/demo.html
@@ -1,0 +1,8 @@
+
+<script src="https://code.highcharts.com/maps/highmaps.js"></script>
+<script src="https://code.highcharts.com/maps/modules/data.js"></script>
+<script src="https://code.highcharts.com/maps/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/mapdata/custom/world.js"></script>
+
+
+<div id="container"></div>

--- a/samples/maps/chart/zoomtype-xy/demo.js
+++ b/samples/maps/chart/zoomtype-xy/demo.js
@@ -1,0 +1,51 @@
+Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/world-population-density.json', function (data) {
+
+    // Initialize the chart
+    Highcharts.mapChart('container', {
+
+        chart: {
+            zoomType: 'xy'
+        },
+
+        title: {
+            text: 'Chart with selection zoom'
+        },
+
+        mapNavigation: {
+            enabled: true,
+            buttonOptions: {
+                alignTo: 'spacingBox',
+                verticalAlign: 'bottom'
+            }
+        },
+
+        colorAxis: {
+            min: 1,
+            max: 1000,
+            type: 'logarithmic'
+        },
+
+        legend: {
+            title: {
+                text: 'Population per km²'
+            },
+            backgroundColor: 'rgba(255,255,255,0.85)'
+        },
+
+        // The map series
+        series: [{
+            data: data,
+            mapData: Highcharts.maps['custom/world'],
+            joinBy: ['iso-a2', 'code'],
+            name: 'Population density',
+            states: {
+                hover: {
+                    color: '#a4edba'
+                }
+            },
+            tooltip: {
+                valueSuffix: '/km²'
+            }
+        }]
+    });
+});

--- a/samples/maps/demo/latlon-advanced/demo.js
+++ b/samples/maps/demo/latlon-advanced/demo.js
@@ -87,7 +87,9 @@ document.getElementById('container').addEventListener('mousemove', function (e) 
             x: Math.round(e.chartX - chart.plotLeft),
             y: Math.round(e.chartY - chart.plotTop)
         });
-        const position = chart.fromPointToLatLon(projectedPosition);
+        const position = chart.mapView.projectedUnitsToLonLat(
+            projectedPosition
+        );
 
         chart.lbl.attr({
             x: e.chartX + 5,

--- a/samples/maps/demo/latlon-advanced/demo.js
+++ b/samples/maps/demo/latlon-advanced/demo.js
@@ -83,18 +83,22 @@ document.getElementById('container').addEventListener('mousemove', function (e) 
         }
 
         e = chart.pointer.normalize(e);
-        const projectedPosition = chart.mapView.pixelsToProjectedUnits({
-            x: Math.round(e.chartX - chart.plotLeft),
-            y: Math.round(e.chartY - chart.plotTop)
-        });
-        const position = chart.mapView.projectedUnitsToLonLat(
-            projectedPosition
-        );
+
+        // @todo Legacy code, remove after launch of v10
+        if (!e.lon && !e.lat) {
+            const projectedPosition = chart.mapView.pixelsToProjectedUnits({
+                x: Math.round(e.chartX - chart.plotLeft),
+                y: Math.round(e.chartY - chart.plotTop)
+            });
+            const position = chart.fromPointToLatLon(projectedPosition);
+            e.lon = position.lon;
+            e.lat = position.lat;
+        }
 
         chart.lbl.attr({
             x: e.chartX + 5,
             y: e.chartY - 22,
-            text: 'Lat: ' + position.lat.toFixed(2) + '<br>Lon: ' + position.lon.toFixed(2)
+            text: 'Lat: ' + e.lat.toFixed(2) + '<br>Lon: ' + e.lon.toFixed(2)
         });
     }
 });

--- a/samples/maps/demo/map-pies/demo.js
+++ b/samples/maps/demo/map-pies/demo.js
@@ -40,7 +40,9 @@ Highcharts.seriesType('mappie', 'pie', {
         }
         // Handle lat/lon support
         if (options.center.lat !== undefined) {
-            const projectedPos = chart.fromLatLonToPoint(options.center),
+            const projectedPos = chart.mapView.lonLatToProjectedUnits(
+                    options.center
+                ),
                 pixelPos = chart.mapView.projectedUnitsToPixels(projectedPos);
 
             options.center = [
@@ -336,11 +338,11 @@ chart.series[0].points.forEach(function (state) {
 
     // Draw connector to state center if the pie has been offset
     if (pieOffset.drawConnector !== false) {
-        const centerPoint = chart.fromLatLonToPoint({
+        const centerPoint = chart.mapView.lonLatToProjectedUnits({
                 lat: centerLat,
                 lon: centerLon
             }),
-            offsetPoint = chart.fromLatLonToPoint({
+            offsetPoint = chart.mapView.lonLatToProjectedUnits({
                 lat: centerLat + (pieOffset.lat || 0),
                 lon: centerLon + (pieOffset.lon || 0)
             });

--- a/samples/maps/demo/map-pies/demo.js
+++ b/samples/maps/demo/map-pies/demo.js
@@ -40,9 +40,7 @@ Highcharts.seriesType('mappie', 'pie', {
         }
         // Handle lat/lon support
         if (options.center.lat !== undefined) {
-            const projectedPos = chart.mapView.lonLatToProjectedUnits(
-                    options.center
-                ),
+            const projectedPos = chart.fromLatLonToPoint(options.center),
                 pixelPos = chart.mapView.projectedUnitsToPixels(projectedPos);
 
             options.center = [
@@ -338,11 +336,11 @@ chart.series[0].points.forEach(function (state) {
 
     // Draw connector to state center if the pie has been offset
     if (pieOffset.drawConnector !== false) {
-        const centerPoint = chart.mapView.lonLatToProjectedUnits({
+        const centerPoint = chart.fromLatLonToPoint({
                 lat: centerLat,
                 lon: centerLon
             }),
-            offsetPoint = chart.mapView.lonLatToProjectedUnits({
+            offsetPoint = chart.fromLatLonToPoint({
                 lat: centerLat + (pieOffset.lat || 0),
                 lon: centerLon + (pieOffset.lon || 0)
             });

--- a/samples/maps/series/latlon-to-point/demo.js
+++ b/samples/maps/series/latlon-to-point/demo.js
@@ -45,11 +45,10 @@ const chart = Highcharts.mapChart('container', {
 });
 
 document.getElementById('addCircle').onclick = () => {
-    const projectedPos = chart.mapView.lonLatToProjectedUnits({
-            lat: 51.507222,
-            lon: -0.1275
-        }),
-        pixelPos = chart.mapView.projectedUnitsToPixels(projectedPos);
+    const pixelPos = chart.mapView.lonLatToPixels({
+        lat: 51.507222,
+        lon: -0.1275
+    });
 
     chart.renderer.circle(
         chart.plotLeft + pixelPos.x,

--- a/samples/maps/series/latlon-to-point/demo.js
+++ b/samples/maps/series/latlon-to-point/demo.js
@@ -45,7 +45,7 @@ const chart = Highcharts.mapChart('container', {
 });
 
 document.getElementById('addCircle').onclick = () => {
-    const projectedPos = chart.fromLatLonToPoint({
+    const projectedPos = chart.mapView.lonLatToProjectedUnits({
             lat: 51.507222,
             lon: -0.1275
         }),

--- a/samples/unit-tests/maps/map-navigation/demo.js
+++ b/samples/unit-tests/maps/map-navigation/demo.js
@@ -225,9 +225,16 @@ QUnit.test('Orthographic map rotation and panning.', assert => {
         return data;
     };
 
+    let event;
     const chart = Highcharts.mapChart('container', {
         chart: {
-            animation: false
+            animation: false,
+            events: {
+                click: function (e) {
+                    // Assign the global event
+                    event = e;
+                }
+            }
         },
 
         title: {
@@ -326,4 +333,21 @@ QUnit.test('Orthographic map rotation and panning.', assert => {
         oldRotation,
         'Rotation should be activated (#16722).'
     );
+
+    // Test event properties
+    controller.click(300, 300);
+    assert.close(
+        event.lon,
+        10.2,
+        5,
+        'Longitude should be available on event'
+    );
+
+    assert.close(
+        event.lat,
+        38.4,
+        10,
+        'Latitude should be available on event'
+    );
+
 });

--- a/samples/unit-tests/maps/mapview-inset/demo.js
+++ b/samples/unit-tests/maps/mapview-inset/demo.js
@@ -88,7 +88,8 @@ QUnit.test('MapView Inset', assert => {
 
     const coords1 = { lon: 95, lat: 55 },
         projectedPos = chart.fromLatLonToPoint(coords1),
-        chartPos = chart.mapView.projectedUnitsToPixels(projectedPos);
+        mapView = chart.mapView,
+        chartPos = mapView.projectedUnitsToPixels(projectedPos);
 
     assert.deepEqual(
         chartPos,
@@ -100,6 +101,14 @@ QUnit.test('MapView Inset', assert => {
         chart.fromPointToLatLon(chart.mapView.pixelsToProjectedUnits(chartPos)),
         coords1,
         'fromPointToLatLon: inside inset'
+    );
+
+    assert.deepEqual(
+        mapView.pixelsToLonLat(
+            mapView.lonLatToPixels(coords1)
+        ),
+        coords1,
+        'pixels <-> lonLat roundtrip, inside inset'
     );
 
     const coords2 = { lon: 5, lat: 5 },

--- a/ts/Core/Chart/ChartDefaults.ts
+++ b/ts/Core/Chart/ChartDefaults.ts
@@ -966,9 +966,10 @@ const ChartDefaults: ChartOptions = {
      *         Y
      * @sample {highstock} stock/chart/zoomtype-xy/
      *         Xy
+     * @sample {highmaps} maps/chart/zoomtype-xy/
+     *         Map with selection zoom
      *
      * @type       {string}
-     * @product    highcharts highstock gantt
      * @validvalue ["x", "y", "xy"]
      * @apioption  chart.zoomType
      */

--- a/ts/Core/DefaultOptions.ts
+++ b/ts/Core/DefaultOptions.ts
@@ -2488,7 +2488,7 @@ const defaultOptions: Options = {
          *
          * @sample {highcharts} highcharts/tooltip/pointformat/
          *         A different point format with value suffix
-         * @sample {highcharts|highstock} highcharts/tooltip/pointformat-extra-infromation/
+         * @sample {highcharts|highstock} highcharts/tooltip/pointformat-extra-information/
          *         Show extra information about points in the tooltip
          * @sample {highmaps} maps/tooltip/format/
          *         Format demo

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -978,6 +978,9 @@ class Pointer {
      * properties `chartX` and `chartY` in order to work on the internal
      * coordinate system.
      *
+     * On map charts, the properties `lon` and `lat` are added to the event
+     * object given that the chart has projection information.
+     *
      * @function Highcharts.Pointer#normalize
      *
      * @param {global.MouseEvent|global.PointerEvent|global.TouchEvent} e

--- a/ts/Core/PointerEvent.d.ts
+++ b/ts/Core/PointerEvent.d.ts
@@ -30,6 +30,8 @@ export interface PointerEvent extends globalThis.PointerEvent {
     accumulate?: boolean;
     chartX: number;
     chartY: number;
+    lat?: number;
+    lon?: number;
     point?: Point;
     touches?: Array<Touch>;
     xAxis?: Array<Pointer.AxisCoordinateObject>;

--- a/ts/Maps/MapNavigation.ts
+++ b/ts/Maps/MapNavigation.ts
@@ -65,6 +65,7 @@ declare global {
             mapNavigation: MapNavigation;
             pointer: MapPointer;
             fitToBox(inner: BBoxObject, outer: BBoxObject): BBoxObject;
+            /** @deprecated */
             mapZoom(
                 howMuch?: number,
                 xProjected?: number,
@@ -443,6 +444,7 @@ extend<Chart|Highcharts.MapNavigationChart>(Chart.prototype, /** @lends Chart.pr
      *
      * Deprecated as of v9.3 in favor of [MapView.zoomBy](https://api.highcharts.com/class-reference/Highcharts.MapView#zoomBy).
      *
+     * @deprecated
      * @function Highcharts.Chart#mapZoom
      *
      * @param {number} [howMuch]

--- a/ts/Maps/MapPointer.ts
+++ b/ts/Maps/MapPointer.ts
@@ -50,11 +50,35 @@ declare global {
 
 /* eslint-disable no-invalid-this */
 
+const normalize = Pointer.prototype.normalize;
 let totalWheelDelta = 0;
 let totalWheelDeltaTimer: number;
 
 // Extend the Pointer
 extend<Pointer|Highcharts.MapPointer>(Pointer.prototype, {
+
+    // Add lon and lat information to pointer events
+    normalize: function <T extends PointerEvent> (
+        e: (T|MouseEvent|PointerEvent|TouchEvent),
+        chartPosition?: Pointer.ChartPositionObject
+    ): T {
+        const chart = this.chart;
+
+        e = normalize.call(this, e, chartPosition);
+
+        if (chart && chart.mapView) {
+            const lonLat = chart.mapView.pixelsToLonLat({
+                x: (e as any).chartX - chart.plotLeft,
+                y: (e as any).chartY - chart.plotTop
+            });
+            if (lonLat) {
+                extend(e, lonLat);
+            }
+        }
+
+        return e as any;
+
+    },
 
     // The event handler for the doubleclick event
     onContainerDblClick: function (

--- a/ts/Maps/MapView.ts
+++ b/ts/Maps/MapView.ts
@@ -433,12 +433,32 @@ class MapView {
     }
 
     /**
+     * Convert map coordinates in longitude/latitude to pixels
+     *
+     * @function Highcharts.MapView#lonLatToPixels
+     * @since  next
+     * @param  {Highcharts.MapLonLatObject} lonLat
+     *         The map coordinates
+     * @return {Highcharts.PositionObject|undefined}
+     *         The pixel position
+     */
+    public lonLatToPixels(
+        lonLat: Highcharts.MapLonLatObject
+    ): PositionObject|undefined {
+        const pos = this.lonLatToProjectedUnits(lonLat);
+        if (pos) {
+            return this.projectedUnitsToPixels(pos);
+        }
+    }
+
+    /**
      * Get projected units from longitude/latitude. Insets are accounted for.
      * Returns an object with x and y values corresponding to positions on the
      * projected plane.
      *
      * @requires modules/map
      *
+     * @since next
      * @sample maps/series/latlon-to-point/ Find a point from lon/lat
      *
      * @param {Highcharts.MapLonLatObject} lonLat Coordinates.
@@ -507,6 +527,8 @@ class MapView {
      * object with the numeric properties `lon` and `lat`.
      *
      * @requires modules/map
+     *
+     * @since next
      *
      * @sample maps/demo/latlon-advanced/ Advanced lat/lon demo
      *
@@ -706,6 +728,22 @@ class MapView {
         const y = centerPxY + scale * (projectedCenter[1] - pos.y);
 
         return { x, y };
+    }
+
+    /**
+     * Convert pixel position to longitude and latitude.
+     *
+     * @function Highcharts.MapView#pixelsToLonLat
+     * @since  next
+     * @param  {Highcharts.PositionObject} pos
+     *         The position in pixels
+     * @return {Highcharts.MapLonLatObject|undefined}
+     *         The map coordinates
+     */
+    public pixelsToLonLat(
+        pos: PositionObject
+    ): Highcharts.MapLonLatObject|undefined {
+        return this.projectedUnitsToLonLat(this.pixelsToProjectedUnits(pos));
     }
 
     /**

--- a/ts/Maps/MapView.ts
+++ b/ts/Maps/MapView.ts
@@ -458,6 +458,8 @@ class MapView {
      *
      * @requires modules/map
      *
+     * @function Highcharts.MapView#lonLatToProjectedUnits
+     *
      * @since next
      * @sample maps/series/latlon-to-point/ Find a point from lon/lat
      *
@@ -527,6 +529,8 @@ class MapView {
      * object with the numeric properties `lon` and `lat`.
      *
      * @requires modules/map
+     *
+     * @function Highcharts.MapView#projectedUnitsToLonLat
      *
      * @since next
      *

--- a/ts/Series/MapPoint/MapPointPoint.ts
+++ b/ts/Series/MapPoint/MapPointPoint.ts
@@ -56,7 +56,7 @@ class MapPointPoint extends ScatterSeries.prototype.pointClass {
     /* eslint-disable valid-jsdoc */
 
     public applyOptions(
-        options: (Highcharts.MapLatLonObject&MapPointPointOptions),
+        options: (Highcharts.MapLonLatObject&MapPointPointOptions),
         x?: number
     ): MapPointPoint {
         const mergedOptions = (


### PR DESCRIPTION
Moved existing translation functions from Chart to MapView, and added new functions `MapView.pixelsToLonLat` and `MapView.lonLatToPixels`. Added `lon` and `lat` properties directly to mouse event arguments.

### To do
 - [x] `pixelsToLonLat({ x, y })`
 - [x] `lonLatToPixels({ lon, lat })`
 - [x] `projectedUnitsToLonLat({ x, y })`. Move from Chart.
 - [x] `lonLatToProjectedUnits({ lon, lat })`. Move from Chart.
 - [x] Add `lon` and `lat` directly to mouse events.
 - [x] Remove deprecated functions from samples (except unit-tests). Use direct mouse events for some samples, but make sure there is coverage for the other functions.
 - [x] Verify class reference.
 - [x] Update docs if any.
