### PR TITLE
Support y prop on points connected to tree grid

### DIFF
--- a/ts/Core/Axis/TreeGrid/TreeGridAxis.ts
+++ b/ts/Core/Axis/TreeGrid/TreeGridAxis.ts
@@ -336,8 +336,8 @@ function getTreeGridFromData(
                 const data = node.data;
 
                 if (isObject(data, true)) {
-                    // Update point
-                    data.y = start + (data.seriesIndex || 0);
+                    // Update point. Allow user-defined y (#14400).
+                    data.y ??= start + (data.seriesIndex || 0);
                     // Remove the property once used
                     delete data.seriesIndex;
                 }


### PR DESCRIPTION
Fixed #14400, drag and drop of tasks in the vertical direction was not supported with the default treegrid axis.

Demo: https://jsfiddle.net/highcharts/Lu91zavj/

Edit: It is probably more complicated that just allowing the `y` property. Since the y-axis categories are picked from the point values, those need to be updated too.

