### PR TITLE
dash/20290-custom-component-add

### DIFF
--- a/docs/dashboards/custom-component.md
+++ b/docs/dashboards/custom-component.md
@@ -56,6 +56,17 @@ class YouTubeComponent extends Component {
 
         return this;
     }
+
+    onDrop(sidebar, dropContext) {
+        super.onDrop.call(this, sidebar, dropContext);
+        if (sidebar && dropContext) {
+            return sidebar.onDropNewComponent(dropContext, {
+                cell: '',
+                type: 'YouTube',
+                videoId: '115hdz9NsrY'
+            });
+        }
+    }
 }
 
 ComponentRegistry.registerComponent('YouTube', YouTubeComponent);
@@ -82,6 +93,24 @@ Dashboards.board({
 });
 ```
 
+### Adding custom component to the sidebar
+To add the custom component to the sidebar, you need to add the two things:
+1. Define the `onDrop` method for the custom component, which will be called when the component is dropped on the dashboard.
+2. For the `editMode` `sidebar` define the list of the components that will be available in the sidebar.
+Use the exact name which was used to register the component in the `ComponentRegistry`.
+```js
+    editMode: {
+        enabled: true,
+        contextMenu: {
+            enabled: true
+        },
+        toolbars: {
+            sidebar: {
+                components: ['YouTube', 'HTML', 'Highcharts']
+            }
+        }
+    },
+```
 ---
 ## Custom HTML Component
 The basic HTML component described in the [Types of Components](https://www.highcharts.com/docs/dashboards/types-of-components) it is easier to use, but requires a lot of configuration. In this example, we will create a custom HTML component, which will require less code to configure.

--- a/docs/dashboards/custom-component.md
+++ b/docs/dashboards/custom-component.md
@@ -57,15 +57,13 @@ class YouTubeComponent extends Component {
         return this;
     }
 
-    onDrop(sidebar, dropContext) {
-        super.onDrop.call(this, sidebar, dropContext);
-        if (sidebar && dropContext) {
-            return sidebar.onDropNewComponent(dropContext, {
-                cell: '',
-                type: 'YouTube',
-                videoId: '115hdz9NsrY'
-            });
-        }
+    getOptionsOnDrop(sidebar) {
+        super.getOptionsOnDrop.call(this, sidebar);
+        return {
+            cell: '',
+            type: 'YouTube',
+            videoId: '115hdz9NsrY'
+        };
     }
 }
 
@@ -95,7 +93,7 @@ Dashboards.board({
 
 ### Adding custom component to the sidebar
 To add the custom component to the sidebar, you need to add the two things:
-1. Define the `onDrop` method for the custom component, which will be called when the component is dropped on the dashboard.
+1. Define the `getOptionsOnDrop` method for the custom component, which will be called when the component is dropped on the dashboard. It should return options for the dropped component.
 2. For the `editMode` `sidebar` define the list of the components that will be available in the sidebar.
 Use the exact name which was used to register the component in the `ComponentRegistry`.
 ```js

--- a/docs/dashboards/edit-mode.md
+++ b/docs/dashboards/edit-mode.md
@@ -31,7 +31,9 @@ The “Large”, “Medium”, and “Small” buttons change the width of the d
 
 The `Add Component` button allows the user to add a new component. When clicked, a sidebar appears, which lets you choose the type of component you want to add and then by drag&drop component type can be selected and dragged to the correct place, which is also indicated by the drop marker.
 
-The sidebar lists the component types provided by the Dashboards API. Please note that [custom, user-defined components](https://www.highcharts.com/docs/dashboards/custom-component) will not be located there.
+The sidebar lists the component types provided by the Dashboards API but only the ones whose modules are loaded. If other types are needed, add the extra modules. The order and the components on the list can be changed by setting the `components` array in the `editMode` option - [API](https://api.highcharts.com/dashboards/#interfaces/Dashboards_EditMode_EditMode.EditMode.Toolbars#sidebar).
+
+In order to add other custom components to the list, please follow the [custom component guide](https://www.highcharts.com/docs/dashboards/custom-component).
 
 ![edit-mode-sidebar.png](edit-mode-sidebar.png)
 

--- a/samples/dashboards/components/custom-component/demo.js
+++ b/samples/dashboards/components/custom-component/demo.js
@@ -29,6 +29,17 @@ class YouTubeComponent extends Component {
 
         return this;
     }
+
+    onDrop(sidebar, dropContext) {
+        super.onDrop.call(this, sidebar, dropContext);
+        if (sidebar && dropContext) {
+            return sidebar.onDropNewComponent(dropContext, {
+                cell: '',
+                type: 'YouTube',
+                videoId: '115hdz9NsrY'
+            });
+        }
+    }
 }
 
 ComponentRegistry.registerComponent('YouTube', YouTubeComponent);
@@ -38,6 +49,11 @@ Dashboards.board('container', {
         enabled: true,
         contextMenu: {
             enabled: true
+        },
+        toolbars: {
+            sidebar: {
+                components: ['YouTube', 'HTML', 'Highcharts']
+            }
         }
     },
     gui: {

--- a/samples/dashboards/components/custom-component/demo.js
+++ b/samples/dashboards/components/custom-component/demo.js
@@ -30,15 +30,13 @@ class YouTubeComponent extends Component {
         return this;
     }
 
-    onDrop(sidebar, dropContext) {
-        super.onDrop.call(this, sidebar, dropContext);
-        if (sidebar && dropContext) {
-            return sidebar.onDropNewComponent(dropContext, {
-                cell: '',
-                type: 'YouTube',
-                videoId: '115hdz9NsrY'
-            });
-        }
+    getOptionsOnDrop(sidebar) {
+        super.getOptionsOnDrop.call(this, sidebar);
+        return {
+            cell: '',
+            type: 'YouTube',
+            videoId: '115hdz9NsrY'
+        };
     }
 }
 

--- a/test/cypress/dashboards/integration/component-add.cy.js
+++ b/test/cypress/dashboards/integration/component-add.cy.js
@@ -134,7 +134,7 @@ describe('Add components through UI', () => {
     });
 
     it('DataGrid component should be added.', function() {
-        grabComponent('datagrid');
+        grabComponent('DataGrid');
         dropComponent('#dashboard-col-0')
         cy.hideSidebar(); // Hide sidebar to avoid interference with the next test.
         cy.board().then((board) => {

--- a/tools/gulptasks/dashboards/api-docs.json
+++ b/tools/gulptasks/dashboards/api-docs.json
@@ -21,6 +21,7 @@
         "../../../ts/Dashboards/EditMode/Toolbar/CellEditToolbar.ts",
         "../../../ts/Dashboards/EditMode/Toolbar/RowEditToolbar.ts",
         "../../../ts/Dashboards/EditMode/Toolbar/SidebarEditToolbar.ts",
+        "../../../ts/Dashboards/EditMode/SidebarPopup.ts",
         "../../../ts/Dashboards/Globals.ts",
         "../../../ts/Dashboards/Layout/Cell.ts",
         "../../../ts/Dashboards/Layout/Layout.ts",

--- a/ts/Dashboards/Actions/DragDrop.ts
+++ b/ts/Dashboards/Actions/DragDrop.ts
@@ -380,8 +380,8 @@ class DragDrop {
     ): void {
         const dragDrop = this,
             mouseCellContext = dragDrop.mouseCellContext,
-            dropPointerSize = dragDrop.options.dropPointerSize,
-            offset = dragDrop.options.rowDropOffset;
+            dropPointerSize = dragDrop.options.dropPointerSize || 0,
+            offset = dragDrop.options.rowDropOffset || 0;
 
         let updateDropPointer = false;
 
@@ -486,7 +486,7 @@ class DragDrop {
     ): void {
         const dragDrop = this,
             mouseCellContext = dragDrop.mouseCellContext as Cell,
-            offset = dragDrop.options.cellDropOffset;
+            offset = dragDrop.options.cellDropOffset || 0;
 
         if (mouseCellContext || contextDetails) {
             dragDrop.onCellDragCellCtx(
@@ -514,7 +514,7 @@ class DragDrop {
         context: ContextDetection.ContextDetails
     ): void {
         const dragDrop = this,
-            dropPointerSize = dragDrop.options.dropPointerSize,
+            dropPointerSize = dragDrop.options.dropPointerSize || 0,
             align = context.side;
 
         let updateDropPointer = false;
@@ -595,7 +595,7 @@ class DragDrop {
         mouseRowContext: Row
     ): void {
         const dragDrop = this,
-            dropPointerSize = dragDrop.options.dropPointerSize,
+            dropPointerSize = dragDrop.options.dropPointerSize || 0,
             rowOffsets = GUIElement.getOffsets(mouseRowContext),
             rowLevelInfo = mouseRowContext.getRowLevelInfo(e.clientY);
 
@@ -789,25 +789,35 @@ namespace DragDrop {
         /**
          * Offset how far from the cell edge the context (dragged element)
          * should be detectable.
+         *
+         * @default 30
          */
-        cellDropOffset: number;
+        cellDropOffset?: number;
+
         /**
          * Size of the drop pointer in pixels.
+         *
+         * @default 16
          */
-        dropPointerSize: number;
+        dropPointerSize?: number;
+
         /**
          * Whether the drag and drop is enabled.
          *
          * Try it:
-         *
          * {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/dashboards/edit-mode/dragdrop-disabled/ | Drag drop disabled}
+         *
+         * @default true
          */
-        enabled: boolean;
+        enabled?: boolean;
+
         /**
          * Offset how far from the row edge the context (dragged element) should
          * be detectable.
+         *
+         * @default 30
          */
-        rowDropOffset: number;
+        rowDropOffset?: number;
     }
 
     /**

--- a/ts/Dashboards/Board.ts
+++ b/ts/Dashboards/Board.ts
@@ -225,6 +225,12 @@ class Board implements Serializable<Board, Board.JSON> {
     public container!: HTMLElement;
 
     /**
+     * All types of components available in the dashboard.
+     * @internal
+     */
+    public componentTypes = ComponentRegistry.types;
+
+    /**
      * The data cursor instance used for interacting with the data.
      * @internal
      * */
@@ -862,11 +868,6 @@ namespace Board {
             large: 1200
         }
     };
-
-    /**
-     * @internal
-     */
-    export const componentTypes = ComponentRegistry.types;
 
     /* *
      *

--- a/ts/Dashboards/Components/Component.ts
+++ b/ts/Dashboards/Components/Component.ts
@@ -26,15 +26,14 @@ import type Board from '../Board';
 import type Cell from '../Layout/Cell';
 import type { ComponentConnectorOptions } from './ComponentOptions';
 import type {
-    ComponentType,
     ComponentTypeRegistry
 } from './ComponentType';
 import type JSON from '../JSON';
 import type Serializable from '../Serializable';
 import type DataModifier from '../../Data/Modifiers/DataModifier';
-import type CSSObject from '../../Core/Renderer/CSSObject';
 import type TextOptions from './TextOptions';
 import type Row from '../Layout/Row';
+import type SidebarPopup from '../EditMode/SidebarPopup';
 
 import CallbackRegistry from '../CallbackRegistry.js';
 import DataConnector from '../../Data/Connectors/DataConnector.js';
@@ -387,6 +386,18 @@ abstract class Component {
      * @internal
      */
     public abstract onTableChanged(e?: Component.EventTypes): void;
+
+
+    /**
+     * When the component is dropped on the dashboard from the sidebar.
+     *
+     * @param sidebar
+     * The sidebar popup.
+     *
+     * @param dropContext
+     * The drop context, cell or row.
+     */
+    public onDrop(sidebar: SidebarPopup, dropContext: Cell|Row): void|Cell {}
 
     /* *
      *

--- a/ts/Dashboards/Components/Component.ts
+++ b/ts/Dashboards/Components/Component.ts
@@ -26,6 +26,7 @@ import type Board from '../Board';
 import type Cell from '../Layout/Cell';
 import type { ComponentConnectorOptions } from './ComponentOptions';
 import type {
+    ComponentType,
     ComponentTypeRegistry
 } from './ComponentType';
 import type JSON from '../JSON';
@@ -389,15 +390,14 @@ abstract class Component {
 
 
     /**
-     * When the component is dropped on the dashboard from the sidebar.
+     * Returns the component's options when it is dropped from the sidebar.
      *
      * @param sidebar
      * The sidebar popup.
-     *
-     * @param dropContext
-     * The drop context, cell or row.
      */
-    public onDrop(sidebar: SidebarPopup, dropContext: Cell|Row): void|Cell {}
+    public getOptionsOnDrop(sidebar: SidebarPopup): Partial<ComponentType['options']> {
+        return {};
+    }
 
     /* *
      *
@@ -1314,9 +1314,9 @@ namespace Component {
         /**
          * Set of options that are available for editing through sidebar.
          */
-        editableOptions: Array<EditableOptions.Options>;
+        editableOptions?: Array<EditableOptions.Options>;
         /** @internal */
-        editableOptionsBindings: EditableOptions.OptionsBindings;
+        editableOptionsBindings?: EditableOptions.OptionsBindings;
         /** @internal */
         presentationModifier?: DataModifier;
         /**
@@ -1337,7 +1337,7 @@ namespace Component {
          *
          * {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/dashboards/demo/crossfilter | Crossfilter Sync } (Navigator Component only)
          */
-        sync: SyncOptions;
+        sync?: SyncOptions;
         /**
          * Connector options
          */

--- a/ts/Dashboards/Components/EditableOptions.ts
+++ b/ts/Dashboards/Components/EditableOptions.ts
@@ -54,6 +54,11 @@ class EditableOptions {
 
     public getOptions(): (Array<EditableOptions.Options>) {
         const options = this.component.options.editableOptions;
+
+        if (!options) {
+            return [];
+        }
+
         for (let i = 0, iEnd = options.length; i < iEnd; i++) {
             const option = options[i];
             if (option.name === 'connectorName') {

--- a/ts/Dashboards/Components/HTMLComponent.ts
+++ b/ts/Dashboards/Components/HTMLComponent.ts
@@ -23,8 +23,6 @@
  * */
 
 import type Cell from '../Layout/Cell.js';
-import type Row from '../Layout/Row.js';
-import type SidebarPopup from '../EditMode/SidebarPopup.js';
 
 import AST from '../../Core/Renderer/HTML/AST.js';
 import Component from './Component.js';
@@ -260,18 +258,16 @@ class HTMLComponent extends Component {
         this.emit({ type: 'afterUpdate' });
     }
 
-    public onDrop(sidebar: SidebarPopup, dropContext: Cell|Row): void|Cell {
-        if (sidebar && dropContext) {
-            return sidebar.onDropNewComponent(dropContext, {
-                cell: '',
-                type: 'HTML',
-                elements: [{
-                    tagName: 'img',
-                    attributes: {
-                        src: 'https://www.highcharts.com/samples/graphics/stock-dark.svg'
-                    }
-                }]
-            });
+    public getOptionsOnDrop(): Partial<HTMLComponent.HTMLComponentOptions> {
+        return {
+            cell: '',
+            type: 'HTML',
+            elements: [{
+                tagName: 'img',
+                attributes: {
+                    src: 'https://www.highcharts.com/samples/graphics/stock-dark.svg'
+                }
+            }]
         }
     }
 

--- a/ts/Dashboards/Components/HTMLComponent.ts
+++ b/ts/Dashboards/Components/HTMLComponent.ts
@@ -268,7 +268,7 @@ class HTMLComponent extends Component {
                     src: 'https://www.highcharts.com/samples/graphics/stock-dark.svg'
                 }
             }]
-        }
+        };
     }
 
     /**

--- a/ts/Dashboards/Components/HTMLComponent.ts
+++ b/ts/Dashboards/Components/HTMLComponent.ts
@@ -23,11 +23,12 @@
  * */
 
 import type Cell from '../Layout/Cell.js';
+import type Row from '../Layout/Row.js';
+import type SidebarPopup from '../EditMode/SidebarPopup.js';
 
 import AST from '../../Core/Renderer/HTML/AST.js';
 import Component from './Component.js';
 import U from '../../Core/Utilities.js';
-
 const {
     merge,
     diffObjects
@@ -257,6 +258,21 @@ class HTMLComponent extends Component {
     public async update(options: Partial<HTMLComponent.HTMLComponentOptions>): Promise<void> {
         await super.update(options);
         this.emit({ type: 'afterUpdate' });
+    }
+
+    public onDrop(sidebar: SidebarPopup, dropContext: Cell|Row): void|Cell {
+        if (sidebar && dropContext) {
+            return sidebar.onDropNewComponent(dropContext, {
+                cell: '',
+                type: 'HTML',
+                elements: [{
+                    tagName: 'img',
+                    attributes: {
+                        src: 'https://www.highcharts.com/samples/graphics/stock-dark.svg'
+                    }
+                }]
+            });
+        }
     }
 
     /**

--- a/ts/Dashboards/EditMode/EditGlobals.ts
+++ b/ts/Dashboards/EditMode/EditGlobals.ts
@@ -150,7 +150,14 @@ const EditGlobals: EditGlobals = {
         small: 'Small',
         style: 'Styles',
         title: 'Title',
-        viewFullscreen: 'View in full screen'
+        viewFullscreen: 'View in full screen',
+        sidebar: {
+            HTML: 'HTML',
+            layout: 'Layout',
+            Highcharts: 'Highcharts',
+            DataGrid: 'DataGrid',
+            KPI: 'KPI'
+        }
     }
 };
 
@@ -345,6 +352,10 @@ namespace EditGlobals {
          */
         settings: string;
         /**
+         * Options for the sidebar and its components.
+         */
+        sidebar:SidebarLangOptions
+        /**
          * @default 'Small'
          */
         small: string;
@@ -361,6 +372,30 @@ namespace EditGlobals {
          */
         viewFullscreen: string;
         [key: string]: any;
+    }
+
+    export interface SidebarLangOptions {
+        [key: string]: string;
+        /**
+         * @default 'HTML'
+         */
+        HTML: string;
+        /**
+         * @default 'Layout'
+         */
+        layout: string;
+        /**
+         * @default 'Highcharts'
+         */
+        Highcharts: string;
+        /**
+         * @default 'DataGrid'
+         */
+        DataGrid: string;
+        /**
+         * @default 'KPI'
+         */
+        KPI: string;
     }
 
     export interface LangAccessibilityOptions {

--- a/ts/Dashboards/EditMode/EditMode.ts
+++ b/ts/Dashboards/EditMode/EditMode.ts
@@ -100,7 +100,7 @@ class EditMode {
                     },
                     row: {
                         enabled: true
-                    }
+                    },
                 },
                 tools: {
                     addComponentBtn: {
@@ -116,7 +116,7 @@ class EditMode {
                         }
                     }
                 }
-            },
+            } as EditMode.Options,
             options || {});
 
         this.board = board;

--- a/ts/Dashboards/EditMode/EditMode.ts
+++ b/ts/Dashboards/EditMode/EditMode.ts
@@ -25,7 +25,6 @@ import type Row from '../Layout/Row';
 import type Board from '../Board';
 import type { HTMLDOMElement } from '../../Core/Renderer/DOMElementType';
 
-import U from '../../Core/Utilities.js';
 import EditGlobals from './EditGlobals.js';
 import EditRenderer from './EditRenderer.js';
 import CellEditToolbar from './Toolbar/CellEditToolbar.js';
@@ -37,7 +36,7 @@ import Resizer from '../Actions/Resizer.js';
 import ConfirmationPopup from './ConfirmationPopup.js';
 import ContextDetection from '../Actions/ContextDetection.js';
 import GUIElement from '../Layout/GUIElement.js';
-
+import U from '../../Core/Utilities.js';
 const {
     addEvent,
     createElement,
@@ -77,18 +76,31 @@ class EditMode {
         this.options = merge(
             // Default options.
             {
+                confirmationPopup: {
+                    close: {
+                        icon: this.iconsURLPrefix + 'close.svg'
+                    }
+                },
+                contextMenu: {
+                    icon: this.iconsURLPrefix + 'menu.svg'
+                },
                 dragDrop: {
                     enabled: true
                 },
+                enabled: true,
                 resize: {
                     enabled: true
                 },
                 settings: {
                     enabled: true
                 },
-                enabled: true,
-                contextMenu: {
-                    icon: this.iconsURLPrefix + 'menu.svg'
+                toolbars: {
+                    cell: {
+                        enabled: true
+                    },
+                    row: {
+                        enabled: true
+                    }
                 },
                 tools: {
                     addComponentBtn: {
@@ -102,19 +114,6 @@ class EditMode {
                             medium: this.iconsURLPrefix + 'tablet.svg',
                             large: this.iconsURLPrefix + 'computer.svg'
                         }
-                    }
-                },
-                confirmationPopup: {
-                    close: {
-                        icon: this.iconsURLPrefix + 'close.svg'
-                    }
-                },
-                toolbars: {
-                    cell: {
-                        enabled: true
-                    },
-                    row: {
-                        enabled: true
                     }
                 }
             },

--- a/ts/Dashboards/EditMode/EditMode.ts
+++ b/ts/Dashboards/EditMode/EditMode.ts
@@ -100,7 +100,7 @@ class EditMode {
                     },
                     row: {
                         enabled: true
-                    },
+                    }
                 },
                 tools: {
                     addComponentBtn: {

--- a/ts/Dashboards/EditMode/SidebarPopup.ts
+++ b/ts/Dashboards/EditMode/SidebarPopup.ts
@@ -99,7 +99,7 @@ class SidebarPopup extends BaseForm {
             });
 
         }
-    }
+    };
 
     /* *
      *
@@ -133,7 +133,9 @@ class SidebarPopup extends BaseForm {
             editMode.options.toolbars?.sidebar || {}
         );
 
-        this.componentsList = this.getComponentsList(this.options.components || []);
+        this.componentsList = this.getComponentsList(
+            this.options.components || []
+        );
 
         this.accordionMenu = new AccordionMenu(
             this.iconsURL,
@@ -162,7 +164,7 @@ class SidebarPopup extends BaseForm {
      */
     public options: SidebarPopup.Options = {
         components: ['HTML', 'layout', 'Highcharts', 'DataGrid', 'KPI']
-    }
+    };
 
     /**
      * Whether the sidebar is visible.
@@ -458,7 +460,9 @@ class SidebarPopup extends BaseForm {
      * @param components
      * List of components that can be added to the board.
      */
-    private getComponentsList(components: Array<string>): Array<SidebarPopup.AddComponentDetails> {
+    private getComponentsList(
+        components: Array<string>
+    ): Array<SidebarPopup.AddComponentDetails> {
         const sidebar = this,
             componentTypes = sidebar.editMode.board.componentTypes,
             componentList: Array<SidebarPopup.AddComponentDetails> = [];

--- a/ts/Dashboards/EditMode/SidebarPopup.ts
+++ b/ts/Dashboards/EditMode/SidebarPopup.ts
@@ -92,7 +92,6 @@ class SidebarPopup extends BaseForm {
                 elements: [
                     {
                         tagName: 'div',
-                        style: { 'text-align': 'center' },
                         textContent: 'Placeholder text'
                     }
                 ]

--- a/ts/Dashboards/EditMode/SidebarPopup.ts
+++ b/ts/Dashboards/EditMode/SidebarPopup.ts
@@ -48,7 +48,7 @@ const {
  * */
 
 /**
- * Class which creates the sidebar and handles its behaviour.
+ * Class which creates the sidebar and handles its behavior.
  */
 class SidebarPopup extends BaseForm {
 
@@ -245,6 +245,7 @@ class SidebarPopup extends BaseForm {
      * Instance of EditMode.
      */
     public editMode: EditMode;
+
     /**
      * Whether the sidebar is visible.
      */
@@ -263,11 +264,11 @@ class SidebarPopup extends BaseForm {
      *
      * @param context
      * The cell or row which is the context of the sidebar.
+     *
      * @returns
      * Whether the sidebar should be on the right side of the screen.
      */
     private detectRightSidebar(context: Cell | Row): boolean {
-
         const editMode = this.editMode;
         const layoutWrapper = editMode.board.layoutsWrapper;
 
@@ -284,6 +285,7 @@ class SidebarPopup extends BaseForm {
     private removeClassNames(): void {
         const classNames = EditGlobals.classNames,
             classList = this.container.classList;
+
         classList.remove(classNames.editSidebarShow);
         classList.remove(classNames.editSidebarRightShow);
     }

--- a/ts/Dashboards/EditMode/SidebarPopup.ts
+++ b/ts/Dashboards/EditMode/SidebarPopup.ts
@@ -464,15 +464,19 @@ class SidebarPopup extends BaseForm {
         components: Array<string>
     ): Array<SidebarPopup.AddComponentDetails> {
         const sidebar = this,
-            componentTypes = sidebar.editMode.board.componentTypes,
+            editMode = sidebar.editMode,
+            componentTypes = editMode.board.componentTypes,
             componentList: Array<SidebarPopup.AddComponentDetails> = [];
 
         components.forEach((componentName: string): void => {
-            const component = componentTypes[componentName as keyof typeof componentTypes];
+            const component = componentTypes[
+                componentName as keyof typeof componentTypes
+            ];
 
             if (component) {
                 componentList.push({
-                    text: component.name,
+                    text: editMode.lang?.sidebar[componentName] ||
+                        component.name,
                     onDrop: component.prototype.onDrop
                 });
             } else if (componentName === 'layout') {

--- a/ts/Dashboards/EditMode/SidebarPopup.ts
+++ b/ts/Dashboards/EditMode/SidebarPopup.ts
@@ -475,8 +475,12 @@ class SidebarPopup extends BaseForm {
                 componentList.push({
                     text: editMode.lang?.sidebar[componentName] ||
                         component.name,
-                    onDrop: function (sidebar: SidebarPopup, dropContext: Cell|Row): Cell|void {
-                        const options = component.prototype.getOptionsOnDrop(sidebar);
+                    onDrop: function (
+                        sidebar: SidebarPopup,
+                        dropContext: Cell|Row
+                    ): Cell|void {
+                        const options =
+                            component.prototype.getOptionsOnDrop(sidebar);
 
                         if (options) {
                             return sidebar.onDropNewComponent(

--- a/ts/Dashboards/EditMode/SidebarPopup.ts
+++ b/ts/Dashboards/EditMode/SidebarPopup.ts
@@ -34,8 +34,7 @@ import U from '../../Core/Utilities.js';
 const {
     addEvent,
     createElement,
-    merge,
-    objectEach
+    merge
 } = U;
 
 /* *
@@ -476,7 +475,16 @@ class SidebarPopup extends BaseForm {
                 componentList.push({
                     text: editMode.lang?.sidebar[componentName] ||
                         component.name,
-                    onDrop: component.prototype.onDrop
+                    onDrop: function (sidebar: SidebarPopup, dropContext: Cell|Row): Cell|void {
+                        const options = component.prototype.getOptionsOnDrop(sidebar);
+
+                        if (options) {
+                            return sidebar.onDropNewComponent(
+                                dropContext,
+                                options
+                            );
+                        }
+                    }
                 });
             } else if (componentName === 'layout') {
                 componentList.push(SidebarPopup.addLayout);

--- a/ts/Dashboards/EditMode/SidebarPopup.ts
+++ b/ts/Dashboards/EditMode/SidebarPopup.ts
@@ -434,7 +434,7 @@ class SidebarPopup extends BaseForm {
         const sidebar = this,
             board = sidebar.editMode.board,
             componentTypes = board.componentTypes,
-            componentList: Array<SidebarPopup.AddComponentDetails> = [];
+            componentList = this.componentsList;
 
         objectEach(componentTypes, (componentType): void => {
             componentList.push({

--- a/ts/Dashboards/Plugins/DataGridComponent.ts
+++ b/ts/Dashboards/Plugins/DataGridComponent.ts
@@ -25,6 +25,8 @@ import type DataTable from '../../Data/DataTable';
 import type BaseDataGridOptions from '../../DataGrid/DataGridOptions';
 import type { ColumnOptions } from '../../DataGrid/DataGridOptions';
 import type MathModifierOptions from '../../Data/Modifiers/MathModifierOptions';
+import type SidebarPopup from '../EditMode/SidebarPopup';
+import type Row from '../Layout/Row';
 
 import Component from '../Components/Component.js';
 import DataConnector from '../../Data/Connectors/DataConnector.js';
@@ -32,7 +34,6 @@ import DataConverter from '../../Data/Converters/DataConverter.js';
 import DataGridSyncHandlers from './DataGridSyncHandlers.js';
 import U from '../../Core/Utilities.js';
 import DataConnectorType from '../../Data/Connectors/DataConnectorType';
-
 const {
     diffObjects,
     merge,
@@ -473,6 +474,28 @@ class DataGridComponent extends Component {
             filteredTable.deleteColumns(columnsToDelete);
 
             return filteredTable;
+        }
+    }
+
+    public onDrop(sidebar: SidebarPopup, dropContext: Cell|Row): void|Cell {
+        if (sidebar && dropContext) {
+            const connectorsIds =
+                sidebar.editMode.board.dataPool.getConnectorIds();
+            let options: Partial<DataGridComponent.ComponentOptions> = {
+                cell: '',
+                type: 'DataGrid'
+            };
+
+            if (connectorsIds.length) {
+                options = {
+                    ...options,
+                    connector: {
+                        id: connectorsIds[0]
+                    }
+                };
+            }
+
+            return sidebar.onDropNewComponent(dropContext, options);
         }
     }
 

--- a/ts/Dashboards/Plugins/DataGridComponent.ts
+++ b/ts/Dashboards/Plugins/DataGridComponent.ts
@@ -26,7 +26,6 @@ import type BaseDataGridOptions from '../../DataGrid/DataGridOptions';
 import type { ColumnOptions } from '../../DataGrid/DataGridOptions';
 import type MathModifierOptions from '../../Data/Modifiers/MathModifierOptions';
 import type SidebarPopup from '../EditMode/SidebarPopup';
-import type Row from '../Layout/Row';
 
 import Component from '../Components/Component.js';
 import DataConnector from '../../Data/Connectors/DataConnector.js';
@@ -477,26 +476,24 @@ class DataGridComponent extends Component {
         }
     }
 
-    public onDrop(sidebar: SidebarPopup, dropContext: Cell|Row): void|Cell {
-        if (sidebar && dropContext) {
-            const connectorsIds =
-                sidebar.editMode.board.dataPool.getConnectorIds();
-            let options: Partial<DataGridComponent.ComponentOptions> = {
-                cell: '',
-                type: 'DataGrid'
+    public getOptionsOnDrop(sidebar: SidebarPopup): Partial<DataGridComponent.ComponentOptions> {
+        const connectorsIds =
+            sidebar.editMode.board.dataPool.getConnectorIds();
+        let options: Partial<DataGridComponent.ComponentOptions> = {
+            cell: '',
+            type: 'DataGrid'
+        };
+
+        if (connectorsIds.length) {
+            options = {
+                ...options,
+                connector: {
+                    id: connectorsIds[0]
+                }
             };
-
-            if (connectorsIds.length) {
-                options = {
-                    ...options,
-                    connector: {
-                        id: connectorsIds[0]
-                    }
-                };
-            }
-
-            return sidebar.onDropNewComponent(dropContext, options);
         }
+
+        return options;
     }
 
     /** @private */

--- a/ts/Dashboards/Plugins/HighchartsComponent.ts
+++ b/ts/Dashboards/Plugins/HighchartsComponent.ts
@@ -33,6 +33,8 @@ import type {
     SeriesOptions
 } from './HighchartsTypes';
 import type MathModifierOptions from '../../Data/Modifiers/MathModifierOptions';
+import type SidebarPopup from '../EditMode/SidebarPopup';
+import type Row from '../Layout/Row';
 
 import Component from '../Components/Component.js';
 import DataConnector from '../../Data/Connectors/DataConnector.js';
@@ -41,7 +43,6 @@ import DataTable from '../../Data/DataTable.js';
 import Globals from '../../Dashboards/Globals.js';
 import HighchartsSyncHandlers from './HighchartsSyncHandlers.js';
 import U from '../../Core/Utilities.js';
-
 const {
     addEvent,
     createElement,
@@ -900,6 +901,37 @@ class HighchartsComponent extends Component {
 
         return this;
     }
+
+    public onDrop(sidebar: SidebarPopup, dropContext: Cell|Row): void|Cell {
+        if (sidebar && dropContext) {
+            const connectorsIds =
+                sidebar.editMode.board.dataPool.getConnectorIds();
+
+            let options: Partial<HighchartsComponent.Options> = {
+                cell: '',
+                type: 'Highcharts',
+                chartOptions: {
+                    chart: {
+                        animation: false,
+                        type: 'column',
+                        zooming: {}
+                    }
+                }
+            };
+
+            if (connectorsIds.length) {
+                options = {
+                    ...options,
+                    connector: {
+                        id: connectorsIds[0]
+                    }
+                };
+            }
+
+            return sidebar.onDropNewComponent(dropContext, options);
+        }
+    }
+
     /**
      * Converts the class instance to a class JSON.
      *

--- a/ts/Dashboards/Plugins/HighchartsComponent.ts
+++ b/ts/Dashboards/Plugins/HighchartsComponent.ts
@@ -34,7 +34,6 @@ import type {
 } from './HighchartsTypes';
 import type MathModifierOptions from '../../Data/Modifiers/MathModifierOptions';
 import type SidebarPopup from '../EditMode/SidebarPopup';
-import type Row from '../Layout/Row';
 
 import Component from '../Components/Component.js';
 import DataConnector from '../../Data/Connectors/DataConnector.js';
@@ -902,34 +901,32 @@ class HighchartsComponent extends Component {
         return this;
     }
 
-    public onDrop(sidebar: SidebarPopup, dropContext: Cell|Row): void|Cell {
-        if (sidebar && dropContext) {
-            const connectorsIds =
-                sidebar.editMode.board.dataPool.getConnectorIds();
+    public getOptionsOnDrop(sidebar: SidebarPopup): Partial<HighchartsComponent.Options> {
+        const connectorsIds =
+            sidebar.editMode.board.dataPool.getConnectorIds();
 
-            let options: Partial<HighchartsComponent.Options> = {
-                cell: '',
-                type: 'Highcharts',
-                chartOptions: {
-                    chart: {
-                        animation: false,
-                        type: 'column',
-                        zooming: {}
-                    }
+        let options: Partial<HighchartsComponent.Options> = {
+            cell: '',
+            type: 'Highcharts',
+            chartOptions: {
+                chart: {
+                    animation: false,
+                    type: 'column',
+                    zooming: {}
+                }
+            }
+        };
+
+        if (connectorsIds.length) {
+            options = {
+                ...options,
+                connector: {
+                    id: connectorsIds[0]
                 }
             };
-
-            if (connectorsIds.length) {
-                options = {
-                    ...options,
-                    connector: {
-                        id: connectorsIds[0]
-                    }
-                };
-            }
-
-            return sidebar.onDropNewComponent(dropContext, options);
         }
+
+        return options;
     }
 
     /**

--- a/ts/Dashboards/Plugins/KPIComponent.ts
+++ b/ts/Dashboards/Plugins/KPIComponent.ts
@@ -29,6 +29,8 @@ import type {
     Options as ChartOptions,
     Highcharts as H
 } from './HighchartsTypes';
+import type Row from '../Layout/Row';
+import type SidebarPopup from '../EditMode/SidebarPopup';
 import type TextOptions from '../Components/TextOptions';
 import type Types from '../../Shared/Types';
 
@@ -630,6 +632,28 @@ class KPIComponent extends Component {
             return thresholdColors[0];
         }
         return '';
+    }
+
+    public onDrop(sidebar: SidebarPopup, dropContext: Cell|Row): void|Cell {
+        if (sidebar && dropContext) {
+            const connectorsIds =
+                sidebar.editMode.board.dataPool.getConnectorIds();
+            let options: Partial<KPIComponent.ComponentOptions> = {
+                cell: '',
+                type: 'KPI'
+            };
+
+            if (connectorsIds.length) {
+                options = {
+                    ...options,
+                    connector: {
+                        id: connectorsIds[0]
+                    }
+                };
+            }
+
+            return sidebar.onDropNewComponent(dropContext, options);
+        }
     }
 
     /**

--- a/ts/Dashboards/Plugins/KPIComponent.ts
+++ b/ts/Dashboards/Plugins/KPIComponent.ts
@@ -29,7 +29,6 @@ import type {
     Options as ChartOptions,
     Highcharts as H
 } from './HighchartsTypes';
-import type Row from '../Layout/Row';
 import type SidebarPopup from '../EditMode/SidebarPopup';
 import type TextOptions from '../Components/TextOptions';
 import type Types from '../../Shared/Types';
@@ -634,26 +633,24 @@ class KPIComponent extends Component {
         return '';
     }
 
-    public onDrop(sidebar: SidebarPopup, dropContext: Cell|Row): void|Cell {
-        if (sidebar && dropContext) {
-            const connectorsIds =
-                sidebar.editMode.board.dataPool.getConnectorIds();
-            let options: Partial<KPIComponent.ComponentOptions> = {
-                cell: '',
-                type: 'KPI'
+    public getOptionsOnDrop(sidebar: SidebarPopup): Partial<KPIComponent.ComponentOptions> {
+        const connectorsIds =
+            sidebar.editMode.board.dataPool.getConnectorIds();
+        let options: Partial<KPIComponent.ComponentOptions> = {
+            cell: '',
+            type: 'KPI'
+        };
+
+        if (connectorsIds.length) {
+            options = {
+                ...options,
+                connector: {
+                    id: connectorsIds[0]
+                }
             };
-
-            if (connectorsIds.length) {
-                options = {
-                    ...options,
-                    connector: {
-                        id: connectorsIds[0]
-                    }
-                };
-            }
-
-            return sidebar.onDropNewComponent(dropContext, options);
         }
+
+        return options;
     }
 
     /**

--- a/ts/Dashboards/Plugins/NavigatorComponent.ts
+++ b/ts/Dashboards/Plugins/NavigatorComponent.ts
@@ -31,15 +31,17 @@ import type Cell from '../Layout/Cell';
 import type DataCursor from '../../Data/DataCursor';
 import type { NavigatorComponentOptions } from './NavigatorComponentOptions';
 import type { RangeModifierOptions, RangeModifierRangeOptions } from '../../Data/Modifiers/RangeModifierOptions';
+import type Row from '../Layout/Row';
 import type Sync from '../Components/Sync/Sync';
+import type SidebarPopup from '../EditMode/SidebarPopup';
 
 import Component from '../Components/Component.js';
 import DataModifier from '../../Data/Modifiers/DataModifier.js';
 const { Range: RangeModifier } = DataModifier.types;
 import Globals from '../Globals.js';
 import NavigatorComponentDefaults from './NavigatorComponentDefaults.js';
-import U from '../../Core/Utilities.js';
 import DataTable from '../../Data/DataTable.js';
+import U from '../../Core/Utilities.js';
 const {
     addEvent,
     defined,
@@ -862,7 +864,9 @@ class NavigatorComponent extends Component {
         }
     }
 
+    public onDrop(sidebar: SidebarPopup, dropContext: Cell|Row): void|Cell {
 
+    }
 }
 
 

--- a/ts/Dashboards/Plugins/NavigatorComponent.ts
+++ b/ts/Dashboards/Plugins/NavigatorComponent.ts
@@ -31,7 +31,6 @@ import type Cell from '../Layout/Cell';
 import type DataCursor from '../../Data/DataCursor';
 import type { NavigatorComponentOptions } from './NavigatorComponentOptions';
 import type { RangeModifierOptions, RangeModifierRangeOptions } from '../../Data/Modifiers/RangeModifierOptions';
-import type Row from '../Layout/Row';
 import type Sync from '../Components/Sync/Sync';
 import type SidebarPopup from '../EditMode/SidebarPopup';
 
@@ -470,7 +469,7 @@ class NavigatorComponent extends Component {
         this.filterAndAssignSyncOptions(navigatorComponentSync);
         this.sync = new NavigatorComponent.Sync(this, this.syncHandlers);
 
-        const crossfilterOptions = this.options.sync.crossfilter;
+        const crossfilterOptions = this.options.sync?.crossfilter;
         if (crossfilterOptions === true || (
             isObject(crossfilterOptions) && crossfilterOptions.enabled
         )) {
@@ -674,7 +673,7 @@ class NavigatorComponent extends Component {
                 options = this.options,
                 column = this.getColumnAssignment(),
                 columnValues = table.getColumn(column[0], true) || [],
-                crossfilterOptions = options.sync.crossfilter;
+                crossfilterOptions = options.sync?.crossfilter;
 
             let values: DataTable.Column = [],
                 data: (
@@ -824,7 +823,7 @@ class NavigatorComponent extends Component {
         shouldRerender: boolean = true
     ): Promise<void> {
         const chart = this.chart,
-            crossfilterOptions = this.options.sync.crossfilter;
+            crossfilterOptions = this.options.sync?.crossfilter;
 
         await super.update(options, false);
 
@@ -864,8 +863,8 @@ class NavigatorComponent extends Component {
         }
     }
 
-    public onDrop(sidebar: SidebarPopup, dropContext: Cell|Row): void|Cell {
-
+    public getOptionsOnDrop(sidebar: SidebarPopup): Partial<NavigatorComponentOptions> {
+        return {};
     }
 }
 


### PR DESCRIPTION
Added a way to drag custom components from the `sidebar`, closes #20290.