### PR TITLE
dash/confirmation-popup-close

### DIFF
--- a/ts/Dashboards/EditMode/ConfirmationPopup.ts
+++ b/ts/Dashboards/EditMode/ConfirmationPopup.ts
@@ -64,6 +64,11 @@ class ConfirmationPopup extends BaseForm {
         editMode: EditMode,
         options?: ConfirmationPopup.Options
     ) {
+        iconsURL =
+            options && options.close && options.close.icon ?
+                options.close.icon :
+                iconsURL;
+
         super(parentDiv, iconsURL);
 
         this.editMode = editMode;


### PR DESCRIPTION
Fixed, it was impossible to change the confirmation popup close button.