### PR TITLE
Fixed #20586 no spacing between css classes

### DIFF
--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
@@ -296,6 +296,12 @@ QUnit.test('General tests', function (assert) {
         'Class name should be applied to plot lines (#8415)'
     );
 
+    assert.strictEqual(
+        chart.yAxis[0].plotLinesAndBands[0].svgElem.element.className,
+        'highcharts-plot-line-label my-custom-class',
+        'Class names should be spaced (#20586)'
+    );
+
     var line = chart.xAxis[0].plotLinesAndBands[0].svgElem.d.split(' ');
 
     assert.strictEqual(

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -325,7 +325,7 @@ class PlotLineOrBand {
                     align: optionsLabel.textAlign || optionsLabel.align,
                     rotation: optionsLabel.rotation,
                     'class': 'highcharts-plot-' + (isBand ? 'band' : 'line') +
-                        '-label' + (optionsLabel.className || ''),
+                        '-label ' + (optionsLabel.className || ''),
                     zIndex
                 });
 


### PR DESCRIPTION
Fixed #20586, plot line CSS classes were not concatenated with spaces, causing the `className` option to fail.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206530639590908