### PR TITLE
Tooltip not showing up for boosted interpolated heatmap

### DIFF
--- a/ts/Series/Heatmap/HeatmapSeries.ts
+++ b/ts/Series/Heatmap/HeatmapSeries.ts
@@ -461,11 +461,9 @@ class HeatmapSeries extends ScatterSeries {
                     chart,
                     xAxis,
                     yAxis,
-                    points,
-                    boost
+                    points
                 } = series,
                 lastPointIndex = points.length - 1,
-                notBoosting = (!boost && !chart.boost),
                 {
                     len: xAxisLen,
                     reversed: xRev

--- a/ts/Series/Heatmap/HeatmapSeries.ts
+++ b/ts/Series/Heatmap/HeatmapSeries.ts
@@ -630,10 +630,8 @@ class HeatmapSeries extends ScatterSeries {
                             )
                         );
 
-                    if (notBoosting) {
-                        series.buildKDTree();
-                        series.directTouch = false;
-                    }
+                    series.buildKDTree();
+                    series.directTouch = false;
 
                     for (let i = 0; i < canvasArea; i++) {
                         const


### PR DESCRIPTION
Fixed, directTouch was only true for non-boost