### PR TITLE
bugfix/20340-histogram-incorrect-bins-x2-range

### DIFF
--- a/samples/unit-tests/series-histogram/histogram/demo.js
+++ b/samples/unit-tests/series-histogram/histogram/demo.js
@@ -473,6 +473,12 @@ QUnit.test('Histogram', function (assert) {
         'Bins frequencies are calculated correctly'
     );
 
+    assert.deepEqual(
+        histogram.data.map(point => point.x2),
+        [32, 42, 52, 62, 72, 82, 91],
+        'Bins x2 value is calculated properly (#20340)'
+    );
+
     histogram.update({
         binWidth: 5
     });

--- a/ts/Series/Histogram/HistogramSeries.ts
+++ b/ts/Series/Histogram/HistogramSeries.ts
@@ -35,8 +35,7 @@ const {
     correctFloat,
     extend,
     isNumber,
-    merge,
-    objectEach
+    merge
 } = U;
 
 /* ************************************************************************** *
@@ -217,7 +216,7 @@ class HistogramSeries extends ColumnSeries {
             data.push({
                 x: Number(key),
                 y: bins[key],
-                x2: correctFloat(Number(x) + binWidth)
+                x2: correctFloat(Number(key) + binWidth)
             });
         }
 


### PR DESCRIPTION
Fixed #20340, histogram bins `x2` value was wrongly calculated.