### PR TITLE
bugfix/18066-categories-xaxis-unwanted-label

### DIFF
--- a/samples/unit-tests/series/softthreshold/demo.js
+++ b/samples/unit-tests/series/softthreshold/demo.js
@@ -138,6 +138,20 @@ QUnit.test('Soft threshold', function (assert) {
         [0, 10],
         'Hard max and flat data and minRange'
     );
+
+    chart.xAxis[0].update({
+        categories: ['cat1', 'cat2']
+    }, false);
+    chart.series[0].points[2].remove(false);
+    chart.series[0].points[1].remove();
+
+    assert.strictEqual(
+        chart.xAxis[0].tickPositions.length,
+        1,
+        `There shouldn't be visible unwanted ticks after updating the series,
+        minRange should be updated based on data if not set in chart
+        configuration (#18066).`
+    );
 });
 
 QUnit.test('Soft threshold = false', function (assert) {

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1240,7 +1240,7 @@ class Axis {
         // Set the automatic minimum range based on the closest point distance
         if (
             axis.isXAxis &&
-            typeof axis.minRange === 'undefined' &&
+            !defined(axis.userMinRange) && // #18066
             !log
         ) {
 


### PR DESCRIPTION
Fixed #18066, after updating the series data to one point with category xAxis there were unwanted labels.