### PR TITLE
Fixed #17801, use of term 'dummy' in code.

### DIFF
--- a/samples/highcharts/demo/spline-irregular-time/demo.js
+++ b/samples/highcharts/demo/spline-irregular-time/demo.js
@@ -12,7 +12,7 @@ Highcharts.chart('container', {
     },
     xAxis: {
         type: 'datetime',
-        dateTimeLabelFormats: { // don't display the dummy year
+        dateTimeLabelFormats: { // don't display the year
             month: '%e. %b',
             year: '%b'
         },
@@ -42,7 +42,7 @@ Highcharts.chart('container', {
 
     colors: ['#6CF', '#39F', '#06C', '#036', '#000'],
 
-    // Define the data points. All series have a dummy year of 1970/71 in order
+    // Define the data points. All series have a year of 1970/71 in order
     // to be compared on the same x axis. Note that in JavaScript, months start
     // at 0 for January, 1 for February etc.
     series: [

--- a/samples/maps/chart/topojson/demo.js
+++ b/samples/maps/chart/topojson/demo.js
@@ -2,7 +2,7 @@ Highcharts.getJSON(
     'https://code.highcharts.com/mapdata/custom/europe.topo.json',
     topology => {
 
-        // Create a dummy data value for each geometry
+        // Create a data value for each geometry
         const data = topology.objects.default.geometries.map((f, i) => i % 5);
 
         // Initialize the chart

--- a/samples/maps/mapview/insetoptions-border/demo.js
+++ b/samples/maps/mapview/insetoptions-border/demo.js
@@ -3,7 +3,7 @@
         'https://code.highcharts.com/mapdata/countries/us/us-all.topo.json'
     ).then(response => response.json());
 
-    // Create a dummy data value for each geometry
+    // Create a data value for each geometry
     const data = topology.objects.default.geometries.map((f, i) => i % 5);
 
     // Initialize the chart

--- a/samples/maps/mapview/insets-complete/demo.js
+++ b/samples/maps/mapview/insets-complete/demo.js
@@ -3,7 +3,7 @@
         'https://code.highcharts.com/mapdata/countries/us/us-all.topo.json'
     ).then(response => response.json());
 
-    // Create a dummy data value for each geometry
+    // Create a data value for each geometry
     const data = topology.objects.default.geometries.map((f, i) => i % 5);
 
     // For the sake of this demo, delete the recommended insets. Note that this

--- a/samples/maps/mapview/insets-extended/demo.js
+++ b/samples/maps/mapview/insets-extended/demo.js
@@ -3,7 +3,7 @@
         'https://code.highcharts.com/mapdata/countries/us/us-all.topo.json'
     ).then(response => response.json());
 
-    // Create a dummy data value for each geometry
+    // Create a data value for each geometry
     const data = topology.objects.default.geometries.map((f, i) => i % 5);
 
     // Initialize the chart

--- a/samples/maps/mapview/projection-custom-d3geo/demo.js
+++ b/samples/maps/mapview/projection-custom-d3geo/demo.js
@@ -27,7 +27,7 @@ if (window.d3) {
         'https://code.highcharts.com/mapdata/custom/world.topo.json'
     ).then(response => response.json());
 
-    // Random dummy data
+    // Add some data for each geometry
     const data = map.objects.default.geometries.map((g, i) => i);
 
     // Initialize the chart

--- a/samples/maps/mapview/projection-custom-proj4js/demo.js
+++ b/samples/maps/mapview/projection-custom-proj4js/demo.js
@@ -32,7 +32,7 @@ Highcharts.Projection.add('UTM', UTMProjectionDefinition);
         'https://code.highcharts.com/mapdata/custom/british-isles.topo.json'
     ).then(response => response.json());
 
-    // Random dummy data
+    // Add some data for each geometry
     const data = map.objects.default.geometries.map((g, i) => i);
 
     // Initialize the chart

--- a/samples/maps/mapview/projection-parallels/demo.js
+++ b/samples/maps/mapview/projection-parallels/demo.js
@@ -3,7 +3,7 @@
         'https://code.highcharts.com/mapdata/custom/europe.topo.json'
     ).then(response => response.json());
 
-    // Create a dummy data value for each geometry
+    // Create a data value for each geometry
     const data = topology.objects.default.geometries.map((f, i) => i % 5);
 
     // For the sake of this demo, delete the embedded recommended map view

--- a/samples/maps/series/data-geometry/demo.js
+++ b/samples/maps/series/data-geometry/demo.js
@@ -2,7 +2,7 @@ Highcharts.getJSON(
     'https://code.highcharts.com/mapdata/custom/europe.topo.json',
     topology => {
 
-        // Create a dummy data value for each feature
+        // Create a data value for each feature
         const data = topology.objects.default.geometries.map((f, i) => i % 5);
 
         // Initialize the chart

--- a/samples/stock/demo/data-grouping/demo.js
+++ b/samples/stock/demo/data-grouping/demo.js
@@ -59,7 +59,7 @@ Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/sam
         },
 
         subtitle: {
-            text: 'Built chart in ...', // dummy text to reserve space for dynamic subtitle
+            text: 'Built chart in ...', // placeholder text to reserve space for dynamic subtitle
             align: 'left'
         },
 

--- a/samples/stock/plotoptions/gapsize-in-highcharts/demo.js
+++ b/samples/stock/plotoptions/gapsize-in-highcharts/demo.js
@@ -13,7 +13,7 @@ Highcharts.chart('container', {
 
     xAxis: {
         type: 'datetime',
-        dateTimeLabelFormats: { // don't display the dummy year
+        dateTimeLabelFormats: { // don't display the year
             month: '%e. %b',
             year: '%b'
         },
@@ -37,7 +37,7 @@ Highcharts.chart('container', {
     series: [{
         name: 'Winter 2007-2008',
         gapSize: 5,
-        // Define the data points. All series have a dummy year
+        // Define the data points. All series have a year
         // of 1970/71 in order to be compared on the same x axis. Note
         // that in JavaScript, months start at 0 for January, 1 for February etc.
         data: [

--- a/ts/Accessibility/Components/SeriesComponent/SeriesDescriber.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesDescriber.ts
@@ -65,7 +65,7 @@ const {
 declare module '../../../Core/Series/PointLike' {
     interface PointLike {
         /** @requires modules/accessibility */
-        hasDummyGraphic?: boolean;
+        hasMockGraphic?: boolean;
     }
 }
 
@@ -104,11 +104,11 @@ function findFirstPointWithGraphic(
 
 
 /**
- * Whether or not we should add a dummy point element in
+ * Whether or not we should add a mock point element in
  * order to describe a point that has no graphic.
  * @private
  */
-function shouldAddDummyPoint(point: Point): boolean {
+function shouldAddMockPoint(point: Point): boolean {
     // Note: Sunburst series use isNull for hidden points on drilldown.
     // Ignore these.
     const series = point.series,
@@ -126,29 +126,29 @@ function shouldAddDummyPoint(point: Point): boolean {
 /**
  * @private
  */
-function makeDummyElement(
+function makeMockElement(
     point: Point,
     pos: PositionObject
 ): SVGElement {
     const renderer = point.series.chart.renderer,
-        dummy = renderer.rect(pos.x, pos.y, 1, 1);
+        mock = renderer.rect(pos.x, pos.y, 1, 1);
 
-    dummy.attr({
-        'class': 'highcharts-a11y-dummy-point',
+    mock.attr({
+        'class': 'highcharts-a11y-mock-point',
         fill: 'none',
         opacity: 0,
         'fill-opacity': 0,
         'stroke-opacity': 0
     });
 
-    return dummy;
+    return mock;
 }
 
 
 /**
  * @private
  */
-function addDummyPointElement(
+function addMockPointElement(
     point: Accessibility.PointComposition
 ): (DOMElementType|undefined) {
     const series = point.series,
@@ -157,28 +157,28 @@ function addDummyPointElement(
         parentGroup = firstGraphic ?
             firstGraphic.parentGroup :
             series.graph || series.group,
-        dummyPos = firstPointWithGraphic ? {
+        mockPos = firstPointWithGraphic ? {
             x: pick(point.plotX, firstPointWithGraphic.plotX, 0),
             y: pick(point.plotY, firstPointWithGraphic.plotY, 0)
         } : {
             x: pick(point.plotX, 0),
             y: pick(point.plotY, 0)
         },
-        dummyElement = makeDummyElement(point, dummyPos);
+        mockElement = makeMockElement(point, mockPos);
 
     if (parentGroup && parentGroup.element) {
-        point.graphic = dummyElement;
-        point.hasDummyGraphic = true;
+        point.graphic = mockElement;
+        point.hasMockGraphic = true;
 
-        dummyElement.add(parentGroup);
+        mockElement.add(parentGroup);
 
         // Move to correct pos in DOM
         parentGroup.element.insertBefore(
-            dummyElement.element,
+            mockElement.element,
             firstGraphic ? firstGraphic.element : null
         );
 
-        return dummyElement.element;
+        return mockElement.element;
     }
 }
 
@@ -566,7 +566,7 @@ function describePointsInSeries(
     if (setScreenReaderProps || setKeyboardProps) {
         series.points.forEach((point): void => {
             const pointEl = point.graphic && point.graphic.element ||
-                    shouldAddDummyPoint(point) && addDummyPointElement(point),
+                    shouldAddMockPoint(point) && addMockPointElement(point),
                 pointA11yDisabled = (
                     point.options &&
                     point.options.accessibility &&

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1035,14 +1035,14 @@ class Point {
             point.applyOptions(options);
 
             // Update visuals, #4146
-            // Handle dummy graphic elements for a11y, #12718
-            const hasDummyGraphic = graphic && point.hasDummyGraphic;
+            // Handle mock graphic elements for a11y, #12718
+            const hasMockGraphic = graphic && point.hasMockGraphic;
             const shouldDestroyGraphic = point.y === null ?
-                !hasDummyGraphic :
-                hasDummyGraphic;
+                !hasMockGraphic :
+                hasMockGraphic;
             if (graphic && shouldDestroyGraphic) {
                 point.graphic = graphic.destroy();
-                delete point.hasDummyGraphic;
+                delete point.hasMockGraphic;
             }
 
             if (isObject(options, true)) {
@@ -1391,8 +1391,8 @@ class Point {
         }
 
         // Apply hover styles to the existing point
-        // Prevent from dummy null points (#14966)
-        if (point.graphic && !point.hasDummyGraphic) {
+        // Prevent from mocked null points (#14966)
+        if (point.graphic && !point.hasMockGraphic) {
 
             if (previousState) {
                 point.graphic.removeClass('highcharts-point-' + previousState);


### PR DESCRIPTION
Renamed use in CSS classes & non-unit test demos, as well as `point.hasDummyGraphic` from a11y module.