### PR TITLE
test/map-pan-core-size

### DIFF
--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3651,9 +3651,7 @@ class Chart {
                         type: 'x'
                     }
             ),
-            chartOptions = chart.options.chart,
-            hasMapNavigation = chart.options.mapNavigation &&
-                chart.options.mapNavigation.enabled;
+            chartOptions = chart.options.chart;
 
         if (chartOptions && chartOptions.panning) {
             chartOptions.panning = panningOptions;
@@ -3821,7 +3819,6 @@ class Chart {
 
                         if (
                             !chart.resetZoomButton &&
-                            !hasMapNavigation &&
                             // Show reset zoom button only when both newMin and
                             // newMax values are between padded axis range.
                             newMin !== paddedMin &&


### PR DESCRIPTION
Removed no longer being used Maps-related code.
The fix itself seems reasonable since MapView prevents default pan and tests are passed.

For local `gulp filesize` it looked as:
```
highcharts.js
          gzipped   compiled  source
New:      102001    303102    2086366
HEAD:     102022    303164    2086530
Diff:     -21B      -62B      -164B
```
