### PR TITLE
Fixed #17593, custom CSS properties were not applied

### DIFF
--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -387,7 +387,7 @@ class AST {
                     key = pair.shift();
 
                 if (key && pair.length) {
-                    (styles as any)[key.replace(
+                    (styles as any)[key.indexOf('--') === 0 ? key : key.replace(
                         /-([a-z])/g,
                         (g): string => g[1].toUpperCase()
                     )] = pair.join(':'); // #17146

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -847,7 +847,15 @@ function css(
     el: DOMElementType,
     styles: CSSObject
 ): void {
-    extend(el.style, styles as any);
+    objectEach(styles, (val, prop): void => {
+        el.style.setProperty(
+            prop.replace(
+                /([A-Z])/g,
+                (a: string, b: string): string => `-${b.toLowerCase()}`
+            ),
+            val as any
+        );
+    });
 }
 
 /**


### PR DESCRIPTION
Fixed #17593, custom CSS properties were not applied

Demo with the fix applied, the legend labels should be green: https://jsfiddle.net/highcharts/547s3vh2/1/

#### To do
 - [ ] Write test
 - [ ] Consider refactoring hyphenate function. It is already used in the exporting module, maybe elsewhere too?