### PR TITLE
bugfix/19374-keyboardNavigation-exit-anchor-removal

### DIFF
--- a/samples/unit-tests/accessibility/accessibility-options/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-options/demo.js
@@ -97,6 +97,11 @@ QUnit.test('Keyboard nav disabled', function (assert) {
         chart.container.getAttribute('tabindex'),
         'There is no tabindex on container'
     );
+
+    assert.ok(
+        !document.querySelector('.highcharts-exit-anchor'),
+        'The exit anchor element shouldn\'t be rendered (#19374).'
+    );
 });
 
 QUnit.test('No data', function (assert) {

--- a/ts/Accessibility/Components/InfoRegionsComponent.ts
+++ b/ts/Accessibility/Components/InfoRegionsComponent.ts
@@ -286,7 +286,8 @@ class InfoRegionsComponent extends AccessibilityComponent {
      * @private
      */
     public initRegionsDefinitions(): void {
-        const component = this;
+        const component = this,
+            accessibilityOptions = this.chart.options.accessibility;
 
         this.screenReaderSections = {
             before: {
@@ -296,8 +297,8 @@ class InfoRegionsComponent extends AccessibilityComponent {
                 ): string {
                     const formatter: (
                         ScreenReaderFormatterCallbackFunction<Chart>|undefined
-                    ) = chart.options.accessibility
-                        .screenReaderSection.beforeChartFormatter;
+                    ) = accessibilityOptions.screenReaderSection
+                        .beforeChartFormatter;
                     return formatter ? formatter(chart) :
                         (component.defaultBeforeChartFormatter as any)(chart);
                 },
@@ -326,8 +327,7 @@ class InfoRegionsComponent extends AccessibilityComponent {
                 buildContent: function (
                     chart: Accessibility.ChartComposition
                 ): string {
-                    const formatter = chart.options.accessibility
-                        .screenReaderSection
+                    const formatter = accessibilityOptions.screenReaderSection
                         .afterChartFormatter;
                     return formatter ? formatter(chart) :
                         component.defaultAfterChartFormatter();
@@ -341,7 +341,10 @@ class InfoRegionsComponent extends AccessibilityComponent {
                     );
                 },
                 afterInserted: function (): void {
-                    if (component.chart.accessibility) {
+                    if (
+                        component.chart.accessibility &&
+                        accessibilityOptions.keyboardNavigation.enabled
+                    ) {
                         component.chart.accessibility
                             .keyboardNavigation.updateExitAnchor(); // #15986
                     }


### PR DESCRIPTION
Fixed #19374, disabled `keyboardNavigation` didn't remove the exit anchor.