### PR TITLE
bugfix/17385 boost load event

### DIFF
--- a/samples/highcharts/demo/vertical-sankey/demo.details
+++ b/samples/highcharts/demo/vertical-sankey/demo.details
@@ -9,5 +9,5 @@ alt_text: >-
 tags:
   - Highcharts demo
 categories:
-  - Trees and networks
+  - More chart types
 ...

--- a/samples/issues/boost/17385-load-redraw/demo.css
+++ b/samples/issues/boost/17385-load-redraw/demo.css
@@ -1,0 +1,4 @@
+#container {
+    width: 600px;
+    margin: 0 auto;
+}

--- a/samples/issues/boost/17385-load-redraw/demo.html
+++ b/samples/issues/boost/17385-load-redraw/demo.html
@@ -1,0 +1,5 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/boost.js"></script>
+
+
+<div id="container"></div>

--- a/samples/issues/boost/17385-load-redraw/demo.js
+++ b/samples/issues/boost/17385-load-redraw/demo.js
@@ -1,0 +1,20 @@
+Highcharts.chart('container', {
+    title: {
+        text: '#17385, series were cleared when updating from chart.events.load'
+    },
+    series: [{
+        data: [1, 3, 2, 4]
+    }, {
+        data: [6, 5, 7, 6]
+    }],
+    chart: {
+        events: {
+            load: e => e.target.yAxis[0].setExtremes(0, 8)
+        }
+    },
+    plotOptions: {
+        series: {
+            boostThreshold: 1
+        }
+    }
+});

--- a/ts/Extensions/Boost/BoostChart.ts
+++ b/ts/Extensions/Boost/BoostChart.ts
@@ -306,12 +306,10 @@ function onChartCallback(
     }
 
     addEvent(chart, 'predraw', preRender);
-    addEvent(chart, 'render', canvasToSVG);
-
-    // addEvent(chart, 'zoom', function () {
-    //     chart.boostForceChartBoost =
-    //         shouldForceChartSeriesBoosting(chart);
-    // });
+    // Use the load event rather than redraw, otherwise user load events will
+    // fire too early (#18755)
+    addEvent(chart, 'load', canvasToSVG, { order: -1 });
+    addEvent(chart, 'redraw', canvasToSVG);
 
     let prevX = -1;
     let prevY = -1;


### PR DESCRIPTION
Fixed #17385, Boost module failed to render multiple series when updating the chart on load.

Closes #17863, #18755.