### PR TITLE
bugfix/17856-heatmap-default-linecolor

### DIFF
--- a/ts/Series/Heatmap/HeatmapSeries.ts
+++ b/ts/Series/Heatmap/HeatmapSeries.ts
@@ -634,7 +634,9 @@ class HeatmapSeries extends ScatterSeries {
                 stateOptions.color ||
                 Color.parse(attr.fill).brighten(brightness || 0).get();
 
-            attr.stroke = stateOptions.lineColor;
+            if (stateOptions.lineColor) {
+                attr.stroke = stateOptions.lineColor;
+            }
         }
 
         return attr;


### PR DESCRIPTION
Fixed #17856.

Previously, when the `lineColor` for a given heatmap marker state was left undefined, the stroke got reset entirely rather than retaining the default value. For example, if `lineColor` was not specified in the heatmap's hover state (when other fields for that state were defined), then the cell borders would disappear upon hovering on a given data point.

This patch adds a null check on the state option object's `lineColor` field, and only assigns it to the point's stroke attribute if it is defined. Consequently, when undefined, the stroke retains its default (normal state) value, in accordance with the documented behavior.