### PR TITLE
bugfix/19179-annotation-outside-plot

### DIFF
--- a/samples/highcharts/cypress/annotations-gui/demo.js
+++ b/samples/highcharts/cypress/annotations-gui/demo.js
@@ -6,6 +6,12 @@ Highcharts.chart('container', {
         text: 'Use the dropdown to add or edit annotations'
     },
     navigation: {
+        annotationsOptions: {
+            crop: false,
+            labelOptions: {
+                crop: false
+            }
+        },
         events: {
             selectButton: function (event) {
                 var newClassName = event.button.className + ' highcharts-active',

--- a/samples/highcharts/cypress/annotations-gui/demo.js
+++ b/samples/highcharts/cypress/annotations-gui/demo.js
@@ -7,7 +7,6 @@ Highcharts.chart('container', {
     },
     navigation: {
         annotationsOptions: {
-            crop: false,
             labelOptions: {
                 crop: false
             }

--- a/test/cypress/integration/Highcharts/stock-tools/basic-annotations/label-crop.cy.js
+++ b/test/cypress/integration/Highcharts/stock-tools/basic-annotations/label-crop.cy.js
@@ -1,0 +1,23 @@
+describe('Label annotation crop property.', () => {
+    beforeEach(() => {
+        cy.viewport(1000, 500);
+    });
+
+    before(() => {
+        cy.visit('/highcharts/cypress/annotations-gui');
+    });
+
+    it('#19179: Should set userOptions.crop based on labelOptions', async () => {
+        cy.get('.highcharts-label-annotation:first')
+            .click();
+
+        cy.get('#container').click(100, 100);
+
+        cy.chart().should(chart => {
+            assert.strictEqual(
+                chart.annotations[0].userOptions.crop,
+                false
+            );
+        });
+    });
+});

--- a/test/cypress/integration/Highcharts/stock-tools/basic-annotations/label-crop.cy.js
+++ b/test/cypress/integration/Highcharts/stock-tools/basic-annotations/label-crop.cy.js
@@ -15,7 +15,7 @@ describe('Label annotation crop property.', () => {
 
         cy.chart().should(chart => {
             assert.strictEqual(
-                chart.annotations[0].userOptions.crop,
+                chart.annotations[0].labels[0].options.crop,
                 false
             );
         });

--- a/ts/Extensions/Annotations/NavigationBindingsDefaults.ts
+++ b/ts/Extensions/Annotations/NavigationBindingsDefaults.ts
@@ -453,7 +453,9 @@ const navigation: NavigationOptions = {
                             langKey: 'label',
                             type: 'basicAnnotation',
                             labelOptions: {
-                                format: '{y:.2f}'
+                                format: '{y:.2f}',
+                                overflow: 'none',
+                                crop: true
                             },
                             labels: [{
                                 point: {
@@ -461,9 +463,7 @@ const navigation: NavigationOptions = {
                                     yAxis: coordsY.axis.index,
                                     x: coordsX.value,
                                     y: coordsY.value
-                                },
-                                overflow: 'none',
-                                crop: true
+                                }
                             }]
                         },
                         navigation


### PR DESCRIPTION
Fixed #19179, changing the crop property on annotations through `annotationOptions` in the chart config did not work.

---
As stated in the API (https://api.highcharts.com/highcharts/navigation.annotationsOptions.labelOptions.crop):

> crop: boolean, Whether to hide the annotation's label that is outside the plot area.

So maybe that's the desired behavior and we should not change it?

---
However, it was impossible to set `labels.crop` to `false` in `annotationOptions` (https://jsfiddle.net/BlackLabel/od3jxtkL/) and this fix solved it so now the users will be able to easily modify this behavior by simply setting `annotationOptions.labelOptions.crop = false`.