### PR TITLE
Fixed #18756, wrong tooltip with Boost and cropped data

### DIFF
--- a/samples/unit-tests/boost/stacking/demo.js
+++ b/samples/unit-tests/boost/stacking/demo.js
@@ -1,5 +1,8 @@
 QUnit.test('Stacked boost series with extremes', function (assert) {
-    var chart = Highcharts.chart('container', {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            width: 600
+        },
         xAxis: {
             min: 0,
             max: 3
@@ -18,14 +21,29 @@ QUnit.test('Stacked boost series with extremes', function (assert) {
         },
         series: [
             {
-                data: [1, 4, 2, 5]
+                data: [1, 4, 2, 5, 6, 3, 2]
             }
         ]
     });
+    const controller = new TestController(chart);
 
     assert.strictEqual(
         chart.container.querySelectorAll('.highcharts-boost-canvas').length,
         1,
         'Chart with boost canvas should be created (#7481)'
     );
+
+    chart.series[0].update({
+        cropThreshold: 1
+    });
+    chart.xAxis[0].setExtremes(3, 6);
+
+    controller.moveTo(560, 200, true);
+    assert.strictEqual(
+        chart.container.querySelector('.highcharts-tooltip text tspan')
+            .textContent,
+        '5',
+        'The tooltip should reflect the actual point when cropped data (#18756)'
+    );
+
 });

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -1139,7 +1139,7 @@ function seriesRenderCanvas(this: Series): void {
         }
 
         eachAsync(
-            isStacked ? this.data : (xData || rawData),
+            isStacked ? this.data.slice(cropStart) : (xData || rawData),
             processPoint,
             doneProcessing
         );


### PR DESCRIPTION
Fixed #18756, wrong or crashing tooltip with Boost, stacking enabled and data length above the `cropThreshold`.