### PR TITLE
bugfix/19457-multiple-dataLabels-enabled/disabled-threw-render-error

### DIFF
--- a/samples/unit-tests/datalabels/multiple-labels/demo.js
+++ b/samples/unit-tests/datalabels/multiple-labels/demo.js
@@ -211,4 +211,17 @@ QUnit.test('Multiple data labels general tests.', function (assert) {
         void 0,
         'Second data label should be disabled (#17589}.'
     );
+
+    assert.ok(
+        true,
+        'No console error should be displayed (#19457).'
+    );
+
+    assert.strictEqual(
+        chart.options.series[0].dataLabels.filter(({ enabled }) =>
+            enabled
+        ).length,
+        chart.series[0].points[0].dataLabels.length,
+        'Only the second point\'s data label should be rendered (#19457).'
+    );
 });

--- a/samples/unit-tests/datalabels/multiple-labels/demo.js
+++ b/samples/unit-tests/datalabels/multiple-labels/demo.js
@@ -212,9 +212,17 @@ QUnit.test('Multiple data labels general tests.', function (assert) {
         'Second data label should be disabled (#17589}.'
     );
 
+    chart.series[0].update({
+        dataLabels: [{
+            enabled: false
+        }, {
+            enabled: true
+        }]
+    });
+
     assert.ok(
         true,
-        'No console error should be displayed (#19457).'
+        'There shouldn\'t be any error in the browser console (#19457).'
     );
 
     assert.strictEqual(

--- a/samples/unit-tests/series/datalabels/demo.js
+++ b/samples/unit-tests/series/datalabels/demo.js
@@ -116,9 +116,9 @@ QUnit.test('Top -90', function (assert) {
         Math.abs(
             chart.series[0].points[0].dataLabel.element.getBoundingClientRect()
                 .top -
-                chart.series[0].points[0].graphic.element
-                    .getBoundingClientRect()
-                    .top
+            chart.series[0].points[0].graphic.element
+                .getBoundingClientRect()
+                .top
         ) < 12,
         'Label is top aligned to element'
     );
@@ -126,9 +126,9 @@ QUnit.test('Top -90', function (assert) {
         Math.abs(
             chart.series[0].points[1].dataLabel.element.getBoundingClientRect()
                 .top -
-                chart.series[0].points[1].graphic.element
-                    .getBoundingClientRect()
-                    .top
+            chart.series[0].points[1].graphic.element
+                .getBoundingClientRect()
+                .top
         ) < 12,
         'Label is top aligned to element'
     );
@@ -202,9 +202,9 @@ QUnit.test('Bottom 90', function (assert) {
         Math.abs(
             chart.series[0].points[0].dataLabel.element.getBoundingClientRect()
                 .bottom -
-                chart.series[0].points[1].dataLabel.element
-                    .getBoundingClientRect()
-                    .bottom
+            chart.series[0].points[1].dataLabel.element
+                .getBoundingClientRect()
+                .bottom
         ) < 12,
         'Labels are equally bottom aligned'
     );
@@ -242,11 +242,11 @@ QUnit.test('Top 90', function (assert) {
                     .getBoundingClientRect()
                     .top
             ) -
-                Math.round(
-                    chart.series[0].points[0].graphic.element
-                        .getBoundingClientRect()
-                        .top
-                )
+            Math.round(
+                chart.series[0].points[0].graphic.element
+                    .getBoundingClientRect()
+                    .top
+            )
         ) < 12,
         'Label is top aligned to element'
     );
@@ -257,11 +257,11 @@ QUnit.test('Top 90', function (assert) {
                     .getBoundingClientRect()
                     .top
             ) -
-                Math.round(
-                    chart.series[0].points[1].graphic.element
-                        .getBoundingClientRect()
-                        .top
-                )
+            Math.round(
+                chart.series[0].points[1].graphic.element
+                    .getBoundingClientRect()
+                    .top
+            )
         ) < 12,
         'Label is top aligned to element'
     );
@@ -321,10 +321,15 @@ QUnit.test('Datalabels overlap in hidden series (#3866)', function (assert) {
         },
         plotOptions: {
             series: {
-                dataLabels: {
-                    enabled: true,
-                    format: '{y} km'
-                }
+                dataLabels: [
+                    {
+                        enabled: false
+                    },
+                    {
+                        enabled: true,
+                        format: '{y} km'
+                    }
+                ]
             }
         },
         series: [
@@ -380,6 +385,19 @@ QUnit.test('Datalabels overlap in hidden series (#3866)', function (assert) {
             point => point.dataLabel.attr('translateY') >= 0
         ),
         'All six labels of the second series should be visible.'
+    );
+
+    assert.ok(
+        true,
+        'No console error should be displayed (#19457).'
+    );
+
+    assert.strictEqual(
+        chart.options.plotOptions.series.dataLabels.filter(({ enabled }) =>
+            enabled
+        ).length,
+        chart.series[0].points[0].dataLabels.length,
+        'Only the second point\'s data label should be rendered (#19457).'
     );
 });
 

--- a/samples/unit-tests/series/datalabels/demo.js
+++ b/samples/unit-tests/series/datalabels/demo.js
@@ -116,9 +116,9 @@ QUnit.test('Top -90', function (assert) {
         Math.abs(
             chart.series[0].points[0].dataLabel.element.getBoundingClientRect()
                 .top -
-            chart.series[0].points[0].graphic.element
-                .getBoundingClientRect()
-                .top
+                chart.series[0].points[0].graphic.element
+                    .getBoundingClientRect()
+                    .top
         ) < 12,
         'Label is top aligned to element'
     );
@@ -126,9 +126,9 @@ QUnit.test('Top -90', function (assert) {
         Math.abs(
             chart.series[0].points[1].dataLabel.element.getBoundingClientRect()
                 .top -
-            chart.series[0].points[1].graphic.element
-                .getBoundingClientRect()
-                .top
+                chart.series[0].points[1].graphic.element
+                    .getBoundingClientRect()
+                    .top
         ) < 12,
         'Label is top aligned to element'
     );
@@ -202,9 +202,9 @@ QUnit.test('Bottom 90', function (assert) {
         Math.abs(
             chart.series[0].points[0].dataLabel.element.getBoundingClientRect()
                 .bottom -
-            chart.series[0].points[1].dataLabel.element
-                .getBoundingClientRect()
-                .bottom
+                chart.series[0].points[1].dataLabel.element
+                    .getBoundingClientRect()
+                    .bottom
         ) < 12,
         'Labels are equally bottom aligned'
     );
@@ -242,11 +242,11 @@ QUnit.test('Top 90', function (assert) {
                     .getBoundingClientRect()
                     .top
             ) -
-            Math.round(
-                chart.series[0].points[0].graphic.element
-                    .getBoundingClientRect()
-                    .top
-            )
+                Math.round(
+                    chart.series[0].points[0].graphic.element
+                        .getBoundingClientRect()
+                        .top
+                )
         ) < 12,
         'Label is top aligned to element'
     );
@@ -257,11 +257,11 @@ QUnit.test('Top 90', function (assert) {
                     .getBoundingClientRect()
                     .top
             ) -
-            Math.round(
-                chart.series[0].points[1].graphic.element
-                    .getBoundingClientRect()
-                    .top
-            )
+                Math.round(
+                    chart.series[0].points[1].graphic.element
+                        .getBoundingClientRect()
+                        .top
+                )
         ) < 12,
         'Label is top aligned to element'
     );
@@ -321,15 +321,10 @@ QUnit.test('Datalabels overlap in hidden series (#3866)', function (assert) {
         },
         plotOptions: {
             series: {
-                dataLabels: [
-                    {
-                        enabled: false
-                    },
-                    {
-                        enabled: true,
-                        format: '{y} km'
-                    }
-                ]
+                dataLabels: {
+                    enabled: true,
+                    format: '{y} km'
+                }
             }
         },
         series: [
@@ -385,19 +380,6 @@ QUnit.test('Datalabels overlap in hidden series (#3866)', function (assert) {
             point => point.dataLabel.attr('translateY') >= 0
         ),
         'All six labels of the second series should be visible.'
-    );
-
-    assert.ok(
-        true,
-        'No console error should be displayed (#19457).'
-    );
-
-    assert.strictEqual(
-        chart.options.plotOptions.series.dataLabels.filter(({ enabled }) =>
-            enabled
-        ).length,
-        chart.series[0].points[0].dataLabels.length,
-        'Only the second point\'s data label should be rendered (#19457).'
     );
 });
 

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -544,8 +544,9 @@ namespace DataLabel {
             // Make the labels for each point
             points.forEach((point): void => {
 
-                const dataLabels: (SVGLabel|SVGElement|undefined)[] =
-                    point.dataLabels || [];
+                // In the local array, items can be undefined if a data label is
+                // disabled, followed by an enabled one (#19457)
+                const dataLabels = point.dataLabels || [];
 
                 // Merge in series options for the point.
                 // @note dataLabelAttribs (like pointAttribs) would eradicate
@@ -804,7 +805,7 @@ namespace DataLabel {
 
                             dataLabel.isActive = true;
                             if (dataLabels[i] && dataLabels[i] !== dataLabel) {
-                                dataLabels[i]?.destroy();
+                                dataLabels[i].destroy();
                             }
                             dataLabels[i] = dataLabel;
                         }
@@ -815,22 +816,19 @@ namespace DataLabel {
                 // Destroy and remove the inactive ones
                 let j = dataLabels.length;
                 while (j--) {
-                    if (dataLabels[j]?.isActive) {
-                        dataLabels[j]!.isActive = false;
-                    } else {
+                    // The item can be undefined if a disabled data label is
+                    // succeeded by an enabled one (#19457)
+                    if (!dataLabels[j] || !dataLabels[j].isActive) {
                         dataLabels[j]?.destroy();
                         dataLabels.splice(j, 1);
+                    } else {
+                        dataLabels[j].isActive = false;
                     }
                 }
 
-                if (dataLabels.length > 0) {
-                    // Write back
-                    point.dataLabel = dataLabels[0];
-                    point.dataLabels = dataLabels.filter(defined);
-                } else {
-                    delete point.dataLabel;
-                    delete point.dataLabels;
-                }
+                // Write back
+                point.dataLabel = dataLabels[0];
+                point.dataLabels = dataLabels;
             });
         }
 

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -544,8 +544,6 @@ namespace DataLabel {
             // Make the labels for each point
             points.forEach((point): void => {
 
-                // In the local array, items can be undefined if a data label is
-                // disabled, followed by an enabled one (#19457)
                 const dataLabels = point.dataLabels || [];
 
                 // Merge in series options for the point.

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -814,10 +814,10 @@ namespace DataLabel {
                 // Destroy and remove the inactive ones
                 let j = dataLabels.length;
                 while (j--) {
-                    if (dataLabels[j].isActive) {
+                    if (dataLabels[j]?.isActive) {
                         dataLabels[j].isActive = false;
                     } else {
-                        dataLabels[j].destroy();
+                        dataLabels[j]?.destroy();
                         dataLabels.splice(j, 1);
                     }
                 }

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -824,16 +824,9 @@ namespace DataLabel {
                 }
 
                 if (dataLabels.length > 0) {
-                    const tempDataLabels: (SVGLabel|SVGElement)[] = [];
-                    dataLabels.forEach(function (dataLabel): void {
-                        if (dataLabel) {
-                            tempDataLabels.push(dataLabel);
-                        }
-                    });
-
                     // Write back
                     point.dataLabel = dataLabels[0];
-                    point.dataLabels = tempDataLabels;
+                    point.dataLabels = dataLabels.filter(defined);
                 } else {
                     delete point.dataLabel;
                     delete point.dataLabels;

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -544,7 +544,8 @@ namespace DataLabel {
             // Make the labels for each point
             points.forEach((point): void => {
 
-                const dataLabels = point.dataLabels || [];
+                const dataLabels: (SVGLabel|SVGElement|undefined)[] =
+                    point.dataLabels || [];
 
                 // Merge in series options for the point.
                 // @note dataLabelAttribs (like pointAttribs) would eradicate
@@ -803,7 +804,7 @@ namespace DataLabel {
 
                             dataLabel.isActive = true;
                             if (dataLabels[i] && dataLabels[i] !== dataLabel) {
-                                dataLabels[i].destroy();
+                                dataLabels[i]?.destroy();
                             }
                             dataLabels[i] = dataLabel;
                         }
@@ -815,16 +816,28 @@ namespace DataLabel {
                 let j = dataLabels.length;
                 while (j--) {
                     if (dataLabels[j]?.isActive) {
-                        dataLabels[j].isActive = false;
+                        dataLabels[j]!.isActive = false;
                     } else {
                         dataLabels[j]?.destroy();
                         dataLabels.splice(j, 1);
                     }
                 }
 
-                // Write back
-                point.dataLabel = dataLabels[0];
-                point.dataLabels = dataLabels;
+                if (dataLabels.length > 0) {
+                    const tempDataLabels: (SVGLabel|SVGElement)[] = [];
+                    dataLabels.forEach(function (dataLabel): void {
+                        if (dataLabel) {
+                            tempDataLabels.push(dataLabel);
+                        }
+                    });
+
+                    // Write back
+                    point.dataLabel = dataLabels[0];
+                    point.dataLabels = tempDataLabels;
+                } else {
+                    delete point.dataLabel;
+                    delete point.dataLabels;
+                }
             });
         }
 


### PR DESCRIPTION
Fixed #19457, multiple `dataLabels` enabled/disabled threw render (console) error.