### PR TITLE
Docs: Fixed typing of PatternOptionsObject.

### DIFF
--- a/ts/Extensions/PatternFill.ts
+++ b/ts/Extensions/PatternFill.ts
@@ -776,11 +776,11 @@ export default PatternFill;
  *//**
  * Background color for the pattern if a `path` is set (not images).
  * @name Highcharts.PatternOptionsObject#backgroundColor
- * @type {Highcharts.ColorString}
+ * @type {Highcharts.ColorString|undefined}
  *//**
  * URL to an image to use as the pattern.
  * @name Highcharts.PatternOptionsObject#image
- * @type {string}
+ * @type {string|undefined}
  *//**
  * Width of the pattern. For images this is automatically set to the width of
  * the element bounding box if not supplied. For non-image patterns the default
@@ -788,17 +788,17 @@ export default PatternFill;
  * box dynamically is only supported for patterns with an automatically
  * calculated ID.
  * @name Highcharts.PatternOptionsObject#width
- * @type {number}
+ * @type {number|undefined}
  *//**
  * Analogous to pattern.width.
  * @name Highcharts.PatternOptionsObject#height
- * @type {number}
+ * @type {number|undefined}
  *//**
  * For automatically calculated width and height on images, it is possible to
  * set an aspect ratio. The image will be zoomed to fill the bounding box,
  * maintaining the aspect ratio defined.
  * @name Highcharts.PatternOptionsObject#aspectRatio
- * @type {number}
+ * @type {number|undefined}
  *//**
  * Horizontal offset of the pattern. Defaults to 0.
  * @name Highcharts.PatternOptionsObject#x
@@ -813,20 +813,20 @@ export default PatternFill;
  * attributes like `path.stroke` and `path.fill`. If a path is supplied for the
  * pattern, the `image` property is ignored.
  * @name Highcharts.PatternOptionsObject#path
- * @type {string|Highcharts.SVGAttributes}
+ * @type {string|Highcharts.SVGAttributes|undefined}
  *//**
  * SVG `patternTransform` to apply to the entire pattern.
  * @name Highcharts.PatternOptionsObject#patternTransform
- * @type {string}
+ * @type {string|undefined}
  * @see [patternTransform demo](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/series/pattern-fill-transform)
  *//**
  * Pattern color, used as default path stroke.
  * @name Highcharts.PatternOptionsObject#color
- * @type {Highcharts.ColorString}
+ * @type {Highcharts.ColorString|undefined}
  *//**
  * Opacity of the pattern as a float value from 0 to 1.
  * @name Highcharts.PatternOptionsObject#opacity
- * @type {number}
+ * @type {number|undefined}
  *//**
  * ID to assign to the pattern. This is automatically computed if not added, and
  * identical patterns are reused. To refer to an existing pattern for a


### PR DESCRIPTION
- Fixed #17546; some optional properties were mandatory in column pattern fill interface.