### PR TITLE
Refactored scrollablePlotArea

### DIFF
--- a/samples/unit-tests/scrollable-plotarea/dynamics/demo.js
+++ b/samples/unit-tests/scrollable-plotarea/dynamics/demo.js
@@ -27,7 +27,9 @@ QUnit.test('Test dynamic behaviour of Scrollable PlotArea', function (assert) {
     chart.setTitle({ text: 'New title' });
 
     assert.ok(
-        chart.fixedRenderer.box.contains(chart.title.element),
+        chart.scrollablePlotArea.fixedRenderer.box.contains(
+            chart.title.element
+        ),
         'Title should be outside the scrollable plot area (#11966)'
     );
 
@@ -38,14 +40,16 @@ QUnit.test('Test dynamic behaviour of Scrollable PlotArea', function (assert) {
     });
 
     assert.ok(
-        chart.fixedRenderer.box.contains(chart.xAxis[0].axisGroup.element),
+        chart.scrollablePlotArea.fixedRenderer.box.contains(
+            chart.xAxis[0].axisGroup.element
+        ),
         'X-axis should be outside the scrollable plot area (#8862)'
     );
 
-    const scrollLeft = chart.scrollingContainer.scrollLeft;
+    const scrollLeft = chart.scrollablePlotArea.scrollingContainer.scrollLeft;
     chart.setSize(chart.chartWidth + 10);
     assert.close(
-        chart.scrollingContainer.scrollLeft,
+        chart.scrollablePlotArea.scrollingContainer.scrollLeft,
         scrollLeft,
         11,
         'Scrolling position should be retained after resize'

--- a/samples/unit-tests/scrollable-plotarea/options/demo.js
+++ b/samples/unit-tests/scrollable-plotarea/options/demo.js
@@ -69,7 +69,7 @@ QUnit.test('fixedRenderer options', function (assert) {
         ]
     });
     assert.equal(
-        chart.fixedRenderer.style.fontFamily,
+        chart.scrollablePlotArea.fixedRenderer.style.fontFamily,
         chart.options.chart.style.fontFamily,
         'fixedRenderer should inherit style from options'
     );

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1035,13 +1035,13 @@ class Axis {
                 force = false; // #7175, don't force it when path is invalid
             } else if (axis.horiz) {
                 y1 = axisTop;
-                y2 = cHeight - axis.bottom;
+                y2 = cHeight - axis.bottom + (chart.scrollablePixelsY || 0);
 
                 x1 = x2 = between(x1, axisLeft, axisLeft + axis.width);
 
             } else {
                 x1 = axisLeft;
-                x2 = cWidth - axis.right;
+                x2 = cWidth - axis.right + (chart.scrollablePixelsX || 0);
 
                 y1 = y2 = between(y1, axisTop, axisTop + axis.height);
             }

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3497,7 +3497,7 @@ class Chart {
                 btnOptions.relativeTo === 'chart' ||
                 btnOptions.relativeTo === 'spacingBox' ?
                     null :
-                    'scrollablePlotBox'
+                    'plotBox'
             );
 
         /**

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -715,21 +715,17 @@ class Chart {
         options: Chart.IsInsideOptionsObject = {}
     ): boolean {
         const {
-            inverted,
-            plotBox,
-            plotLeft,
-            plotTop,
-            scrollablePlotBox
-        } = this;
-
-        let scrollLeft = 0,
-            scrollTop = 0;
-
-        if (options.visiblePlotOnly && this.scrollingContainer) {
-            ({ scrollLeft, scrollTop } = this.scrollingContainer);
-        }
-
-        const series = options.series,
+                inverted,
+                plotBox,
+                plotLeft,
+                plotTop,
+                scrollablePlotBox
+            } = this,
+            { scrollLeft = 0, scrollTop = 0 } = (
+                options.visiblePlotOnly &&
+                this.scrollablePlotArea?.scrollingContainer
+            ) || {},
+            series = options.series,
             box = (options.visiblePlotOnly && scrollablePlotBox) || plotBox,
             x = options.inverted ? plotY : plotX,
             y = options.inverted ? plotX : plotY,

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -436,8 +436,6 @@ class SVGElement implements SVGElementLike {
         box = pick(
             box,
             (renderer as any)[alignTo as any],
-            alignTo === 'scrollablePlotBox' ?
-                (renderer as any).plotBox : void 0,
             renderer as any
         );
 

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1180,10 +1180,6 @@ class Tooltip {
                 pointer,
                 scrollablePixelsY = 0,
                 scrollablePixelsX,
-                scrollingContainer: {
-                    scrollLeft,
-                    scrollTop
-                } = { scrollLeft: 0, scrollTop: 0 },
                 styledMode
             },
             distance,
@@ -1192,6 +1188,11 @@ class Tooltip {
                 positioner
             }
         } = tooltip;
+        const {
+            scrollLeft = 0,
+            scrollTop = 0
+        } = chart.scrollablePlotArea?.scrollingContainer || {};
+
 
         // The area which the tooltip should be limited to. Limit to scrollable
         // plot area if enabled, otherwise limit to the chart container. If

--- a/ts/Extensions/Breadcrumbs/Breadcrumbs.ts
+++ b/ts/Extensions/Breadcrumbs/Breadcrumbs.ts
@@ -525,7 +525,7 @@ class Breadcrumbs {
                     breadcrumbsOptions.relativeTo === 'chart' ||
                     breadcrumbsOptions.relativeTo === 'spacingBox' ?
                         void 0 :
-                        'scrollablePlotBox'
+                        'plotBox'
                 ),
                 bBox = breadcrumbs.group.getBBox(),
                 additionalSpace = 2 * (buttonTheme.padding || 0) +

--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -766,7 +766,7 @@ namespace Exporting {
                         pointerEvents: 'auto',
                         ...chart.renderer.style
                     },
-                    chart.fixedDiv || chart.container
+                    chart.scrollablePlotArea?.fixedDiv || chart.container
                 ) as Exporting.DivElement;
 
             innerMenu = createElement(
@@ -1564,11 +1564,15 @@ namespace Exporting {
      *        Move target
      */
     function moveContainers(this: Chart, moveTo: HTMLDOMElement): void {
-        const chart = this;
+        const { scrollablePlotArea } = this;
         (
-            chart.fixedDiv ? // When scrollablePlotArea is active (#9533)
-                [chart.fixedDiv, chart.scrollingContainer as any] :
-                [chart.container]
+            // When scrollablePlotArea is active (#9533)
+            scrollablePlotArea ?
+                [
+                    scrollablePlotArea.fixedDiv,
+                    scrollablePlotArea.scrollingContainer
+                ] :
+                [this.container]
 
         ).forEach(function (div: HTMLDOMElement): void {
             moveTo.appendChild(div);

--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -195,8 +195,8 @@ class ScrollablePlotArea {
     public innerContainer: HTMLDOMElement;
     public isDirty?: boolean;
     public scrollingContainer: HTMLDOMElement;
-    public scrollingParent: HTMLDOMElement;
-    public scrollableMask: SVGElement;
+    public parentDiv: HTMLDOMElement;
+    public mask: SVGElement;
 
     public constructor(chart: Chart) {
         const chartOptions = chart.options.chart,
@@ -220,7 +220,7 @@ class ScrollablePlotArea {
 
         // Insert a container with relative position that scrolling and fixed
         // container renders to (#10555)
-        const scrollingParent = this.scrollingParent = createElement(
+        const parentDiv = this.parentDiv = createElement(
                 'div',
                 {
                     className: 'highcharts-scrolling-parent'
@@ -235,7 +235,7 @@ class ScrollablePlotArea {
             scrollingContainer = this.scrollingContainer = createElement(
                 'div', {
                     'className': 'highcharts-scrolling'
-                }, styles, scrollingParent
+                }, styles, parentDiv
             ),
 
             innerContainer = this.innerContainer = createElement('div', {
@@ -265,7 +265,7 @@ class ScrollablePlotArea {
             );
 
         // Mask
-        this.scrollableMask = fixedRenderer
+        this.mask = fixedRenderer
             .path()
             .attr({
                 fill: chartOptions.backgroundColor || '#fff',
@@ -306,7 +306,12 @@ class ScrollablePlotArea {
     }
 
     public applyFixed(): void {
-        const { chart, fixedRenderer, isDirty, scrollingContainer } = this,
+        const {
+                chart,
+                fixedRenderer,
+                isDirty,
+                scrollingContainer
+            } = this,
             {
                 axisOffset,
                 chartWidth,
@@ -406,7 +411,7 @@ class ScrollablePlotArea {
         }
 
         if (chart.redrawTrigger !== 'adjustHeight') {
-            this.scrollableMask.attr({ d });
+            this.mask.attr({ d });
         }
     }
 

--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -10,14 +10,6 @@
  *  horizontally on mobile devices. Supports left and right side axes.
  */
 
-/*
-WIP on vertical scrollable plot area (#9378). To do:
-- Bottom axis positioning
-- Test with Gantt
-- Look for size optimizing the code
-- API and demos
- */
-
 'use strict';
 
 /* *
@@ -29,6 +21,7 @@ WIP on vertical scrollable plot area (#9378). To do:
 import type Axis from '../Core/Axis/Axis';
 import type BBoxObject from '../Core/Renderer/BBoxObject';
 import type Chart from '../Core/Chart/Chart';
+import type ChartOptions from '../Core/Chart/ChartOptions';
 import type CSSObject from '../Core/Renderer/CSSObject';
 import type {
     DOMElementType,
@@ -62,21 +55,26 @@ const {
  *
  * */
 
+interface ScrollablePlotAreaOptions {
+    minHeight?: number;
+    minWidth?: number;
+    opacity?: number;
+    scrollPositionX?: number;
+    scrollPositionY?: number;
+}
+
+declare module '../Core/Chart/ChartOptions' {
+    interface ChartOptions {
+        scrollablePlotArea?: ScrollablePlotAreaOptions
+    }
+}
+
 declare module '../Core/Chart/ChartLike'{
     interface ChartLike {
-        fixedDiv?: HTMLDOMElement;
-        fixedRenderer?: SVGRenderer;
-        innerContainer?: HTMLDOMElement;
-        scrollingContainer?: HTMLDOMElement;
-        scrollingParent?: HTMLDOMElement;
-        scrollableDirty?: boolean;
-        scrollableMask?: SVGElement;
         scrollablePixelsX?: number;
         scrollablePixelsY?: number;
         scrollablePlotBox?: BBoxObject;
-        applyFixed(): void;
-        moveFixedElements(): void;
-        setUpScrolling(): void;
+        scrollablePlotArea?: ScrollablePlotArea;
     }
 }
 
@@ -86,117 +84,320 @@ declare module '../Core/Renderer/SVG/SVGRendererLike' {
     }
 }
 
+
 /* *
  *
  *  Functions
  *
  * */
-
 /** @private */
-function chartApplyFixed(
+function onChartRender(
     this: Chart
 ): void {
-    const {
-            axisOffset,
-            chartWidth,
-            chartHeight,
-            container,
-            plotHeight,
-            plotLeft,
-            plotTop,
-            plotWidth,
-            scrollablePixelsX = 0,
-            scrollablePixelsY = 0,
-            scrollingContainer
-        } = this,
-        firstTime = !this.fixedDiv,
-        chartOptions = this.options.chart,
-        scrollableOptions = (chartOptions as any).scrollablePlotArea,
-        { scrollPositionX, scrollPositionY } = scrollableOptions,
-        Renderer = RendererRegistry.getRendererType();
-
-    let { fixedRenderer } = this;
-
-    // First render
-    if (!fixedRenderer) {
-        this.fixedDiv = createElement(
-            'div',
-            {
-                className: 'highcharts-fixed'
-            },
-            {
-                position: 'absolute',
-                overflow: 'hidden',
-                pointerEvents: 'none',
-                zIndex: (chartOptions.style?.zIndex || 0) + 2,
-                top: 0
-            },
-            void 0,
-            true
+    let scrollablePlotArea = this.scrollablePlotArea;
+    if (
+        (this.scrollablePixelsX || this.scrollablePixelsY) &&
+        !scrollablePlotArea
+    ) {
+        this.scrollablePlotArea = scrollablePlotArea = new ScrollablePlotArea(
+            this
         );
-        scrollingContainer?.parentNode.insertBefore(
-            this.fixedDiv,
-            scrollingContainer
-        );
-        css(this.renderTo, { overflow: 'visible' });
+    }
+    scrollablePlotArea?.applyFixed();
+}
 
-        this.fixedRenderer = fixedRenderer = new Renderer(
-            this.fixedDiv,
-            chartWidth,
-            chartHeight,
-            chartOptions.style
-        );
+/** @private */
+function markDirty(
+    this: Axis|Series
+): void {
+    if (this.chart.scrollablePlotArea) {
+        this.chart.scrollablePlotArea.isDirty = true;
+    }
+}
+
+
+class ScrollablePlotArea {
+
+    public static compose(
+        AxisClass: typeof Axis,
+        ChartClass: typeof Chart,
+        SeriesClass: typeof Series
+    ): void {
+
+        if (pushUnique(composed, this.compose)) {
+            addEvent(AxisClass, 'afterInit', markDirty);
+
+            addEvent(
+                ChartClass,
+                'afterSetChartSize',
+                (e: { skipAxes: boolean, target: Chart }): void =>
+                    this.afterSetSize(e.target, e)
+            );
+            addEvent(ChartClass, 'render', onChartRender);
+
+            addEvent(SeriesClass, 'show', markDirty);
+        }
+
+    }
+
+    public static afterSetSize(chart: Chart, e: { skipAxes: boolean }): void {
+        const { minWidth, minHeight } =
+                chart.options.chart.scrollablePlotArea || {},
+            { clipBox, plotBox, inverted, renderer } = chart;
+
+        let scrollablePixelsX: number,
+            scrollablePixelsY: number,
+            corrections: (
+                Record<string, Record<string, (number|string)>>|
+                undefined
+            );
+
+        if (!renderer.forExport) {
+
+            // The amount of pixels to scroll, the difference between chart
+            // width and scrollable width
+            if (minWidth) {
+                chart.scrollablePixelsX = scrollablePixelsX = Math.max(
+                    0,
+                    minWidth - chart.chartWidth
+                );
+
+                if (scrollablePixelsX) {
+                    chart.scrollablePlotBox = (
+                        renderer.scrollablePlotBox = merge(chart.plotBox)
+                    );
+                    plotBox.width = chart.plotWidth += scrollablePixelsX;
+                    clipBox[inverted ? 'height' : 'width'] += scrollablePixelsX;
+
+                    corrections = {
+                        // Corrections for right side
+                        1: { name: 'right', value: scrollablePixelsX }
+                    };
+                }
+
+            // Currently we can only do either X or Y
+            } else if (minHeight) {
+                chart.scrollablePixelsY = scrollablePixelsY = Math.max(
+                    0,
+                    minHeight - chart.chartHeight
+                );
+                if (defined(scrollablePixelsY)) {
+                    chart.scrollablePlotBox = (
+                        renderer.scrollablePlotBox = merge(chart.plotBox)
+                    );
+                    plotBox.height = chart.plotHeight += scrollablePixelsY;
+                    clipBox[inverted ? 'width' : 'height'] += scrollablePixelsY;
+
+                    corrections = {
+                        2: { name: 'bottom', value: scrollablePixelsY }
+                    };
+                }
+            }
+
+            if (corrections && !e.skipAxes) {
+                for (const axis of chart.axes) {
+                    // For right and bottom axes, only fix the plot line length
+                    if ((corrections as any)[axis.side]) {
+                        const originalGetPlotLinePath = axis.getPlotLinePath;
+                        // Get the plot lines right in getPlotLinePath,
+                        // temporarily set it to the adjusted plot width.
+                        // eslint-disable-next-line no-loop-func
+                        axis.getPlotLinePath = function (): SVGPath {
+                            const marginName = (corrections as any)[axis.side]
+                                    .name,
+                                correctionValue =
+                                    (corrections as any)[axis.side].value,
+                                // Is axis.right or axis.bottom
+                                margin = (this as any)[marginName];
+                            // Temporarily adjust
+                            (this as any)[marginName] =
+                                margin - correctionValue;
+                            const path = originalGetPlotLinePath.apply(
+                                this,
+                                arguments as any
+                            ) as any;
+                            // Reset
+                            (this as any)[marginName] = margin;
+                            return path;
+                        };
+
+                    } else {
+                        // Apply the corrected plotWidth
+                        axis.setAxisSize();
+                        axis.setAxisTranslation();
+                    }
+                }
+            }
+        }
+    }
+
+    public chart: Chart;
+    public fixedDiv: HTMLDOMElement;
+    public fixedRenderer: SVGRenderer;
+    public innerContainer: HTMLDOMElement;
+    public isDirty?: boolean;
+    public scrollingContainer: HTMLDOMElement;
+    public scrollingParent: HTMLDOMElement;
+    public scrollableMask: SVGElement;
+
+    public constructor(chart: Chart) {
+        const chartOptions = chart.options.chart,
+            Renderer = RendererRegistry.getRendererType(),
+            scrollableOptions = chartOptions.scrollablePlotArea || {},
+            moveFixedElements = this.moveFixedElements.bind(this),
+            styles: CSSObject = {
+                WebkitOverflowScrolling: 'touch',
+                overflowX: 'hidden',
+                overflowY: 'hidden'
+            };
+
+        if (chart.scrollablePixelsX) {
+            styles.overflowX = 'auto';
+        }
+        if (chart.scrollablePixelsY) {
+            styles.overflowY = 'auto';
+        }
+
+        this.chart = chart;
+
+        // Insert a container with relative position that scrolling and fixed
+        // container renders to (#10555)
+        const scrollingParent = this.scrollingParent = createElement(
+                'div',
+                {
+                    className: 'highcharts-scrolling-parent'
+                },
+                {
+                    position: 'relative'
+                },
+                chart.renderTo
+            ),
+
+            // Add the necessary divs to provide scrolling
+            scrollingContainer = this.scrollingContainer = createElement(
+                'div', {
+                    'className': 'highcharts-scrolling'
+                }, styles, scrollingParent
+            ),
+
+            innerContainer = this.innerContainer = createElement('div', {
+                'className': 'highcharts-inner-container'
+            }, void 0, scrollingContainer),
+
+            fixedDiv = this.fixedDiv = createElement(
+                'div',
+                {
+                    className: 'highcharts-fixed'
+                },
+                {
+                    position: 'absolute',
+                    overflow: 'hidden',
+                    pointerEvents: 'none',
+                    zIndex: (chartOptions.style?.zIndex || 0) + 2,
+                    top: 0
+                },
+                void 0,
+                true
+            ),
+            fixedRenderer = this.fixedRenderer = new Renderer(
+                fixedDiv,
+                chart.chartWidth,
+                chart.chartHeight,
+                chartOptions.style
+            );
+
         // Mask
         this.scrollableMask = fixedRenderer
             .path()
             .attr({
                 fill: chartOptions.backgroundColor || '#fff',
-                'fill-opacity': pick(scrollableOptions.opacity, 0.85),
+                'fill-opacity': scrollableOptions.opacity ?? 0.85,
                 zIndex: -1
             })
             .addClass('highcharts-scrollable-mask')
             .add();
 
-        addEvent(this, 'afterShowResetZoom', this.moveFixedElements);
-        addEvent(this, 'afterApplyDrilldown', this.moveFixedElements);
-        addEvent(this, 'afterLayOutTitles', this.moveFixedElements);
+        scrollingContainer.parentNode.insertBefore(
+            fixedDiv,
+            scrollingContainer
+        );
+        css(chart.renderTo, { overflow: 'visible' });
 
-    } else {
+        addEvent(chart, 'afterShowResetZoom', moveFixedElements);
+        addEvent(chart, 'afterApplyDrilldown', moveFixedElements);
+        addEvent(chart, 'afterLayOutTitles', moveFixedElements);
+
+
+        // On scroll, reset the chart position because it applies to the
+        // scrolled container
+        let lastHoverPoint: typeof chart.hoverPoint;
+        addEvent(scrollingContainer, 'scroll', (): void => {
+            const { pointer, hoverPoint } = chart;
+            if (pointer) {
+                delete pointer.chartPosition;
+                if (hoverPoint) {
+                    lastHoverPoint = hoverPoint;
+                }
+                pointer.runPointActions(void 0, lastHoverPoint, true);
+            }
+        });
+
+        // Now move the container inside
+        innerContainer.appendChild(chart.container);
+
+    }
+
+    public applyFixed(): void {
+        const { chart, fixedRenderer, scrollingContainer } = this,
+            {
+                axisOffset,
+                chartWidth,
+                chartHeight,
+                container,
+                plotHeight,
+                plotLeft,
+                plotTop,
+                plotWidth,
+                scrollablePixelsX = 0,
+                scrollablePixelsY = 0
+            } = chart,
+            chartOptions = chart.options.chart,
+            scrollableOptions = chartOptions.scrollablePlotArea || {},
+            { scrollPositionX, scrollPositionY } = scrollableOptions;
 
         // Set the size of the fixed renderer to the visible width
         fixedRenderer.setSize(chartWidth, chartHeight);
-    }
 
-    if (this.scrollableDirty || firstTime) {
-        this.scrollableDirty = false;
-        this.moveFixedElements();
-    }
+        if (this.isDirty ?? true) {
+            this.isDirty = false;
+            this.moveFixedElements();
+        }
 
-    // Increase the size of the scrollable renderer and background
-    const scrollableWidth = chartWidth + scrollablePixelsX,
-        scrollableHeight = chartHeight + scrollablePixelsY;
-    stop(this.container);
-    css(container, {
-        width: `${scrollableWidth}px`,
-        height: `${scrollableHeight}px`
-    });
-    this.renderer.boxWrapper.attr({
-        width: scrollableWidth,
-        height: scrollableHeight,
-        viewBox: [0, 0, scrollableWidth, scrollableHeight].join(' ')
-    });
-    this.chartBackground?.attr({
-        width: scrollableWidth,
-        height: scrollableHeight
-    });
+        // Increase the size of the scrollable renderer and background
+        const scrollableWidth = chartWidth + scrollablePixelsX,
+            scrollableHeight = chartHeight + scrollablePixelsY;
+        stop(chart.container);
+        css(container, {
+            width: `${scrollableWidth}px`,
+            height: `${scrollableHeight}px`
+        });
+        chart.renderer.boxWrapper.attr({
+            width: scrollableWidth,
+            height: scrollableHeight,
+            viewBox: [0, 0, scrollableWidth, scrollableHeight].join(' ')
+        });
+        chart.chartBackground?.attr({
+            width: scrollableWidth,
+            height: scrollableHeight
+        });
 
-    if (scrollingContainer) {
         css(scrollingContainer, {
-            width: `${this.chartWidth}px`,
-            height: `${this.chartHeight}px`
+            width: `${chartWidth}px`,
+            height: `${chartHeight}px`
         });
 
         // Set scroll position
+        const firstTime = true;
         if (firstTime) {
 
             if (scrollPositionX) {
@@ -208,334 +409,120 @@ function chartApplyFixed(
                     scrollablePixelsY * scrollPositionY;
             }
         }
-    }
 
-    // Mask behind the left and right side
-    const maskTop = plotTop - axisOffset[0] - 1,
-        maskLeft = plotLeft - axisOffset[3] - 1,
-        maskBottom = plotTop + plotHeight + axisOffset[2] + 1,
-        maskRight = plotLeft + plotWidth + axisOffset[1] + 1,
-        maskPlotRight = plotLeft + plotWidth - scrollablePixelsX,
-        maskPlotBottom = plotTop + plotHeight - scrollablePixelsY;
+        // Mask behind the left and right side
+        const maskTop = plotTop - axisOffset[0] - 1,
+            maskLeft = plotLeft - axisOffset[3] - 1,
+            maskBottom = plotTop + plotHeight + axisOffset[2] + 1,
+            maskRight = plotLeft + plotWidth + axisOffset[1] + 1,
+            maskPlotRight = plotLeft + plotWidth - scrollablePixelsX,
+            maskPlotBottom = plotTop + plotHeight - scrollablePixelsY;
 
-    let d: SVGPath;
+        let d: SVGPath = [['M', 0, 0]];
 
+        if (scrollablePixelsX) {
+            d = [
+                // Left side
+                ['M', 0, maskTop],
+                ['L', plotLeft - 1, maskTop],
+                ['L', plotLeft - 1, maskBottom],
+                ['L', 0, maskBottom],
+                ['Z'],
 
-    if (scrollablePixelsX) {
-        d = [
-            // Left side
-            ['M', 0, maskTop],
-            ['L', plotLeft - 1, maskTop],
-            ['L', plotLeft - 1, maskBottom],
-            ['L', 0, maskBottom],
-            ['Z'],
+                // Right side
+                ['M', maskPlotRight, maskTop],
+                ['L', chartWidth, maskTop],
+                ['L', chartWidth, maskBottom],
+                ['L', maskPlotRight, maskBottom],
+                ['Z']
+            ];
+        } else if (scrollablePixelsY) {
+            d = [
+                // Top side
+                ['M', maskLeft, 0],
+                ['L', maskLeft, plotTop - 1],
+                ['L', maskRight, plotTop - 1],
+                ['L', maskRight, 0],
+                ['Z'],
 
-            // Right side
-            ['M', maskPlotRight, maskTop],
-            ['L', chartWidth, maskTop],
-            ['L', chartWidth, maskBottom],
-            ['L', maskPlotRight, maskBottom],
-            ['Z']
-        ];
-    } else if (scrollablePixelsY) {
-        d = [
-            // Top side
-            ['M', maskLeft, 0],
-            ['L', maskLeft, plotTop - 1],
-            ['L', maskRight, plotTop - 1],
-            ['L', maskRight, 0],
-            ['Z'],
-
-            // Bottom side
-            ['M', maskLeft, maskPlotBottom],
-            ['L', maskLeft, chartHeight],
-            ['L', maskRight, chartHeight],
-            ['L', maskRight, maskPlotBottom],
-            ['Z']
-        ];
-    } else {
-        d = [['M', 0, 0]];
-    }
-
-    if (this.redrawTrigger !== 'adjustHeight') {
-        this.scrollableMask?.attr({ d });
-    }
-}
-
-/**
- * These elements are moved over to the fixed renderer and stay fixed when the
- * user scrolls the chart
- * @private
- */
-function chartMoveFixedElements(
-    this: Chart
-): void {
-    const container = this.container,
-        fixedRenderer = this.fixedRenderer,
-        fixedSelectors = [
-            '.highcharts-breadcrumbs-group',
-            '.highcharts-contextbutton',
-            '.highcharts-caption',
-            '.highcharts-credits',
-            '.highcharts-legend',
-            '.highcharts-legend-checkbox',
-            '.highcharts-navigator-series',
-            '.highcharts-navigator-xaxis',
-            '.highcharts-navigator-yaxis',
-            '.highcharts-navigator',
-            '.highcharts-reset-zoom',
-            '.highcharts-drillup-button',
-            '.highcharts-scrollbar',
-            '.highcharts-subtitle',
-            '.highcharts-title'
-        ];
-
-    let axisClass: (string|undefined);
-
-    if (this.scrollablePixelsX && !this.inverted) {
-        axisClass = '.highcharts-yaxis';
-    } else if (this.scrollablePixelsX && this.inverted) {
-        axisClass = '.highcharts-xaxis';
-    } else if (this.scrollablePixelsY && !this.inverted) {
-        axisClass = '.highcharts-xaxis';
-    } else if (this.scrollablePixelsY && this.inverted) {
-        axisClass = '.highcharts-yaxis';
-    }
-
-    if (axisClass) {
-        fixedSelectors.push(
-            `${axisClass}:not(.highcharts-radial-axis)`,
-            `${axisClass}-labels:not(.highcharts-radial-axis-labels)`
-        );
-    }
-
-    for (const className of fixedSelectors) {
-        [].forEach.call(
-            container.querySelectorAll(className),
-            (elem: DOMElementType): void => {
-                (
-                    elem.namespaceURI === (fixedRenderer as any).SVG_NS ?
-                        (fixedRenderer as any).box :
-                        (fixedRenderer as any).box.parentNode
-                ).appendChild(elem);
-                elem.style.pointerEvents = 'auto';
-            }
-        );
-    }
-}
-
-/** @private */
-function chartSetUpScrolling(
-    this: Chart
-): void {
-
-    const css: CSSObject = {
-        WebkitOverflowScrolling: 'touch',
-        overflowX: 'hidden',
-        overflowY: 'hidden'
-    };
-
-    if (this.scrollablePixelsX) {
-        css.overflowX = 'auto';
-    }
-    if (this.scrollablePixelsY) {
-        css.overflowY = 'auto';
-    }
-
-    // Insert a container with position relative
-    // that scrolling and fixed container renders to (#10555)
-    this.scrollingParent = createElement(
-        'div',
-        {
-            className: 'highcharts-scrolling-parent'
-        },
-        {
-            position: 'relative'
-        },
-        this.renderTo
-    );
-
-    // Add the necessary divs to provide scrolling
-    this.scrollingContainer = createElement('div', {
-        'className': 'highcharts-scrolling'
-    }, css, this.scrollingParent);
-
-    // On scroll, reset the chart position because it applies to the scrolled
-    // container
-    let lastHoverPoint: typeof this.hoverPoint;
-    addEvent(this.scrollingContainer, 'scroll', (): void => {
-        if (this.pointer) {
-            delete this.pointer.chartPosition;
-            if (this.hoverPoint) {
-                lastHoverPoint = this.hoverPoint;
-            }
-            this.pointer.runPointActions(void 0, lastHoverPoint, true);
+                // Bottom side
+                ['M', maskLeft, maskPlotBottom],
+                ['L', maskLeft, chartHeight],
+                ['L', maskRight, chartHeight],
+                ['L', maskRight, maskPlotBottom],
+                ['Z']
+            ];
         }
-    });
 
-    this.innerContainer = createElement('div', {
-        'className': 'highcharts-inner-container'
-    }, null as any, this.scrollingContainer);
-
-    // Now move the container inside
-    this.innerContainer.appendChild(this.container);
-
-    // Don't run again
-    this.setUpScrolling = null as any;
-}
-
-/** @private */
-function compose(
-    AxisClass: typeof Axis,
-    ChartClass: typeof Chart,
-    SeriesClass: typeof Series
-): void {
-
-    if (pushUnique(composed, compose)) {
-        addEvent(AxisClass, 'afterInit', onAxisAfterInit);
-
-        extend(ChartClass.prototype, {
-            applyFixed: chartApplyFixed,
-            moveFixedElements: chartMoveFixedElements,
-            setUpScrolling: chartSetUpScrolling
-        });
-        addEvent(ChartClass, 'afterSetChartSize', onChartAfterSetChartSize);
-        addEvent(ChartClass, 'render', onChartRender);
-
-        addEvent(SeriesClass, 'show', onSeriesShow);
+        if (chart.redrawTrigger !== 'adjustHeight') {
+            this.scrollableMask.attr({ d });
+        }
     }
 
-}
+    /**
+     * These elements are moved over to the fixed renderer and stay fixed when
+     * the user scrolls the chart
+     * @private
+     */
+    public moveFixedElements(): void {
+        const {
+                container,
+                inverted,
+                scrollablePixelsX,
+                scrollablePixelsY
+            } = this.chart,
+            fixedRenderer = this.fixedRenderer,
+            fixedSelectors = [
+                '.highcharts-breadcrumbs-group',
+                '.highcharts-contextbutton',
+                '.highcharts-caption',
+                '.highcharts-credits',
+                '.highcharts-legend',
+                '.highcharts-legend-checkbox',
+                '.highcharts-navigator-series',
+                '.highcharts-navigator-xaxis',
+                '.highcharts-navigator-yaxis',
+                '.highcharts-navigator',
+                '.highcharts-reset-zoom',
+                '.highcharts-drillup-button',
+                '.highcharts-scrollbar',
+                '.highcharts-subtitle',
+                '.highcharts-title'
+            ];
 
-/** @private */
-function onAxisAfterInit(
-    this: Axis
-): void {
-    this.chart.scrollableDirty = true;
-}
+        let axisClass: (string|undefined);
 
-/** @private */
-function onChartAfterSetChartSize(
-    this: Chart,
-    e: { skipAxes: boolean }
-): void {
-    const scrollablePlotArea = (this.options.chart as any).scrollablePlotArea,
-        scrollableMinWidth =
-            scrollablePlotArea && scrollablePlotArea.minWidth,
-        scrollableMinHeight =
-            scrollablePlotArea && scrollablePlotArea.minHeight;
+        if (scrollablePixelsX && !inverted) {
+            axisClass = '.highcharts-yaxis';
+        } else if (scrollablePixelsX && inverted) {
+            axisClass = '.highcharts-xaxis';
+        } else if (scrollablePixelsY && !inverted) {
+            axisClass = '.highcharts-xaxis';
+        } else if (scrollablePixelsY && inverted) {
+            axisClass = '.highcharts-yaxis';
+        }
 
-    let scrollablePixelsX: number,
-        scrollablePixelsY: number,
-        corrections: (
-            Record<string, Record<string, (number|string)>>|
-            undefined
-        );
-
-    if (!this.renderer.forExport) {
-
-        // The amount of pixels to scroll, the difference between chart
-        // width and scrollable width
-        if (scrollableMinWidth) {
-            this.scrollablePixelsX = scrollablePixelsX = Math.max(
-                0,
-                scrollableMinWidth - this.chartWidth
+        if (axisClass) {
+            fixedSelectors.push(
+                `${axisClass}:not(.highcharts-radial-axis)`,
+                `${axisClass}-labels:not(.highcharts-radial-axis-labels)`
             );
-            if (scrollablePixelsX) {
-                this.scrollablePlotBox = (
-                    this.renderer.scrollablePlotBox = merge(this.plotBox)
-                );
-                this.plotBox.width = this.plotWidth += scrollablePixelsX;
-                if (this.inverted) {
-                    this.clipBox.height += scrollablePixelsX;
-                } else {
-                    this.clipBox.width += scrollablePixelsX;
+        }
+
+        for (const className of fixedSelectors) {
+            [].forEach.call(
+                container.querySelectorAll(className),
+                (elem: DOMElementType): void => {
+                    (
+                        elem.namespaceURI === fixedRenderer.SVG_NS ?
+                            fixedRenderer.box :
+                            fixedRenderer.box.parentNode
+                    ).appendChild(elem);
+                    elem.style.pointerEvents = 'auto';
                 }
-
-                corrections = {
-                    // Corrections for right side
-                    1: { name: 'right', value: scrollablePixelsX }
-                };
-            }
-
-        // Currently we can only do either X or Y
-        } else if (scrollableMinHeight) {
-            this.scrollablePixelsY = scrollablePixelsY = Math.max(
-                0,
-                scrollableMinHeight - this.chartHeight
             );
-            if (defined(scrollablePixelsY)) {
-                this.scrollablePlotBox = (
-                    this.renderer.scrollablePlotBox = merge(this.plotBox)
-                );
-                this.plotBox.height = this.plotHeight += scrollablePixelsY;
-                if (this.inverted) {
-                    this.clipBox.width += scrollablePixelsY;
-                } else {
-                    this.clipBox.height += scrollablePixelsY;
-                }
-                corrections = {
-                    2: { name: 'bottom', value: scrollablePixelsY }
-                };
-            }
-        }
-
-        if (corrections && !e.skipAxes) {
-            for (const axis of this.axes) {
-                // For right and bottom axes, only fix the plot line length
-                if ((corrections as any)[axis.side]) {
-                    const originalGetPlotLinePath = axis.getPlotLinePath;
-                    // Get the plot lines right in getPlotLinePath,
-                    // temporarily set it to the adjusted plot width.
-                    // eslint-disable-next-line no-loop-func
-                    axis.getPlotLinePath = function (): SVGPath {
-                        const marginName = (corrections as any)[axis.side].name,
-                            correctionValue =
-                                (corrections as any)[axis.side].value,
-                            // axis.right or axis.bottom
-                            margin = (this as any)[marginName];
-
-                        // Temporarily adjust
-                        (this as any)[marginName] = margin - correctionValue;
-                        const path = originalGetPlotLinePath.apply(
-                            this,
-                            arguments as any
-                        ) as any;
-                        // Reset
-                        (this as any)[marginName] = margin;
-                        return path;
-                    };
-
-                } else {
-                    // Apply the corrected plotWidth
-                    axis.setAxisSize();
-                    axis.setAxisTranslation();
-                }
-            }
         }
     }
-}
-
-/** @private */
-function onChartRender(
-    this: Chart
-): void {
-    if (this.scrollablePixelsX || this.scrollablePixelsY) {
-        if (this.setUpScrolling) {
-            this.setUpScrolling();
-        }
-        this.applyFixed();
-
-    } else if (this.fixedDiv) { // Has been in scrollable mode
-        this.applyFixed();
-    }
-}
-
-/** @private */
-function onSeriesShow(
-    this: Series
-): void {
-    this.chart.scrollableDirty = true;
 }
 
 /* *
@@ -543,10 +530,6 @@ function onSeriesShow(
  *  Default Export
  *
  * */
-
-const ScrollablePlotArea = {
-    compose
-};
 
 export default ScrollablePlotArea;
 
@@ -629,4 +612,4 @@ export default ScrollablePlotArea;
  * @apioption   chart.scrollablePlotArea.opacity
  */
 
-(''); // keep doclets above in transpiled file
+(''); // Keep doclets above in transpiled file

--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -78,12 +78,6 @@ declare module '../Core/Chart/ChartLike'{
     }
 }
 
-declare module '../Core/Renderer/SVG/SVGRendererLike' {
-    interface SVGRendererLike {
-        scrollablePlotBox?: BBoxObject;
-    }
-}
-
 
 /* *
  *
@@ -160,9 +154,7 @@ class ScrollablePlotArea {
                 );
 
                 if (scrollablePixelsX) {
-                    chart.scrollablePlotBox = (
-                        renderer.scrollablePlotBox = merge(chart.plotBox)
-                    );
+                    chart.scrollablePlotBox = merge(chart.plotBox);
                     plotBox.width = chart.plotWidth += scrollablePixelsX;
                     clipBox[inverted ? 'height' : 'width'] += scrollablePixelsX;
 
@@ -175,10 +167,8 @@ class ScrollablePlotArea {
                     0,
                     minHeight - chart.chartHeight
                 );
-                if (defined(scrollablePixelsY)) {
-                    chart.scrollablePlotBox = (
-                        renderer.scrollablePlotBox = merge(chart.plotBox)
-                    );
+                if (scrollablePixelsY) {
+                    chart.scrollablePlotBox = merge(chart.plotBox);
                     plotBox.height = chart.plotHeight += scrollablePixelsY;
                     clipBox[inverted ? 'width' : 'height'] += scrollablePixelsY;
 

--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -167,7 +167,7 @@ class ScrollablePlotArea {
                     0,
                     minHeight - chart.chartHeight
                 );
-                if (scrollablePixelsY) {
+                if (defined(scrollablePixelsY)) {
                     chart.scrollablePlotBox = merge(chart.plotBox);
                     plotBox.height = chart.plotHeight += scrollablePixelsY;
                     clipBox[inverted ? 'width' : 'height'] += scrollablePixelsY;

--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -306,7 +306,7 @@ class ScrollablePlotArea {
     }
 
     public applyFixed(): void {
-        const { chart, fixedRenderer, scrollingContainer } = this,
+        const { chart, fixedRenderer, isDirty, scrollingContainer } = this,
             {
                 axisOffset,
                 chartWidth,
@@ -321,19 +321,19 @@ class ScrollablePlotArea {
             } = chart,
             chartOptions = chart.options.chart,
             scrollableOptions = chartOptions.scrollablePlotArea || {},
-            { scrollPositionX, scrollPositionY } = scrollableOptions;
+            { scrollPositionX = 0, scrollPositionY = 0 } = scrollableOptions,
+            scrollableWidth = chartWidth + scrollablePixelsX,
+            scrollableHeight = chartHeight + scrollablePixelsY;
 
         // Set the size of the fixed renderer to the visible width
         fixedRenderer.setSize(chartWidth, chartHeight);
 
-        if (this.isDirty ?? true) {
+        if (isDirty ?? true) {
             this.isDirty = false;
             this.moveFixedElements();
         }
 
         // Increase the size of the scrollable renderer and background
-        const scrollableWidth = chartWidth + scrollablePixelsX,
-            scrollableHeight = chartHeight + scrollablePixelsY;
         stop(chart.container);
         css(container, {
             width: `${scrollableWidth}px`,
@@ -354,18 +354,11 @@ class ScrollablePlotArea {
             height: `${chartHeight}px`
         });
 
-        // Set scroll position
-        const firstTime = true;
-        if (firstTime) {
-
-            if (scrollPositionX) {
-                scrollingContainer.scrollLeft =
-                    scrollablePixelsX * scrollPositionX;
-            }
-            if (scrollPositionY) {
-                scrollingContainer.scrollTop =
-                    scrollablePixelsY * scrollPositionY;
-            }
+        // Set scroll position the first time (this.isDirty was undefined at
+        // the top of this function)
+        if (!defined(isDirty)) {
+            scrollingContainer.scrollLeft = scrollablePixelsX * scrollPositionX;
+            scrollingContainer.scrollTop = scrollablePixelsY * scrollPositionY;
         }
 
         // Mask behind the left and right side


### PR DESCRIPTION
Refactored `scrollablePlotArea` to use a class rather than extending the Chart.

#### Rationale
* Avoid polluting the Chart object with module-specific properties and methods
* Clean up typing
* Some smarter ways of doing things

 #### To do
 - [x] Find a true indication of `firstTime`
 - [x] See if `scrollablePlotBox` can be moved to the ScrollablePlotArea class
 - [x] Why is `scrollablePlotBox` set on the SVGRenderer?
 - [x] In the `afterSetSize` static function, see if the block modifying scrollablePlotBox, plotBox and clipBox should be moved to `applyFixed`.
 - [x] In the `afterSetSize` static function, see if the `Axis.getPlotLinePath` override can be removed and `getPlotLinePath` simply use `chart.scrollablePixelsX` / `…Y`
 - [x] Rename the properties starting with `scrolling…`. The prefix is no longer needed now that we have context.
