### PR TITLE
bugfix/20784-wrong-selection-extremes

### DIFF
--- a/samples/unit-tests/chart/events-selection/demo.js
+++ b/samples/unit-tests/chart/events-selection/demo.js
@@ -1,24 +1,57 @@
 QUnit.test('Selection event', function (assert) {
-    var chart = Highcharts.chart('container', {
+    const chart = Highcharts.chart('container', {
+            chart: {
+                zoomType: 'x',
+                events: {
+                    selection: evt => {
+                        assert.ok(
+                            evt.xAxis[0].min > 3.65 && evt.xAxis[0].min < 3.75,
+                            `Min extreme from selection event should be lower
+                            than 4 and in correct scope (#20784).`
+                        );
+                        assert.ok(
+                            evt.xAxis[0].max < 4.5 && evt.xAxis[0].max > 4.4,
+                            `Max extreme from selection event should be higher
+                            than 4 and in correct scope (#20784).`
+                        );
+                        return false;
+                    }
+                }
+            },
+            series: [{
+                type: 'column',
+                data: [{
+                    x: 3,
+                    y: 1
+                }, {
+                    x: 4,
+                    y: 2
+                }, {
+                    x: 5,
+                    y: 3
+                }]
+            }]
+        }),
+        controller = new TestController(chart);
+
+    controller.pan([270, 100], [400, 100], void 0, true);
+
+    chart.series[0].update({
+        type: 'column',
+        name: 'USD to EUR',
+        data: [1, 3, 2, 4, 3, 5, 4, 6, 5, 7]
+    }, false);
+
+    chart.update({
         chart: {
-            zoomType: 'x',
             events: {
                 selection: function () {
                     this.destroy();
                     return false;
                 }
             }
-        },
-        series: [
-            {
-                type: 'area',
-                name: 'USD to EUR',
-                data: [1, 3, 2, 4, 3, 5, 4, 6, 5, 7]
-            }
-        ]
+        }
     });
-
-    var controller = new TestController(chart);
 
     // Pan
     controller.pan([200, 100], [150, 100], { shiftKey: true });

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3678,16 +3678,22 @@ class Chart {
             }
 
             let newMin = axis.toValue(minPx, true) +
-                    minPointOffset * pointRangeDirection,
+                // Don't apply offset for selection (#20784)
+                    (selection ? 0 : minPointOffset * pointRangeDirection),
                 newMax =
                     axis.toValue(
                         minPx + len / scale, true
                     ) -
                     (
-                        (minPointOffset * pointRangeDirection) ||
-                        // Polar zoom tests failed when this was not commented:
-                        // (axis.isXAxis && axis.pointRangePadding) ||
-                        0
+                        selection ? // Don't apply offset for selection (#20784)
+                            0 :
+                            (
+                                (minPointOffset * pointRangeDirection) ||
+                                // Polar zoom tests failed when this was not
+                                // commented:
+                                // (axis.isXAxis && axis.pointRangePadding) ||
+                                0
+                            )
                     ),
                 allExtremes = axis.allExtremes;
 


### PR DESCRIPTION
Fixed #20784, min and max extremes were wrongly calculated for the selection event.