### PR TITLE
bugfix/19762-offline-export-pdf-scale

### DIFF
--- a/samples/highcharts/exporting/offline-download-scale/demo.css
+++ b/samples/highcharts/exporting/offline-download-scale/demo.css
@@ -1,0 +1,5 @@
+#container {
+    max-width: 800px;
+    height: 400px;
+    margin: 0 auto;
+}

--- a/samples/highcharts/exporting/offline-download-scale/demo.details
+++ b/samples/highcharts/exporting/offline-download-scale/demo.details
@@ -1,0 +1,7 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Kamil Kubik
+ requiresManualTesting: true
+ js_wrap: b
+...

--- a/samples/highcharts/exporting/offline-download-scale/demo.html
+++ b/samples/highcharts/exporting/offline-download-scale/demo.html
@@ -1,0 +1,5 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/modules/offline-exporting.js"></script>
+
+<div id="container"></div>

--- a/samples/highcharts/exporting/offline-download-scale/demo.js
+++ b/samples/highcharts/exporting/offline-download-scale/demo.js
@@ -1,0 +1,16 @@
+Highcharts.chart('container', {
+
+    chart: {
+        width: 800,
+        height: 400
+    },
+
+    exporting: {
+        scale: 2
+    },
+
+    series: [{
+        data: [4, 3, 5, 6, 2, 3]
+    }]
+
+});

--- a/samples/highcharts/exporting/offline-download-scale/test-notes.md
+++ b/samples/highcharts/exporting/offline-download-scale/test-notes.md
@@ -1,0 +1,1 @@
+Download as a PDF and verify that the document is twice the size of the chart, should be 1600x800 (#19762).

--- a/ts/Extensions/OfflineExporting/OfflineExporting.ts
+++ b/ts/Extensions/OfflineExporting/OfflineExporting.ts
@@ -408,6 +408,7 @@ namespace OfflineExporting {
                     svgToPdf(
                         svgNode,
                         0,
+                        scale,
                         (pdfData: string): void => {
                             try {
                                 downloadURL(pdfData, filename);
@@ -1009,10 +1010,13 @@ namespace OfflineExporting {
     export function svgToPdf(
         svgElement: SVGElement,
         margin: number,
+        scale: number,
         callback: Function
     ): void {
-        const width = Number(svgElement.getAttribute('width')) + 2 * margin,
-            height = Number(svgElement.getAttribute('height')) + 2 * margin,
+        const width = (Number(svgElement.getAttribute('width')) + 2 * margin) *
+            scale,
+            height = (Number(svgElement.getAttribute('height')) + 2 * margin) *
+                scale,
             pdfDoc = new win.jspdf.jsPDF( // eslint-disable-line new-cap
                 // setting orientation to portrait if height exceeds width
                 height > width ? 'p' : 'l',


### PR DESCRIPTION
Fixed #19762, offline export PDF documents didn't scale.