### PR TITLE
bugfix/19233-moving-annotations-with-null-points

### DIFF
--- a/samples/unit-tests/axis/ordinal/demo.js
+++ b/samples/unit-tests/axis/ordinal/demo.js
@@ -368,11 +368,9 @@ QUnit.test('lin2val- unit test for values outside the plotArea.', function (asse
         },
         series: [{
             points: [{
-                isInside: true, // #18459
                 x: 3,
                 plotX: -20
             }, {
-                isInside: true, // #18459
                 x: 4.2,
                 plotX: 80 // distance between points 100px
             }]

--- a/samples/unit-tests/axis/ordinal/demo.js
+++ b/samples/unit-tests/axis/ordinal/demo.js
@@ -357,6 +357,7 @@ QUnit.test('lin2val- unit test for values outside the plotArea.', function (asse
     const axis = {
         transA: -0.04,
         min: 3.24,
+        max: 7,
         len: 500,
         translationSlope: 0.2,
         minPixelPadding: 0,
@@ -719,7 +720,7 @@ QUnit.test('Circular translation, #17128.', assert => {
     );
 });
 
-QUnit.test('Moving annotations on ordinal axis, #18459', assert => {
+QUnit.test('Moving annotations on ordinal axis.', assert => {
     const data = [
         [
             1622640600000,
@@ -804,6 +805,45 @@ QUnit.test('Moving annotations on ordinal axis, #18459', assert => {
         x - 50,
         chart.xAxis[0].toPixels(circle.userOptions.shapes[0].point.x),
         0.1,
-        'Annotation dragged on ordinal axis charts should follow mouse pointer.'
+        'Annotation dragged on ordinal axis charts should follow mouse pointer, #18459.'
     );
+
+    // #19233
+    chart.series[0].update({
+        type: 'line',
+        data: Array.from({ length: 50 }, (_, i) => [10 + i * 36e5, i])
+    }, false);
+    chart.series[1].update({
+        type: 'line',
+        data: Array.from({ length: 10 }, (_, i) => [i * 36e5, null])
+    }, false);
+
+    circle.update({
+        shapes: [{
+            type: 'circle',
+            point: {
+                x: 36000010,
+                y: 20,
+                xAxis: 0,
+                yAxis: 0
+            },
+            r: 20
+        }]
+    }, false);
+
+    chart.xAxis[0].setExtremes(null, null);
+
+    const circleX = chart.xAxis[0].toPixels(36000010),
+        circleY = chart.yAxis[0].toPixels(20);
+
+    controller.pan([circleX, circleY], [circleX - 50, circleY]);
+
+    assert.close(
+        circleX - 50,
+        chart.xAxis[0].toPixels(circle.userOptions.shapes[0].point.x),
+        0.1,
+        `Annotation dragged on ordinal axis charts, that have a series with null
+        points only, should follow mouse pointer, #19233.`
+    );
+
 });

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -1410,16 +1410,15 @@ namespace OrdinalAxis {
 
             // Check whether the series has at least one point inside the chart
             const hasPointsInside = function (series: Series): boolean {
-                return series.points.some(function (point): boolean {
-                    let hasPointsInside = false;
+                const { min, max } = axis;
 
-                    if (axis.min && axis.max) {
-                        hasPointsInside =
-                            point.x > axis.min && point.x < axis.max;
-                    }
+                if (defined(min) && defined(max)) {
+                    return series.points.some((point): boolean =>
+                        point.x > min && point.x < max
+                    );
+                }
 
-                    return hasPointsInside;
-                });
+                return false;
             };
 
             let firstPointX: number;

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -1410,7 +1410,16 @@ namespace OrdinalAxis {
 
             // Check whether the series has at least one point inside the chart
             const hasPointsInside = function (series: Series): boolean {
-                return series.points.some((point): boolean => !!point.isInside);
+                return series.points.some(function (point): boolean {
+                    let hasPointsInside = false;
+
+                    if (axis.min && axis.max) {
+                        hasPointsInside =
+                            point.x > axis.min && point.x < axis.max;
+                    }
+
+                    return hasPointsInside;
+                });
             };
 
             let firstPointX: number;

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -1414,7 +1414,7 @@ namespace OrdinalAxis {
 
                 if (defined(min) && defined(max)) {
                     return series.points.some((point): boolean =>
-                        point.x > min && point.x < max
+                        point.x >= min && point.x <= max
                     );
                 }
 


### PR DESCRIPTION
Fixed #19233, dragging annotations on chart with null points was inconsistent.

_Internal note:_ Previous refactor of `getIndexOfPoint` ignored null points, because they have a property `isInside` set to false.
Demo: https://jsfiddle.net/BlackLabel/zuhw5tjr/