### PR TITLE
bugfix/19148-NaN-x-value

### DIFF
--- a/samples/unit-tests/point/point/demo.js
+++ b/samples/unit-tests/point/point/demo.js
@@ -795,3 +795,24 @@ QUnit.test('#14623: colorIndex Series.update()', assert => {
         'Point.colorIndex should be correct'
     );
 });
+
+QUnit.test('NaN x value (#19148).', assert => {
+    const chart = Highcharts.chart('container', {
+        series: [
+            {
+                type: 'area',
+                data: [1, 2, [NaN, 3], 4, 5]
+            }
+        ]
+    });
+
+    chart.series[0].points.forEach(point => {
+        if (Number.isInteger(point.x)) {
+            assert.strictEqual(
+                typeof point.graphic,
+                'object',
+                'The graphic should be created.'
+            );
+        }
+    });
+});

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -346,9 +346,6 @@ class Point {
                 pointValKey
             ) as (number|null|undefined);
         }
-        point.isNull = this.isValid && !this.isValid();
-
-        point.formatPrefix = point.isNull ? 'null' : 'point'; // #9233, #10874
 
         // The point is initially selected by options (#5777)
         if (point.selected) {
@@ -380,6 +377,10 @@ class Point {
         } else if (isNumber(options.x) && series.options.relativeXValue) {
             point.x = series.autoIncrement(options.x);
         }
+
+        point.isNull = this.isValid && !this.isValid();
+
+        point.formatPrefix = point.isNull ? 'null' : 'point'; // #9233, #10874
 
         return point;
     }
@@ -739,7 +740,13 @@ class Point {
      * @function Highcharts.Point#isValid
      */
     public isValid(): boolean {
-        return this.x !== null && isNumber(this.y);
+        return (
+            (
+                isNumber(this.x) ||
+                Object.prototype.toString.call(this.x) === '[object Date]'
+            ) &&
+            isNumber(this.y)
+        );
     }
 
     /**

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -743,7 +743,7 @@ class Point {
         return (
             (
                 isNumber(this.x) ||
-                Object.prototype.toString.call(this.x) === '[object Date]'
+                (this.x as number | Date) instanceof Date
             ) &&
             isNumber(this.y)
         );


### PR DESCRIPTION
Fixed #19148, NaN x value disabled area chart graphic elements.

@TorsteinHonsi the fix provided here #19148 seems to be working fine. I added a check for the date object only and moved the `isNull` assignment below the auto incrementation for the `undefined` x values, which I think was crucial to always base on defined ones.