### PR TITLE
bugfix/18884-sunburst-circular-labels

### DIFF
--- a/ts/Series/Sunburst/SunburstPoint.ts
+++ b/ts/Series/Sunburst/SunburstPoint.ts
@@ -104,11 +104,17 @@ class SunburstPoint extends TreemapPoint {
             end = -Math.PI / 360;
             upperHalf = true;
         }
-        // Check if dataLabels should be render in the
-        // upper half of the circle
+        // Check if dataLabels should be render in the upper half of the circle
         if (end - start > Math.PI) {
             upperHalf = false;
             moreThanHalf = true;
+
+            // Close to the full circle, add some padding so that the SVG
+            // renderer treats it as separate points (#18884).
+            if ((end - start) > 2 * Math.PI - 0.01) {
+                start += 0.01;
+                end -= 0.01;
+            }
         }
 
         if (this.dataLabelPath) {


### PR DESCRIPTION
Fixed #18884, sunburst circular labels did not work when the difference in value was small..

**Demo of the problem:** https://jsfiddle.net/BlackLabel/4hqxa3s0/
**After fix:** https://jsfiddle.net/BlackLabel/fjrus9pw/