### PR TITLE
bugfix/20936-boosted-navigator-inverted-charts

### DIFF
--- a/samples/unit-tests/boost/general/demo.js
+++ b/samples/unit-tests/boost/general/demo.js
@@ -416,6 +416,44 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
             '#17820.'
         );
 
+        chart.update({
+            chart: {
+                inverted: true
+            },
+            navigator: {
+                height: 40
+            }
+        });
+        assert.strictEqual(
+            chart.boost.clipRect.attr('height'),
+            chart.plotHeight,
+            `Clip rect height should take into account navigator boosted series
+            on inverted charts, #20936.`
+        );
+        assert.strictEqual(
+            chart.boost.clipRect.attr('width'),
+            chart.plotWidth + chart.navigator.top + chart.navigator.height,
+            `Clip rect width should take into account navigator boosted series
+            on inverted charts, #20936.`
+        );
+        assert.strictEqual(
+            chart.boost.clipRect.attr('x'),
+            chart.navigator.left,
+            `Clip rect 'x' should take into account navigator boosted
+            series on inverted charts, #20936.`
+        );
+
+        chart.update({
+            navigator: {
+                opposite: true
+            }
+        });
+        assert.strictEqual(
+            chart.boost.clipRect.attr('x'),
+            chart.plotLeft,
+            `Clip rect 'x' should take into account opposite navigator boosted
+            series on inverted charts, #20936.`
+        );
     }
 );
 

--- a/ts/Extensions/Boost/BoostChart.ts
+++ b/ts/Extensions/Boost/BoostChart.ts
@@ -95,14 +95,24 @@ function getBoostClipRect(
     chart: Chart,
     target: BoostTargetObject
 ): BBoxObject {
+    const navigator = chart.navigator;
     let clipBox = {
         x: chart.plotLeft,
         y: chart.plotTop,
         width: chart.plotWidth,
-        height: chart.navigator ? // #17820
-            chart.navigator.top + chart.navigator.height - chart.plotTop :
-            chart.plotHeight
+        height: chart.plotHeight
     };
+
+    if (navigator && chart.inverted) { // #17820, #20936
+        clipBox.width += navigator.top + navigator.height;
+
+        if (!navigator.opposite) {
+            clipBox.x = navigator.left;
+        }
+
+    } else if (navigator && !chart.inverted) {
+        clipBox.height = navigator.top + navigator.height - chart.plotTop;
+    }
 
     // Clipping of individual series (#11906, #19039).
     if ((target as Series).getClipBox) {
@@ -119,6 +129,7 @@ function getBoostClipRect(
             clipBox.y = yAxis.pos;
         }
     }
+
 
     if (target === chart) {
         const verticalAxes =


### PR DESCRIPTION
Fixed #20936, boosted navigator was not included in inverted chart's `clipRect`.