### PR TITLE
bugfix/20291-3d-crosshair

### DIFF
--- a/samples/unit-tests/3d/series/demo.js
+++ b/samples/unit-tests/3d/series/demo.js
@@ -1,35 +1,44 @@
 QUnit.test(
-    'JS error when stack ID\'s are strings in Highcharts 3D.(#4532)',
+    'Stack ID and crosshairs',
     function (assert) {
-        var chart = $('#container')
-            .highcharts({
-                chart: {
-                    type: 'column',
-                    options3d: {
-                        enabled: true,
-                        alpha: 6,
-                        beta: 15,
-                        viewDistance: 0,
-                        depth: 40
-                    }
+        const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'column',
+                options3d: {
+                    enabled: true,
+                    alpha: 6,
+                    beta: 15,
+                    viewDistance: 0,
+                    depth: 40
+                }
+            },
+            series: [
+                {
+                    data: [5, 10],
+                    stack: 'm1'
                 },
-                series: [
-                    {
-                        data: [5, 10],
-                        stack: 'm1'
-                    },
-                    {
-                        data: [2, 4],
-                        stack: 'm1'
-                    }
-                ]
-            })
-            .highcharts();
+                {
+                    data: [2, 4],
+                    stack: 'm1'
+                }
+            ],
+            yAxis: {
+                crosshair: true
+            }
+        });
 
         assert.strictEqual(
-            chart.series[0].points && chart.series[0].points.length === 2,
-            true,
-            'No error.'
+            chart.series[0].points.length,
+            2,
+            'No error should happen when stack ID\'s are strings in 3D.(#4532)'
+        );
+
+        chart.series[0].points[0].onMouseOver();
+
+        assert.strictEqual(
+            chart.yAxis[0].cross.pathArray.length,
+            4,
+            'yAxis crosshair should work for 3d column series.'
         );
     }
 );

--- a/ts/Core/Chart/Chart3D.ts
+++ b/ts/Core/Chart/Chart3D.ts
@@ -368,10 +368,7 @@ namespace Chart3D {
          * Whether it is a 3D chart.
          */
         chartProto.is3d = function (): boolean {
-            return Boolean(
-                this.options.chart.options3d &&
-                this.options.chart.options3d.enabled
-            ); // #4280
+            return !!this.options.chart.options3d?.enabled;
         };
 
         chartProto.propsRequireDirtyBox.push('chart.options3d');

--- a/ts/Series/Column3D/Column3DComposition.ts
+++ b/ts/Series/Column3D/Column3DComposition.ts
@@ -206,6 +206,11 @@ function columnSeriesTranslate3dShapes(
                 point2dPos.y = point.clientX || 0;
             }
 
+            // Crosshair positions
+            point.axisXpos = point2dPos.x;
+            point.axisYpos = point2dPos.y;
+            point.axisZpos = point2dPos.z;
+
             // Calculate and store point's position in 3D,
             // using perspective method.
             point.plot3d = perspective([point2dPos], chart, true, false)[0];


### PR DESCRIPTION
Fixed #20291, y axis crosshair was missing for 3d column.