### PR TITLE
bugfix/16788-waterfall-focusable-points

### DIFF
--- a/samples/unit-tests/series-waterfall/waterfall-array-points/demo.js
+++ b/samples/unit-tests/series-waterfall/waterfall-array-points/demo.js
@@ -20,21 +20,21 @@ QUnit.test('Waterfall point definitions(#4094)', function (assert) {
         ]
     });
 
-    assert.equal(
+    assert.strictEqual(
         chart.xAxis[0].dataMin,
         Date.UTC(2015, 0, 1),
         'X Axis min'
     );
 
-    assert.equal(
+    assert.strictEqual(
         chart.xAxis[0].dataMax,
         Date.UTC(2015, 0, 4),
         'X Axis max'
     );
 
-    assert.equal(
+    assert.strictEqual(
         chart.series[0].data[1].isInside,
         true,
-        'Point is inside plot (#16788)'
+        'The point.isInside flag should be true (#16788).'
     );
 });

--- a/samples/unit-tests/series-waterfall/waterfall-array-points/demo.js
+++ b/samples/unit-tests/series-waterfall/waterfall-array-points/demo.js
@@ -1,5 +1,5 @@
 QUnit.test('Waterfall point definitions(#4094)', function (assert) {
-    $('#container').highcharts({
+    const chart = Highcharts.chart('container', {
         chart: {
             type: 'waterfall'
         },
@@ -11,8 +11,8 @@ QUnit.test('Waterfall point definitions(#4094)', function (assert) {
         series: [
             {
                 data: [
-                    [Date.UTC(2015, 0, 1), 10],
-                    [Date.UTC(2015, 0, 2), 15],
+                    [Date.UTC(2015, 0, 1), 20],
+                    [Date.UTC(2015, 0, 2), -20],
                     [Date.UTC(2015, 0, 3), 5],
                     [Date.UTC(2015, 0, 4), 7]
                 ]
@@ -20,7 +20,21 @@ QUnit.test('Waterfall point definitions(#4094)', function (assert) {
         ]
     });
 
-    var chart = $('#container').highcharts();
-    assert.equal(chart.xAxis[0].dataMin, Date.UTC(2015, 0, 1), 'X Axis min');
-    assert.equal(chart.xAxis[0].dataMax, Date.UTC(2015, 0, 4), 'X Axis max');
+    assert.equal(
+        chart.xAxis[0].dataMin,
+        Date.UTC(2015, 0, 1),
+        'X Axis min'
+    );
+
+    assert.equal(
+        chart.xAxis[0].dataMax,
+        Date.UTC(2015, 0, 4),
+        'X Axis max'
+    );
+
+    assert.equal(
+        chart.series[0].data[1].isInside,
+        true,
+        'Point is inside plot (#16788)'
+    );
 });

--- a/ts/Series/Waterfall/WaterfallSeries.ts
+++ b/ts/Series/Waterfall/WaterfallSeries.ts
@@ -509,6 +509,9 @@ class WaterfallSeries extends ColumnSeries {
                     point.tooltipPos[1] = tooltipY;
                 }
             }
+
+            // Check point position after recalculation (#16788)
+            point.isInside = this.isPointInside(point);
         }
     }
 


### PR DESCRIPTION
Fixed #16788, accessibility issue with some columns not being focusable because of wrong `point.isInside` flag.