### PR TITLE
bugfix/14080-bubblelegend-prevent-default-click

### DIFF
--- a/samples/unit-tests/bubble-legend/layout/demo.js
+++ b/samples/unit-tests/bubble-legend/layout/demo.js
@@ -80,6 +80,48 @@ QUnit.test('Bubble legend ranges', function (assert) {
         true,
         'Bubble legend was properly disabled with the legend'
     );
+
+    chart.addSeries({
+        type: 'bubble',
+        data: [
+            [1, 4, 4],
+            [2, 5, 5]
+        ],
+        events: {
+            legendItemClick(e) {
+                e.preventDefault();
+            }
+        }
+    }, false);
+
+    chart.legend.update({
+        enabled: true,
+        floating: false
+    });
+
+    chart.series[1].legendItem.group.element.dispatchEvent(new Event('click'));
+    chart.series[0].legendItem.group.element.dispatchEvent(new Event('click'));
+
+    assert.ok(
+        true,
+        `There shouldn't be any error in the console, when one series
+        legendItemClick has prevented the event and we click both legend
+        items (#14080).`
+    );
+
+    assert.notOk(
+        isNaN(chart.legend.bubbleLegend.legendItem.labelHeight),
+        `Bubble legend should work correctly, when one series
+        legendItemClick has prevented the event and we click both legend
+        items (#14080).`
+    );
+
+    assert.notOk(
+        isNaN(chart.legend.bubbleLegend.legendItem.labelWidth),
+        `Bubble legend should work correctly, when one series
+        legendItemClick has prevented the event and we click both legend
+        items (#14080).`
+    );
 });
 
 QUnit.test('Negative values (#9678)', function (assert) {

--- a/ts/Core/Foundation.ts
+++ b/ts/Core/Foundation.ts
@@ -83,7 +83,9 @@ namespace Foundation {
 
                     if (isFunction(event)) {
                         component.eventOptions[eventType] = event;
-                        addEvent(component, eventType, event);
+                        addEvent(component, eventType, event, {
+                            order: 0 // #14080 fire those events as firsts
+                        });
                     }
                 }
             }

--- a/ts/Series/Bubble/BubbleLegendComposition.ts
+++ b/ts/Series/Bubble/BubbleLegendComposition.ts
@@ -285,7 +285,12 @@ function onLegendAfterGetAllItems(
 /**
  * Toggle bubble legend depending on the visible status of bubble series.
  */
-function onSeriesLegendItemClick(this: Series): void {
+function onSeriesLegendItemClick(this: Series, e: any): void | boolean {
+    // #14080 don't fire this code if click function is prevented
+    if (e.defaultPrevented) {
+        return false;
+    }
+
     const series = this,
         chart = series.chart,
         visible = series.visible,


### PR DESCRIPTION
Fixed #14080, bubble legend didn't work correctly if the `legendItemClick` event for one series was prevented.