### PR TITLE
Fixed toggling legend with spacebar in firefox

### DIFF
--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -482,12 +482,8 @@ class LegendComponent extends AccessibilityComponent {
                 [
                     [keys.enter, keys.space],
                     function (
-                        this: KeyboardNavigationHandler,
-                        keyCode: number
+                        this: KeyboardNavigationHandler
                     ): number {
-                        if (H.isFirefox && keyCode === keys.space) { // #15520
-                            return this.response.success;
-                        }
                         return component.onKbdClick(this);
                     }
                 ],


### PR DESCRIPTION
Fixed #17839, spacebar would not toggle items in the legend.

Bug at https://bugzilla.mozilla.org/show_bug.cgi?id=1552419, which previously caused preventDefault to not work when pressing spacebar, seems fixed, on my end, in Firefox version 105.0.2

Hence firefox-specific code, which was added in [#15585](https://github.com/highcharts/highcharts/pull/15585) has been removed