### PR TITLE
Bugfix/16979 percent stacking key

### DIFF
--- a/samples/unit-tests/series-column/stacking/demo.js
+++ b/samples/unit-tests/series-column/stacking/demo.js
@@ -135,9 +135,15 @@ QUnit.test('Single series stacking (#2592)', function (assert) {
             },
             plotOptions: {
                 column: {
-                    stacking: 'normal'
+                    stacking: 'normal',
+                    colorByPoint: true
                 }
             },
+            yAxis: [{},
+                {
+                    opposite: true
+                }
+            ],
             series: [
                 {
                     name: 'John',
@@ -172,6 +178,40 @@ QUnit.test('Single series stacking (#2592)', function (assert) {
             'There should be an SVG element for each data point.'
         );
     }
+
+    // Issue #16979
+    // column with stacking = 'percent' shows only one point
+    chart.addSeries({
+        name: 'Percent',
+        data: [
+            [2, 1],
+            [2, 2]
+        ],
+        yAxis: 1,
+        stacking: 'percent'
+    });
+
+    assert.equal(
+        chart.yAxis[1].dataMax,
+        100,
+        'The dataMax should be equal to 100'
+    );
+
+    chart.addSeries({
+        name: 'Percent',
+        data: [
+            [3, -2],
+            [3, 2]
+        ],
+        yAxis: 1,
+        stacking: 'percent'
+    });
+
+    assert.strictEqual(
+        chart.series[3].points[0].barX,
+        chart.series[3].points[1].barX,
+        'The barX of point[0] should be equal to barX of point[1]'
+    );
 });
 
 // Issue #7420

--- a/ts/Extensions/Stacking.ts
+++ b/ts/Extensions/Stacking.ts
@@ -121,6 +121,7 @@ declare global {
         interface StackItemIndicatorObject {
             index: number;
             key?: string;
+            stackKey?: string;
             x: number;
         }
         interface StackItemObject {
@@ -872,12 +873,13 @@ Series.prototype.getStackIndicator = function (
     // changed:
     if (!defined(stackIndicator) ||
         stackIndicator.x !== x ||
-        (key && stackIndicator.key !== key)
+        (key && stackIndicator.stackKey !== key)
     ) {
         stackIndicator = {
             x: x,
             index: 0,
-            key: key
+            key: key,
+            stackKey: key
         };
     } else {
         (stackIndicator).index++;


### PR DESCRIPTION
Fixed #16979, only one point per x value was shown when `stacking` set to `percent`.