### PR TITLE
Fixed #17182, Boost and hiding series in FF

### DIFF
--- a/samples/unit-tests/boost/enter-exit/demo.js
+++ b/samples/unit-tests/boost/enter-exit/demo.js
@@ -1,7 +1,11 @@
 (function () {
     function assertNonBoosted(assert, s) {
         assert.ok(
-            !s.renderTarget || s.renderTarget.attr('href') === '',
+            !s.renderTarget || (
+                s.renderTarget.attr('href') ===
+                // Blank pixel
+                'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+            ),
             'No painted image'
         );
 

--- a/samples/unit-tests/boost/setvisible/demo.js
+++ b/samples/unit-tests/boost/setvisible/demo.js
@@ -20,26 +20,27 @@ QUnit.test('Boosted series show/hide', function (assert) {
         ]
     });
 
-    var s = chart.series[0];
+    const s = chart.series[0],
+        blankPixel = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
 
     assert.strictEqual(
-        s.renderTarget.attr('href').length,
-        0,
+        s.renderTarget.attr('href'),
+        blankPixel,
         'Empty image for the initially hidden series'
     );
 
     s.show();
 
-    assert.strictEqual(
-        s.renderTarget.attr('href').indexOf('data:image/png;base64,'),
-        0,
+    assert.notStrictEqual(
+        s.renderTarget.attr('href'),
+        blankPixel,
         'Painted image for the visible series'
     );
 
     s.hide();
     assert.strictEqual(
-        s.renderTarget.attr('href').length,
-        0,
+        s.renderTarget.attr('href'),
+        blankPixel,
         'Empty image for the dynamically hidden series'
     );
 });

--- a/ts/Extensions/Boost/BoostAttach.ts
+++ b/ts/Extensions/Boost/BoostAttach.ts
@@ -122,7 +122,11 @@ function createAndAttachRenderer(
                 .add(targetGroup);
 
             target.boostClear = function (): void {
-                (target.renderTarget as any).attr({ href: '' });
+                (target.renderTarget as any).attr({
+                    // Insert a blank pixel (#17182)
+                    /* eslint-disable-next-line max-len*/
+                    href: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+                });
             };
 
             target.boostCopy = function (): void {

--- a/ts/Extensions/BoostCanvas.ts
+++ b/ts/Extensions/BoostCanvas.ts
@@ -259,7 +259,11 @@ const initCanvasBoost = function (): void {
                     );
 
                     if (target === this) {
-                        (target.renderTarget as any).attr({ href: '' });
+                        (target.renderTarget as any).attr({
+                            // Insert a blank pixel (#17182)
+                            /* eslint-disable-next-line max-len */
+                            href: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+                        });
                     }
                 };
 

--- a/ts/Extensions/BoostCanvas.ts
+++ b/ts/Extensions/BoostCanvas.ts
@@ -48,6 +48,12 @@ const {
     wrap
 } = U;
 
+// Use a blank pixel for clearing canvas (#17182)
+const b64BlankPixel = (
+    /* eslint-disable-next-line max-len */
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+);
+
 declare module '../Core/Series/SeriesLike' {
     interface SeriesLike extends Highcharts.BoostTargetObject {
         cvsStrokeBatch?: number;
@@ -260,9 +266,7 @@ const initCanvasBoost = function (): void {
 
                     if (target === this) {
                         (target.renderTarget as any).attr({
-                            // Insert a blank pixel (#17182)
-                            /* eslint-disable-next-line max-len */
-                            href: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+                            href: b64BlankPixel
                         });
                     }
                 };
@@ -289,7 +293,7 @@ const initCanvasBoost = function (): void {
                 width: width,
                 height: height,
                 style: 'pointer-events: none',
-                href: ''
+                href: b64BlankPixel
             });
 
             (target.boostClipRect as any).attr(chart.getBoostClipRect(target));
@@ -520,7 +524,7 @@ const initCanvasBoost = function (): void {
                 };
 
             if (this.renderTarget) {
-                this.renderTarget.attr({ 'href': '' });
+                this.renderTarget.attr({ href: b64BlankPixel });
             }
 
             // If we are zooming out from SVG mode, destroy the graphics
@@ -872,7 +876,7 @@ const initCanvasBoost = function (): void {
          */
         function clear(this: Chart): void {
             if (chart.renderTarget) {
-                chart.renderTarget.attr({ href: '' });
+                chart.renderTarget.attr({ href: b64BlankPixel });
             }
 
             if (chart.canvas) {


### PR DESCRIPTION
Fixed #17182, hiding and showing boosted series in Firefox didn't work correctly.