### PR TITLE
dash/light-dark-demo-dg-title

### DIFF
--- a/samples/dashboards/demo/light-dark-theme/demo.css
+++ b/samples/dashboards/demo/light-dark-theme/demo.css
@@ -18,6 +18,10 @@
     fill-opacity: 0.9;
 }
 
+.datagrid {
+    height: 100%;
+}
+
 #dashboard-col-0 h1 {
     margin-bottom: 0;
 }

--- a/samples/dashboards/demo/light-dark-theme/demo.js
+++ b/samples/dashboards/demo/light-dark-theme/demo.js
@@ -108,10 +108,8 @@ Dashboards.board('container', {
             connector: {
                 id: 'sample'
             },
+            className: 'datagrid',
             editable: true,
-            title: {
-                text: 'Data Grid Component'
-            },
             sync: {
                 highlight: true
             }


### PR DESCRIPTION
Removed the datagrid title in the light-dark theme demo.