### PR TITLE
dash/visual-test-climate-timeout 

### DIFF
--- a/test/cypress/visual/Dashboards.cy.js
+++ b/test/cypress/visual/Dashboards.cy.js
@@ -8,7 +8,7 @@ describe('Dashboards climate demo visual tests', () => {
     it('Climate demo', () => {
         cy.boardRendered();
         cy.get('g.highcharts-markers.highcharts-series-1.highcharts-mappoint-series')
-            .children('.highcharts-point').should('have.length', 30);
+            .children('.highcharts-point', {timeout: 15000}).should('have.length', 30);
         cy.get('#demo-content').compareSnapshot('dashboard-climate-loaded', 0.1);
     });
 


### PR DESCRIPTION
Increased the timeout in climate demo visual tests when waiting for all pins to appear on the map.