### PR TITLE
bugfix/14175-datalabels-rotation-update

### DIFF
--- a/samples/unit-tests/datalabels/update/demo.details
+++ b/samples/unit-tests/datalabels/update/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/datalabels/update/demo.html
+++ b/samples/unit-tests/datalabels/update/demo.html
@@ -1,0 +1,6 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/datalabels/update/demo.js
+++ b/samples/unit-tests/datalabels/update/demo.js
@@ -1,0 +1,42 @@
+QUnit.test(
+    'Update dataLabels\' options',
+    assert => {
+        const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'column'
+            },
+            plotOptions: {
+                series: {
+                    dataLabels: {
+                        enabled: true
+                    }
+                }
+            },
+            series: [{
+                data: [1000, 950]
+            }]
+        });
+
+        [-90, 0, -90].forEach(rotation => {
+            chart.series[0].update({
+                dataLabels: {
+                    rotation
+                }
+            });
+
+            const point = chart.series[0].points[0],
+                labelBox = point.dataLabel.element.getBoundingClientRect(),
+                columnBox = point.graphic.element.getBoundingClientRect();
+
+            assert.close(
+                labelBox.x + labelBox.width / 2,
+                columnBox.x + columnBox.width / 2,
+                // Trying to dodge the browsers differences,
+                // previous misplacements were between 7-20 pixels
+                3,
+                `Correct position after updating rotation to ${rotation}
+                (#14175).`
+            );
+        });
+    }
+);

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -544,13 +544,13 @@ namespace DataLabel {
                         rotation,
                         attr: any,
                         dataLabel: SVGLabel = point.dataLabels ?
-                            point.dataLabels[i] : point.dataLabel as any;
+                            point.dataLabels[i] : point.dataLabel as any,
+                        isNew = !dataLabel;
 
                     const labelDistance = pick(
-                            (labelOptions as any).distance,
-                            point.labelDistance
-                        ),
-                        isNew = !dataLabel;
+                        (labelOptions as any).distance,
+                        point.labelDistance
+                    );
 
                     if (labelEnabled) {
                         // Create individual options structure that can be
@@ -635,9 +635,20 @@ namespace DataLabel {
                         dataLabel && (
                             !labelEnabled ||
                             !defined(labelText) ||
-                            !!dataLabel.div !== !!labelOptions.useHTML
+                            !!dataLabel.div !== !!labelOptions.useHTML ||
+                            (
+                                // Change from no rotation to rotation and
+                                // vice versa. Don't use defined() because
+                                // rotation = 0 means also rotation = undefined
+                                (
+                                    !dataLabel.rotation ||
+                                    !labelOptions.rotation
+                                ) &&
+                                dataLabel.rotation !== labelOptions.rotation
+                            )
                         )
                     ) {
+                        isNew = true;
                         point.dataLabel = dataLabel =
                             point.dataLabel && point.dataLabel.destroy() as any;
                         if (point.dataLabels) {


### PR DESCRIPTION
Fixed #14175, enabling and disabling `dataLabels.rotation` misplaced data label's position.
___
This is a regression since `soft series update` was implemented. Previously, we used to destroy labels and recreate them. This PR restores that logic (enabling/disabling rotation now destroys labels). Note: data label is created using `text()` (w/o rotation) or `label()` (w/ rotation), so it seems a reasonable solution.

I have tried to fix this on the alignment level too. It seems rotated labels set `alignFactor = 0.5` while unrotated don't (`alignFactor = 0`). That means returning back to unrotated ones, we render labels with the wrong factor. Tried to fix that, but then we have another and another and another.. issue. Unless we decide to implement animation for rotation change, I would not touch this.