### PR TITLE
bugfix/19075-pie-drilldown-error

### DIFF
--- a/samples/unit-tests/drilldown/pie/demo.js
+++ b/samples/unit-tests/drilldown/pie/demo.js
@@ -329,7 +329,7 @@ QUnit.test('Slice color after drilldown and select (#4359)', function (assert) {
     options.chart.options3d.enabled = true;
     chart3d = $('#container2').highcharts(options).highcharts();
 
-    chart.series[0].points[1].doDrilldown();
+    chart.series[0].points[1].firePointEvent('click');
     chart.series[0].points[0].select();
 
     chart3d.series[0].points[1].doDrilldown();

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -524,7 +524,7 @@ class Point {
             defaultFunction = function (event: MouseEvent): void {
                 // Control key is for Windows, meta (= Cmd key) for Mac, Shift
                 // for Opera.
-                if (point.select) { // #2911
+                if (!point.destroyed && point.select) { // #2911, #19075
                     point.select(
                         null as any,
                         event.ctrlKey || event.metaKey || event.shiftKey


### PR DESCRIPTION
Fixed #19075, an error was thrown when drilling down on pie point when `allowPointSelect` was true.

**Demo of the problem:** https://jsfiddle.net/BlackLabel/ro0n2muv/ (open up console and click the blue part of the pie)
**Demo after fix:** https://jsfiddle.net/BlackLabel/5u9Lhvqe/