### PR TITLE
Fixed #19075: error on pie drilldown

### DIFF
--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -524,7 +524,7 @@ class Point {
             defaultFunction = function (event: MouseEvent): void {
                 // Control key is for Windows, meta (= Cmd key) for Mac, Shift
                 // for Opera.
-                if (point.select) { // #2911
+                if (!point.destroyed && point.select) { // #2911, #19075
                     point.select(
                         null as any,
                         event.ctrlKey || event.metaKey || event.shiftKey


### PR DESCRIPTION
Fix for issue #19075
It seems that defaultFunction is called after point gets destroyed because of drilldown action, so I added check for the point.