### PR TITLE
Fixed random data cropping when trying to zoom in wordcloud

### DIFF
--- a/ts/Series/Wordcloud/WordcloudSeries.ts
+++ b/ts/Series/Wordcloud/WordcloudSeries.ts
@@ -93,13 +93,12 @@ class WordcloudSeries extends ColumnSeries {
      * A word cloud is a visualization of a set of words, where the size and
      * placement of a word is determined by how it is weighted.
      *
-     * @sample highcharts/demo/wordcloud
-     *         Word Cloud chart
+     * @sample highcharts/demo/wordcloud Word Cloud chart
      *
      * @extends      plotOptions.column
      * @excluding    allAreas, boostThreshold, clip, colorAxis, compare,
-     *               compareBase, crisp, cropTreshold, dataGrouping, dataLabels,
-     *               depth, dragDrop, edgeColor, findNearestPointBy,
+     *               compareBase, crisp, cropThreshold, dataGrouping,
+     *               dataLabels, depth, dragDrop, edgeColor, findNearestPointBy,
      *               getExtremesFromAll, grouping, groupPadding, groupZPadding,
      *               joinBy, maxPointWidth, minPointLength, navigatorOptions,
      *               negativeColor, pointInterval, pointIntervalUnit,
@@ -132,6 +131,7 @@ class WordcloudSeries extends ColumnSeries {
         borderWidth: 0,
         clip: false, // Something goes wrong with clip. // @todo fix this
         colorByPoint: true,
+        cropThreshold: Infinity,
         /**
          * A threshold determining the minimum font size that can be applied to
          * a word.


### PR DESCRIPTION
Related to, but not a fix to, #9426.