### PR TITLE
feature/19675-missing-annotations-drag-event

### DIFF
--- a/ts/Extensions/Annotations/AnnotationDefaults.ts
+++ b/ts/Extensions/Annotations/AnnotationDefaults.ts
@@ -681,6 +681,13 @@ const AnnotationDefaults: AnnotationOptions = {
      */
 
     /**
+     * Fires when the annotation is dragged.
+     *
+     * @type      {Highcharts.EventCallbackFunction<Highcharts.Annotation>}
+     * @apioption annotations.events.drag
+     */
+
+    /**
      * Event callback when annotation is removed from the chart.
      *
      * @type      {Highcharts.EventCallbackFunction<Highcharts.Annotation>}


### PR DESCRIPTION
Added missing API reference on the `annotations.events.drag` event.