### PR TITLE
bugfix/18183-legend-item-cut

### DIFF
--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -1358,7 +1358,7 @@ class Legend {
             // defines the scroll top for each page (#2098)
             allItems.forEach((item, i): void => {
                 legendItem = item.legendItem || {};
-                const y = legendItem.y ? legendItem.y - 2 : 0,
+                const y = legendItem.y || 0,
                     h = Math.round(
                         (legendItem as any).label.getBBox().height
                     );
@@ -1398,7 +1398,7 @@ class Legend {
             // PDF export (#1787)
             if (!clipRect) {
                 clipRect = legend.clipRect =
-                    renderer.clipRect(0, padding, 9999, 0);
+                    renderer.clipRect(0, padding - 2, 9999, 0);
                 legend.contentGroup.clip(clipRect);
             }
 

--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -1358,7 +1358,7 @@ class Legend {
             // defines the scroll top for each page (#2098)
             allItems.forEach((item, i): void => {
                 legendItem = item.legendItem || {};
-                const y = legendItem.y || 0,
+                const y = legendItem.y ? legendItem.y - 2 : 0,
                     h = Math.round(
                         (legendItem as any).label.getBBox().height
                     );


### PR DESCRIPTION
Fixed #18183, first line of legend with navigation was cut.

Simplified **demo** of the problem: https://jsfiddle.net/BlackLabel/9rypt16j/

**Cause** of the problem: it seems to me that the `clipRect` `y` used for legend was too high. 

**Solution**: Decreasing `clipRect y` by 2 pixels solves the problem (it does not cut the legend anymore).

But I'm not sure if that's the best solution out there.