### PR TITLE
Fixed #17557, wrong font styling in export in Firefox

### DIFF
--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -263,7 +263,6 @@ namespace Exporting {
     // These CSS properties are not inlined. Remember camelCase.
     const inlineDenylist: Array<RegExp> = [
         /-/, // In Firefox, both hyphened and camelCased names are listed
-        /^all$/, // #17557, Firefox
         /^(clipPath|cssText|d|height|width)$/, // Full words
         /^font$/, // more specific props are set
         /[lL]ogical(Width|Height)$/,
@@ -1489,10 +1488,21 @@ namespace Exporting {
                         node.nodeName
                     );
                     dummySVG.appendChild(dummy);
-                    // Copy, so we can remove the node
-                    defaultStyles[node.nodeName] = merge(
-                        win.getComputedStyle(dummy, null) as any
-                    );
+
+                    // Get the defaults into a standard object (simple merge
+                    // won't do)
+                    const s = win.getComputedStyle(dummy, null),
+                        defaults: Record<string, string> = {};
+                    for (const key in s) {
+                        if (
+                            typeof s[key] === 'string' &&
+                            !/^[0-9]+$/.test(key)
+                        ) {
+                            defaults[key] = s[key];
+                        }
+                    }
+                    defaultStyles[node.nodeName] = defaults;
+
                     // Remove default fill, otherwise text disappears when
                     // exported
                     if (node.nodeName === 'text') {
@@ -1516,15 +1526,6 @@ namespace Exporting {
                 }
 
                 // Apply styles
-                /*
-                if (cssText) {
-                    styleAttr = node.getAttribute('style');
-                    node.setAttribute(
-                        'style',
-                        (styleAttr ? styleAttr + ';' : '') + cssText
-                    );
-                }
-                */
                 css(node, filteredStyles);
 
                 // Set default stroke width (needed at least for IE)


### PR DESCRIPTION
Fixed #17557, a regression since v10.1.0 causing wrong font styling in exported charts with `styledMode` in Firefox.