### PR TITLE
X-property of stackLabels now functions

### DIFF
--- a/ts/Core/Axis/WaterfallAxis.ts
+++ b/ts/Core/Axis/WaterfallAxis.ts
@@ -150,10 +150,11 @@ namespace WaterfallAxis {
             // Render each waterfall stack total
             objectEach(waterfallStacks, function (type): void {
                 objectEach(type, function (
-                    stackItem: StacksItemObject
+                    stackItem: StacksItemObject,
+                    key: string
                 ): void {
                     dummyStackItem.total = stackItem.stackTotal;
-
+                    dummyStackItem.x = +key;
                     if (stackItem.label) {
                         dummyStackItem.label = stackItem.label;
                     }


### PR DESCRIPTION
Fixed #17902, in stacked waterfalls, the `x` value was not available for the context of `stackLabels.formatter`.