### PR TITLE
Added download of rgbcolor to update-vendor

### DIFF
--- a/test/karma-files.json
+++ b/test/karma-files.json
@@ -4,6 +4,7 @@
 	"vendor/moment-timezone-with-data-2012-2022.js",
 	"vendor/proj4.js",
 	"vendor/topojson-client.min.js",
+	"vendor/rgbcolor.js",
 	"node_modules/lolex/lolex.js",
 
 	"code/highcharts.src.js",

--- a/tools/gulptasks/unsorted/update-vendor.js
+++ b/tools/gulptasks/unsorted/update-vendor.js
@@ -13,6 +13,16 @@ function updateVendor() {
     } = require('../../filesystem.js');
 
     const { mkdirSync } = require('fs');
+    const { writeFile } = require('fs/promises');
+
+    let fetch;
+
+    if ('fetch' in global) {
+        fetch = global.fetch;
+    } else {
+        console.log('Using node-fetch');
+        fetch = require('node-fetch');
+    }
 
     // Create the vendor folder if it doesn't exist
     mkdirSync('./vendor', { recursive: true });
@@ -64,6 +74,40 @@ function updateVendor() {
             './vendor/topojson-client.min.js'
         ]
     ].map(([source, target]) => copyFile(source, target));
+
+
+    // Download files from CDN with optional checksum check
+    const dowloadFiles = [
+        {
+            url: 'https://code.highcharts.com/lib/rgbcolor.js',
+            outFile: './vendor/rgbcolor.js',
+            checksum: '44e5e565ddfb294672a214bfdb021ddb31e324d734979571cc2c4285ff34e724'
+        }
+    ];
+
+    function validateChecksum(text, expected) {
+        const crypto = require('node:crypto');
+        const checksum = crypto.createHash('sha256')
+            .update(text).digest('hex');
+
+        if (checksum !== expected) {
+            console.log({ checksum, expected });
+            throw new Error('Checksum mismatch');
+        }
+    }
+
+    dowloadFiles.forEach(({ url, outFile, checksum }) => {
+        promises.push(
+            fetch(url)
+                .then(response => response.text())
+                .then(text => {
+                    if (checksum) {
+                        validateChecksum(text, checksum);
+                    }
+                    return writeFile(outFile, text);
+                })
+        );
+    });
 
     return Promise.all(promises);
 


### PR DESCRIPTION
Should fix failing visual test (likely after it being merged to master).

Could not find a NPM package with a prebuilt script, so went with the `fetch` route. Alternatively we could do a quick compile with `esbuild`