### PR TITLE
Warn for max-len strings in samples

### DIFF
--- a/samples/.eslintrc
+++ b/samples/.eslintrc
@@ -34,7 +34,7 @@ rules:
     max-len: [
         "warn",
         {
-            "ignoreStrings": true
+            "ignoreUrls": true
         }
     ]
     new-cap: 0                  # The ill-named Color object. Fix in HC5

--- a/samples/.eslintrc
+++ b/samples/.eslintrc
@@ -42,6 +42,7 @@ rules:
     no-console: 0               # TODO: Fix manually. Output to a visible div instead.
     no-loss-of-precision: 1
     no-multi-spaces: 0          # Consider key-spacing and exception to align arrays
+    no-multi-str: 0
     no-undefined: 0
     no-use-before-define: ["error", {"functions": false}]
     no-shadow: 0                # 10 violations as of 2015-10-31


### PR DESCRIPTION
No longer exception for strings. It masked long lines when strings were only part of it.