### PR TITLE
bugfix/19992-broken-axis-ticks

### DIFF
--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -1117,13 +1117,10 @@ namespace OrdinalAxis {
                     ), 1); // #3339
 
                     // Set the slope and offset of the values compared to the
-                    // indices in the ordinal positions. Do not calculate slope
-                    // and offset for brokenAxis, as it messes up column metrics
-                    if (!hasBreaks) {
-                        ordinal.slope = slope =
-                            (max - min) / (maxIndex - minIndex);
-                        ordinal.offset = min - (minIndex * slope);
-                    }
+                    // indices in the ordinal positions.
+                    ordinal.slope = slope =
+                        (max - min) / (maxIndex - minIndex);
+                    ordinal.offset = min - (minIndex * slope);
 
                 } else {
                     ordinal.overscrollPointsRange = pick(

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -233,6 +233,7 @@ class ColumnSeries extends Series {
             options = series.options,
             xAxis = series.xAxis,
             yAxis = series.yAxis,
+            hasBreaks = xAxis.brokenAxis?.hasBreaks,
             reversedStacks = xAxis.options.reversedStacks,
             // Keep backward compatibility: reversed xAxis had reversed
             // stacks
@@ -281,7 +282,7 @@ class ColumnSeries extends Series {
 
         const categoryWidth = Math.min(
                 Math.abs(xAxis.transA) * (
-                    (xAxis.ordinal && xAxis.ordinal.slope) ||
+                    (xAxis.ordinal && !hasBreaks && xAxis.ordinal.slope) ||
                 options.pointRange ||
                 xAxis.closestPointRange ||
                 xAxis.tickInterval ||

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -233,7 +233,6 @@ class ColumnSeries extends Series {
             options = series.options,
             xAxis = series.xAxis,
             yAxis = series.yAxis,
-            hasBreaks = xAxis.brokenAxis?.hasBreaks,
             reversedStacks = xAxis.options.reversedStacks,
             // Keep backward compatibility: reversed xAxis had reversed
             // stacks
@@ -282,11 +281,11 @@ class ColumnSeries extends Series {
 
         const categoryWidth = Math.min(
                 Math.abs(xAxis.transA) * (
-                    (!hasBreaks && xAxis.ordinal?.slope) ||
-                options.pointRange ||
-                xAxis.closestPointRange ||
-                xAxis.tickInterval ||
-                1
+                    (!xAxis.brokenAxis?.hasBreaks && xAxis.ordinal?.slope) ||
+                    options.pointRange ||
+                    xAxis.closestPointRange ||
+                    xAxis.tickInterval ||
+                    1
                 ), // #2610
                 xAxis.len // #1535
             ),

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -282,7 +282,7 @@ class ColumnSeries extends Series {
 
         const categoryWidth = Math.min(
                 Math.abs(xAxis.transA) * (
-                    (xAxis.ordinal && !hasBreaks && xAxis.ordinal.slope) ||
+                    (!hasBreaks && xAxis.ordinal?.slope) ||
                 options.pointRange ||
                 xAxis.closestPointRange ||
                 xAxis.tickInterval ||


### PR DESCRIPTION
Fixed #19992, xAxis ticks on broken axes were displayed incorrectly.