### PR TITLE
dash/datagrid-csvurl 

### DIFF
--- a/ts/Dashboards/Plugins/DataGridComponent.ts
+++ b/ts/Dashboards/Plugins/DataGridComponent.ts
@@ -219,6 +219,10 @@ class DataGridComponent extends Component {
 
         this.innerResizeTimeouts = [];
 
+        this.on('tableChanged', (): void => {
+            this.dataGrid?.update({ dataTable: this.filterColumns() });
+        });
+
         // Add the component instance to the registry
         Component.addInstance(this);
     }


### PR DESCRIPTION
Fixed, the `datagrid` component was not rendered when csvURL was declared.