### PR TITLE
Fixed #20270, performance degradation with time formatter in v11.3.0

### DIFF
--- a/ts/Core/Time.ts
+++ b/ts/Core/Time.ts
@@ -124,6 +124,8 @@ const hasOldSafariBug =
  */
 class Time {
 
+    public static formatCache: Record<string, Intl.DateTimeFormat> = {};
+
     /* *
      *
      *  Constructors
@@ -410,13 +412,21 @@ class Time {
             return (timestamp: number | Date): number => {
 
                 try {
+                    // Cache the DateTimeFormat instances for performance
+                    // (#20720)
+                    const cacheKey = `shortOffset,${options.timezone || ''}`,
+                        dateTimeFormat = Time.formatCache[cacheKey] = (
+                            Time.formatCache[cacheKey] ||
+                            // eslint-disable-next-line new-cap
+                            Intl.DateTimeFormat('en', {
+                                timeZone: options.timezone,
+                                timeZoneName: 'shortOffset'
+                            })
+                        );
+
                     // eslint-disable-next-line @typescript-eslint/no-unused-vars
                     const [date, gmt, hours, colon, minutes = 0] =
-                        // eslint-disable-next-line new-cap
-                        Intl.DateTimeFormat('en', {
-                            timeZone: options.timezone,
-                            timeZoneName: 'shortOffset'
-                        })
+                        dateTimeFormat
                             .format(timestamp)
                             .split(/(GMT|:)/)
                             .map(Number),


### PR DESCRIPTION
Fixed #20720, performance degradation with time formatter in v11.3.0
___
_Internal note_
Performance is restored.

Another problem however is that we actually generate 5000 data labels for [this case](https://jsfiddle.net/7w6cgz5n), for in the next run loop over them all and hide overlapping. A possible performance gain would be that the `drawDataLabels` function itself checked the position of the previous data label, and didn't generate a new one in case of an obvious collision. That would save us a lot of DOM traffic and guaranteed huge performance improvement for this case. The questions are if we have the required position information at that point, and if this case is common enough to make it worthwile.