### PR TITLE
bugfix/19465-numberformat-api-demo-typo

### DIFF
--- a/samples/highcharts/members/highcharts-numberformat/demo.js
+++ b/samples/highcharts/members/highcharts-numberformat/demo.js
@@ -16,7 +16,7 @@ var converters = {
 Highcharts.setOptions({
     lang: {
         decimalPoint: '\u066B',
-        thousandsSeparator: '\u066C'
+        thousandsSep: '\u066C'
     }
 });
 
@@ -35,7 +35,10 @@ Highcharts.chart('container', {
     },
 
     series: [{
-        data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4],
+        data: [
+            29.9, 71.5, 106.4, 129.2, 144.0, 176.0,
+            135.6, 148.5, 216.4, 194.1, 95.6, 54.4
+        ],
         dataLabels: {
             enabled: true,
             format: '{y:.1f}',


### PR DESCRIPTION
Fixed #19465, wrong property in `numberFormatter` API demo.