### PR TITLE
Fixed #20255, pie data labels overlapped after hovering

### DIFF
--- a/ts/Extensions/OverlappingDataLabels.ts
+++ b/ts/Extensions/OverlappingDataLabels.ts
@@ -255,9 +255,11 @@ function hideOrShow(label: SVGElement, chart: Chart): boolean {
 
         if (label.oldOpacity !== newOpacity) {
 
-            // Make sure the label is completely hidden to avoid catching clicks
-            // (#4362)
-            if (label.alignAttr && label.placed) { // Data labels
+            // Toggle data labels
+            if (label.hasClass('highcharts-data-label')) {
+
+                // Make sure the label is completely hidden to avoid catching
+                // clicks (#4362)
                 label[
                     newOpacity ? 'removeClass' : 'addClass'
                 ]('highcharts-data-label-hidden');
@@ -278,7 +280,9 @@ function hideOrShow(label: SVGElement, chart: Chart): boolean {
                     complete
                 );
                 fireEvent(chart, 'afterHideOverlappingLabel');
-            } else { // Other labels, tick labels
+
+            // Toggle other labels, tick labels
+            } else {
                 label.attr({
                     opacity: newOpacity
                 });


### PR DESCRIPTION
Fixed #20355, pie data labels inside the pie overlapped after interacting with the chart.