### PR TITLE
bugfix/19518-classname-api-incorrect-link

### DIFF
--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -200,6 +200,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
      * chart's legend and tooltip.
      *
      * @sample {highcharts} highcharts/css/point-series-classname
+     *         Series and point class name
      *
      * @type      {string}
      * @since     5.0.0

--- a/ts/Series/Line/LineSeries.ts
+++ b/ts/Series/Line/LineSeries.ts
@@ -531,6 +531,7 @@ export default LineSeries;
  * chart's legend and tooltip.
  *
  * @sample {highcharts} highcharts/css/point-series-classname
+ *         Series and point class name
  *
  * @type      {string}
  * @since     5.0.0


### PR DESCRIPTION
Fixed #19518, incorrect link in API for `series.className` and `series.line.data.className` caused by missing description.