### PR TITLE
Fixed #20221, line series broke centerInCategory

### DIFF
--- a/samples/unit-tests/series/centerincategory/demo.js
+++ b/samples/unit-tests/series/centerincategory/demo.js
@@ -54,6 +54,13 @@ QUnit.test('series.centerInCategory', function (assert) {
                     [1, 2],
                     [3, 4]
                 ]
+            },
+            // #20221, a series that does not support centerInCategory should
+            // not affect the layout of the ones that do
+            {
+                name: 'Line',
+                type: 'line',
+                data: [1]
             }
         ]
     });

--- a/ts/Core/Axis/Stacking/StackingAxis.ts
+++ b/ts/Core/Axis/Stacking/StackingAxis.ts
@@ -303,21 +303,24 @@ function seriesSetGroupedPoints(
     axis: StackingAxis
 ): void {
 
-    if (
-        this.options.centerInCategory &&
-        (this.is('column') || this.is('columnrange')) &&
-        // With stacking enabled, we already have stacks that we can compute
-        // from
-        !this.options.stacking &&
-        // With only one series, we don't need to consider centerInCategory
-        this.chart.series.length > 1
-    ) {
-        seriesProto.setStackedPoints.call(this, axis, 'group');
+    // Only series types supporting centerInCategory need to do this. That also
+    // applies to resetting (#20221).
+    if (this.is('column') || this.is('columnrange')) {
+        if (
+            this.options.centerInCategory &&
+            // With stacking enabled, we already have stacks that we can compute
+            // from
+            !this.options.stacking &&
+            // With only one series, we don't need to consider centerInCategory
+            this.chart.series.length > 1
+        ) {
+            seriesProto.setStackedPoints.call(this, axis, 'group');
 
-    // After updating, if we now have proper stacks, we must delete the group
-    // pseudo stacks (#14980)
-    } else {
-        axis.stacking.resetStacks();
+        // After updating, if we now have proper stacks, we must delete the
+        // group pseudo stacks (#14980)
+        } else {
+            axis.stacking.resetStacks();
+        }
     }
 }
 


### PR DESCRIPTION
Fixed #20221, the `centerInCategory` option failed when a line series was added last in the `series` array.