### PR TITLE
Fixed #18928, tooltip not showing when one chart hidden

### DIFF
--- a/samples/unit-tests/svgrenderer/shadows/demo.js
+++ b/samples/unit-tests/svgrenderer/shadows/demo.js
@@ -40,7 +40,7 @@ QUnit.test('Series shadows', function (assert) {
 
     assert.strictEqual(
         chart.series[0].graph.attr('filter'),
-        'url(#drop-shadow-0)',
+        `url(#highcharts-drop-shadow-${chart.index})`,
         'Shadows should be updated when old options defined as object and new as boolean (#12091).'
     );
 

--- a/samples/unit-tests/svgrenderer/shadows/demo.js
+++ b/samples/unit-tests/svgrenderer/shadows/demo.js
@@ -1,28 +1,18 @@
 QUnit.test('Series shadows', function (assert) {
     var chart = Highcharts.chart('container', {
-            series: [
-                {
-                    shadow: {
-                        color: 'red',
-                        width: 10,
-                        offsetX: 40,
-                        offsetY: -20,
-                        opacity: 0.05
-                    },
-                    data: [29, 71, 106, 129, 144]
-                }
-            ]
-        }),
-        attributes = [
-            'stroke="blue"',
-            'stroke-opacity="0.2"',
-            'transform="translate(0, 20)'
-        ],
-        defaultAttributes = [
-            'stroke="#000000"',
-            'stroke-opacity="0.15"',
-            'transform="translate(1, 1)'
-        ];
+        series: [
+            {
+                shadow: {
+                    color: 'red',
+                    width: 10,
+                    offsetX: 40,
+                    offsetY: -20,
+                    opacity: 0.05
+                },
+                data: [29, 71, 106, 129, 144]
+            }
+        ]
+    });
 
     chart.series[0].update({
         shadow: {
@@ -50,7 +40,7 @@ QUnit.test('Series shadows', function (assert) {
 
     assert.strictEqual(
         chart.series[0].graph.attr('filter'),
-        'url(#drop-shadow)',
+        'url(#drop-shadow-0)',
         'Shadows should be updated when old options defined as object and new as boolean (#12091).'
     );
 
@@ -65,12 +55,6 @@ QUnit.test('Series shadows', function (assert) {
             }
         ]
     });
-
-    attributes = [
-        'stroke="red"',
-        'stroke-opacity="0.3"',
-        'transform="translate(10, 5)'
-    ];
 
     chart.series[0].update({
         shadow: {

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -601,7 +601,7 @@ class SVGRenderer implements SVGRendererLike {
     ): string {
         const
             id = [
-                `drop-shadow-${this.chartIndex}`,
+                `highcharts-drop-shadow-${this.chartIndex}`,
                 ...Object.keys(shadowOptions)
                     .map((key: string): number|string =>
                         (shadowOptions as any)[key]

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -601,7 +601,7 @@ class SVGRenderer implements SVGRendererLike {
     ): string {
         const
             id = [
-                'drop-shadow',
+                `drop-shadow-${this.chartIndex}`,
                 ...Object.keys(shadowOptions)
                     .map((key: string): number|string =>
                         (shadowOptions as any)[key]

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -1297,6 +1297,8 @@ function getStyle(
     prop: string,
     toInt?: boolean
 ): (number|string|undefined) {
+    const customGetStyle: typeof getStyle = (H as any).getStyle || getStyle;
+
     let style: (number|string|undefined);
 
     // For width and height, return the actual inner pixel size (#4913)
@@ -1322,8 +1324,8 @@ function getStyle(
             0, // #8377
             (
                 offsetWidth -
-                (getStyle(el, 'padding-left', true) || 0) -
-                (getStyle(el, 'padding-right', true) || 0)
+                (customGetStyle(el, 'padding-left', true) || 0) -
+                (customGetStyle(el, 'padding-right', true) || 0)
             )
         );
     }
@@ -1333,8 +1335,8 @@ function getStyle(
             0, // #8377
             (
                 Math.min(el.offsetHeight, el.scrollHeight) -
-                (getStyle(el, 'padding-top', true) || 0) -
-                (getStyle(el, 'padding-bottom', true) || 0)
+                (customGetStyle(el, 'padding-top', true) || 0) -
+                (customGetStyle(el, 'padding-bottom', true) || 0)
             )
         );
     }

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -1297,8 +1297,6 @@ function getStyle(
     prop: string,
     toInt?: boolean
 ): (number|string|undefined) {
-    const customGetStyle: typeof getStyle = (H as any).getStyle || getStyle;
-
     let style: (number|string|undefined);
 
     // For width and height, return the actual inner pixel size (#4913)
@@ -1324,8 +1322,8 @@ function getStyle(
             0, // #8377
             (
                 offsetWidth -
-                (customGetStyle(el, 'padding-left', true) || 0) -
-                (customGetStyle(el, 'padding-right', true) || 0)
+                (getStyle(el, 'padding-left', true) || 0) -
+                (getStyle(el, 'padding-right', true) || 0)
             )
         );
     }
@@ -1335,8 +1333,8 @@ function getStyle(
             0, // #8377
             (
                 Math.min(el.offsetHeight, el.scrollHeight) -
-                (customGetStyle(el, 'padding-top', true) || 0) -
-                (customGetStyle(el, 'padding-bottom', true) || 0)
+                (getStyle(el, 'padding-top', true) || 0) -
+                (getStyle(el, 'padding-bottom', true) || 0)
             )
         );
     }


### PR DESCRIPTION
Fixed #18928, a regression in v11 causing the tooltip to not display in subsequent charts when the first chart in the web page was hidden.
___
Closes #18920 