### PR TITLE
bugfix/17189-mapbubble-joinby-type

### DIFF
--- a/ts/Series/MapBubble/MapBubbleSeries.ts
+++ b/ts/Series/MapBubble/MapBubbleSeries.ts
@@ -246,6 +246,10 @@ class MapBubbleSeries extends BubbleSeries {
          * @default 500
          */
         animationLimit: 500,
+
+        /**
+         * @type {string|Array<string>}
+         */
         joinBy: 'hc-key',
         tooltip: {
             pointFormat: '{point.name}: {point.z}'


### PR DESCRIPTION
Fixed #17189, incorrect type in docs of map bubble `joinBy` option.