### PR TITLE
Samples: more reliable size to prevent false negative visual diffs

### DIFF
--- a/samples/highcharts/demo/column-comparison/demo.css
+++ b/samples/highcharts/demo/column-comparison/demo.css
@@ -44,3 +44,8 @@
     background-color: #0051b4;
     color: white;
 }
+
+.f32 .flag {
+    height: 32px;
+    width: 32px;
+}


### PR DESCRIPTION
This test randomly provides false negative visual diffs because the associated CSS file may or may not be loaded at the time of the snapshot.