### PR TITLE
bugfix/17305-tunnel-height-localstorage

### DIFF
--- a/ts/Extensions/Annotations/Types/Tunnel.ts
+++ b/ts/Extensions/Annotations/Types/Tunnel.ts
@@ -171,6 +171,7 @@ class Tunnel extends CrookedLine {
 
         this.options.typeOptions.height = (this.points[3].y as any) -
             (this.points[0].y as any);
+        this.userOptions.typeOptions.height = this.options.typeOptions.height;
     }
 
 }


### PR DESCRIPTION
Fixed #17305, the height of the Tunnel annotation wasn't overwritten in `localStorage`.