### PR TITLE
Fixed link

### DIFF
--- a/samples/highcharts/website/cyber-venn/demo.js
+++ b/samples/highcharts/website/cyber-venn/demo.js
@@ -610,7 +610,7 @@ const sale = {
                 <div id="terms" class="labels"><a href="#">see terms</a></div>
                 <div id="dash-button">
                 <a class="Button Button-secondary Button-small" 
-                href="https://www.highcharts.com/products/dashboards/">
+                href="https://www.highcharts.com/products/dashboards/" target="_top">
                 <div class="Button-content">Explore Dashboards</div></a></div>
             </div>`
             }


### PR DESCRIPTION
The link in the venn diagram to the dashboard page was loading into the demo iframe. I fixed it so it loads into the main window.