### PR TITLE
Fixed tooltip font family

### DIFF
--- a/samples/highcharts/website/highcharts-timeline/demo.css
+++ b/samples/highcharts/website/highcharts-timeline/demo.css
@@ -10,7 +10,7 @@
     z-index: 0;
     margin: 0;
     padding: 0;
-    font-family: "IBM Plex Sans", sans-serif;
+    font-family: Arial, Helvetica, sans-serif;
 }
 
 #turnover {


### PR DESCRIPTION
I changed the font to web-safe Arial/Helvetica. The external tooltip font wasn't working.