### PR TITLE
bugfix/19143-incorrect-series-name-csv

### DIFF
--- a/samples/unit-tests/data/general/demo.js
+++ b/samples/unit-tests/data/general/demo.js
@@ -112,23 +112,22 @@ QUnit.test('Empty data config', function (assert) {
 });
 
 QUnit.test('Combination charts and column mapping', function (assert) {
-    var csv = [
-        'X values,First,Second,Third,Fourth,Fifth,Sixth',
-        'Oak,10,9,11,20,19,21',
-        'Pine,11,10,12,21,20,22',
-        'Birch,12,11,13,22,21,23'
-    ].join('\n');
-
-    var chart = Highcharts.chart('container', {
-        data: {
-            csv: csv
-        },
-        series: [
-            {
-                type: 'pie'
-            }
-        ]
-    });
+    let csv = [
+            'X values,First,Second,Third,Fourth,Fifth,Sixth',
+            'Oak,10,9,11,20,19,21',
+            'Pine,11,10,12,21,20,22',
+            'Birch,12,11,13,22,21,23'
+        ].join('\n'),
+        chart = Highcharts.chart('container', {
+            data: {
+                csv: csv
+            },
+            series: [
+                {
+                    type: 'pie'
+                }
+            ]
+        });
 
     assert.deepEqual(
         chart.series.map(function (s) {
@@ -202,6 +201,44 @@ QUnit.test('Combination charts and column mapping', function (assert) {
         }),
         [3, 3],
         'Non-cartesian series should pick columns without X-column (#10984)'
+    );
+
+    csv = [
+        '"A";"A";"B";"B"',
+        '"Germany";767.1;"Ukraine";249.1',
+        '"Croatia";20.7;"Poland";298.1',
+        '"Belgium";97.2;;'
+    ].join('\n');
+
+    chart = Highcharts.chart('container', {
+        series: [{
+            type: 'packedbubble',
+            data: []
+        }, {
+            type: 'packedbubble',
+            data: []
+        }],
+        data: {
+            csv: csv,
+            seriesMapping: [{
+                name: 0,
+                value: 1
+            },
+            {
+                name: 2,
+                value: 3
+            }
+            ]
+        }
+    });
+
+    assert.deepEqual(
+        chart.series.map(function (s) {
+            return s.name;
+        }),
+        ['A', 'B'],
+        `Name should be mapped correctly from CSV for packed bubble series,
+        which is non-cartesian (#19143).`
     );
 });
 

--- a/ts/Extensions/Data.ts
+++ b/ts/Extensions/Data.ts
@@ -2220,17 +2220,16 @@ class SeriesBuilder {
             });
 
             if (columnIndexes.length >= 2) {
-                // remove the first one (x col)
+                // Remove the first one (x col)
                 columnIndexes.shift();
 
                 // Sort the remaining
                 columnIndexes.sort(function (a: number, b: number): number {
                     return a - b;
                 });
-
-                // Now use the lowest index as name column
-                this.name = (columns[columnIndexes.shift() as any] as any).name;
             }
+            // Now use the lowest index as name column
+            this.name = (columns[pick(columnIndexes.shift(), 0)] as any).name;
         }
 
         return point;


### PR DESCRIPTION
Fixed #19143, a regression causing incorrect series name from CSV for packed bubble series.