### PR TITLE
bugfix/17148-xrange-align-datalabel

### DIFF
--- a/samples/gantt/demo/resource-management/demo.js
+++ b/samples/gantt/demo/resource-management/demo.js
@@ -120,7 +120,8 @@ Highcharts.ganttChart('container', {
                 enabled: true,
                 format: '{point.name}',
                 style: {
-                    fontWeight: 'normal'
+                    fontWeight: 'normal',
+                    textOverflow: 'ellipsis'
                 }
             }
         }

--- a/ts/Series/XRange/XRangeSeries.ts
+++ b/ts/Series/XRange/XRangeSeries.ts
@@ -259,6 +259,14 @@ class XRangeSeries extends ColumnSeries {
     public alignDataLabel(point: XRangePoint): void {
         const oldPlotX = point.plotX;
         point.plotX = pick(point.dlBox && point.dlBox.centerX, point.plotX);
+
+        if (point.dataLabel && point.shapeArgs && point.shapeArgs.width) {
+            const width = point.shapeArgs.width;
+            point.dataLabel.css({
+                width: `${width}px`
+            });
+        }
+
         super.alignDataLabel.apply(this, arguments);
         point.plotX = oldPlotX;
     }

--- a/ts/Series/XRange/XRangeSeries.ts
+++ b/ts/Series/XRange/XRangeSeries.ts
@@ -260,7 +260,7 @@ class XRangeSeries extends ColumnSeries {
         const oldPlotX = point.plotX;
         point.plotX = pick(point.dlBox && point.dlBox.centerX, point.plotX);
 
-        if (point.dataLabel && point.shapeArgs && point.shapeArgs.width) {
+        if (point.dataLabel && point.shapeArgs?.width) {
             point.dataLabel.css({
                 width: `${point.shapeArgs.width}px`
             });

--- a/ts/Series/XRange/XRangeSeries.ts
+++ b/ts/Series/XRange/XRangeSeries.ts
@@ -261,9 +261,8 @@ class XRangeSeries extends ColumnSeries {
         point.plotX = pick(point.dlBox && point.dlBox.centerX, point.plotX);
 
         if (point.dataLabel && point.shapeArgs && point.shapeArgs.width) {
-            const width = point.shapeArgs.width;
             point.dataLabel.css({
-                width: `${width}px`
+                width: `${point.shapeArgs.width}px`
             });
         }
 

--- a/ts/Series/XRange/XRangeSeriesDefaults.ts
+++ b/ts/Series/XRange/XRangeSeriesDefaults.ts
@@ -108,7 +108,10 @@ const XRangeSeriesDefaults: XRangeSeriesOptions = {
             }
         },
         inside: true,
-        verticalAlign: 'middle'
+        verticalAlign: 'middle',
+        style: {
+            whiteSpace: 'nowrap'
+        }
     },
 
     tooltip: {


### PR DESCRIPTION
Added width to data label in x-range and gantt series, allowing implementers to easily apply word-wrap or ellipsis within the tasks. See #17148.