### PR TITLE
bugfix/10005-wrong-legend-value-series-mapping

### DIFF
--- a/samples/unit-tests/data/csv/demo.js
+++ b/samples/unit-tests/data/csv/demo.js
@@ -643,12 +643,10 @@ QUnit.test('startRow, endRow, startColumn, endColumn', function (assert) {
     });
 });
 
-// Highcharts 4.0.4, Issue #3437
-// Data module fails with numeric data in first column
 QUnit.test('Data module numeric x (#3437)', function (assert) {
-    var data =
-        ',Apples,Oranges\n2010,15,3\n2011,5,2\n2012,13,4\n2013,4,10\n2014,2,6';
-    var chart = Highcharts.chart('container', {
+    const data =
+        ',Apples,Oranges,Bananas\n2010,15,3,10\n2011,5,2,8\n2012,13,4,2\n2013,4,10,7\n2014,2,6,10';
+    const chart = Highcharts.chart('container', {
         data: {
             csv: data
         }
@@ -656,6 +654,48 @@ QUnit.test('Data module numeric x (#3437)', function (assert) {
     assert.ok(
         chart.series.length > 0,
         'The data module failed to load numeric data'
+    );
+
+    chart.update({
+        data: {
+            seriesMapping: [{
+                x: 0,
+                y: 1,
+                A: 1,
+                B: 2,
+                C: 3
+            }, {
+                x: 0,
+                y: 2,
+                A: 1,
+                B: 2,
+                C: 3
+            }, {
+                x: 0,
+                y: 3,
+                A: 1,
+                B: 2,
+                C: 3
+            }]
+        }
+    });
+
+    assert.strictEqual(
+        chart.series[0].name,
+        'Apples',
+        'Each series should have different name from data, #10005.'
+    );
+
+    assert.strictEqual(
+        chart.series[1].name,
+        'Oranges',
+        'Each series should have different name from data, #10005.'
+    );
+
+    assert.strictEqual(
+        chart.series[2].name,
+        'Bananas',
+        'Each series should have different name from data, #10005.'
     );
 });
 

--- a/ts/Extensions/Data.ts
+++ b/ts/Extensions/Data.ts
@@ -2184,8 +2184,6 @@ class SeriesBuilder {
             pointIsArray = builder.pointIsArray,
             point = pointIsArray ? [] as Array<T> : {} as Record<string, T>;
 
-        let columnIndexes;
-
         // Loop each reader and ask it to read its value.
         // Then, build an array or point based on the readers names.
         builder.readers.forEach((reader): void => {
@@ -2207,14 +2205,21 @@ class SeriesBuilder {
 
         // The name comes from the first column (excluding the x column)
         if (typeof this.name === 'undefined' && builder.readers.length >= 2) {
-            columnIndexes = builder.getReferencedColumnIndexes();
+            const columnIndexes: number[] = [];
 
-            // #10005, to find name for series take into account only x and y
-            while (columnIndexes.length > 2) {
-                columnIndexes.pop();
-            }
+            builder.readers.forEach(function (reader): void {
+                if (
+                    reader.configName === 'x' ||
+                    reader.configName === 'name' ||
+                    reader.configName === 'y'
+                ) {
+                    if (typeof reader.columnIndex !== 'undefined') {
+                        columnIndexes.push(reader.columnIndex);
+                    }
+                }
+            });
 
-            if (columnIndexes.length === 2) {
+            if (columnIndexes.length >= 2) {
                 // remove the first one (x col)
                 columnIndexes.shift();
 

--- a/ts/Extensions/Data.ts
+++ b/ts/Extensions/Data.ts
@@ -2208,7 +2208,13 @@ class SeriesBuilder {
         // The name comes from the first column (excluding the x column)
         if (typeof this.name === 'undefined' && builder.readers.length >= 2) {
             columnIndexes = builder.getReferencedColumnIndexes();
-            if (columnIndexes.length >= 2) {
+
+            // #10005, to find name for series take into account only x and y
+            while (columnIndexes.length > 2) {
+                columnIndexes.pop();
+            }
+
+            if (columnIndexes.length === 2) {
                 // remove the first one (x col)
                 columnIndexes.shift();
 


### PR DESCRIPTION
Fixed #10005, wrong series name and legend item by using `data.seriesMapping` property.