### PR TITLE
docs/map-drilldown-insets

### DIFF
--- a/samples/maps/demo/map-drilldown/demo.js
+++ b/samples/maps/demo/map-drilldown/demo.js
@@ -57,7 +57,13 @@ const drilldown = async function (e) {
 // On drill up, reset to the top-level map view
 const drillup = function (e) {
     if (e.seriesOptions.custom && e.seriesOptions.custom.mapView) {
-        e.target.mapView.update(e.seriesOptions.custom.mapView, false);
+        e.target.mapView.update(
+            Highcharts.merge(
+                { insets: undefined },
+                e.seriesOptions.custom.mapView
+            ),
+            false
+        );
     }
 };
 


### PR DESCRIPTION
Added insets clean-up in the demo.

---

In case someone would like to use this demo for a use case with the top map having no insets the lower level insets on drill-up were not cleared.