### PR TITLE
bugfix/19028-columns-point-negative

### DIFF
--- a/samples/unit-tests/series-column/minpointlength/demo.js
+++ b/samples/unit-tests/series-column/minpointlength/demo.js
@@ -1,5 +1,5 @@
 QUnit.test('Negative or positive minPointLength', function (assert) {
-    var chart = Highcharts.chart('container', {
+    const chart = Highcharts.chart('container', {
         chart: {
             type: 'column'
         },
@@ -26,7 +26,7 @@ QUnit.test('Negative or positive minPointLength', function (assert) {
 });
 
 QUnit.test('All zero values', function (assert) {
-    var chart = Highcharts.chart('container', {
+    const chart = Highcharts.chart('container', {
         chart: {
             type: 'column'
         },
@@ -48,6 +48,14 @@ QUnit.test('All zero values', function (assert) {
         'Zero values are draw as positive columns (#10646)'
     );
 
+    assert.deepEqual(
+        chart.series[0].points.map(function (p) {
+            return p.negative;
+        }),
+        [false, false, false, false, false],
+        'Points below threshold should have point.negative set to false.'
+    );
+
     chart.addSeries({
         data: [-1, -2]
     });
@@ -57,4 +65,13 @@ QUnit.test('All zero values', function (assert) {
         0,
         'Zero values should only be drawn as positive when there is room for it (#14876)'
     );
+
+    assert.deepEqual(
+        chart.series[0].points.map(function (p) {
+            return p.negative;
+        }),
+        [true, true, true, true, true],
+        'Only points below threshold should have point.negative set to true.'
+    );
+
 });

--- a/samples/unit-tests/series-column/negativecolor/demo.js
+++ b/samples/unit-tests/series-column/negativecolor/demo.js
@@ -38,7 +38,7 @@ QUnit.test(
             'Positive color'
         );
 
-        const negativeArrBefore =  chart.series[0].points.map(function (p) {
+        const negativeArrBefore = chart.series[0].points.map(function (p) {
             return p.negative;
         });
 
@@ -51,7 +51,8 @@ QUnit.test(
                 return p.negative;
             }),
             negativeArrBefore,
-            'Points below zThreshold should have point.negative set to false.'
+            `After changing the zonesAxis property point.negative properties
+            shouldn't be changed (#19028).`
         );
     }
 );

--- a/samples/unit-tests/series-column/negativecolor/demo.js
+++ b/samples/unit-tests/series-column/negativecolor/demo.js
@@ -1,20 +1,18 @@
 QUnit.test(
     'Negative color should be updated with point\'s value (#4267)',
     function (assert) {
-        var color = '#00ff00',
+        const color = '#00ff00',
             negativeColor = '#ff0000',
-            chart = $('#container')
-                .highcharts({
-                    series: [
-                        {
-                            type: 'column',
-                            data: [5, 10, -5, -10],
-                            color: color,
-                            negativeColor: negativeColor
-                        }
-                    ]
-                })
-                .highcharts(),
+            chart = Highcharts.chart('container', {
+                series: [
+                    {
+                        type: 'column',
+                        data: [5, 10, -5, -10],
+                        color: color,
+                        negativeColor: negativeColor
+                    }
+                ]
+            }),
             points = chart.series[0].points;
 
         chart.series[0].setData([5, -10, -5, 10]);
@@ -38,6 +36,22 @@ QUnit.test(
             points[3].graphic.attr('fill'),
             color,
             'Positive color'
+        );
+
+        const negativeArrBefore =  chart.series[0].points.map(function (p) {
+            return p.negative;
+        });
+
+        chart.series[0].update({
+            zoneAxis: 'x'
+        });
+
+        assert.deepEqual(
+            chart.series[0].points.map(function (p) {
+                return p.negative;
+            }),
+            negativeArrBefore,
+            'Points below zThreshold should have point.negative set to false.'
         );
     }
 );

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2164,8 +2164,7 @@ class Series {
             pointPlacement = series.pointPlacementToXValue(), // #7860
             dynamicallyPlaced = Boolean(pointPlacement),
             threshold = options.threshold,
-            stackThreshold = options.startFromThreshold ? threshold : 0,
-            zoneAxis = this.zoneAxis || 'y';
+            stackThreshold = options.startFromThreshold ? threshold : 0;
         let i,
             plotX,
             lastPlotX,
@@ -2317,13 +2316,8 @@ class Series {
                 )) :
                 plotX; // #1514, #5383, #5518
 
-            // Negative points. For bubble charts, this means negative z
-            // values (#9728)
-            point.negative = (point as any)[zoneAxis] < (
-                (options as any)[zoneAxis + 'Threshold'] ||
-                threshold ||
-                0
-            );
+            // Negative points #19028
+            point.negative = defined(point.y) && point.y < (threshold || 0);
 
             // some API data
             point.category = pick(

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2317,7 +2317,7 @@ class Series {
                 plotX; // #1514, #5383, #5518
 
             // Negative points #19028
-            point.negative = defined(point.y) && point.y < (threshold || 0);
+            point.negative = (point.y || 0) < (threshold || 0);
 
             // some API data
             point.category = pick(

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -727,8 +727,11 @@ class BubbleSeries extends ScatterSeries {
     }
 
     public translateBubble(): void {
-        const { data, radii } = this;
-        const { minPxSize } = this.getPxExtremes();
+        const { data, radii } = this,
+            { minPxSize } = this.getPxExtremes(),
+            options = this.options,
+            threshold = options.threshold,
+            zoneAxis = this.zoneAxis || 'y';
 
         // Set the shape type and arguments to be picked up in drawPoints
         let i = data.length;
@@ -736,6 +739,13 @@ class BubbleSeries extends ScatterSeries {
         while (i--) {
             const point = data[i];
             const radius = radii ? radii[i] : 0; // #1737
+
+            // Negative points means negative z values (#9728)
+            point.negative = (point as any)[zoneAxis] < (
+                (options as any)[zoneAxis + 'Threshold'] ||
+                threshold ||
+                0
+            );
 
             if (isNumber(radius) && radius >= minPxSize / 2) {
                 // Shape arguments

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -729,9 +729,7 @@ class BubbleSeries extends ScatterSeries {
     public translateBubble(): void {
         const { data, radii } = this,
             { minPxSize } = this.getPxExtremes(),
-            options = this.options,
-            threshold = options.threshold,
-            zoneAxis = this.zoneAxis || 'y';
+            options = this.options;
 
         // Set the shape type and arguments to be picked up in drawPoints
         let i = data.length;
@@ -741,11 +739,9 @@ class BubbleSeries extends ScatterSeries {
             const radius = radii ? radii[i] : 0; // #1737
 
             // Negative points means negative z values (#9728)
-            point.negative = (point as any)[zoneAxis] < (
-                (options as any)[zoneAxis + 'Threshold'] ||
-                threshold ||
-                0
-            );
+            if (this.zoneAxis === 'z') {
+                point.negative = (point.z || 0) < (options.zThreshold || 0);
+            }
 
             if (isNumber(radius) && radius >= minPxSize / 2) {
                 // Shape arguments

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -727,9 +727,8 @@ class BubbleSeries extends ScatterSeries {
     }
 
     public translateBubble(): void {
-        const { data, radii } = this,
-            { minPxSize } = this.getPxExtremes(),
-            options = this.options;
+        const { data, options, radii } = this,
+            { minPxSize } = this.getPxExtremes();
 
         // Set the shape type and arguments to be picked up in drawPoints
         let i = data.length;

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -535,6 +535,9 @@ class ColumnSeries extends Series {
                 barX = plotX + seriesXOffset,
                 barW = seriesBarW;
 
+            point.negative = defined(point.y) &&
+                point.y < (series.options.threshold || 0);
+
             // Handle options.minPointLength
             if (minPointLength && Math.abs(barH) < minPointLength) {
                 barH = minPointLength;
@@ -556,6 +559,7 @@ class ColumnSeries extends Series {
                     (dataMin !== dataMax || (yAxis.max || 0) <= threshold)
                 ) {
                     up = !up;
+                    point.negative = !point.negative;
                 }
 
                 // If stacked...

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -535,9 +535,6 @@ class ColumnSeries extends Series {
                 barX = plotX + seriesXOffset,
                 barW = seriesBarW;
 
-            point.negative = defined(point.y) &&
-                point.y < (series.options.threshold || 0);
-
             // Handle options.minPointLength
             if (minPointLength && Math.abs(barH) < minPointLength) {
                 barH = minPointLength;


### PR DESCRIPTION
Fixed #19028, border radius was wrongly applied for negative column points when the `zoneAxis` option was `x`.