### PR TITLE
bugfix/17114-datagrouping-error-plotsize-zero

### DIFF
--- a/samples/unit-tests/series/datagrouping/demo.js
+++ b/samples/unit-tests/series/datagrouping/demo.js
@@ -118,6 +118,24 @@ QUnit.test('General dataGrouping options', function (assert) {
         calledWithNaN,
         'Empty series should not cause getTimezoneOffset to get called with NaN timestamp (#13247)'
     );
+
+    chart.update({
+        chart: {
+            width: 10
+        },
+        plotOptions: {
+            series: {
+                dataGrouping: {
+                    units: void 0
+                }
+            }
+        }
+    });
+
+    assert.ok(
+        true,
+        'No errors when plotSizeX of the chart is zero (#17114).'
+    );
 });
 
 QUnit.test('dataGrouping and keys', function (assert) {

--- a/ts/Extensions/DataGrouping/DataGroupingSeriesComposition.ts
+++ b/ts/Extensions/DataGrouping/DataGroupingSeriesComposition.ts
@@ -333,7 +333,8 @@ function applyGrouping(
         if (
             groupPixelWidth &&
             processedXData &&
-            processedXData.length
+            processedXData.length &&
+            plotSizeX
         ) {
             hasGroupedData = true;
 
@@ -350,7 +351,7 @@ function applyGrouping(
                     xAxis.ordinal.getGroupIntervalFactor(xMin, xMax, series)
                 ) || 1,
                 interval =
-                    (groupPixelWidth * (xMax - xMin) / (plotSizeX as any)) *
+                    (groupPixelWidth * (xMax - xMin) / plotSizeX) *
                     groupIntervalFactor,
                 groupPositions = xAxis.getTimeTicks(
                     DateTimeAxis.Additions.prototype.normalizeTimeTickInterval(


### PR DESCRIPTION
Fixed #17114, chart with data grouping had errors if the plot width was zero.