### PR TITLE
bugfix/17358-heatmap-border-properties

### DIFF
--- a/ts/Series/Heatmap/HeatmapSeries.ts
+++ b/ts/Series/Heatmap/HeatmapSeries.ts
@@ -119,7 +119,12 @@ class HeatmapSeries extends ScatterSeries {
         animation: false,
 
         /**
-         * The border radius for each heatmap item.
+         * The border radius for each heatmap itemdvxv. Border width and color
+         * you can set in marker: plotOptions.heatmap.marker.lineWidth
+         * plotOptions.heatmap.marker.lineColor
+         *
+         * @see [lineWidth](#plotOptions.heatmap.marker.lineWidth)
+         * @see [lineColor](#plotOptions.heatmap.marker.lineColor)
          */
         borderRadius: 0,
 

--- a/ts/Series/Heatmap/HeatmapSeries.ts
+++ b/ts/Series/Heatmap/HeatmapSeries.ts
@@ -119,12 +119,11 @@ class HeatmapSeries extends ScatterSeries {
         animation: false,
 
         /**
-         * The border radius for each heatmap itemdvxv. Border width and color
-         * you can set in marker: plotOptions.heatmap.marker.lineWidth
-         * plotOptions.heatmap.marker.lineColor
+         * The border radius for each heatmap item.
+         * The border's color and width can be set in marker options.
          *
-         * @see [lineWidth](#plotOptions.heatmap.marker.lineWidth)
          * @see [lineColor](#plotOptions.heatmap.marker.lineColor)
+         * @see [lineWidth](#plotOptions.heatmap.marker.lineWidth)
          */
         borderRadius: 0,
 

--- a/ts/Series/Heatmap/HeatmapSeries.ts
+++ b/ts/Series/Heatmap/HeatmapSeries.ts
@@ -119,8 +119,8 @@ class HeatmapSeries extends ScatterSeries {
         animation: false,
 
         /**
-         * The border radius for each heatmap item.
-         * The border's color and width can be set in marker options.
+         * The border radius for each heatmap item. The border's color and
+         * width can be set in marker options.
          *
          * @see [lineColor](#plotOptions.heatmap.marker.lineColor)
          * @see [lineWidth](#plotOptions.heatmap.marker.lineWidth)


### PR DESCRIPTION
Fixed #17358, missing heatmap border width and color information in API