### PR TITLE
bugfix/19730-inverted-centerInCategory-order

### DIFF
--- a/samples/unit-tests/series/centerincategory/demo.js
+++ b/samples/unit-tests/series/centerincategory/demo.js
@@ -312,4 +312,17 @@ QUnit.test('series.centerInCategory', function (assert) {
         2,
         '#17764: Points should be evenly spaced, null point between'
     );
+
+    chart.update({
+        chart: {
+            inverted: true
+        }
+    });
+
+    assert.ok(
+        chart.series[0].points[0].barX <
+        chart.series[1].points[0].barX <
+        chart.series[2].points[0].barX,
+        'Points should have correct order in inverted chart, #19730'
+    );
 });

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -450,6 +450,9 @@ class ColumnSeries extends Series {
                 }
             );
 
+            indexInCategory = this.chart.inverted ?
+                totalInCategory - 1 - indexInCategory : indexInCategory;
+
             // Compute the adjusted x position
             const boxWidth = (totalInCategory - 1) * metrics.paddedWidth +
                 pointWidth;

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -450,7 +450,7 @@ class ColumnSeries extends Series {
                 }
             );
 
-            indexInCategory = this.chart.inverted ?
+            indexInCategory = this.xAxis.reversed ?
                 totalInCategory - 1 - indexInCategory : indexInCategory;
 
             // Compute the adjusted x position


### PR DESCRIPTION
Fixed #19730, `centerInCategory` on inverted column chart had incorrect series order.