### PR TITLE
dash/highcharts-types

### DIFF
--- a/test/typescript-dts/dashboards/tsconfig.json
+++ b/test/typescript-dts/dashboards/tsconfig.json
@@ -13,7 +13,9 @@
         "lib": ["es5", "dom"],
         "paths": {
             "@highcharts/dashboards": ["code/dashboards/dashboards"],
-            "@highcharts/dashboards/*": ["code/dashboards/*"]
+            "@highcharts/dashboards/*": ["code/dashboards/*"],
+            "highcharts": ["code/highcharts.src"],
+            "highcharts/*": ["code/*"]
         },
         "types": []
     },

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1657,7 +1657,7 @@ namespace Point {
         total?: number;
     }
     export interface SeriesPointsOptions {
-        events?: Highcharts.PointEventsOptionsObject;
+        events?: Record<string, Function>;
     }
     export interface UpdateCallbackFunction {
         (this: Point, event: UpdateEventObject): void;

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1657,7 +1657,7 @@ namespace Point {
         total?: number;
     }
     export interface SeriesPointsOptions {
-        events?: Record<string, Function>;
+        events?: PointEventsOptions;
     }
     export interface UpdateCallbackFunction {
         (this: Point, event: UpdateEventObject): void;

--- a/ts/Core/Series/PointOptions.d.ts
+++ b/ts/Core/Series/PointOptions.d.ts
@@ -49,6 +49,9 @@ export interface PointClickEvent extends PointerEvent {
  */
 export interface PointEventsOptions {
     click?: EventCallback<Point, PointClickEvent>;
+    drag?: EventCallback<Point, AnyRecord>;
+    dragStart?: EventCallback<Point, (MouseEvent&AnyRecord)>;
+    drop?: EventCallback<Point, AnyRecord>;
     mouseOut?: EventCallback<Point, PointerEvent>;
     mouseOver?: EventCallback<Point, PointerEvent>;
     remove?: EventCallback<Point, Event>;

--- a/ts/Dashboards/Components/Component.ts
+++ b/ts/Dashboards/Components/Component.ts
@@ -29,7 +29,6 @@ import type {
     ComponentType,
     ComponentTypeRegistry
 } from './ComponentType';
-import type Globals from '../Globals';
 import type JSON from '../JSON';
 import type Serializable from '../Serializable';
 import type DataModifier from '../../Data/Modifiers/DataModifier';
@@ -45,6 +44,7 @@ const {
 } = DG;
 import DataTable from '../../Data/DataTable.js';
 import EditableOptions from './EditableOptions.js';
+import Globals from '../Globals.js';
 import U from '../../Core/Utilities.js';
 const {
     createElement,
@@ -532,13 +532,16 @@ abstract class Component {
                     this.tableEvents.push((table)
                         .on(event, (e: any): void => {
                             clearInterval(this.tableEventTimeout);
-                            this.tableEventTimeout = setTimeout((): void => {
-                                this.emit({
-                                    ...e,
-                                    type: 'tableChanged'
-                                });
-                                this.tableEventTimeout = void 0;
-                            }, 0);
+                            this.tableEventTimeout = Globals.win.setTimeout(
+                                (): void => {
+                                    this.emit({
+                                        ...e,
+                                        type: 'tableChanged'
+                                    });
+                                    this.tableEventTimeout = void 0;
+                                },
+                                0
+                            );
                         }));
                 });
             }

--- a/ts/Dashboards/Components/Component.ts
+++ b/ts/Dashboards/Components/Component.ts
@@ -38,13 +38,10 @@ import type Row from '../Layout/Row';
 
 import CallbackRegistry from '../CallbackRegistry.js';
 import DataConnector from '../../Data/Connectors/DataConnector.js';
-import DG from '../Globals.js';
-const {
-    classNamePrefix
-} = DG;
 import DataTable from '../../Data/DataTable.js';
 import EditableOptions from './EditableOptions.js';
 import Globals from '../Globals.js';
+const { classNamePrefix } = Globals;
 import U from '../../Core/Utilities.js';
 const {
     createElement,

--- a/ts/Dashboards/Components/KPIComponent.ts
+++ b/ts/Dashboards/Components/KPIComponent.ts
@@ -27,7 +27,7 @@ import type CSSObject from '../../Core/Renderer/CSSObject';
 import type {
     Chart,
     Options,
-    Highcharts
+    Highcharts as H
 } from '../Plugins/HighchartsTypes';
 import type TextOptions from './TextOptions';
 import type Types from '../../Shared/Types';
@@ -113,7 +113,7 @@ class KPIComponent extends Component {
      * */
 
     /** @internal */
-    public static charter?: typeof Highcharts;
+    public static charter?: H;
     /**
      * Default options of the KPI component.
      */
@@ -440,7 +440,7 @@ class KPIComponent extends Component {
                 value = value.toLocaleString();
             }
 
-            AST.setElementHTML(this.value, value);
+            AST.setElementHTML(this.value, '' + value);
 
             this.prevValue = prevValue;
         }

--- a/ts/Dashboards/EditMode/SidebarPopup.ts
+++ b/ts/Dashboards/EditMode/SidebarPopup.ts
@@ -18,13 +18,13 @@
  *  Imports
  *
  * */
-import type EditMode from './EditMode';
 import type Cell from '../Layout/Cell';
 import type ComponentType from '../Components/ComponentType';
-import type Row from '../Layout/Row';
 import type DataGridComponent from '../Plugins/DataGridComponent';
-import type KPIComponent from '../Components/KPIComponent';
+import type EditMode from './EditMode';
 import type HighchartsComponent from '../Plugins/HighchartsComponent';
+import type KPIComponent from '../Components/KPIComponent';
+import type Row from '../Layout/Row';
 
 import AccordionMenu from './AccordionMenu.js';
 import BaseForm from '../../Shared/BaseForm.js';
@@ -138,7 +138,8 @@ class SidebarPopup extends BaseForm {
                         chartOptions: {
                             chart: {
                                 animation: false,
-                                type: 'column'
+                                type: 'column',
+                                zooming: {}
                             }
                         }
                     };

--- a/ts/Dashboards/Plugins/HighchartsComponent.ts
+++ b/ts/Dashboards/Plugins/HighchartsComponent.ts
@@ -46,12 +46,12 @@ import U from '../../Core/Utilities.js';
 const {
     addEvent,
     createElement,
-    merge,
-    splat,
-    uniqueKey,
     error,
     diffObjects,
-    isString
+    isString,
+    merge,
+    splat,
+    uniqueKey
 } = U;
 
 /* *
@@ -62,10 +62,10 @@ const {
 
 declare module '../../Core/GlobalsLike' {
     interface GlobalsLike {
-        chart: typeof H.chart;
-        ganttChart: typeof H.chart;
-        mapChart: typeof H.chart;
-        stockChart: typeof H.chart;
+        chart: typeof Chart.chart;
+        ganttChart: typeof Chart.chart;
+        mapChart: typeof Chart.chart;
+        stockChart: typeof Chart.chart;
     }
 }
 
@@ -89,7 +89,7 @@ class HighchartsComponent extends Component {
      * */
 
     /** @private */
-    public static charter?: typeof H;
+    public static charter?: H;
 
     /** @private */
     public static syncHandlers = HighchartsSyncHandlers;
@@ -754,7 +754,7 @@ class HighchartsComponent extends Component {
     private createChart(): Chart {
         const charter = (
             HighchartsComponent.charter ||
-            Globals.win.Highcharts as unknown as typeof H
+            Globals.win.Highcharts as H
         );
         if (this.chartConstructor !== 'chart') {
             const factory = charter[this.chartConstructor];

--- a/ts/Dashboards/Plugins/HighchartsPlugin.ts
+++ b/ts/Dashboards/Plugins/HighchartsPlugin.ts
@@ -20,7 +20,7 @@
  * */
 
 import type PluginHandler from '../PluginHandler';
-import type { Highcharts } from './HighchartsTypes';
+import type { Highcharts as H } from './HighchartsTypes';
 
 import HighchartsComponent from './HighchartsComponent.js';
 import KPIComponent from '../Components/KPIComponent.js';
@@ -52,7 +52,7 @@ declare module '../Components/ComponentType' {
  * Highcharts core to connect.
  */
 function connectHighcharts(
-    highcharts: typeof Highcharts
+    highcharts: H
 ): void {
     HighchartsComponent.charter = highcharts;
     KPIComponent.charter = highcharts;

--- a/ts/Dashboards/Plugins/HighchartsTypes.ts
+++ b/ts/Dashboards/Plugins/HighchartsTypes.ts
@@ -11,8 +11,9 @@
  *
  * */
 
-
 'use strict';
+
+/* eslint-disable max-len */
 
 
 /* *
@@ -22,8 +23,7 @@
  * */
 
 
-import type ColorString from '../../Core/Color/ColorString';
-import type Globals from '../Globals';
+import type { default as H } from 'highcharts/es-modules/Core/Globals';
 
 
 /* *
@@ -33,233 +33,33 @@ import type Globals from '../Globals';
  * */
 
 
-export interface AccessibilityOptions extends Globals.AnyRecord {
+export type { default as Axis } from 'highcharts/es-modules/Core/Axis/Axis';
 
-}
+export type { default as AxisOptions } from 'highcharts/es-modules/Core/Axis/AxisOptions';
 
-export interface AnimationOptions extends Globals.AnyRecord {
-}
+export type { default as Chart } from 'highcharts/es-modules/Core/Chart/Chart';
 
-export interface Axis {
-    coll: AxisCollectionKey;
-    dateTime?: unknown;
-    max: (number|null);
-    min: (number|null);
-    options: Axis;
-    series: Array<Series>;
-    setExtremes(
-        newMin?: number,
-        newMax?: number,
-        redraw?: boolean,
-        animation?: (boolean|Partial<AnimationOptions>),
-        eventArguments?: any
-    ): void;
-}
+export type { default as Globals } from 'highcharts/es-modules/Core/Globals';
 
-export type AxisCollectionKey = ('colorAxis'|'xAxis'|'yAxis'|'zAxis');
+export type Highcharts = typeof H;
 
-export interface AxisOptions extends Globals.AnyRecord {
-    id?: string;
-    events?: EventsOptionsFor<Axis>;
-}
+export type { default as Options } from 'highcharts/es-modules/Core/Options';
 
-export interface Chart {
-    /* eslint-disable-next-line  @typescript-eslint/no-misused-new */
-    new (
-        renderTo: (string|globalThis.HTMLElement),
-        options: Partial<Options>,
-        callback?: Function
-    ): Chart;
-    axes: Array<Axis>;
-    options: Options;
-    resetZoomButton?: SVGElement;
-    series: Array<Series>;
-    tooltip: Tooltip;
-    xAxis: Array<Axis>;
-    yAxis: Array<Axis>;
-    addSeries(
-        options: SeriesOptions,
-        redraw?: boolean,
-        animation?: (boolean|Partial<AnimationOptions>)
-    ): Series;
-    destroy(): void;
-    redraw(
-        animation?: (boolean|Partial<AnimationOptions>)
-    ): void;
-    reflow(
-        e?: Event
-    ): void;
-    setSize(
-        width?: (number|null),
-        height?: (number|null),
-        animation?: (boolean|Partial<AnimationOptions>)
-    ): void;
-    showResetZoom(): void;
-    update(
-        options: Partial<Options>,
-        redraw?: boolean,
-        oneToOne?: boolean,
-        animation?: (boolean|Partial<AnimationOptions>)
-    ): void;
-    zoomOut(): void;
-}
+export type {
+    default as OrdinalAxis
+} from 'highcharts/es-modules/Core/Axis/OrdinalAxis';
 
-export interface ChartOptions extends Globals.AnyRecord {
-    animation?: (boolean|AnimationOptions);
-    backgroundColor?: ColorString;
-    events?: EventsOptionsFor<Chart>;
-    type?: string;
-}
+export type { default as Pane } from 'highcharts/es-modules/Extensions/Pane';
 
-export interface CreditsOptions extends Globals.AnyRecord {
-    enabled?: boolean;
-}
+export type { default as Point } from 'highcharts/es-modules/Core/Series/Point';
 
-export type EventsOptionsFor<T> = Partial<Record<string, ((this: T) => void)>>;
+export type {
+    default as PolarComposition
+} from 'highcharts/es-modules/Series/PolarComposition';
 
-export interface LangOptions {
-    [key: string]: (string|LangOptions|undefined);
-}
+export type { default as Series } from 'highcharts/es-modules/Core/Series/Series';
 
-export interface LegendOptions extends Globals.AnyRecord {
-    enabled?: boolean;
-}
-
-export interface Options extends Globals.AnyRecord {
-    accessibility?: AccessibilityOptions;
-    chart?: ChartOptions;
-    credits?: CreditsOptions;
-    lang?: LangOptions;
-    legend?: LegendOptions;
-    plotOptions?: Record<string, Omit<SeriesOptions, ('data'|'id'|'name')>>;
-    series?: Array<SeriesOptions>;
-    sonification?: SonificationOptions;
-    title?: TitleOptions;
-    tooltip?: TooltipOptions;
-    xAxis?: AxisOptions;
-    yAxis?: AxisOptions;
-}
-
-export interface Point {
-    index: number;
-    isInside?: boolean;
-    x: number;
-    y: (number|null);
-    series: Series;
-}
-
-export interface PointOptions extends Globals.AnyRecord {
-    events?: EventsOptionsFor<Point>;
-}
-
-export type PointShortOptions = (
-    number|
-    string|
-    Array<(number|string|null)>|
-    null
-);
-
-export interface Series {
-    /* eslint-disable-next-line  @typescript-eslint/no-misused-new */
-    new (options: SeriesOptions): Series;
-    options: SeriesOptions;
-    points: Array<Point>;
-    visible?: boolean;
-    destroy(): void;
-    remove(
-        redraw?: boolean,
-        animation?: (boolean|Partial<AnimationOptions>),
-        withEvent?: boolean,
-        keepEvents?: boolean
-    ): void;
-    setData(
-        data: Array<(PointOptions|PointShortOptions)>,
-        redraw?: boolean,
-        animation?: (boolean|Partial<AnimationOptions>),
-        updatePoints?: boolean
-    ): void;
-    setVisible(
-        vis?: boolean,
-        redraw?: boolean
-    ): void;
-    update(
-        options: Partial<SeriesOptions>,
-        redraw?: boolean
-    ): void;
-}
-
-export interface SeriesMarkerOptions extends Globals.AnyRecord {
-    enabled?: boolean;
-}
-
-export interface SeriesOptions extends Globals.AnyRecord {
-    data?: Array<(PointOptions|PointShortOptions)>;
-    id?: string;
-    events?: EventsOptionsFor<Series>;
-    name?: string;
-    marker?: SeriesMarkerOptions;
-    point?: PointOptions;
-    type?: string;
-}
-
-export interface SonificationOptions extends Globals.AnyRecord {
-
-}
-
-export interface TitleOptions extends Globals.AnyRecord {
-    text?: string;
-}
-
-export interface Tooltip {
-    options: TooltipOptions;
-    hide(
-        delay?: number
-    ): void;
-    refresh(
-        pointOrPoints: (Point|Array<Point>),
-        mouseEvent?: PointerEvent
-    ): void;
-}
-
-export interface TooltipOptions extends Globals.AnyRecord {
-    outside?: boolean;
-}
-
-
-/* *
- *
- *  Namespace
- *
- * */
-
-
-export declare namespace Highcharts {
-
-    export function chart(
-        renderTo: (string|globalThis.HTMLElement),
-        options: Partial<Options>,
-        callback?: Function
-    ): Chart;
-
-    export function ganttChart(
-        renderTo: (string|globalThis.HTMLElement),
-        options: Partial<Options>,
-        callback?: Function
-    ): Chart;
-
-    export function mapChart(
-        renderTo: (string|globalThis.HTMLElement),
-        options: Partial<Options>,
-        callback?: Function
-    ): Chart;
-
-    export function stockChart(
-        renderTo: (string|globalThis.HTMLElement),
-        options: Partial<Options>,
-        callback?: Function
-    ): Chart;
-
-}
+export type { default as SeriesOptions } from 'highcharts/es-modules/Core/Series/SeriesOptions';
 
 
 /* *
@@ -269,4 +69,4 @@ export declare namespace Highcharts {
  * */
 
 
-export default Highcharts;
+export default H;

--- a/ts/Extensions/Pane.ts
+++ b/ts/Extensions/Pane.ts
@@ -679,4 +679,4 @@ addEvent(Pointer, 'afterGetHoverData', function (
 });
 
 H.Pane = Pane as any;
-export default H.Pane;
+export default Pane;

--- a/ts/Series/PolarComposition.ts
+++ b/ts/Series/PolarComposition.ts
@@ -378,7 +378,7 @@ function onChartGetAxes(
     this.options.pane.forEach((paneOptions): void => {
         new Pane( // eslint-disable-line no-new
             paneOptions,
-            this
+            this as any
         );
     }, this);
 }

--- a/ts/masters-dashboards/tsconfig.json
+++ b/ts/masters-dashboards/tsconfig.json
@@ -3,10 +3,15 @@
     "compilerOptions": {
         "composite": false,
         "declaration": true,
+        "baseUrl": "./",
         "moduleResolution": "node",
         "outDir": "../../js/",
         "rootDir": "../",
-
+        "paths": {
+            "highcharts/es-modules/*": [
+                "../*"
+            ]
+        }
     },
     "exclude": [
         "../masters/**/*.ts",
@@ -15,5 +20,4 @@
     "include": [
         "../**/*.ts"
     ]
-
 }


### PR DESCRIPTION
Basically we will expect highcharts as an NPM package present in the Dashboards declarations. If we manage to avoid anything related to the plugin, it should only be a dependency when actually using the plugin.

We could create a beta branch in `dashboards-dist` to test it with the wrapper examples.
