### PR TITLE
Regression in tooltip class names for color index

### DIFF
--- a/samples/unit-tests/tooltip/custom-classnames/demo.js
+++ b/samples/unit-tests/tooltip/custom-classnames/demo.js
@@ -35,7 +35,7 @@ QUnit.test(
         assert.strictEqual(
             container.getElementsByClassName(
                 'highcharts-label highcharts-tooltip ' +
-                'highcharts-tooltip-0 oranges'
+                'highcharts-color-0 oranges'
             ).length,
             1,
             'Tooltip with correct classes should exist'
@@ -54,7 +54,7 @@ QUnit.test(
         assert.strictEqual(
             container.getElementsByClassName(
                 'highcharts-label highcharts-tooltip ' +
-                'highcharts-tooltip-0 oranges'
+                'highcharts-color-0 oranges'
             ).length,
             1,
             'Tooltip with correct classes should exist'
@@ -73,7 +73,7 @@ QUnit.test(
         assert.strictEqual(
             container.getElementsByClassName(
                 'highcharts-label highcharts-tooltip-box ' +
-                'highcharts-tooltip-0 oranges'
+                'highcharts-color-0 oranges'
             ).length,
             1,
             'Split tooltip with correct classes should exist for single series'

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -429,7 +429,7 @@ class Tooltip {
 
     /**
      * Get the CSS class names for the tooltip's label. Styles the label
-     * by colorIndex or user-defined CSS.
+     * by `colorIndex` or user-defined CSS.
      *
      * @function Highcharts.Tooltip#getClassName
      *
@@ -450,7 +450,7 @@ class Tooltip {
             'highcharts-label',
             isHeader && 'highcharts-tooltip-header',
             isSplit ? 'highcharts-tooltip-box' : 'highcharts-tooltip',
-            !isHeader && 'highcharts-tooltip-' + pick(
+            !isHeader && 'highcharts-color-' + pick(
                 point.colorIndex, series.colorIndex
             ),
             (seriesOptions && seriesOptions.className)


### PR DESCRIPTION
Tooltip border color was lost on styled mode charts.