### PR TITLE
bugfix/18658-sunburst-labels-blinking

### DIFF
--- a/samples/unit-tests/series-sunburst/allowtraversingtree/demo.js
+++ b/samples/unit-tests/series-sunburst/allowtraversingtree/demo.js
@@ -16,9 +16,6 @@ QUnit.test('Drill to node by click events', function (assert) {
                             id: 'level-3',
                             parent: 'level-2',
                             value: 1
-                        },
-                        {
-                            value: 1
                         }
                     ]
                 }
@@ -40,6 +37,30 @@ QUnit.test('Drill to node by click events', function (assert) {
         level1 = findPointById('level-1'),
         level2 = findPointById('level-2'),
         level3 = findPointById('level-3');
+
+    click(level1);
+    assert.strictEqual(
+        series.rootNode,
+        '',
+        'should have series.rootNode equal "" after clicking level1. (#18658)'
+    );
+
+    click(level2);
+    assert.strictEqual(
+        series.rootNode,
+        'level-2',
+        'should have rootNode equal "level-2" after clicking level2. (#18658)'
+    );
+
+    click(level2);
+    assert.strictEqual(
+        series.rootNode,
+        '',
+        'should have rootNode equal "" after clicking level2 twice. (#18658)'
+    );
+
+    series.addPoint({ value: 1 }, false);
+    series.drillUp();
 
     assert.strictEqual(
         series.rootNode,

--- a/ts/Series/Sunburst/SunburstSeries.ts
+++ b/ts/Series/Sunburst/SunburstSeries.ts
@@ -841,31 +841,8 @@ class SunburstSeries extends TreemapSeries {
                 y: positions[1]
             },
             innerR = positions[3] / 2,
-            renderer = series.chart.renderer,
-            animateLabels: (Function|undefined),
-            animateLabelsCalled = false,
-            addedHack = false,
-            hackDataLabelAnimation = !!(
-                animation &&
-                hasRendered &&
-                idRoot !== idPreviousRoot &&
-                series.dataLabelsGroup
-            );
+            renderer = series.chart.renderer;
 
-        if (hackDataLabelAnimation) {
-            (series.dataLabelsGroup as any).attr({ opacity: 0 });
-            animateLabels = function (): void {
-                const s = series;
-
-                animateLabelsCalled = true;
-                if (s.dataLabelsGroup) {
-                    s.dataLabelsGroup.animate({
-                        opacity: 1,
-                        visibility: 'inherit'
-                    });
-                }
-            };
-        }
         points.forEach(function (point): void {
             let node = point.node,
                 level = mapOptionsToLevel[node.level],
@@ -915,10 +892,7 @@ class SunburstSeries extends TreemapSeries {
                 optionsPoint: point.options,
                 shapeArgs: shape
             });
-            if (!addedHack && visible) {
-                addedHack = true;
-                onComplete = animateLabels;
-            }
+
             point.draw({
                 animatableAttribs: animationInfo.to,
                 attribs: extend(
@@ -935,21 +909,8 @@ class SunburstSeries extends TreemapSeries {
                 shapeArgs: shape
             });
         });
-        // Draw data labels after points
-        // TODO draw labels one by one to avoid addtional looping
-        if (hackDataLabelAnimation && addedHack) {
-            series.hasRendered = false;
-            (series.options.dataLabels as any).defer = true;
-            Series.prototype.drawDataLabels.call(series);
-            series.hasRendered = true;
-            // If animateLabels is called before labels were hidden, then call
-            // it again.
-            if (animateLabelsCalled) {
-                (animateLabels as any)();
-            }
-        } else {
-            Series.prototype.drawDataLabels.call(series);
-        }
+
+        Series.prototype.drawDataLabels.call(series);
     }
 
     /**

--- a/ts/Series/Sunburst/SunburstSeries.ts
+++ b/ts/Series/Sunburst/SunburstSeries.ts
@@ -866,7 +866,6 @@ class SunburstSeries extends TreemapSeries {
                 }
             };
         }
-
         points.forEach(function (point): void {
             let node = point.node,
                 level = mapOptionsToLevel[node.level],
@@ -920,7 +919,6 @@ class SunburstSeries extends TreemapSeries {
                 addedHack = true;
                 onComplete = animateLabels;
             }
-
             point.draw({
                 animatableAttribs: animationInfo.to,
                 attribs: extend(
@@ -937,7 +935,6 @@ class SunburstSeries extends TreemapSeries {
                 shapeArgs: shape
             });
         });
-
         // Draw data labels after points
         // TODO draw labels one by one to avoid addtional looping
         if (hackDataLabelAnimation && addedHack) {
@@ -1012,6 +1009,29 @@ class SunburstSeries extends TreemapSeries {
                 return arr;
             }, [] as Array<SunburstNode.NodeValuesObject>
         );
+    }
+
+    public setRootNode(
+        id: string,
+        redraw?: boolean,
+        eventArguments?: SunburstSeries.SetRootNodeObject
+    ): void {
+        const series = this;
+
+        if ( // If the target node is the only one at level 1, skip it. (#18658)
+            series.nodeMap[id].level === 1 &&
+            series.nodeList
+                .filter((node): boolean => node.level === 1)
+                .length === 1
+        ) {
+            if (series.idPreviousRoot === '') {
+                return;
+            }
+
+            id = '';
+        }
+
+        super.setRootNode(id, redraw, eventArguments);
     }
 
     /**
@@ -1239,6 +1259,14 @@ namespace SunburstSeries {
         optionsPoint: SunburstPointOptions;
         point: SunburstPoint;
         shapeArgs: SunburstNode.NodeValuesObject;
+    }
+
+    export interface SetRootNodeObject {
+        newRootId?: string;
+        previousRootId?: string;
+        redraw?: boolean;
+        series?: object;
+        trigger?: string;
     }
 }
 


### PR DESCRIPTION
Fixed #18658, all sunburst's data labels were disappearing and showing back after one point update.