### PR TITLE
design/gantt grid color

### DIFF
--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -1202,9 +1202,11 @@ g.highcharts-series,
 }
 
 .highcharts-grid-axis .highcharts-tick {
+    stroke: var(--highcharts-neutral-color-20);
     stroke-width: 1px;
 }
 
 .highcharts-grid-axis .highcharts-axis-line {
+    stroke: var(--highcharts-neutral-color-20);
     stroke-width: 1px;
 }

--- a/samples/highcharts/demo/3d-area-multiple/demo.js
+++ b/samples/highcharts/demo/3d-area-multiple/demo.js
@@ -9,7 +9,8 @@ Highcharts.chart('container', {
         }
     },
     title: {
-        text: 'Visual comparison of Mountains Panorama'
+        text: 'Visual comparison of Mountains Panorama',
+        align: 'left'
     },
     accessibility: {
         description: 'The chart is showing the shapes of three mountain ranges as three area line series laid out in 3D behind each other.',

--- a/samples/highcharts/demo/calendar-heatmap-month/demo.js
+++ b/samples/highcharts/demo/calendar-heatmap-month/demo.js
@@ -283,7 +283,8 @@ Highcharts.chart('container', {
                 textOutline: 'none',
                 fontWeight: 'normal',
                 fontSize: '1rem'
-            }
+            },
+            y: 4
         }, {
             enabled: true,
             align: 'left',

--- a/samples/highcharts/demo/combo-timeline/demo.html
+++ b/samples/highcharts/demo/combo-timeline/demo.html
@@ -1,4 +1,5 @@
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
+<script src="https://code.highcharts.com/modules/scrollable-plotarea.js"></script>
 <script src="https://code.highcharts.com/modules/exporting.js"></script>
 <script src="https://code.highcharts.com/modules/export-data.js"></script>
 <script src="https://code.highcharts.com/modules/accessibility.js"></script>

--- a/samples/highcharts/demo/combo-timeline/demo.js
+++ b/samples/highcharts/demo/combo-timeline/demo.js
@@ -1,6 +1,7 @@
 /**
- * This is an advanced demo of setting up Highcharts with the flags feature borrowed from Highcharts Stock.
- * It also shows custom graphics drawn in the chart area on chart load.
+ * This is an advanced demo of setting up Highcharts with the flags feature
+ * borrowed from Highcharts Stock. It also shows custom graphics drawn in the
+ * chart area on chart load.
  */
 
 /**
@@ -298,6 +299,10 @@ const options = {
     chart: {
         events: {
             load: onChartLoad
+        },
+        scrollablePlotArea: {
+            minWidth: 700,
+            scrollPositionX: 1
         }
     },
     xAxis: {

--- a/samples/highcharts/demo/line-boost/demo.js
+++ b/samples/highcharts/demo/line-boost/demo.js
@@ -44,11 +44,13 @@ Highcharts.chart('container', {
     },
 
     title: {
-        text: 'Highcharts drawing ' + n + ' points'
+        text: 'Highcharts drawing ' + n + ' points',
+        align: 'left'
     },
 
     subtitle: {
-        text: 'Using the Boost module'
+        text: 'Using the Boost module',
+        align: 'left'
     },
 
     accessibility: {

--- a/samples/highcharts/demo/polygon/demo.js
+++ b/samples/highcharts/demo/polygon/demo.js
@@ -17,7 +17,7 @@ Highcharts.chart('container', {
         },
         startOnTick: true,
         endOnTick: true,
-        showLastLabel: true
+        tickPixelInterval: 50
     },
     yAxis: {
         title: {

--- a/samples/highcharts/demo/scatter-boost/demo.js
+++ b/samples/highcharts/demo/scatter-boost/demo.js
@@ -58,7 +58,8 @@ Highcharts.chart('container', {
     },
 
     title: {
-        text: 'Scatter chart with 1 million points'
+        text: 'Scatter chart with 1 million points',
+        align: 'left'
     },
 
     legend: {

--- a/samples/highcharts/demo/spline-irregular-time/demo.js
+++ b/samples/highcharts/demo/spline-irregular-time/demo.js
@@ -5,10 +5,12 @@ Highcharts.chart('container', {
         type: 'spline'
     },
     title: {
-        text: 'Snow depth at Vikjafjellet, Norway'
+        text: 'Snow depth at Vikjafjellet, Norway',
+        align: 'left'
     },
     subtitle: {
-        text: 'Irregular time data in Highcharts JS'
+        text: 'Irregular time data in Highcharts JS',
+        align: 'left'
     },
     xAxis: {
         type: 'datetime',

--- a/samples/highcharts/demo/styled-mode-pie/demo.js
+++ b/samples/highcharts/demo/styled-mode-pie/demo.js
@@ -4,7 +4,8 @@ Highcharts.chart('container', {
         styledMode: true
     },
     title: {
-        text: 'Mobile vendor market share, 2021'
+        text: 'Mobile vendor market share, 2021',
+        align: 'left'
     },
     xAxis: {
         categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']

--- a/samples/maps/demo/geoheatmap-earth-statistics/demo.js
+++ b/samples/maps/demo/geoheatmap-earth-statistics/demo.js
@@ -125,8 +125,17 @@
         },
 
         mapView: {
-            center: [0, 0],
-            zoom: 1.5
+            fitToGeometry: {
+                type: 'Polygon',
+                coordinates: [
+                    [
+                        [-180, 0],
+                        [90, 0],
+                        [180, 0],
+                        [-90, 0]
+                    ]
+                ]
+            }
         },
 
         legend: {

--- a/samples/maps/demo/map-drilldown/demo.js
+++ b/samples/maps/demo/map-drilldown/demo.js
@@ -142,8 +142,7 @@ const afterDrillUp = function (e) {
                 textOutline: '1px #000000'
             },
             breadcrumbs: {
-                floating: true,
-                relativeTo: 'spacingBox'
+                floating: true
             },
             drillUpButton: {
                 relativeTo: 'spacingBox',

--- a/samples/stock/demo/rangeselector-datagrouping/demo.css
+++ b/samples/stock/demo/rangeselector-datagrouping/demo.css
@@ -1,6 +1,6 @@
 #container {
     height: 400px;
-    min-width: 600px;
+    min-width: 320px;
     max-width: 800px;
     margin: 0 auto;
 }

--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -1577,6 +1577,7 @@ export default GridAxis;
  * Set border color for the label grid lines.
  *
  * @type      {Highcharts.ColorString}
+ * @default   #e6e6e6
  * @apioption xAxis.grid.borderColor
  */
 

--- a/ts/Core/Chart/GanttChart.ts
+++ b/ts/Core/Chart/GanttChart.ts
@@ -28,6 +28,7 @@ import type Options from '../Options';
 import Chart from './Chart.js';
 import D from '../Defaults.js';
 const { defaultOptions } = D;
+import { Palette } from '../Color/Palettes.js';
 import U from '../Utilities.js';
 const {
     isArray,
@@ -149,6 +150,7 @@ class GanttChart extends Chart {
                 // Defaults
                 {
                     grid: {
+                        borderColor: Palette.neutralColor20,
                         enabled: true
                     },
                     opposite: defaultOptions.xAxis?.opposite ??
@@ -172,6 +174,7 @@ class GanttChart extends Chart {
             // Defaults
             {
                 grid: {
+                    borderColor: Palette.neutralColor20,
                     enabled: true
                 },
 

--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -275,6 +275,7 @@ function chartMoveFixedElements(
         fixedSelectors = [
             '.highcharts-breadcrumbs-group',
             '.highcharts-contextbutton',
+            '.highcharts-caption',
             '.highcharts-credits',
             '.highcharts-legend',
             '.highcharts-legend-checkbox',


### PR DESCRIPTION
Changed the default color of the Gantt axis grid, to a more lightweight presence. The associated options are `xAxis.grid.borderColor` and `yAxis.grid.borderColor`. 