### PR TITLE
bugfix/17280-zero-z-bubbles-disappear

### DIFF
--- a/samples/unit-tests/series-bubble/extremes/demo.js
+++ b/samples/unit-tests/series-bubble/extremes/demo.js
@@ -91,36 +91,3 @@ QUnit.test('Setting X axis extremes on bubble (#5167)', function (assert) {
     assert.ok(chart.yAxis[0].min < 102.9, 'DE point is within range');
     assert.ok(chart.yAxis[0].max > 102.9, 'DE point is within range');
 });
-
-QUnit.test('Calculation of Z extremes when Z = 0 (#17280)', function (assert) {
-    const chart = Highcharts.chart('container', {
-        chart: {
-            type: 'bubble',
-            animation: false
-        },
-
-        series: [{
-            data: [
-                [2, 2, 0]
-            ]
-        }, {
-            data: [
-                [1, 1, 20]
-            ]
-        }]
-    });
-
-    assert.strictEqual(
-        chart.bubbleZExtremes.zMin,
-        0,
-        'The lower Z extreme equals 0'
-    );
-
-    chart.series[1].data[0].update({ z: -20 });
-
-    assert.strictEqual(
-        chart.bubbleZExtremes.zMax,
-        0,
-        'The upper Z extreme equals 0'
-    );
-});

--- a/samples/unit-tests/series-bubble/extremes/demo.js
+++ b/samples/unit-tests/series-bubble/extremes/demo.js
@@ -91,3 +91,36 @@ QUnit.test('Setting X axis extremes on bubble (#5167)', function (assert) {
     assert.ok(chart.yAxis[0].min < 102.9, 'DE point is within range');
     assert.ok(chart.yAxis[0].max > 102.9, 'DE point is within range');
 });
+
+QUnit.test('Calculation of Z extremes when Z = 0 (#17280)', function (assert) {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'bubble',
+            animation: false
+        },
+
+        series: [{
+            data: [
+                [2, 2, 0]
+            ]
+        }, {
+            data: [
+                [1, 1, 20]
+            ]
+        }]
+    });
+
+    assert.strictEqual(
+        chart.bubbleZExtremes.zMin,
+        0,
+        'The lower Z extreme equals 0'
+    );
+
+    chart.series[1].data[0].update({ z: -20 });
+
+    assert.strictEqual(
+        chart.bubbleZExtremes.zMax,
+        0,
+        'The upper Z extreme equals 0'
+    );
+});

--- a/samples/unit-tests/series-bubble/options/demo.js
+++ b/samples/unit-tests/series-bubble/options/demo.js
@@ -43,6 +43,22 @@ QUnit.test('Axis extremes', function (assert) {
         chart.xAxis[0].max > 3,
         'Axis max should be more than max data (#8902)'
     );
+
+    chart.series[0].data[0].update({ z: 0 });
+
+    assert.strictEqual(
+        chart.bubbleZExtremes.zMin,
+        0,
+        'zMin is calculated correctly when there is a point with Z = 0 (#17280)'
+    );
+
+    chart.series[1].data[0].update({ z: -3 });
+
+    assert.strictEqual(
+        chart.bubbleZExtremes.zMax,
+        0,
+        'zMax is calculated correctly when there is a point with Z = 0 (#17280)'
+    );
 });
 
 QUnit.test('Negative values', function (assert) {

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -594,6 +594,8 @@ class BubbleSeries extends ScatterSeries {
                     ).getZExtremes();
 
                     if (zExtremes) {
+                        // Changed '||' to 'pick' because min or max can be 0.
+                        // #17280
                         zMin = Math.min(
                             pick(zMin, zExtremes.zMin),
                             zExtremes.zMin

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -594,8 +594,14 @@ class BubbleSeries extends ScatterSeries {
                     ).getZExtremes();
 
                     if (zExtremes) {
-                        zMin = Math.min(zMin || zExtremes.zMin, zExtremes.zMin);
-                        zMax = Math.max(zMax || zExtremes.zMax, zExtremes.zMax);
+                        zMin = Math.min(
+                            pick(zMin, zExtremes.zMin),
+                            zExtremes.zMin
+                        );
+                        zMax = Math.max(
+                            pick(zMax, zExtremes.zMax),
+                            zExtremes.zMax
+                        );
                         valid = true;
                     }
                 }


### PR DESCRIPTION
Fixed #17280, bubbles with `z: 0` caused points to disappear.