### PR TITLE
Fixed #17907, stuck data label on ortho map

### DIFF
--- a/samples/unit-tests/maps/map-navigation/demo.js
+++ b/samples/unit-tests/maps/map-navigation/demo.js
@@ -310,6 +310,13 @@ QUnit.test('Orthographic map rotation and panning.', assert => {
                     type: 'Point',
                     coordinates: [0, 80]
                 }
+            }, {
+                name: 'B',
+                id: 'B',
+                geometry: {
+                    type: 'Point',
+                    coordinates: [90, 0]
+                }
             }],
             color: '#313f77'
         }]
@@ -371,6 +378,27 @@ QUnit.test('Orthographic map rotation and panning.', assert => {
         chart.mapView.projection.options.rotation,
         oldRotation,
         'Rotation should be activated (#16722).'
+    );
+
+    assert.strictEqual(
+        chart.get('B').dataLabel.attr('visibility'),
+        'hidden',
+        'Data labels behind the horizon on an Ortho map should be hidden (#17907)'
+    );
+    assert.notStrictEqual(
+        chart.get('A').dataLabel.attr('visibility'),
+        'hidden',
+        'Data labels on the near side should not be hidden'
+    );
+    assert.strictEqual(
+        chart.get('B').graphic.attr('visibility'),
+        'hidden',
+        'Point graphics behind the horizon on an Ortho map should be hidden'
+    );
+    assert.notStrictEqual(
+        chart.get('A').graphic.attr('visibility'),
+        'hidden',
+        'Point graphics on the near side should not be hidden'
     );
 
 });

--- a/ts/Core/Renderer/BBoxObject.d.ts
+++ b/ts/Core/Renderer/BBoxObject.d.ts
@@ -32,16 +32,6 @@ export interface BBoxObject extends PositionObject, SizeObject {
 
 /* *
  *
- *  Declatations
- *
- * */
-
-export interface BBoxObjectWithCenter extends BBoxObject {
-    centerX?: number;
-}
-
-/* *
- *
  *  Default Export
  *
  * */

--- a/ts/Core/Renderer/BBoxObject.d.ts
+++ b/ts/Core/Renderer/BBoxObject.d.ts
@@ -24,11 +24,20 @@ import type SizeObject from './SizeObject';
  * */
 
 export interface BBoxObject extends PositionObject, SizeObject {
-    // @todo: create custom type with centerX type.
     height: number;
     width: number;
     x: number;
     y: number;
+}
+
+/* *
+ *
+ *  Declatations
+ *
+ * */
+
+export interface BBoxObjectWithCenter extends BBoxObject {
+    centerX?: number;
 }
 
 /* *

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -17,7 +17,7 @@
  * */
 
 import type AlignObject from '../Renderer/AlignObject';
-import type BBoxObject from '../Renderer/BBoxObject';
+import type { BBoxObject, BBoxObjectWithCenter } from '../Renderer/BBoxObject';
 import type ColorString from '../Color/ColorString';
 import type ColumnPoint from '../../Series/Column/ColumnPoint';
 import type DataLabelOptions from './DataLabelOptions';
@@ -63,7 +63,7 @@ declare module './PointLike' {
         dataLabelPath?: SVGElement;
         dataLabels?: Array<SVGElement>;
         distributeBox?: R.BoxObject;
-        dlBox?: BBoxObject;
+        dlBox?: BBoxObjectWithCenter;
         dlOptions?: DataLabelOptions;
         /** @deprecated */
         positionIndex?: unknown;
@@ -195,7 +195,7 @@ namespace DataLabel {
             inverted = this.isCartesian && chart.inverted,
             enabledDataSorting = this.enabledDataSorting,
             plotX = pick(
-                point.dlBox && (point.dlBox as any).centerX,
+                point.dlBox && point.dlBox.centerX,
                 point.plotX
             ),
             plotY = point.plotY,
@@ -236,6 +236,7 @@ namespace DataLabel {
             visible =
                 this.visible &&
                 point.visible !== false &&
+                defined(plotX) &&
                 (
                     point.series.forceDL ||
                     (enabledDataSorting && !justify) ||
@@ -386,12 +387,8 @@ namespace DataLabel {
             // arrow pointing to thie point
             if (options.shape && !rotation) {
                 dataLabel[isNew ? 'attr' : 'animate']({
-                    anchorX: inverted ?
-                        chart.plotWidth - (point.plotY as any) :
-                        point.plotX,
-                    anchorY: inverted ?
-                        chart.plotHeight - (point.plotX as any) :
-                        point.plotY
+                    anchorX: inverted ? chart.plotWidth - plotY : plotX,
+                    anchorY: inverted ? chart.plotHeight - plotX : plotY
                 });
             }
         }

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -17,7 +17,7 @@
  * */
 
 import type AlignObject from '../Renderer/AlignObject';
-import type { BBoxObject, BBoxObjectWithCenter } from '../Renderer/BBoxObject';
+import type { BBoxObject } from '../Renderer/BBoxObject';
 import type ColorString from '../Color/ColorString';
 import type ColumnPoint from '../../Series/Column/ColumnPoint';
 import type DataLabelOptions from './DataLabelOptions';
@@ -63,7 +63,7 @@ declare module './PointLike' {
         dataLabelPath?: SVGElement;
         dataLabels?: Array<SVGElement>;
         distributeBox?: R.BoxObject;
-        dlBox?: BBoxObjectWithCenter;
+        dlBox?: BBoxObject;
         dlOptions?: DataLabelOptions;
         /** @deprecated */
         positionIndex?: unknown;
@@ -194,10 +194,7 @@ namespace DataLabel {
             chart = this.chart,
             inverted = this.isCartesian && chart.inverted,
             enabledDataSorting = this.enabledDataSorting,
-            plotX = pick(
-                point.dlBox && point.dlBox.centerX,
-                point.plotX
-            ),
+            plotX = point.plotX,
             plotY = point.plotY,
             rotation = options.rotation,
             align = options.align,

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -17,7 +17,7 @@
  * */
 
 import type AlignObject from '../Renderer/AlignObject';
-import type { BBoxObject } from '../Renderer/BBoxObject';
+import type BBoxObject from '../Renderer/BBoxObject';
 import type ColorString from '../Color/ColorString';
 import type ColumnPoint from '../../Series/Column/ColumnPoint';
 import type DataLabelOptions from './DataLabelOptions';

--- a/ts/Series/XRange/XRangePoint.ts
+++ b/ts/Series/XRange/XRangePoint.ts
@@ -21,6 +21,7 @@
 import type Point from '../../Core/Series/Point';
 import type RectangleObject from '../../Core/Renderer/RectangleObject';
 import type Series from '../../Core/Series/Series';
+import type BBoxObject from '../../Core/Renderer/BBoxObject';
 import type {
     XRangePointOptions,
     XRangePointPartialFillOptions
@@ -46,6 +47,9 @@ const {
 import U from '../../Core/Utilities.js';
 const { extend } = U;
 import XRangeSeries from './XRangeSeries.js';
+export interface BBoxObjectWithCenter extends BBoxObject {
+    centerX?: number;
+}
 
 /* *
  *
@@ -113,6 +117,7 @@ class XRangePoint extends ColumnPoint {
 
     public options: XRangePointOptions = void 0 as any;
     public series: XRangeSeries = void 0 as any;
+    public dlBox?: BBoxObjectWithCenter;
 
     /* *
      *

--- a/ts/Series/XRange/XRangePoint.ts
+++ b/ts/Series/XRange/XRangePoint.ts
@@ -47,15 +47,16 @@ const {
 import U from '../../Core/Utilities.js';
 const { extend } = U;
 import XRangeSeries from './XRangeSeries.js';
-export interface BBoxObjectWithCenter extends BBoxObject {
-    centerX?: number;
-}
 
 /* *
  *
  *  Declarations
  *
  * */
+
+interface BBoxObjectWithCenter extends BBoxObject {
+    centerX?: number;
+}
 
 declare module '../../Core/Series/PointLike' {
     interface PointLike {

--- a/ts/Series/XRange/XRangeSeries.ts
+++ b/ts/Series/XRange/XRangeSeries.ts
@@ -270,14 +270,8 @@ class XRangeSeries extends ColumnSeries {
         return pointIndex;
     }
 
-    public alignDataLabel(
-        point: XRangePoint,
-        dataLabel: SVGElement,
-        options: DataLabelOptions,
-        alignTo: BBoxObject,
-        isNew?: boolean | undefined
-    ): void {
-        let oldPlotX = point.plotX;
+    public alignDataLabel(point: XRangePoint): void {
+        const oldPlotX = point.plotX;
         point.plotX = pick(point.dlBox && point.dlBox.centerX, point.plotX);
         super.alignDataLabel.apply(this, arguments);
         point.plotX = oldPlotX;

--- a/ts/Series/XRange/XRangeSeries.ts
+++ b/ts/Series/XRange/XRangeSeries.ts
@@ -21,6 +21,9 @@
 import type Axis from '../../Core/Axis/Axis';
 import type ColumnMetricsObject from '../Column/ColumnMetricsObject';
 import type SeriesClass from '../../Core/Series/Series';
+import type BBoxObject from '../../Core/Renderer/BBoxObject';
+import type SVGElement from '../../Core/Renderer/SVG/SVGElement';
+import type DataLabelOptions from '../../Core/Series/DataLabelOptions';
 import type { SeriesStateHoverOptions } from '../../Core/Series/SeriesOptions';
 import type {
     XRangePointOptions,
@@ -265,6 +268,19 @@ class XRangeSeries extends ColumnSeries {
         }
 
         return pointIndex;
+    }
+
+    public alignDataLabel(
+        point: XRangePoint,
+        dataLabel: SVGElement,
+        options: DataLabelOptions,
+        alignTo: BBoxObject,
+        isNew?: boolean | undefined
+    ): void {
+        let oldPlotX = point.plotX;
+        point.plotX = pick(point.dlBox && point.dlBox.centerX, point.plotX);
+        super.alignDataLabel.apply(this, arguments);
+        point.plotX = oldPlotX;
     }
 
     /**


### PR DESCRIPTION
Fixed #17907, a regression causing data labels on the far side on an orthographic world projection to stick.