### PR TITLE
bugfix/18427-fix-local-build

### DIFF
--- a/tools/gulptasks/dist-examples.js
+++ b/tools/gulptasks/dist-examples.js
@@ -204,11 +204,18 @@ async function createExamples(title, sourcePath, targetPath, template) {
 
     LogLib.success('Created', targetPath);
 
-    const localsidebar = getLocalSidebar(
-        sourcePath
-            .replaceAll('samples/', '')
-            .replaceAll('/demo', '')
-    );
+    let localsidebar;
+    try {
+        localsidebar = getLocalSidebar(
+            sourcePath
+                .replaceAll('samples/', '')
+                .replaceAll('/demo', '')
+        );
+    } catch (e) {
+        LogLib.warn(e);
+        LogLib.warn('Missing sidebar.html, using empty file');
+        localsidebar = '';
+    }
 
     LogLib.success('Created', targetPath);
     const indexContent = localsidebar

--- a/tools/gulptasks/lib/uploadS3.js
+++ b/tools/gulptasks/lib/uploadS3.js
@@ -70,6 +70,9 @@ async function putS3Object(key, body, config = {}) {
  */
 function getGitIgnoreMeProperties() {
     const properties = {};
+    if (!fs.existsSync('./git-ignore-me.properties')) {
+        return {};
+    }
     const lines = fs.readFileSync(
         './git-ignore-me.properties', 'utf8'
     );


### PR DESCRIPTION
See #18427 - freshly-cloned copies of the repository were failing while running `npx gulp dist`.

Caused by two issues:
- A missing `/git-ignore-me.properties` which could contain settings. If the file is missing, return an empty object so the dependencies can use their defaults.
- A missing `sidebar.html` used when running `dist-examples`. If the file is missing, attempt to generate the demos with an empty file.

I couldn't for the life of me figure out where the sidebar.html file was supposed to come from. I see a few references to parameters that come from `git-ignore-me.properties`, including the path where the demos should be created. Absent a sample default file, I return an empty object for downstream processes to fall back to their own defaults.

Fixed #18427