### PR TITLE
Fixed #17677, text and outline not aligned for sunburst data labels

### DIFF
--- a/samples/unit-tests/series-sunburst/datalabels/demo.js
+++ b/samples/unit-tests/series-sunburst/datalabels/demo.js
@@ -9,7 +9,7 @@ QUnit.test('Rotation mode', function (assert) {
                     },
                     {
                         parent: 'root',
-                        name: 'First',
+                        name: 'First<br>item',
                         value: 1
                     },
                     {
@@ -58,6 +58,14 @@ QUnit.test('Rotation mode', function (assert) {
         }),
         [0, 22.5, 67.5, -67.5, -22.5, 22.5, 67.5, -67.5, -22.5],
         'Auto rotationMode should be parallel'
+    );
+
+    assert.strictEqual(
+        chart.series[0].points[1].dataLabel.element
+            .querySelector('.highcharts-text-outline')
+            .getAttribute('y'),
+        null,
+        'The y attribute should not be set on text outline element (#17677)'
     );
 
     chart.series[0].update({

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -614,10 +614,6 @@ class SVGElement implements SVGElementLike {
 
             this.fakeTS = true; // Fake text shadow
 
-            // In order to get the right y position of the clone,
-            // copy over the y setter
-            this.ySetter = this.xSetter;
-
             // Since the stroke is applied on center of the actual outline, we
             // need to double it to get the correct stroke-width outside the
             // glyphs.


### PR DESCRIPTION
Fixed #17677, a regression causing text and outline out of alignment for sunburst data labels