### PR TITLE
Design: line-through and more contrast to hidden legend item

### DIFF
--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -596,9 +596,10 @@ text.highcharts-data-label {
 }
 
 .highcharts-legend-item-hidden * {
-    fill: var(--highcharts-neutral-color-20) !important;
-    stroke: var(--highcharts-neutral-color-20) !important;
+    fill: var(--highcharts-neutral-color-60) !important;
+    stroke: var(--highcharts-neutral-color-60) !important;
     transition: fill 250ms;
+    text-decoration: line-through;
 }
 
 .highcharts-legend-nav-active {

--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -1436,6 +1436,10 @@ const defaultOptions: Options = {
             /**
              * @ignore
              */
+            textDecoration: 'none',
+            /**
+             * @ignore
+             */
             textOverflow: 'ellipsis'
         },
 
@@ -1481,7 +1485,11 @@ const defaultOptions: Options = {
             /**
              * @ignore
              */
-            color: Palette.neutralColor20
+            color: Palette.neutralColor60,
+            /**
+             * @ignore
+             */
+            textDecoration: 'line-through'
         },
 
         /**


### PR DESCRIPTION
Improved contrast for the text of hidden legend item. Added `line-through` to indicate it is hidden.

Before merge: Change base to `v11-design/general`