### PR TITLE
bugfix/19725-drilldown-cartesian-to-non-cartesian

### DIFF
--- a/samples/unit-tests/drilldown/across-types/demo.html
+++ b/samples/unit-tests/drilldown/across-types/demo.html
@@ -1,6 +1,7 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/drilldown.js"></script>
 <script src="https://code.highcharts.com/modules/treemap.js"></script>
+<script src="https://code.highcharts.com/modules/wordcloud.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/drilldown/across-types/demo.js
+++ b/samples/unit-tests/drilldown/across-types/demo.js
@@ -285,4 +285,47 @@ QUnit.test('Drilldown across types', function (assert) {
         1,
         'After drilldown treemap axes options should be reset (#12326).'
     );
+
+    chart.drillUp();
+    chart.update({
+        series: [{
+            type: 'column',
+            data: [{
+                name: 'A',
+                y: 50,
+                drilldown: 'A'
+            }]
+        }],
+        drilldown: {
+            series: [{
+                name: 'A',
+                id: 'A',
+                type: 'wordcloud',
+                data: [{
+                    name: 'Test',
+                    weight: 1
+                }]
+            }]
+        }
+    });
+    chart.series[0].points[0].doDrilldown();
+
+    chart.axes.forEach(axis => {
+        assert.strictEqual(
+            axis.axisLine,
+            void 0,
+            `After drilldown from cartesian series to non-cartesian ${axis.coll}
+            shouldn't be visible. (#19725).`
+        );
+    });
+
+    chart.drillUp();
+    chart.axes.forEach(axis => {
+        assert.notEqual(
+            axis.axisLine,
+            void 0,
+            `After drill up from non-cartesian series to cartesian ${axis.coll}
+            should be visible. (#19725).`
+        );
+    });
 });

--- a/ts/Extensions/Drilldown.ts
+++ b/ts/Extensions/Drilldown.ts
@@ -959,6 +959,8 @@ Chart.prototype.applyDrilldown = function (): void {
         // #3352, async loading
         levelToRemove =
             drilldownLevels[drilldownLevels.length - 1].levelNumber;
+        chart.hasCartesianSeries = drilldownLevels.some((level): boolean =>
+            level.lowerSeries.isCartesian); // #19725
         (this.drilldownLevels as any).forEach(function (
             level: Highcharts.DrilldownLevelObject
         ): void {
@@ -987,7 +989,7 @@ Chart.prototype.applyDrilldown = function (): void {
                             series.remove(false);
                         }
                     } else {
-                        // deal with asonchrynous removing of map series after
+                        // Deal with asonchrynous removing of map series after
                         // zooming into
                         if (
                             series.options &&
@@ -1050,6 +1052,14 @@ Chart.prototype.applyDrilldown = function (): void {
         this.pointer.reset();
 
         fireEvent(this, 'afterDrilldown');
+
+        // Axes shouldn't be visible after drilling into non-cartesian (#19725)
+        if (!chart.hasCartesianSeries) {
+            chart.axes.forEach((axis): void => {
+                axis.destroy(true);
+                axis.init(this, merge(axis.userOptions, axis.options));
+            });
+        }
 
         this.redraw();
         fireEvent(this, 'afterApplyDrilldown');

--- a/ts/Series/Wordcloud/WordcloudSeries.ts
+++ b/ts/Series/Wordcloud/WordcloudSeries.ts
@@ -225,21 +225,6 @@ class WordcloudSeries extends ColumnSeries {
      * Functions
      *
      */
-    public bindAxes(): void {
-        const wordcloudAxis = {
-            endOnTick: false,
-            gridLineWidth: 0,
-            lineWidth: 0,
-            maxPadding: 0,
-            startOnTick: false,
-            title: void 0,
-            tickPositions: []
-        };
-
-        Series.prototype.bindAxes.call(this);
-        extend(this.yAxis.options, wordcloudAxis);
-        extend(this.xAxis.options, wordcloudAxis);
-    }
 
     public pointAttribs(
         point: WordcloudPoint,
@@ -533,6 +518,7 @@ extend(WordcloudSeries.prototype, {
     animate: noop,
     animateDrilldown: noop,
     animateDrillupFrom: noop,
+    isCartesian: false,
     pointClass: WordcloudPoint,
     setClip: noop,
 


### PR DESCRIPTION
Fixed #19725, drilling between cartesian and non-cartesian series didn’t work properly.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205463053195102