### PR TITLE
bugfix/16782-setdata-unsorted-joinby

### DIFF
--- a/samples/unit-tests/maps/globalmap/demo.js
+++ b/samples/unit-tests/maps/globalmap/demo.js
@@ -87,6 +87,27 @@ QUnit.test('Set basemap on chart object', function (assert) {
         a null color, #11636.`
     );
 
+    assert.strictEqual(
+        chart.series[0].points[0].options.name,
+        'Temburong',
+        `The first point from a map source should be bn-te, its name should
+        be taken from a map source.`
+    );
+
+    chart.series[0].update({
+        dataLabels: {
+            enabled: true,
+            format: '{point.hc-key}'
+        }
+    });
+
+    assert.strictEqual(
+        chart.series[0].points[0].dataLabel.textStr,
+        'bn-te',
+        `The first point from a map source should be bn-te, its name should
+        be taken from a map source.`
+    );
+
     chart.series[0].setData(
         [{
             'hc-key': 'bn-be',
@@ -104,10 +125,25 @@ QUnit.test('Set basemap on chart object', function (assert) {
     );
 
     assert.strictEqual(
-        chart.series[0].points[0].properties['hc-key'],
-        'bn-te', // not bn-be
-        `Points should be matched correctly (by joinBy) with unsorted data,
-        #16782`
+        chart.series[0].points[0].options.name,
+        undefined,
+        `After setData with unsorted data without a points' name, the points
+        should be cleared and the first point should be matched correctly
+        (by joinBy), #16782.`
+    );
+
+    assert.strictEqual(
+        chart.series[0].points[0]['hc-key'],
+        'bn-be',
+        `After setData with unsorted data the first point should be matched
+        correctly (by joinBy).`
+    );
+
+    assert.strictEqual(
+        chart.series[0].points[0].dataLabel.textStr,
+        'bn-be',
+        `The first point from a map source should be bn-te, its name should
+        be taken from a map source, #16782.`
     );
 
 });

--- a/samples/unit-tests/maps/globalmap/demo.js
+++ b/samples/unit-tests/maps/globalmap/demo.js
@@ -86,4 +86,28 @@ QUnit.test('Set basemap on chart object', function (assert) {
         `When updating mapData with empty data, the first point should have
         a null color, #11636.`
     );
+
+    chart.series[0].setData(
+        [{
+            'hc-key': 'bn-be',
+            value: 0
+        }, {
+            'hc-key': 'bn-te',
+            value: 1
+        }, {
+            'hc-key': 'bn-bm',
+            value: 2
+        }, {
+            'hc-key': 'bn-tu',
+            value: 3
+        }]
+    );
+
+    assert.strictEqual(
+        chart.series[0].points[0].properties['hc-key'],
+        'bn-te', // not bn-be
+        `Points should be matched correctly (by joinBy) with unsorted data,
+        #16782`
+    );
+
 });

--- a/samples/unit-tests/maps/setdata/demo.js
+++ b/samples/unit-tests/maps/setdata/demo.js
@@ -1,6 +1,6 @@
 QUnit.test('Map set data with updated data (#3894)', function (assert) {
     // Prepare demo data
-    var data = [
+    const data = [
         {
             'hc-key': 'dz',
             value: 0
@@ -830,7 +830,6 @@ QUnit.test('Map set data with updated data (#3894)', function (assert) {
 
         series: [
             {
-                data: data,
                 mapData: Highcharts.maps['custom/world'],
                 joinBy: 'hc-key',
                 name: 'Random data',
@@ -849,7 +848,7 @@ QUnit.test('Map set data with updated data (#3894)', function (assert) {
 
     data[148].value = 1;
 
-    const mapView = $('#container').highcharts().mapView;
+    const mapView = chart.mapView;
 
     const before = Object.assign(
         {},
@@ -857,7 +856,7 @@ QUnit.test('Map set data with updated data (#3894)', function (assert) {
         mapView.zoom
     );
 
-    Highcharts.charts[0].series[0].setData(data);
+    chart.series[0].setData(data);
 
     const after = Object.assign(
         {},

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3382,7 +3382,9 @@ class Chart {
         if (updateAllSeries) {
             chart.getSeriesOrderByLinks().forEach(function (series): void {
                 // Avoid removed navigator series
-                series.update({}, false);
+                if (series.chart) {
+                    series.update({}, false);
+                }
             }, this);
         }
 

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -102,7 +102,6 @@ const {
     fireEvent,
     getStyle,
     isArray,
-    isFunction,
     isNumber,
     isObject,
     isString,
@@ -3383,9 +3382,7 @@ class Chart {
         if (updateAllSeries) {
             chart.getSeriesOrderByLinks().forEach(function (series): void {
                 // Avoid removed navigator series
-                if (series.chart) {
-                    series.update({}, false);
-                }
+                series.update({}, false);
             }, this);
         }
 

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -1266,6 +1266,9 @@ class Series {
      * points, or a different amount of points, as handled by the
      * `updatePoints` parameter.
      *
+     * In Highcharts Maps new data is sorted by the `joinBy` property to match
+     * points (regions) properly.
+     *
      * @sample highcharts/members/series-setdata/
      *         Set new data from a button
      * @sample highcharts/members/series-setdata-pie/

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -1266,9 +1266,6 @@ class Series {
      * points, or a different amount of points, as handled by the
      * `updatePoints` parameter.
      *
-     * In Highcharts Maps new data is sorted by the `joinBy` property to match
-     * points (regions) properly.
-     *
      * @sample highcharts/members/series-setdata/
      *         Set new data from a button
      * @sample highcharts/members/series-setdata-pie/

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -933,25 +933,22 @@ class MapSeries extends ScatterSeries {
     }
 
     /**
-     * Sort data by the joinBy property to match new data with proper points
-     * (regions).
      * @private
      */
-    public sortDataToMatch(data: (PointOptions|PointShortOptions)[]): void {
-        const joinBy = this.joinBy[0],
-            sortArr = (this.points || [])
-                .map((point: any): void => point[joinBy]);
+    public updateData(): boolean {
+        // #16782
+        if (this.processedData) {
+            return false;
+        }
 
-        (data || []).sort((a: any, b: any): number =>
-            sortArr.indexOf(a[joinBy]) - sortArr.indexOf(b[joinBy]));
+        return super.updateData.apply(this, arguments);
     }
 
     /**
      * Extend setData to call processData and generatePoints immediately.
      * @private
      */
-    public setData(data: (PointOptions|PointShortOptions)[]): void {
-        this.sortDataToMatch(data);
+    public setData(): void {
 
         super.setData.apply(this, arguments);
 

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -805,8 +805,7 @@ class MapSeries extends ScatterSeries {
     public getProjectedBounds(): MapBounds|undefined {
         if (!this.bounds && this.chart.mapView) {
 
-            const MAX_VALUE = Number.MAX_VALUE,
-                { insets, projection } = this.chart.mapView,
+            const { insets, projection } = this.chart.mapView,
                 allBounds: MapBounds[] = [];
 
             // Find the bounding box of each point
@@ -934,10 +933,25 @@ class MapSeries extends ScatterSeries {
     }
 
     /**
+     * Sort data by the joinBy property to match new data with proper points
+     * (regions).
+     * @private
+     */
+    public sortDataToMatch(data: (PointOptions|PointShortOptions)[]): void {
+        const joinBy = this.joinBy[0],
+            sortArr = (this.points || [])
+                .map((point: any): void => point[joinBy]);
+
+        (data || []).sort((a: any, b: any): number =>
+            sortArr.indexOf(a[joinBy]) - sortArr.indexOf(b[joinBy]));
+    }
+
+    /**
      * Extend setData to call processData and generatePoints immediately.
      * @private
      */
-    public setData(): void {
+    public setData(data: (PointOptions|PointShortOptions)[]): void {
+        this.sortDataToMatch(data);
 
         super.setData.apply(this, arguments);
 

--- a/ts/Series/MapBubble/MapBubbleSeries.ts
+++ b/ts/Series/MapBubble/MapBubbleSeries.ts
@@ -243,7 +243,7 @@ interface MapBubbleSeries {
     processData: typeof MapSeries.prototype['processData'];
     projectPoint: typeof MapPointSeries.prototype['projectPoint'];
     setOptions: typeof MapSeries.prototype['setOptions'];
-    sortDataToMatch: typeof MapSeries.prototype['sortDataToMatch'];
+    updateData: typeof MapSeries.prototype['updateData'];
     xyFromShape: boolean;
 }
 extend(MapBubbleSeries.prototype, {
@@ -268,7 +268,7 @@ extend(MapBubbleSeries.prototype, {
 
     setOptions: MapSeries.prototype.setOptions,
 
-    sortDataToMatch: MapSeries.prototype.sortDataToMatch,
+    updateData: MapSeries.prototype.updateData,
 
     useMapGeometry: true,
 

--- a/ts/Series/MapBubble/MapBubbleSeries.ts
+++ b/ts/Series/MapBubble/MapBubbleSeries.ts
@@ -23,8 +23,6 @@ import BubbleSeries from '../Bubble/BubbleSeries.js';
 import MapBubblePoint from './MapBubblePoint.js';
 import MapSeries from '../Map/MapSeries.js';
 import SeriesRegistry from '../../Core/Series/SeriesRegistry.js';
-import H from '../../Core/Globals.js';
-const { noop } = H;
 const {
     seriesTypes: {
         mappoint: MapPointSeries
@@ -245,6 +243,7 @@ interface MapBubbleSeries {
     processData: typeof MapSeries.prototype['processData'];
     projectPoint: typeof MapPointSeries.prototype['projectPoint'];
     setOptions: typeof MapSeries.prototype['setOptions'];
+    sortDataToMatch: typeof MapSeries.prototype['sortDataToMatch'];
     xyFromShape: boolean;
 }
 extend(MapBubbleSeries.prototype, {
@@ -268,6 +267,8 @@ extend(MapBubbleSeries.prototype, {
     setData: MapSeries.prototype.setData,
 
     setOptions: MapSeries.prototype.setOptions,
+
+    sortDataToMatch: MapSeries.prototype.sortDataToMatch,
 
     useMapGeometry: true,
 


### PR DESCRIPTION
Fixed #16782, point's `joinBy` was wrong when updating data with an unsorted order.