### PR TITLE
bugfix/18619-yaxis-update-nans

### DIFF
--- a/samples/unit-tests/series-column/animation-cancel/demo.css
+++ b/samples/unit-tests/series-column/animation-cancel/demo.css
@@ -1,0 +1,4 @@
+#container {
+    width: 800px;
+    height: 300px;
+}

--- a/samples/unit-tests/series-column/animation-cancel/demo.details
+++ b/samples/unit-tests/series-column/animation-cancel/demo.details
@@ -1,0 +1,5 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+...

--- a/samples/unit-tests/series-column/animation-cancel/demo.html
+++ b/samples/unit-tests/series-column/animation-cancel/demo.html
@@ -1,0 +1,6 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/series-column/animation-cancel/demo.js
+++ b/samples/unit-tests/series-column/animation-cancel/demo.js
@@ -1,0 +1,32 @@
+QUnit.test(
+    'Updating the chart while the initial animation is running (#18644)',
+    function (assert) {
+        const clock = TestUtilities.lolexInstall(),
+            chart = Highcharts.chart('container', {
+                chart: {
+                    type: 'column'
+                },
+                series: [{
+                    animation: {
+                        duration: 10
+                    },
+                    data: [3]
+                }]
+            });
+
+        chart.update({
+            yAxis: {
+                min: -5
+            }
+        }, false);
+
+        setTimeout(() => {
+            assert.notOk(
+                chart.container.innerHTML.includes('NaN'),
+                'The innerHtml of the chart container should not contain NaNs'
+            );
+        }, 20);
+
+        TestUtilities.lolexRunAndUninstall(clock);
+    }
+);

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -2382,15 +2382,14 @@ class SVGElement implements SVGElementLike {
      */
     public updateTransform(): void {
         const {
-                element,
-                matrix,
-                scaleX,
-                scaleY
-            } = this,
-            // Protection against assigning NaNs to the variables (#18619)
-            rotation = this.rotation || 0,
-            translateX = this.translateX || 0,
-            translateY = this.translateY || 0;
+            element,
+            matrix,
+            rotation = 0,
+            scaleX,
+            scaleY,
+            translateX = 0,
+            translateY = 0
+        } = this;
 
         // Apply translate. Nearly all transformed elements have translation,
         // so instead of checking for translate = 0, do it always (#1767,

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -2382,14 +2382,15 @@ class SVGElement implements SVGElementLike {
      */
     public updateTransform(): void {
         const {
-            element,
-            matrix,
-            rotation = 0,
-            scaleX,
-            scaleY,
-            translateX = 0,
-            translateY = 0
-        } = this;
+                element,
+                matrix,
+                scaleX,
+                scaleY
+            } = this,
+            // Protection against assigning NaNs to the variables (#18619)
+            rotation = this.rotation || 0,
+            translateX = this.translateX || 0,
+            translateY = this.translateY || 0;
 
         // Apply translate. Nearly all transformed elements have translation,
         // so instead of checking for translate = 0, do it always (#1767,

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -147,6 +147,7 @@ class ColumnSeries extends Series {
     public animate(init: boolean): void {
         const series = this,
             yAxis = this.yAxis,
+            yAxisPos = yAxis.pos,
             options = series.options,
             inverted = this.chart.inverted,
             attr: SVGAttributes = {},
@@ -160,8 +161,8 @@ class ColumnSeries extends Series {
             attr.scaleY = 0.001;
             translatedThreshold = clamp(
                 yAxis.toPixels(options.threshold as any),
-                yAxis.pos,
-                yAxis.pos + yAxis.len
+                yAxisPos,
+                yAxisPos + yAxis.len
             );
             if (inverted) {
                 attr.translateX = translatedThreshold - yAxis.len;
@@ -187,7 +188,7 @@ class ColumnSeries extends Series {
                     step: function (val: any, fx: any): void {
                         if (series.group) {
                             attr[translateProp] = translateStart +
-                                fx.pos * (yAxis.pos - translateStart);
+                                fx.pos * (yAxisPos - translateStart);
                             series.group.attr(attr);
                         }
                     }


### PR DESCRIPTION
Fixed #18619, errors about NaN translate attributes sometimes appeared in the console. It happened when updating a chart without redrawing, before it finished the initial animation.

~Fixed #18619, translate attributes could be NaN.~