### PR TITLE
bugfix/19008-nodes-marker-api

### DIFF
--- a/ts/Series/Networkgraph/NetworkgraphSeriesDefaults.ts
+++ b/ts/Series/Networkgraph/NetworkgraphSeriesDefaults.ts
@@ -615,6 +615,13 @@ export default NetworkgraphSeriesDefaults;
  */
 
 /**
+ * Options for the node markers.
+ *
+ * @extends   plotOptions.networkgraph.marker
+ * @apioption series.networkgraph.nodes.marker
+ */
+
+/**
  * Individual data label for each node. The options are the same as
  * the ones for [series.networkgraph.dataLabels](#series.networkgraph.dataLabels).
  *


### PR DESCRIPTION
Fixed #19008, added `series.networkgraph.nodes.marker` options to the API which was missing but was included in some of the Networkgraph examples.

Link: https://api.highcharts.com/highcharts/series.networkgraph.nodes

