### PR TITLE
bugfix/17720-tooltip-outside-split

### DIFF
--- a/samples/unit-tests/tooltip/split/demo.js
+++ b/samples/unit-tests/tooltip/split/demo.js
@@ -228,7 +228,7 @@ QUnit.test('Split tooltip with useHTML and outside', function (assert) {
     assert.close(
         chart.xAxis[0].toPixels(point.x),
         tooltipClient.x + (tooltipClient.width / 2) - pointBox.width,
-        1,
+        2,
         `Tooltip with outside and split properties set to true should be
         rendered properly - x position (#17720).`
     );
@@ -237,7 +237,7 @@ QUnit.test('Split tooltip with useHTML and outside', function (assert) {
         chart.yAxis[0].toPixels(point.y),
         tooltipClient.y + tooltipClient.height -
             pointBox.height - (pointBox.height / 2),
-        1,
+        2,
         `Tooltip with outside and split properties set to true should be
         rendered properly - y position (#17720).`
     );

--- a/samples/unit-tests/tooltip/split/demo.js
+++ b/samples/unit-tests/tooltip/split/demo.js
@@ -210,7 +210,8 @@ QUnit.test('Split tooltip with useHTML and outside', function (assert) {
 
     chart.update({
         tooltip: {
-            useHTML: false
+            useHTML: false,
+            distance: 0
         }
     }, false);
 
@@ -220,24 +221,25 @@ QUnit.test('Split tooltip with useHTML and outside', function (assert) {
 
     chart.tooltip.refresh(chart.series[0].points[0]);
 
-    const pointClient =
-        chart.series[0].points[0].graphic.element.getClientRects()[0],
-        tooltipClient = chart.tooltip.container.getClientRects()[0];
+    const point = chart.series[0].points[0],
+        pointBox = point.graphic.getBBox(),
+        tooltipClient = chart.tooltip.container.getBoundingClientRect();
 
     assert.close(
-        pointClient.x,
-        tooltipClient.x + ((tooltipClient.width - chart.tooltip.distance) / 2),
-        4,
+        chart.xAxis[0].toPixels(point.x),
+        tooltipClient.x + (tooltipClient.width / 2) - pointBox.width,
+        1,
         `Tooltip with outside and split properties set to true should be
-        rendered properly (#17720).`
+        rendered properly - x position (#17720).`
     );
 
     assert.close(
-        pointClient.y,
-        tooltipClient.y + tooltipClient.height - (chart.tooltip.distance / 2),
-        4,
+        chart.yAxis[0].toPixels(point.y),
+        tooltipClient.y + tooltipClient.height -
+            pointBox.height - (pointBox.height / 2),
+        1,
         `Tooltip with outside and split properties set to true should be
-        rendered properly (#17720).`
+        rendered properly - y position (#17720).`
     );
 });
 

--- a/samples/unit-tests/tooltip/split/demo.js
+++ b/samples/unit-tests/tooltip/split/demo.js
@@ -172,7 +172,7 @@ QUnit.test('Split tooltip with empty formats (#8105)', function (assert) {
 });
 
 QUnit.test('Split tooltip with useHTML and outside', function (assert) {
-    var chart = Highcharts.chart('container', {
+    const chart = Highcharts.chart('container', {
         chart: {
             width: 600
         },
@@ -206,6 +206,38 @@ QUnit.test('Split tooltip with useHTML and outside', function (assert) {
         chart.series[0].tt.text.element.tagName,
         'SPAN',
         '#7238: The label is a span'
+    );
+
+    chart.update({
+        tooltip: {
+            useHTML: false
+        }
+    }, false);
+
+    chart.series[0].update({
+        type: 'scatter'
+    });
+
+    chart.tooltip.refresh(chart.series[0].points[0]);
+
+    const pointClient =
+        chart.series[0].points[0].graphic.element.getClientRects()[0],
+        tooltipClient = chart.tooltip.container.getClientRects()[0];
+
+    assert.close(
+        pointClient.x,
+        tooltipClient.x + ((tooltipClient.width - chart.tooltip.distance) / 2),
+        4,
+        `Tooltip with outside and split properties set to true should be
+        rendered properly (#17720).`
+    );
+
+    assert.close(
+        pointClient.y,
+        tooltipClient.y + tooltipClient.height - (chart.tooltip.distance / 2),
+        4,
+        `Tooltip with outside and split properties set to true should be
+        rendered properly (#17720).`
     );
 });
 

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -574,7 +574,7 @@ class Tooltip {
 
             // Split tooltip use updateTooltipContainer to position the tooltip
             // container.
-            if (tooltip.outside && !tooltip.split) {
+            if (tooltip.outside) {
                 const label = this.label;
                 const { xSetter, ySetter } = label;
                 label.xSetter = function (


### PR DESCRIPTION
Fixed #17720, the tooltip with enabled outside and split properties was badly positioned for some series.