### PR TITLE
bugfix/19127-column-pyramid-center-in-category 

### DIFF
--- a/samples/unit-tests/series/centerincategory/demo.js
+++ b/samples/unit-tests/series/centerincategory/demo.js
@@ -161,6 +161,46 @@ QUnit.test('series.centerInCategory', function (assert) {
 
     chart.update({
         chart: {
+            type: 'columnpyramid'
+        },
+        series: [{
+            data: [
+                [0, 2],
+                [1, 1],
+                [2, 2]
+            ]
+        }, {
+            data: [
+                [0, 2],
+                [1, null],
+                [2, 3]
+            ]
+        }, {
+            data: [
+                [0, 2],
+                [1, 2]
+            ]
+        }, {
+            data: [
+                [0, 2],
+                [1, 1]
+            ]
+        }]
+    }, true, true);
+
+    point = chart.series[2].points[1];
+    tickX = chart.xAxis[0].ticks[1].mark.element.getBBox().x;
+
+    const pointBBox = point.graphic.element.getBBox();
+
+    assert.ok(
+        chart.plotLeft + pointBBox.x < tickX &&
+            chart.plotLeft + pointBBox.x + pointBBox.width > tickX,
+        '#19127: Point should be centered on the tick if series is columnpyramid.'
+    );
+
+    chart.update({
+        chart: {
             type: 'column'
         },
         series: [{

--- a/ts/Series/ColumnPyramid/ColumnPyramidSeries.ts
+++ b/ts/Series/ColumnPyramid/ColumnPyramidSeries.ts
@@ -160,6 +160,15 @@ class ColumnPyramidSeries extends ColumnSeries {
                 invBarPos: number,
                 x1, x2, x3, x4, y1, y2;
 
+            // Adjust for null or missing points
+            if (options.centerInCategory) {
+                barX = series.adjustForMissingColumns(
+                    barX,
+                    pointWidth,
+                    point,
+                    metrics
+                );
+            }
 
             point.barX = barX;
             point.pointWidth = pointWidth;


### PR DESCRIPTION
Fixed #19127, `centerInCategory` was not working for column pyramid.