### PR TITLE
Added new option, nodeDistance

### DIFF
--- a/samples/highcharts/demo/organization-chart/demo.js
+++ b/samples/highcharts/demo/organization-chart/demo.js
@@ -106,7 +106,7 @@ Highcharts.chart('container', {
             color: 'white'
         },
         borderColor: 'white',
-        nodeWidth: 65
+        nodeWidth: 'auto'
     }],
     tooltip: {
         outside: true

--- a/samples/highcharts/series-organization/horizontal/demo.js
+++ b/samples/highcharts/series-organization/horizontal/demo.js
@@ -43,7 +43,8 @@ Highcharts.chart('container', {
             color: '#359154'
         }],
         colorByPoint: false,
-        nodeWidth: 'auto'
+        nodeWidth: 'auto',
+        nodeDistance: '50%'
     }],
     exporting: {
         allowHTML: true,

--- a/samples/highcharts/series-organization/horizontal/demo.js
+++ b/samples/highcharts/series-organization/horizontal/demo.js
@@ -43,7 +43,7 @@ Highcharts.chart('container', {
             color: '#359154'
         }],
         colorByPoint: false,
-        nodeWidth: '16%'
+        nodeWidth: 'auto'
     }],
     exporting: {
         allowHTML: true,

--- a/samples/highcharts/series-organization/node-distance/demo.css
+++ b/samples/highcharts/series-organization/node-distance/demo.css
@@ -1,0 +1,6 @@
+#container {
+    min-width: 300px;
+    max-width: 800px;
+    margin: 1em auto;
+    border: 1px solid silver;
+}

--- a/samples/highcharts/series-organization/node-distance/demo.details
+++ b/samples/highcharts/series-organization/node-distance/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+...

--- a/samples/highcharts/series-organization/node-distance/demo.html
+++ b/samples/highcharts/series-organization/node-distance/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/sankey.js"></script>
+<script src="https://code.highcharts.com/modules/organization.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
+
+<div id="container"></div>
+

--- a/samples/highcharts/series-organization/node-distance/demo.js
+++ b/samples/highcharts/series-organization/node-distance/demo.js
@@ -43,7 +43,8 @@ Highcharts.chart('container', {
             color: '#359154'
         }],
         colorByPoint: false,
-        nodeWidth: '16%'
+        nodeWidth: 'auto',
+        nodeDistance: '50%'
     }],
     exporting: {
         allowHTML: true,

--- a/samples/highcharts/series-sankey/node-distance/demo.css
+++ b/samples/highcharts/series-sankey/node-distance/demo.css
@@ -1,0 +1,5 @@
+#container {
+    height: 400px;
+    max-width: 800px;
+    margin: 0 auto;
+}

--- a/samples/highcharts/series-sankey/node-distance/demo.details
+++ b/samples/highcharts/series-sankey/node-distance/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Sankey with nodeDistance
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+...

--- a/samples/highcharts/series-sankey/node-distance/demo.html
+++ b/samples/highcharts/series-sankey/node-distance/demo.html
@@ -1,0 +1,6 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/sankey.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/modules/accessibility.js"></script>
+
+<div id="container"></div>

--- a/samples/highcharts/series-sankey/node-distance/demo.js
+++ b/samples/highcharts/series-sankey/node-distance/demo.js
@@ -1,0 +1,35 @@
+Highcharts.chart('container', {
+
+    title: {
+        text: 'Node distance demo'
+    },
+
+    subtitle: {
+        text: '<em>nodeDistance: 100%</em> means equal to node width'
+    },
+
+    series: [{
+        type: 'sankey',
+        keys: ['from', 'to', 'weight'],
+        nodeWidth: 'auto',
+        nodeDistance: '100%',
+        data: [{
+            from: 'A',
+            to: 'B',
+            weight: 0.3
+        }, {
+            from: 'A',
+            to: 'C',
+            weight: 0.5
+        }, {
+            from: 'B',
+            to: 'D',
+            weight: 0.3
+        }, {
+            from: 'C',
+            to: 'D',
+            weight: 0.3
+        }]
+    }]
+
+});

--- a/samples/highcharts/series-treegraph/color-variation/demo.js
+++ b/samples/highcharts/series-treegraph/color-variation/demo.js
@@ -179,9 +179,10 @@ Highcharts.chart('container', {
                 pointFormat: '{point.name}'
             },
             marker: {
-                symbol: 'rect',
-                width: '25%'
+                symbol: 'rect'
             },
+            nodeWidth: 'auto',
+            nodeDistance: '50%',
             borderRadius: 10,
             dataLabels: {
                 pointFormat: '{point.name}'

--- a/samples/highcharts/series-treegraph/color-variation/demo.js
+++ b/samples/highcharts/series-treegraph/color-variation/demo.js
@@ -185,7 +185,10 @@ Highcharts.chart('container', {
             nodeDistance: '50%',
             borderRadius: 10,
             dataLabels: {
-                pointFormat: '{point.name}'
+                pointFormat: '{point.name}',
+                style: {
+                    whiteSpace: 'nowrap'
+                }
             },
             levels: [
                 {

--- a/samples/highcharts/series-treegraph/node-distance/demo.css
+++ b/samples/highcharts/series-treegraph/node-distance/demo.css
@@ -1,0 +1,6 @@
+#container {
+    max-width: 800px;
+    min-width: 360px;
+    margin: 0 auto;
+    height: 600px;
+}

--- a/samples/highcharts/series-treegraph/node-distance/demo.details
+++ b/samples/highcharts/series-treegraph/node-distance/demo.details
@@ -1,0 +1,6 @@
+---
+name: Treegraph chart
+authors:
+  - Pawel Lysy, Torstein Hønsi
+js_wrap: b
+...

--- a/samples/highcharts/series-treegraph/node-distance/demo.html
+++ b/samples/highcharts/series-treegraph/node-distance/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/treemap.js"></script>
+<script src="https://code.highcharts.com/modules/treegraph.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/modules/accessibility.js"></script>
+
+<div id="container"></div>

--- a/samples/highcharts/series-treegraph/node-distance/demo.js
+++ b/samples/highcharts/series-treegraph/node-distance/demo.js
@@ -1,0 +1,195 @@
+const data = [
+    {
+        id: '0.0',
+        parent: '',
+        name: 'The World'
+    },
+    {
+        id: '1.3',
+        parent: '0.0',
+        name: 'Asia'
+    },
+    {
+        id: '1.1',
+        parent: '0.0',
+        name: 'Africa'
+    },
+    {
+        id: '1.2',
+        parent: '0.0',
+        name: 'America'
+    },
+    {
+        id: '1.4',
+        parent: '0.0',
+        name: 'Europe'
+    },
+    {
+        id: '1.5',
+        parent: '0.0',
+        name: 'Oceanic'
+    },
+
+    /* Africa */
+    {
+        id: '2.1',
+        parent: '1.1',
+        name: 'Eastern Africa'
+    },
+
+    {
+        id: '2.5',
+        parent: '1.1',
+        name: 'Western Africa'
+    },
+
+    {
+        id: '2.3',
+        parent: '1.1',
+        name: 'North Africa'
+    },
+
+    {
+        id: '2.2',
+        parent: '1.1',
+        name: 'Central Africa'
+    },
+
+    {
+        id: '2.4',
+        parent: '1.1',
+        name: 'South America'
+    },
+
+    /* America */
+    {
+        id: '2.9',
+        parent: '1.2',
+        name: 'South America'
+    },
+
+    {
+        id: '2.8',
+        parent: '1.2',
+        name: 'Northern America'
+    },
+
+    {
+        id: '2.7',
+        parent: '1.2',
+        name: 'Central America'
+    },
+
+    {
+        id: '2.6',
+        parent: '1.2',
+        name: 'Caribbean'
+    },
+
+    /* Asia */
+    {
+        id: '2.13',
+        parent: '1.3',
+        name: 'Southern Asia'
+    },
+
+    {
+        id: '2.11',
+        parent: '1.3',
+        name: 'Eastern Asia'
+    },
+
+    {
+        id: '2.12',
+        parent: '1.3',
+        name: 'South-Eastern Asia'
+    },
+
+    {
+        id: '2.14',
+        parent: '1.3',
+        name: 'Western Asia'
+    },
+
+    {
+        id: '2.10',
+        parent: '1.3',
+        name: 'Central Asia'
+    },
+
+    /* Europe */
+    {
+        id: '2.15',
+        parent: '1.4',
+        name: 'Eastern Europe'
+    },
+
+    {
+        id: '2.16',
+        parent: '1.4',
+        name: 'Northern Europe'
+    },
+
+    {
+        id: '2.17',
+        parent: '1.4',
+        name: 'Southern Europe'
+    },
+
+    {
+        id: '2.18',
+        parent: '1.4',
+        name: 'Western Europe'
+    },
+    /* Oceania */
+    {
+        id: '2.19',
+        parent: '1.5',
+        name: 'Australia and New Zealand'
+    },
+
+    {
+        id: '2.20',
+        parent: '1.5',
+        name: 'Melanesia'
+    },
+
+    {
+        id: '2.21',
+        parent: '1.5',
+        name: 'Micronesia'
+    },
+
+    {
+        id: '2.22',
+        parent: '1.5',
+        name: 'Polynesia'
+    }
+];
+
+Highcharts.chart('container', {
+    title: {
+        text: 'Treegraph with a node distance of 50%'
+    },
+    series: [
+        {
+            type: 'treegraph',
+            data,
+            tooltip: {
+                pointFormat: '{point.name}'
+            },
+            marker: {
+                symbol: 'rect'
+            },
+            nodeWidth: 'auto',
+            nodeDistance: '50%',
+            borderRadius: 10,
+            dataLabels: {
+                pointFormat: '{point.name}',
+                style: {
+                    textOutline: 'none'
+                }
+            }
+        }
+    ]
+});

--- a/ts/Series/DependencyWheel/DependencyWheelSeries.ts
+++ b/ts/Series/DependencyWheel/DependencyWheelSeries.ts
@@ -35,7 +35,8 @@ const {
 import U from '../../Core/Utilities.js';
 const {
     extend,
-    merge
+    merge,
+    relativeLength
 } = U;
 
 /* *
@@ -240,7 +241,9 @@ class DependencyWheelSeries extends SankeySeries {
                     centerX = center[0],
                     centerY = center[1],
                     r = center[2] / 2,
-                    innerR = r - (options.nodeWidth as any),
+                    nodeWidth = options.nodeWidth === 'auto' ?
+                        20 : options.nodeWidth,
+                    innerR = r - relativeLength(nodeWidth || 0, r),
                     start = startAngle + factor * (shapeArgs.y || 0),
                     end = startAngle +
                         factor * ((shapeArgs.y || 0) + (shapeArgs.height || 0));

--- a/ts/Series/DependencyWheel/DependencyWheelSeriesDefaults.ts
+++ b/ts/Series/DependencyWheel/DependencyWheelSeriesDefaults.ts
@@ -34,7 +34,7 @@ import type DependencyWheelSeriesOptions from './DependencyWheelSeriesOptions';
  *         Dependency wheel
  *
  * @extends      plotOptions.sankey
- * @exclude      dataSorting, nodeAlignment
+ * @exclude      dataSorting, nodeAlignment, nodeDistance
  * @since        7.1.0
  * @product      highcharts
  * @requires     modules/dependency-wheel

--- a/ts/Series/Organization/OrganizationSeriesDefaults.ts
+++ b/ts/Series/Organization/OrganizationSeriesDefaults.ts
@@ -353,8 +353,8 @@ const OrganizationSeriesDefaults: OrganizationSeriesOptions = {
     minNodeLength: 10,
     /**
      * In a horizontal chart, the width of the nodes in pixels. Note that
-     * most organization charts are vertical, so the name of this option
-     * is counterintuitive.
+     * most organization charts are inverted (vertical), so the name of this
+     * option is counterintuitive.
      *
      * @see [minNodeLength](#plotOptions.organization.minNodeLength)
      *

--- a/ts/Series/Sankey/SankeySeries.ts
+++ b/ts/Series/Sankey/SankeySeries.ts
@@ -338,18 +338,27 @@ class SankeySeries extends ColumnSeries {
         this.generatePoints();
 
         this.nodeColumns = this.createNodeColumns();
-        this.nodeWidth = relativeLength(
-            this.options.nodeWidth as any,
-            this.chart.plotSizeX as any
-        );
 
         const series = this,
             chart = this.chart,
             options = this.options,
-            nodeWidth = this.nodeWidth,
-            nodeColumns = this.nodeColumns;
+            nodeColumns = this.nodeColumns,
+            plotSizeX = chart.plotSizeX || 1,
+            nodePaddingLongitudinal = options.nodePaddingLongitudinal || 0;
 
         this.nodePadding = this.getNodePadding();
+
+        let nodeWidth = options.nodeWidth || 0;
+        if (nodeWidth === 'auto') {
+            // Node width auto means they are evenly distributed along the
+            // width of the plot area
+            nodeWidth = (
+                (plotSizeX + nodePaddingLongitudinal) /
+                (this.nodeColumns?.length || 1)
+            ) - nodePaddingLongitudinal;
+        }
+
+        this.nodeWidth = relativeLength(nodeWidth, plotSizeX);
 
         // Find out how much space is needed. Base it on the translation
         // factor of the most spaceous column.
@@ -368,7 +377,7 @@ class SankeySeries extends ColumnSeries {
 
         this.colDistance =
             (
-                (chart.plotSizeX as any) - nodeWidth -
+                (chart.plotSizeX as any) - this.nodeWidth -
                 (options.borderWidth as any)
             ) / Math.max(1, nodeColumns.length - 1);
 

--- a/ts/Series/Sankey/SankeySeries.ts
+++ b/ts/Series/Sankey/SankeySeries.ts
@@ -42,7 +42,7 @@ const {
 import Color from '../../Core/Color/Color.js';
 const { parse: color } = Color;
 import TU from '../TreeUtilities.js';
-const { getLevelOptions } = TU;
+const { getLevelOptions, getNodeWidth } = TU;
 import U from '../../Core/Utilities.js';
 const {
     clamp,
@@ -343,22 +343,10 @@ class SankeySeries extends ColumnSeries {
             chart = this.chart,
             options = this.options,
             nodeColumns = this.nodeColumns,
-            plotSizeX = chart.plotSizeX || 1,
-            nodePaddingLongitudinal = options.nodePaddingLongitudinal || 0;
+            columnCount = nodeColumns.length;
 
+        this.nodeWidth = getNodeWidth(this, columnCount);
         this.nodePadding = this.getNodePadding();
-
-        let nodeWidth = options.nodeWidth || 0;
-        if (nodeWidth === 'auto') {
-            // Node width auto means they are evenly distributed along the
-            // width of the plot area
-            nodeWidth = (
-                (plotSizeX + nodePaddingLongitudinal) /
-                (this.nodeColumns?.length || 1)
-            ) - nodePaddingLongitudinal;
-        }
-
-        this.nodeWidth = relativeLength(nodeWidth, plotSizeX);
 
         // Find out how much space is needed. Base it on the translation
         // factor of the most spaceous column.

--- a/ts/Series/Sankey/SankeySeriesDefaults.ts
+++ b/ts/Series/Sankey/SankeySeriesDefaults.ts
@@ -297,10 +297,15 @@ const SankeySeriesDefaults: PlotOptionsOf<SankeySeries> = {
     nodePadding: 10,
 
     /**
-     * The padding between nodes in a sankey diagram in the longitudinal
-     * direction, in pixels. The longitudinal direction means the direction that
-     * the chart flows - in a horizontal chart the padding is horizontal, in an
-     * inverted chart (vertical), the padding is vertical.
+     * The distance between nodes in a sankey diagram in the longitudinal
+     * direction. The longitudinal direction means the direction that the chart
+     * flows - in a horizontal chart the distance is horizontal, in an inverted
+     * chart (vertical), the distance is vertical.
+     *
+     * If a number is given, it denotes pixels. If a percentage string is given,
+     * the distance is a percentage of the rendered node width. A `nodeDistance`
+     * of `100%` will render equal widths for the nodes and the gaps between
+     * them.
      *
      * This option applies only when the `nodeWidth` option is `auto`, making
      * the node width respond to the number of columns.
@@ -308,7 +313,7 @@ const SankeySeriesDefaults: PlotOptionsOf<SankeySeries> = {
      * @since next
      * @type {number}
      */
-    nodePaddingLongitudinal: 30,
+    nodeDistance: 30,
 
     showInLegend: false,
 

--- a/ts/Series/Sankey/SankeySeriesDefaults.ts
+++ b/ts/Series/Sankey/SankeySeriesDefaults.ts
@@ -287,6 +287,8 @@ const SankeySeriesDefaults: PlotOptionsOf<SankeySeries> = {
      * @see    [sankey.nodeDistance](#nodeDistance)
      * @sample highcharts/series-sankey/node-distance
      *         Sankey with auto node width combined with node distance
+     * @sample highcharts/series-organization/node-distance
+     *         Organization chart with node distance of 50%
      *
      * @type {number|string}
      */
@@ -320,7 +322,9 @@ const SankeySeriesDefaults: PlotOptionsOf<SankeySeries> = {
      *
      * @since next
      * @sample highcharts/series-sankey/node-distance
-     *         Node distance of 100% means equal to node width
+     *         Sankey with dnode distance of 100% means equal to node width
+     * @sample highcharts/series-organization/node-distance
+     *         Organization chart with node distance of 50%
      * @type   {number|string}
      */
     nodeDistance: 30,

--- a/ts/Series/Sankey/SankeySeriesDefaults.ts
+++ b/ts/Series/Sankey/SankeySeriesDefaults.ts
@@ -278,13 +278,15 @@ const SankeySeriesDefaults: PlotOptionsOf<SankeySeries> = {
      * The pixel width of each node in a sankey diagram or dependency wheel, or
      * the height in case the chart is inverted.
      *
-     * Can be a number or a percentage string, or `auto`. If `auto`, the nodes
-     * are sized to fill up the plot area in the longitudinal direction,
+     * Can be a number or a percentage string.
+     *
+     * Sankey series also support setting it to `auto`. With this setting, the
+     * nodes are sized to fill up the plot area in the longitudinal direction,
      * regardless of the number of levels.
      *
      * @see    [sankey.nodeDistance](#nodeDistance)
      * @sample highcharts/series-sankey/node-distance
-     *         Node width is auto and combined with node distance
+     *         Sankey with auto node width combined with node distance
      *
      * @type {number|string}
      */
@@ -296,9 +298,9 @@ const SankeySeriesDefaults: PlotOptionsOf<SankeySeries> = {
      * so vertical distance by default, or horizontal distance in an inverted
      * (vertical) sankey.
      *
-     * If the number of nodes is so great that it is possible to lay them
-     * out within the plot area with the given `nodePadding`, they will be
-     * rendered with a smaller padding as a strategy to avoid overflow.
+     * If the number of nodes is so great that it is impossible to lay them out
+     * within the plot area with the given `nodePadding`, they will be rendered
+     * with a smaller padding as a strategy to avoid overflow.
      */
     nodePadding: 10,
 

--- a/ts/Series/Sankey/SankeySeriesDefaults.ts
+++ b/ts/Series/Sankey/SankeySeriesDefaults.ts
@@ -278,21 +278,37 @@ const SankeySeriesDefaults: PlotOptionsOf<SankeySeries> = {
      * The pixel width of each node in a sankey diagram or dependency wheel,
      * or the height in case the chart is inverted.
      *
-     * @private
+     * Can be a number or a percentage string, or `auto`. If `auto`, the nodes
+     * area sized to fill up the plot are in the longitudinal direction,
+     * regardless of the number of levels.
      */
     nodeWidth: 20,
 
     /**
      * The padding between nodes in a sankey diagram or dependency wheel, in
-     * pixels.
+     * pixels. For sankey charts, this applies to the nodes of the same column,
+     * so vertical distance by default, or horizontal distance in an inverted
+     * (vertical) sankey.
      *
      * If the number of nodes is so great that it is possible to lay them
      * out within the plot area with the given `nodePadding`, they will be
      * rendered with a smaller padding as a strategy to avoid overflow.
-     *
-     * @private
      */
     nodePadding: 10,
+
+    /**
+     * The padding between nodes in a sankey diagram in the longitudinal
+     * direction, in pixels. The longitudinal direction means the direction that
+     * the chart flows - in a horizontal chart the padding is horizontal, in an
+     * inverted chart (vertical), the padding is vertical.
+     *
+     * This option applies only when the `nodeWidth` option is `auto`, making
+     * the node width respond to the number of columns.
+     *
+     * @since next
+     * @type {number}
+     */
+    nodePaddingLongitudinal: 30,
 
     showInLegend: false,
 

--- a/ts/Series/Sankey/SankeySeriesDefaults.ts
+++ b/ts/Series/Sankey/SankeySeriesDefaults.ts
@@ -275,12 +275,18 @@ const SankeySeriesDefaults: PlotOptionsOf<SankeySeries> = {
     nodeAlignment: 'center',
 
     /**
-     * The pixel width of each node in a sankey diagram or dependency wheel,
-     * or the height in case the chart is inverted.
+     * The pixel width of each node in a sankey diagram or dependency wheel, or
+     * the height in case the chart is inverted.
      *
      * Can be a number or a percentage string, or `auto`. If `auto`, the nodes
-     * area sized to fill up the plot are in the longitudinal direction,
+     * are sized to fill up the plot area in the longitudinal direction,
      * regardless of the number of levels.
+     *
+     * @see    [sankey.nodeDistance](#nodeDistance)
+     * @sample highcharts/series-sankey/node-distance
+     *         Node width is auto and combined with node distance
+     *
+     * @type {number|string}
      */
     nodeWidth: 20,
 
@@ -311,7 +317,9 @@ const SankeySeriesDefaults: PlotOptionsOf<SankeySeries> = {
      * the node width respond to the number of columns.
      *
      * @since next
-     * @type {number}
+     * @sample highcharts/series-sankey/node-distance
+     *         Node distance of 100% means equal to node width
+     * @type   {number|string}
      */
     nodeDistance: 30,
 

--- a/ts/Series/Sankey/SankeySeriesOptions.d.ts
+++ b/ts/Series/Sankey/SankeySeriesOptions.d.ts
@@ -65,7 +65,7 @@ export interface SankeySeriesOptions extends ColumnSeriesOptions, NodesCompositi
     minLinkWidth?: number;
     nodeAlignment?: ('top'|'center'|'bottom')
     nodePadding?: number;
-    nodePaddingLongitudinal?: number;
+    nodeDistance?: number|string;
     nodes?: Array<SankeySeriesNodeOptions>;
     nodeWidth?: number|string;
     states?: SeriesStatesOptions<SankeySeries>;

--- a/ts/Series/Sankey/SankeySeriesOptions.d.ts
+++ b/ts/Series/Sankey/SankeySeriesOptions.d.ts
@@ -65,8 +65,9 @@ export interface SankeySeriesOptions extends ColumnSeriesOptions, NodesCompositi
     minLinkWidth?: number;
     nodeAlignment?: ('top'|'center'|'bottom')
     nodePadding?: number;
+    nodePaddingLongitudinal?: number;
     nodes?: Array<SankeySeriesNodeOptions>;
-    nodeWidth?: number;
+    nodeWidth?: number|string;
     states?: SeriesStatesOptions<SankeySeries>;
     tooltip?: SankeySeriesTooltipOptions;
     width?: number;

--- a/ts/Series/TreeUtilities.ts
+++ b/ts/Series/TreeUtilities.ts
@@ -20,6 +20,8 @@
 
 import type CorePoint from '../Core/Series/Point';
 import type CorePointOptions from '../Core/Series/PointOptions';
+import type SankeySeries from '../Series/Sankey/SankeySeries';
+import type TreegraphSeries from '../Series/Treegraph/TreegraphSeries';
 import type CoreSeries from '../Core/Series/Series';
 import type ColorType from '../Core/Color/ColorType';
 
@@ -31,7 +33,8 @@ const {
     isNumber,
     isObject,
     merge,
-    pick
+    pick,
+    relativeLength
 } = U;
 
 /* *
@@ -290,6 +293,40 @@ function updateRootId(
     return rootId;
 }
 
+/**
+ * Get the node width, which relies on the plot width and the nodeDistance
+ * option.
+ *
+ * @private
+ */
+function getNodeWidth(
+    series: SankeySeries|TreegraphSeries,
+    columnCount: number
+): number {
+    const { chart, options } = series,
+        { nodeDistance = 0, nodeWidth = 0 } = options,
+        { plotSizeX = 1 } = chart;
+
+    // Node width auto means they are evenly distributed along the width of
+    // the plot area
+    if (nodeWidth === 'auto') {
+        if (typeof nodeDistance === 'string' && /%$/.test(nodeDistance)) {
+            const fraction = parseFloat(nodeDistance) / 100,
+                total = columnCount + fraction * (columnCount - 1);
+            return plotSizeX / total;
+        }
+        const nDistance = Number(nodeDistance);
+
+        return (
+            (plotSizeX + nDistance) /
+            (columnCount || 1)
+        ) - nDistance;
+    }
+
+    return relativeLength(nodeWidth, plotSizeX);
+}
+
+
 /* *
  *
  *  Namespace
@@ -374,6 +411,7 @@ namespace TreeUtilities {
 const TreeUtilities = {
     getColor,
     getLevelOptions,
+    getNodeWidth,
     setTreeValues,
     updateRootId
 };

--- a/ts/Series/Treegraph/TreegraphSeries.ts
+++ b/ts/Series/Treegraph/TreegraphSeries.ts
@@ -39,9 +39,10 @@ const { prototype: { symbols } } = SVGRenderer;
 import TreegraphNode from './TreegraphNode.js';
 import TreegraphPoint from './TreegraphPoint.js';
 import TU from '../TreeUtilities.js';
-const { getLevelOptions } = TU;
+const { getLevelOptions, getNodeWidth } = TU;
 import U from '../../Core/Utilities.js';
 const {
+    arrayMax,
     extend,
     merge,
     pick,
@@ -143,7 +144,11 @@ class TreegraphSeries extends TreemapSeries {
         const chart = this.chart,
             series = this,
             plotSizeX = chart.plotSizeX as number,
-            plotSizeY = chart.plotSizeY as number;
+            plotSizeY = chart.plotSizeY as number,
+            columnCount = arrayMax(
+                this.points.map((p): number => p.node.xPosition)
+            );
+
         let minX = Infinity,
             maxX = -Infinity,
             minY = Infinity,
@@ -166,6 +171,10 @@ class TreegraphSeries extends TreemapSeries {
                     level.marker,
                     point.options.marker
                 ),
+                nodeWidth = markerOptions.width ?? getNodeWidth(
+                    this,
+                    columnCount
+                ),
                 radius = relativeLength(
                     markerOptions.radius || 0,
                     Math.min(plotSizeX, plotSizeY)
@@ -174,9 +183,10 @@ class TreegraphSeries extends TreemapSeries {
                 nodeSizeY = (symbol === 'circle' || !markerOptions.height) ?
                     radius * 2 :
                     relativeLength(markerOptions.height, plotSizeY),
-                nodeSizeX = symbol === 'circle' || !markerOptions.width ?
+                nodeSizeX = symbol === 'circle' || !nodeWidth ?
                     radius * 2 :
-                    relativeLength(markerOptions.width, plotSizeX);
+                    relativeLength(nodeWidth, plotSizeX);
+
             node.nodeSizeX = nodeSizeX;
             node.nodeSizeY = nodeSizeY;
 

--- a/ts/Series/Treegraph/TreegraphSeriesDefaults.ts
+++ b/ts/Series/Treegraph/TreegraphSeriesDefaults.ts
@@ -40,7 +40,7 @@ import { Palette } from '../../Core/Color/Palettes';
  * @extends      plotOptions.treemap
  * @excluding    layoutAlgorithm, dashStyle, linecap, lineWidth,
  *               negativeColor, threshold, zones, zoneAxis, colorAxis,
- *               colorKey, compare, dataGrouping, endAgle, gapSize, gapUnit,
+ *               colorKey, compare, dataGrouping, endAngle, gapSize, gapUnit,
  *               ignoreHiddenPoint, innerSize, joinBy, legendType, linecap,
  *               minSize, navigatorOptions, pointRange, allowTraversingTree,
  *               alternateStartingDirection, borderRadius, breadcrumbs,
@@ -253,7 +253,44 @@ const TreegraphSeriesDefaults = {
             textOverflow: 'none'
         }
     },
-    nodeDistance: 30
+    /**
+     * The distance between nodes in a tree graph in the longitudinal direction.
+     * The longitudinal direction means the direction that the chart flows - in
+     * a horizontal chart the distance is horizontal, in an inverted chart
+     * (vertical), the distance is vertical.
+     *
+     * If a number is given, it denotes pixels. If a percentage string is given,
+     * the distance is a percentage of the rendered node width. A `nodeDistance`
+     * of `100%` will render equal widths for the nodes and the gaps between
+     * them.
+     *
+     * This option applies only when the `nodeWidth` option is `auto`, making
+     * the node width respond to the number of columns.
+     *
+     * @since next
+     * @sample highcharts/series-treegraph/node-distance
+     *         Node distance of 100% means equal to node width
+     * @type   {number|string}
+     */
+    nodeDistance: 30,
+
+    /**
+     * The pixel width of each node in a, or the height in case the chart is
+     * inverted. For tree graphs, the node width is only applied if the marker
+     * symbol is `rect`, otherwise the `marker` sizing options apply.
+     *
+     * Can be a number or a percentage string, or `auto`. If `auto`, the nodes
+     * are sized to fill up the plot area in the longitudinal direction,
+     * regardless of the number of levels.
+     *
+     * @since next
+     * @see    [treegraph.nodeDistance](#nodeDistance)
+     * @sample highcharts/series-treegraph/node-distance
+     *         Node width is auto and combined with node distance
+     *
+     * @type {number|string}
+     */
+    nodeWidth: void 0
 } as TreegraphSeriesOptions;
 
 /* *

--- a/ts/Series/Treegraph/TreegraphSeriesDefaults.ts
+++ b/ts/Series/Treegraph/TreegraphSeriesDefaults.ts
@@ -252,7 +252,8 @@ const TreegraphSeriesDefaults = {
         style: {
             textOverflow: 'none'
         }
-    }
+    },
+    nodeDistance: 30
 } as TreegraphSeriesOptions;
 
 /* *

--- a/ts/Series/Treegraph/TreegraphSeriesOptions.d.ts
+++ b/ts/Series/Treegraph/TreegraphSeriesOptions.d.ts
@@ -75,6 +75,8 @@ export interface TreegraphSeriesOptions extends TreemapSeriesOptions {
     collapseButton: CollapseButtonOptions;
     fillSpace: boolean;
     link: TreegraphLinkOptions;
+    nodeDistance?: number|string;
+    nodeWidth?: number|string;
     reversed?: boolean;
     marker: PointMarkerOptions;
 }


### PR DESCRIPTION
Added new option, [sankey.nodeDistance](https://api.highcharts.com/highcharts/series.sankey.nodeDistance) and the possibility of setting [sankey.nodeWidth](https://api.highcharts.com/highcharts/series.sankey.nodeWidth) to `auto`. The same option pair is also supported by organization chart and treegraph series.

Closes https://github.com/highcharts/highcharts/issues/17328

### To do
 - [x] Samples. Make sure different combinations are covered. This should suffice as regression tests too.
 - [x] Should it be default for org charts? Edit: No. Most org charts are inverted.
 - [x] Samples for org chart.
 - [x] Remove (ignore) doclet for dependency wheel.
 - [x] Include doclet for org chart (check `nodeDistance` and `nodeWidth`)
 - [x] What about tree graph? Tree graphs currently don't have a concept of node width or columns, but the same options make sense there.
 - [x] Doclets for tree graph.
 - [x] Alternative name `columnDistance` or `nodeDistance`. Since it is actually the distance between the nodes rather than a padding.