### PR TITLE
Added data scraping attributes to the SVG.

### DIFF
--- a/samples/highcharts/chart/svg-data-scraping/demo.css
+++ b/samples/highcharts/chart/svg-data-scraping/demo.css
@@ -1,0 +1,11 @@
+#container {
+    height: 400px;
+    max-width: 800px;
+}
+
+#output {
+    background-color: #f0f0f0;
+    padding: 15px;
+    margin-top: 20px;
+    max-width: 800px;
+}

--- a/samples/highcharts/chart/svg-data-scraping/demo.details
+++ b/samples/highcharts/chart/svg-data-scraping/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Øystein Moseng
+ js_wrap: b
+...

--- a/samples/highcharts/chart/svg-data-scraping/demo.html
+++ b/samples/highcharts/chart/svg-data-scraping/demo.html
@@ -1,0 +1,6 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
+<script src="https://code.highcharts.com/modules/accessibility.js"></script>
+
+<div id="container"></div>
+<pre id="output"></pre>

--- a/samples/highcharts/chart/svg-data-scraping/demo.js
+++ b/samples/highcharts/chart/svg-data-scraping/demo.js
@@ -1,0 +1,85 @@
+Highcharts.chart('container', {
+    title: {
+        text: 'Demo of data scraping from SVG attributes'
+    },
+    subtitle: {
+        text: 'Subtitle goes here'
+    },
+    caption: {
+        text: 'Caption goes here'
+    },
+    accessibility: {
+        description: 'Alt text goes here'
+    },
+    xAxis: {
+        type: 'logarithmic'
+    },
+    yAxis: {
+        title: {
+            text: 'Index value'
+        }
+    },
+    plotOptions: {
+        series: {
+            pointStart: 1
+        }
+    },
+    series: [{
+        type: 'line',
+        data: [19.9, 21.5, 36.4, 39.2, null, 24.0, 26.0, 25.6]
+    }, {
+        type: 'arearange',
+        data: [
+            [1, 10, 12],
+            [2, 7, 9],
+            [6, 6, 12],
+            [7, 9, 11],
+            [8, 13, 19]
+        ]
+    }]
+});
+
+// Show basic scraping example. Ideally namespaces should be handled better to ensure
+// query selects do not pick up identical attributes from other namespaces.
+
+const NS = 'https://highcharts.com/xmlnamespaces/chart',
+    svg = document.getElementById('container').querySelector('svg'),
+    getElAttr = (el, attr) => el && el.getAttributeNS(NS, attr),
+    getGlobalAttribute = attr => getElAttr(
+        svg.querySelector(`[*|${attr}]`) || svg,
+        attr
+    ),
+    getAxisData = () => [...svg.querySelectorAll('[*|axisdimension]')]
+        .map(el => ({
+            dimension: getElAttr(el, 'axisdimension'),
+            title: getElAttr(el, 'axistitle'),
+            type: getElAttr(el, 'axistype'),
+            visualMax: getElAttr(el, 'axisvisualmax'),
+            visualMin: getElAttr(el, 'axisvisualmin'),
+            dataMax: getElAttr(el, 'axisdatamax'),
+            dataMin: getElAttr(el, 'axisdatamin')
+        })),
+    getSeriesData = () => [...svg.querySelectorAll('[*|seriestype]')]
+        .map(el => ({
+            name: getElAttr(el, 'seriesname'),
+            type: getElAttr(el, 'seriestype'),
+            dataFormat: getElAttr(el, 'dataformat'),
+            pointsinseries: getElAttr(el, 'pointsinseries'),
+            points: [...el.querySelectorAll('[*|pointdata]')].map(p => {
+                const isNull = getElAttr(p, 'pointisnull'),
+                    res = { data: getElAttr(p, 'pointdata') };
+                if (isNull) {
+                    res.isNull = true;
+                }
+                return res;
+            })
+        }));
+
+document.getElementById('output').textContent = JSON.stringify({
+    title: getGlobalAttribute('title'),
+    subtitle: getGlobalAttribute('subtitle'),
+    caption: getGlobalAttribute('caption'),
+    alt: getGlobalAttribute('alt'),
+    axes: getAxisData(),
+    series: getSeriesData()
+}, null, ' ');

--- a/ts/Accessibility/Components/InfoRegionsComponent.ts
+++ b/ts/Accessibility/Components/InfoRegionsComponent.ts
@@ -44,7 +44,10 @@ const {
 import F from '../../Core/FormatUtilities.js';
 const { format } = F;
 import H from '../../Core/Globals.js';
-const { doc } = H;
+const {
+    CUSTOM_SVG_NS,
+    doc
+} = H;
 import HU from '../Utils/HTMLUtilities.js';
 const {
     addClass,
@@ -490,10 +493,8 @@ class InfoRegionsComponent extends AccessibilityComponent {
                 chart.options.sonification &&
                 chart.options.sonification.enabled
             ),
-            sonifyButtonId = 'highcharts-a11y-sonify-data-btn-' +
-                chart.index,
-            dataTableButtonId = 'hc-linkto-highcharts-data-table-' +
-                chart.index,
+            sonifyButtonId = `highcharts-a11y-sonify-data-btn-${chart.index}`,
+            dataTableButtonId = `hc-linkto-highcharts-data-table-${chart.index}`,
             annotationsList = getAnnotationsInfoHTML(
                 chart as Highcharts.AnnotationChart
             ),
@@ -517,6 +518,12 @@ class InfoRegionsComponent extends AccessibilityComponent {
                 annotationsList: annotationsList
             },
             formattedString = A11yI18n.i18nFormat(format, context, chart);
+
+        if (context.chartLongdesc) {
+            chart.renderer.box.setAttributeNS(
+                CUSTOM_SVG_NS, 'chart:alt', context.chartLongdesc
+            );
+        }
 
         this.dataTableButtonId = dataTableButtonId;
         this.sonifyButtonId = sonifyButtonId;

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -55,7 +55,10 @@ const { defaultOptions } = D;
 import F from '../Foundation.js';
 const { registerEventOptions } = F;
 import H from '../Globals.js';
-const { deg2rad } = H;
+const {
+    CUSTOM_SVG_NS,
+    deg2rad
+} = H;
 import { Palette } from '../Color/Palettes.js';
 import Tick from './Tick.js';
 import U from '../Utilities.js';
@@ -3985,6 +3988,21 @@ class Axis {
             axis.stacking.renderStackTotals();
         }
         // End stacked totals
+
+
+        // Set SVG attributes for data scraping
+        const setDataScrapingAttr = (attr: string, val: unknown): void =>
+                axis.axisGroup && axis.axisGroup.element.setAttributeNS(
+                    CUSTOM_SVG_NS, 'chart:' + attr, val as string),
+            extremes = log ? axis.getExtremes() : axis;
+        setDataScrapingAttr('axisdimension', axis.coll);
+        setDataScrapingAttr('axistype', options.type);
+        setDataScrapingAttr('axistitle',
+            options.title && options.title.text || null);
+        setDataScrapingAttr('axisvisualmax', extremes.max);
+        setDataScrapingAttr('axisvisualmin', extremes.min);
+        setDataScrapingAttr('axisdatamax', axis.dataMax);
+        setDataScrapingAttr('axisdatamin', axis.dataMin);
 
         // Record old scaling for updating/animation
         axis.old = {

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -66,6 +66,7 @@ const { registerEventOptions } = Foundation;
 import H from '../Globals.js';
 const {
     charts,
+    CUSTOM_SVG_NS,
     doc,
     marginNames,
     svg,
@@ -1214,6 +1215,11 @@ class Chart {
             if (!this.styledMode) {
                 elem.css((options as any).style);
             }
+
+            // Handle data scraping attrs
+            elem.element.setAttributeNS(
+                CUSTOM_SVG_NS, 'chart:' + name, options.text || ''
+            );
 
             /**
              * The chart title. The title has an `update` method that allows

--- a/ts/Core/Globals.ts
+++ b/ts/Core/Globals.ts
@@ -114,6 +114,7 @@ namespace Globals {
      * */
 
     export const SVG_NS = 'http://www.w3.org/2000/svg',
+        CUSTOM_SVG_NS = 'https://highcharts.com/xmlnamespaces/chart',
         product = 'Highcharts',
         version = '@product.version@',
         win = (

--- a/ts/Core/GlobalsLike.d.ts
+++ b/ts/Core/GlobalsLike.d.ts
@@ -34,6 +34,7 @@ import type Time from './Time';
  */
 export interface GlobalsLike {
     readonly Obj: ObjectConstructor;
+    readonly CUSTOM_SVG_NS: string;
     readonly SVG_NS: string;
     chartCount: number;
     readonly charts: Array<(Chart|undefined)>;

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -46,6 +46,7 @@ const {
     isMS,
     isWebKit,
     noop,
+    CUSTOM_SVG_NS,
     SVG_NS,
     symbolSizes,
     win
@@ -293,6 +294,9 @@ class SVGRenderer implements SVGRendererLike {
         if (container.innerHTML.indexOf('xmlns') === -1) {
             attr(element, 'xmlns', this.SVG_NS);
         }
+
+        // Add namespace for custom attributes
+        attr(element, 'xmlns:chart', this.CUSTOM_SVG_NS);
 
         // object properties
         renderer.isSVG = true;
@@ -2108,6 +2112,7 @@ class SVGRenderer implements SVGRendererLike {
 
 interface SVGRenderer extends SVGRendererLike {
     Element: typeof SVGElement;
+    CUSTOM_SVG_NS: string;
     SVG_NS: string;
     escapes: Record<string, string>;
     symbols: typeof Symbols;
@@ -2124,6 +2129,7 @@ extend(SVGRenderer.prototype, {
      */
     Element: SVGElement,
 
+    CUSTOM_SVG_NS,
     SVG_NS,
 
     /**


### PR DESCRIPTION
Added data scraping attributes to the SVG.
___
Code for adding the attributes is added to the core, so extra reviewing would be nice!

Demo at `highcharts/chart/svg-data-scraping`.

**NB**: Does not add per-datapoint attributes if there are more than 1000 data points (hardcoded). Performance hit for less than this seems totally negligible in my tests. Perhaps this magic number should be a constant on the Highcharts namespace or otherwise configurable?

It also does not pick up a11y dummy markers, which would perhaps be nice in order to add info to null points or to other points without markers.

SVG looks like this for series:
![Img](https://user-images.githubusercontent.com/5276642/171019230-74e62d62-7b77-4dc7-87fc-131a6f1bf8a9.png)

The added attributes are:
- `chart:title`
- `chart:subtitle`
- `chart:caption`
- `chart:alt` (a11y human supplied description)
- `chart:axisdimension` (corresponds to `axis.coll`)
- `chart:axistitle`
- `chart:axistype` (linear, log etc)
- `chart:axisvisualmax`
- `chart:axisvisualmin`
- `chart:axisdatamax`
- `chart:axisdatamin`
- `chart:seriestype`
- `chart:seriesname`
- `chart:dataformat` (for each series - should this be `chart:seriesdataformat`?)
- `chart:pointsinseries` (total num points in `series.data`)
- `chart:pointdata` (for each point graphic)
- `chart:pointisnull` (usually null points do not have graphics, but if they do)

The `chart` namespace is added as `H.CUSTOM_SVG_NS = 'https://highcharts.com/xmlnamespaces/chart'` (which is just a string that has to be unique, nothing needs to be present at this URL).