### PR TITLE
dash/fix-naming

### DIFF
--- a/samples/highcharts/studies/dashboard-strava-csv/demo.mjs
+++ b/samples/highcharts/studies/dashboard-strava-csv/demo.mjs
@@ -5,12 +5,11 @@ import RangeModifier from '../../../../code/es-modules/Data/Modifiers/RangeModif
 import ChainModifier from '../../../../code/es-modules/Data/Modifiers/ChainModifier.js';
 import GroupModifier from '../../../../code/es-modules/Data/Modifiers/GroupModifier.js';
 import SortModifier from '../../../../code/es-modules/Data/Modifiers/SortModifier.js';
-import DataConnector from '../../../../code/es-modules/Data/Connectors/DataConnector.js';
 import DataTable from '../../../../code/es-modules/Data/DataTable.js';
 
 import PluginHandler from '../../../../code/es-modules/Dashboard/PluginHandler.js';
 import Highcharts from '../../../../code/es-modules/masters/highcharts.src.js';
-import HighchartsPlugin from '../../../../code/es-modules/Extensions/DashboardPlugins/HighchartsPlugin.js';
+import HighchartsPlugin from '../../../../code/es-modules/Dashboards/Plugins/HighchartsPlugin.js';
 
 HighchartsPlugin.custom.connectHighcharts(Highcharts);
 PluginHandler.addPlugin(HighchartsPlugin);

--- a/tools/gulptasks/dashboards/dist-build.js
+++ b/tools/gulptasks/dashboards/dist-build.js
@@ -105,7 +105,7 @@ async function distBuild() {
         true,
         file => (
             path.basename(file)[0] !== '.' &&
-            file.includes('dashboard')
+            file.includes('dashboards')
         )
     );
     logLib.success(`Created ${buildGfxTarget}`);

--- a/tools/gulptasks/dashboards/scripts.js
+++ b/tools/gulptasks/dashboards/scripts.js
@@ -14,7 +14,6 @@ const gulp = require('gulp');
  * Gulp task to run the building process of distribution js files the classic
  * way.
  *
- * @deprecated
  * @return {Promise<void>}
  * Promise to keep
  */

--- a/ts/Dashboards/PluginHandler.ts
+++ b/ts/Dashboards/PluginHandler.ts
@@ -39,7 +39,7 @@ namespace PluginHandler {
      *
      * */
 
-    export interface DashboardPlugin<T = (Globals.AnyRecord|undefined)> {
+    export interface DashboardsPlugin<T = (Globals.AnyRecord|undefined)> {
         /** @internal */
         custom: T;
         /**
@@ -78,7 +78,7 @@ namespace PluginHandler {
      * */
 
     /** @internal */
-    export const registry: Record<string, DashboardPlugin> = {};
+    export const registry: Record<string, DashboardsPlugin> = {};
 
     /**
      * Revision of the Dashboard plugin API.
@@ -103,7 +103,7 @@ namespace PluginHandler {
      * Plugin key for the registry. (Default: `plugin.name`)
      */
     export function addPlugin(
-        plugin: DashboardPlugin,
+        plugin: DashboardsPlugin,
         key: string = plugin.name
     ): void {
         const {

--- a/ts/Dashboards/Plugins/DataGridPlugin.ts
+++ b/ts/Dashboards/Plugins/DataGridPlugin.ts
@@ -45,7 +45,7 @@ declare module '../Components/ComponentType' {
 /**
  * Connects DataGrid with the Dashboard plugin.
  *
- * @param {Highcharts} dataGrid DataGrid core to connect.
+ * @param {Dashboards.DataGrid} dataGrid DataGrid core to connect.
  */
 function connectDataGrid(
     DataGridClass: typeof DataGrid
@@ -56,7 +56,7 @@ function connectDataGrid(
 /**
  * Callback function of the Dashboard plugin.
  *
- * @param {Dashboard.DashboardPlugin.Event} e
+ * @param {Dashboards.PluginHandler.Event} e
  * Plugin context provided by the Dashboard.
  */
 function onRegister(
@@ -88,9 +88,9 @@ const DataGridCustom = {
     connectDataGrid
 };
 
-const DataGridPlugin: PluginHandler.DashboardPlugin<typeof DataGridCustom> = {
+const DataGridPlugin: PluginHandler.DashboardsPlugin<typeof DataGridCustom> = {
     custom: DataGridCustom,
-    name: 'DataGrid.DashboardPlugin',
+    name: 'DataGrid.DashboardsPlugin',
     onRegister,
     onUnregister
 };

--- a/ts/Dashboards/Plugins/HighchartsPlugin.ts
+++ b/ts/Dashboards/Plugins/HighchartsPlugin.ts
@@ -61,7 +61,7 @@ function connectHighcharts(
 /**
  * Callback function of the Dashboard plugin.
  *
- * @param {Dashboard.DashboardPlugin.Event} e
+ * @param {Dashboards.PluginHandler.Event} e
  * Plugin context provided by the Dashboard.
  */
 function onRegister(
@@ -112,9 +112,9 @@ const HighchartsCustom = {
     connectHighcharts
 };
 
-const HighchartsPlugin: PluginHandler.DashboardPlugin<typeof HighchartsCustom> = {
+const HighchartsPlugin: PluginHandler.DashboardsPlugin<typeof HighchartsCustom> = {
     custom: HighchartsCustom,
-    name: 'Highcharts.DashboardPlugin',
+    name: 'Highcharts.DashboardsPlugin',
     onRegister,
     onUnregister
 };


### PR DESCRIPTION
Path to icons has changed to `./gfx/dashboards-icons/`.
Plugin names have changed to `DataGrid.DashboardsPlugin` and `Highcharts.DashboardsPlugin`.