### PR TITLE
Implemented linejoin option for maps

### DIFF
--- a/ts/Core/Series/SeriesOptions.d.ts
+++ b/ts/Core/Series/SeriesOptions.d.ts
@@ -86,7 +86,7 @@ export interface SeriesEventsOptions {
 
 export type SeriesFindNearestPointByValue = ('x'|'xy');
 
-export type SeriesLinecapValue = ('butt'|'round'|'square'|string);
+export type SeriesLinecapValue = ('butt'|'round'|'square');
 
 /**
  * Helper interface for series types to add options to all series options.

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -169,6 +169,16 @@ class MapSeries extends ScatterSeries {
         },
 
         /**
+         * The SVG value used for the `stroke-linecap` and `stroke-linejoin` of
+         * the map borders. Round means that borders are rounded in the ends and
+         * bends.
+         *
+         * @type       {Highcharts.SeriesLinecapValue}
+         * @since      next
+         */
+        linecap: 'round',
+
+        /**
          * @ignore-option
          *
          * @private
@@ -980,6 +990,7 @@ class MapSeries extends ScatterSeries {
         } else {
             delete attr['stroke-width'];
         }
+        attr['stroke-linecap'] = attr['stroke-linejoin'] = this.options.linecap;
 
         return attr;
     }

--- a/ts/Series/SolidGauge/SolidGaugeSeriesOptions.d.ts
+++ b/ts/Series/SolidGauge/SolidGaugeSeriesOptions.d.ts
@@ -26,7 +26,7 @@ import type { SeriesStatesOptions } from '../../Core/Series/SeriesOptions';
 
 export interface SolidGaugeSeriesOptions extends GaugeSeriesOptions {
     innerRadius?: string;
-    linecap?: string;
+    linecap?: ('butt'|'round'|'square');
     overshoot?: number;
     radius?: string;
     rounded?: boolean;


### PR DESCRIPTION
Added new [linejoin](https://api.highcharts.com/highmaps/series.map.linejoin) option for maps. Defaults to `round`.

Because currently our maps [look like barbed wire](https://jsfiddle.net/highcharts/c2Lx9vsg/) if we increase the border width.