### PR TITLE
bugfix/20318-navigator-series-datasorting-empty-data

### DIFF
--- a/samples/unit-tests/series/datasorting/demo.js
+++ b/samples/unit-tests/series/datasorting/demo.js
@@ -3,6 +3,9 @@ QUnit.test('Data sorting ', function (assert) {
             chart: {
                 animation: false
             },
+            navigator: {
+                enabled: true
+            },
             series: [
                 {
                     type: 'column',
@@ -24,7 +27,17 @@ QUnit.test('Data sorting ', function (assert) {
         'Series should be correctly sorted.'
     );
 
+    assert.strictEqual(
+        chart.series[1].xData[0],
+        2,
+        `Navigator series data should be correctly set and sorted on initial
+        load, #20318`
+    );
+
     chart.update({
+        navigator: {
+            enabled: false
+        },
         series: {
             data: [3, 2, 1]
         }

--- a/ts/Stock/Navigator/Navigator.ts
+++ b/ts/Stock/Navigator/Navigator.ts
@@ -43,6 +43,7 @@ import NavigatorAxisAdditions from '../../Core/Axis/NavigatorAxisComposition.js'
 import NavigatorComposition from './NavigatorComposition.js';
 import Scrollbar from '../Scrollbar/Scrollbar.js';
 import U from '../../Core/Utilities.js';
+import PointOptions, { PointShortOptions } from '../../Core/Series/PointOptions';
 const {
     addEvent,
     clamp,
@@ -1666,6 +1667,17 @@ class Navigator {
                     base.navigatorSeries = chart.initSeries(
                         mergedNavSeriesOptions
                     );
+                    // Set data on initial run with dataSorting enabled (#20318)
+                    if (
+                        base.navigatorSeries.enabledDataSorting &&
+                        !base.navigatorSeries.xData?.length &&
+                        !base.navigatorSeries.yData?.length &&
+                        mergedNavSeriesOptions.data
+                    ) {
+                        base.navigatorSeries.setData(
+                            mergedNavSeriesOptions.data
+                        );
+                    }
                     base.navigatorSeries.baseSeries = base; // Store ref
                     navigatorSeries.push(base.navigatorSeries);
                 }

--- a/ts/Stock/Navigator/Navigator.ts
+++ b/ts/Stock/Navigator/Navigator.ts
@@ -43,7 +43,6 @@ import NavigatorAxisAdditions from '../../Core/Axis/NavigatorAxisComposition.js'
 import NavigatorComposition from './NavigatorComposition.js';
 import Scrollbar from '../Scrollbar/Scrollbar.js';
 import U from '../../Core/Utilities.js';
-import PointOptions, { PointShortOptions } from '../../Core/Series/PointOptions';
 const {
     addEvent,
     clamp,

--- a/ts/Stock/Navigator/Navigator.ts
+++ b/ts/Stock/Navigator/Navigator.ts
@@ -1667,16 +1667,7 @@ class Navigator {
                         mergedNavSeriesOptions
                     );
                     // Set data on initial run with dataSorting enabled (#20318)
-                    if (
-                        base.navigatorSeries.enabledDataSorting &&
-                        !base.navigatorSeries.xData?.length &&
-                        !base.navigatorSeries.yData?.length &&
-                        mergedNavSeriesOptions.data
-                    ) {
-                        base.navigatorSeries.setData(
-                            mergedNavSeriesOptions.data
-                        );
-                    }
+                    chart.setSortedData();
                     base.navigatorSeries.baseSeries = base; // Store ref
                     navigatorSeries.push(base.navigatorSeries);
                 }


### PR DESCRIPTION
Fixed #20318, `Navigator` series data wasn't set with `dataSorting` enabled on initial run.