### PR TITLE
bugfix/19078-proximate-legend-enabling

### DIFF
--- a/samples/unit-tests/legend/layout/demo.js
+++ b/samples/unit-tests/legend/layout/demo.js
@@ -1,6 +1,7 @@
 QUnit.test('Legend layout', function (assert) {
     var chart = Highcharts.chart('container', {
         legend: {
+            enabled: false,
             layout: 'proximate',
             align: 'right'
         },
@@ -32,6 +33,13 @@ QUnit.test('Legend layout', function (assert) {
                 name: 'Positioned Axis'
             }
         ]
+    });
+
+    // We should be able to update the legend.enabled property, #19078.
+    chart.update({
+        legend: {
+            enabled: true
+        }
     });
 
     chart.series.forEach(function (s) {
@@ -102,6 +110,7 @@ QUnit.test('Proximate layout and dataGrouping', assert => {
             animation: false
         },
         legend: {
+            enabled: true,
             align: 'right',
             layout: 'proximate'
         },
@@ -133,6 +142,19 @@ QUnit.test('Proximate layout and dataGrouping', assert => {
                 ]
             }
         ]
+    });
+
+    // These updates should not cause an error, #19028.
+    chart.update({
+        legend: {
+            enabled: false
+        }
+    });
+
+    chart.update({
+        legend: {
+            enabled: true
+        }
     });
 
     chart.series[1].hide();

--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -235,7 +235,6 @@ class Legend {
      * Legend options.
      */
     public init(chart: Chart, options: LegendOptions): void {
-
         /**
          * Chart of this legend.
          *
@@ -247,29 +246,29 @@ class Legend {
 
         this.setOptions(options);
 
-        if (options.enabled) {
+        const positionProximate = (): void => {
+            if (this.options.enabled && this.proximate) {
+                this.proximatePositions();
+                this.positionItems();
+            }
+        };
 
+        if (options.enabled) {
             // Render it
             this.render();
 
-            // move checkboxes
+            // Move checkboxes
             addEvent(this.chart, 'endResize', function (): void {
                 this.legend.positionCheckboxes();
             });
 
             // On Legend.init and Legend.update, make sure that proximate layout
             // events are either added or removed (#18362).
-            addEvent(
-                this.chart,
-                'render',
-                (): void => {
-                    if (this.proximate) {
-                        this.proximatePositions();
-                        this.positionItems();
-                    }
-                }
-            );
+            addEvent(this.chart, 'render', positionProximate);
         }
+
+        // Need to position the legend after update, #19078.
+        addEvent(this.chart, 'redraw', positionProximate);
     }
 
     /**

--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -246,13 +246,6 @@ class Legend {
 
         this.setOptions(options);
 
-        const positionProximate = (): void => {
-            if (this.options.enabled && this.proximate) {
-                this.proximatePositions();
-                this.positionItems();
-            }
-        };
-
         if (options.enabled) {
             // Render it
             this.render();
@@ -261,14 +254,16 @@ class Legend {
             addEvent(this.chart, 'endResize', function (): void {
                 this.legend.positionCheckboxes();
             });
-
-            // On Legend.init and Legend.update, make sure that proximate layout
-            // events are either added or removed (#18362).
-            addEvent(this.chart, 'render', positionProximate);
         }
 
-        // Need to position the legend after update, #19078.
-        addEvent(this.chart, 'redraw', positionProximate);
+        // On Legend.init and Legend.update, make sure that proximate layout
+        // events are either added or removed (#18362).
+        addEvent(this.chart, 'render', (): void => {
+            if (this.options.enabled && this.proximate) {
+                this.proximatePositions();
+                this.positionItems();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
Fixed #19078, proximate legend did not work after updating the `legend.enabled` property.

**Demo of the problem:** https://jsfiddle.net/BlackLabel/1cmx87k9/
**Demo after fix:** https://jsfiddle.net/BlackLabel/wftjvga3/

**Source of the problem:**
- `proximatePositions()` was called even when `legend.enabled = false` which caused multiple errors
- `proximatePositions()` and `positionItems()` functions were called only in the initial chart render, not after updating 