### PR TITLE
bugfix/15441-tooltip-scroll-keyboardnavigation

### DIFF
--- a/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
@@ -1036,12 +1036,12 @@ namespace SeriesKeyboardNavigation {
         chart.highlightedPoint = this;
 
         // Get position of the tooltip.
-        const tooltipTop = tooltipElement?.getBoundingClientRect().top as any;
+        const tooltipTop = tooltipElement?.getBoundingClientRect().top;
 
-        if (tooltipElement && tooltipTop < 0) {
+        if (tooltipElement && tooltipTop && tooltipTop < 0) {
             // Calculate scroll position.
-            const scrollTop = window.scrollY;
-            const newScrollTop = scrollTop + tooltipTop;
+            const scrollTop = window.scrollY,
+                newScrollTop = scrollTop + tooltipTop;
 
             // Scroll window to new position.
             window.scrollTo({

--- a/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesKeyboardNavigation.ts
@@ -42,7 +42,7 @@ import ChartUtilities from '../../Utils/ChartUtilities.js';
 const {
     getPointFromXY,
     getSeriesFromName,
-    scrollToPoint
+    scrollAxisToPoint
 } = ChartUtilities;
 
 /* *
@@ -1009,7 +1009,8 @@ namespace SeriesKeyboardNavigation {
         this: PointComposition,
         highlightVisually: boolean = true
     ): PointComposition {
-        const chart = this.series.chart;
+        const chart = this.series.chart,
+            tooltipElement = chart.tooltip?.label?.element;
 
         if (!this.isNull && highlightVisually) {
             this.onMouseOver(); // Show the hover marker and tooltip
@@ -1021,7 +1022,7 @@ namespace SeriesKeyboardNavigation {
             // div element of the chart
         }
 
-        scrollToPoint(this);
+        scrollAxisToPoint(this);
 
         // We focus only after calling onMouseOver because the state change can
         // change z-index and mess up the element.
@@ -1033,6 +1034,22 @@ namespace SeriesKeyboardNavigation {
         }
 
         chart.highlightedPoint = this;
+
+        // Get position of the tooltip.
+        const tooltipTop = tooltipElement?.getBoundingClientRect().top as any;
+
+        if (tooltipElement && tooltipTop < 0) {
+            // Calculate scroll position.
+            const scrollTop = window.scrollY;
+            const newScrollTop = scrollTop + tooltipTop;
+
+            // Scroll window to new position.
+            window.scrollTo({
+                behavior: 'smooth',
+                top: newScrollTop
+            });
+        }
+
         return this;
     }
 

--- a/ts/Accessibility/Utils/ChartUtilities.ts
+++ b/ts/Accessibility/Utils/ChartUtilities.ts
@@ -390,7 +390,7 @@ function getRelativePointAxisPosition(axis: Axis, point: Point): number {
  * Get relative position of point on an x/y axis from 0 to 1.
  * @private
  */
-function scrollToPoint(point: Point): void {
+function scrollAxisToPoint(point: Point): void {
     const xAxis = point.series.xAxis,
         yAxis = point.series.yAxis,
         axis = (xAxis && xAxis.scrollbar ? xAxis : yAxis),
@@ -431,7 +431,7 @@ const ChartUtilities = {
     getSeriesA11yElement,
     unhideChartElementFromAT,
     hideSeriesFromAT,
-    scrollToPoint
+    scrollAxisToPoint
 };
 
 export default ChartUtilities;


### PR DESCRIPTION
Fixed #15441, auto-scroll did not follow tooltip when navigating with keyboard while zoomed in.

Fixed #15441 , auto-scroll did not follow tooltip when navigating with keyboard while zoomed in 400%. Also renamed `scrollToPoint()` to `scrollAxisToPoint()` to avoid confusion.