### PR TITLE
Added class reflection to internal wrap.

### DIFF
--- a/samples/unit-tests/utilities/utilities/demo.js
+++ b/samples/unit-tests/utilities/utilities/demo.js
@@ -834,21 +834,19 @@
 
         assert.strictEqual(person.name, 'Torstein Extended', 'Wrapped');
 
-        // Wrap using this.proceed() with no arguments
         Person.prototype.setAge = function (age) {
             this.age = age;
         };
         person.setAge(42);
         assert.strictEqual(person.age, 42, 'Initial age');
 
-        Highcharts.wrap(Person.prototype, 'setAge', function () {
-            this.proceed();
+        Highcharts.wrap(Person.prototype, 'setAge', function (proceed) {
+            proceed();
             this.age += 1;
         });
         person.setAge(43);
         assert.strictEqual(person.age, 44, 'Wrapped age');
 
-        // Wrap with this.proceed() with modified arguments
         Person.prototype.setHeight = function (height) {
             this.height = height;
         };
@@ -859,7 +857,7 @@
             Person.prototype,
             'setHeight',
             function (proceed, height) {
-                this.proceed(height + 1);
+                proceed(height + 1);
             }
         );
         person.setHeight(189);

--- a/ts/Core/Axis/Axis3DComposition.ts
+++ b/ts/Core/Axis/Axis3DComposition.ts
@@ -22,6 +22,7 @@ import type Axis from './Axis';
 import type { OptionsPosition3dValue } from '../Options';
 import type Point from '../Series/Point';
 import type Position3DObject from '../Renderer/Position3DObject';
+import type RadialAxis from './RadialAxis';
 import type SVGPath from '../Renderer/SVG/SVGPath';
 import type Tick from './Tick.js';
 
@@ -85,7 +86,7 @@ declare module '../Series/PointLike' {
  * Axis instance with 3D support.
  * @private
  */
-export declare class Axis3DComposition extends Axis {
+export declare class Axis3DComposition extends RadialAxis.AxisComposition {
     axis3D: Axis3DAdditions;
 }
 

--- a/ts/Core/Chart/Chart3D.ts
+++ b/ts/Core/Chart/Chart3D.ts
@@ -983,8 +983,8 @@ namespace Chart3D {
         addEvent(ChartClass, 'beforeRender', onBeforeRender);
 
         wrap(chartProto, 'isInsidePlot', wrapIsInsidePlot);
-        wrap(ChartClass, 'renderSeries', wrapRenderSeries);
-        wrap(ChartClass, 'setClassName', wrapSetClassName);
+        wrap(chartProto, 'renderSeries', wrapRenderSeries);
+        wrap(chartProto, 'setClassName', wrapSetClassName);
     }
 
     /**

--- a/ts/Core/Globals.ts
+++ b/ts/Core/Globals.ts
@@ -29,14 +29,16 @@ declare global {
     type AnyRecord = Record<string, any>;
 
     type DeepPartial<T> = {
-        [P in keyof T]?: (T[P]|DeepPartial<T[P]>);
-    };
-
-    type DeepRecord<K extends keyof any, T> = {
-        [P in K]: (T|DeepRecord<K, T>);
+        [K in keyof T]?: (T[K]|DeepPartial<T[K]>);
     };
 
     type ExtractArrayType<T> = T extends (infer U)[] ? U : never;
+
+    type FunctionNamesOf<T> = keyof FunctionsOf<T>;
+
+    type FunctionsOf<T> = {
+        [K in keyof T as T[K] extends Function ? K : never]: T[K];
+    };
 
     interface CallableFunction {
         apply<TScope, TArguments extends Array<unknown>, TReturn>(

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -864,26 +864,27 @@ function relativeLength(
  *        arguments as the original function, except that the original function
  *        is unshifted and passed as the first argument.
  */
-function wrap(
-    obj: any,
-    method: string,
-    func: Utilities.WrapProceedFunction
+function wrap<T, K extends FunctionNamesOf<T>>(
+    obj: T,
+    method: K,
+    func: Utilities.WrapProceedFunction<T[K]&Function>
 ): void {
-    const proceed = obj[method];
+    const proceed = obj[method] as T[K]&Function;
 
-    obj[method] = function (): any {
-        const args = Array.prototype.slice.call(arguments),
-            outerArgs = arguments,
-            ctx = this;
+    obj[method] = function (this: T): unknown {
+        const originalArguments = arguments,
+            scope = this;
 
-        ctx.proceed = function (): void {
-            proceed.apply(ctx, arguments.length ? arguments : outerArgs);
-        };
-        args.unshift(proceed);
-        const ret = func.apply(this, args);
-        ctx.proceed = null;
-        return ret;
-    };
+        return func.apply(this, [
+            function (): unknown {
+                return proceed.apply(
+                    scope,
+                    arguments.length ? arguments : originalArguments
+                );
+            } as T[K]&Function,
+            ...[].slice.call(arguments)
+        ]);
+    } as T[K];
 }
 
 /**
@@ -2060,8 +2061,8 @@ namespace Utilities {
         top: number;
         width: number;
     }
-    export interface WrapProceedFunction {
-        (...args: Array<any>): any;
+    export interface WrapProceedFunction<T extends Function> {
+        (proceed: T, ...args: Array<any>): any;
     }
 }
 

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -304,12 +304,11 @@ function compose<T extends typeof Series>(
         ) {
             composedClasses.push(BubbleSeries);
 
-            const bubbleProto = BubbleSeries.prototype as
-                Partial<typeof BubbleSeries.prototype>;
+            const bubbleProto = BubbleSeries.prototype;
 
             // By default, the bubble series does not use the KD-tree, so force
             // it to.
-            delete bubbleProto.buildKDTree;
+            delete (bubbleProto as Partial<Series>).buildKDTree;
             // seriesTypes.bubble.prototype.directTouch = false;
 
             // Needed for markers to work correctly

--- a/ts/Extensions/BoostCanvas.ts
+++ b/ts/Extensions/BoostCanvas.ts
@@ -261,9 +261,9 @@ const initCanvasBoost = function (): void {
                     boost.canvas.getContext('2d') as CanvasRenderingContext2D;
 
                 if (chart.inverted) {
-                    ['moveTo', 'lineTo', 'rect', 'arc'].forEach(function (
-                        fn: string
-                    ): void {
+                    (['moveTo', 'lineTo', 'rect', 'arc'] as const).forEach((
+                        fn
+                    ): void => {
                         wrap(ctx, fn, swapXY);
                     });
                 }

--- a/ts/Series/Flags/FlagsSeries.ts
+++ b/ts/Series/Flags/FlagsSeries.ts
@@ -320,7 +320,7 @@ class FlagsSeries extends ColumnSeries {
         }
 
         // Can be a mix of SVG and HTML and we need events for both (#6303)
-        if (options.useHTML) {
+        if (options.useHTML && series.markerGroup) {
             wrap(series.markerGroup, 'on', function (
                 this: FlagsSeries,
                 proceed


### PR DESCRIPTION
- Added class reflection to internal wrap.
- Removed `ctx.proceed` in wrap callback because of conflict with class functions.