### PR TITLE
bugfix/18617-stacklabels-inverted-chart

### DIFF
--- a/samples/unit-tests/axis/stacklabels/demo.js
+++ b/samples/unit-tests/axis/stacklabels/demo.js
@@ -904,6 +904,9 @@ QUnit.test('Stack labels - reverse axis/inverted chart - #8843.', assert => {
             data: [1, 2, 3, -1, -2, -3]
         }, {
             data: [1, 2, 3, -1, -2, -3]
+        }, {
+            data: [1, 2, 3, -1, -2, -3],
+            stack: 'b'
         }]
     });
 
@@ -978,5 +981,12 @@ QUnit.test('Stack labels - reverse axis/inverted chart - #8843.', assert => {
         alignOptions2.verticalAlign,
         'middle',
         'negative value inverted chart not reversed axis'
+    );
+
+    assert.close(
+        chart.yAxis[0].series[0].points[1].dataLabel.y,
+        chart.yAxis[0].stacking.stacks['column,,,'][1].label.y,
+        2,
+        'Stack label Y positions should be correct for inverted charts (#18617)'
     );
 });

--- a/samples/unit-tests/axis/variwide-stacklabels/demo.js
+++ b/samples/unit-tests/axis/variwide-stacklabels/demo.js
@@ -16,7 +16,10 @@ QUnit.test('#10962 - Stack labels in variwide series', function (assert) {
         },
         plotOptions: {
             series: {
-                stacking: 'normal'
+                stacking: 'normal',
+                dataLabels: {
+                    enabled: true
+                }
             }
         },
         series: [
@@ -45,6 +48,13 @@ QUnit.test('#10962 - Stack labels in variwide series', function (assert) {
 
     var series = chart.series,
         yAxis = chart.yAxis[0];
+
+    assert.close(
+        yAxis.stacking.stacks[series[0].stackKey][4].label.alignAttr.x,
+        series[0].points[4].dataLabel.alignAttr.x,
+        5,
+        'The stack labels should be x-positioned close to the data label.'
+    );
 
     chart.update({
         yAxis: {

--- a/ts/Core/Axis/Stacking/StackItem.ts
+++ b/ts/Core/Axis/Stacking/StackItem.ts
@@ -354,7 +354,7 @@ class StackItem {
                 pick(boxTop, this.total, 0),
             y = axis.toPixels(totalStackValue),
             xAxis = stackBoxProps.xAxis || chart.xAxis[0],
-            x = pick(defaultX, xAxis.toPixels(this.x)) + xOffset,
+            x = pick(defaultX, xAxis.translate(this.x)) + xOffset,
             yZero = axis.toPixels(
                 boxBottom ||
                 (
@@ -371,11 +371,11 @@ class StackItem {
         return inverted ?
             {
                 x: (neg ? y : y - height) - chart.plotLeft,
-                y: x - chart.plotTop,
+                y: xAxis.height - x - width,
                 width: height,
                 height: width
             } : {
-                x: x - chart.plotLeft,
+                x: x + xAxis.transB - chart.plotLeft,
                 y: (neg ? y - height : y) - chart.plotTop,
                 width: width,
                 height: height

--- a/ts/Series/Variwide/VariwideSeries.ts
+++ b/ts/Series/Variwide/VariwideSeries.ts
@@ -311,7 +311,7 @@ class VariwideSeries extends ColumnSeries {
                 pointStack = stack[xValue as any];
                 if (pointStack && !point.isNull) {
                     pointStack.setOffset(
-                        series.chart.plotLeft - ((pointWidth / 2) || 0),
+                        -(pointWidth / 2) || 0,
                         pointWidth || 0,
                         void 0,
                         void 0,


### PR DESCRIPTION
Fixed #18617, stack labels in inverted charts were mispositioned in the y axis.