### PR TITLE
bugfix/18953-sunburst-datalabels-html

### DIFF
--- a/ts/Series/Sunburst/SunburstSeries.ts
+++ b/ts/Series/Sunburst/SunburstSeries.ts
@@ -148,6 +148,16 @@ function getDlOptions(
 
     if (!isNumber(options.rotation)) {
         if (rotationMode === 'auto' || rotationMode === 'circular') {
+
+            if (
+                options.useHTML &&
+                rotationMode === 'circular'
+            ) {
+                // Change rotationMode to 'auto' to avoid using text paths
+                // for HTML labels, see #18953
+                rotationMode = 'auto';
+            }
+
             if (
                 (point.innerArcLength as any) < 1 &&
                 (point.outerArcLength as any) > (shape.radius as any)


### PR DESCRIPTION
Fixed #18953, `dataLabels` in Sunburst series weren't properly positioned when `useHTML` was enabled. 