### PR TITLE
bugfix/18956-short-sankey-bars-circles

### DIFF
--- a/samples/unit-tests/series-area/fillopacity/demo.js
+++ b/samples/unit-tests/series-area/fillopacity/demo.js
@@ -10,14 +10,40 @@ QUnit.test('Fill opacity zero (#4888)', function (assert) {
         },
         series: [
             {
-                data: [1, 3, 2, 4]
+                data: [1, 3, 2, 4],
+                color: '#A1A1A1'
+            },
+            {
+                data: [3, 2, 5, 2],
+                color: 'blue',
+                fillOpacity: 0.25
             }
         ]
     });
 
+    // Testing HEX colors
     assert.strictEqual(
         chart.series[0].area.element.getAttribute('fill').replace(/ /g, ''),
-        'rgba(44,175,254,0)',
+        '#A1A1A1',
+        'Fill color should be set'
+    );
+
+    assert.strictEqual(
+        chart.series[0].area.element.getAttribute('fill-opacity'),
+        '0',
         'Fill opacity should be set'
+    );
+
+    // Testing HTML colors
+    assert.strictEqual(
+        chart.series[1].area.element.getAttribute('fill').replace(/ /g, ''),
+        'blue',
+        'HTML color names should be supported'
+    );
+
+    assert.strictEqual(
+        chart.series[1].area.element.getAttribute('fill-opacity'),
+        '0.25',
+        'Fill opacity should be set when no fillColor defined'
     );
 });

--- a/ts/.eslintrc
+++ b/ts/.eslintrc
@@ -20,6 +20,7 @@
                 "properties": "always"
             }
         ],
+        "capitalized-comments": ["warn", "always", { "ignoreConsecutiveComments": true }],
         "class-methods-use-this": 0,
         "comma-dangle": [
             2,

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -2486,6 +2486,21 @@ const seriesDefaults: PlotOptionsOf<Series> = {
      */
 
     /**
+     * What type of legend symbol to render for this series. Can be one of
+     * `lineMarker` or `rectangle`.
+     *
+     * @validvalue ["lineMarker", "rectangle"]
+     *
+     * @sample {highcharts} highcharts/series/legend-symbol/
+     *         Change the legend symbol
+     *
+     * @type      {string}
+     * @default   rectangle
+     * @since     11.0.1
+     * @apioption plotOptions.series.legendSymbol
+     */
+
+    /**
      * Determines whether the series should look for the nearest point
      * in both dimensions or just the x-dimension when hovering the series.
      * Defaults to `'xy'` for scatter series and `'x'` for most other
@@ -2508,15 +2523,6 @@ const seriesDefaults: PlotOptionsOf<Series> = {
      * @private
      */
     findNearestPointBy: 'x'
-
-    /**
-     * What type of legend symbol to render for this series.
-     *
-     * @validvalue ["lineMarker", "rectangle"]
-     *
-     * @sample {highcharts} highcharts/series/legend-symbol/
-     *         Change the legend symbol
-     */
 
 };
 

--- a/ts/Series/Area/AreaSeries.ts
+++ b/ts/Series/Area/AreaSeries.ts
@@ -310,13 +310,17 @@ class AreaSeries extends LineSeries {
             }
 
             if (!series.chart.styledMode) {
-                attribs.fill = pick(
-                    prop[3],
-                    color(prop[2])
-                        .setOpacity(pick(options.fillOpacity, 0.75))
-                        .get()
-                );
+                // If there is fillColor defined for the area, set it
+                if (prop[3]) {
+                    attribs.fill = prop[3];
+                } else {
+                    // Otherwise, we set it to the series color and add
+                    // fill-opacity (#18939)
+                    attribs.fill = prop[2];
+                    attribs['fill-opacity'] = pick(options.fillOpacity, 0.75);
+                }
             }
+
             area[verb](attribs);
 
             area.startX = areaPath.xMap;


### PR DESCRIPTION
Fixed #18956, a regression causing small sankey nodes rendering as circles.