### PR TITLE
Fixed #19657, gantt grid axis title shortening inconsistent

### DIFF
--- a/samples/gantt/grid-axis/vertical/demo.js
+++ b/samples/gantt/grid-axis/vertical/demo.js
@@ -12,14 +12,20 @@ Highcharts.ganttChart('container', {
                     text: 'Tasks',
                     rotation: 45,
                     y: -15,
-                    x: -15
+                    x: -15,
+                    style: {
+                        width: '100px'
+                    }
                 }
             }, {
                 title: {
                     text: 'Assignee',
                     rotation: 45,
                     y: -15,
-                    x: -15
+                    x: -15,
+                    style: {
+                        width: '100px'
+                    }
                 },
                 labels: {
                     format: '{point.assignee}'
@@ -29,7 +35,10 @@ Highcharts.ganttChart('container', {
                     text: 'Duration',
                     rotation: 45,
                     y: -15,
-                    x: -15
+                    x: -15,
+                    style: {
+                        width: '100px'
+                    }
                 },
                 labels: {
                     format: '{(divide (subtract point.end point.start) 86400000):.0f}'

--- a/samples/unit-tests/gantt/grid-axis/demo.js
+++ b/samples/unit-tests/gantt/grid-axis/demo.js
@@ -1288,7 +1288,8 @@ QUnit.module('labels alignment', function () {
 
         /**
          * Test label positions on the x and yAxis with a single line.
-         * NOTE: options and chart must be set again, due to tests running async.
+         * NOTE: options and chart must be set again, due to tests running
+         * async.
          */
         optionsAxis.labels.useHTML = false;
         optionsAxis.categories = categories;
@@ -1328,7 +1329,8 @@ QUnit.module('labels alignment', function () {
 
         /**
          * Test label positions on the x and yAxis with a single line.
-         * NOTE: options and chart must be set again, due to tests running async.
+         * NOTE: options and chart must be set again, due to tests running
+         * async.
          */
         optionsAxis.categories = map(categories, function (str) {
             return '<span>' + str + '<span>';
@@ -2159,24 +2161,69 @@ QUnit.test(
 );
 
 QUnit.test('slotWidth', assert => {
+
     const chart = Highcharts.ganttChart('container', {
         chart: {
-            width: 600
+            width: 1000
         },
+
+        yAxis: {
+            type: 'category',
+            grid: {
+                enabled: true,
+                borderColor: 'rgba(0,0,0,0.3)',
+                borderWidth: 1,
+                columns: [{
+                    title: {
+                        text: 'Regular Title',
+                        style: {
+                            width: 100
+                        }
+                    },
+                    labels: {
+                        format: '{point.name}'
+                    }
+                }, {
+                    title: {
+                        text: 'The quick brown fox jumps over the lazy dog'
+                    },
+                    labels: {
+                        format: '{point.assignee}'
+                    }
+                }]
+            }
+        },
+
         series: [{
-            data: [
-                {
-                    start: Date.UTC(2017, 8, 1),
-                    end: Date.UTC(2017, 11, 4)
-                }
-            ]
+            name: 'Project 1',
+            data: [{
+                start: Date.UTC(2017, 8, 1),
+                end: Date.UTC(2017, 11, 4),
+                name: 'Start prototye',
+                assignee: 'Ola Nordmann',
+                y: 0
+            }]
         }]
     });
 
-    const axis = chart.xAxis[1];
+    const xAxis = chart.xAxis[1],
+        yAxis = chart.yAxis[0];
 
     assert.ok(
-        axis.ticks[axis.tickPositions[3]].slotWidth < 30,
+        xAxis.ticks[xAxis.tickPositions[3]].slotWidth < 30,
         '#15742: Rightmost tick slotWidth should be much smaller than the other ticks'
+    );
+
+    assert.ok(
+        yAxis.axisTitle.getBBox().width <= yAxis.ticks[0].slotWidth,
+        'The column title should not exceed the cell width'
+    );
+    assert.ok(
+        yAxis.axisTitle.getBBox().width > yAxis.len,
+        'The column title width should not be based on axis length (#19657)'
+    );
+    assert.ok(
+        yAxis.axisTitle.element.textContent.indexOf('...'),
+        'The column title should contain an ellipsis'
     );
 });

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3544,8 +3544,7 @@ class Axis {
         }
 
         if (
-            axisTitleOptions &&
-            axisTitleOptions.text &&
+            axisTitleOptions?.text &&
             axisTitleOptions.enabled !== false
         ) {
             axis.addTitle(showAxis);

--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -489,7 +489,12 @@ function onAfterRender(this: Axis): void {
             firstTick = axis.ticks[axis.tickPositions[0]];
 
         // Adjust the title max width to the column width (#19657)
-        if (axisTitle && !axis.chart.styledMode && firstTick?.slotWidth) {
+        if (
+            axisTitle &&
+            !axis.chart.styledMode &&
+            firstTick?.slotWidth &&
+            !axis.options.title.style.width
+        ) {
             axisTitle.css({ width: `${firstTick.slotWidth}px` });
         }
 

--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -480,13 +480,18 @@ function onAfterInit(this: Axis): void {
  */
 function onAfterRender(this: Axis): void {
     const axis = this,
-        grid = axis.grid,
-        options = axis.options,
+        { axisTitle, grid, options } = axis,
         gridOptions = options.grid || {};
 
     if (gridOptions.enabled === true) {
         const min = axis.min || 0,
-            max = axis.max || 0;
+            max = axis.max || 0,
+            firstTick = axis.ticks[axis.tickPositions[0]];
+
+        // Adjust the title max width to the column width (#19657)
+        if (axisTitle && !axis.chart.styledMode && firstTick?.slotWidth) {
+            axisTitle.css({ width: `${firstTick.slotWidth}px` });
+        }
 
         // @todo acutual label padding (top, bottom, left, right)
         axis.maxLabelDimensions = axis.getMaxLabelDimensions(
@@ -790,7 +795,10 @@ function onAfterSetOptions(
             title: {
                 text: null,
                 reserveSpace: false,
-                rotation: 0
+                rotation: 0,
+                style: {
+                    textOverflow: 'ellipsis'
+                }
             },
 
             // In a grid axis, only allow one unit of certain types,


### PR DESCRIPTION
Fixed #19657, grid axis column headers displayed inconsistently depending on how many rows were in the chart.