### PR TITLE
feature/18839-funnel-pyramid-rounded-corners

### DIFF
--- a/samples/highcharts/plotoptions/funnel-border-radius/demo.css
+++ b/samples/highcharts/plotoptions/funnel-border-radius/demo.css
@@ -1,0 +1,39 @@
+#outer-container {
+    min-width: 300px;
+    max-width: 600px;
+    margin: 1em auto;
+}
+
+#outer-container .button-group {
+    padding-right: 2em;
+    padding-bottom: 4px;
+}
+
+#outer-container button {
+    padding: 1em;
+    border: 0;
+    border-radius: 2px;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+#container {
+    height: 400px;
+    box-shadow: 1px 2px 5px rgba(0 0 0 / 0.2);
+    margin: 1rem 0;
+    padding-right: 1%;
+}
+
+.range-container {
+    position: relative;
+    padding-top: 2em;
+}
+
+input#range {
+    width: 100%;
+}
+
+label[for="range"] {
+    top: 0;
+    position: absolute;
+}

--- a/samples/highcharts/plotoptions/funnel-border-radius/demo.details
+++ b/samples/highcharts/plotoptions/funnel-border-radius/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Funnel border radius
+ authors:
+   - Dawid Dragula
+ js_wrap: b
+...

--- a/samples/highcharts/plotoptions/funnel-border-radius/demo.html
+++ b/samples/highcharts/plotoptions/funnel-border-radius/demo.html
@@ -9,8 +9,8 @@
     </div>
 
     <span class="button-group">
-        <button class="radius-mode" data-value="series">Series Mode</button>
-        <button class="radius-mode" data-value="points">Points Mode</button>
+        <button class="radius-scope" data-value="stack">Stack Scope</button>
+        <button class="radius-scope" data-value="point">Point Scope</button>
     </span>
 
     <div id="container"></div>

--- a/samples/highcharts/plotoptions/funnel-border-radius/demo.html
+++ b/samples/highcharts/plotoptions/funnel-border-radius/demo.html
@@ -1,0 +1,23 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/funnel.js"></script>
+
+<div id="outer-container">
+
+    <div class="range-container">
+        <label for="range"></label>
+        <input id="range" type="range" min="0" max="50" value="10">
+    </div>
+
+    <span class="button-group">
+        <button class="radius-mode" data-value="series">Series Mode</button>
+        <button class="radius-mode" data-value="points">Points Mode</button>
+    </span>
+
+    <div id="container"></div>
+
+    <span class="button-group">
+        <button class="type" data-value="funnel">Funnel</button>
+        <button class="type" data-value="pyramid">Pyramid</button>
+    </span>
+
+</div>

--- a/samples/highcharts/plotoptions/funnel-border-radius/demo.js
+++ b/samples/highcharts/plotoptions/funnel-border-radius/demo.js
@@ -1,0 +1,82 @@
+Highcharts.chart('container', {
+    chart: {
+        type: 'funnel'
+    },
+    accessibility: {
+        enabled: false
+    },
+    title: {
+        text: 'Funnel chart with rounded corners'
+    },
+    plotOptions: {
+        series: {
+            borderRadius: `${document.getElementById('range').value}`,
+            borderWidth: 2,
+            borderColor: '#666',
+            dataLabels: {
+                enabled: true
+            },
+            center: ['47%', '50%'],
+            width: '90%'
+        }
+    },
+    series: [{
+        data: [
+            ['Website visits', 15654],
+            ['Downloads', 4064],
+            ['Requested price list', 1987],
+            ['Invoice sent', 1822]
+        ]
+    }],
+    colors: ['#d7bfff', '#af80ff', '#5920b9', '#48208b']
+});
+
+const label = document.querySelector('label[for="range"]');
+const updateLabel = input => {
+    label.innerText = `${input.value}px`;
+
+    const position = (input.value - input.min) / (input.max - input.min),
+        percent = Math.round(position * 100),
+        pxAdjust = Math.round(label.offsetWidth * position);
+    label.style.left = `calc(${percent}% - ${pxAdjust}px)`;
+};
+updateLabel(document.getElementById('range'));
+
+document.getElementById('range').addEventListener('input', e => {
+    updateLabel(e.target);
+
+    Highcharts.charts.forEach(chart => {
+        chart.update({
+            plotOptions: {
+                series: {
+                    borderRadius: e.target.value
+                }
+            }
+        }, undefined, undefined, false);
+    });
+});
+
+document.querySelectorAll('button.radius-mode').forEach(btn => {
+    btn.addEventListener('click', () => {
+        Highcharts.charts[0].update({
+            plotOptions: {
+                series: {
+                    borderRadiusMode: btn.dataset.value
+                }
+            }
+        });
+    });
+});
+
+document.querySelectorAll('button.type').forEach(btn => {
+    btn.addEventListener('click', () => {
+        Highcharts.charts[0].update({
+            chart: {
+                type: btn.dataset.value
+            },
+            title: {
+                text: btn.innerHTML + ' chart with rounded corners'
+            }
+        });
+    });
+});

--- a/samples/highcharts/plotoptions/funnel-border-radius/demo.js
+++ b/samples/highcharts/plotoptions/funnel-border-radius/demo.js
@@ -2,20 +2,16 @@ Highcharts.chart('container', {
     chart: {
         type: 'funnel'
     },
-    accessibility: {
-        enabled: false
-    },
     title: {
         text: 'Funnel chart with rounded corners'
     },
     plotOptions: {
         series: {
-            borderRadius: `${document.getElementById('range').value}`,
+            borderRadius: {
+                radius: document.getElementById('range').value
+            },
             borderWidth: 2,
             borderColor: '#666',
-            dataLabels: {
-                enabled: true
-            },
             center: ['47%', '50%'],
             width: '90%'
         }
@@ -49,19 +45,23 @@ document.getElementById('range').addEventListener('input', e => {
         chart.update({
             plotOptions: {
                 series: {
-                    borderRadius: e.target.value
+                    borderRadius: {
+                        radius: e.target.value
+                    }
                 }
             }
         }, undefined, undefined, false);
     });
 });
 
-document.querySelectorAll('button.radius-mode').forEach(btn => {
+document.querySelectorAll('button.radius-scope').forEach(btn => {
     btn.addEventListener('click', () => {
         Highcharts.charts[0].update({
             plotOptions: {
                 series: {
-                    borderRadiusMode: btn.dataset.value
+                    borderRadius: {
+                        scope: btn.dataset.value
+                    }
                 }
             }
         });

--- a/samples/unit-tests/series-funnel/funnel/demo.js
+++ b/samples/unit-tests/series-funnel/funnel/demo.js
@@ -191,22 +191,19 @@ QUnit.test('Funnel path', function (assert) {
     assert.strictEqual(
         points[0].graphic.d.split(' ').filter(s => s === 'C').length,
         2,
-        `The first point should have 2 rounded corners,
-        borderRadiusMode: series (#18839)`
+        'The first point should have 2 rounded corners, scope: stack (#18839)'
     );
 
     assert.strictEqual(
         points[1].graphic.d.split(' ').filter(s => s === 'C').length,
         0,
-        `The second point should have 0 rounded corners,
-        borderRadiusMode: series (#18839)`
+        'The second point should have 0 rounded corners, scope: stack (#18839)'
     );
 
     assert.strictEqual(
         points[3].graphic.d.split(' ').filter(s => s === 'C').length,
         4,
-        `The last point should have 4 rounded corners,
-        borderRadiusMode: series (#18839)`
+        'The last point should have 4 rounded corners, scope: stack (#18839)'
     );
 
     series.update({
@@ -219,22 +216,19 @@ QUnit.test('Funnel path', function (assert) {
     assert.strictEqual(
         points[0].graphic.d.split(' ').filter(s => s === 'C').length,
         4,
-        `The first point should have 4 rounded corners,
-        borderRadiusMode: points (#18839)`
+        'The first point should have 4 rounded corners, scope: point (#18839)'
     );
 
     assert.strictEqual(
         points[1].graphic.d.split(' ').filter(s => s === 'C').length,
         4,
-        `The second point should have 4 rounded corners,
-        borderRadiusMode: points (#18839)`
+        'The second point should have 4 rounded corners, scope: point (#18839)'
     );
 
     assert.strictEqual(
         points[3].graphic.d.split(' ').filter(s => s === 'C').length,
         6,
-        `The last point should have 6 rounded corners,
-        borderRadiusMode: points (#18839)`
+        'The last point should have 6 rounded corners, scope: point (#18839)'
     );
 });
 

--- a/samples/unit-tests/series-funnel/funnel/demo.js
+++ b/samples/unit-tests/series-funnel/funnel/demo.js
@@ -210,7 +210,10 @@ QUnit.test('Funnel path', function (assert) {
     );
 
     series.update({
-        borderRadiusMode: 'points'
+        borderRadius: {
+            radius: '1%',
+            scope: 'point'
+        }
     });
 
     assert.strictEqual(

--- a/samples/unit-tests/series-funnel/funnel/demo.js
+++ b/samples/unit-tests/series-funnel/funnel/demo.js
@@ -147,7 +147,7 @@ QUnit.test('Visible funnel items', function (assert) {
     );
 });
 
-QUnit.test('Top path of funnel intact', function (assert) {
+QUnit.test('Funnel path', function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {
             type: 'funnel'
@@ -170,8 +170,11 @@ QUnit.test('Top path of funnel intact', function (assert) {
         ]
     });
 
+    const series = chart.series[0],
+        points = series.points;
+
     assert.strictEqual(
-        chart.series[0].points[3].graphic.element
+        points[3].graphic.element
             .getAttribute('d')
             .split(' ')
             .filter(function (s) {
@@ -179,6 +182,56 @@ QUnit.test('Top path of funnel intact', function (assert) {
             }).length,
         14,
         'The path should have the neck intact (#8277)'
+    );
+
+    series.update({
+        borderRadius: 10
+    });
+
+    assert.strictEqual(
+        points[0].graphic.d.split(' ').filter(s => s === 'C').length,
+        2,
+        `The first point should have 2 rounded corners,
+        borderRadiusMode: series (#18839)`
+    );
+
+    assert.strictEqual(
+        points[1].graphic.d.split(' ').filter(s => s === 'C').length,
+        0,
+        `The second point should have 0 rounded corners,
+        borderRadiusMode: series (#18839)`
+    );
+
+    assert.strictEqual(
+        points[3].graphic.d.split(' ').filter(s => s === 'C').length,
+        4,
+        `The last point should have 4 rounded corners,
+        borderRadiusMode: series (#18839)`
+    );
+
+    series.update({
+        borderRadiusMode: 'points'
+    });
+
+    assert.strictEqual(
+        points[0].graphic.d.split(' ').filter(s => s === 'C').length,
+        4,
+        `The first point should have 4 rounded corners,
+        borderRadiusMode: points (#18839)`
+    );
+
+    assert.strictEqual(
+        points[1].graphic.d.split(' ').filter(s => s === 'C').length,
+        4,
+        `The second point should have 4 rounded corners,
+        borderRadiusMode: points (#18839)`
+    );
+
+    assert.strictEqual(
+        points[3].graphic.d.split(' ').filter(s => s === 'C').length,
+        6,
+        `The last point should have 6 rounded corners,
+        borderRadiusMode: points (#18839)`
     );
 });
 

--- a/ts/Series/Funnel/FunnelSeries.ts
+++ b/ts/Series/Funnel/FunnelSeries.ts
@@ -97,14 +97,22 @@ class FunnelSeries extends PieSeries {
         animation: false,
 
         /**
-         * The border radius is by default set to 0 for the funnel chart.
+         * The corner radius of the border surrounding all points or series,
+         * depending on the [borderRadiusMode](#series.funnel.borderRadiusMode)
+         * set.
+         *
+         * @sample highcharts/plotoptions/funnel-border-radius
+         *         Funnel and pyramid with rounded border
          */
         borderRadius: 0,
 
         /**
          * The `points` mode specifies that all points should have rounded
-         * corners, the `series` mode that only the main corners of the whole
-         * series should be rounded.
+         * corners, the `series` mode that only the corners of the whole series
+         * should be rounded.
+         *
+         * @sample highcharts/plotoptions/funnel-border-radius
+         *         Funnel and pyramid with rounded border
          *
          * @type    {'points'|'series'}
          */

--- a/ts/Series/Funnel/FunnelSeries.ts
+++ b/ts/Series/Funnel/FunnelSeries.ts
@@ -425,6 +425,21 @@ class FunnelSeries extends PieSeries {
             data = series.data,
             path: SVGPath,
             fraction,
+            roundingFactors = (
+                angle: number,
+                r: number,
+                maxT: number
+            ): [number, number] => {
+                const tan = Math.tan(angle / 2);
+                let t = r / tan;
+
+                if (t > maxT) {
+                    t = maxT;
+                    r = t * tan;
+                }
+
+                return [t, Math.tan((Math.PI - angle) / 3.2104) * r];
+            },
             half = (
                 (options.dataLabels as any).position === 'left' ?
                     1 :
@@ -557,53 +572,117 @@ class FunnelSeries extends PieSeries {
                 const h = Math.abs(y3 - y1),
                     xSide = x2 - x4,
                     lBase = x4 - x3,
-                    lSide = Math.sqrt(xSide * xSide + h * h);
-                let r = Math.min(borderRadius, lSide / 2),
-                    rdX: number,
-                    rdY: number,
-                    rY: number;
+                    lSide = Math.sqrt(xSide * xSide + h * h),
+                    alpha = Math.atan(h / xSide),
+                    cosA = Math.cos(alpha),
+                    sinA = Math.sin(alpha),
+                    rev = reversed ? -1 : 1;
+
+                let maxT = lSide / 2,
+                    t: number,
+                    k: number;
 
                 if (y5 !== null) {
-                    r = Math.min(r, Math.abs(y5 - y3) / 2);
+                    maxT = Math.min(maxT, Math.abs(y5 - y3) / 2);
                 }
 
                 if (lBase >= 1) {
-                    r = Math.min(r, lBase / 2);
+                    maxT = Math.min(maxT, lBase / 2);
                 }
 
-                rY = reversed ? -r : r;
-                rdX = r / lSide * xSide;
-                rdY = rY / lSide * h;
-
+                // Creating a point base
+                [t, k] = roundingFactors(alpha, borderRadius, maxT);
                 path = [
-                    ['M', x1 + rdX, y1 + rdY],
-                    ['Q', x1, y1, x1 + r, y1],
-                    ['L', x2 - r, y1],
-                    ['Q', x2, y1, x2 - rdX, y1 + rdY],
-                    ['L', x4 + rdX, y3 - rdY]
+                    ['M', x1 + t * cosA, y1 + t * sinA * rev],
+                    ['C',
+                        x1 + (t - k) * cosA, y1 + (t - k) * sinA * rev,
+                        x1 + t - k, y1,
+                        x1 + t, y1
+                    ],
+                    ['L', x2 - t, y1],
+                    ['C',
+                        x2 - t + k, y1,
+                        x2 - (t - k) * cosA, y1 + (t - k) * sinA * rev,
+                        x2 - t * cosA, y1 + t * sinA * rev
+                    ]
                 ];
 
                 if (y5 !== null) {
+                    // Closure of point with extension
+                    const [tr, kr] = roundingFactors(
+                        Math.PI / 2,
+                        borderRadius,
+                        maxT
+                    );
+                    [t, k] = roundingFactors(
+                        Math.PI / 2 + alpha,
+                        borderRadius,
+                        maxT
+                    );
                     path.push(
-                        ['Q', x4, y3, x4, y3 + rY],
-                        ['L', x4, y5 - rY],
-                        ['Q', x4, y5, x4 - r, y5],
-                        ['L', x3 + r, y5],
-                        ['Q', x3, y5, x3, y5 - rY],
-                        ['L', x3, y3 + rY]
+                        ['L', x4 + t * cosA, y3 - t * sinA * rev],
+                        ['C',
+                            x4 + t * cosA - k * cosA, y3 - (t - k) * sinA * rev,
+                            x4, y3 + (t - k) * rev,
+                            x4, y3 + t * rev
+                        ],
+                        ['L', x4, y5 - tr * rev],
+                        ['C',
+                            x4, y5 - (tr - kr) * rev,
+                            x4 - tr + kr, y5,
+                            x4 - tr, y5
+                        ],
+                        ['L', x3 + tr, y5],
+                        ['C',
+                            x3 + tr - kr, y5,
+                            x3, y5 - (tr - kr) * rev,
+                            x3, y5 - tr * rev
+                        ],
+                        ['L', x3, y3 + tr * rev],
+                        ['C',
+                            x3, y3 + (t - k) * rev,
+                            x3 - (t - k) * cosA, y3 - (t - k) * sinA * rev,
+                            x3 - t * cosA, y3 - t * sinA * rev
+                        ]
                     );
                 } else if (lBase >= 1) {
+                    // Closure of point without extension
+                    [t, k] = roundingFactors(
+                        Math.PI - alpha,
+                        borderRadius,
+                        maxT
+                    );
                     path.push(
-                        ['L', x4 + rdX, y3 - rdY],
-                        ['Q', x4, y3, x4 - r, y3],
-                        ['L', x3 + r, y3]
+                        ['L', x4 + t * cosA, y3 - t * sinA * rev],
+                        ['C',
+                            x4 + (t - k) * cosA, y3 - (t - k) * sinA * rev,
+                            x4 - t + k, y3,
+                            x4 - t, y3
+                        ],
+                        ['L', x3 + t, y3],
+                        ['C',
+                            x3 + t - k, y3,
+                            x3 - (t - k) * cosA, y3 - (t - k) * sinA * rev,
+                            x3 - t * cosA, y3 - t * sinA * rev
+                        ]
+                    );
+                } else {
+                    // Creating a rounded tip of the "pyramid"
+                    [t, k] = roundingFactors(
+                        Math.PI - alpha * 2,
+                        borderRadius,
+                        maxT
+                    );
+
+                    path.push(
+                        ['L', x3 + t * cosA, y3 - t * sinA * rev],
+                        ['C',
+                            x3 + (t - k) * cosA, y3 - (t - k) * sinA * rev,
+                            x3 - (t - k) * cosA, y3 - (t - k) * sinA * rev,
+                            x3 - t * cosA, y3 - t * sinA * rev
+                        ]
                     );
                 }
-
-                path.push(
-                    ['Q', x3, y3, x3 - rdX, y3 - rdY],
-                    ['Z']
-                );
             } else {
                 // Creating the path of funnel points without rounded corners
                 path = [
@@ -614,8 +693,11 @@ class FunnelSeries extends PieSeries {
                 if (y5 !== null) {
                     path.push(['L', x4, y5], ['L', x3, y5]);
                 }
-                path.push(['L', x3, y3], ['Z']);
+                path.push(['L', x3, y3]);
             }
+            path.push(
+                ['Z']
+            );
 
 
             // prepare for using shared dr

--- a/ts/Series/Funnel/FunnelSeriesOptions.d.ts
+++ b/ts/Series/Funnel/FunnelSeriesOptions.d.ts
@@ -36,7 +36,8 @@ export interface FunnelSeriesOptions extends PieSeriesOptions {
     size?: undefined;
     dataLabels?: FunnelDataLabelOptions;
     states?: SeriesStatesOptions<FunnelSeries>;
-    borderRadius?: number;
+    borderRadius: number;
+    borderRadiusMode: 'points'|'series';
 }
 
 export default FunnelSeriesOptions;

--- a/ts/Series/Funnel/FunnelSeriesOptions.d.ts
+++ b/ts/Series/Funnel/FunnelSeriesOptions.d.ts
@@ -36,6 +36,7 @@ export interface FunnelSeriesOptions extends PieSeriesOptions {
     size?: undefined;
     dataLabels?: FunnelDataLabelOptions;
     states?: SeriesStatesOptions<FunnelSeries>;
+    borderRadius?: number;
 }
 
 export default FunnelSeriesOptions;

--- a/ts/Series/Funnel/FunnelSeriesOptions.d.ts
+++ b/ts/Series/Funnel/FunnelSeriesOptions.d.ts
@@ -36,8 +36,6 @@ export interface FunnelSeriesOptions extends PieSeriesOptions {
     size?: undefined;
     dataLabels?: FunnelDataLabelOptions;
     states?: SeriesStatesOptions<FunnelSeries>;
-    borderRadius: number;
-    borderRadiusMode: 'points'|'series';
 }
 
 export default FunnelSeriesOptions;


### PR DESCRIPTION
Added `borderRadius` option support for funnel and pyramid series. See #18839.
___
TODO:
- [x] Add the ability to round the boundaries of funnel points.
- [x] Improve rounding to exact circles inscribed in the angles.
- [x] Handle rounding scope for series edges only (the `borderRadius.scope: 'stack'` option).
- [x] Add tests & samples.