### PR TITLE
Fixed gantts connection lines not clearing/redrawing properly

### DIFF
--- a/ts/Gantt/Connection.ts
+++ b/ts/Gantt/Connection.ts
@@ -844,7 +844,7 @@ class Connection {
             path: SVGPath,
             options = merge(
                 chart.options.connectors, series.options.connectors,
-                fromPoint.options.connect, connection.options
+                fromPoint.options.connectors, connection.options
             ),
             attribs: SVGAttributes = {};
 

--- a/ts/Gantt/Connection.ts
+++ b/ts/Gantt/Connection.ts
@@ -844,7 +844,7 @@ class Connection {
             path: SVGPath,
             options = merge(
                 chart.options.connectors, series.options.connectors,
-                fromPoint.options.connectors, connection.options
+                fromPoint.options.connect, connection.options
             ),
             attribs: SVGAttributes = {};
 

--- a/ts/Gantt/Pathfinder.ts
+++ b/ts/Gantt/Pathfinder.ts
@@ -748,21 +748,25 @@ class Pathfinder {
             ++j
         ) {
             found = false;
+            const oldCon = oldConnections[j];
+
             for (k = 0; k < lenNew; ++k) {
+                const newCon = pathfinder.connections[k];
+
                 if (
-                    oldConnections[j].fromPoint ===
-                        pathfinder.connections[k].fromPoint &&
-                    oldConnections[j].toPoint ===
-                        pathfinder.connections[k].toPoint
+                    typeof oldCon.options !== 'undefined' &&
+                    typeof newCon.options !== 'undefined' &&
+                    newCon.options.type === oldCon.options.type &&
+                    oldCon.fromPoint === newCon.fromPoint &&
+                    oldCon.toPoint === newCon.toPoint
                 ) {
-                    pathfinder.connections[k].graphics =
-                        oldConnections[j].graphics;
+                    newCon.graphics = oldCon.graphics;
                     found = true;
                     break;
                 }
             }
             if (!found) {
-                oldConnections[j].destroy();
+                oldCon.destroy();
             }
         }
 

--- a/ts/Gantt/Pathfinder.ts
+++ b/ts/Gantt/Pathfinder.ts
@@ -754,8 +754,7 @@ class Pathfinder {
                 const newCon = pathfinder.connections[k];
 
                 if (
-                    typeof oldCon.options !== 'undefined' &&
-                    typeof newCon.options !== 'undefined' &&
+                    oldCon.options && newCon.options &&
                     newCon.options.type === oldCon.options.type &&
                     oldCon.fromPoint === newCon.fromPoint &&
                     oldCon.toPoint === newCon.toPoint

--- a/ts/Gantt/Pathfinder.ts
+++ b/ts/Gantt/Pathfinder.ts
@@ -749,6 +749,9 @@ class Pathfinder {
         ) {
             found = false;
             for (k = 0; k < lenNew; ++k) {
+                /* if(
+                    oldConnections[j].options ? .type ===
+                        pathfinder.connections[k].options ? .type */
                 if (
                     oldConnections[j].fromPoint ===
                         pathfinder.connections[k].fromPoint &&

--- a/ts/Gantt/Pathfinder.ts
+++ b/ts/Gantt/Pathfinder.ts
@@ -754,8 +754,8 @@ class Pathfinder {
                 const newCon = pathfinder.connections[k];
 
                 if (
-                    oldCon.options && newCon.options &&
-                    newCon.options.type === oldCon.options.type &&
+                    (oldCon.options && oldCon.options.type) ===
+                    (newCon.options && newCon.options.type) &&
                     oldCon.fromPoint === newCon.fromPoint &&
                     oldCon.toPoint === newCon.toPoint
                 ) {
@@ -768,7 +768,7 @@ class Pathfinder {
                 oldCon.destroy();
             }
         }
-
+        
         // Clear obstacles to force recalculation. This must be done on every
         // redraw in case positions have changed. Recalculation is handled in
         // Connection.getPath on demand.

--- a/ts/Gantt/Pathfinder.ts
+++ b/ts/Gantt/Pathfinder.ts
@@ -768,7 +768,7 @@ class Pathfinder {
                 oldCon.destroy();
             }
         }
-        
+
         // Clear obstacles to force recalculation. This must be done on every
         // redraw in case positions have changed. Recalculation is handled in
         // Connection.getPath on demand.

--- a/ts/Gantt/Pathfinder.ts
+++ b/ts/Gantt/Pathfinder.ts
@@ -749,9 +749,6 @@ class Pathfinder {
         ) {
             found = false;
             for (k = 0; k < lenNew; ++k) {
-                /* if(
-                    oldConnections[j].options ? .type ===
-                        pathfinder.connections[k].options ? .type */
                 if (
                     oldConnections[j].fromPoint ===
                         pathfinder.connections[k].fromPoint &&


### PR DESCRIPTION
Fixed #17833, all connectors weren't redrawn/deleted when updating them

The reason for this issue is the code in `Pathfinder.ts`, from line [744 to 770](https://github.com/highcharts/highcharts/blob/master/ts/Gantt/Pathfinder.ts#L744), during the update-function where it stores what connections are still present, and destroys old ones.

Specifically this conditional at line [752](https://github.com/highcharts/highcharts/blob/master/ts/Gantt/Pathfinder.ts#L752) is the culprit:
```
if (
    oldConnections[j].fromPoint ===
        pathfinder.connections[k].fromPoint &&
    oldConnections[j].toPoint ===
        pathfinder.connections[k].toPoint
)
```

It makes no distinction between lines to and from the same datapoint since they by necessity have the same `toPoint` and `fromPoint` values. This causes the code to store more than one reference to the same connection, and not storing others, on `redraw`.


Question:
- Should I implement a unique id for each connection, maybe in `Connection.ts` we can then use to distinguish between connecting lines? 
- Another option is to also check for the types of the connections, which will make the [demo](https://jsfiddle.net/dmt3fypL/9/) in the issue function, but will cause the same issue if you have multiple connections with same type, source, and destination.

TODO:
- [x] Create a fix for connecting lines which are not being cleared/redrawn properly