### PR TITLE
bugfix/18635-outside-tooltip-inverted-scrollable

### DIFF
--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -628,23 +628,24 @@ class Tooltip {
             // Don't use h if chart isn't inverted (#7242) ???
             h = (chart.inverted && (point as any).h) || 0, // #4117 ???
             outside = this.outside,
+            { body, documentElement } = doc,
             outerWidth = outside ?
                 // substract distance to prevent scrollbars
                 Math.max(
-                    doc.body.scrollWidth,
-                    doc.documentElement.scrollWidth,
-                    doc.body.offsetWidth,
-                    doc.documentElement.offsetWidth,
-                    doc.documentElement.clientWidth
+                    body.scrollWidth,
+                    documentElement.scrollWidth,
+                    body.offsetWidth,
+                    documentElement.offsetWidth,
+                    documentElement.clientWidth
                 ) - 2 * distance :
                 chart.chartWidth,
             outerHeight = outside ?
                 Math.max(
-                    doc.body.scrollHeight,
-                    doc.documentElement.scrollHeight,
-                    doc.body.offsetHeight,
-                    doc.documentElement.offsetHeight,
-                    doc.documentElement.clientHeight
+                    body.scrollHeight,
+                    documentElement.scrollHeight,
+                    body.offsetHeight,
+                    documentElement.offsetHeight,
+                    documentElement.clientHeight
                 ) :
                 chart.chartHeight,
             chartPosition = chart.pointer.getChartPosition(),

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -630,7 +630,13 @@ class Tooltip {
             outside = this.outside,
             outerWidth = outside ?
                 // substract distance to prevent scrollbars
-                doc.documentElement.clientWidth - 2 * distance :
+                Math.max(
+                    doc.body.scrollWidth,
+                    doc.documentElement.scrollWidth,
+                    doc.body.offsetWidth,
+                    doc.documentElement.offsetWidth,
+                    doc.documentElement.clientWidth
+                ) - 2 * distance :
                 chart.chartWidth,
             outerHeight = outside ?
                 Math.max(


### PR DESCRIPTION
Fixed #18635, bad tooltip position in an inverted chart inside a scrollable container when `tooltip.outside` was true.
____
Unfortunately, I cannot add a test for this fix, it would need to add a scroll on the window container, which is unpredictable due to tests in the browser and then tests in a terminal (see the original issue for reference).