### PR TITLE
bugfix/18127-datalabels-default-border

### DIFF
--- a/samples/unit-tests/datalabels/members/demo.js
+++ b/samples/unit-tests/datalabels/members/demo.js
@@ -112,6 +112,12 @@ QUnit.test('Series.drawDataLabels', function (assert) {
         'Should align dataLabel after update'
     );
 
+    assert.equal(
+        point.dataLabel.options.borderWidth,
+        0,
+        'Should have dataLabel.options.borderWidth equal to 0 by default #18127'
+    );
+
     point.options.dataLabels = { enabled: false };
     drawDataLabels.call(series);
     assert.strictEqual(

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -1576,6 +1576,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
          * @since     2.2.1
          * @apioption plotOptions.series.dataLabels.borderWidth
          */
+        borderWidth: 0,
 
         /**
          * A class name for the data label. Particularly in styled mode,


### PR DESCRIPTION
Fixed #18127, a regression causing an unintended border on data labels when setting `backgroundColor` and `borderColor` but no explicit `borderWidth`.