### PR TITLE
feature/18423-organization-chart-link-labels

### DIFF
--- a/samples/highcharts/series-organization/link-labels/demo.css
+++ b/samples/highcharts/series-organization/link-labels/demo.css
@@ -1,0 +1,3 @@
+#container {
+    min-width: 450px;
+}

--- a/samples/highcharts/series-organization/link-labels/demo.details
+++ b/samples/highcharts/series-organization/link-labels/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Link labels in Organization chart
+ authors:
+   - Jakub Szuminski
+ js_wrap: b
+...

--- a/samples/highcharts/series-organization/link-labels/demo.html
+++ b/samples/highcharts/series-organization/link-labels/demo.html
@@ -1,0 +1,5 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/sankey.js"></script>
+<script src="https://code.highcharts.com/modules/organization.js"></script>
+
+<div id="container"></div>

--- a/samples/highcharts/series-organization/link-labels/demo.js
+++ b/samples/highcharts/series-organization/link-labels/demo.js
@@ -13,10 +13,7 @@ Highcharts.chart('container', {
         dataLabels: {
             linkFormat: 'from {point.from} to {point.to}',
             linkTextPath: {
-                enabled: true,
-                attributes: {
-                    startOffset: '80%'
-                }
+                enabled: true
             }
         }
     }]

--- a/samples/highcharts/series-organization/link-labels/demo.js
+++ b/samples/highcharts/series-organization/link-labels/demo.js
@@ -10,9 +10,6 @@ Highcharts.chart('container', {
             ['A', 'C'],
             ['C', 'D']
         ],
-        linkRadius: 0,
-        linkLineWidth: 2,
-        linkColor: '#ccc',
         link: {
             type: 'curved'
         },

--- a/samples/highcharts/series-organization/link-labels/demo.js
+++ b/samples/highcharts/series-organization/link-labels/demo.js
@@ -14,7 +14,9 @@ Highcharts.chart('container', {
             linkFormat: 'from {point.from} to {point.to}',
             linkTextPath: {
                 enabled: true,
-                startOffset: '80%'
+                attributes: {
+                    startOffset: '80%'
+                }
             }
         }
     }]

--- a/samples/highcharts/series-organization/link-labels/demo.js
+++ b/samples/highcharts/series-organization/link-labels/demo.js
@@ -13,7 +13,8 @@ Highcharts.chart('container', {
         dataLabels: {
             linkFormat: 'from {point.from} to {point.to}',
             linkTextPath: {
-                enabled: true
+                enabled: true,
+                startOffset: '80%'
             }
         }
     }]

--- a/samples/highcharts/series-organization/link-labels/demo.js
+++ b/samples/highcharts/series-organization/link-labels/demo.js
@@ -10,9 +10,6 @@ Highcharts.chart('container', {
             ['A', 'C'],
             ['C', 'D']
         ],
-        link: {
-            type: 'curved'
-        },
         dataLabels: {
             linkFormat: 'from {point.from} to {point.to}',
             linkTextPath: {

--- a/samples/highcharts/series-organization/link-labels/demo.js
+++ b/samples/highcharts/series-organization/link-labels/demo.js
@@ -13,9 +13,10 @@ Highcharts.chart('container', {
         linkRadius: 0,
         linkLineWidth: 2,
         linkColor: '#ccc',
+        link: {
+            type: 'curved'
+        },
         dataLabels: {
-            useHTML: false,
-            color: '#000000',
             linkFormat: 'from {point.from} to {point.to}',
             linkTextPath: {
                 enabled: true

--- a/samples/highcharts/series-organization/link-labels/demo.js
+++ b/samples/highcharts/series-organization/link-labels/demo.js
@@ -1,0 +1,25 @@
+Highcharts.chart('container', {
+    title: {
+        text: 'Organization chart with link labels'
+    },
+    series: [{
+        type: 'organization',
+        keys: ['from', 'to'],
+        data: [
+            ['A', 'B'],
+            ['A', 'C'],
+            ['C', 'D']
+        ],
+        linkRadius: 0,
+        linkLineWidth: 2,
+        linkColor: '#ccc',
+        dataLabels: {
+            useHTML: false,
+            color: '#000000',
+            linkFormat: 'from {point.from} to {point.to}',
+            linkTextPath: {
+                enabled: true
+            }
+        }
+    }]
+});

--- a/ts/Series/Organization/OrganizationDataLabelOptions.d.ts
+++ b/ts/Series/Organization/OrganizationDataLabelOptions.d.ts
@@ -23,6 +23,7 @@ import type {
     SankeyDataLabelFormatterContext,
     SankeyDataLabelOptions
 } from '../Sankey/SankeyDataLabelOptions';
+import type DataLabelTextPathOptions from '../../Core/Series/DataLabelOptions';
 
 /* *
  *
@@ -48,6 +49,7 @@ export interface OrganizationDataLabelFormatterContext extends SankeyDataLabelFo
 export interface OrganizationDataLabelOptions extends SankeyDataLabelOptions {
     nodeFormatter?: OrganizationDataLabelsFormatterCallbackFunction;
     linkFormat?: string;
+    linkFormatter?: OrganizationDataLabelsFormatterCallbackFunction;
 }
 
 export default OrganizationDataLabelOptions;

--- a/ts/Series/Organization/OrganizationDataLabelOptions.d.ts
+++ b/ts/Series/Organization/OrganizationDataLabelOptions.d.ts
@@ -23,7 +23,6 @@ import type {
     SankeyDataLabelFormatterContext,
     SankeyDataLabelOptions
 } from '../Sankey/SankeyDataLabelOptions';
-import type DataLabelTextPathOptions from '../../Core/Series/DataLabelOptions';
 
 /* *
  *

--- a/ts/Series/Organization/OrganizationDataLabelOptions.d.ts
+++ b/ts/Series/Organization/OrganizationDataLabelOptions.d.ts
@@ -47,6 +47,7 @@ export interface OrganizationDataLabelFormatterContext extends SankeyDataLabelFo
 
 export interface OrganizationDataLabelOptions extends SankeyDataLabelOptions {
     nodeFormatter?: OrganizationDataLabelsFormatterCallbackFunction;
+    linkFormat?: string;
 }
 
 export default OrganizationDataLabelOptions;

--- a/ts/Series/Organization/OrganizationPoint.ts
+++ b/ts/Series/Organization/OrganizationPoint.ts
@@ -21,7 +21,7 @@
 import type OrganizationPointOptions from './OrganizationPointOptions';
 import type OrganizationSeries from './OrganizationSeries';
 import type { OrganizationSeriesNodeOptions } from './OrganizationSeriesOptions';
-import SankeyPoint from './../Sankey/SankeyPoint';
+import type SankeyPoint from './../Sankey/SankeyPoint';
 import SeriesRegistry from '../../Core/Series/SeriesRegistry.js';
 const {
     seriesTypes: {

--- a/ts/Series/Organization/OrganizationPoint.ts
+++ b/ts/Series/Organization/OrganizationPoint.ts
@@ -21,7 +21,7 @@
 import type OrganizationPointOptions from './OrganizationPointOptions';
 import type OrganizationSeries from './OrganizationSeries';
 import type { OrganizationSeriesNodeOptions } from './OrganizationSeriesOptions';
-import type SankeyPoint from './../Sankey/SankeyPoint';
+import SankeyPoint from './../Sankey/SankeyPoint';
 import SeriesRegistry from '../../Core/Series/SeriesRegistry.js';
 const {
     seriesTypes: {
@@ -101,6 +101,17 @@ class OrganizationPoint extends SankeyPointClass {
      *  Functions
      *
      * */
+
+    init(): OrganizationPoint {
+        SankeyPointClass.prototype.init.apply(this, arguments);
+
+        if (!this.isNode) {
+            this.dataLabelOnNull = true;
+            this.formatPrefix = 'link';
+        }
+
+        return this;
+    }
 
     /**
      * All nodes in an org chart are equal width.

--- a/ts/Series/Organization/OrganizationSeries.ts
+++ b/ts/Series/Organization/OrganizationSeries.ts
@@ -413,8 +413,7 @@ class OrganizationSeries extends SankeySeries {
     public drawDataLabels(): void {
         const dlOptions = this.options.dataLabels;
 
-        if (dlOptions && dlOptions.linkTextPath &&
-            dlOptions.linkTextPath.enabled) {
+        if (dlOptions.linkTextPath && dlOptions.linkTextPath.enabled) {
             for (const link of this.points) {
                 link.options.dataLabels = merge(link.options.dataLabels,
                     { useHTML: false });

--- a/ts/Series/Organization/OrganizationSeries.ts
+++ b/ts/Series/Organization/OrganizationSeries.ts
@@ -410,6 +410,20 @@ class OrganizationSeries extends SankeySeries {
             shapeArgs.height;
     }
 
+    public drawDataLabels(): void {
+        const dlOptions = this.options.dataLabels;
+
+        if (dlOptions && dlOptions.linkTextPath &&
+            dlOptions.linkTextPath.enabled) {
+            for (const link of this.points) {
+                link.options.dataLabels = merge(link.options.dataLabels,
+                    { useHTML: false });
+            }
+        }
+
+        super.drawDataLabels();
+    }
+
     /* eslint-enable valid-jsdoc */
 
 }

--- a/ts/Series/Organization/OrganizationSeriesDefaults.ts
+++ b/ts/Series/Organization/OrganizationSeriesDefaults.ts
@@ -430,7 +430,7 @@ const OrganizationSeriesDefaults: OrganizationSeriesOptions = {
  * The format string specifying what to show for *links* in the
  * organization chart.
  *
- * Best to use with `linkTextPath` enabled.
+ * Best to use with [`linkTextPath`](#series.organization.dataLabels.linkTextPath) enabled.
  *
  * @sample highcharts/series-organization/link-labels
  *         Organization chart with link labels

--- a/ts/Series/Organization/OrganizationSeriesDefaults.ts
+++ b/ts/Series/Organization/OrganizationSeriesDefaults.ts
@@ -413,6 +413,21 @@ const OrganizationSeriesDefaults: OrganizationSeriesOptions = {
  */
 
 /**
+ * The format string specifying what to show for *links* in the
+ * organization chart.
+ *
+ * Best to use with `linkTextPath` enabled which also requires
+ * turning the `dataLabels.useHTML` to `false`.
+ *
+ * @sample highcharts/series-organization/link-labels
+ *         Organization chart with link labels
+ *
+ * @type      {string}
+ * @product   highcharts
+ * @apioption series.organization.dataLabels.linkFormat
+ */
+
+/**
  * An image for the node card, will be inserted by the default
  * `dataLabel.nodeFormatter`.
  *

--- a/ts/Series/Organization/OrganizationSeriesDefaults.ts
+++ b/ts/Series/Organization/OrganizationSeriesDefaults.ts
@@ -454,10 +454,7 @@ const OrganizationSeriesDefaults: OrganizationSeriesOptions = {
 
 /**
  * Options for a _link_ label text which should follow link
- * connection. Border and background are disabled for a label
- * that follows a path.
- *
- * **Note:** Only SVG-based renderer supports this option.
+ * connection.
  *
  * @sample highcharts/series-organization/link-labels
  *         Organization chart with link labels

--- a/ts/Series/Organization/OrganizationSeriesDefaults.ts
+++ b/ts/Series/Organization/OrganizationSeriesDefaults.ts
@@ -416,8 +416,7 @@ const OrganizationSeriesDefaults: OrganizationSeriesOptions = {
  * The format string specifying what to show for *links* in the
  * organization chart.
  *
- * Best to use with `linkTextPath` enabled which also requires
- * turning the `dataLabels.useHTML` to `false`.
+ * Best to use with `linkTextPath` enabled.
  *
  * @sample highcharts/series-organization/link-labels
  *         Organization chart with link labels

--- a/ts/Series/Organization/OrganizationSeriesDefaults.ts
+++ b/ts/Series/Organization/OrganizationSeriesDefaults.ts
@@ -29,7 +29,7 @@ import type Point from '../../Core/Series/Point';
 import type { SankeyDataLabelFormatterContext } from '../Sankey/SankeyDataLabelOptions';
 
 import { Palette } from '../../Core/Color/Palettes.js';
-import { DataLabelTextPathOptions } from '../../Core/Series/DataLabelOptions';
+import { type DataLabelTextPathOptions } from '../../Core/Series/DataLabelOptions';
 
 /* *
  *
@@ -432,15 +432,13 @@ const OrganizationSeriesDefaults: OrganizationSeriesOptions = {
  *
  * Best to use with `linkTextPath` enabled.
  *
- * Defaults to `undefined`.
- *
  * @sample highcharts/series-organization/link-labels
  *         Organization chart with link labels
  *
  * @type      {string}
  * @product   highcharts
  * @apioption series.organization.dataLabels.linkFormat
- * @since 10.3.3
+ * @since next
  */
 
 /**
@@ -448,12 +446,10 @@ const OrganizationSeriesDefaults: OrganizationSeriesOptions = {
  * organization chart. The `linkFormat` option takes
  * precedence over the `linkFormatter`.
  *
- * Defaults to `undefined`.
- *
  * @type      {OrganizationDataLabelsFormatterCallbackFunction}
  * @product   highcharts
  * @apioption series.organization.dataLabels.linkFormatter
- * @since 10.3.3
+ * @since next
  */
 
 /**
@@ -469,7 +465,7 @@ const OrganizationSeriesDefaults: OrganizationSeriesOptions = {
  * @type { DataLabelTextPathOptions }
  * @product highcharts
  * @apioption series.organization.dataLabels.linkTextPath
- * @since 10.3.3
+ * @since next
  */
 
 /**

--- a/ts/Series/Organization/OrganizationSeriesDefaults.ts
+++ b/ts/Series/Organization/OrganizationSeriesDefaults.ts
@@ -20,6 +20,7 @@
 
 import type CSSObject from '../../Core/Renderer/CSSObject';
 import type {
+    OrganizationDataLabelsFormatterCallbackFunction,
     OrganizationDataLabelFormatterContext
 } from './OrganizationDataLabelOptions';
 import type OrganizationPoint from './OrganizationPoint';
@@ -28,6 +29,7 @@ import type Point from '../../Core/Series/Point';
 import type { SankeyDataLabelFormatterContext } from '../Sankey/SankeyDataLabelOptions';
 
 import { Palette } from '../../Core/Color/Palettes.js';
+import { DataLabelTextPathOptions } from '../../Core/Series/DataLabelOptions';
 
 /* *
  *
@@ -413,20 +415,6 @@ const OrganizationSeriesDefaults: OrganizationSeriesOptions = {
  */
 
 /**
- * The format string specifying what to show for *links* in the
- * organization chart.
- *
- * Best to use with `linkTextPath` enabled.
- *
- * @sample highcharts/series-organization/link-labels
- *         Organization chart with link labels
- *
- * @type      {string}
- * @product   highcharts
- * @apioption series.organization.dataLabels.linkFormat
- */
-
-/**
  * An image for the node card, will be inserted by the default
  * `dataLabel.nodeFormatter`.
  *
@@ -436,6 +424,52 @@ const OrganizationSeriesDefaults: OrganizationSeriesOptions = {
  * @type      {string}
  * @product   highcharts
  * @apioption series.organization.nodes.image
+ */
+
+/**
+ * The format string specifying what to show for *links* in the
+ * organization chart.
+ *
+ * Best to use with `linkTextPath` enabled.
+ *
+ * Defaults to `undefined`.
+ *
+ * @sample highcharts/series-organization/link-labels
+ *         Organization chart with link labels
+ *
+ * @type      {string}
+ * @product   highcharts
+ * @apioption series.organization.dataLabels.linkFormat
+ * @since 10.3.3
+ */
+
+/**
+ * Callback to format data labels for _links_ in the
+ * organization chart. The `linkFormat` option takes
+ * precedence over the `linkFormatter`.
+ *
+ * Defaults to `undefined`.
+ *
+ * @type      {OrganizationDataLabelsFormatterCallbackFunction}
+ * @product   highcharts
+ * @apioption series.organization.dataLabels.linkFormatter
+ * @since 10.3.3
+ */
+
+/**
+ * Options for a _link_ label text which should follow link
+ * connection. Border and background are disabled for a label
+ * that follows a path.
+ *
+ * **Note:** Only SVG-based renderer supports this option.
+ *
+ * @sample highcharts/series-organization/link-labels
+ *         Organization chart with link labels
+ *
+ * @type { DataLabelTextPathOptions }
+ * @product highcharts
+ * @apioption series.organization.dataLabels.linkTextPath
+ * @since 10.3.3
  */
 
 /**

--- a/ts/Series/Organization/OrganizationSeriesDefaults.ts
+++ b/ts/Series/Organization/OrganizationSeriesDefaults.ts
@@ -274,8 +274,14 @@ const OrganizationSeriesDefaults: OrganizationSeriesOptions = {
             fontSize: '13px'
         },
 
-        useHTML: true
+        useHTML: true,
 
+        linkTextPath: {
+            attributes: {
+                startOffset: '95%',
+                textAnchor: 'end'
+            }
+        }
     },
     /**
      * The indentation in pixels of hanging nodes, nodes which parent has

--- a/ts/Series/Organization/OrganizationSeriesOptions.d.ts
+++ b/ts/Series/Organization/OrganizationSeriesOptions.d.ts
@@ -66,7 +66,7 @@ export interface OrganizationSeriesNodeOptions extends SankeySeriesNodeOptions {
 }
 
 export interface OrganizationSeriesOptions extends SankeySeriesOptions {
-    dataLabels?: OrganizationDataLabelOptions;
+    dataLabels: OrganizationDataLabelOptions;
     hangingIndent?: number;
     hangingIndentTranslation?: OrganizationHangingIndentTranslationValue;
     levels?: Array<OrganizationSeriesLevelOptions>;

--- a/ts/Series/Sankey/SankeyDataLabelOptions.d.ts
+++ b/ts/Series/Sankey/SankeyDataLabelOptions.d.ts
@@ -19,7 +19,7 @@
 import type DataLabelOptions from '../../Core/Series/DataLabelOptions';
 import type Point from '../../Core/Series/Point';
 import type SankeyPoint from './SankeyPoint';
-import type DataLabelTextPathOptions from '../../Core/Series/DataLabelOptions';
+import type { DataLabelTextPathOptions } from '../../Core/Series/DataLabelOptions';
 /* *
  *
  *  Declarations

--- a/ts/Series/Sankey/SankeySeries.ts
+++ b/ts/Series/Sankey/SankeySeries.ts
@@ -335,16 +335,8 @@ class SankeySeries extends ColumnSeries {
     }
 
     public drawDataLabels(): void {
-        for (const link of this.points) {
-            const dlOptions = this.options.dataLabels;
-            if (dlOptions && dlOptions.linkTextPath &&
-                dlOptions.linkTextPath.enabled) {
-                link.options.dataLabels = merge(link.options.dataLabels,
-                    { useHTML: false });
-            }
-        }
-
-        super.drawDataLabels();
+        ColumnSeries.prototype.drawDataLabels.call(this, this.points);
+        ColumnSeries.prototype.drawDataLabels.call(this, this.nodes);
     }
 
     /**

--- a/ts/Series/Sankey/SankeySeries.ts
+++ b/ts/Series/Sankey/SankeySeries.ts
@@ -335,8 +335,16 @@ class SankeySeries extends ColumnSeries {
     }
 
     public drawDataLabels(): void {
-        ColumnSeries.prototype.drawDataLabels.call(this, this.points);
-        ColumnSeries.prototype.drawDataLabels.call(this, this.nodes);
+        for (const link of this.points) {
+            const dlOptions = this.options.dataLabels;
+            if (dlOptions && dlOptions.linkTextPath &&
+                dlOptions.linkTextPath.enabled) {
+                link.options.dataLabels = merge(link.options.dataLabels,
+                    { useHTML: false });
+            }
+        }
+
+        super.drawDataLabels();
     }
 
     /**


### PR DESCRIPTION
Implemented link data labels for OrganizationSeries. See #18423.

Closes #18423.

@TorsteinHonsi In arcdiagram, link labels look like this: https://jsfiddle.net/BlackLabel/9zwe78x1/
But arcdiagram renders link labels as SVG elements and it uses `linkTextPath`.

Organization chart `dataLabels` are rendered as HTML elements so the easiest way to achieve a similar effect would be to also use `linkTextPath` which only works if `useHTML = false`.

Then, the link dataLabels would look like here: https://jsfiddle.net/BlackLabel/pmtgenqb/
I think that otherwise it will be quite difficult to make them look well.

Should I proceed with this solution & add a short note to the API that `linkFormat` renders `dataLabel`s  for the Organization chart only if `dataLabels.useHTML = false`?

Or should I do something else about it?