### PR TITLE
bugfix/19046-pareto-with-datasorting

### DIFF
--- a/samples/unit-tests/series-pareto/pareto/demo.js
+++ b/samples/unit-tests/series-pareto/pareto/demo.js
@@ -123,17 +123,20 @@ QUnit.test('Pareto', function (assert) {
 });
 
 QUnit.test(
-    'Pareto wasnt working with baseSeries set to 0 - #10471',
+    'Pareto with baseSeries set to 0 (#10471) and with dataSorting (#19046)',
     function (assert) {
         var chart = Highcharts.chart('container', {
             series: [
                 {
                     type: 'column',
-                    data: [155, 55, 231, 22, 72, 51, 36, 10]
+                    data: [155, 55, 231, 22, 72, 51, 36, 10],
+                    dataSorting: {
+                        enabled: true
+                    }
                 },
                 {
                     type: 'column',
-                    data: [755, 222, 151, 86, 72, 51, 36, 10]
+                    data: [1, 2, 3, 4, 5]
                 },
                 {
                     type: 'pareto',
@@ -146,6 +149,21 @@ QUnit.test(
             chart.series[2].points.length,
             chart.series[0].points.length,
             'Number of points in pareto series should be equal amount of point in assigned series'
+        );
+
+        assert.deepEqual(
+            chart.series[2].yData,
+            [
+                36.550632911392,
+                61.075949367089,
+                72.46835443038,
+                81.170886075949,
+                89.240506329114,
+                94.936708860759,
+                98.417721518987,
+                100
+            ],
+            'Pareto series should work if the base series has dataSorting enabled, #19046'
         );
     }
 );

--- a/ts/Series/ParetoSeries/ParetoSeries.ts
+++ b/ts/Series/ParetoSeries/ParetoSeries.ts
@@ -167,14 +167,44 @@ class ParetoSeries extends LineSeries {
      * @requires modules/pareto
      */
     public setDerivedData(): void {
-        const xValues = (this.baseSeries as any).xData,
-            yValues = (this.baseSeries as any).yData,
-            sum = this.sumPointsPercents(
-                yValues,
-                xValues,
-                null as any,
-                true
-            );
+        const baseSeries = this.baseSeries;
+
+        let xValues: Array<number> = [],
+            yValues: Array<number> = [];
+
+        if (!baseSeries) {
+            return;
+        }
+
+        // If base series needs sorting, set & sort the data, #19046.
+        if (baseSeries.enabledDataSorting) {
+            this.chart.setSeriesData();
+
+            // Array of [x, y]
+            const data: Array<[number, number]> = [];
+
+            for (let i = 0; i < (baseSeries?.xData?.length || 0); i++) {
+                data.push([
+                    baseSeries?.xData?.[i] || 0,
+                    baseSeries?.yData?.[i] as any || 0
+                ]);
+            }
+
+            data.sort((a, b): number => b[1] - a[1]);
+
+            xValues = data.map((d): number => d[0]);
+            yValues = data.map((d): number => d[1]);
+        } else {
+            xValues = baseSeries.xData || [];
+            yValues = baseSeries.yData as any;
+        }
+
+        const sum = this.sumPointsPercents(
+            yValues,
+            xValues,
+            null as any,
+            true
+        );
 
         this.setData(
             this.sumPointsPercents(yValues, xValues, sum, false),

--- a/ts/Series/ParetoSeries/ParetoSeries.ts
+++ b/ts/Series/ParetoSeries/ParetoSeries.ts
@@ -167,14 +167,16 @@ class ParetoSeries extends LineSeries {
      * @requires modules/pareto
      */
     public setDerivedData(): void {
-        const baseSeries = this.baseSeries;
+        if (!this.baseSeries) {
+            return;
+        }
+
+        const baseSeries = this.baseSeries,
+            xData = baseSeries?.xData || [],
+            yData = baseSeries?.yData as Array<number> || [];
 
         let xValues: Array<number> = [],
             yValues: Array<number> = [];
-
-        if (!baseSeries) {
-            return;
-        }
 
         // If base series needs sorting, set & sort the data, #19046.
         if (baseSeries.enabledDataSorting) {
@@ -183,29 +185,27 @@ class ParetoSeries extends LineSeries {
             // Array of [x, y]
             const data: Array<[number, number]> = [];
 
-            for (let i = 0; i < (baseSeries?.xData?.length || 0); i++) {
+            for (let i = 0; i < xData.length; i++) {
                 data.push([
-                    baseSeries?.xData?.[i] || 0,
-                    baseSeries?.yData?.[i] as any || 0
+                    xData[i] || 0,
+                    yData[i] || 0
                 ]);
             }
 
-            data.sort((a, b): number => b[1] - a[1]);
+            // Sort the data by 'x' or 'y'
+            const sortKey: number = +(
+                (baseSeries?.options?.dataSorting?.sortKey || 'y') === 'y'
+            );
+            data.sort((a, b): number => b[sortKey] - a[sortKey]);
 
             xValues = data.map((d): number => d[0]);
             yValues = data.map((d): number => d[1]);
         } else {
-            xValues = baseSeries.xData || [];
-            yValues = baseSeries.yData as any;
+            xValues = xData;
+            yValues = yData;
         }
 
-        const sum = this.sumPointsPercents(
-            yValues,
-            xValues,
-            null as any,
-            true
-        );
-
+        const sum = this.sumPointsPercents(yValues, xValues, 0, true);
         this.setData(
             this.sumPointsPercents(yValues, xValues, sum, false),
             false


### PR DESCRIPTION
Fixed #19046, Pareto series did not work for series with `dataSorting` enabled.

**Demo of the issue:** https://jsfiddle.net/BlackLabel/75s1cak0/
**Demo after fix:** https://jsfiddle.net/BlackLabel/skjgtyLu/

**Tasks:**
- [x] Fix the issue
- [x] Add a test