### PR TITLE
bugfix/19093-svg-filter-shadow-issue

### DIFF
--- a/samples/unit-tests/svgrenderer/shadows/demo.js
+++ b/samples/unit-tests/svgrenderer/shadows/demo.js
@@ -34,14 +34,20 @@ QUnit.test('Series shadows', function (assert) {
         'Shadows amount should be updated (#12091)'
     );
 
+    assert.ok(
+        chart.series[0].graph.attr('filter').indexOf('userpacense') !== -1,
+        `Shadow should have 'filterUnits: userSpaceOnUse' attribute
+        with line series (#19093)`
+    );
+
     chart.series[0].update({
         shadow: true
     });
 
     assert.strictEqual(
         chart.series[0].graph.attr('filter'),
-        `url(#highcharts-drop-shadow-${chart.index})`,
-        'Shadows should be updated when old options defined as object and new as boolean (#12091).'
+        `url(#highcharts-drop-shadow-${chart.index}-userpacense)`,
+        'Shadows should be updated when old options defined as object and new as boolean (#12091, #19093).'
     );
 
     chart = Highcharts.chart('container', {
@@ -69,5 +75,17 @@ QUnit.test('Series shadows', function (assert) {
     assert.ok(
         chart.series[0].graph.attr('filter').indexOf('red') !== -1,
         'Shadows should be updated when old options defined as boolean and new as object (#12091).'
+    );
+
+    chart.series[0].update({
+        type: 'column'
+    });
+
+    const firstColumn = chart.series[0].points[0];
+
+    assert.ok(
+        firstColumn.graphic.attr('filter').indexOf('userpacense') === -1,
+        `Shadow shouldn't have 'filterUnits: userSpaceOnUse' on other types
+        of series (#19093)`
     );
 });

--- a/samples/unit-tests/svgrenderer/shadows/demo.js
+++ b/samples/unit-tests/svgrenderer/shadows/demo.js
@@ -35,7 +35,7 @@ QUnit.test('Series shadows', function (assert) {
     );
 
     assert.ok(
-        chart.series[0].graph.attr('filter').indexOf('userpacense') !== -1,
+        chart.series[0].graph.attr('filter').indexOf('userspaceonuse') !== -1,
         `Shadow should have 'filterUnits: userSpaceOnUse' attribute
         with line series (#19093)`
     );
@@ -46,7 +46,9 @@ QUnit.test('Series shadows', function (assert) {
 
     assert.strictEqual(
         chart.series[0].graph.attr('filter'),
-        `url(#highcharts-drop-shadow-${chart.index}-userpacense)`,
+        `url(#highcharts-drop-shadow-${
+            chart.index
+        }-filterunits-userspaceonuse)`,
         'Shadows should be updated when old options defined as object and new as boolean (#12091, #19093).'
     );
 

--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -139,6 +139,7 @@ class AST {
         'dy',
         'disabled',
         'fill',
+        'filterUnits',
         'flood-color',
         'flood-opacity',
         'height',

--- a/ts/Core/Renderer/SVG/SVGAttributes.d.ts
+++ b/ts/Core/Renderer/SVG/SVGAttributes.d.ts
@@ -59,6 +59,7 @@ export interface SVGAttributes {
     fill?: ColorType;
     'fill-opacity'?: number;
     filter?: string;
+    filterUnits?: string;
     'flood-color'?: string;
     'flood-opacity'?: number;
     gradientUnits?: 'userSpaceOnUse';

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -603,10 +603,10 @@ class SVGRenderer implements SVGRendererLike {
             id = [
                 `highcharts-drop-shadow-${this.chartIndex}`,
                 ...Object.keys(shadowOptions)
-                    .map((key: string): number|string =>
-                        (shadowOptions as any)[key]
+                    .map((key: string): string =>
+                        `${key}-${(shadowOptions as any)[key]}`
                     )
-            ].join('-').replace(/[^a-z0-9\-]/g, ''),
+            ].join('-').toLowerCase().replace(/[^a-z0-9\-]/g, ''),
             options: ShadowOptionsObject = merge({
                 color: '#000000',
                 offsetX: 1,

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -619,7 +619,8 @@ class SVGRenderer implements SVGRendererLike {
             this.definition({
                 tagName: 'filter',
                 attributes: {
-                    id
+                    id,
+                    filterUnits: options.filterUnits
                 },
                 children: [{
                     tagName: 'feDropShadow',

--- a/ts/Core/Renderer/ShadowOptionsObject.d.ts
+++ b/ts/Core/Renderer/ShadowOptionsObject.d.ts
@@ -24,6 +24,7 @@ import type ColorString from '../Color/ColorString';
 
 export interface ShadowOptionsObject {
     color: ColorString;
+    filterUnits?: string;
     offsetX: number;
     offsetY: number;
     opacity: number;

--- a/ts/Series/Line/LineSeries.ts
+++ b/ts/Series/Line/LineSeries.ts
@@ -184,16 +184,13 @@ class LineSeries extends Series {
                 // zone (1) #3932
                     .shadow(
                         (i < 2) &&
-                        (options.shadow ?
-                            // If shadow is defined, call function with
-                            // `filterUnits: 'userSpaceOnUse'` to avoid known
-                            // SVG filter bug (#19093)
-                            (isObject(options.shadow) ?
-                                merge(
-                                    options.shadow,
-                                    { filterUnits: 'userSpaceOnUse' }
-                                ) : { filterUnits: 'userSpaceOnUse' }
-                            ) : options.shadow
+                        options.shadow &&
+                        // If shadow is defined, call function with
+                        // `filterUnits: 'userSpaceOnUse'` to avoid known
+                        // SVG filter bug (#19093)
+                        merge(
+                            { filterUnits: 'userSpaceOnUse' },
+                            isObject(options.shadow) ? options.shadow : {}
                         )
                     );
             }

--- a/ts/Series/Line/LineSeries.ts
+++ b/ts/Series/Line/LineSeries.ts
@@ -30,7 +30,8 @@ import SeriesRegistry from '../../Core/Series/SeriesRegistry.js';
 import U from '../../Core/Utilities.js';
 const {
     defined,
-    merge
+    merge,
+    isObject
 } = U;
 
 /* *
@@ -179,9 +180,22 @@ class LineSeries extends Series {
                 }
 
                 graph[verb](attribs)
-                    // Add shadow to normal series (0) or to first
-                    // zone (1) #3932
-                    .shadow((i < 2) && options.shadow);
+                // Add shadow to normal series (0) or to first
+                // zone (1) #3932
+                    .shadow(
+                        (i < 2) &&
+                        (options.shadow ?
+                            // If shadow is defined, call function with
+                            // `filterUnits: 'userSpaceOnUse'` to avoid known
+                            // SVG filter bug (#19093)
+                            (isObject(options.shadow) ?
+                                merge(
+                                    options.shadow,
+                                    { filterUnits: 'userSpaceOnUse' }
+                                ) : { filterUnits: 'userSpaceOnUse' }
+                            ) : options.shadow
+                        )
+                    );
             }
 
             // Helpers for animation


### PR DESCRIPTION
Fixed #19093, SVG `<filter>` issue with shadow enabled on line series when points had the same `x` or `y` value.