### PR TITLE
Docs: Removed align defaults because of opposite dynamic. 

### DIFF
--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -2522,8 +2522,6 @@ namespace AxisDefaults {
              *         Solid gauge labels auto aligned
              *
              * @type       {Highcharts.AlignValue}
-             * @default    {highcharts|highmaps} right
-             * @default    {highstock} left
              * @apioption  yAxis.labels.align
              */
 


### PR DESCRIPTION
See #16300