### PR TITLE
bugfix-17352-tooltip-scrollablePlotArea 

### DIFF
--- a/samples/unit-tests/tooltip/outside/demo.js
+++ b/samples/unit-tests/tooltip/outside/demo.js
@@ -81,3 +81,33 @@ QUnit.test('Outside tooltip styling', function (assert) {
         '#11494: Setting tooltip.style.zIndex should also work'
     );
 });
+
+QUnit.test('Tooltip visibility after the scrollablePlotArea change, #17352.',
+    assert => {
+        const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'spline',
+                scrollablePlotArea: {
+                    minHeight: 200
+                }
+            },
+            series: [{
+                data: [0, 1, 2, 3, 4]
+            }]
+        });
+
+        document.getElementById('container').style.height = "190px";
+        chart.reflow();
+
+        document.getElementById('container').style.height = "400px";
+        chart.reflow();
+
+        chart.tooltip.refresh(chart.series[0].points[0]);
+
+        assert.notOk(
+            chart.tooltip.isHidden,
+            `After updating the scrollablePlotArea, the tooltip should be still
+            visible.`
+        );
+    }
+);

--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -46,6 +46,7 @@ import U from '../Core/Utilities.js';
 const {
     addEvent,
     createElement,
+    defined,
     merge,
     pick
 } = U;
@@ -128,7 +129,7 @@ addEvent(Chart, 'afterSetChartSize', function (e: { skipAxes: boolean }): void {
                 0,
                 scrollableMinHeight - this.chartHeight
             );
-            if (scrollablePixelsY) {
+            if (defined(scrollablePixelsY)) {
                 this.scrollablePlotBox = (
                     this.renderer.scrollablePlotBox = merge(this.plotBox)
                 );


### PR DESCRIPTION
Fixed #17352, the tooltip was not visible after updating scrollablePlotArea.