### PR TITLE
bugfix/14103-lollipop-marker-color

### DIFF
--- a/samples/unit-tests/series-lollipop/lollipop/demo.js
+++ b/samples/unit-tests/series-lollipop/lollipop/demo.js
@@ -1,28 +1,29 @@
 QUnit.test('Lollipop offset affection.', function (assert) {
-    var chart = Highcharts.chart('container', {
-        chart: {
-            type: 'lollipop'
-        },
-        series: [
-            {
-                color: '#0000ff',
-                negativeColor: '#ff0000',
-                data: [
-                    {
-                        low: 2
-                    },
-                    3,
-                    -4,
-                    2,
-                    -5
-                ]
+    const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'lollipop'
             },
-            {
-                type: 'errorbar',
-                data: [[2, 3]]
-            }
-        ]
-    });
+            series: [
+                {
+                    color: '#0000ff',
+                    negativeColor: '#ff0000',
+                    data: [
+                        {
+                            low: 2
+                        },
+                        3,
+                        -4,
+                        2,
+                        -5
+                    ]
+                },
+                {
+                    type: 'errorbar',
+                    data: [[2, 3]]
+                }
+            ]
+        }),
+        points = chart.series[0].points;
 
     assert.close(
         chart.series[0].data[0].shapeArgs.x,
@@ -41,5 +42,27 @@ QUnit.test('Lollipop offset affection.', function (assert) {
             '#ff0000'
         ],
         '#15523: Only negative points should use negativeColor'
+    );
+
+    chart.series[0].update({
+        marker: {
+            fillColor: '#00ff00'
+        }
+    });
+
+    assert.strictEqual(
+        chart.series[0].points[0].graphic.attr('fill'),
+        '#00ff00',
+        '#14103: Marker fillColor should be applied.'
+    );
+
+    points[0].setState('hover', false);
+    points[0].setState();
+
+    assert.strictEqual(
+        chart.series[0].points[0].graphic.attr('fill'),
+        '#00ff00',
+        `#14103: Marker fillColor should be not be changed after changing
+        state.`
     );
 });

--- a/ts/Series/Lollipop/LollipopPoint.ts
+++ b/ts/Series/Lollipop/LollipopPoint.ts
@@ -42,7 +42,8 @@ const {
 import U from '../../Core/Utilities.js';
 const {
     isObject,
-    extend
+    extend,
+    pick
 } = U;
 
 /* *
@@ -81,6 +82,43 @@ class LollipopPoint extends DumbbellPoint {
         return pointProto.init.apply(this, arguments);
     }
 
+    /**
+     * Extend the series' setState method by setting fill color of markers.
+     * @private
+     *
+     * @function Highcharts.Series#drawPoints
+     *
+     * @param {Highcharts.Series} this The series of points.
+     *
+     */
+    public setState(): void {
+        const point = this,
+            series = point.series,
+            chart = series.chart,
+            seriesLowColor = series.options.lowColor,
+            seriesMarker = series.options.marker,
+            pointOptions = point.options,
+            pointLowColor = pointOptions.lowColor,
+            zoneColor = point.zone && point.zone.color,
+            lowerGraphicColor = pick(
+                pointLowColor,
+                seriesLowColor,
+                pointOptions.marker ? pointOptions.marker.fillColor : void 0,
+                seriesMarker ? seriesMarker.fillColor : void 0,
+                pointOptions.color,
+                zoneColor,
+                point.color,
+                series.color
+            );
+
+        DumbbellPoint.prototype.setState.apply(point, arguments as any);
+
+        if (!point.state && point.lowerGraphic && !chart.styledMode) {
+            point.lowerGraphic.attr({
+                fill: lowerGraphicColor
+            });
+        }
+    }
 }
 
 /* *

--- a/ts/Series/Lollipop/LollipopSeries.ts
+++ b/ts/Series/Lollipop/LollipopSeries.ts
@@ -129,6 +129,45 @@ class LollipopSeries extends DumbbellSeries {
         return [pick(point.y, point.low)];
     }
 
+    /**
+     * Extend the series' drawPoints method by setting fill color of markers.
+     * @private
+     *
+     * @function Highcharts.Series#drawPoints
+     *
+     * @param {Highcharts.Series} this The series of points.
+     *
+     */
+    public drawPoints(): void {
+        const series = this,
+            chart = series.chart,
+            seriesLowColor = series.lowColor = series.options.lowColor,
+            seriesMarkerOptions = series.options.marker;
+
+        DumbbellSeries.prototype.drawPoints.apply(series, arguments as any);
+
+        series.points.forEach((point: LollipopPoint): void => {
+            if (point.lowerGraphic && !chart.styledMode) {
+                const pointMarkerOptions = point.options.marker,
+                    zoneColor = point.zone && point.zone.color,
+                    lowerGraphicColor = pick(
+                        pointMarkerOptions ? pointMarkerOptions.fillColor :
+                            void 0,
+                        seriesMarkerOptions ? seriesMarkerOptions.fillColor :
+                            void 0,
+                        point.options.lowColor,
+                        seriesLowColor,
+                        point.options.color,
+                        zoneColor,
+                        point.color,
+                        series.color
+                    );
+                point.lowerGraphic.attr({
+                    fill: lowerGraphicColor
+                });
+            }
+        });
+    }
 }
 
 /* *
@@ -148,13 +187,13 @@ interface LollipopSeries {
 }
 
 extend(LollipopSeries.prototype, {
+    pointClass: LollipopPoint,
     pointArrayMap: ['y'],
     pointValKey: 'y',
     translatePoint: areaProto.translate,
     drawPoint: areaProto.drawPoints,
     drawDataLabels: colProto.drawDataLabels,
-    setShapeArgs: colProto.translate,
-    pointClass: LollipopPoint
+    setShapeArgs: colProto.translate
 });
 
 /* *


### PR DESCRIPTION
Fixed #14103, marker fill color was not applied for the Lollipop series.