### PR TITLE
Samples: Sync axes and tooltips

### DIFF
--- a/samples/highcharts/blog/synchronize-axes-multiple-charts/demo.css
+++ b/samples/highcharts/blog/synchronize-axes-multiple-charts/demo.css
@@ -3,6 +3,20 @@
     flex: 1;
 }
 
+#reset-zoom {
+    float: right;
+    padding: 1em;
+    visibility: hidden;
+}
+
+#reset-zoom.visible {
+    visibility: visible;
+}
+
+.dashboard {
+    clear: both;
+}
+
 .flex-container {
     display: flex;
     justify-content: center;

--- a/samples/highcharts/blog/synchronize-axes-multiple-charts/demo.details
+++ b/samples/highcharts/blog/synchronize-axes-multiple-charts/demo.details
@@ -1,6 +1,6 @@
 ---
- name: Synchronize the axes on multiple charts
+ name: Synchronize the axes and tooltips on multiple charts
  authors:
-   - Karol Kolodziej
+   - Karol Kolodziej, Torstein Hønsi
  js_wrap: b
 ...

--- a/samples/highcharts/blog/synchronize-axes-multiple-charts/demo.html
+++ b/samples/highcharts/blog/synchronize-axes-multiple-charts/demo.html
@@ -3,9 +3,13 @@
 <script src="https://code.highcharts.com/modules/exporting.js"></script>
 <script src="https://code.highcharts.com/modules/accessibility.js"></script>
 
-<div class="chart" id="container1"></div>
-<div class="flex-container">
-  <div class="chart" id="container2"></div>
-  <div class="chart" id="container3"></div>
+<button id="reset-zoom">Reset zoom</button>
+
+<div class="dashboard">
+  <div class="chart" id="container1"></div>
+  <div class="flex-container">
+    <div class="chart" id="container2"></div>
+    <div class="chart" id="container3"></div>
+  </div>
+  <div class="chart" id="container4"></div>
 </div>
-<div class="chart" id="container4"></div>


### PR DESCRIPTION
A continuation of the topic of the blog post [How to synchronize the axes of multiple charts](https://www.highcharts.com/blog/tutorials/how-to-synchronize-the-axes-on-multiple-charts/).

The following adjustments are made:
* No master chart. Zooming on either chart is reflected on all others. Initial extremes are set as the union of all charts' extremes instead of the master.
* One common Reset Zoom button.
* Tooltips are synchronized.
* The `tickPositions` are not hard set, instead allowed to be calculated based on the chart size and the synchronized min and max.

[See the preview here](https://highcharts.github.io/highcharts-utils/samples/#gh/1084683bb0/sample/highcharts/blog/synchronize-axes-multiple-charts).