### PR TITLE
bugfix/18693-tooltip-stickoncontact-followpointer

### DIFF
--- a/samples/unit-tests/tooltip/stickoncontact/demo.js
+++ b/samples/unit-tests/tooltip/stickoncontact/demo.js
@@ -158,6 +158,50 @@ QUnit.test(
                     { x: tooltipPosition1.x + 1, y: tooltipPosition1.y + 1 },
                     'Tooltip should move with pointer movement.'
                 );
+
+                chart.update({
+                    tooltip: {
+                        followPointer: false
+                    }
+                }, false);
+
+                chart.series[0].update({
+                    type: 'column',
+                    tooltip: {
+                        followPointer: true
+                    }
+                }, false);
+
+                chart.addSeries({
+                    type: 'scatter',
+                    data: [0]
+                });
+
+                const columnBox = chart.series[0].points[0].graphic.getBBox(),
+                    pointBox2 = chart.series[1].points[0].graphic.getBBox();
+
+                controller.moveTo(
+                    columnBox.x + chart.plotLeft + (columnBox.width / 2),
+                    columnBox.y + chart.plotTop + (columnBox.height / 2)
+                );
+
+                controller.moveTo(
+                    pointBox2.x + chart.plotLeft + (pointBox2.width / 2),
+                    pointBox2.y + chart.plotTop + (pointBox2.height / 2)
+                );
+
+                controller.moveTo(
+                    columnBox.x + chart.plotLeft + (columnBox.width / 2),
+                    columnBox.y + chart.plotTop + (columnBox.height / 2)
+                );
+                assert.notEqual(
+                    tooltip.label.visibility,
+                    'hidden',
+                    `There should be no errors in the console and tooltip should
+                    be visible, when moving mouse between one series with
+                    followPointer set to true and second series set to false
+                    (#18693).`
+                );
             }
         );
     }

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1631,8 +1631,8 @@ class Tooltip {
         const tooltip = this;
 
         if (!this.shouldStickOnContact()) {
-            if (tooltip.tracker && Object.keys(tooltip.tracker).length) {
-                tooltip.tracker.destroy();
+            if (tooltip.tracker) {
+                tooltip.tracker = tooltip.tracker.destroy();
             }
             return;
         }
@@ -1679,7 +1679,7 @@ class Tooltip {
                 Math.max(Math.abs(anchorPos[1]), labelBBox.height)
         );
 
-        if (tooltip.tracker && Object.keys(tooltip.tracker).length) {
+        if (tooltip.tracker) {
             tooltip.tracker.attr(box);
         } else {
             tooltip.tracker = label.renderer

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1631,7 +1631,7 @@ class Tooltip {
         const tooltip = this;
 
         if (!this.shouldStickOnContact()) {
-            if (tooltip.tracker) {
+            if (tooltip.tracker && Object.keys(tooltip.tracker).length) {
                 tooltip.tracker.destroy();
             }
             return;
@@ -1679,7 +1679,7 @@ class Tooltip {
                 Math.max(Math.abs(anchorPos[1]), labelBBox.height)
         );
 
-        if (tooltip.tracker) {
+        if (tooltip.tracker && Object.keys(tooltip.tracker).length) {
             tooltip.tracker.attr(box);
         } else {
             tooltip.tracker = label.renderer


### PR DESCRIPTION
Fixed #18693, `tooltip.stickOnContact` threw errors on hover between one series with `followPointer` set to true and the second series `followPointer` set to false.