### PR TITLE
Tools: Better rendering of styledMode charts in visual tests

### DIFF
--- a/samples/highcharts/website/highcharts-timeline/demo.js
+++ b/samples/highcharts/website/highcharts-timeline/demo.js
@@ -286,7 +286,7 @@ const imgPath = 'https://cdn.rawgit.com/highcharts/highcharts/0b81a74ecd2fbd2e9b
 const options = {
     chart: {
         height: 600,
-        styledMode: (true),
+        styledMode: true,
         scrollablePlotArea: {
             minWidth: 700,
             scrollPositionX: 0
@@ -628,8 +628,8 @@ if (Highcharts.Series.types.flags) {
                 x: Date.UTC(2012, 11, 25),
                 text:
                 `<p style="margin-top:20px">Packt Publishing published
-                <em>Learning Highcharts by Example</em>.<br>Since 
-                then, many other books have 
+                <em>Learning Highcharts by Example</em>.<br>Since
+                then, many other books have
                 been written about Highcharts.</p>`,
                 title: '<p class="wide">First Book</p>',
                 className: 'book'

--- a/samples/highcharts/website/homepage-2021/demo.js
+++ b/samples/highcharts/website/homepage-2021/demo.js
@@ -19,7 +19,7 @@ const candlestick = function () {
     // create the chart
         Highcharts.stockChart('hero', {
             chart: {
-                styledMode: (true),
+                styledMode: true,
                 margin: [0, 0, 0, 0],
                 height: 430,
                 animation: {

--- a/samples/highcharts/website/icon-chart/demo.js
+++ b/samples/highcharts/website/icon-chart/demo.js
@@ -33,7 +33,7 @@ const iceberg = {
             duration: 3000,
             easing: 'easeOutQuint'
         },
-        styledMode: (true),
+        styledMode: true,
         margin: 0,
         spacing: 0,
         events: {
@@ -384,7 +384,7 @@ const iceberg = {
                 pointFormatter: function () {
                     return `<p class="berg-tip" aria-hidden="true">
                         <span>
-                        Pinnacle icebergs</span> - a 
+                        Pinnacle icebergs</span> - a
                         large central spire or pyramid.</p>`;
                 }
             },
@@ -443,7 +443,7 @@ const iceberg = {
                         formatter: function () {
                             const htmlString =
                                     `<div class="berg-label">
-                                        <p class="label-title" 
+                                        <p class="label-title"
                                         style="font-weight:700;">Pinnacle</p>
                                         <p  class="label-percent">33%</p>
                                     </div>`;
@@ -475,7 +475,7 @@ const iceberg = {
             tooltip: {
                 pointFormatter: function () {
                     return `<p class="berg-tip" aria-hidden="true">
-                                <span>Tabular icebergs</span> - 
+                                <span>Tabular icebergs</span> -
                                 horizontal and flat-topped.</p>`;
 
                 }
@@ -530,7 +530,7 @@ const iceberg = {
                         formatter: function () {
                             const htmlString =
                                     `<div class="berg-label">
-                                        <p class="label-title" 
+                                        <p class="label-title"
                                         style="font-weight:700;">Tabular</p>
                                         <p  class="label-percent">23%</p>
                                     </div>`;
@@ -562,7 +562,7 @@ const iceberg = {
             tooltip: {
                 pointFormatter: function () {
                     return `<p class="berg-tip" aria-hidden="true">
-                        <span>Dry Dock icebergs</span> - eroded into a 
+                        <span>Dry Dock icebergs</span> - eroded into a
                         U shape.</p>`;
                 }
             },
@@ -625,7 +625,7 @@ const iceberg = {
                         formatter: function () {
                             const htmlString =
                                     `<div class="berg-label">
-                                        <p class="label-title" 
+                                        <p class="label-title"
                                         style="font-weight:700;">Dry Dock</p>
                                         <p  class="label-percent">19%</p>
                                     </div>`;
@@ -661,7 +661,7 @@ const iceberg = {
             tooltip: {
                 pointFormatter: function () {
                     return `<p class="berg-tip" aria-hidden="true">
-                                    <span>Dome icebergs</span> - large, 
+                                    <span>Dome icebergs</span> - large,
                                     smooth, rounded tops.</p>`;
                 }
             },
@@ -722,7 +722,7 @@ const iceberg = {
                     formatter: function () {
                         const htmlString =
                                 `<div class="berg-label">
-                                    <p class="label-title" 
+                                    <p class="label-title"
                                     style="font-weight:700;">Dome</p>
                                     <p  class="label-percent">15%</p>
                                 </div>`;
@@ -757,7 +757,7 @@ const iceberg = {
             tooltip: {
                 pointFormatter: function () {
                     return `<p class="berg-tip" aria-hidden="true">
-                                <span>Wedge icebergs</span> - tabular 
+                                <span>Wedge icebergs</span> - tabular
                                 icebergs that have
                                 tilted.</p>`;
 
@@ -808,7 +808,7 @@ const iceberg = {
                     formatter: function () {
                         const htmlString =
                                 `<div class="berg-label">
-                                    <p class="label-title" 
+                                    <p class="label-title"
                                     style="font-weight:700;">Wedge</p>
                                     <p  class="label-percent">10%</p>
                                 </div>`;
@@ -911,7 +911,7 @@ const charts = {
             duration: 3000,
             easing: 'easeOutQuint'
         },
-        styledMode: (true),
+        styledMode: true,
         margin: 0,
         spacing: 0,
         accessibility: {

--- a/samples/highcharts/website/icon-editor/demo.js
+++ b/samples/highcharts/website/icon-editor/demo.js
@@ -16,7 +16,7 @@ const editor = function () {
                     duration: 4000,
                     easing: 'easeOutQuint'
                 },
-                styledMode: (true),
+                styledMode: true,
                 alignTicks: false,
                 margin: 0,
                 spacing: 0,
@@ -260,7 +260,7 @@ const editor = function () {
                         y: 20,
                         dataLabels: {
                             formatter: function () {
-                                return `<div id="particle-3" 
+                                return `<div id="particle-3"
                                 class="particle"></div>`;
                             }
                         }
@@ -270,7 +270,7 @@ const editor = function () {
                         y: 20,
                         dataLabels: {
                             formatter: function () {
-                                return `<div id="particle-2" 
+                                return `<div id="particle-2"
                                 class="particle"></div>`;
                             }
                         }
@@ -280,7 +280,7 @@ const editor = function () {
                         y: 20,
                         dataLabels: {
                             formatter: function () {
-                                return `<div id="particle-6" 
+                                return `<div id="particle-6"
                                 class="particle"></div>`;
                             }
                         }
@@ -290,7 +290,7 @@ const editor = function () {
                         y: 20,
                         dataLabels: {
                             formatter: function () {
-                                return `<div id="particle-5" 
+                                return `<div id="particle-5"
                                 class="particle"></div>`;
                             }
                         }

--- a/samples/highcharts/website/icon-gantt/demo.js
+++ b/samples/highcharts/website/icon-gantt/demo.js
@@ -117,7 +117,7 @@ const ganttChart = function () {
 
                 }
             },
-            styledMode: (true)
+            styledMode: true
         },
         lang: {
             accessibility: {
@@ -523,7 +523,7 @@ const gantt = {
             duration: 1000,
             easing: 'easeOutQuint'
         },
-        styledMode: (true),
+        styledMode: true,
         margin: 0,
         spacing: 0,
         plotBackgroundImage: 'gantt.png',

--- a/samples/highcharts/website/icon-map/demo.js
+++ b/samples/highcharts/website/icon-map/demo.js
@@ -590,7 +590,7 @@ const finalMap = function () {
             // Initialize the chart
             Highcharts.mapChart('maps', {
                 chart: {
-                    styledMode: (true),
+                    styledMode: true,
                     animation: {
 
                         duration: 1000

--- a/samples/highcharts/website/icon-stock/demo.js
+++ b/samples/highcharts/website/icon-stock/demo.js
@@ -68,7 +68,7 @@ Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', func
                 duration: 2000,
                 easing: 'easeOutQuint'
             },
-            styledMode: (true),
+            styledMode: true,
             margin: 0,
             spacing: 0,
             alignTicks: false,
@@ -380,7 +380,7 @@ Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', func
                 duration: 2000,
                 easing: 'easeOutQuint'
             },
-            styledMode: (true),
+            styledMode: true,
             margin: 0,
             spacing: 0,
             alignTicks: false,

--- a/samples/highcharts/website/static-candlestick/demo.js
+++ b/samples/highcharts/website/static-candlestick/demo.js
@@ -39,7 +39,7 @@ const candlestick = function () {
     // create the chart
         Highcharts.stockChart('hero', {
             chart: {
-                styledMode: (true),
+                styledMode: true,
                 margin: [0, 0, 0, 0],
                 height: 430,
                 animation: {

--- a/samples/highcharts/website/static-chart/demo.js
+++ b/samples/highcharts/website/static-chart/demo.js
@@ -30,7 +30,7 @@ const iceberg = {
             duration: 3000,
             easing: 'easeOutQuint'
         },
-        styledMode: (true),
+        styledMode: true,
         margin: 0,
         spacing: 0,
         events: {
@@ -381,7 +381,7 @@ const iceberg = {
                 pointFormatter: function () {
                     return `<p class="berg-tip" aria-hidden="true">
                     <span>
-                    Pinnacle icebergs</span> - a 
+                    Pinnacle icebergs</span> - a
                     large central spire or pyramid.</p>`;
                 }
             },
@@ -440,7 +440,7 @@ const iceberg = {
                         formatter: function () {
                             const htmlString =
                                 `<div class="berg-label">
-                                    <p class="label-title" 
+                                    <p class="label-title"
                                     style="font-weight:700;">Pinnacle</p>
                                     <p  class="label-percent">33%</p>
                                 </div>`;
@@ -472,7 +472,7 @@ const iceberg = {
             tooltip: {
                 pointFormatter: function () {
                     return `<p class="berg-tip" aria-hidden="true">
-                            <span>Tabular icebergs</span> - 
+                            <span>Tabular icebergs</span> -
                             horizontal and flat-topped.</p>`;
 
                 }
@@ -527,7 +527,7 @@ const iceberg = {
                         formatter: function () {
                             const htmlString =
                                 `<div class="berg-label">
-                                    <p class="label-title" 
+                                    <p class="label-title"
                                     style="font-weight:700;">Tabular</p>
                                     <p  class="label-percent">23%</p>
                                 </div>`;
@@ -559,7 +559,7 @@ const iceberg = {
             tooltip: {
                 pointFormatter: function () {
                     return `<p class="berg-tip" aria-hidden="true">
-                    <span>Dry Dock icebergs</span> - eroded into a 
+                    <span>Dry Dock icebergs</span> - eroded into a
                     U shape.</p>`;
                 }
             },
@@ -622,7 +622,7 @@ const iceberg = {
                         formatter: function () {
                             const htmlString =
                                 `<div class="berg-label">
-                                    <p class="label-title" 
+                                    <p class="label-title"
                                     style="font-weight:700;">Dry Dock</p>
                                     <p  class="label-percent">19%</p>
                                 </div>`;
@@ -658,7 +658,7 @@ const iceberg = {
             tooltip: {
                 pointFormatter: function () {
                     return `<p class="berg-tip" aria-hidden="true">
-                                <span>Dome icebergs</span> - large, 
+                                <span>Dome icebergs</span> - large,
                                 smooth, rounded tops.</p>`;
                 }
             },
@@ -719,7 +719,7 @@ const iceberg = {
                     formatter: function () {
                         const htmlString =
                             `<div class="berg-label">
-                                <p class="label-title" 
+                                <p class="label-title"
                                 style="font-weight:700;">Dome</p>
                                 <p  class="label-percent">15%</p>
                             </div>`;
@@ -754,7 +754,7 @@ const iceberg = {
             tooltip: {
                 pointFormatter: function () {
                     return `<p class="berg-tip" aria-hidden="true">
-                            <span>Wedge icebergs</span> - tabular 
+                            <span>Wedge icebergs</span> - tabular
                             icebergs that have
                             tilted.</p>`;
 
@@ -805,7 +805,7 @@ const iceberg = {
                     formatter: function () {
                         const htmlString =
                             `<div class="berg-label">
-                                <p class="label-title" 
+                                <p class="label-title"
                                 style="font-weight:700;">Wedge</p>
                                 <p  class="label-percent">10%</p>
                             </div>`;

--- a/samples/highcharts/website/static-gantt/demo.js
+++ b/samples/highcharts/website/static-gantt/demo.js
@@ -118,7 +118,7 @@ const ganttChart = function () {
 
                 }
             },
-            styledMode: (true)
+            styledMode: true
         },
         lang: {
             accessibility: {

--- a/samples/highcharts/website/static-map/demo.js
+++ b/samples/highcharts/website/static-map/demo.js
@@ -29,7 +29,7 @@ const finalMap = function () {
             // Initialize the chart
             Highcharts.mapChart('maps', {
                 chart: {
-                    styledMode: (true),
+                    styledMode: true,
                     animation: {
 
                         duration: 1000

--- a/samples/highcharts/website/static-stock/demo.js
+++ b/samples/highcharts/website/static-stock/demo.js
@@ -64,7 +64,7 @@ Highcharts.getJSON('https://demo-live-data.highcharts.com/aapl-ohlcv.json', func
                 duration: 2000,
                 easing: 'easeOutQuint'
             },
-            styledMode: (true),
+            styledMode: true,
             margin: 0,
             spacing: 0,
             alignTicks: false,

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -648,7 +648,7 @@ module.exports = function (config) {
     config.set(options);
 };
 
-function createVisualTestTemplate(argv, path, js, assertion) {
+function createVisualTestTemplate(argv, samplePath, js, assertion) {
     let scriptBody = resolveJSON(js);
 
     // Don't do intervals (typically for gauge samples, add point etc)
@@ -666,7 +666,7 @@ function createVisualTestTemplate(argv, path, js, assertion) {
         '$1_animation: '
     );
 
-    let html = getHTML(path);
+    let html = getHTML(samplePath);
     let resets = [];
 
     // Reset global options, but only if necessary
@@ -682,9 +682,19 @@ function createVisualTestTemplate(argv, path, js, assertion) {
         resets.push('callbacks');
     }
 
+    // Include highcharts.css, to be inserted into the SVG in
+    // karma-setup.js:getSVG
+    if (scriptBody.indexOf('styledMode: true') !== -1) {
+        var css = fs.readFileSync(
+            path.join(__dirname, '../code/css/highcharts.css'),
+            'utf8'
+        );
+        html += '<style id="highcharts.css">' + css + '</style>';
+    }
+
     resets = JSON.stringify(resets);
     return `
-        QUnit.test('${path}', function (assert) {
+        QUnit.test('${samplePath}', function (assert) {
             // Apply demo.html
             document.getElementById('demo-html').innerHTML = \`${html}\`;
 

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -685,11 +685,19 @@ function createVisualTestTemplate(argv, samplePath, js, assertion) {
     // Include highcharts.css, to be inserted into the SVG in
     // karma-setup.js:getSVG
     if (scriptBody.indexOf('styledMode: true') !== -1) {
-        var css = fs.readFileSync(
+        const highchartsCSS = fs.readFileSync(
             path.join(__dirname, '../code/css/highcharts.css'),
             'utf8'
         );
-        html += '<style id="highcharts.css">' + css + '</style>';
+        html += `<style id="highcharts.css">${highchartsCSS}</style>`;
+
+        const demoCSS = fs.readFileSync(
+            path.join(__dirname, `../samples/${samplePath}/demo.css`),
+            'utf8'
+        );
+
+        html += `<style id="demo.css">${demoCSS}</style>`;
+
     }
 
     resets = JSON.stringify(resets);

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -521,21 +521,22 @@ function getSVG(chart) {
             );
 
         if (chart.styledMode) {
-            svg = svg.replace(
-                '</defs>',
-                '<style>' +
-                '* {' +
-                '   fill: rgba(0, 0, 0, 0.1);' +
-                '   stroke: black;' +
-                '   stroke-width: 1px;' +
-                '}' +
-                'text, tspan {' +
-                '    fill: blue;' +
-                '    stroke: none;' +
-                '}' +
-                '</style>' +
-                '</defs>'
-            );
+            var css = document.getElementById('highcharts.css');
+            if (css) {
+                svg = svg
+                    // Get the typography styling right
+                    .replace(
+                        ' class="highcharts-root" ',
+                        ' class="highcharts-root highcharts-container" ' +
+                            'style="width:auto; height:auto" '
+                    )
+
+                    // Insert highcharts.css
+                    .replace(
+                        '</defs>',
+                        '<style>' + css.innerText + '</style></defs>'
+                );
+            }
         }
 
         // Renderer samples

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -521,8 +521,8 @@ function getSVG(chart) {
             );
 
         if (chart.styledMode) {
-            var css = document.getElementById('highcharts.css');
-            if (css) {
+            var highchartsCSS = document.getElementById('highcharts.css');
+            if (highchartsCSS) {
                 svg = svg
                     // Get the typography styling right
                     .replace(
@@ -534,7 +534,17 @@ function getSVG(chart) {
                     // Insert highcharts.css
                     .replace(
                         '</defs>',
-                        '<style>' + css.innerText + '</style></defs>'
+                        '<style>' + highchartsCSS.innerText + '</style></defs>'
+                );
+            }
+
+            var demoCSS = document.getElementById('demo.css');
+            if (demoCSS) {
+                svg = svg
+                    // Insert demo.css
+                    .replace(
+                        '</defs>',
+                        '<style>' + demoCSS.innerText + '</style></defs>'
                 );
             }
         }


### PR DESCRIPTION
It now injects the contents of `highcharts.css` into the SVG so the styling is representative. This will catch regressions in how the class names/ids and their combination with CSS rules are set up.