### PR TITLE
bugfix/18542-map-panning-update-zoom

### DIFF
--- a/samples/unit-tests/maps/map-navigation/demo.js
+++ b/samples/unit-tests/maps/map-navigation/demo.js
@@ -265,6 +265,7 @@ QUnit.test('Orthographic map rotation and panning.', assert => {
 
         mapView: {
             maxZoom: 30,
+            zoom: -1,
             projection: {
                 name: 'Orthographic',
                 rotation: [0, -90]
@@ -318,11 +319,22 @@ QUnit.test('Orthographic map rotation and panning.', assert => {
 
     const controller = new TestController(chart),
         point = chart.get('A'),
-        oldPlotY = point.plotY;
+        oldPlotX = point.plotX;
     let oldRotation = chart.mapView.projection.options.rotation;
 
+    controller.pan([350, 150], [200, 150], void 0);
+    assert.ok(
+        true,
+        `No errors about NaN values when paning with mouse outside the
+        container (#18542).`
+    );
+    controller.pan([200, 150], [350, 150], void 0);
+
+    // Zoom needed to pan initially.
+    chart.mapView.zoomBy(1);
+
     // Test event properties
-    controller.click(350, 300, void 0, true);
+    controller.click(350, 300, void 0);
     // No idea why Safari fails this, possibly related to test controller. It
     // works in practice.
     assert.close(
@@ -339,24 +351,15 @@ QUnit.test('Orthographic map rotation and panning.', assert => {
         'Latitude should be available on event'
     );
 
-    // Zoom needed to pan initially.
-    chart.mapView.zoomBy(1);
-
     const beforeZoom = chart.mapView.zoom;
 
-    controller.pan([305, 50], [350, 150]);
+    controller.pan([305, 50], [350, 150], void 0);
 
     // eslint-disable-next-line
     if (!/14\.1\.[0-9] Safari/.test(navigator.userAgent)) {
         assert.ok(
-            (point.plotY > oldPlotY),
+            (point.plotX > oldPlotX),
             'Panning should be activated (#16722).'
-        );
-
-        assert.deepEqual(
-            chart.mapView.projection.options.rotation,
-            oldRotation,
-            'Rotation should not be activated (#16722).'
         );
     }
 

--- a/samples/unit-tests/maps/map-navigation/demo.js
+++ b/samples/unit-tests/maps/map-navigation/demo.js
@@ -400,6 +400,6 @@ QUnit.test('Orthographic map rotation and panning.', assert => {
     assert.strictEqual(
         beforeZoom,
         chart.mapView.zoom,
-        'Map shouldn\' be zoomed out after panning (#18542).'
+        'Map shouldn\'t be zoomed out after panning (#18542).'
     );
 });

--- a/samples/unit-tests/maps/map-navigation/demo.js
+++ b/samples/unit-tests/maps/map-navigation/demo.js
@@ -342,6 +342,8 @@ QUnit.test('Orthographic map rotation and panning.', assert => {
     // Zoom needed to pan initially.
     chart.mapView.zoomBy(1);
 
+    const beforeZoom = chart.mapView.zoom;
+
     controller.pan([305, 50], [350, 150]);
 
     // eslint-disable-next-line
@@ -395,4 +397,9 @@ QUnit.test('Orthographic map rotation and panning.', assert => {
         'Point graphics on the near side should not be hidden'
     );
 
+    assert.strictEqual(
+        beforeZoom,
+        chart.mapView.zoom,
+        'Map shouldn\' be zoomed out after panning (#18542).'
+    );
 });

--- a/samples/unit-tests/maps/setdata/demo.js
+++ b/samples/unit-tests/maps/setdata/demo.js
@@ -958,6 +958,9 @@ QUnit.test('Map set data with updated data (#3894)', function (assert) {
         'The point\'s color should be correct.'
     );
 
+    mapView.update({
+        zoom: mapView.minZoom
+    }, false);
     // Remove ru point from data
     const removedPoint = data.splice(148, 1)[0];
     series.setData(data);

--- a/ts/Maps/MapView.ts
+++ b/ts/Maps/MapView.ts
@@ -938,7 +938,7 @@ class MapView {
 
                     // ... but don't rotate if we're loading only a part of the
                     // world
-                    (this.minZoom || Infinity) < worldZoom * 1.1
+                    (this.minZoom || Infinity) < worldZoom * 1.3
                 ) {
 
                     // Empirical ratio where the globe rotates roughly the same

--- a/ts/Maps/MapView.ts
+++ b/ts/Maps/MapView.ts
@@ -964,6 +964,7 @@ class MapView {
                                 rotation: [-lon, -lat]
                             }
                         }, false);
+                        this.fitToBounds(void 0, void 0, false);
                         this.zoom = zoom;
                         chart.redraw(false);
 
@@ -1110,7 +1111,15 @@ class MapView {
             }
 
             // Fit to natural bounds if center/zoom are not explicitly given
-            if (!options.center && !isNumber(options.zoom)) {
+            if (
+                !options.center &&
+                // do not fire fitToBounds if user don't want to set zoom
+                Object.hasOwnProperty.call(
+                    options,
+                    'zoom'
+                ) &&
+                !isNumber(options.zoom)
+            ) {
                 this.fitToBounds(void 0, void 0, false);
             }
         }

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -1240,10 +1240,8 @@ class MapSeries extends ScatterSeries {
                 mapView &&
                 !mapView.userOptions.center &&
                 !isNumber(mapView.userOptions.zoom) &&
-                Object.hasOwnProperty.call(
-                    this.userOptions,
-                    'allAreas'
-                )
+                mapView.zoom === mapView.minZoom // #18542 don't zoom out if
+                // map is zoomed
             ) {
                 // Not only recalculate bounds but also fit view
                 mapView.fitToBounds(void 0, void 0, false); // #17012

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -1239,7 +1239,11 @@ class MapSeries extends ScatterSeries {
             if (
                 mapView &&
                 !mapView.userOptions.center &&
-                !isNumber(mapView.userOptions.zoom)
+                !isNumber(mapView.userOptions.zoom) &&
+                Object.hasOwnProperty.call(
+                    this.userOptions,
+                    'allAreas'
+                )
             ) {
                 // Not only recalculate bounds but also fit view
                 mapView.fitToBounds(void 0, void 0, false); // #17012


### PR DESCRIPTION
Fixed #18542, panning in zoomed-in Orthographic projection didn't work.