### PR TITLE
bugfix/19175-map-selection-panning

### DIFF
--- a/samples/unit-tests/maps/interaction/demo.js
+++ b/samples/unit-tests/maps/interaction/demo.js
@@ -4,8 +4,12 @@ QUnit.test('Hover color', function (assert) {
     Highcharts.Color.names = {};
 
     var chart = Highcharts.mapChart('container', {
+            mapNavigation: {
+                enabled: true
+            },
             series: [
                 {
+                    allowPointSelect: true,
                     mapData: Highcharts.maps['custom/europe'],
                     data: [
                         ['no', 5],
@@ -55,4 +59,13 @@ QUnit.test('Hover color', function (assert) {
 
     // Reset
     Highcharts.Color.names = colorNames;
+
+    point1.firePointEvent('click');
+    chart.mapView.zoomBy(1);
+
+    assert.strictEqual(
+        point1.selected,
+        true,
+        'Point should be selected after zooming/panning the chart (#19175).'
+    );
 });

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -1282,7 +1282,7 @@ class MapSeries extends ScatterSeries {
 
                 if (point.projectedPath && !point.projectedPath.length) {
                     point.setVisible(false);
-                } else {
+                } else if (!point.visible) {
                     point.setVisible(true);
                 }
             });


### PR DESCRIPTION
Fixed #19175, selected point was lost after map zomming or panning.