### PR TITLE
bugfix/17281-bubble-marker-symbol 

### DIFF
--- a/samples/unit-tests/series-bubble/marker/demo.js
+++ b/samples/unit-tests/series-bubble/marker/demo.js
@@ -174,3 +174,26 @@ QUnit.test('Bubble animation and async redraws (#13494)', assert => {
         TestUtilities.lolexUninstall(clock);
     }
 });
+
+QUnit.test('Bubble with custom symbol markers, #17281.', function (assert) {
+    Highcharts.chart("container", {
+        series: [{
+            type: "bubble",
+            data: [
+                [1, 1, 1],
+                [2, 2, 2],
+                [3, 3, 3]
+            ],
+            zMin: 1.1,
+            marker: {
+                symbol: 'url(https://www.highcharts.com/samples/graphics/sun.png)'
+            }
+        }]
+    });
+
+    assert.ok(
+        true,
+        `When the custom marker is set and the point is out of zThreshold, the
+        symbol should not be displayed and there should be no errors.`
+    );
+});

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -621,8 +621,12 @@ class BubbleSeries extends ScatterSeries {
                     height: 2 * radius
                 };
             } else { // below zThreshold
-                // #1691
-                point.shapeArgs = point.plotY = point.dlBox = void 0;
+                point.shapeArgs = point.dlBox = void 0; // #1691
+                point.plotY = 0; // #17281
+                point.marker = {
+                    width: 0,
+                    height: 0
+                };
             }
         }
 


### PR DESCRIPTION
Fixed #17281, an error in console when bubble with custom marker was out of `zThreshold`.