### PR TITLE
bugfix/a11y-series-description

### DIFF
--- a/samples/unit-tests/accessibility/descriptions-added/demo.html
+++ b/samples/unit-tests/accessibility/descriptions-added/demo.html
@@ -1,4 +1,5 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/stock/modules/stock.js"></script>
 <script src="https://code.highcharts.com/modules/exporting.js"></script>
 <script src="https://code.highcharts.com/modules/export-data.js"></script>
 <script src="https://code.highcharts.com/modules/accessibility.js"></script>

--- a/samples/unit-tests/accessibility/descriptions-added/demo.js
+++ b/samples/unit-tests/accessibility/descriptions-added/demo.js
@@ -155,3 +155,24 @@ QUnit.test('Proxy region', function (assert) {
 
     testProxyRegions(' after update');
 });
+
+QUnit.test('Describing series which is grouped', function (assert) {
+    const chart = Highcharts.stockChart('container', {
+        series: [
+            {
+                type: 'column',
+                data: Array.from({ length: 1000 }, () => Math.random() * 100),
+                pointInterval: 24 * 36e5,
+                dataGrouping: {
+                    enabled: true,
+                    forced: true
+                }
+            }
+        ]
+    });
+
+    assert.ok(
+        chart.series[0].group.element.ariaLabel.length,
+        'Group element has ariaLabel.'
+    );
+});

--- a/samples/unit-tests/accessibility/descriptions-added/demo.js
+++ b/samples/unit-tests/accessibility/descriptions-added/demo.js
@@ -172,7 +172,7 @@ QUnit.test('Describing series which is grouped', function (assert) {
     });
 
     assert.ok(
-        chart.series[0].group.element.ariaLabel.length,
+        chart.series[0].group.element.getAttribute('aria-label'),
         'Group element has ariaLabel.'
     );
 });

--- a/ts/Accessibility/Components/SeriesComponent/SeriesComponent.ts
+++ b/ts/Accessibility/Components/SeriesComponent/SeriesComponent.ts
@@ -161,7 +161,7 @@ class SeriesComponent extends AccessibilityComponent {
         ): void {
             const shouldDescribeSeries = (series.options.accessibility &&
                 series.options.accessibility.enabled) !== false &&
-                series.visible && series.data.length !== 0;
+                series.visible && series.getPointsCollection().length !== 0;
 
             if (shouldDescribeSeries) {
                 describeSeries(series);


### PR DESCRIPTION
Fixed #20656, series with manipulated points were missing a11y description on initial load.