### PR TITLE
bugfix/15863-axis-tick-hide-by-translation

### DIFF
--- a/samples/unit-tests/axis/labels/demo.js
+++ b/samples/unit-tests/axis/labels/demo.js
@@ -219,7 +219,7 @@ QUnit.test(
         });
 
         assert.ok(
-            chart.yAxis[0].ticks[50].label.attr('y') > 0,
+            chart.yAxis[0].ticks[50].label.attr('visibility') !== 'hidden',
             '50 label is placed'
         );
 
@@ -230,7 +230,7 @@ QUnit.test(
 
         setTimeout(function () {
             assert.ok(
-                chart.yAxis[0].ticks[50].label.attr('y') < 0,
+                chart.yAxis[0].ticks[50].label.attr('visibility') === 'hidden',
                 '50 label is hidden'
             );
 

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -1078,10 +1078,10 @@ class Tick {
             // Set the new position, and show or hide
             if (show && isNumber(xy.y)) {
                 xy.opacity = opacity;
-                label[tick.isNewLabel ? 'attr' : 'animate'](xy);
+                label[tick.isNewLabel ? 'attr' : 'animate'](xy).show();
                 tick.isNewLabel = false;
             } else {
-                label.attr('y', -9999 as any); // #1338
+                label.hide(); // #1338, #15863
                 tick.isNewLabel = true;
             }
         }


### PR DESCRIPTION
Part of #15863, Deleted hiding by translation of the ticks.