### PR TITLE
Added option gantt.connectors.radius

### DIFF
--- a/ts/Gantt/Connection.ts
+++ b/ts/Gantt/Connection.ts
@@ -215,6 +215,13 @@ extend(defaultOptions, {
         type: 'straight',
 
         /**
+         * The corner radius for this chart's Pathfinder connecting lines
+         *
+         * @since next
+         */
+        radius: 0,
+
+        /**
          * Set the default pixel width for this chart's Pathfinder connecting
          * lines.
          *

--- a/ts/Gantt/Pathfinder.ts
+++ b/ts/Gantt/Pathfinder.ts
@@ -142,6 +142,7 @@ declare global {
             lineColor?: ColorString;
             lineWidth?: number;
             marker?: ConnectorsMarkerOptions;
+            radius?: number;
             startMarker?: ConnectorsStartMarkerOptions;
             type?: PathfinderTypeValue;
         }
@@ -324,6 +325,13 @@ extend(defaultOptions, {
          * @since   6.2.0
          */
         type: 'straight',
+
+        /**
+         * The corner radius for the connector line
+         *
+         * @since next
+         */
+        radius: 0,
 
         /**
          * Set the default pixel width for this chart's Pathfinder connecting

--- a/ts/Gantt/PathfinderAlgorithms.ts
+++ b/ts/Gantt/PathfinderAlgorithms.ts
@@ -14,6 +14,8 @@
 import type Point from '../Core/Series/Point';
 import type PositionObject from '../Core/Renderer/PositionObject';
 import type SVGPath from '../Core/Renderer/SVG/SVGPath';
+
+import PathUtilities from '../Series/PathUtilities.js';
 import U from '../Core/Utilities.js';
 const {
     extend,
@@ -380,8 +382,13 @@ const simpleConnect = function (
     // Finally add the endSegment
     segments.push(endSegment);
 
+    const path = PathUtilities.applyRadius(
+        pathFromSegments(segments),
+        options.radius
+    );
+
     return {
-        path: pathFromSegments(segments),
+        path,
         obstacles: segments
     };
 };

--- a/ts/Series/Gantt/GanttSeries.ts
+++ b/ts/Series/Gantt/GanttSeries.ts
@@ -137,6 +137,7 @@ class GanttSeries extends XRangeSeries {
             animation: {
                 reversed: true // Dependencies go from child to parent
             },
+            radius: 0,
             startMarker: {
                 enabled: true,
                 symbol: 'arrow-filled',
@@ -317,7 +318,7 @@ export default GanttSeries;
  * A `gantt` series.
  *
  * @extends   series,plotOptions.gantt
- * @excluding boostThreshold, connectors, dashStyle, findNearestPointBy,
+ * @excluding boostThreshold, dashStyle, findNearestPointBy,
  *            getExtremesFromAll, marker, negativeColor, pointInterval,
  *            pointIntervalUnit, pointPlacement, pointStart
  * @product   gantt


### PR DESCRIPTION
Added new option, `gantt.connectors.radius`, to allow curved connectors between task dependencies.