### PR TITLE
tools/dashboards-lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "jsdoc-highcharts": "npx gulp jsdoc-watch --products highcharts --skip-websearch",
     "jsdoc-highstock": "npx gulp jsdoc-watch --products highstock --skip-websearch",
     "lint": "cd ts && npx eslint",
+    "lint-dashboards": "cd ts/Dashboards && npx eslint",
     "ts-compile:test": "npx tsc -p test && npx tsc -p samples",
     "gulp": "npx gulp",
     "utils": "highcharts-utils",
@@ -124,6 +125,9 @@
     ],
     "./ts/**/*.ts": [
       "npm run lint"
+    ],
+    "./ts/Dashboards/**/*.ts": [
+      "npm run lint-dashboards"
     ],
     "*.css": [
       "stylelint"

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "*.js": [
       "eslint"
     ],
-    "./ts/**/*.ts": [
+    "./ts/!(Dashboards)**/*.ts": [
       "npm run lint"
     ],
     "./ts/Dashboards/**/*.ts": [


### PR DESCRIPTION
Alternate solution could be to remove Dashboards from `ts/.eslintignore`, and just have a single linting run.