### PR TITLE
bugfix/8324-drillup-length-undefined

### DIFF
--- a/samples/unit-tests/drilldown/drillup/demo.js
+++ b/samples/unit-tests/drilldown/drillup/demo.js
@@ -416,3 +416,45 @@ QUnit.test(
             the main series should go back to its original state.`
         );
     });
+
+QUnit.test(
+    'Drillup after asynchronous drilldown on the chart, #8324.',
+    function (assert) {
+        let assertPassed = true;
+        try {
+            Highcharts.chart('container', {
+                chart: {
+                    type: 'column',
+                    events: {
+                        load: function () {
+                            const chart = this,
+                                point = chart.series[0].data[0];
+
+                            chart.addSingleSeriesAsDrilldown(point, {
+                                data: [{
+                                    y: 1,
+                                    drilldown: true
+                                }, {
+                                    y: 2,
+                                    drilldown: true
+                                }]
+                            });
+                            chart.applyDrilldown();
+                            chart.drillUp();
+                        }
+                    }
+                },
+                series: [{
+                    data: [{
+                        y: 3,
+                        drilldown: true
+                    }]
+                }]
+            });
+        } catch {
+            assertPassed = false;
+        }
+
+        assert.ok(assertPassed, 'It should not update the length of udefined ddDupes.');
+    }
+);

--- a/ts/Extensions/Drilldown.ts
+++ b/ts/Extensions/Drilldown.ts
@@ -1073,7 +1073,9 @@ Chart.prototype.drillUp = function (): void {
 
     this.redraw();
 
-    (this.ddDupes as any).length = []; // #3315
+    if (this.ddDupes) {
+        this.ddDupes.length = 0; // #3315
+    } // #8324
 
     // Fire a once-off event after all series have been drilled up (#5158)
     fireEvent(chart, 'drillupall');


### PR DESCRIPTION
Fixed #8324, an error was thrown when calling `drillUp()` after `chart.applyDrilldown()`