### PR TITLE
Feature/pie connectors

### DIFF
--- a/samples/highcharts/plotoptions/pie-datalabels-softconnector-false/demo.js
+++ b/samples/highcharts/plotoptions/pie-datalabels-softconnector-false/demo.js
@@ -5,6 +5,7 @@ Highcharts.chart('container', {
     plotOptions: {
         pie: {
             dataLabels: {
+                connectorShape: 'fixedOffset',
                 softConnector: false
             }
         }

--- a/samples/highcharts/plotoptions/pie-datalabels-softconnector-true/demo.js
+++ b/samples/highcharts/plotoptions/pie-datalabels-softconnector-true/demo.js
@@ -5,6 +5,7 @@ Highcharts.chart('container', {
     plotOptions: {
         pie: {
             dataLabels: {
+                connectorShape: 'fixedOffset'
                 // softConnector: true // by default
             }
         }

--- a/ts/Series/Pie/PieSeriesDefaults.ts
+++ b/ts/Series/Pie/PieSeriesDefaults.ts
@@ -218,41 +218,40 @@ const PieSeriesDefaults: PlotOptionsOf<PieSeries> = {
 
         /**
          * Specifies the method that is used to generate the connector path.
-         * Highcharts provides 3 built-in connector shapes: `'fixedOffset'`
-         * (default), `'straight'` and `'crookedLine'`. Using
-         * `'crookedLine'` has the most sense (in most of the cases) when
-         * `'alignTo'` is set.
+         * Highcharts provides 3 built-in connector shapes: `'crookedLine'`
+         * (default since v11), `'fixedOffset'` and `'straight'`.
          *
-         * Users can provide their own method by passing a function instead
-         * of a String. 3 arguments are passed to the callback:
+         * Users can provide their own method by passing a function instead of a
+         * string. Three arguments are passed to the callback:
          *
-         * - Object that holds the information about the coordinates of the
+         * - An object that holds the information about the coordinates of the
          *   label (`x` & `y` properties) and how the label is located in
-         *   relation to the pie (`alignment` property). `alignment` can by
-         *   one of the following:
-         *   `'left'` (pie on the left side of the data label),
-         *   `'right'` (pie on the right side of the data label) or
+         *   relation to the pie (`alignment` property). `alignment` can by one
+         *   of the following: `'left'` (pie on the left side of the data
+         *   label), `'right'` (pie on the right side of the data label) or
          *   `'center'` (data label overlaps the pie).
          *
-         * - Object that holds the information about the position of the
-         *   connector. Its `touchingSliceAt`  porperty tells the position
-         *   of the place where the connector touches the slice.
+         * - An object that holds the information about the position of the
+         *   connector. Its `touchingSliceAt`  porperty tells the position of
+         *   the place where the connector touches the slice.
          *
          * - Data label options
          *
-         * The function has to return an SVG path definition in array form
-         * (see the example).
+         * The function has to return an SVG path definition in array form (see
+         * the example).
          *
-         * @sample {highcharts} highcharts/plotoptions/pie-datalabels-connectorshape-string/
+         * @sample {highcharts}
+         *         highcharts/plotoptions/pie-datalabels-connectorshape-string/
          *         connectorShape is a String
-         * @sample {highcharts} highcharts/plotoptions/pie-datalabels-connectorshape-function/
+         * @sample {highcharts}
+         *         highcharts/plotoptions/pie-datalabels-connectorshape-function/
          *         connectorShape is a function
          *
          * @type    {string|Function}
          * @since   7.0.0
          * @product highcharts highmaps
          */
-        connectorShape: 'fixedOffset',
+        connectorShape: 'crookedLine',
 
         /**
          * The width of the line connecting the data label to the pie slice.
@@ -275,7 +274,9 @@ const PieSeriesDefaults: PlotOptionsOf<PieSeries> = {
         /**
          * Works only if `connectorShape` is `'crookedLine'`. It defines how
          * far from the vertical plot edge the coonnector path should be
-         * crooked.
+         * crooked. With the default, `undefined`, the crook is placed so that
+         * the horizontal line from the label intersects with the radial line
+         * extending through the center of the pie slice.
          *
          * @sample {highcharts} highcharts/plotoptions/pie-datalabels-crookdistance/
          *         crookDistance set to 90%
@@ -283,7 +284,7 @@ const PieSeriesDefaults: PlotOptionsOf<PieSeries> = {
          * @since   7.0.0
          * @product highcharts highmaps
          */
-        crookDistance: '70%',
+        crookDistance: void 0,
 
         /**
          * The distance of the data label from the pie's edge. Negative
@@ -333,13 +334,14 @@ const PieSeriesDefaults: PlotOptionsOf<PieSeries> = {
         },
 
         /**
-         * Whether to render the connector as a soft arc or a line with
-         * sharp break. Works only if `connectorShape` equals to
-         * `fixedOffset`.
+         * Whether to render the connector as a soft arc or a line with a sharp
+         * break. Works only if `connectorShape` equals to `fixedOffset`.
          *
-         * @sample {highcharts} highcharts/plotoptions/pie-datalabels-softconnector-true/
+         * @sample {highcharts}
+         *         highcharts/plotoptions/pie-datalabels-softconnector-true/
          *         Soft
-         * @sample {highcharts} highcharts/plotoptions/pie-datalabels-softconnector-false/
+         * @sample {highcharts}
+         *         highcharts/plotoptions/pie-datalabels-softconnector-false/
          *         Non soft
          *
          * @since   2.1.7


### PR DESCRIPTION
Made the pie series connectors use `connectorShape: 'crookedLine'` and `crookDistance: undefined` by default. 

This PR is part of the Highcharts v11 facelift and should not be merged until other visual changes are verified.

### To do
 - [x] Last minute visual change: The [hard-coded number 10 pixels](https://github.com/highcharts/highcharts/blob/28f023a604cbe0efdf1d6fcfb1c4d534fbe9ed5a/ts/Series/Pie/PieDataLabel.ts#L420-L425) must be replaced by the label's actual measure. (Do this after the relative font-size branch has been merged into the v11-design branch)

### Possible improvement
Also _considering_ an option to let the connectors extend through / below the label. We could implement `verticalAlign` for the pie data label, in which case the label itself would shift up and down (middle by default). Additionally, we could support `verticalAlign: 'baseline'`, in which case 10 should be replaced by the `fontMetrics` of the label.

Then we would need another option to make the connector start point at the other side of the label.