### PR TITLE
demo/20917-deprecated-zooming-options

### DIFF
--- a/samples/dashboards/cypress/sync-chart-extremes/demo.js
+++ b/samples/dashboards/cypress/sync-chart-extremes/demo.js
@@ -42,7 +42,9 @@ Dashboards.board('container', {
             chart: {
                 animation: false,
                 type: 'column',
-                zoomType: 'x',
+                zooming: {
+                    type: 'x'
+                },
                 panning: {
                     enabled: true
                 },
@@ -79,8 +81,10 @@ Dashboards.board('container', {
             chart: {
                 type: 'column',
                 animation: false,
-                zoomType: 'x',
-                zoomBySingleTouch: true
+                zooming: {
+                    singleTouch: true,
+                    type: 'x'
+                }
             },
             plotOptions: {
                 series: {
@@ -106,8 +110,10 @@ Dashboards.board('container', {
                 inverted: true,
                 type: 'column',
                 animation: false,
-                zoomType: 'x',
-                zoomBySingleTouch: true
+                zooming: {
+                    singleTouch: true,
+                    type: 'x'
+                }
             },
             plotOptions: {
                 series: {

--- a/samples/dashboards/demo/axes-sync/demo.js
+++ b/samples/dashboards/demo/axes-sync/demo.js
@@ -29,7 +29,9 @@ Highcharts.setOptions({
         spacingBottom: 20,
         height: 300,
         type: 'area',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     legend: {
         enabled: false
@@ -138,7 +140,9 @@ Dashboards.board('container', {
         },
         chartOptions: {
             chart: {
-                zoomType: 'x'
+                zooming: {
+                    type: 'x'
+                }
             },
             title: {
                 text: 'Global'
@@ -176,7 +180,9 @@ Dashboards.board('container', {
         },
         chartOptions: {
             chart: {
-                zoomType: 'x'
+                zooming: {
+                    type: 'x'
+                }
             },
             title: {
                 text: 'South-East Asia'
@@ -220,7 +226,9 @@ Dashboards.board('container', {
         },
         chartOptions: {
             chart: {
-                zoomType: 'y'
+                zooming: {
+                    type: 'y'
+                }
             },
             title: {
                 text: 'Africa'
@@ -264,7 +272,9 @@ Dashboards.board('container', {
         },
         chartOptions: {
             chart: {
-                zoomType: 'y'
+                zooming: {
+                    type: 'y'
+                }
             },
             title: {
                 text: 'Europe'

--- a/samples/dashboards/demo/sync-extremes/demo.js
+++ b/samples/dashboards/demo/sync-extremes/demo.js
@@ -86,7 +86,9 @@ Dashboards.board('container', {
             },
             chart: {
                 type: 'bar',
-                zoomType: 'x'
+                zooming: {
+                    type: 'x'
+                }
             },
             plotOptions: {
                 series: {
@@ -148,7 +150,9 @@ Dashboards.board('container', {
             },
             chart: {
                 type: 'bar',
-                zoomType: 'x'
+                zooming: {
+                    type: 'x'
+                }
             },
             plotOptions: {
                 series: {
@@ -210,7 +214,9 @@ Dashboards.board('container', {
             },
             chart: {
                 type: 'bar',
-                zoomType: 'x'
+                zooming: {
+                    type: 'x'
+                }
             },
             plotOptions: {
                 series: {

--- a/samples/gantt/gantt/bigdata/demo.js
+++ b/samples/gantt/gantt/bigdata/demo.js
@@ -52241,7 +52241,9 @@ data.vessels.forEach(function (vessel, i) {
 
 Highcharts.ganttChart('container', {
     chart: {
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
 
     yAxis: {

--- a/samples/highcharts/accessibility/accessible-datetime/demo.js
+++ b/samples/highcharts/accessibility/accessible-datetime/demo.js
@@ -3,7 +3,9 @@ Highcharts.chart('container', {
         text: 'Random data on a date axis.'
     },
     chart: {
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
     xAxis: {
         type: 'datetime',

--- a/samples/highcharts/annotations-advanced/controllable-image/demo.js
+++ b/samples/highcharts/annotations-advanced/controllable-image/demo.js
@@ -1,6 +1,8 @@
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         events: {
             load: function () {
                 this.annotations.forEach(function (annotation) {

--- a/samples/highcharts/annotations-advanced/controllable/demo.js
+++ b/samples/highcharts/annotations-advanced/controllable/demo.js
@@ -17,7 +17,9 @@ const chart = Highcharts.chart('container', {
 
     chart: {
         // inverted: true,
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         events: {
             load: function () {
                 this.annotations.forEach(function (annotation) {

--- a/samples/highcharts/annotations-advanced/elliott-wave/demo.js
+++ b/samples/highcharts/annotations-advanced/elliott-wave/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         // inverted: true,
-        zoomType: 'xy',
+        zooming: {
+            type: 'xy'
+        },
         events: {
             load: function () {
                 this.annotations.forEach(function (annotation) {

--- a/samples/highcharts/annotations-advanced/fibonacci/demo.js
+++ b/samples/highcharts/annotations-advanced/fibonacci/demo.js
@@ -1,6 +1,8 @@
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'xy',
+        zooming: {
+            type: 'xy'
+        },
         events: {
             load: function () {
                 this.annotations.forEach(function (annotation) {

--- a/samples/highcharts/annotations-advanced/vertical-line/demo.js
+++ b/samples/highcharts/annotations-advanced/vertical-line/demo.js
@@ -1,6 +1,8 @@
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'xy',
+        zooming: {
+            type: 'xy'
+        },
         // inverted: true,
         events: {
             load: function () {

--- a/samples/highcharts/annotations/ellipse/demo.js
+++ b/samples/highcharts/annotations/ellipse/demo.js
@@ -1,6 +1,8 @@
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         events: {
             load: function () {
                 this.annotations.forEach(function (annotation) {

--- a/samples/highcharts/annotations/mock-point/demo.js
+++ b/samples/highcharts/annotations/mock-point/demo.js
@@ -1,6 +1,8 @@
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
 
     title: {

--- a/samples/highcharts/annotations/mock-points/demo.js
+++ b/samples/highcharts/annotations/mock-points/demo.js
@@ -23,7 +23,9 @@ function getMinMax(chart) {
 
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
 
     title: {

--- a/samples/highcharts/blog/annotations-aapl-iphone/demo.js
+++ b/samples/highcharts/blog/annotations-aapl-iphone/demo.js
@@ -12,7 +12,9 @@
     // Create the chart
     Highcharts.stockChart('container', {
         chart: {
-            zoomType: 'x'
+            zooming: {
+                type: 'x'
+            }
         },
         title: {
             text: 'AAPL Stock Price'

--- a/samples/highcharts/blog/annotations-avg-plotline/demo.js
+++ b/samples/highcharts/blog/annotations-avg-plotline/demo.js
@@ -28,7 +28,9 @@
 
     Highcharts.stockChart('container', {
         chart: {
-            zoomType: 'x'
+            zooming: {
+                type: 'x'
+            }
         },
 
         xAxis: {

--- a/samples/highcharts/blog/chart-boost-module/demo.js
+++ b/samples/highcharts/blog/chart-boost-module/demo.js
@@ -38,7 +38,9 @@ console.time('line');
 Highcharts.chart('container', {
 
     chart: {
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
 
     boost: {

--- a/samples/highcharts/blog/corn-production/demo.js
+++ b/samples/highcharts/blog/corn-production/demo.js
@@ -24,7 +24,9 @@ const chart = Highcharts.chart('production', {
         '#9F8170'
     ],
     chart: {
-        zoomType: 'xy',
+        zooming: {
+            type: 'xy'
+        },
         type: 'column'
     },
     title: {
@@ -143,7 +145,9 @@ for (const [key, value] of Object.entries(countries)) {
 Highcharts.chart('production_heatmap', {
 
     chart: {
-        // zoomType: 'xy',
+        // zooming: {
+        //     type: 'xy'
+        // },
         type: 'heatmap',
         marginTop: 60,
         marginBottom: 80,
@@ -260,7 +264,9 @@ const chart2 = Highcharts.chart('trade', {
         '#9F8170', '#9F8170'
     ],
     chart: {
-        zoomType: 'xy',
+        zooming: {
+            type: 'xy'
+        },
         type: 'column'
     },
 

--- a/samples/highcharts/blog/movie-cummulative-income/demo.js
+++ b/samples/highcharts/blog/movie-cummulative-income/demo.js
@@ -29,7 +29,9 @@ Highcharts.chart('container', {
         }
     },
     chart: {
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         marginRight: 120
     },
     tooltip: {

--- a/samples/highcharts/blog/movie-gross-income-filter/demo.js
+++ b/samples/highcharts/blog/movie-gross-income-filter/demo.js
@@ -29,7 +29,9 @@ Highcharts.chart('container', {
         }
     },
     chart: {
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         marginRight: 120
     },
     tooltip: {

--- a/samples/highcharts/blog/movie-gross-income/demo.js
+++ b/samples/highcharts/blog/movie-gross-income/demo.js
@@ -29,7 +29,9 @@ Highcharts.chart('container', {
         }
     },
     chart: {
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         marginRight: 120
     },
     tooltip: {

--- a/samples/highcharts/blog/scatter-regression/demo.js
+++ b/samples/highcharts/blog/scatter-regression/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'scatter',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'GDP per capita vs Self-reported Life Satisfaction, 2015'

--- a/samples/highcharts/blog/sound-pressure-level-annotations/demo.js
+++ b/samples/highcharts/blog/sound-pressure-level-annotations/demo.js
@@ -49,7 +49,9 @@ const data3 = [
 Highcharts.chart('container', {
     chart: {
         type: 'scatter',
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
     title: {
         text: 'Sound pressure level'

--- a/samples/highcharts/blog/sound-pressure-level-zoomtype/demo.js
+++ b/samples/highcharts/blog/sound-pressure-level-zoomtype/demo.js
@@ -49,7 +49,9 @@ const data3 = [
 const chart = Highcharts.chart('container', {
     chart: {
         type: 'scatter',
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
     title: {
         text: 'Sound pressure level'

--- a/samples/highcharts/blog/synchronize-axes-multiple-charts/demo.js
+++ b/samples/highcharts/blog/synchronize-axes-multiple-charts/demo.js
@@ -46,7 +46,7 @@ const global = [
 
         if (
             mainChart.options.chart.otherChartsFollowAxes &&
-        Highcharts.lastChartRender
+            Highcharts.lastChartRender
         ) {
             mainChart.xAxis[0].setExtremes(
                 mainChart.xAxis[0].min,
@@ -97,7 +97,9 @@ Highcharts.setOptions({
 Highcharts.chart('container1', {
     chart: {
         otherChartsFollowAxes: true,
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'Polio (Pol3) immunization coverage among 1-year-olds (%) '

--- a/samples/highcharts/boost/area-stacked/demo.js
+++ b/samples/highcharts/boost/area-stacked/demo.js
@@ -34,7 +34,9 @@ Highcharts.chart('container', {
 
     chart: {
         type: 'area',
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
 
     boost: {

--- a/samples/highcharts/boost/area/demo.js
+++ b/samples/highcharts/boost/area/demo.js
@@ -33,7 +33,9 @@ Highcharts.chart('container', {
 
     chart: {
         type: 'area',
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         panning: true,
         panKey: 'shift'
     },

--- a/samples/highcharts/boost/arearange/demo.js
+++ b/samples/highcharts/boost/arearange/demo.js
@@ -38,7 +38,9 @@ Highcharts.chart('container', {
 
     chart: {
         type: 'arearange',
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         panning: true,
         panKey: 'shift'
     },

--- a/samples/highcharts/boost/areaspline/demo.js
+++ b/samples/highcharts/boost/areaspline/demo.js
@@ -33,7 +33,9 @@ Highcharts.chart('container', {
 
     chart: {
         type: 'areaspline',
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         panning: true,
         panKey: 'shift'
     },

--- a/samples/highcharts/boost/bar/demo.js
+++ b/samples/highcharts/boost/bar/demo.js
@@ -33,7 +33,9 @@ Highcharts.chart('container', {
 
     chart: {
         type: 'bar',
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         panning: true,
         panKey: 'shift'
     },

--- a/samples/highcharts/boost/bubble/demo.js
+++ b/samples/highcharts/boost/bubble/demo.js
@@ -18,7 +18,9 @@ console.time('bubble');
 Highcharts.chart('container', {
 
     chart: {
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
 
     xAxis: {

--- a/samples/highcharts/boost/column/demo.js
+++ b/samples/highcharts/boost/column/demo.js
@@ -33,7 +33,9 @@ Highcharts.chart('container', {
 
     chart: {
         type: 'column',
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         panning: true,
         panKey: 'shift'
     },

--- a/samples/highcharts/boost/columnrange/demo.js
+++ b/samples/highcharts/boost/columnrange/demo.js
@@ -38,7 +38,9 @@ Highcharts.chart('container', {
 
     chart: {
         type: 'columnrange',
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         panning: true,
         panKey: 'shift'
     },

--- a/samples/highcharts/boost/connect-nulls/demo.js
+++ b/samples/highcharts/boost/connect-nulls/demo.js
@@ -2,7 +2,9 @@ console.time('line');
 
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         panning: true,
         panKey: 'shift'
     },
@@ -35,7 +37,9 @@ Highcharts.chart('container', {
 
 Highcharts.chart('container-2', {
     chart: {
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         panning: true,
         panKey: 'shift'
     },

--- a/samples/highcharts/boost/line-devicepixelratio/demo.js
+++ b/samples/highcharts/boost/line-devicepixelratio/demo.js
@@ -34,7 +34,9 @@ console.time('line');
 Highcharts.chart('container', {
 
     chart: {
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         panning: true,
         panKey: 'shift'
     },

--- a/samples/highcharts/boost/line-export-pixelratio/demo.js
+++ b/samples/highcharts/boost/line-export-pixelratio/demo.js
@@ -34,7 +34,9 @@ console.time('line');
 Highcharts.chart('container', {
 
     chart: {
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         panning: true,
         panKey: 'shift'
     },

--- a/samples/highcharts/boost/line-series-heavy-dynamic/demo.js
+++ b/samples/highcharts/boost/line-series-heavy-dynamic/demo.js
@@ -43,11 +43,13 @@ Highcharts.setOptions({
 });
 
 console.time('line');
-const chart =  Highcharts.stockChart('container', {
+const chart = Highcharts.stockChart('container', {
 
     chart: {
         animation: false,
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
 
     title: {

--- a/samples/highcharts/boost/line-series-heavy-stock/demo.js
+++ b/samples/highcharts/boost/line-series-heavy-stock/demo.js
@@ -58,7 +58,9 @@ console.time('line');
 Highcharts.stockChart('container', {
 
     chart: {
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
 
     title: {

--- a/samples/highcharts/boost/line-series-heavy/demo.js
+++ b/samples/highcharts/boost/line-series-heavy/demo.js
@@ -52,7 +52,9 @@ console.time('line');
 Highcharts.chart('container', {
 
     chart: {
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
 
     title: {

--- a/samples/highcharts/boost/line/demo.js
+++ b/samples/highcharts/boost/line/demo.js
@@ -34,7 +34,9 @@ console.time('line');
 Highcharts.chart('container', {
 
     chart: {
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         panning: true,
         panKey: 'shift'
     },

--- a/samples/highcharts/boost/scatter-pie/demo.js
+++ b/samples/highcharts/boost/scatter-pie/demo.js
@@ -18,7 +18,9 @@ console.time('asyncRender');
 Highcharts.chart('container', {
 
     chart: {
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
 
     xAxis: {

--- a/samples/highcharts/boost/scatter-smaller/demo.js
+++ b/samples/highcharts/boost/scatter-smaller/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'scatter',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'Height Versus Weight of 507 Individuals by Gender'

--- a/samples/highcharts/boost/scatter/demo.js
+++ b/samples/highcharts/boost/scatter/demo.js
@@ -17,7 +17,9 @@ console.time('scatter');
 Highcharts.chart('container', {
 
     chart: {
-        zoomType: 'xy',
+        zooming: {
+            type: 'xy'
+        },
         height: '100%'
     },
 

--- a/samples/highcharts/chart/events-load-class/demo.js
+++ b/samples/highcharts/chart/events-load-class/demo.js
@@ -14,7 +14,9 @@
 Highcharts.chart('container', {
 
     chart: {
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
 
     title: {

--- a/samples/highcharts/chart/events-selection-points/demo.js
+++ b/samples/highcharts/chart/events-selection-points/demo.js
@@ -33,7 +33,7 @@ function selectPointsByDrag(e) {
         series.points.forEach(point => {
             if (
                 point.x >= e.xAxis[0].min && point.x <= e.xAxis[0].max &&
-                    point.y >= e.yAxis[0].min && point.y <= e.yAxis[0].max
+                point.y >= e.yAxis[0].min && point.y <= e.yAxis[0].max
             ) {
                 point.select(true, true);
             }
@@ -85,7 +85,9 @@ Highcharts.chart('container', {
             selectedpoints: selectedPoints,
             click: unselectByClick
         },
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
 
     series: [{

--- a/samples/highcharts/chart/events-selection/demo.js
+++ b/samples/highcharts/chart/events-selection/demo.js
@@ -30,7 +30,9 @@ Highcharts.chart('container', {
                 }, 1000);
             }
         },
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
     title: {
         text: 'Chart selection demo'

--- a/samples/highcharts/chart/pankey/demo.js
+++ b/samples/highcharts/chart/pankey/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'line',
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         panning: true,
         panKey: 'shift'
     },

--- a/samples/highcharts/chart/panning-type/demo.js
+++ b/samples/highcharts/chart/panning-type/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'line',
-        zoomType: 'xy',
+        zooming: {
+            type: 'xy'
+        },
         panning: {
             enabled: true,
             type: 'xy'

--- a/samples/highcharts/chart/resetzoombutton-position/demo.js
+++ b/samples/highcharts/chart/resetzoombutton-position/demo.js
@@ -1,13 +1,15 @@
 Highcharts.chart('container', {
 
     chart: {
-        zoomType: 'x',
-        resetZoomButton: {
-            position: {
-                // align: 'right', // by default
-                // verticalAlign: 'top', // by default
-                x: 0,
-                y: -30
+        zooming: {
+            type: 'x',
+            resetButton: {
+                position: {
+                    // align: 'right', // by default
+                    // verticalAlign: 'top', // by default
+                    x: 0,
+                    y: -30
+                }
             }
         }
     },

--- a/samples/highcharts/chart/resetzoombutton-relativeto/demo.js
+++ b/samples/highcharts/chart/resetzoombutton-relativeto/demo.js
@@ -1,16 +1,18 @@
 Highcharts.chart('container', {
 
     chart: {
-        zoomType: 'x',
         borderWidth: 1,
-        resetZoomButton: {
-            position: {
-                // align: 'right', // by default
-                // verticalAlign: 'top', // by default
-                x: -10,
-                y: 10
-            },
-            relativeTo: 'chart'
+        zooming: {
+            type: 'x',
+            resetButton: {
+                position: {
+                    // align: 'right', // by default
+                    // verticalAlign: 'top', // by default
+                    x: -10,
+                    y: 10
+                },
+                relativeTo: 'chart'
+            }
         }
     },
 

--- a/samples/highcharts/chart/resetzoombutton-theme/demo.js
+++ b/samples/highcharts/chart/resetzoombutton-theme/demo.js
@@ -1,17 +1,19 @@
 Highcharts.chart('container', {
 
     chart: {
-        zoomType: 'x',
-        resetZoomButton: {
-            theme: {
-                fill: 'white',
-                stroke: 'silver',
-                r: 0,
-                states: {
-                    hover: {
-                        fill: '#41739D',
-                        style: {
-                            color: 'white'
+        zooming: {
+            type: 'x',
+            resetButton: {
+                theme: {
+                    fill: 'white',
+                    stroke: 'silver',
+                    r: 0,
+                    states: {
+                        hover: {
+                            fill: '#41739D',
+                            style: {
+                                color: 'white'
+                            }
                         }
                     }
                 }

--- a/samples/highcharts/chart/zoombysingletouch/demo.html
+++ b/samples/highcharts/chart/zoombysingletouch/demo.html
@@ -4,14 +4,14 @@
     <figure class="highcharts-figure">
         <div id="container"></div>
         <p class="highcharts-description">
-            This demo has <code>chart.zoomBySingleTouch</code> set to true. Use
+            This demo has <code>zooming.singleTouch</code> set to true. Use
             the buttons to toggle it to prevent the chart from zooming when
             scrolling the page or reading point values in the tooltip.
         </p>
     </figure>
 
     <div class="toggle-buttons">
-        <button data-zoombysingletouch="true" class="active">True</button>
-        <button data-zoombysingletouch="false">False</button>
+        <button data-singletouchzoom="true" class="active">True</button>
+        <button data-singletouchzoom="false">False</button>
     </div>
 </div>

--- a/samples/highcharts/chart/zoombysingletouch/demo.js
+++ b/samples/highcharts/chart/zoombysingletouch/demo.js
@@ -5,8 +5,10 @@ const chart = Highcharts.chart('container', {
     },
 
     chart: {
-        zoomBySingleTouch: true,
-        zoomType: 'x'
+        zooming: {
+            type: 'x',
+            singleTouch: true
+        }
     },
 
     xAxis: {
@@ -27,12 +29,14 @@ const chart = Highcharts.chart('container', {
 document.querySelector('.toggle-buttons').addEventListener(
     'click',
     e => {
-        const value = e.target.dataset.zoombysingletouch;
+        const value = e.target.dataset.singletouchzoom;
         if (value) {
-            const zoomBySingleTouch = value === 'true';
+            const singleTouch = value === 'true';
             chart.update({
                 chart: {
-                    zoomBySingleTouch
+                    zooming: {
+                        singleTouch
+                    }
                 }
             });
 

--- a/samples/highcharts/chartchooser/categorical-comparison-bar-monochrome/demo.js
+++ b/samples/highcharts/chartchooser/categorical-comparison-bar-monochrome/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'bar',
-        zoomType: 'y'
+        zooming: {
+            type: 'y'
+        }
     },
     title: {
         text: 'Total organic area 2012 and 2018'

--- a/samples/highcharts/chartchooser/categorical-comparison-bar-patterns/demo.js
+++ b/samples/highcharts/chartchooser/categorical-comparison-bar-patterns/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'bar',
-        zoomType: 'y'
+        zooming: {
+            type: 'y'
+        }
     },
     title: {
         text: 'Total organic area 2012 and 2018'

--- a/samples/highcharts/chartchooser/categorical-comparison-bar/demo.js
+++ b/samples/highcharts/chartchooser/categorical-comparison-bar/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'bar',
-        zoomType: 'y'
+        zooming: {
+            type: 'y'
+        }
     },
     title: {
         text: 'Top 10 EU countries in organic farming area (2018)'

--- a/samples/highcharts/chartchooser/categorical-comparison-column-monochrome/demo.js
+++ b/samples/highcharts/chartchooser/categorical-comparison-column-monochrome/demo.js
@@ -4,7 +4,9 @@ Highcharts.setOptions({
 Highcharts.chart('container', {
     chart: {
         type: 'column',
-        zoomType: 'y'
+        zooming: {
+            type: 'y'
+        }
     },
     title: {
         text: 'Corn vs wheat estimated production for 2020 (1000 MT)'

--- a/samples/highcharts/chartchooser/categorical-comparison-column-patterns/demo.js
+++ b/samples/highcharts/chartchooser/categorical-comparison-column-patterns/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'column',
-        zoomType: 'y'
+        zooming: {
+            type: 'y'
+        }
     },
     title: {
         text: 'Corn vs wheat estimated production for 2020 (1000 MT)'

--- a/samples/highcharts/chartchooser/categorical-comparison-column/demo.js
+++ b/samples/highcharts/chartchooser/categorical-comparison-column/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'column',
-        zoomType: 'y'
+        zooming: {
+            type: 'y'
+        }
     },
     title: {
         text: 'Top 10 countries in wheat exportation (2019)'

--- a/samples/highcharts/chartchooser/continuous-comparison-scatter-trend-line/demo.js
+++ b/samples/highcharts/chartchooser/continuous-comparison-scatter-trend-line/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'scatter',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         HTML: true,

--- a/samples/highcharts/chartchooser/continuous-comparison-scatter/demo.js
+++ b/samples/highcharts/chartchooser/continuous-comparison-scatter/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'scatter',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         HTML: true,

--- a/samples/highcharts/chartchooser/continuous-distribution-bubble-patterns/demo.js
+++ b/samples/highcharts/chartchooser/continuous-distribution-bubble-patterns/demo.js
@@ -2,7 +2,9 @@ Highcharts.chart('container', {
     chart: {
         type: 'bubble',
         plotBorderWidth: 1,
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
 
     legend: {

--- a/samples/highcharts/chartchooser/continuous-distribution-bubble/demo.js
+++ b/samples/highcharts/chartchooser/continuous-distribution-bubble/demo.js
@@ -2,7 +2,9 @@ Highcharts.chart('container', {
     chart: {
         type: 'bubble',
         plotBorderWidth: 1,
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
 
     legend: {

--- a/samples/highcharts/chartchooser/continuous-distribution-marker-clusters-grid/demo.js
+++ b/samples/highcharts/chartchooser/continuous-distribution-marker-clusters-grid/demo.js
@@ -4,7 +4,9 @@ const type = 'grid',
 Highcharts.chart('container', {
     chart: {
         type: 'scatter',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     accessibility: {
         description: ''
@@ -39,7 +41,7 @@ Highcharts.chart('container', {
     },
 
     series: [
-    // Marker clusters
+        // Marker clusters
         {
             name: 'Weight and height by country',
             dataLabels: {

--- a/samples/highcharts/chartchooser/continuous-distribution-marker-clusters/demo.js
+++ b/samples/highcharts/chartchooser/continuous-distribution-marker-clusters/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'scatter',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     accessibility: {
         description: ''

--- a/samples/highcharts/chartchooser/continuous-distribution-scatter/demo.js
+++ b/samples/highcharts/chartchooser/continuous-distribution-scatter/demo.js
@@ -52,7 +52,9 @@ getData().then(data => {
     Highcharts.chart('container', {
         chart: {
             type: 'scatter',
-            zoomType: 'xy'
+            zooming: {
+                type: 'xy'
+            }
         },
         colors,
         title: {

--- a/samples/highcharts/chartchooser/continuous-flow-streamgraph-monochrome/demo.js
+++ b/samples/highcharts/chartchooser/continuous-flow-streamgraph-monochrome/demo.js
@@ -3,7 +3,9 @@ Highcharts.chart('container', {
     chart: {
         type: 'streamgraph',
         marginBottom: 30,
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
     title: {
         floating: true,

--- a/samples/highcharts/chartchooser/continuous-flow-streamgraph/demo.js
+++ b/samples/highcharts/chartchooser/continuous-flow-streamgraph/demo.js
@@ -2,7 +2,9 @@ Highcharts.chart('container', {
     chart: {
         type: 'streamgraph',
         marginBottom: 30,
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
     title: {
         floating: true,

--- a/samples/highcharts/chartchooser/continuous-relationship-scatte-trend-line/demo.js
+++ b/samples/highcharts/chartchooser/continuous-relationship-scatte-trend-line/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'scatter',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'Vitamin D in preventing COVID-19 infection'

--- a/samples/highcharts/chartchooser/continuous-relationship-scatter/demo.js
+++ b/samples/highcharts/chartchooser/continuous-relationship-scatter/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'scatter',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'Vitamin D in preventing COVID-19 infection'

--- a/samples/highcharts/chartchooser/continuous-trend-line-annotations/demo.js
+++ b/samples/highcharts/chartchooser/continuous-trend-line-annotations/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'spline',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'NASA Budget as a % of Fed Budget'

--- a/samples/highcharts/chartchooser/continuous-trend-line/demo.js
+++ b/samples/highcharts/chartchooser/continuous-trend-line/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'spline',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'NASA Budget as a % of Fed Budget'

--- a/samples/highcharts/coloraxis/changed-default-color-key/demo.js
+++ b/samples/highcharts/coloraxis/changed-default-color-key/demo.js
@@ -3,7 +3,9 @@ Highcharts.chart('container', {
     chart: {
         type: 'bubble',
         plotBorderWidth: 1,
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
 
     colorAxis: [{}, {

--- a/samples/highcharts/css/annotations/demo.js
+++ b/samples/highcharts/css/annotations/demo.js
@@ -1887,7 +1887,9 @@ Highcharts.chart('container', {
     chart: {
         styledMode: true,
         type: 'area',
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         panning: true,
         panKey: 'shift'
     },

--- a/samples/highcharts/css/bubble/demo.js
+++ b/samples/highcharts/css/bubble/demo.js
@@ -2,7 +2,9 @@ Highcharts.chart('container', {
 
     chart: {
         type: 'bubble',
-        zoomType: 'xy',
+        zooming: {
+            type: 'xy'
+        },
         styledMode: true
     },
 
@@ -96,7 +98,7 @@ Highcharts.chart('container', {
                 y: 126.4,
                 z: 35.3,
                 name:
-                'US',
+                    'US',
                 country: 'United States'
             },
             { x: 65.4, y: 50.8, z: 28.5, name: 'HU', country: 'Hungary' },

--- a/samples/highcharts/css/error-bar/demo.js
+++ b/samples/highcharts/css/error-bar/demo.js
@@ -1,6 +1,8 @@
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'xy',
+        zooming: {
+            type: 'xy'
+        },
         styledMode: true
     },
     title: {

--- a/samples/highcharts/css/scatter/demo.js
+++ b/samples/highcharts/css/scatter/demo.js
@@ -2,7 +2,9 @@ Highcharts.chart('container', {
     chart: {
         type: 'scatter',
         styledMode: true,
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'Height Versus Weight of 507 Individuals by Gender'

--- a/samples/highcharts/demo/annotations/demo.js
+++ b/samples/highcharts/demo/annotations/demo.js
@@ -1886,7 +1886,9 @@ Highcharts.chart('container', {
 
     chart: {
         type: 'area',
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         panning: true,
         panKey: 'shift',
         scrollablePlotArea: {

--- a/samples/highcharts/demo/arearange/demo.js
+++ b/samples/highcharts/demo/arearange/demo.js
@@ -6,7 +6,9 @@
     Highcharts.chart('container', {
         chart: {
             type: 'arearange',
-            zoomType: 'x',
+            zooming: {
+                type: 'x'
+            },
             scrollablePlotArea: {
                 minWidth: 600,
                 scrollPositionX: 1

--- a/samples/highcharts/demo/bubble-3d/demo.js
+++ b/samples/highcharts/demo/bubble-3d/demo.js
@@ -3,7 +3,9 @@ Highcharts.chart('container', {
     chart: {
         type: 'bubble',
         plotBorderWidth: 1,
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
 
     title: {

--- a/samples/highcharts/demo/bubble/demo.js
+++ b/samples/highcharts/demo/bubble/demo.js
@@ -3,7 +3,9 @@ Highcharts.chart('container', {
     chart: {
         type: 'bubble',
         plotBorderWidth: 1,
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
 
     legend: {
@@ -121,7 +123,7 @@ Highcharts.chart('container', {
                 y: 126.4,
                 z: 35.3,
                 name:
-                'US',
+                    'US',
                 country: 'United States'
             },
             { x: 65.4, y: 50.8, z: 28.5, name: 'HU', country: 'Hungary' },

--- a/samples/highcharts/demo/combo-dual-axes/demo.js
+++ b/samples/highcharts/demo/combo-dual-axes/demo.js
@@ -1,6 +1,8 @@
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'Karasjok weather, 2021',

--- a/samples/highcharts/demo/combo-multi-axes/demo.js
+++ b/samples/highcharts/demo/combo-multi-axes/demo.js
@@ -1,6 +1,8 @@
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'Average Monthly Weather Data for Tokyo',

--- a/samples/highcharts/demo/dynamic-master-detail/demo.js
+++ b/samples/highcharts/demo/dynamic-master-detail/demo.js
@@ -52,7 +52,7 @@
             },
             tooltip: {
                 format: '<b>{series.name}</b><br/>{x:%A %B %e %Y}:<br/>' +
-                        '1 USD = {y:.2f} EUR',
+                    '1 USD = {y:.2f} EUR',
                 shared: true
             },
             legend: {
@@ -95,7 +95,9 @@
                 backgroundColor: null,
                 marginLeft: 50,
                 marginRight: 20,
-                zoomType: 'x',
+                zooming: {
+                    type: 'x'
+                },
                 events: {
 
                     // listen to the selection event on the master chart to

--- a/samples/highcharts/demo/error-bar/demo.js
+++ b/samples/highcharts/demo/error-bar/demo.js
@@ -1,6 +1,8 @@
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'Temperature vs Rainfall'

--- a/samples/highcharts/demo/fan-chart/demo.js
+++ b/samples/highcharts/demo/fan-chart/demo.js
@@ -4,7 +4,9 @@ const colors = Highcharts.getOptions().colors;
 Highcharts.chart('container', {
     chart: {
         type: 'arearange',
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
     title: {
         text: 'EU GDP'

--- a/samples/highcharts/demo/line-boost/demo.js
+++ b/samples/highcharts/demo/line-boost/demo.js
@@ -40,7 +40,9 @@ console.time('line');
 Highcharts.chart('container', {
 
     chart: {
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
 
     title: {

--- a/samples/highcharts/demo/line-time-series/demo.js
+++ b/samples/highcharts/demo/line-time-series/demo.js
@@ -6,7 +6,9 @@
 
     Highcharts.chart('container', {
         chart: {
-            zoomType: 'x'
+            zooming: {
+                type: 'x'
+            }
         },
         title: {
             text: 'USD to EUR exchange rate over time',

--- a/samples/highcharts/demo/scatter-boost/demo.js
+++ b/samples/highcharts/demo/scatter-boost/demo.js
@@ -25,7 +25,9 @@ console.time('scatter');
 Highcharts.chart('container', {
 
     chart: {
-        zoomType: 'xy',
+        zooming: {
+            type: 'xy'
+        },
         height: '100%'
     },
 

--- a/samples/highcharts/demo/scatter/demo.js
+++ b/samples/highcharts/demo/scatter/demo.js
@@ -52,7 +52,9 @@ getData().then(data => {
     Highcharts.chart('container', {
         chart: {
             type: 'scatter',
-            zoomType: 'xy'
+            zooming: {
+                type: 'xy'
+            }
         },
         title: {
             text: 'Olympics athletes by height and weight',

--- a/samples/highcharts/demo/streamgraph/demo.js
+++ b/samples/highcharts/demo/streamgraph/demo.js
@@ -4,7 +4,9 @@ Highcharts.chart('container', {
     chart: {
         type: 'streamgraph',
         marginBottom: 30,
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
 
     // Make sure connected countries have similar colors

--- a/samples/highcharts/dragdrop/drag-xrange/demo.js
+++ b/samples/highcharts/dragdrop/drag-xrange/demo.js
@@ -6,7 +6,9 @@ Highcharts.chart('container', {
     chart: {
         animation: false,
         type: 'xrange',
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
 
     title: {
@@ -41,7 +43,7 @@ Highcharts.chart('container', {
                     dragStart: function (e) {
                         setDragStatus(
                             'Drag started at page coordinates ' +
-                                e.chartX + '/' + e.chartY + (
+                            e.chartX + '/' + e.chartY + (
                                 e.updateProp ?
                                     '. Updating ' + e.updateProp :
                                     ''

--- a/samples/highcharts/esm/async-await/demo.js
+++ b/samples/highcharts/esm/async-await/demo.js
@@ -9,7 +9,9 @@
         chart: {
             type: 'bubble',
             plotBorderWidth: 1,
-            zoomType: 'xy'
+            zooming: {
+                type: 'xy'
+            }
         },
         legend: {
             enabled: false
@@ -99,7 +101,7 @@
                     y: 102.5,
                     z: 12,
                     name:
-                    'NL',
+                        'NL',
                     country: 'Netherlands'
                 },
                 { x: 80.3, y: 86.1, z: 11.8, name: 'SE', country: 'Sweden' },
@@ -111,7 +113,7 @@
                     y: 93.2,
                     z: 24.7,
                     name:
-                    'UK',
+                        'UK',
                     country: 'United Kingdom'
                 },
                 { x: 69.2, y: 57.6, z: 10.4, name: 'IT', country: 'Italy' },
@@ -121,7 +123,7 @@
                     y: 126.4,
                     z: 35.3,
                     name:
-                    'US',
+                        'US',
                     country: 'United States'
                 },
                 { x: 65.4, y: 50.8, z: 28.5, name: 'HU', country: 'Hungary' },

--- a/samples/highcharts/marker-clusters/basic/demo.js
+++ b/samples/highcharts/marker-clusters/basic/demo.js
@@ -11,7 +11,9 @@ for (let i = 0; i < n; i += 1) {
 
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'xy',
+        zooming: {
+            type: 'xy'
+        },
         height: '100%'
     },
     title: {

--- a/samples/highcharts/marker-clusters/grid/demo.js
+++ b/samples/highcharts/marker-clusters/grid/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'scatter',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'Height Versus Weight of 507 Individuals'

--- a/samples/highcharts/marker-clusters/kmeans/demo.js
+++ b/samples/highcharts/marker-clusters/kmeans/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'scatter',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'Height Versus Weight of 507 Individuals'

--- a/samples/highcharts/members/chart-callback/demo.js
+++ b/samples/highcharts/members/chart-callback/demo.js
@@ -14,7 +14,9 @@
 
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
     title: {
         text: 'Events added from Chart prototype'

--- a/samples/highcharts/plotoptions/bubble-datalabels/demo.js
+++ b/samples/highcharts/plotoptions/bubble-datalabels/demo.js
@@ -3,7 +3,9 @@ Highcharts.chart('container', {
     chart: {
         type: 'bubble',
         plotBorderWidth: 1,
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
 
     title: {

--- a/samples/highcharts/plotoptions/bubble-displaynegative-false/demo.js
+++ b/samples/highcharts/plotoptions/bubble-displaynegative-false/demo.js
@@ -3,7 +3,9 @@ Highcharts.chart('container', {
     chart: {
         type: 'bubble',
         plotBorderWidth: 1,
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
 
     title: {

--- a/samples/highcharts/plotoptions/bubble-negative/demo.js
+++ b/samples/highcharts/plotoptions/bubble-negative/demo.js
@@ -3,7 +3,9 @@ Highcharts.chart('container', {
     chart: {
         type: 'bubble',
         plotBorderWidth: 1,
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
 
     title: {

--- a/samples/highcharts/plotoptions/bubble-radialgradient/demo.js
+++ b/samples/highcharts/plotoptions/bubble-radialgradient/demo.js
@@ -3,7 +3,9 @@ Highcharts.chart('container', {
     chart: {
         type: 'bubble',
         plotBorderWidth: 1,
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
 
     title: {

--- a/samples/highcharts/plotoptions/bubble-size/demo.js
+++ b/samples/highcharts/plotoptions/bubble-size/demo.js
@@ -3,7 +3,9 @@ Highcharts.chart('container', {
     chart: {
         type: 'bubble',
         plotBorderWidth: 1,
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
 
     title: {

--- a/samples/highcharts/plotoptions/bubble-sizeby/demo.js
+++ b/samples/highcharts/plotoptions/bubble-sizeby/demo.js
@@ -3,7 +3,9 @@ Highcharts.chart('container', {
     chart: {
         type: 'bubble',
         plotBorderWidth: 1,
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
 
     title: {

--- a/samples/highcharts/plotoptions/error-bar-styling/demo.js
+++ b/samples/highcharts/plotoptions/error-bar-styling/demo.js
@@ -1,6 +1,8 @@
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
     title: {
         text: 'Temperature'

--- a/samples/highcharts/plotoptions/series-datalabels-allowoverlap-false/demo.js
+++ b/samples/highcharts/plotoptions/series-datalabels-allowoverlap-false/demo.js
@@ -1,6 +1,8 @@
 const chart = Highcharts.chart('container', {
     chart: {
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
     title: {
         text: 'Hide overlapping data labels'

--- a/samples/highcharts/plotoptions/series-marker-enabledthreshold/demo.js
+++ b/samples/highcharts/plotoptions/series-marker-enabledthreshold/demo.js
@@ -10,7 +10,9 @@ for (let x = 0; x <= 60; x++) {
 Highcharts.chart('container', {
 
     chart: {
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
 
     title: {

--- a/samples/highcharts/series-bubble/textpath-datalabels/demo.js
+++ b/samples/highcharts/series-bubble/textpath-datalabels/demo.js
@@ -3,7 +3,9 @@ Highcharts.chart('container', {
     chart: {
         type: 'bubble',
         plotBorderWidth: 1,
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
 
     legend: {

--- a/samples/highcharts/series-timeline/datetime-axis/demo.js
+++ b/samples/highcharts/series-timeline/datetime-axis/demo.js
@@ -1,6 +1,8 @@
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         type: 'timeline'
     },
     xAxis: {

--- a/samples/highcharts/studies/function-series/demo.js
+++ b/samples/highcharts/studies/function-series/demo.js
@@ -45,7 +45,7 @@
                 const series = this,
                     xAxis = this.xAxis;
 
-                xAxis.setExtremes = function ()  {
+                xAxis.setExtremes = function () {
                     Highcharts.Axis.prototype.setExtremes
                         .apply(this, arguments);
                     series.setData([]);
@@ -76,7 +76,9 @@ for (let i = 0; i < 100; i += 0.1) {
 
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
     title: {
         text: 'Measured vs Expected Data'

--- a/samples/highcharts/studies/pinch-zoom/demo.js
+++ b/samples/highcharts/studies/pinch-zoom/demo.js
@@ -32,7 +32,9 @@ Highcharts.addEvent(Highcharts.Axis, 'setExtremes', function (e) {
 
     Highcharts.chart('container', {
         chart: {
-            zoomType: 'xy',
+            zooming: {
+                type: 'xy'
+            },
             panning: {
                 enabled: true,
                 type: 'x'

--- a/samples/highcharts/website/blog-landing-page/demo.js
+++ b/samples/highcharts/website/blog-landing-page/demo.js
@@ -356,7 +356,9 @@ const network = Highcharts.chart('network', {
 const scatter = Highcharts.chart('scatter', {
     chart: {
         type: 'scatter',
-        zoomType: 'xy',
+        zooming: {
+            type: 'xy'
+        },
         animation: {
             duration: 500,
             easing: 'easeInQuint'

--- a/samples/highcharts/website/homepage-2023-new/demo.js
+++ b/samples/highcharts/website/homepage-2023-new/demo.js
@@ -683,7 +683,9 @@ const str = {
         type: 'streamgraph',
         marginBottom: 10,
         // height: 430,
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         backgroundColor: 'transparent',
         animation: {
             duration: 2000,

--- a/samples/highcharts/website/homepage-2023/demo.js
+++ b/samples/highcharts/website/homepage-2023/demo.js
@@ -663,7 +663,9 @@ const str = {
         type: 'streamgraph',
         marginBottom: 30,
         height: 430,
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         backgroundColor: 'transparent',
         animation: {
             duration: 2000,

--- a/samples/highcharts/website/small-demos-dashboards/demo.js
+++ b/samples/highcharts/website/small-demos-dashboards/demo.js
@@ -180,20 +180,20 @@ function climate() {
                             afterSetExtremes: function (e) {
                                 window.clearTimeout(selectionTimeout);
                                 selectionTimeout =
-                                window.setTimeout(async () => {
-                                    if (
-                                        activeTimeRange[0] !== e.min ||
-                                    activeTimeRange[1] !== e.max
-                                    ) {
-                                        activeTimeRange = [e.min, e.max];
-                                        await updateBoard(
-                                            board,
-                                            activeCity,
-                                            activeColumn,
-                                            activeScale
-                                        );
-                                    }
-                                }, 50);
+                                    window.setTimeout(async () => {
+                                        if (
+                                            activeTimeRange[0] !== e.min ||
+                                            activeTimeRange[1] !== e.max
+                                        ) {
+                                            activeTimeRange = [e.min, e.max];
+                                            await updateBoard(
+                                                board,
+                                                activeCity,
+                                                activeColumn,
+                                                activeScale
+                                            );
+                                        }
+                                    }, 50);
                             }
                         }
                     },
@@ -209,7 +209,7 @@ function climate() {
                     chart: {
                         map: await fetch(
                             'https://code.highcharts.com/mapdata/' +
-                        'custom/world.topo.json'
+                            'custom/world.topo.json'
                         ).then(response => response.json()),
                         styledMode: true,
                         height: 190,
@@ -305,8 +305,8 @@ function climate() {
                             headerFormat: '',
                             pointFormat: (
                                 '<b>{point.name}</b><br>' +
-                            'Elevation: {point.custom.elevation}m<br>' +
-                            '{point.y:.1f}˚{point.custom.yScale}'
+                                'Elevation: {point.custom.elevation}m<br>' +
+                                '{point.y:.1f}˚{point.custom.yScale}'
                             )
                         }
                     }],
@@ -431,7 +431,7 @@ function climate() {
         const cityTable = await dataPool.getConnectorTable(city);
 
         if (newData) {
-        // Update time range selector
+            // Update time range selector
             timeRangeSelector.chart.series[0].update({
                 type: column[0] === 'T' ? 'spline' : 'column',
                 data: cityTable.modified
@@ -485,23 +485,45 @@ function climate() {
         // Update city grid selection
         const showCelsius = scale === 'C';
         if (newData) {
-        // await selectionGrid.update({
-        //     dataGridOptions: {
-        //         columns: {
-        //             TNC: {
-        //                 show: showCelsius
-        //             },
-        //             TNF: {
-        //                 show: !showCelsius
-        //             },
-        //             TXC: {
-        //                 show: showCelsius
-        //             },
-        //             TXF: {
-        //                 show: !showCelsius
-        //             }
-        //         }
-        //     },
+            // await selectionGrid.update({
+            //     dataGridOptions: {
+            //         columns: {
+            //             TNC: {
+            //                 show: showCelsius
+            //             },
+            //             TNF: {
+            //                 show: !showCelsius
+            //             },
+            //             TXC: {
+            //                 show: showCelsius
+            //             },
+            //             TXF: {
+            //                 show: !showCelsius
+            //             }
+            //         }
+            //     },
+            //     columnAssignment: {
+            //         time: 'x',
+            //         FD: column === 'FD' ? 'y' : null,
+            //         ID: column === 'ID' ? 'y' : null,
+            //         RR1: column === 'RR1' ? 'y' : null,
+            //         TN: null,
+            //         TNC: column === 'TNC' ? 'y' : null,
+            //         TNF: column === 'TNF' ? 'y' : null,
+            //         TX: null,
+            //         TXC: column === 'TXC' ? 'y' : null,
+            //         TXF: column === 'TXF' ? 'y' : null,
+            //         Date: null
+            //     }
+            // });
+        }
+
+        // selectionGrid.dataGrid.scrollToRow(
+        //   selectionTable.getRowIndexBy('time', rangeTable.getCell('time', 0))
+        // );
+
+        // // Update city chart selection
+        // await cityChart.update({
         //     columnAssignment: {
         //         time: 'x',
         //         FD: column === 'FD' ? 'y' : null,
@@ -514,40 +536,18 @@ function climate() {
         //         TXC: column === 'TXC' ? 'y' : null,
         //         TXF: column === 'TXF' ? 'y' : null,
         //         Date: null
+        //     },
+        //     chartOptions: {
+        //         chart: {
+        //             type: column[0] === 'T' ? 'spline' : 'column'
+        //         },
+        //         colorAxis: {
+        //             min: colorMin,
+        //             max: colorMax,
+        //             stops: colorStops
+        //         }
         //     }
         // });
-        }
-
-        // selectionGrid.dataGrid.scrollToRow(
-        //   selectionTable.getRowIndexBy('time', rangeTable.getCell('time', 0))
-        // );
-
-    // // Update city chart selection
-    // await cityChart.update({
-    //     columnAssignment: {
-    //         time: 'x',
-    //         FD: column === 'FD' ? 'y' : null,
-    //         ID: column === 'ID' ? 'y' : null,
-    //         RR1: column === 'RR1' ? 'y' : null,
-    //         TN: null,
-    //         TNC: column === 'TNC' ? 'y' : null,
-    //         TNF: column === 'TNF' ? 'y' : null,
-    //         TX: null,
-    //         TXC: column === 'TXC' ? 'y' : null,
-    //         TXF: column === 'TXF' ? 'y' : null,
-    //         Date: null
-    //     },
-    //     chartOptions: {
-    //         chart: {
-    //             type: column[0] === 'T' ? 'spline' : 'column'
-    //         },
-    //         colorAxis: {
-    //             min: colorMin,
-    //             max: colorMax,
-    //             stops: colorStops
-    //         }
-    //     }
-    // });
     }
 }
 
@@ -870,7 +870,6 @@ function extremes() {
                 },
                 chart: {
                     type: 'column',
-                    zoomType: 'x',
                     margin: [10, 10, 10, 35],
                     spacing: 0,
                     height: 130,
@@ -879,11 +878,16 @@ function extremes() {
                             chart1 = this;
                         }
                     },
-                    resetZoomButton: {
-                        align: 'center',
-                        theme: {
-                            zIndex: 20,
-                            padding: 4
+                    zooming: {
+                        type: 'x',
+                        resetButton: {
+                            position: {
+                                align: 'center'
+                            },
+                            theme: {
+                                zIndex: 20,
+                                padding: 4
+                            }
                         }
                     }
                 },
@@ -942,7 +946,6 @@ function extremes() {
                 },
                 chart: {
                     type: 'column',
-                    zoomType: 'x',
                     margin: [10, 10, 10, 35],
                     spacing: 0,
                     height: 130,
@@ -951,11 +954,16 @@ function extremes() {
                             chart2 = this;
                         }
                     },
-                    resetZoomButton: {
-                        align: 'center',
-                        theme: {
-                            zIndex: 20,
-                            padding: 4
+                    zooming: {
+                        type: 'x',
+                        resetButton: {
+                            position: {
+                                align: 'center'
+                            },
+                            theme: {
+                                zIndex: 20,
+                                padding: 4
+                            }
                         }
                     }
                 },

--- a/samples/highcharts/website/themes-demo/demo.js
+++ b/samples/highcharts/website/themes-demo/demo.js
@@ -1,6 +1,8 @@
 const chartOptions = {
     chart: {
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'Average Monthly Weather Data for Tokyo',

--- a/samples/highcharts/xaxis/minrange/demo.js
+++ b/samples/highcharts/xaxis/minrange/demo.js
@@ -1,6 +1,8 @@
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
     xAxis: {
         minRange: 5

--- a/samples/highcharts/xaxis/type-datetime/demo.js
+++ b/samples/highcharts/xaxis/type-datetime/demo.js
@@ -1,6 +1,8 @@
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'x'
+        zooming: {
+            type: 'x'
+        }
     },
     xAxis: {
         type: 'datetime',

--- a/samples/highcharts/xaxis/units/demo.js
+++ b/samples/highcharts/xaxis/units/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
 
     chart: {
-        zoomType: 'x',
+        zooming: {
+            type: 'x'
+        },
         events: {
             render: function () {
                 const info = this.xAxis[0].tickPositions.info;

--- a/samples/highcharts/xaxis/zoomenabled/demo.js
+++ b/samples/highcharts/xaxis/zoomenabled/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'line',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
 
     xAxis: {

--- a/samples/stock/chart/events-selection/demo.js
+++ b/samples/stock/chart/events-selection/demo.js
@@ -8,7 +8,9 @@
 
     Highcharts.stockChart('container', {
         chart: {
-            zoomType: 'x',
+            zooming: {
+                type: 'x'
+            },
             events: {
                 selection(event) {
                     if (event.xAxis) {

--- a/samples/stock/chart/panning/demo.js
+++ b/samples/stock/chart/panning/demo.js
@@ -12,7 +12,9 @@
                 type: 'xy'
             },
             panKey: 'alt',
-            zoomType: 'xy'
+            zooming: {
+                type: 'xy'
+            }
         },
 
         title: {

--- a/samples/stock/demo/data-grouping/demo.js
+++ b/samples/stock/demo/data-grouping/demo.js
@@ -21,7 +21,9 @@
                     }
                 }
             },
-            zoomType: 'x'
+            zooming: {
+                type: 'x'
+            }
         },
 
         rangeSelector: {

--- a/samples/stock/demo/depth-chart/demo.js
+++ b/samples/stock/demo/depth-chart/demo.js
@@ -1,7 +1,9 @@
 Highcharts.chart('container', {
     chart: {
         type: 'area',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'ETH-BTC Market Depth'

--- a/samples/stock/demo/lazy-loading/demo.js
+++ b/samples/stock/demo/lazy-loading/demo.js
@@ -25,7 +25,9 @@ fetch(dataURL)
         Highcharts.stockChart('container', {
             chart: {
                 type: 'candlestick',
-                zoomType: 'x'
+                zooming: {
+                    type: 'x'
+                }
             },
 
             navigator: {

--- a/samples/stock/indicators/custom-regression-column/demo.js
+++ b/samples/stock/indicators/custom-regression-column/demo.js
@@ -67,7 +67,9 @@ Highcharts.seriesType(
 
 Highcharts.chart('container', {
     chart: {
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'Average Monthly Temperature and Rainfall in Tokyo'

--- a/samples/stock/indicators/custom-regression-scatter/demo.js
+++ b/samples/stock/indicators/custom-regression-scatter/demo.js
@@ -68,7 +68,9 @@ Highcharts.seriesType(
 Highcharts.chart('container', {
     chart: {
         type: 'scatter',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     title: {
         text: 'Height Versus Weight of 507 Individuals by Gender'

--- a/samples/stock/yaxis/heatmap-scrollbars/demo.js
+++ b/samples/stock/yaxis/heatmap-scrollbars/demo.js
@@ -10,7 +10,9 @@ Highcharts.chart('container', {
     },
     chart: {
         type: 'heatmap',
-        zoomType: 'xy'
+        zooming: {
+            type: 'xy'
+        }
     },
     xAxis: {
         min: Date.UTC(2015, 4, 1),

--- a/samples/stock/yaxis/scrollbar/demo.js
+++ b/samples/stock/yaxis/scrollbar/demo.js
@@ -7,7 +7,9 @@
 
     Highcharts.stockChart('container', {
         chart: {
-            zoomType: 'xy'
+            zooming: {
+                type: 'xy'
+            }
         },
         title: {
             text: 'Scrollbar on Y axis'


### PR DESCRIPTION
Fixed #20917, demos were using deprecated zooming options: `zoomType`, `zoomBySingleTouch` & `resetZoomButton`.