### PR TITLE
bugfix/18103-y-zoom-inverted-issue

### DIFF
--- a/samples/unit-tests/chart/zoomtype/demo.js
+++ b/samples/unit-tests/chart/zoomtype/demo.js
@@ -2,7 +2,7 @@ QUnit.test('Zoom type', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {
             type: 'line',
-            zoomType: 'x',
+            zoomType: 'y',
             width: 600,
             height: 300
         },
@@ -81,6 +81,21 @@ QUnit.test('Zoom type', function (assert) {
         chart.resetZoomButton.translateY - chart.plotTop,
         buttonY,
         'The zoom button should have been re-aligned'
+    );
+
+    chart.zoomOut();
+    chart.update({
+        chart: {
+            inverted: true
+        }
+    });
+    const plotTop = chart.plotTop;
+
+    // zoom at the top of the plot
+    controller.pan([500, plotTop + 10], [530, plotTop + 10]);
+    assert.ok(
+        chart.resetZoomButton,
+        'Y zoom should work when panning at the top of the plot on inverted chart (#18103)'
     );
 });
 

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -770,7 +770,8 @@ class Chart {
 
         if (!options.ignoreY && e.isInsidePlot) {
             const yAxis = (
-                options.axis && !options.axis.isXAxis && options.axis
+                !inverted && options.axis &&
+                !options.axis.isXAxis && options.axis
             ) || (
                 series && (inverted ? series.xAxis : series.yAxis)
             ) || {


### PR DESCRIPTION
Fixed #18103, Y zoom while panning on top of the plot when chart inverted was not working.