### PR TITLE
dash/text-options

### DIFF
--- a/test/typescript-dts/dashboards/dashboards.ts
+++ b/test/typescript-dts/dashboards/dashboards.ts
@@ -23,6 +23,26 @@ function test_board() {
                     csv: ''
                 }
             }]
-        }
+        },
+        gui: {
+            layouts: [{
+                rows: [{
+                    cells: [{
+                        id: 'cell1'
+                    }]
+                }]
+            }]
+        },
+        components: [{
+            type: 'HTML',
+            cell: 'cell1',
+            title: {
+                className: 'custom-title',
+                text: 'My title',
+                style: {
+                    color: 'red'
+                }
+            }
+        }]
     });
 }

--- a/tools/gulptasks/dashboards/api-docs.json
+++ b/tools/gulptasks/dashboards/api-docs.json
@@ -38,6 +38,7 @@
         "../../../ts/DataGrid/DataGridOptions.d.ts",
         "../../../ts/Dashboards/Plugins/HighchartsComponent.ts",
         "../../../ts/Dashboards/Plugins/DataGridComponent.ts",
+        "../../../ts/Dashboards/Components/TextOptions.d.ts"
     ],
     "entryPointStrategy": "expand",
     "excludeInternal": true,

--- a/ts/Dashboards/Board.ts
+++ b/ts/Dashboards/Board.ts
@@ -788,7 +788,7 @@ namespace Board {
          *
          * @default true
          **/
-        enabled: boolean;
+        enabled?: boolean;
         /**
          * General options for the layouts applied to all layouts.
          **/

--- a/ts/Dashboards/Components/Component.ts
+++ b/ts/Dashboards/Components/Component.ts
@@ -1333,6 +1333,9 @@ namespace Component {
     /** @internal */
     export type ConnectorTypes = DataConnector;
 
+    /**
+     * Allowed types for the text.
+    */
     export type TextOptionsType = string | false | TextOptions | undefined;
     /** @internal */
     export interface MessageTarget {

--- a/ts/Dashboards/Components/TextOptions.d.ts
+++ b/ts/Dashboards/Components/TextOptions.d.ts
@@ -15,10 +15,23 @@
  * */
 
 import type CSSObject from '../../Core/Renderer/CSSObject';
+
+/**
+ * Options for configuring a more custom text.
+*/
 declare interface TextOptions {
-    style?: CSSObject;
-    text?: string;
+    /**
+     * The class name which is added to the text element.
+    */
     className?: string;
+    /**
+     * A collection of CSS properties for the text.
+    */
+    style?: CSSObject;
+    /**
+     * The text content itself.
+    */
+    text?: string;
 }
 
 export default TextOptions;


### PR DESCRIPTION
Fixed, added TextOptions to documentation, changed `gui.enabled` as optional.