### PR TITLE
bugfix/18960-dumbbell-data-labels

### DIFF
--- a/samples/highcharts/demo/dumbbell/demo.js
+++ b/samples/highcharts/demo/dumbbell/demo.js
@@ -93,7 +93,10 @@ Highcharts.chart('container', {
 
     series: [{
         name: 'Life expectancy change',
-        data: data
+        data: data,
+        dataLabels: {
+            enabled: true
+        }
     }]
 
 });

--- a/samples/highcharts/demo/dumbbell/demo.js
+++ b/samples/highcharts/demo/dumbbell/demo.js
@@ -93,10 +93,7 @@ Highcharts.chart('container', {
 
     series: [{
         name: 'Life expectancy change',
-        data: data,
-        dataLabels: {
-            enabled: true
-        }
+        data: data
     }]
 
 });

--- a/samples/highcharts/series-dumbbell/styled-mode-dumbbell/demo.js
+++ b/samples/highcharts/series-dumbbell/styled-mode-dumbbell/demo.js
@@ -22,6 +22,14 @@ Highcharts.chart('container', {
         }
     }],
 
+    plotOptions: {
+        series: {
+            dataLabels: {
+                enabled: true
+            }
+        }
+    },
+
     series: [{
         data: [[32, 45], [43, 56], [32, 42], [28, 56]]
     }, {

--- a/ts/Series/Dumbbell/DumbbellSeries.ts
+++ b/ts/Series/Dumbbell/DumbbellSeries.ts
@@ -483,6 +483,16 @@ class DumbbellSeries extends AreaRangeSeries {
 
         return pointAttribs;
     }
+
+    /**
+     * Set the shape arguments for dummbells.
+     * @private
+     */
+    public setShapeArgs(): void {
+        colProto.translate.apply(this);
+        columnRangeProto.afterColumnTranslate.apply(this);
+    }
+
 }
 
 /* *
@@ -496,7 +506,6 @@ interface DumbbellSeries {
     crispCol: typeof colProto.crispCol;
     trackerGroups: Array<string>;
     translatePoint: typeof AreaRangeSeries.prototype['translate'];
-    setShapeArgs: typeof columnRangeProto['translate'];
     seriesDrawPoints: typeof AreaRangeSeries.prototype['drawPoints'];
 }
 extend(DumbbellSeries.prototype, {
@@ -504,7 +513,6 @@ extend(DumbbellSeries.prototype, {
     drawGraph: noop,
     drawTracker: ColumnSeries.prototype.drawTracker,
     pointClass: DumbbellPoint,
-    setShapeArgs: columnRangeProto.translate,
     seriesDrawPoints: areaRangeProto.drawPoints,
     trackerGroups: ['group', 'markerGroup', 'dataLabelsGroup'],
     translatePoint: areaRangeProto.translate


### PR DESCRIPTION
Fixed #18960, a regression in v11, wrong placement for data labels in dumbbell series.

The issue was the change of `ColumnRangeSeries.prototype.translate()` function which was used in `DumbellSeries` as a `setShapeArgs` function.

**Demo before fix:** https://jsfiddle.net/kluvin/a1Lg4k75/
**Demo after fix:** https://jsfiddle.net/BlackLabel/e9fa0ck8/
