### PR TITLE
Fixed #19726 Docs did not adequately explain tickPlacement for category axes

### DIFF
--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -1744,7 +1744,8 @@ namespace AxisDefaults {
          * For categorized axes only. If `on` the tick mark is placed in the
          * center of the category, if `between` the tick mark is placed between
          * categories. The default is `between` if the `tickInterval` is 1, else
-         * `on`.
+         * `on`. In order to render tick marks on a category axis it is necessary
+         * to provide a [tickWidth](#xAxis.tickWidth).
          *
          * @sample {highcharts} highcharts/xaxis/tickmarkplacement-between/
          *         "between" by default


### PR DESCRIPTION
Fixed #19726, Docs did not explain that for category axes, `tickWidth` must be set in order to the see the effects of `tickPlacement`.

NB: I have an issue building docs, please somebody test that this does not format wierdly! 😆 