### PR TITLE
bugfix/18435-gantt-zoom-tooltip-misplaced

### DIFF
--- a/samples/unit-tests/series-xrange/xrange/demo.js
+++ b/samples/unit-tests/series-xrange/xrange/demo.js
@@ -798,4 +798,27 @@ QUnit.test('XRange series and tooltip position', assert => {
         2.001,
         'Inverted chart, no reversed xAxis, reversed yAxis'
     );
+
+    chart.update({
+        chart: {
+            inverted: false
+        },
+        xAxis: {
+            reversed: false
+        }
+    });
+
+    chart.xAxis[0].setExtremes(4.8, 10);
+    chart.tooltip.refresh(chart.series[0].points[0]);
+
+    const chartContainer = chart.container.getBoundingClientRect();
+    labelBox = chart.tooltip.label.element.getBoundingClientRect();
+
+    assert.close(
+        labelBox.left + labelBox.width / 2,
+        chart.plotLeft + chartContainer.left,
+        2,
+        'Tooltip on plotLeft when only far right part of the point is visible'
+    );
+
 });

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -2790,7 +2790,7 @@ class Axis {
             dataMin: axis.dataMin as any,
             dataMax: axis.dataMax as any,
             userMin: axis.userMin,
-            userMax: axis.userMax,
+            userMax: axis.userMax
         };
     }
 

--- a/ts/Series/XRange/XRangeSeries.ts
+++ b/ts/Series/XRange/XRangeSeries.ts
@@ -400,7 +400,12 @@ class XRangeSeries extends ColumnSeries {
 
         // Centering tooltip position (#14147)
         if (!inverted) {
-            tooltipPos[xIndex] += (xAxis.reversed ? -1 : 0) * shapeArgs.width;
+            tooltipPos[xIndex] = clamp(
+                tooltipPos[xIndex] +
+                (xAxis.reversed ? -1 : 0) * shapeArgs.width,
+                0,
+                xAxis.len - 1
+            );
         } else {
             tooltipPos[xIndex] += shapeArgs.width / 2;
         }


### PR DESCRIPTION
Fixed #18435, tooltip was misplaced outside the plot area when zooming in gantt and x-range series.