### PR TITLE
Docs: Added Tooltip.getPosition to public API.

### DIFF
--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -615,11 +615,22 @@ class Tooltip {
     }
 
     /**
-     * Place the tooltip in a chart without spilling over
-     * and not covering the point it self.
+     * Place the tooltip in a chart without spilling over and not covering the
+     * point it self.
      *
-     * @private
      * @function Highcharts.Tooltip#getPosition
+     *
+     * @param {number} boxWidth
+     *        Width of the tooltip box.
+     *
+     * @param {number} boxHeight
+     *        Height of the tooltip box.
+     *
+     * @param {Highcharts.Point} point
+     *        Tooltip-related point.
+     *
+     * @return {Highcharts.PositionObject}
+     *         Recommend position of the tooltip.
      */
     public getPosition(
         boxWidth: number,

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -616,7 +616,7 @@ class Tooltip {
 
     /**
      * Place the tooltip in a chart without spilling over and not covering the
-     * point it self.
+     * point itself.
      *
      * @function Highcharts.Tooltip#getPosition
      *
@@ -627,10 +627,10 @@ class Tooltip {
      *        Height of the tooltip box.
      *
      * @param {Highcharts.Point} point
-     *        Tooltip-related point.
+     *        Tooltip related point.
      *
      * @return {Highcharts.PositionObject}
-     *         Recommend position of the tooltip.
+     *         Recommended position of the tooltip.
      */
     public getPosition(
         boxWidth: number,


### PR DESCRIPTION
Closed #14848, missing type-safe access to the default tooltip positioner in a `TooltiPositionerCallbackFunction `.