### PR TITLE
Docs: Improved typing of colors option.

### DIFF
--- a/ts/Core/DefaultOptions.ts
+++ b/ts/Core/DefaultOptions.ts
@@ -116,7 +116,7 @@ const defaultOptions: Options = {
      * @sample {highcharts} highcharts/chart/colors/
      *         Assign a global color theme
      *
-     * @type    {Array<Highcharts.ColorString>}
+     * @type    {Array<(Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject)>}
      * @default ["#7cb5ec", "#434348", "#90ed7d", "#f7a35c", "#8085e9",
      *          "#f15c80", "#e4d354", "#2b908f", "#f45b5b", "#91e8e1"]
      */


### PR DESCRIPTION
- Fixed #14156, `GradientColorObject` was an invalid type in `Options.colors`.