### PR TITLE
bugfix/18647-tilemap-single-points

### DIFF
--- a/samples/unit-tests/series-tilemap/coloraxis/demo.js
+++ b/samples/unit-tests/series-tilemap/coloraxis/demo.js
@@ -1,5 +1,5 @@
 QUnit.test('Tilemap and ColorAxis', function (assert) {
-    var chart = Highcharts.chart('container', {
+    const chart = Highcharts.chart('container', {
             chart: {
                 type: 'tilemap'
             },
@@ -44,18 +44,48 @@ QUnit.test('Tilemap and ColorAxis', function (assert) {
         tileShape: 'circle'
     });
 
-    var point = chart.series[0].points[1];
+    const point = chart.series[0].points[1];
     point.setState('hover');
 
     assert.notEqual(
         point.graphic.element.getAttribute('cx'),
         'NaN',
-        'Circle shape of tilemap should not have cx attribute with NaN values on hover.'
+        `Circle shape of tilemap should not have cx attribute with NaN values
+        on hover.`
     );
 
     assert.notEqual(
         point.graphic.element.getAttribute('cy'),
         'NaN',
-        'Circle shape of tilemap should not have cy attribute with NaN values on hover.'
+        `Circle shape of tilemap should not have cy attribute with NaN values
+        on hover.`
+    );
+
+    chart.series[0].remove(false);
+    chart.addSeries({
+        tileShape: 'circle',
+        data: [{
+            x: 0,
+            y: 0,
+            value: 0.02
+        }]
+    });
+
+    assert.notEqual(
+        point.radius,
+        0,
+        `When there is a single data point in the series, circle shape tiles
+        should render on the chart properly (#18647).`
+    );
+
+    chart.series[0].update({
+        tileShape: 'diamond'
+    });
+
+    assert.ok(
+        chart.series[0].points[0].shapeArgs.d[1][1] -
+            chart.series[0].points[0].shapeArgs.d[3][1] > 0,
+        `When there is a single data point in the series, diamond shape tiles
+        should render on the chart properly (#18647).`
     );
 });

--- a/ts/Series/Tilemap/TilemapSeries.ts
+++ b/ts/Series/Tilemap/TilemapSeries.ts
@@ -276,7 +276,11 @@ class TilemapSeries extends HeatmapSeries {
         );
 
         return {
-            padding: Math.abs(coord1 - coord2) || 0,
+            padding: (
+                axis.single ? // if there is only one tick adjust padding #18647
+                    Math.abs(coord1 - coord2) / 2 :
+                    Math.abs(coord1 - coord2)
+            ) || 0,
 
             // Offset the yAxis length to compensate for shift. Setting the
             // length factor to 2 would add the same margin to max as min.


### PR DESCRIPTION
Fixed #18647, when there was a single data point in the TileMap series, circle and diamond shape tiles didn't render properly.