### PR TITLE
bugfix/18303-point-visibility-drillup

### DIFF
--- a/samples/unit-tests/drilldown/pie/demo.js
+++ b/samples/unit-tests/drilldown/pie/demo.js
@@ -270,7 +270,8 @@ QUnit.test('Slice color after drilldown and select (#4359)', function (assert) {
                 pie: {
                     depth: 35,
                     allowPointSelect: true,
-                    colors: ['#00e500', '#004400']
+                    colors: ['#00e500', '#004400'],
+                    ignoreHiddenPoint: false
                 }
             },
             series: [
@@ -281,13 +282,20 @@ QUnit.test('Slice color after drilldown and select (#4359)', function (assert) {
                             y: 23.73
                         },
                         {
-                            y: 76.27,
+                            y: 73.27,
                             drilldown: 'Recycled Materials'
+                        },
+                        {
+                            y: 3,
+                            visible: false
                         }
                     ]
                 }
             ],
             drilldown: {
+                animation: {
+                    duration: Number.MIN_VALUE
+                },
                 series: [
                     {
                         animation: false,
@@ -337,6 +345,13 @@ QUnit.test('Slice color after drilldown and select (#4359)', function (assert) {
         chart3d.series[0].points[0].graphic.top.attr('fill'),
         chart3d.series[0].options.colors[0],
         'Proper select-state color'
+    );
+
+    chart.drillUp();
+    assert.strictEqual(
+        chart.series[0].points[2].graphic.visibility,
+        'hidden',
+        'The invisible slice should still be hidden after drill-up (#18303)'
     );
 
     chart.destroy();

--- a/ts/Extensions/Drilldown.ts
+++ b/ts/Extensions/Drilldown.ts
@@ -1533,7 +1533,10 @@ ColumnSeries.prototype.animateDrillupTo = function (init?: boolean): void {
                         dataLabel = point.dataLabel;
 
 
-                    if (point.graphic && point.visible) { // #3407
+                    if (
+                        point.graphic && // #3407
+                        point.visible // Don't show if invisible (#18303)
+                    ) {
                         point.graphic[verb](inherit);
                     }
 

--- a/ts/Extensions/Drilldown.ts
+++ b/ts/Extensions/Drilldown.ts
@@ -1533,7 +1533,7 @@ ColumnSeries.prototype.animateDrillupTo = function (init?: boolean): void {
                         dataLabel = point.dataLabel;
 
 
-                    if (point.graphic) { // #3407
+                    if (point.graphic && point.visible) { // #3407
                         point.graphic[verb](inherit);
                     }
 


### PR DESCRIPTION
Fixed #18303, a point with `visible: false` was shown after drill-up.