### PR TITLE
bugfix/17139-proj4-chart

### DIFF
--- a/ts/Extensions/GeoJSON.ts
+++ b/ts/Extensions/GeoJSON.ts
@@ -384,7 +384,7 @@ Chart.prototype.transformToLatLon = function (
         sinAngle = transform.sinAngle ||
             (transform.rotation && Math.sin(transform.rotation)),
         // Note: Inverted sinAngle to reverse rotation direction
-        projected = win.proj4(transform.crs, 'WGS84', transform.rotation ? {
+        projected = proj4(transform.crs, 'WGS84', transform.rotation ? {
             x: normalized.x * cosAngle + normalized.y * -sinAngle,
             y: normalized.x * sinAngle + normalized.y * cosAngle
         } : normalized);


### PR DESCRIPTION
Fixed #17139, `chart.proj4` option didn't work.