### PR TITLE
Bugfix/20284 ordinal scatter boost

### DIFF
--- a/samples/unit-tests/axis/ordinal/demo.js
+++ b/samples/unit-tests/axis/ordinal/demo.js
@@ -1201,3 +1201,39 @@ QUnit.test('Ordinal axis + Scatter series #19243', function (assert) {
     );
 
 });
+
+
+QUnit.test('Scatter boost ordinal updates, #20284.', assert => {
+    const data = [{
+        type: 'line',
+        data: [
+            [0, 95.82],
+            [3, 95.84],
+            [6, 95.75],
+            [7, 95.48],
+            [11, 95.6],
+            [12, 95.37],
+            [13, 95.16],
+            [15, 95.15],
+            [18, 94.9],
+            [21, 95.04],
+            [22, 95.38]
+        ],
+        showInNavigator: true
+    }, {
+        type: 'scatter',
+        data: [
+            [3, 95],
+            [11, 95]
+        ],
+        showInNavigator: false
+    }];
+
+    const chart = Highcharts.stockChart('container', {
+        series: data
+    });
+
+    chart.update({ series: data.reverse() });
+
+    assert.ok(true, 'there should be no error');
+});

--- a/samples/unit-tests/axis/ordinal/demo.js
+++ b/samples/unit-tests/axis/ordinal/demo.js
@@ -1235,5 +1235,6 @@ QUnit.test('Scatter boost ordinal updates, #20284.', assert => {
 
     chart.update({ series: data.reverse() });
 
-    assert.ok(true, 'there should be no error');
+    const length = chart.series[0].processedXData.length;
+    assert.notEqual(length, 0, 'The processedXData should be calculated.');
 });

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -912,8 +912,6 @@ function scatterProcessData(
         yMin >= (yAxis.old.min ?? -Number.MAX_VALUE) &&
         yMax <= (yAxis.old.max ?? Number.MAX_VALUE)
     ) {
-        // series.processedYData = yData;
-        // series.processedXData = xData;
         series.processedXData ??= xData;
         series.processedYData ??= yData;
         return true;

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -912,6 +912,10 @@ function scatterProcessData(
         yMin >= (yAxis.old.min ?? -Number.MAX_VALUE) &&
         yMax <= (yAxis.old.max ?? Number.MAX_VALUE)
     ) {
+        // series.processedYData = yData;
+        // series.processedXData = xData;
+        series.processedXData ??= xData;
+        series.processedYData ??= yData;
         return true;
     }
 


### PR DESCRIPTION
Fixed #20284, `processedXData` weren't assigned on updates in scatter + ordinal + boost.