### PR TITLE
bugfix/19173-treegraph-custom-marker

### DIFF
--- a/samples/unit-tests/series-treegraph/treegraph/demo.js
+++ b/samples/unit-tests/series-treegraph/treegraph/demo.js
@@ -12,7 +12,13 @@ QUnit.test('Treegraph series',
                     }],
                     dataLabels: {
                         pointFormat: '{point.id}'
-                    }
+                    },
+                    levels: [{
+                        level: 2,
+                        marker: {
+                            symbol: 'url(https://www.highcharts.com/samples/graphics/sun.png)'
+                        }
+                    }]
                 }]
             }),
             series = chart.series[0];
@@ -47,6 +53,12 @@ QUnit.test('Treegraph series',
             series.data[1].dataLabel.visibility,
             'inherit',
             'Visible points should have visible data labels (#18891)'
+        );
+
+        assert.strictEqual(
+            series.points[1].graphic.element.nodeName,
+            'image',
+            'The SVG element of the second point should be an image (#19173)'
         );
     }
 );

--- a/ts/Series/DrawPointUtilities.ts
+++ b/ts/Series/DrawPointUtilities.ts
@@ -34,11 +34,12 @@ export interface DrawPointParams {
     css?: CSSObject;
     group: SVGElement;
     onComplete?: Function;
+    imageUrl?: string;
     isNew?: boolean;
     renderer: SVGRenderer;
     shadow?: (boolean|Partial<ShadowOptionsObject>);
     shapeArgs?: SVGAttributes;
-    shapeType: 'arc'|'circle'|'path'|'rect'|'text';
+    shapeType: 'arc'|'circle'|'image'|'path'|'rect'|'text';
 }
 
 /* *
@@ -86,9 +87,15 @@ function draw(
 
     if ((point.shouldDraw())) {
         if (!graphic) {
-            point.graphic = graphic = params.shapeType === 'text' ?
-                renderer.text() :
-                renderer[params.shapeType](params.shapeArgs || {});
+            if (params.shapeType === 'text') {
+                graphic = renderer.text();
+            } else if (params.shapeType === 'image') {
+                graphic = renderer.image(params.imageUrl || '')
+                    .attr(params.shapeArgs || {});
+            } else {
+                graphic = renderer[params.shapeType](params.shapeArgs || {});
+            }
+            point.graphic = graphic;
             graphic.add(params.group);
         }
         if (css) {

--- a/ts/Series/Treegraph/TreegraphSeries.ts
+++ b/ts/Series/Treegraph/TreegraphSeries.ts
@@ -750,6 +750,7 @@ export default TreegraphSeries;
  * @sample highcharts/series-treegraph/level-options
  *          Treegraph chart with level options applied
  *
+ * @type      {Array<*>}
  * @excluding layoutStartingDirection, layoutAlgorithm
  * @apioption series.treegraph.levels
  */
@@ -758,6 +759,12 @@ export default TreegraphSeries;
  * Set collapsed status for nodes level-wise.
  * @type {boolean}
  * @apioption series.treegraph.levels.collapsed
+ */
+
+/**
+ * Set marker options for nodes at the level.
+ * @extends   series.treegraph.marker
+ * @apioption series.treegraph.levels.marker
  */
 
 /**

--- a/ts/Series/Treegraph/TreegraphSeries.ts
+++ b/ts/Series/Treegraph/TreegraphSeries.ts
@@ -42,7 +42,6 @@ const { getLevelOptions } = TU;
 import U from '../../Core/Utilities.js';
 const {
     extend,
-    isArray,
     merge,
     pick,
     relativeLength,
@@ -54,7 +53,6 @@ import TreegraphLayout from './TreegraphLayout.js';
 import { TreegraphSeriesLevelOptions } from './TreegraphSeriesOptions.js';
 import TreegraphSeriesDefaults from './TreegraphSeriesDefaults.js';
 import SVGLabel from '../../Core/Renderer/SVG/SVGLabel.js';
-import DataLabelOptions from '../../Core/Series/DataLabelOptions.js';
 import TreemapPoint from '../Treemap/TreemapPoint.js';
 
 /* *
@@ -609,9 +607,19 @@ class TreegraphSeries extends TreemapSeries {
                 point.options.borderRadius,
                 level.borderRadius,
                 this.options.borderRadius
-            );
+            ),
+            symbolFn = symbols[symbol || 'circle'];
 
-        point.shapeType = 'path';
+        if (symbolFn === void 0) {
+            point.hasImage = true;
+            point.shapeType = 'image';
+            point.imageUrl = (
+                (symbol as string).match(/^url\((.*?)\)$/) as any
+            )[1];
+        } else {
+            point.shapeType = 'path';
+        }
+
         if (!point.visible && point.linkToParent) {
             const parentNode = point.linkToParent.fromNode;
             if (parentNode) {
@@ -620,17 +628,18 @@ class TreegraphSeries extends TreemapSeries {
                 if (!point.shapeArgs) {
                     point.shapeArgs = {};
                 }
-                extend(point.shapeArgs, {
-                    d: symbols[symbol || 'circle'](
-                        x,
-                        y,
-                        width,
-                        height,
-                        borderRadius ? { r: borderRadius } : void 0
-                    ),
-                    x,
-                    y
-                });
+                if (!point.hasImage) {
+                    extend(point.shapeArgs, {
+                        d: symbolFn(
+                            x,
+                            y,
+                            width,
+                            height,
+                            borderRadius ? { r: borderRadius } : void 0
+                        )
+                    });
+                }
+                extend(point.shapeArgs, { x, y });
                 point.plotX = parentNode.plotX;
                 point.plotY = parentNode.plotY;
             }
@@ -638,19 +647,21 @@ class TreegraphSeries extends TreemapSeries {
             point.plotX = nodeX;
             point.plotY = nodeY;
             point.shapeArgs = {
-                d: symbols[symbol || 'circle'](
-                    nodeX,
-                    nodeY,
-                    width,
-                    height,
-                    borderRadius ? { r: borderRadius } : void 0
-                ),
                 x: nodeX,
                 y: nodeY,
                 width,
                 height,
                 cursor: !point.node.isLeaf ? 'pointer' : 'default'
             };
+            if (!point.hasImage) {
+                point.shapeArgs.d = symbolFn(
+                    nodeX,
+                    nodeY,
+                    width,
+                    height,
+                    borderRadius ? { r: borderRadius } : void 0
+                );
+            }
         }
 
         // Set the anchor position for tooltip.

--- a/ts/Series/Treemap/TreemapPoint.ts
+++ b/ts/Series/Treemap/TreemapPoint.ts
@@ -69,6 +69,8 @@ class TreemapPoint extends ScatterPoint {
 
     public drillId?: (boolean|string);
 
+    public imageUrl?: string;
+
     public name: string = void 0 as any;
 
     public node: TreemapNode = void 0 as any;
@@ -79,7 +81,7 @@ class TreemapPoint extends ScatterPoint {
 
     public series: TreemapSeries = void 0 as any;
 
-    public shapeType: 'arc'|'circle'|'path'|'rect'|'text' = 'rect';
+    public shapeType: 'arc'|'circle'|'image'|'path'|'rect'|'text' = 'rect';
 
     public sortIndex?: number;
 

--- a/ts/Series/Treemap/TreemapSeries.ts
+++ b/ts/Series/Treemap/TreemapSeries.ts
@@ -1100,6 +1100,7 @@ class TreemapSeries extends ScatterSeries {
                 attribs,
                 css,
                 group: (series as any)[groupKey],
+                imageUrl: point.imageUrl,
                 renderer,
                 shadow,
                 shapeArgs,


### PR DESCRIPTION
Fixed #19173, could not set a custom image as marker symbol in treegraph series.

---
TO DO:
- [x] Add rendering images when the image URL is set in the `symbol` option.
- [x] Add regression tests.
- [x] Update & fix docs (missing `marker` property in `levels`, `levels` as an object instead of an array).
