### PR TITLE
Fixed #18490, tooltip.outside failed to clean up container

### DIFF
--- a/samples/unit-tests/tooltip/outside/demo.js
+++ b/samples/unit-tests/tooltip/outside/demo.js
@@ -41,14 +41,16 @@ QUnit.test('Outside tooltip styling and correct position', function (assert) {
                 }
             },
             tooltip: {
-                outside: true
+                outside: true,
+                hideDelay: 0
             },
             series: [{
                 data: [1, 3, 2, 4]
             }]
         }),
         point = chart.series[0].points[0],
-        tooltip = chart.tooltip;
+        tooltip = chart.tooltip,
+        controller = new TestController(chart);
 
     // Set hoverPoint
     point.onMouseOver();
@@ -104,6 +106,20 @@ QUnit.test('Outside tooltip styling and correct position', function (assert) {
         Math.round(pointX),
         'Tooltip position should appear at point with sets margin for chart and container'
     );
+
+    assert.strictEqual(
+        chart.tooltip.container.parentNode.nodeName,
+        'BODY',
+        'The outside tooltip should be part of the body'
+    );
+
+    controller.moveTo(-1, -1);
+    assert.strictEqual(
+        chart.tooltip.container.parentNode,
+        null,
+        'When hiding the tooltip, the container should be removed from DOM (#18490)'
+    );
+
 });
 
 QUnit.test('Tooltip when markers are outside, #17929.', function (assert) {

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -1318,29 +1318,6 @@ class SVGElement implements SVGElementLike {
     }
 
     /**
-     * Fade out an element by animating its opacity down to 0, and hide it on
-     * complete. Used internally for the tooltip.
-     *
-     * @function Highcharts.SVGElement#fadeOut
-     *
-     * @param {number} [duration=150]
-     * The fade duration in milliseconds.
-     */
-    public fadeOut(duration?: number): void {
-        const elemWrapper = this;
-
-        elemWrapper.animate({
-            opacity: 0
-        }, {
-            duration: pick(duration, 150),
-            complete: function (): void {
-                // #3088, assuming we're only using this for tooltips
-                elemWrapper.hide();
-            }
-        });
-    }
-
-    /**
      * @private
      * @function Highcharts.SVGElement#fillSetter
      * @param {Highcharts.ColorType} value

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -141,7 +141,7 @@ class Tooltip {
 
     public chart: Chart;
 
-    public container: globalThis.HTMLElement = void 0 as any;
+    public container?: globalThis.HTMLElement;
 
     public crosshairs: Array<null> = [];
 
@@ -410,7 +410,7 @@ class Tooltip {
             options = this.options,
             doSplit = this.split && this.allowShared;
 
-        let container: globalThis.HTMLElement,
+        let container = this.container,
             renderer: SVGRenderer = this.chart.renderer;
 
         // If changing from a split tooltip to a non-split tooltip, we must
@@ -453,8 +453,6 @@ class Tooltip {
                         (chartStyle && chartStyle.zIndex || 0) + 3
                     )
                 });
-
-                H.doc.body.appendChild(container);
 
                 /**
                  * Reference to the tooltip's renderer, when
@@ -522,13 +520,17 @@ class Tooltip {
                     value: string
                 ): void {
                     xSetter.call(label, tooltip.distance);
-                    container.style.left = value + 'px';
+                    if (container) {
+                        container.style.left = value + 'px';
+                    }
                 };
                 label.ySetter = function (
                     value: string
                 ): void {
                     ySetter.call(label, tooltip.distance);
-                    container.style.top = value + 'px';
+                    if (container) {
+                        container.style.top = value + 'px';
+                    }
                 };
             }
 
@@ -537,6 +539,11 @@ class Tooltip {
                 .shadow(options.shadow)
                 .add();
         }
+
+        if (container && !container.parentElement) {
+            H.doc.body.appendChild(container);
+        }
+
         return this.label;
     }
 
@@ -788,15 +795,28 @@ class Tooltip {
     public hide(delay?: number): void {
         const tooltip = this;
 
-        // disallow duplicate timers (#1728, #1766)
+        // Disallow duplicate timers (#1728, #1766)
         U.clearTimeout(this.hideTimer as any);
         delay = pick(delay, this.options.hideDelay);
         if (!this.isHidden) {
             this.hideTimer = syncTimeout(function (): void {
-                // If there is a delay, do fadeOut with the default duration. If
+                const label = tooltip.getLabel();
+                // If there is a delay, fade out with the default duration. If
                 // the hideDelay is 0, we assume no animation is wanted, so we
                 // pass 0 duration. #12994.
-                tooltip.getLabel().fadeOut(delay ? void 0 : delay);
+                tooltip.getLabel().animate({
+                    opacity: 0
+                }, {
+                    duration: delay ? 150 : delay,
+                    complete: (): void => {
+                        // #3088, assuming we're only using this for tooltips
+                        label.hide();
+                        // Clear the container for outside tooltip (#18490)
+                        if (tooltip.container) {
+                            tooltip.container.remove();
+                        }
+                    }
+                });
                 tooltip.isHidden = true;
             }, delay);
         }
@@ -1765,6 +1785,7 @@ class Tooltip {
     public updatePosition(point: Point): void {
         const {
                 chart,
+                container,
                 distance,
                 options
             } = this,
@@ -1783,7 +1804,7 @@ class Tooltip {
             pad;
 
         // Set the renderer size dynamically to prevent document size to change
-        if (this.outside) {
+        if (this.outside && container) {
             // Corrects positions, occurs with tooltip positioner (#16944)
             if (options.positioner) {
                 pos.x += left - distance;
@@ -1801,7 +1822,7 @@ class Tooltip {
             // Anchor and tooltip container need scaling if chart container has
             // scale transform/css zoom. #11329.
             if (scaleX !== 1 || scaleY !== 1) {
-                css(this.container, {
+                css(container, {
                     transform: `scale(${scaleX}, ${scaleY})`
                 });
                 anchorX *= scaleX;


### PR DESCRIPTION
Fixed #18490, tooltip container was not cleaned up from DOM when `tooltip.outside` applied.
___ 
Closes #19325