### PR TITLE
Docs: Restored missing options of NavigationButtonOptions.

### DIFF
--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -38,7 +38,7 @@ import AST from '../../Core/Renderer/HTML/AST.js';
 import Chart from '../../Core/Chart/Chart.js';
 import ChartNavigationComposition from '../../Core/Chart/ChartNavigationComposition.js';
 import D from '../../Core/DefaultOptions.js';
-const { defaultOptions } = D;
+const { defaultOptions, setOptions } = D;
 import ExportingDefaults from './ExportingDefaults.js';
 import ExportingSymbols from './ExportingSymbols.js';
 import Fullscreen from './Fullscreen.js';
@@ -258,7 +258,7 @@ namespace Exporting {
      *
      * */
 
-    const composedClasses: Array<typeof Chart> = [];
+    const composedClasses: Array<Function> = [];
 
     // These CSS properties are not inlined. Remember camelCase.
     const inlineBlacklist: Array<RegExp> = [
@@ -688,6 +688,28 @@ namespace Exporting {
                     }
                 );
             }
+        }
+
+        if (composedClasses.indexOf(setOptions) === -1) {
+            composedClasses.push(setOptions);
+
+            defaultOptions.exporting = merge(
+                ExportingDefaults.exporting,
+                defaultOptions.exporting
+            );
+
+            defaultOptions.lang = merge(
+                ExportingDefaults.lang,
+                defaultOptions.lang
+            );
+
+            // Buttons and menus are collected in a separate config option set
+            // called 'navigation'. This can be extended later to add control
+            // buttons like zoom and pan right click menus.
+            defaultOptions.navigation = merge(
+                ExportingDefaults.navigation,
+                defaultOptions.navigation
+            );
         }
     }
 
@@ -1764,35 +1786,6 @@ namespace Exporting {
     }
 
 }
-
-/* *
- *
- *  Registry
- *
- * */
-
-defaultOptions.exporting = merge(
-    ExportingDefaults.exporting,
-    defaultOptions.exporting
-);
-defaultOptions.lang = merge(ExportingDefaults.lang, defaultOptions.lang);
-
-// Buttons and menus are collected in a separate config option set called
-// 'navigation'. This can be extended later to add control buttons like
-// zoom and pan right click menus.
-/**
- * A collection of options for buttons and menus appearing in the exporting
- * module or in Stock Tools.
- *
- * @requires     modules/exporting
- * @optionparent navigation
- *
- * @private
- */
-defaultOptions.navigation = merge(
-    ExportingDefaults.navigation,
-    defaultOptions.navigation
-);
 
 /* *
  *

--- a/ts/Extensions/Exporting/ExportingDefaults.ts
+++ b/ts/Extensions/Exporting/ExportingDefaults.ts
@@ -561,8 +561,6 @@ const lang = {
      * in full screen.
      *
      * @since 8.0.1
-     *
-     * @private
      */
     viewFullscreen: 'View in full screen',
 
@@ -571,8 +569,6 @@ const lang = {
      * from full screen.
      *
      * @since 8.0.1
-     *
-     * @private
      */
     exitFullscreen: 'Exit from full screen',
 
@@ -582,8 +578,6 @@ const lang = {
      *
      * @since    3.0.1
      * @requires modules/exporting
-     *
-     * @private
      */
     printChart: 'Print chart',
 
@@ -592,8 +586,6 @@ const lang = {
      *
      * @since    2.0
      * @requires modules/exporting
-     *
-     * @private
      */
     downloadPNG: 'Download PNG image',
 
@@ -602,8 +594,6 @@ const lang = {
      *
      * @since    2.0
      * @requires modules/exporting
-     *
-     * @private
      */
     downloadJPEG: 'Download JPEG image',
 
@@ -612,8 +602,6 @@ const lang = {
      *
      * @since    2.0
      * @requires modules/exporting
-     *
-     * @private
      */
     downloadPDF: 'Download PDF document',
 
@@ -622,8 +610,6 @@ const lang = {
      *
      * @since    2.0
      * @requires modules/exporting
-     *
-     * @private
      */
     downloadSVG: 'Download SVG vector image',
 
@@ -633,13 +619,18 @@ const lang = {
      *
      * @since    3.0
      * @requires modules/exporting
-     *
-     * @private
      */
     contextButtonTitle: 'Chart context menu'
 
 };
 
+/**
+ * A collection of options for buttons and menus appearing in the exporting
+ * module or in Stock Tools.
+ *
+ * @requires     modules/exporting
+ * @optionparent navigation
+ */
 const navigation: NavigationOptions = {
 
     /**
@@ -650,8 +641,6 @@ const navigation: NavigationOptions = {
      * `.highcharts-contextbutton` and `.highcharts-button-symbol` classes.
      *
      * @requires modules/exporting
-     *
-     * @private
      */
     buttonOptions: {
 
@@ -831,6 +820,7 @@ const navigation: NavigationOptions = {
 
             /**
              * Default stroke for the buttons.
+             *
              * @type      {Highcharts.ColorString}
              * @default   none
              * @apioption navigation.buttonOptions.theme.stroke
@@ -858,8 +848,6 @@ const navigation: NavigationOptions = {
      * @type    {Highcharts.CSSObject}
      * @default {"border": "1px solid #999999", "background": "#ffffff", "padding": "5px 0"}
      * @since   2.0
-     *
-     * @private
      */
     menuStyle: {
         /** @ignore-option */
@@ -885,8 +873,6 @@ const navigation: NavigationOptions = {
      * @type    {Highcharts.CSSObject}
      * @default {"padding": "0.5em 1em", "color": "#333333", "background": "none", "fontSize": "11px/14px", "transition": "background 250ms, color 250ms"}
      * @since   2.0
-     *
-     * @private
      */
     menuItemStyle: {
         /** @ignore-option */
@@ -915,8 +901,6 @@ const navigation: NavigationOptions = {
      * @type    {Highcharts.CSSObject}
      * @default {"background": "#335cad", "color": "#ffffff"}
      * @since   2.0
-     *
-     * @private
      */
     menuItemHoverStyle: {
         /** @ignore-option */

--- a/ts/Maps/MapNavigation.ts
+++ b/ts/Maps/MapNavigation.ts
@@ -37,7 +37,7 @@ const {
     objectEach,
     pick
 } = U;
-import './MapNavigationOptionsDefault.js';
+import './MapNavigationDefaults.js';
 import ButtonThemeObject, { ButtonThemeStatesObject } from '../Core/Renderer/SVG/ButtonThemeObject';
 
 /* *

--- a/ts/Maps/MapNavigationDefaults.ts
+++ b/ts/Maps/MapNavigationDefaults.ts
@@ -34,7 +34,7 @@ const { extend } = U;
  * @product      highmaps
  * @optionparent mapNavigation
  */
-const defaultOptions: MapNavigationOptions = {
+const MapNavigationDefaults: MapNavigationOptions = {
 
     /**
      * General options for the map navigation buttons. Individual options
@@ -296,7 +296,7 @@ extend(D.defaultOptions.lang, {
     zoomOut: 'Zoom out'
 });
 // Set the default map navigation options
-D.defaultOptions.mapNavigation = defaultOptions;
+D.defaultOptions.mapNavigation = MapNavigationDefaults;
 
 /* *
  *
@@ -304,4 +304,4 @@ D.defaultOptions.mapNavigation = defaultOptions;
  *
  * */
 
-export default defaultOptions;
+export default MapNavigationDefaults;

--- a/ts/Series/Networkgraph/NetworkgraphSeriesDefaults.ts
+++ b/ts/Series/Networkgraph/NetworkgraphSeriesDefaults.ts
@@ -49,6 +49,8 @@ import type Point from '../../Core/Series/Point';
  *               boostBlending
  * @requires     modules/networkgraph
  * @optionparent plotOptions.networkgraph
+ *
+ * @private
  */
 const NetworkgraphSeriesDefaults: NetworkgraphSeriesOptions = {
     stickyTracking: false,

--- a/ts/Series/PackedBubble/PackedBubbleSeriesDefaults.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeriesDefaults.ts
@@ -41,6 +41,8 @@ const { isNumber } = U;
  * @since        7.0.0
  * @requires     highcharts-more
  * @optionparent plotOptions.packedbubble
+ *
+ * @private
  */
 const PackedBubbleSeriesDefaults: PackedBubbleSeriesOptions = {
     /**


### PR DESCRIPTION
Fixed #17138, NavigationButtonOptions no longer has verticalAlign property