### PR TITLE
bugfix/16841-stochastic-missing-D-line

### DIFF
--- a/samples/unit-tests/indicator-slow-stochastic/recalculations/demo.js
+++ b/samples/unit-tests/indicator-slow-stochastic/recalculations/demo.js
@@ -70,4 +70,49 @@ QUnit.test('Test Slow Stochastic calculations on data updates.', assert => {
         series[0].points.length - periods[0] - 1,
         'After addPoint number of Slow Stochastic points is correct'
     );
+
+    series[1].setData([]);
+
+    series[0].setData([
+        [100, 100, 100, 100],
+        [100, 100, 100, 100],
+        [100, 100, 100, 100],
+        [100, 100, 100, 100],
+        [100, 100, 100, 100],
+        [100, 100, 100, 100],
+        [100, 100, 100, 100],
+        [100, 100, 100, 100],
+        [100, 100, 100, 100],
+        [100, 100, 100, 100],
+        [100, 100, 100, 100],
+        [100, 100, 100, 100],
+        [100, 100, 100, 100],
+        [100, 100, 100, 100], //14th
+        [100, 100, 100, 100],
+        [100, 100, 100, 100], // %D
+        [100, 100, 100, 100],
+        [100, 100, 100, 100]
+    ]);
+
+    assert.strictEqual(
+        series[1].data.length,
+        0,
+        `If all values of the main series are the same, the indicator values
+        should not be calculated, #16841`
+    );
+
+    // Add next 14 points with the same values to the main series
+    for (let i = 0; i < 14; i++) {
+        series[0].addPoint([200, 200, 200, 200]);
+    }
+
+    const lastIndex = series[1].yData.length - 1;
+
+    assert.deepEqual(
+        [series[1].yData[lastIndex][0], series[1].yData[lastIndex][1]],
+        [series[1].yData[lastIndex - 1][0], series[1].yData[lastIndex - 1][1]],
+        `If N-period previous points of the main series have the same values,
+        the last point of the indicator should have the same values as the
+        previous one, #16841`
+    );
 });

--- a/ts/Stock/Indicators/Stochastic/StochasticIndicator.ts
+++ b/ts/Stock/Indicators/Stochastic/StochasticIndicator.ts
@@ -206,7 +206,7 @@ class StochasticIndicator extends SMAIndicator {
             K = CL / HL * 100;
 
             xData.push(xVal[i]);
-            yData.push([K, null]);
+            yData.push([isNaN(K) ? yData[yData.length - 1][0] : K, null]);
 
             // Calculate smoothed %D, which is SMA of %K
             if (i >= (periodK - 1) + (periodD - 1)) {

--- a/ts/Stock/Indicators/Stochastic/StochasticIndicator.ts
+++ b/ts/Stock/Indicators/Stochastic/StochasticIndicator.ts
@@ -216,13 +216,16 @@ class StochasticIndicator extends SMAIndicator {
                 constantValues = false;
             }
 
-            xData.push(xVal[i]);
+            const length = xData.push(xVal[i]);
 
+            // If N-period previous values are constant which results in NaN %K,
+            // we need to use previous %K value if it is a number,
+            // otherwise we should use null
             if (isNaN(K)) {
                 yData.push([
-                    yData[yData.length - 1] &&
-                        typeof yData[yData.length - 1][0] === 'number' ?
-                        yData[yData.length - 1][0] : null,
+                    yData[length - 2] &&
+                        typeof yData[length - 2][0] === 'number' ?
+                        yData[length - 2][0] : null,
                     null
                 ]);
             } else {
@@ -242,7 +245,7 @@ class StochasticIndicator extends SMAIndicator {
             }
 
             SO.push([xVal[i], K, D]);
-            yData[yData.length - 1][1] = D;
+            yData[length - 1][1] = D;
         }
 
         return {


### PR DESCRIPTION
Fixed #16841, Slow Stochastic Indicator was missing `%D` line when the `K` value was `NaN`.