### PR TITLE
bugfix/17359-polar-stickyTracking 

### DIFF
--- a/samples/unit-tests/pointer/hover/demo.js
+++ b/samples/unit-tests/pointer/hover/demo.js
@@ -214,10 +214,6 @@ QUnit.test('Tooltip should be shown for value equal to max', function (assert) {
             max: 100
         },
 
-        tooltip: {
-            //shared: true
-        },
-
         series: [
             {
                 data: [99, 100, 101, 36, 47, 16],
@@ -282,5 +278,28 @@ QUnit.test('Hover state when axis is updated (#12569).', function (assert) {
     assert.ok(
         series.halo && series.halo.visibility !== 'hidden',
         'Halo and hover state should be visible.'
+    );
+});
+
+QUnit.test('Polar chart without stickyTracking, #17359.', function (assert) {
+    var chart = Highcharts.chart('container', {
+            chart: {
+                polar: true
+            },
+            series: [{
+                stickyTracking: false,
+                data: [1, 2, 3, 4, 5]
+            }]
+        }),
+        controller = new TestController(chart),
+        x = 300,
+        y = 120;
+
+    controller.setPosition(x - 1, y - 1);
+    controller.moveTo(x, y);
+
+    assert.ok(
+        chart.tooltip.isHidden,
+        'The tooltip should not be displayed when not hovering over the series.'
     );
 });

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -812,10 +812,8 @@ class Pointer {
         if (hoverPoint) {
             // When tooltip is shared, it displays more than one point
             if (shared && !hoverSeries.noSharedTooltip) {
-                searchSeries = series.filter(function (s): boolean {
-                    return eventArgs.filter ?
-                        eventArgs.filter(s) : filter(s) && !s.noSharedTooltip;
-                });
+                searchSeries = series.filter((s): boolean => s.stickyTracking &&
+                    (eventArgs.filter || filter)(s));
 
                 // Get all points with the same x value as the hoverPoint
                 searchSeries.forEach(function (s): any {

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -795,8 +795,9 @@ class Pointer {
             [hoverSeries as any] :
             // Filter what series to look in.
             series.filter(function (s): boolean {
-                return eventArgs.filter ? eventArgs.filter(s) : filter(s) &&
-                    s.stickyTracking;
+                return eventArgs.filter ?
+                    eventArgs.filter(s) && s.stickyTracking :
+                    filter(s) && s.stickyTracking;
             });
 
         // Use existing hovered point or find the one closest to coordinates.

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -812,8 +812,10 @@ class Pointer {
         if (hoverPoint) {
             // When tooltip is shared, it displays more than one point
             if (shared && !hoverSeries.noSharedTooltip) {
-                searchSeries = series.filter((s): boolean => s.stickyTracking &&
-                    (eventArgs.filter || filter)(s));
+                searchSeries = series.filter(function (s): boolean {
+                    return eventArgs.filter ?
+                        eventArgs.filter(s) : filter(s) && !s.noSharedTooltip;
+                });
 
                 // Get all points with the same x value as the hoverPoint
                 searchSeries.forEach(function (s): any {

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -794,11 +794,8 @@ class Pointer {
             // Only search on hovered series if it has stickyTracking false
             [hoverSeries as any] :
             // Filter what series to look in.
-            series.filter(function (s): boolean {
-                return eventArgs.filter ?
-                    eventArgs.filter(s) && s.stickyTracking :
-                    filter(s) && s.stickyTracking;
-            });
+            series.filter((s): boolean => s.stickyTracking &&
+                (eventArgs.filter || filter)(s));
 
         // Use existing hovered point or find the one closest to coordinates.
         const hoverPoint = useExisting || !e ?


### PR DESCRIPTION
Fixed #17359, `stickyTracking` was not respected correctly for polar charts.