### PR TITLE
Fixed #18857, map series bad animation on update

### DIFF
--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -4231,7 +4231,8 @@ class Series {
                 'minY',
                 'maxY',
                 'minX',
-                'maxX'
+                'maxX',
+                'transformGroups' // #18857
             );
             if (options.visible !== false) {
                 preserve.push('area', 'graph');


### PR DESCRIPTION
Fixed #18857, map animated from top left on any `series.update`