### PR TITLE
bugfix/18459-moving-ordinal-annotations

### DIFF
--- a/samples/unit-tests/axis/ordinal/demo.html
+++ b/samples/unit-tests/axis/ordinal/demo.html
@@ -1,5 +1,7 @@
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/modules/boost.js"></script>
+<script src="https://code.highcharts.com/modules/annotations.js"></script>
+<script src="https://code.highcharts.com/stock/indicators/indicators.js"></script>
 
 
 <div id="qunit"></div>

--- a/samples/unit-tests/axis/ordinal/demo.js
+++ b/samples/unit-tests/axis/ordinal/demo.js
@@ -615,34 +615,42 @@ QUnit.test('Ordinal axis, data grouping and boost module, #14055.', assert => {
 });
 
 QUnit.test('Circular translation, #17128.', assert => {
+    const data = [{
+        type: 'line',
+        data: [
+            [548935806499, 95.82],
+            [1548936121889, 95.84],
+            [1548936895949, 95.75],
+            [1548937941785, 95.48],
+            [1548938881593, 95.6],
+            [1548939834796, 95.37],
+            [1548940821273, 95.16],
+            [1548941760541, 95.15],
+            [1548942617180, 94.9],
+            [1548943265472, 95.04],
+            [1548943953574, 94.93],
+            [1548944604420, 94.94],
+            [1548945157396, 95.19],
+            [1548945448867, 94.92],
+            [1548946059662, 94.98],
+            [1548946666809, 95.17],
+            [1548947190658, 95.38]
+        ],
+        showInNavigator: true
+    }, {
+        type: 'scatter',
+        data: [
+            [1548936121889, 90],
+            [1548938881593, 95]
+        ],
+        showInNavigator: false
+    }];
+
     const chart = Highcharts.stockChart('container', {
-            series: [{
-                data: [
-                    [548935806499, 95.82],
-                    [1548936121889, 95.84],
-                    [1548936895949, 95.75],
-                    [1548937941785, 95.48],
-                    [1548938881593, 95.6],
-                    [1548939834796, 95.37],
-                    [1548940821273, 95.16],
-                    [1548941760541, 95.15],
-                    [1548942617180, 94.9],
-                    [1548943265472, 95.04],
-                    [1548943953574, 94.93],
-                    [1548944604420, 94.94],
-                    [1548945157396, 95.19],
-                    [1548945448867, 94.92],
-                    [1548946059662, 94.98],
-                    [1548946666809, 95.17],
-                    [1548947190658, 95.38]
-                ]
-            }, {
-                type: 'scatter',
-                data: [
-                    [1548936121889, 90],
-                    [1548938881593, 95]
-                ]
-            }]
+            series: data,
+            legend: {
+                enabled: true
+            }
         }),
         x = Date.UTC(2019, 0, 31, 14, 30);
 
@@ -653,6 +661,34 @@ QUnit.test('Circular translation, #17128.', assert => {
             chart.xAxis[0].toPixels(x))
         ),
         `When two series (line and scatter) are visible, circular translation of
+        the date should return the same value.`
+    );
+
+    chart.xAxis[0].setExtremes(
+        Date.UTC(2019, 0, 31, 14),
+        Date.UTC(2019, 0, 31, 15)
+    );
+
+    assert.strictEqual(
+        Highcharts.dateFormat(undefined, x),
+        Highcharts.dateFormat(undefined, chart.xAxis[0].toValue(
+            chart.xAxis[0].toPixels(x))
+        ),
+        `After zooming, when the scatterer series is not visible, a circular
+        translation of the date should return the same value.`
+    );
+
+    // Reverse the order of the series
+    chart.xAxis[0].setExtremes();
+    chart.update({ series: data.reverse() });
+
+    // Perform the exact same tests as above
+    assert.strictEqual(
+        Highcharts.dateFormat(undefined, x),
+        Highcharts.dateFormat(undefined, chart.xAxis[0].toValue(
+            chart.xAxis[0].toPixels(x))
+        ),
+        `When two series (scatter and line) are visible, circular translation of
         the date should return the same value.`
     );
 

--- a/samples/unit-tests/axis/ordinal/demo.js
+++ b/samples/unit-tests/axis/ordinal/demo.js
@@ -706,3 +706,92 @@ QUnit.test('Circular translation, #17128.', assert => {
         translation of the date should return the same value.`
     );
 });
+
+QUnit.test('Moving annotations on ordinal axis, #18459', assert => {
+    const data = [
+        [
+            1622640600000,
+            124.28,
+            125.24,
+            124.05,
+            125.06
+        ],
+        [
+            1622727000000,
+            124.68,
+            124.85,
+            123.13,
+            123.54
+        ],
+        [
+            1622813400000,
+            124.07,
+            126.16,
+            123.85,
+            125.89
+        ],
+        [
+            1623072600000,
+            126.17,
+            126.32,
+            124.83,
+            125.9
+        ],
+        [
+            1623159000000,
+            126.6,
+            128.46,
+            126.21,
+            126.74
+        ],
+        [
+            1623245400000,
+            127.21,
+            127.75,
+            126.52,
+            127.13
+        ]
+    ];
+
+    const chart = Highcharts.stockChart('container', {
+        series: [{
+            type: 'ohlc',
+            data: data
+        }, {
+            type: 'sma',
+            linkedTo: ':previous',
+            params: {
+                period: 2
+            }
+        }]
+    });
+
+    chart.xAxis[0].setExtremes(1622727000000, 1622813400000);
+
+    const circle = chart.addAnnotation({
+        shapes: [{
+            type: 'circle',
+            point: {
+                x: 1623072600000,
+                y: 125,
+                xAxis: 0,
+                yAxis: 0
+            },
+            r: 20
+        }]
+    });
+
+    const controller = new TestController(chart),
+        { x: pointX, y: pointY } = circle.userOptions.shapes[0].point,
+        x = chart.xAxis[0].toPixels(pointX),
+        y = chart.yAxis[0].toPixels(pointY);
+
+    controller.pan([x, y], [x - 50, y]);
+
+    assert.close(
+        x - 50,
+        chart.xAxis[0].toPixels(circle.userOptions.shapes[0].point.x),
+        0.1,
+        'Annotation dragged on ordinal axis charts should follow mouse pointer.'
+    );
+});

--- a/samples/unit-tests/axis/ordinal/demo.js
+++ b/samples/unit-tests/axis/ordinal/demo.js
@@ -355,9 +355,11 @@ QUnit.test('lin2val- unit test for values outside the plotArea.', function (asse
         },
         series: [{
             points: [{
+                isInside: true, // #18459
                 x: 3,
                 plotX: -20
             }, {
+                isInside: true, // #18459
                 x: 4.2,
                 plotX: 80 // distance between points 100px
             }]

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -1422,8 +1422,8 @@ namespace OrdinalAxis {
                     defined(firstPoint?.plotX) &&
                     hasPointsInside(series) &&
                     (
-                        !defined(firstPointX) ||
-                        firstPoint.plotX < firstPointX
+                        firstPoint.plotX < firstPointX ||
+                        !defined(firstPointX)
                     )
                 ) {
                     firstPointX = firstPoint.plotX;

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -1407,26 +1407,31 @@ namespace OrdinalAxis {
                 axis = ordinal.axis,
                 firstPointVal = ordinal.positions ? ordinal.positions[0] : 0;
 
-            let firstPointX = axis.series[0].points &&
-                axis.series[0].points[0] &&
-                axis.series[0].points[0].plotX ||
-                axis.minPixelPadding; // #15987
+            // Check whether the series has at least one point inside the chart
+            const hasPointsInside = function (series: Series): boolean {
+                return series.points.some((point): boolean => !!point.isInside);
+            };
+
+            let firstPointX: number;
 
             // When more series assign to axis, find the smallest one, #15987.
-            if (axis.series.length > 1) {
-                axis.series.forEach(function (series): void {
-                    if (
-                        series.points &&
-                        defined(series.points[0]) &&
-                        defined(series.points[0].plotX) &&
-                        series.points[0].plotX < firstPointX &&
-                        // #17128
-                        series.points[0].plotX >= pick(axis.min, -Infinity)
-                    ) {
-                        firstPointX = series.points[0].plotX;
-                    }
-                });
-            }
+            axis.series.forEach((series): void => {
+                const firstPoint = series.points?.[0];
+
+                if (
+                    defined(firstPoint?.plotX) &&
+                    hasPointsInside(series) &&
+                    (
+                        !defined(firstPointX) ||
+                        firstPoint.plotX < firstPointX
+                    )
+                ) {
+                    firstPointX = firstPoint.plotX;
+                }
+            });
+
+            // If undefined, give a default value
+            firstPointX ??= axis.minPixelPadding;
 
             // Distance in pixels between two points on the ordinal axis in the
             // current zoom.

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -1420,11 +1420,11 @@ namespace OrdinalAxis {
 
                 if (
                     defined(firstPoint?.plotX) &&
-                    hasPointsInside(series) &&
                     (
                         firstPoint.plotX < firstPointX ||
                         !defined(firstPointX)
-                    )
+                    ) &&
+                    hasPointsInside(series)
                 ) {
                     firstPointX = firstPoint.plotX;
                 }


### PR DESCRIPTION
Fixed #18459, dragging annotations on chart with ordinal axes was inconsistent.