### PR TITLE
Fixed #18362, updating legend.layout from/to proximate

### DIFF
--- a/samples/unit-tests/legend/layout/demo.js
+++ b/samples/unit-tests/legend/layout/demo.js
@@ -55,7 +55,22 @@ QUnit.test('Legend layout', function (assert) {
     );
 
     chart.legend.update({
-        useHTML: true
+        layout: 'vertical'
+    });
+
+    assert.ok(
+        chart.legend.group.getBBox().height < 200,
+        'The legend items should be laid out succesively (#18362)'
+    );
+    assert.ok(
+        chart.legend.group.translateY + chart.legend.group.getBBox().height <
+            chart.chartHeight,
+        'The legend items should not spill out of the chart (#18362)'
+    );
+
+    chart.legend.update({
+        useHTML: true,
+        layout: 'proximate'
     });
 
     assert.ok(

--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -257,19 +257,6 @@ class Legend {
             addEvent(this.chart, 'endResize', function (): void {
                 this.legend.positionCheckboxes();
             });
-
-            if (this.proximate) {
-                this.unchartrender = addEvent(
-                    this.chart,
-                    'render',
-                    function (): void {
-                        this.legend.proximatePositions();
-                        this.legend.positionItems();
-                    }
-                );
-            } else if (this.unchartrender) {
-                this.unchartrender();
-            }
         }
     }
 
@@ -308,6 +295,21 @@ class Legend {
         this.proximate = options.layout === 'proximate' && !this.chart.inverted;
         // #12705: baseline has to be reset on every update
         this.baseline = void 0;
+
+        // On Legend.init and Legend.update, make sure that proximate layout
+        // events are either added or removed (#18362).
+        if (this.proximate) {
+            this.unchartrender = addEvent(
+                this.chart,
+                'render',
+                function (): void {
+                    this.legend.proximatePositions();
+                    this.legend.positionItems();
+                }
+            );
+        } else if (this.unchartrender) {
+            this.unchartrender();
+        }
     }
 
     /**


### PR DESCRIPTION
Fixed #18362, updating `legend.layout` from or to `proximate` resulted in bad legend item positions.