### PR TITLE
bugfix/17288-shadow-group-not-preserved

### DIFF
--- a/samples/unit-tests/svgrenderer/shadows/demo.js
+++ b/samples/unit-tests/svgrenderer/shadows/demo.js
@@ -99,4 +99,24 @@ QUnit.test('Series shadows', function (assert) {
         checkAttributes(chart.series[0].graph.shadows, attributes),
         'Shadows should be updated when old options defined as boolean and new as object (#12091).'
     );
+
+    chart.update({
+        chart: {
+            inverted: false,
+            type: 'pie'
+        },
+        series: [{
+            shadow: true
+        }]
+    });
+
+    chart.series[0].update();
+
+    assert.ok(
+        checkAttributes(
+            [chart.series[0].shadowGroup.element],
+            defaultAttributes
+        ),
+        'Shadow group should not be hidden after series update (#17288).'
+    );
 });

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -4219,7 +4219,8 @@ class Series {
                 'group',
                 'markerGroup',
                 'dataLabelsGroup',
-                'transformGroup'
+                'transformGroup',
+                'shadowGroup'
             ],
             // Animation must be enabled when calling update before the initial
             // animation has first run. This happens when calling update


### PR DESCRIPTION
Fixed #17288, pie chart series were not applied on update

~~Fixed #17288, shadowGroup was not applied after the series update.~~