### PR TITLE
bugfix/19999-tooltip-fill-styled-mode

### DIFF
--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -284,6 +284,11 @@
     transition: stroke 150ms;
 }
 
+.highcharts-tooltip .highcharts-tracker {
+    fill: none;
+    stroke: none;
+}
+
 .highcharts-tooltip text {
     fill: var(--highcharts-neutral-color-80);
     font-size: 0.8em;


### PR DESCRIPTION
Fixed #19999, in styled mode, the tooltip appeared with a fill color when `tooltip.stickOnContact` was set to true.