### PR TITLE
Merge regression, standalone navigator not registered to Highcharts

### DIFF
--- a/ts/masters/modules/navigator.src.ts
+++ b/ts/masters/modules/navigator.src.ts
@@ -17,3 +17,5 @@ import NavigatorComposition from '../../Stock/Navigator/NavigatorComposition.js'
 const G: AnyRecord = Highcharts;
 G.StandaloneNavigator = G.StandaloneNavigator || StandaloneNavigator;
 NavigatorComposition.compose(G.Chart, G.Axis, G.Series);
+
+G.navigator = StandaloneNavigator.navigator;


### PR DESCRIPTION
It disappeared when the webpack branch was merged; assuming it was a failure.