### PR TITLE
bugfix/17995-measure-control-points-position

### DIFF
--- a/samples/unit-tests/annotations/annotations-measure/demo.js
+++ b/samples/unit-tests/annotations/annotations-measure/demo.js
@@ -6,6 +6,7 @@ QUnit.test('#13664 - annotation measure on yAxis', function (assert) {
                 height: '50%'
             },
             {
+                min: 3,
                 top: '50%',
                 height: '50%'
             }
@@ -84,5 +85,16 @@ QUnit.test('#13664 - annotation measure on yAxis', function (assert) {
         0.5,
         `Annotation's label's X position should be close
         to the X position of the annotation after updates.`
+    );
+
+    const axisMiddlePos = chart.yAxis[1].top + chart.yAxis[1].height / 2,
+        { y, height } = chart.annotations[0].controlPoints[0].graphic.getBBox(),
+        controlPointYPos = y + height / 2;
+
+    assert.equal(
+        controlPointYPos,
+        axisMiddlePos,
+        `Annotation's control points should be positioned in the middle of yAxis
+        #17995`
     );
 });

--- a/ts/Extensions/Annotations/Types/Measure.ts
+++ b/ts/Extensions/Annotations/Types/Measure.ts
@@ -1076,7 +1076,7 @@ Measure.prototype.defaultOptions = merge(
                     x, y;
 
                 if (selectType === 'x') {
-                    targetY = (ext.yAxisMax - ext.yAxisMin) / 2;
+                    targetY = (ext.yAxisMax + ext.yAxisMin) / 2;
 
                     // first control point
                     if (cpIndex === 0) {


### PR DESCRIPTION
Fixed #17995, measure's control points were positioned incorrectly when `yAxis.min` wasn't equal to 0.