### PR TITLE
dash/columnAssignment-datagrid

### DIFF
--- a/samples/dashboards/cypress/component-datagrid/demo.html
+++ b/samples/dashboards/cypress/component-datagrid/demo.html
@@ -1,6 +1,6 @@
 <div id="container">
 
-<pre id="csv" style="display:none">Food,Vitamin A,notVisible
+<pre id="csv" style="display:none">Food,Vitamin A,hiddenColumn
 Beef Liver,6421, 100
 Lamb Liver, 2122, 100
 Cod Liver Oil, 1350, 100

--- a/samples/dashboards/cypress/component-datagrid/demo.html
+++ b/samples/dashboards/cypress/component-datagrid/demo.html
@@ -1,10 +1,10 @@
 <div id="container">
 
-<pre id="csv" style="display:none">Food,Vitamin A
-Beef Liver,6421
-Lamb Liver, 2122
-Cod Liver Oil, 1350
-Mackerel, 388
+<pre id="csv" style="display:none">Food,Vitamin A,notVisible
+Beef Liver,6421, 100
+Lamb Liver, 2122, 100
+Cod Liver Oil, 1350, 100
+Mackerel, 388, 100
 Tuna, 214
 Salmon, 180
 Egg Yolk, 140

--- a/samples/dashboards/cypress/component-datagrid/demo.mjs
+++ b/samples/dashboards/cypress/component-datagrid/demo.mjs
@@ -51,7 +51,8 @@ Dashboards.board('container', {
             },
             columnAssignment: {
                 Food: 'x',
-                'Vitamin A': 'y'
+                'Vitamin A': 'y',
+                notVisible: null
             },
             chartOptions: {
                 xAxis: {
@@ -83,9 +84,7 @@ Dashboards.board('container', {
                 highlight: true,
                 extremes: true
             },
-            columnAssignment: {
-                notVisible: null
-            }
+            columnsToShow: ['Food', 'Vitamin A']
         }
     ]
 }, true);

--- a/samples/dashboards/cypress/component-datagrid/demo.mjs
+++ b/samples/dashboards/cypress/component-datagrid/demo.mjs
@@ -82,6 +82,9 @@ Dashboards.board('container', {
             sync: {
                 highlight: true,
                 extremes: true
+            },
+            columnAssignment: {
+                notVisible: null
             }
         }
     ]

--- a/samples/dashboards/cypress/component-datagrid/demo.mjs
+++ b/samples/dashboards/cypress/component-datagrid/demo.mjs
@@ -84,7 +84,7 @@ Dashboards.board('container', {
                 highlight: true,
                 extremes: true
             },
-            columnsToShow: ['Food', 'Vitamin A']
+            visibleColumns: ['Food', 'Vitamin A']
         }
     ]
 }, true);

--- a/test/cypress/integration/Dashboards/Components/DataGridComponent.cy.js
+++ b/test/cypress/integration/Dashboards/Components/DataGridComponent.cy.js
@@ -3,6 +3,10 @@ describe('layout resize on window changes', () => {
         cy.visit('/dashboards/cypress/component-datagrid');
     });
 
+    it('The columnAssignment should be respected', () =>{
+        cy.get('.highcharts-datagrid-column-header').should('have.length', 2);
+    })
+
     it('Chart and DataGridComponent should have synced hover events.', () => {
         const firstDataGridRow = cy.get('.highcharts-datagrid-cell').eq(0)
 

--- a/ts/Dashboards/Plugins/DataGridComponent.ts
+++ b/ts/Dashboards/Plugins/DataGridComponent.ts
@@ -382,24 +382,24 @@ class DataGridComponent extends Component {
     }
 
     /**
-     * Based on the `columnsToShow` option, filter the columns of the table.
+     * Based on the `visibleColumns` option, filter the columns of the table.
      *
      * @internal
      */
     private filterColumns(): DataTable|undefined {
         const table = this.connector?.table.modified,
-            columnsToShow = this.options.columnsToShow;
+            visibleColumns = this.options.visibleColumns;
 
         if (table) {
-            // Show all columns if no columnsToShow is provided.
-            if(!columnsToShow?.length ) {
+            // Show all columns if no visibleColumns is provided.
+            if(!visibleColumns?.length ) {
                 return table;
             }
 
             const columnsToDelete = table.getColumnNames().filter((columnName): boolean => {
-                if (columnsToShow?.length) {
+                if (visibleColumns?.length) {
                     // Don't add columns that are not listed.
-                    if (!columnsToShow.includes(columnName)) {
+                    if (!visibleColumns.includes(columnName)) {
                         return true;
                     }
 
@@ -515,8 +515,11 @@ namespace DataGridComponent {
          */
         chartID?: string;
 
+        /** @private */
+        tableAxisMap?: Record<string, string | null>;
+
         /**
-         * If the `columnsToShow` option is not provided, the data grid will
+         * If the `visibleColumns` option is not provided, the data grid will
          * calculate and include each column from the data connector.
          * When declared, the data grid will only include the columns that are
          * listed.
@@ -525,13 +528,10 @@ namespace DataGridComponent {
          * `dataGridOptions.columns` option.
          * ```
          * Example
-         * columnsToShow: ['Food', 'Vitamin A']
+         * visibleColumns: ['Food', 'Vitamin A']
          * ```
          */
-        columnsToShow?: Array<string>;
-
-        /** @private */
-        tableAxisMap?: Record<string, string | null>;
+        visibleColumns?: Array<string>;
 
     }
 

--- a/ts/Dashboards/Plugins/DataGridComponent.ts
+++ b/ts/Dashboards/Plugins/DataGridComponent.ts
@@ -382,19 +382,19 @@ class DataGridComponent extends Component {
     }
 
     /**
-     * Based on the `columnAssignment` option, filter the columns of the table.
+     * Based on the `columnsToShow` option, filter the columns of the table.
      *
      * @internal
      */
     private filterColumns(): DataTable|undefined {
         const table = this.connector?.table.modified,
-            columnAssignment = this.options.columnAssignment || {};
+            columnsToShow = this.options.columnsToShow;
 
         if (table) {
             const columnsToDelete = table.getColumnNames().filter((columnName): boolean => {
-                if (columnAssignment) {
-                    // Don't add columns that are explicitly mapped to null.
-                    if (columnAssignment[columnName] === null) {
+                if (columnsToShow?.length) {
+                    // Don't add columns that are not listed.
+                    if (!columnsToShow.includes(columnName)) {
                         return true;
                     }
 
@@ -402,7 +402,7 @@ class DataGridComponent extends Component {
                     return false;
                 }
 
-                // Show all columns if no columnAssignment is provided.
+                // Show all columns if no columnsToShow is provided.
                 return false;
             });
 
@@ -513,20 +513,19 @@ namespace DataGridComponent {
         chartID?: string;
 
         /**
-         * When the `columnAssignment` set for given column is `null`, the
-         * column is not included in the component `dataTable` thus it is not
-         * rendered in the data grid.
+         * If the `columnsToShow` option is not provided, the data grid will
+         * calculate and include each column from the data connector.
+         * When declared, the data grid will only include the columns that are
+         * listed.
          *
          * Alternatively, the column visibility can be controlled by the
          * `dataGridOptions.columns` option.
          * ```
          * Example
-         * columnAssignment: {
-         *      'Vitamin A': null
-         * }
+         * columnsToShow: ['Food', 'Vitamin A']
          * ```
          */
-        columnAssignment?: Record<string, null>;
+        columnsToShow?: Array<string>;
 
         /** @private */
         tableAxisMap?: Record<string, string | null>;

--- a/ts/Dashboards/Plugins/DataGridComponent.ts
+++ b/ts/Dashboards/Plugins/DataGridComponent.ts
@@ -391,6 +391,11 @@ class DataGridComponent extends Component {
             columnsToShow = this.options.columnsToShow;
 
         if (table) {
+            // Show all columns if no columnsToShow is provided.
+            if(!columnsToShow?.length ) {
+                return table;
+            }
+
             const columnsToDelete = table.getColumnNames().filter((columnName): boolean => {
                 if (columnsToShow?.length) {
                     // Don't add columns that are not listed.
@@ -401,8 +406,6 @@ class DataGridComponent extends Component {
                     // Show the other columns.
                     return false;
                 }
-
-                // Show all columns if no columnsToShow is provided.
                 return false;
             });
 


### PR DESCRIPTION
Added the `visibleColumns` option which allows filtering the columns that should be visible in the `DataGridComponent`.