### PR TITLE
bugfix/18876-tooltip-update-userOptions

### DIFF
--- a/samples/unit-tests/tooltip/pointformat/demo.js
+++ b/samples/unit-tests/tooltip/pointformat/demo.js
@@ -11,23 +11,25 @@ QUnit.test('Repetetive formats', function (assert) {
             width: 200,
             height: 200
         },
+        series: [{
+            data: [1.11]
+        }]
+    });
+
+    chart.update({
         tooltip: {
             headerFormat: '',
             pointFormat: '{point.y} - {point.y}',
             valuePrefix: 'NOK '
-        },
-        series: [
-            {
-                data: [1.11]
-            }
-        ]
+        }
     });
 
     chart.series[0].points[0].onMouseOver();
     assert.strictEqual(
         chart.tooltip.label.text.element.textContent,
         'NOK 1,11 - NOK 1,11',
-        'Formatting should be preserved when repeated (#8101)'
+        `Formatting should be preserved when repeated (#8101) and tooltip should
+        be updated (#18876).`
     );
 
     // Reset

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -830,8 +830,7 @@ class Series {
         const typeOptions = (e.plotOptions as any)[this.type],
             userPlotOptions = (
                 userOptions.plotOptions || {} as SeriesTypePlotOptions
-            ),
-            typeUserPlotOptions = userPlotOptions && userPlotOptions[this.type];
+            );
 
         // use copy to prevent undetected changes (#9762)
         /**
@@ -842,16 +841,13 @@ class Series {
         this.userOptions = e.userOptions;
 
         const options: SeriesTypeOptions = merge(
-                typeOptions,
-                plotOptions && plotOptions.series,
-                // #3881, chart instance plotOptions[type] should trump
-                // plotOptions.series
-                typeUserPlotOptions,
-                seriesUserOptions
-            ),
-            defaultTypePlotOptions = defaultOptions.plotOptions &&
-                defaultOptions.plotOptions[this.type],
-            typePlotOptions = plotOptions && plotOptions[this.type];
+            typeOptions,
+            plotOptions?.series,
+            // #3881, chart instance plotOptions[type] should trump
+            // plotOptions.series
+            userPlotOptions?.[this.type],
+            seriesUserOptions
+        );
 
         // The tooltip options are merged between global and series specific
         // options. Importance order asscendingly:
@@ -861,23 +857,15 @@ class Series {
         // (7)this series options
         this.tooltipOptions = merge(
             defaultOptions.tooltip, // 1
-            (
-                defaultOptions.plotOptions &&
-                defaultOptions.plotOptions.series &&
-                defaultOptions.plotOptions.series.tooltip
-            ), // 2
-            defaultTypePlotOptions && defaultTypePlotOptions.tooltip, // 3
+            defaultOptions.plotOptions?.series?.tooltip, // 2
+            defaultOptions.plotOptions?.[this.type]?.tooltip, // 3
             (
                 defaultOptions.tooltip &&
                 chartOptions.tooltip &&
                 cleanRecursively(chartOptions.tooltip, defaultOptions.tooltip)
             ), // 4 - #18876 take only "userOptions" (calculate them)
-            (
-                plotOptions &&
-                plotOptions.series &&
-                plotOptions.series.tooltip
-            ), // 5
-            typePlotOptions && typePlotOptions.tooltip, // 6
+            plotOptions?.series?.tooltip, // 5
+            plotOptions?.[this.type]?.tooltip, // 6
             seriesUserOptions.tooltip // 7
         );
 
@@ -885,8 +873,8 @@ class Series {
         // unless user says otherwise.
         this.stickyTracking = pick(
             seriesUserOptions.stickyTracking,
-            typeUserPlotOptions && typeUserPlotOptions.stickyTracking,
-            userPlotOptions.series && userPlotOptions.series.stickyTracking,
+            userPlotOptions?.[this.type]?.stickyTracking,
+            userPlotOptions?.series?.stickyTracking,
             (
                 this.tooltipOptions.shared && !this.noSharedTooltip ?
                     true :

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1739,8 +1739,6 @@ class Tooltip {
      */
     public update(options: TooltipOptions): void {
         this.destroy();
-        // Update user options (#6218)
-        merge(true, (this.chart.options.tooltip as any).userOptions, options);
         this.init(this.chart, merge(true, this.options, options));
     }
 


### PR DESCRIPTION
Fixed #18876, updating the `tooltip` didn't work when wasn't declared in the chart configuration.

_______

I have also removed some castings to `any` around the code I have added a fix.