### PR TITLE
bugfix/19035-tooltip-pointer-events

### DIFF
--- a/samples/unit-tests/tooltip/outside/demo.js
+++ b/samples/unit-tests/tooltip/outside/demo.js
@@ -30,7 +30,7 @@ QUnit.test('Outside tooltip and styledMode (#11783)', function (assert) {
     );
 });
 
-QUnit.test('Outside tooltip styling and correct position', function (assert) {
+QUnit.test('Outside tooltip styling, correct position & pointer-events', function (assert) {
     const chart = Highcharts.chart('container', {
             chart: {
                 width: 400,
@@ -41,16 +41,45 @@ QUnit.test('Outside tooltip styling and correct position', function (assert) {
                 }
             },
             tooltip: {
-                outside: true
+                hideDelay: 0,
+                outside: true,
+                style: {
+                    pointerEvents: 'auto'
+                },
+                useHTML: true,
+                headerFormat: '',
+                pointFormat: '<div style="width: 400px; height: 400px;">Hello</div>'
             },
-            series: [
-                {
-                    data: [1, 3, 2, 4]
-                }
-            ]
+            series: [{
+                type: 'column',
+                data: [1, 2, 2, 2, 2, 1]
+            }]
         }),
+        points = chart.series[0].points,
         point = chart.series[0].points[0],
-        tooltip = chart.tooltip;
+        tooltip = chart.tooltip,
+        controller = new TestController(chart);
+
+    controller.moveTo(
+        chart.plotLeft + points[1].plotX,
+        chart.plotTop + points[1].plotY
+    );
+
+    controller.moveTo(
+        chart.plotLeft + points[1].plotX,
+        chart.plotTop + chart.plotHeight + 10
+    );
+
+    controller.moveTo(
+        chart.plotLeft + points[0].plotX,
+        chart.plotTop + points[0].plotY
+    );
+
+    assert.notEqual(
+        chart.tooltip.label.visibility,
+        'hidden',
+        'Tooltip should show after hovering over a series even with pointer-events set (#19025)'
+    );
 
     // Set hoverPoint
     point.onMouseOver();

--- a/samples/unit-tests/tooltip/outside/demo.js
+++ b/samples/unit-tests/tooltip/outside/demo.js
@@ -30,7 +30,7 @@ QUnit.test('Outside tooltip and styledMode (#11783)', function (assert) {
     );
 });
 
-QUnit.test('Outside tooltip styling, correct position & pointer-events', function (assert) {
+QUnit.test('Outside tooltip styling and correct position', function (assert) {
     const chart = Highcharts.chart('container', {
             chart: {
                 width: 400,
@@ -44,7 +44,7 @@ QUnit.test('Outside tooltip styling, correct position & pointer-events', functio
                 outside: true
             },
             series: [{
-                data: [1, 2, 2, 2, 2, 1]
+                data: [1, 3, 2, 4]
             }]
         }),
         point = chart.series[0].points[0],

--- a/samples/unit-tests/tooltip/outside/demo.js
+++ b/samples/unit-tests/tooltip/outside/demo.js
@@ -41,45 +41,14 @@ QUnit.test('Outside tooltip styling, correct position & pointer-events', functio
                 }
             },
             tooltip: {
-                hideDelay: 0,
-                outside: true,
-                style: {
-                    pointerEvents: 'auto'
-                },
-                useHTML: true,
-                headerFormat: '',
-                pointFormat: '<div style="width: 400px; height: 400px;">Hello</div>'
+                outside: true
             },
             series: [{
-                type: 'column',
                 data: [1, 2, 2, 2, 2, 1]
             }]
         }),
-        points = chart.series[0].points,
         point = chart.series[0].points[0],
-        tooltip = chart.tooltip,
-        controller = new TestController(chart);
-
-    controller.moveTo(
-        chart.plotLeft + points[1].plotX,
-        chart.plotTop + points[1].plotY
-    );
-
-    controller.moveTo(
-        chart.plotLeft + points[1].plotX,
-        chart.plotTop + chart.plotHeight + 10
-    );
-
-    controller.moveTo(
-        chart.plotLeft + points[0].plotX,
-        chart.plotTop + points[0].plotY
-    );
-
-    assert.notEqual(
-        chart.tooltip.label.visibility,
-        'hidden',
-        'Tooltip should show after hovering over a series even with pointer-events set (#19025)'
-    );
+        tooltip = chart.tooltip;
 
     // Set hoverPoint
     point.onMouseOver();

--- a/samples/unit-tests/tooltip/pointformat/demo.js
+++ b/samples/unit-tests/tooltip/pointformat/demo.js
@@ -1,20 +1,22 @@
-QUnit.test('Repetetive formats', function (assert) {
+QUnit.test('Repetetive formats and pointer-events', function (assert) {
     Highcharts.setOptions({
         lang: {
             decimalPoint: ','
         }
     });
 
-    var chart = Highcharts.chart('container', {
-        chart: {
-            type: 'column',
-            width: 200,
-            height: 200
-        },
-        series: [{
-            data: [1.11]
-        }]
-    });
+    const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'column',
+                width: 200,
+                height: 200
+            },
+            series: [{
+                data: [1.11, 1.2]
+            }]
+        }),
+        points = chart.series[0].points,
+        controller = new TestController(chart);
 
     chart.update({
         tooltip: {
@@ -38,4 +40,38 @@ QUnit.test('Repetetive formats', function (assert) {
             decimalPoint: '.'
         }
     });
+
+    chart.update({
+        tooltip: {
+            hideDelay: 0,
+            outside: true,
+            style: {
+                pointerEvents: 'auto'
+            },
+            useHTML: true,
+            headerFormat: '',
+            pointFormat: '<div style="width: 200px; height: 300px; background-color: blue;">Hello</div>'
+        }
+    });
+
+    controller.moveTo(
+        chart.plotLeft + points[1].plotX,
+        chart.plotTop + points[1].plotY + 10
+    );
+
+    controller.moveTo(
+        chart.plotLeft + points[1].plotX,
+        chart.plotTop + chart.plotHeight + 10
+    );
+
+    controller.moveTo(
+        chart.plotLeft + points[0].plotX,
+        chart.plotTop + points[0].plotY + 10
+    );
+
+    assert.notEqual(
+        chart.tooltip.label.visibility,
+        'hidden',
+        'Tooltip should show after hovering over a point even with pointer-events set (#19025)'
+    );
 });

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -408,13 +408,7 @@ class Tooltip {
         const tooltip = this,
             styledMode = this.chart.styledMode,
             options = this.options,
-            doSplit = this.split && this.allowShared,
-            pointerEvents = (
-                options.style.pointerEvents ||
-                (
-                    this.shouldStickOnContact() ? 'auto' : 'none'
-                )
-            );
+            doSplit = this.split && this.allowShared;
 
         let container: globalThis.HTMLElement,
             renderer: SVGRenderer = this.chart.renderer;
@@ -447,9 +441,9 @@ class Tooltip {
 
                 container.className = 'highcharts-tooltip-container';
 
-                // We need to set pointerEvents = 'none' as otherwise
-                // it makes the area under the tooltip non-hoverable
-                // even after the tooltip disappears, #19035.
+                // We need to set pointerEvents = 'none' as otherwise it makes
+                // the area under the tooltip non-hoverable even after the
+                // tooltip disappears, #19035.
                 css(container, {
                     position: 'absolute',
                     top: '1px',
@@ -511,7 +505,12 @@ class Tooltip {
                         })
                         // #2301, #2657
                         .css(options.style)
-                        .css({ pointerEvents });
+                        .css({
+                            pointerEvents: (
+                                options.style.pointerEvents ||
+                                (this.shouldStickOnContact() ? 'auto' : 'none')
+                            )
+                        });
                 }
             }
             // Split tooltip use updateTooltipContainer to position the tooltip

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -449,7 +449,7 @@ class Tooltip {
                 css(container, {
                     position: 'absolute',
                     top: '1px',
-                    pointerEvents,
+                    pointerEvents: 'none',
                     zIndex: Math.max(
                         this.options.style.zIndex || 0,
                         (chartStyle && chartStyle.zIndex || 0) + 3

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -446,6 +446,10 @@ class Tooltip {
                 this.container = container = H.doc.createElement('div');
 
                 container.className = 'highcharts-tooltip-container';
+
+                // We need to set pointerEvents = 'none' as otherwise
+                // it makes the area under the tooltip non-hoverable
+                // even after the tooltip disappears, #19035.
                 css(container, {
                     position: 'absolute',
                     top: '1px',


### PR DESCRIPTION
Fixed #19035, tooltip tap or click stopped working after pinch zoom in iOS.

**Demo** of the problem: https://jsfiddle.net/BlackLabel/hospxk7e/
1. Hover over one of the points till the tooltip is shown
2. Hover under the chart so that the tooltip hides
3. Notice that the entire area under the tooltip is "non-hoverable" once it was covered by the tooltip

