### PR TITLE
bugfix/20876-drillupall-event-performance

### DIFF
--- a/samples/unit-tests/drilldown/drillup/demo.js
+++ b/samples/unit-tests/drilldown/drillup/demo.js
@@ -370,9 +370,34 @@ QUnit.test('Multi-level drilldown gets mixed  (#3579)', function (assert) {
 QUnit.test(
     'Drilldown on the chart with category axis and cropThreshold set, #16135.',
     function (assert) {
+        let redraws = 0,
+            drillupall = 0;
+
         const chart = Highcharts.chart('container', {
             chart: {
-                type: 'column'
+                type: 'column',
+                events: {
+                    drillupall: function () {
+                        drillupall++;
+
+                        assert.strictEqual(
+                            redraws,
+                            2,
+                            `After drilldown and drillup there should be only
+                            two redraws events called (#20876).`
+                        );
+
+                        assert.strictEqual(
+                            drillupall,
+                            1,
+                            `After drilldown and drillup there should be only
+                            one drillupall event called (#20876).`
+                        );
+                    },
+                    redraw: function () {
+                        redraws++;
+                    }
+                }
             },
             xAxis: {
                 type: 'category'
@@ -394,20 +419,18 @@ QUnit.test(
                 ]
             }],
             drilldown: {
-                drilldown: {
-                    breadcrumbs: {
-                        showFullPath: false
-                    },
-                    series: [{
-                        data: [
-                            ['x-0', 1],
-                            ['x-1', 2],
-                            ['x-2', 3]
-                        ],
-                        name: 'DrillSeries',
-                        id: 'DrillSeries'
-                    }]
-                }
+                breadcrumbs: {
+                    showFullPath: false
+                },
+                series: [{
+                    data: [
+                        ['x-0', 1],
+                        ['x-1', 2],
+                        ['x-2', 3]
+                    ],
+                    name: 'DrillSeries',
+                    id: 'DrillSeries'
+                }]
             }
         });
 

--- a/ts/Extensions/Drilldown/Drilldown.ts
+++ b/ts/Extensions/Drilldown/Drilldown.ts
@@ -734,7 +734,10 @@ class ChartAdditions {
                 if (
                     oldSeries.xAxis &&
                     oldSeries.xAxis.names &&
-                    (drilldownLevelsNumber === 0 || i === drilldownLevelsNumber)
+                    (
+                        drilldownLevelsNumber === 0 ||
+                        i === drilldownLevelsNumber - 1
+                    )
                 ) {
                     oldSeries.xAxis.names.length = 0;
                 }
@@ -793,13 +796,6 @@ class ChartAdditions {
 
                 if (!chart.mapView) {
                     fireEvent(chart, 'afterDrillUp');
-                    chart.redraw();
-                    if (chart.ddDupes) {
-                        chart.ddDupes.length = 0; // #3315
-                    } // #8324
-                    // Fire a once-off event after all series have been drilled
-                    // up (#5158)
-                    fireEvent(chart, 'drillupall');
                 } else {
                     const shouldAnimate = level.levelNumber === levelNumber &&
                         isMultipleDrillUp,
@@ -881,17 +877,22 @@ class ChartAdditions {
                             }
 
                             newSeries.isDrilling = false;
-                            if (chart.ddDupes) {
-                                chart.ddDupes.length = 0; // #3315
-                            } // #8324
-                            // Fire a once-off event after all series have been
-                            // drilled up (#5158)
-                            fireEvent(chart, 'drillupall');
                         }
                     }
                 }
             }
         }
+
+        if (!chart.mapView) {
+            chart.redraw();
+        }
+
+        if (chart.ddDupes) {
+            chart.ddDupes.length = 0; // #3315
+        } // #8324
+        // Fire a once-off event after all series have been
+        // drilled up (#5158)
+        fireEvent(chart, 'drillupall');
     }
 
     /**


### PR DESCRIPTION
Fixed #20876, redraw and drillupall events were called too many times during chart drill up.

___

There was a mistake in the old test in chart configuration (`drilldown.drilldown`), after fixing that I figured out, that that functionality was broken (#16135). Now it is fixed.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206866370104681