### PR TITLE
Fixed #20346, stack labels align combined with rotation

### DIFF
--- a/ts/Core/Axis/Stacking/StackItem.ts
+++ b/ts/Core/Axis/Stacking/StackItem.ts
@@ -318,7 +318,11 @@ class StackItem {
                 x: label.alignAttr.x,
                 y: label.alignAttr.y,
                 rotation: options.rotation,
-                rotationOriginX: labelBox.width / 2,
+                rotationOriginX: labelBox.width * {
+                    left: 0,
+                    center: 0.5,
+                    right: 1
+                }[options.textAlign || 'center'],
                 rotationOriginY: labelBox.height / 2
             });
 


### PR DESCRIPTION
Fixed #20346, placement issues with stack labels when `textAlign` was combined with rotation.