### PR TITLE
bugfix/17861-zoomtype-update

### DIFF
--- a/samples/unit-tests/chart/zoomtype/demo.js
+++ b/samples/unit-tests/chart/zoomtype/demo.js
@@ -372,7 +372,7 @@ QUnit.test('Zooming scatter charts', function (assert) {
     });
 
     assert.strictEqual(
-        chart.options.chart.zooming.type,
+        chart.zooming.type,
         'xy',
         'There should be support for updating the deprecated zoomType (#17861)'
     );
@@ -388,7 +388,7 @@ QUnit.test('Zooming scatter charts', function (assert) {
     });
 
     assert.strictEqual(
-        chart.options.chart.zooming.resetButton.theme.zIndex,
+        chart.zooming.resetButton.theme.zIndex,
         8,
         'Deprecated zooming properties should be updated (#17861)'
     );

--- a/samples/unit-tests/chart/zoomtype/demo.js
+++ b/samples/unit-tests/chart/zoomtype/demo.js
@@ -103,7 +103,7 @@ QUnit.test('Zooming scatter charts', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {
             type: 'scatter',
-            zoomType: 'xy',
+            zoomType: 'y',
             width: 600,
             height: 400
         },
@@ -363,6 +363,35 @@ QUnit.test('Zooming scatter charts', function (assert) {
             }
         ]
     });
+
+    // Update the deprecated properties
+    chart.update({
+        chart: {
+            zoomType: 'xy'
+        }
+    });
+
+    assert.strictEqual(
+        chart.options.chart.zooming.type,
+        'xy',
+        'There should be support for updating the deprecated zoomType (#17861)'
+    );
+
+    chart.update({
+        chart: {
+            resetZoomButton: {
+                theme: {
+                    zIndex: 8
+                }
+            }
+        }
+    });
+
+    assert.strictEqual(
+        chart.options.chart.zooming.resetButton.theme.zIndex,
+        8,
+        'Deprecated zooming properties should be updated (#17861)'
+    );
 
     // Do the first zoom
     chart.pointer.zoomX = chart.pointer.zoomY = true;

--- a/samples/unit-tests/pointer/touch/demo.js
+++ b/samples/unit-tests/pointer/touch/demo.js
@@ -416,7 +416,6 @@ QUnit.test('Touch and panning', function (assert) {
             ]
         }),
         offset = Highcharts.offset(chart.container);
-    console.log('chart: ', chart);
 
     Array.prototype.item = function (i) {
         // eslint-disable-line no-extend-native

--- a/samples/unit-tests/pointer/touch/demo.js
+++ b/samples/unit-tests/pointer/touch/demo.js
@@ -416,6 +416,7 @@ QUnit.test('Touch and panning', function (assert) {
             ]
         }),
         offset = Highcharts.offset(chart.container);
+    console.log('chart: ', chart);
 
     Array.prototype.item = function (i) {
         // eslint-disable-line no-extend-native

--- a/ts/Core/Axis/NavigatorAxisComposition.ts
+++ b/ts/Core/Axis/NavigatorAxisComposition.ts
@@ -88,9 +88,9 @@ function onAxisZoom(
         chartOptions = chart.options,
         navigator = chartOptions.navigator,
         navigatorAxis = axis.navigatorAxis,
-        pinchType = chartOptions.chart.zooming.pinchType,
+        pinchType = chart.zooming.pinchType,
         rangeSelector = chartOptions.rangeSelector,
-        zoomType = chartOptions.chart.zooming.type;
+        zoomType = chart.zooming.type;
 
     if (axis.isXAxis && ((navigator && navigator.enabled) ||
             (rangeSelector && rangeSelector.enabled))) {

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -406,21 +406,23 @@ class Chart {
      * @private
      * @function Highcharts.Chart#setZoomOptions
      */
-    public setZoomOptions(chartOptions?: ChartOptions): void {
+    public setZoomOptions(): void {
         const chart = this,
-            options = chartOptions ? chartOptions : chart.options.chart;
+            options = chart.options.chart,
+            zooming = options.zooming;
 
         chart.zooming = {
-            ...options.zooming,
-            type: pick(options.zoomType, options.zooming.type),
-            key: pick(options.zoomKey, options.zooming.key),
-            pinchType: pick(options.pinchType, options.zooming.pinchType),
+            ...zooming,
+            type: pick(options.zoomType, zooming.type),
+            key: pick(options.zoomKey, zooming.key),
+            pinchType: pick(options.pinchType, zooming.pinchType),
             singleTouch: pick(
                 options.zoomBySingleTouch,
-                options.zooming.singleTouch,
-                false),
+                zooming.singleTouch,
+                false
+            ),
             resetButton: merge(
-                options.zooming.resetButton,
+                zooming.resetButton,
                 options.resetZoomButton
             )
         };
@@ -459,7 +461,6 @@ class Chart {
 
             const optionsChart = options.chart;
 
-            this.setZoomOptions(optionsChart);
             // Override (by copy of user options) or clear tooltip options
             // in chart.options.plotOptions (#6218)
             objectEach(options.plotOptions, function (
@@ -605,6 +606,8 @@ class Chart {
             chart.yAxis = [];
 
             chart.pointCount = chart.colorCounter = chart.symbolCounter = 0;
+
+            this.setZoomOptions();
 
             // Fire after init but before first render, before axes and series
             // have been initialized.

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -37,7 +37,10 @@ import type {
 } from '../Options';
 import type ChartLike from './ChartLike';
 import type ChartOptions from './ChartOptions';
-import type { ChartPanningOptions } from './ChartOptions';
+import type {
+    ChartPanningOptions,
+    ChartResetZoomButtonOptions
+} from './ChartOptions';
 import type ColorAxis from '../Axis/Color/ColorAxis';
 import type Point from '../Series/Point';
 import type PointerEvent from '../PointerEvent';
@@ -395,6 +398,67 @@ class Chart {
     }
 
     /**
+     * Function setting zoom options after chart init and after chart update.
+     * Offers support for deprecated options.
+     *
+     * @private
+     * @function Highcharts.Chart#setZoomOptions
+     */
+    public setZoomOptions(optionsChart: ChartOptions): void {
+        const zooming = optionsChart.zooming = optionsChart.zooming || {},
+            userOptions = this.userOptions.chart,
+            defaultZoomButton: ChartResetZoomButtonOptions = {
+                theme: {
+                    zIndex: 6
+                },
+                position: {
+                    align: 'right',
+                    x: -10,
+                    y: 10
+                }
+            };
+
+        zooming.type = pick(
+            userOptions?.zooming?.type,
+            userOptions?.zoomType,
+            zooming.type,
+            optionsChart.zoomType
+        );
+        zooming.key = pick(
+            userOptions?.zooming?.key,
+            userOptions?.zoomKey,
+            zooming.key,
+            optionsChart.zoomKey
+        );
+        zooming.pinchType = pick(
+            userOptions?.zooming?.pinchType,
+            userOptions?.pinchType,
+            zooming.pinchType,
+            optionsChart.pinchType
+        );
+        zooming.singleTouch = pick(
+            userOptions?.zooming?.singleTouch,
+            userOptions?.zoomBySingleTouch,
+            zooming.singleTouch,
+            optionsChart.zoomBySingleTouch
+        );
+
+        if (userOptions?.zooming?.resetButton) {
+            zooming.resetButton = merge(
+                defaultZoomButton,
+                userOptions?.zooming?.resetButton
+            );
+        } else if (userOptions?.resetZoomButton) {
+            zooming.resetButton = merge(
+                defaultZoomButton,
+                userOptions?.resetZoomButton
+            );
+        } else {
+            zooming.resetButton = defaultZoomButton;
+        }
+    }
+
+    /**
      * Overridable function that initializes the chart. The constructor's
      * arguments are passed on directly.
      *
@@ -471,28 +535,7 @@ class Chart {
             this.callback = callback;
             this.isResizing = 0;
 
-            const zooming = optionsChart.zooming = optionsChart.zooming || {};
-
-            // Other options have no default so just pick
-            if (userOptions.chart && !userOptions.chart.zooming) {
-                zooming.resetButton = optionsChart.resetZoomButton;
-            }
-            zooming.key = pick(
-                zooming.key,
-                optionsChart.zoomKey
-            );
-            zooming.pinchType = pick(
-                zooming.pinchType,
-                optionsChart.pinchType
-            );
-            zooming.singleTouch = pick(
-                zooming.singleTouch,
-                optionsChart.zoomBySingleTouch
-            );
-            zooming.type = pick(
-                zooming.type,
-                optionsChart.zoomType
-            );
+            this.setZoomOptions(optionsChart);
 
             /**
              * The options structure for the chart after merging
@@ -3138,8 +3181,10 @@ class Chart {
         const optionsChart = options.chart;
 
         if (optionsChart) {
-
             merge(true, chart.options.chart, optionsChart);
+
+            // Add support for deprecated zooming options like zoomType, #17861
+            this.setZoomOptions(chart.options.chart);
 
             // Setter function
             if ('className' in optionsChart) {

--- a/ts/Core/Chart/ChartDefaults.ts
+++ b/ts/Core/Chart/ChartDefaults.ts
@@ -492,7 +492,7 @@ const ChartDefaults: ChartOptions = {
      *
      * @type       {string}
      * @default    {highcharts} undefined
-     * @default    {highstock} x
+     * @default    {highstock} undefined
      * @since      3.0
      * @product    highcharts highstock gantt
      * @deprecated
@@ -1028,7 +1028,6 @@ const ChartDefaults: ChartOptions = {
      * @product    highcharts highstock gantt
      * @deprecated
      */
-    zoomBySingleTouch: false,
 
     /**
      * Chart zooming options.

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -2090,7 +2090,7 @@ class Pointer {
      */
     private touchSelect(e: PointerEvent): boolean {
         return Boolean(
-            this.chart.options.chart.zooming.singleTouch &&
+            this.chart.zooming.singleTouch &&
             e.touches &&
             e.touches.length === 1
         );
@@ -2107,13 +2107,13 @@ class Pointer {
             options = chart.options.chart,
             inverted = chart.inverted;
 
-        let zoomType = options.zooming.type || '',
+        let zoomType = chart.zooming.type || '',
             zoomX,
             zoomY;
 
         // Look for the pinchType option
         if (/touch/.test(e.type)) {
-            zoomType = pick(options.zooming.pinchType, zoomType);
+            zoomType = pick(chart.zooming.pinchType, zoomType);
         }
 
         this.zoomX = zoomX = /x/.test(zoomType);

--- a/ts/Extensions/DraggablePoints.ts
+++ b/ts/Extensions/DraggablePoints.ts
@@ -3044,7 +3044,7 @@ Chart.prototype.zoomOrPanKeyPressed = function (e: Event): boolean {
     // Check whether the panKey and zoomKey are set in chart.userOptions
     const chartOptions = this.options.chart || {},
         panKey = chartOptions.panKey && chartOptions.panKey + 'Key',
-        zoomKey = chartOptions.zooming.key && chartOptions.zooming.key + 'Key';
+        zoomKey = this.zooming.key && this.zooming.key + 'Key';
 
     return ((e as any)[zoomKey as any] || (e as any)[panKey as any]);
 };

--- a/ts/Maps/MapPointer.ts
+++ b/ts/Maps/MapPointer.ts
@@ -177,7 +177,7 @@ wrap(Pointer.prototype, 'zoomOption', function (
         (mapNavigation as any).enableTouchZoom,
         (mapNavigation as any).enabled)
     ) {
-        this.chart.options.chart.zooming.pinchType = 'xy';
+        this.chart.zooming.pinchType = 'xy';
     }
 
     proceed.apply(this, [].slice.call(arguments, 1));

--- a/ts/Stock/Navigator/NavigatorComposition.ts
+++ b/ts/Stock/Navigator/NavigatorComposition.ts
@@ -277,9 +277,8 @@ function onChartBeforeShowResetZoom(
     if (((navigator && navigator.enabled) ||
         (rangeSelector && rangeSelector.enabled)) &&
         ((!isTouchDevice &&
-        (chartOptions.chart as any).zooming.type === 'x') ||
-        (isTouchDevice &&
-        (chartOptions.chart as any).zooming.pinchType === 'x'))
+        this.zooming.type === 'x') ||
+        (isTouchDevice && this.zooming.pinchType === 'x'))
     ) {
         return false;
     }


### PR DESCRIPTION
Fixed #17861, updating the deprecated properties for zoom didn't work (`chart.zoomType`, `chart.zoomKey`, `chart.resetZoomButton`, `chart.pinchType`, `chart.singleTouch`).

**Demo after fix:** https://jsfiddle.net/BlackLabel/61zrypqv/
