### PR TITLE
bugfix/17486-bubbleZExtremes-remove 

### DIFF
--- a/samples/unit-tests/bubble-legend/styles/demo.js
+++ b/samples/unit-tests/bubble-legend/styles/demo.js
@@ -64,22 +64,4 @@ QUnit.test('Bubble legend ranges', function (assert) {
         true,
         'Bubble legend was properly disabled with the legend'
     );
-
-    const initialBubbleZExtremes = chart.bubbleZExtremes;
-    chart.series[0].addPoint([1, 15, 100]);
-    chart.series[0].remove();
-    chart.addSeries({
-        type: 'bubble',
-        data: [
-            [1, 1, 1],
-            [2, 2, 2]
-        ]
-    });
-
-    assert.deepEqual(
-        initialBubbleZExtremes,
-        chart.bubbleZExtremes,
-        `Newly added series and the chart bubbleZExtremes should not be polluted
-        by the previous series that has been removed, #17486.`
-    );
 });

--- a/samples/unit-tests/bubble-legend/styles/demo.js
+++ b/samples/unit-tests/bubble-legend/styles/demo.js
@@ -64,4 +64,22 @@ QUnit.test('Bubble legend ranges', function (assert) {
         true,
         'Bubble legend was properly disabled with the legend'
     );
+
+    const initialBubbleZExtremes = chart.bubbleZExtremes;
+    chart.series[0].addPoint([1, 15, 100]);
+    chart.series[0].remove();
+    chart.addSeries({
+        type: 'bubble',
+        data: [
+            [1, 1, 1],
+            [2, 2, 2]
+        ]
+    });
+
+    assert.deepEqual(
+        initialBubbleZExtremes,
+        chart.bubbleZExtremes,
+        `Newly added series and the chart bubbleZExtremes should not be polluted
+        by the previous series that has been removed, #17486.`
+    );
 });

--- a/samples/unit-tests/series-bubble/minmaxsize/demo.js
+++ b/samples/unit-tests/series-bubble/minmaxsize/demo.js
@@ -223,4 +223,50 @@ QUnit.test('Set min/max size', function (assert) {
         15,
         'Bubble size is minSize for highest value, despite maxSize being computed smaller'
     );
+
+    // Reset options after the above tests
+    chart.series[0].update({
+        minSize: null,
+        maxSize: null
+    });
+
+    const initialBubbleZExtremes = chart.bubbleZExtremes,
+        initialWidth = chart.series[0].points[5].graphic.attr('width');
+
+    // Add the biggest bubble
+    chart.series[0].addPoint([2, 2, 100]);
+
+    assert.notStrictEqual(
+        initialWidth,
+        chart.series[0].points[5].graphic.attr('width'),
+        `After adding a new big point, other points should adjust size.`
+    );
+
+    chart.series[0].remove(false);
+
+    chart.addSeries({
+        type: 'bubble',
+        data: [
+            [0, 0, 0],
+            [1, 0, 1],
+            [2, 0, 2],
+            [3, 0, 3],
+            [4, 0, 4],
+            [5, 0, 5]
+        ]
+    });
+
+    assert.strictEqual(
+        initialWidth,
+        chart.series[0].points[5].graphic.attr('width'),
+        `After reseting a series, the bubble size should be the same as initial
+        size (chart.bubbleZExtremes should be recalculated), #17486.`
+    );
+
+    assert.deepEqual(
+        initialBubbleZExtremes,
+        chart.bubbleZExtremes,
+        `Newly added series and the chart bubbleZExtremes should not be polluted
+        by the previous series that has been removed, #17486.`
+    );
 });

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -719,7 +719,7 @@ addEvent(BubbleSeries, 'updatedData', (e): void => {
     delete e.target.chart.bubbleZExtremes;
 });
 
-// After removing series, delete the chart-level Z extremes cache.
+// After removing series, delete the chart-level Z extremes cache, #17502.
 addEvent(BubbleSeries, 'remove', (e): void => {
     delete e.target.chart.bubbleZExtremes;
 });

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -719,6 +719,11 @@ addEvent(BubbleSeries, 'updatedData', (e): void => {
     delete e.target.chart.bubbleZExtremes;
 });
 
+// After removing series, delete the chart-level Z extremes cache.
+addEvent(BubbleSeries, 'remove', (e): void => {
+    delete e.target.chart.bubbleZExtremes;
+});
+
 /* *
  *
  *  Axis ?


### PR DESCRIPTION
Fixed #17486, `bubbleZExtremes` was not removed when the bubble series was removed.