### PR TITLE
Fixed sync-aliases demo, added trim of headers

### DIFF
--- a/samples/dashboards/issues/sync-aliases/demo.js
+++ b/samples/dashboards/issues/sync-aliases/demo.js
@@ -58,7 +58,9 @@ Dashboards.board('container', {
         cell: 'dashboard-col-0',
         type: 'Highcharts',
         columnAssignment: {
-            Date: 'x'
+            Date: 'x',
+            air: 'y',
+            water: 'y'
         },
         chartOptions: {
             chart: {

--- a/test/typescript-karma/Data/Connectors/CSVConnector.test.js
+++ b/test/typescript-karma/Data/Connectors/CSVConnector.test.js
@@ -57,6 +57,34 @@ test('CSVConnector from string', async (assert) => {
     assert.ok(!foundComment, 'Comment is not added to the dataTable');
 });
 
+test('CSVConnector from string, spaces in header', async (assert) =>{
+    const csv = `Number, Letter, Color
+1, B, Red`;
+
+    const connector = new CSVConnector({ csv });
+    await connector.load();
+
+    assert.deepEqual(
+        connector.table.getColumnNames(),
+        ['Number', 'Letter', 'Color'],
+        'DataTable headers are trimmed of whitespace'
+    );
+})
+
+test('CSVConnector from string, quoted spaces in header', async (assert) =>{
+    const csv = `" Number"," Letter"," Color"
+"1","B","Red"`;
+
+    const connector = new CSVConnector({ csv });
+    await connector.load();
+
+    assert.deepEqual(
+        connector.table.getColumnNames(),
+        [' Number', ' Letter', ' Color'],
+        'Quoted DataTable headers are not trimmed of whitespace'
+    );
+})
+
 test('CSVConnector from string, with decimalpoint option', async (assert) => {
     const csv = 'Date;Value\n2016-01-01;1,100\n2016-01-02;2,000\n2016-01-03;3,000';
 

--- a/ts/Data/Converters/CSVConverter.ts
+++ b/ts/Data/Converters/CSVConverter.ts
@@ -278,7 +278,7 @@ class CSVConverter extends DataConverter {
 
                 // Remove ""s from the headers
                 for (let i = 0; i < headers.length; i++) {
-                    headers[i] = headers[i].replace(/^["']|["']$/g, '');
+                    headers[i] = headers[i].trim().replace(/^["']|["']$/g, '');
                 }
 
                 converter.headers = headers;


### PR DESCRIPTION
Fixed whitespaces not being removed from names when using CSVConnector with `firstRowAsNames` enabled