### PR TITLE
bugfix/17438-point-update-categories 

### DIFF
--- a/samples/unit-tests/axis/category/demo.js
+++ b/samples/unit-tests/axis/category/demo.js
@@ -654,6 +654,27 @@ QUnit.test(
             'Zero,One,,Three',
             'Preserved names'
         );
+
+        chart.series[0].remove(false);
+        chart.xAxis[0].update({
+            type: 'category',
+            categories: ['A', 'B', 'C']
+        }, false);
+        chart.addSeries({
+            data: [4, 1, 9]
+        });
+        chart.update({
+            series: [{
+                data: [4, 1, 20]
+            }]
+        });
+        assert.strictEqual(
+            chart.series[0].points[2].x,
+            2,
+            `When the categories are explicitly enabled, updating the data, as
+            an array of only y values, should not change points' x values,
+            #17438`
+        );
     }
 );
 

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1408,6 +1408,8 @@ class Axis {
             this.names[x] = point.name as any;
             // Backwards mapping is much faster than array searching (#7725)
             (this.names as any).keys[point.name as any] = x;
+        } else if (point.x) {
+            x = point.x; // #17438
         }
 
         return x as any;


### PR DESCRIPTION
Fixed #17438, updating points with the category axis gave the wrong x position.