### PR TITLE
bugfix/20451-symbolwidth-height-coloraxis

### DIFF
--- a/samples/unit-tests/coloraxis/coloraxis-padding/demo.js
+++ b/samples/unit-tests/coloraxis/coloraxis-padding/demo.js
@@ -106,6 +106,37 @@ QUnit.test('Color axis width, height and padding', function (assert) {
         2,
         'Color axis width should be changed after changing chart size.'
     );
+
+    const symbolHeight = 50,
+        symbolWidth = 250;
+
+    chart.colorAxis[0].update({
+        width: void 0,
+        height: void 0
+    }, false);
+
+    chart.update({
+        legend: {
+            symbolHeight: 50,
+            symbolWidth: 250
+        }
+    });
+
+    colorAxisBox = chart.colorAxis[0].gridGroup.getBBox();
+
+    assert.close(
+        colorAxisBox.width,
+        symbolWidth,
+        1.01,
+        'Color axis width should be set (#).'
+    );
+
+    assert.close(
+        colorAxisBox.height,
+        symbolHeight,
+        1.01,
+        'Color axis height should be set (#).'
+    );
 });
 
 QUnit.test('Color axis padding with long labels (#15551)', function (assert) {

--- a/samples/unit-tests/coloraxis/coloraxis-padding/demo.js
+++ b/samples/unit-tests/coloraxis/coloraxis-padding/demo.js
@@ -128,14 +128,14 @@ QUnit.test('Color axis width, height and padding', function (assert) {
         colorAxisBox.width,
         symbolWidth,
         1.01,
-        'Color axis width should be set (#).'
+        'Color axis width should be set based on legend.symbolWidth (#20451).'
     );
 
     assert.close(
         colorAxisBox.height,
         symbolHeight,
         1.01,
-        'Color axis height should be set (#).'
+        'Color axis height should be set based on legend.symbolHeight (#20451).'
     );
 });
 

--- a/ts/Core/Axis/Color/ColorAxis.ts
+++ b/ts/Core/Axis/Color/ColorAxis.ts
@@ -848,10 +848,12 @@ class ColorAxis extends Axis implements AxisLike {
                 horiz
             } = axis,
             {
-                legend: legendOptions,
                 height: colorAxisHeight,
                 width: colorAxisWidth
             } = axis.options,
+            {
+                legend: legendOptions
+            } = chart.options,
             width = pick(
                 defined(colorAxisWidth) ?
                     relativeLength(colorAxisWidth, chart.chartWidth) : void 0,


### PR DESCRIPTION
Fixed #20451, `legend.symbolWidth` and `legend.symbolHeight` should change color axis dimensions if `colorAxis.width` or `colorAxis.height` is not set.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206375923491752