### PR TITLE
Fixed #17146, HTML and inline style parsing issue

### DIFF
--- a/samples/unit-tests/ast/ast/demo.details
+++ b/samples/unit-tests/ast/ast/demo.details
@@ -1,0 +1,5 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+...

--- a/samples/unit-tests/ast/ast/demo.html
+++ b/samples/unit-tests/ast/ast/demo.html
@@ -1,0 +1,6 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/ast/ast/demo.js
+++ b/samples/unit-tests/ast/ast/demo.js
@@ -1,0 +1,16 @@
+QUnit.test(
+    'parseStyle',
+    assert => {
+        const AST = Highcharts.AST;
+
+
+        assert.deepEqual(
+            AST.parseStyle('display: none; -webkit-mask: url(https://www.example.com/png.png) center center no-repeat'),
+            {
+                display: 'none',
+                WebkitMask: 'url(https://www.example.com/png.png) center center no-repeat'
+            },
+            'Parse style should handle common patterns'
+        );
+    }
+);

--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -361,13 +361,13 @@ class AST {
             .split(';')
             .reduce((styles, line): CSSObject => {
                 const pair = line.split(':').map((s): string => s.trim()),
-                    key = pair[0].replace(
+                    key = pair.shift();
+
+                if (key && pair.length) {
+                    (styles as any)[key.replace(
                         /-([a-z])/g,
                         (g): string => g[1].toUpperCase()
-                    );
-
-                if (pair[1]) {
-                    (styles as any)[key] = pair[1];
+                    )] = pair.join(':'); // #17146
                 }
                 return styles;
             }, {} as CSSObject);


### PR DESCRIPTION
Fixed #17146, a regression in v10 with parsing of HTML with inline style rules containing a colon