### PR TITLE
Added not-equal operators to dataLabels.filter

### DIFF
--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -469,16 +469,18 @@ namespace DataLabel {
         const filter = options.filter;
 
         if (filter) {
-            const op = filter.operator;
-            const prop = (point as any)[filter.property];
-            const val = filter.value;
+            const op = filter.operator,
+                prop = (point as any)[filter.property],
+                val = filter.value;
             if (
                 (op === '>' && prop > (val as any)) ||
                 (op === '<' && prop < (val as any)) ||
                 (op === '>=' && prop >= (val as any)) ||
                 (op === '<=' && prop <= (val as any)) ||
                 (op === '==' && prop == val) || // eslint-disable-line eqeqeq
-                (op === '===' && prop === val)
+                (op === '===' && prop === val) ||
+                (op === '!=' && prop != val) || // eslint-disable-line eqeqeq
+                (op === '!==' && prop !== val)
             ) {
                 return true;
             }

--- a/ts/Core/Series/DataLabelOptions.d.ts
+++ b/ts/Core/Series/DataLabelOptions.d.ts
@@ -33,7 +33,9 @@ import type { SymbolTypeRegistry } from '../Renderer/SVG/SymbolType';
  *
  * */
 
-export type DataLabelFilterOperatorValue = ('>'|'<'|'>='|'<='|'=='|'===');
+export type DataLabelFilterOperatorValue = (
+    '>'|'<'|'>='|'<='|'=='|'==='|'!='|'!=='
+);
 
 export interface TextPathAttributes extends SVGAttributes {
     startOffset?: string;

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -1734,7 +1734,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
 
         /**
          * The operator to compare by. Can be one of `>`, `<`, `>=`, `<=`,
-         * `==`, and `===`.
+         * `==`, `===`, `!=` and `!==`.
          *
          * @type       {string}
          * @validvalue [">", "<", ">=", "<=", "==", "==="]


### PR DESCRIPTION
Added two new operators to `dataLabels.filter.operator`; `!=` and `!==`. See #20254.

Closes #20254.