### PR TITLE
docs/18565-api-links-to-missing-properties

### DIFF
--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -951,7 +951,7 @@ namespace AxisDefaults {
              *
              * @type      {boolean}
              * @since     4.1.10
-             * @product   highcharts gantt
+             * @product   highcharts highstock gantt
              * @apioption xAxis.labels.reserveSpace
              */
             reserveSpace: void 0,
@@ -2542,8 +2542,6 @@ namespace AxisDefaults {
              * Angular gauges and solid gauges defaults to `"center"`.
              * Solid gauges with two labels have additional option `"auto"`
              * for automatic horizontal and vertical alignment.
-             *
-             * @see [yAxis.labels.distance](#yAxis.labels.distance)
              *
              * @sample {highcharts} highcharts/yaxis/labels-align-left/
              *         Left


### PR DESCRIPTION
Fixed #18565, a few API links did not work properly.

1. Added `xAxis.labels.reserveSpace` to Highstock API (link from https://api.highcharts.com/highstock/xAxis.labels.align to `reserveSpace` will work)
2. Removed `See yAxis.labels.distance` link from `yAxis.labels.align` as it did not work for Highstock, Highmaps and Gantt.