### PR TITLE
bugfix/18406-labelposition-any-cast-fix

### DIFF
--- a/samples/unit-tests/series-pie/datalabel/demo.js
+++ b/samples/unit-tests/series-pie/datalabel/demo.js
@@ -422,7 +422,7 @@ QUnit.test('Pie labels outside plot (#3163)', function (assert) {
         labelYPos = [];
 
     for (var i = 0; i < seriesData.length; i++) {
-        labelYPos.push(seriesData[i].labelPosition.final.y);
+        labelYPos.push(seriesData[i].labelPosition.computed.y);
     }
 
     function isLabelInsidePlot() {

--- a/ts/Series/Funnel/FunnelSeries.ts
+++ b/ts/Series/Funnel/FunnelSeries.ts
@@ -365,7 +365,7 @@ class FunnelSeries extends PieSeries {
                     x: 0,
                     y: y as any
                 },
-                'final': {
+                computed: {
                     // used for generating connector path -
                     // initialized later in drawDataLabels function
                     // x: undefined,

--- a/ts/Series/Pie/PieDataLabel.ts
+++ b/ts/Series/Pie/PieDataLabel.ts
@@ -426,8 +426,10 @@ namespace ColumnDataLabel {
                 };
                 // labelPos.x = x;
                 // labelPos.y = y;
-                (labelPosition as any).final.x = x;
-                (labelPosition as any).final.y = y;
+                if (labelPosition) {
+                    labelPosition.computed.x = x;
+                    labelPosition.computed.y = y;
+                }
 
                 // Detect overflowing data labels
                 if (pick((options as any).crop, true)) {

--- a/ts/Series/Pie/PiePoint.ts
+++ b/ts/Series/Pie/PiePoint.ts
@@ -114,8 +114,8 @@ class PiePoint extends Point {
 
         return connectorShape.call(this, {
             // pass simplified label position object for user's convenience
-            x: (labelPosition as any).final.x,
-            y: (labelPosition as any).final.y,
+            x: (labelPosition as any).computed.x,
+            y: (labelPosition as any).computed.y,
             alignment: (labelPosition as any).alignment
         }, (labelPosition as any).connectorPosition, options);
     }
@@ -423,7 +423,7 @@ namespace PiePoint {
     export interface LabelPositionObject {
         alignment: AlignValue;
         connectorPosition: LabelConnectorPositionObject;
-        'final': Record<string, undefined>;
+        computed: Record<string, undefined>;
         natural: CorePositionObject;
     }
 

--- a/ts/Series/Pie/PieSeries.ts
+++ b/ts/Series/Pie/PieSeries.ts
@@ -538,7 +538,7 @@ class PieSeries extends Series {
                     y: positions[1] + radiusY + Math.sin(angle) *
                     point.labelDistance
                 },
-                'computed': {
+                computed: {
                 // used for generating connector path -
                 // initialized later in drawDataLabels function
                 // x: undefined,

--- a/ts/Series/Pie/PieSeries.ts
+++ b/ts/Series/Pie/PieSeries.ts
@@ -538,7 +538,7 @@ class PieSeries extends Series {
                     y: positions[1] + radiusY + Math.sin(angle) *
                     point.labelDistance
                 },
-                'final': {
+                'computed': {
                 // used for generating connector path -
                 // initialized later in drawDataLabels function
                 // x: undefined,

--- a/ts/Series/VariablePie/VariablePieSeries.ts
+++ b/ts/Series/VariablePie/VariablePieSeries.ts
@@ -437,7 +437,7 @@ class VariablePieSeries extends PieSeries {
                     y: positions[1] + pointRadiusY +
                         Math.sin(angle) * point.labelDistance
                 },
-                'final': {
+                computed: {
                     // used for generating connector path -
                     // initialized later in drawDataLabels function
                     // x: undefined,


### PR DESCRIPTION
Changed `labelPosition.final` to `labelPosition.computed` for Pie & Funnel series + removed casting from one place that caused testing errors.