### PR TITLE
bugfix/20231-map-point-name

### DIFF
--- a/samples/unit-tests/maps/series-map/demo.js
+++ b/samples/unit-tests/maps/series-map/demo.js
@@ -202,15 +202,30 @@ QUnit.test(
 
 QUnit.test('Null points', function (assert) {
     var chart = Highcharts.mapChart('container', {
+        chart: {
+            map: Highcharts.maps['custom/europe']
+        },
         series: [
             {
-                mapData: Highcharts.maps['custom/europe'],
                 data: [
                     ['no', 5],
                     ['fr', 3],
                     ['gb', 2],
                     ['it', null]
                 ]
+            },
+            {
+                data: [
+                    {
+                        'hc-key': 'pl',
+                        value: 0,
+                        name: ''
+                    }
+                ],
+                dataLabels: {
+                    enabled: true,
+                    format: '{point.name}'
+                }
             }
         ]
     });
@@ -253,5 +268,22 @@ QUnit.test('Null points', function (assert) {
         chart.series[0].transformGroups[0].element.getAttribute('stroke-width'),
         '0',
         'The stroke width should be 0'
+    );
+
+    // Data labels tests #20231
+    assert.strictEqual(
+        chart.series[1].points[0].name,
+        '',
+        'The name should be an empty string.'
+    );
+
+    chart.series[1].points[0].update({
+        name: 'Name'
+    });
+
+    assert.strictEqual(
+        chart.series[1].points[0].name,
+        'Name',
+        'The name should be updated.'
     );
 });

--- a/ts/Series/Map/MapPoint.ts
+++ b/ts/Series/Map/MapPoint.ts
@@ -136,7 +136,12 @@ class MapPoint extends ScatterPoint {
                     series.mapMap[mapKey];
 
             if (mapPoint) {
-                extend(point, mapPoint); // copy over properties
+                // Copy over properties; #20231 prioritize point.name
+                extend(
+                    point, {
+                        ...mapPoint,
+                        name: point.name || mapPoint.name
+                    });
             } else if (series.pointArrayMap.indexOf('value') !== -1) {
                 point.value = point.value || null;
             }

--- a/ts/Series/Map/MapPoint.ts
+++ b/ts/Series/Map/MapPoint.ts
@@ -139,7 +139,9 @@ class MapPoint extends ScatterPoint {
                 // Copy over properties; #20231 prioritize point.name
                 extend(point, {
                     ...mapPoint,
-                    name: point.name || mapPoint.name
+                    name: typeof point.name !== 'undefined' ?
+                        point.name :
+                        mapPoint.name
                 });
             } else if (series.pointArrayMap.indexOf('value') !== -1) {
                 point.value = point.value || null;

--- a/ts/Series/Map/MapPoint.ts
+++ b/ts/Series/Map/MapPoint.ts
@@ -137,11 +137,10 @@ class MapPoint extends ScatterPoint {
 
             if (mapPoint) {
                 // Copy over properties; #20231 prioritize point.name
-                extend(
-                    point, {
-                        ...mapPoint,
-                        name: point.name || mapPoint.name
-                    });
+                extend(point, {
+                    ...mapPoint,
+                    name: point.name || mapPoint.name
+                });
             } else if (series.pointArrayMap.indexOf('value') !== -1) {
                 point.value = point.value || null;
             }

--- a/ts/Series/Map/MapPoint.ts
+++ b/ts/Series/Map/MapPoint.ts
@@ -139,9 +139,7 @@ class MapPoint extends ScatterPoint {
                 // Copy over properties; #20231 prioritize point.name
                 extend(point, {
                     ...mapPoint,
-                    name: typeof point.name !== 'undefined' ?
-                        point.name :
-                        mapPoint.name
+                    name: point.name ?? mapPoint.name
                 });
             } else if (series.pointArrayMap.indexOf('value') !== -1) {
                 point.value = point.value || null;

--- a/ts/Series/Map/MapSeriesDefaults.ts
+++ b/ts/Series/Map/MapSeriesDefaults.ts
@@ -65,8 +65,9 @@ const MapSeriesDefaults: MapSeriesOptions = {
         formatter: function (): string { // #2945
             const { numberFormatter } = this.series.chart;
             const { value } = this.point as MapPoint;
-
-            return isNumber(value) ? numberFormatter(value, -1) : '';
+            return isNumber(value) ?
+                numberFormatter(value, -1) :
+                this.point.name; // #20231
         },
         inside: true, // for the color
         overflow: false as any,


### PR DESCRIPTION
Fixed #20231, if `mapPoint.name` was given, `point.name` didn't take effect