### PR TITLE
bugfix/18166-mapline-stroke-width-zoom-scale

### DIFF
--- a/samples/unit-tests/maps/mapline-linewidth/demo.js
+++ b/samples/unit-tests/maps/mapline-linewidth/demo.js
@@ -56,5 +56,17 @@ QUnit.test(
             0.0000000001,
             'Line width in mapline should have a value of 10 on hover state (#5201, #17105).'
         );
+
+        chart.series[1].points[0].update({
+            lineWidth: 15
+        });
+
+        const pointLineWidth = chart.series[1].points[0].graphic['stroke-width'];
+        chart.mapView.zoomBy(2);
+
+        assert.ok(
+            chart.series[1].points[0].graphic['stroke-width'] < pointLineWidth,
+            'Line width set on point in mapline should scale down on zoom, #18166.'
+        );
     }
 );

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -763,8 +763,24 @@ class MapSeries extends ScatterSeries {
             transform properties, it should induce a single updateTransform and
             symbolAttr call.
             */
-            const scale = svgTransform.scaleX;
-            const flipFactor = svgTransform.scaleY > 0 ? 1 : -1;
+            const scale = svgTransform.scaleX,
+                flipFactor = svgTransform.scaleY > 0 ? 1 : -1;
+            const animatePoints = (scale: number): void => { // #18166
+                series.points.forEach((point): void => {
+                    const graphic = point.graphic;
+                    let strokeWidth;
+
+                    if (
+                        graphic &&
+                        graphic['stroke-width'] &&
+                        (strokeWidth = this.getStrokeWidth(point.options))
+                    ) {
+                        graphic.attr({
+                            'stroke-width': strokeWidth / scale
+                        });
+                    }
+                });
+            };
             if (renderer.globalAnimation && chart.hasRendered) {
                 const startTranslateX = Number(
                     transformGroup.attr('translateX')
@@ -796,20 +812,7 @@ class MapSeries extends ScatterSeries {
                         'stroke-width': strokeWidth / scaleStep
                     });
 
-                    series.points.forEach((point): void => { // #18166
-                        const graphic = point.graphic;
-                        let strokeWidth;
-
-                        if (
-                            graphic &&
-                            graphic['stroke-width'] &&
-                            (strokeWidth = this.getStrokeWidth(point.options))
-                        ) {
-                            graphic.attr({
-                                'stroke-width': strokeWidth / scaleStep
-                            });
-                        }
-                    });
+                    animatePoints(scaleStep); // #18166
 
                 };
 
@@ -823,20 +826,7 @@ class MapSeries extends ScatterSeries {
                     svgTransform, { 'stroke-width': strokeWidth / scale }
                 ));
 
-                series.points.forEach((point): void => { // #18166
-                    const graphic = point.graphic;
-                    let strokeWidth;
-
-                    if (
-                        graphic &&
-                        graphic['stroke-width'] &&
-                        (strokeWidth = this.getStrokeWidth(point.options))
-                    ) {
-                        graphic.attr({
-                            'stroke-width': strokeWidth / scale
-                        });
-                    }
-                });
+                animatePoints(scale); // #18166
             }
         });
 

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -792,13 +792,25 @@ class MapSeries extends ScatterSeries {
                             ) * fx.pos
                         ),
                         scaleX: scaleStep,
-                        scaleY: scaleStep * flipFactor
+                        scaleY: scaleStep * flipFactor,
+                        'stroke-width': strokeWidth / scaleStep
                     });
 
-                    transformGroup.element.setAttribute(
-                        'stroke-width',
-                        strokeWidth / scaleStep
-                    );
+                    series.points.forEach((point): void => { // #18166
+                        const graphic = point.graphic;
+                        let strokeWidth;
+
+                        if (
+                            graphic &&
+                            graphic['stroke-width'] &&
+                            (strokeWidth = this.getStrokeWidth(point.options))
+                        ) {
+                            graphic.attr({
+                                'stroke-width': strokeWidth / scaleStep
+                            });
+                        }
+                    });
+
                 };
 
                 transformGroup
@@ -807,16 +819,24 @@ class MapSeries extends ScatterSeries {
 
             // When dragging or first rendering, animation is off
             } else {
-                transformGroup.attr(svgTransform);
+                transformGroup.attr(merge(
+                    svgTransform, { 'stroke-width': strokeWidth / scale }
+                ));
 
-                // Set the stroke-width directly on the group element so the
-                // children inherit it. We need to use setAttribute directly,
-                // because the stroke-widthSetter method expects a stroke color
-                // also to be set.
-                transformGroup.element.setAttribute(
-                    'stroke-width',
-                    strokeWidth / scale
-                );
+                series.points.forEach((point): void => { // #18166
+                    const graphic = point.graphic;
+                    let strokeWidth;
+
+                    if (
+                        graphic &&
+                        graphic['stroke-width'] &&
+                        (strokeWidth = this.getStrokeWidth(point.options))
+                    ) {
+                        graphic.attr({
+                            'stroke-width': strokeWidth / scale
+                        });
+                    }
+                });
             }
         });
 

--- a/ts/Series/MapLine/MapLineSeries.ts
+++ b/ts/Series/MapLine/MapLineSeries.ts
@@ -68,7 +68,13 @@ class MapLineSeries extends MapSeries {
      */
     public static defaultOptions: MapLineSeriesOptions = merge(MapSeries.defaultOptions, {
         /**
-         * The width of the map line.
+         * Pixel width of the mapline line.
+         *
+         * @type      {number}
+         * @since     next
+         * @product   highmaps
+         * @default   1
+         * @apioption plotOptions.mapline.lineWidth
          */
         lineWidth: 1,
 
@@ -243,6 +249,15 @@ export default MapLineSeries;
  * @since 10.2.0
  * @product   highmaps
  * @apioption plotOptions.mapline.states.hover.lineWidth
+ */
+
+/**
+ * Pixel width of the mapline line.
+ *
+ * @type      {number|undefined}
+ * @since     next
+ * @product   highmaps
+ * @apioption series.mapline.data.lineWidth
  */
 
 /**


### PR DESCRIPTION
Fixed #18166, border or line width set on point was not scaling on zoom in `map` and `mapline` series.