### PR TITLE
bugfix/18080-arearange-zoom-markers

### DIFF
--- a/samples/unit-tests/series-arearange/markers/demo.js
+++ b/samples/unit-tests/series-arearange/markers/demo.js
@@ -72,6 +72,49 @@ QUnit.test('Markers for arearange.', function (assert) {
         1, // Marker in the legend
         'No artifacts after zoom in boost mode (#7557)'
     );
+
+    chart.update({
+        chart: {
+            zooming: {
+                type: 'x'
+            }
+        },
+        series: [{
+            marker: {
+                enabled: undefined
+            },
+            boostThreshold: 1000
+        }]
+    });
+
+    const xAxis = chart.xAxis[0];
+
+    xAxis.setExtremes(0, 5);
+    xAxis.setExtremes();
+
+    assert.notOk(
+        !!xAxis.series[0].points[0].graphics[0],
+        `Bottom point's graphic shouldn't exist when chart is zoomed out,
+        #18080.`
+    );
+    assert.notOk(
+        !!xAxis.series[0].points[0].graphics[1],
+        `Top point's graphic shouldn't exist when chart is zoomed out,
+        #18080.`
+    );
+
+    xAxis.setExtremes(0, 5);
+
+    assert.ok(
+        xAxis.series[0].points[0].graphics[0].element,
+        `Bottom point's graphic should exist when chart is zoomed, #18080.`
+    );
+
+    assert.ok(
+        xAxis.series[0].points[0].graphics[1].element,
+        `Top point's graphic should exist when chart is zoomed, #18080.`
+    );
+
 });
 
 QUnit.test('Zones', function (assert) {

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -133,7 +133,7 @@ class Point {
 
     public graphic?: SVGElement;
 
-    public graphics?: Array<SVGElement>;
+    public graphics?: Array<SVGElement|undefined>;
 
     public id: string = void 0 as any;
 
@@ -466,7 +466,7 @@ class Point {
 
         props.plural.forEach(function (plural: any): void {
             (point as any)[plural].forEach(function (item: any): void {
-                if (item.element) {
+                if (item && item.element) {
                     item.destroy();
                 }
             });

--- a/ts/Series/AreaRange/AreaRangeSeries.ts
+++ b/ts/Series/AreaRange/AreaRangeSeries.ts
@@ -595,9 +595,10 @@ class AreaRangeSeries extends AreaSeries {
                 y: point.y
             };
 
-            if (point.graphic) {
+            if (point.graphic || point.graphics[0]) {
                 point.graphics[0] = point.graphic;
             }
+
             point.graphic = point.graphics[1];
             point.plotY = point.plotHigh;
             if (defined(point.plotHighX)) {
@@ -629,7 +630,8 @@ class AreaRangeSeries extends AreaSeries {
         while (i < pointLength) {
             point = series.points[i];
             point.graphics = point.graphics || [];
-            if (point.graphic) {
+
+            if (point.graphic || point.graphics[1]) {
                 point.graphics[1] = point.graphic;
             }
             point.graphic = point.graphics[0];

--- a/ts/Series/DotPlot/DotPlotSeries.ts
+++ b/ts/Series/DotPlot/DotPlotSeries.ts
@@ -104,7 +104,7 @@ class DotPlotSeries extends ColumnSeries {
         this.points.forEach(function (point: DotPlotPoint): void {
             let yPos: number,
                 attr: SVGAttributes,
-                graphics: Array<SVGElement>,
+                graphics: Array<SVGElement|undefined>,
                 pointAttr,
                 pointMarkerOptions = point.marker || {},
                 symbol = (
@@ -171,17 +171,24 @@ class DotPlotSeries extends ColumnSeries {
                         r: radius
                     };
 
-                    if (graphics[i]) {
-                        graphics[i].animate(attr);
+                    let graphic = graphics[i];
+
+                    if (graphic) {
+                        graphic.animate(attr);
                     } else {
-                        graphics[i] = renderer.symbol(symbol)
+                        graphic = renderer.symbol(symbol)
                             .attr(extend(attr, pointAttr))
                             .add(point.graphic);
                     }
-                    graphics[i].isActive = true;
+                    graphic.isActive = true;
+                    graphics[i] = graphic;
                 }
             }
             graphics.forEach((graphic, i): void => {
+                if (!graphic) {
+                    return;
+                }
+
                 if (!graphic.isActive) {
                     graphic.destroy();
                     graphics.splice(i, 1);

--- a/ts/Series/Item/ItemSeries.ts
+++ b/ts/Series/Item/ItemSeries.ts
@@ -246,7 +246,7 @@ class ItemSeries extends PieSeries {
 
         this.points.forEach(function (point): void {
             let attr: SVGAttributes,
-                graphics: Array<SVGElement>,
+                graphics: Array<SVGElement|undefined>,
                 pointAttr: (SVGAttributes|undefined),
                 pointMarkerOptions = point.marker || {},
                 symbol: SymbolKey = (
@@ -317,14 +317,16 @@ class ItemSeries extends PieSeries {
                         attr.r = r;
                     }
 
-                    if (graphics[val]) {
-                        graphics[val].animate(attr);
+                    let graphic = graphics[val];
+
+                    if (graphic) {
+                        graphic.animate(attr);
                     } else {
                         if (pointAttr) {
                             extend(attr, pointAttr);
                         }
 
-                        graphics[val] = renderer
+                        graphic = renderer
                             .symbol(
                                 symbol,
                                 void 0,
@@ -338,12 +340,16 @@ class ItemSeries extends PieSeries {
                             .attr(attr)
                             .add(point.graphic);
                     }
-                    graphics[val].isActive = true;
-
+                    graphic.isActive = true;
+                    graphics[val] = graphic;
                     i++;
                 }
             }
             graphics.forEach((graphic, i): void => {
+                if (!graphic) {
+                    return;
+                }
+
                 if (!graphic.isActive) {
                     graphic.destroy();
                     graphics.splice(i, 1);


### PR DESCRIPTION
Fixed #18080, hovering over area range points after zoom reset was throwing errors.