### PR TITLE
bugfix/16050-endontick-docs-correction

### DIFF
--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -588,7 +588,10 @@ namespace AxisDefaults {
          *
          * @productdesc {highstock}
          * In Highcharts Stock, `endOnTick` is always `false` when the navigator
-         * is enabled, to prevent jumpy scrolling.
+         * is enabled, to prevent jumpy scrolling. With disabled navigator
+         * enabling `endOnTick` may lead to extending the xAxis to show the last
+         * tick, therefore range selector buttons may not have an active state
+         * if the axis gets extended.
          *
          * @sample {highcharts} highcharts/yaxis/endontick/
          *         True by default


### PR DESCRIPTION
Improved docs for `endOnTick` in Stock API.