### PR TITLE
docs/20012-fix-wrong-histogram-dependency

### DIFF
--- a/ts/Series/Histogram/HistogramSeriesDefaults.ts
+++ b/ts/Series/Histogram/HistogramSeriesDefaults.ts
@@ -38,7 +38,7 @@ import type HistogramSeriesOptions from './HistogramSeriesOptions';
  *               stacking, boostBlending
  * @product      highcharts
  * @since        6.0.0
- * @requires     modules/histogram
+ * @requires     modules/histogram-bellcurve
  * @optionparent plotOptions.histogram
  */
 const HistogramSeriesDefaults: HistogramSeriesOptions = {
@@ -92,7 +92,7 @@ const HistogramSeriesDefaults: HistogramSeriesOptions = {
  * @excluding data, dataParser, dataURL, boostThreshold, boostBlending
  * @product   highcharts
  * @since     6.0.0
- * @requires  modules/histogram
+ * @requires  modules/histogram-bellcurve
  * @apioption series.histogram
  */
 


### PR DESCRIPTION
Fixed #20012, changed the histogram series to correctly point to `modules/histogram-bellcurve` instead of the non-existent module.