### PR TITLE
docs/20115-overscroll-navigator

### DIFF
--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -1465,8 +1465,10 @@ namespace AxisDefaults {
 
         /**
          * Additional range on the right side of the xAxis. Works similar to
-         * `xAxis.maxPadding`, but value is set in milliseconds. Can be set for
-         * both main `xAxis` and the navigator's `xAxis`.
+         * `xAxis.maxPadding`, but value is set in milliseconds. This property
+         * should be set to the same value for both the main `xAxis` and the
+         * navigator's `xAxis` to maintain consistent behavior during
+         * interactions such as dragging or resizing the navigator.
          *
          * @sample {highstock} stock/xaxis/overscroll/
          *         One minute overscroll with live data


### PR DESCRIPTION
Fixed #20115, the `xAxis.overscroll` documentation to clarify that the same `overscroll` value should be applied to both the main chart's `xAxis` and the navigator's `xAxis` in Highcharts Stock. This ensures that the overscroll feature remains active during navigator interactions.