### PR TITLE
Fixed #20192, very small box width and ellipsis

### DIFF
--- a/samples/unit-tests/svgrenderer/text/demo.js
+++ b/samples/unit-tests/svgrenderer/text/demo.js
@@ -342,8 +342,13 @@ QUnit.test('textOverflow: ellipsis.', function (assert) {
     text1 = ren.text('01234567', 0, 100).css(style).add();
     assert.strictEqual(
         getTextContent(text1),
-        '',
-        'Width was too small for ellipsis.'
+        '0…',
+        'With 1px box width and ellipsis, it should be truncated.'
+    );
+    assert.strictEqual(
+        text1.element.style.clipPath.indexOf('polygon'),
+        0,
+        'With 1px box width and ellipsis, a clip polygon should exist (#20192)'
     );
 
     /**

--- a/ts/Core/Renderer/CSSObject.d.ts
+++ b/ts/Core/Renderer/CSSObject.d.ts
@@ -52,6 +52,7 @@ export interface CSSObject {
     bottom?: string;
     boxShadow?: string;
     clip?: string;
+    clipPath?: string;
     color?: ('contrast'|ColorString);
     cursor?: CursorValue;
     direction?: string;


### PR DESCRIPTION
Fixed #20192, ellipsis failed to handle very small text widths. Text disappeared if the width was smaller than the equivalent to two characters.