### PR TITLE
18801-legend-pages-mac-firefox

### DIFF
--- a/samples/unit-tests/legend/navigation/demo.js
+++ b/samples/unit-tests/legend/navigation/demo.js
@@ -22,7 +22,7 @@ QUnit.test(
 
         chart.update({
             chart: {
-                width: 400
+                width: 440
             },
             legend: {
                 maxHeight: 40,

--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -1381,7 +1381,8 @@ class Legend {
                     // check the last item
                     i === allItems.length - 1 &&
                     // if adding next page is needed (#18768)
-                    y + h - pages[len - 1] > clipHeight
+                    y + h - pages[len - 1] > clipHeight &&
+                    y > pages[len - 1]
                 ) {
                     pages.push(y);
                     legendItem.pageIx = len;


### PR DESCRIPTION
Fixed test added in #18801 that didn't work in Firefox on Mac due to specific font handling.