### PR TITLE
Feature/sunburst rotationmode

### DIFF
--- a/samples/highcharts/demo/sunburst/demo.js
+++ b/samples/highcharts/demo/sunburst/demo.js
@@ -1405,8 +1405,7 @@ Highcharts.chart('container', {
                 property: 'innerArcLength',
                 operator: '>',
                 value: 16
-            },
-            rotationMode: 'circular'
+            }
         },
         levels: [{
             level: 1,

--- a/samples/highcharts/plotoptions/sunburst-datalabels-rotationmode-circular/demo.html
+++ b/samples/highcharts/plotoptions/sunburst-datalabels-rotationmode-circular/demo.html
@@ -3,3 +3,10 @@
 <script src="https://code.highcharts.com/modules/exporting.js"></script>
 
 <div id="container"></div>
+
+<div id="button-row">
+    <button>circular</button>
+    <button>auto</button>
+    <button>parallel</button>
+    <button>perpendicular</button>
+</div>

--- a/samples/highcharts/plotoptions/sunburst-datalabels-rotationmode-circular/demo.js
+++ b/samples/highcharts/plotoptions/sunburst-datalabels-rotationmode-circular/demo.js
@@ -850,10 +850,10 @@ Highcharts.chart('container', {
 });
 
 [...document.querySelectorAll('#button-row button')].forEach(button =>
-    button.addEventListener('click', button => {
+    button.addEventListener('click', e => {
         Highcharts.charts[0].series[0].update({
             dataLabels: {
-                rotationMode: button.innerText
+                rotationMode: e.target.innerText
             }
         });
     })

--- a/samples/highcharts/plotoptions/sunburst-datalabels-rotationmode-circular/demo.js
+++ b/samples/highcharts/plotoptions/sunburst-datalabels-rotationmode-circular/demo.js
@@ -848,3 +848,13 @@ Highcharts.chart('container', {
         pointFormat: 'Arrivals to <b>{point.name}</b>: <b>{point.value}</b>'
     }
 });
+
+[...document.querySelectorAll('#button-row button')].forEach(button =>
+    button.addEventListener('click', button => {
+        Highcharts.charts[0].series[0].update({
+            dataLabels: {
+                rotationMode: button.innerText
+            }
+        });
+    })
+);

--- a/samples/unit-tests/series-sunburst/datalabels/demo.js
+++ b/samples/unit-tests/series-sunburst/datalabels/demo.js
@@ -53,11 +53,19 @@ QUnit.test('Rotation mode', function (assert) {
     });
 
     assert.deepEqual(
-        chart.series[0].points.map(function (point) {
-            return Number(point.dataLabel.rotation.toFixed(1));
-        }),
-        [0, 22.5, 67.5, -67.5, -22.5, 22.5, 67.5, -67.5, -22.5],
-        'Auto rotationMode should be parallel'
+        chart.series[0].points.map(point => typeof point.dataLabel.textPath),
+        [
+            'undefined',
+            'object',
+            'object',
+            'object',
+            'object',
+            'object',
+            'object',
+            'object',
+            'object'
+        ],
+        'Auto rotationMode should be circular'
     );
 
     assert.strictEqual(

--- a/ts/Series/Sunburst/SunburstSeries.ts
+++ b/ts/Series/Sunburst/SunburstSeries.ts
@@ -621,22 +621,24 @@ class SunburstSeries extends TreemapSeries {
 
             /**
              * Decides how the data label will be rotated relative to the
-             * perimeter of the sunburst. Valid values are `auto`, `circular`,
-             * `parallel` and `perpendicular`. When `auto`, the best fit will be
-             * computed for the point. The `circular` option works similiar
-             * to `auto`, but uses the `textPath` feature - labels are curved,
-             * resulting in a better layout, however multiple lines and
-             * `textOutline` are not supported.
+             * perimeter of the sunburst. Valid values are `circular`, `auto`,
+             * `parallel` and `perpendicular`. When `circular`, the best fit
+             * will be computed for the point, so that the label is curved
+             * around the center when there is room for it, otherwise
+             * perpendicular. The legacy `auto` option works similiar to
+             * `circular`, but instead of curving the labels they are tangent to
+             * the perimiter.
              *
              * The `rotation` option takes precedence over `rotationMode`.
              *
              * @type       {string}
-             * @sample {highcharts} highcharts/plotoptions/sunburst-datalabels-rotationmode-circular/
+             * @sample {highcharts}
+             *         highcharts/plotoptions/sunburst-datalabels-rotationmode-circular/
              *         Circular rotation mode
              * @validvalue ["auto", "perpendicular", "parallel", "circular"]
              * @since      6.0.0
              */
-            rotationMode: 'auto',
+            rotationMode: 'circular',
 
             style: {
                 /** @internal */

--- a/ts/Series/Sunburst/SunburstSeries.ts
+++ b/ts/Series/Sunburst/SunburstSeries.ts
@@ -189,6 +189,12 @@ function getDlOptions(
         }
 
         if (rotationMode !== 'auto' && rotationMode !== 'circular') {
+
+            if (point.dataLabel && point.dataLabel.textPath) {
+                options.textPath = {
+                    enabled: false
+                };
+            }
             rotationRad = (
                 (shape.end as any) -
                 ((shape.end as any) - (shape.start as any)) / 2


### PR DESCRIPTION
Changed default `rotationMode` to `circular` for sunburst data labels.

#### Upgrade note
Changed default `rotationMode` to `circular` for sunburst data labels.