### PR TITLE
Default linewidth for graph 2px

### DIFF
--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -319,7 +319,7 @@ div.highcharts-tooltip {
 
 .highcharts-graph {
     fill: none;
-    stroke-width: 1px;
+    stroke-width: 2px;
     stroke-linecap: round;
     stroke-linejoin: round;
 }

--- a/samples/unit-tests/indicator-dmi/recalculations/demo.js
+++ b/samples/unit-tests/indicator-dmi/recalculations/demo.js
@@ -202,7 +202,7 @@ QUnit.test(
 
         assert.strictEqual(
             DMIIndicator.graph.element.getAttribute('stroke-width'),
-            '1',
+            '2',
             'The DX line width should be correct.'
         );
 

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -63,7 +63,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
      *
      * @product highcharts highstock
      */
-    lineWidth: 1,
+    lineWidth: 2,
 
     /**
      * For some series, there is a limit that shuts down animation


### PR DESCRIPTION
Set the default `series.lineWidth` of line graphs to to 2px for better accessibility.