### PR TITLE
Fixed #18672, updated google font link for themes BrandDark & BrandLight

### DIFF
--- a/ts/Extensions/Themes/BrandDark.ts
+++ b/ts/Extensions/Themes/BrandDark.ts
@@ -289,7 +289,7 @@ namespace BrandDarkTheme {
     export function apply(): void {
         // Load the fonts
         createElement('link', {
-            href: 'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:200,300,400,600,700',
+            href: 'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@200;300;400;600;700',
             rel: 'stylesheet',
             type: 'text/css'
         }, null as any, document.getElementsByTagName('head')[0]);

--- a/ts/Extensions/Themes/BrandLight.ts
+++ b/ts/Extensions/Themes/BrandLight.ts
@@ -253,7 +253,7 @@ namespace BrandLightTheme {
     export function apply(): void {
         // Load the fonts
         createElement('link', {
-            href: 'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:200,300,400,600,700',
+            href: 'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@200;300;400;600;700',
             rel: 'stylesheet',
             type: 'text/css'
         }, null as any, document.getElementsByTagName('head')[0]);


### PR DESCRIPTION
Fixed #18672.

When you try to use `BrandDark` or `BrandLight` themes, the fonts do not load correctly due to faulty google fonts url.

Updated font from `https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:200,300,400,600,700` to `https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@200;300;400;600;700`. 

Previous font url works fine for css1, but css2 has different way to request fonts for required weights. https://developers.google.com/fonts/docs/css2