### PR TITLE
Fixed doc for stocks yAxis labelAlign

### DIFF
--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -2536,6 +2536,7 @@ namespace AxisDefaults {
              *         Solid gauge labels auto aligned
              *
              * @type       {Highcharts.AlignValue}
+             * @default    {highstock} right
              * @apioption  yAxis.labels.align
              */
 


### PR DESCRIPTION
Fixed #17873 , default value for `yAxis.label.align` was listed as `left` in the docs.