### PR TITLE
bugfix/17186-csv-empty-cells

### DIFF
--- a/samples/unit-tests/export-data/basics/demo.js
+++ b/samples/unit-tests/export-data/basics/demo.js
@@ -379,9 +379,9 @@ QUnit.test('Pie chart, multiple', function (assert) {
 
     var csv = [
         '"Category","Categories","Subcategories"',
-        '"Animals",2',
+        '"Animals",2,',
         '"Cats",,1',
-        '"Plants",2',
+        '"Plants",2,',
         '"Dogs",,1',
         '"Potatoes",,1',
         '"Trees",,1'
@@ -1103,8 +1103,8 @@ QUnit.test('Point name (#13293)', function (assert) {
         }),
         csv =
             '"Category","Series 1 (x)","Series 1 (y)","Series 2"\n' +
-            '"Point2",1,9\n' +
-            '"Point1",2,6\n' +
+            '"Point2",1,9,\n' +
+            '"Point1",2,6,\n' +
             '20,,,9\n' +
             '30,,,6';
 
@@ -1154,8 +1154,8 @@ QUnit.test('Point name with category (#13293)', function (assert) {
         }),
         csv =
             '"Category","Series 1","Series 2"\n' +
-            '"Point2",9\n' +
-            '"Point1",6\n' +
+            '"Point2",9,\n' +
+            '"Point1",6,\n' +
             '20,,9\n' +
             '30,,6';
 

--- a/ts/Extensions/ExportData.ts
+++ b/ts/Extensions/ExportData.ts
@@ -889,7 +889,9 @@ Chart.prototype.getCSV = function (
             decimalPoint === ',' ? ';' : ','
         ),
         // '\n' isn't working with the js csv data extraction
-        lineDelimiter = csvOptions.lineDelimiter;
+        lineDelimiter = csvOptions.lineDelimiter,
+        // assuming the first row is the header, so all the columns presented
+        columnsNumber = rows.length ? rows[0].length : 0;
 
     // Transform the rows to CSV
     rows.forEach(function (row: Array<(number|string)>, i: number): void {
@@ -908,6 +910,11 @@ Chart.prototype.getCSV = function (
             }
             row[j] = val;
         }
+        // Append empty columns if any
+        for (let k = columnsNumber - row.length; k > 0; k--) {
+            row.push('');
+        }
+
         // Add the values
         csv += row.join(itemDelimiter);
 


### PR DESCRIPTION
Fixed #17186. Added appending delimiters to the row to markup empty cells when needed. 

The first row returned from `this.getDataRows()` is used to determine how many columns should the CSV have (Please, see [ExportData.ts :894](https://github.com/highcharts/highcharts/compare/master...mik-the-deutsch-dev:master#diff-cef6e25630962677be4a94d5ecb5a257df6355c123f2306b4389afd50c8c0456R894)). Is this a correct and reliable solution?