### PR TITLE
bugfix/17963-breadcrumbs-scrollablePlotArea

### DIFF
--- a/samples/unit-tests/breadcrumbs/buttons/demo.js
+++ b/samples/unit-tests/breadcrumbs/buttons/demo.js
@@ -315,7 +315,10 @@ QUnit.test('Breadcrumbs button positioning.', function (assert) {
         chart: {
             type: 'column',
             width: 600,
-            plotBorderWidth: 1
+            plotBorderWidth: 1,
+            scrollablePlotArea: {
+                minHeight: 1000
+            }
         },
         xAxis: {
             type: 'category'
@@ -431,6 +434,11 @@ QUnit.test('Breadcrumbs button positioning.', function (assert) {
         chart.breadcrumbs.options.buttonSpacing,
         0,
         'Options from navigation.breadcrumbs should be handled'
+    );
+
+    assert.ok(
+        chart.breadcrumbs.group.element.closest('.highcharts-fixed'),
+        `Breadcrumbs should be a part of fixedSelectors group #17963.`
     );
 });
 

--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -263,6 +263,7 @@ Chart.prototype.moveFixedElements = function (): void {
     let container = this.container,
         fixedRenderer = this.fixedRenderer,
         fixedSelectors = [
+            '.highcharts-breadcrumbs-group',
             '.highcharts-contextbutton',
             '.highcharts-credits',
             '.highcharts-legend',


### PR DESCRIPTION
Fixed #17963, breadcrumbs' position and display were incorrect when `scrollablePlotArea` was enabled.