### PR TITLE
Fixed regression with exporting styled mode charts in Safari

### DIFF
--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -1427,7 +1427,7 @@ namespace Exporting {
                                 node.setAttribute(hyphenate(prop), val);
                             }
                         // Styles
-                        } else {
+                        } else if (prop !== 'parentRule') {
                             (filteredStyles as any)[prop] = val;
                         }
                     }


### PR DESCRIPTION
Fixed regression with exporting charts in Safari when `chart.styledMode` was true.