### PR TITLE
bugfix/18312-tooltip-split

### DIFF
--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -2149,6 +2149,8 @@ const defaultOptions: Options = {
          * tooltips for charts with multiple line series, generally making them
          * easier to read. This option takes precedence over `tooltip.shared`.
          *
+         * Not supported for [polar](#chart.polar) and [inverted](#chart.inverted) charts.
+         *
          * @productdesc {highstock} In Highcharts Stock, tooltips are split
          * by default since v6.0.0. Stock charts typically contain
          * multi-dimension points and multiple panes, making split tooltips


### PR DESCRIPTION
Fixed #18312, added info to the API about `tooltip.split` not working for `polar` & `inverted` charts