### PR TITLE
bugfix/16550-week-dataTime-format 

### DIFF
--- a/samples/unit-tests/gantt/grid-axis/demo.js
+++ b/samples/unit-tests/gantt/grid-axis/demo.js
@@ -2167,3 +2167,32 @@ QUnit.test('slotWidth', assert => {
         '#15742: Rightmost tick slotWidth should be much smaller than the other ticks'
     );
 });
+
+QUnit.test('Week dataTime format for useUTC: false, #16550.', assert => {
+    const chart = Highcharts.ganttChart('container', {
+        chart: {
+            width: 800
+        },
+        xAxis: [{
+            tickInterval: 7 * 24 * 3600 * 1000
+        }],
+        time: {
+            useUTC: false
+        },
+        series: [{
+            data: [{
+                start: new Date("2015-04-12T01:00:00").getTime(),
+                end: new Date("2015-04-22T03:15:00").getTime()
+            }]
+        }]
+    });
+    const axis = chart.xAxis[0],
+        ticks = axis.ticks,
+        tickPositions = axis.tickPositions;
+
+    assert.notEqual(
+        ticks[tickPositions[0]].label.textStr,
+        ticks[tickPositions[1]].label.textStr,
+        'The first two axis labels should not be the same.'
+    );
+});

--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -1444,7 +1444,14 @@ dateFormats.E = function (this: Time, timestamp: number): string {
 
 // Adds week date format
 dateFormats.W = function (this: Time, timestamp: number): string {
-    const d = new this.Date(timestamp);
+    const time = this,
+        d = new this.Date(timestamp),
+        unitsToOmmit = (['Hours', 'Milliseconds', 'Minutes', 'Seconds'] as Array<Time.TimeUnitValue>);
+
+    unitsToOmmit.forEach(function (format): void { // #16550
+        time.set(format, d, 0);
+    }
+    );
     const firstDay = (this.get('Day', d) + 6) % 7;
     const thursday = new this.Date(d.valueOf());
     this.set('Date', thursday, this.get('Date', d) - firstDay + 3);


### PR DESCRIPTION
Fixed #16550, the week `dateFormat` was not calculated correctly when `useUTC: false`.