### PR TITLE
Update types for `userMin` and `userMax` Extremes to indicate they can be `undefined`

### DIFF
--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -4427,8 +4427,8 @@ namespace Axis {
         dataMin: number;
         max: number;
         min: number;
-        userMax: number;
-        userMin: number;
+        userMax: number | undefined;
+        userMin: number | undefined;
     }
     export interface PanningState {
         startMin: (number);
@@ -4683,12 +4683,12 @@ export default Axis;
  * The user defined maximum, either from the `max` option or from a zoom or
  * `setExtremes` action.
  * @name Highcharts.ExtremesObject#userMax
- * @type {number}
+ * @type {number|undefined}
  *//**
  * The user defined minimum, either from the `min` option or from a zoom or
  * `setExtremes` action.
  * @name Highcharts.ExtremesObject#userMin
- * @type {number}
+ * @type {number|undefined}
  */
 
 /**

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -2789,8 +2789,8 @@ class Axis {
                 axis.max as any,
             dataMin: axis.dataMin as any,
             dataMax: axis.dataMax as any,
-            userMin: axis.userMin as any,
-            userMax: axis.userMax as any
+            userMin: axis.userMin,
+            userMax: axis.userMax,
         };
     }
 


### PR DESCRIPTION
The Axis Extremes `userMin` and `userMax` values are `undefined` until an action has been performed that sets a zoom level (such as zooming in with the mouse or calling `setExtremes`). The TypeScript types and documentation https://api.highcharts.com/class-reference/Highcharts.ExtremesObject#userMax indicated the values are always present (`number`s only), which is not correct. Fixed here.