### PR TITLE
bugfix/19922-range-selector-all-state

### DIFF
--- a/samples/unit-tests/rangeselector/buttons-range-state/demo.js
+++ b/samples/unit-tests/rangeselector/buttons-range-state/demo.js
@@ -149,7 +149,7 @@ QUnit.test('Range selector buttons states (#3375)', function (assert) {
                     }
                 ],
                 inputEnabled: false,
-                selected: 0
+                selected: 2
             },
             series: [
                 {
@@ -174,7 +174,7 @@ QUnit.test('Range selector buttons states (#3375)', function (assert) {
             .join(',');
     }
 
-    assert.strictEqual(getStates(), '2,0,3,0', 'Initial state');
+    assert.strictEqual(getStates(), '0,0,3,2', 'Initial state. If selected range is greater than data, all should be selected (#19922).');
 
     chart.rangeSelector.clickButton(1);
     assert.strictEqual(getStates(), '0,2,3,3', 'Selected 2h');

--- a/ts/Stock/RangeSelector/RangeSelector.ts
+++ b/ts/Stock/RangeSelector/RangeSelector.ts
@@ -518,7 +518,8 @@ class RangeSelector {
             allButtonsEnabled = rangeSelector.options.allButtonsEnabled,
             buttons = rangeSelector.buttons;
 
-        let selectedExists = isNumber(selected);
+        let selectedExists = isNumber(selected),
+            isSelectedTooGreat = false;
 
         rangeSelector.buttonOptions.forEach((
             rangeOptions: RangeSelectorButtonOptions,
@@ -546,6 +547,10 @@ class RangeSelector {
                 // Disable the All button if we're already showing all
                 isAllButAlreadyShowingAll = false,
                 isSameRange = range === actualRange;
+
+            if (isSelected && isTooGreatRange) {
+                isSelectedTooGreat = true;
+            }
 
             // Months and years have a variable range so we check the extremes
             if (
@@ -581,6 +586,7 @@ class RangeSelector {
             // across the night gap.
             const disable = (
                 !allButtonsEnabled &&
+                !(isSelectedTooGreat && type === 'all') &&
                 (
                     isTooGreatRange ||
                     isTooSmallRange ||
@@ -589,6 +595,7 @@ class RangeSelector {
                 )
             );
             const select = (
+                isSelectedTooGreat ||
                 (isSelected && isSameRange) ||
                 (isSameRange && !selectedExists && !isYTDButNotSelected) ||
                 (isSelected && rangeSelector.frozenStates)


### PR DESCRIPTION
Fixed #19922, 'all' option now auto-selects if data range is smaller than selected range.