### PR TITLE
Tools: Silent console.log during karma tests

### DIFF
--- a/.github/workflows/highcharts-headless.yml
+++ b/.github/workflows/highcharts-headless.yml
@@ -106,6 +106,8 @@ jobs:
         run: |
           export DISPLAY=:99
           npx gulp test --single-run --splitbrowsers ChromeHeadless
+      - name: Output logged errors
+        run: cat ./test/console.log
       - name: Check Firefox
         run: |
           firefox --version
@@ -114,7 +116,8 @@ jobs:
         run: |
           export DISPLAY=:99
           npx gulp test --single-run --splitbrowsers Firefox --force
-
+      - name: Output logged errors
+        run: cat ./test/console.log
       - name: Run timezone tests
         if: ${{ inputs.testTimezones }}
         run: |

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -349,6 +349,10 @@ module.exports = function (config) {
         port: 9876,  // karma web server port
         colors: true,
         logLevel: config.LOG_INFO,
+        browserConsoleLogOptions: {
+            path: `${process.cwd()}/test/console.log`,
+            terminal: false
+        },
         browsers: browsers,
         autoWatch: false,
         singleRun: true, // Karma captures browsers, runs the tests and exits

--- a/tools/gulptasks/test.js
+++ b/tools/gulptasks/test.js
@@ -238,6 +238,7 @@ function checkDocsConsistency() {
  *         Promise to keep
  */
 async function test() {
+    const fs = require('fs');
     const argv = require('yargs').argv;
     const log = require('./lib/log');
 
@@ -365,6 +366,35 @@ specified by config.imageCapture.resultsOutputPath.
                 resolve();
             }
         ).start());
+
+        // Capture console.error, console.warn and console.log
+        const consoleLogPath = `${BASE}/test/console.log`;
+        const consoleLog = await fs.promises.readFile(
+            consoleLogPath,
+            'utf-8'
+        ).catch(() => {});
+        if (consoleLog) {
+            const errors = (consoleLog.match(/ ERROR:/g) || []).length,
+                warnings = (consoleLog.match(/ WARN:/g) || []).length,
+                logs = (consoleLog.match(/ LOG:/g) || []).length;
+
+            const message = [];
+            if (errors) {
+                message.push(`${errors} errors`.red);
+            }
+            if (warnings) {
+                message.push(`${warnings} warnings`.yellow);
+            }
+            if (logs) {
+                message.push(`${logs} logs`);
+            }
+
+            log.message(
+                `The browser console logged ${message.join(', ')}.\n` +
+                'They can be reviewed in ' + consoleLogPath.cyan + '.'
+            );
+        }
+
     }
 }
 


### PR DESCRIPTION
Removed inline `console.warn` and `log` statements in the terminal when running `gulp test`. It clogged up the output and made identification of legitimate failures cumbersome. Instead write them to a file and provide a summary at the end.

![Skjermbilde 2024-02-01 kl  09 37 00](https://github.com/highcharts/highcharts/assets/227836/26ba717e-241e-4d92-bfd4-e2b072b999ec)
