### PR TITLE
Tools: added markdown linter

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,6 +51,7 @@ Gulp.registry(new GulpForwardReference());
     'jsdoc-zips',
     'lint',
     'lint-dts',
+    'lint-markdown-docs',
     'lint-samples',
     'lint-ts',
     'palette',

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "karma-sharding": "^4.4.0",
         "lint-staged": "^13.0.3",
         "lolex": "^6.0.0",
+        "markdownlint": "^0.26.2",
         "marked": "^4.1.0",
         "mkdirp": "^1.0.4",
         "pixelmatch": "^5.3.0",
@@ -14655,6 +14656,61 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/markdownlint": {
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.26.2.tgz",
+      "integrity": "sha512-2Am42YX2Ex5SQhRq35HxYWDfz1NLEOZWWN25nqd2h3AHRKsGRE+Qg1gt1++exW792eXTrR4jCNHfShfWk9Nz8w==",
+      "dev": true,
+      "dependencies": {
+        "markdown-it": "13.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/markdownlint/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/markdownlint/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/markdownlint/node_modules/linkify-it": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/markdownlint/node_modules/markdown-it": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
     },
     "node_modules/marked": {
       "version": "4.1.0",
@@ -33193,6 +33249,51 @@
       "integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ==",
       "dev": true,
       "requires": {}
+    },
+    "markdownlint": {
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.26.2.tgz",
+      "integrity": "sha512-2Am42YX2Ex5SQhRq35HxYWDfz1NLEOZWWN25nqd2h3AHRKsGRE+Qg1gt1++exW792eXTrR4jCNHfShfWk9Nz8w==",
+      "dev": true,
+      "requires": {
+        "markdown-it": "13.0.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+          "dev": true
+        },
+        "linkify-it": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+          "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+          "dev": true,
+          "requires": {
+            "uc.micro": "^1.0.1"
+          }
+        },
+        "markdown-it": {
+          "version": "13.0.1",
+          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+          "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1",
+            "entities": "~3.0.1",
+            "linkify-it": "^4.0.1",
+            "mdurl": "^1.0.1",
+            "uc.micro": "^1.0.5"
+          }
+        }
+      }
     },
     "marked": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "karma-sharding": "^4.4.0",
     "lint-staged": "^13.0.3",
     "lolex": "^6.0.0",
+    "markdownlint": "^0.26.2",
     "marked": "^4.1.0",
     "mkdirp": "^1.0.4",
     "pixelmatch": "^5.3.0",

--- a/tools/gulptasks/lint-markdown-docs.js
+++ b/tools/gulptasks/lint-markdown-docs.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) Highsoft AS
+ */
+
+const gulp = require('gulp');
+const glob = require('glob');
+
+const markdownlint = require('markdownlint');
+
+/* eslint-disable camelcase */
+
+function task() {
+    const logLib = require('./lib/log');
+
+    logLib.message('Linting ...');
+
+    const files = glob.sync('docs/**/*.md');
+
+    const lintPromise = new Promise(resolve => {
+        markdownlint({
+            files,
+            config: {
+                default: false,
+                MD033: {
+                    allowed_elements: ['iframe']
+                }
+            }
+        }, (errors, lints) => resolve({ errors, lints }));
+    });
+
+
+    return lintPromise.then(({ errors, lints }) => {
+        if (errors) {
+            logLib.failure(errors);
+        }
+        if (Object.entries(lints).length > 1) {
+            logLib.warn('Uh-oh! Linting errors:\n', lints);
+            throw new Error('Failed markdown lint');
+        }
+        logLib.success('Finished linting');
+    });
+}
+
+gulp.task('lint-markdown', task);


### PR DESCRIPTION
Added markdown linting using https://github.com/DavidAnson/markdownlint. Run with `npx gulp lint-markdown`.

Only rule enabled is no-inline-html, with an allowance for `iframe`. Currently that gives us

```sh
docs/chart-and-series-types/treegraph-chart.md: 3: MD033/no-inline-html Inline HTML [Element: ul]
docs/chart-and-series-types/treegraph-chart.md: 4: MD033/no-inline-html Inline HTML [Element: li]    
docs/chart-and-series-types/treegraph-chart.md: 5: MD033/no-inline-html Inline HTML [Element: li]    
docs/chart-and-series-types/treegraph-chart.md: 6: MD033/no-inline-html Inline HTML [Element: li]    
docs/maps/create-custom-maps.md: 59: MD033/no-inline-html Inline HTML [Element: map]                 
docs/maps/map-collection.md: 28: MD033/no-inline-html Inline HTML [Element: p]                       
docs/maps/map-collection.md: 28: MD033/no-inline-html Inline HTML [Element: code]           
docs/maps/map-collection.md: 28: MD033/no-inline-html Inline HTML [Element: strong]
```