### PR TITLE
Simplified dashboards visual test workflow

### DIFF
--- a/.github/workflows/dashboards-visual-test.yml
+++ b/.github/workflows/dashboards-visual-test.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
 
       - name: Install dependencies
         uses: cypress-io/github-action@v6
@@ -59,12 +58,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           clean: false
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
 
       - name: Install dependencies
         uses: cypress-io/github-action@v6

--- a/.github/workflows/dashboards-visual-test.yml
+++ b/.github/workflows/dashboards-visual-test.yml
@@ -34,7 +34,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           runTests: false
 
@@ -46,8 +46,8 @@ jobs:
       - name: Install utils
         run: npm i github:highcharts/highcharts-utils
 
-      - name: Run cypress via action
-        uses: cypress-io/github-action@v5
+      - name: Create visual test base images
+        uses: cypress-io/github-action@v6
         with:
           start: npx cross-env NODE_PATH=${GITHUB_WORKSPACE}/node_modules node node_modules/@highcharts/highcharts-utils/server --localOnly
           wait-on: 'http://localhost:3031/dashboards.js'
@@ -67,7 +67,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           runTests: false
 
@@ -79,8 +79,8 @@ jobs:
       - name: Build Dashboards
         run: npx gulp dashboards/scripts
 
-      - name: Run cypress via action
-        uses: cypress-io/github-action@v5
+      - name: Run visual test
+        uses: cypress-io/github-action@v6
         with:
           start: npx cross-env NODE_PATH=${GITHUB_WORKSPACE}/node_modules node node_modules/@highcharts/highcharts-utils/server --localOnly
           wait-on: 'http://localhost:3031/dashboards.js'

--- a/.github/workflows/dashboards-visual-test.yml
+++ b/.github/workflows/dashboards-visual-test.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Checkout current branch
         uses: actions/checkout@v3
-        width:
+        with:
           clean: false
 
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/dashboards-visual-test.yml
+++ b/.github/workflows/dashboards-visual-test.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
-  cypress_visual_base:
+  cypress_visual_test:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
@@ -55,39 +55,16 @@ jobs:
           config-file: test/cypress/configs/dashboards.visual.config.mjs
           install: false
 
-      - name: Store artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: reference
-          path: |
-            cypress/screenshots
-            cypress/snapshots
-
-
-  cypress_visual_actual:
-    needs: cypress_visual_base
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [lts/*]
-    steps:
-      - uses: actions/checkout@v3
+      - name: Checkout current branch
+        uses: actions/checkout@v3
+        width:
+          clean: false
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-
-      - name: Checkout current branch
-        uses: actions/checkout@v3
-
-      - name: Download references
-        uses: actions/download-artifact@v3
-        with:
-          name: reference
-          path: cypress # this path is root relative, not based on the working-directory above
 
       - name: Install dependencies
         uses: cypress-io/github-action@v5
@@ -105,7 +82,6 @@ jobs:
       - name: Run cypress via action
         uses: cypress-io/github-action@v5
         with:
-          install-command: npm ci && npx gulp scripts
           start: npx cross-env NODE_PATH=${GITHUB_WORKSPACE}/node_modules node node_modules/@highcharts/highcharts-utils/server --localOnly
           wait-on: 'http://localhost:3031/dashboards.js'
           env: type=actual
@@ -114,6 +90,7 @@ jobs:
 
       - name: Store artifacts
         uses: actions/upload-artifact@v3
+        if: ${{ always() }}
         with:
           name: post-tests
           path: |

--- a/.github/workflows/dashboards-visual-test.yml
+++ b/.github/workflows/dashboards-visual-test.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Install dependencies
         uses: cypress-io/github-action@v6
@@ -54,10 +55,19 @@ jobs:
           config-file: test/cypress/configs/dashboards.visual.config.mjs
           install: false
 
+      - name: Stop server
+        run: kill $(lsof -t -i:3030)
+
       - name: Checkout current branch
         uses: actions/checkout@v3
         with:
           clean: false
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Install dependencies
         uses: cypress-io/github-action@v6


### PR DESCRIPTION
Combined the two job into one job. Fixes an issue with the visual-regression plugin saves files relatively, which was not picked up by `save-artifact`