### PR TITLE
bugfix/17926-pointer-events-after-drawpoints-refactor

### DIFF
--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -837,7 +837,7 @@ class ColumnSeries extends Series {
      * Draw the tracker for a point.
      * @private
      */
-    public drawTracker(): void {
+    public drawTracker(points: Array<ColumnPoint> = this.points): void {
         const series = this,
             chart = series.chart,
             pointer = chart.pointer,
@@ -853,7 +853,7 @@ class ColumnSeries extends Series {
         let dataLabels;
 
         // Add reference to the point
-        series.points.forEach(function (point): void {
+        points.forEach(function (point): void {
             dataLabels = (
                 isArray(point.dataLabels) ?
                     point.dataLabels :

--- a/ts/Series/Histogram/HistogramSeries.ts
+++ b/ts/Series/Histogram/HistogramSeries.ts
@@ -316,6 +316,7 @@ interface HistogramSeries extends DerivedComposition.SeriesComposition {
     animate: typeof ColumnSeries.prototype.animate;
     destroy: typeof ColumnSeries.prototype.destroy;
     drawPoints: typeof ColumnSeries.prototype.drawPoints;
+    drawTracker: typeof ColumnSeries.prototype.drawTracker;
     group: typeof ColumnSeries.prototype.group;
     init: typeof ColumnSeries.prototype.init;
     pointAttribs: typeof ColumnSeries.prototype.pointAttribs;

--- a/ts/Series/Sankey/SankeySeries.ts
+++ b/ts/Series/Sankey/SankeySeries.ts
@@ -324,6 +324,10 @@ class SankeySeries extends ColumnSeries {
         };
 
     }
+    public drawTracker(): void {
+        ColumnSeries.prototype.drawTracker.call(this, this.points);
+        ColumnSeries.prototype.drawTracker.call(this, this.nodes);
+    }
 
     public drawPoints(): void {
         ColumnSeries.prototype.drawPoints.call(this, this.points);

--- a/ts/Series/Treegraph/TreegraphSeries.ts
+++ b/ts/Series/Treegraph/TreegraphSeries.ts
@@ -51,7 +51,6 @@ import TreegraphLink from './TreegraphLink.js';
 import TreegraphLayout from './TreegraphLayout.js';
 import { TreegraphSeriesLevelOptions } from './TreegraphSeriesOptions.js';
 import TreegraphSeriesDefaults from './TreegraphSeriesDefaults.js';
-import { support } from 'jquery';
 
 /* *
  *

--- a/ts/Series/Treegraph/TreegraphSeries.ts
+++ b/ts/Series/Treegraph/TreegraphSeries.ts
@@ -51,6 +51,7 @@ import TreegraphLink from './TreegraphLink.js';
 import TreegraphLayout from './TreegraphLayout.js';
 import { TreegraphSeriesLevelOptions } from './TreegraphSeriesOptions.js';
 import TreegraphSeriesDefaults from './TreegraphSeriesDefaults.js';
+import { support } from 'jquery';
 
 /* *
  *
@@ -268,6 +269,11 @@ class TreegraphSeries extends TreemapSeries {
         node.children.forEach((childNode): void => {
             this.setCollapsedStatus(childNode, visibility);
         });
+    }
+
+    public drawTracker(): void {
+        ColumnSeries.prototype.drawTracker.apply(this, arguments);
+        ColumnSeries.prototype.drawTracker.call(this, this.links);
     }
 
     /**

--- a/ts/Series/Windbarb/WindbarbSeries.ts
+++ b/ts/Series/Windbarb/WindbarbSeries.ts
@@ -438,6 +438,7 @@ interface WindbarbSeries extends OnSeriesComposition.SeriesComposition {
     pointArrayMap: Array<string>;
     pointClass: typeof WindbarbPoint;
     remove: typeof ColumnSeries.prototype.remove;
+    drawTracker: typeof ColumnSeries.prototype.remove;
     windArrow(point: WindbarbPoint): (SVGElement|SVGPath);
 
 }


### PR DESCRIPTION
Fixed regressions with missing tooltip on organization chart and sankey chart nodes after v10.3.0.

Fixes #17926, Fixes #17980.