### PR TITLE
Fixed #10073, distribution and maxDistance

### DIFF
--- a/ts/Core/Renderer/RendererUtilities.ts
+++ b/ts/Core/Renderer/RendererUtilities.ts
@@ -19,8 +19,8 @@
 import U from '../Utilities.js';
 const {
     clamp,
-    erase,
     pick,
+    pushUnique,
     stableSort
 } = U;
 
@@ -125,9 +125,8 @@ namespace RendererUtilities {
             while (step && total > reducedLen) {
                 i = Math.floor(cursor);
                 box = boxes[i];
-                if (forDeletion.indexOf(i) === -1) {
+                if (pushUnique(forDeletion, i)) {
                     total -= box.size;
-                    forDeletion.push(i);
                 }
                 cursor += step;
 


### PR DESCRIPTION
Fixed #10073, flags were clumped together on the left side of the chart when `allowOverlapX` was false and the flags were dense.