### PR TITLE
bugfix/16675-custom-annotations-button

### DIFF
--- a/samples/unit-tests/annotations/annotations-events/demo.js
+++ b/samples/unit-tests/annotations/annotations-events/demo.js
@@ -4,6 +4,7 @@ QUnit.test('Annotations events - general', function (assert) {
         removeEventCalled = 0,
         closeEventCalled = 0,
         circleAfterUpdateCalled = 0,
+        customButtonClicked = 0,
         popupOptions,
         getShapes = function () {
             return [
@@ -28,6 +29,17 @@ QUnit.test('Annotations events - general', function (assert) {
             ];
         },
         chart = Highcharts.chart('container', {
+            exporting: {
+                buttons: {
+                    customButton: {
+                        className: 'highcharts-label-annotation button',
+                        symbol: 'triangle',
+                        onclick() {
+                            customButtonClicked++;
+                        }
+                    }
+                }
+            },
             annotations: [
                 {
                     shapes: getShapes(),
@@ -66,6 +78,7 @@ QUnit.test('Annotations events - general', function (assert) {
                 }
             ],
             navigation: {
+                bindingsClassName: 'highcharts-button-symbol',
                 events: {
                     showPopup: function (event) {
                         popupOptions = event.options;
@@ -209,5 +222,14 @@ QUnit.test('Annotations events - general', function (assert) {
     assert.ok(
         closeEventCalled,
         '#15730: Popup should close when hiding annotation'
+    );
+
+    const customButton = chart.exportSVGElements[3].element;
+    Highcharts.fireEvent(customButton, 'click');
+    controller.click(150, 150);
+    assert.ok(
+        customButtonClicked && chart.annotations[2].options.visible,
+        `#16675: Annotation should be added from the custom button, that has a
+        custom SVG symbol.`
     );
 });

--- a/ts/Extensions/Annotations/NavigationBindings.ts
+++ b/ts/Extensions/Annotations/NavigationBindings.ts
@@ -541,11 +541,8 @@ class NavigationBindings {
 
                         if (
                             bindings &&
-                            (
-                                !bindings.button.className.indexOf ||
-                                bindings.button.className
-                                    .indexOf('highcharts-disabled-btn') === -1
-                            )
+                            (!bindings.button.classList
+                                .contains('highcharts-disabled-btn'))
                         ) {
                             navigation.bindingsButtonClick(
                                 bindings.button,

--- a/ts/Extensions/Annotations/NavigationBindings.ts
+++ b/ts/Extensions/Annotations/NavigationBindings.ts
@@ -541,8 +541,11 @@ class NavigationBindings {
 
                         if (
                             bindings &&
-                            bindings.button.className
-                                .indexOf('highcharts-disabled-btn') === -1
+                            (
+                                !bindings.button.className.indexOf ||
+                                bindings.button.className
+                                    .indexOf('highcharts-disabled-btn') === -1
+                            )
                         ) {
                             navigation.bindingsButtonClick(
                                 bindings.button,
@@ -1109,7 +1112,7 @@ class NavigationBindings {
             classNames: Array<[string, HTMLDOMElement]> = [],
             elemClassName: (string|null|undefined);
 
-        while (element) {
+        while (element && element.tagName) {
             elemClassName = attr(element, 'class');
             if (elemClassName) {
                 classNames = classNames.concat(


### PR DESCRIPTION
Fixed #16675, adding annotation from a custom button was not possible, if the button had a custom SVG symbol.