### PR TITLE
Fixed the demo for crosshair label.

### DIFF
--- a/samples/stock/xaxis/crosshairs-xy/demo.js
+++ b/samples/stock/xaxis/crosshairs-xy/demo.js
@@ -2,7 +2,6 @@ Highcharts.stockChart('container', {
 
     yAxis: {
         crosshair: {
-            enabled: true,
             label: {
                 enabled: true
             }

--- a/samples/stock/xaxis/crosshairs-xy/demo.js
+++ b/samples/stock/xaxis/crosshairs-xy/demo.js
@@ -1,7 +1,12 @@
 Highcharts.stockChart('container', {
 
     yAxis: {
-        crosshair: true
+        crosshair: {
+            enabled: true,
+            label: {
+                enabled: true
+            }
+        }
     },
 
     rangeSelector: {

--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -232,7 +232,7 @@ namespace AxisDefaults {
          * @sample {highcharts} highcharts/xaxis/crosshair-both/
          *         Crosshair on both axes
          * @sample {highstock} stock/xaxis/crosshairs-xy/
-         *         Crosshair on both axes
+         *         Crosshair on both axes, with yAxis label
          * @sample {highmaps} highcharts/xaxis/crosshair-both/
          *         Crosshair on both axes
          *

--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -232,7 +232,7 @@ namespace AxisDefaults {
          * @sample {highcharts} highcharts/xaxis/crosshair-both/
          *         Crosshair on both axes
          * @sample {highstock} stock/xaxis/crosshairs-xy/
-         *         Crosshair on both axes, with yAxis label
+         *         Crosshair on both axes, with y axis label
          * @sample {highmaps} highcharts/xaxis/crosshair-both/
          *         Crosshair on both axes
          *


### PR DESCRIPTION
Original demo didn't have the `yAxis crosshair label` enabled. 

Since the same demo is also used for showing the crosshair functionality, I decided to change the title instead of creating a new one (since the differences between label enabled/disabled are minor).

**Old:** https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/stock/xaxis/crosshairs-xy/
**New:** https://jsfiddle.net/BlackLabel/rj83w0h5/

**API:** https://api.highcharts.com/highstock/yAxis.crosshair
https://api.highcharts.com/highstock/yAxis.crosshair.label.enabled
