### PR TITLE
bugfix/17297-maps-remove-point

### DIFF
--- a/samples/unit-tests/maps/mapbubble/demo.js
+++ b/samples/unit-tests/maps/mapbubble/demo.js
@@ -90,4 +90,14 @@ QUnit.test('MapBubble', function (assert) {
         `When hovering over mapbubble series with shared tooltip,
         there should be no errors in the console.`
     );
+
+    // Remove one point from the mapbubble series (#17297).
+    const origLength = chart.series[1].points.length;
+    chart.series[1].points[1].remove();
+    const newLength = chart.series[1].points.length;
+    assert.strictEqual(
+        newLength,
+        origLength - 1,
+        'The length of the points array should be shorter by 1 after poit.remove() (#17297)'
+    );
 });

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -3932,9 +3932,9 @@ class Series {
         }
 
         // Insert undefined item
-        (series.updateParallelArrays as any)(point, 'splice', [i, 0, 0]);
+        series.updateParallelArrays(point, 'splice', [i, 0, 0]);
         // Update it
-        series.updateParallelArrays(point as any, i);
+        series.updateParallelArrays(point, i);
 
         if (names && point.name) {
             names[x as any] = point.name;
@@ -3962,7 +3962,7 @@ class Series {
                 data[0].remove(false);
             } else {
                 data.shift();
-                series.updateParallelArrays(point as any, 'shift');
+                series.updateParallelArrays(point, 'shift');
 
                 (dataOptions as any).shift();
             }
@@ -4027,7 +4027,7 @@ class Series {
                 }
                 data.splice(i, 1);
                 (series.options.data as any).splice(i, 1);
-                (series.updateParallelArrays as any)(
+                series.updateParallelArrays(
                     point || { series: series },
                     'splice',
                     [i, 1]

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -668,17 +668,16 @@ class Series {
      */
     public updateParallelArrays(
         point: Point,
-        i: (number|string)
+        i: (number|string),
+        iArgs?: Array<any>
     ): void {
         const series = point.series,
-            args = arguments,
             fn = isNumber(i) ?
                 // Insert the value in the given position
                 function (key: string): void {
                     const val = key === 'y' && series.toYData ?
                         series.toYData(point) :
                         (point as any)[key];
-
                     (series as any)[key + 'Data'][i] = val;
                 } :
                 // Apply the method specified in i with the following
@@ -686,7 +685,7 @@ class Series {
                 function (key: string): void {
                     (Array.prototype as any)[i].apply(
                         (series as any)[key + 'Data'],
-                        Array.prototype.slice.call(args, 2)
+                        iArgs
                     );
                 };
 
@@ -3933,7 +3932,7 @@ class Series {
         }
 
         // Insert undefined item
-        (series.updateParallelArrays as any)(point, 'splice', i, 0, 0);
+        (series.updateParallelArrays as any)(point, 'splice', [i, 0, 0]);
         // Update it
         series.updateParallelArrays(point as any, i);
 
@@ -4031,8 +4030,7 @@ class Series {
                 (series.updateParallelArrays as any)(
                     point || { series: series },
                     'splice',
-                    i,
-                    1
+                    [i, 1]
                 );
 
                 if (point) {

--- a/ts/Series/MapBubble/MapBubbleSeries.ts
+++ b/ts/Series/MapBubble/MapBubbleSeries.ts
@@ -285,6 +285,26 @@ class MapBubbleSeries extends BubbleSeries {
         this.getRadii();
         this.translateBubble();
     }
+
+    updateParallelArrays(
+        point: Point,
+        i: (number|string),
+        iArgs?: Array<any>
+    ): void {
+        super.updateParallelArrays.call(
+            this,
+            point,
+            i,
+            iArgs
+        );
+
+        let processedXData = this.processedXData,
+            xData = this.xData;
+
+        if (processedXData && xData) {
+            processedXData.length = xData.length;
+        }
+    }
 }
 
 /* *


### PR DESCRIPTION
Fixed #17297, incorrect `series.points` array's length after `point.remove()` in MapBubbleSeries.