### PR TITLE
Fixed issue with leaked DOM element in export-data tests

### DIFF
--- a/ts/Extensions/ExportData/ExportData.ts
+++ b/ts/Extensions/ExportData/ExportData.ts
@@ -1125,6 +1125,7 @@ function compose(
         // Add an event listener to handle the showTable option
         addEvent(ChartClass, 'afterViewData', onChartAfterViewData);
         addEvent(ChartClass, 'render', onChartRenderer);
+        addEvent(ChartClass, 'destroy', onChartDestroy);
 
         chartProto.downloadCSV = chartDownloadCSV;
         chartProto.downloadXLS = chartDownloadXLS;
@@ -1338,6 +1339,16 @@ function onChartRenderer(
     ) {
         this.viewData();
     }
+}
+
+/**
+ * Clean up
+ * @private
+ */
+function onChartDestroy(
+    this: Chart
+): void {
+    this.dataTableDiv?.remove();
 }
 
 /* *


### PR DESCRIPTION
When `exporting.showTable` was set, `chart.destroy` didn't remove the data table. In real life this is usually no problem, but it broke tests downstream because the table was floating around in the web page.