### PR TITLE
bugfix/17627-quotation-marks

### DIFF
--- a/samples/unit-tests/ast/ast/demo.js
+++ b/samples/unit-tests/ast/ast/demo.js
@@ -12,5 +12,40 @@ QUnit.test(
             },
             'Parse style should handle common patterns'
         );
+
+        // Make all quotation marks parse correctly to DOM (#17627)
+        const ren = new Highcharts.Renderer(
+            document.getElementById('container'),
+            600,
+            400
+        );
+
+        ren.text(
+            '<span id="greenText" style="color: green;">green</span>',
+            100,
+            100
+        ).add();
+
+        ren.text(
+            "<span id='redText' style='color: red;'>red</span>",
+            200,
+            100
+        ).add();
+
+        assert.strictEqual(
+            document.getElementById('greenText')
+                .outerHTML
+                .includes(('fill: green')),
+            true,
+            'Text element should be green (#17627).'
+        );
+
+        assert.strictEqual(
+            document.getElementById('redText')
+                .outerHTML
+                .includes(('fill: red')),
+            true,
+            'Text element should be red (#17627).'
+        );
     }
 );

--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -563,7 +563,8 @@ class AST {
             .trim()
             // The style attribute throws a warning when parsing when CSP is
             // enabled (#6884), so use an alias and pick it up below
-            .replace(/ style="/g, ' data-style="');
+            // Make all quotation marks parse correctly to DOM (#17627)
+            .replace(/ style=(["'])/g, ' data-style=$1');
 
         let doc;
         if (hasValidDOMParser) {


### PR DESCRIPTION
Fixed #17627, single quoted attributes were not recognized and caused color style not to apply in tooltips.

~~Fixed #17627, some quotation marks spoiled DOM element.~~