### PR TITLE
db/cy-board-fix

### DIFF
--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -20,7 +20,6 @@ Cypress.Commands.add('pan', chartElement => {
 
 Cypress.Commands.add('board', () =>
     cy.window().its('Dashboards.boards').should('exist').then(boards =>{
-        console.log(boards)
         if(boards.length){
             return new Promise((resolve) =>{
                 const [board] = boards;

--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -40,7 +40,10 @@ Cypress.Commands.add('boardRendered', () =>
                     setInterval(()=>{
                         // If highcharts component, wait for chart to be rendered
                         if(component.type === 'Highcharts'){
-                            if(component.chart.hasRendered){
+                            if(
+                                component.chart.hasRendered &&
+                                component.chart.series.every(series => series.hasRendered && series.finishedAnimating)){
+
                                 resolve(component)
                             }
 

--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -24,7 +24,7 @@ Cypress.Commands.add('board', () =>
         if (D) {
             if (D.boards[0]) {
                  resolve(D.boards[0]);
-            } else {
+            } else if(D.addEvent) {
                 const unbind = D.addEvent(D.Dashboards, 'load', function() {
                     unbind();
                     resolve(this);

--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -19,21 +19,52 @@ Cypress.Commands.add('pan', chartElement => {
 })
 
 Cypress.Commands.add('board', () =>
-    cy.window().then(win => new Cypress.Promise((resolve, reject) => {
-        const D = win.Dashboards;
-        if (D) {
-            if (D.boards[0]) {
-                 resolve(D.boards[0]);
-            } else if(D.addEvent) {
-                const unbind = D.addEvent(D.Dashboards, 'load', function() {
-                    unbind();
-                    resolve(this);
-                });
+    cy.window().its('Dashboards.boards').should('exist').then(boards =>{
+        console.log(boards)
+        if(boards.length){
+            return new Promise((resolve) =>{
+                const [board] = boards;
+                resolve(board)
+
+            })
+        } else return Promise.reject('No boards found')
+    })
+);
+
+Cypress.Commands.add('boardRendered', () =>
+    cy.board().then( async board=>{
+        await Promise.all(
+            board.mountedComponents.map(async ({component}) => {
+                return new Promise((resolve, reject) =>{
+                    let attempts = 0;
+
+                    setInterval(()=>{
+                        // If highcharts component, wait for chart to be rendered
+                        if(component.type === 'Highcharts'){
+                            if(component.chart.hasRendered){
+                                resolve(component)
+                            }
+
+                        } else if(component.hasLoaded){
+
+                            resolve(component)
+
+                        }
+
+                        attempts++;
+
+                        if(attempts > 10){
+                            reject('Took more than 10 attempts')
+                        }
+
+
+                    }, 200)
+
+                })
             }
-        } else {
-            reject(new Error('global Dashboards namespace is missing.'));
-        }
-    }))
+            )
+        )
+    })
 );
 
 Cypress.Commands.add('hideSidebar', () =>

--- a/test/cypress/visual/Dashboards.cy.js
+++ b/test/cypress/visual/Dashboards.cy.js
@@ -2,10 +2,8 @@ describe('Dashboards climate demo visual tests', () => {
     before(()=>{
         cy.intercept('/**/world.topo.json').as('getTopo');
         cy.visit('/dashboards/demos/climate');
-
+        cy.board()
         cy.wait('@getTopo') // wait for data to be laoded
-
-        cy.wait(500)
     })
 
     it('Climate demo', () => {
@@ -16,7 +14,6 @@ describe('Dashboards climate demo visual tests', () => {
     it('edit mode', ()=>{
         cy.toggleEditMode()
         cy.get('.highcharts-dashboards-component').first().click()
-        cy.wait(500)
         cy.get('#demo-content')
             .compareSnapshot('dashboard-climate-edit-mode', 0.1);
 
@@ -31,12 +28,12 @@ describe('Test the rest',  ()=>{
     for(const demo of DEMOS_TO_VISUALLY_TEST){
         it('visually comparison after load ' + demo, ()=>{
             cy.visit(demo);
-            cy.wait(1500); // TODO: should have a 'animationSettled' command
+            cy.boardRendered();
 
             cy.get('#demo-content')
                 .compareSnapshot(
                     demo.replace('/', '')
-                    .replace(/\//g, '-') + '-loaded', 
+                    .replace(/\//g, '-') + '-loaded',
                     0.1
                 );
         })

--- a/test/cypress/visual/Dashboards.cy.js
+++ b/test/cypress/visual/Dashboards.cy.js
@@ -2,11 +2,11 @@ describe('Dashboards climate demo visual tests', () => {
     before(()=>{
         cy.intercept('/**/world.topo.json').as('getTopo');
         cy.visit('/dashboards/demos/climate');
-        cy.board()
         cy.wait('@getTopo') // wait for data to be laoded
     })
 
     it('Climate demo', () => {
+        cy.board()
         cy.get('#demo-content')
             .compareSnapshot('dashboard-climate-loaded', 0.1);
     })

--- a/test/cypress/visual/Dashboards.cy.js
+++ b/test/cypress/visual/Dashboards.cy.js
@@ -4,7 +4,6 @@ describe('Dashboards climate demo visual tests', () => {
         cy.visit('/dashboards/demos/climate');
 
         cy.wait('@getTopo') // wait for data to be laoded
-        cy.board() // ensure dashboard is loaded
 
         cy.wait(500)
     })
@@ -33,7 +32,6 @@ describe('Test the rest',  ()=>{
         it('visually comparison after load ' + demo, ()=>{
             cy.visit(demo);
             cy.wait(1500); // TODO: should have a 'animationSettled' command
-            cy.board();
 
             cy.get('#demo-content')
                 .compareSnapshot(

--- a/test/cypress/visual/Dashboards.cy.js
+++ b/test/cypress/visual/Dashboards.cy.js
@@ -6,7 +6,7 @@ describe('Dashboards climate demo visual tests', () => {
     })
 
     it('Climate demo', () => {
-        cy.board()
+        cy.boardRendered()
         cy.get('#demo-content')
             .compareSnapshot('dashboard-climate-loaded', 0.1);
     })


### PR DESCRIPTION
changed `cy.board` to use built-in cypress functionality, which includes automatic retries. Also added `cy.boardRendered`, which waits for components (and especially chart components) to have rendered.