### PR TITLE
Wider slots for labels to avoid truncating to nothing, see #19857

### DIFF
--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3036,7 +3036,7 @@ class Axis {
             }
 
         } else { // #4411
-            newTickInterval = getStep(lineHeight);
+            newTickInterval = getStep(lineHeight * 0.75);
         }
 
         this.autoRotation = autoRotation;

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -2970,7 +2970,7 @@ class Axis {
             rotationOption = labelOptions.rotation,
             // We don't know the actual rendered line height at this point, but
             // it defaults to 0.75em
-            lineHeight = this.labelMetrics().h * 0.75,
+            lineHeight = this.labelMetrics().h,
             range = Math.max((this.max as any) - (this.min as any), 0),
             // Return the multiple of tickInterval that is needed to avoid
             // collision

--- a/ts/Core/Axis/Axis3DComposition.ts
+++ b/ts/Core/Axis/Axis3DComposition.ts
@@ -324,9 +324,7 @@ function wrapAxisGetSlotWidth(
     tick: Tick
 ): number {
     const axis = this,
-        chart = axis.chart,
-        ticks = axis.ticks,
-        gridGroup = axis.gridGroup;
+        { chart, gridGroup, tickPositions, ticks } = axis;
 
     if (
         axis.categories &&
@@ -350,9 +348,9 @@ function wrapAxisGetSlotWidth(
                     pick(options3d.viewDistance, 0)
                 )
             },
-            tickId = tick.pos,
-            prevTick = ticks[tickId - 1],
-            nextTick = ticks[tickId + 1];
+            index = tickPositions.indexOf(tick.pos),
+            prevTick = ticks[tickPositions[index - 1]],
+            nextTick = ticks[tickPositions[index + 1]];
 
         let labelPos,
             prevLabelPos,
@@ -360,12 +358,7 @@ function wrapAxisGetSlotWidth(
 
         // Check whether the tick is not the first one and previous tick
         // exists, then calculate position of previous label.
-        if (
-            tickId !== 0 &&
-            prevTick &&
-            prevTick.label &&
-            prevTick.label.xy
-        ) {
+        if (prevTick?.label?.xy) {
             prevLabelPos = perspective3D({ // #8621
                 x: prevTick.label.xy.x,
                 y: prevTick.label.xy.y,


### PR DESCRIPTION
Alternative approach to #19857. Let's see how visual tests go.

The root cause was that the computed slot width was too small, smaller than the line height of the labels. There is some logic in the Axis that ensures labels are not rotated when the length of the text is smaller than the height. In this scenario, we would get the situation that the width was smaller than the height, but larger than the allocated slot width. In which turn the `Tick.handleOverflow` function would try to add an ellipsis. But since the label already was only two letters wide, this resulted in the whole label disappearing because "01" would not be shorter as "0...". 

On a side note, our ellipsis shortening could be improved. HTML would shorten "01" progressively as "0..", "0.", "0" before it ultimately disappears to "".