### PR TITLE
Docs: Fixed types of tooltip and yAxis.labels options.

### DIFF
--- a/test/typescript-dts/highcharts/highcharts.ts
+++ b/test/typescript-dts/highcharts/highcharts.ts
@@ -15,7 +15,8 @@ test_seriesColumn();
 test_seriesDependencyWheel();
 test_seriesLine();
 test_seriesPie();
-
+test_tooltip();
+test_yAxis();
 
 /**
  * Tests legend options.
@@ -484,4 +485,31 @@ function test_seriesPie() {
             }]
         }]
     });
+}
+
+/**
+ * Tests TooltipOptions in a common use cases.
+ */
+function test_tooltip() {
+    Highcharts.chart('container', {
+        tooltip: {
+            borderWidth: 10 // #18977
+        }
+    });
+}
+
+/**
+ * Tests YAxisLabelsOptions in a common use cases.
+ */
+function test_yAxis() {
+    Highcharts.chart('container', {
+        chart: {
+            polar: true
+        },
+        yAxis: {
+            labels: {
+                distance: "10%" // #18977
+            }
+        }
+    })
 }

--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -772,21 +772,20 @@ namespace AxisDefaults {
              * @sample {highcharts} highcharts/xaxis/labels-reservespace-true/
              *         Left-aligned labels on a vertical category axis
              *
-             * @type       {Highcharts.AlignValue}
-             * @apioption  xAxis.labels.align
+             * @type      {Highcharts.AlignValue}
+             * @apioption xAxis.labels.align
              */
 
             /**
-             * Whether to allow the axis labels to overlap.
-             * When false, overlapping labels are hidden.
+             * Whether to allow the axis labels to overlap. When false,
+             * overlapping labels are hidden.
              *
              * @sample {highcharts} highcharts/xaxis/labels-allowoverlap-true/
              *         X axis labels overlap enabled
              *
-             * @type {boolean}
-             * @default false
+             * @type      {boolean}
+             * @default   false
              * @apioption xAxis.labels.allowOverlap
-             *
              */
 
             /**
@@ -831,10 +830,6 @@ namespace AxisDefaults {
              * The label's pixel distance from the perimeter of the plot area.
              * On cartesian charts, this is overridden if the `labels.y` setting
              * is set.
-             *
-             * * On polar charts, if it's a percentage string, it is interpreted
-             * the same as [series.radius](#plotOptions.gauge.radius), so the
-             * label can be aligned under the gauge's shape.
              *
              * @sample {highcharts} highcharts/yaxis/labels-distance/
              *         Polar chart, labels centered under the arc
@@ -2527,6 +2522,24 @@ namespace AxisDefaults {
          * @extends xAxis.labels
          */
         labels: {
+
+            /**
+             * The label's pixel distance from the perimeter of the plot area.
+             * On cartesian charts, this is overridden if the `labels.y` setting
+             * is set.
+             *
+             * On polar charts, if it's a percentage string, it is interpreted
+             * the same as [series.radius](#plotOptions.gauge.radius), so the
+             * label can be aligned under the gauge's shape.
+             *
+             * @sample {highcharts} highcharts/yaxis/labels-distance/
+             *         Polar chart, labels centered under the arc
+             *
+             * @type      {number|string}
+             * @product   highcharts
+             * @apioption yAxis.labels.distance
+             */
+
             /**
              * The y position offset of all labels relative to the tick
              * positions on the axis. For polar and radial axis consider the use

--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -2492,6 +2492,8 @@ const defaultOptions: Options = {
          *         Background and border demo
          * @sample {highmaps} highcharts/css/tooltip-border-background/
          *         Tooltip in styled mode
+         *
+         * @type {number}
          */
         borderWidth: void 0,
 

--- a/ts/Core/TooltipOptions.d.ts
+++ b/ts/Core/TooltipOptions.d.ts
@@ -45,7 +45,7 @@ export interface TooltipOptions {
     backgroundColor: ColorType;
     borderColor?: ColorType;
     borderRadius: number;
-    borderWidth: number|undefined;
+    borderWidth?: number;
     className?: string;
     changeDecimals?: number;
     /** @deprecated */


### PR DESCRIPTION
Fixed #18977 