### PR TITLE
bugfix/19715-dataGrouping-dataSorting-chart-update-fails

### DIFF
--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -4375,6 +4375,8 @@ class Series {
 
         series.initialType = initialType;
         chart.linkSeries(); // Links are lost in series.remove (#3028)
+        // setData isn't called with dataSorting & dataGrouping enabled (#19715)
+        chart.setSeriesData();
 
         // #15383: Fire updatedData if the type has changed to keep linked
         // series such as indicators updated


### PR DESCRIPTION
Fixed #19715, chart update fails with `dataGrouping` & `dataSorting`.