### PR TITLE
Columns of column chart float above x-axis when using datetime y-axis

### DIFF
--- a/ts/Core/Time.ts
+++ b/ts/Core/Time.ts
@@ -741,12 +741,14 @@ class Time {
                 time.set(
                     'Date',
                     minDate,
-                    (
-                        time.get('Date', minDate) -
-                        minDay + startOfWeek +
-                        // We don't want to skip days that are before
-                        // startOfWeek (#7051)
-                        (minDay < startOfWeek ? -7 : 0)
+                    Math.max(1,
+                        (
+                            time.get('Date', minDate) -
+                            minDay + startOfWeek +
+                            // We don't want to skip days that are before
+                            // startOfWeek (#7051)
+                            (minDay < startOfWeek ? -7 : 0)
+                        )
                     )
                 );
             }


### PR DESCRIPTION
This fixes #17084.