### PR TITLE
Fixed #16958, differences in mapbubble API docs.

### DIFF
--- a/ts/Series/MapBubble/MapBubbleSeries.ts
+++ b/ts/Series/MapBubble/MapBubbleSeries.ts
@@ -242,6 +242,9 @@ class MapBubbleSeries extends BubbleSeries {
          * @apioption plotOptions.mapbubble.zThreshold
          */
 
+        /**
+         * @default 500
+         */
         animationLimit: 500,
         joinBy: 'hc-key',
         tooltip: {

--- a/ts/Series/Scatter/ScatterSeries.ts
+++ b/ts/Series/Scatter/ScatterSeries.ts
@@ -144,12 +144,14 @@ class ScatterSeries extends LineSeries {
          * series, in a scatter plot the series.name by default shows in the
          * headerFormat and point.x and point.y in the pointFormat.
          *
-         * @product highcharts highstock
+         * @product highcharts highstock highmaps
          */
         tooltip: {
-            headerFormat:
-            '<span style="color:{point.color}">\u25CF</span> ' +
-            '<span style="font-size: 10px"> {series.name}</span><br/>',
+            /**
+             * @product highcharts highstock
+             */
+            headerFormat: '<span style="color:{point.color}">\u25CF</span> ' +
+                '<span style="font-size: 10px"> {series.name}</span><br/>',
             pointFormat: 'x: <b>{point.x}</b><br/>y: <b>{point.y}</b><br/>'
         }
 


### PR DESCRIPTION

---
If some option is not visible in API it is a nice way to "enable" it by setting some parameters, like `@default` for `animationLimit` in this PR.