### PR TITLE
Samples/gantt - syntax update

### DIFF
--- a/samples/gantt/chart/scrollable-plotarea-vertical/demo.js
+++ b/samples/gantt/chart/scrollable-plotarea-vertical/demo.js
@@ -1,5 +1,5 @@
-var today = new Date(),
-    day = 1000 * 60 * 60 * 24;
+let today = new Date();
+const day = 1000 * 60 * 60 * 24;
 
 // Set to 00:00:00:000 today
 today.setUTCHours(0);

--- a/samples/gantt/current-date-indicator/demo/demo.js
+++ b/samples/gantt/current-date-indicator/demo/demo.js
@@ -1,4 +1,4 @@
-var today = new Date(),
+const today = new Date(),
     day = 1000 * 60 * 60 * 24;
 
 // Set to 00:00:00:000 today

--- a/samples/gantt/current-date-indicator/object-config/demo.js
+++ b/samples/gantt/current-date-indicator/object-config/demo.js
@@ -1,4 +1,4 @@
-var today = new Date(),
+const today = new Date(),
     day = 1000 * 60 * 60 * 24;
 
 // Set to 00:00:00:000 today

--- a/samples/gantt/gantt/bigdata/demo.js
+++ b/samples/gantt/gantt/bigdata/demo.js
@@ -1,6 +1,6 @@
 console.time('load');
 
-var data = {
+const data = {
     vessels: [{
         name: 'TS1_PS',
         utilized: 0,
@@ -52194,12 +52194,12 @@ var data = {
     }]
 };
 
-var series = [];
+const series = [];
 
 data.vessels.forEach(function (vessel, i) {
-    var seriesData = vessel.trips.reduce(function (acc, cur) {
-        var startTime = cur.start;
-        var points = [];
+    const seriesData = vessel.trips.reduce(function (acc, cur) {
+        let startTime = cur.start;
+        const points = [];
         cur.voyages.forEach(function (voyage) {
             if (voyage.loadDuration) {
                 voyage.loadDuration *= 1000 * 60 * 60;

--- a/samples/gantt/gantt/demo/demo.js
+++ b/samples/gantt/gantt/demo/demo.js
@@ -1,5 +1,5 @@
-var today = new Date(),
-    day = 1000 * 60 * 60 * 24;
+let today = new Date();
+const day = 1000 * 60 * 60 * 24;
 
 // Set to 00:00:00:000 today
 today.setUTCHours(0);

--- a/samples/gantt/gantt/grouping-vertically/demo.js
+++ b/samples/gantt/gantt/grouping-vertically/demo.js
@@ -1,5 +1,5 @@
-var today = new Date(),
-    day = 1000 * 60 * 60 * 24;
+let today = new Date();
+const day = 1000 * 60 * 60 * 24;
 
 // Set to 00:00:00:000 today
 today.setUTCHours(0);

--- a/samples/gantt/treegrid-axis/collapsed-dynamically/demo.js
+++ b/samples/gantt/treegrid-axis/collapsed-dynamically/demo.js
@@ -37,12 +37,12 @@ Highcharts.chart('container', {
         }]
     }]
 }, function (chart) {
-    var treeGrid = chart.yAxis[0],
+    const treeGrid = chart.yAxis[0],
         ticks = treeGrid.ticks,
         // Nodes to collapse.
         ticksToCollapse = ['Node 1', 'Node 2'];
     Highcharts.objectEach(ticks, function (tick) {
-        var textStr = tick.label && tick.label.textStr,
+        const textStr = tick.label && tick.label.textStr,
             doCollapse = (Highcharts.inArray(textStr, ticksToCollapse) > -1);
         if (doCollapse) {
             // Pass in false to avoid a redraw.

--- a/samples/gantt/treegrid-axis/demo/demo.js
+++ b/samples/gantt/treegrid-axis/demo/demo.js
@@ -1,4 +1,4 @@
-var today = +(new Date().setHours(0, 0, 0, 0)),
+const today = +(new Date().setHours(0, 0, 0, 0)),
     msDay = 24 * 60 * 60 * 1000;
 
 // THE CHART

--- a/samples/gantt/treegrid-axis/indentation-0px/demo.js
+++ b/samples/gantt/treegrid-axis/indentation-0px/demo.js
@@ -1,4 +1,4 @@
-var today = +(new Date().setHours(0, 0, 0, 0)),
+const today = +(new Date().setHours(0, 0, 0, 0)),
     msDay = 24 * 60 * 60 * 1000;
 
 // THE CHART

--- a/samples/gantt/treegrid-axis/labels-levels/demo.js
+++ b/samples/gantt/treegrid-axis/labels-levels/demo.js
@@ -1,4 +1,4 @@
-var today = +(new Date().setHours(0, 0, 0, 0)),
+const today = +(new Date().setHours(0, 0, 0, 0)),
     msDay = 24 * 60 * 60 * 1000;
 
 // THE CHART

--- a/samples/gantt/treegrid-axis/uniquenames-true/demo.js
+++ b/samples/gantt/treegrid-axis/uniquenames-true/demo.js
@@ -1,4 +1,4 @@
-var today = +(new Date().setHours(0, 0, 0, 0)),
+const today = +(new Date().setHours(0, 0, 0, 0)),
     msDay = 24 * 60 * 60 * 1000;
 
 // THE CHART


### PR DESCRIPTION
Updated keyword var to const/let in all the appropriate places in samples/gantt.
Some modifications were made where let was used instead of const.
This was done mostly with ESlint fix. Some changes made by hand.