### PR TITLE
bugfix/19495-point-class-missing-member

### DIFF
--- a/tools/gulptasks/jsdoc-classes.js
+++ b/tools/gulptasks/jsdoc-classes.js
@@ -64,6 +64,7 @@ const SOURCE_GLOBS = [
     'js/Maps/MapNavigation.js',
     'js/Maps/MapView.js',
     'js/Series/AreaRange/AreaRangeSeries.js',
+    'js/Series/AreaRange/AreaRangePoint.js',
     'js/Series/Column/ColumnSeries.js',
     'js/Series/Networkgraph/NetworkgraphSeries.js',
     'js/Series/Organization/OrganizationSeries.js',


### PR DESCRIPTION
Fixed #19495, `Highcharts.Point#high` and `Highcharts.Point#low` properties were missing in class Point members in API docs.

-----
`Highcharts.Point#high` and `Highcharts.Point#low` and also `Highcharts.Point#graphics` are not in [highcharts.d.ts](https://raw.githubusercontent.com/highcharts/highcharts-dist/master/highcharts.d.ts) and they shouldn't be. These properties are added/used in `highcharts-more.js` library, so TS declarations are present in [highcharts-more.d.ts](https://raw.githubusercontent.com/highcharts/highcharts-dist/master/highcharts-more.d.ts) and it works perfectly.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205232177984789