### PR TITLE
Corner radius study

### DIFF
--- a/samples/highcharts/studies/corner-radius/demo.css
+++ b/samples/highcharts/studies/corner-radius/demo.css
@@ -1,0 +1,5 @@
+#container {
+    min-width: 300px;
+    max-width: 800px;
+    margin: 1em auto;
+}

--- a/samples/highcharts/studies/corner-radius/demo.css
+++ b/samples/highcharts/studies/corner-radius/demo.css
@@ -1,5 +1,16 @@
-#container {
+#outer-container {
     min-width: 300px;
     max-width: 800px;
     margin: 1em auto;
+}
+
+#outer-container .button-group {
+    padding-right: 2em;
+}
+
+#outer-container button {
+    padding: 1em;
+    border: 0;
+    border-radius: 2px;
+    font-size: 12px;
 }

--- a/samples/highcharts/studies/corner-radius/demo.details
+++ b/samples/highcharts/studies/corner-radius/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Rounded Corners - Highcharts
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+...

--- a/samples/highcharts/studies/corner-radius/demo.html
+++ b/samples/highcharts/studies/corner-radius/demo.html
@@ -1,0 +1,4 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+
+<div id="container"></div>

--- a/samples/highcharts/studies/corner-radius/demo.html
+++ b/samples/highcharts/studies/corner-radius/demo.html
@@ -1,4 +1,16 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 
+<div id="outer-container">
+    <div id="container"></div>
 
-<div id="container"></div>
+    <span class="button-group">
+        <button class="corner-radius" data-value="50%">50% radius</button>
+        <button class="corner-radius" data-value="10px">10px radius</button>
+        <button class="corner-radius" data-value="0">No radius</button>
+    </span>
+    <span class="button-group">
+        <button class="chart-type" data-value="column">Column</button>
+        <button class="chart-type" data-value="bar">Bar</button>
+    </span>
+
+</div>

--- a/samples/highcharts/studies/corner-radius/demo.js
+++ b/samples/highcharts/studies/corner-radius/demo.js
@@ -1,0 +1,137 @@
+(function (H) {
+    const relativeLength = H.relativeLength;
+
+    H.wrap(H.seriesTypes.column.prototype, 'translate', function (proceed) {
+        proceed.call(this);
+
+        const reversed = this.yAxis.options.reversed;
+
+        this.points.forEach(point => {
+            const { width, height, x, y } = point.shapeArgs;
+
+            // Get the radius
+            const r = Math.min(
+                    relativeLength(this.options.cornerRadius, width),
+                    width / 2
+                ),
+                flip = (point.negative ? -1 : 1) * (reversed ? -1 : 1) === -1,
+                rTop = flip ? 0 : r,
+                rBtm = flip ? r : 0;
+
+            if (r) {
+
+                /*
+
+                The naming of control points:
+
+                  / a -------- b \
+                 /                \
+                h                  c
+                |                  |
+                |                  |
+                |                  |
+                g                  d
+                 \                /
+                  \ f -------- e /
+
+                */
+
+                const a = [x + rTop, y],
+                    b = [x + width - rTop, y],
+                    c = [x + width, y + rTop],
+                    d = [x + width, y + height - rBtm],
+                    e = [x + width - rBtm, y + height],
+                    f = [x + rBtm, y + height],
+                    g = [x, y + height - rBtm],
+                    h = [x, y + rTop];
+
+                // Column is lower than the radius
+                if (height < rTop) {
+                    // Apply Pythagoras
+                    const altitude = rTop - height,
+                        base = Math.sqrt(
+                            Math.pow(rTop, 2) - Math.pow(altitude, 2)
+                        );
+                    c[0] = d[0] = x + width - rTop + base;
+                    e[0] = Math.min(c[0], e[0]);
+                    f[0] = Math.max(d[0], f[0]);
+                    g[0] = h[0] = x + rTop - base;
+                    c[1] = h[1] = y + height;
+                }
+
+                if (height < rBtm) {
+                    const altitude = rBtm - height,
+                        base = Math.sqrt(
+                            Math.pow(rBtm, 2) - Math.pow(altitude, 2)
+                        );
+                    c[0] = d[0] = x + width - rBtm + base;
+                    b[0] = Math.min(c[0], b[0]);
+                    a[0] = Math.max(d[0], a[0]);
+                    g[0] = h[0] = x + rBtm - base;
+                    d[1] = g[1] = y;
+
+                }
+
+                // Preserve the box for data labels
+                point.dlBox = point.shapeArgs;
+
+                point.shapeType = 'path';
+                point.shapeArgs = {
+                    d: [
+                        ['M', ...a],
+                        // top side
+                        ['L', ...b],
+                        // top right corner
+                        ['A', rTop, rTop, 0, 0, 1, ...c],
+                        // right side
+                        ['L', ...d],
+                        // bottom right corner
+                        ['A', rBtm, rBtm, 0, 0, 1, ...e],
+                        // bottom side
+                        ['L', ...f],
+                        // bottom left corner
+                        ['A', rBtm, rBtm, 0, 0, 1, ...g],
+                        // left side
+                        ['L', ...h],
+                        // top left corner
+                        ['A', rTop, rTop, 0, 0, 1, ...a],
+                        ['Z']
+                    ]
+                };
+            }
+
+        });
+    });
+}(Highcharts));
+
+
+Highcharts.chart('container', {
+    xAxis: {
+        categories: ['Apples', 'Pears', 'Bananas', 'Oranges']
+    },
+    accessibility: {
+        enabled: false
+    },
+    title: {
+        text: 'Highcharts with rounded corners'
+    },
+    legend: {
+        enabled: false
+    },
+    plotOptions: {
+        series: {
+            colorByPoint: true,
+            cornerRadius: '50%',
+            borderWidth: 2,
+            borderColor: '#333',
+            dataLabels: {
+                enabled: true
+            }
+        }
+    },
+    series: [{
+        data: [50, -50, 500, -300],
+        type: 'column'
+    }],
+    colors: ["#d7bfff", "#af80ff", "#5920b9", "#48208b"]
+});

--- a/samples/highcharts/studies/corner-radius/demo.js
+++ b/samples/highcharts/studies/corner-radius/demo.js
@@ -1,111 +1,178 @@
+/**
+ * Corner radius for column charts
+ *
+ * @todo
+ * - Stacks, refactor math for reuse of top and bottom logic
+ * - Optionally round only end or also base of the stack
+ * - Columnrange, both ends rounded
+ * - What next? Core inclusion, separate module or update the featured plugin?
+ */
+
 (function (H) {
     const relativeLength = H.relativeLength;
 
     H.wrap(H.seriesTypes.column.prototype, 'translate', function (proceed) {
         proceed.call(this);
 
-        const reversed = this.yAxis.options.reversed;
+        const yAxis = this.yAxis,
+            reversed = yAxis.options.reversed;
 
-        this.points.forEach(point => {
+        for (const point of this.points) {
             const { width, height, x, y } = point.shapeArgs;
+
+            let stackY = y,
+                stackHeight = height;
+            if (point.stackTotal) {
+                const stackEnd = yAxis.translate(
+                        point.stackTotal, false, true, false, true
+                    ),
+                    stackThreshold = yAxis.translate(
+                        this.options.threshold, false, true, false, true
+                    ),
+                    box = this.crispCol(
+                        0,
+                        Math.min(stackEnd, stackThreshold),
+                        0,
+                        Math.abs(stackEnd - stackThreshold)
+                    );
+                stackY = box.y;
+                stackHeight = box.height;
+            }
 
             // Get the radius
             const r = Math.min(
                     relativeLength(this.options.cornerRadius, width),
                     width / 2
-                ),
-                flip = (point.negative ? -1 : 1) * (reversed ? -1 : 1) === -1,
-                rTop = flip ? 0 : r,
+                ) || 0,
+                flip = (point.negative ? -1 : 1) * (reversed ? -1 : 1) === -1;
+            let rTop = flip ? 0 : r,
                 rBtm = flip ? r : 0;
 
-            if (r) {
-
-                /*
-
-                The naming of control points:
-
-                  / a -------- b \
-                 /                \
-                h                  c
-                |                  |
-                |                  |
-                |                  |
-                g                  d
-                 \                /
-                  \ f -------- e /
-
-                */
-
-                const a = [x + rTop, y],
-                    b = [x + width - rTop, y],
-                    c = [x + width, y + rTop],
-                    d = [x + width, y + height - rBtm],
-                    e = [x + width - rBtm, y + height],
-                    f = [x + rBtm, y + height],
-                    g = [x, y + height - rBtm],
-                    h = [x, y + rTop];
-
-                // Column is lower than the radius
-                if (height < rTop) {
-                    // Apply Pythagoras
-                    const altitude = rTop - height,
-                        base = Math.sqrt(
-                            Math.pow(rTop, 2) - Math.pow(altitude, 2)
-                        );
-                    c[0] = d[0] = x + width - rTop + base;
-                    e[0] = Math.min(c[0], e[0]);
-                    f[0] = Math.max(d[0], f[0]);
-                    g[0] = h[0] = x + rTop - base;
-                    c[1] = h[1] = y + height;
-                }
-
-                if (height < rBtm) {
-                    const altitude = rBtm - height,
-                        base = Math.sqrt(
-                            Math.pow(rBtm, 2) - Math.pow(altitude, 2)
-                        );
-                    c[0] = d[0] = x + width - rBtm + base;
-                    b[0] = Math.min(c[0], b[0]);
-                    a[0] = Math.max(d[0], a[0]);
-                    g[0] = h[0] = x + rBtm - base;
-                    d[1] = g[1] = y;
-
-                }
-
-                // Preserve the box for data labels
-                point.dlBox = point.shapeArgs;
-
-                point.shapeType = 'path';
-                point.shapeArgs = {
-                    d: [
-                        ['M', ...a],
-                        // top side
-                        ['L', ...b],
-                        // top right corner
-                        ['A', rTop, rTop, 0, 0, 1, ...c],
-                        // right side
-                        ['L', ...d],
-                        // bottom right corner
-                        ['A', rBtm, rBtm, 0, 0, 1, ...e],
-                        // bottom side
-                        ['L', ...f],
-                        // bottom left corner
-                        ['A', rBtm, rBtm, 0, 0, 1, ...g],
-                        // left side
-                        ['L', ...h],
-                        // top left corner
-                        ['A', rTop, rTop, 0, 0, 1, ...a],
-                        ['Z']
-                    ]
-                };
+            // Deep in stack, cancel rounding
+            if (rTop && rTop < y - stackY) {
+                rTop = 0;
+            }
+            if (rBtm && rBtm < (stackY + stackHeight) - (y + height)) {
+                rBtm = 0;
             }
 
-        });
+
+            /*
+
+            The naming of control points:
+
+              / a -------- b \
+             /                \
+            h                  c
+            |                  |
+            |                  |
+            |                  |
+            g                  d
+             \                /
+              \ f -------- e /
+
+            */
+
+            const a = [x + rTop, y],
+                b = [x + width - rTop, y],
+                c = [x + width, y + rTop],
+                d = [x + width, y + height - rBtm],
+                e = [x + width - rBtm, y + height],
+                f = [x + rBtm, y + height],
+                g = [x, y + height - rBtm],
+                h = [x, y + rTop];
+
+            // Inside stacks, cut off part of the top
+            const cutTop = rTop && y - stackY;
+            if (cutTop) {
+                // Apply Pythagoras
+                const altitude = rTop - cutTop,
+                    base = Math.sqrt(
+                        Math.pow(rTop, 2) - Math.pow(altitude, 2)
+                    );
+                a[0] -= base;
+                b[0] += base;
+                c[1] = h[1] = y + rTop - cutTop;
+            }
+
+            // Column is lower than the radius. Cut off bottom inside the top
+            // radius.
+            if (height < rTop - cutTop) {
+                // Apply Pythagoras
+                const altitude = rTop - cutTop - height,
+                    base = Math.sqrt(
+                        Math.pow(rTop, 2) - Math.pow(altitude, 2)
+                    );
+                c[0] = d[0] = x + width - rTop + base;
+                e[0] = Math.min(c[0], e[0]);
+                f[0] = Math.max(d[0], f[0]);
+                g[0] = h[0] = x + rTop - base;
+                c[1] = h[1] = y + height;
+            }
+
+            // Inside stacks, cut off part of the bottom
+            const cutBtm = rBtm && (stackY + stackHeight) - (y + height);
+            if (cutBtm) {
+                // Apply Pythagoras
+                const altitude = rBtm - cutBtm,
+                    base = Math.sqrt(
+                        Math.pow(rBtm, 2) - Math.pow(altitude, 2)
+                    );
+                e[0] += base;
+                f[0] -= base;
+                d[1] = g[1] = y + height - rBtm + cutBtm;
+            }
+
+            // Cut off top inside the bottom radius
+            if (height < rBtm - cutBtm) {
+                const altitude = rBtm - cutBtm - height,
+                    base = Math.sqrt(
+                        Math.pow(rBtm, 2) - Math.pow(altitude, 2)
+                    );
+                c[0] = d[0] = x + width - rBtm + base;
+                b[0] = Math.min(c[0], b[0]);
+                a[0] = Math.max(d[0], a[0]);
+                g[0] = h[0] = x + rBtm - base;
+                d[1] = g[1] = y;
+
+            }
+
+            // Preserve the box for data labels
+            point.dlBox = point.shapeArgs;
+
+            point.shapeType = 'path';
+            point.shapeArgs = {
+                d: [
+                    ['M', ...a],
+                    // top side
+                    ['L', ...b],
+                    // top right corner
+                    ['A', rTop, rTop, 0, 0, 1, ...c],
+                    // right side
+                    ['L', ...d],
+                    // bottom right corner
+                    ['A', rBtm, rBtm, 0, 0, 1, ...e],
+                    // bottom side
+                    ['L', ...f],
+                    // bottom left corner
+                    ['A', rBtm, rBtm, 0, 0, 1, ...g],
+                    // left side
+                    ['L', ...h],
+                    // top left corner
+                    ['A', rTop, rTop, 0, 0, 1, ...a],
+                    ['Z']
+                ]
+            };
+
+        }
     });
 }(Highcharts));
 
 
-Highcharts.chart('container', {
+const chart = Highcharts.chart('container', {
+    chart: {
+        type: 'column'
+    },
     xAxis: {
         categories: ['Apples', 'Pears', 'Bananas', 'Oranges']
     },
@@ -120,18 +187,50 @@ Highcharts.chart('container', {
     },
     plotOptions: {
         series: {
-            colorByPoint: true,
             cornerRadius: '50%',
             borderWidth: 2,
-            borderColor: '#333',
+            borderColor: '#666',
             dataLabels: {
                 enabled: true
-            }
+            },
+            stacking: 'normal'
         }
     },
     series: [{
-        data: [50, -50, 500, -300],
-        type: 'column'
+        data: [50, -50, 500, -90]
+    }, {
+        data: [50, 250, 260, -50]
+    }, {
+        data: [150, 20, 30, -120]
     }],
     colors: ["#d7bfff", "#af80ff", "#5920b9", "#48208b"]
+});
+
+
+document.querySelectorAll('button.corner-radius').forEach(btn => {
+    btn.addEventListener(
+        'click',
+        () => {
+            chart.update({
+                plotOptions: {
+                    series: {
+                        cornerRadius: btn.dataset.value
+                    }
+                }
+            });
+        }
+    );
+});
+
+document.querySelectorAll('button.chart-type').forEach(btn => {
+    btn.addEventListener(
+        'click',
+        () => {
+            chart.update({
+                chart: {
+                    type: btn.dataset.value
+                }
+            });
+        }
+    );
 });


### PR DESCRIPTION
Studying how rounded corners for columns can be implemented. 

Contrary to the [highcharts-rounded-corners](https://www.npmjs.com/package/highcharts-rounded-corners) plugin, which individually sets rounding for each corner, this study attempts to deal with stacking and and positive/negative columns in a smarter way.

To do
 - [ ] Refactor the cut-off math to reduce repeated patterns.
 - [ ] An option to round the end, the base or both.
 - [ ] Column range. Both ends should be rounded.
 - [ ] What next? Core inclusion, separate module or just update the plugin?

*Preview*
https://highcharts.github.io/highcharts-utils/samples/#gh/ffe4fc9e48/sample/highcharts/studies/corner-radius
