### PR TITLE
Fixed #17498, a regression when exporting rotated HTML labels

### DIFF
--- a/samples/unit-tests/exporting/exportchart/demo.js
+++ b/samples/unit-tests/exporting/exportchart/demo.js
@@ -1,5 +1,9 @@
 QUnit.test('Testing exportChart', function (assert) {
     var chart = Highcharts.chart('container', {
+        chart: {
+            width: 400,
+            height: 300
+        },
         credits: {
             enabled: false
         },
@@ -18,6 +22,11 @@ QUnit.test('Testing exportChart', function (assert) {
                 'Nov',
                 'Dec'
             ]
+        },
+        yAxis: {
+            title: {
+                useHTML: true
+            }
         },
         series: [
             {
@@ -38,7 +47,8 @@ QUnit.test('Testing exportChart', function (assert) {
             }
         ],
         exporting: {
-            filename: 'custom-file-name'
+            filename: 'custom-file-name',
+            allowHTML: true
         }
     });
 
@@ -53,12 +63,26 @@ QUnit.test('Testing exportChart', function (assert) {
 
         // Run export
         chart.exportChart();
+
+        // Assert
         assert.strictEqual(postData.type, 'image/png', 'Posting for PNG');
+
         assert.strictEqual(
             postData.filename,
             'custom-file-name',
             'Custom filename'
         );
+
+        assert.ok(
+            /foreignObject/.test(postData.svg),
+            'The generated SVG should contain a foreignObjet'
+        );
+
+        assert.notOk(
+            /NaN/.test(postData.svg),
+            'The generated SVG should not contain NaN (17498)'
+        );
+
     } finally {
         Highcharts.HttpUtilities.post = originalPost;
     }

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -1508,9 +1508,12 @@ class SVGElement implements SVGElementLike {
                         // width and height in case of rotation (below)
                         extend({} as any, (element as any).getBBox()) : {
 
-                            // Legacy IE in export mode
+                            // HTML elements with `exporting.allowHTML` and
+                            // legacy IE in export mode
                             width: (element as any).offsetWidth,
-                            height: (element as any).offsetHeight
+                            height: (element as any).offsetHeight,
+                            x: 0,
+                            y: 0
                         };
 
                     // #3842


### PR DESCRIPTION
Fixed #17498, a regression when exporting rotated labels with `useHTML` and `exporting.allowHTML`.