### PR TITLE
bugfix/20441-dataclasses-map-interaction

### DIFF
--- a/ts/Core/Axis/Color/ColorAxis.ts
+++ b/ts/Core/Axis/Color/ColorAxis.ts
@@ -813,6 +813,7 @@ class ColorAxis extends Axis implements AxisLike {
                             const affectedSeries: SeriesClass[] = [];
                             for (const point of getPointsInDataClass(i)) {
                                 point.setVisible(vis);
+                                point.hiddenInDataClass = !vis; // #20441
                                 if (
                                     affectedSeries.indexOf(point.series) === -1
                                 ) {

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -122,6 +122,7 @@ class Point {
     public formatPrefix: string = 'point';
     public graphic?: SVGElement;
     public graphics?: Array<SVGElement|undefined>;
+    public hiddenInDataClass?: boolean = false;
     public id!: string;
     public isNew?: boolean;
     public isNull?: boolean;

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -319,6 +319,16 @@ class MapSeries extends ScatterSeries {
                         );
                     }
 
+                    // If the map point is not visible and is not null (e.g.
+                    // hidden by data classes), then the point should be
+                    // visible, but without value
+                    graphic.attr({
+                        visibility: (
+                            point.visible ||
+                            (!point.visible && !point.isNull)
+                        ) ? 'inherit' : 'hidden'
+                    });
+
                     graphic.animate = function (params,
                         options, complete): SVGElement {
 
@@ -977,10 +987,12 @@ class MapSeries extends ScatterSeries {
                     };
                 }
 
-                if (point.projectedPath && !point.projectedPath.length) {
-                    point.setVisible(false);
-                } else if (!point.visible) {
-                    point.setVisible(true);
+                if (!point.hiddenInDataClass) { // #20441
+                    if (point.projectedPath && !point.projectedPath.length) {
+                        point.setVisible(false);
+                    } else if (!point.visible) {
+                        point.setVisible(true);
+                    }
                 }
             });
         }


### PR DESCRIPTION
Fixed #20441, point visibility was reverted after interaction with a map.