### PR TITLE
Fixed #17100 excessive padding with tickAmount

### DIFF
--- a/samples/stock/indicators/trix/demo.css
+++ b/samples/stock/indicators/trix/demo.css
@@ -1,4 +1,4 @@
 #container {
-    height: 400px;
+    height: 500px;
     min-width: 310px;
 }

--- a/samples/stock/indicators/trix/demo.css
+++ b/samples/stock/indicators/trix/demo.css
@@ -1,4 +1,4 @@
 #container {
-    height: 500px;
+    height: 400px;
     min-width: 310px;
 }

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -70,7 +70,6 @@ const {
     error,
     extend,
     fireEvent,
-    getMagnitude,
     isArray,
     isNumber,
     isString,
@@ -83,6 +82,24 @@ const {
     splat,
     syncTimeout
 } = U;
+
+const getNormalizedTickInterval = (
+    axis: Axis,
+    tickInterval: number
+): number => normalizeTickInterval(
+    tickInterval,
+    void 0,
+    void 0,
+    pick(
+        axis.options.allowDecimals,
+        // If the tick interval is greather than 0.5, avoid decimals, as
+        // linear axes are often used to render discrete values (#3363). If
+        // a tick amount is set, allow decimals by default, as it increases
+        // the chances for a good fit.
+        tickInterval < 0.5 || axis.tickAmount !== void 0
+    ),
+    !!axis.tickAmount
+);
 
 /* *
  *
@@ -1889,22 +1906,11 @@ class Axis {
             axis.tickInterval = minTickInterval;
         }
 
-        // for linear axes, get magnitude and normalize the interval
+        // For linear axes, normalize the interval
         if (!axis.dateTime && !axis.logarithmic && !tickIntervalOption) {
-            axis.tickInterval = normalizeTickInterval(
-                axis.tickInterval,
-                void 0,
-                getMagnitude(axis.tickInterval),
-                pick(
-                    options.allowDecimals,
-                    // If the tick interval is greather than 0.5, avoid
-                    // decimals, as linear axes are often used to render
-                    // discrete values. #3363. If a tick amount is set, allow
-                    // decimals by default, as it increases the chances for a
-                    // good fit.
-                    axis.tickInterval < 0.5 || this.tickAmount !== void 0
-                ),
-                !!this.tickAmount
+            axis.tickInterval = getNormalizedTickInterval(
+                axis,
+                axis.tickInterval
             );
         }
 
@@ -2025,14 +2031,9 @@ class Axis {
                     this.max as any
                 );
             } else {
-                tickPositions = this.getLinearTickPositions(
-                    this.tickInterval,
-                    this.min as any,
-                    this.max as any
-                );
                 const startingTickInterval = this.tickInterval;
-                let adjustedTickInterval = this.tickInterval;
-                while (adjustedTickInterval < startingTickInterval * 2) {
+                let adjustedTickInterval = startingTickInterval;
+                while (adjustedTickInterval <= startingTickInterval * 2) {
                     tickPositions = this.getLinearTickPositions(
                         this.tickInterval,
                         this.min as any,
@@ -2046,16 +2047,9 @@ class Axis {
                         this.tickAmount &&
                         tickPositions.length > this.tickAmount
                     ) {
-                        adjustedTickInterval *= 1.1;
-                        this.tickInterval = normalizeTickInterval(
-                            adjustedTickInterval,
-                            void 0,
-                            getMagnitude(adjustedTickInterval),
-                            pick(
-                                options.allowDecimals,
-                                true
-                            ),
-                            true
+                        this.tickInterval = getNormalizedTickInterval(
+                            this,
+                            adjustedTickInterval *= 1.1
                         );
                     } else {
                         break;

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -2452,7 +2452,37 @@ class Axis {
 
             // We have too many ticks, run second pass to try to reduce ticks
             } else if (currentTickAmount > tickAmount) {
-                axis.tickInterval *= 2;
+                /**
+                 * @todo #17100
+                 * - Refactor to avoid duplication with the code block in
+                 *   `setTickInterval`
+                 * - Guard for dateTime, log axis and tick interval option (like
+                 *   the original)
+                 */
+                if (
+                    !axis.dateTime &&
+                    !axis.logarithmic &&
+                    !axis.options.tickInterval
+                ) {
+                    axis.tickInterval = normalizeTickInterval(
+                        axis.tickInterval * 1.1,
+                        void 0,
+                        getMagnitude(axis.tickInterval * 1.1),
+                        pick(
+                            options.allowDecimals,
+                            // If the tick interval is greather than 0.5, avoid
+                            // decimals, as linear axes are often used to render
+                            // discrete values. #3363. If a tick amount is set,
+                            // allow decimals by default, as it increases the
+                            // chances for a good fit.
+                            axis.tickInterval < 0.5 ||
+                                this.tickAmount !== void 0
+                        ),
+                        true
+                    );
+                } else {
+                    axis.tickInterval *= 2;
+                }
                 axis.setTickPositions();
             }
 

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -2030,6 +2030,37 @@ class Axis {
                     this.min as any,
                     this.max as any
                 );
+                const startingTickInterval = this.tickInterval;
+                let adjustedTickInterval = this.tickInterval;
+                while (adjustedTickInterval < startingTickInterval * 2) {
+                    tickPositions = this.getLinearTickPositions(
+                        this.tickInterval,
+                        this.min as any,
+                        this.max as any
+                    );
+
+                    // If there are more tick positions than the set tickAmount,
+                    // increase the tickInterval and continue until it fits.
+                    // (#17100)
+                    if (
+                        this.tickAmount &&
+                        tickPositions.length > this.tickAmount
+                    ) {
+                        adjustedTickInterval *= 1.1;
+                        this.tickInterval = normalizeTickInterval(
+                            adjustedTickInterval,
+                            void 0,
+                            getMagnitude(adjustedTickInterval),
+                            pick(
+                                options.allowDecimals,
+                                true
+                            ),
+                            true
+                        );
+                    } else {
+                        break;
+                    }
+                }
             }
 
             // Too dense ticks, keep only the first and last (#4477)
@@ -2450,40 +2481,6 @@ class Axis {
 
                 adjustExtremes();
 
-            // We have too many ticks, run second pass to try to reduce ticks
-            } else if (currentTickAmount > tickAmount) {
-                /**
-                 * @todo #17100
-                 * - Refactor to avoid duplication with the code block in
-                 *   `setTickInterval`
-                 * - Guard for dateTime, log axis and tick interval option (like
-                 *   the original)
-                 */
-                if (
-                    !axis.dateTime &&
-                    !axis.logarithmic &&
-                    !axis.options.tickInterval
-                ) {
-                    axis.tickInterval = normalizeTickInterval(
-                        axis.tickInterval * 1.1,
-                        void 0,
-                        getMagnitude(axis.tickInterval * 1.1),
-                        pick(
-                            options.allowDecimals,
-                            // If the tick interval is greather than 0.5, avoid
-                            // decimals, as linear axes are often used to render
-                            // discrete values. #3363. If a tick amount is set,
-                            // allow decimals by default, as it increases the
-                            // chances for a good fit.
-                            axis.tickInterval < 0.5 ||
-                                this.tickAmount !== void 0
-                        ),
-                        true
-                    );
-                } else {
-                    axis.tickInterval *= 2;
-                }
-                axis.setTickPositions();
             }
 
             // The finalTickAmt property is set in getTickAmount

--- a/ts/Core/Axis/LogarithmicAxis.ts
+++ b/ts/Core/Axis/LogarithmicAxis.ts
@@ -279,11 +279,7 @@ namespace LogarithmicAxis {
                         tickPixelIntervalOption / (totalPixelLength || 1)
                 );
 
-                interval = normalizeTickInterval(
-                    interval,
-                    void 0,
-                    getMagnitude(interval)
-                );
+                interval = normalizeTickInterval(interval);
 
                 positions = axis.getLinearTickPositions(
                     interval,

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -931,7 +931,7 @@ function getMagnitude(num: number): number {
  */
 function normalizeTickInterval(
     interval: number,
-    multiples?: Array<any>,
+    multiples?: Array<number>,
     magnitude?: number,
     allowDecimals?: boolean,
     hasTickAmount?: boolean
@@ -940,8 +940,8 @@ function normalizeTickInterval(
         retInterval = interval;
 
     // round to a tenfold of 1, 2, 2.5 or 5
-    magnitude = pick(magnitude, 1);
-    const normalized = interval / (magnitude as any);
+    magnitude = pick(magnitude, getMagnitude(interval));
+    const normalized = interval / magnitude;
 
     // multiples for a linear scale
     if (!multiples) {
@@ -960,8 +960,8 @@ function normalizeTickInterval(
                 multiples = multiples.filter(function (num: number): boolean {
                     return num % 1 === 0;
                 });
-            } else if ((magnitude as any) <= 0.1) {
-                multiples = [1 / (magnitude as any)];
+            } else if (magnitude <= 0.1) {
+                multiples = [1 / magnitude];
             }
         }
     }
@@ -973,7 +973,7 @@ function normalizeTickInterval(
         if (
             (
                 hasTickAmount &&
-                retInterval * (magnitude as any) >= interval
+                retInterval * magnitude >= interval
             ) ||
             (
                 !hasTickAmount &&


### PR DESCRIPTION
Fixed #17100, excessive padding in some cases when `tickAmount` was set.

### To do
 - [x] Verify that the visual diffs make sense
 - [x] If so, refactor to avoid duplicated code