### PR TITLE
Fixed broken cypress test: time-cycles.

### DIFF
--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -132,6 +132,7 @@ Cypress.Commands.add('selectAnnotation', (annotationClassName, parentClassName) 
 
     if (parentClassName) {
         cy.get(`.${parentClassName}`).children().eq(1).click();
+        cy.wait(100); // wait a bit for the DOM to settle 
     }
     cy.get(`.${annotationClassName}`).click();
 })


### PR DESCRIPTION
Fixed broken cypress test: time-cycles.

It seems to me, that usage of `searchPoint` method in this improvement PR: https://github.com/highcharts/highcharts/pull/20577 caused some small DOM changes, which were caught by cypress mouse clicks unintentionally during the test.