### PR TITLE
demo/19162-wrong-timeline-docs

### DIFF
--- a/docs/chart-and-series-types/timeline-series.md
+++ b/docs/chart-and-series-types/timeline-series.md
@@ -85,8 +85,8 @@ Use the `alternate` property in the `dataLabels` configuration, for placing the 
 Other configuring options
 -------------------------
 
-Customize a timeline chart with options that are standard to most Highcharts charts, such as data labels `width`, `distance` or using the point properties, `color`, `x`, `y`, `markers` or the connectors. In the demo below the color properties of the `marker` data point property is setting the color of a section in the timeline.
+Customize a timeline chart with options that are standard to most Highcharts charts, such as data labels `width`, `distance` or using the point properties, `color`, `x`, `markers` or the connectors. In the demo below the color properties of the `marker` data point property is setting the color of a section in the timeline.
 
 The demo below illustrates styling of different elements in the timeline series chart.
 
-<iframe width="100%" height="470" style="null" src=https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/blog/timeline/embedded/result allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 470px; border: none;" src=https://www.highcharts.com/samples/embed/highcharts/blog/timeline allow="fullscreen"></iframe>


### PR DESCRIPTION
Fixed #19162, `timeline` docs refered to non-existing `point.y` property, last demo on page was not working.