### PR TITLE
bugfix/20006-treegraph-collapsed-export

### DIFF
--- a/samples/highcharts/demo/treegraph-chart/demo.js
+++ b/samples/highcharts/demo/treegraph-chart/demo.js
@@ -1,7 +1,8 @@
 Highcharts.chart('container', {
     chart: {
         spacingBottom: 30,
-        marginRight: 120
+        marginRight: 120,
+        height: 1200
     },
     title: {
         text: 'Phylogenetic language tree'

--- a/samples/unit-tests/series-treegraph/treegraph/demo.html
+++ b/samples/unit-tests/series-treegraph/treegraph/demo.html
@@ -1,6 +1,7 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/treemap.js"></script>
 <script src="https://code.highcharts.com/modules/treegraph.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/series-treegraph/treegraph/demo.js
+++ b/samples/unit-tests/series-treegraph/treegraph/demo.js
@@ -184,5 +184,21 @@ QUnit.test('Treegraph series',
             point2.collapsed && point3.collapsed,
             'Multiple nodes should collapse simultaneously (#19552).'
         );
+
+        const exportedSVG = chart.getSVGForExport(),
+            selector = '#container .highcharts-series-1' +
+                ' .highcharts-level-group-3 path',
+            inChartPos = +document.querySelectorAll(selector)[0]
+                .getAttribute('x');
+
+        // Replace the chart with its exported image
+        chart.destroy();
+        document.getElementById('container').innerHTML = exportedSVG;
+
+        assert.strictEqual(
+            inChartPos,
+            +document.querySelectorAll(selector)[0].getAttribute('x'),
+            'Dynamically collapsed point should exported as such (#20006).'
+        );
     }
 );

--- a/ts/Series/Treegraph/TreegraphPoint.ts
+++ b/ts/Series/Treegraph/TreegraphPoint.ts
@@ -182,12 +182,10 @@ class TreegraphPoint extends TreemapPoint {
 
     public toggleCollapse(state?: boolean): void {
         const series = this.series;
-        this.collapsed = this.options.collapsed = state ?? !this.collapsed;
 
-        // Update userOptions.data
-        if (series.options.data) {
-            series.options.data[series.data.indexOf(this)] = this.options;
-        }
+        this.update({
+            collapsed: state ?? !this.collapsed
+        }, false, void 0, false);
 
         fireEvent(series, 'toggleCollapse');
         series.redraw();

--- a/ts/Series/Treegraph/TreegraphPoint.ts
+++ b/ts/Series/Treegraph/TreegraphPoint.ts
@@ -40,8 +40,7 @@ import U from '../../Core/Utilities.js';
 const {
     addEvent,
     fireEvent,
-    merge,
-    pick
+    merge
 } = U;
 
 /* *
@@ -95,12 +94,12 @@ class TreegraphPoint extends TreemapPoint {
             series = point.series,
             parentGroup = point.graphic && point.graphic.parentGroup,
             levelOptions =
-                (series.mapOptionsToLevel as any)[point.node.level || 0] || {},
+                series.mapOptionsToLevel[point.node.level || 0] || {},
             btnOptions = merge(
                 series.options.collapseButton,
                 levelOptions.collapseButton,
                 point.options.collapseButton
-            ) as CollapseButtonOptions,
+            ),
             { width, height, shape, style } = btnOptions,
             padding = 2,
             chart = this.series.chart,
@@ -182,9 +181,16 @@ class TreegraphPoint extends TreemapPoint {
     }
 
     public toggleCollapse(state?: boolean): void {
-        this.collapsed = pick(state, !this.collapsed);
-        fireEvent(this.series, 'toggleCollapse');
-        this.series.redraw();
+        const series = this.series;
+        this.collapsed = this.options.collapsed = state ?? !this.collapsed;
+
+        // Update userOptions.data
+        if (series.options.data) {
+            series.options.data[series.data.indexOf(this)] = this.options;
+        }
+
+        fireEvent(series, 'toggleCollapse');
+        series.redraw();
     }
 
     public destroy(): void {
@@ -228,7 +234,7 @@ class TreegraphPoint extends TreemapPoint {
 addEvent(TreegraphPoint, 'mouseOut', function (): void {
     const btn = this.collapseButton,
         btnOptions = this.collapseButtonOptions;
-    if (btn && btnOptions && btnOptions.onlyOnHover && !this.collapsed) {
+    if (btn && btnOptions?.onlyOnHover && !this.collapsed) {
         btn.animate({ opacity: 0 });
     }
 });
@@ -237,9 +243,7 @@ addEvent(TreegraphPoint, 'mouseOver', function (): void {
     if (this.collapseButton && this.visible) {
         this.collapseButton.animate(
             { opacity: 1 },
-            this.series.options.states &&
-            this.series.options.states.hover &&
-            this.series.options.states.hover.animation
+            this.series.options.states?.hover?.animation
         );
     }
 });


### PR DESCRIPTION
Fixed #20006, dynamically collapsed nodes were not exported correctly for treegraph.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205846970443550