### PR TITLE
dashboards/events-demo-test-notes

### DIFF
--- a/samples/dashboards/component-options/events/test-notes.md
+++ b/samples/dashboards/component-options/events/test-notes.md
@@ -1,1 +1,0 @@
-1. Check if every event is logged in the console (`mount`, `unmount`, `resize`, `update`).


### PR DESCRIPTION
Removed unecessary test notes, cypress test covers it.