### PR TITLE
bugfix/18544-boost-null-values-data-length

### DIFF
--- a/samples/unit-tests/boost/general/demo.js
+++ b/samples/unit-tests/boost/general/demo.js
@@ -117,7 +117,7 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
     }
 );
 QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
-    'Combination with non-boostable series types (#7634)',
+    'Combination with non-boostable series types and null values (#7634)',
     function (assert) {
         var chart = Highcharts.chart('container', {
             boost: {
@@ -158,6 +158,16 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
             chart.series[2].points.length,
             5,
             '5 points should be generated for flags series'
+        );
+
+        chart.addSeries({
+            data: [null, 9, 4, null]
+        });
+
+        assert.strictEqual(
+            chart.series[3].points.length,
+            4,
+            'array length should include values with null'
         );
     }
 );

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -1053,7 +1053,7 @@ function seriesRenderCanvas(this: Series): void {
                 isYInside = (y || 0) >= yMin && y <= yMax;
             }
 
-            if (y !== null && x >= xMin && x <= xMax && isYInside) {
+            if (x >= xMin && x <= xMax && isYInside) {
 
                 clientX = xAxis.toPixels(x, true);
 


### PR DESCRIPTION
Fixed #18544, data length for null values with [boost.seriesThreshold](https://api.highcharts.com/highcharts/boost.seriesThreshold).