### PR TITLE
Included all es-modules files in replacement

### DIFF
--- a/tools/gulptasks/scripts-code.js
+++ b/tools/gulptasks/scripts-code.js
@@ -90,7 +90,7 @@ function scriptsCode() {
 
             logLib.success('Processed code sources');
 
-            fsLib.getFilePaths('code/es-modules/masters', true).forEach(filePath => {
+            fsLib.getFilePaths('code/es-modules', true).forEach(filePath => {
                 const content = fs.readFileSync(filePath).toString();
 
                 if (content) {


### PR DESCRIPTION
Follow up to https://github.com/highcharts/highcharts/pull/20947

Previous fix did not include at least https://code.highcharts.com/es-modules/Stock/StockTools/StockToolbar.js