### PR TITLE
Fixed #20856, crosshair label position regression

### DIFF
--- a/samples/unit-tests/axis/crosshairs/demo.js
+++ b/samples/unit-tests/axis/crosshairs/demo.js
@@ -143,11 +143,14 @@ QUnit.test('Crosshair on multiple axes (#4927)', function (assert) {
     });
 });
 
-QUnit.test('Crosshair with snap false (#5066)', function (assert) {
+QUnit.test('Crosshair with snap false', function (assert) {
     var chart = Highcharts.chart('container', {
         xAxis: {
             crosshair: {
-                snap: false
+                snap: false,
+                label: {
+                    enabled: true
+                }
             }
         },
 
@@ -179,18 +182,23 @@ QUnit.test('Crosshair with snap false (#5066)', function (assert) {
     });
 
     var controller = new TestController(chart);
-    controller.mouseMove(100, 100);
+    controller.mouseMove(500, 100);
 
     assert.strictEqual(
         chart.xAxis[0].cross.element.nodeName,
         'path',
-        'X axis has cross'
+        'X axis should have crosshair (#5066)'
     );
 
     assert.strictEqual(
         chart.yAxis[0].cross.element.nodeName,
         'path',
-        'Y axis has cross'
+        'Y axis should have crosshair (#5066)'
+    );
+
+    assert.ok(
+        chart.xAxis[0].crossLabel.x > 300,
+        'X axis cross label should be on the right side of the chart (#20856)'
     );
 
     chart.renderTo.style.position = 'static';

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -575,8 +575,8 @@ namespace StockChart {
         // Check the edges
         if (horiz) {
             limit = {
-                left: left - crossBox.x,
-                right: left + axis.width - crossBox.x
+                left,
+                right: left + axis.width
             };
         } else {
             limit = {


### PR DESCRIPTION
Fixed #20856, a regression in v11.4.0 causing wrong crosshair label position on the right side of the chart