### PR TITLE
bugfix/18718-aria-expanded-state-sync

### DIFF
--- a/ts/Accessibility/Components/InfoRegionsComponent.ts
+++ b/ts/Accessibility/Components/InfoRegionsComponent.ts
@@ -271,6 +271,13 @@ class InfoRegionsComponent extends AccessibilityComponent {
             }
         });
 
+        this.addEvent(chart, 'afterHideData', function (): void {
+            if (component.viewDataTableButton) {
+                component.viewDataTableButton
+                    .setAttribute('aria-expanded', 'false');
+            }
+        });
+
         this.announcer = new Announcer(chart, 'assertive');
     }
 

--- a/ts/Extensions/ExportData/ExportData.ts
+++ b/ts/Extensions/ExportData/ExportData.ts
@@ -1030,6 +1030,8 @@ function chartToggleDataTable(
                 element: this.dataTableDiv,
                 wasHidden: createContainer || oldDisplay !== style.display
             });
+        } else {
+            fireEvent(this, 'afterHideData');
         }
     }
 


### PR DESCRIPTION
Fixed #18718 , aria-expanded state for table was out of sync when viewing or hiding the data table.