### PR TITLE
bugfix/20007-contrast-color-label-bg

### DIFF
--- a/samples/unit-tests/datalabels/contrast/demo.js
+++ b/samples/unit-tests/datalabels/contrast/demo.js
@@ -132,6 +132,41 @@ QUnit.test(
             dataLabels outside the bar chart should get the contrast (black)
             color (#17413).`
         );
+
+        chart.series[0].update({
+            dataLabels: {
+                backgroundColor: '#fff'
+            }
+        });
+
+        assert.strictEqual(
+            Highcharts.color(
+                points[0].dataLabel.element.childNodes[1].style.color
+            ).get(),
+            Highcharts.color(
+                'rgb(0, 0, 0)'
+            ).get(),
+            `Prioritize checking the data label background color when the
+            color of the data label is specified (#20007).`
+        );
+
+        chart.series[0].update({
+            color: '#ddd',
+            dataLabels: {
+                backgroundColor: 'auto'
+            }
+        });
+
+        assert.strictEqual(
+            Highcharts.color(
+                points[0].dataLabel.element.childNodes[1].style.color
+            ).get(),
+            Highcharts.color(
+                'rgb(0, 0, 0)'
+            ).get(),
+            `When the data label background color is set to 'auto', set the
+            data label color by contrast to the point color. (#20007).`
+        );
     }
 );
 

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -621,8 +621,12 @@ namespace DataLabel {
                             (!point.isNull || point.dataLabelOnNull) &&
                             applyFilter(point, labelOptions)
                         ),
-                        style = labelOptions.style || {},
-                        labelDistance = labelOptions.distance;
+                        {
+                            backgroundColor,
+                            borderColor,
+                            distance,
+                            style = {}
+                        } = labelOptions;
 
                     let labelConfig,
                         formatString,
@@ -654,10 +658,6 @@ namespace DataLabel {
                                 labelOptions.formatter
                             ).call(labelConfig, labelOptions);
 
-                        if (labelOptions.backgroundColor !== 'none') {
-                            labelBgColor = labelOptions.backgroundColor;
-                        }
-
                         rotation = labelOptions.rotation;
 
                         if (!chart.styledMode) {
@@ -670,6 +670,10 @@ namespace DataLabel {
                             );
                             // Get automated contrast color
                             if (style.color === 'contrast') {
+                                if (backgroundColor !== 'none') {
+                                    labelBgColor = backgroundColor;
+                                }
+
                                 point.contrastColor = renderer.getContrast(
                                     labelBgColor !== 'auto' && labelBgColor ||
                                     (point.color || series.color) as any
@@ -678,10 +682,10 @@ namespace DataLabel {
                                 style.color = (
                                     labelBgColor || // #20007
                                     (
-                                        !defined(labelDistance) &&
+                                        !defined(distance) &&
                                         labelOptions.inside
                                     ) ||
-                                    pInt(labelDistance || 0) < 0 ||
+                                    pInt(distance || 0) < 0 ||
                                     seriesOptions.stacking
                                 ) ?
                                     point.contrastColor :
@@ -702,10 +706,6 @@ namespace DataLabel {
                         };
 
                         if (!chart.styledMode) {
-                            const {
-                                backgroundColor,
-                                borderColor
-                            } = labelOptions;
                             attr.fill = backgroundColor === 'auto' ?
                                 point.color :
                                 backgroundColor;

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -622,8 +622,7 @@ namespace DataLabel {
                             applyFilter(point, labelOptions)
                         ),
                         style = labelOptions.style || {},
-                        labelDistance = labelOptions.distance,
-                        labelBgColor = labelOptions.backgroundColor;
+                        labelDistance = labelOptions.distance;
 
                     let labelConfig,
                         formatString,
@@ -632,7 +631,8 @@ namespace DataLabel {
                         attr: SVGAttributes = {},
                         dataLabel: SVGLabel|SVGElement|undefined =
                             dataLabels[i],
-                        isNew = !dataLabel;
+                        isNew = !dataLabel,
+                        labelBgColor;
 
                     if (labelEnabled) {
                         // Create individual options structure that can be
@@ -653,6 +653,10 @@ namespace DataLabel {
                                 ] ||
                                 labelOptions.formatter
                             ).call(labelConfig, labelOptions);
+
+                        if (labelOptions.backgroundColor !== 'none') {
+                            labelBgColor = labelOptions.backgroundColor;
+                        }
 
                         rotation = labelOptions.rotation;
 

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -622,7 +622,8 @@ namespace DataLabel {
                             applyFilter(point, labelOptions)
                         ),
                         style = labelOptions.style || {},
-                        labelDistance = labelOptions.distance;
+                        labelDistance = labelOptions.distance,
+                        labelBgColor = labelOptions.backgroundColor;
 
                     let labelConfig,
                         formatString,
@@ -666,10 +667,12 @@ namespace DataLabel {
                             // Get automated contrast color
                             if (style.color === 'contrast') {
                                 point.contrastColor = renderer.getContrast(
+                                    labelBgColor !== 'auto' && labelBgColor ||
                                     (point.color || series.color) as any
                                 );
 
                                 style.color = (
+                                    labelBgColor || // #20007
                                     (
                                         !defined(labelDistance) &&
                                         labelOptions.inside


### PR DESCRIPTION
Fixed #20007, contrast color setting for data labels did not respect their background colors.