### PR TITLE
bugfix/18584-vertical-line-local-storage-update

### DIFF
--- a/samples/unit-tests/stock-tools/bindings/demo.js
+++ b/samples/unit-tests/stock-tools/bindings/demo.js
@@ -70,6 +70,46 @@ QUnit.test('Bindings general tests', function (assert) {
         );
     }
 
+    const verticalAnnotation = chart.addAnnotation({
+            type: 'verticalLine',
+            typeOptions: {
+                point: {
+                    xAxis: 0,
+                    yAxis: 0,
+                    x: 5,
+                    y: 15
+                }
+            }
+        }),
+        { x, y } = verticalAnnotation.shapes[0].graphic.getBBox();
+
+    controller.mouseDown(
+        plotLeft + x - 10,
+        plotTop + y - 15
+    );
+
+    controller.mouseMove(
+        plotLeft + 100,
+        plotTop + 100
+    );
+
+    controller.mouseUp();
+
+    selectButton('save-chart');
+
+    const annotationStorage = localStorage.getItem('highcharts-chart');
+
+    assert.deepEqual(
+        JSON.parse(annotationStorage).annotations[0].typeOptions,
+        verticalAnnotation.userOptions.typeOptions,
+        'Annotation position saves correctly in localStorage after drag and drop'
+    );
+
+    verticalAnnotation.destroy();
+    chart.annotations.length = 0;
+
+    localStorage.removeItem('highcharts-chart');
+
     // Annotations with multiple steps:
     [
         'circle-annotation',

--- a/ts/Extensions/Annotations/Types/VerticalLine.ts
+++ b/ts/Extensions/Annotations/Types/VerticalLine.ts
@@ -117,6 +117,7 @@ class VerticalLine extends Annotation {
             );
 
         typeOptions.connector = connector.options;
+        this.userOptions.typeOptions.point = typeOptions.point;
     }
 
     public addLabels(): void {


### PR DESCRIPTION
 Fixed #18584, vertical line annotation position was incorrect when saved to options after drag and drop.