### PR TITLE
Semgrep scan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,9 +55,6 @@ executors:
   node_image:
     docker:
       - image: cimg/node:16.3.0-browsers
-  semgrep_image:
-    docker:
-      - image: returntocorp/semgrep
 
 commands:
   generate_references_command:
@@ -73,9 +70,11 @@ commands:
 jobs:
   security_scan:
     docker:
-      - image: returntocorp/semgrep
-    name: Scan ts-folder for OWASP top-ten vulnerabilities
-    run: semgrep ci --config "p/owasp-top-ten" "ts/"
+      - image: returntocorp/semgrep #semgrep reccomends this docker image
+    steps:
+      - run:
+          name: Scan ts-folder for OWASP top-ten vulnerabilities
+          command: semgrep ci --config "p/owasp-top-ten" ts/
 
   checkout_and_install:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,9 @@ executors:
   node_image:
     docker:
       - image: cimg/node:16.3.0-browsers
+  semgrep_image:
+    docker:
+      - image: returntocorp/semgrep
 
 commands:
   generate_references_command:
@@ -68,6 +71,12 @@ commands:
       - run: "npx karma start test/karma-conf.js --tests stock/*/* --reference --browsercount << parameters.browsercount >> --no-fail-on-empty-test-suite"
       - run: "npx karma start test/karma-conf.js --tests gantt/*/* --reference --browsercount << parameters.browsercount >> --no-fail-on-empty-test-suite"
 jobs:
+  security_scan:
+    docker:
+      - image: returntocorp/semgrep
+    name: Scan ts-folder for OWASP top-ten vulnerabilities
+    run: semgrep ci --config "p/owasp-top-ten" "ts/"
+
   checkout_and_install:
     <<: *defaults
     environment:


### PR DESCRIPTION
Implemented a semgrep scan into the CircleCI pipeline

A few notes:
- It scans the ts-folder for the OWASP top 10 web app vulnerabilities
- Our `ts/`-folder passes the scan 100% as-is
- I have *not* tested this `config.yml` because I didn't want to mess with our CircleCI account and pipelines
- But I have used a totally separate throwaway CircleCI account to test and reason about CircleCI configs in general

I do have a decently sized scan-report done with way more rules (from running `semgrep` with the `--config auto` flag) in case we want more rules, and I have also learnt to make custom rules (`semgrep` has a decent tutorial) in case we ever need anything custom!

EDIT: 
Also feel free to say if we should run the scan somewhere else in the pipeline! I assume that the pipeline in CircleCI is separate from the pre-commit scans, but if not, should we have this scan there in stead?