### PR TITLE
dash/datatable-aliases

### DIFF
--- a/samples/dashboards/sync/datacursor-sync/demo.js
+++ b/samples/dashboards/sync/datacursor-sync/demo.js
@@ -146,6 +146,10 @@ function buildChartOptions(type, table, cursor) {
 // Build table with Highcharts.Series aliases
 function buildVegeTable() {
     const table = new DataTable({
+        aliases: {
+            name: 'vegetable',
+            y: 'amount'
+        },
         columns: {
             vegetable: [
                 'Broccoli',
@@ -171,9 +175,6 @@ function buildVegeTable() {
         },
         id: 'Vegetables'
     });
-
-    table.setColumnAlias('name', 'vegetable');
-    table.setColumnAlias('y', 'amount');
 
     return table;
 }

--- a/samples/highcharts/website/small-demos-dashboards/demo.js
+++ b/samples/highcharts/website/small-demos-dashboards/demo.js
@@ -516,7 +516,7 @@ function climate() {
         }
 
         // selectionGrid.dataGrid.scrollToRow(
-        //     selectionTable.getRowIndexBy('time', rangeTable.getCell('time', 0))
+        //   selectionTable.getRowIndexBy('time', rangeTable.getCell('time', 0))
         // );
 
     // // Update city chart selection
@@ -769,6 +769,10 @@ function datacursor() {
     // Build table with Highcharts.Series aliases
     function buildVegeTable() {
         const table = new DataTable({
+            aliases: {
+                name: 'vegetable',
+                y: 'amount'
+            },
             columns: {
                 vegetable: [
                     'Broccoli',
@@ -794,9 +798,6 @@ function datacursor() {
             },
             id: 'Vegetables'
         });
-
-        table.setColumnAlias('name', 'vegetable');
-        table.setColumnAlias('y', 'amount');
 
         return table;
     }

--- a/test/typescript-karma/Data/DataTable.test.js
+++ b/test/typescript-karma/Data/DataTable.test.js
@@ -6,7 +6,7 @@ QUnit.test('DataTable clone', function (assert) {
 
     table.setRows([[ 'row1', 1 ]]);
     table.setCell('1', 0, 100);
-    table.setColumnAlias('x', 'x-alias');
+    table.aliases.x = 'x-alias';
 
     const tableClone = table.clone();
 
@@ -50,10 +50,10 @@ QUnit.test('DataTable clone', function (assert) {
 QUnit.test('DataTable Column Aliases', function (assert) {
     const table = new DataTable();
 
-    table.setColumnAlias('x', 'population');
-    table.setColumnAlias('y', 'gdp');
-    table.setColumnAlias('z', 'id');
-    table.setColumnAlias('f', 'population');
+    table.aliases.x = 'population';
+    table.aliases.y = 'gdp';
+    table.aliases.z = 'id';
+    table.aliases.f = 'population';
 
     table.setRows([{
         id: 'My Land',
@@ -70,20 +70,13 @@ QUnit.test('DataTable Column Aliases', function (assert) {
         nonexistant: 1
     }]);
 
-    table.setColumnAlias('beta', 'nonexistant');
-    assert.strictEqual(
-        table.setColumnAlias('beta', 'a'),
-        false,
-        'Returns false when attempting to add an existing alias.'
-    );
-
     assert.deepEqual(
         table.getColumn('x'),
         table.getColumns(['population'])['population'],
         'Table should return correct column for alias.'
     );
 
-    table.setColumnAlias('population', 'gdp')
+    table.aliases.population = 'gdp';
     assert.deepEqual(
         table.getColumn('population'),
         table.getColumn('gdp'),
@@ -203,7 +196,7 @@ QUnit.test('DataTable Column Rename', function (assert) {
 
     // Force move following alias
     table.setColumn('newColumn', []);
-    table.setColumnAlias('existingColumnAlias', 'newEmptyColumn');
+    table.aliases.existingColumnAlias = 'newEmptyColumn';
 
     assert.ok(
         table.renameColumn('existingColumn', 'existingColumnAlias'),

--- a/ts/Dashboards/SerializeHelper/DataTableHelper.ts
+++ b/ts/Dashboards/SerializeHelper/DataTableHelper.ts
@@ -74,7 +74,7 @@ function jsonSupportFor(
 function toJSON(
     obj: DataTable
 ): DataTableHelper.JSON {
-    const aliases = obj.getColumnAliases(),
+    const aliases = obj.aliases,
         aliasKeys = Object.keys(aliases),
         json: DataTableHelper.JSON = {
             $class: 'Data.DataTable',

--- a/ts/Data/DataTable.ts
+++ b/ts/Data/DataTable.ts
@@ -141,7 +141,19 @@ class DataTable implements DataEvent.Emitter {
         options: DataTable.Options = {}
     ) {
 
-        this.aliases = {};
+        /**
+         * Dictionary of all column aliases and their mapped column. If a column
+         * for one of the get-methods matches an column alias, this column will
+         * be replaced with the mapped column by the column alias.
+         *
+         * @name Highcharts.DataTable#aliases
+         * @type {Highcharts.Dictionary<string>}
+         */
+        this.aliases = (
+            options.aliases ?
+                JSON.parse(JSON.stringify(options.aliases)) :
+                {}
+        );
 
         /**
          * Whether the ID was automatic generated or given in the constructor.
@@ -211,11 +223,7 @@ class DataTable implements DataEvent.Emitter {
      *
      * */
 
-    /**
-     * Mapping aliases to column names.
-     * @private
-     */
-    private readonly aliases: DataTable.ColumnAliases;
+    public readonly aliases: DataTable.ColumnAliases;
 
     public readonly autoId: boolean;
 
@@ -690,33 +698,6 @@ class DataTable implements DataEvent.Emitter {
             [columnNameOrAlias],
             asReference
         )[columnNameOrAlias];
-    }
-
-    /**
-     * Fetches all column aliases and their mapped columns.
-     *
-     * @function Highcharts.DataTable#getColumnAliases
-     *
-     * @return {Highcharts.Dictionary<string>}
-     * Returns all column aliases.
-     */
-    public getColumnAliases(): DataTable.ColumnAliases {
-        const aliases = this.aliases,
-            aliasKeys = Object.keys(aliases),
-            columnAliases: DataTable.ColumnAliases = {};
-
-        for (
-            let i = 0,
-                iEnd = aliasKeys.length,
-                alias: string;
-            i < iEnd;
-            ++i
-        ) {
-            alias = aliasKeys[i];
-            columnAliases[alias] = aliases[alias];
-        }
-
-        return columnAliases;
     }
 
     public getColumnAsNumbers(
@@ -1321,36 +1302,6 @@ class DataTable implements DataEvent.Emitter {
         eventDetail?: DataEvent.Detail
     ): void {
         this.setColumns({ [columnNameOrAlias]: column }, rowIndex, eventDetail);
-    }
-
-    /**
-     * Defines an alias for a column. If a column name for one of the
-     * get-functions matches an column alias, the column name will be replaced
-     * with the original column name.
-     *
-     * @function Highcharts.DataTable#setColumnAlias
-     *
-     * @param {string} columnAlias
-     * Column alias to create.
-     *
-     * @param {string} columnName
-     * Original column name to create an alias for.
-     *
-     * @return {boolean}
-     * `true` if successfully changed, `false` if reserved.
-     */
-    public setColumnAlias(
-        columnAlias: string,
-        columnName: string
-    ): boolean {
-        const aliases = this.aliases;
-
-        if (!aliases[columnAlias]) {
-            aliases[columnAlias] = columnName;
-            return true;
-        }
-
-        return false;
     }
 
     /**

--- a/ts/Data/README.md
+++ b/ts/Data/README.md
@@ -52,9 +52,9 @@ names. That way also row objects can have different key-value pairs, but
 identical data.
 
 ```TypeScript
-table.setColumnAlias('movie_title', 'title');
+table.aliases['movie_title'] = 'title';
 table.getColumn('movie_title')[0] === table.getColumn('title')[0];
-table.deleteColumnAlias('movie_title');
+delete table.aliases['movie_title'];
 table.getColumn('movie_title') === undefined;
 ```
 
@@ -146,8 +146,8 @@ In case of a series that only accepts data points as objects, you might need to
 set up column aliases to retrieve the expected structure.
 
 ```TypeScript
-table.setColumnAlias('name', 'year');
-table.setColumnAlias('label', 'title');
+table.aliases.name = 'year';
+table.aliases.label = 'title';
 const chart = new Highcharts.chart('container', {
     series: [{
         type: 'timeline',


### PR DESCRIPTION
`DataTable.aliases` property replaces `DataTable.getColumnAliases()` and `DataTable.setColumnAlias()`.