### PR TITLE
Fixed #20429 toggling bellcurve visibility throws error

### DIFF
--- a/samples/unit-tests/series-bellcurve/bellcurve/demo.js
+++ b/samples/unit-tests/series-bellcurve/bellcurve/demo.js
@@ -70,6 +70,15 @@ QUnit.test('Curve bell', function (assert) {
         'After updating bellcurve\'s pointsInInterval number of points is correct'
     );
 
+    bellcurve.update({ visible: false });
+    bellcurve.update({ visible: true });
+
+    assert.equal(
+        bellcurve.visible,
+        true,
+        'Curve bell should be visible after toggling visibility off and on'
+    );
+
     baseSeries.remove();
     assert.ok(
         chart.series.indexOf(bellcurve) !== -1,

--- a/ts/Series/Bellcurve/BellcurveSeries.ts
+++ b/ts/Series/Bellcurve/BellcurveSeries.ts
@@ -164,16 +164,13 @@ class BellcurveSeries extends AreaSplineSeries {
         if (series.baseSeries?.yData?.length || 0 > 1) {
             series.setMean();
             series.setStandardDeviation();
-
-            if (series.points?.length && series.points[0]?.destroyed) {
-                series.points = series.data;
-            }
-
             series.setData(
                 series.derivedData(
                     series.mean || 0,
                     series.standardDeviation || 0
                 ),
+                false,
+                void 0,
                 false
             );
         }

--- a/ts/Series/Bellcurve/BellcurveSeries.ts
+++ b/ts/Series/Bellcurve/BellcurveSeries.ts
@@ -164,6 +164,11 @@ class BellcurveSeries extends AreaSplineSeries {
         if (series.baseSeries?.yData?.length || 0 > 1) {
             series.setMean();
             series.setStandardDeviation();
+
+            if (series.points.length && series.points[0]?.destroyed) {
+                series.points = series.data;
+            }
+
             series.setData(
                 series.derivedData(
                     series.mean || 0,

--- a/ts/Series/Bellcurve/BellcurveSeries.ts
+++ b/ts/Series/Bellcurve/BellcurveSeries.ts
@@ -165,7 +165,7 @@ class BellcurveSeries extends AreaSplineSeries {
             series.setMean();
             series.setStandardDeviation();
 
-            if (series.points.length && series.points[0]?.destroyed) {
+            if (series.points?.length && series.points[0]?.destroyed) {
                 series.points = series.data;
             }
 


### PR DESCRIPTION
Fixed #20429, toggling bellcurve visibility threw error

~~Fixed #20429, series.points were all destroyed when setData attempted to use them.~~

I am not entirely sure how to word this PR

When setData is called on a series without visibility, points will be destroyed. For the Bellcurve series, setData seems to be called every time the series is updated. So when turning visibility off, then on, an error will throw because setData attempts to use the very properties it destroyed the last time it ran.

Perhaps there are other ways of fixing this, such as shifting when setData is called for the BellcurveSeries 🤔 .

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206335993588357