### PR TITLE
Fixed regression in series label color in styled mode

### DIFF
--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -473,6 +473,11 @@ text.highcharts-data-label {
     stroke-width: 0;
 }
 
+.highcharts-series-label text {
+    fill: inherit;
+    font-weight: bold;
+}
+
 .highcharts-series:not(.highcharts-pie-series) .highcharts-point-select,
 .highcharts-markers .highcharts-point-select {
     fill: var(--highcharts-neutral-color-20);

--- a/samples/highcharts/css/series-marker/demo.html
+++ b/samples/highcharts/css/series-marker/demo.html
@@ -1,4 +1,5 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/series-label.js"></script>
 <script src="https://code.highcharts.com/modules/exporting.js"></script>
 
 <div id="container"></div>


### PR DESCRIPTION
Fixed a regression in v11 causing series label color not to follow the series color in styled mode.