### PR TITLE
bugfix/18974-cumulative-datagrouping-approximation

### DIFF
--- a/docs/stock/cumulative-sum.md
+++ b/docs/stock/cumulative-sum.md
@@ -7,3 +7,5 @@ For the following data: `[10, 8, 15, 20, 8, 15]` the Cumulative Sum returns `[10
 ![cumulative-sum.png](cumulative-sum.png)
 
 The `cumulative` can be enabled in the chart's options using the [series.cumulative](https://api.highcharts.com/highstock/plotOptions.series.cumulative) property or enabled/disabled by the [series.setCumulative()](https://api.highcharts.com/class-reference/Highcharts.Series#setCumulative) method or on all the series belonging to a specific y-axis by the [yAxis.setCumulative()](https://api.highcharts.com/class-reference/Highcharts.Axis#setCumulative) method.
+
+With `dataGrouping` enabled, default grouping [approximation](https://api.highcharts.com/highstock/plotOptions.series.dataGrouping.approximation) is set to _sum_.

--- a/samples/unit-tests/series/cumulative/demo.js
+++ b/samples/unit-tests/series/cumulative/demo.js
@@ -94,4 +94,11 @@ QUnit.test('Stock: general tests for the Cumulative Sum', function (assert) {
         1 + 4 should be equal to 5 (second point of the second series).`
     );
 
+    assert.strictEqual(
+        chart.series[0].getDGApproximation(),
+        'sum',
+        `Default approximation when dataGrouping
+        is enabled should be equal to sum, #18974.`
+    );
+
 });

--- a/ts/Extensions/DataGrouping/DataGroupingSeriesComposition.ts
+++ b/ts/Extensions/DataGrouping/DataGroupingSeriesComposition.ts
@@ -552,7 +552,12 @@ function getDGApproximation(
     if (this.is('hlc')) {
         return 'hlc';
     }
-    if (this.is('column')) {
+    if (
+        // #18974, default approximation for cumulative
+        // should be `sum` when `dataGrouping` is enabled
+        this.is('column') ||
+        this.options.cumulative
+    ) {
         return 'sum';
     }
     return 'average';

--- a/ts/Series/DataModifyComposition.ts
+++ b/ts/Series/DataModifyComposition.ts
@@ -777,6 +777,8 @@ export default DataModifyComposition;
  * Adds the `cumulativeSum` field to each point object that can be accessed
  * e.g. in the [tooltip.pointFormat](https://api.highcharts.com/highstock/tooltip.pointFormat).
  *
+ * With `dataGrouping` enabled, default grouping approximation is set to `sum`.
+ *
  * @see [Axis.setCumulative()](/class-reference/Highcharts.Axis#setCumulative)
  * @see [Series.setCumulative()](/class-reference/Highcharts.Series#setCumulative)
  *


### PR DESCRIPTION
Fixed #18974, wrong approximation set for cumulative sum when `dataGrouping` was enabled.