### PR TITLE
Fixed #17538, export failed in Firefox using styled mode and CSS vars

### DIFF
--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -269,8 +269,8 @@ namespace Exporting {
         /perspective/,
         /TapHighlightColor/,
         /^transition/,
-        /^length$/ // #7700
-        // /^text (border|color|cursor|height|webkitBorder)/
+        /^length$/, // #7700
+        /^[0-9]+$/ // #17538
     ];
 
     // These ones are translated to attributes rather than styles


### PR DESCRIPTION
Fixed #17538, export failed in Firefox using styled mode and CSS variables

