### PR TITLE
bugfix/19053-item-series-update

### DIFF
--- a/ts/Series/Item/ItemSeries.ts
+++ b/ts/Series/Item/ItemSeries.ts
@@ -345,18 +345,21 @@ class ItemSeries extends PieSeries {
                     i++;
                 }
             }
-            graphics.forEach((graphic, i): void => {
+
+            for (let j = 0; j < graphics.length; j++) {
+                const graphic = graphics[j];
                 if (!graphic) {
                     return;
                 }
 
                 if (!graphic.isActive) {
                     graphic.destroy();
-                    graphics.splice(i, 1);
+                    graphics.splice(j, 1);
+                    j--; // Need to substract 1 after splice, #19053
                 } else {
                     graphic.isActive = false;
                 }
-            });
+            }
         });
     }
 


### PR DESCRIPTION
Fixed #19053, a regression since 10.3 causing item series update not to work correctly. 

**Demo of the problem:** https://jsfiddle.net/BlackLabel/1x2L70h5/
_Some of the graphics from before-update were still there even though they shouldn't be._ 

**Demo after fix:** https://jsfiddle.net/BlackLabel/u6m4rks8/