### PR TITLE
bugfix/17753-incorrect-symbol-in-attribute

### DIFF
--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -2807,7 +2807,10 @@ class Chart {
             // Make chart behave as an image with the title as alt text
             this.renderer.boxWrapper.attr({
                 role: 'img',
-                'aria-label': (title && title.element.textContent) || ''
+                'aria-label': (
+                    (title && title.element.textContent) || ''
+                // #17753, < is not allowed in SVG attributes
+                ).replace(/</g, '&lt;')
             });
 
             if (!(

--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -354,6 +354,11 @@ class AST {
                 });
                 delete attributes[key];
             }
+
+            // #17753, < is not allowed in SVG attributes
+            if (isString(val) && attributes[key]) {
+                attributes[key] = val.replace(/</g, '&lt;') as any;
+            }
         });
         return attributes;
     }


### PR DESCRIPTION
Fixed #17753, removed not allowed `<` symbol from attributes.