### PR TITLE
bugfix/16850 boost stack log

### DIFF
--- a/samples/highcharts/demo/vertical-sankey/demo.details
+++ b/samples/highcharts/demo/vertical-sankey/demo.details
@@ -9,5 +9,5 @@ alt_text: >-
 tags:
   - Highcharts demo
 categories:
-  - Trees and networks
+  - More chart types
 ...

--- a/samples/issues/boost/16850-stacked-area/demo.css
+++ b/samples/issues/boost/16850-stacked-area/demo.css
@@ -1,0 +1,3 @@
+#container {
+    height: 400px;
+}

--- a/samples/issues/boost/16850-stacked-area/demo.details
+++ b/samples/issues/boost/16850-stacked-area/demo.details
@@ -1,0 +1,5 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Torstein Hønsi
+...

--- a/samples/issues/boost/16850-stacked-area/demo.html
+++ b/samples/issues/boost/16850-stacked-area/demo.html
@@ -1,5 +1,4 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
-<script src="https://code.highcharts.com/modules/boost
-.js"></script>
+<script src="https://code.highcharts.com/modules/boost.js"></script>
 
 <div id="container"></div>

--- a/samples/issues/boost/16850-stacked-area/demo.html
+++ b/samples/issues/boost/16850-stacked-area/demo.html
@@ -1,0 +1,5 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/boost
+.js"></script>
+
+<div id="container"></div>

--- a/samples/issues/boost/16850-stacked-area/demo.js
+++ b/samples/issues/boost/16850-stacked-area/demo.js
@@ -1,0 +1,22 @@
+Highcharts.chart('container', {
+    title: {
+        text: 'The stem (simplified area) of the points should show'
+    },
+    yAxis: {
+        type: 'logarithmic'
+    },
+    series: [{
+        data: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
+    }],
+    chart: {
+        type: 'area'
+    },
+    plotOptions: {
+        area: {
+            stacking: 'normal'
+        },
+        series: {
+            boostThreshold: 10
+        }
+    }
+});

--- a/samples/issues/boost/16850-stacked-area/demo.js
+++ b/samples/issues/boost/16850-stacked-area/demo.js
@@ -1,6 +1,6 @@
 Highcharts.chart('container', {
     title: {
-        text: 'The stem (simplified area) of the points should show'
+        text: 'The stem (simplified area) of the points should be visible'
     },
     yAxis: {
         type: 'logarithmic'

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -1007,7 +1007,6 @@ class WGLRenderer {
             }
 
             if (drawAsBar) {
-                // maxVal = y;
                 minVal = low;
 
                 if ((low as any) === false || typeof low === 'undefined') {
@@ -1018,7 +1017,10 @@ class WGLRenderer {
                     }
                 }
 
-                if (!isRange && !isStacked) {
+                if (
+                    (!isRange && !isStacked) ||
+                    yAxis.logarithmic // #16850
+                ) {
                     minVal = Math.max(
                         threshold === null ? yMin : threshold, // #5268
                         yMin


### PR DESCRIPTION
Fixed #16850, the Boost module failed to render a stacked area series on a logarithimc axis.
