### PR TITLE
Tools: used absolute paths for cypress articfacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,6 +204,17 @@ jobs:
       - run:
           name: Run cypress tests (Chrome)
           command: npx cypress run --browser chrome --headless
+      - store_artifacts:
+          path: /home/circleci/repo/highcharts/cypress/videos
+          destination: cypress-chrome
+      - store_artifacts:
+          path: /home/circleci/repo/highcharts/cypress/screenshots
+          destination: cypress-chrome
+      - run:
+          command: |
+            rm -rf /home/circleci/repo/highcharts/cypress/videos
+            rm -rf /home/circleci/repo/highcharts/cypress/screenshots
+          name: Clear Cypress videos and screenshots after storage (Chrome)
       - browser-tools/install-firefox
       - browser-tools/install-geckodriver
       - run:
@@ -216,8 +227,10 @@ jobs:
           command: npx cypress run --browser firefox --headless
       - store_artifacts:
           path: /home/circleci/repo/highcharts/cypress/videos
+          destination: cypress-firefox
       - store_artifacts:
           path: /home/circleci/repo/highcharts/cypress/screenshots
+          destination: cypress-firefox
 
   check_for_docs_changes_and_deploy:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,9 +215,9 @@ jobs:
           name: Run cypress tests (Firefox)
           command: npx cypress run --browser firefox --headless
       - store_artifacts:
-          path: cypress/videos
+          path: /home/circleci/repo/highcharts/cypress/videos
       - store_artifacts:
-          path: cypress/screenshots
+          path: /home/circleci/repo/highcharts/cypress/screenshots
 
   check_for_docs_changes_and_deploy:
     <<: *defaults


### PR DESCRIPTION
Fixes Chrome Cypress artifacts not being saved.

There is still an issue with the Firefox videos failing to process: 
![image](https://user-images.githubusercontent.com/7478772/160408346-7ea38876-159b-41b9-b775-b36a9ad67f32.png)
