### PR TITLE
bugfix/18122-annotation-drag-hybrid-devices

### DIFF
--- a/ts/Extensions/Annotations/EventEmitter.ts
+++ b/ts/Extensions/Annotations/EventEmitter.ts
@@ -309,8 +309,7 @@ abstract class EventEmitter {
             // Using experimental property on event object to check if event was
             // created by touch on screen on hybrid device (#18122)
             firesTouchEvents = (
-                (e as any).sourceCapabilities &&
-                (e as any).sourceCapabilities.firesTouchEvents
+                (e as any)?.sourceCapabilities?.firesTouchEvents
             ) || false;
 
         e = pointer.normalize(e);

--- a/ts/Extensions/Annotations/EventEmitter.ts
+++ b/ts/Extensions/Annotations/EventEmitter.ts
@@ -308,13 +308,10 @@ abstract class EventEmitter {
             pointer = emitter.chart.pointer,
             // Using experimental property on event object to check if event was
             // created by touch on screen on hybrid device (#18122)
-            firesTouchEvents = pick(
-                (
-                    (e as any).sourceCapabilities &&
-                    (e as any).sourceCapabilities.firesTouchEvents
-                ),
-                false
-            );
+            firesTouchEvents = (
+                (e as any).sourceCapabilities &&
+                (e as any).sourceCapabilities.firesTouchEvents
+            ) || false;
 
         e = pointer.normalize(e);
 

--- a/ts/Extensions/Annotations/EventEmitter.ts
+++ b/ts/Extensions/Annotations/EventEmitter.ts
@@ -305,7 +305,16 @@ abstract class EventEmitter {
         }
 
         const emitter = this,
-            pointer = emitter.chart.pointer;
+            pointer = emitter.chart.pointer,
+            // Using experimental property on event object to check if event was
+            // created by touch on screen on hybrid device (#18122)
+            firesTouchEvents = pick(
+                (
+                    (e as any).sourceCapabilities &&
+                    (e as any).sourceCapabilities.firesTouchEvents
+                ),
+                false
+            );
 
         e = pointer.normalize(e);
 
@@ -316,7 +325,7 @@ abstract class EventEmitter {
         emitter.chart.hasDraggedAnnotation = true;
         emitter.removeDrag = addEvent(
             doc,
-            isTouchDevice ? 'touchmove' : 'mousemove',
+            isTouchDevice || firesTouchEvents ? 'touchmove' : 'mousemove',
             function (e: AnnotationEventObject): void {
                 emitter.hasDragged = true;
 
@@ -329,11 +338,11 @@ abstract class EventEmitter {
                 prevChartX = e.chartX;
                 prevChartY = e.chartY;
             },
-            isTouchDevice ? { passive: false } : void 0
+            isTouchDevice || firesTouchEvents ? { passive: false } : void 0
         );
         emitter.removeMouseUp = addEvent(
             doc,
-            isTouchDevice ? 'touchend' : 'mouseup',
+            isTouchDevice || firesTouchEvents ? 'touchend' : 'mouseup',
             function (e: AnnotationEventObject): void {
                 // Sometimes the target is the annotation and sometimes its the
                 // controllable
@@ -356,7 +365,7 @@ abstract class EventEmitter {
                 ), 'afterUpdate');
                 emitter.onMouseUp(e);
             },
-            isTouchDevice ? { passive: false } : void 0
+            isTouchDevice || firesTouchEvents ? { passive: false } : void 0
         );
     }
 


### PR DESCRIPTION
Fixed #18122, Annotation drag didn't work by using touch on hybrid devices.
---
I couldn't find any good way to remove `as any` in that case of usage experimental property. Also, I think, the only way to create a test is to test that specific function with passing event object as an argument - I am not sure if that's necessary and that's why I didn't add any test for now.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205322875854021