### PR TITLE
Tools: Allow setting default browser for karma

### DIFF
--- a/samples/unit-tests/axis/stacklabels/demo.js
+++ b/samples/unit-tests/axis/stacklabels/demo.js
@@ -702,9 +702,10 @@ QUnit.test('Stack labels - scrollable plot Area #12133.', assert => {
     const stack = getStack(chart),
         dataLabel = chart.series[0].points[0].dataLabel;
 
-    assert.equal(
+    assert.close(
         stack.alignAttr.y,
         dataLabel.alignAttr.y,
+        1,
         'the `y` position should be the same for dataLabel and stackLabel'
     );
 });

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -201,6 +201,8 @@ module.exports = function (config) {
     // Browsers
     let browsers = argv.browsers ?
         argv.browsers.split(',') :
+        // Use karma.defaultbrowser=FirefoxHeadless to bypass WebGL problems in
+        // Chrome 109
         [getProperties()['karma.defaultbrowser'] || 'ChromeHeadless'];
     if (argv.oldie) {
         browsers = ['Win.IE8'];

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -201,7 +201,7 @@ module.exports = function (config) {
     // Browsers
     let browsers = argv.browsers ?
         argv.browsers.split(',') :
-        ['ChromeHeadless'];
+        [getProperties()['karma.defaultbrowser'] || 'ChromeHeadless'];
     if (argv.oldie) {
         browsers = ['Win.IE8'];
     } else if (argv.browsers === 'all') {
@@ -209,7 +209,7 @@ module.exports = function (config) {
     }
 
     const browserCount = argv.browsercount || (Math.max(1, os.cpus().length - 2));
-    if (!argv.browsers && browserCount && !isNaN(browserCount)  && browserCount > 1) {
+    if (!argv.browsers && browserCount && !isNaN(browserCount) && browserCount > 1) {
         // Sharding / splitting tests across multiple browser instances
         frameworks = [...frameworks, 'sharding'];
         // create a duplicate of the added browsers ${numberOfInstances} times.
@@ -219,7 +219,7 @@ module.exports = function (config) {
             }
             return browserInstances;
         }, [])
-        : new Array(browserCount).fill('ChromeHeadless');
+        : new Array(browserCount).fill(browsers[0]);
     } else {
         if (argv.splitbrowsers) {
             browsers = argv.splitbrowsers.split(',');

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -771,7 +771,7 @@ class MapSeries extends ScatterSeries {
             const scale = svgTransform.scaleX,
                 flipFactor = svgTransform.scaleY > 0 ? 1 : -1;
             const animatePoints = (scale: number): void => { // #18166
-                series.points.forEach((point): void => {
+                (series.points || []).forEach((point): void => {
                     const graphic = point.graphic;
                     let strokeWidth;
 


### PR DESCRIPTION
Allow setting default browser for karma. This provides a simple workaround for [Chrome 109's missing WebGL support in headless mode](https://bugs.chromium.org/p/chromium/issues/detail?id=1407025&q=webgl&can=2).

### Usage
Open or create the file `/git-ignore-me.properties` in the _highcharts_ repo root, and add this
```
# Karma tests
karma.defaultbrowser=FirefoxHeadless
```