### PR TITLE
bugfix/17970-heatmap-update-point-wrong-color

### DIFF
--- a/samples/unit-tests/series-heatmap/datalabel/demo.js
+++ b/samples/unit-tests/series-heatmap/datalabel/demo.js
@@ -1,5 +1,5 @@
 QUnit.test('Check last point visible (#5254)', function (assert) {
-    var chart = Highcharts.chart('container', {
+    const chart = Highcharts.chart('container', {
         chart: {
             type: 'heatmap'
         },
@@ -34,9 +34,11 @@ QUnit.test('Check last point visible (#5254)', function (assert) {
         ]
     });
 
-    var point = chart.series[0].points[0];
-    var leftX = point.dataLabel.translateX;
-    var bottomY = point.dataLabel.translateY;
+    const series = chart.series[0],
+        point = series.points[0],
+        leftX = point.dataLabel.translateX,
+        bottomY = point.dataLabel.translateY;
+
     assert.strictEqual(typeof leftX, 'number', 'All well so far');
 
     assert.ok(
@@ -61,7 +63,6 @@ QUnit.test('Check last point visible (#5254)', function (assert) {
         }
     });
 
-    point = chart.series[0].points[0];
     assert.ok(
         point.dataLabel.translateX > leftX,
         'align:right gives a higher X position than align:left'
@@ -70,5 +71,19 @@ QUnit.test('Check last point visible (#5254)', function (assert) {
     assert.ok(
         point.dataLabel.translateY < bottomY,
         'verticalAlign:top gives a smaller Y position than verticalAlign:bottom'
+    );
+
+    point.update({
+        value: null
+    });
+
+    point.update({
+        value: 5
+    });
+
+    assert.strictEqual(
+        point.color,
+        series.color,
+        `#17970: Ex-null point shouldn’t have a null color after update.`
     );
 });

--- a/ts/Series/Heatmap/HeatmapPoint.ts
+++ b/ts/Series/Heatmap/HeatmapPoint.ts
@@ -80,6 +80,11 @@ class HeatmapPoint extends ScatterPoint {
         options: HeatmapPointOptions,
         x?: number
     ): HeatmapPoint {
+        // #17970, if point is null remove its color, because it may be updated
+        if (this.isNull || this.value === null) {
+            delete this.color;
+        }
+
         const point: HeatmapPoint = super.applyOptions.call(
             this,
             options,


### PR DESCRIPTION
Fixed #17970, wrong color on heatmap point when updating from `null` to a valid number.