### PR TITLE
bugfix/17405-zoom-ordinal 

### DIFF
--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -947,7 +947,8 @@ namespace OrdinalAxis {
                 ordinalPositions = [] as Array<number>,
                 overscrollPointsRange = Number.MAX_VALUE,
                 useOrdinal = false,
-                adjustOrdinalExtremesPoints = false;
+                adjustOrdinalExtremesPoints = false,
+                isBoosted = false;
 
             // Apply the ordinal logic
             if (isOrdinal || hasBreaks) { // #4167 YAxis is never ordinal ?
@@ -968,6 +969,10 @@ namespace OrdinalAxis {
                     }
                     distanceBetweenPoint =
                         series.processedXData[1] - series.processedXData[0];
+
+                    if (series.isSeriesBoosting) {
+                        isBoosted = series.isSeriesBoosting;
+                    }
 
                     if (
                         (!ignoreHiddenSeries || series.visible !== false) &&
@@ -1037,7 +1042,8 @@ namespace OrdinalAxis {
                 // If the distance between points is not identical throughout
                 // all series, remove the first and last ordinal position to
                 // avoid enabling ordinal logic when it is not needed, #17405.
-                if (adjustOrdinalExtremesPoints) {
+                // Only for boosted series because changes are negligible.
+                if (adjustOrdinalExtremesPoints && isBoosted) {
                     ordinalPositions.pop();
                     ordinalPositions.shift();
                 }

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -958,7 +958,10 @@ namespace OrdinalAxis {
 
                     // For an axis with multiple series, check if the distance
                     // between points is identical throughout all series.
-                    if (i > 0) {
+                    if (
+                        i > 0 &&
+                        series.options.id !== 'highcharts-navigator-series'
+                    ) {
                         adjustOrdinalExtremesPoints =
                             distanceBetweenPoint !== series.processedXData[1] -
                                 series.processedXData[0];

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -946,13 +946,25 @@ namespace OrdinalAxis {
                 i,
                 ordinalPositions = [] as Array<number>,
                 overscrollPointsRange = Number.MAX_VALUE,
-                useOrdinal = false;
+                useOrdinal = false,
+                adjustOrdinalExtremesPoints = false;
 
             // Apply the ordinal logic
             if (isOrdinal || hasBreaks) { // #4167 YAxis is never ordinal ?
+                let distanceBetweenPoint = 0;
 
                 axis.series.forEach(function (series, i): void {
                     uniqueOrdinalPositions = [];
+
+                    // For an axis with multiple series, check if the distance
+                    // between points is identical throughout all series.
+                    if (i > 0) {
+                        adjustOrdinalExtremesPoints =
+                            distanceBetweenPoint !== series.processedXData[1] -
+                                series.processedXData[0];
+                    }
+                    distanceBetweenPoint =
+                        series.processedXData[1] - series.processedXData[0];
 
                     if (
                         (!ignoreHiddenSeries || series.visible !== false) &&
@@ -1018,6 +1030,14 @@ namespace OrdinalAxis {
                         }
                     }
                 });
+
+                // If the distance between points is not identical throughout
+                // all series, remove the first and last ordinal position to
+                // avoid enabling ordinal logic when it is not needed, #17405.
+                if (adjustOrdinalExtremesPoints) {
+                    ordinalPositions.pop();
+                    ordinalPositions.shift();
+                }
 
                 // cache the length
                 len = ordinalPositions.length;


### PR DESCRIPTION
Fixed #17405, zooming on boosted charts froze under certain conditions.

Word of comment about that issue: 

- Before each series/axis render we calculate if the ordinal logic is needed. We do that by checking the distance between points of the combined series.
- This is a very data-specific issue. Each of these two series doesn't need ordinal logic because each point is spaced equally. However, one series has much more points than the other.
- After zooming we might end up with two series where the first and/or last position might not be exactly equally spaced which will force the chart to use ordinal while in reality, it doesn't need that.
This behavior caused an infinite loop.
