### PR TITLE
bugfix/17042-panning-ordinal

### DIFF
--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -650,9 +650,11 @@ namespace OrdinalAxis {
                 // how many ordinal units did we move?
                 movedUnits = ((mouseDownX as any) - chartX) / pointPixelWidth,
                 // get index of all the chart's points
+                extendedOrdinalPositions = xAxis.ordinal.getExtendedPositions(),
                 extendedAxis = {
                     ordinal: {
-                        positions: xAxis.ordinal.getExtendedPositions()
+                        positions: extendedOrdinalPositions,
+                        extendedOrdinalPositions: extendedOrdinalPositions
                     }
                 },
                 index2val = xAxis.index2val,


### PR DESCRIPTION
Fixed #17042, panning on ordinal axis when whole data visible caused an unnecessary change of extremes.