### PR TITLE
docs/19034-point-position

### DIFF
--- a/samples/highcharts/point/position/demo.css
+++ b/samples/highcharts/point/position/demo.css
@@ -1,0 +1,5 @@
+#container {
+    min-width: 300px;
+    max-width: 600px;
+    margin: 0 auto;
+}

--- a/samples/highcharts/point/position/demo.details
+++ b/samples/highcharts/point/position/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Point Position Example
+ authors:
+   - Jakub Szumiński
+ js_wrap: b
+...

--- a/samples/highcharts/point/position/demo.html
+++ b/samples/highcharts/point/position/demo.html
@@ -1,0 +1,4 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="container"></div>
+<button id="invert">Invert the chart</button>

--- a/samples/highcharts/point/position/demo.js
+++ b/samples/highcharts/point/position/demo.js
@@ -1,0 +1,38 @@
+const chart = Highcharts.chart('container', {
+    chart: {
+        events: {
+            render() {
+                const chart = this,
+                    // get the position of the first point
+                    pos = chart.series[0].points[0].pos(true);
+
+                // if this is the first render, create a custom SVG element
+                // and assign it to chart.customSVG
+                if (!chart.customSVG) {
+                    chart.customSVG = chart.renderer.circle(pos[0], pos[1], 10)
+                        .attr({ fill: '#1a1a1a' })
+                        .add();
+                } else {
+                    // if this is not the first render, move the customSVG
+                    // to the correct position
+                    chart.customSVG.animate({
+                        x: pos[0],
+                        y: pos[1]
+                    });
+                }
+            }
+        }
+    },
+    series: [{
+        type: 'line',
+        data: [1, 2, 3, 4]
+    }]
+});
+
+document.getElementById('invert').addEventListener('click', () => {
+    chart.update({
+        chart: {
+            inverted: !chart.options.chart.inverted
+        }
+    });
+});

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -820,8 +820,13 @@ class Point {
 
     /**
      * Get the pixel position of the point relative to the plot area.
-     * @private
-     * @function Highcharts.Point#pos
+     *
+     * @sample highcharts/point/position
+     *         Get point's position in pixels.
+     *
+     * @param {boolean} chartCoordinates
+     * Whether to return the position relative to the plot area of the chart.
+     *
      */
     public pos(
         chartCoordinates?: boolean,

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2139,6 +2139,11 @@ class Series {
              * to the X axis position if the series has one, otherwise relative
              * to the plot area. Depending on the series type this value might
              * not be defined.
+             *
+             * The value is relative to the direction of the axis so in an
+             * inverted chart plotX is going from the bottom to the top.
+             *
+             * @see Highcharts.Point#pos
              * @name Highcharts.Point#plotX
              * @type {number|undefined}
              */
@@ -2231,6 +2236,11 @@ class Series {
              * to the Y axis position if the series has one, otherwise relative
              * to the plot area. Depending on the series type this value might
              * not be defined.
+             *
+             * The value is relative to the direction of the axis so in an
+             * inverted chart plotY is going from the right to left.
+             *
+             * @see Highcharts.Point#pos
              * @name Highcharts.Point#plotY
              * @type {number|undefined}
              */


### PR DESCRIPTION
Fixed #19034, `Highcharts.Point#pos` will now be a public function available in the API.

---
TODO
- [x] Expose `Point.pos` in the docs (remove `@private`)
- [x] Provide a link from `plotX` and `plotY` to `Point.pos`
- [x] Create a `@sample` for `Point.pos`
- [ ] Add correct params & return to `Highcharts.Point#pos`
- [ ] Improve the information about `plotX` and `plotY` (what happens when `chart.inverted`)
