### PR TITLE
bugfix/17498 export usehtml rotation

### DIFF
--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -1508,9 +1508,12 @@ class SVGElement implements SVGElementLike {
                         // width and height in case of rotation (below)
                         extend({} as any, (element as any).getBBox()) : {
 
-                            // Legacy IE in export mode
+                            // HTML elements with `exporting.allowHTML` and
+                            // legacy IE in export mode
                             width: (element as any).offsetWidth,
-                            height: (element as any).offsetHeight
+                            height: (element as any).offsetHeight,
+                            x: 0,
+                            y: 0
                         };
 
                     // #3842


### PR DESCRIPTION
- Tools: Purge CloudFlare
- Fixed #17498, a regression when exporting rotated HTML labels
