### PR TITLE
Fixed #19039, boosted series were not clipped to panes

### DIFF
--- a/ts/Extensions/Boost/BoostChart.ts
+++ b/ts/Extensions/Boost/BoostChart.ts
@@ -107,21 +107,21 @@ function getBoostClipRect(
         height: chart.plotHeight
     };
 
-    /* Uncomment to fix #19039
-    if (target instanceof Series) {
-        clipBox = target.getClipBox();
+    // Clipping of individal series (#11906, #19039).
+    if ((target as Series).getClipBox) {
+        const { xAxis, yAxis } = target as Series;
+        clipBox = (target as Series).getClipBox();
         if (chart.inverted) {
             const lateral = clipBox.width;
             clipBox.width = clipBox.height;
             clipBox.height = lateral;
-            clipBox.x = target.yAxis.pos;
-            clipBox.y = target.xAxis.pos;
+            clipBox.x = yAxis.pos;
+            clipBox.y = xAxis.pos;
         } else {
-            clipBox.x = target.xAxis.pos;
-            clipBox.y = target.yAxis.pos;
+            clipBox.x = xAxis.pos;
+            clipBox.y = yAxis.pos;
         }
     }
-    */
 
     if (target === chart) {
         const verticalAxes =


### PR DESCRIPTION
Fixed #19039, boosted series were not clipped to panes