### PR TITLE
Docs: Added dateTimeLabelFormat and text to axislabel formatter context.

### DIFF
--- a/test/typescript-dts/classes/Axis.ts
+++ b/test/typescript-dts/classes/Axis.ts
@@ -1,0 +1,32 @@
+import * as Highcharts from 'highcharts';
+
+test_Axis_defaultLabelFormatter();
+
+function test_Axis_defaultLabelFormatter() {
+    const chart = new Highcharts.Chart({}),
+        axis = new Highcharts.Axis(chart, {}),
+        tick = new Highcharts.Tick(axis, 1),
+        ctx1: Highcharts.AxisLabelsFormatterContextObject = {
+            axis,
+            chart,
+            dateTimeLabelFormat: '%d',
+            isFirst: !!tick.isFirst,
+            isLast: !!tick.isLast,
+            pos: tick.pos,
+            tick,
+            value: 0
+        },
+        ctx2: Highcharts.AxisLabelsFormatterContextObject = {
+            axis,
+            chart,
+            isFirst: !!tick.isFirst,
+            isLast: !!tick.isFirst,
+            pos: tick.pos,
+            text: '',
+            tick,
+            value: 0
+        };
+
+    axis.defaultLabelFormatter.call(ctx1, ctx1);
+    axis.defaultLabelFormatter.call(ctx2, ctx2);
+}

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -4553,6 +4553,10 @@ export default Axis;
  * @name Highcharts.AxisLabelsFormatterContextObject#chart
  * @type {Highcharts.Chart}
  *//**
+ * Default formatting of date/time labels.
+ * @name Highcharts.AxisLabelsFormatterContextObject#dateTimeLabelFormat
+ * @type {string|undefined}
+ *//**
  * Whether the label belongs to the first tick on the axis.
  * @name Highcharts.AxisLabelsFormatterContextObject#isFirst
  * @type {boolean}
@@ -4571,7 +4575,7 @@ export default Axis;
  * dates will be formatted as strings, and numbers with language-specific comma
  * separators, thousands separators and numeric symbols like `k` or `M`.
  * @name Highcharts.AxisLabelsFormatterContextObject#text
- * @type {string}
+ * @type {string|undefined}
  *//**
  * The Tick instance.
  * @name Highcharts.AxisLabelsFormatterContextObject#tick

--- a/ts/Core/Axis/AxisOptions.d.ts
+++ b/ts/Core/Axis/AxisOptions.d.ts
@@ -82,7 +82,7 @@ AxisLabelFormatterContextObject
 export interface AxisLabelFormatterContextObject {
     axis: Axis;
     chart: Chart;
-    dateTimeLabelFormat: string;
+    dateTimeLabelFormat?: string;
     isFirst: boolean;
     isLast: boolean;
     pos: number;

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -276,11 +276,11 @@ class Tick {
         const ctx: AxisLabelFormatterContextObject = {
             axis,
             chart,
-            dateTimeLabelFormat: dateTimeLabelFormat as any,
+            dateTimeLabelFormat: dateTimeLabelFormat,
             isFirst,
             isLast,
             pos,
-            tick: tick as any,
+            tick: tick,
             tickPositionInfo,
             value
         };
@@ -300,7 +300,7 @@ class Tick {
                 return labelOptions.formatter.call(ctx, ctx);
             }
             if (labelOptions.format) {
-                ctx.text = axis.defaultLabelFormatter.call(ctx);
+                ctx.text = axis.defaultLabelFormatter.call(ctx, ctx);
                 return F.format(labelOptions.format, ctx, chart);
             }
             return axis.defaultLabelFormatter.call(ctx, ctx);


### PR DESCRIPTION
- Fixed #16309, added `Highcharts.AxisLabelsFormatterContextObject.dateTimeLabelFormat`
- Fixed typing of internal `AxisLabelFormatterContextObject.dateTimeLabelFormat`
- Fixed typing of `Highcharts.AxisLabelsFormatterContextObject.text`
- Fixed typing and internal call of `AxisLabelFormatterContextObject.text`
