### PR TITLE
bugfix/17565-stock-tooltip-split

### DIFF
--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -328,9 +328,11 @@ class Tooltip {
         if (this.label) {
             this.label = this.label.destroy();
         }
-        if (this.split && this.tt) {
+        if (this.split) {
             this.cleanSplit(true);
-            this.tt = this.tt.destroy();
+            if (this.tt) {
+                this.tt = this.tt.destroy();
+            }
         }
         if (this.renderer) {
             this.renderer = this.renderer.destroy() as any;
@@ -473,11 +475,11 @@ class Tooltip {
 
         // If changing from a split tooltip to a non-split tooltip, we must
         // destroy it in order to get the SVG right. #13868.
-        if (tooltip.label) {
-            const wasSplit = !tooltip.label.hasClass('highcharts-label');
+        if (this.label) {
+            const wasSplit = !this.label.hasClass('highcharts-label');
 
-            if ((doSplit && !wasSplit) || (!doSplit && wasSplit)) {
-                tooltip.destroy();
+            if ((!doSplit && wasSplit) || (doSplit && !wasSplit)) {
+                this.destroy();
             }
         }
 


### PR DESCRIPTION
Fixed #17565, stock tooltip issue after first hovering over a flag and then hovering over a series (problem with going from non-split to split tooltip).