### PR TITLE
Fixed #17236, a11y timeout caused test issues.

### DIFF
--- a/samples/unit-tests/accessibility/accessibility-options/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-options/demo.js
@@ -26,6 +26,9 @@ QUnit.test('Accessibility disabled', function (assert) {
             accessibility: {
                 enabled: false
             },
+            title: {
+                text: 'No a11y'
+            },
             series: [
                 {
                     data: [1, 2, 3, 4, 5, 6]
@@ -40,6 +43,18 @@ QUnit.test('Accessibility disabled', function (assert) {
     assert.notOk(
         srSection && screenReaderSectionHasContents(srSection),
         'There be no screen reader region'
+    );
+
+    assert.strictEqual(
+        chart.renderer.box.getAttribute('aria-label'),
+        'No a11y',
+        'SVG root has aria label'
+    );
+
+    assert.strictEqual(
+        chart.renderer.box.getAttribute('role'),
+        'img',
+        'SVG root has img role'
     );
 });
 
@@ -237,6 +252,11 @@ QUnit.test('pointDescriptionFormatter', function (assert) {
 
 QUnit.test('Chart description', function (assert) {
     var chart = Highcharts.chart('container', {
+        lang: {
+            accessibility: {
+                svgContainerLabel: 'Test'
+            }
+        },
         accessibility: {
             description: 'Description: Yo.'
         },
@@ -250,6 +270,16 @@ QUnit.test('Chart description', function (assert) {
         getScreenReaderSectionEl(chart).innerHTML.indexOf('Description: Yo.') >
             -1,
         'Chart description included in screen reader region'
+    );
+    assert.strictEqual(
+        chart.renderer.box.getAttribute('role'),
+        null,
+        'SVG root has no role'
+    );
+    assert.strictEqual(
+        chart.renderer.box.getAttribute('aria-label'),
+        'Test',
+        'SVG root has aria label from lang'
     );
 
     chart.update({});

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -2780,14 +2780,11 @@ class Chart {
             opts && !this.accessibility &&
             !(opts.accessibility && opts.accessibility.enabled === false)
         ) {
-            const renderer = this.renderer;
-            if (renderer && renderer.boxWrapper) {
-                // Make chart behave as an image with the title as alt text
-                renderer.boxWrapper.attr({
-                    role: 'img',
-                    'aria-label': opts.title && opts.title.text || ''
-                });
-            }
+            // Make chart behave as an image with the title as alt text
+            this.renderer.boxWrapper.attr({
+                role: 'img',
+                'aria-label': opts.title && opts.title.text || ''
+            });
 
             error(
                 'Highcharts warning: Consider including the ' +

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -2775,22 +2775,29 @@ class Chart {
      * Emit console warning if the a11y module is not loaded.
      */
     public warnIfA11yModuleNotLoaded():void {
-        setTimeout(():void => {
-            const opts = this && this.options;
-            if (
-                opts && !this.accessibility &&
-                !(opts.accessibility && opts.accessibility.enabled === false)
-            ) {
-                error(
-                    'Highcharts warning: Consider including the ' +
-                    '"accessibility.js" module to make your chart more ' +
-                    'usable for people with disabilities. Set the ' +
-                    '"accessibility.enabled" option to false to remove this ' +
-                    'warning. See https://www.highcharts.com/docs/accessibility/accessibility-module.',
-                    false, this
-                );
+        const opts = this.options;
+        if (
+            opts && !this.accessibility &&
+            !(opts.accessibility && opts.accessibility.enabled === false)
+        ) {
+            const renderer = this.renderer;
+            if (renderer && renderer.boxWrapper) {
+                // Make chart behave as an image with the title as alt text
+                renderer.boxWrapper.attr({
+                    role: 'img',
+                    'aria-label': opts.title && opts.title.text || ''
+                });
             }
-        }, 100);
+
+            error(
+                'Highcharts warning: Consider including the ' +
+                '"accessibility.js" module to make your chart more ' +
+                'usable for people with disabilities. Set the ' +
+                '"accessibility.enabled" option to false to remove this ' +
+                'warning. See https://www.highcharts.com/docs/accessibility/accessibility-module.',
+                false, this
+            );
+        }
     }
 
 

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -2776,24 +2776,23 @@ class Chart {
      */
     public warnIfA11yModuleNotLoaded():void {
         const opts = this.options;
-        if (
-            opts && !this.accessibility &&
-            !(opts.accessibility && opts.accessibility.enabled === false)
-        ) {
+        if (opts && !this.accessibility) {
             // Make chart behave as an image with the title as alt text
             this.renderer.boxWrapper.attr({
                 role: 'img',
                 'aria-label': opts.title && opts.title.text || ''
             });
 
-            error(
-                'Highcharts warning: Consider including the ' +
-                '"accessibility.js" module to make your chart more ' +
-                'usable for people with disabilities. Set the ' +
-                '"accessibility.enabled" option to false to remove this ' +
-                'warning. See https://www.highcharts.com/docs/accessibility/accessibility-module.',
-                false, this
-            );
+            if (!(opts.accessibility && opts.accessibility.enabled === false)) {
+                error(
+                    'Highcharts warning: Consider including the ' +
+                    '"accessibility.js" module to make your chart more ' +
+                    'usable for people with disabilities. Set the ' +
+                    '"accessibility.enabled" option to false to remove this ' +
+                    'warning. See https://www.highcharts.com/docs/accessibility/accessibility-module.',
+                    false, this
+                );
+            }
         }
     }
 

--- a/ts/Core/Renderer/SVG/SVGAttributes.d.ts
+++ b/ts/Core/Renderer/SVG/SVGAttributes.d.ts
@@ -85,6 +85,7 @@ export interface SVGAttributes {
     refY?: number;
     rx?: number;
     ry?: number;
+    role?: string;
     rotation?: number;
     rotationOriginX?: number;
     rotationOriginY?: number;


### PR DESCRIPTION
Fixed #17236, timeout for accessibility module warning caused test issues.
___
The `setTimeout` should be unnecessary, technically, so suggesting its removal since it caused issues for users.

Also added some minimal code to make the chart behave as an image with alt text = chart title if the module is not loaded, as opposed to the gibberish one would otherwise get with screen readers et al.