### PR TITLE
bugfix/17820-navigator-clip-rect-boost

### DIFF
--- a/samples/unit-tests/boost/general/demo.css
+++ b/samples/unit-tests/boost/general/demo.css
@@ -1,0 +1,5 @@
+#container {
+    width: 600px;
+    height: 350px;
+    margin: 0 auto;
+}

--- a/samples/unit-tests/boost/general/demo.css
+++ b/samples/unit-tests/boost/general/demo.css
@@ -1,5 +1,5 @@
 #container {
     width: 600px;
-    height: 350px;
+    height: 400px;
     margin: 0 auto;
 }

--- a/samples/unit-tests/boost/general/demo.js
+++ b/samples/unit-tests/boost/general/demo.js
@@ -279,7 +279,7 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
 );
 
 QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
-    'The boost clip-path should have the same size as the chart area, #14444.',
+    'The boost clip-path should have appropriate size, #14444, #17820.',
     function (assert) {
         function generataSeries() {
             const series = Array.from(Array(100)).map(function () {
@@ -351,6 +351,30 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
             chart.yAxis[0].height,
             `After setting the axis position manually, the boost clip-path
             shouldn\'t be bigger than the axis size.`
+        );
+
+        // #17820
+        chart.update({
+            chart: {
+                inverted: false
+            },
+            navigator: {
+                enabled: true,
+                height: 80,
+                series: {
+                    boostThreshold: 1,
+                    color: 'red',
+                    type: 'line',
+                    dataGrouping: {
+                        enabled: false
+                    }
+                }
+            }
+        });
+        assert.strictEqual(
+            chart.boost.clipRect.attr('height'),
+            chart.navigator.top + chart.navigator.height - chart.plotTop,
+            'Clip rect should take into account navigator boosted series, #17820.'
         );
     }
 );

--- a/ts/Extensions/Boost/BoostChart.ts
+++ b/ts/Extensions/Boost/BoostChart.ts
@@ -104,7 +104,9 @@ function getBoostClipRect(
         x: chart.plotLeft,
         y: chart.plotTop,
         width: chart.plotWidth,
-        height: chart.plotHeight
+        height: chart.navigator ? // #17820
+            chart.navigator.top + chart.navigator.height - chart.plotTop :
+            chart.plotHeight
     };
 
     // Clipping of individal series (#11906, #19039).
@@ -134,8 +136,6 @@ function getBoostClipRect(
                 chart.plotTop +
                 verticalAxes[0].len
             );
-        } else {
-            clipBox.height = chart.plotHeight;
         }
     }
 


### PR DESCRIPTION
Fixed #17820, clip rect did not take into account boosted navigator.