### PR TITLE
bugfix/16626-secondary-grid-axis-units 

### DIFF
--- a/samples/unit-tests/gantt/grid-axis/demo.js
+++ b/samples/unit-tests/gantt/grid-axis/demo.js
@@ -1862,6 +1862,46 @@ QUnit.test(
             '2019',
             '#15692: Primary axis should show years'
         );
+
+        chart.setSize(800);
+
+        chart.update({
+            series: [{
+                data: [{
+                    start: Date.UTC(2018, 6, 2),
+                    end: Date.UTC(2019, 6, 1)
+                }]
+            }],
+            xAxis: [{
+                units: [['month', [6]]]
+            }, {
+                units: [['year', null]]
+            }]
+        }, true, true);
+
+        assert.strictEqual(
+            chart.xAxis[0].tickPositions.map(tickPosition =>
+                chart.xAxis[0].ticks[tickPosition].label.textStr
+            ).join(', '),
+            'July, January, July',
+            'Primary axis should show months when xAxis.units set (#16626)'
+        );
+
+        chart.update({
+            xAxis: [{
+                units: [['year', null]]
+            }, {
+                units: [['month', [6]]]
+            }]
+        }, true, true);
+
+        assert.strictEqual(
+            chart.xAxis[1].tickPositions.map(tickPosition =>
+                chart.xAxis[1].ticks[tickPosition].label.textStr
+            ).join(', '),
+            'July, January, July',
+            'Secondary axis should show months when xAxis.units set (#16626)'
+        );
     }
 );
 

--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -871,7 +871,8 @@ function onAfterSetOptions(
                 defined(userOptions.linkedTo) &&
 
                 !defined(userOptions.tickPositioner) &&
-                !defined(userOptions.tickInterval)
+                !defined(userOptions.tickInterval) &&
+                !defined(userOptions.units)
             ) {
                 gridAxisOptions.tickPositioner = function (
                     min: number,


### PR DESCRIPTION
Fixed #16626, secondary grid axis ignored `xAxis.units` set.