### PR TITLE
Refactor: Got rid of SVGElement init function

### DIFF
--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -160,7 +160,7 @@ class SVGElement implements SVGElementLike {
     // @todo public d?: number;
     // @todo public div?: HTMLDOMElement;
     public doTransform?: boolean;
-    public element: DOMElementType = void 0 as any;
+    public element: DOMElementType;
     public fakeTS?: boolean;
     public firstLineMetrics?: FontMetricsObject;
     public handleZ?: boolean;
@@ -178,7 +178,7 @@ class SVGElement implements SVGElementLike {
     public placed?: boolean;
     public r?: number;
     public radAttr?: SVGAttributes;
-    public renderer: SVGRenderer = void 0 as any;
+    public renderer: SVGRenderer;
     public rotation?: number;
     public rotationOriginX?: number;
     public rotationOriginY?: number;
@@ -1665,10 +1665,10 @@ class SVGElement implements SVGElementLike {
      * @param {string} nodeName
      * The SVG node name.
      */
-    public init(
+    public constructor(
         renderer: SVGRenderer,
         nodeName: string
-    ): void {
+    ) {
 
         /**
          * The primary DOM node. Each `SVGElement` instance wraps a main DOM

--- a/ts/Core/Renderer/SVG/SVGLabel.ts
+++ b/ts/Core/Renderer/SVG/SVGLabel.ts
@@ -93,8 +93,7 @@ class SVGLabel extends SVGElement {
         baseline?: boolean,
         className?: string
     ) {
-        super();
-        this.init(renderer, 'g');
+        super(renderer, 'g');
 
         this.textStr = str;
         this.x = x;

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -567,10 +567,7 @@ class SVGRenderer implements SVGRendererLike {
      * The generated SVGElement.
      */
     public createElement(nodeName: string): SVGElement {
-        const wrapper = new this.Element();
-
-        wrapper.init(this as any, nodeName);
-        return wrapper;
+        return new this.Element(this, nodeName);
     }
 
     /**

--- a/ts/Core/Renderer/SVG/SVGRenderer3D.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer3D.ts
@@ -473,14 +473,9 @@ namespace SVGRenderer3D {
         type: string,
         shapeArgs: SVGAttributes
     ): SVGElement3D {
-        // base
-        const elem3d = new SVGElement3D.types[type]();
-
-        // init
-        elem3d.init(this, 'g');
+        const elem3d = new SVGElement3D.types[type](this, 'g');
         elem3d.initArgs(shapeArgs);
 
-        // return
         return elem3d;
     }
 


### PR DESCRIPTION
Replaced `SVGElement.init` with `constructor`.