### PR TITLE
Standardized datetime formats

### DIFF
--- a/samples/unit-tests/axis/datetime-ticks/demo.js
+++ b/samples/unit-tests/axis/datetime-ticks/demo.js
@@ -35,7 +35,7 @@ QUnit.test(
         assert.strictEqual(
             chart.xAxis[0].ticks[chart.xAxis[0].tickPositions[0]].label.element
                 .textContent,
-            '6. Nov',
+            '6 Nov',
             'Tick positions correct'
         );
 
@@ -43,7 +43,7 @@ QUnit.test(
             Object.keys(chart.xAxis[0].ticks).map(function (pos) {
                 return chart.xAxis[0].ticks[pos].label.element.textContent;
             }),
-            ['6. Nov', '01:00', '01:00', '02:00', '03:00', '04:00'],
+            ['6 Nov', '01:00', '01:00', '02:00', '03:00', '04:00'],
             'The same label should be repeated across DST change (#6797)'
         );
 

--- a/samples/unit-tests/gantt/tooltip/demo.js
+++ b/samples/unit-tests/gantt/tooltip/demo.js
@@ -22,7 +22,7 @@ QUnit.test('Gantt tooltip', assert => {
     assert.strictEqual(
         chart.tooltip.label.text.element.textContent
             .replace(/\u200B/g, ';'),
-        'Series 1;Task;Start: Tuesday, Jan  1, 2019;End: Monday, Jan  7, 2019;',
+        'Series 1;Task;Start: Tuesday,  1 Jan 2019;End: Monday,  7 Jan 2019;',
         'All times on midnight - tooltip should show the date without time'
     );
 
@@ -31,7 +31,7 @@ QUnit.test('Gantt tooltip', assert => {
     assert.strictEqual(
         chart.tooltip.label.text.element.textContent
             .replace(/\u200B/g, ';'),
-        'Series 1;Milestone;Saturday, Jan  5, 2019;',
+        'Series 1;Milestone;Saturday,  5 Jan 2019;',
         'All times on midnight - tooltip should show the date without time'
     );
 
@@ -58,8 +58,8 @@ QUnit.test('Gantt tooltip', assert => {
         [
             'Series 1',
             'Task',
-            'Start: Tuesday, Jan  1, 08:00',
-            'End: Monday, Jan  7, 16:00',
+            'Start: Tuesday,  1 Jan, 08:00',
+            'End: Monday,  7 Jan, 16:00',
             ''
         ],
         'Intraday times - tooltip should show the date and time of day'
@@ -70,7 +70,7 @@ QUnit.test('Gantt tooltip', assert => {
     assert.strictEqual(
         chart.tooltip.label.text.element.textContent
             .replace(/\u200B/g, ';'),
-        'Series 1;Milestone;Saturday, Jan  5, 12:00;',
+        'Series 1;Milestone;Saturday,  5 Jan, 12:00;',
         'Intraday times - tooltip should show the date and time of day'
     );
 });
@@ -101,7 +101,7 @@ QUnit.test(
         assert.strictEqual(
             chart.container.querySelector('.highcharts-tooltip').textContent
                 .replace(/\u200B/g, ';'),
-            'Series 1;Task 1;Start: Monday, Jun  1, 18:00;End: Tuesday, Jun  2, 18:00;',
+            'Series 1;Task 1;Start: Monday,  1 Jun, 18:00;End: Tuesday,  2 Jun, 18:00;',
             'The tooltip should show the start and end shifted 6 hours relative to UTC.'
         );
     }

--- a/samples/unit-tests/series/pointstart/demo.js
+++ b/samples/unit-tests/series/pointstart/demo.js
@@ -18,10 +18,10 @@ QUnit.test(
         var controller = new TestController(chart),
             series = chart.series[0],
             expectedTexts = [
-                'Wednesday, Jan  1, 2014',
-                'Friday, Jan  3, 2014',
-                'Sunday, Jan  5, 2014',
-                'Tuesday, Jan  7, 2014'
+                'Wednesday,  1 Jan 2014',
+                'Friday,  3 Jan 2014',
+                'Sunday,  5 Jan 2014',
+                'Tuesday,  7 Jan 2014'
             ],
             texts = [],
             pointX = 0,

--- a/samples/unit-tests/tooltip/split/demo.js
+++ b/samples/unit-tests/tooltip/split/demo.js
@@ -237,7 +237,7 @@ QUnit.test('Split tooltip with useHTML and outside', function (assert) {
         chart.yAxis[0].toPixels(point.y),
         tooltipClient.y + tooltipClient.height -
             pointBox.height - (pointBox.height / 2),
-        2,
+        4,
         `Tooltip with outside and split properties set to true should be
         rendered properly - y position (#17720).`
     );

--- a/samples/unit-tests/tooltip/sub-millisec-tooltip/demo.js
+++ b/samples/unit-tests/tooltip/sub-millisec-tooltip/demo.js
@@ -26,7 +26,7 @@ QUnit.test('Sub-millisecond tooltip(#4223)', function (assert) {
             chart.series[0].points[0].x,
             chart.options.tooltip.dateTimeLabelFormats
         ),
-        '%A, %b %e, %H:%M:%S.%L',
+        '%A, %e %b, %H:%M:%S.%L',
         'Milliseconds are preserved in tooltip'
     );
 });

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -2790,7 +2790,7 @@ class Axis {
             dataMin: axis.dataMin as any,
             dataMax: axis.dataMax as any,
             userMin: axis.userMin,
-            userMax: axis.userMax,
+            userMax: axis.userMax
         };
     }
 

--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -543,14 +543,14 @@ namespace AxisDefaults {
              * @type {string|*}
              */
             day: {
-                main: '%e. %b'
+                main: '%e %b'
             },
             /**
              * @declare Highcharts.AxisDateTimeLabelFormatsOptionsObject
              * @type {string|*}
              */
             week: {
-                main: '%e. %b'
+                main: '%e %b'
             },
             /**
              * @declare Highcharts.AxisDateTimeLabelFormatsOptionsObject

--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -2317,17 +2317,17 @@ const defaultOptions: Options = {
          */
         dateTimeLabelFormats: {
             /** @internal */
-            millisecond: '%A, %b %e, %H:%M:%S.%L',
+            millisecond: '%A, %e %b, %H:%M:%S.%L',
             /** @internal */
-            second: '%A, %b %e, %H:%M:%S',
+            second: '%A, %e %b, %H:%M:%S',
             /** @internal */
-            minute: '%A, %b %e, %H:%M',
+            minute: '%A, %e %b, %H:%M',
             /** @internal */
-            hour: '%A, %b %e, %H:%M',
+            hour: '%A, %e %b, %H:%M',
             /** @internal */
-            day: '%A, %b %e, %Y',
+            day: '%A, %e %b %Y',
             /** @internal */
-            week: 'Week from %A, %b %e, %Y',
+            week: 'Week from %A, %e %b %Y',
             /** @internal */
             month: '%B %Y',
             /** @internal */

--- a/ts/Extensions/DataGrouping/DataGrouping.ts
+++ b/ts/Extensions/DataGrouping/DataGrouping.ts
@@ -349,13 +349,13 @@ export default DataGroupingComposition;
  * ```js
  * {
  *     millisecond: [
- *         '%A, %b %e, %H:%M:%S.%L', '%A, %b %e, %H:%M:%S.%L', '-%H:%M:%S.%L'
+ *         '%A, %e %b, %H:%M:%S.%L', '%A, %e %b, %H:%M:%S.%L', '-%H:%M:%S.%L'
  *     ],
- *     second: ['%A, %b %e, %H:%M:%S', '%A, %b %e, %H:%M:%S', '-%H:%M:%S'],
- *     minute: ['%A, %b %e, %H:%M', '%A, %b %e, %H:%M', '-%H:%M'],
- *     hour: ['%A, %b %e, %H:%M', '%A, %b %e, %H:%M', '-%H:%M'],
- *     day: ['%A, %b %e, %Y', '%A, %b %e', '-%A, %b %e, %Y'],
- *     week: ['Week from %A, %b %e, %Y', '%A, %b %e', '-%A, %b %e, %Y'],
+ *     second: ['%A, %e %b, %H:%M:%S', '%A, %e %b, %H:%M:%S', '-%H:%M:%S'],
+ *     minute: ['%A, %e %b, %H:%M', '%A, %e %b, %H:%M', '-%H:%M'],
+ *     hour: ['%A, %e %b, %H:%M', '%A, %e %b, %H:%M', '-%H:%M'],
+ *     day: ['%A, %e %b %Y', '%A, %e %b', '-%A, %e %b %Y'],
+ *     week: ['Week from %A, %e %b %Y', '%A, %e %b', '-%A, %e %b %Y'],
  *     month: ['%B %Y', '%B', '-%B %Y'],
  *     year: ['%Y', '%Y', '-%Y']
  * }

--- a/ts/Extensions/DataGrouping/DataGroupingDefaults.ts
+++ b/ts/Extensions/DataGrouping/DataGroupingDefaults.ts
@@ -39,34 +39,34 @@ const common = {
     // dealing with a range
     dateTimeLabelFormats: {
         millisecond: [
-            '%A, %b %e, %H:%M:%S.%L',
-            '%A, %b %e, %H:%M:%S.%L',
+            '%A, %e %b, %H:%M:%S.%L',
+            '%A, %e %b, %H:%M:%S.%L',
             '-%H:%M:%S.%L'
         ],
         second: [
-            '%A, %b %e, %H:%M:%S',
-            '%A, %b %e, %H:%M:%S',
+            '%A, %e %b, %H:%M:%S',
+            '%A, %e %b, %H:%M:%S',
             '-%H:%M:%S'
         ],
         minute: [
-            '%A, %b %e, %H:%M',
-            '%A, %b %e, %H:%M',
+            '%A, %e %b, %H:%M',
+            '%A, %e %b, %H:%M',
             '-%H:%M'
         ],
         hour: [
-            '%A, %b %e, %H:%M',
-            '%A, %b %e, %H:%M',
+            '%A, %e %b, %H:%M',
+            '%A, %e %b, %H:%M',
             '-%H:%M'
         ],
         day: [
-            '%A, %b %e, %Y',
-            '%A, %b %e',
-            '-%A, %b %e, %Y'
+            '%A, %e %b %Y',
+            '%A, %e %b',
+            '-%A, %e %b %Y'
         ],
         week: [
-            'Week from %A, %b %e, %Y',
-            '%A, %b %e',
-            '-%A, %b %e, %Y'
+            'Week from %A, %e %b %Y',
+            '%A, %e %b',
+            '-%A, %e %b %Y'
         ],
         month: [
             '%B %Y',

--- a/ts/Stock/RangeSelector/RangeSelector.ts
+++ b/ts/Stock/RangeSelector/RangeSelector.ts
@@ -991,7 +991,7 @@ class RangeSelector {
         // we need to use setAttribute instead
         input.setAttribute(
             'type',
-            preferredInputType(options.inputDateFormat || '%b %e, %Y')
+            preferredInputType(options.inputDateFormat || '%e %b %Y')
         );
 
         if (!chart.styledMode) {

--- a/ts/Stock/RangeSelector/RangeSelectorDefaults.ts
+++ b/ts/Stock/RangeSelector/RangeSelectorDefaults.ts
@@ -401,7 +401,7 @@ const rangeSelector: RangeSelectorOptions = {
 
     /**
      * The date format in the input boxes when not selected for editing.
-     * Defaults to `%b %e, %Y`.
+     * Defaults to `%e %b %Y`.
      *
      * This is used to determine which type of input to show,
      * `datetime-local`, `date` or `time` and falling back to `text` when
@@ -414,7 +414,7 @@ const rangeSelector: RangeSelectorOptions = {
      *         Milliseconds in the range selector
      *
      */
-    inputDateFormat: '%b %e, %Y',
+    inputDateFormat: '%e %b %Y',
 
     /**
      * A custom callback function to parse values entered in the input boxes


### PR DESCRIPTION
Standardized the default formats across the chart. Tooltips and axis labels now prefer the `%e %b` (day month) format for dates as per the British English standard. This format also works better in most non-English locales.

Closes https://github.com/highcharts/highcharts/issues/18576