### PR TITLE
bugfix/19793-trendline-duplicate-x-values

### DIFF
--- a/samples/unit-tests/indicator-trendline/recalculations/demo.js
+++ b/samples/unit-tests/indicator-trendline/recalculations/demo.js
@@ -54,4 +54,22 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
         'red',
         'Line color changed'
     );
+
+    chart.series[0].setData([
+        [1, 1],
+        [1, 2],
+        [2, 2],
+        [2, 4],
+        [3, 3],
+        [3, 2],
+        [4, 8]
+    ]);
+    const trendLineYData = chart.series[1].yData;
+
+    assert.deepEqual(
+        correctFloat(trendLineYData[0], 2) === 0.9 &&
+            correctFloat(trendLineYData[trendLineYData.length - 1], 2) === 6.6,
+        true,
+        'Correct values for duplicated xAxis main series values, #19793.'
+    );
 });

--- a/samples/unit-tests/indicator-trendline/recalculations/demo.js
+++ b/samples/unit-tests/indicator-trendline/recalculations/demo.js
@@ -30,7 +30,7 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
     chart.series[0].points[3].remove();
 
     assert.deepEqual(
-        correctFloat(tr[0], 2) === 1.1 &&
+        correctFloat(tr[0], 2) === 0.92 &&
             correctFloat(tr[tr.length - 1], 2) === 4.4,
         true,
         'Correct values after point.remove()'

--- a/samples/unit-tests/indicator-trendline/recalculations/demo.js
+++ b/samples/unit-tests/indicator-trendline/recalculations/demo.js
@@ -29,9 +29,8 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
 
     chart.series[0].points[3].remove();
 
-    // Values corrected for #18710 fix
     assert.deepEqual(
-        correctFloat(tr[0], 2) === 0.92 &&
+        correctFloat(tr[0], 2) === 1.1 &&
             correctFloat(tr[tr.length - 1], 2) === 4.4,
         true,
         'Correct values after point.remove()'
@@ -67,9 +66,33 @@ QUnit.test('Test algorithm on data updates.', function (assert) {
     const trendLineYData = chart.series[1].yData;
 
     assert.deepEqual(
-        correctFloat(trendLineYData[0], 2) === 0.9 &&
-            correctFloat(trendLineYData[trendLineYData.length - 1], 2) === 6.6,
+        correctFloat(trendLineYData[0], 2) === 1.1 &&
+            correctFloat(trendLineYData[trendLineYData.length - 1], 2) === 5.8,
         true,
         'Correct values for duplicated xAxis main series values, #19793.'
+    );
+
+    const alpha = 1.57692,
+        beta = -0.461538,
+        trendlineX = chart.series[1].xData,
+        trendlineY = chart.series[1].yData,
+        firstPointX = trendlineX[0],
+        firstPointY = trendlineY[0],
+        lastPointX = trendlineX[trendlineX.length - 1],
+        lastPointY = trendlineY[trendlineY.length - 1];
+
+    assert.close(
+        // y = ax + b
+        alpha * firstPointX + beta,
+        firstPointY,
+        0.0001,
+        'Data values should be equal to the math linear regression calculations.'
+    );
+    assert.close(
+        // y = ax + b
+        alpha * lastPointX + beta,
+        lastPointY,
+        0.0001,
+        'Data values should be equal to the math linear regression calculations.'
     );
 });

--- a/ts/Stock/Indicators/TrendLine/TrendLineIndicator.ts
+++ b/ts/Stock/Indicators/TrendLine/TrendLineIndicator.ts
@@ -113,7 +113,7 @@ class TrendLineIndicator extends SMAIndicator {
             LR: Array<Array<number>> = [],
             xData: Array<number> = [],
             yData: Array<number> = [],
-            index: number = params.index || 3;
+            index: number = params.index;
 
         let numerator = 0,
             denominator = 0,

--- a/ts/Stock/Indicators/TrendLine/TrendLineIndicator.ts
+++ b/ts/Stock/Indicators/TrendLine/TrendLineIndicator.ts
@@ -107,8 +107,9 @@ class TrendLineIndicator extends SMAIndicator {
         series: TLinkedSeries,
         params: TrendLineParamsOptions
     ): IndicatorValuesObject<TLinkedSeries> {
-        const xVal: Array<number> = (series.xData as any),
+        const orgXVal: Array<number> = (series.xData as any),
             yVal: Array<Array<number>> = (series.yData as any),
+            xVal: Array<number> = [],
             LR: Array<Array<number>> = [],
             xData: Array<number> = [],
             yData: Array<number> = [],
@@ -117,7 +118,16 @@ class TrendLineIndicator extends SMAIndicator {
         let numerator = 0,
             denominator = 0,
             xValSum = 0,
-            yValSum = 0;
+            yValSum = 0,
+            counter = 0;
+
+        // Create an array of consecutive xValues, (don't remove duplicates)
+        for (let i = 0; i < orgXVal.length; i++) {
+            if (i === 0 || orgXVal[i] !== orgXVal[i - 1]) {
+                counter++;
+            }
+            xVal.push(counter);
+        }
 
         for (let i = 0; i < xVal.length; i++) {
             const y = isArray(yVal[i]) ? yVal[i][index] : (yVal[i] as any);
@@ -137,11 +147,11 @@ class TrendLineIndicator extends SMAIndicator {
         // Calculate linear regression:
         for (let i = 0; i < xVal.length; i++) {
             // Check if the xVal is already used
-            if (xVal[i] === xData[xData.length - 1]) {
+            if (orgXVal[i] === xData[xData.length - 1]) {
                 continue;
             }
-            const x = xVal[i],
-                y = meanY + (numerator / denominator) * (x - meanX);
+            const x = orgXVal[i],
+                y = meanY + (numerator / denominator) * (xVal[i] - meanX);
 
             LR.push([x, y]);
             xData.push(x);

--- a/ts/Stock/Indicators/TrendLine/TrendLineIndicator.ts
+++ b/ts/Stock/Indicators/TrendLine/TrendLineIndicator.ts
@@ -113,7 +113,7 @@ class TrendLineIndicator extends SMAIndicator {
             LR: Array<Array<number>> = [],
             xData: Array<number> = [],
             yData: Array<number> = [],
-            uniqueXVal: Array<number> = [...new Set(xVal)],
+            uniqueXVal: Array<number> = [],
             index: number = (params.index as any);
 
         // Generate an array of unique xValues

--- a/ts/Stock/Indicators/TrendLine/TrendLineIndicator.ts
+++ b/ts/Stock/Indicators/TrendLine/TrendLineIndicator.ts
@@ -130,9 +130,8 @@ class TrendLineIndicator extends SMAIndicator {
         }
 
         for (let i = 0; i < xVal.length; i++) {
-            const y = isArray(yVal[i]) ? yVal[i][index] : (yVal[i] as any);
             xValSum += xVal[i];
-            yValSum += y;
+            yValSum += isArray(yVal[i]) ? yVal[i][index] : (yVal[i] as any);
         }
 
         const meanX = xValSum / xVal.length,

--- a/ts/Stock/Indicators/TrendLine/TrendLineIndicator.ts
+++ b/ts/Stock/Indicators/TrendLine/TrendLineIndicator.ts
@@ -28,7 +28,8 @@ import U from '../../../Core/Utilities.js';
 const {
     extend,
     merge,
-    isArray
+    isArray,
+    pushUnique
 } = U;
 
 /* *
@@ -113,10 +114,15 @@ class TrendLineIndicator extends SMAIndicator {
             xData: Array<number> = [],
             yData: Array<number> = [],
             uniqueXVal: Array<number> = [...new Set(xVal)],
-            uniqueXLen: number = uniqueXVal.length,
             index: number = (params.index as any);
 
-        let sumX = (uniqueXLen - 1) * uniqueXLen / 2,
+        // Generate an array of unique xValues
+        xVal.forEach((x: number): void => {
+            pushUnique(uniqueXVal, x);
+        });
+
+        let uniqueXLen: number = uniqueXVal.length,
+            sumX = (uniqueXLen - 1) * uniqueXLen / 2,
             sumY = 0,
             sumXY = 0,
             sumX2 =

--- a/ts/Stock/Indicators/TrendLine/TrendLineOptions.d.ts
+++ b/ts/Stock/Indicators/TrendLine/TrendLineOptions.d.ts
@@ -25,6 +25,7 @@ import type {
 
 export interface TrendLineParamsOptions extends SMAParamsOptions {
     // for inheritance
+    index: number;
 }
 
 export interface TrendLineOptions extends SMAOptions {


### PR DESCRIPTION
Fixed #19793, trendline was not working for duplicate `x` values.