### PR TITLE
bugfix/20319-funnel-chart-borderRadius-path-issue

### DIFF
--- a/samples/unit-tests/series-funnel/funnel/demo.js
+++ b/samples/unit-tests/series-funnel/funnel/demo.js
@@ -230,6 +230,37 @@ QUnit.test('Funnel path', function (assert) {
         6,
         'The last point should have 6 rounded corners, scope: point (#18839)'
     );
+
+    series.update({
+        data: [
+            ['A', 4],
+            ['B', 1],
+            ['C', 1],
+            ['D', 1],
+            ['E', 1]
+        ]
+    });
+
+    assert.ok(
+        series.points[3].graphic.d.split(' ').filter(s => s === 'Z').length,
+        'The fourth point path is properly closed (#20319)'
+    );
+
+    assert.strictEqual(
+        series.points[3].graphic.d.split(' ').filter(s => s === 'C').length,
+        4,
+        'The fourth point should have 4 rounded corners, scope: point (#20319)'
+    );
+
+    series.update({
+        borderRadius: 5
+    });
+
+    assert.strictEqual(
+        series.points[3].graphic.d.split(' ').filter(s => s === 'C').length,
+        0,
+        'The fourth point should not have rounded corners (#20319)'
+    );
 });
 
 QUnit.test('Funnel dataLabels', function (assert) {

--- a/ts/Series/Funnel/FunnelSeries.ts
+++ b/ts/Series/Funnel/FunnelSeries.ts
@@ -43,6 +43,7 @@ const {
 import U from '../../Core/Utilities.js';
 const {
     addEvent,
+    correctFloat,
     extend,
     fireEvent,
     isArray,
@@ -403,19 +404,19 @@ class FunnelSeries extends PieSeries {
         Individual point coordinate naming:
 
         x1,y1 _________________ x2,y1
-            \                         /
-            \                       /
-            \                     /
-            \                   /
-                \                 /
-            x3,y3 _________ x4,y3
+        \                         /
+         \                       /
+          \                     /
+           \                   /
+            \                 /
+           x3,y3 _________ x4,y3
 
         Additional for the base of the neck:
 
-                |               |
-                |               |
-                |               |
-            x3,y5 _________ x4,y5
+             |               |
+             |               |
+             |               |
+           x3,y5 _________ x4,y5
 
         */
 
@@ -442,7 +443,7 @@ class FunnelSeries extends PieSeries {
             x4 = x3 + tempWidth;
 
             // the entire point is within the neck
-            if (y1 > neckY) {
+            if (correctFloat(y1) >= neckY) {
                 x1 = x3 = centerX - neckWidth / 2;
                 x2 = x4 = centerX + neckWidth / 2;
 
@@ -478,7 +479,9 @@ class FunnelSeries extends PieSeries {
                     lBase = x4 - x3,
                     lSide = Math.sqrt(xSide * xSide + h * h);
 
-                alpha = Math.atan(h / xSide);
+                // If xSide equals zero, return Infinity to avoid dividing
+                // by zero (#20319)
+                alpha = Math.atan(xSide !== 0 ? h / xSide : Infinity);
                 maxT = lSide / 2;
                 if (y5 !== null) {
                     maxT = Math.min(maxT, Math.abs(y5 - y3) / 2);


### PR DESCRIPTION
Fixed #20319, funnel point path not rendered properly when the point's top coordinates where within top boundaries of the funnel neck.