### PR TITLE
docs/19376-incorrect-colors

### DIFF
--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -91,7 +91,7 @@ const defaultOptions: Options = {
      *     "#2ee0ca",
      *     "#fa4b42",
      *     "#feb56a",
-     *     "#91e8e12
+     *     "#91e8e1"
      * ]
      */
     colors: Palettes.colors,


### PR DESCRIPTION
Fixed #19376, default colors in the API were incorrect.