### PR TITLE
bugfix/19200-annotation-label-html-style

### DIFF
--- a/samples/unit-tests/annotations/annotations-labels-options/demo.js
+++ b/samples/unit-tests/annotations/annotations-labels-options/demo.js
@@ -1,5 +1,5 @@
 QUnit.test('Setting graphic attributes for a label', function (assert) {
-    var expected = {
+    const expected = {
             text: 'Max',
             backgroundColor: 'blue',
             borderColor: 'black',
@@ -24,19 +24,30 @@ QUnit.test('Setting graphic attributes for a label', function (assert) {
                 }
             ]
         }),
-        label = chart.annotations[0].labels[0].graphic,
-        actual = {
-            text: label.text.textStr,
-            backgroundColor: label.box.attr('fill'),
-            borderColor: label.box.attr('stroke'),
-            borderRadius: label.box.r,
-            borderWidth: label.box['stroke-width'],
-            padding: label.padding,
-            shape: label.box.symbolName,
-            style: {
-                fontSize: label.text.styles.fontSize
-            }
+        annotation = chart.annotations[0],
+        actual = () => {
+            const label = annotation.labels[0].graphic;
+            return {
+                text: label.text.textStr,
+                backgroundColor: label.box.attr('fill'),
+                borderColor: label.box.attr('stroke'),
+                borderRadius: label.box.r,
+                borderWidth: label.box['stroke-width'],
+                padding: label.padding,
+                shape: label.box.symbolName,
+                style: {
+                    fontSize: label.text.styles.fontSize
+                }
+            };
         };
 
-    assert.deepEqual(actual, expected);
+    assert.deepEqual(actual(), expected, 'The attributes should be as expected for label with useHTML: false');
+
+    annotation.update({
+        labelOptions: {
+            useHTML: true
+        }
+    });
+
+    assert.deepEqual(actual(), expected, 'The attributes should be as expected for label with useHTML: true (#19200)');
 });

--- a/ts/Core/Renderer/HTML/HTMLRenderer.ts
+++ b/ts/Core/Renderer/HTML/HTMLRenderer.ts
@@ -314,7 +314,7 @@ class HTMLRenderer extends SVGRenderer {
                             // updating the shadow div counterpart with the same
                             // style.
                             css: function (styles: CSSObject): HTMLElement {
-                                wrapper.css.call(parentGroup, styles);
+                                wrapper.css(styles);
                                 (
                                     [
                                         // #6794

--- a/ts/Core/Renderer/HTML/HTMLRenderer.ts
+++ b/ts/Core/Renderer/HTML/HTMLRenderer.ts
@@ -240,7 +240,8 @@ class HTMLRenderer extends SVGRenderer {
                     // Ensure dynamically updating position when any parent
                     // is translated
                     parents.reverse().forEach(function (parentGroup): void {
-                        const cls = attr(parentGroup.element, 'class');
+                        const cls = attr(parentGroup.element, 'class'),
+                            parentProtoCss = parentGroup.css;
 
                         /**
                          * Common translate setter for X and Y on the HTML
@@ -314,7 +315,12 @@ class HTMLRenderer extends SVGRenderer {
                             // updating the shadow div counterpart with the same
                             // style.
                             css: function (styles: CSSObject): HTMLElement {
-                                wrapper.css(styles);
+
+                                // Call the base css method. The `parentGroup`
+                                // can be either an SVGElement or an SVGLabel,
+                                // in which the css method is extended (#19200).
+                                parentProtoCss.call(parentGroup, styles);
+
                                 (
                                     [
                                         // #6794


### PR DESCRIPTION
Fixed #19200, styles were not applied to the annotation label when `useHTML` was enabled.