### PR TITLE
bugfix/18945-dragdrop-first-row

### DIFF
--- a/ts/Extensions/DraggablePoints.ts
+++ b/ts/Extensions/DraggablePoints.ts
@@ -2376,7 +2376,7 @@ Point.prototype.getDropValues = function (
         // If we are updating a single prop, and it has a validation function
         // for the prop, run it. If it fails, don't update the value.
         if (
-            newVal &&
+            isNumber(newVal) &&
             !(
                 updateSingleProp &&
                 val.propValidate &&


### PR DESCRIPTION
Fixed #18945, dragging point to row with index of 0 didn't work in gantt/x-range.