### PR TITLE
Bugfix/19742 anchor pos moved twice

### DIFF
--- a/samples/unit-tests/series/datagrouping-anchor/demo.js
+++ b/samples/unit-tests/series/datagrouping-anchor/demo.js
@@ -371,26 +371,26 @@ QUnit.test('Data grouping anchor for single point in the dataset', function (ass
     assert.strictEqual(
         chart.series[0].points[0].x,
         0,
-        'for dataGrouping anchor the point should be at the beginning'
+        'anchor: `start` -> beginning of the group'
     );
     assert.strictEqual(
         chart.series[1].points[0].x,
         hour,
-        'for dataGrouping anchor middle the point should be after 1h'
+        'anchor: `middle` -> middle of the group'
     );
     assert.strictEqual(
         chart.series[2].points[0].x,
         hour * 2,
-        'for dataGrouping anchor end the point should be after 2h'
+        'anchor: `end` -> end of the group'
     );
 });
 
-QUnit.test('Anchor should be applied to the last point as well', function (assert) {
+QUnit.test('DataGrouping unequal series length', function (assert) {
     const data = [
-        1, // first group
-        2, // first group ---> (1 + 2) / 2 = 1,5
-        3, // second group
-        4, // second group ---> (3 + 4) / 2 = 3,5
+        1,
+        2,
+        3,
+        4,
         1,
         2,
         3,
@@ -400,6 +400,7 @@ QUnit.test('Anchor should be applied to the last point as well', function (asser
         3,
         {
             y: 4,
+            // To make lastAnchor: lastPoint visible
             x: 3600 * 1000 * 10 + 4250000
         }
     ];
@@ -449,13 +450,9 @@ QUnit.test('Anchor should be applied to the last point as well', function (asser
             }
         }]
     });
-    const xPositions = [
-        chart.series[0].points.at(-2).x,
-        chart.series[1].points.at(-1).x
-    ];
     assert.equal(
-        xPositions[0],
-        xPositions[1],
+        chart.series[0].points.at(-2).x,
+        chart.series[1].points.at(-1).x,
         `last point of series 1 and second to last point in series 2 should be
             in the same position`
     );
@@ -465,7 +462,8 @@ QUnit.test('Anchor should be applied to the last point as well', function (asser
     assert.equal(
         content,
         'Thursday,  1 Jan, 00:00-01:59',
-        'Tooltip\'s content should show correct group range for the first point'
+        `Tooltip\'s content should show correct group range for the point with
+        anchor: middle`
     );
 
     chart.series[0].update({
@@ -476,7 +474,6 @@ QUnit.test('Anchor should be applied to the last point as well', function (asser
     });
 
     chart.tooltip.refresh(chart.series[0].points.at(-1));
-    // 10:00-11:59
     content = chart.tooltip.tt.text.element.childNodes[0].innerHTML;
     assert.equal(
         content,

--- a/samples/unit-tests/series/datagrouping-anchor/demo.js
+++ b/samples/unit-tests/series/datagrouping-anchor/demo.js
@@ -1,48 +1,48 @@
 QUnit.test('Data grouping anchor for points in the middle of the data set.', function (assert) {
     const chart = Highcharts.stockChart('container', {
-        yAxis: [{
-            height: '33.33%',
-            offset: 0
-        }, {
-            height: '33.33%',
-            top: '33.33%',
-            offset: 0
-        }, {
-            height: '33.33%',
-            top: '66.66%',
-            offset: 0
-        }],
-        plotOptions: {
-            series: {
-                data: [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4],
-                pointInterval: 3600 * 1000,
-                dataGrouping: {
-                    approximation: 'average',
-                    enabled: true,
-                    forced: true,
-                    units: [
-                        ['hour', [2]]
-                    ]
+            yAxis: [{
+                height: '33.33%',
+                offset: 0
+            }, {
+                height: '33.33%',
+                top: '33.33%',
+                offset: 0
+            }, {
+                height: '33.33%',
+                top: '66.66%',
+                offset: 0
+            }],
+            plotOptions: {
+                series: {
+                    data: [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4],
+                    pointInterval: 3600 * 1000,
+                    dataGrouping: {
+                        approximation: 'average',
+                        enabled: true,
+                        forced: true,
+                        units: [
+                            ['hour', [2]]
+                        ]
+                    }
                 }
-            }
-        },
-        series: [{
-            type: 'column',
-            yAxis: 0
-        }, {
-            yAxis: 1,
-            type: 'column',
-            dataGrouping: {
-                anchor: 'middle'
-            }
-        }, {
-            yAxis: 2,
-            type: 'column',
-            dataGrouping: {
-                anchor: 'end'
-            }
-        }]
-    }),
+            },
+            series: [{
+                type: 'column',
+                yAxis: 0
+            }, {
+                yAxis: 1,
+                type: 'column',
+                dataGrouping: {
+                    anchor: 'middle'
+                }
+            }, {
+                yAxis: 2,
+                type: 'column',
+                dataGrouping: {
+                    anchor: 'end'
+                }
+            }]
+        }),
         hour = 3600 * 1000;
 
     assert.strictEqual(
@@ -295,7 +295,7 @@ QUnit.test('Deprecated smoothed option.', function (assert) {
     assert.strictEqual(
         chart.series[0].points[chart.series[0].points.length - 1].x,
         11.7 * hour,
-        `When the smoothed enabled, the last point 
+        `When the smoothed enabled, the last point
         should be placed where the last group point is.`
     );
     assert.strictEqual(
@@ -305,15 +305,15 @@ QUnit.test('Deprecated smoothed option.', function (assert) {
         the point from the main series should match the navigator series.`
     );
 });
-QUnit.skip('Data grouping anchor for single point in the dataset', function (assert) {
+QUnit.test('Data grouping anchor for single point in the dataset', function (assert) {
     const data = [
         1,
         2
     ];
-        const chart = Highcharts.stockChart('container', {
+    const chart = Highcharts.stockChart('container', {
             chart: {
                 height: 800,
-                type: "column"
+                type: 'column'
             },
             yAxis: [{
                 height: '33.33%',

--- a/samples/unit-tests/series/datagrouping-anchor/demo.js
+++ b/samples/unit-tests/series/datagrouping-anchor/demo.js
@@ -1,45 +1,48 @@
 QUnit.test('Data grouping anchor for points in the middle of the data set.', function (assert) {
     const chart = Highcharts.stockChart('container', {
-            yAxis: [{
-                height: '33.33%',
-                offset: 0
-            }, {
-                height: '33.33%',
-                top: '33.33%',
-                offset: 0
-            }, {
-                height: '33.33%',
-                top: '66.66%',
-                offset: 0
-            }],
-            plotOptions: {
-                series: {
-                    data: [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4],
-                    pointInterval: 3600 * 1000,
-                    dataGrouping: {
-                        approximation: 'average',
-                        enabled: true,
-                        forced: true,
-                        units: [
-                            ['hour', [2]]
-                        ]
-                    }
-                }
-            },
-            series: [{
-                yAxis: 0
-            }, {
-                yAxis: 1,
+        yAxis: [{
+            height: '33.33%',
+            offset: 0
+        }, {
+            height: '33.33%',
+            top: '33.33%',
+            offset: 0
+        }, {
+            height: '33.33%',
+            top: '66.66%',
+            offset: 0
+        }],
+        plotOptions: {
+            series: {
+                data: [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4],
+                pointInterval: 3600 * 1000,
                 dataGrouping: {
-                    anchor: 'middle'
+                    approximation: 'average',
+                    enabled: true,
+                    forced: true,
+                    units: [
+                        ['hour', [2]]
+                    ]
                 }
-            }, {
-                yAxis: 2,
-                dataGrouping: {
-                    anchor: 'end'
-                }
-            }]
-        }),
+            }
+        },
+        series: [{
+            type: 'column',
+            yAxis: 0
+        }, {
+            yAxis: 1,
+            type: 'column',
+            dataGrouping: {
+                anchor: 'middle'
+            }
+        }, {
+            yAxis: 2,
+            type: 'column',
+            dataGrouping: {
+                anchor: 'end'
+            }
+        }]
+    }),
         hour = 3600 * 1000;
 
     assert.strictEqual(
@@ -62,7 +65,7 @@ QUnit.test('Data grouping anchor for points in the middle of the data set.', fun
     );
     assert.ok(
         chart.xAxis[0].max >=
-            chart.series[2].points[chart.series[2].points.length - 1].x,
+        chart.series[2].points[chart.series[2].points.length - 1].x,
         `When the last anchor set, the extremes should be changed
         and the last point should be visible.`
     );
@@ -301,4 +304,87 @@ QUnit.test('Deprecated smoothed option.', function (assert) {
         `When navigator anchors options are not declared,
         the point from the main series should match the navigator series.`
     );
+});
+QUnit.skip('Data grouping anchor for single point in the dataset', function (assert) {
+    const data = [
+        1,
+        2
+    ];
+        const chart = Highcharts.stockChart('container', {
+            chart: {
+                height: 800,
+                type: "column"
+            },
+            yAxis: [{
+                height: '33.33%',
+                offset: 0,
+                title: {
+                    text: 'Anchor start- default'
+                }
+            }, {
+                height: '33.33%',
+                top: '33.33%',
+                offset: 0,
+                title: {
+                    text: 'Anchor middle'
+                }
+            }, {
+                height: '33.33%',
+                top: '66.66%',
+                offset: 0,
+                title: {
+                    text: 'Anchor end'
+                }
+            }],
+            tooltip: {
+                split: false
+            },
+            plotOptions: {
+                series: {
+                    pointInterval: 3600 * 1000,
+                    dataGrouping: {
+                        approximation: 'average',
+                        enabled: true,
+                        forced: true,
+                        units: [
+                            ['hour', [2]]
+                        ]
+                    }
+                }
+            },
+            series: [{
+                data: data,
+                yAxis: 0
+
+            }, {
+                data: data,
+                yAxis: 1,
+                dataGrouping: {
+                    anchor: 'middle'
+                }
+            }, {
+                data: data,
+                yAxis: 2,
+                dataGrouping: {
+                    anchor: 'end'
+                }
+            }]
+        }),
+        hour = 3600 * 1000;
+    assert.strictEqual(
+        chart.series[0].points[0].x,
+        0,
+        'for dataGrouping anchor the point should be at the beginning'
+    );
+    assert.strictEqual(
+        chart.series[1].points[0].x,
+        hour,
+        'for dataGrouping anchor middle the point should be after 1h'
+    );
+    assert.strictEqual(
+        chart.series[2].points[0].x,
+        hour * 2,
+        'for dataGrouping anchor end the point should be after 2h'
+    );
+
 });

--- a/samples/unit-tests/series/datagrouping-anchor/demo.js
+++ b/samples/unit-tests/series/datagrouping-anchor/demo.js
@@ -27,17 +27,14 @@ QUnit.test('Data grouping anchor for points in the middle of the data set.', fun
                 }
             },
             series: [{
-                type: 'column',
                 yAxis: 0
             }, {
                 yAxis: 1,
-                type: 'column',
                 dataGrouping: {
                     anchor: 'middle'
                 }
             }, {
                 yAxis: 2,
-                type: 'column',
                 dataGrouping: {
                     anchor: 'end'
                 }
@@ -353,17 +350,17 @@ QUnit.test('Data grouping anchor for single point in the dataset', function (ass
                 }
             },
             series: [{
-                data: data,
+                data,
                 yAxis: 0
 
             }, {
-                data: data,
+                data,
                 yAxis: 1,
                 dataGrouping: {
                     anchor: 'middle'
                 }
             }, {
-                data: data,
+                data,
                 yAxis: 2,
                 dataGrouping: {
                     anchor: 'end'

--- a/ts/Extensions/DataGrouping/DataGrouping.ts
+++ b/ts/Extensions/DataGrouping/DataGrouping.ts
@@ -27,10 +27,12 @@ import DataGroupingSeriesComposition from './DataGroupingSeriesComposition.js';
 import F from '../../Core/Templating.js';
 const { format } = F;
 import U from '../../Core/Utilities.js';
+import Point from '../../Core/Series/Point';
 const {
     addEvent,
     extend,
-    isNumber
+    isNumber,
+    pick
 } = U;
 
 /* *
@@ -76,10 +78,12 @@ function onTooltipHeaderFormatter(
     this: Tooltip,
     e: Event&AnyRecord
 ): void {
+
     const chart = this.chart,
         time = chart.time,
         labelConfig = e.labelConfig,
         series = labelConfig.series as Series,
+        point = labelConfig.point as Point,
         options = series.options,
         tooltipOptions = series.tooltipOptions,
         dataGroupingOptions = options.dataGrouping,
@@ -132,12 +136,22 @@ function onTooltipHeaderFormatter(
             );
         }
 
-        // now format the key
-        formattedKey = time.dateFormat(xDateFormat as any, labelConfig.key);
+        const groupStart = pick(
+                series &&
+                    series.groupMap &&
+                    series.groupMap[point.index].startX,
+                labelConfig.key
+            ),
+            groupEnd = groupStart + currentDataGrouping?.totalRange - 1;
+
+        formattedKey = time.dateFormat(
+            xDateFormat as any,
+            groupStart
+        );
         if (xDateFormatEnd) {
             formattedKey += time.dateFormat(
                 xDateFormatEnd,
-                labelConfig.key + (currentDataGrouping as any).totalRange - 1
+                groupEnd
             );
         }
 

--- a/ts/Extensions/DataGrouping/DataGrouping.ts
+++ b/ts/Extensions/DataGrouping/DataGrouping.ts
@@ -137,9 +137,7 @@ function onTooltipHeaderFormatter(
         }
 
         const groupStart = pick(
-                series &&
-                    series.groupMap &&
-                    series.groupMap[point.index].groupStart,
+                series.groupMap?.[point.index].groupStart,
                 labelConfig.key
             ),
             groupEnd = groupStart + currentDataGrouping?.totalRange - 1;

--- a/ts/Extensions/DataGrouping/DataGrouping.ts
+++ b/ts/Extensions/DataGrouping/DataGrouping.ts
@@ -139,7 +139,7 @@ function onTooltipHeaderFormatter(
         const groupStart = pick(
                 series &&
                     series.groupMap &&
-                    series.groupMap[point.index].startX,
+                    series.groupMap[point.index].groupStart,
                 labelConfig.key
             ),
             groupEnd = groupStart + currentDataGrouping?.totalRange - 1;

--- a/ts/Extensions/DataGrouping/DataGroupingSeriesComposition.ts
+++ b/ts/Extensions/DataGrouping/DataGroupingSeriesComposition.ts
@@ -215,18 +215,15 @@ function anchorPoints(
 
     const groupedDataLastIndex = groupedXData.length - 1,
         anchor = dataGroupingOptions.anchor,
-        firstAnchor = pick(dataGroupingOptions.firstAnchor, false),
-        lastAnchor = pick(dataGroupingOptions.lastAnchor, false);
+        firstAnchor = dataGroupingOptions.firstAnchor,
+        lastAnchor = dataGroupingOptions.lastAnchor;
     let i = groupedXData.length - 1,
         iEnd = 0;
     // Anchor points that are not extremes.
 
     // Change the first point position, but only when it is
     // the first point in the data set not in the current zoom.
-    if (
-        firstAnchor &&
-            series.xData[0] >= groupedXData[0]
-    ) {
+    if (firstAnchor && series.xData[0] >= groupedXData[0]) {
         iEnd++;
         const groupStart = series.groupMap[0].start,
             groupLength = series.groupMap[0].length;

--- a/ts/Extensions/DataGrouping/DataGroupingSeriesComposition.ts
+++ b/ts/Extensions/DataGrouping/DataGroupingSeriesComposition.ts
@@ -248,8 +248,10 @@ function anchorPoints(
         }
 
         // Change the last point position but only when it is
-        // the last point in the data set not in the current zoom.
+        // the last point in the data set not in the current zoom,
+        // or if it is not the 1st point simutainously.
         if (
+            groupedDataLength > 0 &&
             lastAnchor &&
             lastAnchor !== 'start' &&
             totalRange &&

--- a/ts/Extensions/DataGrouping/DataGroupingSeriesComposition.ts
+++ b/ts/Extensions/DataGrouping/DataGroupingSeriesComposition.ts
@@ -206,9 +206,9 @@ function anchorPoints(
 
     if (!(
         dataGroupingOptions &&
-            series.xData &&
-            totalRange &&
-            series.groupMap
+        series.xData &&
+        totalRange &&
+        series.groupMap
     )) {
         return;
     }
@@ -217,14 +217,13 @@ function anchorPoints(
         anchor = dataGroupingOptions.anchor,
         firstAnchor = dataGroupingOptions.firstAnchor,
         lastAnchor = dataGroupingOptions.lastAnchor;
-    let i = groupedXData.length - 1,
-        iEnd = 0;
-    // Anchor points that are not extremes.
+    let anchorIndexIterator = groupedXData.length - 1,
+        anchorFirstIndex = 0;
 
     // Change the first point position, but only when it is
     // the first point in the data set not in the current zoom.
     if (firstAnchor && series.xData[0] >= groupedXData[0]) {
-        iEnd++;
+        anchorFirstIndex++;
         const groupStart = series.groupMap[0].start,
             groupLength = series.groupMap[0].length;
         let firstGroupEnd;
@@ -251,7 +250,7 @@ function anchorPoints(
             totalRange &&
             groupedXData[groupedDataLastIndex] >= xMax - totalRange
     ) {
-        i--;
+        anchorIndexIterator--;
         const lastGroupStart = series.groupMap[
             series.groupMap.length - 1
         ].start;
@@ -271,9 +270,9 @@ function anchorPoints(
                 ({ middle: 0.5, end: 1 } as AnchorChoiceType)[anchor]
         );
 
-        while (i >= iEnd) {
-            groupedXData[i] += shiftInterval;
-            i--;
+        while (anchorIndexIterator >= anchorFirstIndex) {
+            groupedXData[anchorIndexIterator] += shiftInterval;
+            anchorIndexIterator--;
         }
     }
 }
@@ -396,8 +395,8 @@ function applyGrouping(
         // to the new anchoring mechanism. #12455.
         if (
             dataGroupingOptions &&
-                dataGroupingOptions.smoothed &&
-                groupedXData.length
+            dataGroupingOptions.smoothed &&
+            groupedXData.length
         ) {
             dataGroupingOptions.firstAnchor = 'firstPoint';
             dataGroupingOptions.anchor = 'middle';
@@ -669,7 +668,8 @@ function groupData(
             pointX = groupPositions[pos];
             series.dataGroupInfo = {
                 start: groupAll ? start : ((series.cropStart as any) + start),
-                length: values[0].length
+                length: values[0].length,
+                groupStart: pointX
             };
             groupedY = approximationFn.apply(series, values);
 
@@ -701,9 +701,7 @@ function groupData(
             if (typeof groupedY !== 'undefined') {
                 groupedXData.push(pointX);
                 groupedYData.push(groupedY);
-                groupMap.push(extend(series.dataGroupInfo, {
-                    groupStart: pointX
-                }));
+                groupMap.push(series.dataGroupInfo);
             }
 
             // reset the aggregate arrays

--- a/ts/Extensions/DataGrouping/DataGroupingSeriesComposition.ts
+++ b/ts/Extensions/DataGrouping/DataGroupingSeriesComposition.ts
@@ -270,6 +270,8 @@ function anchorPoints(
                 ({ middle: 0.5, end: 1 } as AnchorChoiceType)[anchor]
         );
 
+        // Anchor the rest of the points apart from the ones, that were
+        // previously moved.
         while (anchorIndexIterator >= anchorFirstIndex) {
             groupedXData[anchorIndexIterator] += shiftInterval;
             anchorIndexIterator--;

--- a/ts/Extensions/DataGrouping/DataGroupingSeriesComposition.ts
+++ b/ts/Extensions/DataGrouping/DataGroupingSeriesComposition.ts
@@ -103,7 +103,7 @@ export interface DataGroupingInfoObject {
     length?: number;
     options?: (PointOptions|PointShortOptions|SeriesTypeOptions);
     start?: number;
-    startX?: number
+    groupStart?: number
 }
 
 export interface DataGroupingResultObject {
@@ -705,7 +705,7 @@ function groupData(
                 groupedXData.push(pointX);
                 groupedYData.push(groupedY);
                 groupMap.push(extend(series.dataGroupInfo, {
-                    startX: pointX
+                    groupStart: pointX
                 }));
             }
 


### PR DESCRIPTION
Fixed #19743 and #19742, `DataGrouping` anchor positions weren't working correctly if there was only 1 point. Also Tooltip didn't take into consideration the anchors.

Closes #19742