### PR TITLE
bugfix/18520-legend-item-font-size-issue

### DIFF
--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -729,8 +729,25 @@ class Legend {
             // Get the baseline for the first item - the font size is equal for
             // all
             if (!legend.baseline) {
+                const legendUserOptions = legend.chart.userOptions.legend;
+                let fontSize: string | number | undefined;
+
+                if (legendUserOptions &&
+                    legendUserOptions.itemStyle &&
+                    legendUserOptions.itemStyle.fontSize) {
+                    // if the fontSize is defined by the user
+                    fontSize = legendUserOptions.itemStyle.fontSize;
+                } else if (!legendUserOptions ||
+                    !legendUserOptions.itemStyle ||
+                    !legendUserOptions.itemStyle.font ||
+                    !/px|rem|em/.test(legendUserOptions.itemStyle.font)) {
+                    // if neither fontSize nor font are defined by the user
+                    // then take the default value from itemStyle.fontSize
+                    fontSize = (itemStyle as any).fontSize;
+                }
+
                 legend.fontMetrics = renderer.fontMetrics(
-                    chart.styledMode ? 12 : (itemStyle as any).fontSize,
+                    chart.styledMode ? 12 : fontSize,
                     label
                 );
                 legend.baseline =


### PR DESCRIPTION
Fixed #18520:

If `fontSize` property is not defined by the user, but the `font` property is, the `legend.fontMetrics` are given undefined for the first argument (to inherit `fontSize` from DOM). 

If neither `fontSize` nor `font` are defined by the user, we pass the default `fontSize` to the `legend.fontMetrics`.