### PR TITLE
bugfix/18720-stack-y-float-issue

### DIFF
--- a/samples/unit-tests/series-column/stacking/demo.js
+++ b/samples/unit-tests/series-column/stacking/demo.js
@@ -1,27 +1,25 @@
 QUnit.test(
     'Negative stack with just one point should be also calculate (#4979)',
     function (assert) {
-        var chart = $('#container')
-                .highcharts({
-                    chart: {
-                        type: 'column'
+        const chart = Highcharts.chart('container', {
+                chart: {
+                    type: 'column'
+                },
+                plotOptions: {
+                    column: {
+                        borderWidth: 0,
+                        stacking: 'percent'
+                    }
+                },
+                series: [
+                    {
+                        data: [-10]
                     },
-                    plotOptions: {
-                        column: {
-                            borderWidth: 0,
-                            stacking: 'percent'
-                        }
-                    },
-                    series: [
-                        {
-                            data: [-10]
-                        },
-                        {
-                            data: [10]
-                        }
-                    ]
-                })
-                .highcharts(),
+                    {
+                        data: [10]
+                    }
+                ]
+            }),
             oldHeight = chart.series[0].points[0].graphic.getBBox(true).height;
 
         chart.series[0].addPoint(-10, false);
@@ -36,9 +34,7 @@ QUnit.test(
 );
 
 QUnit.test('Column outside plot area(#4264)', function (assert) {
-    var chart;
-
-    $('#container').highcharts({
+    const chart = Highcharts.chart('container', {
         chart: {
             type: 'column',
             zoomType: 'xy'
@@ -111,8 +107,6 @@ QUnit.test('Column outside plot area(#4264)', function (assert) {
             }
         ]
     });
-
-    chart = $('#container').highcharts();
 
     assert.equal(
         chart.series[0].points[0].graphic.attr('y') +

--- a/samples/unit-tests/series-column/stacking/demo.js
+++ b/samples/unit-tests/series-column/stacking/demo.js
@@ -150,14 +150,14 @@ QUnit.test('Single series stacking (#2592)', function (assert) {
                     data: [
                         [0, 5],
                         [0, 6],
-                        [1, 10]
+                        [1, 10.9]
                     ]
                 },
                 {
                     name: 'Jane',
                     data: [
                         [0, 2],
-                        [1, 2]
+                        [1, 2.2]
                     ]
                 }
             ]
@@ -178,6 +178,15 @@ QUnit.test('Single series stacking (#2592)', function (assert) {
             'There should be an SVG element for each data point.'
         );
     }
+
+    // Issue #18720
+    // stackY was different than stackTotal because of correctFloat() applied
+    // to only stackTotal
+    assert.equal(
+        chart.series[0].points[2].stackTotal,
+        chart.series[0].points[2].stackY,
+        'stackTotal should be the same as stackY for the same column.'
+    );
 
     // Issue #16979
     // column with stacking = 'percent' shows only one point

--- a/ts/Core/Axis/Stacking/StackingAxis.ts
+++ b/ts/Core/Axis/Stacking/StackingAxis.ts
@@ -491,8 +491,10 @@ function seriesSetStackedPoints(
             // This point's index within the stack, pushed to stack.points[1]
             stack.cumulative = (stack.total || 1) - 1;
         } else {
-            stack.cumulative =
-                pick(stack.cumulative, stackThreshold as any) + (y || 0);
+            stack.cumulative = correctFloat(
+                pick(stack.cumulative, stackThreshold as any) +
+                (y || 0)
+            );
         }
 
         if (y !== null) {


### PR DESCRIPTION
Fixed #18720, the `correctFloat` method was not applied to `stackY` which was throwing strange values like `12.00013...`  instead of `12`.