### PR TITLE
bugfix/17948-tooltip-reversed-stacks-position

### DIFF
--- a/samples/unit-tests/tooltip/shared/demo.js
+++ b/samples/unit-tests/tooltip/shared/demo.js
@@ -113,8 +113,7 @@ QUnit.test(
 );
 
 QUnit.test(
-    'Click event was called for a wrong series (#5622)',
-    function (assert) {
+    'Click event was called for a wrong series (#5622)', assert => {
         var $container = $('#container'),
             chart = $container
                 .highcharts({
@@ -212,8 +211,8 @@ QUnit.test(
     }
 );
 
-QUnit.test('Shared tooltip with pointPlacement and stickOnContact', function (assert) {
-    var chart = Highcharts.chart('container', {
+QUnit.test('Shared tooltip with pointPlacement and stickOnContact', assert => {
+    const chart = Highcharts.chart('container', {
         chart: {
             type: 'column'
         },
@@ -223,7 +222,7 @@ QUnit.test('Shared tooltip with pointPlacement and stickOnContact', function (as
             stickOnContact: true
         },
         plotOptions: {
-            column: {
+            series: {
                 stacking: 'normal',
                 kdNow: true
             }
@@ -256,8 +255,8 @@ QUnit.test('Shared tooltip with pointPlacement and stickOnContact', function (as
         ]
     });
 
-    var point = chart.series[0].points[0],
-        offset = Highcharts.offset(chart.container);
+    const offset = Highcharts.offset(chart.container);
+    let point = chart.series[0].points[0];
 
     // Set hoverPoint
     point.onMouseOver();
@@ -277,6 +276,39 @@ QUnit.test('Shared tooltip with pointPlacement and stickOnContact', function (as
         chart.tooltip.tracker.attr('height'),
         heightBefore,
         '#15843: Tracker height should be the same after hovering another point in the same stack'
+    );
+
+    // remove all series
+    while (chart.series.length) {
+        chart.series[0].remove(false);
+    }
+
+    chart.addSeries({
+        data: [4, 4]
+    }, false);
+    chart.addSeries({
+        data: [5, 15]
+    }, false);
+    chart.update({
+        chart: {
+            type: 'bar'
+        },
+        yAxis: {
+            reversedStacks: false
+        }
+    });
+
+    point = chart.series[0].points[0];
+    point.onMouseOver();
+
+    const hoverPoint = chart.hoverPoint,
+        pointX = hoverPoint.series.yAxis.toPixels(hoverPoint.stackTotal, true);
+
+    assert.strictEqual(
+        point.tooltipPos[0],
+        pointX,
+        `#17948: Tooltip should be displayed at the end of the bar,
+            when reversedStacks is set to false.`
     );
 });
 

--- a/samples/unit-tests/tooltip/shared/demo.js
+++ b/samples/unit-tests/tooltip/shared/demo.js
@@ -255,8 +255,8 @@ QUnit.test('Shared tooltip with pointPlacement and stickOnContact', assert => {
         ]
     });
 
-    const offset = Highcharts.offset(chart.container);
-    let point = chart.series[0].points[0];
+    const offset = Highcharts.offset(chart.container),
+        point = chart.series[0].points[0];
 
     // Set hoverPoint
     point.onMouseOver();
@@ -298,15 +298,15 @@ QUnit.test('Shared tooltip with pointPlacement and stickOnContact', assert => {
         }
     });
 
-    point = chart.series[0].points[0];
-    point.onMouseOver();
+    chart.series[0].points[0].onMouseOver();
 
-    const hoverPoint = chart.hoverPoint,
-        pointX = hoverPoint.series.yAxis.toPixels(hoverPoint.stackTotal, true);
+    const predictedTooltipX = chart.series[1].points[0].tooltipPos[0] +
+        chart.plotLeft + chart.tooltip.distance;
 
-    assert.strictEqual(
-        point.tooltipPos[0],
-        pointX,
+    assert.close(
+        predictedTooltipX,
+        chart.tooltip.now.x,
+        1,
         `#17948: Tooltip should be displayed at the end of the bar,
             when reversedStacks is set to false.`
     );

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -364,6 +364,16 @@ class Tooltip {
 
         points = splat(points);
 
+        // If reversedStacks are false the tooltip position should be taken from
+        // the last point (#17948)
+        if (
+            points[0].series &&
+            points[0].series.yAxis &&
+            !points[0].series.yAxis.options.reversedStacks
+        ) {
+            points = points.slice().reverse();
+        }
+
         // When tooltip follows mouse, relate the position to the mouse
         if (this.followPointer && mouseEvent) {
             if (typeof mouseEvent.chartX === 'undefined') {
@@ -373,14 +383,6 @@ class Tooltip {
                 mouseEvent.chartX - plotLeft,
                 mouseEvent.chartY - plotTop
             ];
-        // #17948, if reversedStacks are false tooltip position should be taken
-        // from the last point
-        } else if (
-            points[0].series.yAxis &&
-            !points[0].series.yAxis.options.reversedStacks &&
-            points[points.length - 1].tooltipPos
-        ) {
-            ret = points[points.length - 1].tooltipPos as number[];
 
         // Some series types use a specificly calculated tooltip position for
         // each point

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -373,6 +373,14 @@ class Tooltip {
                 mouseEvent.chartX - plotLeft,
                 mouseEvent.chartY - plotTop
             ];
+        // #17948, if reversedStacks are false tooltip position should be taken
+        // from the last point
+        } else if (
+            points[0].series.yAxis &&
+            !points[0].series.yAxis.options.reversedStacks &&
+            points[points.length - 1].tooltipPos
+        ) {
+            ret = points[points.length - 1].tooltipPos as number[];
 
         // Some series types use a specificly calculated tooltip position for
         // each point

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -600,10 +600,8 @@ class ColumnSeries extends Series {
             // #3648)
             point.tooltipPos = chart.inverted ?
                 [
-                    clamp( // Place the tooltip at the end of stack, #17948
-                        !yAxis.options.reversedStacks && point.stackTotal ?
-                            yAxis.toPixels(point.stackTotal, true) :
-                            yAxis.len + yAxis.pos - chart.plotLeft - plotY,
+                    clamp(
+                        yAxis.len + yAxis.pos - chart.plotLeft - plotY,
                         yAxis.pos - chart.plotLeft,
                         yAxis.len + yAxis.pos - chart.plotLeft
                     ),

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -600,8 +600,10 @@ class ColumnSeries extends Series {
             // #3648)
             point.tooltipPos = chart.inverted ?
                 [
-                    clamp(
-                        yAxis.len + yAxis.pos - chart.plotLeft - plotY,
+                    clamp( // Place the tooltip at the end of stack, #17948
+                        !yAxis.options.reversedStacks && point.stackTotal ?
+                            yAxis.toPixels(point.stackTotal, true) :
+                            yAxis.len + yAxis.pos - chart.plotLeft - plotY,
                         yAxis.pos - chart.plotLeft,
                         yAxis.len + yAxis.pos - chart.plotLeft
                     ),


### PR DESCRIPTION
Fixed #17948, the tooltip position was bad when `yAxis.reversedStacks` was set to `false`.