### PR TITLE
Fixed grammar "can not" -> "cannot" and typo "wether" -> "whether"

### DIFF
--- a/docs/chart-and-series-types/venn-series.md
+++ b/docs/chart-and-series-types/venn-series.md
@@ -127,7 +127,7 @@ The venn series can be used to create both Venn and Euler diagrams.
 
 **Venn diagram of The Unattainable Triangle**
 
-The unattainable triangle is a reference often used in marketing and advertising, which says that you can either have it fast, cheap, or good, but you can not have it all. In the triangle the three qualities make up the corners, while the sides create the relationship between these qualities. Since the reference is all about relationships this can also be very well displayed as a venn diagram, as can be seen in the following demo [Venn diagram of the Unattainable Triangle.](https://highcharts.com/demo/venn-diagram)
+The unattainable triangle is a reference often used in marketing and advertising, which says that you can either have it fast, cheap, or good, but you cannot have it all. In the triangle the three qualities make up the corners, while the sides create the relationship between these qualities. Since the reference is all about relationships this can also be very well displayed as a venn diagram, as can be seen in the following demo [Venn diagram of the Unattainable Triangle.](https://highcharts.com/demo/venn-diagram)
 
 <iframe style="width: 100%; height: 520px; border: none;" src=https://www.highcharts.com/samples/embed/highcharts/demo/venn-diagram allow="fullscreen"></iframe>
 

--- a/docs/chart-concepts/3d-charts.md
+++ b/docs/chart-concepts/3d-charts.md
@@ -64,7 +64,7 @@ General
 
 For all 3D charts the following options are the most important (part of _chart.options3d_):
 
-*   enabled                   This indicates wether the chart has to have 3D or not, set this to true.
+*   enabled                   This indicates whether the chart has to have 3D or not, set this to true.
 *   depth                        The total depth of the chart, defaults to 100.
 *   viewDistance          This defines how far a viewer is from the chart.
 *   alpha & beta           The angles to rotate the view of the chart.

--- a/docs/chart-concepts/plot-bands-and-plot-lines.md
+++ b/docs/chart-concepts/plot-bands-and-plot-lines.md
@@ -81,7 +81,7 @@ Dynamically update
 
 After render time a chart can be updated with new plot bands or lines, or if you want some can be removed. This is done by using the functions addPlotBand(), addPlotLine(), removePlotBand() or removePlotLine(). With use of these functions the chart allows for interaction with the user. 
 
-When removing a plot band or line it is critical that the object which should be removed has been given an id. Without it the object can not be recognized and the function can not be executed.
+When removing a plot band or line it is critical that the object which should be removed has been given an id. Without it the object cannot be recognized and the function cannot be executed.
 
 Some simple examples of how a plot band can be [added](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/members/axis-addplotband/) to the chart and how it can be [removed](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/xaxis/plotbands-id/).
 

--- a/docs/chart-design-and-style/style-by-css.md
+++ b/docs/chart-design-and-style/style-by-css.md
@@ -14,7 +14,7 @@ WHAT CAN BE STYLED?
 -------------------
 Typography, colors and visual properties like stroke width and style can be set by CSS.
 
-However, layout and positioning of elements like the title or legend can not be controlled by CSS. This is a limitation of CSS for SVG, that does not (yet - [SVG 2 Geometric Style Properties](https://github.com/w3c/svgwg/wiki/SVG-2-new-features#geometric-attributes-that-can-now-be-specified-as-style-properties)) allow geometric attributes like `x`, `y`, `width` or `height`. And even if those were settable, we would still need to compute the layout flow in JavaScript. Instead, positioning is subject to Highcharts JavaScript options like `align`, `verticalAlign` etc.
+However, layout and positioning of elements like the title or legend cannot be controlled by CSS. This is a limitation of CSS for SVG, that does not (yet - [SVG 2 Geometric Style Properties](https://github.com/w3c/svgwg/wiki/SVG-2-new-features#geometric-attributes-that-can-now-be-specified-as-style-properties)) allow geometric attributes like `x`, `y`, `width` or `height`. And even if those were settable, we would still need to compute the layout flow in JavaScript. Instead, positioning is subject to Highcharts JavaScript options like `align`, `verticalAlign` etc.
 
 
 WHAT CSS RULES APPLY

--- a/docs/working-with-data/getting-data-across-domains-jsonp.md
+++ b/docs/working-with-data/getting-data-across-domains-jsonp.md
@@ -3,7 +3,7 @@ Cross domain data
 
 It is not possible to use the jQuery .getJSON() function on JSON files outside of your own domain. It is however possible to use JSONP.
 
-The difference between JSON and JSONP is that in a regular JSON file you would just use the ordinary JSON syntax. This can not be returned cross domain. With JSONP what is done is wrapping the JSON content with a callback function in PHP which returns a json object. This can come in handy if the data you wish to display is on another domain than your own. A great number of data providers have JSONP services, for example Google and Twitter.
+The difference between JSON and JSONP is that in a regular JSON file you would just use the ordinary JSON syntax. This cannot be returned cross domain. With JSONP what is done is wrapping the JSON content with a callback function in PHP which returns a json object. This can come in handy if the data you wish to display is on another domain than your own. A great number of data providers have JSONP services, for example Google and Twitter.
 
 Here is an example:
 

--- a/samples/readme.md
+++ b/samples/readme.md
@@ -88,7 +88,7 @@ unit tests task. The chart and its container are shared between multiple tests
 and test-specific options get reverted after each test.
 
 The limitations of the underlying `Chart.update` function applies, so that
-callback functions are not supported as they can not be reverted. Additionally
+callback functions are not supported as they cannot be reverted. Additionally
 the `Chart.update` function is not wrapped in a template and therefor has to be
 avoided as well. If you need to test with callback functions or multiple
 updates, test templates are not for you.

--- a/samples/unit-tests/series-sunburst/api-dynamics/demo.js
+++ b/samples/unit-tests/series-sunburst/api-dynamics/demo.js
@@ -31,7 +31,7 @@ QUnit.test('Chart.setSize.', function (assert) {
         });
     chart.setSize(200, 200);
     // TODO find something to tests against.
-    // This only tests wether setSize is executed without errors
+    // This only tests whether setSize is executed without errors
     assert.strictEqual('todo', 'todo', 'todo');
 });
 

--- a/samples/unit-tests/series-wordcloud/api-dynamics/demo.js
+++ b/samples/unit-tests/series-wordcloud/api-dynamics/demo.js
@@ -62,7 +62,7 @@ QUnit.test('Chart.setSize.', function (assert) {
         });
     chart.setSize(200, 200);
     // TODO find something to tests against.
-    // This only tests wether setSize is executed without errors
+    // This only tests whether setSize is executed without errors
     assert.strictEqual('todo', 'todo', 'todo');
 });
 

--- a/samples/unit-tests/tooltip/formatter/demo.js
+++ b/samples/unit-tests/tooltip/formatter/demo.js
@@ -14,7 +14,7 @@ QUnit.test('Formatter returns undefined', function (assert) {
 
     chart.tooltip.refresh(chart.series[0].points[0]);
 
-    // Test wether tooltip.refresh raises an exception.
+    // Test whether tooltip.refresh raises an exception.
     assert.ok(
         true,
         'Tooltip.refresh passes when formatter returns undefined. #5922'

--- a/tools/compile.js
+++ b/tools/compile.js
@@ -2,7 +2,7 @@
 /* eslint no-console:0, no-path-concat:0, no-nested-ternary:0, valid-jsdoc:0 */
 /* eslint-disable func-style */
 
-// NOPE, YOU CAN NOT FIX IT! The JS compiler is gone and only the Java version
+// NOPE, YOU CANNOT FIX IT! The JS compiler is gone and only the Java version
 // is left. NOPE, closure-gun is a Java wrapper. (-_-) Keep the old version.
 const ClosureCompiler = require('google-closure-compiler').jsCompiler;
 

--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -178,7 +178,7 @@ class LegendComponent extends AccessibilityComponent {
         const component = this;
         this.recreateProxies();
 
-        // Note: Chart could create legend dynamically, so events can not be
+        // Note: Chart could create legend dynamically, so events cannot be
         // tied to the component's chart's current legend.
         // @todo 1. attach component to created legends
         // @todo 2. move listeners to composition and access `this.component`

--- a/ts/Accessibility/Components/SeriesComponent/SeriesDescriber.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesDescriber.ts
@@ -701,7 +701,7 @@ function describeSeries(
         // For some series types the order of elements do not match the
         // order of points in series. In that case we have to reverse them
         // in order for AT to read them out in an understandable order.
-        // Due to z-index issues we can not do this for 3D charts.
+        // Due to z-index issues we cannot do this for 3D charts.
         if (seriesEl.lastChild === firstPointEl && !is3d) {
             reverseChildNodes(seriesEl);
         }

--- a/ts/Accessibility/Options/A11yDefaults.ts
+++ b/ts/Accessibility/Options/A11yDefaults.ts
@@ -593,7 +593,7 @@ const Options: DeepPartial<A11yOptions> = {
                  * Style options for the focus border drawn around elements
                  * while navigating through them. Note that some browsers in
                  * addition draw their own borders for focused elements. These
-                 * automatic borders can not be styled by Highcharts.
+                 * automatic borders cannot be styled by Highcharts.
                  *
                  * In styled mode, the border is given the
                  * `.highcharts-focus-border` class.

--- a/ts/Core/Axis/TreeGrid/TreeGridAxis.ts
+++ b/ts/Core/Axis/TreeGrid/TreeGridAxis.ts
@@ -192,7 +192,7 @@ function getBreakFromNode(
  * All the data points to display in the axis.
  *
  * @param {boolean} uniqueNames
- * Wether or not the data node with the same name should share grid cell. If
+ * Whether or not the data node with the same name should share grid cell. If
  * true they do share cell. False by default.
  *
  * @param {number} numberOfSeries

--- a/ts/Core/Chart/Chart3D.ts
+++ b/ts/Core/Chart/Chart3D.ts
@@ -730,7 +730,7 @@ namespace Chart3D {
             options3d: {
 
                 /**
-                 * Wether to render the chart using the 3D functionality.
+                 * Whether to render the chart using the 3D functionality.
                  *
                  * @since   4.0
                  * @product highcharts

--- a/ts/Core/Geometry/CircleUtilities.ts
+++ b/ts/Core/Geometry/CircleUtilities.ts
@@ -239,7 +239,7 @@ namespace CircleUtilities {
     }
 
     /**
-     * Tests wether the first circle is completely overlapping the second
+     * Tests whether the first circle is completely overlapping the second
      * circle.
      *
      * @private
@@ -264,7 +264,7 @@ namespace CircleUtilities {
     }
 
     /**
-     * Tests wether a point lies within a given circle.
+     * Tests whether a point lies within a given circle.
      * @private
      * @param {Highcharts.PositionObject} point
      * The point to test for.
@@ -283,7 +283,7 @@ namespace CircleUtilities {
     }
 
     /**
-     * Tests wether a point lies within a set of circles.
+     * Tests whether a point lies within a set of circles.
      *
      * @private
      *
@@ -306,7 +306,7 @@ namespace CircleUtilities {
     }
 
     /**
-     * Tests wether a point lies outside a set of circles.
+     * Tests whether a point lies outside a set of circles.
      *
      * TODO: add unit tests.
      *

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -673,7 +673,7 @@ class SVGRenderer implements SVGRendererLike {
      * The shape type.
      *
      * @param {boolean} [useHTML=false]
-     * Wether to use HTML to render the label.
+     * Whether to use HTML to render the label.
      *
      * @return {Highcharts.SVGElement}
      * The button element.
@@ -2048,7 +2048,7 @@ class SVGRenderer implements SVGRendererLike {
      *        coordinates it should be pinned to.
      *
      * @param {boolean} [useHTML=false]
-     *        Wether to use HTML to render the label.
+     *        Whether to use HTML to render the label.
      *
      * @param {boolean} [baseline=false]
      *        Whether to position the label relative to the text baseline,

--- a/ts/Core/Renderer/SVG/TextBuilder.ts
+++ b/ts/Core/Renderer/SVG/TextBuilder.ts
@@ -503,7 +503,7 @@ class TextBuilder {
         // Cache the lengths to avoid checking the same twice
         const lengths = [] as Array<number>;
 
-        // Word wrap can not be truncated to shorter than one word, ellipsis
+        // Word wrap cannot be truncated to shorter than one word, ellipsis
         // text can be completely blank.
         let minIndex = words ? 1 : 0;
         let maxIndex = (text || words || '').length;

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -3753,7 +3753,7 @@ class Series {
             }
             if (tree[sideB]) {
                 // compare distance to current best to splitting point to
-                // decide wether to check side B or not
+                // decide whether to check side B or not
                 if (Math.sqrt(tdist * tdist) < (ret as any)[kdComparer]) {
                     nPoint2 = _search(
                         search,

--- a/ts/Extensions/DraggablePoints.ts
+++ b/ts/Extensions/DraggablePoints.ts
@@ -634,7 +634,7 @@ if (seriesTypes.boxplot) {
             }
         },
         median: {
-            // Median can not be dragged individually, just move the whole
+            // Median cannot be dragged individually, just move the whole
             // point for this.
             axis: 'y',
             move: true

--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -1590,7 +1590,7 @@ namespace Exporting {
             }
         };
 
-        // Register update() method for navigation. Can not be set the same way
+        // Register update() method for navigation. Cannot be set the same way
         // as for exporting, because navigation options are shared with bindings
         // which has separate update() logic.
         ChartNavigationComposition

--- a/ts/Extensions/Sonification/ChartSonify.ts
+++ b/ts/Extensions/Sonification/ChartSonify.ts
@@ -965,7 +965,7 @@ export default ChartSonify;
  * receives the point as argument, and should return a numeric value. The points
  * with the lowest numeric values are then played first, and the time between
  * points will be proportional to the distance between the numeric values. This
- * option can not be overridden per series.
+ * option cannot be overridden per series.
  * @name Highcharts.SonificationOptions#pointPlayTime
  * @type {string|Function}
  *//**

--- a/ts/README.md
+++ b/ts/README.md
@@ -150,6 +150,6 @@ similarities.
 
 ### Test with Internet Explorer in mind
 
-Be aware that TypeScript can not convert all modern syntax to a pattern, that is
+Be aware that TypeScript cannot convert all modern syntax to a pattern, that is
 compatible with Internet Explorer. Debugging tests can become challenging, if
 they firstly fail because of syntax errors.

--- a/ts/Series/ColumnPyramid/ColumnPyramidSeries.ts
+++ b/ts/Series/ColumnPyramid/ColumnPyramidSeries.ts
@@ -199,7 +199,7 @@ class ColumnPyramidSeries extends ColumnSeries {
 
             // topXwidth and bottomXwidth = width of lines from the center
             // calculated from tanges proportion.
-            // Can not be a NaN #12514
+            // Cannot be a NaN #12514
             topXwidth = stackHeight ?
                 (barW * (barY - topPointY)) / stackHeight : 0;
             // like topXwidth, but with height of point

--- a/ts/Series/Networkgraph/ReingoldFruchtermanLayout.ts
+++ b/ts/Series/Networkgraph/ReingoldFruchtermanLayout.ts
@@ -579,7 +579,7 @@ class ReingoldFruchtermanLayout {
             for (const node of this.nodes) {
                 for (const repNode of this.nodes) {
                     if (
-                        // Node can not repulse itself:
+                        // Node cannot repulse itself:
                         node !== repNode &&
                         // Only close nodes affect each other:
                         // layout.getDistR(node, repNode) < 2 * k &&

--- a/ts/Series/PackedBubble/PackedBubbleLayout.ts
+++ b/ts/Series/PackedBubble/PackedBubbleLayout.ts
@@ -219,7 +219,7 @@ class PackedBubbleLayout extends ReingoldFruchtermanLayout {
             layout.nodes.forEach((repNode): void => {
                 force = 0;
                 if (
-                    // Node can not repulse itself:
+                    // Node cannot repulse itself:
                     node !== repNode &&
                     // Only close nodes affect each other:
 

--- a/ts/Series/SolidGauge/SolidGaugeSeries.ts
+++ b/ts/Series/SolidGauge/SolidGaugeSeries.ts
@@ -116,7 +116,7 @@ const solidGaugeOptions: SolidGaugeSeriesOptions = {
      */
 
     /**
-     * Wether to draw rounded edges on the gauge.
+     * Whether to draw rounded edges on the gauge.
      *
      * @sample {highcharts} highcharts/demo/gauge-activity/
      *         Activity Gauge

--- a/ts/Series/Treemap/TreemapSeries.ts
+++ b/ts/Series/Treemap/TreemapSeries.ts
@@ -1619,7 +1619,7 @@ class TreemapSeries extends ScatterSeries {
      * The id of the new root node.
      *
      * @param {boolean} [redraw=true]
-     * Wether to redraw the chart or not.
+     * Whether to redraw the chart or not.
      *
      * @param {Object} [eventArguments]
      * Arguments to be accessed in event handler.
@@ -1631,7 +1631,7 @@ class TreemapSeries extends ScatterSeries {
      * Id of the previous root.
      *
      * @param {boolean} [eventArguments.redraw]
-     * Wether to redraw the chart after.
+     * Whether to redraw the chart after.
      *
      * @param {Object} [eventArguments.series]
      * The series to update the root of.
@@ -1663,7 +1663,7 @@ class TreemapSeries extends ScatterSeries {
          * @param {Object} args The event arguments.
          * @param {string} args.newRootId Id of the new root.
          * @param {string} args.previousRootId Id of the previous root.
-         * @param {boolean} args.redraw Wether to redraw the chart after.
+         * @param {boolean} args.redraw Whether to redraw the chart after.
          * @param {Object} args.series The series to update the root of.
          * @param {string} [args.trigger=undefined] The action which
          * triggered the event. Undefined if the setRootNode is called

--- a/ts/Series/Wordcloud/WordcloudUtils.ts
+++ b/ts/Series/Wordcloud/WordcloudUtils.ts
@@ -183,7 +183,7 @@ function isPolygonsOverlappingOnAxis(
 }
 
 /**
- * Checks wether two convex polygons are colliding by using the Separating
+ * Checks whether two convex polygons are colliding by using the Separating
  * Axis Theorem.
  *
  * @private


### PR DESCRIPTION
As documented in [Cannot vs. Can Not vs. Can’t—What’s the Difference?](https://www.grammarly.com/blog/cannot-or-can-not/) proper form in these cases is "cannot". This PR fixes/replaces occurrences of "can not" with "cannot". Also, it fixes "wether" to "whether".