### PR TITLE
Docs: Added missing colorByPoint option to sunburst levels.

### DIFF
--- a/tools/gulptasks/jsdoc-classes.js
+++ b/tools/gulptasks/jsdoc-classes.js
@@ -54,7 +54,7 @@ const SOURCE_GLOBS = [
     'js/Extensions/Drilldown.js',
     'js/Extensions/ExportData/ExportData.js',
     'js/Extensions/Exporting/Exporting.js',
-    'js/Extensions/FullScreen.js',
+    'js/Extensions/Exporting/Fullscreen.js',
     'js/Extensions/GeoJSON.js',
     'js/Extensions/MarkerClusters.js',
     'js/Extensions/OfflineExporting/OfflineExporting.js',

--- a/ts/Series/Sunburst/SunburstSeries.ts
+++ b/ts/Series/Sunburst/SunburstSeries.ts
@@ -490,6 +490,14 @@ class SunburstSeries extends TreemapSeries {
          */
 
         /**
+         * Determines whether the chart should receive one color per point based
+         * on this level.
+         *
+         * @type      {boolean}
+         * @apioption plotOptions.sunburst.levels.colorByPoint
+         */
+
+        /**
          * Can set a `colorVariation` on all points which lies on the same
          * level.
          *


### PR DESCRIPTION
Fixed #16399, 'colorByPoint' does not exist in type 'PlotSunburstLevelsOptions'