### PR TITLE
Fixed boost refresh after empty series array.

### DIFF
--- a/samples/highcharts/boost/line-markers/demo.js
+++ b/samples/highcharts/boost/line-markers/demo.js
@@ -1,4 +1,4 @@
-Highcharts.chart('container', {
+const chart = Highcharts.chart('container', {
 
     boost: {
         useGPUTranslations: true
@@ -18,14 +18,21 @@ Highcharts.chart('container', {
     },
 
     series: [{
-        data: [1, 3, 2, 4, 5, 3]
-    }, {
-        data: [6, 5, 7, 6, 8, 4]
-    }, {
-        data: [9, 8, 9, 8, 7, 9]
-    }, {
-        data: [11, 10, 12, 11, 10, 13],
-        type: 'scatter'
+        data: [11, 10, 12, 11, 10, 13]
     }]
 
+});
+chart.series[0].remove(); // test boost refresh after empty series array
+chart.addSeries({
+    data: [1, 3, 2, 4, 5, 3]
+});
+chart.addSeries({
+    data: [6, 5, 7, 6, 8, 4]
+});
+chart.addSeries({
+    data: [9, 8, 9, 8, 7, 9]
+});
+chart.addSeries({
+    data: [11, 10, 12, 11, 10, 13],
+    type: 'scatter'
 });

--- a/ts/Extensions/Boost/BoostChart.ts
+++ b/ts/Extensions/Boost/BoostChart.ts
@@ -189,7 +189,7 @@ function onChartCallback(
 
         // Clear the canvas
         if (chart.boost.clear) {
-            chart.boost.clear(chart);
+            chart.boost.clear();
         }
 
         if (

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -418,7 +418,7 @@ function createAndAttachRenderer(
         // Fall back to image tag if foreignObject isn't supported,
         // or if we're exporting.
         if (chart.renderer.forExport || !foSupported) {
-            boost.target = chart.renderer.image(
+            target.renderTarget = boost.target = chart.renderer.image(
                 '',
                 0,
                 0,
@@ -448,7 +448,8 @@ function createAndAttachRenderer(
                 .createElement('foreignObject')
                 .add(targetGroup);
 
-            boost.target = doc.createElement('canvas') as any;
+            target.renderTarget = boost.target =
+                doc.createElement('canvas') as any;
             boost.targetCtx = boost.target.getContext('2d');
 
             boost.targetFo.element.appendChild(boost.target as any);
@@ -510,7 +511,7 @@ function createAndAttachRenderer(
     }
 
     boost.resize();
-    boost.clear(target);
+    boost.clear();
 
     if (!boost.wgl) {
         boost.wgl = new WGLRenderer((wgl): void => {
@@ -717,7 +718,7 @@ function exitBoost(
 
         // Clear previous run
         if (boost.clear) {
-            boost.clear(series);
+            boost.clear();
         }
     }
 }
@@ -795,7 +796,7 @@ function onSeriesHide(
             boost.wgl.clear();
         }
         if (boost.clear) {
-            boost.clear(this);
+            boost.clear();
         }
     }
 }
@@ -962,7 +963,7 @@ function seriesRenderCanvas(this: Series): void {
         // When switching from chart boosting mode, destroy redundant
         // series boosting targets
         if (this.boost && this.boost.target) {
-            this.boost.target = this.boost.target.destroy();
+            this.renderTarget = this.boost.target = this.boost.target.destroy();
         }
     }
 
@@ -1168,8 +1169,7 @@ function wrapPointHaloPath(
         point.plotY = series.xAxis.len - plotX;
     }
 
-    const halo: SVGPath =
-        proceed.apply(this, Array.prototype.slice.call(arguments, 1));
+    const halo: SVGPath = proceed.apply(this, [].slice.call(arguments, 1));
 
     if (series.boosted && inverted) {
         point.plotX = plotX;
@@ -1264,7 +1264,6 @@ function wrapSeriesFunctions(
     if (method === 'translate') {
         [
             'column',
-            'bar',
             'arearange',
             'columnrange',
             'heatmap',
@@ -1292,7 +1291,7 @@ function wrapSeriesGetExtremes(
     ) {
         return {};
     }
-    return proceed.apply(this, Array.prototype.slice.call(arguments, 1));
+    return proceed.apply(this, [].slice.call(arguments, 1));
 }
 
 /**
@@ -1315,7 +1314,7 @@ function wrapSeriesMarkerAttribs(
     }
 
     const attribs: SVGAttributes =
-        proceed.apply(this, Array.prototype.slice.call(arguments, 1));
+        proceed.apply(this, [].slice.call(arguments, 1));
 
     if (series.boosted && inverted) {
         point.plotX = plotX;
@@ -1376,7 +1375,7 @@ function wrapSeriesProcessData(
             series.options.stacking ||
             !hasExtremes(series, true)
         ) {
-            proceed.apply(series, Array.prototype.slice.call(arguments, 1));
+            proceed.apply(series, [].slice.call(arguments, 1));
             dataToMeasure = series.processedXData;
         }
 
@@ -1405,7 +1404,7 @@ function wrapSeriesProcessData(
         }
     // The series type is not boostable
     } else {
-        proceed.apply(this, Array.prototype.slice.call(arguments, 1));
+        proceed.apply(this, [].slice.call(arguments, 1));
     }
 }
 

--- a/ts/Extensions/Boost/BoostTargetObject.d.ts
+++ b/ts/Extensions/Boost/BoostTargetObject.d.ts
@@ -21,13 +21,19 @@ export interface BoostTargetAdditions {
     targetCtx?: CanvasRenderingContext2D;
     targetFo?: SVGElement;
     wgl?: WGLRenderer;
-    clear?(boostTarget: BoostTargetObject): void;
+    clear?(): void;
     copy?(): void;
     resize?(): void;
 }
 
 export interface BoostTargetObject {
     boost?: BoostTargetAdditions;
+    /**
+     * Needed to proper refresh boosted canvas during series replacements.
+     * @deprecated
+     * @todo Fix dependency to use boost.target.
+     */
+    renderTarget?: (HTMLElement|SVGElement);
 }
 
 /* *

--- a/ts/Extensions/BoostCanvas.ts
+++ b/ts/Extensions/BoostCanvas.ts
@@ -274,9 +274,7 @@ const initCanvasBoost = function (): void {
                     });
                 };
 
-                boost.clear = function (
-                    boostTarget: BoostTargetObject
-                ): void {
+                boost.clear = function (): void {
                     ctx.clearRect(
                         0,
                         0,
@@ -284,7 +282,7 @@ const initCanvasBoost = function (): void {
                         boost.canvas.height
                     );
 
-                    if (target === boostTarget) {
+                    if (target === boost.target) {
                         boost.target.attr({
                             href: b64BlankPixel
                         });
@@ -336,7 +334,7 @@ const initCanvasBoost = function (): void {
                     this.chart.boost.copy();
                 }
             } else if (this.boost && this.boost.clear) {
-                this.boost.clear(this);
+                this.boost.clear();
             }
         },
 
@@ -574,7 +572,7 @@ const initCanvasBoost = function (): void {
             series.buildKDTree = noop; // Do not start building while drawing
 
             if (boost.clear) {
-                boost.clear(this);
+                boost.clear();
             }
 
             // if (this.canvas) {


### PR DESCRIPTION
- Fixed boost refresh when no series is present.
- Fixed a double wrap of BarSeries.translate inherited from ColumnSeries.
