### PR TITLE
bugfix/20142-pie-selected-legend-styled-mode

### DIFF
--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -366,7 +366,7 @@ g.highcharts-series,
 }
 
 .highcharts-legend-series-active g.highcharts-series:not(.highcharts-series-hover),
-.highcharts-legend-point-active .highcharts-point:not(.highcharts-point-hover),
+.highcharts-legend-point-active .highcharts-point:not(.highcharts-point-hover, .highcharts-point-select),
 .highcharts-legend-series-active .highcharts-markers:not(.highcharts-series-hover),
 .highcharts-legend-series-active .highcharts-data-labels:not(.highcharts-series-hover) {
     opacity: 0.2;


### PR DESCRIPTION
Fixed #20142, pie selected point was semi-transparent on legend hover in styled mode.

This fix affects only series with `series.legendType: 'point'`, as for those on legend item hover, `highcharts-legend-point-active` class is added to the container.
**Demo to test:** https://jsfiddle.net/BlackLabel/zc184akv/