### PR TITLE
docs/16096-api-panning-type-details

### DIFF
--- a/ts/Core/Chart/ChartDefaults.ts
+++ b/ts/Core/Chart/ChartDefaults.ts
@@ -466,6 +466,9 @@ const ChartDefaults: ChartOptions = {
          * Decides in what dimensions the user can pan the chart. Can be
          * one of `x`, `y`, or `xy`.
          *
+         * When this option is set to `y` or `xy`, [yAxis.startOnTick](#yAxis.startOnTick)
+         * and [yAxis.endOnTick](#yAxis.endOnTick) are overwritten to `false`.
+         *
          * @sample {highcharts} highcharts/chart/panning-type
          *         Zooming and xy panning
          *


### PR DESCRIPTION
Fixed #16096, added information about overwriting `yAxis.startOnTick` and `yAxis.endOnTick` to false when `panning.type` is y or xy to api.