### PR TITLE
Tools: Removed UMD factory from ESM masters declarations.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -260,17 +260,17 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.321.1.tgz",
-      "integrity": "sha512-SndPRdeofP2j1kPDLoPbJL8DzzjSciFb1S+Tda3UljOy9gQl68OAruwKloXHJE8GRkLJnYowlwLu36H1MvADJg==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.327.0.tgz",
+      "integrity": "sha512-gEchcni8JwSlU8vz+jn1Up9Rn8uMQdq/qB776tMaxWFBlruGIn71yN2/TYEzF7VRPvmpwNPWA6ox16fJ/7y2dw==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.321.1",
+        "@aws-sdk/client-sts": "3.327.0",
         "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/credential-provider-node": "3.321.1",
+        "@aws-sdk/credential-provider-node": "3.327.0",
         "@aws-sdk/eventstream-serde-browser": "3.310.0",
         "@aws-sdk/eventstream-serde-config-resolver": "3.310.0",
         "@aws-sdk/eventstream-serde-node": "3.310.0",
@@ -281,35 +281,35 @@
         "@aws-sdk/invalid-dependency": "3.310.0",
         "@aws-sdk/md5-js": "3.310.0",
         "@aws-sdk/middleware-bucket-endpoint": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.310.0",
-        "@aws-sdk/middleware-endpoint": "3.310.0",
-        "@aws-sdk/middleware-expect-continue": "3.310.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.310.0",
-        "@aws-sdk/middleware-host-header": "3.310.0",
-        "@aws-sdk/middleware-location-constraint": "3.310.0",
-        "@aws-sdk/middleware-logger": "3.310.0",
-        "@aws-sdk/middleware-recursion-detection": "3.310.0",
-        "@aws-sdk/middleware-retry": "3.310.0",
-        "@aws-sdk/middleware-sdk-s3": "3.310.0",
-        "@aws-sdk/middleware-serde": "3.310.0",
-        "@aws-sdk/middleware-signing": "3.310.0",
-        "@aws-sdk/middleware-ssec": "3.310.0",
-        "@aws-sdk/middleware-stack": "3.310.0",
-        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/middleware-content-length": "3.325.0",
+        "@aws-sdk/middleware-endpoint": "3.325.0",
+        "@aws-sdk/middleware-expect-continue": "3.325.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.326.0",
+        "@aws-sdk/middleware-host-header": "3.325.0",
+        "@aws-sdk/middleware-location-constraint": "3.325.0",
+        "@aws-sdk/middleware-logger": "3.325.0",
+        "@aws-sdk/middleware-recursion-detection": "3.325.0",
+        "@aws-sdk/middleware-retry": "3.327.0",
+        "@aws-sdk/middleware-sdk-s3": "3.326.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/middleware-signing": "3.325.0",
+        "@aws-sdk/middleware-ssec": "3.325.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/middleware-user-agent": "3.327.0",
         "@aws-sdk/node-config-provider": "3.310.0",
         "@aws-sdk/node-http-handler": "3.321.1",
         "@aws-sdk/protocol-http": "3.310.0",
         "@aws-sdk/signature-v4-multi-region": "3.310.0",
-        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/smithy-client": "3.325.0",
         "@aws-sdk/types": "3.310.0",
         "@aws-sdk/url-parser": "3.310.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
-        "@aws-sdk/util-defaults-mode-node": "3.316.0",
-        "@aws-sdk/util-endpoints": "3.319.0",
-        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
+        "@aws-sdk/util-defaults-mode-node": "3.325.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "@aws-sdk/util-retry": "3.327.0",
         "@aws-sdk/util-stream-browser": "3.310.0",
         "@aws-sdk/util-stream-node": "3.321.1",
         "@aws-sdk/util-user-agent-browser": "3.310.0",
@@ -325,9 +325,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.321.1.tgz",
-      "integrity": "sha512-ecoT4tBGtRJR5G7oLBTMXZmgZZlff1amhSdKPEtkWxv6kWc8VPb5rRuRgVPsDR9HuesI6ZVlODptvGtnfkIJwA==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.327.0.tgz",
+      "integrity": "sha512-4cJzDs5GHSED47QYo3LSgqX+CBtKV0lp6HugkX5pvERB+FGCNLenUcSzyU93BCV2oWUP4K+m7dxV6h3RmD4/ow==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -336,28 +336,28 @@
         "@aws-sdk/fetch-http-handler": "3.310.0",
         "@aws-sdk/hash-node": "3.310.0",
         "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.310.0",
-        "@aws-sdk/middleware-endpoint": "3.310.0",
-        "@aws-sdk/middleware-host-header": "3.310.0",
-        "@aws-sdk/middleware-logger": "3.310.0",
-        "@aws-sdk/middleware-recursion-detection": "3.310.0",
-        "@aws-sdk/middleware-retry": "3.310.0",
-        "@aws-sdk/middleware-serde": "3.310.0",
-        "@aws-sdk/middleware-stack": "3.310.0",
-        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/middleware-content-length": "3.325.0",
+        "@aws-sdk/middleware-endpoint": "3.325.0",
+        "@aws-sdk/middleware-host-header": "3.325.0",
+        "@aws-sdk/middleware-logger": "3.325.0",
+        "@aws-sdk/middleware-recursion-detection": "3.325.0",
+        "@aws-sdk/middleware-retry": "3.327.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/middleware-user-agent": "3.327.0",
         "@aws-sdk/node-config-provider": "3.310.0",
         "@aws-sdk/node-http-handler": "3.321.1",
         "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/smithy-client": "3.325.0",
         "@aws-sdk/types": "3.310.0",
         "@aws-sdk/url-parser": "3.310.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
-        "@aws-sdk/util-defaults-mode-node": "3.316.0",
-        "@aws-sdk/util-endpoints": "3.319.0",
-        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
+        "@aws-sdk/util-defaults-mode-node": "3.325.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "@aws-sdk/util-retry": "3.327.0",
         "@aws-sdk/util-user-agent-browser": "3.310.0",
         "@aws-sdk/util-user-agent-node": "3.310.0",
         "@aws-sdk/util-utf8": "3.310.0",
@@ -368,9 +368,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.321.1.tgz",
-      "integrity": "sha512-PBVfHQbyrsfzbnO6u9d9Sik8JlXGLhHj3zLd87iBkYXBdHwD5NuvwWu7OtjUtrHjP4SfzodVwfjmTbDAFqbtzw==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.327.0.tgz",
+      "integrity": "sha512-sN7uvHT2TYkLRTNnfrdeWoJoryeWOEuEwd4i52AKSq6QBgRnQm897yAe3y4Pe9vjz3F38butgfx+PKwD0xJQFw==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -379,28 +379,28 @@
         "@aws-sdk/fetch-http-handler": "3.310.0",
         "@aws-sdk/hash-node": "3.310.0",
         "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.310.0",
-        "@aws-sdk/middleware-endpoint": "3.310.0",
-        "@aws-sdk/middleware-host-header": "3.310.0",
-        "@aws-sdk/middleware-logger": "3.310.0",
-        "@aws-sdk/middleware-recursion-detection": "3.310.0",
-        "@aws-sdk/middleware-retry": "3.310.0",
-        "@aws-sdk/middleware-serde": "3.310.0",
-        "@aws-sdk/middleware-stack": "3.310.0",
-        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/middleware-content-length": "3.325.0",
+        "@aws-sdk/middleware-endpoint": "3.325.0",
+        "@aws-sdk/middleware-host-header": "3.325.0",
+        "@aws-sdk/middleware-logger": "3.325.0",
+        "@aws-sdk/middleware-recursion-detection": "3.325.0",
+        "@aws-sdk/middleware-retry": "3.327.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/middleware-user-agent": "3.327.0",
         "@aws-sdk/node-config-provider": "3.310.0",
         "@aws-sdk/node-http-handler": "3.321.1",
         "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/smithy-client": "3.325.0",
         "@aws-sdk/types": "3.310.0",
         "@aws-sdk/url-parser": "3.310.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
-        "@aws-sdk/util-defaults-mode-node": "3.316.0",
-        "@aws-sdk/util-endpoints": "3.319.0",
-        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
+        "@aws-sdk/util-defaults-mode-node": "3.325.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "@aws-sdk/util-retry": "3.327.0",
         "@aws-sdk/util-user-agent-browser": "3.310.0",
         "@aws-sdk/util-user-agent-node": "3.310.0",
         "@aws-sdk/util-utf8": "3.310.0",
@@ -411,42 +411,42 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.321.1.tgz",
-      "integrity": "sha512-AB+N4a1TVEKl9Sd5O2TxTprEZp7Va6zPZLMraFAYMdmJVBmCmmwyBs7ygju685DpQ1dos5PRsKCRcossyY5pDQ==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.327.0.tgz",
+      "integrity": "sha512-9gNE2QjcDZIVMSdSYkEX+biWkgn7yhk43j7Mj65o4vVWagv3S2ubDm/ofz4hfaZw16U3je/hyRxprGpT/iCABw==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/credential-provider-node": "3.321.1",
+        "@aws-sdk/credential-provider-node": "3.327.0",
         "@aws-sdk/fetch-http-handler": "3.310.0",
         "@aws-sdk/hash-node": "3.310.0",
         "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.310.0",
-        "@aws-sdk/middleware-endpoint": "3.310.0",
-        "@aws-sdk/middleware-host-header": "3.310.0",
-        "@aws-sdk/middleware-logger": "3.310.0",
-        "@aws-sdk/middleware-recursion-detection": "3.310.0",
-        "@aws-sdk/middleware-retry": "3.310.0",
-        "@aws-sdk/middleware-sdk-sts": "3.310.0",
-        "@aws-sdk/middleware-serde": "3.310.0",
-        "@aws-sdk/middleware-signing": "3.310.0",
-        "@aws-sdk/middleware-stack": "3.310.0",
-        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/middleware-content-length": "3.325.0",
+        "@aws-sdk/middleware-endpoint": "3.325.0",
+        "@aws-sdk/middleware-host-header": "3.325.0",
+        "@aws-sdk/middleware-logger": "3.325.0",
+        "@aws-sdk/middleware-recursion-detection": "3.325.0",
+        "@aws-sdk/middleware-retry": "3.327.0",
+        "@aws-sdk/middleware-sdk-sts": "3.326.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/middleware-signing": "3.325.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/middleware-user-agent": "3.327.0",
         "@aws-sdk/node-config-provider": "3.310.0",
         "@aws-sdk/node-http-handler": "3.321.1",
         "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/smithy-client": "3.325.0",
         "@aws-sdk/types": "3.310.0",
         "@aws-sdk/url-parser": "3.310.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
-        "@aws-sdk/util-defaults-mode-node": "3.316.0",
-        "@aws-sdk/util-endpoints": "3.319.0",
-        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
+        "@aws-sdk/util-defaults-mode-node": "3.325.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "@aws-sdk/util-retry": "3.327.0",
         "@aws-sdk/util-user-agent-browser": "3.310.0",
         "@aws-sdk/util-user-agent-node": "3.310.0",
         "@aws-sdk/util-utf8": "3.310.0",
@@ -503,15 +503,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.321.1.tgz",
-      "integrity": "sha512-prndSVQhiikNaI40bYnM2Q8PkC35FCwhbQnBk6KXNvdtfo9RqatMC639F+6oryb3BuMy++Ij4Yoi8WnPBs5Sww==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.327.0.tgz",
+      "integrity": "sha512-pB1wb5kbvg77ouXyDXXxZcDkShBq9bk10qdu5nGOlazC5dFZ61lKnVipd/3zkGm0PVdeac7PsHnbi+d8uRKE0Q==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.310.0",
         "@aws-sdk/credential-provider-imds": "3.310.0",
         "@aws-sdk/credential-provider-process": "3.310.0",
-        "@aws-sdk/credential-provider-sso": "3.321.1",
+        "@aws-sdk/credential-provider-sso": "3.327.0",
         "@aws-sdk/credential-provider-web-identity": "3.310.0",
         "@aws-sdk/property-provider": "3.310.0",
         "@aws-sdk/shared-ini-file-loader": "3.310.0",
@@ -523,16 +523,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.321.1.tgz",
-      "integrity": "sha512-5B1waOwSvY2JMLGRebo7IUqnTaGoCnby9cRbG/dhi7Ke97M3V8380S9THDJ/bktjL8zHEVfBVZy7HhXHzhSjEg==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.327.0.tgz",
+      "integrity": "sha512-fHlS5/V8qfyPyxPcL609xnpEuDRW2KiVRsi4WkikYdJsUREDS1UeQ5AS9xFY1ARFeQuoFDjJ1XeiWYyKZep1yw==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.310.0",
         "@aws-sdk/credential-provider-imds": "3.310.0",
-        "@aws-sdk/credential-provider-ini": "3.321.1",
+        "@aws-sdk/credential-provider-ini": "3.327.0",
         "@aws-sdk/credential-provider-process": "3.310.0",
-        "@aws-sdk/credential-provider-sso": "3.321.1",
+        "@aws-sdk/credential-provider-sso": "3.327.0",
         "@aws-sdk/credential-provider-web-identity": "3.310.0",
         "@aws-sdk/property-provider": "3.310.0",
         "@aws-sdk/shared-ini-file-loader": "3.310.0",
@@ -559,15 +559,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.321.1.tgz",
-      "integrity": "sha512-kg0rc1OacJFgAvmZj0TOu+BSc+yRdnC5dO/RAag3XU6+hlQI5/C080RQp9Qj6V7ga0HtAJMRwJcUlCPA3RJPug==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.327.0.tgz",
+      "integrity": "sha512-BiY87WKAgnBjN5Hfm2LBcJ/0gRnRwvBAG09MrsyTwGju8FYGV+e0YvFrT70CKFMUFD9t5/eztntox+q7sHOXkg==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.321.1",
+        "@aws-sdk/client-sso": "3.327.0",
         "@aws-sdk/property-provider": "3.310.0",
         "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/token-providers": "3.321.1",
+        "@aws-sdk/token-providers": "3.327.0",
         "@aws-sdk/types": "3.310.0",
         "tslib": "^2.5.0"
       },
@@ -759,9 +759,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
-      "integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.325.0.tgz",
+      "integrity": "sha512-t38VBKCpNqSKqSu0OfWMJs7cwaRHFGQxIF9lV8JMCM/2lyUpN4JcfuzSTK+MFN2eDZEHp5DiNg8w07GXXusRYg==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.310.0",
@@ -773,12 +773,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
-      "integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.325.0.tgz",
+      "integrity": "sha512-3CavuOHCKiWUnCtzrUFbhbEP26qIgzzRs5C3vpOJhDUhugBubIWgPGGRLpbnIro+P4XJPwM3pMziNzhKVuSDlQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
         "@aws-sdk/types": "3.310.0",
         "@aws-sdk/url-parser": "3.310.0",
         "@aws-sdk/util-middleware": "3.310.0",
@@ -789,9 +789,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.310.0.tgz",
-      "integrity": "sha512-l3d1z2gt+gINJDnPSyu84IxfzjzPfCQrqC1sunw2cZGo/sXtEiq698Q3SiTcO2PGP4LBQAy2RHb5wVBJP708CQ==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.325.0.tgz",
+      "integrity": "sha512-Hj4D+zeet4gdUpSiMeHZfIzcnXkZI2krGyUw4U1psPzCqOp7WP5307g+1NWXOlVu3H3tF5r3rEgthQOQj2zNfA==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.310.0",
@@ -803,9 +803,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.310.0.tgz",
-      "integrity": "sha512-5ndnLgzgGVpWkmHBAiYkagHqiSuow8q62J4J6E2PzaQ77+fm8W3nfdy7hK5trHokEyouCZdxT/XK/IRhgj/4PA==",
+      "version": "3.326.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.326.0.tgz",
+      "integrity": "sha512-MtcvSU+wKu4/a/trIJmb4Tfb682U9uP5YYA5aXzdhxOxG11wj86uBIeQrdbUxhtTXMgmvwn1193dvTi91EUEaQ==",
       "dev": true,
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
@@ -821,9 +821,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
-      "integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.325.0.tgz",
+      "integrity": "sha512-IN28gsxcRy4J+FxxCHvzb2NORBx8uMA+h9QYS4BBZfpKVYIZh+mudHgYcdNHWlKXmlTGjhWBNWTeByhzuSKAiA==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.310.0",
@@ -835,9 +835,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.310.0.tgz",
-      "integrity": "sha512-LFm0JTQWwTPWL/tZU2wsQTl8J5PpDEkXjEhaXVKamtyH0xhysRqd+0n92n65dc8oztAuQkb9xUbErGn5b6gsew==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.325.0.tgz",
+      "integrity": "sha512-T2OrpXXY9I1nHvIGSlQD6qj1FDG3WDFSu65+Bh4pMl+zVh0IqIEajiK++TfrdQl+sJxRGQd/euoeXXL4JYw9JA==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.310.0",
@@ -848,9 +848,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
-      "integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.325.0.tgz",
+      "integrity": "sha512-S8rWgTpN2b/+UDDm+yZMFM6rw1zwO8KT0GAIQbAhB96shyD5eKen/UfihCTB7YMvbD2piebymwJTvxv6bn1VqQ==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.310.0",
@@ -861,9 +861,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
-      "integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.325.0.tgz",
+      "integrity": "sha512-2l1ABF7KePsoKz8KaNvD2uxo1zHqkFHK4PL/wW/FbcwOcE08f0R7qX++st/bPpVjXX/j/5vWTnNNgJOIOrZhyw==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.310.0",
@@ -875,16 +875,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
-      "integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.327.0.tgz",
+      "integrity": "sha512-LCG+oRIPc4XJ+DYqkSCgggavxWi4+hP3Rw40vHdHMNvJpCiUJMwVJ+dULEywEP/WZvr4AEkWiRrHmJVpSLeZ+Q==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/service-error-classification": "3.310.0",
+        "@aws-sdk/service-error-classification": "3.327.0",
         "@aws-sdk/types": "3.310.0",
         "@aws-sdk/util-middleware": "3.310.0",
-        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-retry": "3.327.0",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -893,9 +893,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.310.0.tgz",
-      "integrity": "sha512-QK9x9g2ksg0hOjjYgqddeFcn5ctUEGdxJVu4OumPXceulefMcSO2jyH2qTybYSA93nqNQFdFmg5wQfvIRUWFCQ==",
+      "version": "3.326.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.326.0.tgz",
+      "integrity": "sha512-IyonHEiDMn0fdYWxA/TAnNj8M/xG5EJWvoOKcakl891f+JPaWeRsV2oE1fIjqM/waM3jqNXLDTrm06QfAYmgBQ==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.310.0",
@@ -908,12 +908,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
-      "integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
+      "version": "3.326.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.326.0.tgz",
+      "integrity": "sha512-suOkuXxyAfOH0hznK63ZU10EoytKX5YPs9amO416VbgYFtuIeliCmntYfnl1jUvutp0fctGGpEGE9OnoYI+fhw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.325.0",
         "@aws-sdk/types": "3.310.0",
         "tslib": "^2.5.0"
       },
@@ -922,9 +922,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
-      "integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.325.0.tgz",
+      "integrity": "sha512-QAZYaFfAw1a06Vg39JiYIq0kSJ6EuUPOiKfK/Goj0cBv78lrXWuKdf04UF3U8Rqk/4mamnsTqUSwf4NoKkF0hw==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.310.0",
@@ -935,9 +935,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
-      "integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.325.0.tgz",
+      "integrity": "sha512-SOwPwaCE3vSCGwFzkIlnOUSkeCUzKTyIQnFVjlQkqGuMxMX/iDaQQGaX+HUbuGIuULCEQqjZH4dLKZcor8eVZw==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.310.0",
@@ -952,9 +952,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.310.0.tgz",
-      "integrity": "sha512-CnEwNKVpd5bXnrCKPaePF8mWTA9ET21OMBb54y9b0fd8K02zoOcdBz4DWfh1SjFD4HkgCdja4egd8l2ivyvqmw==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.325.0.tgz",
+      "integrity": "sha512-hxmvvWVfVrbfUw8pDEPlsR6Sb+IUdhq0cOJc7SL5XO9ddRXJ5DjT2Z2ao9FB424hJgAcOrqIO5ECjdIRs+O4FQ==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.310.0",
@@ -965,9 +965,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
-      "integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.325.0.tgz",
+      "integrity": "sha512-cZWehA4grGvX1IKlY9atJgD0bq3ew7YRJgY7GA6DSgsU7GrZ61Qvi+H7IuGx5AdeAwaTnbnTGN4qCaA2EfxNhA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
@@ -977,14 +977,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.319.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.319.0.tgz",
-      "integrity": "sha512-ytaLx2dlR5AdMSne6FuDCISVg8hjyKj+cHU20b2CRA/E/z+XXrLrssp4JrCgizRKPPUep0psMIa22Zd6osTT5Q==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.327.0.tgz",
+      "integrity": "sha512-4rDSNY1xhlqfRcY97CQKcgs6AOe4ovtiRdCAjg2InnLOZHRVFoHhOIDxWNK2W1K2Pl65z4EGH6RXmB1t0srJHA==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.310.0",
         "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1076,9 +1076,9 @@
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
-      "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.327.0.tgz",
+      "integrity": "sha512-bCWnw+uH3gI6yPxLi4a4WV71P1KlJU7Z4+iMBY1Gt4+ZsaPAJX9pAbuQcFhFH++4xTk/QaVMzSvD0uQ+u0B/NQ==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -1139,12 +1139,12 @@
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.316.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz",
-      "integrity": "sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.325.0.tgz",
+      "integrity": "sha512-sqDFuhjxd8+Q9qI8MmXe/g1/FgoViwetv14K+bpHK7pGlOIvDyT7TboDNClfgqSLdgTDCEaoC3JRSi9Y5RgbmA==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
         "@aws-sdk/types": "3.310.0",
         "tslib": "^2.5.0"
       },
@@ -1153,12 +1153,12 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.321.1.tgz",
-      "integrity": "sha512-I1sXS4qXirSvgvrOIPf+e1D7GvC83DdeyMxHZvuhHgeMCqDAzToS8OLxOX0enN9xZRHWAQYja8xyeGbDL2I0Zw==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.327.0.tgz",
+      "integrity": "sha512-7x1nXJiFlXz6umdkcvZJAR8GxyhxqmgLi4laBc1ZYcxHzOb02EFqloSmax6/SNJNKlL2QmGbEXuPIGV1wf45uQ==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.321.1",
+        "@aws-sdk/client-sso-oidc": "3.327.0",
         "@aws-sdk/property-provider": "3.310.0",
         "@aws-sdk/shared-ini-file-loader": "3.310.0",
         "@aws-sdk/types": "3.310.0",
@@ -1263,9 +1263,9 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.316.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz",
-      "integrity": "sha512-6FSqLhYmaihtH2n1s4b2rlLW0ABU8N6VZIfzLfe2ING4PF0MzfaMMhnTFUHVXfKCVGoR8yP6iyFTRCyHGVEL1w==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.325.0.tgz",
+      "integrity": "sha512-gcowpXTo8E8N3jxD2KW+csiicJ7HPkhWnpL925xgwe0oq091OpATsKFrBOL18h72VfRWf4FAsR9lVwxSQ78zSA==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.310.0",
@@ -1278,9 +1278,9 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.316.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.316.0.tgz",
-      "integrity": "sha512-dkYy10hdjPSScXXvnjGpZpnJxllkb6ICHgLMwZ4JczLHhPM12T/4PQ758YN8HS+muiYDGX1Bl2z1jd/bMcewBQ==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.325.0.tgz",
+      "integrity": "sha512-/5uoOrgNxoUxv3AwsdXjMA3f6KJA6fi69otA0RiINjilCdcbOxq5GI11AFEyRio/+e+imriX4+UYjsguUR+f4g==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/config-resolver": "3.310.0",
@@ -1295,9 +1295,9 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.319.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.319.0.tgz",
-      "integrity": "sha512-3I64UMoYA2e2++oOUJXRcFtYLpLylnZFRltWfPo1B3dLlf+MIWat9djT+mMus+hW1ntLsvAIVu1hLVePJC0gvw==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.327.0.tgz",
+      "integrity": "sha512-2+2jTfBzhXsfpOci61gzaoBUVdGhFWja7k5cLAfOaRROkK+m+Zv532+m3cCQZjBXJ6pJ952MbiAroRSjFq0/SQ==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.310.0",
@@ -1344,12 +1344,12 @@
       }
     },
     "node_modules/@aws-sdk/util-retry": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.310.0.tgz",
-      "integrity": "sha512-FwWGhCBLfoivTMUHu1LIn4NjrN9JLJ/aX5aZmbcPIOhZVFJj638j0qDgZXyfvVqBuBZh7M8kGq0Oahy3dp69OA==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.327.0.tgz",
+      "integrity": "sha512-y15NLGTAT2vaLzA8klJ6Bo8NGjVAa3/njqc4iCbta/3GqKpQU0zbvw3Y5aWyHp8BhV4DSUTp088jWjaoZlSqgw==",
       "dev": true,
       "dependencies": {
-        "@aws-sdk/service-error-classification": "3.310.0",
+        "@aws-sdk/service-error-classification": "3.327.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1500,9 +1500,9 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.5.tgz",
-      "integrity": "sha512-9M398B/QH5DlfCOTKDZT1ozXr0x8uBEeFd+dJraGUZGiaNpGCDVGCc14hZexsMblw3XxltJ+6kSvogp9J+5a9g==",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.8.tgz",
+      "integrity": "sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -1511,7 +1511,7 @@
         "@babel/helper-compilation-targets": "^7.21.5",
         "@babel/helper-module-transforms": "^7.21.5",
         "@babel/helpers": "^7.21.5",
-        "@babel/parser": "^7.21.5",
+        "@babel/parser": "^7.21.8",
         "@babel/template": "^7.20.7",
         "@babel/traverse": "^7.21.5",
         "@babel/types": "^7.21.5",
@@ -1606,9 +1606,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.5.tgz",
-      "integrity": "sha512-yNSEck9SuDvPTEUYm4BSXl6ZVC7yO5ZLEMAhG3v3zi7RDxyL/nQDemWWZmw4L0stPWwhpnznRRyJHPRcbXR2jw==",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.8.tgz",
+      "integrity": "sha512-+THiN8MqiH2AczyuZrnrKL6cAxFRRQDKW9h1YkBvbgKmAm6mwiacig1qT73DHIWMGo40GRnsEfN3LA+E6NtmSw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -1638,9 +1638,9 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.21.5.tgz",
-      "integrity": "sha512-1+DPMcln46eNAta/rPIqQYXYRGvQ/LRy6bRKnSt9Dzt/yLjNUbbsh+6yzD6fUHmtzc9kWvVnAhtcMSMyziHmUA==",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.21.8.tgz",
+      "integrity": "sha512-zGuSdedkFtsFHGbexAvNuipg1hbtitDLo2XE8/uf6Y9sOQV1xsYX/2pNbtedp/X0eU1pIt+kGvaqHCowkRbS5g==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -1929,9 +1929,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.5.tgz",
-      "integrity": "sha512-J+IxH2IsxV4HbnTrSWgMAQj0UEo61hDA4Ny8h8PCX0MLXiibqHbqIOVneqdocemSBc22VpBKxt4J6FQzy9HarQ==",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.8.tgz",
+      "integrity": "sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -3258,9 +3258,9 @@
       }
     },
     "node_modules/@definitelytyped/utils/node_modules/@types/node": {
-      "version": "14.18.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.43.tgz",
-      "integrity": "sha512-n3eFEaoem0WNwLux+k272P0+aq++5o05bA9CfiwKPdYPB5ZambWKdWoeHy7/OJiizMhzg27NLaZ6uzjLTzXceQ==",
+      "version": "14.18.44",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.44.tgz",
+      "integrity": "sha512-Sg79dXC3jrRlG0QOLrK5eq2hRzpU4pkD7xBiYNYJ6r9OitJMxkpTpWf6m3qa2AWzb76uMHx+6x5T1Y/WAiS3nw==",
       "dev": true
     },
     "node_modules/@definitelytyped/utils/node_modules/fs-extra": {
@@ -4690,9 +4690,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
-      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.0.0.tgz",
+      "integrity": "sha512-cD2uPTDnQQCVpmRefonO98/PPijuOnnEy5oytWJFPY1N9aJCz2wJ5kSGWO+zJoed2cY2JxQh6yBuUq4vIn61hw==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -5989,9 +5989,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1369.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1369.0.tgz",
-      "integrity": "sha512-DdCQjlhQDi9w8J4moqECrrp9ARWCay0UI38adPSS0GG43gh3bl3OoMlgKJ8aZxi4jUvzE48K9yhFHz4y/mazZw==",
+      "version": "2.1372.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1372.0.tgz",
+      "integrity": "sha512-SkpBohTXS7yJL6I/k+Dk5o2k8xgyVKs1n9zo08DvCaheSmvpMKQHqdj/wCbf1cjLRFr/Ckc1YGDj3SsikPsBgw==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -8140,9 +8140,9 @@
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
-      "version": "14.18.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.43.tgz",
-      "integrity": "sha512-n3eFEaoem0WNwLux+k272P0+aq++5o05bA9CfiwKPdYPB5ZambWKdWoeHy7/OJiizMhzg27NLaZ6uzjLTzXceQ==",
+      "version": "14.18.44",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.44.tgz",
+      "integrity": "sha512-Sg79dXC3jrRlG0QOLrK5eq2hRzpU4pkD7xBiYNYJ6r9OitJMxkpTpWf6m3qa2AWzb76uMHx+6x5T1Y/WAiS3nw==",
       "dev": true
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -9392,9 +9392,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.379",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.379.tgz",
-      "integrity": "sha512-eRMq6Cf4PhjB14R9U6QcXM/VRQ54Gc3OL9LKnFugUIh2AXm3KJlOizlSfVIgjH76bII4zHGK4t0PVTE5qq8dZg==",
+      "version": "1.4.384",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.384.tgz",
+      "integrity": "sha512-I97q0MmRAAqj53+a8vZsDkEXBZki+ehYAOPzwtQzALip52aEp2+BJqHFtTlsfjoqVZYwPpHC8wM6MbsSZQ/Eqw==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -21068,14 +21068,14 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
-      "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+      "version": "6.1.14",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.14.tgz",
+      "integrity": "sha512-piERznXu0U7/pW7cdSn7hjqySIVTYT6F76icmFk7ptU7dDYlXTm5r9A6K04R2vU3olYgoKeo1Cg3eeu5nhftAw==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
-        "minipass": "^4.0.0",
+        "minipass": "^5.0.0",
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
@@ -21115,9 +21115,9 @@
       }
     },
     "node_modules/tar/node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -22590,9 +22590,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.81.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.81.0.tgz",
-      "integrity": "sha512-AAjaJ9S4hYCVODKLQTgG5p5e11hiMawBwV2v8MYLE0C/6UAGLuAF4n1qa9GOwdxnicaP+5k6M5HrLmD4+gIB8Q==",
+      "version": "5.82.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.82.0.tgz",
+      "integrity": "sha512-iGNA2fHhnDcV1bONdUu554eZx+XeldsaeQ8T67H6KKHl2nUSwX8Zm7cmzOA46ox/X1ARxf7Bjv8wQ/HsB5fxBg==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -23210,17 +23210,17 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.321.1.tgz",
-      "integrity": "sha512-SndPRdeofP2j1kPDLoPbJL8DzzjSciFb1S+Tda3UljOy9gQl68OAruwKloXHJE8GRkLJnYowlwLu36H1MvADJg==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.327.0.tgz",
+      "integrity": "sha512-gEchcni8JwSlU8vz+jn1Up9Rn8uMQdq/qB776tMaxWFBlruGIn71yN2/TYEzF7VRPvmpwNPWA6ox16fJ/7y2dw==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.321.1",
+        "@aws-sdk/client-sts": "3.327.0",
         "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/credential-provider-node": "3.321.1",
+        "@aws-sdk/credential-provider-node": "3.327.0",
         "@aws-sdk/eventstream-serde-browser": "3.310.0",
         "@aws-sdk/eventstream-serde-config-resolver": "3.310.0",
         "@aws-sdk/eventstream-serde-node": "3.310.0",
@@ -23231,35 +23231,35 @@
         "@aws-sdk/invalid-dependency": "3.310.0",
         "@aws-sdk/md5-js": "3.310.0",
         "@aws-sdk/middleware-bucket-endpoint": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.310.0",
-        "@aws-sdk/middleware-endpoint": "3.310.0",
-        "@aws-sdk/middleware-expect-continue": "3.310.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.310.0",
-        "@aws-sdk/middleware-host-header": "3.310.0",
-        "@aws-sdk/middleware-location-constraint": "3.310.0",
-        "@aws-sdk/middleware-logger": "3.310.0",
-        "@aws-sdk/middleware-recursion-detection": "3.310.0",
-        "@aws-sdk/middleware-retry": "3.310.0",
-        "@aws-sdk/middleware-sdk-s3": "3.310.0",
-        "@aws-sdk/middleware-serde": "3.310.0",
-        "@aws-sdk/middleware-signing": "3.310.0",
-        "@aws-sdk/middleware-ssec": "3.310.0",
-        "@aws-sdk/middleware-stack": "3.310.0",
-        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/middleware-content-length": "3.325.0",
+        "@aws-sdk/middleware-endpoint": "3.325.0",
+        "@aws-sdk/middleware-expect-continue": "3.325.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.326.0",
+        "@aws-sdk/middleware-host-header": "3.325.0",
+        "@aws-sdk/middleware-location-constraint": "3.325.0",
+        "@aws-sdk/middleware-logger": "3.325.0",
+        "@aws-sdk/middleware-recursion-detection": "3.325.0",
+        "@aws-sdk/middleware-retry": "3.327.0",
+        "@aws-sdk/middleware-sdk-s3": "3.326.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/middleware-signing": "3.325.0",
+        "@aws-sdk/middleware-ssec": "3.325.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/middleware-user-agent": "3.327.0",
         "@aws-sdk/node-config-provider": "3.310.0",
         "@aws-sdk/node-http-handler": "3.321.1",
         "@aws-sdk/protocol-http": "3.310.0",
         "@aws-sdk/signature-v4-multi-region": "3.310.0",
-        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/smithy-client": "3.325.0",
         "@aws-sdk/types": "3.310.0",
         "@aws-sdk/url-parser": "3.310.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
-        "@aws-sdk/util-defaults-mode-node": "3.316.0",
-        "@aws-sdk/util-endpoints": "3.319.0",
-        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
+        "@aws-sdk/util-defaults-mode-node": "3.325.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "@aws-sdk/util-retry": "3.327.0",
         "@aws-sdk/util-stream-browser": "3.310.0",
         "@aws-sdk/util-stream-node": "3.321.1",
         "@aws-sdk/util-user-agent-browser": "3.310.0",
@@ -23272,9 +23272,9 @@
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.321.1.tgz",
-      "integrity": "sha512-ecoT4tBGtRJR5G7oLBTMXZmgZZlff1amhSdKPEtkWxv6kWc8VPb5rRuRgVPsDR9HuesI6ZVlODptvGtnfkIJwA==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.327.0.tgz",
+      "integrity": "sha512-4cJzDs5GHSED47QYo3LSgqX+CBtKV0lp6HugkX5pvERB+FGCNLenUcSzyU93BCV2oWUP4K+m7dxV6h3RmD4/ow==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -23283,28 +23283,28 @@
         "@aws-sdk/fetch-http-handler": "3.310.0",
         "@aws-sdk/hash-node": "3.310.0",
         "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.310.0",
-        "@aws-sdk/middleware-endpoint": "3.310.0",
-        "@aws-sdk/middleware-host-header": "3.310.0",
-        "@aws-sdk/middleware-logger": "3.310.0",
-        "@aws-sdk/middleware-recursion-detection": "3.310.0",
-        "@aws-sdk/middleware-retry": "3.310.0",
-        "@aws-sdk/middleware-serde": "3.310.0",
-        "@aws-sdk/middleware-stack": "3.310.0",
-        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/middleware-content-length": "3.325.0",
+        "@aws-sdk/middleware-endpoint": "3.325.0",
+        "@aws-sdk/middleware-host-header": "3.325.0",
+        "@aws-sdk/middleware-logger": "3.325.0",
+        "@aws-sdk/middleware-recursion-detection": "3.325.0",
+        "@aws-sdk/middleware-retry": "3.327.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/middleware-user-agent": "3.327.0",
         "@aws-sdk/node-config-provider": "3.310.0",
         "@aws-sdk/node-http-handler": "3.321.1",
         "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/smithy-client": "3.325.0",
         "@aws-sdk/types": "3.310.0",
         "@aws-sdk/url-parser": "3.310.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
-        "@aws-sdk/util-defaults-mode-node": "3.316.0",
-        "@aws-sdk/util-endpoints": "3.319.0",
-        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
+        "@aws-sdk/util-defaults-mode-node": "3.325.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "@aws-sdk/util-retry": "3.327.0",
         "@aws-sdk/util-user-agent-browser": "3.310.0",
         "@aws-sdk/util-user-agent-node": "3.310.0",
         "@aws-sdk/util-utf8": "3.310.0",
@@ -23312,9 +23312,9 @@
       }
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.321.1.tgz",
-      "integrity": "sha512-PBVfHQbyrsfzbnO6u9d9Sik8JlXGLhHj3zLd87iBkYXBdHwD5NuvwWu7OtjUtrHjP4SfzodVwfjmTbDAFqbtzw==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.327.0.tgz",
+      "integrity": "sha512-sN7uvHT2TYkLRTNnfrdeWoJoryeWOEuEwd4i52AKSq6QBgRnQm897yAe3y4Pe9vjz3F38butgfx+PKwD0xJQFw==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -23323,28 +23323,28 @@
         "@aws-sdk/fetch-http-handler": "3.310.0",
         "@aws-sdk/hash-node": "3.310.0",
         "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.310.0",
-        "@aws-sdk/middleware-endpoint": "3.310.0",
-        "@aws-sdk/middleware-host-header": "3.310.0",
-        "@aws-sdk/middleware-logger": "3.310.0",
-        "@aws-sdk/middleware-recursion-detection": "3.310.0",
-        "@aws-sdk/middleware-retry": "3.310.0",
-        "@aws-sdk/middleware-serde": "3.310.0",
-        "@aws-sdk/middleware-stack": "3.310.0",
-        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/middleware-content-length": "3.325.0",
+        "@aws-sdk/middleware-endpoint": "3.325.0",
+        "@aws-sdk/middleware-host-header": "3.325.0",
+        "@aws-sdk/middleware-logger": "3.325.0",
+        "@aws-sdk/middleware-recursion-detection": "3.325.0",
+        "@aws-sdk/middleware-retry": "3.327.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/middleware-user-agent": "3.327.0",
         "@aws-sdk/node-config-provider": "3.310.0",
         "@aws-sdk/node-http-handler": "3.321.1",
         "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/smithy-client": "3.325.0",
         "@aws-sdk/types": "3.310.0",
         "@aws-sdk/url-parser": "3.310.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
-        "@aws-sdk/util-defaults-mode-node": "3.316.0",
-        "@aws-sdk/util-endpoints": "3.319.0",
-        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
+        "@aws-sdk/util-defaults-mode-node": "3.325.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "@aws-sdk/util-retry": "3.327.0",
         "@aws-sdk/util-user-agent-browser": "3.310.0",
         "@aws-sdk/util-user-agent-node": "3.310.0",
         "@aws-sdk/util-utf8": "3.310.0",
@@ -23352,42 +23352,42 @@
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.321.1.tgz",
-      "integrity": "sha512-AB+N4a1TVEKl9Sd5O2TxTprEZp7Va6zPZLMraFAYMdmJVBmCmmwyBs7ygju685DpQ1dos5PRsKCRcossyY5pDQ==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.327.0.tgz",
+      "integrity": "sha512-9gNE2QjcDZIVMSdSYkEX+biWkgn7yhk43j7Mj65o4vVWagv3S2ubDm/ofz4hfaZw16U3je/hyRxprGpT/iCABw==",
       "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/credential-provider-node": "3.321.1",
+        "@aws-sdk/credential-provider-node": "3.327.0",
         "@aws-sdk/fetch-http-handler": "3.310.0",
         "@aws-sdk/hash-node": "3.310.0",
         "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.310.0",
-        "@aws-sdk/middleware-endpoint": "3.310.0",
-        "@aws-sdk/middleware-host-header": "3.310.0",
-        "@aws-sdk/middleware-logger": "3.310.0",
-        "@aws-sdk/middleware-recursion-detection": "3.310.0",
-        "@aws-sdk/middleware-retry": "3.310.0",
-        "@aws-sdk/middleware-sdk-sts": "3.310.0",
-        "@aws-sdk/middleware-serde": "3.310.0",
-        "@aws-sdk/middleware-signing": "3.310.0",
-        "@aws-sdk/middleware-stack": "3.310.0",
-        "@aws-sdk/middleware-user-agent": "3.319.0",
+        "@aws-sdk/middleware-content-length": "3.325.0",
+        "@aws-sdk/middleware-endpoint": "3.325.0",
+        "@aws-sdk/middleware-host-header": "3.325.0",
+        "@aws-sdk/middleware-logger": "3.325.0",
+        "@aws-sdk/middleware-recursion-detection": "3.325.0",
+        "@aws-sdk/middleware-retry": "3.327.0",
+        "@aws-sdk/middleware-sdk-sts": "3.326.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
+        "@aws-sdk/middleware-signing": "3.325.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
+        "@aws-sdk/middleware-user-agent": "3.327.0",
         "@aws-sdk/node-config-provider": "3.310.0",
         "@aws-sdk/node-http-handler": "3.321.1",
         "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.316.0",
+        "@aws-sdk/smithy-client": "3.325.0",
         "@aws-sdk/types": "3.310.0",
         "@aws-sdk/url-parser": "3.310.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.316.0",
-        "@aws-sdk/util-defaults-mode-node": "3.316.0",
-        "@aws-sdk/util-endpoints": "3.319.0",
-        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.325.0",
+        "@aws-sdk/util-defaults-mode-node": "3.325.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
+        "@aws-sdk/util-retry": "3.327.0",
         "@aws-sdk/util-user-agent-browser": "3.310.0",
         "@aws-sdk/util-user-agent-node": "3.310.0",
         "@aws-sdk/util-utf8": "3.310.0",
@@ -23432,15 +23432,15 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.321.1.tgz",
-      "integrity": "sha512-prndSVQhiikNaI40bYnM2Q8PkC35FCwhbQnBk6KXNvdtfo9RqatMC639F+6oryb3BuMy++Ij4Yoi8WnPBs5Sww==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.327.0.tgz",
+      "integrity": "sha512-pB1wb5kbvg77ouXyDXXxZcDkShBq9bk10qdu5nGOlazC5dFZ61lKnVipd/3zkGm0PVdeac7PsHnbi+d8uRKE0Q==",
       "dev": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.310.0",
         "@aws-sdk/credential-provider-imds": "3.310.0",
         "@aws-sdk/credential-provider-process": "3.310.0",
-        "@aws-sdk/credential-provider-sso": "3.321.1",
+        "@aws-sdk/credential-provider-sso": "3.327.0",
         "@aws-sdk/credential-provider-web-identity": "3.310.0",
         "@aws-sdk/property-provider": "3.310.0",
         "@aws-sdk/shared-ini-file-loader": "3.310.0",
@@ -23449,16 +23449,16 @@
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.321.1.tgz",
-      "integrity": "sha512-5B1waOwSvY2JMLGRebo7IUqnTaGoCnby9cRbG/dhi7Ke97M3V8380S9THDJ/bktjL8zHEVfBVZy7HhXHzhSjEg==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.327.0.tgz",
+      "integrity": "sha512-fHlS5/V8qfyPyxPcL609xnpEuDRW2KiVRsi4WkikYdJsUREDS1UeQ5AS9xFY1ARFeQuoFDjJ1XeiWYyKZep1yw==",
       "dev": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.310.0",
         "@aws-sdk/credential-provider-imds": "3.310.0",
-        "@aws-sdk/credential-provider-ini": "3.321.1",
+        "@aws-sdk/credential-provider-ini": "3.327.0",
         "@aws-sdk/credential-provider-process": "3.310.0",
-        "@aws-sdk/credential-provider-sso": "3.321.1",
+        "@aws-sdk/credential-provider-sso": "3.327.0",
         "@aws-sdk/credential-provider-web-identity": "3.310.0",
         "@aws-sdk/property-provider": "3.310.0",
         "@aws-sdk/shared-ini-file-loader": "3.310.0",
@@ -23479,15 +23479,15 @@
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.321.1.tgz",
-      "integrity": "sha512-kg0rc1OacJFgAvmZj0TOu+BSc+yRdnC5dO/RAag3XU6+hlQI5/C080RQp9Qj6V7ga0HtAJMRwJcUlCPA3RJPug==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.327.0.tgz",
+      "integrity": "sha512-BiY87WKAgnBjN5Hfm2LBcJ/0gRnRwvBAG09MrsyTwGju8FYGV+e0YvFrT70CKFMUFD9t5/eztntox+q7sHOXkg==",
       "dev": true,
       "requires": {
-        "@aws-sdk/client-sso": "3.321.1",
+        "@aws-sdk/client-sso": "3.327.0",
         "@aws-sdk/property-provider": "3.310.0",
         "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/token-providers": "3.321.1",
+        "@aws-sdk/token-providers": "3.327.0",
         "@aws-sdk/types": "3.310.0",
         "tslib": "^2.5.0"
       }
@@ -23649,9 +23649,9 @@
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
-      "integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.325.0.tgz",
+      "integrity": "sha512-t38VBKCpNqSKqSu0OfWMJs7cwaRHFGQxIF9lV8JMCM/2lyUpN4JcfuzSTK+MFN2eDZEHp5DiNg8w07GXXusRYg==",
       "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.310.0",
@@ -23660,12 +23660,12 @@
       }
     },
     "@aws-sdk/middleware-endpoint": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
-      "integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.325.0.tgz",
+      "integrity": "sha512-3CavuOHCKiWUnCtzrUFbhbEP26qIgzzRs5C3vpOJhDUhugBubIWgPGGRLpbnIro+P4XJPwM3pMziNzhKVuSDlQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/middleware-serde": "3.310.0",
+        "@aws-sdk/middleware-serde": "3.325.0",
         "@aws-sdk/types": "3.310.0",
         "@aws-sdk/url-parser": "3.310.0",
         "@aws-sdk/util-middleware": "3.310.0",
@@ -23673,9 +23673,9 @@
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.310.0.tgz",
-      "integrity": "sha512-l3d1z2gt+gINJDnPSyu84IxfzjzPfCQrqC1sunw2cZGo/sXtEiq698Q3SiTcO2PGP4LBQAy2RHb5wVBJP708CQ==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.325.0.tgz",
+      "integrity": "sha512-Hj4D+zeet4gdUpSiMeHZfIzcnXkZI2krGyUw4U1psPzCqOp7WP5307g+1NWXOlVu3H3tF5r3rEgthQOQj2zNfA==",
       "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.310.0",
@@ -23684,9 +23684,9 @@
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.310.0.tgz",
-      "integrity": "sha512-5ndnLgzgGVpWkmHBAiYkagHqiSuow8q62J4J6E2PzaQ77+fm8W3nfdy7hK5trHokEyouCZdxT/XK/IRhgj/4PA==",
+      "version": "3.326.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.326.0.tgz",
+      "integrity": "sha512-MtcvSU+wKu4/a/trIJmb4Tfb682U9uP5YYA5aXzdhxOxG11wj86uBIeQrdbUxhtTXMgmvwn1193dvTi91EUEaQ==",
       "dev": true,
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
@@ -23699,9 +23699,9 @@
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
-      "integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.325.0.tgz",
+      "integrity": "sha512-IN28gsxcRy4J+FxxCHvzb2NORBx8uMA+h9QYS4BBZfpKVYIZh+mudHgYcdNHWlKXmlTGjhWBNWTeByhzuSKAiA==",
       "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.310.0",
@@ -23710,9 +23710,9 @@
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.310.0.tgz",
-      "integrity": "sha512-LFm0JTQWwTPWL/tZU2wsQTl8J5PpDEkXjEhaXVKamtyH0xhysRqd+0n92n65dc8oztAuQkb9xUbErGn5b6gsew==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.325.0.tgz",
+      "integrity": "sha512-T2OrpXXY9I1nHvIGSlQD6qj1FDG3WDFSu65+Bh4pMl+zVh0IqIEajiK++TfrdQl+sJxRGQd/euoeXXL4JYw9JA==",
       "dev": true,
       "requires": {
         "@aws-sdk/types": "3.310.0",
@@ -23720,9 +23720,9 @@
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
-      "integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.325.0.tgz",
+      "integrity": "sha512-S8rWgTpN2b/+UDDm+yZMFM6rw1zwO8KT0GAIQbAhB96shyD5eKen/UfihCTB7YMvbD2piebymwJTvxv6bn1VqQ==",
       "dev": true,
       "requires": {
         "@aws-sdk/types": "3.310.0",
@@ -23730,9 +23730,9 @@
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
-      "integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.325.0.tgz",
+      "integrity": "sha512-2l1ABF7KePsoKz8KaNvD2uxo1zHqkFHK4PL/wW/FbcwOcE08f0R7qX++st/bPpVjXX/j/5vWTnNNgJOIOrZhyw==",
       "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.310.0",
@@ -23741,24 +23741,24 @@
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
-      "integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.327.0.tgz",
+      "integrity": "sha512-LCG+oRIPc4XJ+DYqkSCgggavxWi4+hP3Rw40vHdHMNvJpCiUJMwVJ+dULEywEP/WZvr4AEkWiRrHmJVpSLeZ+Q==",
       "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/service-error-classification": "3.310.0",
+        "@aws-sdk/service-error-classification": "3.327.0",
         "@aws-sdk/types": "3.310.0",
         "@aws-sdk/util-middleware": "3.310.0",
-        "@aws-sdk/util-retry": "3.310.0",
+        "@aws-sdk/util-retry": "3.327.0",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.310.0.tgz",
-      "integrity": "sha512-QK9x9g2ksg0hOjjYgqddeFcn5ctUEGdxJVu4OumPXceulefMcSO2jyH2qTybYSA93nqNQFdFmg5wQfvIRUWFCQ==",
+      "version": "3.326.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.326.0.tgz",
+      "integrity": "sha512-IyonHEiDMn0fdYWxA/TAnNj8M/xG5EJWvoOKcakl891f+JPaWeRsV2oE1fIjqM/waM3jqNXLDTrm06QfAYmgBQ==",
       "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.310.0",
@@ -23768,20 +23768,20 @@
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
-      "integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
+      "version": "3.326.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.326.0.tgz",
+      "integrity": "sha512-suOkuXxyAfOH0hznK63ZU10EoytKX5YPs9amO416VbgYFtuIeliCmntYfnl1jUvutp0fctGGpEGE9OnoYI+fhw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/middleware-signing": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.325.0",
         "@aws-sdk/types": "3.310.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
-      "integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.325.0.tgz",
+      "integrity": "sha512-QAZYaFfAw1a06Vg39JiYIq0kSJ6EuUPOiKfK/Goj0cBv78lrXWuKdf04UF3U8Rqk/4mamnsTqUSwf4NoKkF0hw==",
       "dev": true,
       "requires": {
         "@aws-sdk/types": "3.310.0",
@@ -23789,9 +23789,9 @@
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
-      "integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.325.0.tgz",
+      "integrity": "sha512-SOwPwaCE3vSCGwFzkIlnOUSkeCUzKTyIQnFVjlQkqGuMxMX/iDaQQGaX+HUbuGIuULCEQqjZH4dLKZcor8eVZw==",
       "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.310.0",
@@ -23803,9 +23803,9 @@
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.310.0.tgz",
-      "integrity": "sha512-CnEwNKVpd5bXnrCKPaePF8mWTA9ET21OMBb54y9b0fd8K02zoOcdBz4DWfh1SjFD4HkgCdja4egd8l2ivyvqmw==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.325.0.tgz",
+      "integrity": "sha512-hxmvvWVfVrbfUw8pDEPlsR6Sb+IUdhq0cOJc7SL5XO9ddRXJ5DjT2Z2ao9FB424hJgAcOrqIO5ECjdIRs+O4FQ==",
       "dev": true,
       "requires": {
         "@aws-sdk/types": "3.310.0",
@@ -23813,23 +23813,23 @@
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
-      "integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.325.0.tgz",
+      "integrity": "sha512-cZWehA4grGvX1IKlY9atJgD0bq3ew7YRJgY7GA6DSgsU7GrZ61Qvi+H7IuGx5AdeAwaTnbnTGN4qCaA2EfxNhA==",
       "dev": true,
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.319.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.319.0.tgz",
-      "integrity": "sha512-ytaLx2dlR5AdMSne6FuDCISVg8hjyKj+cHU20b2CRA/E/z+XXrLrssp4JrCgizRKPPUep0psMIa22Zd6osTT5Q==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.327.0.tgz",
+      "integrity": "sha512-4rDSNY1xhlqfRcY97CQKcgs6AOe4ovtiRdCAjg2InnLOZHRVFoHhOIDxWNK2W1K2Pl65z4EGH6RXmB1t0srJHA==",
       "dev": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.310.0",
         "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-endpoints": "3.319.0",
+        "@aws-sdk/util-endpoints": "3.327.0",
         "tslib": "^2.5.0"
       }
     },
@@ -23900,9 +23900,9 @@
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
-      "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.327.0.tgz",
+      "integrity": "sha512-bCWnw+uH3gI6yPxLi4a4WV71P1KlJU7Z4+iMBY1Gt4+ZsaPAJX9pAbuQcFhFH++4xTk/QaVMzSvD0uQ+u0B/NQ==",
       "dev": true
     },
     "@aws-sdk/shared-ini-file-loader": {
@@ -23943,23 +23943,23 @@
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.316.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.316.0.tgz",
-      "integrity": "sha512-6YXOKbRnXeS8r8RWzuL6JMBolDYM5Wa4fD/VY6x/wK78i2xErHOvqzHgyyeLI1MMw4uqyd4wRNJNWC9TMPduXw==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.325.0.tgz",
+      "integrity": "sha512-sqDFuhjxd8+Q9qI8MmXe/g1/FgoViwetv14K+bpHK7pGlOIvDyT7TboDNClfgqSLdgTDCEaoC3JRSi9Y5RgbmA==",
       "dev": true,
       "requires": {
-        "@aws-sdk/middleware-stack": "3.310.0",
+        "@aws-sdk/middleware-stack": "3.325.0",
         "@aws-sdk/types": "3.310.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.321.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.321.1.tgz",
-      "integrity": "sha512-I1sXS4qXirSvgvrOIPf+e1D7GvC83DdeyMxHZvuhHgeMCqDAzToS8OLxOX0enN9xZRHWAQYja8xyeGbDL2I0Zw==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.327.0.tgz",
+      "integrity": "sha512-7x1nXJiFlXz6umdkcvZJAR8GxyhxqmgLi4laBc1ZYcxHzOb02EFqloSmax6/SNJNKlL2QmGbEXuPIGV1wf45uQ==",
       "dev": true,
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.321.1",
+        "@aws-sdk/client-sso-oidc": "3.327.0",
         "@aws-sdk/property-provider": "3.310.0",
         "@aws-sdk/shared-ini-file-loader": "3.310.0",
         "@aws-sdk/types": "3.310.0",
@@ -24043,9 +24043,9 @@
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.316.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.316.0.tgz",
-      "integrity": "sha512-6FSqLhYmaihtH2n1s4b2rlLW0ABU8N6VZIfzLfe2ING4PF0MzfaMMhnTFUHVXfKCVGoR8yP6iyFTRCyHGVEL1w==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.325.0.tgz",
+      "integrity": "sha512-gcowpXTo8E8N3jxD2KW+csiicJ7HPkhWnpL925xgwe0oq091OpATsKFrBOL18h72VfRWf4FAsR9lVwxSQ78zSA==",
       "dev": true,
       "requires": {
         "@aws-sdk/property-provider": "3.310.0",
@@ -24055,9 +24055,9 @@
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.316.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.316.0.tgz",
-      "integrity": "sha512-dkYy10hdjPSScXXvnjGpZpnJxllkb6ICHgLMwZ4JczLHhPM12T/4PQ758YN8HS+muiYDGX1Bl2z1jd/bMcewBQ==",
+      "version": "3.325.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.325.0.tgz",
+      "integrity": "sha512-/5uoOrgNxoUxv3AwsdXjMA3f6KJA6fi69otA0RiINjilCdcbOxq5GI11AFEyRio/+e+imriX4+UYjsguUR+f4g==",
       "dev": true,
       "requires": {
         "@aws-sdk/config-resolver": "3.310.0",
@@ -24069,9 +24069,9 @@
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.319.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.319.0.tgz",
-      "integrity": "sha512-3I64UMoYA2e2++oOUJXRcFtYLpLylnZFRltWfPo1B3dLlf+MIWat9djT+mMus+hW1ntLsvAIVu1hLVePJC0gvw==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.327.0.tgz",
+      "integrity": "sha512-2+2jTfBzhXsfpOci61gzaoBUVdGhFWja7k5cLAfOaRROkK+m+Zv532+m3cCQZjBXJ6pJ952MbiAroRSjFq0/SQ==",
       "dev": true,
       "requires": {
         "@aws-sdk/types": "3.310.0",
@@ -24106,12 +24106,12 @@
       }
     },
     "@aws-sdk/util-retry": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.310.0.tgz",
-      "integrity": "sha512-FwWGhCBLfoivTMUHu1LIn4NjrN9JLJ/aX5aZmbcPIOhZVFJj638j0qDgZXyfvVqBuBZh7M8kGq0Oahy3dp69OA==",
+      "version": "3.327.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.327.0.tgz",
+      "integrity": "sha512-y15NLGTAT2vaLzA8klJ6Bo8NGjVAa3/njqc4iCbta/3GqKpQU0zbvw3Y5aWyHp8BhV4DSUTp088jWjaoZlSqgw==",
       "dev": true,
       "requires": {
-        "@aws-sdk/service-error-classification": "3.310.0",
+        "@aws-sdk/service-error-classification": "3.327.0",
         "tslib": "^2.5.0"
       }
     },
@@ -24227,9 +24227,9 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.5.tgz",
-      "integrity": "sha512-9M398B/QH5DlfCOTKDZT1ozXr0x8uBEeFd+dJraGUZGiaNpGCDVGCc14hZexsMblw3XxltJ+6kSvogp9J+5a9g==",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.8.tgz",
+      "integrity": "sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
@@ -24238,7 +24238,7 @@
         "@babel/helper-compilation-targets": "^7.21.5",
         "@babel/helper-module-transforms": "^7.21.5",
         "@babel/helpers": "^7.21.5",
-        "@babel/parser": "^7.21.5",
+        "@babel/parser": "^7.21.8",
         "@babel/template": "^7.20.7",
         "@babel/traverse": "^7.21.5",
         "@babel/types": "^7.21.5",
@@ -24309,9 +24309,9 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.5.tgz",
-      "integrity": "sha512-yNSEck9SuDvPTEUYm4BSXl6ZVC7yO5ZLEMAhG3v3zi7RDxyL/nQDemWWZmw4L0stPWwhpnznRRyJHPRcbXR2jw==",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.8.tgz",
+      "integrity": "sha512-+THiN8MqiH2AczyuZrnrKL6cAxFRRQDKW9h1YkBvbgKmAm6mwiacig1qT73DHIWMGo40GRnsEfN3LA+E6NtmSw==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -24334,9 +24334,9 @@
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.21.5.tgz",
-      "integrity": "sha512-1+DPMcln46eNAta/rPIqQYXYRGvQ/LRy6bRKnSt9Dzt/yLjNUbbsh+6yzD6fUHmtzc9kWvVnAhtcMSMyziHmUA==",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.21.8.tgz",
+      "integrity": "sha512-zGuSdedkFtsFHGbexAvNuipg1hbtitDLo2XE8/uf6Y9sOQV1xsYX/2pNbtedp/X0eU1pIt+kGvaqHCowkRbS5g==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -24554,9 +24554,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.5.tgz",
-      "integrity": "sha512-J+IxH2IsxV4HbnTrSWgMAQj0UEo61hDA4Ny8h8PCX0MLXiibqHbqIOVneqdocemSBc22VpBKxt4J6FQzy9HarQ==",
+      "version": "7.21.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.8.tgz",
+      "integrity": "sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==",
       "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -25483,9 +25483,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.43",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.43.tgz",
-          "integrity": "sha512-n3eFEaoem0WNwLux+k272P0+aq++5o05bA9CfiwKPdYPB5ZambWKdWoeHy7/OJiizMhzg27NLaZ6uzjLTzXceQ==",
+          "version": "14.18.44",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.44.tgz",
+          "integrity": "sha512-Sg79dXC3jrRlG0QOLrK5eq2hRzpU4pkD7xBiYNYJ6r9OitJMxkpTpWf6m3qa2AWzb76uMHx+6x5T1Y/WAiS3nw==",
           "dev": true
         },
         "fs-extra": {
@@ -26642,9 +26642,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.16.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
-      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.0.0.tgz",
+      "integrity": "sha512-cD2uPTDnQQCVpmRefonO98/PPijuOnnEy5oytWJFPY1N9aJCz2wJ5kSGWO+zJoed2cY2JxQh6yBuUq4vIn61hw==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -27671,9 +27671,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.1369.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1369.0.tgz",
-      "integrity": "sha512-DdCQjlhQDi9w8J4moqECrrp9ARWCay0UI38adPSS0GG43gh3bl3OoMlgKJ8aZxi4jUvzE48K9yhFHz4y/mazZw==",
+      "version": "2.1372.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1372.0.tgz",
+      "integrity": "sha512-SkpBohTXS7yJL6I/k+Dk5o2k8xgyVKs1n9zo08DvCaheSmvpMKQHqdj/wCbf1cjLRFr/Ckc1YGDj3SsikPsBgw==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -29438,9 +29438,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.43",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.43.tgz",
-          "integrity": "sha512-n3eFEaoem0WNwLux+k272P0+aq++5o05bA9CfiwKPdYPB5ZambWKdWoeHy7/OJiizMhzg27NLaZ6uzjLTzXceQ==",
+          "version": "14.18.44",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.44.tgz",
+          "integrity": "sha512-Sg79dXC3jrRlG0QOLrK5eq2hRzpU4pkD7xBiYNYJ6r9OitJMxkpTpWf6m3qa2AWzb76uMHx+6x5T1Y/WAiS3nw==",
           "dev": true
         },
         "ansi-styles": {
@@ -30406,9 +30406,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.379",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.379.tgz",
-      "integrity": "sha512-eRMq6Cf4PhjB14R9U6QcXM/VRQ54Gc3OL9LKnFugUIh2AXm3KJlOizlSfVIgjH76bII4zHGK4t0PVTE5qq8dZg==",
+      "version": "1.4.384",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.384.tgz",
+      "integrity": "sha512-I97q0MmRAAqj53+a8vZsDkEXBZki+ehYAOPzwtQzALip52aEp2+BJqHFtTlsfjoqVZYwPpHC8wM6MbsSZQ/Eqw==",
       "dev": true
     },
     "elliptic": {
@@ -39446,23 +39446,23 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
-      "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+      "version": "6.1.14",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.14.tgz",
+      "integrity": "sha512-piERznXu0U7/pW7cdSn7hjqySIVTYT6F76icmFk7ptU7dDYlXTm5r9A6K04R2vU3olYgoKeo1Cg3eeu5nhftAw==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
-        "minipass": "^4.0.0",
+        "minipass": "^5.0.0",
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
       },
       "dependencies": {
         "minipass": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-          "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+          "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
           "dev": true
         },
         "yallist": {
@@ -40631,9 +40631,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.81.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.81.0.tgz",
-      "integrity": "sha512-AAjaJ9S4hYCVODKLQTgG5p5e11hiMawBwV2v8MYLE0C/6UAGLuAF4n1qa9GOwdxnicaP+5k6M5HrLmD4+gIB8Q==",
+      "version": "5.82.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.82.0.tgz",
+      "integrity": "sha512-iGNA2fHhnDcV1bONdUu554eZx+XeldsaeQ8T67H6KKHl2nUSwX8Zm7cmzOA46ox/X1ARxf7Bjv8wQ/HsB5fxBg==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",

--- a/test/typescript-dts/es-modules/modules/boost.ts
+++ b/test/typescript-dts/es-modules/modules/boost.ts
@@ -1,0 +1,7 @@
+import Highcharts from 'highcharts/es-modules/masters/highcharts.src.js';
+import 'highcharts/es-modules/masters/modules/boost.src.js';
+
+const chart = new Highcharts.Chart('container', {});
+
+// Highcharts should be decorated with boost types:
+chart.isChartSeriesBoosting(chart);

--- a/test/typescript-dts/es-modules/modules/boost.ts
+++ b/test/typescript-dts/es-modules/modules/boost.ts
@@ -1,7 +1,5 @@
 import Highcharts from 'highcharts/es-modules/masters/highcharts.src.js';
 import 'highcharts/es-modules/masters/modules/boost.src.js';
 
-const chart = Highcharts.chart('container', {});
-
-// Highcharts.Chart should be composed with boost functions:
-chart.isChartSeriesBoosting(chart);
+// Highcharts should be composed with boost functions:
+Highcharts.hasWebGLSupport();

--- a/test/typescript-dts/es-modules/modules/boost.ts
+++ b/test/typescript-dts/es-modules/modules/boost.ts
@@ -1,7 +1,7 @@
 import Highcharts from 'highcharts/es-modules/masters/highcharts.src.js';
 import 'highcharts/es-modules/masters/modules/boost.src.js';
 
-const chart = new Highcharts.Chart('container', {});
+const chart = Highcharts.chart('container', {});
 
-// Highcharts should be decorated with boost types:
+// Highcharts.Chart should be composed with boost functions:
 chart.isChartSeriesBoosting(chart);

--- a/test/typescript-karma/masters/modules/boost.test.js
+++ b/test/typescript-karma/masters/modules/boost.test.js
@@ -1,0 +1,12 @@
+import Highcharts from '/base/code/es-modules/masters/highcharts.src.js';
+import '/base/code/es-modules/masters/modules/boost.src.js';
+
+QUnit.test('Highcharts boost composition', function (assert) {
+
+    assert.strictEqual(
+        typeof Highcharts.hasWebGLSupport,
+        'function',
+        'Highcharts should be decorated with boost functions.'
+    );
+
+});

--- a/tools/gulptasks/jsdoc-dts.js
+++ b/tools/gulptasks/jsdoc-dts.js
@@ -66,9 +66,7 @@ function jsDocESMDTS() {
                     ''
                 ].join('\n') :
                 [
-                    `import factory from '${source}';`,
-                    `export * from '${source}';`,
-                    'export default factory;',
+                    `import '${source}';`,
                     ''
                 ].join('\n')
         ));

--- a/ts/Extensions/Boost/Boost.ts
+++ b/ts/Extensions/Boost/Boost.ts
@@ -92,8 +92,14 @@ function compose(
 }
 
 /**
- * Returns true if the current browser supports webgl
- * @private
+ * Returns true if the current browser supports WebGL.
+ *
+ * @requires module:modules/boost
+ *
+ * @function Highcharts.hasWebGLSupport
+ *
+ * @return {boolean}
+ * `true` if the browser supports WebGL.
  */
 function hasWebGLSupport(): boolean {
     let canvas,

--- a/ts/Extensions/Boost/BoostChart.ts
+++ b/ts/Extensions/Boost/BoostChart.ts
@@ -128,14 +128,11 @@ function getBoostClipRect(
 
 /**
  * Returns true if the chart is in series boost mode.
- *
- * @function Highcharts.Chart#isChartSeriesBoosting
- *
+ * @private
  * @param {Highcharts.Chart} chart
- *        the chart to check
- *
+ * Chart to check.
  * @return {boolean}
- *         true if the chart is in series boost mode
+ * `true` if the chart is in series boost mode.
  */
 function isChartSeriesBoosting(
     chart: Chart

--- a/ts/Series/OHLC/OHLCSeriesDefaults.ts
+++ b/ts/Series/OHLC/OHLCSeriesDefaults.ts
@@ -50,6 +50,7 @@ const OHLCSeriesDefaults: OHLCSeriesOptions = {
      * be represented as `point.y`, which is later used to set dataLabel
      * position and [compare](#plotOptions.series.compare).
      *
+     * @declare    Highcharts.OptionsPointValKeyValue
      * @default    close
      * @validvalue ["open", "high", "low", "close"]
      * @product    highstock


### PR DESCRIPTION
After testing PR #18934 it becomes clear, that for the ESM modules from `/es-modules/masters/` no UMD `factory` function exists. The declarations for ESM define such function, but this function can not be found in ESM sources. Therefor these exports can be removed. Instead a reference to the UMD declarations is enough to get TypeScript decorate the Highcharts declarations.

Touches #17952