### PR TITLE
bugfix/19516-readonly-css-properties

### DIFF
--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -261,9 +261,10 @@ namespace Exporting {
     const inlineDenylist: Array<RegExp> = [
         /-/, // In Firefox, both hyphened and camelCased names are listed
         /^(clipPath|cssText|d|height|width)$/, // Full words
-        /^font$/, // more specific props are set
+        /^font$/, // More specific props are set
         /[lL]ogical(Width|Height)$/,
         /^parentRule$/,
+        /^(cssRules|ownerRules)$/, // #19516 read-only properties
         /perspective/,
         /TapHighlightColor/,
         /^transition/,


### PR DESCRIPTION
Fixed #19516, read-only CSS properties weren't excluded during the export of the chart.

---
Fix based on documentation from: https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet?retiredLocale=pl Excluded read-only instances.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205266300237757