### PR TITLE
bugfix/15863-axis-title-translation

### DIFF
--- a/samples/unit-tests/axis/title/demo.js
+++ b/samples/unit-tests/axis/title/demo.js
@@ -389,6 +389,7 @@ QUnit.test('Axis title multiline', function (assert) {
         'The title should be on a single line'
     );
     assert.ok(chart.plotWidth > crammedPlotWidth, 'Plot width increased');
+
 });
 
 // Highcharts 4.0.1, Issue #3027

--- a/samples/unit-tests/axis/title/demo.js
+++ b/samples/unit-tests/axis/title/demo.js
@@ -389,7 +389,6 @@ QUnit.test('Axis title multiline', function (assert) {
         'The title should be on a single line'
     );
     assert.ok(chart.plotWidth > crammedPlotWidth, 'Plot width increased');
-
 });
 
 // Highcharts 4.0.1, Issue #3027

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3684,30 +3684,30 @@ class Axis {
             // The part of a multiline text that is below the baseline of the
             // first line. Subtract 1 to preserve pixel-perfectness from the
             // old behaviour (v5.0.12), where only one line was allowed.
-            textHeightOvershoot = Math.max(
-                (axisTitle as any).getBBox(null, 0).height - fontMetrics.h - 1,
+            textHeightOvershoot = axisTitle ? Math.max(
+                axisTitle.getBBox(false, 0).height - fontMetrics.h - 1,
                 0
-            ),
+            ) : 0,
 
             // the position in the length direction of the axis
             alongAxis = ({
                 low: margin + (horiz ? 0 : axisLength),
                 middle: margin + axisLength / 2,
                 high: margin + (horiz ? axisLength : 0)
-            } as any)[axisTitleOptions.align as any],
+            })[axisTitleOptions.align],
 
             // the position in the perpendicular direction of the axis
             offAxis = (horiz ? axisTop + this.height : axisLeft) +
                 (horiz ? 1 : -1) * // horizontal axis reverses the margin
                 (opposite ? -1 : 1) * // so does opposite axes
-                (this.axisTitleMargin as any) +
+                (this.axisTitleMargin || 0) +
                 [
                     -textHeightOvershoot, // top
                     textHeightOvershoot, // right
                     fontMetrics.f, // bottom
                     -textHeightOvershoot // left
                 ][this.side],
-            titlePosition: PositionObject = {
+            titlePosition = {
                 x: horiz ?
                     alongAxis + xOption :
                     offAxis + (opposite ? this.width : 0) + offset + xOption,
@@ -3980,14 +3980,12 @@ class Axis {
         if (axisTitle && showAxis) {
             const titleXy = axis.getTitlePosition();
 
-            if (isNumber(titleXy.y)) {
+            if (isNumber(titleXy.y) && isNumber(titleXy.x)) {
                 axisTitle[axisTitle.isNew ? 'attr' : 'animate'](titleXy);
                 axisTitle.isNew = false;
-            } else {
-                axisTitle.hide();
-                axisTitle.isNew = true;
             }
         }
+
 
         // Stacked totals:
         if (stackLabelOptions && stackLabelOptions.enabled && axis.stacking) {

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3984,7 +3984,7 @@ class Axis {
                 axisTitle[axisTitle.isNew ? 'attr' : 'animate'](titleXy);
                 axisTitle.isNew = false;
             } else {
-                axisTitle.attr('y', -9999 as any);
+                axisTitle.hide();
                 axisTitle.isNew = true;
             }
         }

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3981,8 +3981,11 @@ class Axis {
             const titleXy = axis.getTitlePosition();
 
             if (isNumber(titleXy.y) && isNumber(titleXy.x)) {
-                axisTitle[axisTitle.isNew ? 'attr' : 'animate'](titleXy);
+                axisTitle[axisTitle.isNew ? 'attr' : 'animate'](titleXy).show();
                 axisTitle.isNew = false;
+            } else {
+                axisTitle.hide();
+                axisTitle.isNew = true;
             }
         }
 

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3979,14 +3979,8 @@ class Axis {
 
         if (axisTitle && showAxis) {
             const titleXy = axis.getTitlePosition();
-
-            if (isNumber(titleXy.y) && isNumber(titleXy.x)) {
-                axisTitle[axisTitle.isNew ? 'attr' : 'animate'](titleXy).show();
-                axisTitle.isNew = false;
-            } else {
-                axisTitle.hide();
-                axisTitle.isNew = true;
-            }
+            axisTitle[axisTitle.isNew ? 'attr' : 'animate'](titleXy);
+            axisTitle.isNew = false;
         }
 
 


### PR DESCRIPTION
Part of #15863, Removed Axis title translation to `y: -9999`.