### PR TITLE
dash/rangemodifier-crossfilter

### DIFF
--- a/samples/highcharts/data-tools/rangemodifier-crossfilter/demo.css
+++ b/samples/highcharts/data-tools/rangemodifier-crossfilter/demo.css
@@ -1,0 +1,92 @@
+:root {
+    --color-background: #fff;
+    --color-tbody-background: #eee;
+    --color-text: #000;
+    --color-thead-background: #ddd;
+    --color-tbody-highlight1: #def;
+    --color-tbody-highlight2: #bdf;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --color-background: #111;
+        --color-tbody-background: #222;
+        --color-text: #eee;
+        --color-thead-background: #333;
+        --color-tbody-highlight1: #a9c;
+        --color-tbody-highlight2: #bac;
+    }
+}
+
+html {
+    background-color: var(--color-background);
+    color: var(--color-text);
+}
+
+form#filter {
+    background-color: var(--color-background);
+    color: var(--color-text);
+    display: flex;
+    justify-content: stretch;
+}
+
+form#filter fieldset {
+    flex-grow: 1;
+    text-align: center;
+    border: 1px solid silver;
+}
+
+form#filter label {
+    clear: both;
+    float: left;
+    height: 1.5em;
+    margin: 0.25em 0.25em 0 0;
+    overflow: hidden;
+    text-align: right;
+    text-overflow: ellipsis;
+    width: 45%;
+}
+
+form#filter input[type="text"] {
+    float: left;
+    height: 1.5em;
+    margin-top: 0.25em;
+    width: 45%;
+}
+
+table {
+    background-color: var(--color-background);
+    color: var(--color-text);
+    width: 100%;
+}
+
+table td,
+table th {
+    line-height: 1.5em;
+    padding: 0.25em 0.5em;
+    vertical-align: top;
+    white-space: pre-wrap;
+    width: 25%;
+}
+
+table thead th {
+    background-color: var(--color-thead-background);
+}
+
+table tbody td {
+    background-color: var(--color-tbody-background);
+}
+
+tr.highlight td {
+    background-color: var(--color-tbody-highlight1);
+}
+
+tr td.highlight {
+    background-color: var(--color-tbody-highlight2);
+}
+
+@media (max-width: 600px) {
+    form {
+        flex-direction: column;
+    }
+}

--- a/samples/highcharts/data-tools/rangemodifier-crossfilter/demo.details
+++ b/samples/highcharts/data-tools/rangemodifier-crossfilter/demo.details
@@ -1,0 +1,7 @@
+---
+ name: RangeModifier crossfilter demo
+ authors:
+   - Sophie Bremer
+ js_wrap: b
+ skipTest: true
+...

--- a/samples/highcharts/data-tools/rangemodifier-crossfilter/demo.html
+++ b/samples/highcharts/data-tools/rangemodifier-crossfilter/demo.html
@@ -1,0 +1,76 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/data-tools.js"></script>
+<script src="https://code.highcharts.com/modules/accessibility.js"></script>
+
+<form id="filter">
+    <fieldset>
+        <legend>City Filter</legend>
+        <label for="filter-city-min">Minimum:</label>
+        <input type="text" id="filter-city-min" placeholder="Aa" value="Aa" />
+        <label for="filter-city-max">Maximum:</label>
+        <input type="text" id="filter-city-max" placegolder="Zz" value="Zz" />
+    </fieldset>
+    <fieldset>
+        <legend>Elevation Filter</legend>
+        <label for="filter-elevation-min">Minimum:</label>
+        <input type="text" id="filter-elevation-min" placeholder="1" value="1" />
+        <label for="filter-elevation-max">Maximum:</label>
+        <input type="text" id="filter-elevation-max" placegolder="3490" value="3490" />
+    </fieldset>
+    <fieldset>
+        <legend>Longitude Filter</legend>
+        <label for="filter-lon-min">West:</label>
+        <input type="text" id="filter-lon-min" placeholder="-180" value="-180" />
+        <label for="filter-lon-max">East:</label>
+        <input type="text" id="filter-lon-max" placegolder="+180" value="+180" />
+    </fieldset>
+</form>
+
+<div id="container"></div>
+
+<noscript>City;Elevation;Latitude;Longitude
+Auckland;98;-36.84;174.74
+Bangkok;1;13.75;100.49
+Beijing;63;39.91;116.4
+Buenos Aires;10;-34.60;-58.38
+Cairo;22;30.04;31.24
+Caracas;909;10.48;-66.90
+Casablanca;75;33.53;-7.58
+Chongqing;244;29.56;106.55
+Dakar;37;14.69;-17.45
+Delhi;225;28.61;77.23
+Dhaka;3;23.76;90.39
+Dublin;8;53.35;-6.26
+Grytviken;17;-54.28;-36.51
+Helsinki;25;60.17;24.94
+Honolulu;6;21.31;-157.86
+Instanbul;268;41.01;28.96
+Jakarta;3;-6.16;106.83
+Johannesburg;1753;-26.20;28.05
+Karachi;10;24.86;67.01
+Kathmandu;1298;27.72;85.32
+Kinshasa;240;-4.33;15.32
+Lagos;41;6.46;3.38
+Lhasa;3490;29.65;91.17
+Lima;107;-12.06;-77.04
+London;14;51.51;-0.13
+Los Angeles;93;34.05;-118.25
+Madrid;667;40.42;-3.70
+Manila;7;14.60;120.98
+Mexico City;2216;19.43;-99.13
+Mumbai;14;19.08;72.88
+New York;10;40.71;-74.01
+Odesa;40;46.49;30.74
+Osaka;12;34.69;135.5
+Port aux Français;16;-49.35;70.22
+Port Moresby;39;-9.48;147.15
+Reykjavík;12;64.15;-21.94
+São Paulo;760;-23.55;-46.63
+Shanghai;122;31.23;121.47
+Singapore;11;1.28;103.83
+Sydney;35;-33.87;151.21
+Tokyo;17;35.69;139.69
+Ulaanbaatar;1350;47.92;106.92
+Vancouver;76;49.26;-123.11
+Xining;2275;36.62;101.78
+</noscript>

--- a/samples/highcharts/data-tools/rangemodifier-crossfilter/demo.js
+++ b/samples/highcharts/data-tools/rangemodifier-crossfilter/demo.js
@@ -1,0 +1,93 @@
+const CSVConnector = Highcharts.DataConnector.types.CSV;
+const escapeStringForHTML = Highcharts.A11yHTMLUtilities.escapeStringForHTML;
+
+const container = document.getElementById('container');
+const form = document.getElementById('filter');
+
+(async () => {
+    const csv = new CSVConnector({
+        csv: document.querySelector('noscript').innerText,
+        dataModifier: {
+            type: 'Range',
+            ranges: [{
+                column: 'City',
+                minValue: 'Aa',
+                maxValue: 'Zz'
+            }, {
+                column: 'Elevation',
+                minValue: 1,
+                maxValue: 3490
+            }, {
+                column: 'Longitude',
+                minValue: -180,
+                maxValue: +180
+            }]
+        }
+    });
+
+    await csv.load();
+
+    renderTable(container, csv.table.modified);
+
+    form.querySelectorAll('input').forEach(input => {
+        input.onchange = () => updateRange(csv.table, input.parentElement);
+    });
+
+    console.log(csv.table);
+
+})();
+
+// Updates Range
+
+async function updateRange(table, fieldset) {
+    const inputs = fieldset.querySelectorAll('input');
+    const legend = fieldset.querySelector('legend').innerText;
+    const modifier = table.getModifier();
+    const range = [
+        'City Filter',
+        'Elevation Filter',
+        'Longitude Filter'
+    ].indexOf(legend);
+
+    let min = inputs[0].value;
+    let max = inputs[1].value;
+
+    if (range > 0) {
+        min = parseInt(min, 10);
+        max = parseInt(max, 10);
+    }
+
+    modifier.options.ranges[range].maxValue = max;
+    modifier.options.ranges[range].minValue = min;
+
+    await table.setModifier(modifier);
+
+    renderTable(container, table.modified);
+}
+
+// Render Simple HTML Table
+
+function renderTable(container, table) {
+    const html = [];
+
+    html.push('<table>');
+    html.push('<thead>');
+    html.push('<tr>');
+    for (const column of table.getColumnNames()) {
+        html.push('<th>', escapeStringForHTML(column), '</th>');
+    }
+    html.push('</tr>');
+    html.push('</thead>');
+    html.push('<tbody>');
+    for (const row of table.getRows()) {
+        html.push('<tr>');
+        for (const value of row) {
+            html.push('<td>', escapeStringForHTML('' + value), '</td>');
+        }
+        html.push('</tr>');
+    }
+    html.push('</tbody>');
+    html.push('</table>');
+
+    container.innerHTML = html.join('');
+}

--- a/test/typescript-karma/Data/Modifiers/RangeModifier.test.js
+++ b/test/typescript-karma/Data/Modifiers/RangeModifier.test.js
@@ -1,52 +1,60 @@
 import DataTable from '/base/code/es-modules/Data/DataTable.js';
 import RangeModifier from '/base/code/es-modules/Data/Modifiers/RangeModifier.js';
 
-QUnit.test('RangeModifier.modify', function (assert) {
+QUnit.test('RangeModifier.modify', async function (assert) {
 
-    const done = assert.async(),
-        table = new DataTable({
+    const table = new DataTable({
             columns: {
                 x: [ -2, -1, 0, 1, 2 ],
-                y: [ 'a', 'b', 'c', 'd', 'e' ]
+                y: [ 'a', 'b', 'c', 'd', 'e' ],
+                z: [ 1e1, 1e2, 1e3, 1e4, 1e5 ]
             }
         }),
-        modifier = new RangeModifier({});
+        modifier = new RangeModifier();
 
-    modifier
-        .modify(table)
-        .then((table) => {
-            assert.deepEqual(
-                table.modified.getRow(0),
-                table.getRow(0),
-                'Filtered table should contain same rows.'
-            );
-            return table;
-        })
-        .then((table) => {
-            modifier.options.ranges.push({
-                column: 'y',
-                minValue: 'A',
-                maxValue: 'b'
-            });
-            return modifier.modify(table);
-        })
-        .then((table) => {
-            assert.deepEqual(
-                table.modified.getColumns(),
-                {
-                    x: [ -2, -1 ],
-                    y: [ 'a', 'b' ]
-                },
-                'Filtered table should contain reduced number of rows.'
-            );
-            return table;
-        })
-        .catch((e) =>
-            assert.notOk(true, e)
-        )
-        .then(() =>
-            done()
-        );
+    await modifier.modify(table);
+
+    assert.deepEqual(
+        table.modified.getRow(0),
+        table.getRow(0),
+        'Filtered table should contain same rows.'
+    );
+
+    modifier.options.ranges.push({
+        column: 'y',
+        minValue: 'A',
+        maxValue: 'b'
+    });
+
+    await modifier.modify(table);
+
+    assert.deepEqual(
+        table.modified.getColumns(),
+        {
+            x: [ -2, -1 ],
+            y: [ 'a', 'b' ],
+            z: [ 10, 100 ]
+        },
+        'Filtered table should contain reduced number of rows.'
+    );
+
+    modifier.options.ranges.push({
+        column: 'z',
+        minValue: 50,
+        maxValue: 100
+    });
+
+    await modifier.modify(table);
+
+    assert.deepEqual(
+        table.modified.getColumns(),
+        {
+            x: [ -1 ],
+            y: [ 'b' ],
+            z: [ 100 ]
+        },
+        'Filtered table should contain intersective reduction of rows.'
+    );
 
 });
 
@@ -54,6 +62,7 @@ QUnit.test('RangeModifier.modifyCell', function (assert) {
 
     const done = assert.async(),
         modifier = new RangeModifier({
+            additive: true,
             ranges: [{
                 column: 'x',
                 minValue: -10,
@@ -102,6 +111,7 @@ QUnit.test('RangeModifier.modifyColumns', function (assert) {
 
     const done = assert.async(),
         modifier = new RangeModifier({
+            additive: true,
             ranges: [{
                 column: 'x',
                 minValue: -10,
@@ -151,6 +161,7 @@ QUnit.test('RangeModifier.modifyRows', function (assert) {
 
     const done = assert.async(),
         modifier = new RangeModifier({
+            additive: true,
             ranges: [{
                 column: 'x',
                 minValue: -10,

--- a/ts/Dashboards/Plugins/DataGridSyncHandlers.ts
+++ b/ts/Dashboards/Plugins/DataGridSyncHandlers.ts
@@ -211,7 +211,7 @@ const configs: {
                 this.on('afterSetConnector', (): void => registerCursorListeners());
             }
         },
-        visibilityHandler: function(this: DataGridComponent): void {
+        visibilityHandler: function (this: DataGridComponent): void {
             const component = this,
                 { board } = component;
 
@@ -229,7 +229,7 @@ const configs: {
                             show: cursor.state !== 'series.hide'
                         }
                     }
-                })
+                });
             };
 
             const registerCursorListeners = (): void => {

--- a/ts/Data/Modifiers/RangeModifier.ts
+++ b/ts/Data/Modifiers/RangeModifier.ts
@@ -197,7 +197,11 @@ class RangeModifier extends DataModifier {
                         cell >= range.minValue &&
                         cell <= range.maxValue
                     ) {
-                        row = table.getRow(j);
+                        row = (
+                            additive ?
+                                table.getRow(j) :
+                                modified.getRow(j)
+                        );
 
                         if (row) {
                             rows.push(row);

--- a/ts/Data/Modifiers/RangeModifier.ts
+++ b/ts/Data/Modifiers/RangeModifier.ts
@@ -11,13 +11,16 @@
  *
  * */
 
+
 'use strict';
+
 
 /* *
  *
  *  Imports
  *
  * */
+
 
 import type DataEvent from '../DataEvent';
 import type {
@@ -32,11 +35,13 @@ const {
     merge
 } = U;
 
+
 /* *
  *
  *  Class
  *
  * */
+
 
 /**
  * Filters out table rows with a specific value range.
@@ -45,26 +50,29 @@ const {
  */
 class RangeModifier extends DataModifier {
 
+
     /* *
      *
      *  Static Properties
      *
      * */
 
+
     /**
      * Default options for the range modifier.
      */
     public static readonly defaultOptions: RangeModifierOptions = {
         type: 'Range',
-        ranges: [],
-        strict: false
+        ranges: []
     };
+
 
     /* *
      *
      *  Constructor
      *
      * */
+
 
     /**
      * Constructs an instance of the range modifier.
@@ -80,22 +88,26 @@ class RangeModifier extends DataModifier {
         this.options = merge(RangeModifier.defaultOptions, options);
     }
 
+
     /* *
      *
      *  Properties
      *
      * */
 
+
     /**
      * Options of the range modifier.
      */
     public readonly options: RangeModifierOptions;
+
 
     /* *
      *
      *  Functions
      *
      * */
+
 
     /**
      * Replaces table rows with filtered rows.
@@ -118,14 +130,16 @@ class RangeModifier extends DataModifier {
         modifier.emit({ type: 'modify', detail: eventDetail, table });
 
         const {
+            additive,
             ranges,
             strict
         } = modifier.options;
 
         if (ranges.length) {
-            const columns = table.getColumns(),
-                rows: Array<DataTable.Row> = [],
-                modified = table.modified;
+            const modified = table.modified;
+
+            let columns = table.getColumns(),
+                rows: Array<DataTable.Row> = [];
 
             for (
                 let i = 0,
@@ -142,6 +156,13 @@ class RangeModifier extends DataModifier {
                     typeof range.minValue !== typeof range.maxValue
                 ) {
                     continue;
+                }
+
+                if (i > 0 && !additive) {
+                    modified.deleteRows();
+                    modified.setRows(rows);
+                    columns = modified.getColumns();
+                    rows = [];
                 }
 
                 rangeColumn = (columns[range.column] || []);
@@ -198,11 +219,16 @@ class RangeModifier extends DataModifier {
     /**
      * Utility function that returns the first row index
      * if the table has been modified by a range modifier
-     * @param {DataTable} table the table to get the offset from
      *
-     * @return {number} The row offset of the modified table
+     * @param {DataTable} table
+     * The table to get the offset from.
+     *
+     * @return {number}
+     * The row offset of the modified table.
      */
-    public getModifiedTableOffset(table: DataTable): number {
+    public getModifiedTableOffset(
+        table: DataTable
+    ): number {
         const { ranges } = this.options;
 
         if (ranges) {
@@ -228,13 +254,17 @@ class RangeModifier extends DataModifier {
 
         return 0;
     }
+
+
 }
+
 
 /* *
  *
  *  Registry
  *
  * */
+
 
 declare module './DataModifierType' {
     interface DataModifierTypes {
@@ -244,10 +274,12 @@ declare module './DataModifierType' {
 
 DataModifier.registerType('Range', RangeModifier);
 
+
 /* *
  *
  *  Default Export
  *
  * */
+
 
 export default RangeModifier;

--- a/ts/Data/Modifiers/RangeModifierOptions.ts
+++ b/ts/Data/Modifiers/RangeModifierOptions.ts
@@ -38,6 +38,11 @@ export interface RangeModifierOptions extends DataModifierOptions {
     type: 'Range';
 
     /**
+     * If set to true, multiple ranges will add up instead of reduce.
+     */
+    additive?: boolean;
+
+    /**
      * Value ranges to include in the result.
      */
     ranges: Array<RangeModifierRangeOptions>;
@@ -45,7 +50,7 @@ export interface RangeModifierOptions extends DataModifierOptions {
     /**
      * If set to true, it will also compare the value type.
      */
-    strict: boolean;
+    strict?: boolean;
 
 }
 


### PR DESCRIPTION
RangeModifier will now intersect the results of multiple ranges by default. Use the `additive` option to concatenate results of multiple ranges.

Based on #19441 - merge first!