### PR TITLE
bugfix/19002-a11y-stripped-signs

### DIFF
--- a/samples/unit-tests/accessibility/accessibility-exporting/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-exporting/demo.js
@@ -49,6 +49,9 @@ QUnit.test('Exporting button and menu HTML/ARIA markup', function (assert) {
 
 QUnit.test('Exported chart should not contain HTML elements from a11y module', function (assert) {
     var chart = Highcharts.chart('container', {
+            title: {
+                text: 'Title < title'
+            },
             series: [{
                 data: [1, 2, 3, 4, 5, 6]
             }],
@@ -59,7 +62,14 @@ QUnit.test('Exported chart should not contain HTML elements from a11y module', f
         svg = chart.getSVGForExport(),
         hasHTMLElements = svg.match(
             /<(div|p|h[1-7]|button|a|li|ul|ol|table|input|select)(\s[^>]+)?>/gu
-        );
+        ),
+        hasTitleChanged = svg.match(/\bTitle\b(?:\s&lt;\s)\btitle\b/g);
 
     assert.strictEqual(hasHTMLElements, null, 'Should not have any HTML elements in the SVG');
+
+    assert.strictEqual(
+        hasTitleChanged[0],
+        'Title &lt; title',
+        'Title should replace `<` to `&lt;` for exporting, (#17753, #19002)'
+    );
 });

--- a/samples/unit-tests/title/title/demo.js
+++ b/samples/unit-tests/title/title/demo.js
@@ -109,8 +109,8 @@ QUnit.test('Title alignment', function (assert) {
         .getAttribute('aria-label');
 
     assert.ok(
-        !/\</g.test(ariaValue),
-        '"<" should not be included in aria-label#17753'
+        /\</g.test(ariaValue),
+        '"<" can be included in aria-label if not for export (#17753, #19002)'
     );
 
     chart.update({

--- a/ts/Accessibility/Components/AnnotationsA11y.ts
+++ b/ts/Accessibility/Components/AnnotationsA11y.ts
@@ -174,7 +174,8 @@ function getAnnotationListItems(chart: AnnotationChart): string[] {
     return labels.map((label): string => {
         const desc = escapeStringForHTML(
             stripHTMLTagsFromString(
-                getAnnotationLabelDescription(label)
+                getAnnotationLabelDescription(label),
+                chart.renderer.forExport
             )
         );
         return desc ? `<li>${desc}</li>` : '';

--- a/ts/Accessibility/Components/ContainerComponent.ts
+++ b/ts/Accessibility/Components/ContainerComponent.ts
@@ -170,7 +170,13 @@ class ContainerComponent extends AccessibilityComponent {
                 credits.element.setAttribute(
                     'aria-label', chart.langFormat(
                         'accessibility.credits',
-                        { creditsStr: stripHTMLTags(credits.textStr) }
+                        {
+                            creditsStr:
+                                stripHTMLTags(
+                                    credits.textStr,
+                                    chart.renderer.forExport
+                                )
+                        }
                     )
                 );
             }

--- a/ts/Accessibility/Components/InfoRegionsComponent.ts
+++ b/ts/Accessibility/Components/InfoRegionsComponent.ts
@@ -556,7 +556,7 @@ class InfoRegionsComponent extends AccessibilityComponent {
         const el = this.linkedDescriptionElement,
             content = el && el.innerHTML || '';
 
-        return stripHTMLTagsFromString(content);
+        return stripHTMLTagsFromString(content, this.chart.renderer.forExport);
     }
 
 
@@ -636,7 +636,10 @@ class InfoRegionsComponent extends AccessibilityComponent {
         const subtitle = (
             this.chart.options.subtitle
         );
-        return stripHTMLTagsFromString(subtitle && subtitle.text || '');
+        return stripHTMLTagsFromString(
+            subtitle && subtitle.text || '',
+            this.chart.renderer.forExport
+        );
     }
 
 

--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -369,7 +369,8 @@ class LegendComponent extends AccessibilityComponent {
                 chart.legend.options.title &&
                 chart.legend.options.title.text ||
                 ''
-            ).replace(/<br ?\/?>/g, ' ')
+            ).replace(/<br ?\/?>/g, ' '),
+            chart.renderer.forExport
         );
         const legendLabel = chart.langFormat(
             'accessibility.legend.legendLabel' + (legendTitle ? '' : 'NoTitle'),
@@ -438,7 +439,10 @@ class LegendComponent extends AccessibilityComponent {
             'accessibility.legend.legendItem',
             {
                 chart: this.chart,
-                itemName: stripHTMLTags((item as any).name),
+                itemName: stripHTMLTags(
+                    (item as any).name,
+                    this.chart.renderer.forExport
+                ),
                 item
             }
         );

--- a/ts/Accessibility/Components/SeriesComponent/SeriesDescriber.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesDescriber.ts
@@ -561,7 +561,8 @@ function setPointScreenReaderAttribs(
                 )
             ) ||
             a11yPointOptions.descriptionFormatter?.(point) ||
-            defaultPointDescriptionFormatter(point)
+            defaultPointDescriptionFormatter(point),
+            series.chart.renderer.forExport
         );
 
     pointElement.setAttribute('role', 'img');
@@ -704,7 +705,8 @@ function describeSeriesElement(
         stripHTMLTags(
             (a11yOptions.series as any).descriptionFormatter &&
             (a11yOptions.series as any).descriptionFormatter(series) ||
-            defaultSeriesDescriptionFormatter(series)
+            defaultSeriesDescriptionFormatter(series),
+            series.chart.renderer.forExport
         )
     );
 }

--- a/ts/Accessibility/Utils/ChartUtilities.ts
+++ b/ts/Accessibility/Utils/ChartUtilities.ts
@@ -86,7 +86,8 @@ function getChartTitle(chart: Accessibility.ChartComposition): string {
         chart.options.title.text ||
         chart.langFormat(
             'accessibility.defaultChartTitle', { chart: chart }
-        )
+        ),
+        chart.renderer.forExport
     );
 }
 

--- a/ts/Accessibility/Utils/HTMLUtilities.ts
+++ b/ts/Accessibility/Utils/HTMLUtilities.ts
@@ -358,9 +358,14 @@ function reverseChildNodes(node: DOMElementType): void {
  * text contains tags.
  * @private
  */
-function stripHTMLTagsFromString(str: string): string {
-    return typeof str === 'string' ?
-        str.replace(/<\/?[^>]+(>|$)/g, '') : str;
+function stripHTMLTagsFromString(
+    str: string,
+    isForExport: boolean = false
+): string {
+    return (typeof str === 'string') ?
+        (isForExport ?
+            str.replace(/<\/?[^>]+(>|$)/g, '') :
+            str.replace(/<\/?(?!\s)[^>]+(>|$)/g, '')) : str;
 }
 
 


### PR DESCRIPTION
Fixed #19002, with `a11y` enabled `<` sign was stripped, causing issues with screen readers.