### PR TITLE
docs/18881-stacked-area-connectnulls

### DIFF
--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -276,6 +276,9 @@ const seriesDefaults: PlotOptionsOf<Series> = {
      * Whether to connect a graph line across null points, or render a gap
      * between the two points on either side of the null.
      *
+     * In stacked area chart, if connectNulls is set to true,
+     * null points are interpreted as 0.
+     *
      * @sample {highcharts} highcharts/plotoptions/series-connectnulls-false/
      *         False by default
      * @sample {highcharts} highcharts/plotoptions/series-connectnulls-true/


### PR DESCRIPTION
Fixed #18881, added information about different `connectNulls` behaviour in stacked area.