### PR TITLE
Fix: improper place to define variable causing errors in some edge cases

### DIFF
--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -682,10 +682,10 @@ namespace LegendComponent {
         const items = this.legend.allItems;
         const oldIx = this.accessibility &&
                 this.accessibility.components.legend.highlightedLegendItemIx;
-        const itemToHighlight = items[ix],
-            legendItem = itemToHighlight.legendItem || {};
-
+        const itemToHighlight = items[ix];
+        
         if (itemToHighlight) {
+            const legendItem = itemToHighlight.legendItem || {};
             if (isNumber(oldIx) && items[oldIx]) {
                 setLegendItemHoverState(false, items[oldIx]);
             }

--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -682,10 +682,9 @@ namespace LegendComponent {
         const items = this.legend.allItems;
         const oldIx = this.accessibility &&
                 this.accessibility.components.legend.highlightedLegendItemIx;
-        const itemToHighlight = items[ix];
+        const itemToHighlight = items[ix], legendItem = itemToHighlight?.legendItem || {};;
         
-        if (itemToHighlight) {
-            const legendItem = itemToHighlight.legendItem || {};
+        if (itemToHighlight && legendItem) {
             if (isNumber(oldIx) && items[oldIx]) {
                 setLegendItemHoverState(false, items[oldIx]);
             }

--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -682,7 +682,7 @@ namespace LegendComponent {
         const items = this.legend.allItems;
         const oldIx = this.accessibility &&
                 this.accessibility.components.legend.highlightedLegendItemIx;
-        const itemToHighlight = items[ix], legendItem = itemToHighlight?.legendItem || {};;
+        const itemToHighlight = items[ix], legendItem = itemToHighlight?.legendItem;;
         
         if (itemToHighlight && legendItem) {
             if (isNumber(oldIx) && items[oldIx]) {


### PR DESCRIPTION
This pull request introduces a small code change, moving the declaration of the legendItem variable to where it is needed, preventing an error in some edge case when itemToHighlight might be undefined. This modification has no functional impact on the code's behavior, other than fixing this small bug.