### PR TITLE
bugfix/18147-polar-hidden-datalabels

### DIFF
--- a/samples/unit-tests/chart/polar/demo.js
+++ b/samples/unit-tests/chart/polar/demo.js
@@ -33,6 +33,9 @@ QUnit.test('Polar chart data', function (assert) {
 
     chart.series[0].update({
         type: 'spline',
+        dataLabels: {
+            enabled: true
+        },
         data: [
             { x: 45, y: 5 },
             { x: 90, y: 2 },
@@ -46,6 +49,13 @@ QUnit.test('Polar chart data', function (assert) {
             p => p.slice(1).every(Highcharts.isNumber)
         ),
         '#15489: Graph path should not contain any NaN values'
+    );
+
+    assert.ok(
+        [...chart.series[0].dataLabelsGroup.element.childNodes].every(
+            dl => dl.getAttribute('visibility') !== 'hidden'
+        ),
+        '#18147: All data labels should be visible'
     );
 });
 QUnit.test(

--- a/ts/Extensions/Pane.ts
+++ b/ts/Extensions/Pane.ts
@@ -616,17 +616,14 @@ addEvent(Chart, 'afterIsInsidePlot', function (
     const chart = this;
 
     if (chart.polar) {
-        let x = e.x - (e.options.paneCoordinates ? chart.plotLeft : 0),
-            y = e.y - (e.options.paneCoordinates ? chart.plotTop : 0);
-
         if (e.options.inverted) {
-            [x, y] = [y, x];
+            [e.x, e.y] = [e.y, e.x];
         }
 
         e.isInsidePlot = (chart as Highcharts.PaneChart).pane.some(
             (pane): boolean => isInsidePane(
-                x,
-                y,
+                e.x,
+                e.y,
                 pane.center,
                 pane.axis && pane.axis.normalizedStartAngleRad,
                 pane.axis && pane.axis.normalizedEndAngleRad


### PR DESCRIPTION
Fixes #18147, some data labels weren't rendered correctly in polar charts.