### PR TITLE
Provide additional info to tooltip positioner

### DIFF
--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1160,7 +1160,8 @@ class Tooltip {
                         plotY: y,
                         negative: point.negative,
                         ttBelow: point.ttBelow,
-                        h: anchor[2] || 0
+                        h: anchor[2] || 0,
+                        point
                     } as any);
                 } else {
                     tooltip.hide();


### PR DESCRIPTION
It would be very nice to provide the point itself to the tooltip positioner because in that way customers may provide extra information within series data array elements.
In my case we desparately need this ability, because there is no other way to get a link between positioner and the point.
You had this in previous releases (at least on 6.3.1 which we are currently using), and no it's gone.