### PR TITLE
bugfix/16686-vbp-yaxis-extremes 

### DIFF
--- a/samples/unit-tests/indicator-volume-by-price/recalculations/demo.js
+++ b/samples/unit-tests/indicator-volume-by-price/recalculations/demo.js
@@ -363,3 +363,92 @@ QUnit.test('VBP series errors.', function (assert) {
     );
 
 });
+
+QUnit.test('YAxis extremes with VBP series.', function (assert) {
+    const data = [[
+            1631539800000,
+            150.63,
+            151.42,
+            148.75,
+            149.55
+        ], [
+            1631626200000,
+            150.35,
+            151.07,
+            146.91,
+            148.12
+        ], [
+            1631712600000,
+            148.56,
+            149.44,
+            146.37,
+            149.03
+        ], [
+            1631799000000,
+            148.44,
+            148.97,
+            147.22,
+            148.79
+        ], [
+            1631885400000,
+            148.82,
+            148.82,
+            145.76,
+            146.06
+        ]],
+        volume = [[
+            1631539800000,
+            102404300
+        ], [
+            1631626200000,
+            109296300
+        ], [
+            1631712600000,
+            83281300
+        ], [
+            1631799000000,
+            68034100
+        ], [
+            1631885400000,
+            129868800
+        ]];
+
+
+    const chart = Highcharts.stockChart('container', {
+        yAxis: [{
+            height: '60%'
+        }, {
+            top: '65%',
+            height: '35%',
+            offset: 0
+        }],
+        series: [{
+            type: 'candlestick',
+            id: 'AAPL',
+            name: 'AAPL',
+            data: data
+        }, {
+            type: 'column',
+            id: 'volume',
+            name: 'Volume',
+            data: volume,
+            yAxis: 1
+        }, {
+            type: 'vbp',
+            linkedTo: 'AAPL',
+            showInLegend: true,
+            compare: 'percent'
+        }]
+    });
+
+    assert.strictEqual(
+        chart.yAxis[0].min,
+        144,
+        'YAxis min should remain unnaffected after adding VBP to chart, #16686.'
+    );
+    assert.strictEqual(
+        chart.yAxis[0].max,
+        152,
+        'YAxis max should remain unnaffected after adding VBP to chart, #16686.'
+    );
+});

--- a/ts/Series/DataModifyComposition.ts
+++ b/ts/Series/DataModifyComposition.ts
@@ -305,11 +305,6 @@ namespace DataModifyComposition {
      * @private
      */
     function afterGetExtremes(this: Series, e: AnyRecord|Event): void {
-        if (this.is('vbp')) {
-            // Do not recalculate extremes for VBP series, #16686.
-            return;
-        }
-
         const dataExtremes: DataExtremesObject = (e as any).dataExtremes,
             activeYData = dataExtremes.activeYData;
 

--- a/ts/Series/DataModifyComposition.ts
+++ b/ts/Series/DataModifyComposition.ts
@@ -305,6 +305,11 @@ namespace DataModifyComposition {
      * @private
      */
     function afterGetExtremes(this: Series, e: AnyRecord|Event): void {
+        if (this.is('vbp')) {
+            // Do not recalculate extremes for VBP series, #16686.
+            return;
+        }
+
         const dataExtremes: DataExtremesObject = (e as any).dataExtremes,
             activeYData = dataExtremes.activeYData;
 

--- a/ts/Stock/Indicators/VBP/VBPIndicator.ts
+++ b/ts/Stock/Indicators/VBP/VBPIndicator.ts
@@ -22,6 +22,7 @@ import type AxisType from '../../../Core/Axis/AxisType';
 import type Chart from '../../../Core/Chart/Chart';
 import type ColumnSeries from '../../../Series/Column/ColumnSeries';
 import type CSSObject from '../../../Core/Renderer/CSSObject';
+import type DataExtremesObject from '../../../Core/Series/DataExtremesObject';
 import type IndicatorValuesObject from '../IndicatorValuesObject';
 import type LineSeries from '../../../Series/Line/LineSeries';
 import type SVGAttributes from '../../../Core/Renderer/SVG/SVGAttributes';
@@ -46,7 +47,6 @@ const {
 } = SeriesRegistry.seriesTypes;
 import U from '../../../Core/Utilities.js';
 import StockChart from '../../../Core/Chart/StockChart.js';
-import DataExtremesObject from '../../../Core/Series/DataExtremesObject';
 const {
     addEvent,
     arrayMax,

--- a/ts/Stock/Indicators/VBP/VBPIndicator.ts
+++ b/ts/Stock/Indicators/VBP/VBPIndicator.ts
@@ -46,6 +46,7 @@ const {
 } = SeriesRegistry.seriesTypes;
 import U from '../../../Core/Utilities.js';
 import StockChart from '../../../Core/Chart/StockChart.js';
+import DataExtremesObject from '../../../Core/Series/DataExtremesObject';
 const {
     addEvent,
     arrayMax,
@@ -529,6 +530,27 @@ class VBPIndicator extends SMAIndicator {
                 );
             }
         }
+    }
+
+    public getExtremes(): DataExtremesObject {
+        const prevCompare = this.options.compare,
+            prevCumulative = this.options.cumulative;
+        let ret: DataExtremesObject;
+
+        // Temporarily disable cumulative and compare while getting the extremes
+        if (this.options.compare) {
+            this.options.compare = void 0;
+            ret = super.getExtremes();
+            this.options.compare = prevCompare;
+        } else if (this.options.cumulative) {
+            this.options.cumulative = false;
+            ret = super.getExtremes();
+            this.options.cumulative = prevCumulative;
+        } else {
+            ret = super.getExtremes();
+        }
+
+        return ret;
     }
 
     public getValues <TLinkedSeries extends LineSeries>(


### PR DESCRIPTION
Fixed #16686, yAxis extremes were incorrect with VBP indicator compare.

Although it looks like a hacky solution, VBP (with compare) recalculations should not affect the yAxis extremes calculations, since due to the VBP position and rotation, `yData` does not affect the `yAxis` ticks.