### PR TITLE
bugfix/19672-dateformat-seconds

### DIFF
--- a/test/ts-node-unit-tests/tests/global-utils.test.ts
+++ b/test/ts-node-unit-tests/tests/global-utils.test.ts
@@ -1,4 +1,4 @@
-import { ok } from 'assert';
+import { ok, strictEqual } from 'assert';
 import { describe } from '../test-utils';
 
 export function testGlobalUtilities() {
@@ -61,4 +61,13 @@ export function testGlobalUtilities() {
             throw new Error(`${prop} should be either a function or an object/array`);
         }
     });
+}
+
+export function testTime() {
+    const Highcharts = require('../../../code/highcharts.src.js')();
+    const time = new Highcharts.Time();
+    strictEqual(
+        time.dateFormat('%A, %e %b, %H:%M:%S', Date.UTC(1893, 0, 1, 0, 0, 0, 0)),
+        'Sunday,  1 Jan, 00:00:00'
+    );
 }

--- a/ts/Core/Time.ts
+++ b/ts/Core/Time.ts
@@ -564,7 +564,7 @@ class Time {
                     // Lower case AM or PM
                     P: hours < 12 ? 'am' : 'pm',
                     // Two digits seconds, 00 through  59
-                    S: pad(date.getSeconds()),
+                    S: pad(this.get('Seconds', date)),
                     // Milliseconds (naming from Ruby)
                     L: pad(Math.floor((timestamp as any) % 1000), 3)
                 },


### PR DESCRIPTION
Fixed #19672, changed the way we get the seconds in dateFormat. Formatting was not working as expected. 