### PR TITLE
docs/20055-datasorting-bullet

### DIFF
--- a/ts/Series/Bullet/BulletSeriesDefaults.ts
+++ b/ts/Series/Bullet/BulletSeriesDefaults.ts
@@ -113,7 +113,7 @@ const BulletSeriesDefaults: BulletSeriesOptions = {
  * @extends   series,plotOptions.bullet
  * @since     6.0.0
  * @product   highcharts
- * @excluding dataParser, dataURL, marker, dataSorting, boostThreshold,
+ * @excluding dataParser, dataURL, marker, boostThreshold,
  *            boostBlending
  * @requires  modules/bullet
  * @apioption series.bullet


### PR DESCRIPTION
Fixed #20055, `dataSorting` option was missing in API docs for bullet series.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205813287920103