### PR TITLE
bugfix/17929-tooltip-marke-on-edge 

### DIFF
--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1119,7 +1119,8 @@ class Tooltip {
                     chart.polar ||
                     currentSeries.options.clip === false ||
                     points.some((p): boolean => // #16004
-                        p.series.shouldShowTooltip(checkX, checkY)
+                        chart.pointer.isDirectTouch ||
+                            p.series.shouldShowTooltip(checkX, checkY)
                     )
                 ) {
                     const label = tooltip.getLabel();


### PR DESCRIPTION
Fixed #17929, the tooltip was not visible sometimes when the marker was on edge.