### PR TITLE
bugfix/19202-exclude-item-series-legenditemclick

### DIFF
--- a/ts/Series/Item/ItemSeries.ts
+++ b/ts/Series/Item/ItemSeries.ts
@@ -708,4 +708,9 @@ export default ItemSeries;
  * @apioption series.pie.data.legendIndex
  */
 
+/**
+ * @excluding legendItemClick
+ * @apioption series.item.events
+ */
+
 ''; // adds the doclets above to the transpiled file


### PR DESCRIPTION
Fixed #19202, excluded `events.legendItemClick` from _item_ series API.