### PR TITLE
Fixed a test that modified defaultOptions.xAxis

### DIFF
--- a/samples/unit-tests/highcharts/setoptions/demo.js
+++ b/samples/unit-tests/highcharts/setoptions/demo.js
@@ -1,6 +1,10 @@
 QUnit.test('Stock chart specific options in setOptions', function (assert) {
-    const yAxis = Highcharts.merge(Highcharts.defaultOptions.yAxis);
+
+    const xAxis = Highcharts.defaultOptions.xAxis;
     let chart;
+
+    Highcharts.defaultOptions.xAxis = Highcharts.merge(xAxis);
+
 
     chart = $('#container')
         .highcharts('StockChart', {
@@ -106,7 +110,8 @@ QUnit.test('Stock chart specific options in setOptions', function (assert) {
     // Reset to defaults
     delete Highcharts.defaultOptions.scrollbar.enabled;
     delete Highcharts.defaultOptions.navigator.enabled;
-    delete Highcharts.defaultOptions.rangeSelector.enabled;
+    Highcharts.defaultOptions.rangeSelector.enabled = undefined;
     delete Highcharts.defaultOptions.tooltip.split;
-    Highcharts.defaultOptions.yAxis = yAxis;
+    Highcharts.defaultOptions.xAxis = xAxis;
+
 });


### PR DESCRIPTION
This test modified `defaultOptions.xAxis`, causing 5 failed tests downstream when running `gulp test --browsercount 1`. I now get 0 failures on my setup.