### PR TITLE
Fixed handling of non-columns in DataTable.

### DIFF
--- a/test/typescript-karma/Data/DataTable.test.js
+++ b/test/typescript-karma/Data/DataTable.test.js
@@ -562,22 +562,25 @@ QUnit.test('DataTable.getColumnAsNumbers', function (assert) {
 });
 
 QUnit.test('DataTable.getRows', function (assert) {
-    const table = new DataTable();
+    const table = new DataTable({ 'a': [ 0 ] });
 
-    try {
-        table.getRowObject(undefined, undefined, ['Non-Existing-Column']);
-        table.getRows(undefined, undefined, ['Non-Existing-Column']);
-        assert.ok(
-            true,
-            'Table should not break when accessing non-existing column'
-        );
-    }
-    catch (error) {
-        assert.notOk(
-            true,
-            'Table should not break when accessing non-existing column'
-        );
-    }
+    const rowObject = table
+        .getRowObject(undefined, ['Non-Existing Column']);
+
+    assert.deepEqual(
+        Object.keys(rowObject),
+        ['Non-Existing Column'],
+        'Table should return row with non-existing column.'
+    );
+
+    const cellArray = table
+        .getRow(undefined, ['Non-Existing Column']);
+
+    assert.deepEqual(
+        cellArray,
+        [ undefined ],
+        'Table should return row with non-existing column.'
+    );
 
 });
 

--- a/test/typescript-karma/Data/DataTable.test.js
+++ b/test/typescript-karma/Data/DataTable.test.js
@@ -164,7 +164,7 @@ QUnit.test('DataTable Column Aliases', function (assert) {
         'Table should return cell values of deleted column.'
     );
 
-    assert.ok(
+    assert.strictEqual(
         typeof table.getColumn('population'),
         'undefined',
         'Table should have removed column "population".'
@@ -558,6 +558,26 @@ QUnit.test('DataTable.getColumnAsNumbers', function (assert) {
         isNaN(table.getColumnAsNumbers('test7', true)[0]),
         'Table should return column "test7" after conversion. (#2)'
     );
+
+});
+
+QUnit.test('DataTable.getRows', function (assert) {
+    const table = new DataTable();
+
+    try {
+        table.getRowObject(undefined, undefined, ['Non-Existing-Column']);
+        table.getRows(undefined, undefined, ['Non-Existing-Column']);
+        assert.ok(
+            true,
+            'Table should not break when accessing non-existing column'
+        );
+    }
+    catch (error) {
+        assert.notOk(
+            true,
+            'Table should not break when accessing non-existing column'
+        );
+    }
 
 });
 

--- a/ts/Data/DataTable.ts
+++ b/ts/Data/DataTable.ts
@@ -980,8 +980,6 @@ class DataTable implements DataEvent.Emitter {
 
         columnNamesOrAliases = (columnNamesOrAliases || Object.keys(columns));
 
-        const columnNamesLength = columnNamesOrAliases.length;
-
         for (
             let i = rowIndex,
                 i2 = 0,
@@ -996,19 +994,9 @@ class DataTable implements DataEvent.Emitter {
         ) {
             row = rows[i2] = {};
 
-            for (
-                let j = 0,
-                    jEnd = columnNamesLength,
-                    columnName: string;
-                j < jEnd;
-                ++j
-            ) {
-                columnName = columnNamesOrAliases[j];
+            for (const columnName of columnNamesOrAliases) {
                 column = columns[(aliasMap[columnName] || columnName)];
-
-                if (column) {
-                    row[columnName] = column[i];
-                }
+                row[columnName] = (column ? column[i] : void 0);
             }
         }
 
@@ -1044,8 +1032,6 @@ class DataTable implements DataEvent.Emitter {
 
         columnNamesOrAliases = (columnNamesOrAliases || Object.keys(columns));
 
-        const columnNamesLength = columnNamesOrAliases.length;
-
         for (
             let i = rowIndex,
                 i2 = 0,
@@ -1054,19 +1040,15 @@ class DataTable implements DataEvent.Emitter {
                     (rowIndex + rowCount)
                 ),
                 column: DataTable.Column,
-                columnName: string,
                 row: DataTable.Row;
             i < iEnd;
             ++i, ++i2
         ) {
-            row = rows[i2] = new Array(columnNamesLength);
-            for (let j = 0; j < columnNamesLength; ++j) {
-                columnName = columnNamesOrAliases[j];
-                column = columns[(aliasMap[columnName] || columnName)];
+            row = rows[i2] = [];
 
-                if (column) {
-                    row[j] = column[i];
-                }
+            for (const columnName of columnNamesOrAliases) {
+                column = columns[(aliasMap[columnName] || columnName)];
+                row.push(column ? column[i] : void 0);
             }
         }
 

--- a/ts/Data/DataTable.ts
+++ b/ts/Data/DataTable.ts
@@ -989,6 +989,7 @@ class DataTable implements DataEvent.Emitter {
                     table.rowCount,
                     (rowIndex + rowCount)
                 ),
+                column: DataTable.Column,
                 row: DataTable.RowObject;
             i < iEnd;
             ++i, ++i2
@@ -1003,9 +1004,11 @@ class DataTable implements DataEvent.Emitter {
                 ++j
             ) {
                 columnName = columnNamesOrAliases[j];
-                row[columnName] = columns[
-                    (aliasMap[columnName] || columnName)
-                ][i];
+                column = columns[(aliasMap[columnName] || columnName)];
+
+                if (column) {
+                    row[columnName] = column[i];
+                }
             }
         }
 
@@ -1050,6 +1053,7 @@ class DataTable implements DataEvent.Emitter {
                     table.rowCount,
                     (rowIndex + rowCount)
                 ),
+                column: DataTable.Column,
                 columnName: string,
                 row: DataTable.Row;
             i < iEnd;
@@ -1058,7 +1062,11 @@ class DataTable implements DataEvent.Emitter {
             row = rows[i2] = new Array(columnNamesLength);
             for (let j = 0; j < columnNamesLength; ++j) {
                 columnName = columnNamesOrAliases[j];
-                row[j] = columns[(aliasMap[columnName] || columnName)][i];
+                column = columns[(aliasMap[columnName] || columnName)];
+
+                if (column) {
+                    row[j] = column[i];
+                }
             }
         }
 


### PR DESCRIPTION
Handles `undefined is not an object` exceptions when providing non-existing columns to the row getter functions of DataTable.