### PR TITLE
bugfix/20424-cumulativeSum-now-exists-on-type-point

### DIFF
--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -117,6 +117,7 @@ class Point {
     public category!: (number|string);
     public color?: ColorType;
     public colorIndex?: number;
+    public cumulativeSum?: number;
     public dataLabels?: Array<SVGElement|SVGLabel>;
     public destroyed?: boolean;
     public formatPrefix: string = 'point';


### PR DESCRIPTION
Link to the issue - https://github.com/highcharts/highcharts/issues/20424.

The expected behavior is that type point has property 'cumulativeSum'. This has been added in by the pr.