### PR TITLE
bugfix/20572-hcmore-chart-destroy

### DIFF
--- a/samples/unit-tests/chart/destroy/demo.html
+++ b/samples/unit-tests/chart/destroy/demo.html
@@ -1,5 +1,6 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/highcharts-more.js"></script>
 <script src="https://code.highcharts.com/modules/no-data-to-display.js"></script>
 <script src="https://code.highcharts.com/modules/static-scale.js"></script>
 <script src="https://code.highcharts.com/modules/pictorial.js"></script>

--- a/samples/unit-tests/chart/destroy/demo.js
+++ b/samples/unit-tests/chart/destroy/demo.js
@@ -1,42 +1,3 @@
-/*
-QUnit.test('Chart destroy', function (assert) {
-
-    var chart = Highcharts
-        .chart('container', {
-            chart: {
-                height: 300
-            },
-            xAxis: {
-                categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-            },
-            series: [{
-                data: [29.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4]
-            }]
-        });
-
-    assert.strictEqual(
-        typeof chart.series,
-        'object',
-        'Properties available'
-    );
-
-    chart.destroy();
-
-    assert.strictEqual(
-        chart.series,
-        undefined,
-        'Properties deleted'
-    );
-
-    assert.strictEqual(
-        document.getElementById('container').innerHTML,
-        '',
-        'Container emptied'
-    );
-
-});
-*/
-
 QUnit.test('Destroy in own callback', function (assert) {
     var done = assert.async();
 
@@ -107,7 +68,7 @@ QUnit.test('Destroy in own callback', function (assert) {
 
 // Highcharts 4.0.4, Issue #3600: No-data-to-display module broken with chart creation in callback
 QUnit.test('Destroy in own callback and recreate (#3600)', function (assert) {
-    var newChart;
+    let newChart;
 
     Highcharts.chart(
         'container',
@@ -152,5 +113,25 @@ QUnit.test('Destroy in own callback and recreate (#3600)', function (assert) {
         newChart.options.title.text,
         'New chart title',
         'New chart generated'
+    );
+
+    newChart = Highcharts.chart('container', {
+        tooltip: {
+            shared: true
+        },
+        series: [{
+            data: [3, 5, 7]
+        }, {
+            data: [7, 5, 2]
+        }]
+    });
+
+    newChart.series[0].points[1].onMouseOver();
+    newChart.destroy();
+
+    assert.ok(
+        true,
+        `Destroy chart with highchare-more during mouse over the point,
+        console should be clear #20572.`
     );
 });

--- a/ts/Series/PolarComposition.ts
+++ b/ts/Series/PolarComposition.ts
@@ -1428,7 +1428,6 @@ function wrapPointPos(
 
         if (
             chart.polar &&
-            !this.destroyed &&
             isNumber(plotX) &&
             isNumber(plotY)
         ) {

--- a/ts/Series/PolarComposition.ts
+++ b/ts/Series/PolarComposition.ts
@@ -1422,17 +1422,24 @@ function wrapPointPos(
     chartCoordinates?: boolean,
     plotY: number|undefined = this.plotY
 ): [number, number]|undefined {
-    const { plotX, series } = this,
-        { chart } = series;
+    if (!this.destroyed) {
+        const { plotX, series } = this,
+            { chart } = series;
 
-    if (chart.polar && !this.destroyed && isNumber(plotX) && isNumber(plotY)) {
-        return [
-            plotX + (chartCoordinates ? chart.plotLeft : 0),
-            plotY + (chartCoordinates ? chart.plotTop : 0)
-        ];
+        if (
+            chart.polar &&
+            !this.destroyed &&
+            isNumber(plotX) &&
+            isNumber(plotY)
+        ) {
+            return [
+                plotX + (chartCoordinates ? chart.plotLeft : 0),
+                plotY + (chartCoordinates ? chart.plotTop : 0)
+            ];
+        }
+
+        return proceed.call(this, chartCoordinates, plotY);
     }
-
-    return proceed.call(this, chartCoordinates, plotY);
 }
 
 /* *


### PR DESCRIPTION
Fixed #20572, destroying a chart after point hover produced an error.