### PR TITLE
bugfix/17006-datalabels-series-opacity

### DIFF
--- a/samples/unit-tests/datalabels/multiple-labels/demo.js
+++ b/samples/unit-tests/datalabels/multiple-labels/demo.js
@@ -192,4 +192,17 @@ QUnit.test('Multiple data labels general tests.', function (assert) {
         result,
         'All data labels should be visible when chart is inverted (#12370).'
     );
+
+    const newOpacity = 0.4;
+
+    chart.series[0].update({
+        opacity: newOpacity
+    });
+
+    assert.strictEqual(
+        chart.series[0].dataLabelsGroup.opacity,
+        newOpacity,
+        `Data labels should inherit the opacity from the series on the initial
+        render (#17006).`
+    );
 });

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -518,7 +518,7 @@ namespace DataLabel {
                     (group[
                         seriesOptions.animation ? 'animate' : 'attr'
                     ] as any)(
-                        { opacity: 1 },
+                        { opacity: seriesOptions.opacity }, // #17006
                         animationConfig
                     );
                 }


### PR DESCRIPTION
Fixed #17006, data labels should inherit the series opacity.