### PR TITLE
dash/v2-render-to-deprecated-fix

### DIFF
--- a/ts/Dashboards/Components/Component.ts
+++ b/ts/Dashboards/Components/Component.ts
@@ -1210,6 +1210,7 @@ namespace Component {
 
         /**
          * Cell id, where component is attached.
+         * Deprecated, use `renderTo` instead.
          *
          * @deprecated
          */
@@ -1217,8 +1218,6 @@ namespace Component {
 
         /**
          * Cell id, where component is attached.
-         *
-         * @deprecated
          */
         renderTo?: string;
 


### PR DESCRIPTION
The new option - `renderTo` was mistakenly marked as deprecated.