### PR TITLE
bugfix/19343-xrange-tooltip-positioning

### DIFF
--- a/samples/unit-tests/series-xrange/xrange/demo.js
+++ b/samples/unit-tests/series-xrange/xrange/demo.js
@@ -822,4 +822,28 @@ QUnit.test('XRange series and tooltip position', assert => {
         'Tooltip on plotLeft when only far right part of the point is visible'
     );
 
+    chart.update({
+        xAxis: {
+            left: '75%',
+            width: '25%'
+        },
+        yAxis: {
+            top: '75%',
+            height: '25%'
+        }
+    });
+
+    const point = chart.series[0].points[0];
+
+    assert.strictEqual(
+        point.tooltipPos[0],
+        chart.xAxis[0].left - chart.plotLeft,
+        'Tooltip position should be correct on the resized x-axis. (#19343)'
+    );
+
+    assert.ok(
+        point.tooltipPos[1] > chart.yAxis[0].top - chart.plotTop,
+        `Tooltip y position should be greater than the top boundery of the
+        resized y-axis. (#19343)`
+    );
 });

--- a/ts/Series/XRange/XRangeSeries.ts
+++ b/ts/Series/XRange/XRangeSeries.ts
@@ -413,22 +413,22 @@ class XRangeSeries extends ColumnSeries {
         );
 
         // Centering tooltip position (#14147)
-        if (!inverted) {
+        if (inverted) {
+            tooltipPos[xIndex] += shapeArgs.width / 2;
+        } else {
             tooltipPos[xIndex] = clamp(
                 tooltipPos[xIndex] +
                 (xAxis.reversed ? -1 : 0) * shapeArgs.width,
                 0,
-                xAxis.len - 1
+                xAxis.left + xAxis.len - 1
             );
-        } else {
-            tooltipPos[xIndex] += shapeArgs.width / 2;
         }
         tooltipPos[yIndex] = clamp(
             tooltipPos[yIndex] + (
                 (inverted ? -1 : 1) * tooltipYOffset
             ),
             0,
-            yAxis.len - 1
+            yAxis.top + yAxis.len - 1
         );
 
         // Add a partShapeArgs to the point, based on the shapeArgs property

--- a/ts/Series/XRange/XRangeSeries.ts
+++ b/ts/Series/XRange/XRangeSeries.ts
@@ -285,7 +285,9 @@ class XRangeSeries extends ColumnSeries {
             oldColWidth = (point.shapeArgs && point.shapeArgs.width || 0) / 2,
             seriesXOffset = this.pointXOffset = metrics.offset,
             posX = pick(point.x2, (point.x as any) + (point.len || 0)),
-            borderRadius = options.borderRadius;
+            borderRadius = options.borderRadius,
+            plotTop = this.chart.plotTop,
+            plotLeft = this.chart.plotLeft;
 
 
         let plotX = point.plotX,
@@ -419,16 +421,16 @@ class XRangeSeries extends ColumnSeries {
             tooltipPos[xIndex] = clamp(
                 tooltipPos[xIndex] +
                 (xAxis.reversed ? -1 : 0) * shapeArgs.width,
-                0,
-                xAxis.left + xAxis.len - 1
+                xAxis.left - plotLeft,
+                xAxis.left + xAxis.len - plotLeft - 1
             );
         }
         tooltipPos[yIndex] = clamp(
             tooltipPos[yIndex] + (
                 (inverted ? -1 : 1) * tooltipYOffset
             ),
-            0,
-            yAxis.top + yAxis.len - 1
+            yAxis.top - plotTop,
+            yAxis.top + yAxis.len - plotTop - 1
         );
 
         // Add a partShapeArgs to the point, based on the shapeArgs property


### PR DESCRIPTION
Fixed #19343, tooltip positioning on xrange points lying on shifted axes.