### PR TITLE
Docs: Removed unsupported plotOptions.flags.cropThreshold.

### DIFF
--- a/ts/Series/Flags/FlagsSeriesDefaults.ts
+++ b/ts/Series/Flags/FlagsSeriesDefaults.ts
@@ -38,8 +38,8 @@ import { Palette } from '../../Core/Color/Palettes.js';
  *
  * @extends      plotOptions.column
  * @excluding    animation, borderColor, borderRadius, borderWidth,
- *               colorByPoint, dataGrouping, pointPadding, pointWidth,
- *               turboThreshold
+ *               colorByPoint, cropThreshold, dataGrouping, pointPadding,
+ *               pointWidth, turboThreshold
  * @product      highstock
  * @optionparent plotOptions.flags
  */
@@ -269,9 +269,9 @@ const FlagsSeriesDefaults: FlagsSeriesOptions = {
  *
  * @extends   series,plotOptions.flags
  * @excluding animation, borderColor, borderRadius, borderWidth, colorByPoint,
- *            connectNulls, dashStyle, dataGrouping, dataParser, dataURL,
- *            gapSize, gapUnit, linecap, lineWidth, marker, pointPadding,
- *            pointWidth, step, turboThreshold, useOhlcData
+ *            connectNulls, cropThreshold, dashStyle, dataGrouping, dataParser,
+ *            dataURL, gapSize, gapUnit, linecap, lineWidth, marker,
+ *            pointPadding, pointWidth, step, turboThreshold, useOhlcData
  * @product   highstock
  * @apioption series.flags
  */


### PR DESCRIPTION
Fixed #17176 by removing `plotOptions.flags.cropThreshold`.