### PR TITLE
bugfix/17314-align-threshold-and-stacking

### DIFF
--- a/samples/unit-tests/chart/alignthresholds/demo.js
+++ b/samples/unit-tests/chart/alignthresholds/demo.js
@@ -202,4 +202,32 @@ QUnit.test('alignThresholds', function (assert) {
         'Panes, two axes of different pane, thresholds should not be aligned'
     );
 
+    chart.series[2].remove(false);
+    chart.update({
+        chart: {
+            animation: false
+        },
+        plotOptions: {
+            series: {
+                stacking: 'normal',
+                animation: false
+            }
+        },
+        yAxis: [{
+            height: void 0,
+            top: void 0
+        }, {
+            top: void 0,
+            height: void 0
+        }]
+    });
+
+    const point1Box = chart.series[0].points[0].shapeArgs,
+        point2Box = chart.series[1].points[0].shapeArgs;
+
+    assert.strictEqual(
+        point1Box.y + point1Box.height,
+        point2Box.y + point2Box.height,
+        '#17314: alignThresholds and stacking should place columns correctly.'
+    );
 });

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -683,7 +683,7 @@ class Axis {
      */
     public getSeriesExtremes(): void {
         const axis = this,
-            chart = axis.chart;
+            { chart, stacking } = axis;
 
         let xExtremes;
 
@@ -695,10 +695,10 @@ class Axis {
             axis.dataMin = axis.dataMax = axis.threshold = null as any;
             axis.softThreshold = !axis.isXAxis;
 
-            if (axis.stacking) {
+            if (stacking) {
                 // #17314 clear stacks before new build
-                axis.stacking.cleanStacks();
-                axis.stacking.buildStacks();
+                stacking.cleanStacks();
+                stacking.buildStacks();
             }
 
             // loop through this axis' series

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -696,6 +696,8 @@ class Axis {
             axis.softThreshold = !axis.isXAxis;
 
             if (axis.stacking) {
+                // #17314 clear stacks before new build
+                axis.stacking.cleanStacks();
                 axis.stacking.buildStacks();
             }
 


### PR DESCRIPTION
Fixed #17314, `chart.alignThresholds` and stacking were not working correctly together.