### PR TITLE
bugfix/17820-clip-rect-navigator-boost

### DIFF
--- a/samples/unit-tests/boost/general/demo.js
+++ b/samples/unit-tests/boost/general/demo.js
@@ -329,5 +329,22 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
             `After setting the axis position manually, the boost clip-path
             shouldn\'t be bigger than the axis size.`
         );
+        chart.update({
+            chart: {
+                inverted: false
+            },
+            navigator: {
+                enabled: true,
+                height: 80,
+                series: {
+                    boostThreshold: 1,
+                    color: 'red',
+                    type: 'line',
+                    dataGrouping: {
+                        enabled: false
+                    }
+                }
+            }
+        });
     }
 );

--- a/ts/Extensions/Boost/BoostChart.ts
+++ b/ts/Extensions/Boost/BoostChart.ts
@@ -104,23 +104,20 @@ function getBoostClipRect(
         x: chart.plotLeft,
         y: chart.plotTop,
         width: chart.plotWidth,
-        height: chart.plotHeight
+        height: chart.navigator ?
+            chart.navigator.top + chart.navigator.height - chart.plotTop :
+            chart.plotHeight
     };
 
-    if (target === chart) {
-        const verticalAxes =
-            chart.inverted ? chart.xAxis : chart.yAxis; // #14444
+    const verticalAxes = chart.inverted ? chart.xAxis : chart.yAxis; // #14444
 
-        if (verticalAxes.length <= 1) {
-            clipBox.y = Math.min(verticalAxes[0].pos, clipBox.y);
-            clipBox.height = (
-                verticalAxes[0].pos -
-                chart.plotTop +
-                verticalAxes[0].len
-            );
-        } else {
-            clipBox.height = chart.plotHeight;
-        }
+    if (target === chart && verticalAxes.length <= 1) {
+        clipBox.y = Math.min(verticalAxes[0].pos, clipBox.y);
+        clipBox.height = (
+            verticalAxes[0].pos -
+            chart.plotTop +
+            verticalAxes[0].len
+        );
     }
 
     return clipBox;


### PR DESCRIPTION
Fixed #17820, clip rect did not take into account boosted navigator.

Demo `.com`: https://jsfiddle.net/BlackLabel/g12drxjo/
Demo from branch: https://jsfiddle.net/BlackLabel/zm1bsdqv/