### PR TITLE
dash/kpi-inline-style

### DIFF
--- a/css/dashboards/dashboards.css
+++ b/css/dashboards/dashboards.css
@@ -283,6 +283,11 @@
     font-size: 2em;
 }
 
+.highcharts-dashboards-component-kpi-content {
+    display: flex;
+    flex-direction: column;
+}
+
 .highcharts-dashboards-component-title {
     color: var(--highcharts-neutral-color-100);
     margin: 0.5em 10px;

--- a/ts/Dashboards/Plugins/KPIComponent.ts
+++ b/ts/Dashboards/Plugins/KPIComponent.ts
@@ -303,9 +303,6 @@ class KPIComponent extends Component {
     public async load(): Promise<this> {
         await super.load();
 
-        this.contentElement.style.display = 'flex';
-        this.contentElement.style.flexDirection = 'column';
-
         this.linkValueToChart();
 
         return this;


### PR DESCRIPTION
Fixed, it was impossible to set KPI content `flex-direction`.