### PR TITLE
bugfix/15863-TreeGridTick-hide-by-translation

### DIFF
--- a/ts/Core/Axis/TreeGridTick.ts
+++ b/ts/Core/Axis/TreeGridTick.ts
@@ -200,7 +200,7 @@ namespace TreeGridTick {
         }
 
         // Set the new position, and show or hide
-        icon.attr({ y: shouldRender ? 0 : -9999 }); // #14904, #1338
+        icon[shouldRender ? 'show' : 'hide'](); // #14904, #1338
 
         // Presentational attributes
         if (!renderer.styledMode) {


### PR DESCRIPTION
Part of #15863, Removed hide by translation from `TreeGridTick`.
