### PR TITLE
bugfix/15863-stacking-labels-translation

### DIFF
--- a/ts/Extensions/Stacking.ts
+++ b/ts/Extensions/Stacking.ts
@@ -465,7 +465,7 @@ class StackItem {
                 label.show();
             } else {
                 // Move label away to avoid the overlapping issues
-                label.alignAttr.y = -9999;
+                label.hide();
                 isJustify = false;
             }
 


### PR DESCRIPTION
Replaced hiding by translation of the stacking labels with `SVGElement.hide()`. Touches #15863 