### PR TITLE
Refactor, make point.graphic an array of elements

### DIFF
--- a/samples/unit-tests/series-arearange/markers/demo.js
+++ b/samples/unit-tests/series-arearange/markers/demo.js
@@ -37,11 +37,11 @@ QUnit.test('Markers for arearange.', function (assert) {
 
     chart.series[0].points.forEach(point => {
         assert.ok(
-            point.lowerGraphic !== undefined,
+            point.graphics[0] !== undefined,
             'Bottom marker for point: x=' + point.x + ' exists.'
         );
         assert.ok(
-            point.upperGraphic !== undefined,
+            point.graphics[1] !== undefined,
             'Top marker for point: x=' + point.x + ' exists.'
         );
     });
@@ -110,7 +110,7 @@ QUnit.test('Zones', function (assert) {
 
     assert.deepEqual(
         chart.series[0].points.map(function (p) {
-            return [p.upperGraphic.attr('fill'), p.lowerGraphic.attr('fill')];
+            return [p.graphics[1].attr('fill'), p.graphics[0].attr('fill')];
         }),
         [
             ['red', 'red'],

--- a/samples/unit-tests/series-dumbbell/markers/demo.js
+++ b/samples/unit-tests/series-dumbbell/markers/demo.js
@@ -43,8 +43,8 @@ QUnit.test('Markers and zones for dumbbell.', function (assert) {
     assert.deepEqual(
         chart.series[0].points.map(function (p) {
             return [
-                p.upperGraphic.attr('fill'),
-                p.lowerGraphic.attr('fill'),
+                p.graphics[1].attr('fill'),
+                p.graphics[0].attr('fill'),
                 p.connector.attr('stroke')
             ];
         }),
@@ -61,13 +61,13 @@ QUnit.test('Markers and zones for dumbbell.', function (assert) {
     chart.series[0].points[1].setState('hover');
 
     assert.strictEqual(
-        chart.series[0].points[1].upperGraphic.attr('fill'),
+        chart.series[0].points[1].graphics[1].attr('fill'),
         '#ffff00',
         'The upper marker should have a correct color on hover.'
     );
 
     assert.strictEqual(
-        chart.series[0].points[1].lowerGraphic.attr('fill'),
+        chart.series[0].points[1].graphics[0].attr('fill'),
         chart.series[0].lowColor,
         'The lower marker should have a correct color (lowColor) on hover.'
     );
@@ -75,13 +75,13 @@ QUnit.test('Markers and zones for dumbbell.', function (assert) {
     chart.series[0].points[1].setState('');
 
     assert.strictEqual(
-        chart.series[0].points[1].upperGraphic.attr('fill'),
+        chart.series[0].points[1].graphics[1].attr('fill'),
         '#ffff00',
         'The upper marker should have a correct color without any state.'
     );
 
     assert.strictEqual(
-        chart.series[0].points[1].lowerGraphic.attr('fill'),
+        chart.series[0].points[1].graphics[0].attr('fill'),
         chart.series[0].lowColor,
         'The lower marker should have a correct color (lowColor) without any state.'
     );
@@ -98,7 +98,7 @@ QUnit.test('Markers and zones for dumbbell.', function (assert) {
     chart.series[0].points[1].setState('');
 
     assert.strictEqual(
-        chart.series[0].points[1].upperGraphic.attr('fill'),
+        chart.series[0].points[1].graphics[1].attr('fill'),
         chart.series[0].options.marker.fillColor,
         'After mouseOut (without any state), the upper marker should have a correct color.'
     );
@@ -131,11 +131,11 @@ QUnit.test('setData() and marker update for dumbbell.', function (assert) {
 
     chart.series[0].points.forEach(point => {
         assert.ok(
-            point.lowerGraphic !== undefined,
+            point.graphics[0] !== undefined,
             'Bottom marker for point: x=' + point.x + ' exists.'
         );
         assert.ok(
-            point.upperGraphic !== undefined,
+            point.graphics[1] !== undefined,
             'Top marker for point: x=' + point.x + ' exists.'
         );
         assert.ok(
@@ -151,9 +151,9 @@ QUnit.test('setData() and marker update for dumbbell.', function (assert) {
     });
 
     assert.strictEqual(
-        chart.series[0].points[1].upperGraphic.attr('fill'),
+        chart.series[0].points[1].graphics[1].attr('fill'),
         '#ff0000',
-        'After point.marker.fillColor update, the upperGraphic should have a correct color.'
+        'After point.marker.fillColor update, the graphics[1] should have a correct color.'
     );
 
     chart.series[0].update({
@@ -162,9 +162,9 @@ QUnit.test('setData() and marker update for dumbbell.', function (assert) {
 
     chart.series[0].points.forEach(function (point) {
         assert.strictEqual(
-            point.lowerGraphic.attr('fill'),
+            point.graphics[0].attr('fill'),
             '#000000',
-            'After series.lowColor update, all the lowerGraphics should have a correct color.'
+            'After series.lowColor update, all the graphics[0]s should have a correct color.'
         );
     });
 });

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -66,6 +66,7 @@ declare module './PointLike' {
         dlBox?: BBoxObject;
         dlOptions?: DataLabelOptions;
         graphic?: SVGElement;
+        graphics?: Array<SVGElement>;
         /** @deprecated */
         positionIndex?: unknown;
         top?: number;

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -575,7 +575,7 @@ class Point {
         kinds = kinds || { graphic: 1, dataLabel: 1 };
 
         if (kinds.graphic) {
-            props.push('graphic', 'upperGraphic', 'shadowGroup');
+            props.push('graphic', 'shadowGroup');
         }
         if (kinds.dataLabel) {
             props.push(

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -411,7 +411,12 @@ class Point {
          */
         function destroyPoint(): void {
             // Remove all events and elements
-            if (point.graphic || point.dataLabel || point.dataLabels) {
+            if (
+                point.graphic ||
+                point.graphics ||
+                point.dataLabel ||
+                point.dataLabels
+            ) {
                 removeEvent(point);
                 point.destroyElements();
             }
@@ -589,7 +594,11 @@ class Point {
             }
         }
 
-        ['dataLabel', 'connector'].forEach(function (prop: string): void {
+        [
+            'graphic',
+            'dataLabel',
+            'connector'
+        ].forEach(function (prop: string): void {
             const plural = prop + 's';
             if ((kinds as any)[prop] && (point as any)[plural]) {
                 graphicalProps.plural.push(plural);

--- a/ts/Extensions/DraggablePoints.ts
+++ b/ts/Extensions/DraggablePoints.ts
@@ -872,7 +872,11 @@ if (seriesTypes.arearange) {
             handlePositioner: function (
                 point: AreaRangePoint
             ): PositionObject {
-                const bBox = point.lowerGraphic && point.lowerGraphic.getBBox();
+                const bBox = (
+                    point.graphics &&
+                    point.graphics[0] &&
+                    point.graphics[0].getBBox()
+                );
 
                 return bBox ? {
                     x: bBox.x + bBox.width / 2,
@@ -899,7 +903,11 @@ if (seriesTypes.arearange) {
             handlePositioner: function (
                 point: AreaRangePoint
             ): PositionObject {
-                const bBox = point.upperGraphic && point.upperGraphic.getBBox();
+                const bBox = (
+                    point.graphics &&
+                    point.graphics[1] &&
+                    point.graphics[1].getBBox()
+                );
 
                 return bBox ? {
                     x: bBox.x + bBox.width / 2,

--- a/ts/Series/AreaRange/AreaRangePoint.ts
+++ b/ts/Series/AreaRange/AreaRangePoint.ts
@@ -90,8 +90,6 @@ class AreaRangePoint extends AreaPoint {
      */
     public low: number = void 0 as any;
 
-    public lowerGraphic?: SVGElement;
-
     public options: AreaRangePointOptions = void 0 as any;
 
     public origProps?: Partial<AreaRangePoint>;
@@ -107,8 +105,6 @@ class AreaRangePoint extends AreaPoint {
     public plotX: number = void 0 as any;
 
     public series: AreaRangeSeries = void 0 as any;
-
-    public upperGraphic?: SVGElement;
 
     /* *
      *
@@ -141,7 +137,7 @@ class AreaRangePoint extends AreaPoint {
         }
 
         // Change state also for the top marker
-        this.graphic = this.upperGraphic;
+        this.graphic = this.graphics && this.graphics[1];
         this.plotY = this.plotHigh;
 
         if (isPolar) {
@@ -155,7 +151,7 @@ class AreaRangePoint extends AreaPoint {
 
         // Now restore defaults
         this.plotY = this.plotLow;
-        this.graphic = this.lowerGraphic;
+        this.graphic = this.graphics && this.graphics[0];
 
         if (isPolar) {
             this.plotX = this.plotLowX;

--- a/ts/Series/AreaRange/AreaRangeSeries.ts
+++ b/ts/Series/AreaRange/AreaRangeSeries.ts
@@ -620,6 +620,7 @@ class AreaRangeSeries extends AreaSeries {
         i = 0;
         while (i < pointLength) {
             point = series.points[i];
+            point.graphics = point.graphics || [];
 
             // Save original props to be overridden by temporary props for top
             // points
@@ -632,8 +633,10 @@ class AreaRangeSeries extends AreaSeries {
                 y: point.y
             };
 
-            point.lowerGraphic = point.graphic;
-            point.graphic = point.upperGraphic;
+            if (point.graphic) {
+                point.graphics[0] = point.graphic;
+            }
+            point.graphic = point.graphics[1];
             point.plotY = point.plotHigh;
             if (defined(point.plotHighX)) {
                 point.plotX = point.plotHighX;
@@ -663,8 +666,11 @@ class AreaRangeSeries extends AreaSeries {
         i = 0;
         while (i < pointLength) {
             point = series.points[i];
-            point.upperGraphic = point.graphic;
-            point.graphic = point.lowerGraphic;
+            point.graphics = point.graphics || [];
+            if (point.graphic) {
+                point.graphics[1] = point.graphic;
+            }
+            point.graphic = point.graphics[0];
             if (point.origProps) {
                 extend(point, point.origProps);
                 delete point.origProps;

--- a/ts/Series/DotPlot/DotPlotPoint.d.ts
+++ b/ts/Series/DotPlot/DotPlotPoint.d.ts
@@ -26,7 +26,6 @@ import type SVGAttributes from '../../Core/Renderer/SVG/SVGAttributes';
  *
  * */
 declare class DotPlotPoint extends ColumnPoint {
-    public graphics?: Record<string, SVGElement>;
     public options: DotPlotPointOptions;
     public pointAttr?: SVGAttributes;
     public series: DotPlotSeries;

--- a/ts/Series/DotPlot/DotPlotSeries.ts
+++ b/ts/Series/DotPlot/DotPlotSeries.ts
@@ -36,7 +36,6 @@ import U from '../../Core/Utilities.js';
 const {
     extend,
     merge,
-    objectEach,
     pick
 } = U;
 
@@ -105,8 +104,7 @@ class DotPlotSeries extends ColumnSeries {
         this.points.forEach(function (point: DotPlotPoint): void {
             let yPos: number,
                 attr: SVGAttributes,
-                graphics: Record<string, SVGElement>,
-                itemY: (number|undefined),
+                graphics: Array<SVGElement>,
                 pointAttr,
                 pointMarkerOptions = point.marker || {},
                 symbol = (
@@ -123,7 +121,7 @@ class DotPlotSeries extends ColumnSeries {
                 x: number,
                 y: number;
 
-            point.graphics = graphics = point.graphics || {};
+            point.graphics = graphics = point.graphics || [];
             pointAttr = point.pointAttr ?
                 (
                     (point.pointAttr as any)[
@@ -145,13 +143,13 @@ class DotPlotSeries extends ColumnSeries {
                     point.graphic = renderer.g('point').add(series.group);
                 }
 
-                itemY = point.y;
                 yTop = pick(point.stackY, point.y as any);
                 size = Math.min(
                     point.pointWidth,
                     series.yAxis.transA - itemPaddingTranslated
                 );
-                for (yPos = yTop; yPos > yTop - (point.y as any); yPos--) {
+                let i = Math.floor(yTop);
+                for (yPos = yTop; yPos > yTop - (point.y as any); yPos--, i--) {
 
                     x = point.barX + (
                         isSquare ?
@@ -173,24 +171,20 @@ class DotPlotSeries extends ColumnSeries {
                         r: radius
                     };
 
-                    if (graphics[itemY as any]) {
-                        graphics[itemY as any].animate(attr);
+                    if (graphics[i]) {
+                        graphics[i].animate(attr);
                     } else {
-                        graphics[itemY as any] = renderer.symbol(symbol)
+                        graphics[i] = renderer.symbol(symbol)
                             .attr(extend(attr, pointAttr))
                             .add(point.graphic);
                     }
-                    graphics[itemY as any].isActive = true;
-                    (itemY as any)--;
+                    graphics[i].isActive = true;
                 }
             }
-            objectEach(graphics, function (
-                graphic: SVGElement,
-                key: string
-            ): void {
+            graphics.forEach((graphic, i): void => {
                 if (!graphic.isActive) {
                     graphic.destroy();
-                    delete graphic[key];
+                    graphics.splice(i, 1);
                 } else {
                     graphic.isActive = false;
                 }

--- a/ts/Series/Dumbbell/DumbbellPoint.ts
+++ b/ts/Series/Dumbbell/DumbbellPoint.ts
@@ -85,11 +85,12 @@ class DumbbellPoint extends AreaRangePoint {
 
         if (!point.state) {
             verb = 'animate';
-            if (point.lowerGraphic && !chart.styledMode) {
-                point.lowerGraphic.attr({
+            const [lowerGraphic, upperGraphic] = point.graphics || [];
+            if (lowerGraphic && !chart.styledMode) {
+                lowerGraphic.attr({
                     fill: lowerGraphicColor
                 });
-                if (point.upperGraphic) {
+                if (upperGraphic) {
                     origProps = {
                         y: point.y,
                         zone: point.zone
@@ -103,7 +104,7 @@ class DumbbellPoint extends AreaRangePoint {
                         point.zone ? point.zone.color : void 0,
                         point.color
                     );
-                    point.upperGraphic.attr({
+                    upperGraphic.attr({
                         fill: upperGraphicColor
                     });
                     extend(point, origProps);

--- a/ts/Series/Dumbbell/DumbbellSeries.ts
+++ b/ts/Series/Dumbbell/DumbbellSeries.ts
@@ -241,7 +241,7 @@ class DumbbellSeries extends AreaRangeSeries {
         }
 
         // Connector should reflect upper marker's zone color
-        if (point.upperGraphic) {
+        if (point.graphics && point.graphics[1]) {
             origProps = {
                 y: point.y,
                 zone: point.zone
@@ -388,16 +388,17 @@ class DumbbellSeries extends AreaRangeSeries {
         // Draw connectors and color upper markers
         while (i < pointLength) {
             point = series.points[i];
+            const [lowerGraphic, upperGraphic] = point.graphics || [];
 
             series.drawConnector(point);
 
-            if (point.upperGraphic) {
-                (point.upperGraphic.element as any).point = point;
-                point.upperGraphic.addClass('highcharts-lollipop-high');
+            if (upperGraphic) {
+                (upperGraphic.element as any).point = point;
+                upperGraphic.addClass('highcharts-lollipop-high');
             }
             (point.connector.element as any).point = point;
 
-            if (point.lowerGraphic) {
+            if (lowerGraphic) {
                 zoneColor = point.zone && point.zone.color;
                 lowerGraphicColor = pick(
                     point.options.lowColor,
@@ -408,11 +409,11 @@ class DumbbellSeries extends AreaRangeSeries {
                     series.color
                 );
                 if (!chart.styledMode) {
-                    point.lowerGraphic.attr({
+                    lowerGraphic.attr({
                         fill: lowerGraphicColor
                     });
                 }
-                point.lowerGraphic.addClass('highcharts-lollipop-low');
+                lowerGraphic.addClass('highcharts-lollipop-low');
             }
             i++;
         }

--- a/ts/Series/Item/ItemPoint.ts
+++ b/ts/Series/Item/ItemPoint.ts
@@ -45,8 +45,6 @@ class ItemPoint extends PieSeries.prototype.pointClass {
      *
      * */
 
-    public graphics: Record<string, SVGElement> = void 0 as any;
-
     public options: ItemPointOptions = void 0 as any;
 
     public series: ItemSeries = void 0 as any;

--- a/ts/Series/Item/ItemSeries.ts
+++ b/ts/Series/Item/ItemSeries.ts
@@ -246,7 +246,7 @@ class ItemSeries extends PieSeries {
 
         this.points.forEach(function (point): void {
             let attr: SVGAttributes,
-                graphics: Record<string, SVGElement>,
+                graphics: Array<SVGElement>,
                 pointAttr: (SVGAttributes|undefined),
                 pointMarkerOptions = point.marker || {},
                 symbol: SymbolKey = (
@@ -264,7 +264,7 @@ class ItemSeries extends PieSeries {
                 width: number,
                 height: number;
 
-            point.graphics = graphics = point.graphics || {};
+            point.graphics = graphics = point.graphics || [];
 
             if (!series.chart.styledMode) {
                 pointAttr = series.pointAttribs(
@@ -280,7 +280,7 @@ class ItemSeries extends PieSeries {
                         .add(series.group);
                 }
 
-                for (let val = 0; val < (point.y as any); val++) {
+                for (let val = 0; val < (point.y || 0); val++) {
 
                     // Semi-circle
                     if (series.center && series.slots) {
@@ -324,10 +324,10 @@ class ItemSeries extends PieSeries {
                         graphics[val] = renderer
                             .symbol(
                                 symbol,
-                                null as any,
-                                null as any,
-                                null as any,
-                                null as any,
+                                void 0,
+                                void 0,
+                                void 0,
+                                void 0,
                                 {
                                     backgroundSize: 'within'
                                 }
@@ -337,17 +337,13 @@ class ItemSeries extends PieSeries {
                     }
                     graphics[val].isActive = true;
 
-
                     i++;
                 }
             }
-            objectEach(graphics, function (
-                graphic: SVGElement,
-                key: string
-            ): void {
+            graphics.forEach((graphic, i): void => {
                 if (!graphic.isActive) {
                     graphic.destroy();
-                    delete graphics[key];
+                    graphics.splice(i, 1);
                 } else {
                     graphic.isActive = false;
                 }


### PR DESCRIPTION
Multiple graphics per point is a common pattern among series types. Now we can have a uniform way of dealing with operations like destroying and updating/animation them instead of bloating the core with series-specific stuff like `upperGraphic`. 

We can (and should?) still use the `point.graphic` property for the main graphic. In cases where the z-index of multiple graphics is the same (like item series), `point.graphic` can be a group element that holds the multiple `graphics`. In other cases (like `temperatureColors`), the graphics are intermixed and a common group cannot be used.