### PR TITLE
bugfix/17012-map-series-bounds

### DIFF
--- a/samples/unit-tests/maps/setdata/demo.js
+++ b/samples/unit-tests/maps/setdata/demo.js
@@ -805,6 +805,10 @@ QUnit.test('Map set data with updated data (#3894)', function (assert) {
 
     // Initialize the chart
     const chart = Highcharts.mapChart('container', {
+        accessibility: {
+            enabled: false
+        },
+
         title: {
             text: ''
         },
@@ -846,17 +850,79 @@ QUnit.test('Map set data with updated data (#3894)', function (assert) {
         ]
     });
 
-    data[148].value = 1;
+    const series = chart.series[0],
+        mapView = chart.mapView;
 
-    const mapView = chart.mapView;
+    let centerBeforeUpdate,
+        zoomBeforeUpdate;
+
+    series.setData([{
+        'hc-key': 'us',
+        value: 155
+    }]);
+
+    // Check both updates: "allAreas: true" and back to "allAreas: false"
+    // The view should be changed.
+    for (let i = 0; i < 2; i++) {
+        centerBeforeUpdate = mapView.center;
+        zoomBeforeUpdate = mapView.zoom;
+
+        series.update({
+            allAreas: !series.options.allAreas
+        });
+
+        assert.notDeepEqual(
+            centerBeforeUpdate,
+            mapView.center,
+            `When updating "allAreas: ${series.options.allAreas}", the mapView
+            should fit view (center), #17012.`
+        );
+
+        assert.notEqual(
+            zoomBeforeUpdate,
+            mapView.zoom,
+            `When updating "allAreas: ${series.options.allAreas}", the mapView
+            should fit view (zoom), #17012.`
+        );
+    }
+
+    mapView.update({
+        center: [660, 8054],
+        zoom: -2.4
+    });
+
+    // Check both updates: "allAreas: true" and back to "allAreas: false" with
+    // center and zoom set by a user. The view should not be changed.
+    for (let i = 0; i < 2; i++) {
+        centerBeforeUpdate = mapView.center;
+        zoomBeforeUpdate = mapView.zoom;
+
+        series.update({
+            allAreas: !series.options.allAreas
+        });
+
+        assert.deepEqual(
+            centerBeforeUpdate,
+            mapView.center,
+            `When updating "allAreas: ${series.options.allAreas}" with center
+            set by a user in userOptions, the view shouldn't be changed.`
+        );
+
+        assert.equal(
+            zoomBeforeUpdate,
+            mapView.zoom,
+            `When updating "allAreas: ${series.options.allAreas}" with zoom set
+            by a user in userOptions, the view shouldn't be changed.`
+        );
+    }
+
+    data[148].value = 1;
 
     const before = Object.assign(
         {},
         mapView.center,
         mapView.zoom
     );
-
-    const series = chart.series[0];
 
     series.setData(data);
 

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -1246,8 +1246,10 @@ class MapSeries extends ScatterSeries {
         if (this.chart.hasRendered && (this.isDirtyData || !this.hasRendered)) {
             this.processData();
             this.generatePoints();
+
+            // Not only recalculate bounds (as previously), but also fit view
             delete this.bounds;
-            this.getProjectedBounds();
+            mapView && mapView.fitToBounds(void 0, void 0, false); // #17012
         }
 
         if (mapView) {

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -1247,9 +1247,19 @@ class MapSeries extends ScatterSeries {
             this.processData();
             this.generatePoints();
 
-            // Not only recalculate bounds (as previously), but also fit view
             delete this.bounds;
-            mapView && mapView.fitToBounds(void 0, void 0, false); // #17012
+            if (
+                mapView &&
+                !mapView.userOptions.center &&
+                !isNumber(mapView.userOptions.zoom)
+            ) {
+                // Not only recalculate bounds but also fit view
+                mapView.fitToBounds(void 0, void 0, false); // #17012
+            } else {
+                // If user defined his own center and zoom, get bounds but
+                // don't change view
+                this.getProjectedBounds();
+            }
         }
 
         if (mapView) {

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -1256,7 +1256,7 @@ class MapSeries extends ScatterSeries {
                 // Not only recalculate bounds but also fit view
                 mapView.fitToBounds(void 0, void 0, false); // #17012
             } else {
-                // If user defined his own center and zoom, get bounds but
+                // If center and zoom is defined in user options, get bounds but
                 // don't change view
                 this.getProjectedBounds();
             }


### PR DESCRIPTION
Fixed #17012, toggling `allAreas` did not correctly update the bounds of the map.