### PR TITLE
Fixed #17048, added option to remember kbd focus for points.

### DIFF
--- a/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
@@ -444,11 +444,8 @@ class SeriesKeyboardNavigation {
                     }]
             ],
 
-            init: function (
-                this: KeyboardNavigationHandler
-            ): number {
-                highlightFirstValidPointInChart(chart);
-                return this.response.success;
+            init: function (this: KeyboardNavigationHandler): number {
+                return keyboardNavigation.onHandlerInit(this);
             },
 
             validate: function (): boolean {
@@ -477,6 +474,32 @@ class SeriesKeyboardNavigation {
             isNext = keyCode === keys.right || keyCode === keys.down;
 
         return this.attemptHighlightAdjacentPoint(handler, isNext);
+    }
+
+
+    /**
+     * When keyboard navigation inits.
+     * @private
+     * @param {Highcharts.KeyboardNavigationHandler} handler The handler object
+     * @return {number}
+     * response
+     */
+    public onHandlerInit(
+        handler: KeyboardNavigationHandler
+    ): number {
+        const chart = this.chart,
+            kbdNavOptions = chart.options.accessibility.keyboardNavigation;
+
+        if (
+            kbdNavOptions.seriesNavigation.rememberPointFocus &&
+            chart.highlightedPoint
+        ) {
+            chart.highlightedPoint.highlight();
+        } else {
+            highlightFirstValidPointInChart(chart);
+        }
+
+        return handler.response.success;
     }
 
 
@@ -525,7 +548,8 @@ class SeriesKeyboardNavigation {
      * @private
      */
     public onHandlerTerminate(): void {
-        const chart = this.chart;
+        const chart = this.chart,
+            kbdNavOptions = chart.options.accessibility.keyboardNavigation;
 
         if (chart.tooltip) {
             chart.tooltip.hide(0);
@@ -542,7 +566,9 @@ class SeriesKeyboardNavigation {
             chart.highlightedPoint.onMouseOut();
         }
 
-        delete chart.highlightedPoint;
+        if (!kbdNavOptions.seriesNavigation.rememberPointFocus) {
+            delete chart.highlightedPoint;
+        }
     }
 
 

--- a/ts/Accessibility/Options/Options.ts
+++ b/ts/Accessibility/Options/Options.ts
@@ -114,6 +114,7 @@ declare global {
             mode?: string;
             pointNavigationEnabledThreshold: (boolean|number);
             skipNullPoints: boolean;
+            rememberPointFocus: boolean;
         }
         interface AccessibilityOptions {
             announceNewData: AccessibilityAnnounceNewDataOptions;
@@ -794,7 +795,17 @@ const Options: DeepPartial<OptionsType> = {
                  * @type  {boolean|number}
                  * @since 8.0.0
                  */
-                pointNavigationEnabledThreshold: false
+                pointNavigationEnabledThreshold: false,
+
+                /**
+                 * Remember which point was focused even after navigating away
+                 * from the series, so that when navigating back to the series
+                 * you start at the last focused point.
+                 *
+                 * @type  {boolean}
+                 * @since next
+                 */
+                rememberPointFocus: false
             }
         },
 


### PR DESCRIPTION
Added option to remember keyboard focus for points: `accessibility.keyboardNavigation.seriesNavigation.rememberPointFocus`.
___
Closes #17048.