### PR TITLE
Enhancement: exporting button useHTML

### DIFF
--- a/samples/highcharts/exporting/buttons-text-usehtml/demo.css
+++ b/samples/highcharts/exporting/buttons-text-usehtml/demo.css
@@ -1,0 +1,5 @@
+#container {
+    height: 400px;
+    margin: 0 auto;
+    max-width: 800px;
+}

--- a/samples/highcharts/exporting/buttons-text-usehtml/demo.css
+++ b/samples/highcharts/exporting/buttons-text-usehtml/demo.css
@@ -3,3 +3,7 @@
     margin: 0 auto;
     max-width: 800px;
 }
+
+.highcharts-button span {
+    transition: color 250ms;
+}

--- a/samples/highcharts/exporting/buttons-text-usehtml/demo.details
+++ b/samples/highcharts/exporting/buttons-text-usehtml/demo.details
@@ -1,0 +1,8 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Torstein Hønsi
+ resources:
+   - 'https://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css'
+ js_wrap: b
+...

--- a/samples/highcharts/exporting/buttons-text-usehtml/demo.html
+++ b/samples/highcharts/exporting/buttons-text-usehtml/demo.html
@@ -1,0 +1,4 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
+
+<div id="container"></div>

--- a/samples/highcharts/exporting/buttons-text-usehtml/demo.js
+++ b/samples/highcharts/exporting/buttons-text-usehtml/demo.js
@@ -18,7 +18,15 @@ Highcharts.chart('container', {
         buttonOptions: {
             theme: {
                 style: {
-                    fontSize: '20px'
+                    fontSize: '20px',
+                    color: '#888'
+                },
+                states: {
+                    hover: {
+                        style: {
+                            color: '#000'
+                        }
+                    }
                 }
             },
             useHTML: true

--- a/samples/highcharts/exporting/buttons-text-usehtml/demo.js
+++ b/samples/highcharts/exporting/buttons-text-usehtml/demo.js
@@ -1,0 +1,53 @@
+Highcharts.chart('container', {
+
+    title: {
+        text: 'Export button text icons'
+    },
+
+    xAxis: {
+        categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+            'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+    },
+
+    series: [{
+        data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0,
+            135.6, 148.5, 216.4, 194.1, 95.6, 54.4]
+    }],
+
+    navigation: {
+        buttonOptions: {
+            theme: {
+                style: {
+                    fontSize: '20px'
+                }
+            },
+            useHTML: true
+        }
+    },
+
+    exporting: {
+        buttons: {
+            contextButton: {
+                enabled: false
+            },
+            exportButton: {
+                text: '<i class="fa fa-download"></i>',
+                // Use only the download related menu items from the default
+                // context button
+                menuItems: [
+                    'downloadPNG',
+                    'downloadJPEG',
+                    'downloadPDF',
+                    'downloadSVG'
+                ]
+            },
+            printButton: {
+                text: '<i class="fa fa-print"></i>',
+                onclick: function () {
+                    this.print();
+                }
+            }
+        }
+    }
+
+});

--- a/samples/readme.md
+++ b/samples/readme.md
@@ -56,7 +56,7 @@ that is available in the test environment.
 
 ```js
 // Instanciate
-var controller = new TestController(chart);
+const controller = new TestController(chart);
 
 // Simulate panning with the shift key pressed. X and Y are chart coordinates.
 controller.pan([200, 100], [150, 100], { shiftKey: true });

--- a/samples/unit-tests/svgrenderer/button/demo.js
+++ b/samples/unit-tests/svgrenderer/button/demo.js
@@ -74,4 +74,31 @@ QUnit.test('General button() tests', function (assert) {
         'blue',
         'Button function should not mutate its options (#13798).'
     );
+
+    const chart = Highcharts.chart('container', {});
+    const controller = new TestController(chart);
+    let clickedHTMLButton = false;
+    chart.renderer.button(
+        'Klikk',
+        100,
+        100,
+        function () {
+            clickedHTMLButton = true;
+        },
+        {},
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true
+    ).add();
+
+    controller.click(120, 110);
+
+    assert.ok(
+        clickedHTMLButton,
+        'The useHTML button should respond to click'
+    );
+
+
 });

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -832,9 +832,9 @@ class SVGRenderer implements SVGRendererLike {
             // HTML labels don't need to handle pointer events because click and
             // mouseenter/mouseleave is bound to the underlying <g> element.
             // Should this be reconsidered, we need more complex logic to share
-            // events between the <g> and its <div> counterpart, and
-            // avoid triggering mouseenter/mouseleave when hovering from one to
-            // the other (#17440).
+            // events between the <g> and its <div> counterpart, and avoid
+            // triggering mouseenter/mouseleave when hovering from one to the
+            // other (#17440).
             if (useHTML) {
                 label.text.css({ pointerEvents: 'none' });
             }

--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -416,7 +416,12 @@ namespace Exporting {
                 0,
                 0,
                 callback as any,
-                attr
+                attr,
+                void 0,
+                void 0,
+                void 0,
+                void 0,
+                btnOptions.useHTML
             )
             .addClass(options.className as any)
             .attr({

--- a/ts/Extensions/Exporting/ExportingDefaults.ts
+++ b/ts/Extensions/Exporting/ExportingDefaults.ts
@@ -719,6 +719,8 @@ const navigation: NavigationOptions = {
          *
          * @sample highcharts/exporting/buttons-text/
          *         Full text button
+         * @sample highcharts/exporting/buttons-text-usehtml/
+         *         Icon using CSS font in text
          * @sample highcharts/exporting/buttons-text-symbol/
          *         Combined symbol and text
          *
@@ -726,6 +728,19 @@ const navigation: NavigationOptions = {
          * @default   null
          * @since     3.0
          * @apioption navigation.buttonOptions.text
+         */
+
+        /**
+         * Whether to use HTML for rendering the button. HTML allows for things
+         * like inline CSS or image-based icons.
+         *
+         * @sample highcharts/exporting/buttons-text-usehtml/
+         *         Icon using CSS font in text
+         *
+         * @type      boolean
+         * @default   false
+         * @since     next
+         * @apioption navigation.buttonOptions.useHTML
          */
 
         /**

--- a/ts/Extensions/Exporting/ExportingOptions.d.ts
+++ b/ts/Extensions/Exporting/ExportingOptions.d.ts
@@ -79,6 +79,7 @@ export interface ExportingButtonOptions {
     text?: string;
     theme?: ButtonThemeObject;
     titleKey?: string;
+    useHTML?: boolean;
     verticalAlign?: VerticalAlignValue;
     width?: number;
     x?: number;


### PR DESCRIPTION
Added `exporting.buttonOptions.useHTML` to allow HTML with icons etc. in exporting buttons.

Original external PR: https://github.com/highcharts/highcharts/pull/17736

Preview: https://highcharts.github.io/highcharts-utils/samples/#gh/9dce2aae16/sample/highcharts/exporting/buttons-text-usehtml

# To do
 - [x] Handle mouseenter and mouseleave on the HTML overlay
 - [x] Make transition work in the demo
 - [x] Figure out why the [standard button doesn't work](https://jsfiddle.net/highcharts/mpa29qcr/) with `useHTML`. 