### PR TITLE
bugfix/17116-stack-labels-negative

### DIFF
--- a/samples/unit-tests/series-column/stacking/demo.js
+++ b/samples/unit-tests/series-column/stacking/demo.js
@@ -244,3 +244,35 @@ QUnit.test('Null threshold (#7420)', function (assert) {
         'The points should have an extent'
     );
 });
+
+QUnit.test('Negative stack labels in the inverted chart should be properly calculated. (#17116)', function (assert) {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            inverted: true,
+            spacingRight: 200
+        },
+        yAxis: {
+            min: -500,
+            stackLabels: {
+                enabled: true
+            }
+        },
+        series: [{
+            type: 'column',
+            stacking: 'normal',
+            data: [-50]
+        }]
+    });
+
+    const point = chart.series[0].points[0],
+        pointPos = chart.plotWidth + chart.plotLeft - point.plotY,
+        label = chart.yAxis[0].stacking.stacks['-column,,,'][0].label,
+        labelPos = chart.plotLeft + label.x,
+        labelWidth = label.width;
+        
+    assert.strictEqual(
+        pointPos - (labelPos + labelWidth) < 1,
+        true,
+        'The stack label should be in close range'
+    );
+});

--- a/ts/Extensions/Stacking.ts
+++ b/ts/Extensions/Stacking.ts
@@ -480,6 +480,12 @@ class StackItem {
                     stackBox
                 );
             }
+
+            // Check if chart is inverted with negative values #17116
+            if (chart.inverted) {
+                label.alignAttr.x += chart.spacing[1] * (isNegative ? 1 : 0);
+            }
+
             label.attr({
                 x: label.alignAttr.x,
                 y: label.alignAttr.y


### PR DESCRIPTION
Fixed #17116, wrong stack labels calculations when `inverted` is set to `true`