### PR TITLE
bugfix/19808-range-selector-states

### DIFF
--- a/samples/unit-tests/rangeselector/members/demo.js
+++ b/samples/unit-tests/rangeselector/members/demo.js
@@ -162,6 +162,98 @@ QUnit.test('RangeSelector.updateButtonStates, visual output', assert => {
         undefined,
         'The selected option should remain after redraw (#9209)'
     );
+
+    // #19808
+    chart.update({
+        rangeSelector: {
+            buttons: [
+                {
+                    type: 'week',
+                    count: 1,
+                    text: '1W'
+                },
+                {
+                    type: 'month',
+                    count: 1,
+                    text: '1M'
+                },
+                {
+                    type: 'year',
+                    count: 1,
+                    text: '1Y'
+                }
+            ]
+        },
+        xAxis: {
+            minRange: 5 * 24 * 36e5
+        },
+        series: {
+            dataGrouping: {
+                enabled: false
+            },
+            data: (function () {
+                const dataArrayTmp = [];
+                const startDate = new Date('2015-01-01');
+                for (startDate; startDate <= new Date('2016-02-01'); startDate.setDate(startDate.getDate() + 1)) {
+                    dataArrayTmp.push([startDate.getTime(), 1]);
+                }
+                return dataArrayTmp;
+            }())
+        }
+    });
+    const day = 24 * 36e5,
+        xAxis = chart.xAxis[0],
+        max = xAxis.max,
+        buttons = chart.rangeSelector.buttons,
+        correctStates = [0, 2, 2, 0];
+
+    // Week
+    const weekState = [
+        6.4 * day, // (0) inactive
+        6.5 * day, // (2) active
+        7.5 * day, // (2) active
+        7.6 * day  // (0) inactive
+    ].map(range => {
+        xAxis.setExtremes(max - range, null);
+        return buttons[0].state;
+    });
+    assert.deepEqual(
+        weekState,
+        correctStates,
+        'Week state button should have correct states in various ranges, #19808.'
+    );
+
+    // Month
+    const monthState = [
+        26.9 * day, // (0) inactive
+        27 * day,   // (2) active
+        32 * day,   // (2) active
+        32.1 * day  // (0) inactive
+    ].map(range => {
+        xAxis.setExtremes(max - range, null);
+        return buttons[1].state;
+    });
+    assert.deepEqual(
+        monthState,
+        correctStates,
+        'Month state button should have correct states in various ranges, #19808.'
+    );
+
+    // Month
+    const yearState = [
+        363.5 * day, // (0) inactive
+        364 * day,   // (2) active
+        367 * day,   // (2) active
+        367.5 * day  // (0) inactive
+    ].map(range => {
+        xAxis.setExtremes(max - range, null);
+        return buttons[2].state;
+    });
+    assert.deepEqual(
+        yearState,
+        correctStates,
+        'Year state button should have correct states in various ranges, #19808.'
+    );
 });
 
 QUnit.test('RangeSelector.getYTDExtremes', function (assert) {

--- a/samples/unit-tests/rangeselector/members/demo.js
+++ b/samples/unit-tests/rangeselector/members/demo.js
@@ -239,7 +239,7 @@ QUnit.test('RangeSelector.updateButtonStates, visual output', assert => {
         'Month state button should have correct states in various ranges, #19808.'
     );
 
-    // Month
+    // Year
     const yearState = [
         363.5 * day, // (0) inactive
         364 * day,   // (2) active

--- a/ts/Stock/RangeSelector/RangeSelector.ts
+++ b/ts/Stock/RangeSelector/RangeSelector.ts
@@ -527,7 +527,6 @@ class RangeSelector {
         ): void => {
             const range = rangeOptions._range,
                 type = rangeOptions.type,
-                count = rangeOptions.count || 1,
                 button = buttons[i],
                 offsetRange =
                     (rangeOptions._offsetMax as any) -
@@ -552,19 +551,12 @@ class RangeSelector {
                 isSelectedTooGreat = true;
             }
 
-            // Months and years have a variable range so we check the extremes
-            if (
-                (type === 'month' || type === 'year') &&
-                (
-                    actualRange + 36e5 >=
-                    { month: 28, year: 365 }[type] * day * count - offsetRange
-                ) &&
-                (
-                    actualRange - 36e5 <=
-                    { month: 31, year: 366 }[type] * day * count + offsetRange
-                )
-            ) {
-                isSameRange = true;
+            if (type === 'week' || type === 'month') {
+                isSameRange = !!range &&
+                    range >= actualRange * 0.9 && range <= actualRange * 1.1;
+            } else if (type === 'year') {
+                isSameRange = !!range &&
+                    range >= actualRange * 0.99 && range <= actualRange * 1.01;
             } else if (type === 'ytd') {
                 isSameRange = (ytdMax - ytdMin + offsetRange) === actualRange;
                 isYTDButNotSelected = !isSelected;

--- a/ts/Stock/RangeSelector/RangeSelector.ts
+++ b/ts/Stock/RangeSelector/RangeSelector.ts
@@ -527,7 +527,6 @@ class RangeSelector {
         ): void => {
             const range = rangeOptions._range,
                 type = rangeOptions.type,
-                day = 864e5,
                 button = buttons[i],
                 offsetRange =
                     (rangeOptions._offsetMax as any) -
@@ -553,12 +552,16 @@ class RangeSelector {
             }
             if (type === 'week') {
                 isSameRange = !!range &&
-                    range >= actualRange - (0.5 * day) &&
-                    range <= actualRange + (0.5 * day);
-            } else if (type === 'month' || type === 'year') {
+                    actualRange >= range - (0.5 * day) &&
+                    actualRange <= range + (0.5 * day);
+            } else if (type === 'month') {
                 isSameRange = !!range &&
-                    range >= actualRange - (3 * day) &&
-                    range <= actualRange + (3 * day);
+                    actualRange >= range - (3 * day) &&
+                    actualRange <= range + (2 * day);
+            } else if (type === 'year') {
+                isSameRange = !!range &&
+                        actualRange >= range - (1 * day) &&
+                        actualRange <= range + (2 * day);
             } else if (type === 'ytd') {
                 isSameRange = (ytdMax - ytdMin + offsetRange) === actualRange;
                 isYTDButNotSelected = !isSelected;

--- a/ts/Stock/RangeSelector/RangeSelector.ts
+++ b/ts/Stock/RangeSelector/RangeSelector.ts
@@ -527,6 +527,7 @@ class RangeSelector {
         ): void => {
             const range = rangeOptions._range,
                 type = rangeOptions.type,
+                day = 864e5,
                 button = buttons[i],
                 offsetRange =
                     (rangeOptions._offsetMax as any) -
@@ -550,13 +551,14 @@ class RangeSelector {
             if (isSelected && isTooGreatRange) {
                 isSelectedTooGreat = true;
             }
-
-            if (type === 'week' || type === 'month') {
+            if (type === 'week') {
                 isSameRange = !!range &&
-                    range >= actualRange * 0.9 && range <= actualRange * 1.1;
-            } else if (type === 'year') {
+                    range >= actualRange - (0.5 * day) &&
+                    range <= actualRange + (0.5 * day);
+            } else if (type === 'month' || type === 'year') {
                 isSameRange = !!range &&
-                    range >= actualRange * 0.99 && range <= actualRange * 1.01;
+                    range >= actualRange - (3 * day) &&
+                    range <= actualRange + (3 * day);
             } else if (type === 'ytd') {
                 isSameRange = (ytdMax - ytdMin + offsetRange) === actualRange;
                 isYTDButNotSelected = !isSelected;

--- a/ts/Stock/RangeSelector/RangeSelectorDefaults.ts
+++ b/ts/Stock/RangeSelector/RangeSelectorDefaults.ts
@@ -79,8 +79,13 @@ const lang: Record<string, string> = {
 /**
  * The range selector is a tool for selecting ranges to display within
  * the chart. It provides buttons to select preconfigured ranges in
- * the chart, like 1 day, 1 week, 1 month etc. It also provides input
- * boxes where min and max dates can be manually input.
+ * the chart, like 1 day, 1 week, 1 month etc., and input boxes where min and
+ * max dates can be manually input.
+ *
+ * To enhance user experience, buttons will be highlighted when the visible
+ * range is between the following values:
+ * Week (6.5/7.5 days), month (27/32 days), year (364/367 days). Other ranges
+ * remain unaffected and use strict values.
  *
  * @product      highstock gantt
  * @optionparent rangeSelector


### PR DESCRIPTION
Fixed #19808, the range selector week button behaved weirdly after using the scrollbar.

~~Fixed #19808, week/month buttons state was incorrect.~~

- [x] Add test once agreed on a final solution.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205568209738908