### PR TITLE
bugfix/14320-export-data-table 

### DIFF
--- a/samples/unit-tests/export-data/basics/demo.js
+++ b/samples/unit-tests/export-data/basics/demo.js
@@ -1170,7 +1170,7 @@ QUnit.test('Toggle data table (#13690)', function (assert) {
     var chart = Highcharts.chart('container', {
         series: [
             {
-                data: [2, 5, 1, 6, 7, 8, 5]
+                data: [2, 5, 1, 6, 7]
             }
         ]
     });
@@ -1186,6 +1186,35 @@ QUnit.test('Toggle data table (#13690)', function (assert) {
         'none',
         'Table should not be visible again.'
     );
+
+    chart.viewData();
+    const csv = '"Category","Series 1"\n' +
+        `0,2\n` +
+        `1,5\n` +
+        '2,1\n' +
+        '3,6\n' +
+        '4,7';
+    assert.strictEqual(
+        csv,
+        chart.getCSV(),
+        'The table should show the values.'
+    );
+
+    chart.series[0].update({
+        data: [7, 6, 5, 4, 3]
+    });
+    const csvUpdated = '"Category","Series 1"\n' +
+        '0,7\n' +
+        '1,6\n' +
+        '2,5\n' +
+        '3,4\n' +
+        '4,3';
+    assert.strictEqual(
+        csvUpdated,
+        chart.getCSV(),
+        'The table should re-render after a data update, #14320.'
+    );
+    chart.hideData();
 });
 
 QUnit.test('Point without y data, but with value (#13785)', function (assert) {

--- a/ts/Extensions/ExportData.ts
+++ b/ts/Extensions/ExportData.ts
@@ -462,13 +462,9 @@ addEvent(Chart, 'render', function (): void {
         this.options &&
         this.options.exporting &&
         this.options.exporting.showTable &&
-        !this.options.chart.forExport &&
-        !this.dataTableDiv
+        !this.options.chart.forExport
     ) {
         this.viewData();
-    } else if (this.dataTableDiv) {
-        // Data table was not re-rendered after a data update, #14320.
-        AST.setElementHTML(this.dataTableDiv, this.getTable());
     }
 });
 

--- a/ts/Extensions/ExportData.ts
+++ b/ts/Extensions/ExportData.ts
@@ -466,6 +466,9 @@ addEvent(Chart, 'render', function (): void {
         !this.dataTableDiv
     ) {
         this.viewData();
+    } else if (this.dataTableDiv) {
+        // Data table was not re-rendered after a data update, #14320.
+        AST.setElementHTML(this.dataTableDiv, this.getTable());
     }
 });
 


### PR DESCRIPTION
Fixed #14320, the table was not re-rendered after a data update.

Replaces https://github.com/highcharts/highcharts/pull/14344