### PR TITLE
Fixed #18927, shadow of split tooltip left artifacts in Safari

### DIFF
--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -31,7 +31,7 @@ import type TooltipOptions from './TooltipOptions';
 import F from './FormatUtilities.js';
 const { format } = F;
 import H from './Globals.js';
-const { doc } = H;
+const { doc, isSafari } = H;
 import { Palette } from './Color/Palettes.js';
 import R from './Renderer/RendererUtilities.js';
 const { distribute } = R;
@@ -1573,6 +1573,18 @@ class Tooltip {
             container.style.left = boxExtremes.left + 'px';
             container.style.top = chartTop + 'px';
         }
+
+        // Workaround for #18927, artefacts left by the shadows of split
+        // tooltips in Safari v16 (2023). Check again with later versions if we
+        // can remove this.
+        if (isSafari) {
+            tooltipLabel.attr({
+                // Force a redraw of the whole group by chaning the opacity
+                // slightly
+                opacity: tooltipLabel.opacity === 1 ? 0.999 : 1
+            });
+        }
+
     }
 
     /**


### PR DESCRIPTION
Fixed #18927, a regression in Safari, causing artifacts left by the shadows of split tooltip elements after they moved.
___
Reviewer note @karolkolodziej - I didn't add unit tests because this issue is so deep in the rendering internals of Safari that we don't know how to test it.