### PR TITLE
Fixed #17547, no forced boost with zoom.

### DIFF
--- a/ts/Extensions/Boost/Boost.ts
+++ b/ts/Extensions/Boost/Boost.ts
@@ -366,7 +366,8 @@ export default Boost;
 
 /**
  * If set to true, the whole chart will be boosted if one of the series
- * crosses its threshold, and all the series can be boosted.
+ * crosses its threshold, and all the series can be boosted. If the
+ * `chart.zoomType` option is set, it will default to `false`.
  *
  * @type      {boolean}
  * @default   true

--- a/ts/Extensions/Boost/Boost.ts
+++ b/ts/Extensions/Boost/Boost.ts
@@ -183,17 +183,12 @@ export default Boost;
  */
 
 /**
- * Set the series threshold for when the boost should kick in globally.
+ * The chart will be boosted, if one of the series crosses its threshold and all
+ * the series in the chart can be boosted.
  *
- * Setting to e.g. 20 will cause the whole chart to enter boost mode
- * if there are 20 or more series active. When the chart is in boost mode,
- * every series in it will be rendered to a common canvas. This offers
- * a significant speed improvment in charts with a very high
- * amount of series.
- *
- * @type      {number}
- * @default   50
- * @apioption boost.seriesThreshold
+ * @type      {boolean}
+ * @default   true
+ * @apioption boost.allowForce
  */
 
 /**
@@ -312,6 +307,20 @@ export default Boost;
  */
 
 /**
+ * Set the series threshold for when the boost should kick in globally.
+ *
+ * Setting to e.g. 20 will cause the whole chart to enter boost mode
+ * if there are 20 or more series active. When the chart is in boost mode,
+ * every series in it will be rendered to a common canvas. This offers
+ * a significant speed improvment in charts with a very high
+ * amount of series.
+ *
+ * @type      {number}
+ * @default   50
+ * @apioption boost.seriesThreshold
+ */
+
+/**
  * Enable or disable GPU translations. GPU translations are faster than doing
  * the translation in JavaScript.
  *
@@ -362,16 +371,6 @@ export default Boost;
  * @default   5000
  * @requires  modules/boost
  * @apioption plotOptions.series.boostThreshold
- */
-
-/**
- * If set to true, the whole chart will be boosted if one of the series
- * crosses its threshold, and all the series can be boosted. If the
- * `chart.zoomType` option is set, it will default to `false`.
- *
- * @type      {boolean}
- * @default   true
- * @apioption boost.allowForce
  */
 
 /**

--- a/ts/Extensions/Boost/BoostChart.ts
+++ b/ts/Extensions/Boost/BoostChart.ts
@@ -291,9 +291,16 @@ function patientMax(...args: Array<Array<unknown>>): number {
  * True, if boosting should be forced.
  */
 function shouldForceChartSeriesBoosting(chart: Chart): boolean {
+
+    chart.boost = chart.boost || {};
+
+    if (typeof chart.boost.forceChartBoost !== 'undefined') {
+        return chart.boost.forceChartBoost;
+    }
+
     const allowBoostForce = pick(
         chart.options.boost && chart.options.boost.allowForce,
-        true
+        !chart.options.chart.zoomType
     );
 
     // If there are more than five series currently boosting,
@@ -301,12 +308,6 @@ function shouldForceChartSeriesBoosting(chart: Chart): boolean {
     let sboostCount = 0,
         canBoostCount = 0,
         series;
-
-    chart.boost = chart.boost || {};
-
-    if (typeof chart.boost.forceChartBoost !== 'undefined') {
-        return chart.boost.forceChartBoost;
-    }
 
     if (chart.series.length > 1) {
         for (let i = 0; i < chart.series.length; i++) {
@@ -317,8 +318,10 @@ function shouldForceChartSeriesBoosting(chart: Chart): boolean {
             // See #8950
             // Also don't count if the series is hidden.
             // See #9046
-            if (series.options.boostThreshold === 0 ||
-                series.visible === false) {
+            if (
+                series.options.boostThreshold === 0 ||
+                series.visible === false
+            ) {
                 continue;
             }
 

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -1369,7 +1369,6 @@ function wrapSeriesProcessData(
         // do default behaviour.
         if (
             // First pass with options.data:
-            !getSeriesBoosting(dataToMeasure) ||
             series.type === 'heatmap' ||
             series.type === 'treemap' ||
             // processedYData for the stack (#7481):


### PR DESCRIPTION
Fixed #17547; When the `chart.zoomType` option is set, boosted rendering will not be forced as long as threshold is not reached.