### PR TITLE
Fixed #17013, map view fit to bounds after setData

### DIFF
--- a/samples/unit-tests/maps/setdata/demo.js
+++ b/samples/unit-tests/maps/setdata/demo.js
@@ -1013,4 +1013,20 @@ QUnit.test('Map set data with updated data (#3894)', function (assert) {
         '#15782, mapNav should not overlap with ' +
             'export icon (Bottom right side).'
     );
+
+    // Verify that bounds adapt when setting data (#17013)
+    const worldScale = chart.series[0].transformGroups[0].scaleX;
+    chart.series[0].update({
+        allAreas: false
+    });
+
+    chart.series[0].setData([{
+        'hc-key': 'ru',
+        value: 148
+    }]);
+
+    assert.ok(
+        chart.series[0].transformGroups[0].scaleX / worldScale > 2,
+        'The view should be zoomed into the new point (#17013)'
+    );
 });

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -17,6 +17,7 @@
  * */
 
 import type {
+    AnimationOptions,
     AnimationStepCallbackFunction
 } from '../../Core/Animation/AnimationOptions';
 import type ColorType from '../../Core/Color/ColorType';
@@ -941,12 +942,22 @@ class MapSeries extends ScatterSeries {
      * Extend setData to call processData and generatePoints immediately.
      * @private
      */
-    public setData(): void {
+    public setData(
+        data: Array<(PointOptions|PointShortOptions)>,
+        redraw: boolean = true,
+        animation?: (boolean|Partial<AnimationOptions>),
+        updatePoints?: boolean
+    ): void {
 
-        super.setData.apply(this, arguments);
+        delete this.bounds;
+        super.setData.call(this, data, false, void 0, updatePoints);
 
         this.processData();
         this.generatePoints();
+
+        if (redraw) {
+            this.chart.redraw(animation);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixed #17013, map view did not fit correctly to bounds after running `Series.setData`.