### PR TITLE
Better default value for legend.valueDecimals

### DIFF
--- a/ts/Core/Axis/Color/ColorAxis.ts
+++ b/ts/Core/Axis/Color/ColorAxis.ts
@@ -890,12 +890,12 @@ class ColorAxis extends Axis implements AxisLike {
      * @private
      */
     public getDataClassLegendSymbols(): Array<ColorAxis.LegendItemObject> {
-        const axis = this;
-        const chart = axis.chart;
-        const legendItems = axis.legendItems;
-        const legendOptions = chart.options.legend;
-        const valueDecimals = (legendOptions as any).valueDecimals;
-        const valueSuffix = (legendOptions as any).valueSuffix || '';
+        const axis = this,
+            chart = axis.chart,
+            legendItems = axis.legendItems,
+            legendOptions = chart.options.legend,
+            valueDecimals = pick(legendOptions.valueDecimals, -1),
+            valueSuffix = pick(legendOptions.valueSuffix, '');
 
         let name;
 

--- a/ts/Core/DefaultOptions.ts
+++ b/ts/Core/DefaultOptions.ts
@@ -1686,6 +1686,26 @@ const defaultOptions: Options = {
          */
 
         /**
+         * For a color axis with data classes, how many decimals to render in
+         * the legend. The default preserves the decimals of the range numbers.
+         *
+         * @type      {number}
+         * @default   -1
+         * @product   highcharts highmaps
+         * @apioption legend.valueDecimals
+         */
+
+        /**
+         * For a color axis with data classes, a suffix for the range numbers in
+         * the legend.
+         *
+         * @type      {string}
+         * @default   ''
+         * @product   highcharts highmaps
+         * @apioption legend.valueSuffix
+         */
+
+        /**
          * The width of the legend box. If a number is set, it translates to
          * pixels. Since v7.0.2 it allows setting a percent string of the full
          * chart width, for example `40%`.

--- a/ts/Core/Legend/LegendOptions.d.ts
+++ b/ts/Core/Legend/LegendOptions.d.ts
@@ -76,6 +76,8 @@ export interface LegendOptions {
     symbolWidth?: number;
     title: LegendTitleOptions;
     useHTML?: boolean;
+    valueDecimals?: number;
+    valueSuffix?: string;
     verticalAlign: VerticalAlignValue;
     width?: (number|string);
     x: number;


### PR DESCRIPTION
Better default value for `legend.valueDecimals` for color axis with data classes. Now it preserves the decimals of the `from` and `to` settings by default.