### PR TITLE
bugfix/17186-csv-empty-cells

### DIFF
--- a/samples/unit-tests/export-data/basics/demo.js
+++ b/samples/unit-tests/export-data/basics/demo.js
@@ -379,9 +379,9 @@ QUnit.test('Pie chart, multiple', function (assert) {
 
     var csv = [
         '"Category","Categories","Subcategories"',
-        '"Animals",2',
+        '"Animals",2,',
         '"Cats",,1',
-        '"Plants",2',
+        '"Plants",2,',
         '"Dogs",,1',
         '"Potatoes",,1',
         '"Trees",,1'
@@ -1103,8 +1103,8 @@ QUnit.test('Point name (#13293)', function (assert) {
         }),
         csv =
             '"Category","Series 1 (x)","Series 1 (y)","Series 2"\n' +
-            '"Point2",1,9\n' +
-            '"Point1",2,6\n' +
+            '"Point2",1,9,\n' +
+            '"Point1",2,6,\n' +
             '20,,,9\n' +
             '30,,,6';
 
@@ -1154,8 +1154,8 @@ QUnit.test('Point name with category (#13293)', function (assert) {
         }),
         csv =
             '"Category","Series 1","Series 2"\n' +
-            '"Point2",9\n' +
-            '"Point1",6\n' +
+            '"Point2",9,\n' +
+            '"Point1",6,\n' +
             '20,,9\n' +
             '30,,6';
 

--- a/ts/Extensions/ExportData.ts
+++ b/ts/Extensions/ExportData.ts
@@ -909,16 +909,11 @@ Chart.prototype.getCSV = function (
             row[j] = val;
         }
 
-        // The first row is the header, so number of all the columns presented
-        const numberOfColumns = rows.length ? rows[0].length : 0;
-
+        // The first row is the header, so number of all the columns presented.
         // Empty columns between not-empty cells are covered in the getDataRows
         // method. Add empty values only to the end of the row so all rows have
         // the same number of columns, #17186
-        const rowLength = row.length;
-        for (let k = 0; k < numberOfColumns - rowLength; k++) {
-            row.push(void 0);
-        }
+        row.length = rows.length ? rows[0].length : 0;
 
         // Add the values
         csv += row.join(itemDelimiter);

--- a/ts/Extensions/ExportData.ts
+++ b/ts/Extensions/ExportData.ts
@@ -892,8 +892,8 @@ Chart.prototype.getCSV = function (
         lineDelimiter = csvOptions.lineDelimiter;
 
     // Transform the rows to CSV
-    rows.forEach(function (row: Array<(number|string)>, i: number): void {
-        let val: (number|string) = '',
+    rows.forEach((row: Array<(number|string|undefined)>, i: number): void => {
+        let val: (number|string|undefined) = '',
             j = row.length;
 
         while (j--) {
@@ -908,6 +908,18 @@ Chart.prototype.getCSV = function (
             }
             row[j] = val;
         }
+
+        // The first row is the header, so number of all the columns presented
+        const numberOfColumns = rows.length ? rows[0].length : 0;
+
+        // Empty columns between not-empty cells are covered in the getDataRows
+        // method. Add empty values only to the end of the row so all rows have
+        // the same number of columns, #17186
+        const rowLength = row.length;
+        for (let k = 0; k < numberOfColumns - rowLength; k++) {
+            row.push(void 0);
+        }
+
         // Add the values
         csv += row.join(itemDelimiter);
 

--- a/ts/Extensions/ExportData.ts
+++ b/ts/Extensions/ExportData.ts
@@ -909,9 +909,10 @@ Chart.prototype.getCSV = function (
             row[j] = val;
         }
 
-        // The first row is the header, so number of all the columns presented.
+        // The first row is the header - it defines the number of columns.
         // Empty columns between not-empty cells are covered in the getDataRows
-        // method. Add empty values only to the end of the row so all rows have
+        // method.
+        // Now add empty values only to the end of the row so all rows have
         // the same number of columns, #17186
         row.length = rows.length ? rows[0].length : 0;
 


### PR DESCRIPTION
Fixed #17186, CSV rows were missing delimiters when data was missing at the end of a row.

This is a continuation of: https://github.com/highcharts/highcharts/pull/17195

I checked the above solution and I think it's the best when it comes to performance.
If we'd like to add this logic to the `getDataRows` method, we would have to loop rows one more time. In this case, we could add this code here: https://github.com/highcharts/highcharts/blob/96fb71da571456bd45724df75767e92bfdb014e3/ts/Extensions/ExportData.ts#L793

What do you think @TorsteinHonsi? Should it be even fixed in the first place? As a workaround, the `null` points could be added to data. But, the CSV should have the same number of cells in all rows by definition.

Demo: http://jsfiddle.net/BlackLabel/pxLgb2d6/
