### PR TITLE
bugfix/17481-zones-scrollablePlotArea 

### DIFF
--- a/samples/unit-tests/scrollable-plotarea/dynamics/demo.js
+++ b/samples/unit-tests/scrollable-plotarea/dynamics/demo.js
@@ -41,6 +41,25 @@ QUnit.test('Test dynamic behaviour of Scrollable PlotArea', function (assert) {
         chart.fixedRenderer.box.contains(chart.xAxis[0].axisGroup.element),
         'X-axis should be outside the scrollable plot area (#8862)'
     );
+
+    chart.series[0].update({
+        zones: [{
+            value: 0,
+            color: '#f7a35c'
+        }, {
+            value: 1.5,
+            color: '#7cb5ec'
+        }, {
+            color: '#90ed7d'
+        }]
+    });
+
+    assert.strictEqual(
+        chart.series[0].clips[0].attr('width'),
+        chart.plotWidth,
+        `When the zones are applied, their' clip width should equal the chart's
+        plotWidth, #17481.`
+    );
 });
 
 QUnit.test('Responsive scrollable plot area (#12991)', function (assert) {

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -3040,7 +3040,7 @@ class Series {
             clips = (this.clips || []) as Array<SVGElement>,
             graph = this.graph,
             area = this.area,
-            chartSizeMax = Math.max(chart.chartWidth, chart.chartHeight),
+            chartSizeMax = Math.max(chart.plotWidth, chart.plotHeight),
             axis: Axis = (this as any)[
                 (this.zoneAxis || 'y') + 'Axis'
             ],

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -3040,7 +3040,7 @@ class Series {
             clips = (this.clips || []) as Array<SVGElement>,
             graph = this.graph,
             area = this.area,
-            chartSizeMax = Math.max(chart.plotWidth, chart.plotHeight),
+            plotSizeMax = Math.max(chart.plotWidth, chart.plotHeight),
             axis: Axis = (this as any)[
                 (this.zoneAxis || 'y') + 'Axis'
             ],
@@ -3088,7 +3088,7 @@ class Series {
                 translatedFrom = clamp(
                     pick(translatedTo, translatedFrom),
                     0,
-                    chartSizeMax
+                    plotSizeMax
                 );
                 translatedTo = clamp(
                     Math.round(
@@ -3098,7 +3098,7 @@ class Series {
                         ) || 0
                     ),
                     0,
-                    chartSizeMax
+                    plotSizeMax
                 );
 
                 if (ignoreZones) {
@@ -3114,7 +3114,7 @@ class Series {
                         x: inverted ? pxPosMax : pxPosMin,
                         y: 0,
                         width: pxRange,
-                        height: chartSizeMax
+                        height: plotSizeMax
                     };
                     if (!horiz) {
                         clipAttr.x = chart.plotHeight - clipAttr.x;
@@ -3123,7 +3123,7 @@ class Series {
                     clipAttr = {
                         x: 0,
                         y: inverted ? pxPosMax : pxPosMin,
-                        width: chartSizeMax,
+                        width: plotSizeMax,
                         height: pxRange
                     };
                     if (horiz) {


### PR DESCRIPTION
Fixed #17481, zones clip was incorrectly calculated and the line was partially missing when `scrollablePlotArea` was enabled.