### PR TITLE
bugfix/15569-zoom-by-drag-improvement 

### DIFF
--- a/samples/unit-tests/chart/zoomtype/demo.css
+++ b/samples/unit-tests/chart/zoomtype/demo.css
@@ -3,7 +3,3 @@
     height: 400px;
     margin: 0 auto;
 }
-
-.flex-container {
-    display: flex;
-}

--- a/samples/unit-tests/chart/zoomtype/demo.css
+++ b/samples/unit-tests/chart/zoomtype/demo.css
@@ -3,3 +3,7 @@
     height: 400px;
     margin: 0 auto;
 }
+
+.flex-container {
+    display: flex;
+}

--- a/samples/unit-tests/chart/zoomtype/demo.js
+++ b/samples/unit-tests/chart/zoomtype/demo.js
@@ -575,3 +575,44 @@ QUnit.test('Zooming chart with multiple panes', function (assert) {
         'Y zoom on the second pane should not affect y-zoom on the first pane when chart inverted (#1289)'
     );
 });
+
+QUnit.test('Zooming accross multiple charts, #15569', assert => {
+    const options = {
+        chart: {
+            zooming: {
+                type: 'x'
+            },
+            width: 300,
+            height: 400
+        },
+        series: [{
+            data: [1, 2, 5, 13, 4, 5, 12, 4]
+        }]
+    };
+
+    // Add two containers in a flexbox and append them to the HC container
+    const mainContainer = document.querySelector('#container'),
+        flexContainer = document.createElement('div'),
+        container1 = document.createElement('div'),
+        container2 = document.createElement('div');
+    flexContainer.classList.add('flex-container');
+    flexContainer.appendChild(container1);
+    flexContainer.appendChild(container2);
+    mainContainer.appendChild(flexContainer);
+
+    const chart0 = Highcharts.chart(container1, options);
+    Highcharts.chart(container2, options);
+
+    const controller = new TestController(chart0);
+
+    controller.pan(
+        [chart0.xAxis[0].toPixels(6), 250],
+        [chart0.xAxis[0].toPixels(6) + 300, 250]
+    );
+
+    assert.ok(
+        chart0.xAxis[0].displayBtn,
+        'Ending a zoom on a different chart should result in a zoom in.'
+    );
+    flexContainer.remove(); // Remove this line to visually debug the chart
+});

--- a/samples/unit-tests/chart/zoomtype/demo.js
+++ b/samples/unit-tests/chart/zoomtype/demo.js
@@ -595,7 +595,8 @@ QUnit.test('Zooming accross multiple charts, #15569', assert => {
         flexContainer = document.createElement('div'),
         container1 = document.createElement('div'),
         container2 = document.createElement('div');
-    flexContainer.classList.add('flex-container');
+
+    flexContainer.style.display = 'flex';
     flexContainer.appendChild(container1);
     flexContainer.appendChild(container2);
     mainContainer.appendChild(flexContainer);

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1167,9 +1167,9 @@ class Pointer {
     public onContainerMouseLeave(e: MouseEvent): void {
         const chart = charts[pick(Pointer.hoverChartIndex, -1)];
 
-        this.onContainerMouseMove(e);
-
         e = this.normalize(e);
+
+        this.onContainerMouseMove(e);
 
         // #4886, MS Touch end fires mouseleave but with no related target
         if (
@@ -1202,7 +1202,7 @@ class Pointer {
             tooltip = chart.tooltip,
             pEvt = this.normalize(e);
 
-        this.setHoverChartIndex();
+        this.setHoverChartIndex(e);
 
         if (chart.mouseIsDown === 'mousedown' || this.touchSelect(pEvt)) {
             this.drag(pEvt);
@@ -2003,7 +2003,7 @@ class Pointer {
      * @private
      * @function Highcharts.Pointer#setHoverChartIndex
      */
-    public setHoverChartIndex(): void {
+    public setHoverChartIndex(e?: MouseEvent): void {
         const chart = this.chart;
         const hoverChart = H.charts[pick(Pointer.hoverChartIndex, -1)];
 
@@ -2012,7 +2012,7 @@ class Pointer {
             hoverChart !== chart
         ) {
             hoverChart.pointer.onContainerMouseLeave(
-                { relatedTarget: chart.container } as any
+                e || { relatedTarget: chart.container } as any
             );
         }
 

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1167,6 +1167,8 @@ class Pointer {
     public onContainerMouseLeave(e: MouseEvent): void {
         const chart = charts[pick(Pointer.hoverChartIndex, -1)];
 
+        this.onContainerMouseMove(e);
+
         e = this.normalize(e);
 
         // #4886, MS Touch end fires mouseleave but with no related target


### PR DESCRIPTION
Fixed #15569, at rapid mouse movements outside the chart, zoom didn't work properly.