### PR TITLE
docs/19480-plotlineorband-missing-properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "jsdoc": "npx gulp jsdoc-watch --skip-websearch",
     "jsdoc-highcharts": "npx gulp jsdoc-watch --products highcharts --skip-websearch",
     "jsdoc-highstock": "npx gulp jsdoc-watch --products highstock --skip-websearch",
-    "dts": "npx gulp dts && npx gulp dtslint",
     "ts-compile:test": "npx tsc -p test && npx tsc -p samples",
     "gulp": "npx gulp",
     "utils": "highcharts-utils",

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -101,7 +101,14 @@ class PlotLineOrBand {
      * */
 
     public axis: PlotLineOrBandAxis.Composition;
-    public id?: string;
+
+    /**
+     * The id of the plot line or plot band.
+     *
+     * @name Highcharts.PlotLineOrBand#id
+     * @type {string}
+     */
+    public id?: string = void 0 as any;
     public isActive?: boolean;
     public eventsAdded?: boolean;
     public label?: SVGElement;
@@ -126,9 +133,21 @@ class PlotLineOrBand {
         fireEvent(this, 'render');
 
         const plotLine = this,
+            /**
+             * Related axis.
+             *
+             * @name Highcharts.PlotLineOrBand#axis
+             * @type {Highcharts.Axis}
+             */
             axis = plotLine.axis,
             horiz = axis.horiz,
             log = axis.logarithmic,
+            /**
+             * Options of the plot line or band.
+             *
+             * @name Highcharts.PlotLineOrBand#options
+             * @type {AxisPlotBandsOptions|AxisPlotLinesOptions}
+             */
             options = plotLine.options as (PlotBandOptions|PlotLineOptions),
             color = options.color,
             zIndex = pick(options.zIndex, 0),
@@ -213,7 +232,6 @@ class PlotLineOrBand {
                 .add(group);
         }
 
-
         // Set the path or return
         if (isLine) {
             path = axis.getPlotLinePath({
@@ -293,6 +311,12 @@ class PlotLineOrBand {
         zIndex?: number
     ): void {
         const plotLine = this,
+            /**
+             * PlotLine axis
+             *
+             * @name Highcharts.Axis
+             * @type {PlotLineOrBandAxis.Composition}
+             */
             axis = plotLine.axis,
             renderer = axis.chart.renderer;
 

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -311,12 +311,6 @@ class PlotLineOrBand {
         zIndex?: number
     ): void {
         const plotLine = this,
-            /**
-             * PlotLine axis
-             *
-             * @name Highcharts.Axis
-             * @type {PlotLineOrBandAxis.Composition}
-             */
             axis = plotLine.axis,
             renderer = axis.chart.renderer;
 


### PR DESCRIPTION
Fixed #19480, added missing TypeScript definitions for `PlotLineOrBand` properties.
Removed `dts` script from `package.json`, as the defined commands weren't present in any of the gulp scripts.