### PR TITLE
bugfix/17888-plotLine-label-align

### DIFF
--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
@@ -230,7 +230,8 @@ QUnit.test('Defaults', assert => {
 QUnit.test('General tests', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {
-            width: 600
+            width: 600,
+            marginRight: 50
         },
         xAxis: {
             plotBands: [
@@ -252,7 +253,21 @@ QUnit.test('General tests', function (assert) {
                     value: 12500,
                     className: 'my-custom-class',
                     width: 2,
-                    color: 'red'
+                    color: 'red',
+                    label: {
+                        align: 'right',
+                        textAlign: 'left',
+                        text: 'label'
+                    }
+                }, {
+                    value: 15000,
+                    color: 'red',
+                    label: {
+                        align: 'right',
+                        clip: true,
+                        textAlign: 'left',
+                        text: 'label'
+                    }
                 }
             ]
         },
@@ -287,6 +302,18 @@ QUnit.test('General tests', function (assert) {
         line[line.length - 1],
         'Z',
         'Border should be rendered around the shape (#5909)'
+    );
+
+    assert.ok(
+        chart.yAxis[0].plotLinesAndBands[0].label.actualWidth > 0,
+        'Plot line label should be able to render outside plot area #17888.'
+    );
+
+    assert.strictEqual(
+        chart.yAxis[0].plotLinesAndBands[1].label.actualWidth,
+        0,
+        `Plot label with clip: true should not be able to render outside plot
+        area #15777.`
     );
 
     // Radial Axes plot lines

--- a/ts/Core/Axis/PlotLineOrBand/PlotBandOptions.d.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotBandOptions.d.ts
@@ -32,6 +32,7 @@ import type PlotLineOrBand from './PlotLineOrBand';
 
 export interface PlotBandLabelOptions {
     align?: AlignValue;
+    clip?: boolean;
     formatter?: FormatUtilities.FormatterCallback<PlotLineOrBand>;
     rotation?: number;
     style?: CSSObject;

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOptions.d.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOptions.d.ts
@@ -32,6 +32,7 @@ import type PlotLineOrBand from './PlotLineOrBand';
 
 export interface PlotLineLabelOptions {
     align?: AlignValue;
+    clip?: boolean;
     formatter?: FormatUtilities.FormatterCallback<PlotLineOrBand>;
     rotation?: number;
     style?: CSSObject;

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -345,13 +345,12 @@ class PlotLineOrBand {
             width: arrayMax(xBounds) - x,
             height: arrayMax(yBounds) - y
         });
-
         if (!label.alignValue || label.alignValue === 'left') {
             label.css({
                 width: (
                     label.rotation === 90 ?
                         axis.height - (label.alignAttr.y - axis.top) :
-                        axis.width - (label.alignAttr.x - axis.left)
+                        axis.chart.chartWidth - (label.alignAttr.x - axis.left)
                 ) + 'px'
             });
         }

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -265,7 +265,6 @@ class PlotLineOrBand {
             // apply defaults
             optionsLabel = merge({
                 align: horiz && isBand && 'center',
-                clip: false,
                 x: horiz ? !isBand && 4 : 10,
                 verticalAlign: !horiz && isBand && 'middle',
                 y: horiz ? isBand ? 16 : 10 : isBand ? 6 : -4,
@@ -347,14 +346,14 @@ class PlotLineOrBand {
             height: arrayMax(yBounds) - y
         });
         if (!label.alignValue || label.alignValue === 'left') {
-            const length = optionsLabel.clip ?
+            const width = optionsLabel.clip ?
                 axis.width : axis.chart.chartWidth;
 
             label.css({
                 width: (
                     label.rotation === 90 ?
                         axis.height - (label.alignAttr.y - axis.top) :
-                        length - (label.alignAttr.x - axis.left)
+                        width - (label.alignAttr.x - axis.left)
                 ) + 'px'
             });
         }
@@ -923,7 +922,7 @@ export default PlotLineOrBand;
  * @type      {boolean}
  * @default   false
  * @since     next
- * @apioption xAxis.plotLines.clip
+ * @apioption xAxis.plotLines.labels.clip
  */
 
 /**

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -265,6 +265,7 @@ class PlotLineOrBand {
             // apply defaults
             optionsLabel = merge({
                 align: horiz && isBand && 'center',
+                clip: false,
                 x: horiz ? !isBand && 4 : 10,
                 verticalAlign: !horiz && isBand && 'middle',
                 y: horiz ? isBand ? 16 : 10 : isBand ? 6 : -4,
@@ -346,11 +347,14 @@ class PlotLineOrBand {
             height: arrayMax(yBounds) - y
         });
         if (!label.alignValue || label.alignValue === 'left') {
+            const length = optionsLabel.clip ?
+                axis.width : axis.chart.chartWidth;
+
             label.css({
                 width: (
                     label.rotation === 90 ?
                         axis.height - (label.alignAttr.y - axis.top) :
-                        axis.chart.chartWidth - (label.alignAttr.x - axis.left)
+                        length - (label.alignAttr.x - axis.left)
                 ) + 'px'
             });
         }
@@ -911,6 +915,15 @@ export default PlotLineOrBand;
  * @default    left
  * @since      2.1
  * @apioption  xAxis.plotLines.label.align
+ */
+
+/**
+ * Whether to hide labels that are outside the plot area.
+ *
+ * @type      {boolean}
+ * @default   false
+ * @since     next
+ * @apioption xAxis.plotLines.clip
  */
 
 /**


### PR DESCRIPTION
Fixed #17888, plot line labels with `align: 'right'` and `textAlign: 'left'` weren't displayed.