### PR TITLE
docs/20061-api-improvement-jitter-boost

### DIFF
--- a/ts/Series/Scatter/ScatterSeriesDefaults.ts
+++ b/ts/Series/Scatter/ScatterSeriesDefaults.ts
@@ -71,6 +71,8 @@ const ScatterSeriesDefaults: PlotOptionsOf<ScatterSeries> = {
      * https://api.highcharts.com/highcharts/plotOptions.column.pointPadding)
      * settings.
      *
+     * **Note:** With boost mode enabled, the jitter effect is not supported.
+     *
      * @sample {highcharts} highcharts/demo/scatter-jitter
      *         Jitter on a scatter plot
      *


### PR DESCRIPTION
Fixed #20061, added API info about `jitter` not being supported when using Boost mode.