### PR TITLE
bugfix/15863-fadeOut-hide-by-translation

### DIFF
--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -1403,7 +1403,7 @@ class SVGElement implements SVGElementLike {
             duration: pick(duration, 150),
             complete: function (): void {
                 // #3088, assuming we're only using this for tooltips
-                elemWrapper.attr({ y: -9999 }).hide();
+                elemWrapper.hide();
             }
         });
     }


### PR DESCRIPTION
Part of #15863, removed `SVGElement.fadeOut()` hiding by translation.