### PR TITLE
bugfix/19744-polar-series-clip

### DIFF
--- a/samples/unit-tests/chart/polar/demo.js
+++ b/samples/unit-tests/chart/polar/demo.js
@@ -345,12 +345,23 @@ QUnit.test('Polar and clipping', assert => {
         chart: {
             polar: true
         },
-        series: [
-            {
-                data: [1, 2, 3]
-            }
-        ]
+        yAxis: {
+            max: 3,
+            endOnTick: false
+        },
+        series: [{
+            data: [1, 2, 3]
+        }, {
+            data: [2, 4, 2],
+            clip: false
+        }]
     });
+
+    assert.strictEqual(
+        chart.series[1].group.element.getAttribute('clip-path'),
+        'none',
+        'Series.clip:false should be respected in polar chart'
+    );
 
     const oldLen = chart.container.querySelectorAll('defs clipPath').length;
 

--- a/ts/Series/PolarComposition.ts
+++ b/ts/Series/PolarComposition.ts
@@ -718,7 +718,7 @@ function onSeriesAfterTranslate(
                 ): void {
                     let circ: Array<number>;
 
-                    if (chart.polar) {
+                    if (chart.polar && this.options.clip !== false) {
                         // For clipping purposes there is a need for
                         // coordinates from the absolute center
                         circ = this.yAxis.pane.center;


### PR DESCRIPTION
Fixed #19744, series' `clip` option was not working in polar charts.