### PR TITLE
bugfix/18245-map-zoom-buttons-style-v11

### DIFF
--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -963,6 +963,14 @@ input.highcharts-range-selector {
     text-align: center;
 }
 
+.highcharts-button.highcharts-zoom-in text {
+    transform: translateX(2.25px);
+}
+
+.highcharts-button.highcharts-zoom-out text {
+    transform: translateX(3.75px);
+}
+
 .highcharts-mapview-inset-border {
     stroke: var(--highcharts-neutral-color-20);
     stroke-width: 1px;


### PR DESCRIPTION
Fixed #18245, centered map navigation buttons' text.