### PR TITLE
bugfix/17664-ichimoku-cloud-position

### DIFF
--- a/samples/unit-tests/indicator-ichimoku-kinko-hyo/recalculations/demo.js
+++ b/samples/unit-tests/indicator-ichimoku-kinko-hyo/recalculations/demo.js
@@ -317,7 +317,7 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
     assert.strictEqual(
         chart.series[0].points.length,
         chart.series[1].points.length -
-            chart.series[1].options.params.periodSenkouSpanB,
+            chart.series[1].options.params.periodSenkouSpanB + 2,
         'Initial number of Ichimoku points is correct'
     );
 
@@ -333,7 +333,7 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
     assert.strictEqual(
         chart.series[0].points.length,
         chart.series[1].points.length -
-            chart.series[1].options.params.periodSenkouSpanB,
+            chart.series[1].options.params.periodSenkouSpanB + 2,
         'After addPoint number of Ichimoku points is correct'
     );
 
@@ -465,12 +465,14 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
         'Line color changed'
     );
 
-    chart.series[0].points[27].remove();
+    const dataPoints = chart.series[0].points;
+
+    dataPoints[dataPoints.length - 1].remove();
 
     assert.strictEqual(
-        chart.series[0].points.length,
-        chart.series[1].points.length -
-            chart.series[1].options.params.periodSenkouSpanB,
+        dataPoints.length,
+        chart.series[1].yData.length -
+            chart.series[1].options.params.periodSenkouSpanB + 2,
         'After removePoint number of Ichimoku points is correct'
     );
 

--- a/ts/Stock/Indicators/IKH/IKHIndicator.ts
+++ b/ts/Stock/Indicators/IKH/IKHIndicator.ts
@@ -894,27 +894,37 @@ class IKHIndicator extends SMAIndicator {
                 IKH[i] = [];
             }
 
-            if (typeof IKH[i + period] === 'undefined') {
-                IKH[i + period] = [];
+            if (typeof IKH[i + period - 1] === 'undefined') {
+                IKH[i + period - 1] = [];
             }
 
-            IKH[i + period][0] = TS;
-            IKH[i + period][1] = KS;
-            IKH[i + period][2] = void 0;
+            IKH[i + period - 1][0] = TS;
+            IKH[i + period - 1][1] = KS;
+            IKH[i + period - 1][2] = void 0;
 
-            IKH[i][2] = CS;
+            if (typeof IKH[i + 1] === 'undefined') {
+                IKH[i + 1] = [];
+            }
+
+            IKH[i + 1][2] = CS;
 
             if (i <= period) {
-                IKH[i + period][3] = void 0;
-                IKH[i + period][4] = void 0;
+                IKH[i + period - 1][3] = void 0;
+                IKH[i + period - 1][4] = void 0;
             }
 
+            if (typeof IKH[i + 2 * period - 2] === 'undefined') {
+                IKH[i + 2 * period - 2] = [];
+            }
+
+            // After shifting the IKH cloud by two points 'to the left' it adds
+            // additional points needed for a proper IKH series length. #17664
             if (typeof IKH[i + 2 * period] === 'undefined') {
                 IKH[i + 2 * period] = [];
             }
 
-            IKH[i + 2 * period][3] = SSA;
-            IKH[i + 2 * period][4] = SSB;
+            IKH[i + 2 * period - 2][3] = SSA;
+            IKH[i + 2 * period - 2][4] = SSB;
 
             xData.push(date);
         }

--- a/ts/Stock/Indicators/IKH/IKHIndicator.ts
+++ b/ts/Stock/Indicators/IKH/IKHIndicator.ts
@@ -637,7 +637,7 @@ class IKHIndicator extends SMAIndicator {
 
         // Generate senkouSpan area:
 
-        // If graphColection exist then remove svg
+        // If graphCollection exist then remove svg
         // element and indicator property
         if (indicator.graphCollection) {
             indicator.graphCollection.forEach(function (
@@ -648,7 +648,7 @@ class IKHIndicator extends SMAIndicator {
             });
         }
 
-        // Clean grapCollection or initialize it
+        // Clean graphCollection or initialize it
         indicator.graphCollection = [];
 
         // When user set negativeColor property
@@ -678,7 +678,7 @@ class IKHIndicator extends SMAIndicator {
                     const x = Math.floor(sectionPoints.length / 2);
 
                     // When middle points has equal values
-                    // Compare all ponints plotY value sum
+                    // Compare all points plotY value sum
                     if (sectionPoints[x].plotY === sectionNextPoints[x].plotY) {
                         pointsPlotYSum = 0;
                         nextPointsPlotYSum = 0;
@@ -915,12 +915,6 @@ class IKHIndicator extends SMAIndicator {
 
             if (typeof IKH[i + 2 * period - 2] === 'undefined') {
                 IKH[i + 2 * period - 2] = [];
-            }
-
-            // After shifting the IKH cloud by two points 'to the left' it adds
-            // additional points needed for a proper IKH series length. #17664
-            if (typeof IKH[i + 2 * period] === 'undefined') {
-                IKH[i + 2 * period] = [];
             }
 
             IKH[i + 2 * period - 2][3] = SSA;


### PR DESCRIPTION
Fixed #17664, Ichimoku cloud was incorrectly positioned.

Following @pawellysy suggestions, I have changed the position of `senkou span A` and `senkou span B`. Moreover, the position of `chikou span` was also incorrect by one day, so it's fixed now.

All of the above was tested on our AAPL data, and compared with the tradingview AAPL data from NASDAQ.
DEMO for testing: https://jsfiddle.net/BlackLabel/o1qv4m2n/