### PR TITLE
bugfix/18768-missing-legend-page

### DIFF
--- a/samples/unit-tests/legend/navigation/demo.js
+++ b/samples/unit-tests/legend/navigation/demo.js
@@ -19,5 +19,24 @@ QUnit.test(
             4,
             'There should be enough pages to fully fit all elements (#13683)'
         );
+
+        chart.update({
+            chart: {
+                width: 400
+            },
+            legend: {
+                maxHeight: 40,
+                itemStyle: {
+                    fontSize: '12px'
+                }
+            }
+        }, false);
+        chart.addSeries({});
+
+        assert.strictEqual(
+            chart.legend.pages.length,
+            3,
+            'The last item should not be omitted (#18768)'
+        );
     }
 );

--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -1380,10 +1380,8 @@ class Legend {
                 if (
                     // check the last item
                     i === allItems.length - 1 &&
-                    // if adding next page is needed
-                    y + h - pages[len - 1] > clipHeight &&
-                    // and will fully fit inside a new page
-                    h <= clipHeight
+                    // if adding next page is needed (#18768)
+                    y > pages[len - 1]
                 ) {
                     pages.push(y);
                     legendItem.pageIx = len;

--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -1381,7 +1381,7 @@ class Legend {
                     // check the last item
                     i === allItems.length - 1 &&
                     // if adding next page is needed (#18768)
-                    y > pages[len - 1]
+                    y + h - pages[len - 1] > clipHeight
                 ) {
                     pages.push(y);
                     legendItem.pageIx = len;


### PR DESCRIPTION
Fixed #18768, missing the last item in a legend when it was alone on a page.