### PR TITLE
Testing alternative fix to #19106

### DIFF
--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -1336,6 +1336,21 @@ class SVGElement implements SVGElementLike {
         }
     }
 
+    /**
+     * @private
+     * @function Highcharts.SVGElement#hrefSetter
+     * @param {Highcharts.ColorType} value
+     * @param {string} key
+     * @param {Highcharts.SVGDOMElement} element
+     */
+    public hrefSetter(
+        value: string,
+        key: string,
+        element: SVGDOMElement
+    ): void {
+        // Namespace is needed for offline export, #19106
+        element.setAttributeNS('http://www.w3.org/1999/xlink', key, value);
+    }
 
     /**
      * Get the bounding box (width, height, x and y) for the element. Generally


### PR DESCRIPTION
Fixed https://github.com/highcharts/highcharts/issues/19106, offline export of external images didn't work.


Testing as an alternative to https://github.com/highcharts/highcharts/pull/19392

This solution is more modular, and probably more robust as it will allow updating `href` dynamically. Let's see how the file size turns out.