### PR TITLE
Better fix for #17281, bubbles not hiding when below zThreshold

### DIFF
--- a/samples/unit-tests/series-bubble/marker/demo.js
+++ b/samples/unit-tests/series-bubble/marker/demo.js
@@ -176,7 +176,7 @@ QUnit.test('Bubble animation and async redraws (#13494)', assert => {
 });
 
 QUnit.test('Bubble with custom symbol markers, #17281.', function (assert) {
-    Highcharts.chart("container", {
+    const chart = Highcharts.chart("container", {
         series: [{
             type: "bubble",
             data: [
@@ -191,8 +191,9 @@ QUnit.test('Bubble with custom symbol markers, #17281.', function (assert) {
         }]
     });
 
-    assert.ok(
-        true,
+    assert.strictEqual(
+        typeof chart.series[0].points[0].graphic,
+        'undefined',
         `When the custom marker is set and the point is out of zThreshold, the
         symbol should not be displayed and there should be no errors.`
     );

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -747,12 +747,9 @@ class BubbleSeries extends ScatterSeries {
                     height: 2 * radius
                 };
             } else { // below zThreshold
-                point.shapeArgs = point.dlBox = void 0; // #1691
-                point.plotY = 0; // #17281
-                point.marker = {
-                    width: 0,
-                    height: 0
-                };
+                // #1691
+                point.shapeArgs = point.plotY = point.dlBox = void 0;
+                point.isInside = false; // #17281
             }
         }
 


### PR DESCRIPTION
With the old fix, the graphics stayed after update, but with reduced size. Now they are destroyed.