### PR TITLE
Fixed #19488, plot line label not correctly aligned with useHTML

### DIFF
--- a/samples/unit-tests/plotbandslines/plotbandslines/demo.js
+++ b/samples/unit-tests/plotbandslines/plotbandslines/demo.js
@@ -1,4 +1,4 @@
-QUnit.test('Plot band labels outside plot area (#3983)', function (assert) {
+QUnit.test('Plot band labels', function (assert) {
     var chart,
         options = {
             chart: {
@@ -31,6 +31,27 @@ QUnit.test('Plot band labels outside plot area (#3983)', function (assert) {
                         }
                     }
                 ]
+            },
+
+            yAxis: {
+                plotLines: [{
+                    value: 4,
+                    label: {
+                        text: 'Big text',
+                        useHTML: true,
+                        style: {
+                            fontSize: '2em'
+                        },
+                        align: 'right'
+                    }
+                }, {
+                    value: 5,
+                    label: {
+                        text: 'Small text',
+                        useHTML: true,
+                        align: 'right'
+                    }
+                }]
             },
 
             series: [
@@ -66,17 +87,29 @@ QUnit.test('Plot band labels outside plot area (#3983)', function (assert) {
     assert.equal(
         typeof chart.xAxis[0].plotLinesAndBands[0].label,
         'undefined',
-        'Highcharts - before'
+        'Label less than x axis should not be rendered'
     );
     assert.equal(
         typeof chart.xAxis[0].plotLinesAndBands[1].label,
         'object',
-        'Highcharts - within'
+        'Label within x axis should be rendered'
     );
     assert.equal(
         typeof chart.xAxis[0].plotLinesAndBands[2].label,
         'undefined',
-        'Highcharts - after'
+        'Label greater than x axis should not be rendered'
+    );
+
+
+    assert.close(
+        chart.yAxis[0].plotLinesAndBands[0].label.element
+            .getBoundingClientRect()
+            .right,
+        chart.yAxis[0].plotLinesAndBands[1].label.element
+            .getBoundingClientRect()
+            .right,
+        1,
+        'Font size should be considered when laying out label (#19488)'
     );
 });
 

--- a/samples/unit-tests/plotbandslines/plotbandslines/demo.js
+++ b/samples/unit-tests/plotbandslines/plotbandslines/demo.js
@@ -100,7 +100,6 @@ QUnit.test('Plot band labels', function (assert) {
         'Label greater than x axis should not be rendered'
     );
 
-
     assert.close(
         chart.yAxis[0].plotLinesAndBands[0].label.element
             .getBoundingClientRect()

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -298,7 +298,7 @@ class PlotLineOrBand {
 
         let label = plotLine.label;
 
-        // add the SVG element
+        // Add the SVG element
         if (!label) {
             /**
              * SVG element of the label.
@@ -319,8 +319,7 @@ class PlotLineOrBand {
                     'class': 'highcharts-plot-' + (isBand ? 'band' : 'line') +
                         '-label ' + ((optionsLabel as any).className || ''),
                     zIndex
-                })
-                .add();
+                });
 
             if (!axis.chart.styledMode) {
                 label.css(merge({
@@ -328,9 +327,11 @@ class PlotLineOrBand {
                     textOverflow: 'ellipsis'
                 }, optionsLabel.style));
             }
+
+            label.add();
         }
 
-        // get the bounding box and align the label
+        // Get the bounding box and align the label
         // #3000 changed to better handle choice between plotband or plotline
         const xBounds = (path as any).xBounds ||
             [path[0][1], path[1][1], (isBand ? path[2][1] : path[0][1])];


### PR DESCRIPTION
Fixed #19488, plot line label not correctly aligned when `useHTML` was true.