### PR TITLE
Refactor: Removed stroke/stroke-width workaround for older browser bug

### DIFF
--- a/samples/highcharts/series-arcdiagram/centered-links/demo.js
+++ b/samples/highcharts/series-arcdiagram/centered-links/demo.js
@@ -10,7 +10,6 @@ Highcharts.chart('container', {
         centeredLinks: true,
         keys: ['from', 'to', 'weight'],
         type: 'arcdiagram',
-        borderWidth: 2,
         data: [
             ['Brazil', 'Portugal', 5],
             ['Brazil', 'France', 1],

--- a/samples/highcharts/series-arcdiagram/centered-links/demo.js
+++ b/samples/highcharts/series-arcdiagram/centered-links/demo.js
@@ -10,6 +10,7 @@ Highcharts.chart('container', {
         centeredLinks: true,
         keys: ['from', 'to', 'weight'],
         type: 'arcdiagram',
+        borderWidth: 2,
         data: [
             ['Brazil', 'Portugal', 5],
             ['Brazil', 'France', 1],

--- a/samples/unit-tests/annotations/annotations-dynamic/demo.js
+++ b/samples/unit-tests/annotations/annotations-dynamic/demo.js
@@ -202,17 +202,17 @@ QUnit.test("Annotation's dynamic methods", function (assert) {
     });
 
     assert.strictEqual(
-        fib.shapes[0].graphic.stroke,
+        fib.shapes[0].graphic.attr('stroke'),
         'blue',
         '#15424: First line should be blue (lineColors[0])'
     );
     assert.strictEqual(
-        fib.shapes[3].graphic.stroke,
+        fib.shapes[3].graphic.attr('stroke'),
         'red',
         '#15424: Third line should be red (lineColors[2])'
     );
     assert.strictEqual(
-        fib.shapes[5].graphic.stroke,
+        fib.shapes[5].graphic.attr('stroke'),
         'blue',
         '#15424: Fourth line should be blue (lineColor)'
     );

--- a/samples/unit-tests/annotations/annotations-labels-options/demo.js
+++ b/samples/unit-tests/annotations/annotations-labels-options/demo.js
@@ -28,7 +28,7 @@ QUnit.test('Setting graphic attributes for a label', function (assert) {
         actual = {
             text: label.text.textStr,
             backgroundColor: label.box.attr('fill'),
-            borderColor: label.box.stroke,
+            borderColor: label.box.attr('stroke'),
             borderRadius: label.box.r,
             borderWidth: label.box['stroke-width'],
             padding: label.padding,

--- a/samples/unit-tests/axis/stacklabels/demo.js
+++ b/samples/unit-tests/axis/stacklabels/demo.js
@@ -503,7 +503,7 @@ QUnit.test('Stack labels styles options #13330', function (assert) {
     );
 
     assert.strictEqual(
-        stackLabel.label.stroke,
+        stackLabel.label.attr('stroke'),
         stackLabel.options.borderColor,
         'This stack-label stroke atribute should be same as ' +
             'set in options #13330'

--- a/samples/unit-tests/chart/chart-update-chart-1/demo.js
+++ b/samples/unit-tests/chart/chart-update-chart-1/demo.js
@@ -181,11 +181,7 @@ QUnit.test('Option chart border and background update', function (assert) {
         '#ffffff',
         'Chart background is updated'
     );
-    assert.strictEqual(
-        chart.chartBackground.element.getAttribute('stroke'),
-        null,
-        'Chart border is removed'
-    );
+
     assert.strictEqual(
         chart.chartBackground.element.getAttribute('rx'),
         '0',

--- a/samples/unit-tests/indicator-macd/recalculations/demo.js
+++ b/samples/unit-tests/indicator-macd/recalculations/demo.js
@@ -507,13 +507,13 @@ QUnit.test('After changing the MACD params all points should calculate properly,
         from the colour array.`
     );
     assert.strictEqual(
-        chart.series[1].graphsignal.stroke,
+        chart.series[1].graphsignal.attr('stroke'),
         Highcharts.getOptions().colors[2],
         `When colour is not specified, each element (signalLine) should get it
         from the colour array.`
     );
     assert.strictEqual(
-        chart.series[1].graphmacd.stroke,
+        chart.series[1].graphmacd.attr('stroke'),
         Highcharts.getOptions().colors[3],
         `When colour is not specified, each element (macdLine) should get it
         from the colour array.`

--- a/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
+++ b/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
@@ -260,7 +260,7 @@ function (assert) {
         'Series last price indicator should be visible.'
     );
     assert.strictEqual(
-        chart.series[0].lastPrice.stroke,
+        chart.series[0].lastPrice.attr('stroke'),
         '#ff0000',
         'Cross label fill color should be red.'
     );
@@ -296,7 +296,7 @@ function (assert) {
         'Series last price indicator should be visible again.'
     );
     assert.strictEqual(
-        chart.series[0].lastPrice.stroke,
+        chart.series[0].lastPrice.attr('stroke'),
         '#ff0000',
         'Cross label fill color should be red again.'
     );

--- a/samples/unit-tests/series-candlestick/color/demo.js
+++ b/samples/unit-tests/series-candlestick/color/demo.js
@@ -29,7 +29,7 @@ QUnit.test('Candlestick series colors tests.', function (assert) {
             points.forEach(function (p) {
                 p.onMouseOver();
                 stroke = split ? chart.tooltip.label.element.lastChild.childNodes[3].getAttribute('stroke') :
-                    chart.tooltip.label.stroke;
+                    chart.tooltip.label.attr('stroke');
                 strokes.push(stroke);
             });
 

--- a/samples/unit-tests/series-heatmap/datalabel/demo.js
+++ b/samples/unit-tests/series-heatmap/datalabel/demo.js
@@ -44,7 +44,7 @@ QUnit.test('Check last point visible (#5254)', function (assert) {
         '#15922: useHTML dataLabel should be visible'
     );
     assert.strictEqual(
-        point.graphic.stroke,
+        point.graphic.attr('stroke'),
         'red',
         '#15922: Point borderColor should work'
     );

--- a/samples/unit-tests/series-heatmap/marker/demo.js
+++ b/samples/unit-tests/series-heatmap/marker/demo.js
@@ -122,7 +122,7 @@ QUnit.test('General marker tests', function (assert) {
     );
 
     assert.strictEqual(
-        point.graphic.stroke,
+        point.graphic.attr('stroke'),
         'red',
         "Marker's lineWidth color should set correctly through point.marker."
     );

--- a/samples/unit-tests/series-pie/datalabel/demo.js
+++ b/samples/unit-tests/series-pie/datalabel/demo.js
@@ -617,7 +617,7 @@ QUnit.test('Connector color of individual point (#8864).', function (assert) {
     });
 
     assert.ok(
-        chart.series[0].points[0].connector.stroke === '#bada55',
+        chart.series[0].points[0].connector.attr('stroke') === '#bada55',
         'Color applied to indiviudal connector.'
     );
 });

--- a/samples/unit-tests/series-timeline/datalabels/demo.js
+++ b/samples/unit-tests/series-timeline/datalabels/demo.js
@@ -86,7 +86,7 @@ QUnit.test('Timeline: General tests.', function (assert) {
 
     var connector = series.points[0].connector,
         connectorWidth = connector.strokeWidth(),
-        connectorColor = connector.stroke;
+        connectorColor = connector.attr('stroke');
 
     assert.strictEqual(
         connectorWidth,

--- a/samples/unit-tests/tooltip/split-bordercolor/demo.js
+++ b/samples/unit-tests/tooltip/split-bordercolor/demo.js
@@ -24,7 +24,7 @@ QUnit.test('tooltip.borderColor #6831', function (assert) {
     tooltip.refresh([p1, p2]);
 
     assert.strictEqual(
-        tooltip.tt.box.stroke,
+        tooltip.tt.box.attr('stroke'),
         'red',
         'borderColor is applied on all tooltips'
     );

--- a/samples/unit-tests/tooltip/split/demo.js
+++ b/samples/unit-tests/tooltip/split/demo.js
@@ -340,7 +340,7 @@ QUnit.test(
         chart.series[0].points[0].onMouseOver();
 
         assert.strictEqual(
-            chart.series[0].tt.box.stroke,
+            chart.series[0].tt.box.attr('stroke'),
             firstPointColor,
             'Label stroke should be the same as the first point color.'
         );
@@ -348,7 +348,7 @@ QUnit.test(
         chart.series[0].points[1].onMouseOver();
 
         assert.strictEqual(
-            chart.series[0].tt.box.stroke,
+            chart.series[0].tt.box.attr('stroke'),
             secondPointColor,
             'Label stroke should be the same as the second point color.'
         );

--- a/tools/gulptasks/lib/log.js
+++ b/tools/gulptasks/lib/log.js
@@ -96,7 +96,7 @@ function say(text) {
             default:
                 break;
             case 'darwin':
-                ChildProcess.execSync('say -v Alex "[[volm 0.5]]' + text.replace(/"/g, '') + '"');
+                ChildProcess.execSync('say -v Daniel "[[volm 0.5]]' + text.replace(/"/g, '') + '"');
                 break;
             case 'win32':
                 ChildProcess.execSync(

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -151,7 +151,6 @@ class SVGElement implements SVGElementLike {
     public firstLineMetrics?: FontMetricsObject;
     public handleZ?: boolean;
     public hasBoxWidthChanged?: boolean;
-    public hasStroke?: boolean;
     // @todo public height?: number;
     public inverted?: boolean;
     public matrix?: Array<number>;
@@ -2156,9 +2155,7 @@ class SVGElement implements SVGElementLike {
     }
 
     /**
-     * WebKit and Batik have problems with a stroke-width of zero, so in this
-     * case we remove the stroke attribute altogether. #1270, #1369, #3065,
-     * #3072.
+     * Set the stroke-width and record it on the SVGElement
      *
      * @private
      * @function Highcharts.SVGElement#strokeSetter
@@ -2166,32 +2163,14 @@ class SVGElement implements SVGElementLike {
      * @param {string} key
      * @param {Highcharts.SVGDOMElement} element
      */
-    public strokeSetter(
-        value: (number|string|ColorType),
-        key: string,
+    public 'stroke-widthSetter'(
+        value: (number|string),
+        key: 'stroke-width',
         element: SVGDOMElement
     ): void {
-        (this as AnyRecord)[key] = value;
-        // Only apply the stroke attribute if the stroke width is defined and
-        // larger than 0
-        if (this.stroke && this['stroke-width']) {
-            // Use prototype as instance may be overridden
-            SVGElement.prototype.fillSetter.call(
-                this,
-                this.stroke,
-                'stroke',
-                element
-            );
-
-            element.setAttribute('stroke-width', this['stroke-width']);
-            this.hasStroke = true;
-        } else if (key === 'stroke-width' && value === 0 && this.hasStroke) {
-            element.removeAttribute('stroke');
-            this.hasStroke = false;
-        } else if (this.renderer.styledMode && this['stroke-width']) {
-            element.setAttribute('stroke-width', this['stroke-width']);
-            this.hasStroke = true;
-        }
+        // Record it for quick access in getter
+        this[key] = value;
+        element.setAttribute(key, value);
     }
 
     /**
@@ -2643,7 +2622,7 @@ interface SVGElement extends SVGElementLike {
 }
 
 // Some shared setters and getters
-SVGElement.prototype['stroke-widthSetter'] = SVGElement.prototype.strokeSetter;
+SVGElement.prototype.strokeSetter = SVGElement.prototype.fillSetter;
 SVGElement.prototype.yGetter = SVGElement.prototype.xGetter;
 SVGElement.prototype.matrixSetter =
 SVGElement.prototype.rotationOriginXSetter =

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -4665,7 +4665,7 @@ class Series {
                     );
                 }
 
-                if (graph && !graph.dashstyle) {
+                if (graph && !graph.dashstyle && isNumber(lineWidth)) {
                     attribs = {
                         'stroke-width': lineWidth
                     };

--- a/ts/Series/ArcDiagram/ArcDiagramSeries.ts
+++ b/ts/Series/ArcDiagram/ArcDiagramSeries.ts
@@ -634,7 +634,7 @@ class ArcDiagramSeries extends SankeySeries {
         state?: StatesOptionsKey
     ): SVGAttributes {
         if (point && point.isNode) {
-            const { opacity, ...attrs } = ColumnSeries.prototype.pointAttribs
+            const { opacity, ...attrs } = Series.prototype.pointAttribs
                 .apply(this, arguments);
             return attrs;
         }

--- a/ts/Series/ArcDiagram/ArcDiagramSeries.ts
+++ b/ts/Series/ArcDiagram/ArcDiagramSeries.ts
@@ -634,10 +634,8 @@ class ArcDiagramSeries extends SankeySeries {
         state?: StatesOptionsKey
     ): SVGAttributes {
         if (point && point.isNode) {
-            const { opacity, ...attrs } = Series.prototype.pointAttribs.apply(
-                this,
-                arguments
-            );
+            const { opacity, ...attrs } = ColumnSeries.prototype.pointAttribs
+                .apply(this, arguments);
             return attrs;
         }
         return super.pointAttribs.apply(this, arguments);

--- a/ts/Series/ArcDiagram/ArcDiagramSeries.ts
+++ b/ts/Series/ArcDiagram/ArcDiagramSeries.ts
@@ -195,6 +195,7 @@ class ArcDiagramSeries extends SankeySeries {
         marker: {
             symbol: 'circle',
             fillOpacity: 1,
+            lineWidth: 0,
             states: {}
         }
     } as ArcDiagramSeriesOptions);

--- a/ts/Series/Line/LineSeries.ts
+++ b/ts/Series/Line/LineSeries.ts
@@ -161,7 +161,7 @@ class LineSeries extends Series {
 
                 attribs = {
                     'stroke': prop[2],
-                    'stroke-width': options.lineWidth,
+                    'stroke-width': options.lineWidth || 0,
                     // Polygon series use filled graph
                     'fill': (series.fillGraph && series.color) || 'none'
                 };


### PR DESCRIPTION
Removed stroke/stroke-width workaround for older browser bug.

If this passes, we can simplify the fix in #17834.