### PR TITLE
bugfix/20166-columns-gridLines-and-pointPlacement

### DIFF
--- a/samples/unit-tests/axis/pointplacement/demo.js
+++ b/samples/unit-tests/axis/pointplacement/demo.js
@@ -41,7 +41,7 @@ QUnit.test('Axis pointPlacement', assert => {
     );
 
     assert.strictEqual(
-        axis.ticks[-1], null,
+        axis.ticks[-1], undefined,
         'No tick at -1 when pointPlacement is set for cartesian series'
     );
 

--- a/samples/unit-tests/axis/pointplacement/demo.js
+++ b/samples/unit-tests/axis/pointplacement/demo.js
@@ -40,6 +40,11 @@ QUnit.test('Axis pointPlacement', assert => {
         'No padded ticks'
     );
 
+    assert.strictEqual(
+        axis.ticks[-1], null,
+        'No tick at -1 when pointPlacement is set for cartesian series'
+    );
+
     controller.pan([200, 60], [400, 60]);
 
     const rangeBefore = axis.max - axis.min;

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -981,7 +981,6 @@ class Axis {
             cHeight = (old && chart.oldChartHeight) || chart.chartHeight,
             cWidth = (old && chart.oldChartWidth) || chart.chartWidth,
             transB = axis.transB;
-
         let translatedValue = options.translatedValue,
             force = options.force,
             x1: number,
@@ -989,7 +988,6 @@ class Axis {
             x2: number,
             y2: number,
             skip: boolean;
-
         // eslint-disable-next-line valid-jsdoc
         /**
          * Check if x is between a and b. If not, either move to a/b
@@ -1030,9 +1028,16 @@ class Axis {
 
             x1 = x2 = Math.round(translatedValue + transB);
             y1 = y2 = Math.round(cHeight - translatedValue - transB);
-            if (!isNumber(translatedValue)) { // No min or max
+
+            if (
+                !axis.horiz ?
+                    (y1 < axisTop || y1 > axisTop + axis.height) :
+                    (x1 < axisLeft || x1 > axisLeft + axis.width) ||
+                // #7175, don't force it when path is invalid
+                !isNumber(translatedValue)
+            ) {
                 skip = true;
-                force = false; // #7175, don't force it when path is invalid
+                force = false;
             } else if (axis.horiz) {
                 y1 = axisTop;
                 y2 = cHeight - axis.bottom;
@@ -3932,22 +3937,12 @@ class Axis {
             // we can get the position of the neighbour label. #808.
             if (tickPositions.length) { // #1300
                 tickPositions.forEach(function (pos: number, i: number): void {
-                    if (
-                        (isNumber(axis.max) && pos <= axis.max) &&
-                        (isNumber(axis.min) && pos >= axis.min)
-                    ) {
-                        axis.renderTick(pos, i, slideInTicks);
-                    }
+                    axis.renderTick(pos, i, slideInTicks);
                 });
                 // In a categorized axis, the tick marks are displayed
                 // between labels. So we need to add a tick mark and
                 // grid line at the left edge of the X axis.
-                if (
-                    tickmarkOffset &&
-                    (isNumber(axis.max) && axis.max >= -1) &&
-                    (isNumber(axis.min) && axis.min <= -1) &&
-                    (axis.min === 0 || axis.single)
-                ) {
+                if (tickmarkOffset && (axis.min === 0 || axis.single)) {
                     if (!ticks[-1]) {
                         ticks[-1] = new Tick(axis, -1, null as any, true);
                     }

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3931,26 +3931,21 @@ class Axis {
             // Major ticks. Pull out the first item and render it last so that
             // we can get the position of the neighbour label. #808.
             if (tickPositions.length) { // #1300
-
-                const extraTick = axis.series.find( // #20166
-                    (series): string | number | false | undefined => (
-                        series.xAxis && series.options.pointPlacement
-                    )
-                );
-
-                if (extraTick && chart.inverted) {
-                    tickPositions.pop();
-                }
-
                 tickPositions.forEach(function (pos: number, i: number): void {
-                    axis.renderTick(pos, i, slideInTicks);
+                    if (
+                        (isNumber(axis.max) && pos <= axis.max) &&
+                        (isNumber(axis.min) && pos >= axis.min)
+                    ) {
+                        axis.renderTick(pos, i, slideInTicks);
+                    }
                 });
                 // In a categorized axis, the tick marks are displayed
                 // between labels. So we need to add a tick mark and
                 // grid line at the left edge of the X axis.
                 if (
-                    !extraTick &&
                     tickmarkOffset &&
+                    (isNumber(axis.max) && axis.max >= -1) &&
+                    (isNumber(axis.min) && axis.min <= -1) &&
                     (axis.min === 0 || axis.single)
                 ) {
                     if (!ticks[-1]) {

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3934,10 +3934,20 @@ class Axis {
                 tickPositions.forEach(function (pos: number, i: number): void {
                     axis.renderTick(pos, i, slideInTicks);
                 });
+
                 // In a categorized axis, the tick marks are displayed
                 // between labels. So we need to add a tick mark and
                 // grid line at the left edge of the X axis.
-                if (tickmarkOffset && (axis.min === 0 || axis.single)) {
+                if (
+                    !axis.series.find( // #20166
+                        (series): string | number | false | undefined => (
+                            series.is('column') &&
+                            series.options.pointPlacement
+                        )
+                    ) &&
+                    tickmarkOffset &&
+                    (axis.min === 0 || axis.single)
+                ) {
                     if (!ticks[-1]) {
                         ticks[-1] = new Tick(axis, -1, null as any, true);
                     }

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3931,20 +3931,25 @@ class Axis {
             // Major ticks. Pull out the first item and render it last so that
             // we can get the position of the neighbour label. #808.
             if (tickPositions.length) { // #1300
+
+                const extraTick = axis.series.find( // #20166
+                    (series): string | number | false | undefined => (
+                        series.xAxis && series.options.pointPlacement
+                    )
+                );
+
+                if (extraTick && chart.inverted) {
+                    tickPositions.pop();
+                }
+
                 tickPositions.forEach(function (pos: number, i: number): void {
                     axis.renderTick(pos, i, slideInTicks);
                 });
-
                 // In a categorized axis, the tick marks are displayed
                 // between labels. So we need to add a tick mark and
                 // grid line at the left edge of the X axis.
                 if (
-                    !axis.series.find( // #20166
-                        (series): string | number | false | undefined => (
-                            series.xAxis &&
-                            series.options.pointPlacement
-                        )
-                    ) &&
+                    !extraTick &&
                     tickmarkOffset &&
                     (axis.min === 0 || axis.single)
                 ) {
@@ -3953,7 +3958,6 @@ class Axis {
                     }
                     ticks[-1].render(-1);
                 }
-
             }
 
             // Alternate grid color

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3941,7 +3941,7 @@ class Axis {
                 if (
                     !axis.series.find( // #20166
                         (series): string | number | false | undefined => (
-                            series.is('column') &&
+                            series.xAxis &&
                             series.options.pointPlacement
                         )
                     ) &&

--- a/ts/Core/Axis/Color/ColorAxis.ts
+++ b/ts/Core/Axis/Color/ColorAxis.ts
@@ -239,6 +239,11 @@ class ColorAxis extends Axis implements AxisLike {
         if (userOptions.dataClasses) {
             axis.initDataClasses(userOptions);
         }
+
+        if (userOptions.title) {
+            merge(axis.options.title, userOptions.title);
+        }
+
         axis.initStops();
 
         // Override original axis properties
@@ -280,7 +285,6 @@ class ColorAxis extends Axis implements AxisLike {
             // Forced options
             {
                 showEmpty: false,
-                title: null,
                 visible: this.chart.options.legend.enabled &&
                     userOptions.visible !== false
             }
@@ -327,6 +331,7 @@ class ColorAxis extends Axis implements AxisLike {
      */
     public getOffset(): void {
         const axis = this;
+        const renderer = axis.chart.renderer;
         const group = axis.legendItem?.group;
         const sideOffset = axis.chart.axisOffset[axis.side];
 

--- a/ts/Core/Axis/Color/ColorAxisDefaults.ts
+++ b/ts/Core/Axis/Color/ColorAxisDefaults.ts
@@ -74,7 +74,7 @@ import { Palette } from '../../Color/Palettes.js';
  *               categories, crosshair, dateTimeLabelFormats, left,
  *               lineWidth, linkedTo, maxZoom, minRange, minTickInterval,
  *               offset, opposite, pane, plotBands, plotLines,
- *               reversedStacks, scrollbar, showEmpty, title, top,
+ *               reversedStacks, scrollbar, showEmpty, top,
  *               zoomEnabled
  * @product      highcharts highstock highmaps
  * @type         {*|Array<*>}


### PR DESCRIPTION
Fixed #20166, columns with `pointPlacement` had a superfluous tick to the left of the chart, visible with `gridLineWidth`.

Note: Firefox headless broke at me so this was committed with `--no-verify` so I could review github-side checks 😬 

This could be a messy addition to otherwise clean code but I am unsure if i should:
- Create a variable at the top of the `axis.render` function which checks for column series with `pointPlacement`
- Create it closer to the check
- Handle it some other way

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206008636612601