### PR TITLE
feature/19096-sankey-nodes-alignment

### DIFF
--- a/samples/highcharts/plotoptions/sankey-nodealignment/demo.css
+++ b/samples/highcharts/plotoptions/sankey-nodealignment/demo.css
@@ -1,0 +1,30 @@
+* {
+    user-select: none;
+}
+
+#outer-container {
+    min-width: 300px;
+    max-width: 600px;
+    margin: 1em auto;
+}
+
+#outer-container .input-group {
+    padding-right: 2em;
+    padding-bottom: 4px;
+}
+
+#outer-container button,
+input {
+    padding: 1em;
+    border: 0;
+    border-radius: 2px;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+#container {
+    height: 400px;
+    box-shadow: 1px 2px 5px rgba(0 0 0 / 0.2);
+    margin: 1rem 0;
+    padding-right: 1%;
+}

--- a/samples/highcharts/plotoptions/sankey-nodealignment/demo.details
+++ b/samples/highcharts/plotoptions/sankey-nodealignment/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Dawid Dragula
+ js_wrap: b
+...

--- a/samples/highcharts/plotoptions/sankey-nodealignment/demo.html
+++ b/samples/highcharts/plotoptions/sankey-nodealignment/demo.html
@@ -1,0 +1,28 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/sankey.js"></script>
+<script src="https://code.highcharts.com/modules/organization.js"></script>
+<script src="https://code.highcharts.com/modules/accessibility.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
+
+<div id="outer-container">
+
+    <span class="input-group">
+        <button class="node-alignment" data-value="top">Align Top</button>
+        <button class="node-alignment" data-value="center">Align Center</button>
+        <button class="node-alignment" data-value="bottom">Align Bottom</button>
+    </span>
+
+    <div id="container"></div>
+
+    <span class="input-group">
+        <button class="type" data-value="sankey">Sankey</button>
+        <button class="type" data-value="organization">Organization</button>
+    </span>
+
+    <span class="input-group">
+      <input type="checkbox" id="inverted" />
+      <label for="inverted">Inverted Chart</label>
+    </span>
+
+</div>
+

--- a/samples/highcharts/plotoptions/sankey-nodealignment/demo.js
+++ b/samples/highcharts/plotoptions/sankey-nodealignment/demo.js
@@ -1,0 +1,50 @@
+Highcharts.chart('container', {
+    chart: {
+        type: 'sankey'
+    },
+    title: {
+        text: 'nodeAlignment: \'top\''
+    },
+    series: [{
+        nodeAlignment: 'top',
+        keys: ['from', 'to', 'weight'],
+        data: [
+            ['A1', 'B1', 1],
+            ['A1', 'B2', 4],
+            ['A2', 'B2', 5],
+            ['A2', 'B3', 2],
+            ['B2', 'C1', 6],
+            ['B2', 'C2', 8],
+            ['C2', 'D1', 2]
+        ]
+    }]
+});
+
+document.querySelectorAll('button.node-alignment').forEach(btn => {
+    btn.addEventListener('click', () => {
+        Highcharts.charts[0].series[0].update({
+            nodeAlignment: btn.dataset.value
+        });
+        Highcharts.charts[0].title.update({
+            text: `nodeAlignment: '${btn.dataset.value}'`
+        });
+    });
+});
+
+document.querySelectorAll('button.type').forEach(btn => {
+    btn.addEventListener('click', () => {
+        Highcharts.charts[0].update({
+            chart: {
+                type: btn.dataset.value
+            }
+        });
+    });
+});
+
+document.getElementById('inverted').addEventListener('change', e => {
+    Highcharts.charts[0].update({
+        chart: {
+            inverted: e.target.checked
+        }
+    }, true, true, false);
+});

--- a/samples/unit-tests/series-sankey/sankey/demo.js
+++ b/samples/unit-tests/series-sankey/sankey/demo.js
@@ -133,6 +133,35 @@ QUnit.test('Sankey', function (assert) {
         `Border radius should not greater than half the height of the node,
         small nodes shouldn't be rendered as circles (#18956).`
     );
+
+    const lastNode = series.nodeColumns[2][0];
+
+    assert.close(
+        lastNode.nodeY,
+        (chart.plotHeight - lastNode.graphic.height) / 2,
+        2,
+        'Center-aligned nodes should be in the correct y-position. (#19096)'
+    );
+
+    series.update({
+        nodeAlignment: 'top'
+    });
+
+    assert.strictEqual(
+        lastNode.nodeY,
+        0,
+        'Top-aligned nodes should be in the correct y-position. (#19096)'
+    );
+
+    series.update({
+        nodeAlignment: 'bottom'
+    });
+
+    assert.strictEqual(
+        lastNode.nodeY,
+        chart.plotHeight - lastNode.graphic.height,
+        'Bottom-aligned nodes should be in the correct y-position. (#19096)'
+    );
 });
 
 QUnit.test('Sankey nodeFormat, nodeFormatter', function (assert) {

--- a/ts/Series/ArcDiagram/ArcDiagramSeries.ts
+++ b/ts/Series/ArcDiagram/ArcDiagramSeries.ts
@@ -73,10 +73,11 @@ class ArcDiagramSeries extends SankeySeries {
      * @product      highcharts
      * @requires     modules/arc-diagram
      * @exclude      curveFactor, connectEnds, connectNulls, colorAxis, colorKey,
-     *               dataSorting, dragDrop, getExtremesFromAll, nodePadding,
-     *               centerInCategory, pointInterval, pointIntervalUnit,
-     *               pointPlacement, pointStart, relativeXValue, softThreshold,
-     *               stack, stacking, step, xAxis, yAxis
+     *               dataSorting, dragDrop, getExtremesFromAll, nodeAlignment,
+     *               nodePadding, centerInCategory, pointInterval,
+     *               pointIntervalUnit, pointPlacement, pointStart,
+     *               relativeXValue, softThreshold, stack, stacking, step,
+     *               xAxis, yAxis
      * @optionparent plotOptions.arcdiagram
      */
     public static defaultOptions: ArcDiagramSeriesOptions = merge(SankeySeries.defaultOptions, {

--- a/ts/Series/DependencyWheel/DependencyWheelSeriesDefaults.ts
+++ b/ts/Series/DependencyWheel/DependencyWheelSeriesDefaults.ts
@@ -34,7 +34,7 @@ import type DependencyWheelSeriesOptions from './DependencyWheelSeriesOptions';
  *         Dependency wheel
  *
  * @extends      plotOptions.sankey
- * @exclude      dataSorting
+ * @exclude      dataSorting, nodeAlignment
  * @since        7.1.0
  * @product      highcharts
  * @requires     modules/dependency-wheel

--- a/ts/Series/Sankey/SankeyColumnComposition.ts
+++ b/ts/Series/Sankey/SankeyColumnComposition.ts
@@ -152,14 +152,13 @@ namespace SankeyColumnComposition {
             }, 0);
 
             // Node alignment option handling #19096
-            switch (series.options.nodeAlignment) {
-                case 'top':
-                    return 0;
-                case 'bottom':
-                    return (series.chart.plotSizeY || 0) - height;
-                default:
-                    return ((series.chart.plotSizeY || 0) - height) / 2;
-            }
+            return {
+                top: 0,
+                center: 0.5,
+                bottom: 1
+            }[series.options.nodeAlignment || 'center'] * (
+                (series.chart.plotSizeY || 0) - height
+            );
         }
 
 

--- a/ts/Series/Sankey/SankeyColumnComposition.ts
+++ b/ts/Series/Sankey/SankeyColumnComposition.ts
@@ -150,7 +150,16 @@ namespace SankeyColumnComposition {
                 height += nodeHeight;
                 return height;
             }, 0);
-            return ((series.chart.plotSizeY || 0) - height) / 2;
+
+            // Node alignment option handling #19096
+            switch (series.options.nodeAlignment) {
+                case 'top':
+                    return 0;
+                case 'bottom':
+                    return (series.chart.plotSizeY || 0) - height;
+                default:
+                    return ((series.chart.plotSizeY || 0) - height) / 2;
+            }
         }
 
 

--- a/ts/Series/Sankey/SankeySeriesDefaults.ts
+++ b/ts/Series/Sankey/SankeySeriesDefaults.ts
@@ -244,6 +244,14 @@ const SankeySeriesDefaults: PlotOptionsOf<SankeySeries> = {
     minLinkWidth: 0,
 
     /**
+     * Determines which side of the chart the nodes are to be aligned to.
+     *
+     * @type      {'top'|'center'|'bottom'}
+     * @apioption plotOptions.sankey.nodeAlignemt
+     */
+    nodeAlignment: 'center',
+
+    /**
      * The pixel width of each node in a sankey diagram or dependency wheel,
      * or the height in case the chart is inverted.
      *

--- a/ts/Series/Sankey/SankeySeriesDefaults.ts
+++ b/ts/Series/Sankey/SankeySeriesDefaults.ts
@@ -244,7 +244,9 @@ const SankeySeriesDefaults: PlotOptionsOf<SankeySeries> = {
     minLinkWidth: 0,
 
     /**
-     * Determines which side of the chart the nodes are to be aligned to.
+     * Determines which side of the chart the nodes are to be aligned to. When
+     * the chart is inverted, `top` aligns to the left and `bottom` to the
+     * right.
      *
      * @sample highcharts/plotoptions/sankey-nodealignment
      *         Node alignment demonstrated

--- a/ts/Series/Sankey/SankeySeriesDefaults.ts
+++ b/ts/Series/Sankey/SankeySeriesDefaults.ts
@@ -246,8 +246,11 @@ const SankeySeriesDefaults: PlotOptionsOf<SankeySeries> = {
     /**
      * Determines which side of the chart the nodes are to be aligned to.
      *
+     * @sample highcharts/plotoptions/sankey-nodealignment
+     *         Node alignment demonstrated
+     *
      * @type      {'top'|'center'|'bottom'}
-     * @apioption plotOptions.sankey.nodeAlignemt
+     * @apioption plotOptions.sankey.nodeAlignment
      */
     nodeAlignment: 'center',
 

--- a/ts/Series/Sankey/SankeySeriesOptions.d.ts
+++ b/ts/Series/Sankey/SankeySeriesOptions.d.ts
@@ -63,6 +63,7 @@ export interface SankeySeriesOptions extends ColumnSeriesOptions, NodesCompositi
     linkOpacity?: number;
     mass?: undefined;
     minLinkWidth?: number;
+    nodeAlignment?: ('top'|'center'|'bottom')
     nodePadding?: number;
     nodes?: Array<SankeySeriesNodeOptions>;
     nodeWidth?: number;


### PR DESCRIPTION
Added the [nodeAlignment](https://api.highcharts.com/highcharts/series.sankey.nodeAlignment) option for the Sankey series to specify the side of a chart nodes should align.

---
TO DO:
- [x] Add and implement the option.
- [x] Check and, if necessary, disable the option in the children series.
- [x] Add regression tests.
- [x] Add a demo.

Closes #19096.