### PR TITLE
bugfix/19341-boost-tooltip-shows-null-value

### DIFF
--- a/samples/unit-tests/boost/general/demo.js
+++ b/samples/unit-tests/boost/general/demo.js
@@ -166,8 +166,8 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
 
         assert.strictEqual(
             chart.series[3].points.length,
-            4,
-            'array length should include values with null'
+            2,
+            'Null points should not be added to the series\' kd-tree (#19341)'
         );
     }
 );

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -1055,7 +1055,7 @@ function seriesRenderCanvas(this: Series): void {
                 isYInside = (y || 0) >= yMin && y <= yMax;
             }
 
-            if (x >= xMin && x <= xMax && isYInside) {
+            if (y !== null && x >= xMin && x <= xMax && isYInside) {
 
                 clientX = xAxis.toPixels(x, true);
 


### PR DESCRIPTION
Fixed #19341, null points could be hovered in the boost module.
___
_**Internal note:** This bug was introduced in #18551. I can't see any reason why null points should also be added to KD-tree. In the case of https://github.com/highcharts/highcharts/pull/18551#issuecomment-1439109364, the number of points in a series can be checked by referring to e.g. `series.processedXData`; point index also from this, or e.g. from the `point.i` parameter._
