### PR TITLE
Samples: brushed up Gantt Project Management demo

### DIFF
--- a/docs/gantt/gantt-axis-grid.md
+++ b/docs/gantt/gantt-axis-grid.md
@@ -16,13 +16,13 @@ If the min and maximum width of the chart is set, there is more control over the
 
 _See example below for setting tickIntervals per Axis grid._
 
-    
+
     xAxis: [{
         labels: {
           format: '{value:%w}' // day of the week
         },
         grid: { // default setting
-          enabled: true 
+          enabled: true
         }
         tickInterval: 1000 * 60 * 60 * 24, // Day
       }, {
@@ -30,11 +30,11 @@ _See example below for setting tickIntervals per Axis grid._
           format: '{value:%W}'
         },
         tickInterval: 1000 * 60 * 60 * 24 * 7 // week
-      }], 
+      }],
 
 _See live code example for setting tickInterval per Axis grid_
 
-<iframe src="https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/gantt/grid-axis/with-tickinterval/embedded/result,js/" id="JSFEMB_18012" width="100%" height="450" frameborder="0" sandbox="allow-modals allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" allow="camera *; encrypted-media *;"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/gantt/grid-axis/with-tickinterval" id="JSFEMB_18012" width="100%" height="450" frameborder="0" sandbox="allow-modals allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" allow="camera *; encrypted-media *;"></iframe>
 
 Vertical Axis
 -------------
@@ -43,4 +43,4 @@ In a Gantt chart it is common to display a table on the left side of the chart t
 
 _Example of defining a table along the vertical axis with Axis.grid option_
 
-<iframe src="https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/gantt/grid-axis/vertical/embedded/result,js/" id="JSFEMB_18012" width="100%" height="450" frameborder="0" sandbox="allow-modals allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" allow="camera *; encrypted-media *;"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/gantt/grid-axis/vertical" id="JSFEMB_18012" width="100%" height="450" frameborder="0" sandbox="allow-modals allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" allow="camera *; encrypted-media *;"></iframe>

--- a/docs/gantt/gantt-grouping-tasks.md
+++ b/docs/gantt/gantt-grouping-tasks.md
@@ -5,7 +5,7 @@ Split bigger tasks up in subtasks or group resources together if they belong to 
 
 _Example of defining subtasks and grouping them with one parent task._
 
-<iframe src="https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/gantt/gantt/grouping-hierarchy/embedded/result,js/" id="JSFEMB_18012" width="100%" height="400" frameborder="0" sandbox="allow-modals allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" allow="camera *; encrypted-media *;" allow="fullscreen"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/gantt/gantt/grouping-hierarchy" id="JSFEMB_18012" width="100%" height="400" frameborder="0" sandbox="allow-modals allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" allow="camera *; encrypted-media *;" allow="fullscreen"></iframe>
 
 Gantt charts have a vertical axis of type [`treegrid`](https://api.highcharts.com/gantt/yAxis.type) by default. Notice in the above example how that results automatically in collapsable subtasks. Set the parent task's data point with [`collapsed: true`](https://api.highcharts.com/gantt/series.gantt.data.collapsed) to render the task collapsed from the start.
 
@@ -16,11 +16,11 @@ For grouping tasks in a Gantt chart on horizontal tracks, use a vertical [`categ
 
 Code example for setting a category axis
 
-    
+
     yAxis: {
-        categories: ['Resource 1', 'Resource 2', 'Resource 3']   
-      } 
+        categories: ['Resource 1', 'Resource 2', 'Resource 3']
+      }
 
 _See example below for grouping tasks vertically in horizontal tracks_
 
-<iframe src="https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/gantt/gantt/grouping-vertically/embedded/result,js/" id="JSFEMB_18012" width="100%" height="400" frameborder="0" sandbox="allow-modals allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" allow="camera *; encrypted-media *;" allow="fullscreen"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/gantt/gantt/grouping-vertically" id="JSFEMB_18012" width="100%" height="400" frameborder="0" sandbox="allow-modals allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" allow="camera *; encrypted-media *;" allow="fullscreen"></iframe>

--- a/docs/gantt/gantt-task-config.md
+++ b/docs/gantt/gantt-task-config.md
@@ -12,7 +12,7 @@ Set the [`milestone`](https://api.highcharts.com/gantt/series.gantt.data.milesto
 
 _See milestone example below, one of the data points in the series has the milestone property set to true_
 
-<iframe src="https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/gantt/gantt/one-milestone-point/embedded/result,js/" id="JSFEMB_18012" width="100%" height="400" frameborder="0" sandbox="allow-modals allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" allow="camera *; encrypted-media *;" allow="fullscreen"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/gantt/gantt/one-milestone-point" id="JSFEMB_18012" width="100%" height="400" frameborder="0" sandbox="allow-modals allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" allow="camera *; encrypted-media *;" allow="fullscreen"></iframe>
 
 Progress bar
 ------------

--- a/docs/gantt/gantt-task-dependencies.md
+++ b/docs/gantt/gantt-task-dependencies.md
@@ -5,7 +5,7 @@ Visualizing the work breakdown structure of a project involves also describing t
 
 _Code example of defining dependencies_
 
-<iframe src="https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/gantt/gantt/one-milestone-point/embedded/result,js/" id="JSFEMB_18012" width="100%" height="400" frameborder="0" sandbox="allow-modals allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" allow="camera *; encrypted-media *;" allow="fullscreen"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/gantt/gantt/one-milestone-point" id="JSFEMB_18012" width="100%" height="400" frameborder="0" sandbox="allow-modals allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" allow="camera *; encrypted-media *;" allow="fullscreen"></iframe>
 
 Customize dependency connectors
 -------------------------------
@@ -16,10 +16,10 @@ The pathfinder property is also available on data series, see [`series.pathfinde
 
 _See code example for configuring dependencies_
 
-<iframe src="https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/gantt/gantt/tweaking-dependencies/embedded/result,js/" id="JSFEMB_18012" width="100%" height="400" frameborder="0" sandbox="allow-modals allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" allow="camera *; encrypted-media *;" allow="fullscreen"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/gantt/gantt/tweaking-dependencies" id="JSFEMB_18012" width="100%" height="400" frameborder="0" sandbox="allow-modals allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" allow="camera *; encrypted-media *;" allow="fullscreen"></iframe>
 
 A single dependency is composed by setting the [`dependency`](https://api.highcharts.com/gantt/series.gantt.data.dependency) property on a data point (task) to an object. This object has defined pathfinder options allowing for configuration of a singular dependency
 
 _See example below, where the color and endmarker are defined on the successor task_
 
-<iframe src="https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/gantt/gantt/tweaking-single-dependency/embedded/result,js/" id="JSFEMB_18012" width="100%" height="400" frameborder="0" sandbox="allow-modals allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" allow="camera *; encrypted-media *;" allow="fullscreen"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/gantt/gantt/tweaking-single-dependency" id="JSFEMB_18012" width="100%" height="400" frameborder="0" sandbox="allow-modals allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation-by-user-activation" allow="camera *; encrypted-media *;" allow="fullscreen"></iframe>

--- a/samples/gantt/demo/project-management/demo.css
+++ b/samples/gantt/demo/project-management/demo.css
@@ -2,3 +2,7 @@
     max-width: 1000px;
     margin: 1em auto;
 }
+
+.highcharts-label-icon {
+    opacity: 0.5;
+}

--- a/samples/gantt/demo/project-management/demo.css
+++ b/samples/gantt/demo/project-management/demo.css
@@ -1,4 +1,4 @@
 #container {
-    max-width: 800px;
+    max-width: 1000px;
     margin: 1em auto;
 }

--- a/samples/gantt/demo/project-management/demo.html
+++ b/samples/gantt/demo/project-management/demo.html
@@ -1,5 +1,6 @@
 <script src="https://code.highcharts.com/gantt/highcharts-gantt.js"></script>
 <script src="https://code.highcharts.com/gantt/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/gantt/modules/pattern-fill.js"></script>
 <script src="https://code.highcharts.com/gantt/modules/accessibility.js"></script>
 
 <div id="container"></div>

--- a/samples/gantt/demo/project-management/demo.js
+++ b/samples/gantt/demo/project-management/demo.js
@@ -10,7 +10,7 @@ const options = {
 
     plotOptions: {
         series: {
-            borderRadius: 12,
+            borderRadius: '50%',
             connectors: {
                 dashStyle: 'ShortDot',
                 lineWidth: 2,

--- a/samples/gantt/demo/project-management/demo.js
+++ b/samples/gantt/demo/project-management/demo.js
@@ -199,19 +199,16 @@ const options = {
                 format: ''
             }
         },
+        dateTimeLabelFormats: {
+            day: '%e<br><span style="opacity: 0.5; font-size: 0.7em">' +
+                '%a</span>'
+        },
         grid: {
             borderWidth: 0
         },
         gridLineWidth: 1,
-        labels: {
-            format: '<span style="{#eq value axis.options.custom.today}font-size:1.4em;font-weight:bold{/eq}">' +
-                '{value:%e}<br>' +
-                '<span style="opacity: 0.5; font-size: 0.7em">' +
-                '{value:%a}</span></span>'
-        },
         min: today - 3 * day,
         max: today + 18 * day,
-        tickInterval: day,
         custom: {
             today,
             weekendPlotBands: true
@@ -222,6 +219,14 @@ const options = {
             borderWidth: 0
         },
         gridLineWidth: 0,
+        labels: {
+            symbol: {
+                width: 8,
+                height: 6,
+                x: -4,
+                y: -2
+            }
+        },
         staticScale: 30
     },
     accessibility: {

--- a/samples/gantt/demo/project-management/demo.js
+++ b/samples/gantt/demo/project-management/demo.js
@@ -143,49 +143,14 @@ const options = {
         }]
     }],
     tooltip: {
-        pointFormatter: function () {
-            const { dateFormat, defined, isObject } = Highcharts,
-                point = this,
-                format = '%e. %b',
-                options = point.options,
-                completed = options.completed,
-                amount = isObject(completed) ? completed.amount : completed,
-                status = ((amount || 0) * 100) + '%',
-
-                lines = [{
-                    value: point.name,
-                    style: 'font-weight: bold;'
-                }, {
-                    title: 'Start',
-                    value: dateFormat(format, point.start)
-                }, {
-                    visible: !options.milestone,
-                    title: 'End',
-                    value: dateFormat(format, point.end)
-                }, {
-                    title: 'Completed',
-                    value: status
-                }, {
-                    title: 'Owner',
-                    value: options.owner || 'unassigned'
-                }];
-
-            return lines.reduce(function (str, line) {
-                var s = '',
-                    style = (
-                        defined(line.style) ? line.style : 'font-size: 0.8em;'
-                    );
-                if (line.visible !== false) {
-                    s = (
-                        '<span style="' + style + '">' +
-                        (defined(line.title) ? line.title + ': ' : '') +
-                        (defined(line.value) ? line.value : '') +
-                        '</span><br/>'
-                    );
-                }
-                return str + s;
-            }, '');
-        }
+        pointFormat: '<span style="font-weight: bold">{point.name}</span><br>' +
+            '{point.start:%e %b}' +
+            '{#unless point.milestone} → {point.end:%e %b}{/unless}' +
+            '<br>' +
+            '{#if point.completed}' +
+            'Completed: {multiply point.completed.amount 100}%<br>' +
+            '{/if}' +
+            'Owner: {#if point.owner}{point.owner}{else}unassigned{/if}'
     },
     title: {
         text: 'Gantt Project Management'
@@ -200,8 +165,7 @@ const options = {
             }
         },
         dateTimeLabelFormats: {
-            day: '%e<br><span style="opacity: 0.5; font-size: 0.7em">' +
-                '%a</span>'
+            day: '%e<br><span style="opacity: 0.5; font-size: 0.7em">%a</span>'
         },
         grid: {
             borderWidth: 0

--- a/samples/gantt/demo/project-management/demo.js
+++ b/samples/gantt/demo/project-management/demo.js
@@ -14,6 +14,7 @@ const options = {
             connectors: {
                 dashStyle: 'ShortDot',
                 lineWidth: 2,
+                radius: 5,
                 startMarker: {
                     enabled: false
                 }

--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -1535,7 +1535,8 @@ export default GridAxis;
 
 /**
  * Set cell height for grid axis labels. By default this is calculated from font
- * size. This option only applies to horizontal axes.
+ * size. This option only applies to horizontal axes. For vertical axes, check
+ * the [#yAxis.staticScale](yAxis.staticScale) option.
  *
  * @sample gantt/grid-axis/cellheight
  *         Gant chart with custom cell height


### PR DESCRIPTION
Brushed up the Gantt Project Management demo.

### To do
 - [x] Check responsive. Particularly the x-axis labels don't work well now.
 - [x] Percentage `borderRadius`, currently not implemented for Gantt series.
 - [x] Check out plus/minus symbols for the tree grid.

Related to do's, may or may not be part of this PR:
 - [x] Rounded corners for the connector, like org chart (separate PR: #19109).
 - [x] `plotOptions.series.connector` is not in the API, instead `connector` sits on the root level.
 - [x] Could not find info about tree grid in the docs nor API. Check out.
