### PR TITLE
bugfix/17142-venn-sets-comma-issue

### DIFF
--- a/samples/unit-tests/series-venn/members/demo.js
+++ b/samples/unit-tests/series-venn/members/demo.js
@@ -417,6 +417,10 @@ QUnit.test('processVennData', function (assert) {
         {
             sets: ['B', 'A'],
             value: 2
+        },
+        {
+            sets: ['D,E'],
+            value: 2
         }
     ];
     assert.deepEqual(
@@ -433,9 +437,22 @@ QUnit.test('processVennData', function (assert) {
             {
                 sets: ['A', 'B'],
                 value: 2
+            },
+            {
+                sets: ['D,E'],
+                value: 2
+            },
+            {
+                sets: ['A', 'D,E'],
+                value: 0
+            },
+            {
+                sets: ['B', 'D,E'],
+                value: 0
             }
         ],
-        'should remove duplicate sets and just update existing values for the set.'
+        `should remove duplicate sets and just update existing values for the 
+        set; everything should work when commas inside strings.`
     );
 
     // add missing relations between sets as value = 0.

--- a/samples/unit-tests/series-venn/members/demo.js
+++ b/samples/unit-tests/series-venn/members/demo.js
@@ -325,13 +325,15 @@ QUnit.test('loss', function (assert) {
 });
 
 QUnit.test('processVennData', function (assert) {
-    var vennPrototype = Highcharts.Series.types.venn.prototype,
+    var vennSeries = Highcharts.Series.types.venn,
+        vennPrototype = vennSeries.prototype,
         processVennData = vennPrototype.utils.processVennData,
+        defaultSplitter = vennSeries.splitter,
         data;
 
     // data is undefined.
     assert.deepEqual(
-        processVennData(data),
+        processVennData(data, defaultSplitter),
         [],
         'should return empty array when data is not an array.'
     );
@@ -339,7 +341,7 @@ QUnit.test('processVennData', function (assert) {
     // values in data should be objects.
     data = [2];
     assert.deepEqual(
-        processVennData(data),
+        processVennData(data, defaultSplitter),
         [],
         'should ignore values in data that are not of type object.'
     );
@@ -360,7 +362,7 @@ QUnit.test('processVennData', function (assert) {
         }
     ];
     assert.deepEqual(
-        processVennData(data),
+        processVennData(data, defaultSplitter),
         [
             {
                 sets: ['C'],
@@ -386,7 +388,7 @@ QUnit.test('processVennData', function (assert) {
         }
     ];
     assert.deepEqual(
-        processVennData(data),
+        processVennData(data, defaultSplitter),
         [
             {
                 sets: ['B'],
@@ -424,7 +426,7 @@ QUnit.test('processVennData', function (assert) {
         }
     ];
     assert.deepEqual(
-        processVennData(data),
+        processVennData(data, defaultSplitter),
         [
             {
                 sets: ['A'],
@@ -471,7 +473,7 @@ QUnit.test('processVennData', function (assert) {
         }
     ];
     assert.deepEqual(
-        processVennData(data),
+        processVennData(data, defaultSplitter),
         [
             {
                 sets: ['A'],
@@ -513,7 +515,7 @@ QUnit.test('processVennData', function (assert) {
         }
     ];
     assert.deepEqual(
-        processVennData(data),
+        processVennData(data, defaultSplitter),
         [
             {
                 sets: ['A'],
@@ -531,7 +533,7 @@ QUnit.test('processVennData', function (assert) {
         }
     ];
     assert.deepEqual(
-        processVennData(data),
+        processVennData(data, defaultSplitter),
         [],
         'should remove relations that has invalid values in sets.'
     );

--- a/ts/Series/Venn/VennSeries.ts
+++ b/ts/Series/Venn/VennSeries.ts
@@ -90,11 +90,11 @@ declare global {
             loss: number;
         }
         interface VennPropsObject {
-            overlapping: Record<string, number>;
-            totalOverlap: number;
+            overlapping?: Record<string, number>;
+            totalOverlap?: number;
         }
         interface VennRelationObject extends VennPropsObject {
-            circle: CircleObject;
+            circle?: CircleObject;
             sets: Array<string>;
             value: number;
         }
@@ -121,6 +121,8 @@ class VennSeries extends ScatterSeries {
      *  Static Properties
      *
      * */
+
+    public static splitter = 'highcharts-split';
 
     /**
      * A Venn diagram displays all possible logical relations between a
@@ -336,7 +338,10 @@ class VennSeries extends ScatterSeries {
                 const property = isInternal ? 'internal' : 'external';
 
                 // Add the circle to the list.
-                data[property].push(set.circle);
+                if (set.circle) {
+                    data[property].push(set.circle);
+                }
+
                 return data;
             }, {
                 internal: [],
@@ -651,7 +656,8 @@ class VennSeries extends ScatterSeries {
         this.generatePoints();
 
         // Process the data before passing it into the layout function.
-        const relations = VennUtils.processVennData(this.options.data as any);
+        const relations = VennUtils.processVennData(this.options.data as any,
+            VennSeries.splitter);
 
         // Calculate the positions of each circle.
         const {

--- a/ts/Series/Venn/VennUtils.ts
+++ b/ts/Series/Venn/VennUtils.ts
@@ -815,8 +815,11 @@ function processVennData(
                 return validSets.indexOf(set) === -1;
             })
         ) {
-            mapOfIdToRelation[(relation.sets as any).sort().join()] =
-                relation as any;
+            mapOfIdToRelation[
+                (relation.sets as any)
+                    .sort()
+                    .join('SPLIT//COMBINATIONS')
+            ] = relation as any;
         }
         return mapOfIdToRelation;
     }, {});
@@ -830,13 +833,13 @@ function processVennData(
         const remaining = arr.slice(i + 1);
 
         remaining.forEach(function (set2: string): void {
-            combinations.push(set + ',' + set2);
+            combinations.push(set + 'SPLIT//COMBINATIONS' + set2);
         });
         return combinations;
     }, []).forEach(function (combination: string): void {
         if (!mapOfIdToRelation[combination]) {
             const obj: Highcharts.VennRelationObject = {
-                sets: combination.split(','),
+                sets: combination.split('SPLIT//COMBINATIONS'),
                 value: 0
             } as any;
 

--- a/ts/Series/Venn/VennUtils.ts
+++ b/ts/Series/Venn/VennUtils.ts
@@ -91,26 +91,31 @@ function addOverlapToSets(
     relations: Array<Highcharts.VennRelationObject>
 ): Array<Highcharts.VennRelationObject> {
     // Calculate the amount of overlap per set.
-    const mapOfIdToProps = relations
+    const mapOfIdToProps: Record<string, Highcharts.VennPropsObject> = {};
+
+    relations
         // Filter out relations consisting of 2 sets.
         .filter((relation): boolean => (relation.sets.length === 2))
         // Sum up the amount of overlap for each set.
-        .reduce(
-            (map, relation): Record<string, Highcharts.VennPropsObject> => {
-                relation.sets.forEach((set, i, arr): void => {
-                    if (!isObject(map[set])) {
-                        map[set] = {
-                            overlapping: {},
-                            totalOverlap: 0
-                        };
+        .forEach((relation): void => {
+            relation.sets.forEach((set, i, arr): void => {
+                if (!isObject(mapOfIdToProps[set])) {
+                    mapOfIdToProps[set] = {
+                        totalOverlap: 0,
+                        overlapping: {}
+                    };
+                }
+
+                mapOfIdToProps[set] = {
+                    totalOverlap: (mapOfIdToProps[set].totalOverlap || 0) +
+                        relation.value,
+                    overlapping: {
+                        ...(mapOfIdToProps[set].overlapping || {}),
+                        [arr[1 - i]]: relation.value
                     }
-                    map[set].totalOverlap += relation.value;
-                    map[set].overlapping[arr[1 - i]] = relation.value;
-                });
-                return map;
-            },
-            {} as Record<string, Highcharts.VennPropsObject>
-        );
+                };
+            });
+        });
 
     relations
         // Filter out single sets
@@ -455,8 +460,11 @@ function layoutGreedyVenn(
     ): void {
         const circle = set.circle;
 
-        circle.x = coordinates.x;
-        circle.y = coordinates.y;
+        if (circle) {
+            circle.x = coordinates.x;
+            circle.y = coordinates.y;
+        }
+
         positionedSets.push(set);
     };
 
@@ -481,14 +489,23 @@ function layoutGreedyVenn(
     sortedByOverlap.forEach(function (
         set: Highcharts.VennRelationObject
     ): void {
-        const circle = set.circle,
-            radius = circle.r,
+        const circle = set.circle;
+        if (!circle) {
+            return;
+        }
+
+        const radius = circle.r,
             overlapping = set.overlapping;
 
         const bestPosition = positionedSets.reduce(
             (best, positionedSet, i): Highcharts.VennLabelOverlapObject => {
-                const positionedCircle = positionedSet.circle,
-                    overlap = overlapping[positionedSet.sets[0]];
+                const positionedCircle = positionedSet.circle;
+
+                if (!positionedCircle || !overlapping) {
+                    return best;
+                }
+
+                const overlap = overlapping[positionedSet.sets[0]];
 
                 // Calculate the distance between the sets to get the
                 // correct overlap
@@ -513,12 +530,17 @@ function layoutGreedyVenn(
                     positionedSet2: Highcharts.VennRelationObject
                 ): void {
                     const positionedCircle2 = positionedSet2.circle,
-                        overlap2 = overlapping[positionedSet2.sets[0]],
-                        distance2 = getDistanceBetweenCirclesByOverlap(
-                            radius,
-                            positionedCircle2.r,
-                            overlap2
-                        );
+                        overlap2 = overlapping[positionedSet2.sets[0]];
+
+                    if (!positionedCircle2) {
+                        return;
+                    }
+
+                    const distance2 = getDistanceBetweenCirclesByOverlap(
+                        radius,
+                        positionedCircle2.r,
+                        overlap2
+                    );
 
                     // Add intersections to list of coordinates.
                     possibleCoordinates = possibleCoordinates.concat(
@@ -788,7 +810,8 @@ function nelderMead(
  * @return {Array<object>} Returns an array of valid venn data.
  */
 function processVennData(
-    data: Array<VennPointOptions>
+    data: Array<VennPointOptions>,
+    splitter: string
 ): Array<Highcharts.VennRelationObject> {
     const d = isArray(data) ? data : [];
 
@@ -798,8 +821,8 @@ function processVennData(
             x: VennPointOptions
         ): Array<string> {
             // Check if x is a valid set, and that it is not an duplicate.
-            if (isValidSet(x) && arr.indexOf((x.sets as any)[0]) === -1) {
-                arr.push((x.sets as any)[0]);
+            if (x.sets && isValidSet(x) && arr.indexOf(x.sets[0]) === -1) {
+                arr.push(x.sets[0]);
             }
             return arr;
         }, [])
@@ -810,16 +833,18 @@ function processVennData(
         relation: VennPointOptions
     ): Record<string, Highcharts.VennRelationObject> {
         if (
+            relation.sets &&
             isValidRelation(relation) &&
-            !(relation.sets as any).some(function (set: string): boolean {
+            !relation.sets.some(function (set: string): boolean {
                 return validSets.indexOf(set) === -1;
             })
         ) {
             mapOfIdToRelation[
-                (relation.sets as any)
-                    .sort()
-                    .join('SPLIT//COMBINATIONS')
-            ] = relation as any;
+                relation.sets.sort().join(splitter)
+            ] = {
+                sets: relation.sets,
+                value: relation.value || 0
+            };
         }
         return mapOfIdToRelation;
     }, {});
@@ -833,15 +858,15 @@ function processVennData(
         const remaining = arr.slice(i + 1);
 
         remaining.forEach(function (set2: string): void {
-            combinations.push(set + 'SPLIT//COMBINATIONS' + set2);
+            combinations.push(set + splitter + set2);
         });
         return combinations;
     }, []).forEach(function (combination: string): void {
         if (!mapOfIdToRelation[combination]) {
             const obj: Highcharts.VennRelationObject = {
-                sets: combination.split('SPLIT//COMBINATIONS'),
+                sets: combination.split(splitter),
                 value: 0
-            } as any;
+            };
 
             mapOfIdToRelation[combination] = obj;
         }
@@ -869,7 +894,11 @@ function sortByTotalOverlap(
     a: Highcharts.VennRelationObject,
     b: Highcharts.VennRelationObject
 ): number {
-    return b.totalOverlap - a.totalOverlap;
+    if (typeof b.totalOverlap !== 'undefined' &&
+        typeof a.totalOverlap !== 'undefined') {
+        return b.totalOverlap - a.totalOverlap;
+    }
+    return NaN;
 }
 
 /* *


### PR DESCRIPTION
Fixed #17142, Venn diagram did not work when there was a comma in the string in the `series.data.sets` array.

**Example** of the problem: 
`['A,']` and `['B']` = `'A,,B'` `(combination)` which caused issues when `combination.split(',')`

**Solution:**
I join the elements of the array with a string `SPLIT//COMBINATIONS` which is unlikely to occur in user's code, but maybe we would want to join the sets with another unique string.