### PR TITLE
Added support for axis offset in percent

### DIFF
--- a/samples/highcharts/yaxis/offset-centered/demo.css
+++ b/samples/highcharts/yaxis/offset-centered/demo.css
@@ -1,4 +1,5 @@
 #container {
-    width: 400px;
-    height: 400px;
+    max-width: 600px;
+    min-width: 360px;
+    margin: 0 auto;
 }

--- a/samples/highcharts/yaxis/offset-centered/demo.details
+++ b/samples/highcharts/yaxis/offset-centered/demo.details
@@ -1,5 +1,5 @@
 ---
- name: Highcharts Demo
+ name: Centered axes
  authors:
    - Torstein Hønsi
  js_wrap: b

--- a/samples/highcharts/yaxis/offset-centered/demo.js
+++ b/samples/highcharts/yaxis/offset-centered/demo.js
@@ -1,10 +1,14 @@
 Highcharts.chart('container', {
 
-    chart: {
+    _chart: {
         marginTop: 50,
         marginBottom: 50,
         marginLeft: 50,
         marginRight: 50
+    },
+
+    title: {
+        text: 'Centered axes'
     },
 
     xAxis: {
@@ -13,7 +17,10 @@ Highcharts.chart('container', {
         max: 5,
         tickInterval: 1,
         lineColor: 'black',
-        offset: -150
+        offset: '-50%',
+        labels: {
+            reserveSpace: false
+        }
     },
     yAxis: {
         min: -5,
@@ -21,7 +28,10 @@ Highcharts.chart('container', {
         tickInterval: 1,
         lineWidth: 1,
         lineColor: 'black',
-        offset: -150,
+        offset: '-50%',
+        labels: {
+            reserveSpace: false
+        },
         title: {
             text: null
         }

--- a/samples/unit-tests/axis/title/demo.js
+++ b/samples/unit-tests/axis/title/demo.js
@@ -306,12 +306,9 @@ QUnit.test('title.reserveSpace', function (assert) {
                 reserveSpaceTrue < reserveSpaceFalse :
                 reserveSpaceTrue > reserveSpaceFalse,
             axisName +
-                ': reserveSpaceTrue ' +
-                dir +
-                ' ' +
+                `: reserveSpaceTrue (${dir} = ${reserveSpaceTrue}) ` +
                 (lessThan ? '<' : '>') +
-                ' reserveSpaceFalse ' +
-                dir
+                ` reserveSpaceFalse (${dir} = ${reserveSpaceFalse})`
         );
         assert.equal(
             reserveSpaceFalse,

--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -1375,8 +1375,12 @@ namespace AxisDefaults {
          */
 
         /**
-         * The distance in pixels from the plot area to the axis line.
-         * A positive offset moves the axis with it's line, labels and ticks
+         * The distance from the plot area to the axis line. A numeric value
+         * means pixels. A percentage string offsets the axis by a percentage
+         * of the plot area size, so `-50%` will render it in the middle of the
+         * plot.
+         *
+         * A positive offset moves the axis with its line, labels and ticks
          * away from the plot area. This is typically used when two or more
          * axes are displayed on the same side of the plot. With multiple
          * axes the offset is dynamically adjusted to avoid collision, this
@@ -1385,11 +1389,11 @@ namespace AxisDefaults {
          * @sample {highcharts} highcharts/yaxis/offset/
          *         Y axis offset of 70
          * @sample {highcharts} highcharts/yaxis/offset-centered/
-         *         Axes positioned in the center of the plot
+         *         Percentage offset
          * @sample {highstock} stock/xaxis/offset/
          *         Y axis offset by 70 px
          *
-         * @type {number}
+         * @type {number|string}
          */
         offset: void 0,
 

--- a/ts/Core/Axis/AxisOptions.d.ts
+++ b/ts/Core/Axis/AxisOptions.d.ts
@@ -156,7 +156,7 @@ export interface AxisOptions {
     minPadding: number;
     minRange?: number;
     minTickInterval?: number;
-    offset?: number;
+    offset?: number|string;
     offsets?: [number, number, number, number];
     opposite: boolean;
     ordinal?: boolean;

--- a/ts/Core/Axis/RadialAxis.ts
+++ b/ts/Core/Axis/RadialAxis.ts
@@ -978,7 +978,8 @@ namespace RadialAxis {
             // Gauges
             this.startAngleRad = start;
             this.endAngleRad = end;
-            this.offset = options.offset || 0;
+            this.offset = typeof options.offset === 'number' ?
+                options.offset : 0;
 
             // Normalize Start and End to <0, 2*PI> range
             // (in degrees: <0,360>)


### PR DESCRIPTION
Added support for `xAxis.offset` and `yAxis.offset` in percent.

___

Makes it easier to make centered axes without knowing the pixel size of the chart
<img width="525" alt="Skjermbilde 2023-04-29 kl  08 14 09" src="https://user-images.githubusercontent.com/227836/235287106-ca5d312f-78c1-47b1-80a9-22dedc9dec11.png">
