### PR TITLE
bugfix/16753-number-in-parameter-name

### DIFF
--- a/ts/Extensions/Annotations/Popup/Popup.ts
+++ b/ts/Extensions/Annotations/Popup/Popup.ts
@@ -309,7 +309,7 @@ class Popup {
                 optionName
             );
 
-        if (!inputName.match(/\d/g)) {
+        if (!optionName.match(/^\d+$/)) {
             // add label
             createElement(
                 'label',


### PR DESCRIPTION
Fixes #16753, when adding a custom indicator, if the parameter name contained any digits, the stock tools pop-up did not display it.