### PR TITLE
Docs: Made lineWidth option of timeline series public.

### DIFF
--- a/ts/Series/Timeline/TimelineSeries.ts
+++ b/ts/Series/Timeline/TimelineSeries.ts
@@ -22,13 +22,9 @@
 
 import type BBoxObject from '../../Core/Renderer/BBoxObject';
 import type RangeSelector from '../../Stock/RangeSelector/RangeSelector';
-import type {
-    TimelineDataLabelContextObject,
-    TimelineDataLabelOptions
-} from './TimelineDataLabelOptions';
+import type TimelineDataLabelOptions from './TimelineDataLabelOptions';
 import type TimelinePointOptions from './TimelinePointOptions';
 import type TimelineSeriesOptions from './TimelineSeriesOptions';
-import type Point from '../../Core/Series/Point';
 import type {
     PointMarkerOptions,
     PointStatesOptions
@@ -39,7 +35,6 @@ import type SVGAttributes from '../../Core/Renderer/SVG/SVGAttributes';
 import type SVGLabel from '../../Core/Renderer/SVG/SVGLabel';
 
 import LegendSymbol from '../../Core/Legend/LegendSymbol.js';
-import { Palette } from '../../Core/Color/Palettes.js';
 import SeriesRegistry from '../../Core/Series/SeriesRegistry.js';
 const {
     seriesTypes: {
@@ -49,6 +44,7 @@ const {
 } = SeriesRegistry;
 import SVGElement from '../../Core/Renderer/SVG/SVGElement.js';
 import TimelinePoint from './TimelinePoint.js';
+import TimelineSeriesDefaults from './TimelineSeriesDefaults.js';
 import U from '../../Core/Utilities.js';
 const {
     addEvent,
@@ -83,181 +79,10 @@ class TimelineSeries extends LineSeries {
      *
      * */
 
-    /**
-     * The timeline series presents given events along a drawn line.
-     *
-     * @sample highcharts/series-timeline/alternate-labels
-     *         Timeline series
-     * @sample highcharts/series-timeline/inverted
-     *         Inverted timeline
-     * @sample highcharts/series-timeline/datetime-axis
-     *         With true datetime axis
-     *
-     * @extends      plotOptions.line
-     * @since        7.0.0
-     * @product      highcharts
-     * @excluding    animationLimit, boostThreshold, connectEnds, connectNulls,
-     *               cropThreshold, dashStyle, findNearestPointBy,
-     *               getExtremesFromAll, negativeColor, pointInterval,
-     *               pointIntervalUnit, pointPlacement, pointStart,
-     *               softThreshold, stacking, step, threshold, turboThreshold,
-     *               zoneAxis, zones, dataSorting, boostBlending
-     * @requires     modules/timeline
-     * @optionparent plotOptions.timeline
-     *
-     * @private
-     */
-    public static defaultOptions: TimelineSeriesOptions = merge(LineSeries.defaultOptions, {
-        colorByPoint: true,
-        stickyTracking: false,
-        ignoreHiddenPoint: true,
-        /**
-         * @ignore
-         * @private
-         */
-        legendType: 'point',
-        lineWidth: 4,
-        tooltip: {
-            headerFormat: '<span style="color:{point.color}">\u25CF</span> ' +
-                '<span style="font-size: 10px"> {point.key}</span><br/>',
-            pointFormat: '{point.description}'
-        },
-        states: {
-            hover: {
-                lineWidthPlus: 0
-            }
-        },
-        /**
-         * @declare Highcharts.TimelineDataLabelsOptionsObject
-         *
-         * @private
-         */
-        dataLabels: {
-
-            enabled: true,
-
-            allowOverlap: true,
-
-            /**
-             * Whether to position data labels alternately. For example, if
-             * [distance](#plotOptions.timeline.dataLabels.distance)
-             * is set equal to `100`, then data labels will be positioned
-             * alternately (on both sides of the point) at a distance of 100px.
-             *
-             * @sample {highcharts} highcharts/series-timeline/alternate-disabled
-             *         Alternate disabled
-             */
-            alternate: true,
-
-            backgroundColor: Palette.backgroundColor,
-
-            borderWidth: 1,
-
-            borderColor: Palette.neutralColor40,
-
-            borderRadius: 3,
-
-            color: Palette.neutralColor80,
-
-            /**
-             * The color of the line connecting the data label to the point.
-             * The default color is the same as the point's color.
-             *
-             * In styled mode, the connector stroke is given in the
-             * `.highcharts-data-label-connector` class.
-             *
-             * @sample {highcharts} highcharts/series-timeline/connector-styles
-             *         Custom connector width and color
-             *
-             * @type      {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
-             * @apioption plotOptions.timeline.dataLabels.connectorColor
-             */
-
-            /**
-             * The width of the line connecting the data label to the point.
-             *
-             * In styled mode, the connector stroke width is given in the
-             * `.highcharts-data-label-connector` class.
-             *
-             * @sample {highcharts} highcharts/series-timeline/connector-styles
-             *         Custom connector width and color
-             */
-            connectorWidth: 1,
-
-            /**
-             * A pixel value defining the distance between the data label and
-             * the point. Negative numbers puts the label on top of the point.
-             */
-            distance: 100,
-
-            // eslint-disable-next-line valid-jsdoc
-            /**
-             * @type    {Highcharts.TimelineDataLabelsFormatterCallbackFunction}
-             * @default function () {
-             *   let format;
-             *
-             *   if (!this.series.chart.styledMode) {
-             *       format = '<span style="color:' + this.point.color +
-             *           '">● </span>';
-             *   } else {
-             *       format = '<span>● </span>';
-             *   }
-             *   format += '<span>' + (this.key || '') + '</span><br/>' +
-             *       (this.point.label || '');
-             *   return format;
-             * }
-             */
-            formatter: function (
-                this: (Point.PointLabelObject|TimelineDataLabelContextObject)
-            ): string {
-                let format;
-
-                if (!this.series.chart.styledMode) {
-                    format = '<span style="color:' + this.point.color +
-                        '">● </span>';
-                } else {
-                    format = '<span>● </span>';
-                }
-                format += '<span class="highcharts-strong">' +
-                    ((this as any).key || '') + '</span><br/>' +
-                    ((this.point as any).label || '');
-                return format;
-            },
-
-            style: {
-                /** @internal */
-                textOutline: 'none',
-                /** @internal */
-                fontWeight: 'normal',
-                /** @internal */
-                fontSize: '12px'
-            },
-
-            /**
-             * Shadow options for the data label.
-             *
-             * @type {boolean|Highcharts.CSSObject}
-             */
-            shadow: false,
-
-            /**
-             * @type      {number}
-             * @apioption plotOptions.timeline.dataLabels.width
-             */
-
-            verticalAlign: 'middle'
-
-        },
-        marker: {
-            enabledThreshold: 0,
-            symbol: 'square',
-            radius: 6,
-            lineWidth: 2,
-            height: 15
-        },
-        showInLegend: false,
-        colorKey: 'x'
-    } as TimelineSeriesOptions);
+    public static defaultOptions: TimelineSeriesOptions = merge(
+        LineSeries.defaultOptions,
+        TimelineSeriesDefaults
+    );
 
     /* *
      *
@@ -704,84 +529,3 @@ export default TimelineSeries;
  */
 
 ''; // dettach doclets above
-
-/* *
- *
- *  API Options
- *
- * */
-
-/**
- * The `timeline` series. If the [type](#series.timeline.type) option is
- * not specified, it is inherited from [chart.type](#chart.type).
- *
- * @extends   series,plotOptions.timeline
- * @excluding animationLimit, boostThreshold, connectEnds, connectNulls,
- *            cropThreshold, dashStyle, dataParser, dataURL, findNearestPointBy,
- *            getExtremesFromAll, negativeColor, pointInterval,
- *            pointIntervalUnit, pointPlacement, pointStart, softThreshold,
- *            stacking, stack, step, threshold, turboThreshold, zoneAxis, zones,
- *            dataSorting, boostBlending
- * @product   highcharts
- * @requires  modules/timeline
- * @apioption series.timeline
- */
-
-/**
- * An array of data points for the series. For the `timeline` series type,
- * points can be given with three general parameters, `name`, `label`,
- * and `description`:
- *
- * Example:
- *
- * ```js
- * series: [{
- *    type: 'timeline',
- *    data: [{
- *        name: 'Jan 2018',
- *        label: 'Some event label',
- *        description: 'Description to show in tooltip'
- *    }]
- * }]
- * ```
- * If all points additionally have the `x` values, and xAxis type is set to
- * `datetime`, then events are laid out on a true time axis, where their
- * placement reflects the actual time between them.
- *
- * @sample {highcharts} highcharts/series-timeline/alternate-labels
- *         Alternate labels
- * @sample {highcharts} highcharts/series-timeline/datetime-axis
- *         Real time intervals
- *
- * @type      {Array<*>}
- * @extends   series.line.data
- * @excluding marker, y
- * @product   highcharts
- * @apioption series.timeline.data
- */
-
-/**
- * The name of event.
- *
- * @type      {string}
- * @product   highcharts
- * @apioption series.timeline.data.name
- */
-
-/**
- * The label of event.
- *
- * @type      {string}
- * @product   highcharts
- * @apioption series.timeline.data.label
- */
-
-/**
- * The description of event. This description will be shown in tooltip.
- *
- * @type      {string}
- * @product   highcharts
- * @apioption series.timeline.data.description
- */
-
-''; // adds doclets above to transpiled file

--- a/ts/Series/Timeline/TimelineSeriesDefaults.ts
+++ b/ts/Series/Timeline/TimelineSeriesDefaults.ts
@@ -1,0 +1,294 @@
+/* *
+ *
+ *  Timeline Series.
+ *
+ *  (c) 2010-2021 Highsoft AS
+ *
+ *  Author: Daniel Studencki
+ *
+ *  License: www.highcharts.com/license
+ *
+ *  !!!!!!! SOURCE GETS TRANSPILED BY TYPESCRIPT. EDIT TS FILE ONLY. !!!!!!!
+ *
+ * */
+
+'use strict';
+
+/* *
+ *
+ *  Imports
+ *
+ * */
+
+import type { TimelineDataLabelContextObject } from
+    './TimelineDataLabelOptions';
+import type Point from '../../Core/Series/Point';
+import type TimelineSeriesOptions from './TimelineSeriesOptions';
+
+import { Palette } from '../../Core/Color/Palettes.js';
+
+/* *
+ *
+ *  API Options
+ *
+ * */
+
+/**
+ * The timeline series presents given events along a drawn line.
+ *
+ * @sample highcharts/series-timeline/alternate-labels
+ *         Timeline series
+ * @sample highcharts/series-timeline/inverted
+ *         Inverted timeline
+ * @sample highcharts/series-timeline/datetime-axis
+ *         With true datetime axis
+ *
+ * @extends      plotOptions.line
+ * @excluding    animationLimit, boostThreshold, connectEnds, connectNulls,
+ *               cropThreshold, dashStyle, findNearestPointBy,
+ *               getExtremesFromAll, negativeColor, pointInterval,
+ *               pointIntervalUnit, pointPlacement, pointStart,
+ *               softThreshold, stacking, step, threshold, turboThreshold,
+ *               zoneAxis, zones, dataSorting, boostBlending
+ * @product      highcharts
+ * @since        7.0.0
+ * @requires     modules/timeline
+ * @optionparent plotOptions.timeline
+ */
+const TimelineSeriesDefaults: TimelineSeriesOptions = {
+    colorByPoint: true,
+    stickyTracking: false,
+    ignoreHiddenPoint: true,
+
+    /**
+     * @ignore
+     */
+    legendType: 'point',
+
+    /**
+     * Pixel width of the graph line.
+     */
+    lineWidth: 4,
+
+    tooltip: {
+        headerFormat: '<span style="color:{point.color}">\u25CF</span> ' +
+            '<span style="font-size: 10px"> {point.key}</span><br/>',
+        pointFormat: '{point.description}'
+    },
+    states: {
+        hover: {
+            lineWidthPlus: 0
+        }
+    },
+    /**
+     * @declare Highcharts.TimelineDataLabelsOptionsObject
+     */
+    dataLabels: {
+
+        enabled: true,
+
+        allowOverlap: true,
+
+        /**
+         * Whether to position data labels alternately. For example, if
+         * [distance](#plotOptions.timeline.dataLabels.distance)
+         * is set equal to `100`, then data labels will be positioned
+         * alternately (on both sides of the point) at a distance of 100px.
+         *
+         * @sample {highcharts} highcharts/series-timeline/alternate-disabled
+         *         Alternate disabled
+         */
+        alternate: true,
+
+        backgroundColor: Palette.backgroundColor,
+
+        borderWidth: 1,
+
+        borderColor: Palette.neutralColor40,
+
+        borderRadius: 3,
+
+        color: Palette.neutralColor80,
+
+        /**
+         * The color of the line connecting the data label to the point.
+         * The default color is the same as the point's color.
+         *
+         * In styled mode, the connector stroke is given in the
+         * `.highcharts-data-label-connector` class.
+         *
+         * @sample {highcharts} highcharts/series-timeline/connector-styles
+         *         Custom connector width and color
+         *
+         * @type      {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
+         * @apioption plotOptions.timeline.dataLabels.connectorColor
+         */
+
+        /**
+         * The width of the line connecting the data label to the point.
+         *
+         * In styled mode, the connector stroke width is given in the
+         * `.highcharts-data-label-connector` class.
+         *
+         * @sample {highcharts} highcharts/series-timeline/connector-styles
+         *         Custom connector width and color
+         */
+        connectorWidth: 1,
+
+        /**
+         * A pixel value defining the distance between the data label and
+         * the point. Negative numbers puts the label on top of the point.
+         */
+        distance: 100,
+
+        // eslint-disable-next-line valid-jsdoc
+        /**
+         * @type    {Highcharts.TimelineDataLabelsFormatterCallbackFunction}
+         * @default function () {
+         *   let format;
+         *
+         *   if (!this.series.chart.styledMode) {
+         *       format = '<span style="color:' + this.point.color +
+         *           '">● </span>';
+         *   } else {
+         *       format = '<span>● </span>';
+         *   }
+         *   format += '<span>' + (this.key || '') + '</span><br/>' +
+         *       (this.point.label || '');
+         *   return format;
+         * }
+         */
+        formatter: function (
+            this: (Point.PointLabelObject|TimelineDataLabelContextObject)
+        ): string {
+            let format;
+
+            if (!this.series.chart.styledMode) {
+                format = '<span style="color:' + this.point.color +
+                    '">● </span>';
+            } else {
+                format = '<span>● </span>';
+            }
+            format += '<span class="highcharts-strong">' +
+                ((this as any).key || '') + '</span><br/>' +
+                ((this.point as any).label || '');
+            return format;
+        },
+
+        style: {
+            /** @internal */
+            textOutline: 'none',
+            /** @internal */
+            fontWeight: 'normal',
+            /** @internal */
+            fontSize: '12px'
+        },
+
+        /**
+         * Shadow options for the data label.
+         *
+         * @type {boolean|Highcharts.CSSObject}
+         */
+        shadow: false,
+
+        /**
+         * @type      {number}
+         * @apioption plotOptions.timeline.dataLabels.width
+         */
+
+        verticalAlign: 'middle'
+
+    },
+    marker: {
+        enabledThreshold: 0,
+        symbol: 'square',
+        radius: 6,
+        lineWidth: 2,
+        height: 15
+    },
+    showInLegend: false,
+    colorKey: 'x'
+};
+
+/**
+ * The `timeline` series. If the [type](#series.timeline.type) option is
+ * not specified, it is inherited from [chart.type](#chart.type).
+ *
+ * @extends   series,plotOptions.timeline
+ * @excluding animationLimit, boostThreshold, connectEnds, connectNulls,
+ *            cropThreshold, dashStyle, dataParser, dataURL, findNearestPointBy,
+ *            getExtremesFromAll, negativeColor, pointInterval,
+ *            pointIntervalUnit, pointPlacement, pointStart, softThreshold,
+ *            stacking, stack, step, threshold, turboThreshold, zoneAxis, zones,
+ *            dataSorting, boostBlending
+ * @product   highcharts
+ * @requires  modules/timeline
+ * @apioption series.timeline
+ */
+
+/**
+ * An array of data points for the series. For the `timeline` series type,
+ * points can be given with three general parameters, `name`, `label`,
+ * and `description`:
+ *
+ * Example:
+ *
+ * ```js
+ * series: [{
+ *    type: 'timeline',
+ *    data: [{
+ *        name: 'Jan 2018',
+ *        label: 'Some event label',
+ *        description: 'Description to show in tooltip'
+ *    }]
+ * }]
+ * ```
+ * If all points additionally have the `x` values, and xAxis type is set to
+ * `datetime`, then events are laid out on a true time axis, where their
+ * placement reflects the actual time between them.
+ *
+ * @sample {highcharts} highcharts/series-timeline/alternate-labels
+ *         Alternate labels
+ * @sample {highcharts} highcharts/series-timeline/datetime-axis
+ *         Real time intervals
+ *
+ * @type      {Array<*>}
+ * @extends   series.line.data
+ * @excluding marker, y
+ * @product   highcharts
+ * @apioption series.timeline.data
+ */
+
+/**
+ * The name of event.
+ *
+ * @type      {string}
+ * @product   highcharts
+ * @apioption series.timeline.data.name
+ */
+
+/**
+ * The label of event.
+ *
+ * @type      {string}
+ * @product   highcharts
+ * @apioption series.timeline.data.label
+ */
+
+/**
+ * The description of event. This description will be shown in tooltip.
+ *
+ * @type      {string}
+ * @product   highcharts
+ * @apioption series.timeline.data.description
+ */
+
+''; // adds doclets above to transpiled file
+
+/* *
+ *
+ *  Default Export
+ *
+ * */
+
+export default TimelineSeriesDefaults;


### PR DESCRIPTION
Fixed #13994, `lineWidth` missing in timeline options.