### PR TITLE
bugfix/indicators-with-empty-dataset

### DIFF
--- a/samples/unit-tests/indicator-cmf/recalculations/demo.js
+++ b/samples/unit-tests/indicator-cmf/recalculations/demo.js
@@ -152,4 +152,22 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
         chart.series.indexOf(indicator) === -1,
         'Indicator is removed after series remove.'
     );
+
+    while (chart.series.length) {
+        chart.series[0].remove(false);
+    }
+    chart.addSeries({
+        id: 'main',
+        data: []
+    }, false);
+    chart.addSeries({
+        type: 'cmf',
+        linkedTo: 'main'
+    });
+
+    assert.ok(
+        true,
+        `No errors when adding indicator linkedTo a series with empty dataset
+        (#18176, #18177).`
+    );
 });

--- a/ts/Stock/Indicators/SMA/SMAIndicator.ts
+++ b/ts/Stock/Indicators/SMA/SMAIndicator.ts
@@ -372,15 +372,15 @@ class SMAIndicator extends LineSeries {
      * @private
      */
     public recalculateValues(): void {
-        let indicator = this,
+        const indicator = this,
             oldData = indicator.points || [],
             oldDataLength = (indicator.xData || []).length,
             emptySet: IndicatorValuesObject<typeof LineSeries.prototype> = {
                 values: [],
                 xData: [],
                 yData: []
-            },
-            processedData: IndicatorValuesObject<typeof LineSeries.prototype>,
+            };
+        let processedData: IndicatorValuesObject<typeof LineSeries.prototype>,
             croppedDataValues = [],
             overwriteData = true,
             oldFirstPointIndex,
@@ -395,7 +395,9 @@ class SMAIndicator extends LineSeries {
         // we will try to access Series object without any properties
         // (except for prototyped ones). This is what happens
         // for example when using Axis.setDataGrouping(). See #16670
-        processedData = indicator.linkedParent.options ?
+        processedData = indicator.linkedParent.options &&
+            indicator.linkedParent.yData && // #18176, #18177 indicators should
+            indicator.linkedParent.yData.length ? // work with empty dataset
             (
                 indicator.getValues(
                     indicator.linkedParent,


### PR DESCRIPTION
Fixed #18176 and fixed #18178, indicators didn't work with an empty dataset.