### PR TITLE
Fixed #20758, a regression in auto rotation of axis labels

### DIFF
--- a/samples/highcharts/demo/heatmap/demo.css
+++ b/samples/highcharts/demo/heatmap/demo.css
@@ -5,6 +5,10 @@
     margin: 1em auto;
 }
 
+.highcharts-description {
+    margin: 10px;
+}
+
 .highcharts-data-table table {
     font-family: Verdana, sans-serif;
     border-collapse: collapse;

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -250,7 +250,7 @@ class Axis {
     public linkedParent?: Axis;
     public max?: number;
     public maxLabelDimensions?: SizeObject;
-    public maxLabelLength!: number;
+    public maxLabelLength?: number;
     public min?: number;
     public minorTickInterval!: number;
     public minorTicks!: Record<string, Tick>;

--- a/ts/Core/Axis/Color/ColorAxis.ts
+++ b/ts/Core/Axis/Color/ColorAxis.ts
@@ -440,7 +440,7 @@ class ColorAxis extends Axis implements AxisLike {
                 horiz ?
                     itemDistance :
                     pick(labelOptions.x, labelOptions.distance) +
-                        this.maxLabelLength
+                        (this.maxLabelLength || 0)
             )
         );
         legendItem.labelHeight = height + padding + (horiz ? labelPadding : 0);


### PR DESCRIPTION
Fixed #20758, a regression in v10.0.0 cause auto rotation of axis labels not to work correctly in certain heatmap setups.