### PR TITLE
Fixed drag and drop of packed bubbles.

### DIFF
--- a/ts/Series/PackedBubble/PackedBubbleSeries.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeries.ts
@@ -101,6 +101,7 @@ class PackedBubbleSeries extends BubbleSeries {
         SeriesClass: typeof SeriesType
     ): void {
         BubbleSeries.compose(AxisClass, ChartClass, LegendClass, SeriesClass);
+        DragNodesComposition.compose(ChartClass);
         PackedBubbleLayout.compose(ChartClass);
     }
 


### PR DESCRIPTION
Fixed #17785, a regression causing drag and drop of bubbles between packed bubble groups to fail.