### PR TITLE
db/dragDrop-enabled

### DIFF
--- a/samples/dashboards/cypress/add-layout/demo.mjs
+++ b/samples/dashboards/cypress/add-layout/demo.mjs
@@ -17,6 +17,9 @@ Dashboards.board('container', {
     editMode: {
         enabled: true,
         contextMenu: {
+            dragDrop: {
+                // drag drop options, leave empty - needed for testing
+            },
             enabled: true,
             items: ['verticalSeparator', 'editMode']
         },

--- a/ts/Dashboards/Actions/DragDrop.ts
+++ b/ts/Dashboards/Actions/DragDrop.ts
@@ -71,6 +71,8 @@ class DragDrop {
         this.editMode = editMode;
         this.options = merge(DragDrop.defaultOptions, options);
 
+        this.enabled = !!this.options.enabled;
+
         this.mockElement = createElement(
             'div',
             { className: EditGlobals.classNames.dragMock },
@@ -103,6 +105,11 @@ class DragDrop {
      * The editMode reference.
      */
     public editMode: EditMode;
+
+    /**
+     * Whether the drag drop is enabled.
+     */
+    public enabled: boolean;
 
     /**
      * DragDrop options.

--- a/ts/Dashboards/EditMode/EditMode.ts
+++ b/ts/Dashboards/EditMode/EditMode.ts
@@ -201,19 +201,20 @@ class EditMode {
     public initEditMode(): void {
         const editMode = this;
 
-        if (
-            !(editMode.options.resize &&
-                !editMode.options.resize.enabled)
+        if (!(editMode.options.resize &&
+                editMode.options.resize.enabled !== false)
         ) {
-            editMode.resizer = new Resizer(editMode);
+            editMode.resizer = new Resizer(editMode, editMode.options.resize);
         }
 
-        // Init dragDrop.
-        if (
-            !(editMode.options.dragDrop &&
-                !editMode.options.dragDrop.enabled)
+        // If dragDrop is disabled in options, don't init it.
+        if (!(editMode.options.dragDrop &&
+                editMode.options.dragDrop.enabled !== false)
         ) {
-            editMode.dragDrop = new DragDrop(editMode);
+            editMode.dragDrop = new DragDrop(
+                editMode,
+                editMode.options.dragDrop
+            );
         }
 
         // Init rowToolbar.


### PR DESCRIPTION
DragDrop did not work when empty options.

DradDrop is tested in the cypress. No need for additional tests.