### PR TITLE
Support HTML in export labels

### DIFF
--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -416,7 +416,12 @@ namespace Exporting {
                 0,
                 0,
                 callback as any,
-                attr
+                attr,
+                {},
+                {},
+                {},
+                'rect',
+                btnOptions.useHTML
             )
             .addClass(options.className as any)
             .attr({

--- a/ts/Extensions/Exporting/ExportingOptions.d.ts
+++ b/ts/Extensions/Exporting/ExportingOptions.d.ts
@@ -79,6 +79,7 @@ export interface ExportingButtonOptions {
     text?: string;
     theme?: ButtonThemeObject;
     titleKey?: string;
+    useHTML?: boolean;
     verticalAlign?: VerticalAlignValue;
     width?: number;
     x?: number;


### PR DESCRIPTION
This allows to set `useHTML` in export label options and passes it through to the renderer in order to, well surprise, render HTML :)
Refs: https://www.highcharts.com/forum/viewtopic.php?t=34732, http://jsfiddle.net/zfngxoow

I'm a first-time contributor, although I read the guidelines, I'm not sure if I'm doing everything the right way. E.g. should some tests be added somewhere? I'm also unsure about the parameter values I had to explicitly set, like `'rect` because `undefined` was not allowed for those optional params. Are API docs (e.g. https://api.highcharts.com/highcharts/exporting.buttons.contextButton) generated I assume?