### PR TITLE
Fixed #16134, drilldown not working on boosted series

### DIFF
--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1426,13 +1426,18 @@ class Axis {
             names = this.names,
             i = names.length;
 
-        if (i > 0) {
+        let cleared: boolean|undefined;
+
+        const clearNames = (): void => {
             Object.keys((names as any).keys).forEach(function (
                 key: string
             ): void {
                 delete ((names as any).keys)[key];
             });
             names.length = 0;
+        };
+
+        if (i > 0) {
 
             this.minRange = this.userMinRange; // Reset
             (this.series || []).forEach(function (series): void {
@@ -1461,6 +1466,13 @@ class Axis {
                     i: number
                 ): void { // #9487
                     let x;
+
+                    // Make sure names are cleared only when there is new data
+                    // present, prevents clearing in Boost mode.
+                    if (!cleared) {
+                        clearNames();
+                        cleared = true;
+                    }
 
                     if (
                         point &&


### PR DESCRIPTION
Fixed #16134, drilldown not working on boosted series

To do 
 - [x] Fix the basic drilling between series
 - [x] Fix issue with Boost, [category names are not updated](https://jsfiddle.net/highcharts/c4m5srpd/1/) when switching series.
 - [ ] Fix issue with drilldown only working for the lower axis labels (using two different indexing systems for boost, test case [here](https://jsfiddle.net/highcharts/dtgub2hf/1/))
 - [ ] Write test that covers both