### PR TITLE
Tools: Validate samples for categories and tags outside demo

### DIFF
--- a/samples/gantt/chart/scrollable-plotarea-vertical/demo.details
+++ b/samples/gantt/chart/scrollable-plotarea-vertical/demo.details
@@ -3,6 +3,4 @@ name: Gantt Chart with Scrollable Plot Area
 js_wrap: b
 authors:
   - Torstein Hønsi
-tags: []
-categories: []
 ...

--- a/samples/gantt/current-date-indicator/demo/demo.details
+++ b/samples/gantt/current-date-indicator/demo/demo.details
@@ -3,6 +3,4 @@ name: Current Date Indicator Demo
 js_wrap: b
 authors:
   - Lars Cabrera
-tags: []
-categories: []
 ...

--- a/samples/gantt/current-date-indicator/object-config/demo.details
+++ b/samples/gantt/current-date-indicator/object-config/demo.details
@@ -3,6 +3,4 @@ name: Current Date Indicator Demo
 js_wrap: b
 authors:
   - Lars Cabrera
-tags: []
-categories: []
 ...

--- a/samples/gantt/dragdrop/drag-gantt/demo.details
+++ b/samples/gantt/dragdrop/drag-gantt/demo.details
@@ -3,6 +3,4 @@ name: Highcharts Demo
 authors:
   - Øystein Moseng
 js_wrap: b
-tags: []
-categories: []
 ...

--- a/samples/gantt/gantt/bigdata/demo.details
+++ b/samples/gantt/gantt/bigdata/demo.details
@@ -3,6 +3,4 @@ name: Gantt Demo
 js_wrap: b
 authors:
   - Øystein Moseng
-tags: []
-categories: []
 ...

--- a/samples/gantt/gantt/demo/demo.details
+++ b/samples/gantt/gantt/demo/demo.details
@@ -3,6 +3,4 @@ name: Gantt Demo
 js_wrap: b
 authors:
   - Lars Cabrera
-tags: []
-categories: []
 ...

--- a/samples/gantt/gantt/milestones/demo.details
+++ b/samples/gantt/gantt/milestones/demo.details
@@ -3,6 +3,4 @@ name: Gantt Chart with Milestones
 js_wrap: b
 authors:
   - Lars Cabrera
-tags: []
-categories: []
 ...

--- a/samples/gantt/gantt/multiple-projects/demo.details
+++ b/samples/gantt/gantt/multiple-projects/demo.details
@@ -3,6 +3,4 @@ name: Gantt Chart with Multiple Projects
 js_wrap: b
 authors:
   - Lars Cabrera
-tags: []
-categories: []
 ...

--- a/samples/gantt/gantt/simple-gantt-chart/demo.details
+++ b/samples/gantt/gantt/simple-gantt-chart/demo.details
@@ -3,6 +3,4 @@ name: Simple Gantt Chart
 js_wrap: b
 authors:
   - Lars Cabrera
-tags: []
-categories: []
 ...

--- a/samples/gantt/gantt/years-and-months/demo.details
+++ b/samples/gantt/gantt/years-and-months/demo.details
@@ -3,6 +3,4 @@ name: Gantt Chart with Years and Months
 js_wrap: b
 authors:
   - Lars Cabrera
-tags: []
-categories: []
 ...

--- a/samples/gantt/grid-axis/cellheight/demo.details
+++ b/samples/gantt/grid-axis/cellheight/demo.details
@@ -3,6 +3,4 @@ name: Gantt Chart with custom cell height
 js_wrap: b
 authors:
   - Jon Arild Nygård
-tags: []
-categories: []
 ...

--- a/samples/gantt/grid-axis/date-time-label-formats/demo.details
+++ b/samples/gantt/grid-axis/date-time-label-formats/demo.details
@@ -3,6 +3,4 @@ name: Gantt Chart with custom axis date format.
 js_wrap: b
 authors:
   - Karol Kołodziej
-tags: []
-categories: []
 ...

--- a/samples/gantt/grid-axis/demo/demo.details
+++ b/samples/gantt/grid-axis/demo/demo.details
@@ -3,6 +3,4 @@ name: GridAxis Demo
 js_wrap: b
 authors:
   - Lars Cabrera
-tags: []
-categories: []
 ...

--- a/samples/gantt/grid-axis/with-navigator/demo.details
+++ b/samples/gantt/grid-axis/with-navigator/demo.details
@@ -3,6 +3,4 @@ name: GridAxis with Navigator
 js_wrap: b
 authors:
   - Lars Cabrera
-tags: []
-categories: []
 ...

--- a/samples/gantt/pathfinder/algorithm-margin/demo.details
+++ b/samples/gantt/pathfinder/algorithm-margin/demo.details
@@ -3,6 +3,4 @@ name: Gantt Chart with Different Algorithm Margins
 js_wrap: b
 authors:
   - Øystein Moseng
-tags: []
-categories: []
 ...

--- a/samples/gantt/pathfinder/auto-marker-placement/demo.details
+++ b/samples/gantt/pathfinder/auto-marker-placement/demo.details
@@ -3,6 +3,4 @@ name: Pathfinder with Automatic Marker Placement
 js_wrap: b
 authors:
   - Lars Cabrera
-tags: []
-categories: []
 ...

--- a/samples/gantt/pathfinder/demo/demo.details
+++ b/samples/gantt/pathfinder/demo/demo.details
@@ -3,6 +3,4 @@ name: Connectors Demo
 js_wrap: b
 authors:
   - Øystein Moseng
-tags: []
-categories: []
 ...

--- a/samples/gantt/pathfinder/simple-connect/demo.details
+++ b/samples/gantt/pathfinder/simple-connect/demo.details
@@ -3,6 +3,4 @@ name: Connectors Demo
 js_wrap: b
 authors:
   - Øystein Moseng
-tags: []
-categories: []
 ...

--- a/samples/gantt/treegrid-axis/collapsed-dynamically/demo.details
+++ b/samples/gantt/treegrid-axis/collapsed-dynamically/demo.details
@@ -3,6 +3,4 @@ name: TreeGrid Demo
 js_wrap: b
 authors:
   - Jon Arild Nygård
-tags: []
-categories: []
 ...

--- a/samples/gantt/treegrid-axis/collapsed/demo.details
+++ b/samples/gantt/treegrid-axis/collapsed/demo.details
@@ -3,6 +3,4 @@ name: TreeGrid Demo
 js_wrap: b
 authors:
   - Jon Arild Nygård
-tags: []
-categories: []
 ...

--- a/samples/gantt/treegrid-axis/demo/demo.details
+++ b/samples/gantt/treegrid-axis/demo/demo.details
@@ -3,6 +3,4 @@ name: TreeGrid Demo
 js_wrap: b
 authors:
   - Jon Arild Nygård
-tags: []
-categories: []
 ...

--- a/samples/gantt/treegrid-axis/indentation-0px/demo.details
+++ b/samples/gantt/treegrid-axis/indentation-0px/demo.details
@@ -3,6 +3,4 @@ name: TreeGrid Demo
 js_wrap: b
 authors:
   - Jon Arild Nygård
-tags: []
-categories: []
 ...

--- a/samples/gantt/treegrid-axis/labels-levels/demo.details
+++ b/samples/gantt/treegrid-axis/labels-levels/demo.details
@@ -3,6 +3,4 @@ name: TreeGrid Demo
 js_wrap: b
 authors:
   - Jon Arild Nygård
-tags: []
-categories: []
 ...

--- a/samples/gantt/treegrid-axis/uniquenames-true/demo.details
+++ b/samples/gantt/treegrid-axis/uniquenames-true/demo.details
@@ -3,6 +3,4 @@ name: TreeGrid Demo
 js_wrap: b
 authors:
   - Jon Arild Nygård
-tags: []
-categories: []
 ...

--- a/samples/gantt/xrange-series/demo/demo.details
+++ b/samples/gantt/xrange-series/demo/demo.details
@@ -4,6 +4,4 @@ js_wrap: b
 authors:
   - Torstein Hønsi
   - Lars Cabrera
-tags: []
-categories: []
 ...

--- a/samples/highcharts/labels/full-date/demo.details
+++ b/samples/highcharts/labels/full-date/demo.details
@@ -3,10 +3,4 @@ name: Basic line
 authors:
   - Torstein Hønsi
 js_wrap: b
-alt_text: >-
-  Highcharts basic line chart JavaScript example displays graph plot of solar
-  employment growth areas over time.
-tags:
-  - Highcharts demo
-categories: []
 ...

--- a/samples/highcharts/labels/full-date/readme.md
+++ b/samples/highcharts/labels/full-date/readme.md
@@ -1,5 +1,0 @@
-# Basic line
-A [line chart](https://api.highcharts.com/highcharts/plotOptions.line) is often used to visualize [trends](https://smartvikisogn.github.io/HChartsCatalog/webpages/trend.html). In this demo, the number of employees in the solar installation is in a constant progress since 2013, where the other sector’s employees number has been stable.
-
-#### Tip
-Creating a line chart with Highcharts library is a time-saving task, as many features are already set by default such as the [tooltip](https://api.highcharts.com/highcharts/tooltip), colors, responsiveness, [title](https://api.highcharts.com/class-reference/Chart.title)s position, etc.

--- a/samples/highcharts/labels/no-decimal-places/demo.details
+++ b/samples/highcharts/labels/no-decimal-places/demo.details
@@ -3,10 +3,4 @@ name: Basic line
 authors:
   - Torstein Hønsi
 js_wrap: b
-alt_text: >-
-  Highcharts basic line chart JavaScript example displays graph plot of solar
-  employment growth areas over time.
-tags:
-  - Highcharts demo
-categories: []
 ...

--- a/samples/highcharts/labels/no-decimal-places/readme.md
+++ b/samples/highcharts/labels/no-decimal-places/readme.md
@@ -1,5 +1,0 @@
-# Basic line
-A [line chart](https://api.highcharts.com/highcharts/plotOptions.line) is often used to visualize [trends](https://smartvikisogn.github.io/HChartsCatalog/webpages/trend.html). In this demo, the number of employees in the solar installation is in a constant progress since 2013, where the other sector’s employees number has been stable.
-
-#### Tip
-Creating a line chart with Highcharts library is a time-saving task, as many features are already set by default such as the [tooltip](https://api.highcharts.com/highcharts/tooltip), colors, responsiveness, [title](https://api.highcharts.com/class-reference/Chart.title)s position, etc.

--- a/samples/highcharts/labels/one-decimal-place/demo.details
+++ b/samples/highcharts/labels/one-decimal-place/demo.details
@@ -3,10 +3,4 @@ name: Basic line
 authors:
   - Torstein Hønsi
 js_wrap: b
-alt_text: >-
-  Highcharts basic line chart JavaScript example displays graph plot of solar
-  employment growth areas over time.
-tags:
-  - Highcharts demo
-categories: []
 ...

--- a/samples/highcharts/labels/one-decimal-place/readme.md
+++ b/samples/highcharts/labels/one-decimal-place/readme.md
@@ -1,5 +1,0 @@
-# Basic line
-A [line chart](https://api.highcharts.com/highcharts/plotOptions.line) is often used to visualize [trends](https://smartvikisogn.github.io/HChartsCatalog/webpages/trend.html). In this demo, the number of employees in the solar installation is in a constant progress since 2013, where the other sector’s employees number has been stable.
-
-#### Tip
-Creating a line chart with Highcharts library is a time-saving task, as many features are already set by default such as the [tooltip](https://api.highcharts.com/highcharts/tooltip), colors, responsiveness, [title](https://api.highcharts.com/class-reference/Chart.title)s position, etc.

--- a/samples/highcharts/labels/two-decimal-places/demo.details
+++ b/samples/highcharts/labels/two-decimal-places/demo.details
@@ -3,10 +3,4 @@ name: Basic line
 authors:
   - Torstein Hønsi
 js_wrap: b
-alt_text: >-
-  Highcharts basic line chart JavaScript example displays graph plot of solar
-  employment growth areas over time.
-tags:
-  - Highcharts demo
-categories: []
 ...

--- a/samples/highcharts/labels/two-decimal-places/readme.md
+++ b/samples/highcharts/labels/two-decimal-places/readme.md
@@ -1,5 +1,0 @@
-# Basic line
-A [line chart](https://api.highcharts.com/highcharts/plotOptions.line) is often used to visualize [trends](https://smartvikisogn.github.io/HChartsCatalog/webpages/trend.html). In this demo, the number of employees in the solar installation is in a constant progress since 2013, where the other sector’s employees number has been stable.
-
-#### Tip
-Creating a line chart with Highcharts library is a time-saving task, as many features are already set by default such as the [tooltip](https://api.highcharts.com/highcharts/tooltip), colors, responsiveness, [title](https://api.highcharts.com/class-reference/Chart.title)s position, etc.

--- a/samples/highcharts/series-organization/different-link-types/demo.details
+++ b/samples/highcharts/series-organization/different-link-types/demo.details
@@ -3,7 +3,4 @@ name: Organization chart
 authors:
   - Pawel Lysy
 js_wrap: b
-new_until: 2022-04-31
-tags:
-  - Highcharts demo
 ...

--- a/samples/highcharts/studies/covid-19/demo.details
+++ b/samples/highcharts/studies/covid-19/demo.details
@@ -4,8 +4,4 @@ authors:
   - Torstein Hønsi
 requiresManualTesting: true
 js_wrap: b
-tags:
-  - Highcharts Maps demo
-categories:
-  - Dynamic
 ...

--- a/samples/highcharts/studies/parliament-improved/demo.details
+++ b/samples/highcharts/studies/parliament-improved/demo.details
@@ -3,11 +3,4 @@ name: Parliament (item) chart
 authors:
   - Torstein Hønsi
 js_wrap: b
-alt_text: >-
-  Highcharts parliament item chart JavaScript example visualizes German
-  political party breakdown by color and percentage proportion.
-tags:
-  - Highcharts demo
-categories:
-  - More chart types
 ...

--- a/samples/highcharts/studies/treegraph-chart/demo.details
+++ b/samples/highcharts/studies/treegraph-chart/demo.details
@@ -3,9 +3,4 @@ name: Treegraph chart
 authors:
   - Pawel Lysy
 js_wrap: b
-new_until: 2022-06-31
-tags:
-  - Highcharts demo
-categories:
-  - More chart types
 ...


### PR DESCRIPTION
Because it was easy for our developers to forget to remove meta information for the demo pages when copying samples for other purposes.