### PR TITLE
bugfix/17790-fixed-duplicate-price-indicators

### DIFF
--- a/samples/unit-tests/indicator-current-price/recalculations/demo.js
+++ b/samples/unit-tests/indicator-current-price/recalculations/demo.js
@@ -101,13 +101,13 @@ QUnit.test('Price indicator labels rendering and visibility, #14879, #17790.',
                 }
             },
             series: [{
-                data: [1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1],
+                compare: 'percent',
+                data: [100, 1, 1, 10, 1],
                 lastPrice: {
                     enabled: true,
-                    label: {
-                        enabled: true
-                    }
+                    color: 'red'
                 },
+                // label
                 lastVisiblePrice: {
                     enabled: true,
                     label: {
@@ -122,6 +122,16 @@ QUnit.test('Price indicator labels rendering and visibility, #14879, #17790.',
             'inherit',
             'Last visible price label should be visible, #14879.'
         );
+
+        chart.series[0].update({
+            data: [1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1],
+            lastPrice: {
+                enabled: true,
+                label: {
+                    enabled: true
+                }
+            }
+        });
 
         chart.xAxis[0].setExtremes(2, 4); // 'Drag' the chart to redraw labels
 

--- a/samples/unit-tests/indicator-current-price/recalculations/demo.js
+++ b/samples/unit-tests/indicator-current-price/recalculations/demo.js
@@ -47,7 +47,7 @@ QUnit.test('Test current and last price indicator.', function (assert) {
     );
 
     assert.ok(
-        chart.series[1].crossLabel.hasClass('highcharts-color-1'),
+        chart.series[1].lastVisiblePriceLabel.hasClass('highcharts-color-1'),
         '#15706: Second lastVisiblePrice label should have correct color class'
     );
 });
@@ -118,9 +118,9 @@ QUnit.test('The currentPriceIndicator label should be visible, #14879.',
         });
 
         assert.strictEqual(
-            chart.series[0].crossLabel.visibility,
+            chart.series[0].lastVisiblePrice.visibility,
             'inherit',
-            'Crosshair label should be visible.'
+            'Last visible price label should be visible.'
         );
     }
 );

--- a/samples/unit-tests/indicator-current-price/recalculations/demo.js
+++ b/samples/unit-tests/indicator-current-price/recalculations/demo.js
@@ -89,7 +89,7 @@ QUnit.test(
     }
 );
 
-QUnit.test('The currentPriceIndicator label should be visible, #14879.',
+QUnit.test('Price indicator labels rendering and visibility, #14879, #17790.',
     function (assert) {
         const chart = Highcharts.stockChart('container', {
             stockTools: {
@@ -101,13 +101,13 @@ QUnit.test('The currentPriceIndicator label should be visible, #14879.',
                 }
             },
             series: [{
-                compare: 'percent',
-                data: [100, 1, 1, 10, 1],
+                data: [1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1],
                 lastPrice: {
                     enabled: true,
-                    color: 'red'
+                    label: {
+                        enabled: true
+                    }
                 },
-                // label
                 lastVisiblePrice: {
                     enabled: true,
                     label: {
@@ -120,7 +120,15 @@ QUnit.test('The currentPriceIndicator label should be visible, #14879.',
         assert.strictEqual(
             chart.series[0].lastVisiblePrice.visibility,
             'inherit',
-            'Last visible price label should be visible.'
+            'Last visible price label should be visible, #14879.'
+        );
+
+        chart.xAxis[0].setExtremes(2, 4); // 'Drag' the chart to redraw labels
+
+        assert.strictEqual(
+            document.querySelectorAll('.highcharts-crosshair-label').length,
+            2, // One for lastPrice label, one for lastVisiblePrice label
+            'There should only be two price labels rendered, #17790.'
         );
     }
 );

--- a/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
+++ b/samples/unit-tests/indicator-price-indicator/recalculations/demo.js
@@ -158,7 +158,7 @@ QUnit.test(
         chart.xAxis[0].setExtremes(min, max1);
 
         assert.strictEqual(
-            chart.series[0].crossLabel.added,
+            chart.series[0].lastVisiblePriceLabel.added,
             true,
             'Label shouldn\t be deleted #11480'
         );
@@ -229,17 +229,17 @@ function (assert) {
     chart.navigationBindings.options.bindings.currentPriceIndicator.init
         .call(chart.navigationBindings, button);
     assert.strictEqual(
-        chart.series[0].crossLabel.visibility,
+        chart.series[0].lastVisiblePriceLabel.visibility,
         'inherit',
         'Series price indicator should be visible.'
     );
     assert.strictEqual(
-        chart.series[0].crossLabel.element.childNodes[0].getAttribute('fill'),
+        chart.series[0].lastVisiblePriceLabel.element.childNodes[0].getAttribute('fill'),
         '#00ff00',
-        'Cross label fill color should be blue.'
+        'Last visible price label fill color should be blue.'
     );
 
-    // Show currentPriceIndicator togehter with axis croshair.
+    // Show currentPriceIndicator together with axis crosshair.
     controller.moveTo(200, 200);
     assert.strictEqual(
         chart.yAxis[0].crossLabel.visibility,
@@ -255,7 +255,7 @@ function (assert) {
     // Adjust extremes to show the lastPrice line.
     chart.xAxis[0].setExtremes(0, 4);
     assert.strictEqual(
-        chart.series[0].crossLabel.visibility,
+        chart.series[0].lastVisiblePriceLabel.visibility,
         'inherit',
         'Series last price indicator should be visible.'
     );
@@ -291,7 +291,7 @@ function (assert) {
         'Cross label fill color should be blue again.'
     );
     assert.strictEqual(
-        chart.series[0].crossLabel.visibility,
+        chart.series[0].lastVisiblePriceLabel.visibility,
         'inherit',
         'Series last price indicator should be visible again.'
     );
@@ -389,7 +389,7 @@ QUnit.test('The currentPriceIndicator for multiple series, #14888.', function (a
                 'Each series\' lastPrice line should have color as series.'
             );
             assert.strictEqual(
-                series.crossLabel.attr('fill'),
+                series.lastVisiblePriceLabel.attr('fill'),
                 series.color,
                 'Each series\' lastVisiblePrice label should have color as series.'
             );

--- a/ts/Extensions/PriceIndication.ts
+++ b/ts/Extensions/PriceIndication.ts
@@ -24,8 +24,9 @@ const {
 declare module '../Core/Series/SeriesLike' {
     interface SeriesLike {
         lastPrice?: SVGElement;
+        lastPriceLabel?: SVGElement;
         lastVisiblePrice?: SVGElement;
-        crossLabel?: SVGElement;
+        lastVisiblePriceLabel?: SVGElement;
     }
 }
 
@@ -345,6 +346,12 @@ addEvent(Series, 'afterRender', function (): void {
             yAxis.cross = series.lastPrice;
             yValue = isArray(y) ? y[3] : y;
 
+            if (series.lastPriceLabel) {
+                series.lastPriceLabel.destroy();
+            }
+
+            delete yAxis.crossLabel;
+
             yAxis.drawCrosshair((null as any), ({
                 x: x,
                 y: yValue,
@@ -360,6 +367,8 @@ addEvent(Series, 'afterRender', function (): void {
                 ); // #15222
                 series.lastPrice.y = yValue;
             }
+
+            series.lastPriceLabel = yAxis.crossLabel;
         }
 
         if (lastVisiblePrice && lastVisiblePrice.enabled && pLength > 0) {
@@ -372,8 +381,8 @@ addEvent(Series, 'afterRender', function (): void {
             yAxis.cross = series.lastVisiblePrice;
             lastPoint = points[pLength - crop];
 
-            if (series.crossLabel) {
-                series.crossLabel.destroy();
+            if (series.lastVisiblePriceLabel) {
+                series.lastVisiblePriceLabel.destroy();
             }
             // Set to undefined to avoid collision with
             // the yAxis crosshair #11480
@@ -390,7 +399,7 @@ addEvent(Series, 'afterRender', function (): void {
                 }
             }
 
-            series.crossLabel = yAxis.crossLabel;
+            series.lastVisiblePriceLabel = yAxis.crossLabel;
         }
 
         // Restore crosshair:


### PR DESCRIPTION
Fixed #17790, `lastPrice` and `lastVisiblePrice` labels were not destroyed during redraw.

Demo for testing: https://jsfiddle.net/BlackLabel/Lz1pumsr/