### PR TITLE
bugfix/20688-editmode-remove-component

### DIFF
--- a/test/cypress/dashboards/integration/Components/events.cy.js
+++ b/test/cypress/dashboards/integration/Components/events.cy.js
@@ -64,4 +64,10 @@ describe('Component events', () => {
 
     cy.get('#unmount').should('have.value', 'unmount');
   });
+
+  it('Disabling edit mode should be possible after removing component', () => {
+    cy.toggleEditMode();
+    cy.get('.highcharts-dashboards-edit-toggle-container')
+      .should('have.attr', 'aria-checked', 'false');
+  });
 });

--- a/ts/Dashboards/EditMode/EditMode.ts
+++ b/ts/Dashboards/EditMode/EditMode.ts
@@ -551,7 +551,7 @@ class EditMode {
 
         // Remove highlight from the context row if exists.
         if (this.editCellContext) {
-            this.editCellContext.row.setHighlight(true);
+            this.editCellContext.row?.setHighlight(true);
         }
 
         // TODO all buttons should be deactivated.


### PR DESCRIPTION
Fixed #20688, it was impossible to disable edit mode right after removing the component.