### PR TITLE
bugfix/incorrect-outline-offline-exporting

### DIFF
--- a/samples/highcharts/exporting/offline-download-pdffont/demo.js
+++ b/samples/highcharts/exporting/offline-download-pdffont/demo.js
@@ -16,7 +16,13 @@ Highcharts.chart('container', {
         data: [1, 3, 2, 4],
         type: 'column',
         colorByPoint: true,
-        name: 'Αυτή είναι η σειρά'
+        name: 'Αυτή είναι η σειρά',
+        dataLabels: {
+            enabled: true,
+            style: {
+                textOutline: 'red'
+            }
+        }
     }],
 
     exporting: {

--- a/samples/highcharts/exporting/offline-download-pdffont/demo.js
+++ b/samples/highcharts/exporting/offline-download-pdffont/demo.js
@@ -13,15 +13,13 @@ Highcharts.chart('container', {
     },
 
     series: [{
-        data: [1, 3, 2, 4],
+        data: [123, 345, 234, 456],
         type: 'column',
         colorByPoint: true,
         name: 'Αυτή είναι η σειρά',
         dataLabels: {
             enabled: true,
-            style: {
-                textOutline: 'red'
-            }
+            inside: true
         }
     }],
 

--- a/samples/highcharts/exporting/offline-download-pdffont/test-notes.md
+++ b/samples/highcharts/exporting/offline-download-pdffont/test-notes.md
@@ -1,4 +1,4 @@
-Download as PDF and verify that the text is correct. Data labels should be positioned correctly and their red outline should be removed in exported pdf, #17170.
+Download as PDF and verify that the text is correct. Verify that the data labels are positioned correctly and there are no artifacts left from the outlines (#17170).
 
 (Some overlap may occur due to different text metrics in the browser font vs the
 PDF reader.)

--- a/samples/highcharts/exporting/offline-download-pdffont/test-notes.md
+++ b/samples/highcharts/exporting/offline-download-pdffont/test-notes.md
@@ -1,4 +1,4 @@
-Download as PDF and verify that the text is correct.
+Download as PDF and verify that the text is correct. Data labels should be positioned correctly and their red outline should be removed in exported pdf, #17170.
 
 (Some overlap may occur due to different text metrics in the browser font vs the
 PDF reader.)

--- a/ts/Extensions/OfflineExporting/OfflineExporting.ts
+++ b/ts/Extensions/OfflineExporting/OfflineExporting.ts
@@ -394,7 +394,7 @@ namespace OfflineExporting {
                     el.removeChild(titleElement);
                 });
 
-                // Remove all .highcharts-text-outline elements, #19041, #17170
+                // Remove all .highcharts-text-outline elements, #17170
                 outlineElements =
                     el.getElementsByClassName('highcharts-text-outline');
                 while (outlineElements.length > 0) {

--- a/ts/Extensions/OfflineExporting/OfflineExporting.ts
+++ b/ts/Extensions/OfflineExporting/OfflineExporting.ts
@@ -363,7 +363,8 @@ namespace OfflineExporting {
                         curParent = curParent.parentNode as any;
                     }
                 };
-            let titleElements;
+            let titleElements,
+                outlineElements;
 
             // Workaround for the text styling. Making sure it does pick up
             // settings for parent elements.
@@ -392,6 +393,13 @@ namespace OfflineExporting {
                 ): void {
                     el.removeChild(titleElement);
                 });
+
+                // Remove all .highcharts-text-outline elements, #19041, #17170
+                outlineElements =
+                    el.getElementsByClassName('highcharts-text-outline');
+                while (outlineElements.length > 0) {
+                    el.removeChild(outlineElements[0]);
+                }
             });
 
             const svgNode = dummySVGContainer.querySelector('svg');


### PR DESCRIPTION
Fixed #17170, data labels with outline or shadow were misplaced in PDF files exported using the offline exporting module.