### PR TITLE
Fixed #17685, tooltip stuck with useHTML and stickOnContact

### DIFF
--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1182,8 +1182,7 @@ class Pointer {
             // `useHTML` options.
             !(
                 tooltip &&
-                tooltip.shouldStickOnContact() &&
-                this.inClass(pEvt.target as any, 'highcharts-tooltip')
+                tooltip.shouldStickOnContact(pEvt)
             )
         ) {
             if (
@@ -1241,6 +1240,7 @@ class Pointer {
      */
     public onDocumentMouseMove(e: MouseEvent): void {
         const chart = this.chart;
+        const tooltip = chart.tooltip;
         const chartPosition = this.chartPosition;
         const pEvt = this.normalize(e, chartPosition);
 
@@ -1253,6 +1253,10 @@ class Pointer {
                 {
                     visiblePlotOnly: true
                 }
+            ) &&
+            !(
+                tooltip &&
+                tooltip.shouldStickOnContact(pEvt)
             ) &&
             !this.inClass(pEvt.target as any, 'highcharts-tracker')
         ) {

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -543,18 +543,6 @@ class Pointer {
         e: PointerEvent
     ): (Point|undefined) {
 
-        const chart = this.chart;
-        const hoverPoint = chart.hoverPoint;
-        const tooltip = chart.tooltip;
-
-        if (
-            hoverPoint &&
-            tooltip &&
-            tooltip.isStickyOnContact()
-        ) {
-            return hoverPoint;
-        }
-
         let closest: (Point|undefined);
 
         /** @private */
@@ -1123,14 +1111,6 @@ class Pointer {
         const chart = charts[pick(Pointer.hoverChartIndex, -1)];
         const tooltip = this.chart.tooltip;
 
-        // #14434: tooltip.options.outside
-        if (tooltip && tooltip.shouldStickOnContact() && this.inClass(
-            e.relatedTarget as any,
-            'highcharts-tooltip-container'
-        )) {
-            return;
-        }
-
         e = this.normalize(e);
 
         // #4886, MS Touch end fires mouseleave but with no related target
@@ -1164,8 +1144,9 @@ class Pointer {
      * @function Highcharts.Pointer#onContainerMouseMove
      */
     public onContainerMouseMove(e: MouseEvent): void {
-        const chart = this.chart;
-        const pEvt = this.normalize(e);
+        const chart = this.chart,
+            tooltip = chart.tooltip,
+            pEvt = this.normalize(e);
 
         this.setHoverChartIndex();
 
@@ -1194,9 +1175,20 @@ class Pointer {
                         visiblePlotOnly: true
                     }
                 )
+            ) &&
+
+            // If the tooltip has stickOnContact enabled, do nothing. This
+            // applies regardless of any combinations of the `split` and
+            // `useHTML` options.
+            !(
+                tooltip &&
+                tooltip.shouldStickOnContact() &&
+                this.inClass(pEvt.target as any, 'highcharts-tooltip')
             )
         ) {
-            if (this.inClass(pEvt.target as any, 'highcharts-no-tooltip')) {
+            if (
+                this.inClass(pEvt.target as any, 'highcharts-no-tooltip')
+            ) {
                 this.reset(false, 0);
             } else {
                 this.runPointActions(pEvt);
@@ -1251,15 +1243,10 @@ class Pointer {
         const chart = this.chart;
         const chartPosition = this.chartPosition;
         const pEvt = this.normalize(e, chartPosition);
-        const tooltip = chart.tooltip;
 
         // If we're outside, hide the tooltip
         if (
             chartPosition &&
-            (
-                !tooltip ||
-                !tooltip.isStickyOnContact()
-            ) &&
             !chart.isInsidePlot(
                 pEvt.chartX - chart.plotLeft,
                 pEvt.chartY - chart.plotTop,

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -926,8 +926,16 @@ class Tooltip {
         );
     }
 
-    public shouldStickOnContact(): boolean {
-        return !!(!this.followPointer && this.options.stickOnContact);
+    public shouldStickOnContact(pointerEvent?: PointerEvent): boolean {
+        return !!(
+            !this.followPointer &&
+            this.options.stickOnContact &&
+            (
+                !pointerEvent || this.chart.pointer.inClass(
+                    pointerEvent.target as any, 'highcharts-tooltip'
+                )
+            )
+        );
     }
 
     /**

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -149,8 +149,6 @@ class Tooltip {
 
     public hideTimer?: number;
 
-    public inContact?: boolean;
-
     public isHidden: boolean = true;
 
     public isSticky: boolean = false;
@@ -453,31 +451,9 @@ class Tooltip {
             pointerEvents = (
                 options.style.pointerEvents ||
                 (
-                    !this.followPointer &&
-                    options.stickOnContact ? 'auto' : 'none'
+                    this.shouldStickOnContact() ? 'auto' : 'none'
                 )
-            ),
-            onMouseEnter = function (): void {
-                tooltip.inContact = true;
-            },
-            onMouseLeave = function (e: MouseEvent): void {
-                const series = tooltip.chart.hoverSeries;
-
-                // #14143, #13310: tooltip.options.useHTML
-                tooltip.inContact = tooltip.shouldStickOnContact() &&
-                    tooltip.chart.pointer.inClass(
-                        e.relatedTarget as any,
-                        'highcharts-tooltip'
-                    );
-
-                if (
-                    !tooltip.inContact &&
-                    series &&
-                    series.onMouseOut
-                ) {
-                    series.onMouseOut();
-                }
-            };
+            );
         let container: globalThis.HTMLElement,
             renderer: SVGRenderer = this.chart.renderer;
 
@@ -517,9 +493,6 @@ class Tooltip {
                         (chartStyle && chartStyle.zIndex || 0) + 3
                     )
                 });
-
-                addEvent(container, 'mouseenter', onMouseEnter);
-                addEvent(container, 'mouseleave', onMouseLeave);
 
                 H.doc.body.appendChild(container);
 
@@ -605,8 +578,6 @@ class Tooltip {
             }
 
             this.label
-                .on('mouseenter', onMouseEnter)
-                .on('mouseleave', onMouseLeave)
                 .attr({ zIndex: 8 })
                 .add();
         }
@@ -957,13 +928,6 @@ class Tooltip {
 
     public shouldStickOnContact(): boolean {
         return !!(!this.followPointer && this.options.stickOnContact);
-    }
-
-    /**
-     * Returns true, if the pointer is in contact with the tooltip tracker.
-     */
-    public isStickyOnContact(): boolean {
-        return !!(this.shouldStickOnContact() && this.inContact);
     }
 
     /**
@@ -1641,10 +1605,7 @@ class Tooltip {
     private drawTracker(): void {
         const tooltip = this;
 
-        if (
-            tooltip.followPointer ||
-            !tooltip.options.stickOnContact
-        ) {
+        if (!this.shouldStickOnContact()) {
             if (tooltip.tracker) {
                 tooltip.tracker.destroy();
             }


### PR DESCRIPTION
Fixed #17685, the tooltip sometimes got stuck when combining the `useHTML` and `stickOnContact` options.
___

@bre1470 What do you make of this refactoring?

It turns the implementation upside down, so instead of listening for `mouseenter` and `mouseleave` setting the `tooltip.inContact` property accordingly, it listens for `mousemove` on the main container and does nothing if the target element is inside a tooltip (SVG or HTML alike). Which should effectively prevent issues caused by `mouseleave` not triggering correctly.

The inspiration is an early refactoring of mouseenter/mouseleave on the chart container itself, where I found these events to be unstable and to fail for example when the window itself lost focus. Instead I set a global mousemove event on the whole page. So this PR's idea is kind of a smaller-scale approach of the same problem. 

Do you see any obvious caveats?