### PR TITLE
bugfix/18858-boost-point-colors

### DIFF
--- a/samples/highcharts/boost/line-data-color/demo.css
+++ b/samples/highcharts/boost/line-data-color/demo.css
@@ -1,0 +1,5 @@
+#container {
+    height: 400px;
+    max-width: 800px;
+    margin: 0 auto;
+}

--- a/samples/highcharts/boost/line-data-color/demo.details
+++ b/samples/highcharts/boost/line-data-color/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Dawid Dragula
+ js_wrap: b
+...

--- a/samples/highcharts/boost/line-data-color/demo.html
+++ b/samples/highcharts/boost/line-data-color/demo.html
@@ -1,0 +1,4 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/boost.js"></script>
+
+<div id="container"></div>

--- a/samples/highcharts/boost/line-data-color/demo.js
+++ b/samples/highcharts/boost/line-data-color/demo.js
@@ -1,0 +1,25 @@
+console.time('line');
+Highcharts.chart('container', {
+    title: {
+        text: 'Boosted line chart with individually colored data'
+    },
+    plotOptions: {
+        series: {
+            boostThreshold: 1
+        }
+    },
+    series: [{
+        data: Array.from({ length: 30 }, (_, i) => ({
+            x: i,
+            y: i,
+            color: i % 2 === 0 ? '#00f' : '#f0f'
+        }))
+    }, {
+        data: Array.from({ length: 30 }, (_, i) => ({
+            x: -i,
+            y: -i,
+            color: i % 3 === 0 ? '#ff0' : '#f00'
+        }))
+    }]
+});
+console.timeEnd('line');

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -1434,7 +1434,13 @@ class WGLRenderer {
             if (s.colorData.length > 0) {
                 shader.setUniform('hasColor', 1);
                 cbuffer = new WGLVertexBuffer(gl, shader);
-                cbuffer.build(s.colorData, 'aColor', 4);
+                cbuffer.build(
+                    // The color array attribute for vertex is assigned from 0,
+                    // so it needs to be shifted to be applied to further
+                    // segments. #18858
+                    Array(s.segments[0].from).concat(s.colorData),
+                    'aColor', 4
+                );
                 cbuffer.bind();
             } else {
                 // Set the hasColor uniform to false (0) when the series

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -1432,11 +1432,15 @@ class WGLRenderer {
 
             // If there are entries in the colorData buffer, build and bind it.
             if (s.colorData.length > 0) {
-                shader.setUniform('hasColor', 1.0);
+                shader.setUniform('hasColor', 1);
                 cbuffer = new WGLVertexBuffer(gl, shader);
                 cbuffer.build(s.colorData, 'aColor', 4);
                 cbuffer.bind();
             } else {
+                // Set the hasColor uniform to false (0) when the series
+                // contains no colorData buffer points. #18858
+                shader.setUniform('hasColor', 0);
+
                 // #15869, a buffer with fewer points might already be bound by
                 // a different series/chart causing out of range errors
                 gl.disableVertexAttribArray(


### PR DESCRIPTION
Fixed #18858, invisible series when point color was set in the chart boost mode.