### PR TITLE
docs/mapline-data-geometry

### DIFF
--- a/ts/Core/Chart/ChartDefaults.ts
+++ b/ts/Core/Chart/ChartDefaults.ts
@@ -1280,8 +1280,7 @@ const ChartDefaults: ChartOptions = {
      *
      * @see In styled mode, a plot background image can be set with the
      *      `.highcharts-plot-background` class and a [custom pattern](
-     *      https://www.highcharts.com/docs/chart-design-and-style/
-     *      gradients-shadows-and-patterns).
+     *      https://www.highcharts.com/docs/chart-design-and-style/gradients-shadows-and-patterns).
      *
      * @sample {highcharts} highcharts/chart/plotbackgroundimage/
      *         Skies

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -1511,9 +1511,14 @@ export default MapSeries;
  * it is recommended to use `mapData` to define the geometry instead
  * of defining it on the data points themselves.
  *
- * The geometry object is compatible to that of a `feature` in geoJSON, so
- * features of geoJSON can be passed directly into the `data`, optionally
+ * The geometry object is compatible to that of a `feature` in GeoJSON, so
+ * features of GeoJSON can be passed directly into the `data`, optionally
  * after first filtering and processing it.
+ *
+ * For pre-projected maps (like GeoJSON maps from our
+ * [map collection](https://code.highcharts.com/mapdata/)), user has to specify
+ * coordinates in `projectedUnits` for geometry type other than `Point`,
+ * instead of `[longitude, latitude]`.
  *
  * @sample maps/series/data-geometry/
  *         Geometry defined in data


### PR DESCRIPTION
Improved the documentation for [mapline geometry](https://api.highcharts.com/highmaps/series.mapline.data.geometry).

Also, the link for chart patterns was formatted incorrectly in [plotBackgroundImage API](https://api.highcharts.com/highcharts/chart.plotBackgroundImage).