### PR TITLE
bugfix/19042-annotation-label-edit

### DIFF
--- a/ts/Extensions/Annotations/NavigationBindings.ts
+++ b/ts/Extensions/Annotations/NavigationBindings.ts
@@ -879,7 +879,7 @@ class NavigationBindings {
             // If it's a number (not "format" options), parse it:
             if (
                 isNumber(parsedValue) &&
-                !value.match(/px/g) &&
+                !value.match(/px|em/g) &&
                 !field.match(/format/g)
             ) {
                 value = parsedValue as any;


### PR DESCRIPTION
Fixed #19042, text of annotation label was missing after updating it.