### PR TITLE
bugfix/12063-packedbubble-bad-positions-after-width-update

### DIFF
--- a/samples/unit-tests/series-packedbubble/update/demo.js
+++ b/samples/unit-tests/series-packedbubble/update/demo.js
@@ -1,25 +1,22 @@
 QUnit.test('Series update', function (assert) {
-    var series,
-        point,
-        radius,
-        chart = Highcharts.chart('container', {
-            chart: {
-                type: 'packedbubble',
-                width: 500,
-                height: 500,
-                marginTop: 46,
-                marginBottom: 53
-            },
-            series: [
-                {
-                    layoutAlgorithm: {
-                        splitSeries: true,
-                        parentNodeLimit: true
-                    },
-                    data: [50, 80, 50]
-                }
-            ]
-        });
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'packedbubble',
+            width: 500,
+            height: 500,
+            marginTop: 46,
+            marginBottom: 53
+        },
+        series: [
+            {
+                layoutAlgorithm: {
+                    splitSeries: true,
+                    parentNodeLimit: true
+                },
+                data: [50, 80, 50]
+            }
+        ]
+    });
     chart.update({
         series: [
             {
@@ -27,9 +24,9 @@ QUnit.test('Series update', function (assert) {
             }
         ]
     });
-    series = chart.series[0];
-    point = series.data[5];
-    radius = point.marker.radius;
+    const series = chart.series[0],
+        point = series.data[5],
+        radius = point.marker.radius;
     assert.strictEqual(
         !series.parentNode.graphic,
         false,
@@ -45,4 +42,31 @@ QUnit.test('Series update', function (assert) {
         point.radius,
         'Point radius should not be updated after adding series other than packedbubble.'
     );
+
+    chart.series[1].remove(false);
+    chart.series[0].setData([], false);
+
+    chart.update({
+        chart: {
+            width: 400,
+            marginTop: 80,
+            marginLeft: 50
+        }
+    });
+
+    ['group', 'markerGroup', 'parentNodesGroup'].forEach(group => {
+        assert.strictEqual(
+            series[group].translateX,
+            chart.plotLeft,
+            `Horizontally position of series.${group} should be same as
+            chart.plotLeft (#12063).`
+        );
+
+        assert.strictEqual(
+            series[group].translateY,
+            chart.plotTop,
+            `Vertically position of series.${group} should be same as
+            chart.plotTop (#12063).`
+        );
+    });
 });

--- a/ts/Series/PackedBubble/PackedBubbleSeries.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeries.ts
@@ -554,9 +554,9 @@ class PackedBubbleSeries extends BubbleSeries {
         this.calculateParentRadius();
         if (
             this.parentNode &&
-            this.parentNode.plotX &&
-            this.parentNode.plotY &&
-            this.parentNodeRadius
+            defined(this.parentNode.plotX) &&
+            defined(this.parentNode.plotY) &&
+            defined(this.parentNodeRadius)
         ) {
             parentAttribs = merge({
                 x: this.parentNode.plotX -

--- a/ts/Series/PackedBubble/PackedBubbleSeries.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeries.ts
@@ -547,26 +547,32 @@ class PackedBubbleSeries extends BubbleSeries {
             this.visible ? 'inherit' : 'hidden',
             0.1, chart.seriesGroup
         );
-        (this.group as any).attr({
+        this.group?.attr({
             zIndex: 2
         });
 
         this.calculateParentRadius();
-        parentAttribs = merge({
-            x: (this.parentNode as any).plotX -
-                (this.parentNodeRadius as any),
-            y: (this.parentNode as any).plotY -
-                (this.parentNodeRadius as any),
-            width: (this.parentNodeRadius as any) * 2,
-            height: (this.parentNodeRadius as any) * 2
-        }, parentOptions);
-        if (!(this.parentNode as any).graphic) {
-            this.graph = (this.parentNode as any).graphic =
-                chart.renderer.symbol((parentOptions as any).symbol)
-                    .add(this.parentNodesGroup);
+        if (
+            this.parentNode &&
+            this.parentNode.plotX &&
+            this.parentNode.plotY &&
+            this.parentNodeRadius
+        ) {
+            parentAttribs = merge({
+                x: this.parentNode.plotX -
+                    this.parentNodeRadius,
+                y: this.parentNode.plotY -
+                    this.parentNodeRadius,
+                width: this.parentNodeRadius * 2,
+                height: this.parentNodeRadius * 2
+            }, parentOptions);
+            if (!this.parentNode.graphic) {
+                this.graph = this.parentNode.graphic =
+                    chart.renderer.symbol((parentOptions as any).symbol)
+                        .add(this.parentNodesGroup);
+            }
+            this.parentNode.graphic.attr(parentAttribs);
         }
-        (this.parentNode as any).graphic.attr(parentAttribs);
-
     }
 
     public drawTracker(): void {

--- a/ts/Series/PackedBubble/PackedBubbleSeries.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeries.ts
@@ -539,18 +539,17 @@ class PackedBubbleSeries extends BubbleSeries {
 
         let parentAttribs: SVGAttributes = {};
 
-        // create the group for parent Nodes if doesn't exist
-        if (!this.parentNodesGroup) {
-            this.parentNodesGroup = this.plotGroup(
-                'parentNodesGroup',
-                'parentNode',
-                this.visible ? 'inherit' : 'hidden',
-                0.1, chart.seriesGroup
-            );
-            (this.group as any).attr({
-                zIndex: 2
-            });
-        }
+        // Create the group for parent Nodes if doesn't exist
+        // If exists it will only be adjusted to the updated plot size (#12063)
+        this.parentNodesGroup = this.plotGroup(
+            'parentNodesGroup',
+            'parentNode',
+            this.visible ? 'inherit' : 'hidden',
+            0.1, chart.seriesGroup
+        );
+        (this.group as any).attr({
+            zIndex: 2
+        });
 
         this.calculateParentRadius();
         parentAttribs = merge({


### PR DESCRIPTION
Fixed #12063, packed bubble parent nodes had a bad position after width update.