### PR TITLE
bugfix/18950-bar-race-resize

### DIFF
--- a/samples/highcharts/demo/bar-race/demo.js
+++ b/samples/highcharts/demo/bar-race/demo.js
@@ -52,7 +52,11 @@ let dataset, chart;
                 (point.dataLabels || []).forEach(
                     label =>
                         (label.attr = function (hash) {
-                            if (hash && hash.text !== undefined) {
+                            if (
+                                hash &&
+                                hash.text !== undefined &&
+                                chart.isResizing === 0
+                            ) {
                                 const text = hash.text;
 
                                 delete hash.text;


### PR DESCRIPTION
Fixed #18950, Bar Race Chart (from this blog post: https://www.highcharts.com/blog/tutorials/bar-chart-race/) threw `Maximum call size exceeded` when the animation was playing and the user was resizing the window.