### PR TITLE
New option mapView.fitToGeometry

### DIFF
--- a/samples/maps/demo/data-class-ranges/demo.js
+++ b/samples/maps/demo/data-class-ranges/demo.js
@@ -20,7 +20,10 @@
             },
 
             mapNavigation: {
-                enabled: true
+                enabled: true,
+                buttonOptions: {
+                    align: 'right'
+                }
             },
 
             mapView: {

--- a/samples/maps/demo/data-class-ranges/demo.js
+++ b/samples/maps/demo/data-class-ranges/demo.js
@@ -23,6 +23,22 @@
                 enabled: true
             },
 
+            mapView: {
+                fitToGeometry: {
+                    type: 'MultiPoint',
+                    coordinates: [
+                        // Alaska west
+                        [-164, 54],
+                        // Greenland north
+                        [-35, 84],
+                        // New Zealand east
+                        [179, -38],
+                        // Chile south
+                        [-68, -55]
+                    ]
+                }
+            },
+
             legend: {
                 title: {
                     text: 'Individuals per km²',

--- a/samples/maps/demo/doubleclickzoomto/demo.js
+++ b/samples/maps/demo/doubleclickzoomto/demo.js
@@ -23,7 +23,26 @@
 
             mapNavigation: {
                 enabled: true,
-                enableDoubleClickZoomTo: true
+                enableDoubleClickZoomTo: true,
+                buttonOptions: {
+                    verticalAlign: 'bottom'
+                }
+            },
+
+            mapView: {
+                fitToGeometry: {
+                    type: 'MultiPoint',
+                    coordinates: [
+                        // Alaska west
+                        [-164, 54],
+                        // Greenland north
+                        [-35, 84],
+                        // New Zealand east
+                        [179, -38],
+                        // Chile south
+                        [-68, -55]
+                    ]
+                }
             },
 
             colorAxis: {

--- a/samples/maps/demo/map-bubble/demo.js
+++ b/samples/maps/demo/map-bubble/demo.js
@@ -35,6 +35,22 @@
                 }
             },
 
+            mapView: {
+                fitToGeometry: {
+                    type: 'MultiPoint',
+                    coordinates: [
+                        // Alaska west
+                        [-164, 54],
+                        // Greenland north
+                        [-35, 84],
+                        // New Zealand east
+                        [179, -38],
+                        // Chile south
+                        [-68, -55]
+                    ]
+                }
+            },
+
             series: [{
                 name: 'Countries',
                 color: '#E0E0E0',

--- a/samples/maps/demo/rich-info/demo.js
+++ b/samples/maps/demo/rich-info/demo.js
@@ -180,6 +180,22 @@
             }
         },
 
+        mapView: {
+            fitToGeometry: {
+                type: 'MultiPoint',
+                coordinates: [
+                    // Alaska west
+                    [-164, 54],
+                    // Greenland north
+                    [-35, 84],
+                    // New Zealand east
+                    [179, -38],
+                    // Chile south
+                    [-68, -55]
+                ]
+            }
+        },
+
         colorAxis: {
             type: 'logarithmic',
             endOnTick: false,

--- a/samples/maps/demo/spider-map/demo.js
+++ b/samples/maps/demo/spider-map/demo.js
@@ -31,6 +31,22 @@
             }
         },
 
+        mapView: {
+            fitToGeometry: {
+                type: 'MultiPoint',
+                coordinates: [
+                    // Alaska west
+                    [-164, 54],
+                    // Greenland north
+                    [-35, 84],
+                    // New Zealand east
+                    [179, -38],
+                    // Chile south
+                    [-68, -55]
+                ]
+            }
+        },
+
         title: {
             text: 'Norwegian medals in the Summer Olympics (1996 - 2020)',
             align: 'left'

--- a/samples/maps/mapview/fittogeometry/demo.css
+++ b/samples/maps/mapview/fittogeometry/demo.css
@@ -1,0 +1,21 @@
+.highcharts-figure {
+    min-width: 360px;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+#container {
+    width: 400px;
+    height: 400px;
+    margin: 0 auto;
+}
+
+.loading {
+    margin-top: 10em;
+    text-align: center;
+    color: gray;
+}
+
+.highcharts-description {
+    margin-top: 1rem;
+}

--- a/samples/maps/mapview/fittogeometry/demo.css
+++ b/samples/maps/mapview/fittogeometry/demo.css
@@ -5,7 +5,7 @@
 }
 
 #container {
-    width: 400px;
+    width: 500px;
     height: 400px;
     margin: 0 auto;
 }

--- a/samples/maps/mapview/fittogeometry/demo.details
+++ b/samples/maps/mapview/fittogeometry/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Fit to geometry
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+...

--- a/samples/maps/mapview/fittogeometry/demo.html
+++ b/samples/maps/mapview/fittogeometry/demo.html
@@ -11,12 +11,14 @@
     <button id="none">None</button>
 
     <div class="highcharts-description">
-        <p>When the map view is fitted to a `MultiPoint` geometry, it makes sure
-        that those points are within the view. When fitted to a `Polygon`
-        geometry, the <a href="https://en.wikipedia.org/wiki/Geodesic">geodesic</a>
+        <p>When the map view is fitted to a <code>MultiPoint</code> geometry, it
+        makes sure that those points are within the view. When fitted to a
+        <code>Polygon</code> geometry, the <a
+        href="https://en.wikipedia.org/wiki/Geodesic">geodesic</a>
         between the points in the polygon is fitted within the view.</p>
 
         <p>The Brazil and Arabia buttons demonstrate how extract the geometries
-        from the source map and fit to one shape or multiple shapes respectively.</p>
+        from the source map and fit to one shape or multiple shapes
+        respectively.</p>
     </div>
 </figure>

--- a/samples/maps/mapview/fittogeometry/demo.html
+++ b/samples/maps/mapview/fittogeometry/demo.html
@@ -1,0 +1,22 @@
+
+<script src="https://code.highcharts.com/maps/highmaps.js"></script>
+
+<figure class="highcharts-figure">
+    <div id="container"></div>
+
+    <button id="multipoint">Fit to MultiPoint</button>
+    <button id="polygon">Fit to Polygon</button>
+    <button id="country">Fit to Brazil</button>
+    <button id="region">Fit to Arabia</button>
+    <button id="none">None</button>
+
+    <div class="highcharts-description">
+        <p>When the map view is fitted to a `MultiPoint` geometry, it makes sure
+        that those points are within the view. When fitted to a `Polygon`
+        geometry, the <a href="https://en.wikipedia.org/wiki/Geodesic">geodesic</a>
+        between the points in the polygon is fitted within the view.</p>
+
+        <p>The Brazil and Arabia buttons demonstrate how extract the geometries
+        from the source map and fit to one shape or multiple shapes respectively.</p>
+    </div>
+</figure>

--- a/samples/maps/mapview/fittogeometry/demo.js
+++ b/samples/maps/mapview/fittogeometry/demo.js
@@ -1,0 +1,187 @@
+(async () => {
+
+    const topology = await fetch(
+        'https://code.highcharts.com/mapdata/custom/world.topo.json'
+    ).then(response => response.json());
+    const geojson = Highcharts.topo2geo(topology);
+
+    const data = await fetch(
+        'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/world-population-density.json'
+    ).then(response => response.json());
+
+    const multiPointGeometry = {
+        type: 'MultiPoint',
+        coordinates: [
+            // Alaska west
+            [-164, 54],
+            // Greenland north
+            [-35, 84],
+            // New Zealand east
+            [179, -38],
+            // Chile south
+            [-68, -55]
+        ]
+    };
+
+    const polygonGeometry = {
+        type: 'Polygon',
+        coordinates: [
+            [
+                // Africa
+                [-17, 32],
+                [51, 32],
+                [51, -30],
+                [-17, -30],
+                [-17, 32]
+            ]
+        ]
+    };
+
+    // Find the geometry for one specific feature
+    const countryGeometry = geojson.features.find(f =>
+        f.properties.name === 'Brazil'
+    ).geometry;
+
+    // Combine the geometries of multiple features into one, so that we can fit
+    // the map to a region
+    const regionGeometry = geojson.features
+        .filter(f =>
+            ['Oman', 'Saudi Arabia', 'Yemen'].includes(f.properties.name)
+        )
+        .reduce((combined, f) => {
+            const geometry = f.geometry;
+            if (geometry.type === 'Polygon') {
+                combined.coordinates.push(geometry.coordinates);
+            } else if (geometry.type === 'MultiPolygon') {
+                combined.coordinates.push.apply(
+                    combined.coordinates,
+                    geometry.coordinates
+                );
+            }
+            return combined;
+        }, {
+            type: 'MultiPolygon',
+            coordinates: []
+        });
+
+
+    // Initialize the chart
+    const chart = Highcharts.mapChart('container', {
+
+        chart: {
+            plotBorderWidth: 1
+        },
+
+        title: {
+            text: 'Fit to geometry'
+        },
+
+        legend: {
+            enabled: false
+        },
+
+        colorAxis: {
+            min: 1,
+            max: 1000,
+            minColor: '#a6d7ff',
+            maxColor: '#0b407b',
+            type: 'logarithmic'
+        },
+
+        mapView: {
+            fitToGeometry: multiPointGeometry,
+            padding: 5
+        },
+
+        series: [{
+            data,
+            mapData: geojson,
+            joinBy: ['iso-a2', 'code'],
+            name: 'Population density',
+            states: {
+                hover: {
+                    color: '#a4edba'
+                }
+            },
+            tooltip: {
+                valueSuffix: '/km²'
+            },
+            borderWidth: 0
+        }, {
+            type: 'mappoint',
+            id: 'preview',
+            keys: ['lon', 'lat'],
+            marker: {
+                radius: 5,
+                fillColor: '#ffffff',
+                lineWidth: 2,
+                lineColor: '#000000'
+            },
+            data: multiPointGeometry.coordinates
+        }]
+
+
+    });
+
+    document.getElementById('multipoint').addEventListener('click', () => {
+        chart.mapView.update({ fitToGeometry: multiPointGeometry });
+        const preview = chart.get('preview');
+        if (preview) {
+            preview.remove();
+        }
+        chart.addSeries({
+            type: 'mappoint',
+            id: 'preview',
+            keys: ['lon', 'lat'],
+            marker: {
+                radius: 5,
+                symbol: 'circle',
+                fillColor: '#ffffff',
+                lineWidth: 2,
+                lineColor: '#000000'
+            },
+            data: multiPointGeometry.coordinates
+        });
+    });
+
+    document.getElementById('polygon').addEventListener('click', () => {
+        chart.mapView.update({ fitToGeometry: polygonGeometry });
+        const preview = chart.get('preview');
+        if (preview) {
+            preview.remove();
+        }
+        chart.addSeries({
+            type: 'mapline',
+            id: 'preview',
+            data: [{ geometry: polygonGeometry }],
+            dashStyle: 'dash',
+            lineWidth: 2,
+            animation: false,
+            color: '#039'
+        });
+    });
+
+    document.getElementById('country').addEventListener('click', () => {
+        chart.mapView.update({ fitToGeometry: countryGeometry });
+        const preview = chart.get('preview');
+        if (preview) {
+            preview.remove();
+        }
+    });
+
+    document.getElementById('region').addEventListener('click', () => {
+        chart.mapView.update({ fitToGeometry: regionGeometry });
+        const preview = chart.get('preview');
+        if (preview) {
+            preview.remove();
+        }
+    });
+
+    document.getElementById('none').addEventListener('click', () => {
+        chart.mapView.update({ fitToGeometry: undefined });
+        const preview = chart.get('preview');
+        if (preview) {
+            preview.remove();
+        }
+    });
+})();

--- a/samples/maps/mapview/fittogeometry/demo.js
+++ b/samples/maps/mapview/fittogeometry/demo.js
@@ -90,7 +90,7 @@
 
         mapView: {
             fitToGeometry: multiPointGeometry,
-            padding: 5
+            padding: 15
         },
 
         series: [{

--- a/samples/maps/mapview/maxzoom/demo.js
+++ b/samples/maps/mapview/maxzoom/demo.js
@@ -27,7 +27,7 @@
             },
 
             mapView: {
-                maxZoom: 16
+                maxZoom: 4
             },
 
             legend: {

--- a/ts/Extensions/GeoJSON.ts
+++ b/ts/Extensions/GeoJSON.ts
@@ -97,6 +97,12 @@ declare global {
             hType?: string,
             series?: Series
         ): Array<any>;
+
+        /** @requires modules/maps */
+        function topo2geo(
+            topology: TopoJSON,
+            objectName?: string
+        ): GeoJSON;
     }
     interface Window {
         d3: any;
@@ -656,6 +662,7 @@ wrap(Chart.prototype, 'addCredits', function (
 });
 
 H.geojson = geojson;
+H.topo2geo = topo2geo;
 
 const GeoJSONModule = {
     geojson,

--- a/ts/Maps/GeoJSON.d.ts
+++ b/ts/Maps/GeoJSON.d.ts
@@ -20,6 +20,11 @@ export interface GeoJSONGeometryPoint extends BaseGeometry {
     coordinates: LonLatArray;
 }
 
+export interface MultiPoint extends BaseGeometry{
+    type: 'MultiPoint';
+    coordinates: LonLatArray[];
+}
+
 export interface LineString extends BaseGeometry{
     type: 'LineString';
     coordinates: LonLatArray[];
@@ -42,6 +47,7 @@ export interface MultiPolygon extends BaseGeometry {
 
 export interface GeoJSONGeometryMultiPointRegistry {
     LineString: LineString;
+    MultiPoint: MultiPoint;
     Polygon: Polygon;
     MultiLineString: MultiLineString;
     MultiPolygon: MultiPolygon;
@@ -55,7 +61,9 @@ interface GeoJSONGeometryRegistry extends GeoJSONGeometryMultiPointRegistry {
     Point: GeoJSONGeometryPoint;
 }
 
-type GeoJSONGeometry = GeoJSONGeometryRegistry[keyof GeoJSONGeometryRegistry];
+export type GeoJSONGeometry = GeoJSONGeometryRegistry[
+    keyof GeoJSONGeometryRegistry
+];
 
 export interface GeoJSON {
     bbox: [number, number, number, number];

--- a/ts/Maps/MapViewOptions.d.ts
+++ b/ts/Maps/MapViewOptions.d.ts
@@ -15,7 +15,7 @@
  * */
 import type ColorType from '../Core/Color/ColorType';
 import type ProjectionOptions from './ProjectionOptions';
-import type { MultiLineString, Polygon } from './GeoJSON';
+import type { GeoJSONGeometryMultiPoint, MultiLineString, Polygon } from './GeoJSON';
 
 /* *
  *
@@ -71,6 +71,7 @@ export interface MapViewInsetOptionsOptions {
 }
 
 export interface MapViewOptions {
+    fitToGeometry?: GeoJSONGeometryMultiPoint;
     center: LonLatArray;
     insetOptions?: MapViewInsetOptionsOptions;
     insets?: MapViewInsetsOptions[];

--- a/ts/Maps/MapViewOptionsDefault.ts
+++ b/ts/Maps/MapViewOptionsDefault.ts
@@ -47,17 +47,16 @@ const defaultOptions: MapViewOptions = {
     /**
      * Fit the map to a geometry object consisting of individual points or
      * polygons. This is practical for responsive maps where we want to focus on
-     * a specific area regardless of map size - unlike setting `center`
-     * and `zoom`, where the view doesn't scale with different map sizes.
+     * a specific area regardless of map size - unlike setting `center` and
+     * `zoom`, where the view doesn't scale with different map sizes.
      *
      * The geometry can be combined with the [padding](#mapView.padding) option
      * to avoid touching the edges of the chart.
      *
-     * @type {Highcharts.GeoJSONGeometryMultiPoint}
+     * @type {object}
      * @since next
      *
-     * @sample maps/mapview/fittogeometry
-     *         Fitting the view to geometries
+     * @sample maps/mapview/fittogeometry Fitting the view to geometries
      */
     fitToGeometry: void 0,
 

--- a/ts/Maps/MapViewOptionsDefault.ts
+++ b/ts/Maps/MapViewOptionsDefault.ts
@@ -45,6 +45,20 @@ const defaultOptions: MapViewOptions = {
     center: [0, 0],
 
     /**
+     * Fit the map to a geometry object consisting of individual points or
+     * polygons. This is practical for responsive maps where we want to focus on
+     * a specific area regardless of map size. This is unlike setting `center`
+     * and `zoom`, where the view doesn't scale with different map sizes.
+     *
+     * @type {Highcharts.GeoJSONGeometryMultiPoint}
+     * @since next
+     *
+     * @sample maps/mapview/fittogeometry
+     *         Fitting the view to geometries
+     */
+    fitToGeometry: void 0,
+
+    /**
      * Prevents the end user from zooming too far in on the map. See
      * [zoom](#mapView.zoom).
      *

--- a/ts/Maps/MapViewOptionsDefault.ts
+++ b/ts/Maps/MapViewOptionsDefault.ts
@@ -47,8 +47,11 @@ const defaultOptions: MapViewOptions = {
     /**
      * Fit the map to a geometry object consisting of individual points or
      * polygons. This is practical for responsive maps where we want to focus on
-     * a specific area regardless of map size. This is unlike setting `center`
+     * a specific area regardless of map size - unlike setting `center`
      * and `zoom`, where the view doesn't scale with different map sizes.
+     *
+     * The geometry can be combined with the [padding](#mapView.padding) option
+     * to avoid touching the edges of the chart.
      *
      * @type {Highcharts.GeoJSONGeometryMultiPoint}
      * @since next


### PR DESCRIPTION
Added new option, [mapView.fitToGeometry](https://api.highcharts.com/highmaps/mapView.fitToGeometry).

This will fill a gap in the options, as `center` and `zoom` alone are not able to fit the map to a desired area if we don't know the size of the map. Specifically for responsive sized maps.

Preview: https://highcharts.github.io/highcharts-utils/samples/#gh/8932ecc66d/sample/maps/mapview/fittogeometry

### To do
 - [x] Go over other samples, most importantly demos, and add `fitToGeometry` where beneficial.