### PR TITLE
docs/node16-apple-setup

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ gulp
 
 ### Node setup for Apple Mx CPU
 
-Since [Node 16 TLS](https://nodejs.org/en/) is a ARM64 version available for Macs with Apple Ax CPU. Some node packages like [node-canvas](https://github.com/Automattic/node-canvas#compiling) with integrated compiling might fail. Install additional tools to resolve the problem:
+When running Node natively on ARM64 MacOS, some Node packages like [node-canvas](https://github.com/Automattic/node-canvas#compiling) with integrated compiling might fail. Install additional tools to resolve the problem:
 
 - [Homebrew](https://brew.sh/) and run `brew install pkg-config cairo pango libpng jpeg giflib librsvg pixman`
 

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,12 @@ npm install
 gulp
 ```
 
+### Node setup for Apple Mx CPU
+
+Since [Node 16 TLS](https://nodejs.org/en/) is a ARM64 version available for Macs with Apple Ax CPU. Some node packages like [node-canvas](https://github.com/Automattic/node-canvas#compiling) with integrated compiling might fail. Install additional tools to resolve the problem:
+
+- [Homebrew](https://brew.sh/) and run `brew install pkg-config cairo pango libpng jpeg giflib librsvg pixman`
+
 ## Generate API docs
 Run in this `highcharts` repository the doc generator with
 `npx gulp jsdoc-watch`, which also starts a new server with the generated API


### PR DESCRIPTION
Added docs for Node setup for Apple.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206408652981583