### PR TITLE
Refactor: PiePoint.setVisible relay to Point.update

### DIFF
--- a/samples/unit-tests/series-treemap/ignorehiddenpoint/demo.js
+++ b/samples/unit-tests/series-treemap/ignorehiddenpoint/demo.js
@@ -66,9 +66,9 @@ QUnit.test('ignoreHiddenPoint: false.', function (assert) {
     );
     point.setVisible(false);
     assert.strictEqual(
-        !!point.graphic.element,
-        true,
-        'Point hidden. Point graphic should still be drawn.'
+        typeof point.graphic,
+        'undefined',
+        'Point hidden. Point graphic should be removed.'
     );
     point.setVisible(true);
     assert.strictEqual(

--- a/ts/Series/Pie/PiePoint.ts
+++ b/ts/Series/Pie/PiePoint.ts
@@ -176,51 +176,13 @@ class PiePoint extends Point {
      */
     public setVisible(
         vis: boolean,
-        redraw?: boolean
+        redraw: boolean = true
     ): void {
-        const series = this.series,
-            chart = series.chart,
-            ignoreHiddenPoint = series.options.ignoreHiddenPoint;
-
-        redraw = pick(redraw, ignoreHiddenPoint);
-
         if (vis !== this.visible) {
-
             // If called without an argument, toggle visibility
-            this.visible = this.options.visible = vis =
-                typeof vis === 'undefined' ? !this.visible : vis;
-            // update userOptions.data
-            (series.options.data as any)[series.data.indexOf(this)] =
-                this.options;
-
-            // Show and hide associated elements. This is performed
-            // regardless of redraw or not, because chart.redraw only
-            // handles full series.
-            ['graphic', 'dataLabel', 'connector'].forEach(
-                (key: string): void => {
-                    if ((this as any)[key]) {
-                        (this as any)[key][vis ? 'show' : 'hide'](vis);
-                    }
-                }
-            );
-
-            if (this.legendItem) {
-                chart.legend.colorizeItem(this, vis);
-            }
-
-            // #4170, hide halo after hiding point
-            if (!vis && this.state === 'hover') {
-                this.setState('');
-            }
-
-            // Handle ignore hidden slices
-            if (ignoreHiddenPoint) {
-                series.isDirty = true;
-            }
-
-            if (redraw) {
-                chart.redraw();
-            }
+            this.update({
+                visible: vis ?? !this.visible
+            }, redraw, void 0, false);
         }
     }
 


### PR DESCRIPTION
Looks like we can strip out a block of redundant code from `PieSeries.setVisible` because `Point.update` already handles the same concerns. 

Based on input from https://github.com/highcharts/highcharts/pull/20276#issuecomment-1857950257