### PR TITLE
Some Dashboards demo styling

### DIFF
--- a/css/dashboards/gui.css
+++ b/css/dashboards/gui.css
@@ -53,12 +53,16 @@
 
 @media (prefers-color-scheme: dark) {
     :root {
-        --highcharts-dashboards-wrapper-background-color: #808080;
+        --highcharts-dashboards-main-background-color: #444444;
+        --highcharts-dashboards-wrapper-background-color: #222222;
+        --highcharts-dashboards-main-font-color: #ffffff;
     }
 }
 
 .highcharts-dashboards-dark {
-    --highcharts-dashboards-wrapper-background-color: #808080;
+    --highcharts-dashboards-main-background-color: #444444;
+    --highcharts-dashboards-wrapper-background-color: #222222;
+    --highcharts-dashboards-main-font-color: #ffffff;
 }
 
 .highcharts-dashboards,
@@ -124,7 +128,13 @@
         0 0.25rem 0.5313rem rgba(var(--highcharts-dashboards-shadow-color), 0.03),
         0 0.125rem 0.1875rem rgba(var(--highcharts-dashboards-shadow-color), 0.03);
     background-clip: border-box;
+    border-radius: 3px;
     overflow: auto;
+}
+
+.highcharts-dashboards-component-title {
+    color: var(--highcharts-dashboards-main-font-color);
+    margin: 0.5em 10px;
 }
 
 .highcharts-dashboards-component img {

--- a/css/dashboards/gui.css
+++ b/css/dashboards/gui.css
@@ -7,31 +7,29 @@
  */
 
 :root,
-.highcharts-dashboards-light {
-    /* Base colors */
-    --highcharts-dashboards-neutral-color-100: #000000;
-    --highcharts-dashboards-neutral-color-80: #333333;
-    --highcharts-dashboards-neutral-color-50: #808080;
-    --highcharts-dashboards-neutral-color-20: #cccccc;
-    --highcharts-dashboards-neutral-color-5: #f7f7f7;
-    --highcharts-dashboards-neutral-color-3: #f2f2f2;
-    --highcharts-dashboards-neutral-color-0: #ffffff;
-    --highcharts-dashboards-red-color: #e01d5a;
-    --highcharts-dashboards-blue-border-color: 26, 54, 126;
-    --highcharts-dashboards-transparent: transparent;
+.highcharts-light {
+    /* Neutral colors */
+    --highcharts-neutral-color-100: #000000;
+    --highcharts-neutral-color-80: #333333;
+    --highcharts-neutral-color-60: #666666;
+    --highcharts-neutral-color-20: #cccccc;
+    --highcharts-neutral-color-5: #f2f2f2;
+    --highcharts-neutral-color-3: #f7f7f7;
+    --highcharts-neutral-color-0: #ffffff;
+
+    /* Highlight colors */
+    --highcharts-highlight-color-100: #0022ff;
+    --highcharts-highlight-color-80: #334eff;
+    --highcharts-highlight-color-60: #667aff;
+    --highcharts-highlight-color-20: #ccd3ff;
+    --highcharts-highlight-color-10: #e6e9ff;
+
+    /* Other colors */
+    --highcharts-dashboards-danger-color: #e01d5a;
 
     /* General */
-    --highcharts-dashboards-main-background-color: #ffffff;
-    --highcharts-dashboards-wrapper-background-color: #f3f3f3;
-    --highcharts-dashboards-main-font-color: #000000;
+    --highcharts-background-color: #ffffff;
     --highcharts-dashboards-shadow-color: 4, 9, 20;
-
-    /* Pointer */
-    --highcharts-dashboards-pointer-selected-color: #2196f3;
-    --highcharts-dashboards-pointer-color: #8085e8;
-
-    /* Row */
-    --highcharts-dashboards-row-border-color: #4b4b4d;
 
     /* Edit row */
     --highcharts-dashboards-edit-row-color: #7bb343;
@@ -39,35 +37,69 @@
     --highcharts-dashboards-edit-row-highlight-color: 224, 239, 173;
 
     /* Edit cell */
-    --highcharts-dashboards-edit-cell-color: #1779ba;
     --highcharts-dashboards-highlight-cell-color: 0, 0, 0;
-
-    /* Sidebar */
-    --highcharts-dashboards-sidebar-button-color: #2196f3;
-    --highcharts-dashboards-sidebar-button-contrast-color: #0d47a1;
 
     /* Dropdown */
     --highcharts-dashboards-dropdown-box-shadow-color: 34, 34, 34, 0.1;
-    --highcharts-dashboards-dropdown-border-color: #838394;
 }
 
 @media (prefers-color-scheme: dark) {
     :root {
-        --highcharts-dashboards-main-background-color: #444444;
-        --highcharts-dashboards-wrapper-background-color: #222222;
-        --highcharts-dashboards-main-font-color: #ffffff;
+        /* UI colors */
+        --highcharts-background-color: #333333;
+
+        /*
+            Neutral color variations
+            https://www.highcharts.com/samples/highcharts/css/palette-helper
+        */
+        --highcharts-neutral-color-100: rgb(255, 255, 255);
+        --highcharts-neutral-color-80: rgb(214, 214, 214);
+        --highcharts-neutral-color-60: rgb(173, 173, 173);
+        --highcharts-neutral-color-40: rgb(133, 133, 133);
+        --highcharts-neutral-color-20: rgb(92, 92, 92);
+        --highcharts-neutral-color-10: rgb(71, 71, 71);
+        --highcharts-neutral-color-5: rgb(61, 61, 61);
+        --highcharts-neutral-color-3: rgb(57, 57, 57);
+        --highcharts-neutral-color-0: rgb(0, 0, 0);
+
+        /* Highlight color variations */
+        --highcharts-highlight-color-100: rgb(122, 167, 255);
+        --highcharts-highlight-color-80: rgb(108, 144, 214);
+        --highcharts-highlight-color-60: rgb(94, 121, 173);
+        --highcharts-highlight-color-20: rgb(65, 74, 92);
+        --highcharts-highlight-color-10: rgb(58, 63, 71);
     }
 }
 
-.highcharts-dashboards-dark {
-    --highcharts-dashboards-main-background-color: #444444;
-    --highcharts-dashboards-wrapper-background-color: #222222;
-    --highcharts-dashboards-main-font-color: #ffffff;
+.highcharts-dark {
+    /* UI colors */
+    --highcharts-background-color: #333333;
+
+    /*
+        Neutral color variations
+        https://www.highcharts.com/samples/highcharts/css/palette-helper
+    */
+    --highcharts-neutral-color-100: rgb(255, 255, 255);
+    --highcharts-neutral-color-80: rgb(214, 214, 214);
+    --highcharts-neutral-color-60: rgb(173, 173, 173);
+    --highcharts-neutral-color-40: rgb(133, 133, 133);
+    --highcharts-neutral-color-20: rgb(92, 92, 92);
+    --highcharts-neutral-color-10: rgb(71, 71, 71);
+    --highcharts-neutral-color-5: rgb(61, 61, 61);
+    --highcharts-neutral-color-3: rgb(57, 57, 57);
+    --highcharts-neutral-color-0: rgb(0, 0, 0);
+
+    /* Highlight color variations */
+    --highcharts-highlight-color-100: rgb(122, 167, 255);
+    --highcharts-highlight-color-80: rgb(108, 144, 214);
+    --highcharts-highlight-color-60: rgb(94, 121, 173);
+    --highcharts-highlight-color-20: rgb(65, 74, 92);
+    --highcharts-highlight-color-10: rgb(58, 63, 71);
 }
 
 .highcharts-dashboards,
 .highcharts-dashboards-wrapper {
-    background-color: var(--highcharts-dashboards-wrapper-background-color);
+    background-color: var(--highcharts-neutral-color-5);
     padding: 20px 10px;
     position: relative;
     overflow: hidden;
@@ -107,7 +139,7 @@
 .highcharts-dashboards-row,
 .highcharts-dashboards-row .highcharts-dashboards-cell {
     box-sizing: border-box;
-    border: 1px dashed var(--highcharts-dashboards-transparent);
+    border: 1px dashed transparent;
 }
 
 .highcharts-dashboards-cell img {
@@ -121,7 +153,7 @@
 .highcharts-dashboards-cell > .highcharts-dashboards-component {
     position: relative;
     margin: 5px;
-    background-color: var(--highcharts-dashboards-main-background-color);
+    background-color: var(--highcharts-background-color);
     box-shadow:
         0 0.4688rem 2.1875rem rgba(var(--highcharts-dashboards-shadow-color), 0.03),
         0 0.9375rem 1.4063rem rgba(var(--highcharts-dashboards-shadow-color), 0.03),
@@ -133,7 +165,7 @@
 }
 
 .highcharts-dashboards-component-title {
-    color: var(--highcharts-dashboards-main-font-color);
+    color: var(--highcharts-neutral-color-100);
     margin: 0.5em 10px;
 }
 
@@ -155,7 +187,7 @@
 }
 
 .highcharts-dashboards-edit-enabled .highcharts-dashboards-row {
-    border: 1px dashed var(--highcharts-dashboards-row-border-color);
+    border: 1px dashed var(--highcharts-neutral-color-60);
 }
 
 .highcharts-dashboards-edit-enabled .highcharts-dashboards-edit-row-context-highlight {
@@ -164,8 +196,8 @@
             -45deg,
             rgba(var(--highcharts-dashboards-edit-row-highlight-color), 0.7),
             rgba(var(--highcharts-dashboards-edit-row-highlight-color), 0.7) 5px,
-            var(--highcharts-dashboards-neutral-color-0) 5px,
-            var(--highcharts-dashboards-neutral-color-0) 10px
+            var(--highcharts-neutral-color-0) 5px,
+            var(--highcharts-neutral-color-0) 10px
         );
 }
 
@@ -175,7 +207,7 @@
     z-index: 100;
     pointer-events: auto;
     transition: all 0.5s ease;
-    border-color: var(--highcharts-dashboards-edit-cell-color);
+    border-color: var(--highcharts-highlight-color-60);
     box-sizing: border-box;
 }
 
@@ -197,8 +229,8 @@
             45deg,
             rgba(var(--highcharts-dashboards-edit-row-highlight-color), 0.7),
             rgba(var(--highcharts-dashboards-edit-row-highlight-color), 0.7) 10px,
-            var(--highcharts-dashboards-neutral-color-0) 10px,
-            var(--highcharts-dashboards-neutral-color-0) 20px
+            var(--highcharts-neutral-color-0) 10px,
+            var(--highcharts-neutral-color-0) 20px
         );
     opacity: 0.5;
     transition: 0.1s;
@@ -215,7 +247,7 @@
     display: none;
     cursor: grab;
     pointer-events: none;
-    background-color: var(--highcharts-dashboards-main-background-color);
+    background-color: var(--highcharts-background-color);
     box-shadow:
         0 0.4688rem 2.1875rem rgba(var(--highcharts-dashboards-shadow-color), 0.03),
         0 0.9375rem 1.4063rem rgba(var(--highcharts-dashboards-shadow-color), 0.03),
@@ -228,7 +260,7 @@
     z-index: 100;
     display: none;
     pointer-events: none;
-    border: 4px solid var(--highcharts-dashboards-pointer-selected-color);
+    border: 4px solid var(--highcharts-highlight-color-60);
     opacity: 0.5;
 }
 
@@ -237,7 +269,7 @@
     z-index: 101;
     display: none;
     pointer-events: none;
-    border: 2px solid var(--highcharts-dashboards-pointer-color);
+    border: 2px solid var(--highcharts-highlight-color-20);
 }
 
 .w-1-5 {
@@ -262,9 +294,9 @@
 
 .highcharts-dashboards-edit-resize-snap {
     position: absolute;
-    background: var(--highcharts-dashboards-main-background-color);
+    background: var(--highcharts-background-color);
     border-radius: 9999px;
-    border: 1px solid var(--highcharts-dashboards-neutral-color-50);
+    border: 1px solid var(--highcharts-neutral-color-60);
     z-index: 10;
 }
 
@@ -285,13 +317,13 @@
 }
 
 .highcharts-dashboards-edit-resizer-menu-btn-active {
-    color: var(--highcharts-dashboards-sidebar-button-color);
+    color: var(--highcharts-highlight-color-60);
 }
 
 .highcharts-dashboards-cell > .highcharts-dashboards-component .title-wrapper {
     margin: 0;
     padding-bottom: 15px;
-    border-bottom: 1px solid rgba(var(--highcharts-dashboards-blue-border-color), 0.125);
+    border-bottom: 1px solid var(--highcharts-highlight-color-10);
 }
 
 .highcharts-dashboards-toolbar {
@@ -306,13 +338,13 @@
 .highcharts-dashboards-toolbar .tools-row {
     display: inline-block;
     float: left;
-    background-color: var(--highcharts-dashboards-neutral-color-50);
+    background-color: var(--highcharts-neutral-color-60);
     padding: 0 10px;
 }
 
 .highcharts-dashboards-toolbar .tools-cell {
     display: inline-block;
-    background-color: var(--highcharts-dashboards-neutral-color-20);
+    background-color: var(--highcharts-neutral-color-20);
     padding: 0 10px;
 }
 
@@ -361,7 +393,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: var(--highcharts-dashboards-neutral-color-20);
+    background-color: var(--highcharts-neutral-color-20);
     -webkit-transition: 0.4s;
     transition: 0.4s;
     border-radius: 34px;
@@ -374,18 +406,18 @@
     width: 16px;
     left: 4px;
     bottom: 4px;
-    background-color: var(--highcharts-dashboards-neutral-color-0);
+    background-color: var(--highcharts-neutral-color-0);
     -webkit-transition: 0.4s;
     transition: 0.4s;
     border-radius: 50%;
 }
 
 .highcharts-dashboards-edit-toggle-wrapper input:checked + .highcharts-dashboards-edit-toggle-slider {
-    background-color: var(--highcharts-dashboards-pointer-selected-color);
+    background-color: var(--highcharts-highlight-color-60);
 }
 
 .highcharts-dashboards-edit-toggle-wrapper input:focus + .highcharts-dashboards-edit-toggle-slider {
-    box-shadow: 0 0 1px var(--highcharts-dashboards-pointer-selected-color);
+    box-shadow: 0 0 1px var(--highcharts-highlight-color-60);
 }
 
 .highcharts-dashboards-edit-toggle-wrapper input:checked + .highcharts-dashboards-edit-toggle-slider::before {
@@ -410,7 +442,7 @@
 
 /* Edit Mode */
 .highcharts-dashboards-edit-context-menu {
-    background-color: var(--highcharts-dashboards-main-background-color);
+    background-color: var(--highcharts-background-color);
     margin-left: auto;
     border-radius: 3px;
     position: absolute;
@@ -428,19 +460,19 @@
     height: 32px;
     margin-left: auto;
     padding: 5px;
-    border-color: var(--highcharts-dashboards-transparent);
+    border-color: transparent;
     border-radius: 3px;
     float: right;
 }
 
 .highcharts-dashboards-edit-context-menu-btn div {
     height: 4px;
-    background-color: var(--highcharts-dashboards-neutral-color-50);
+    background-color: var(--highcharts-neutral-color-60);
     margin: 0 0 4px;
 }
 
 .highcharts-dashboards-edit-context-menu-btn:hover {
-    border: 1px solid var(--highcharts-dashboards-neutral-color-80);
+    border: 1px solid var(--highcharts-neutral-color-80);
 }
 
 .highcharts-dashboards-edit-menu-item {
@@ -454,18 +486,18 @@
 
 .highcharts-dashboards-edit-context-menu-item {
     padding: 10px 15px;
-    color: var(--highcharts-dashboards-neutral-color-50);
+    color: var(--highcharts-neutral-color-60);
     font-size: 0.876em;
     line-height: 1em;
     cursor: pointer;
 }
 
 .highcharts-dashboards-edit-context-menu-item:hover {
-    color: var(--highcharts-dashboards-main-font-color);
+    color: var(--highcharts-neutral-color-100);
 }
 
 .highcharts-dashboards-edit-separator {
-    background-color: var(--highcharts-dashboards-neutral-color-20);
+    background-color: var(--highcharts-neutral-color-20);
     height: 1px;
     margin: 5px 0;
     padding: 0;
@@ -473,7 +505,7 @@
 }
 
 .highcharts-dashboards-edit-toolbar {
-    color: var(--highcharts-dashboards-neutral-color-50);
+    color: var(--highcharts-neutral-color-60);
     position: absolute;
     z-index: 99;
     border-radius: 3px;
@@ -519,21 +551,21 @@
 }
 
 .highcharts-dashboards-edit-toolbar-cell {
-    background-color: var(--highcharts-dashboards-edit-cell-color);
+    background-color: var(--highcharts-highlight-color-60);
     border-top-right-radius: 5px;
     border-bottom-right-radius: 5px;
-    color: var(--highcharts-dashboards-main-background-color);
+    color: var(--highcharts-background-color);
 }
 
 .highcharts-dashboards-edit-toolbar-cell .highcharts-dashboards-edit-toolbar-item:hover {
-    background-color: var(--highcharts-dashboards-sidebar-button-contrast-color);
+    background-color: var(--highcharts-highlight-color-80);
 }
 
 .highcharts-dashboards-edit-toolbar-cell-outline {
     position: absolute;
     pointer-events: none;
     display: none;
-    border: 2px solid var(--highcharts-dashboards-edit-cell-color);
+    border: 2px solid var(--highcharts-highlight-color-60);
     opacity: 1;
 }
 
@@ -547,7 +579,7 @@
 
 .highcharts-dashboards-edit-menu-vertical-separator {
     height: 1px;
-    background-color: var(--highcharts-dashboards-neutral-color-20);
+    background-color: var(--highcharts-neutral-color-20);
     margin-top: 2px;
     margin-bottom: 2px;
     padding: 0;
@@ -559,8 +591,8 @@
     left: -340px; /* width + paddings */
     transition: 0.5s;
     width: 300px;
-    background-color: var(--highcharts-dashboards-main-background-color);
-    color: var(--highcharts-dashboards-neutral-color-50);
+    background-color: var(--highcharts-background-color);
+    color: var(--highcharts-neutral-color-60);
     position: absolute;
     z-index: 1000;
     min-height: 500px;
@@ -582,8 +614,8 @@
 .highcharts-dashboards-edit-tools-btn {
     display: inline-block;
     padding: 4px 10px 4px 30px;
-    background-color: var(--highcharts-dashboards-transparent);
-    border: 1px solid var(--highcharts-dashboards-transparent);
+    background-color: transparent;
+    border: 1px solid transparent;
     background-repeat: no-repeat;
     background-size: 22px;
     background-position-y: 4px;
@@ -591,7 +623,7 @@
 }
 
 .highcharts-dashboards-edit-tools-btn:hover {
-    border: 1px solid var(--highcharts-dashboards-neutral-color-20);
+    border: 1px solid var(--highcharts-neutral-color-20);
 }
 
 .highcharts-dashboards-edit-sidebar-item {
@@ -601,15 +633,15 @@
 .highcharts-dashboards-edit-sidebar-item input,
 .highcharts-dashboards-edit-sidebar-item textarea,
 .highcharts-dashboards-edit-sidebar-item select {
-    color: var(--highcharts-dashboards-neutral-color-50);
-    border: 1px solid var(--highcharts-dashboards-neutral-color-50);
+    color: var(--highcharts-neutral-color-60);
+    border: 1px solid var(--highcharts-neutral-color-60);
     border-radius: 3px;
 }
 
 .highcharts-dashboards-edit-sidebar .highcharts-dashboards-edit-button,
 .highcharts-dashboards-edit-sidebar-item button {
-    background-color: var(--highcharts-dashboards-edit-cell-color);
-    color: var(--highcharts-dashboards-neutral-color-0);
+    background-color: var(--highcharts-highlight-color-60);
+    color: var(--highcharts-neutral-color-0);
     padding: 5px 10px;
     margin-top: 20px;
     border: none;
@@ -619,14 +651,14 @@
 
 .highcharts-dashboards-edit-sidebar .highcharts-dashboards-edit-button:hover,
 .highcharts-dashboards-edit-sidebar-item button:hover {
-    background-color: var(--highcharts-dashboards-sidebar-button-contrast-color);
+    background-color: var(--highcharts-highlight-color-80);
 }
 
 .highcharts-dashboards-edit-button.highcharts-dashboards-edit-sidebar-button-nav {
     min-width: 34px;
     min-height: 34px;
     background-position: 50% 50%;
-    background-color: var(--highcharts-dashboards-main-background-color);
+    background-color: var(--highcharts-background-color);
 }
 
 .highcharts-dashboards-edit-sidebar-button-nav.highcharts-dashboards-edit-close-btn {
@@ -635,8 +667,8 @@
 }
 
 .highcharts-dashboards-edit-sidebar-button-nav.highcharts-dashboards-edit-close-btn:hover {
-    background-color: var(--highcharts-dashboards-main-background-color);
-    border: 1px solid var(--highcharts-dashboards-sidebar-button-contrast-color);
+    background-color: var(--highcharts-background-color);
+    border: 1px solid var(--highcharts-highlight-color-80);
 }
 
 .highcharts-dashboards-edit-sidebar .highcharts-dashboards-edit-button {
@@ -660,9 +692,9 @@
 }
 
 .highcharts-dashboards-edit-sidebar .highcharts-dashboards-edit-label-text {
-    background: var(--highcharts-dashboards-neutral-color-20);
-    border: 1px solid var(--highcharts-dashboards-neutral-color-20);
-    color: var(--highcharts-dashboards-main-font-color);
+    background: var(--highcharts-neutral-color-20);
+    border: 1px solid var(--highcharts-neutral-color-20);
+    color: var(--highcharts-neutral-color-100);
     font-weight: bold;
     padding: 3px;
     margin-top: 15px;
@@ -670,7 +702,7 @@
 }
 
 .highcharts-dashboards-edit-sidebar-title {
-    color: var(--highcharts-dashboards-neutral-color-80);
+    color: var(--highcharts-neutral-color-80);
     padding: 5px 5px 5px 30px;
     text-transform: uppercase;
     position: relative;
@@ -687,7 +719,7 @@
     width: 24px;
     height: 20px;
     background-size: 20px;
-    background-color: var(--highcharts-dashboards-edit-cell-color);
+    background-color: var(--highcharts-highlight-color-60);
     -webkit-mask-image: url("https://code.highcharts.com/gfx/dashboard-icons/settings.svg");
     mask-image: url("https://code.highcharts.com/gfx/dashboard-icons/settings.svg");
     -webkit-mask-repeat: no-repeat;
@@ -714,7 +746,7 @@
 }
 
 .highcharts-dashboards-edit-grid-items div:hover {
-    background-color: var(--highcharts-dashboards-wrapper-background-color);
+    background-color: var(--highcharts-neutral-color-5);
 }
 
 .highcharts-dashboards-edit-sidebar-tabs {
@@ -728,10 +760,10 @@
 .highcharts-dashboards-edit-sidebar-tab {
     text-align: left;
     padding: 5px;
-    border-bottom: 3px solid var(--highcharts-dashboards-transparent);
+    border-bottom: 3px solid transparent;
     transition: 0.3s;
     font-size: 0.876em;
-    color: var(--highcharts-dashboards-main-font-color);
+    color: var(--highcharts-neutral-color-100);
     margin-left: 25px;
 }
 
@@ -748,8 +780,8 @@
 .highcharts-dashboards-edit-toolbar-tab-active {
     cursor: pointer;
     opacity: 1;
-    border-color: var(--highcharts-dashboards-edit-cell-color);
-    color: var(--highcharts-dashboards-edit-cell-color);
+    border-color: var(--highcharts-highlight-color-60);
+    color: var(--highcharts-highlight-color-60);
 }
 
 .highcharts-dashboards-edit-tabs-buttons-wrapper {
@@ -778,7 +810,7 @@
     display: none;
     left: 50%;
     transform: translate(-50%, 0);
-    background-color: var(--highcharts-dashboards-main-background-color);
+    background-color: var(--highcharts-background-color);
     color: var(--highcharts-neutral-color-60);
     font-size: 0.876em;
     max-height: 90%;
@@ -818,8 +850,8 @@
 
 /* stylelint-disable-next-line max-line-length */
 .highcharts-dashboards-edit-confirmation-popup .highcharts-dashboards-edit-confirmation-popup-content button.highcharts-dashboards-edit-confirmation-popup-confirm-btn {
-    background-color: var(--highcharts-dashboards-red-color);
-    color: var(--highcharts-dashboards-main-font-color);
+    background-color: var(--highcharts-dashboards-danger-color);
+    color: var(--highcharts-neutral-color-100);
 }
 
 .highcharts-dashboards-edit-overlay {
@@ -873,18 +905,18 @@ ul.highcharts-dashboards-dropdown-content {
     display: flex;
     flex-direction: column;
     gap: 4px;
-    background: var(--highcharts-dashboards-main-background-color);
+    background: var(--highcharts-background-color);
     box-sizing: border-box;
     padding: 16px 8px;
     margin-top: 4px;
-    border: 1px solid var(--highcharts-dashboards-dropdown-border-color);
+    border: 1px solid var(--highcharts-neutral-color-60);
     box-shadow: 0 10px 24px rgba(var(--highcharts-dashboards-dropdown-box-shadow-color));
     list-style-type: none;
 }
 
 div.highcharts-dashboards-dropdown {
     position: relative;
-    color: var(--highcharts-dashboards-main-font-color);
+    color: var(--highcharts-neutral-color-100);
     font-weight: 700;
     font-size: 14px;
     display: flex;
@@ -893,7 +925,7 @@ div.highcharts-dashboards-dropdown {
 }
 
 .highcharts-dashboards-dropdown > button.highcharts-dashboards-dropdown-button {
-    color: var(--highcharts-dashboards-main-font-color);
+    color: var(--highcharts-neutral-color-100);
     box-sizing: border-box;
     display: flex;
     justify-content: space-between;
@@ -902,8 +934,8 @@ div.highcharts-dashboards-dropdown {
     padding: 6px 8px;
     margin: 2px;
     gap: 2px;
-    background: var(--highcharts-dashboards-main-background-color);
-    border: 1px solid var(--highcharts-dashboards-dropdown-border-color);
+    background: var(--highcharts-background-color);
+    border: 1px solid var(--highcharts-neutral-color-60);
     border-radius: 2px;
 }
 
@@ -914,16 +946,16 @@ button.highcharts-dashboards-select-option-button {
     align-items: center;
     cursor: pointer;
     margin: 0;
-    background: var(--highcharts-dashboards-main-background-color);
-    color: var(--highcharts-dashboards-main-font-color);
+    background: var(--highcharts-background-color);
+    color: var(--highcharts-neutral-color-100);
 }
 
 button.highcharts-dashboards-select-option-button:hover {
-    background-color: var(--highcharts-dashboards-wrapper-background-color);
+    background-color: var(--highcharts-neutral-color-5);
 }
 
 button.highcharts-dashboards-select-option-button:hover {
-    background-color: var(--highcharts-dashboards-neutral-color-3);
+    background-color: var(--highcharts-neutral-color-5);
 }
 
 /* End of Dropdown */
@@ -933,7 +965,7 @@ button.highcharts-dashboards-select-option-button:hover {
     display: flex;
     margin: 4px 0;
     flex-direction: column;
-    background-color: var(--highcharts-dashboards-main-background-color);
+    background-color: var(--highcharts-background-color);
     border-radius: 2px;
 }
 
@@ -960,7 +992,7 @@ div.highcharts-dashboards-nested-content {
     margin: 12px;
     padding: 4px;
     flex-direction: column;
-    background-color: var(--highcharts-dashboards-neutral-color-5);
+    background-color: var(--highcharts-neutral-color-3);
 }
 
 /* end of nested options dropdown */
@@ -981,17 +1013,17 @@ button.highcharts-dashboards-outer-accordeon-header-btn {
 }
 
 button.highcharts-dashboards-outer-accordeon-header-btn:hover {
-    background-color: var(--highcharts-dashboards-neutral-color-50);
+    background-color: var(--highcharts-neutral-color-60);
 }
 
 div.highcharts-dashboards-outer-accordeon {
     padding: 0;
-    background: var(--highcharts-dashboards-neutral-color-20);
+    background: var(--highcharts-neutral-color-20);
     margin: 8px 0;
     font-style: normal;
     font-weight: 700;
     font-size: 14px;
-    color: var(--highcharts-dashboards-neutral-color-80);
+    color: var(--highcharts-neutral-color-80);
     line-height: 16px;
 }
 

--- a/css/datagrid.css
+++ b/css/datagrid.css
@@ -6,11 +6,33 @@
  * License: www.highcharts.com/license
  */
 
-:root {
+:root,
+.highcharts-light {
     --highcharts-datagrid-grid-color: #dddddd;
+    --highcharts-datagrid-text-color: #000000;
     --highcharts-datagrid-background-color: #ffffff;
     --highcharts-datagrid-header-background-color: #eeeeee;
-    --highcharts-datagrid-row-hover-color: #808080;
+    --highcharts-datagrid-row-hover-color: #e6ebf5;
+    --highcharts-datagrid-highlight-color: rgba(255, 0, 0, 0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --highcharts-datagrid-grid-color: #888888;
+        --highcharts-datagrid-text-color: #ffffff;
+        --highcharts-datagrid-background-color: #444444;
+        --highcharts-datagrid-header-background-color: #666666;
+        --highcharts-datagrid-row-hover-color: #666666;
+        --highcharts-datagrid-highlight-color: rgba(255, 0, 0, 0.5);
+    }
+}
+
+.highcharts-dark {
+    --highcharts-datagrid-grid-color: #888888;
+    --highcharts-datagrid-text-color: #ffffff;
+    --highcharts-datagrid-background-color: #444444;
+    --highcharts-datagrid-header-background-color: #666666;
+    --highcharts-datagrid-row-hover-color: #666666;
     --highcharts-datagrid-highlight-color: rgba(255, 0, 0, 0.5);
 }
 
@@ -19,6 +41,7 @@
     height: 100%;
     box-sizing: border-box;
     border: 1px solid var(--highcharts-datagrid-grid-color);
+    color: var(--highcharts-datagrid-text-color);
 }
 
 .hc-dg-outer-container {

--- a/css/datagrid.css
+++ b/css/datagrid.css
@@ -8,40 +8,84 @@
 
 :root,
 .highcharts-light {
-    --highcharts-datagrid-grid-color: #dddddd;
-    --highcharts-datagrid-text-color: #000000;
-    --highcharts-datagrid-background-color: #ffffff;
-    --highcharts-datagrid-header-background-color: #eeeeee;
-    --highcharts-datagrid-row-hover-color: #e6ebf5;
-    --highcharts-datagrid-highlight-color: rgba(255, 0, 0, 0.5);
+    --highcharts-background-color: #ffffff;
+
+    /* Neutral colors */
+    --highcharts-neutral-color-100: #000000;
+    --highcharts-neutral-color-80: #333333;
+    --highcharts-neutral-color-60: #666666;
+    --highcharts-neutral-color-20: #cccccc;
+    --highcharts-neutral-color-10: #e6e6e6;
+    --highcharts-neutral-color-5: #f2f2f2;
+    --highcharts-neutral-color-3: #f7f7f7;
+    --highcharts-neutral-color-0: #ffffff;
+
+    /* Highlight colors */
+    --highcharts-highlight-color-100: #0022ff;
+    --highcharts-highlight-color-80: #334eff;
+    --highcharts-highlight-color-60: #667aff;
+    --highcharts-highlight-color-20: #ccd3ff;
+    --highcharts-highlight-color-10: #e6e9ff;
 }
 
 @media (prefers-color-scheme: dark) {
     :root {
-        --highcharts-datagrid-grid-color: #888888;
-        --highcharts-datagrid-text-color: #ffffff;
-        --highcharts-datagrid-background-color: #444444;
-        --highcharts-datagrid-header-background-color: #666666;
-        --highcharts-datagrid-row-hover-color: #666666;
-        --highcharts-datagrid-highlight-color: rgba(255, 0, 0, 0.5);
+        /* UI colors */
+        --highcharts-background-color: #333333;
+
+        /*
+            Neutral color variations
+            https://www.highcharts.com/samples/highcharts/css/palette-helper
+        */
+        --highcharts-neutral-color-100: rgb(255, 255, 255);
+        --highcharts-neutral-color-80: rgb(214, 214, 214);
+        --highcharts-neutral-color-60: rgb(173, 173, 173);
+        --highcharts-neutral-color-40: rgb(133, 133, 133);
+        --highcharts-neutral-color-20: rgb(92, 92, 92);
+        --highcharts-neutral-color-10: rgb(71, 71, 71);
+        --highcharts-neutral-color-5: rgb(61, 61, 61);
+        --highcharts-neutral-color-3: rgb(57, 57, 57);
+
+        /* Highlight color variations */
+        --highcharts-highlight-color-100: rgb(122, 167, 255);
+        --highcharts-highlight-color-80: rgb(108, 144, 214);
+        --highcharts-highlight-color-60: rgb(94, 121, 173);
+        --highcharts-highlight-color-20: rgb(65, 74, 92);
+        --highcharts-highlight-color-10: rgb(58, 63, 71);
     }
 }
 
 .highcharts-dark {
-    --highcharts-datagrid-grid-color: #888888;
-    --highcharts-datagrid-text-color: #ffffff;
-    --highcharts-datagrid-background-color: #444444;
-    --highcharts-datagrid-header-background-color: #666666;
-    --highcharts-datagrid-row-hover-color: #666666;
-    --highcharts-datagrid-highlight-color: rgba(255, 0, 0, 0.5);
+    /* UI colors */
+    --highcharts-background-color: #333333;
+
+    /*
+        Neutral color variations
+        https://www.highcharts.com/samples/highcharts/css/palette-helper
+    */
+    --highcharts-neutral-color-100: rgb(255, 255, 255);
+    --highcharts-neutral-color-80: rgb(214, 214, 214);
+    --highcharts-neutral-color-60: rgb(173, 173, 173);
+    --highcharts-neutral-color-40: rgb(133, 133, 133);
+    --highcharts-neutral-color-20: rgb(92, 92, 92);
+    --highcharts-neutral-color-10: rgb(71, 71, 71);
+    --highcharts-neutral-color-5: rgb(61, 61, 61);
+    --highcharts-neutral-color-3: rgb(57, 57, 57);
+
+    /* Highlight color variations */
+    --highcharts-highlight-color-100: rgb(122, 167, 255);
+    --highcharts-highlight-color-80: rgb(108, 144, 214);
+    --highcharts-highlight-color-60: rgb(94, 121, 173);
+    --highcharts-highlight-color-20: rgb(65, 74, 92);
+    --highcharts-highlight-color-10: rgb(58, 63, 71);
 }
 
 .hc-dg-container {
     position: relative;
     height: 100%;
     box-sizing: border-box;
-    border: 1px solid var(--highcharts-datagrid-grid-color);
-    color: var(--highcharts-datagrid-text-color);
+    border: 1px solid var(--highcharts-neutral-color-20);
+    color: var(--highcharts-neutral-color-100);
 }
 
 .hc-dg-outer-container {
@@ -69,8 +113,8 @@
 .hc-dg-cell {
     display: flex;
     align-items: center;
-    border-left: 1px solid var(--highcharts-datagrid-grid-color);
-    border-top: 1px solid var(--highcharts-datagrid-grid-color);
+    border-left: 1px solid var(--highcharts-neutral-color-20);
+    border-top: 1px solid var(--highcharts-neutral-color-20);
     overflow: hidden;
     padding: 0 8px;
     flex: 1;
@@ -86,19 +130,19 @@
     margin: 0 -8px;
     padding: 0 6px;
     box-sizing: border-box;
-    border: 2px solid var(--highcharts-datagrid-highlight-color);
+    border: 2px solid var(--highcharts-highlight-color-100);
     outline: none;
     font: inherit;
 }
 
 .hc-dg-row {
     display: flex;
-    background: var(--highcharts-datagrid-background-color);
+    background: var(--highcharts-background-color);
     width: 100%;
 }
 
 .hc-dg-row.hovered {
-    background-color: var(--highcharts-datagrid-row-hover-color);
+    background-color: var(--highcharts-highlight-color-20);
 }
 
 .hc-dg-row:first-child .hc-dg-cell {
@@ -108,8 +152,8 @@
 .hc-dg-column-header {
     display: flex;
     align-items: center;
-    border-left: 1px solid var(--highcharts-datagrid-grid-color);
-    border-bottom: 1px solid var(--highcharts-datagrid-grid-color);
+    border-left: 1px solid var(--highcharts-neutral-color-20);
+    border-bottom: 1px solid var(--highcharts-neutral-color-20);
     overflow: hidden;
     padding: 0 8px;
     flex: 1;
@@ -123,14 +167,14 @@
 
 .hc-dg-column-headers {
     display: flex;
-    background-color: var(--highcharts-datagrid-header-background-color);
+    background-color: var(--highcharts-neutral-color-10);
     width: 100%;
 }
 
 .hc-dg-col-resize-handle {
     cursor: ew-resize;
     opacity: 0;
-    background-color: var(--highcharts-datagrid-highlight-color);
+    background-color: var(--highcharts-highlight-color-100);
     position: absolute;
     top: 0;
     width: 5px;
@@ -138,7 +182,7 @@
 
 .hc-dg-col-resize-crosshair {
     position: absolute;
-    background-color: var(--highcharts-datagrid-highlight-color);
+    background-color: var(--highcharts-highlight-color-100);
     width: 3px;
     left: 0;
     opacity: 0;

--- a/samples/dashboards/demos/climate/demo.css
+++ b/samples/dashboards/demos/climate/demo.css
@@ -11,7 +11,7 @@
     --color-background: none;
 }
 
-.highcharts-dashboards-wrapper.highcharts-dashboards-dark-mode {
+.highcharts-dashboards-wrapper.highcharts-dark {
     --button-filter: invert(1);
     --color-background: #46475d;
 }
@@ -36,7 +36,7 @@
     --color-text: #2f2b38;
 }
 
-.highcharts-dashboards-wrapper.highcharts-dashboards-dark-mode #kpi-layout {
+.highcharts-dashboards-wrapper.highcharts-dark #kpi-layout {
     --color-axis-labels: #838394;
     --color-background: #0d0d0d;
     --color-pane: #20202c;
@@ -62,7 +62,7 @@
     --color-row2-background: #f7f7f7;
 }
 
-.highcharts-dashboards-wrapper.highcharts-dashboards-dark-mode #selection-grid {
+.highcharts-dashboards-wrapper.highcharts-dark #selection-grid {
     --color-background: #20202c;
     --color-border: #4a4a53;
     --color-header-background: #0d0d0d;
@@ -88,7 +88,7 @@
     --color-thumb-line: #f7f7f7;
 }
 
-.highcharts-dashboards-wrapper.highcharts-dashboards-dark-mode #time-range-selector {
+.highcharts-dashboards-wrapper.highcharts-dark #time-range-selector {
     --color-axis-labels: #e7e7ec;
     --color-background: #0d0d0d;
     --color-grid: #838394;
@@ -116,7 +116,7 @@
     --color-tooltip-background: #dadae2;
 }
 
-.highcharts-dashboards-wrapper.highcharts-dashboards-dark-mode #world-map {
+.highcharts-dashboards-wrapper.highcharts-dark #world-map {
     --color-navigation: #20202b;
     --color-navigation-line: #646478;
     --color-navigation-text: #838393;
@@ -570,7 +570,7 @@ div.highcharts-dashboards-wrapper .highcharts-dashboards-edit-context-menu-btn {
 
 /* Safari fix for manual dark mode */
 /* stylelint-disable-next-line max-line-length */
-.highcharts-dashboards-wrapper.highcharts-dashboards-dark-mode #world-map .highcharts-series-1 .highcharts-data-label text {
+.highcharts-dashboards-wrapper.highcharts-dark #world-map .highcharts-series-1 .highcharts-data-label text {
     paint-order: stroke;
     stroke-width: 2px;
 }

--- a/samples/dashboards/demos/climate/demo.js
+++ b/samples/dashboards/demos/climate/demo.js
@@ -571,17 +571,16 @@ async function setupDashboard() {
                         events: {
                             click: function () {
                                 const board = this.menu.editMode.board,
-                                    darModeClass =
-                                        Dashboards.classNamePrefix + 'dark-mode';
+                                    darkModeClass = 'highcharts-dark';
 
                                 darkMode = !darkMode;
 
                                 if (darkMode) {
                                     board.container.classList
-                                        .add(darModeClass);
+                                        .add(darkModeClass);
                                 } else {
                                     board.container.classList
-                                        .remove(darModeClass);
+                                        .remove(darkModeClass);
                                 }
                             }
                         }

--- a/samples/dashboards/demos/component-highcharts/demo.js
+++ b/samples/dashboards/demos/component-highcharts/demo.js
@@ -20,6 +20,9 @@ Dashboards.board('container', {
         type: 'Highcharts',
         cell: 'cell-id',
         chartOptions: {
+            title: {
+                text: 'Line chart'
+            },
             series: [{
                 data: [1, 2, 3, 2, 3]
             }]
@@ -28,6 +31,9 @@ Dashboards.board('container', {
         type: 'Highcharts',
         cell: 'cell-id-2',
         chartOptions: {
+            title: {
+                text: 'Pie chart'
+            },
             series: [{
                 type: 'pie',
                 data: [1, 2, 3, 2, 3]

--- a/samples/dashboards/demos/light-dark-theme/demo.css
+++ b/samples/dashboards/demos/light-dark-theme/demo.css
@@ -2,6 +2,10 @@
 @import url("https://code.highcharts.com/css/datagrid.css");
 @import url("https://code.highcharts.com/css/dashboards/gui.css");
 
+* {
+    transition: background-color 100ms, color 100ms;
+}
+
 .highcharts-description {
     margin-top: 1em;
 }

--- a/samples/dashboards/demos/light-dark-theme/demo.css
+++ b/samples/dashboards/demos/light-dark-theme/demo.css
@@ -2,6 +2,10 @@
 @import url("https://code.highcharts.com/css/datagrid.css");
 @import url("https://code.highcharts.com/css/dashboards/gui.css");
 
+.highcharts-description {
+    margin-top: 1em;
+}
+
 #csv {
     display: none;
 }

--- a/samples/dashboards/demos/light-dark-theme/demo.html
+++ b/samples/dashboards/demos/light-dark-theme/demo.html
@@ -3,7 +3,30 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/dashboards-plugin.js"></script>
 
-<div id="container">
+<div id="container"></div>
+
+<div class="highcharts-description">
+    This demo uses a tri-state theme selector, where the "Light" option
+    applies default colors, and the "Dark" option applies CSS variables for
+    dark colors. The "System default" option applies those color variables
+    only if <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme">
+    prefers-color-scheme</a> is <code>dark</code>.
+</div>
+
+<h4>Color theme</h4>
+<label>
+    <input type="radio" name="color-mode" value="none" checked>
+    System default
+</label>
+<label>
+    <input type="radio" name="color-mode" value="light">
+    Light
+</label>
+<label>
+    <input type="radio" name="color-mode" value="dark">
+    Dark
+</label>
+
 
 <pre id="csv">Food,Vitamin A
 Beef Liver,6421

--- a/samples/dashboards/demos/light-dark-theme/demo.js
+++ b/samples/dashboards/demos/light-dark-theme/demo.js
@@ -44,9 +44,15 @@ Dashboards.board('container', {
                 Food: 'x',
                 'Vitamin A': 'y'
             },
+            title: {
+                text: 'Column chart'
+            },
             chartOptions: {
                 xAxis: {
                     type: 'category'
+                },
+                title: {
+                    text: ''
                 },
                 chart: {
                     animation: false,
@@ -54,10 +60,7 @@ Dashboards.board('container', {
                 },
                 plotOptions: {
                     series: {
-                        dragDrop: {
-                            draggableY: true,
-                            dragPrecisionY: 1
-                        }
+                        colorByPoint: true
                     }
                 }
             }
@@ -66,9 +69,24 @@ Dashboards.board('container', {
             type: 'DataGrid',
             connector,
             editable: true,
+            title: {
+                text: 'Grid component'
+            },
             sync: {
                 highlight: true
             }
         }
     ]
 });
+
+
+[...document.querySelectorAll('input[name="color-mode"]')]
+    .forEach(input => {
+        input.addEventListener('click', e => {
+            document.getElementById('container').className =
+                e.target.value === 'none' ?
+                    '' :
+                    `highcharts-${e.target.value} ` +
+                    `highcharts-dashboards-${e.target.value}`;
+        });
+    });

--- a/samples/dashboards/demos/light-dark-theme/demo.js
+++ b/samples/dashboards/demos/light-dark-theme/demo.js
@@ -84,9 +84,6 @@ Dashboards.board('container', {
     .forEach(input => {
         input.addEventListener('click', e => {
             document.getElementById('container').className =
-                e.target.value === 'none' ?
-                    '' :
-                    `highcharts-${e.target.value} ` +
-                    `highcharts-dashboards-${e.target.value}`;
+                e.target.value === 'none' ? '' : `highcharts-${e.target.value}`;
         });
     });


### PR DESCRIPTION
Some styling of dashboards and dash demos

* Rounded corners for the components in accordance with the design sketch
* Left and right padding for the component title to match chart and grid components
* Non-default titles for some of the components to make it a tad more lifelike
* Dark mode demo with tri-state switch
* More consistent colors in dark mode. Text colors, impolementation for grid component (using the `.highcharts-light` and `.highcharts-dark` nomenclature.
* Use common variable names. When merged with v11, we get the same naming for neutral and highlight colors. After that we should consider a separate file for the color variables.