### PR TITLE
bugfix/17014-boostTreshold-null-point-error

### DIFF
--- a/samples/unit-tests/boost/general/demo.js
+++ b/samples/unit-tests/boost/general/demo.js
@@ -169,6 +169,29 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
             2,
             'Null points should not be added to the series\' kd-tree (#19341)'
         );
+
+        chart.update({
+            xAxis: {
+                min: 0,
+                max: 10
+            },
+
+            yAxis: {
+                min: 0,
+                max: 10
+            }
+        });
+
+        chart.addSeries({
+            data: [1, 2, 3, 4, null, 6, 7],
+            boostThreshold: 5
+        });
+
+        assert.ok(
+            true,
+            `There shouldn't be any error in the console, after chart render
+            (#17014).`
+        );
     }
 );
 

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -62,7 +62,8 @@ const {
     isArray,
     isNumber,
     pick,
-    wrap
+    wrap,
+    defined
 } = U;
 import WGLRenderer from './WGLRenderer.js';
 
@@ -1032,7 +1033,7 @@ function seriesRenderCanvas(this: Series): void {
             low: number = false as any,
             isYInside = true;
 
-        if (typeof d === 'undefined') {
+        if (!defined(d)) {
             return true;
         }
 


### PR DESCRIPTION
Fixed #17014, `boostTreshold` with null point threw an error.