### PR TITLE
Added useHTML for series-label

### DIFF
--- a/ts/Extensions/SeriesLabel/SeriesLabel.ts
+++ b/ts/Extensions/SeriesLabel/SeriesLabel.ts
@@ -485,7 +485,15 @@ function drawSeriesLabels(chart: Chart): void {
                 }
 
                 series.labelBySeries = label = chart.renderer
-                    .label(labelText, 0, 0, 'connector')
+                    .label(
+                        labelText,
+                        0,
+                        0,
+                        'connector',
+                        0,
+                        0,
+                        labelOptions.useHTML
+                    )
                     .addClass(
                         'highcharts-series-label ' +
                         'highcharts-series-label-' + series.index + ' ' +

--- a/ts/Extensions/SeriesLabel/SeriesLabelDefaults.ts
+++ b/ts/Extensions/SeriesLabel/SeriesLabelDefaults.ts
@@ -130,6 +130,11 @@ const SeriesLabelDefaults: SeriesLabelOptions = {
     },
 
     /**
+     * Whether to use HTML to render the series label.
+     */
+    useHTML: false,
+
+    /**
      * An array of boxes to avoid when laying out the labels. Each
      * item has a `left`, `right`, `top` and `bottom` property.
      *

--- a/ts/Extensions/SeriesLabel/SeriesLabelOptions.d.ts
+++ b/ts/Extensions/SeriesLabel/SeriesLabelOptions.d.ts
@@ -36,6 +36,7 @@ export interface SeriesLabelOptions {
     minFontSize?: (number|null);
     onArea?: (boolean|null);
     style?: CSSObject;
+    useHTML?: boolean;
 }
 
 /* *


### PR DESCRIPTION
Added new feature, [series.label.useHTML](https://api.highcharts.com/highcharts/plotOptions.series.label) to support HTML formatting in series labels. See #17282.