### PR TITLE
bugfix/18501-stack-labels-vertical-align-logarithmic

### DIFF
--- a/samples/unit-tests/axis/stacklabels/demo.js
+++ b/samples/unit-tests/axis/stacklabels/demo.js
@@ -543,6 +543,25 @@ QUnit.test('Stack labels various', function (assert) {
         'There should still be two labels after redraw'
     );
 
+    chart.yAxis[0].update({
+        type: 'logarithmic',
+        stackLabels: {
+            enabled: true,
+            verticalAlign: 'bottom'
+        }
+    });
+
+    const yAxisGridBox = chart.yAxis[0].gridGroup.getBBox(),
+        firstStackLabel =
+            chart.yAxis[0].stacking.stacks['column,,,']['0'].label;
+
+    assert.close(
+        yAxisGridBox.y + yAxisGridBox.height,
+        firstStackLabel.absoluteBox.y + firstStackLabel.absoluteBox.height,
+        1,
+        `#18501: Vertical alignment of stack labels should work with
+        logarithmic axes.`
+    );
 });
 
 QUnit.test(

--- a/ts/Core/Axis/Stacking/StackItem.ts
+++ b/ts/Core/Axis/Stacking/StackItem.ts
@@ -355,9 +355,15 @@ class StackItem {
             y = axis.toPixels(totalStackValue),
             xAxis = stackBoxProps.xAxis || chart.xAxis[0],
             x = pick(defaultX, xAxis.toPixels(this.x)) + xOffset,
-            yZero = axis.toPixels(boxBottom ? boxBottom :
-                (axis.logarithmic && isNumber(axis.min) ?
-                    Math.pow(10, axis.min) : 0)),
+            yZero = axis.toPixels(
+                boxBottom ||
+                (
+                    isNumber(axis.min) &&
+                    axis.logarithmic &&
+                    axis.logarithmic.lin2log(axis.min)
+                ) ||
+                0
+            ),
             height = Math.abs(y - yZero),
             inverted = chart.inverted,
             neg = stackItem.isNegative;

--- a/ts/Core/Axis/Stacking/StackItem.ts
+++ b/ts/Core/Axis/Stacking/StackItem.ts
@@ -355,7 +355,9 @@ class StackItem {
             y = axis.toPixels(totalStackValue),
             xAxis = stackBoxProps.xAxis || chart.xAxis[0],
             x = pick(defaultX, xAxis.toPixels(this.x)) + xOffset,
-            yZero = axis.toPixels(boxBottom ? boxBottom : 0),
+            yZero = axis.toPixels(boxBottom ? boxBottom :
+                (axis.logarithmic && isNumber(axis.min) ?
+                    Math.pow(10, axis.min) : 0)),
             height = Math.abs(y - yZero),
             inverted = chart.inverted,
             neg = stackItem.isNegative;


### PR DESCRIPTION
Fixed #18501, vertical alignment of stack labels didn't work with logarithmic axes.