### PR TITLE
bugfix/19493-stocktools-popup-edit

### DIFF
--- a/ts/Extensions/Annotations/NavigationBindings.ts
+++ b/ts/Extensions/Annotations/NavigationBindings.ts
@@ -986,7 +986,7 @@ class NavigationBindings {
 
             if (
                 parentEditables &&
-                option &&
+                defined(option) &&
                 nonEditables.indexOf(key) === -1 &&
                 (
                     (


### PR DESCRIPTION
Fixed #19493, zero values in Stock Tools popup fields were missing.