### PR TITLE
bugfix/18636-waterfall-missing-lines

### DIFF
--- a/samples/unit-tests/series-waterfall/null-value/demo.js
+++ b/samples/unit-tests/series-waterfall/null-value/demo.js
@@ -1,18 +1,26 @@
 QUnit.test(
-    'The connector line in waterfall in case of a null value (#8024)',
+    'The connector line in waterfall in case of a null value (#18636)',
     function (assert) {
-        var chart = Highcharts.chart('container', {
-            series: [
-                {
-                    type: 'waterfall',
-                    data: [120000, null, 231000, -342000, -233000]
-                }
-            ]
-        });
+        const chart = Highcharts.chart('container', {
+                series: [
+                    {
+                        type: 'waterfall',
+                        data: [120000, null, 231000, -342000, -233000]
+                    }
+                ]
+            }),
+            series = chart.series[0];
 
-        assert.notOk(
-            isNaN(chart.series[0].graph.pathArray[2][2]),
-            'The connector line skips a point with a null Y (#18636)'
+        assert.strictEqual(
+            series.graph.pathArray.length, 4,
+            'Connector lines should display correctly with false connectNulls'
+        );
+
+        series.update({ connectNulls: true });
+
+        assert.strictEqual(
+            series.graph.pathArray.length, 6,
+            'Connector lines should display correctly with true connectNulls'
         );
     }
 );

--- a/samples/unit-tests/series-waterfall/null-value/demo.js
+++ b/samples/unit-tests/series-waterfall/null-value/demo.js
@@ -2,29 +2,17 @@ QUnit.test(
     'The connector line in waterfall in case of a null value (#8024)',
     function (assert) {
         var chart = Highcharts.chart('container', {
-                series: [
-                    {
-                        type: 'waterfall',
-                        data: [120000, null, 231000, -342000, -233000]
-                    }
-                ]
-            }),
-            splittedPath = chart.series[0].graph.d.split(' '),
-            startPoint = [splittedPath[4], splittedPath[5]],
-            endPoint = [splittedPath[7], splittedPath[8]];
+            series: [
+                {
+                    type: 'waterfall',
+                    data: [120000, null, 231000, -342000, -233000]
+                }
+            ]
+        });
 
-        // Test: the eqality of path's x coordinate of points next to each other
-        assert.strictEqual(
-            startPoint[0],
-            endPoint[0],
-            'The x coordinates are equal.'
-        );
-
-        // Test: the eqality of path's y coordinate of points next to each other
-        assert.strictEqual(
-            startPoint[1],
-            endPoint[1],
-            'The y coordinates are equal.'
+        assert.notOk(
+            isNaN(chart.series[0].graph.pathArray[2][2]),
+            'The connector line skips a point with a null Y (#18636)'
         );
     }
 );

--- a/ts/Series/Waterfall/WaterfallSeries.ts
+++ b/ts/Series/Waterfall/WaterfallSeries.ts
@@ -639,8 +639,8 @@ class WaterfallSeries extends ColumnSeries {
     ): SVGPath {
 
         let data = this.data.filter((d): Boolean =>
-                // Skip points where Y is null (#18636)
-                d.y !== null
+                // Skip points where Y is not a number (#18636)
+                isNumber(d.y)
             ),
             yAxis = this.yAxis,
             length = data.length,
@@ -662,6 +662,14 @@ class WaterfallSeries extends ColumnSeries {
             i: (number|undefined);
 
         for (i = 1; i < length; i++) {
+
+            if (!( // Skip lines that would pass over the null point (#18636)
+                this.options.connectNulls ||
+                isNumber(this.data[data[i].index - 1].y)
+            )) {
+                continue;
+            }
+
             pointArgs = data[i].shapeArgs;
             prevPoint = data[i - 1];
             prevArgs = data[i - 1].shapeArgs;

--- a/ts/Series/Waterfall/WaterfallSeries.ts
+++ b/ts/Series/Waterfall/WaterfallSeries.ts
@@ -638,7 +638,10 @@ class WaterfallSeries extends ColumnSeries {
         this: WaterfallSeries
     ): SVGPath {
 
-        let data = this.data,
+        let data = this.data.filter((d): Boolean =>
+                // Skip points where Y is null (#18636)
+                d.y !== null
+            ),
             yAxis = this.yAxis,
             length = data.length,
             graphNormalizer =


### PR DESCRIPTION
Fixed #18636, waterfall lines missing when there was a `null` point.