### PR TITLE
samples/maps - syntax update

### DIFF
--- a/samples/maps/chart/transform-on-chart/demo.js
+++ b/samples/maps/chart/transform-on-chart/demo.js
@@ -1,4 +1,4 @@
-var transforms = {
+const transforms = {
     default: Highcharts.maps['countries/gb/gb-all']['hc-transform']['default'], // eslint-disable-line dot-notation
     custom: Highcharts.maps['countries/gb/gb-all']['hc-transform']['gb-all-shetland']
 };

--- a/samples/maps/members/axis-update/demo.js
+++ b/samples/maps/members/axis-update/demo.js
@@ -8,10 +8,8 @@
         'https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/world-population-density.json'
     ).then(response => response.json());
 
-    var chart;
-
     // Initialize the chart
-    chart = Highcharts.mapChart('container', {
+    const chart = Highcharts.mapChart('container', {
 
         title: {
             text: 'Update the color axis'

--- a/samples/maps/members/chart-setsize-jquery-resizable/demo.js
+++ b/samples/maps/members/chart-setsize-jquery-resizable/demo.js
@@ -7,7 +7,7 @@
     Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/world-population-density.json', function (data) {
 
         // Initialize the chart
-        var chart = Highcharts.mapChart('container', {
+        const chart = Highcharts.mapChart('container', {
 
             chart: {
                 height: 500 // initial height

--- a/samples/maps/members/point-remove/demo.js
+++ b/samples/maps/members/point-remove/demo.js
@@ -9,7 +9,7 @@
     ).then(response => response.json());
 
     // Initialize the chart
-    var chart = Highcharts.mapChart('container', {
+    const chart = Highcharts.mapChart('container', {
 
         title: {
             text: 'Remove selected points'

--- a/samples/maps/members/point-zoomto/demo.js
+++ b/samples/maps/members/point-zoomto/demo.js
@@ -14,7 +14,7 @@
     });
 
     // Initialize the chart
-    var chart = Highcharts.mapChart('container', {
+    const chart = Highcharts.mapChart('container', {
 
         title: {
             text: 'Zoom to point'

--- a/samples/maps/members/series-setdata/demo.js
+++ b/samples/maps/members/series-setdata/demo.js
@@ -7,7 +7,7 @@
     Highcharts.getJSON('https://cdn.jsdelivr.net/gh/highcharts/highcharts@v7.0.0/samples/data/world-population-density.json', function (data) {
 
         // Initialize the chart
-        var chart = Highcharts.mapChart('container', {
+        const chart = Highcharts.mapChart('container', {
 
             title: {
                 text: 'Set random data'

--- a/samples/maps/plotoptions/series-allareas-false/demo.js
+++ b/samples/maps/plotoptions/series-allareas-false/demo.js
@@ -5,7 +5,7 @@
     ).then(response => response.json());
 
     // Prepare demo data
-    var data = [{
+    const data = [{
         'hc-key': 'us',
         value: 3
     }, {

--- a/samples/maps/plotoptions/series-events-click/demo.js
+++ b/samples/maps/plotoptions/series-events-click/demo.js
@@ -23,7 +23,7 @@
                 series: {
                     events: {
                         click: function (e) {
-                            var text = '<b>Clicked</b><br>Series: ' + this.name +
+                            const text = '<b>Clicked</b><br>Series: ' + this.name +
                                     '<br>Point: ' + e.point.name + ' (' + e.point.value + '/km²)';
                             if (!this.chart.clickLabel) {
                                 this.chart.clickLabel = this.chart.renderer

--- a/samples/maps/plotoptions/series-point-events-click/demo.js
+++ b/samples/maps/plotoptions/series-point-events-click/demo.js
@@ -26,7 +26,7 @@
                 point: {
                     events: {
                         click: function () {
-                            var text = '<b>Clicked point</b><br>Series: ' + this.series.name +
+                            const text = '<b>Clicked point</b><br>Series: ' + this.series.name +
                                         '<br>Point: ' + this.name + ' (' + this.value + '/km²)',
                                 chart = this.series.chart;
                             if (!chart.clickLabel) {

--- a/samples/maps/series/joinby-double/demo.js
+++ b/samples/maps/series/joinby-double/demo.js
@@ -4,7 +4,7 @@
         'https://code.highcharts.com/mapdata/custom/nordic-countries-core.topo.json'
     ).then(response => response.json());
 
-    var data = [{
+    const data = [{
         code: 'DK',
         value: 2
     }, {

--- a/samples/maps/series/joinby-null/demo.js
+++ b/samples/maps/series/joinby-null/demo.js
@@ -4,7 +4,7 @@
         'https://code.highcharts.com/mapdata/custom/nordic-countries-core.topo.json'
     ).then(response => response.json());
 
-    var data = [1, 3, 5, 2, 4, 1, 3];
+    const data = [1, 3, 5, 2, 4, 1, 3];
 
 
     // Initialize the chart

--- a/samples/maps/series/joinby-single/demo.js
+++ b/samples/maps/series/joinby-single/demo.js
@@ -4,7 +4,7 @@
         'https://code.highcharts.com/mapdata/custom/nordic-countries-core.topo.json'
     ).then(response => response.json());
 
-    var data = [{
+    const data = [{
         name: 'Denmark',
         value: 2
     }, {

--- a/samples/maps/series/latlon-transform/demo.js
+++ b/samples/maps/series/latlon-transform/demo.js
@@ -1,9 +1,5 @@
-var chart,
-    transform,
-    position;
-
 // Initialize the chart
-chart = Highcharts.mapChart('container', {
+const chart = Highcharts.mapChart('container', {
     title: {
         text: 'Highmaps legacy lat/lon demo'
     },
@@ -56,8 +52,13 @@ chart = Highcharts.mapChart('container', {
 
 // Transform definition is grabbed from map, under the "hc-transform" object.
 // To get the mainland transform defintion, use the "default" definition instead of "gb-all-shetland".
-transform = Highcharts.maps['countries/gb/gb-all']['hc-transform']['gb-all-shetland'];
-position = chart.transformFromLatLon({ lat: 58.78, lon: -1.26 }, transform);
+const transform = Highcharts.maps['countries/gb/gb-all']['hc-transform']['gb-all-shetland'];
+
+const position = chart.transformFromLatLon({
+    lat: 58.78,
+    lon: -1.26
+}, transform);
+
 chart.series[2].addPoint({
     name: 'Manually transformed point<br>(relative to Shetland)',
     x: position.x,

--- a/samples/maps/series/mapline-mappoint-path-xy/demo.js
+++ b/samples/maps/series/mapline-mappoint-path-xy/demo.js
@@ -1,4 +1,4 @@
-var series = [{
+const series = [{
     type: 'map',
     name: 'Areas',
     data: [{


### PR DESCRIPTION
Updated keyword var to const/let in all the appropriate places in samples/maps.
Some modifications were made where let was used instead of const.
This was done mostly with ESlint fix. Some changes made by hand.