### PR TITLE
demo/19322-negative-logarithm-tick-interval

### DIFF
--- a/samples/highcharts/yaxis/type-log-negative/demo.js
+++ b/samples/highcharts/yaxis/type-log-negative/demo.js
@@ -4,6 +4,10 @@
  * logarithmic axis never reaches or crosses zero.
  */
 (function (H) {
+    /* eslint-disable no-underscore-dangle */
+    const logAdditions =
+        H._modules['Core/Axis/LogarithmicAxis.js'].Additions.prototype;
+
     H.addEvent(H.Axis, 'afterInit', function () {
         const logarithmic = this.logarithmic;
 
@@ -37,6 +41,132 @@
             };
         }
     });
+
+    // Add support for negative axis values to the tick positioning function.
+    logAdditions.getLogTickPositions = function (interval, min, max, minor) {
+        const log = this,
+            axis = log.axis,
+            axisLength = axis.len,
+            options = axis.options;
+        let positions = [];
+
+        if (!minor) {
+            log.minorAutoInterval = void 0;
+        }
+
+        if (interval >= 0.5) {
+            interval = Math.round(interval);
+            positions = axis.getLinearTickPositions(interval, min, max);
+        } else if (interval >= 0.08) {
+            const roundedMin = Math.floor(min);
+            let intermediate,
+                i,
+                j,
+                len,
+                pos,
+                lastPos,
+                break2;
+
+            if (interval > 0.3) {
+                intermediate = [1, 2, 4];
+            } else if (interval > 0.15) {
+                intermediate = [1, 2, 4, 6, 8];
+            } else {
+                intermediate = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+            }
+
+            for (i = roundedMin; i < max + 1 && !break2; i++) {
+                len = intermediate.length;
+                if (options.custom.allowNegativeLog) {
+                    if (i <= 0) {
+                        for (j = len - 1; j >= 0 && !break2; j--) {
+                            pos = -log.log2lin(
+                                (log.lin2log(-i) || 1) * intermediate[j]
+                            );
+
+                            if (pos > min &&
+                                (!minor || lastPos <= max) &&
+                                typeof lastPos !== 'undefined') {
+                                positions.push(lastPos);
+                            }
+                            if (lastPos > max) {
+                                break2 = true;
+                            }
+                            lastPos = pos;
+                        }
+
+                        if (lastPos < min || lastPos > max) {
+                            lastPos = undefined;
+                        }
+                    }
+
+                    if (i === 0 && min <= 0 && max >= 0) {
+                        positions.push(0);
+                    }
+
+                    if (i >= 0) {
+                        for (j = 0; j < len && !break2; j++) {
+                            pos = log.log2lin(
+                                (log.lin2log(i) || 1) * intermediate[j]
+                            );
+
+                            if (pos > min &&
+                                (!minor || lastPos <= max) &&
+                                typeof lastPos !== 'undefined') {
+                                positions.push(lastPos);
+                            }
+                            if (lastPos > max) {
+                                break2 = true;
+                            }
+                            lastPos = pos;
+                        }
+                    }
+                } else {
+                    for (j = 0; j < len && !break2; j++) {
+                        pos = log.log2lin(log.lin2log(i) * intermediate[j]);
+                        if (pos > min &&
+                            (!minor || lastPos <= max) &&
+                            typeof lastPos !== 'undefined') {
+                            positions.push(lastPos);
+                        }
+                        if (lastPos > max) {
+                            break2 = true;
+                        }
+                        lastPos = pos;
+                    }
+                }
+            }
+        } else {
+            const realMin = log.lin2log(min),
+                realMax = log.lin2log(max),
+                tickIntervalOption =
+                    minor ? axis.getMinorTickInterval() : options.tickInterval,
+                filteredTickIntervalOption =
+                    tickIntervalOption === 'auto' ? null : tickIntervalOption,
+                tickPixelIntervalOption =
+                    options.tickPixelInterval / (minor ? 5 : 1),
+                totalPixelLength =
+                    minor ? axisLength / axis.tickPositions.length : axisLength;
+
+            interval = H.pick(
+                filteredTickIntervalOption,
+                log.minorAutoInterval,
+                (realMax - realMin) * tickPixelIntervalOption /
+                (totalPixelLength || 1)
+            );
+            interval = H.normalizeTickInterval(interval);
+            positions = axis.getLinearTickPositions(interval, realMin, realMax)
+                .map(log.log2lin);
+
+            if (!minor) {
+                log.minorAutoInterval = interval / 5;
+            }
+        }
+        if (!minor) {
+            axis.tickInterval = interval;
+        }
+        return positions;
+    };
 }(Highcharts));
 
 

--- a/samples/highcharts/yaxis/type-log-negative/demo.js
+++ b/samples/highcharts/yaxis/type-log-negative/demo.js
@@ -43,130 +43,88 @@
     });
 
     // Add support for negative axis values to the tick positioning function.
-    logAdditions.getLogTickPositions = function (interval, min, max, minor) {
-        const log = this,
-            axis = log.axis,
-            axisLength = axis.len,
-            options = axis.options;
-        let positions = [];
-
-        if (!minor) {
-            log.minorAutoInterval = void 0;
+    H.wrap(logAdditions, 'getLogTickPositions', function (
+        proceed,
+        interval,
+        min,
+        max,
+        minor
+    ) {
+        if (
+            !this.axis.options.custom.allowNegativeLog ||
+            interval >= 0.5 ||
+            interval < 0.08
+        ) {
+            return proceed.call(this, interval, min, max, minor);
         }
 
-        if (interval >= 0.5) {
-            interval = Math.round(interval);
-            positions = axis.getLinearTickPositions(interval, min, max);
-        } else if (interval >= 0.08) {
-            const roundedMin = Math.floor(min);
-            let intermediate,
-                i,
-                j,
-                len,
-                pos,
-                lastPos,
-                break2;
+        const log = this,
+            roundedMin = Math.floor(min),
+            positions = [];
+        let intermediate,
+            i,
+            j,
+            len,
+            pos,
+            lastPos,
+            break2;
 
-            if (interval > 0.3) {
-                intermediate = [1, 2, 4];
-            } else if (interval > 0.15) {
-                intermediate = [1, 2, 4, 6, 8];
-            } else {
-                intermediate = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-            }
+        if (interval > 0.3) {
+            intermediate = [1, 2, 4];
+        } else if (interval > 0.15) {
+            intermediate = [1, 2, 4, 6, 8];
+        } else {
+            intermediate = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+        }
 
-            for (i = roundedMin; i < max + 1 && !break2; i++) {
-                len = intermediate.length;
-                if (options.custom.allowNegativeLog) {
-                    if (i <= 0) {
-                        for (j = len - 1; j >= 0 && !break2; j--) {
-                            pos = -log.log2lin(
-                                (log.lin2log(-i) || 1) * intermediate[j]
-                            );
+        for (i = roundedMin; i < max + 1 && !break2; i++) {
+            len = intermediate.length;
+            if (i <= 0) {
+                for (j = len - 1; j >= 0 && !break2; j--) {
+                    pos = -log.log2lin(
+                        (log.lin2log(-i) || 1) * intermediate[j]
+                    );
 
-                            if (pos > min &&
-                                (!minor || lastPos <= max) &&
-                                typeof lastPos !== 'undefined') {
-                                positions.push(lastPos);
-                            }
-                            if (lastPos > max) {
-                                break2 = true;
-                            }
-                            lastPos = pos;
-                        }
-
-                        if (lastPos < min || lastPos > max) {
-                            lastPos = undefined;
-                        }
+                    if (pos > min &&
+                        (!minor || lastPos <= max) &&
+                        typeof lastPos !== 'undefined') {
+                        positions.push(lastPos);
                     }
-
-                    if (i === 0 && min <= 0 && max >= 0) {
-                        positions.push(0);
+                    if (lastPos > max) {
+                        break2 = true;
                     }
+                    lastPos = pos;
+                }
 
-                    if (i >= 0) {
-                        for (j = 0; j < len && !break2; j++) {
-                            pos = log.log2lin(
-                                (log.lin2log(i) || 1) * intermediate[j]
-                            );
-
-                            if (pos > min &&
-                                (!minor || lastPos <= max) &&
-                                typeof lastPos !== 'undefined') {
-                                positions.push(lastPos);
-                            }
-                            if (lastPos > max) {
-                                break2 = true;
-                            }
-                            lastPos = pos;
-                        }
-                    }
-                } else {
-                    for (j = 0; j < len && !break2; j++) {
-                        pos = log.log2lin(log.lin2log(i) * intermediate[j]);
-                        if (pos > min &&
-                            (!minor || lastPos <= max) &&
-                            typeof lastPos !== 'undefined') {
-                            positions.push(lastPos);
-                        }
-                        if (lastPos > max) {
-                            break2 = true;
-                        }
-                        lastPos = pos;
-                    }
+                if (lastPos < min || lastPos > max) {
+                    lastPos = undefined;
                 }
             }
-        } else {
-            const realMin = log.lin2log(min),
-                realMax = log.lin2log(max),
-                tickIntervalOption =
-                    minor ? axis.getMinorTickInterval() : options.tickInterval,
-                filteredTickIntervalOption =
-                    tickIntervalOption === 'auto' ? null : tickIntervalOption,
-                tickPixelIntervalOption =
-                    options.tickPixelInterval / (minor ? 5 : 1),
-                totalPixelLength =
-                    minor ? axisLength / axis.tickPositions.length : axisLength;
 
-            interval = H.pick(
-                filteredTickIntervalOption,
-                log.minorAutoInterval,
-                (realMax - realMin) * tickPixelIntervalOption /
-                (totalPixelLength || 1)
-            );
-            interval = H.normalizeTickInterval(interval);
-            positions = axis.getLinearTickPositions(interval, realMin, realMax)
-                .map(log.log2lin);
+            if (i === 0 && min <= 0 && max >= 0) {
+                positions.push(0);
+            }
 
-            if (!minor) {
-                log.minorAutoInterval = interval / 5;
+            if (i >= 0) {
+                for (j = 0; j < len && !break2; j++) {
+                    pos = log.log2lin((log.lin2log(i) || 1) * intermediate[j]);
+
+                    if (pos > min &&
+                        (!minor || lastPos <= max) &&
+                        typeof lastPos !== 'undefined') {
+                        positions.push(lastPos);
+                    }
+                    if (lastPos > max) {
+                        break2 = true;
+                    }
+                    lastPos = pos;
+                }
             }
         }
-        if (!minor) {
-            axis.tickInterval = interval;
-        }
+
         return positions;
-    };
+    });
+
 }(Highcharts));
 
 


### PR DESCRIPTION
Added the ability to set a custom `tickInterval` to the [negative logarithmic axis demo](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/yaxis/type-log-negative/). Closes #19322.