### PR TITLE
bugfix/18443-guidebox-classname-property

### DIFF
--- a/ts/Extensions/DraggablePoints.ts
+++ b/ts/Extensions/DraggablePoints.ts
@@ -2145,7 +2145,7 @@ Chart.prototype.setGuideBoxState = function (
 
     return (guideBox as any)
         .attr({
-            className: stateOptions.className,
+            'class': stateOptions.className,
             stroke: stateOptions.lineColor,
             strokeWidth: stateOptions.lineWidth,
             fill: stateOptions.color,


### PR DESCRIPTION
Fixed #18443, the `className` property in `guideBox` didn't work for drag & drop.