### PR TITLE
bugfix/20086-mapbubble-wrong-hover-point

### DIFF
--- a/samples/unit-tests/maps/mapbubble/demo.js
+++ b/samples/unit-tests/maps/mapbubble/demo.js
@@ -42,6 +42,38 @@ QUnit.test('MapBubble', function (assert) {
         }]
     });
 
+    const done = assert.async();
+
+    setTimeout(() => {
+        const point = chart.series[1].points[0],
+            { plotX, plotY } = point,
+            chartPosition = Highcharts.offset(chart.container),
+            chartX = chart.plotLeft + plotX + chartPosition.left,
+            chartY = chart.plotTop + plotY + chartPosition.top;
+
+        // Simulate mouse move over the point
+        chart.pointer.onContainerMouseMove({
+            type: 'mousemove',
+            pageX: chartX,
+            pageY: chartY,
+            target: chart.container
+        });
+
+        assert.strictEqual(
+            chart.hoverPoint,
+            point,
+            'The hoverPoint should be the expected mapbubble point (#20086).'
+        );
+
+        assert.strictEqual(
+            chart.tooltip.label.text.element.textContent,
+            '●  Series 2​: 3',
+            'The tooltip should contain the correct capital information (#20086).'
+        );
+
+        done();
+    }, 0);
+
     assert.strictEqual(
         chart.series[1].points[0].color,
         'green',

--- a/ts/Series/MapBubble/MapBubblePoint.ts
+++ b/ts/Series/MapBubble/MapBubblePoint.ts
@@ -34,6 +34,19 @@ const { extend } = U;
 
 /* *
  *
+ *  Declarations
+ *
+ * */
+
+declare module '../../Core/Series/KDPointSearchObjectLike' {
+    interface KDPointSearchObjectLike {
+        plotX?: number;
+        plotY?: number;
+    }
+}
+
+/* *
+ *
  *  Class
  *
  * */

--- a/ts/Series/MapBubble/MapBubbleSeries.ts
+++ b/ts/Series/MapBubble/MapBubbleSeries.ts
@@ -275,7 +275,7 @@ class MapBubbleSeries extends BubbleSeries {
         compareX?: boolean
     ): (Point|undefined) {
         return this.searchKDTree({
-            clientX: e.chartX - this.chart.plotLeft,
+            plotX: e.chartX - this.chart.plotLeft,
             plotY: e.chartY - this.chart.plotTop
         }, compareX, e);
     }
@@ -342,6 +342,8 @@ extend(MapBubbleSeries.prototype, {
     processData: mapProto.processData,
 
     projectPoint: mapPointProto.projectPoint,
+
+    kdAxisArray: ['plotX', 'plotY'],
 
     setData: mapProto.setData,
 


### PR DESCRIPTION
Fixed #20086, a bug where hovering over `mapbubble` series points would fail to show the correct point.