### PR TITLE
bugfix/18145-grey-series-boost

### DIFF
--- a/ts/Extensions/Boost/NamedColors.ts
+++ b/ts/Extensions/Boost/NamedColors.ts
@@ -80,6 +80,7 @@ const defaultHTMLColorMap: Record<string, ColorString> = {
     gold: '#ffd700',
     goldenrod: '#daa520',
     gray: '#808080',
+    grey: '#808080',
     green: '#008000',
     greenyellow: '#adff2f',
     honeydew: '#f0fff0',


### PR DESCRIPTION
Fixed #18145, boost module couldn't render series with colour set to grey.