### PR TITLE
bugfix/19121-measure-annotation-update

### DIFF
--- a/samples/unit-tests/annotations/annotations-measure/demo.js
+++ b/samples/unit-tests/annotations/annotations-measure/demo.js
@@ -124,8 +124,9 @@ QUnit.test('#13664 - annotation measure on yAxis', function (assert) {
         }
     });
 
-    assert.close(
-        bbox.x, chart.annotations[0].shapesGroup.getBBox().x, 1,
+    assert.equal(
+        bbox.x,
+        chart.annotations[0].shapesGroup.getBBox().x,
         'The annotation should stay in the same place after update, #19121.'
     );
 });

--- a/samples/unit-tests/annotations/annotations-measure/demo.js
+++ b/samples/unit-tests/annotations/annotations-measure/demo.js
@@ -110,7 +110,6 @@ QUnit.test('#13664 - annotation measure on yAxis', function (assert) {
     // drag the annotation to the left
     controller.mouseDown(bbox.x + bbox.width / 2, bbox.y + bbox.height / 2);
     controller.mouseMove(bbox.x - 50, bbox.y);
-    controller.mouseMove(bbox.x - 50, bbox.y);
     controller.mouseUp();
 
     bbox = chart.annotations[0].shapesGroup.getBBox();

--- a/samples/unit-tests/annotations/annotations-measure/demo.js
+++ b/samples/unit-tests/annotations/annotations-measure/demo.js
@@ -43,6 +43,8 @@ QUnit.test('#13664 - annotation measure on yAxis', function (assert) {
         }]
     });
 
+    var controller = new TestController(chart);
+
     let bbox = chart.annotations[0].shapesGroup.getBBox();
     assert.ok(
         bbox.y === chart.yAxis[1].top,
@@ -101,5 +103,30 @@ QUnit.test('#13664 - annotation measure on yAxis', function (assert) {
         Math.round(axisMiddlePos),
         `Annotation's control points should be positioned in the middle of yAxis
         #17995`
+    );
+
+    bbox = chart.annotations[0].shapesGroup.getBBox();
+
+    // drag the annotation to the left
+    controller.mouseDown(bbox.x + bbox.width / 2, bbox.y + bbox.height / 2);
+    controller.mouseMove(bbox.x - 50, bbox.y);
+    controller.mouseMove(bbox.x - 50, bbox.y);
+    controller.mouseUp();
+
+    bbox = chart.annotations[0].shapesGroup.getBBox();
+
+    chart.annotations[0].update({
+        typeOptions: {
+            label: {
+                style: {
+                    color: 'red'
+                }
+            }
+        }
+    });
+
+    assert.close(
+        bbox.x, chart.annotations[0].shapesGroup.getBBox().x, 1,
+        'The annotation should stay in the same place after update, #19121.'
     );
 });

--- a/ts/Extensions/Annotations/Types/Measure.ts
+++ b/ts/Extensions/Annotations/Types/Measure.ts
@@ -397,6 +397,18 @@ function updateStartPoints(
         this.offsetX = 0;
         this.offsetY = 0;
     }
+
+    this.options.typeOptions.point = {
+        x: this.startXMin,
+        y: this.startYMin
+    };
+
+    // We need to update userOptions as well as they are used in
+    // the Annotation.update() method to initialize the annotation, #19121.
+    this.userOptions.typeOptions.point = {
+        x: this.startXMin,
+        y: this.startYMin
+    };
 }
 
 /* *
@@ -828,18 +840,6 @@ class Measure extends Annotation {
         this.shapes.forEach((item): void =>
             item.translate(dx, dy)
         );
-
-        this.options.typeOptions.point = {
-            x: this.startXMin,
-            y: this.startYMin
-        };
-
-        // We need to update userOptions as well as they are used in
-        // the Annotation.update() method to initialize the annotation, #19121.
-        this.userOptions.typeOptions.point = {
-            x: this.startXMin,
-            y: this.startYMin
-        };
     }
 
 }

--- a/ts/Extensions/Annotations/Types/Measure.ts
+++ b/ts/Extensions/Annotations/Types/Measure.ts
@@ -833,6 +833,13 @@ class Measure extends Annotation {
             x: this.startXMin,
             y: this.startYMin
         };
+
+        // We need to update userOptions as well as they are used in
+        // the Annotation.update() method to initialize the annotation, #19121.
+        this.userOptions.typeOptions.point = {
+            x: this.startXMin,
+            y: this.startYMin
+        };
     }
 
 }


### PR DESCRIPTION
Fixed #19121, `Measure Annotation` went back to its initial position after update.

**GIF of the problem is here:** https://www.highcharts.com/forum/viewtopic.php?f=12&t=50985

**The source of the problem:**
1. When we create a new `Measure Annotation` its initial position is set in the `annotation.userOptions`
2. When we drag the `Measure Annotation` we update its coordinates in `annotation.options`
3. When we update the annotation - `Annotation.update(userOptions, redraw)` - we initialize the annotation with `userOptions` (set initially), not with `options` (which were updated after dragging)

**Simple solution:** updating both `options` and `userOptions` after dragging.