### PR TITLE
bugfix/17007-vbp-indicator-redraw-issue

### DIFF
--- a/samples/unit-tests/indicator-volume-by-price/recalculations/demo.js
+++ b/samples/unit-tests/indicator-volume-by-price/recalculations/demo.js
@@ -161,9 +161,9 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
     });
 
     assert.strictEqual(
-        VBPIndicator.options.params.ranges,
+        VBPIndicator.volumeDataArray.length,
         6,
-        'We should be able to update VBP params with update(), #17007.'
+        'VBP params should be updated after update(), #17007.'
     );
 
     VBPIndicator.update({

--- a/samples/unit-tests/indicator-volume-by-price/recalculations/demo.js
+++ b/samples/unit-tests/indicator-volume-by-price/recalculations/demo.js
@@ -154,6 +154,24 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
 
     // End of #16277 testing, start other tests
 
+    VBPIndicator.update({
+        params: {
+            ranges: 6
+        }
+    });
+
+    assert.strictEqual(
+        VBPIndicator.options.params.ranges,
+        6,
+        'We should be able to update VBP params with update(), #17007.'
+    );
+
+    VBPIndicator.update({
+        params: {
+            ranges: 12
+        }
+    });
+
     function round(array) {
         return array.map(function (value) {
             return value === null ? null : Number(value.toFixed(2));

--- a/ts/Stock/Indicators/VBP/VBPIndicator.ts
+++ b/ts/Stock/Indicators/VBP/VBPIndicator.ts
@@ -252,9 +252,12 @@ class VBPIndicator extends SMAIndicator {
      * */
 
     public init(
-        chart: Chart
+        chart: Chart,
+        options: VBPOptions
     ): VBPIndicator {
         const indicator = this;
+
+        delete options.data;
 
         super.init.apply(indicator, arguments);
 
@@ -300,13 +303,6 @@ class VBPIndicator extends SMAIndicator {
                     indicator.zoneLinesSVG = indicator.zoneLinesSVG.destroy();
                 }
             };
-
-        // Fire recalculateValues() after the indicator is updated, #17007
-        indicator.dataEventsToUnbind.push(
-            addEvent(indicator, 'afterUpdate', function (): void {
-                this.recalculateValues();
-            })
-        );
 
         // If base series is deleted, indicator series data is filled with
         // an empty array

--- a/ts/Stock/Indicators/VBP/VBPIndicator.ts
+++ b/ts/Stock/Indicators/VBP/VBPIndicator.ts
@@ -258,6 +258,11 @@ class VBPIndicator extends SMAIndicator {
 
         super.init.apply(indicator, arguments);
 
+        // Fire recalculateValues() after indicator update, #17007
+        addEvent(this, 'afterUpdate', function (): void {
+            this.recalculateValues();
+        });
+
         // Only after series are linked add some additional logic/properties.
         const unbinder = addEvent(
             StockChart,

--- a/ts/Stock/Indicators/VBP/VBPIndicator.ts
+++ b/ts/Stock/Indicators/VBP/VBPIndicator.ts
@@ -257,6 +257,8 @@ class VBPIndicator extends SMAIndicator {
     ): VBPIndicator {
         const indicator = this;
 
+        // series.update() sends data that is not necessary
+        // as everything is calculated in getValues(), #17007
         delete options.data;
 
         super.init.apply(indicator, arguments);

--- a/ts/Stock/Indicators/VBP/VBPIndicator.ts
+++ b/ts/Stock/Indicators/VBP/VBPIndicator.ts
@@ -258,11 +258,6 @@ class VBPIndicator extends SMAIndicator {
 
         super.init.apply(indicator, arguments);
 
-        // Fire recalculateValues() after indicator update, #17007
-        addEvent(this, 'afterUpdate', function (): void {
-            this.recalculateValues();
-        });
-
         // Only after series are linked add some additional logic/properties.
         const unbinder = addEvent(
             StockChart,
@@ -305,6 +300,13 @@ class VBPIndicator extends SMAIndicator {
                     indicator.zoneLinesSVG = indicator.zoneLinesSVG.destroy();
                 }
             };
+
+        // Fire recalculateValues() after the indicator is updated, #17007
+        indicator.dataEventsToUnbind.push(
+            addEvent(indicator, 'afterUpdate', function (): void {
+                this.recalculateValues();
+            })
+        );
 
         // If base series is deleted, indicator series data is filled with
         // an empty array


### PR DESCRIPTION
Fixed #17007, VBP indicator did not update correctly.

**Problem:**
_the problem was that the values, for example_ `volumeDataArray`, _for the indicator series were not updated after_ `series.update`

**Solution:**
_after each update, trigger_ `series.recalculateValues()`