### PR TITLE
dash/20511-error-missing

### DIFF
--- a/ts/Dashboards/Utilities.ts
+++ b/ts/Dashboards/Utilities.ts
@@ -170,7 +170,12 @@ function uniqueKey(): string {
  *
  * @return {void}
  */
-function error(code: string, stop?: boolean): void {
+function error(code: number|string, stop?: boolean): void {
+    // TODO- replace with proper error handling
+    if (code === 16) {
+        console.warn('Dashboard error: Dashboards library loaded more than once. This may cause undefined behavior.');
+        return;
+    }
     coreError(code, stop);
 }
 

--- a/ts/Dashboards/Utilities.ts
+++ b/ts/Dashboards/Utilities.ts
@@ -24,6 +24,7 @@
 
 import U from '../Core/Utilities.js';
 const {
+    error: coreError,
     isClass,
     isDOMElement,
     isObject,
@@ -149,6 +150,30 @@ function uniqueKey(): string {
     return `dashboard-${coreUniqueKey().replace('highcharts-', '')}`;
 }
 
+/**
+ * Provide error messages for debugging, with links to online explanation. This
+ * function can be overridden to provide custom error handling.
+ *
+ * @sample highcharts/chart/highcharts-error/
+ *         Custom error handler
+ *
+ * @function Dashboards.error
+ *
+ * @param {number|string} code
+ *        The error code. See
+ *        [errors.xml](https://github.com/highcharts/highcharts/blob/master/errors/errors.xml)
+ *        for available codes. If it is a string, the error message is printed
+ *        directly in the console.
+ *
+ * @param {boolean} [stop=false]
+ *        Whether to throw an error or just log a warning in the console.
+ *
+ * @return {void}
+ */
+function error(code: string, stop?: boolean): void {
+    coreError(code, stop);
+}
+
 /* *
  *
  *  Default Export
@@ -156,6 +181,7 @@ function uniqueKey(): string {
  * */
 
 const Utilities = {
+    error,
     merge,
     uniqueKey
 };

--- a/ts/masters-dashboards/dashboards.src.ts
+++ b/ts/masters-dashboards/dashboards.src.ts
@@ -58,6 +58,7 @@ declare global {
     interface Dashboards {
         board: typeof Board.board;
         boards: typeof Globals.boards;
+        error: typeof Utilities.error;
         merge: typeof Utilities.merge;
         uniqueKey: typeof Utilities.uniqueKey;
         win: typeof Globals.win;
@@ -93,6 +94,7 @@ declare global {
 const G = Globals as unknown as Dashboards;
 
 G.board = Board.board;
+G.error = Utilities.error;
 G.merge = Utilities.merge;
 G.uniqueKey = Utilities.uniqueKey;
 G.Board = Board;


### PR DESCRIPTION
Fixed execution error when loading the same module twice, closes #20511.

___
Now when the `error` is available we no longer have an execution error but the message here isn't clear enough.

![image](https://github.com/highcharts/highcharts/assets/57004120/0424e971-3b82-4966-9102-88476b61ecb2)

Should we create our own set of error messages similar to:
https://github.com/highcharts/highcharts/blob/master/ts/Extensions/Debugger/ErrorMessages.ts
by editing the `error-messages.js` 

Or should we have a different approach to handling errors?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206474436071712