### PR TITLE
bugfix/18683-stock-flags-demo-bug

### DIFF
--- a/samples/highcharts/css/flags/demo.js
+++ b/samples/highcharts/css/flags/demo.js
@@ -1,5 +1,5 @@
 Highcharts.getJSON(
-    'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/usdeur.json',
+    'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v10.3.3/samples/data/usdeur.json',
     function (data) {
 
         var year = new Date(data[data.length - 1][0]).getFullYear(); // Get year of last data point

--- a/samples/highcharts/demo/dynamic-master-detail/demo.js
+++ b/samples/highcharts/demo/dynamic-master-detail/demo.js
@@ -1,5 +1,5 @@
 Highcharts.getJSON(
-    'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/usdeur.json',
+    'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v10.3.3/samples/data/usdeur.json',
     data => {
         let detailChart;
 

--- a/samples/highcharts/demo/line-time-series/demo.js
+++ b/samples/highcharts/demo/line-time-series/demo.js
@@ -1,5 +1,5 @@
 Highcharts.getJSON(
-    'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/usdeur.json',
+    'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v10.3.3/samples/data/usdeur.json',
     function (data) {
 
         Highcharts.chart('container', {

--- a/samples/highcharts/website/small-demos-stock/demo.js
+++ b/samples/highcharts/website/small-demos-stock/demo.js
@@ -397,15 +397,15 @@ function compare() {
     }
 
     Highcharts.getJSON(
-        'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/msft-c.json',
+        'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v10.3.3/samples/data/msft-c.json',
         success
     );
     Highcharts.getJSON(
-        'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/aapl-c.json',
+        'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v10.3.3/samples/data/aapl-c.json',
         success
     );
     Highcharts.getJSON(
-        'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/goog-c.json',
+        'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v10.3.3/samples/data/goog-c.json',
         success
     );
 }
@@ -931,7 +931,7 @@ function ab() {
 }
 
 function flags() {
-    Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/usdeur.json', function (data) {
+    Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v10.3.3/samples/data/usdeur.json', function (data) {
 
         var lastDate = data[data.length - 1][0],  // Get year of last data point
             days = 24 * 36e5; // Milliseconds in a day

--- a/samples/stock/demo/flags-general/demo.js
+++ b/samples/stock/demo/flags-general/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/usdeur.json', function (data) {
+Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v10.3.3/samples/data/usdeur.json', function (data) {
 
     // Create the chart
     Highcharts.stockChart('container', {
@@ -38,15 +38,15 @@ Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/sam
                 description: 'Flagged events.'
             },
             data: [{
-                x: Date.UTC(2017, 11, 2),
+                x: Date.UTC(2021, 11, 2),
                 title: 'A',
                 text: 'Some event with a description'
             }, {
-                x: Date.UTC(2017, 11, 15),
+                x: Date.UTC(2021, 11, 15),
                 title: 'B',
                 text: 'Some event with a description'
             }, {
-                x: Date.UTC(2017, 11, 22),
+                x: Date.UTC(2021, 11, 22),
                 title: 'C',
                 text: 'Some event with a description'
             }],

--- a/samples/stock/demo/flags-general/demo.js
+++ b/samples/stock/demo/flags-general/demo.js
@@ -38,15 +38,15 @@ Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/sam
                 description: 'Flagged events.'
             },
             data: [{
-                x: Date.UTC(2021, 11, 2),
+                x: Date.UTC(2017, 11, 2),
                 title: 'A',
                 text: 'Some event with a description'
             }, {
-                x: Date.UTC(2021, 11, 15),
+                x: Date.UTC(2017, 11, 15),
                 title: 'B',
                 text: 'Some event with a description'
             }, {
-                x: Date.UTC(2021, 11, 22),
+                x: Date.UTC(2017, 11, 22),
                 title: 'C',
                 text: 'Some event with a description'
             }],

--- a/samples/stock/demo/flags-placement/demo.js
+++ b/samples/stock/demo/flags-placement/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/usdeur.json', function (data) {
+Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v10.3.3/samples/data/usdeur.json', function (data) {
 
     var lastDate = data[data.length - 1][0],  // Get year of last data point
         days = 24 * 36e5; // Milliseconds in a day

--- a/samples/stock/demo/flags-shapes/demo.js
+++ b/samples/stock/demo/flags-shapes/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/usdeur.json', function (data) {
+Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v10.3.3/samples/data/usdeur.json', function (data) {
 
     var year = new Date(data[data.length - 1][0]).getFullYear(); // Get year of last data point
 

--- a/samples/stock/demo/yaxis-plotbands/demo.js
+++ b/samples/stock/demo/yaxis-plotbands/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/usdeur.json', function (data) {
+Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v10.3.3/samples/data/usdeur.json', function (data) {
 
     var startDate = new Date(data[data.length - 1][0]),
         minRate = 1,

--- a/samples/stock/demo/yaxis-plotlines/demo.js
+++ b/samples/stock/demo/yaxis-plotlines/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/usdeur.json', function (data) {
+Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v10.3.3/samples/data/usdeur.json', function (data) {
 
     var startDate = new Date(data[data.length - 1][0]), // Get year of last data point
         minRate = 1,

--- a/samples/stock/issues/2543/demo.js
+++ b/samples/stock/issues/2543/demo.js
@@ -1,4 +1,4 @@
-Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/usdeur.json', function (data) {
+Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v10.3.3/samples/data/usdeur.json', function (data) {
 
     // Create the chart
     Highcharts.stockChart('container', {

--- a/samples/stock/plotoptions/flags-allowoverlapx/demo.js
+++ b/samples/stock/plotoptions/flags-allowoverlapx/demo.js
@@ -1,4 +1,6 @@
-Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/usdeur.json', function (data) {
+Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v10.3.3/samples/data/usdeur.json', function (data) {
+    const year = 2021,
+        monthIndex = 11;
 
     // Create the chart
     Highcharts.stockChart('container', {
@@ -36,148 +38,147 @@ Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/sam
             type: 'flags',
             allowOverlapX: true,
             data: [{
-                x: Date.UTC(2015, 5, 12, 1),
+                x: Date.UTC(year, monthIndex, 12, 1),
                 title: '1'
             }, {
-                x: Date.UTC(2015, 5, 12, 2),
+                x: Date.UTC(year, monthIndex, 12, 2),
                 title: '2'
             }, {
-                x: Date.UTC(2015, 5, 12, 3),
+                x: Date.UTC(year, monthIndex, 12, 3),
                 title: '3'
             }, {
-                x: Date.UTC(2015, 5, 12, 4),
+                x: Date.UTC(year, monthIndex, 12, 4),
                 title: '4'
             }, {
-                x: Date.UTC(2015, 5, 12, 5),
+                x: Date.UTC(year, monthIndex, 12, 5),
                 title: '5'
             }, {
-                x: Date.UTC(2015, 5, 12, 6),
+                x: Date.UTC(year, monthIndex, 12, 6),
                 title: '6'
             }, {
-                x: Date.UTC(2015, 5, 12, 7),
+                x: Date.UTC(year, monthIndex, 12, 7),
                 title: '7'
             }, {
-                x: Date.UTC(2015, 5, 12, 8),
+                x: Date.UTC(year, monthIndex, 12, 8),
                 title: '8'
             }, {
-                x: Date.UTC(2015, 5, 12, 9),
-                title: '9'
-            },
-
-
-            {
-                x: Date.UTC(2015, 5, 13, 1),
-                title: '1'
-            }, {
-                x: Date.UTC(2015, 5, 13, 2),
-                title: '2'
-            }, {
-                x: Date.UTC(2015, 5, 13, 3),
-                title: '3'
-            }, {
-                x: Date.UTC(2015, 5, 13, 4),
-                title: '4'
-            }, {
-                x: Date.UTC(2015, 5, 13, 5),
-                title: '5'
-            }, {
-                x: Date.UTC(2015, 5, 13, 6),
-                title: '6'
-            }, {
-                x: Date.UTC(2015, 5, 13, 7),
-                title: '7'
-            }, {
-                x: Date.UTC(2015, 5, 13, 8),
-                title: '8'
-            }, {
-                x: Date.UTC(2015, 5, 13, 9),
+                x: Date.UTC(year, monthIndex, 12, 9),
                 title: '9'
             },
 
             {
-                x: Date.UTC(2015, 5, 14, 1),
+                x: Date.UTC(year, monthIndex, 13, 1),
                 title: '1'
             }, {
-                x: Date.UTC(2015, 5, 14, 2),
+                x: Date.UTC(year, monthIndex, 13, 2),
                 title: '2'
             }, {
-                x: Date.UTC(2015, 5, 14, 3),
+                x: Date.UTC(year, monthIndex, 13, 3),
                 title: '3'
             }, {
-                x: Date.UTC(2015, 5, 14, 4),
+                x: Date.UTC(year, monthIndex, 13, 4),
                 title: '4'
             }, {
-                x: Date.UTC(2015, 5, 14, 5),
+                x: Date.UTC(year, monthIndex, 13, 5),
                 title: '5'
             }, {
-                x: Date.UTC(2015, 5, 14, 6),
+                x: Date.UTC(year, monthIndex, 13, 6),
                 title: '6'
             }, {
-                x: Date.UTC(2015, 5, 14, 7),
+                x: Date.UTC(year, monthIndex, 13, 7),
                 title: '7'
             }, {
-                x: Date.UTC(2015, 5, 14, 8),
+                x: Date.UTC(year, monthIndex, 13, 8),
                 title: '8'
             }, {
-                x: Date.UTC(2015, 5, 14, 9),
+                x: Date.UTC(year, monthIndex, 13, 9),
                 title: '9'
             },
 
             {
-                x: Date.UTC(2015, 5, 15, 1),
+                x: Date.UTC(year, monthIndex, 14, 1),
                 title: '1'
             }, {
-                x: Date.UTC(2015, 5, 15, 2),
+                x: Date.UTC(year, monthIndex, 14, 2),
                 title: '2'
             }, {
-                x: Date.UTC(2015, 5, 15, 3),
+                x: Date.UTC(year, monthIndex, 14, 3),
                 title: '3'
             }, {
-                x: Date.UTC(2015, 5, 15, 4),
+                x: Date.UTC(year, monthIndex, 14, 4),
                 title: '4'
             }, {
-                x: Date.UTC(2015, 5, 15, 5),
+                x: Date.UTC(year, monthIndex, 14, 5),
                 title: '5'
             }, {
-                x: Date.UTC(2015, 5, 15, 6),
+                x: Date.UTC(year, monthIndex, 14, 6),
                 title: '6'
             }, {
-                x: Date.UTC(2015, 5, 15, 7),
+                x: Date.UTC(year, monthIndex, 14, 7),
                 title: '7'
             }, {
-                x: Date.UTC(2015, 5, 15, 8),
+                x: Date.UTC(year, monthIndex, 14, 8),
                 title: '8'
             }, {
-                x: Date.UTC(2015, 5, 15, 9),
+                x: Date.UTC(year, monthIndex, 14, 9),
                 title: '9'
             },
 
             {
-                x: Date.UTC(2015, 5, 16, 1),
+                x: Date.UTC(year, monthIndex, 15, 1),
                 title: '1'
             }, {
-                x: Date.UTC(2015, 5, 16, 2),
+                x: Date.UTC(year, monthIndex, 15, 2),
                 title: '2'
             }, {
-                x: Date.UTC(2015, 5, 16, 3),
+                x: Date.UTC(year, monthIndex, 15, 3),
                 title: '3'
             }, {
-                x: Date.UTC(2015, 5, 16, 4),
+                x: Date.UTC(year, monthIndex, 15, 4),
                 title: '4'
             }, {
-                x: Date.UTC(2015, 5, 16, 5),
+                x: Date.UTC(year, monthIndex, 15, 5),
                 title: '5'
             }, {
-                x: Date.UTC(2015, 5, 16, 6),
+                x: Date.UTC(year, monthIndex, 15, 6),
                 title: '6'
             }, {
-                x: Date.UTC(2015, 5, 16, 7),
+                x: Date.UTC(year, monthIndex, 15, 7),
                 title: '7'
             }, {
-                x: Date.UTC(2015, 5, 16, 8),
+                x: Date.UTC(year, monthIndex, 15, 8),
                 title: '8'
             }, {
-                x: Date.UTC(2015, 5, 16, 9),
+                x: Date.UTC(year, monthIndex, 15, 9),
+                title: '9'
+            },
+
+            {
+                x: Date.UTC(year, monthIndex, 16, 1),
+                title: '1'
+            }, {
+                x: Date.UTC(year, monthIndex, 16, 2),
+                title: '2'
+            }, {
+                x: Date.UTC(year, monthIndex, 16, 3),
+                title: '3'
+            }, {
+                x: Date.UTC(year, monthIndex, 16, 4),
+                title: '4'
+            }, {
+                x: Date.UTC(year, monthIndex, 16, 5),
+                title: '5'
+            }, {
+                x: Date.UTC(year, monthIndex, 16, 6),
+                title: '6'
+            }, {
+                x: Date.UTC(year, monthIndex, 16, 7),
+                title: '7'
+            }, {
+                x: Date.UTC(year, monthIndex, 16, 8),
+                title: '8'
+            }, {
+                x: Date.UTC(year, monthIndex, 16, 9),
                 title: '9'
             }],
             onSeries: 'dataseries',


### PR DESCRIPTION
Fixed #18683, flags demo did not work. 

This problem probably stemmed from the difference in data length imported with `Highcharts.getJSON()` method in `Highcharts-Utils` and `jsfiddle` (I don't know why but `Highcharts-Utils` have data till 2021 while in JSFiddle the data ends in 2017).

I simply positioned the flags in 2017, which is included in the data imported in JSFiddle.
