### PR TITLE
bugfix/18110-softmin-max-padding

### DIFF
--- a/samples/unit-tests/axis/softmin-softmax/demo.js
+++ b/samples/unit-tests/axis/softmin-softmax/demo.js
@@ -45,6 +45,40 @@ QUnit.test('softMin and softMax', function (assert) {
     chart.series[0].setData([-100, -101, -102]);
 
     assert.strictEqual(chart.yAxis[0].max, 100, 'Soft max should be respected');
+
+    let { min, max } = chart.yAxis[0];
+    let diff = max - min;
+
+    chart.yAxis[0].update({
+        softMin: undefined,
+        minPadding: 0.5
+    });
+
+    assert.strictEqual(
+        chart.yAxis[0].min,
+        min - diff / 2,
+        'Min padding should be added when when soft max set, #18110'
+    );
+
+    chart.yAxis[0].update({
+        softMin: -200,
+        softMax: undefined
+    });
+
+    min = chart.yAxis[0].min;
+    max = chart.yAxis[0].max;
+    diff = max - min;
+
+    chart.yAxis[0].update({
+        minPadding: 0,
+        maxPadding: 0.5
+    });
+
+    assert.strictEqual(
+        chart.yAxis[0].max,
+        max + diff / 2,
+        'Max padding should be added when when soft min set, #18110'
+    );
 });
 
 QUnit.test('softMax combined with ceiling (#6359)', function (assert) {

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1726,6 +1726,22 @@ class Axis {
         // adjust min and max for the minimum range
         axis.adjustForMinRange();
 
+        // Handle options for floor, ceiling, softMin and softMax (#6359)
+        if (!isNumber(axis.userMin)) {
+            if (
+                isNumber(options.softMin) && options.softMin < (axis.min as any)
+            ) {
+                axis.min = hardMin = options.softMin; // #6894
+            }
+        }
+        if (!isNumber(axis.userMax)) {
+            if (
+                isNumber(options.softMax) && options.softMax > (axis.max as any)
+            ) {
+                axis.max = hardMax = options.softMax; // #6894
+            }
+        }
+
         // Pad the values to get clear of the chart's edges. To avoid
         // tickInterval taking the padding into account, we do this after
         // computing tick interval (#1337).
@@ -1748,26 +1764,11 @@ class Axis {
             }
         }
 
-        // Handle options for floor, ceiling, softMin and softMax (#6359)
-        if (!isNumber(axis.userMin)) {
-            if (
-                isNumber(options.softMin) && options.softMin < (axis.min as any)
-            ) {
-                axis.min = hardMin = options.softMin; // #6894
-            }
-            if (isNumber(options.floor)) {
-                axis.min = Math.max(axis.min as any, options.floor);
-            }
+        if (!isNumber(axis.userMin) && isNumber(options.floor)) {
+            axis.min = Math.max(axis.min as any, options.floor);
         }
-        if (!isNumber(axis.userMax)) {
-            if (
-                isNumber(options.softMax) && options.softMax > (axis.max as any)
-            ) {
-                axis.max = hardMax = options.softMax; // #6894
-            }
-            if (isNumber(options.ceiling)) {
-                axis.max = Math.min(axis.max as any, options.ceiling);
-            }
+        if (!isNumber(axis.userMax) && isNumber(options.ceiling)) {
+            axis.max = Math.min(axis.max as any, options.ceiling);
         }
 
         // When the threshold is soft, adjust the extreme value only if the data

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1723,7 +1723,7 @@ class Axis {
             axis.beforePadding();
         }
 
-        // adjust min and max for the minimum range
+        // Adjust min and max for the minimum range
         axis.adjustForMinRange();
 
         // Handle options for floor, ceiling, softMin and softMax (#6359)


### PR DESCRIPTION
Fixed #18110, `yAxis.maxPadding` was ignored when `yAxis.softMin` was set.