### PR TITLE
feature/18007-allow-table-sorting

### DIFF
--- a/samples/unit-tests/export-data/basics/demo.js
+++ b/samples/unit-tests/export-data/basics/demo.js
@@ -1268,6 +1268,8 @@ QUnit.test('Sortable table (#16972)', function (assert) {
         }
     });
 
+    chart.dataTableDiv.children[0].children[1].children[0].children[0].click();
+
     assert.strictEqual(
         chart.dataTableDiv.children[0].children[2].children[0].children[0]
             .innerText,

--- a/samples/unit-tests/export-data/basics/demo.js
+++ b/samples/unit-tests/export-data/basics/demo.js
@@ -1263,11 +1263,27 @@ QUnit.test('Sortable table (#16972)', function (assert) {
         }
         ],
         exporting: {
-            showTable: true
+            showTable: true,
+            allowTableSorting: false
+        }
+    });
+
+    assert.strictEqual(
+        chart.dataTableDiv.children[0].children[2].children[0].children[0]
+            .innerText,
+        'NL',
+        `Data order in table should not change when allowTableSorting equals
+        false, #18007.`
+    );
+
+    chart.update({
+        exporting: {
+            allowTableSorting: true
         }
     });
 
     chart.dataTableDiv.children[0].children[1].children[0].children[0].click();
+
     assert.strictEqual(
         chart.dataTableDiv.children[0].children[3].children[0].innerText,
         'BE',

--- a/ts/Extensions/ExportData/ExportData.ts
+++ b/ts/Extensions/ExportData/ExportData.ts
@@ -1253,7 +1253,11 @@ function onChartAfterViewData(
             };
 
 
-    if (dataTableDiv) {
+    if (
+        dataTableDiv &&
+        chart.options.exporting &&
+        chart.options.exporting.allowTableSorting
+    ) {
         const row = dataTableDiv.querySelector('thead tr');
         if (row) {
             row.childNodes.forEach((th: any): void => {

--- a/ts/Extensions/Exporting/ExportingDefaults.ts
+++ b/ts/Extensions/Exporting/ExportingDefaults.ts
@@ -58,7 +58,7 @@ const exporting: ExportingOptions = {
      */
 
     /**
-     * Allows to sort table data by clicking on columns' headers.
+     * Allows the end user to sort the data table by clicking on column headers.
      *
      * @since next
      * @apioption exporting.allowTableSorting

--- a/ts/Extensions/Exporting/ExportingDefaults.ts
+++ b/ts/Extensions/Exporting/ExportingDefaults.ts
@@ -58,6 +58,14 @@ const exporting: ExportingOptions = {
      */
 
     /**
+     * Allows to sort table data by clicking on columns' headers.
+     *
+     * @since next
+     * @apioption exporting.allowTableSorting
+     */
+    allowTableSorting: true,
+
+    /**
      * Additional chart options to be merged into the chart before exporting to
      * an image format. This does not apply to printing the chart via the export
      * menu.

--- a/ts/Extensions/Exporting/ExportingOptions.d.ts
+++ b/ts/Extensions/Exporting/ExportingOptions.d.ts
@@ -33,6 +33,7 @@ import type { SymbolKey } from '../../Core/Renderer/SVG/SymbolType';
 
 export interface ExportingOptions {
     allowHTML?: boolean;
+    allowTableSorting?: boolean;
     buttons?: ExportingButtonsOptions;
     chartOptions?: Options;
     enabled?: boolean;


### PR DESCRIPTION
Added new option, [exporting.allowTableSorting](https://api.highcharts.com/highcharts/exporting.allowTableSorting), to allow turning off sorting of the data table. See #18007.

closes #18007