### PR TITLE
bugfix/18790-custom-symbol-marker-position

### DIFF
--- a/samples/unit-tests/svgrenderer/symbol/demo.js
+++ b/samples/unit-tests/svgrenderer/symbol/demo.js
@@ -276,4 +276,23 @@ QUnit.test('Image', assert => {
         TestUtilities.lolexUninstall(clock);
         throw error;
     }
+
+    symbol1.imgwidth = 56;
+    symbol1.imgheight = 150;
+    symbol1.attr({
+        width: 0,
+        height: 0
+    });
+
+    assert.equal(
+        symbol1.translateX,
+        -symbol1.imgwidth / 2,
+        'Symbol should be correctly centered in X (#18790)'
+    );
+
+    assert.equal(
+        symbol1.translateY,
+        -symbol1.imgheight / 2,
+        'Symbol should be correctly centered in Y (#18790)'
+    );
 });

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -1497,8 +1497,8 @@ class SVGRenderer implements SVGRendererLike {
 
                         if (!alignByTranslate) {
                             this.translate(
-                                ((width || 0) - (imgSize * scale)) / 2,
-                                ((height || 0) - (imgSize * scale)) / 2
+                                ((width || 0) - (imgwidth * scale)) / 2,
+                                ((height || 0) - (imgheight * scale)) / 2
                             );
                         }
                     }


### PR DESCRIPTION
Fixed #18790, custom symbols were incorrectly positioned in some cases.