### PR TITLE
Fixed #18001, area opacity for HTML colors.

### DIFF
--- a/samples/unit-tests/series-area/fillopacity/demo.js
+++ b/samples/unit-tests/series-area/fillopacity/demo.js
@@ -11,6 +11,11 @@ QUnit.test('Fill opacity zero (#4888)', function (assert) {
         series: [
             {
                 data: [1, 3, 2, 4]
+            },
+            {
+                data: [3, 2, 5, 2],
+                color: 'blue',
+                fillOpacity: 0.25
             }
         ]
     });
@@ -20,4 +25,18 @@ QUnit.test('Fill opacity zero (#4888)', function (assert) {
         'rgba(44,175,254,0)',
         'Fill opacity should be set'
     );
+
+    const areaFill = chart.series[1].area.element.getAttribute('fill').replace(/ /g, '');
+    assert.ok(
+        areaFill === 'blue' || areaFill === 'rgba(0,0,255,0.25)',
+        'There should be support for HTML color names'
+    );
+
+    if (areaFill === 'blue') {
+        assert.strictEqual(
+            chart.series[1].area.element.getAttribute('fill-opacity'),
+            '0.25',
+            'There should be opacity set for the HTML color names'
+        );
+    }
 });

--- a/samples/unit-tests/series-area/fillopacity/demo.js
+++ b/samples/unit-tests/series-area/fillopacity/demo.js
@@ -10,7 +10,8 @@ QUnit.test('Fill opacity zero (#4888)', function (assert) {
         },
         series: [
             {
-                data: [1, 3, 2, 4]
+                data: [1, 3, 2, 4],
+                color: '#A1A1A1'
             },
             {
                 data: [3, 2, 5, 2],
@@ -20,23 +21,29 @@ QUnit.test('Fill opacity zero (#4888)', function (assert) {
         ]
     });
 
+    // Testing HEX colors
     assert.strictEqual(
         chart.series[0].area.element.getAttribute('fill').replace(/ /g, ''),
-        'rgba(44,175,254,0)',
+        '#A1A1A1',
+        'Fill color should be set'
+    );
+
+    assert.strictEqual(
+        chart.series[0].area.element.getAttribute('fill-opacity'),
+        '0',
         'Fill opacity should be set'
     );
 
-    const areaFill = chart.series[1].area.element.getAttribute('fill').replace(/ /g, '');
-    assert.ok(
-        areaFill === 'blue' || areaFill === 'rgba(0,0,255,0.25)',
-        'There should be support for HTML color names'
+    // Testing HTML colors
+    assert.strictEqual(
+        chart.series[1].area.element.getAttribute('fill').replace(/ /g, ''),
+        'blue',
+        'HTML color names should be supported'
     );
 
-    if (areaFill === 'blue') {
-        assert.strictEqual(
-            chart.series[1].area.element.getAttribute('fill-opacity'),
-            '0.25',
-            'There should be opacity set for the HTML color names'
-        );
-    }
+    assert.strictEqual(
+        chart.series[1].area.element.getAttribute('fill-opacity'),
+        '0.25',
+        'Fill opacity should be set when no fillColor defined'
+    );
 });

--- a/ts/.eslintrc
+++ b/ts/.eslintrc
@@ -20,6 +20,7 @@
                 "properties": "always"
             }
         ],
+        "capitalized-comments": ["warn", "always", { "ignoreConsecutiveComments": true }],
         "class-methods-use-this": 0,
         "comma-dangle": [
             2,

--- a/ts/Series/Area/AreaSeries.ts
+++ b/ts/Series/Area/AreaSeries.ts
@@ -309,13 +309,16 @@ class AreaSeries extends LineSeries {
                 area.isArea = true;
             }
 
-            // if there is fillColor defined for the area, set it
-            if (!series.chart.styledMode && prop[3]) {
-                attribs.fill = prop[3];
-            } else if (!series.chart.styledMode) {
-                // otherwise, we set it to the series color & add fill-opacity
-                attribs.fill = prop[2];
-                attribs['fill-opacity'] = pick(options.fillOpacity, 0.75);
+            if (!series.chart.styledMode) {
+                // If there is fillColor defined for the area, set it
+                if (prop[3]) {
+                    attribs.fill = prop[3];
+                } else {
+                    // Otherwise, we set it to the series color and add
+                    // fill-opacity (#18939)
+                    attribs.fill = prop[2];
+                    attribs['fill-opacity'] = pick(options.fillOpacity, 0.75);
+                }
             }
 
             area[verb](attribs);

--- a/ts/Series/Area/AreaSeries.ts
+++ b/ts/Series/Area/AreaSeries.ts
@@ -309,19 +309,15 @@ class AreaSeries extends LineSeries {
                 area.isArea = true;
             }
 
-            if (!series.chart.styledMode) {
-                const colorWithOpacity = color(prop[2])
-                    .setOpacity(pick(options.fillOpacity, 0.75))
-                    .get();
-
-                attribs.fill = pick(prop[3], colorWithOpacity);
-
-                // if colorWithOpacity is the same as color
-                // it means that the color is "named" (ex. 'red', 'blue', etc.)
-                if (!prop[3] && colorWithOpacity === prop[2]) {
-                    attribs['fill-opacity'] = pick(options.fillOpacity, 0.75);
-                }
+            // if there is fillColor defined for the area, set it
+            if (!series.chart.styledMode && prop[3]) {
+                attribs.fill = prop[3];
+            } else if (!series.chart.styledMode) {
+                // otherwise, we set it to the series color & add fill-opacity
+                attribs.fill = prop[2];
+                attribs['fill-opacity'] = pick(options.fillOpacity, 0.75);
             }
+
             area[verb](attribs);
 
             area.startX = areaPath.xMap;

--- a/ts/Series/Area/AreaSeries.ts
+++ b/ts/Series/Area/AreaSeries.ts
@@ -310,12 +310,17 @@ class AreaSeries extends LineSeries {
             }
 
             if (!series.chart.styledMode) {
-                attribs.fill = pick(
-                    prop[3],
-                    color(prop[2])
-                        .setOpacity(pick(options.fillOpacity, 0.75))
-                        .get()
-                );
+                const colorWithOpacity = color(prop[2])
+                    .setOpacity(pick(options.fillOpacity, 0.75))
+                    .get();
+
+                attribs.fill = pick(prop[3], colorWithOpacity);
+
+                // if colorWithOpacity is the same as color
+                // it means that the color is "named" (ex. 'red', 'blue', etc.)
+                if (!prop[3] && colorWithOpacity === prop[2]) {
+                    attribs['fill-opacity'] = pick(options.fillOpacity, 0.75);
+                }
             }
             area[verb](attribs);
 


### PR DESCRIPTION
Fixed #18001, `fillOpacity` did not work for the area when the color was not HEX or RGBA, but an HTML color like _red, blue_, etc.

**Before fix:** https://jsfiddle.net/BlackLabel/8s95Lamo/
**After fix:** https://jsfiddle.net/BlackLabel/jvykotx1/

I've added an `if` which is checking whether the `color(series.color).setOpacity(fillOpacity) == series.color` because if that's true that means that the `series.color` is an HTML color (if it's HEX or RGBA, there will be a difference after setting the opacity).

I've added 2 tests which are checking this case, but unfortunately, I had to add an if statement outside one assertion as the test would pass in Utils, but not in Karma (Karma would have `fill: rgba(0, 0, 255, 0.25)` instead of `fill: blue, fill-opacity: 0.25` which is the case for Utils).