### PR TITLE
bugfix/17167-legend-title-no-data

### DIFF
--- a/samples/unit-tests/legend/legend-general/demo.js
+++ b/samples/unit-tests/legend/legend-general/demo.js
@@ -141,8 +141,11 @@ QUnit.test('Legend redraws', function (assert) {
         }
     });
 
-    assert.strictEqual(chart.legend.group.attr('visibility'), 'hidden',
-        'Legend title is not visible (#17167)');
+    assert.strictEqual(
+        chart.legend.group.attr('visibility'),
+        'hidden',
+        'Legend title should not be visible (#17167)'
+    );
 });
 
 QUnit.test(

--- a/samples/unit-tests/legend/legend-general/demo.js
+++ b/samples/unit-tests/legend/legend-general/demo.js
@@ -130,6 +130,18 @@ QUnit.test('Legend redraws', function (assert) {
     chart.series[0].hide(true);
 
     assert.strictEqual(visible, false, 'Legend item text has changed (#2165)');
+
+    chart.series[0].remove();
+
+    chart.update({
+        legend: {
+            title: {
+                text: 'Legend'
+            }
+        }
+    });
+
+    assert.strictEqual(chart.legend.group.visibility === 'hidden', true, 'Legend title is not visible (#17167)');
 });
 
 QUnit.test(

--- a/samples/unit-tests/legend/legend-general/demo.js
+++ b/samples/unit-tests/legend/legend-general/demo.js
@@ -131,7 +131,7 @@ QUnit.test('Legend redraws', function (assert) {
 
     assert.strictEqual(visible, false, 'Legend item text has changed (#2165)');
 
-    chart.series[0].remove();
+    chart.series[0].remove(false);
 
     chart.update({
         legend: {
@@ -141,7 +141,8 @@ QUnit.test('Legend redraws', function (assert) {
         }
     });
 
-    assert.strictEqual(chart.legend.group.visibility === 'hidden', true, 'Legend title is not visible (#17167)');
+    assert.strictEqual(chart.legend.group.attr('visibility'), 'hidden',
+        'Legend title is not visible (#17167)');
 });
 
 QUnit.test(

--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -1200,7 +1200,7 @@ class Legend {
         }
 
         // hide the border if no items
-        box[display ? 'show' : 'hide']();
+        legendGroup[display ? 'show' : 'hide']();
 
         // Open for responsiveness
         if (chart.styledMode && legendGroup.getStyle('display') === 'none') {


### PR DESCRIPTION
Fixed #17167, legend title didn't hide when chart data was empty.