### PR TITLE
bugfix/15608-macd-color

### DIFF
--- a/samples/unit-tests/indicator-macd/recalculations/demo.js
+++ b/samples/unit-tests/indicator-macd/recalculations/demo.js
@@ -501,6 +501,25 @@ QUnit.test('After changing the MACD params all points should calculate properly,
     );
 
     assert.strictEqual(
+        chart.series[1].color,
+        Highcharts.getOptions().colors[1],
+        `When colour is not specified, each element (columns) should get it
+        from the colour array.`
+    );
+    assert.strictEqual(
+        chart.series[1].graphsignal.stroke,
+        Highcharts.getOptions().colors[2],
+        `When colour is not specified, each element (signalLine) should get it
+        from the colour array.`
+    );
+    assert.strictEqual(
+        chart.series[1].graphmacd.stroke,
+        Highcharts.getOptions().colors[3],
+        `When colour is not specified, each element (macdLine) should get it
+        from the colour array.`
+    );
+
+    assert.strictEqual(
         seriesPoints[seriesPoints.length - 1].x,
         secondMACCD[secondMACCD.length - 1].x,
         `After changing the short period to 13, the x value of the last MACD

--- a/samples/unit-tests/indicator-macd/recalculations/demo.js
+++ b/samples/unit-tests/indicator-macd/recalculations/demo.js
@@ -501,7 +501,7 @@ QUnit.test('After changing the MACD params all points should calculate properly,
     );
 
     assert.strictEqual(
-        chart.series[1].color,
+        chart.series[1].points[0].graphic.attr('fill'),
         Highcharts.getOptions().colors[1],
         `When colour is not specified, each element (columns) should get it
         from the colour array.`

--- a/ts/Stock/Indicators/MACD/MACDIndicator.ts
+++ b/ts/Stock/Indicators/MACD/MACDIndicator.ts
@@ -32,6 +32,7 @@ const {
     }
 } = SeriesRegistry;
 import U from '../../../Core/Utilities.js';
+import ColorString from '../../../Core/Color/ColorString';
 const {
     extend,
     correctFloat,
@@ -190,6 +191,9 @@ class MACDIndicator extends SMAIndicator {
     public init(): void {
         SeriesRegistry.seriesTypes.sma.prototype.init.apply(this, arguments);
 
+        const originalColor = this.color,
+            originalColorIndex = this.userOptions._colorIndex;
+
         // Check whether series is initialized. It may be not initialized,
         // when any of required indicators is missing.
         if (this.options) {
@@ -207,6 +211,33 @@ class MACDIndicator extends SMAIndicator {
                 }
             }, this.options);
 
+            // If the default colour doesn't set, get the next available from
+            // the array and apply it #15608.
+            if (this.userOptions._colorIndex) {
+                if (
+                    this.options.signalLine &&
+                    this.options.signalLine.styles &&
+                    !this.options.signalLine.styles.lineColor
+                ) {
+                    this.userOptions._colorIndex++;
+                    this.getCyclic('color', void 0, this.chart.options.colors);
+                    this.options.signalLine.styles.lineColor =
+                        this.color as ColorString;
+                }
+
+                if (
+                    this.options.macdLine &&
+                    this.options.macdLine.styles &&
+                    !this.options.macdLine.styles.lineColor
+                ) {
+                    this.userOptions._colorIndex++;
+                    this.getCyclic('color', void 0, this.chart.options.colors);
+                    this.options.macdLine.styles.lineColor =
+                        this.color as ColorString;
+                }
+            }
+
+
             // Zones have indexes automatically calculated, we need to
             // translate them to support multiple lines within one indicator
             this.macdZones = {
@@ -221,6 +252,10 @@ class MACDIndicator extends SMAIndicator {
             };
             this.resetZones = true;
         }
+
+        // Reset color and index #15608.
+        this.color = originalColor;
+        this.userOptions._colorIndex = originalColorIndex;
     }
 
     public toYData(

--- a/ts/Stock/Indicators/MACD/MACDIndicator.ts
+++ b/ts/Stock/Indicators/MACD/MACDIndicator.ts
@@ -197,23 +197,9 @@ class MACDIndicator extends SMAIndicator {
         // Check whether series is initialized. It may be not initialized,
         // when any of required indicators is missing.
         if (this.options) {
-            // Set default color for a signal line and the histogram:
-            this.options = merge({
-                signalLine: {
-                    styles: {
-                        lineColor: this.color
-                    }
-                },
-                macdLine: {
-                    styles: {
-                        color: this.color
-                    }
-                }
-            }, this.options);
-
             // If the default colour doesn't set, get the next available from
             // the array and apply it #15608.
-            if (this.userOptions._colorIndex) {
+            if (defined(this.userOptions._colorIndex)) {
                 if (
                     this.options.signalLine &&
                     this.options.signalLine.styles &&

--- a/ts/Stock/Indicators/MACD/MACDOptions.d.ts
+++ b/ts/Stock/Indicators/MACD/MACDOptions.d.ts
@@ -21,7 +21,7 @@ import type {
     SeriesStatesOptions,
     SeriesZonesOptions
 } from '../../../Core/Series/SeriesOptions';
-import type TooltipOptions from '../../../Core/TooltipOptions';
+import ColorString from '../../../Core/Color/ColorString';
 
 /* *
 *
@@ -56,8 +56,11 @@ export interface MACDOptions extends SMAOptions {
 }
 
 export interface MACDLineOptions {
-    styles?: CSSObject;
+    styles?: MACDLineStyleOptions;
     zones?: Array<SeriesZonesOptions>;
+}
+export interface MACDLineStyleOptions extends CSSObject {
+    lineColor?: ColorString
 }
 
 export interface MACDZonesOptions {


### PR DESCRIPTION
Fixed #15608, the MACD indicator did not have default colors.