### PR TITLE
bugfix/18168-legend-proximate-layout

### DIFF
--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -1054,7 +1054,7 @@ class Legend {
 
         for (const box of distribute(boxes, chart.plotHeight)) {
             legendItem = box.item.legendItem || {};
-            if (box.pos) {
+            if (isNumber(box.pos)) {
                 legendItem.y = chart.plotTop - chart.spacing[0] + box.pos;
             }
         }


### PR DESCRIPTION
Fixed #18168, legend item was mispositioned if the related series was located at the top of the chart and proximate layout was enabled.