### PR TITLE
bugfix/20264-toogling-inverted-packedbubble

### DIFF
--- a/samples/unit-tests/series-packedbubble/update/demo.js
+++ b/samples/unit-tests/series-packedbubble/update/demo.js
@@ -1,5 +1,5 @@
 QUnit.test('Series update', function (assert) {
-    const chart = Highcharts.chart('container', {
+    let chart = Highcharts.chart('container', {
         chart: {
             type: 'packedbubble',
             width: 500,
@@ -69,4 +69,41 @@ QUnit.test('Series update', function (assert) {
             chart.plotTop (#12063).`
         );
     });
+
+    chart = Highcharts.chart('container', {
+        series: [{
+            type: 'bar',
+            data: [4, 3, 5, 6, 2, 3]
+        }]
+    });
+
+    chart.series[0].update({
+        type: 'packedbubble'
+    });
+
+    const sharedClipBox =
+        chart.sharedClips[chart.series[0].sharedClipKey].getBBox();
+
+    assert.strictEqual(
+        sharedClipBox.width,
+        chart.plotWidth,
+        `For inverted chart without axes (e.g. created by updating series type
+        from inverted series) clip box width should be the same as chart plot
+        width, #20264.`
+    );
+
+    assert.strictEqual(
+        sharedClipBox.height,
+        chart.plotHeight,
+        `For inverted chart without axes (e.g. created by updating series type
+        from inverted series) clip box height should be the same as chart plot
+        height, #20264.`
+    );
+
+    assert.notEqual(
+        chart.inverted,
+        true,
+        `After updating from bar (inverted) chart to packedbubble (non-inverted)
+        chart.inverted option should be updated (#20264).`
+    );
 });

--- a/samples/unit-tests/series-packedbubble/update/demo.js
+++ b/samples/unit-tests/series-packedbubble/update/demo.js
@@ -81,29 +81,30 @@ QUnit.test('Series update', function (assert) {
         type: 'packedbubble'
     });
 
-    const sharedClipBox =
-        chart.sharedClips[chart.series[0].sharedClipKey].getBBox();
-
-    assert.strictEqual(
-        sharedClipBox.width,
-        chart.plotWidth,
-        `For inverted chart without axes (e.g. created by updating series type
-        from inverted series) clip box width should be the same as chart plot
-        width, #20264.`
-    );
-
-    assert.strictEqual(
-        sharedClipBox.height,
-        chart.plotHeight,
-        `For inverted chart without axes (e.g. created by updating series type
-        from inverted series) clip box height should be the same as chart plot
-        height, #20264.`
-    );
-
     assert.notEqual(
         chart.inverted,
         true,
         `After updating from bar (inverted) chart to packedbubble (non-inverted)
         chart.inverted option should be updated (#20264).`
+    );
+
+    chart.update({
+        chart: {
+            inverted: true
+        }
+    });
+
+    assert.strictEqual(
+        chart.sharedClips[chart.series[0].sharedClipKey].attr('width'),
+        chart.plotWidth,
+        `For inverted chart without axes clip box width should be the same as
+        chart plot width, #20264.`
+    );
+
+    assert.strictEqual(
+        chart.sharedClips[chart.series[0].sharedClipKey].attr('height'),
+        chart.plotHeight,
+        `For inverted chart without axes clip box height should be the same as
+        chart plot height, #20264.`
     );
 });

--- a/ts/.eslintrc
+++ b/ts/.eslintrc
@@ -55,7 +55,9 @@
         "no-useless-return": 0,
         "object-curly-spacing": [2, "always"],
         "object-shorthand": 0,
-        "prefer-const": 1, // @todo
+        "prefer-const": [1, {
+            "destructuring": "all"
+        }], // @todo
         "prefer-spread": 0, // @todo
         "prefer-rest-params": 0, // @todo
         "require-unicode-regexp": 0, // incompatible with ES2017- targets

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2394,13 +2394,9 @@ class Series {
             seriesBox.height = yAxis.len;
         }
 
-        // If chart is set to inverted and there are no axes or axes length are
-        // the same as plot sizes clip box shouldn't be inverted (#20264)
-        if (
-            chart.inverted &&
-            (!xAxis || xAxis.len === chart.plotSizeX) &&
-            (!yAxis || yAxis.len === chart.plotSizeY)
-        ) {
+        // If chart is set to inverted and there are no axes, clip box shouldn't
+        // be inverted (#20264)
+        if (chart.inverted && !xAxis && !yAxis) {
             [seriesBox.width, seriesBox.height] =
                 [seriesBox.height, seriesBox.width];
         }

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2394,6 +2394,17 @@ class Series {
             seriesBox.height = yAxis.len;
         }
 
+        // If chart is set to inverted and there are no axes or axes length are
+        // the same as plot sizes clip box shouldn't be inverted (#20264)
+        if (
+            chart.inverted &&
+            (!xAxis || xAxis.len === chart.plotSizeX) &&
+            (!yAxis || yAxis.len === chart.plotSizeY)
+        ) {
+            [seriesBox.width, seriesBox.height] =
+                [seriesBox.height, seriesBox.width];
+        }
+
         return seriesBox;
     }
 
@@ -4289,6 +4300,9 @@ class Series {
             series.remove(false, false, false, true);
 
             if (casting) {
+                // #20264: Re-detect a certain chart properties from new series
+                chart.propFromSeries();
+
                 // Modern browsers including IE11
                 if (Object.setPrototypeOf) {
                     Object.setPrototypeOf(

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2395,8 +2395,8 @@ class Series {
             height = yAxis.len;
         }
 
-        // If the chart is inverted and the series is not invertible, the clip
-        // box shouldn't be inverted (#20264)
+        // If the chart is inverted and the series is not invertible, the chart
+        // clip box should be inverted, but not the series clip box (#20264)
         if (chart.inverted && !this.invertible) {
             [width, height] = [height, width];
         }

--- a/ts/Series/PackedBubble/PackedBubbleSeries.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeries.ts
@@ -122,6 +122,8 @@ class PackedBubbleSeries extends BubbleSeries {
 
     public hoverPoint?: PackedBubblePoint;
 
+    public invertible = false;
+
     public layout!: PackedBubbleLayout;
 
     public options!: PackedBubbleSeriesOptions;

--- a/ts/Series/Pie/PieSeries.ts
+++ b/ts/Series/Pie/PieSeries.ts
@@ -101,6 +101,8 @@ class PieSeries extends Series {
 
     public endAngleRad?: number;
 
+    public invertible = false;
+
     public options!: PieSeriesOptions;
 
     public points!: Array<PiePoint>;


### PR DESCRIPTION
Fixed #20264, the packed bubble series was not rendered correctly in an inverted chart.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206127404572389