### PR TITLE
bugfix/19069-stacked-column-bar-stroke

### DIFF
--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -484,8 +484,9 @@ text.highcharts-data-label {
     stroke: var(--highcharts-neutral-color-100);
 }
 
-.highcharts-column-series rect.highcharts-point {
-    /* rect to prevent stroke on 3D columns */
+.highcharts-column-series path.highcharts-point,
+.highcharts-bar-series path.highcharts-point {
+    /* path to prevent stroke on 3D columns and bars */
     stroke: var(--highcharts-background-color);
 }
 


### PR DESCRIPTION
Fixed #19069, columns and bars had unnecessary stroke in styled mode.