### PR TITLE
bugfix/17141-dataGrouping-multiple-series

### DIFF
--- a/samples/unit-tests/series/datagrouping/demo.js
+++ b/samples/unit-tests/series/datagrouping/demo.js
@@ -1038,3 +1038,28 @@ QUnit.test('The dataGrouping enabling/disabling.', function (assert) {
         );
     });
 });
+
+QUnit.test('Data grouping multiple series on zoom, #17141.', function (assert) {
+    const chart = Highcharts.stockChart('container', {
+        chart: {
+            width: 500
+        },
+        series: [{
+            data: Array.from(Array(5000)).map(() => Math.random() * 10)
+        }, {
+            data: Array.from(Array(5000)).map(() => Math.random() * 10)
+        }]
+    });
+
+    chart.xAxis[0].setExtremes(200, 220);
+    assert.notOk(
+        chart.series[0].hasGroupedData,
+        `After zooming to a point where groupinng is no longer needed, it should
+        not be applied.`
+    );
+    assert.notOk(
+        chart.series[1].hasGroupedData,
+        `After zooming to a point where groupinng is no longer needed, it should
+        not be applied.`
+    );
+});

--- a/ts/Extensions/DataGrouping.ts
+++ b/ts/Extensions/DataGrouping.ts
@@ -1114,10 +1114,12 @@ Axis.prototype.applyGrouping = function (
     const axis = this,
         series = axis.series;
 
+    // Reset the groupPixelWidth for all series, #17141.
     series.forEach(function (series): void {
-        // Reset the groupPixelWidth, then calculate if needed.
         series.groupPixelWidth = void 0; // #2110
+    });
 
+    series.forEach(function (series): void {
         series.groupPixelWidth = (
             axis.getGroupPixelWidth &&
             axis.getGroupPixelWidth()


### PR DESCRIPTION
 Fixed #17141, data grouping was not applied properly in charts with multiple series.