### PR TITLE
Samples: Occasionally failing column-comparison

### DIFF
--- a/samples/highcharts/demo/column-comparison/demo.js
+++ b/samples/highcharts/demo/column-comparison/demo.js
@@ -214,7 +214,9 @@ const chart = Highcharts.chart('container', {
             useHTML: true,
             animate: true,
             format: '{chart.options.countries.(value).ucCode}<br>' +
-                '<span class="f32"><span style="height:32px;" class="flag {value}"></span></span>',
+                '<span class="f32">' +
+                '<span style="display:inline-block;height:32px;vertical-align:text-top;" ' +
+                'class="flag {value}"></span></span>',
             style: {
                 textAlign: 'center'
             }


### PR DESCRIPTION
The previous change needed `display: inline-block` to work, and `vertical-align` for pixel perfection.