### PR TITLE
tools/gulp-test-refactors

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,6 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged && \
-npx gulp lint-ts && \
-npm run test:precommit && \
-npx ts-node ./test/ts-node-unit-tests
+npm run test:precommit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,7 +3,5 @@
 
 npx lint-staged && \
 npx gulp lint-ts && \
-# npx gulp dashboards/test && \
-npx gulp test && \
-npx gulp test-ts && \
+npm run test:precommit && \
 npx ts-node ./test/ts-node-unit-tests

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dgulp": "gulp dashboards/scripts-watch",
     "dtest": "gulp dashboards/test",
     "test": "npx gulp test-ts --force && npx gulp test --force --speak",
-    "test:precommit": "npx gulp test-ts && npx gulp test",
+    "test:precommit": "npx gulp test-ts && npx gulp test && npx ts-node ./test/ts-node-unit-tests",
     "testall": "npx gulp test --browsers all --force --speak",
     "test-all": "npx gulp test --browsers all --force --speak",
     "test-dts": "npx gulp scripts && npx gulp jsdoc-dts && npx gulp lint-dts",
@@ -33,6 +33,7 @@
     "jsdoc": "npx gulp jsdoc-watch --skip-websearch",
     "jsdoc-highcharts": "npx gulp jsdoc-watch --products highcharts --skip-websearch",
     "jsdoc-highstock": "npx gulp jsdoc-watch --products highstock --skip-websearch",
+    "lint": "cd ts && npx eslint",
     "ts-compile:test": "npx tsc -p test && npx tsc -p samples",
     "gulp": "npx gulp",
     "utils": "highcharts-utils",
@@ -120,6 +121,9 @@
   "lint-staged": {
     "*.js": [
       "eslint"
+    ],
+    "./ts/**/*.ts": [
+      "npm run lint"
     ],
     "*.css": [
       "stylelint"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dgulp": "gulp dashboards/scripts-watch",
     "dtest": "gulp dashboards/test",
     "test": "npx gulp test-ts --force && npx gulp test --force --speak",
+    "test:precommit": "npx gulp test-ts && npx gulp test",
     "testall": "npx gulp test --browsers all --force --speak",
     "test-all": "npx gulp test --browsers all --force --speak",
     "test-dts": "npx gulp scripts && npx gulp jsdoc-dts && npx gulp lint-dts",

--- a/tools/gulptasks/lib/fs.js
+++ b/tools/gulptasks/lib/fs.js
@@ -112,7 +112,7 @@ function copyFile(fileSourcePath, fileTargetPath) {
  * @param {boolean} [includeEntries]
  *        Set to true to remove containing entries as well
  *
- * @param {Function} [filterCallback]
+ * @param {Function | undefined} [filterCallback]
  *        Callback to return `true` for files to delete.
  *
  * @return {void}
@@ -121,24 +121,25 @@ function copyFile(fileSourcePath, fileTargetPath) {
  */
 function deleteDirectory(
     directoryPath,
-    includeEntries,
-    filterCallback
+    includeEntries = true,
+    filterCallback = void 0
 ) {
-
     if (!FS.existsSync(directoryPath)) {
         return;
     }
 
     if (includeEntries) {
+        if (!filterCallback) {
+            FS.rmSync(directoryPath, { recursive: true });
+            return;
+        }
+
         getDirectoryPaths(directoryPath).forEach(
             path => deleteDirectory(path, true, filterCallback)
         );
 
         for (const filePath of getFilePaths(directoryPath)) {
-            if (
-                !filterCallback ||
-                filterCallback(filePath) === true
-            ) {
+            if (filterCallback(filePath) === true) {
                 deleteFile(filePath, true);
             }
         }

--- a/tools/gulptasks/test-ts.js
+++ b/tools/gulptasks/test-ts.js
@@ -5,7 +5,6 @@
 const gulp = require('gulp');
 const path = require('path');
 
-const { shouldRun, saveRun } = require('./test');
 
 /* *
  *
@@ -47,9 +46,9 @@ const TESTS_DIRECTORY = path.join(BASE, 'test', 'typescript-karma');
  *         Promise to keep
  */
 async function testTS() {
-
     const log = require('./lib/log');
     const Yargs = require('yargs');
+    const { shouldRun, saveRun } = require('./lib/test');
 
 
     const argv = Yargs.argv;

--- a/tools/gulptasks/test.js
+++ b/tools/gulptasks/test.js
@@ -225,108 +225,6 @@ function checkDocsConsistency() {
 
 }
 
-/**
- * Saves test run information
- * @param {{ configFile: string, codeDirectory: string, jsDirectory: string, testsDirectory: string }} config
- * Configuration
- *
- * @return {void}
- */
-function saveRun({
-    configFile,
-    codeDirectory,
-    jsDirectory,
-    testsDirectory
-}) {
-
-    const FS = require('fs');
-    const FSLib = require('./lib/fs');
-    const StringLib = require('./lib/string');
-
-    const latestCodeHash = FSLib.getDirectoryHash(
-        codeDirectory, true, StringLib.removeComments
-    );
-    const latestJsHash = FSLib.getDirectoryHash(
-        jsDirectory, true, StringLib.removeComments
-    );
-    const latestTestsHash = FSLib.getDirectoryHash(
-        testsDirectory, true, StringLib.removeComments
-    );
-
-    const configuration = {
-        latestCodeHash,
-        latestJsHash,
-        latestTestsHash
-    };
-
-    FS.writeFileSync(configFile, JSON.stringify(configuration));
-}
-
-/**
- * Checks if tests should run
- * @param {{ configFile: string, codeDirectory: string, jsDirectory: string, testsDirectory: string }}} config
- * Configuration
- *
- * @return {Promise<boolean>}
- * True if outdated
- */
-async function shouldRun({
-    configFile,
-    codeDirectory,
-    jsDirectory,
-    testsDirectory
-}) {
-
-    const fs = require('fs');
-    const fsLib = require('./lib/fs');
-    const logLib = require('./lib/log');
-    const stringLib = require('./lib/string');
-
-    let configuration = {
-        latestCodeHash: '',
-        latestJsHash: '',
-        latestTestsHash: ''
-    };
-
-    if (fs.existsSync(configFile)) {
-        configuration = JSON.parse(
-            fs.readFileSync(configFile).toString()
-        );
-    }
-
-    const latestCodeHash = fsLib.getDirectoryHash(
-        codeDirectory, true, stringLib.removeComments
-    );
-    const latestJsHash = fsLib.getDirectoryHash(
-        jsDirectory, true, stringLib.removeComments
-    );
-    const latestTestsHash = fsLib.getDirectoryHash(
-        testsDirectory, true, stringLib.removeComments
-    );
-
-    if (latestCodeHash === configuration.latestCodeHash &&
-        latestJsHash !== configuration.latestJsHash
-    ) {
-
-        throw new Error('Code out of sync');
-    }
-
-    if (latestCodeHash === configuration.latestCodeHash &&
-        latestTestsHash === configuration.latestTestsHash
-    ) {
-
-        logLib.success(
-            '✓ Source code and unit tests not have been modified' +
-            ' since the last successful test run.'
-        );
-
-        return false;
-    }
-
-    return true;
-}
-
-
 /* *
  *
  *  Tasks
@@ -342,6 +240,8 @@ async function shouldRun({
 async function test() {
     const argv = require('yargs').argv;
     const log = require('./lib/log');
+
+    const { shouldRun, saveRun } = require('./lib/test');
 
     if (argv.help) {
         log.message(`
@@ -499,9 +399,3 @@ Set a different disconnect timeout from default config
 }
 
 gulp.task('test', gulp.series('test-docs', 'scripts', test));
-
-module.exports = {
-    test,
-    shouldRun,
-    saveRun
-};


### PR DESCRIPTION
Improves pre-commit hook running time by
* Running `test-ts` before `test`, which avoids running the `scripts` gulp task twice
* Running linting on the ts-folder via lint-staged

Also a minor improvement to `deleteDirectory` and a refactor of the `shouldRun` and `saveRun` functions used in `gulp test` and `gulp test-ts`.

<details>
<summary>Run times of precommit script</summary>

## Command: `time ./.husky/pre-commit` 
After running scripts-clean, with no staged files. No scripts-clean before 2nd run.

### On master:

#### 1st run
```
Executed in   98.63 secs    fish           external
   usr time  153.25 secs    0.07 millis  153.25 secs
   sys time   21.60 secs    1.52 millis   21.60 secs
```
#### 2nd run
```
Executed in   50.67 secs    fish           external
   usr time   84.90 secs    0.09 millis   84.90 secs
   sys time    6.11 secs    1.65 millis    6.11 secs
```
### On tools/gulp-test-refactors:

#### 1st run:
```
Executed in   59.09 secs    fish           external
   usr time   85.06 secs    0.09 millis   85.06 secs
   sys time   16.57 secs    2.39 millis   16.57 secs
```
#### 2nd run
```
Executed in   31.21 secs    fish           external
   usr time   52.47 secs    0.07 millis   52.47 secs
   sys time    4.14 secs    2.47 millis    4.14 secs
```
</details>

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205674704399600