### PR TITLE
bugfix/18710-trendline-add-remove-points

### DIFF
--- a/samples/unit-tests/indicator-trendline/recalculations/demo.js
+++ b/samples/unit-tests/indicator-trendline/recalculations/demo.js
@@ -29,9 +29,10 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
 
     chart.series[0].points[3].remove();
 
+    // Values corrected for #18710 fix
     assert.deepEqual(
-        correctFloat(tr[0], 2) === 1.1 &&
-            correctFloat(tr[tr.length - 1], 2) === 4.5,
+        correctFloat(tr[0], 2) === 0.92 &&
+            correctFloat(tr[tr.length - 1], 2) === 4.4,
         true,
         'Correct values after point.remove()'
     );

--- a/ts/Stock/Indicators/SMA/SMAIndicator.ts
+++ b/ts/Stock/Indicators/SMA/SMAIndicator.ts
@@ -457,8 +457,9 @@ class SMAIndicator extends LineSeries {
 
                 indicator.updateData(croppedDataValues);
 
-            // Omit addPoint() and removePoint() cases
             } else if (
+                indicator.updateAllPoints || // #18710
+                // Omit addPoint() and removePoint() cases
                 processedData.xData.length !== oldDataLength - 1 &&
                 processedData.xData.length !== oldDataLength + 1
             ) {
@@ -524,6 +525,7 @@ interface SMAIndicator extends IndicatorLike {
     nameSuffixes: Array<string>;
     pointClass: typeof SMAPoint;
     useCommonDataGrouping: boolean;
+    updateAllPoints?: boolean;
 }
 extend(SMAIndicator.prototype, {
     calculateOn: {

--- a/ts/Stock/Indicators/TrendLine/TrendLineIndicator.ts
+++ b/ts/Stock/Indicators/TrendLine/TrendLineIndicator.ts
@@ -95,6 +95,7 @@ class TrendLineIndicator extends SMAIndicator {
     public data: Array<TrendLinePoint> = void 0 as any;
     public options: TrendLineOptions = void 0 as any;
     public points: Array<TrendLinePoint> = void 0 as any;
+    public updateAllPoints?: boolean = true;
 
     /* *
      *
@@ -106,13 +107,21 @@ class TrendLineIndicator extends SMAIndicator {
         series: TLinkedSeries,
         params: TrendLineParamsOptions
     ): IndicatorValuesObject<TLinkedSeries> {
-        const xVal: Array<number> = (series.xData as any),
+        const orgXVal: Array<number> = (series.xData as any),
             yVal: Array<Array<number>> = (series.yData as any),
             LR: Array<Array<number>> = [],
             xData: Array<number> = [],
             yData: Array<number> = [],
-            xValLength: number = xVal.length,
+            xValLength: number = orgXVal.length,
             index: number = (params.index as any);
+
+        let xVal: Array<number> = [];
+        // Create a fake xVal array with consecutive values to avoid issues with
+        // ordinal, point.remove etc. #18710
+        for (let i = 0; i < xValLength; i ++) {
+            xVal[i] = i;
+        }
+
 
         let sumX = 0,
             sumY = 0,
@@ -149,8 +158,8 @@ class TrendLineIndicator extends SMAIndicator {
             y = alpha * x + beta;
 
             // Prepare arrays required for getValues() method
-            LR[i] = [x, y];
-            xData[i] = x;
+            LR[i] = [orgXVal[i], y];
+            xData[i] = orgXVal[i];
             yData[i] = y;
         }
 


### PR DESCRIPTION
Fixed #18710, trendline points were not recalculated after adding or removing a point to main series.

As a side note, I have also improved the `getValues` method for trendline recalculation. Previous approach did not work, when `ordinal: true` or when point got removed and the xAxis values were not incremented by 1 anymore (missing point in the middle of the data).