### PR TITLE
Fixed #19692, mousewheel zoom was enabled even when general zoom was not

### DIFF
--- a/test/cypress/readme.md
+++ b/test/cypress/readme.md
@@ -27,6 +27,6 @@ The Cypress docs has a good [article](https://docs.cypress.io/guides/references/
 
 ## Running tests locally
 
-Requires `highcharts-utils` to be running (`npx highcharts-utils` should do the trick). Cypress can then be run in the CLI using `npx cypress run`. Run `npx cypress info` to get a list of available browsers.
+Requires `highcharts-utils` to be running (`npx highcharts-utils` should do the trick). Cypress can then be run in the CLI using `npx cypress run`. Run `npx cypress info` to get a list of available browsers. To run a specific test, use the `--spec` parameter, like `npx cypress run --spec "test/cypress/integration/Highcharts/mouse-wheel-zoom/zoom-chart.cy.js"`.
 
 For good amount of helpful debugging functionality you can also use the GUI with `npx cypress open`.

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -156,7 +156,10 @@ class StockChart extends Chart {
                         type: 'x'
                     },
                     zooming: {
-                        pinchType: 'x'
+                        pinchType: 'x',
+                        mouseWheel: {
+                            type: 'x'
+                        }
                     }
                 },
                 navigator: {


### PR DESCRIPTION
Fixed #19692, mouse wheel zoom was enabled even when general zoom was not

We should have a test, but I didn't manage to get cypress right. For now I'm using this: https://jsfiddle.net/highcharts/01tman8z/ . Note that when zooming is enabled, and you try to zoom out past the current extremes, browser scroll kicks in because there is nothing left to zoom in the chart.