### PR TITLE
bugfix/19736-scrollable-indicators

### DIFF
--- a/ts/Extensions/Annotations/Popup/PopupAnnotations.ts
+++ b/ts/Extensions/Annotations/Popup/PopupAnnotations.ts
@@ -145,7 +145,7 @@ function addToolbar(
 
     // set small size
     if (popupDiv.className.indexOf(toolbarClass) === -1) {
-        popupDiv.className += ' ' + toolbarClass;
+        popupDiv.className += ' ' + toolbarClass + ' highcharts-no-mousewheel';
     }
 
     // set position

--- a/ts/Extensions/MouseWheelZoom/MouseWheelZoom.ts
+++ b/ts/Extensions/MouseWheelZoom/MouseWheelZoom.ts
@@ -24,6 +24,7 @@ import type BBoxObject from '../../Core/Renderer/BBoxObject';
 import type { YAxisOptions } from '../../Core/Axis/AxisOptions';
 
 import U from '../../Core/Utilities.js';
+import DOMElementType from '../../Core/Renderer/DOMElementType';
 const {
     addEvent,
     isObject,
@@ -259,7 +260,6 @@ const zoomBy = function (
     }
 };
 
-
 /**
  * @private
  */
@@ -269,14 +269,20 @@ function onAfterGetContainer(this: Chart): void {
             optionsToObject(chart.options.chart.zooming.mouseWheel);
 
     if (wheelZoomOptions.enabled) {
+        let haltScroll: boolean | undefined = false;
 
         addEvent(this.container, 'wheel', (e: PointerEvent): void => {
             e = this.pointer.normalize(e);
+            haltScroll = chart.pointer.inClass(
+                e.target as DOMElementType,
+                'highcharts-no-mousewheel'
+            );
             // Firefox uses e.detail, WebKit and IE uses deltaX, deltaY, deltaZ.
             if (chart.isInsidePlot(
                 e.chartX - chart.plotLeft,
                 e.chartY - chart.plotTop
-            )) {
+            ) && !haltScroll) {
+
                 const wheelSensitivity = pick(
                         wheelZoomOptions.sensitivity,
                         1.1
@@ -298,7 +304,7 @@ function onAfterGetContainer(this: Chart): void {
             }
 
             // prevent page scroll
-            if (e.preventDefault) {
+            if (e.preventDefault && !haltScroll) {
                 e.preventDefault();
             }
         });

--- a/ts/Extensions/MouseWheelZoom/MouseWheelZoom.ts
+++ b/ts/Extensions/MouseWheelZoom/MouseWheelZoom.ts
@@ -21,10 +21,9 @@ import type GlobalsLike from '../../Core/GlobalsLike';
 import type PointerEvent from '../../Core/PointerEvent';
 import type MouseWheelZoomOptions from './MouseWheelZoomOptions';
 import type BBoxObject from '../../Core/Renderer/BBoxObject';
-import type { YAxisOptions } from '../../Core/Axis/AxisOptions';
+import type DOMElementType from '../../Core/Renderer/DOMElementType';
 
 import U from '../../Core/Utilities.js';
-import DOMElementType from '../../Core/Renderer/DOMElementType';
 const {
     addEvent,
     isObject,


### PR DESCRIPTION
Fixed #19736 , `mouseWheel` zooming prevented scrolling in Stock Tools popups.