### PR TITLE
Fixed error on doc build

### DIFF
--- a/docs/sonification/advanced-mapping.md
+++ b/docs/sonification/advanced-mapping.md
@@ -73,7 +73,7 @@ For instrument tracks, pitch mapping has a few extra features compared to the ot
 
 **Human readable note names:**
 
-Note pitches can be declared both as numbers or as human readable strings. As numbers, they denote a semitone offset from the "c0" note. As strings, they take the form "<note><octave>", for example `a5`, `Eb4`, or `g#7`.
+Note pitches can be declared both as numbers or as human readable strings. As numbers, they denote a semitone offset from the "c0" note. As strings, they take the form `<note><octave>`, for example `a5`, `Eb4`, or `g#7`.
 
     mapping: {
         volume: 0.7,


### PR DESCRIPTION
The `<octave>` was interpreted as an element missing a closing tag, which the doc-builder builder did not allow