### PR TITLE
dash/fix-demo-sizing

### DIFF
--- a/samples/dashboards/gui/cell-class-name/demo.css
+++ b/samples/dashboards/gui/cell-class-name/demo.css
@@ -13,8 +13,7 @@
 
 .custom-rest {
     background-color: #e295ee;
-    padding: 5px;
+    padding: 20px 5px 5px;
     border-radius: 5px;
     box-shadow: 4px 6px 10px #0000008c;
-    margin-top: 15px;
 }


### PR DESCRIPTION
Fixed sizing issue in cell class demo. Resizing in component does not seem to catch final size if margin is involved.