### PR TITLE
bugfix/19110-misaligned-sankey-links

### DIFF
--- a/samples/unit-tests/series-sankey/sankey/demo.js
+++ b/samples/unit-tests/series-sankey/sankey/demo.js
@@ -818,6 +818,24 @@ QUnit.test('Wrong spacings when zero minLinkWidth #13308', function (assert) {
         'The translate-factor value should not be changed significantly ' +
             'while changing the minLinkWidth (#13308)'
     );
+
+    const series = chart.addSeries({
+        type: 'sankey',
+        keys: ['from', 'to', 'weight'],
+        minLinkWidth: 30,
+        data: [
+            ['Brazil', 'Portugal', 1],
+            ['Canada', 'Portugal', 1],
+            ['Mexico', 'Portugal', 1],
+            ['India', 'Portugal', 1],
+            ['USA', 'Portugal', 2]
+        ]
+    });
+
+    assert.ok(
+        series.translationFactor >= 0,
+        'The translationFactor property shouldn\'t be less than zero (#19110).'
+    );
 });
 
 QUnit.test('#14584: Sankey overlapping datalabels', assert => {

--- a/ts/Series/Sankey/SankeyColumnComposition.ts
+++ b/ts/Series/Sankey/SankeyColumnComposition.ts
@@ -105,7 +105,8 @@ namespace SankeyColumnComposition {
                 while (i--) {
                     if (column[i].getSum() * factor < minLinkWidth) {
                         column.splice(i, 1);
-                        remainingHeight -= minLinkWidth;
+                        remainingHeight =
+                            Math.max(0, remainingHeight - minLinkWidth);
                         skipPoint = true;
                     }
                 }


### PR DESCRIPTION
Fixed #19110, chart's height, and `minLinkWidth` misaligned sankey links.