### PR TITLE
bugfix/18947-gantt-darkmode-colors

### DIFF
--- a/samples/gantt/demo/styled-mode/demo.css
+++ b/samples/gantt/demo/styled-mode/demo.css
@@ -8,5 +8,4 @@
 .highcharts-treegrid-node-level-1 {
     font-size: 13px;
     font-weight: bold;
-    fill: black;
 }

--- a/ts/Gantt/Connection.ts
+++ b/ts/Gantt/Connection.ts
@@ -731,6 +731,7 @@ class Connection {
                     .symbol(options.symbol as any)
                     .addClass(
                         'highcharts-point-connecting-path-' + type + '-marker'
+                        + ' highcharts-color-' + this.fromPoint.colorIndex
                     )
                     .attr(box)
                     .add((pathfinder as any).group);

--- a/ts/Gantt/Connection.ts
+++ b/ts/Gantt/Connection.ts
@@ -730,8 +730,8 @@ class Connection {
                 connection.graphics[type] = renderer
                     .symbol(options.symbol as any)
                     .addClass(
-                        'highcharts-point-connecting-path-' + type + '-marker'
-                        + ' highcharts-color-' + this.fromPoint.colorIndex
+                        'highcharts-point-connecting-path-' + type + '-marker' +
+                        ' highcharts-color-' + this.fromPoint.colorIndex
                     )
                     .attr(box)
                     .add((pathfinder as any).group);


### PR DESCRIPTION
Fixed #18947, better colors for arrows and top-level task title in dark mode in styled mode Gantt.