### PR TITLE
tools/gh-actions-merge

### DIFF
--- a/.github/workflows/visual-compare.yml
+++ b/.github/workflows/visual-compare.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           ref: master
 
+      - name: Error if merge fails
+        run: echo "::error::Was not able to merge with master"
+
       - name: Use Node.js lts/*
         uses: actions/setup-node@v3
         with:
@@ -49,7 +52,7 @@ jobs:
           fetch-depth: 0
 
       - name: Merge master into PR branch
-        run: git merge origin/master --ff-only
+        run: git merge origin/master
 
       - name: Use Node.js lts/*
         uses: actions/setup-node@v3

--- a/.github/workflows/visual-compare.yml
+++ b/.github/workflows/visual-compare.yml
@@ -25,7 +25,7 @@ jobs:
           ref: master
 
       - name: Error if merge fails
-        run: echo "::error::Was not able to merge with master"
+        run: echo "::error::Was not able to merge with master" && exit 1
 
       - name: Use Node.js lts/*
         uses: actions/setup-node@v3

--- a/.github/workflows/visual-compare.yml
+++ b/.github/workflows/visual-compare.yml
@@ -24,8 +24,6 @@ jobs:
         with:
           ref: master
 
-      - name: Error if merge fails
-        run: echo "::error::Was not able to merge with master" && exit 1
 
       - name: Use Node.js lts/*
         uses: actions/setup-node@v3
@@ -52,7 +50,12 @@ jobs:
           fetch-depth: 0
 
       - name: Merge master into PR branch
+        id: mergeMaster
         run: git merge origin/master
+
+      - name: Error if merge fails
+        if: ${{ always() && steps.mergeMaster.outcome == 'failure' }}
+        run: echo "::error::Was not able to merge cleanly with master"
 
       - name: Use Node.js lts/*
         uses: actions/setup-node@v3
@@ -116,7 +119,12 @@ jobs:
           fetch-depth: 0
 
       - name: Merge master into PR branch
-        run: git merge origin/master --ff-only
+        id: mergeMaster
+        run: git merge origin/master
+
+      - name: Error if merge fails
+        if: ${{ always() && steps.mergeMaster.outcome == 'failure' }}
+        run: echo "::error::Was not able to merge cleanly with master"
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3


### PR DESCRIPTION
Removes `--ff-only` from the merges in comparison workflows, adds a better exit message if the merge doesn't work.