### PR TITLE
bugfix/20476-map-navigation-data-labels-overlap

### DIFF
--- a/samples/unit-tests/maps/map-navigation/demo.js
+++ b/samples/unit-tests/maps/map-navigation/demo.js
@@ -147,6 +147,10 @@ QUnit.test('Map navigation button alignment', assert => {
             }
         },
 
+        tooltip: {
+            animation: false
+        },
+
         series: [
             {
                 data: [
@@ -196,6 +200,14 @@ QUnit.test('Map navigation button alignment', assert => {
         chart.plotTop + chart.plotHeight,
         1.5,
         'The buttons should be bottom-aligned to the plot box after redraw (#12776)'
+    );
+
+    chart.tooltip.refresh(chart.series[0].data[0]);
+
+    assert.ok(
+        chart.mapNavigation.navButtonsGroup.zIndex <
+        chart.tooltip.label.element.getAttribute('data-z-index'),
+        'Map navigation group zIndex should be lower than tooltip zIndex (#20476)'
     );
 });
 

--- a/ts/Maps/MapNavigation.ts
+++ b/ts/Maps/MapNavigation.ts
@@ -205,7 +205,7 @@ class MapNavigation {
             if (!mapNav.navButtonsGroup) {
                 mapNav.navButtonsGroup = chart.renderer.g()
                     .attr({
-                        zIndex: 4 // #4955, // #8392
+                        zIndex: 7 // #4955, // #8392 // #20476
                     })
                     .add();
             }

--- a/ts/Maps/MapNavigation.ts
+++ b/ts/Maps/MapNavigation.ts
@@ -205,7 +205,7 @@ class MapNavigation {
             if (!mapNav.navButtonsGroup) {
                 mapNav.navButtonsGroup = chart.renderer.g()
                     .attr({
-                        zIndex: 7 // #4955, // #8392 // #20476
+                        zIndex: 7 // #4955, #8392, #20476
                     })
                     .add();
             }


### PR DESCRIPTION
Fixed #20476, `dataLabels` were overlapping map navigation buttons.