### PR TITLE
#20771: Handled a missing null/undefined check

### DIFF
--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -560,7 +560,7 @@ class Series {
             // repeat for xAxis and yAxis
             (series.axisTypes || []).forEach(function (coll: string): void {
                 // loop through the chart's axis objects
-                (chart as any)[coll].forEach(function (axis: Axis): void {
+                ((chart as any)[coll] || []).forEach(function (axis: Axis): void {
                     axisOptions = axis.options;
 
                     // apply if the series xAxis or yAxis option matches


### PR DESCRIPTION
Issue https://github.com/highcharts/highcharts/issues/20771

When axisTypes has a value `colorAxis` and the field does not exist on `chart` object, an error is thrown: 

`Uncaught TypeError: Cannot read properties of undefined (reading 'forEach')`

This change will fix the issue