### PR TITLE
tools/bs-safari-version

### DIFF
--- a/test/karma-bs.json
+++ b/test/karma-bs.json
@@ -23,9 +23,9 @@
     "Mac.Safari": {
         "base": "BrowserStack",
         "browser": "safari",
-        "browser_version": "16.5",
+        "browser_version": "17.0",
         "os": "OS X",
-        "os_version": "Ventura"
+        "os_version": "Sonoma"
     },
     "Win.Chrome": {
         "base": "BrowserStack",


### PR DESCRIPTION
Seems Safari 16.5 got stuck in fullscreen mode at some point, which threw quite a few tests off. Latest Safari + MacOS works better, see [this test-run](https://github.com/highcharts/highcharts/actions/runs/7111802751)