### PR TITLE
Fixed #20752, a regression with data label animation in tree graphs

### DIFF
--- a/samples/unit-tests/series-treegraph/treegraph/demo.js
+++ b/samples/unit-tests/series-treegraph/treegraph/demo.js
@@ -39,10 +39,10 @@ QUnit.test('Treegraph series',
             'The point A should not be X positioned on 0 (#19038)'
         );
 
-        assert.ok(
-            !series.data[1].dataLabel ||
-                series.data[1].dataLabel.visibility === 'hidden',
-            'Hidden points should have hidden data labels (#18891)'
+        assert.stricEqual(
+            series.data[1].dataLabel.visibility,
+            'hidden',
+            'Hidden points should have hidden data labels (#18891, #20752)'
         );
 
         series.data[0].update({

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -62,6 +62,7 @@ declare module './PointLike' {
         bottom?: number;
         contrastColor?: ColorString;
         dataLabel?: SVGElement|SVGLabel;
+        dataLabelOnHidden?: boolean;
         dataLabelOnNull?: boolean;
         dataLabelPath?: SVGElement;
         dataLabels?: Array<SVGElement>;
@@ -580,7 +581,7 @@ namespace DataLabel {
                     // Options for one datalabel
                     const labelEnabled = (
                             labelOptions.enabled &&
-                            point.visible &&
+                            (point.visible || point.dataLabelOnHidden) &&
                             // #2282, #4641, #7112, #10049
                             (!point.isNull || point.dataLabelOnNull) &&
                             applyFilter(point, labelOptions)

--- a/ts/Series/Treegraph/TreegraphPoint.ts
+++ b/ts/Series/Treegraph/TreegraphPoint.ts
@@ -61,15 +61,16 @@ class TreegraphPoint extends TreemapPoint {
      *
      * */
 
-    public options!: TreegraphPointOptions;
-    public isLink = false;
     public collapseButton?: SVGElement;
-    public series!: TreegraphSeries;
+    public collapseButtonOptions?: CollapseButtonOptions;
     public collapsed?: boolean;
-    public node!: TreegraphNode;
+    public dataLabelOnHidden = true;
+    public isLink = false;
     public level?: number;
     public linkToParent?: TreegraphLink;
-    public collapseButtonOptions?: CollapseButtonOptions;
+    public node!: TreegraphNode;
+    public options!: TreegraphPointOptions;
+    public series!: TreegraphSeries;
 
     /* *
      *


### PR DESCRIPTION
Fixed #20752, a regression since v11.2 causing data labels not to animate on collapsing and expanding of nodes in a tree graph