### PR TITLE
Improve UX on data classes legend item

### DIFF
--- a/samples/highcharts/chartchooser/continuous-distribution-map/demo.js
+++ b/samples/highcharts/chartchooser/continuous-distribution-map/demo.js
@@ -60,7 +60,12 @@
                     plotOptions: {
                         mapline: {
                             showInLegend: false,
-                            enableMouseTracking: false
+                            enableMouseTracking: false,
+                            states: {
+                                inactive: {
+                                    opacity: 1
+                                }
+                            }
                         }
                     },
 

--- a/samples/maps/mapview/projection-explorer/demo.js
+++ b/samples/maps/mapview/projection-explorer/demo.js
@@ -149,7 +149,12 @@
 
                 plotOptions: {
                     series: {
-                        animationLimit: 500
+                        animationLimit: 500,
+                        states: {
+                            inactive: {
+                                opacity: 1
+                            }
+                        }
                     },
                     mapline: {
                         enableMouseTracking: false

--- a/ts/Core/Axis/Color/ColorAxis.ts
+++ b/ts/Core/Axis/Color/ColorAxis.ts
@@ -897,17 +897,13 @@ class ColorAxis extends Axis implements AxisLike {
         const valueDecimals = (legendOptions as any).valueDecimals;
         const valueSuffix = (legendOptions as any).valueSuffix || '';
 
-        const getPointsInDataClass = (i: number): Point[] => {
-            const points: Point[] = [];
-            axis.series.forEach((series): void => {
-                series.points.forEach((point): void => {
-                    if (point.dataClass === i) {
-                        points.push(point);
-                    }
-                });
-            });
-            return points;
-        };
+        const getPointsInDataClass = (i: number): Point[] =>
+            axis.series.reduce((points, s): Point[] => {
+                points.push(...s.points.filter((point): boolean =>
+                    point.dataClass === i
+                ));
+                return points;
+            }, [] as Point[]);
 
         let name;
 
@@ -937,10 +933,10 @@ class ColorAxis extends Axis implements AxisLike {
                     name += numberFormatter(to, valueDecimals) + valueSuffix;
                 }
                 // Add a mock object to the legend items
-                legendItems.push(extend(
+                legendItems.push(extend<ColorAxis.LegendItemObject>(
                     {
-                        chart: chart,
-                        name: name,
+                        chart,
+                        name,
                         options: {},
                         drawLegendSymbol: LegendSymbol.drawRectangle,
                         visible: true,
@@ -948,13 +944,11 @@ class ColorAxis extends Axis implements AxisLike {
 
                         // Override setState to set either normal or inactive
                         // state to all points in this data class
-                        setState: function (
-                            state?: (StatesOptionsKey|'')
-                        ): void {
+                        setState: (state?: (StatesOptionsKey|'')): void => {
                             getPointsInDataClass(i).forEach((point): void =>
                                 point.setState(state)
                             );
-                        } as Function,
+                        },
 
                         // Override setState to show or hide all points in this
                         // data class
@@ -1006,9 +1000,9 @@ namespace ColorAxis {
         options: object;
         drawLegendSymbol: typeof LegendSymbol['drawRectangle'];
         visible: boolean;
-        setState: Function;
+        setState: Point['setState'];
         isDataClass: true;
-        setVisible: () => void;
+        setVisible: Function;
     }
 
     export interface MarkerOptions {

--- a/ts/Core/Axis/Color/ColorAxis.ts
+++ b/ts/Core/Axis/Color/ColorAxis.ts
@@ -897,6 +897,18 @@ class ColorAxis extends Axis implements AxisLike {
         const valueDecimals = (legendOptions as any).valueDecimals;
         const valueSuffix = (legendOptions as any).valueSuffix || '';
 
+        const getPointsInDataClass = (i: number): Point[] => {
+            const points: Point[] = [];
+            axis.series.forEach((series): void => {
+                series.points.forEach((point): void => {
+                    if (point.dataClass === i) {
+                        points.push(point);
+                    }
+                });
+            });
+            return points;
+        };
+
         let name;
 
         if (!legendItems.length) {
@@ -932,21 +944,27 @@ class ColorAxis extends Axis implements AxisLike {
                         options: {},
                         drawLegendSymbol: LegendSymbol.drawRectangle,
                         visible: true,
-                        setState: noop,
                         isDataClass: true,
+
+                        // Override setState to set either normal or inactive
+                        // state to all points in this data class
+                        setState: function (
+                            state?: (StatesOptionsKey|'')
+                        ): void {
+                            getPointsInDataClass(i).forEach((point): void =>
+                                point.setState(state)
+                            );
+                        } as Function,
+
+                        // Override setState to show or hide all points in this
+                        // data class
                         setVisible: function (
                             this: ColorAxis.LegendItemObject
                         ): void {
                             this.visible = vis = axis.visible = !vis;
-                            axis.series.forEach(function (series): void {
-                                series.points.forEach(function (
-                                    point: Point
-                                ): void {
-                                    if (point.dataClass === i) {
-                                        (point as any).setVisible(vis);
-                                    }
-                                });
-                            });
+                            getPointsInDataClass(i).forEach((point): void =>
+                                point.setVisible(vis)
+                            );
                             chart.legend.colorizeItem(this as any, vis);
                         }
                     },

--- a/ts/Core/Axis/Color/ColorAxis.ts
+++ b/ts/Core/Axis/Color/ColorAxis.ts
@@ -897,7 +897,7 @@ class ColorAxis extends Axis implements AxisLike {
         const valueDecimals = (legendOptions as any).valueDecimals;
         const valueSuffix = (legendOptions as any).valueSuffix || '';
 
-        const getPointsInDataClass = (i: number): Point[] =>
+        const getPointsInDataClass = (i: number): Array<Point> =>
             axis.series.reduce((points, s): Point[] => {
                 points.push(...s.points.filter((point): boolean =>
                     point.dataClass === i
@@ -945,9 +945,9 @@ class ColorAxis extends Axis implements AxisLike {
                         // Override setState to set either normal or inactive
                         // state to all points in this data class
                         setState: (state?: (StatesOptionsKey|'')): void => {
-                            getPointsInDataClass(i).forEach((point): void =>
-                                point.setState(state)
-                            );
+                            for (const point of getPointsInDataClass(i)) {
+                                point.setState(state);
+                            }
                         },
 
                         // Override setState to show or hide all points in this
@@ -956,9 +956,9 @@ class ColorAxis extends Axis implements AxisLike {
                             this: ColorAxis.LegendItemObject
                         ): void {
                             this.visible = vis = axis.visible = !vis;
-                            getPointsInDataClass(i).forEach((point): void =>
-                                point.setVisible(vis)
-                            );
+                            for (const point of getPointsInDataClass(i)) {
+                                point.setVisible(vis);
+                            }
                             chart.legend.colorizeItem(this as any, vis);
                         }
                     },

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1372,28 +1372,25 @@ class Point {
                     chart.options.chart.animation,
                     stateOptions.animation
                 );
+                const opacity = pointAttribs.opacity;
 
                 // Some inactive points (e.g. slices in pie) should apply
                 // opacity also for their labels
-                if (isNumber(pointAttribs.opacity)) {
+                if (isNumber(opacity)) {
                     (point.dataLabels || []).forEach(function (
                         label: SVGElement
                     ): void {
-                        if (label) {
-                            label.animate(
-                                {
-                                    opacity: pointAttribs.opacity
-                                },
-                                pointAttribsAnimation
-                            );
+                        if (
+                            label &&
+                            !label.hasClass('highcharts-data-label-hidden')
+                        ) {
+                            label.animate({ opacity }, pointAttribsAnimation);
                         }
                     });
 
                     if (point.connector) {
                         point.connector.animate(
-                            {
-                                opacity: pointAttribs.opacity
-                            },
+                            { opacity },
                             pointAttribsAnimation
                         );
                     }

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -83,7 +83,7 @@ declare module './PointLike' {
         onMouseOver(e?: PointerEvent): void;
         select(selected?: boolean | null, accumulate?: boolean): void;
         setState(
-            state?: string,
+            state?: (StatesOptionsKey|''),
             move?: boolean
         ): void;
     }

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1375,10 +1375,7 @@ class Point {
 
                 // Some inactive points (e.g. slices in pie) should apply
                 // opacity also for their labels
-                if (
-                    series.options.inactiveOtherPoints &&
-                    isNumber(pointAttribs.opacity)
-                ) {
+                if (isNumber(pointAttribs.opacity)) {
                     (point.dataLabels || []).forEach(function (
                         label: SVGElement
                     ): void {

--- a/ts/Series/Map/MapPoint.ts
+++ b/ts/Series/Map/MapPoint.ts
@@ -201,7 +201,7 @@ class MapPoint extends ScatterSeries.prototype.pointClass {
     public setVisible(vis?: boolean): void {
         const method = vis ? 'show' : 'hide';
 
-        this.visible = this.options.visible = Boolean(vis);
+        this.visible = this.options.visible = !!vis;
 
         // Show and hide associated elements
         if (this.dataLabel) {

--- a/ts/Series/Map/MapPoint.ts
+++ b/ts/Series/Map/MapPoint.ts
@@ -185,7 +185,12 @@ class MapPoint extends ScatterSeries.prototype.pointClass {
      */
     public onMouseOver(e?: PointerEvent): void {
         U.clearTimeout(this.colorInterval as any);
-        if (!this.isNull || this.series.options.nullInteraction) {
+        if (
+            // Valid...
+            (!this.isNull && this.visible) ||
+            // ... or interact anyway
+            this.series.options.nullInteraction
+        ) {
             super.onMouseOver.call(this, e);
         } else {
             // #3401 Tooltip doesn't hide when hovering over null points

--- a/ts/Series/Map/MapPoint.ts
+++ b/ts/Series/Map/MapPoint.ts
@@ -193,6 +193,24 @@ class MapPoint extends ScatterSeries.prototype.pointClass {
         }
     }
 
+    public setVisible(vis?: boolean): void {
+        const method = vis ? 'show' : 'hide';
+
+        this.visible = this.options.visible = Boolean(vis);
+
+        // Show and hide associated elements
+        if (this.dataLabel) {
+            this.dataLabel[method]();
+        }
+
+        // For invisible map points, render them as null points rather than
+        // fully removing them. Makes more sense for color axes with data
+        // classes.
+        if (this.graphic) {
+            this.graphic.attr(this.series.pointAttribs(this));
+        }
+    }
+
     /**
      * Highmaps only. Zoom in on the point using the global animation.
      *

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -966,6 +966,14 @@ class MapSeries extends ScatterSeries {
             pointStrokeWidth = seriesStrokeWidth / mapView.getScale();
         }
 
+        // Invisible map points means that the data value is removed from the
+        // map, but not the map area shape itself. Instead it is rendered like a
+        // null point. To fully remove a map area, it should be removed from the
+        // mapData.
+        if (!point.visible) {
+            attr.fill = this.options.nullColor;
+        }
+
         (attr as any)['stroke-width'] = pick(
             pointStrokeWidth,
             // By default set the stroke-width on the group element and let all

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -398,10 +398,6 @@ class MapSeries extends ScatterSeries {
                  * @apioption plotOptions.series.states.select.color
                  */
                 color: Palette.neutralColor20
-            },
-
-            inactive: {
-                opacity: 1
             }
         }
     } as MapSeriesOptions);


### PR DESCRIPTION
Improved the UX on legend items when using a color axis with data classes. Hovering now renders other map areas as inactive, and clicking the legend item renders them as `null` rather than completely hiding them.

Demo with the changes applied: https://jsfiddle.net/7o3qd4av/
