### PR TITLE
bugfix/20998-axis-left-dataLabels-overflow

### DIFF
--- a/samples/unit-tests/datalabels/xy/demo.js
+++ b/samples/unit-tests/datalabels/xy/demo.js
@@ -61,4 +61,16 @@ QUnit.test('Data label alignment and x/y options (#13580)', assert => {
     testAlignment('left', 'top');
     testAlignment('center', 'middle');
     testAlignment('right', 'bottom');
+
+    chart.update({
+        xAxis: {
+            left: 150
+        }
+    });
+
+    assert.ok(
+        chart.isInsidePlot(label.translateX, label.translateY),
+        `Label should be inside the plot if horizontal axis 'left' value is
+        greater than default.`
+    );
 });

--- a/samples/unit-tests/datalabels/xy/demo.js
+++ b/samples/unit-tests/datalabels/xy/demo.js
@@ -23,6 +23,76 @@ QUnit.test('Data label alignment and x/y options (#13580)', assert => {
 
     const label = chart.series[0].points[0].dataLabel;
 
+    // Overflow left
+    chart.update({
+        xAxis: {
+            left: -40
+        }
+    });
+    assert.close(
+        label.absoluteBox.x,
+        chart.plotLeft,
+        1,
+        `Label should be inside the plot if horizontal axis 'left' value is
+        lower than chart.marginLeft.`
+    );
+
+    // Overflow right
+    chart.update({
+        xAxis: {
+            left: 170
+        }
+    });
+    assert.close(
+        label.absoluteBox.x + label.width,
+        chart.plotWidth + chart.plotLeft,
+        1,
+        `Label should be inside the plot if horizontal axis 'left' value is
+        greater than chart.marginLeft.`
+    );
+
+    // Overflow top
+    chart.update({
+        yAxis: {
+            top: 20
+        },
+        series: {
+            dataLabels: {
+                y: -50
+            }
+        }
+    });
+    assert.close(
+        label.absoluteBox.y,
+        chart.plotTop,
+        1,
+        `Label should be inside the plot if vertical axis 'top' value is
+        different than default.`
+    );
+
+    // Overflow bottom
+    chart.update({
+        chart: {
+            inverted: true
+        },
+        xAxis: {
+            top: 100
+        },
+        series: {
+            dataLabels: {
+                y: 150
+            }
+        }
+    });
+    assert.close(
+        label.absoluteBox.y + label.height,
+        chart.plotTop + chart.plotHeight,
+        1,
+        `Label should be inside the plot if inverted charts xAxis 'top' value is
+        different than default.`
+    );
+
+
     const testAlignment = (align, verticalAlign) => {
         chart.series[0].update({
             dataLabels: {
@@ -62,15 +132,4 @@ QUnit.test('Data label alignment and x/y options (#13580)', assert => {
     testAlignment('center', 'middle');
     testAlignment('right', 'bottom');
 
-    chart.update({
-        xAxis: {
-            left: 150
-        }
-    });
-
-    assert.ok(
-        chart.isInsidePlot(label.translateX, label.translateY),
-        `Label should be inside the plot if horizontal axis 'left' value is
-        greater than default.`
-    );
 });

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -847,15 +847,19 @@ namespace DataLabel {
             align = options.align,
             verticalAlign = options.verticalAlign,
             padding = dataLabel.box ? 0 : (dataLabel.padding || 0),
-            horizontalAxis = this.xAxis?.horiz ? this.xAxis :
-                this.yAxis?.horiz ? this.yAxis : void 0;
+            horizontalAxis = chart.inverted ? this.yAxis : this.xAxis,
+            horizontalAxisShift = horizontalAxis ?
+                horizontalAxis.left - chart.plotLeft : 0,
+            verticalAxis = chart.inverted ? this.xAxis : this.yAxis,
+            verticalAxisShift = verticalAxis ?
+                verticalAxis.top - chart.plotTop : 0;
 
         let { x = 0, y = 0 } = options,
             off,
             justified;
 
         // Off left
-        off = (alignAttr.x || 0) + padding;
+        off = (alignAttr.x || 0) + padding + horizontalAxisShift;
         if (off < 0) {
             if (align === 'right' && x >= 0) {
                 options.align = 'left';
@@ -867,8 +871,7 @@ namespace DataLabel {
         }
 
         // Off right
-        off = (alignAttr.x || 0) + bBox.width - padding +
-            (horizontalAxis ? horizontalAxis.left - chart.plotLeft : 0);
+        off = (alignAttr.x || 0) + bBox.width - padding + horizontalAxisShift;
         if (off > chart.plotWidth) {
             if (align === 'left' && x <= 0) {
                 options.align = 'right';
@@ -880,7 +883,7 @@ namespace DataLabel {
         }
 
         // Off top
-        off = alignAttr.y + padding;
+        off = alignAttr.y + padding + verticalAxisShift;
         if (off < 0) {
             if (verticalAlign === 'bottom' && y >= 0) {
                 options.verticalAlign = 'top';
@@ -892,7 +895,7 @@ namespace DataLabel {
         }
 
         // Off bottom
-        off = (alignAttr.y || 0) + bBox.height - padding;
+        off = (alignAttr.y || 0) + bBox.height - padding + verticalAxisShift;
         if (off > chart.plotHeight) {
             if (verticalAlign === 'top' && y <= 0) {
                 options.verticalAlign = 'bottom';

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -846,7 +846,9 @@ namespace DataLabel {
         const chart = this.chart,
             align = options.align,
             verticalAlign = options.verticalAlign,
-            padding = dataLabel.box ? 0 : (dataLabel.padding || 0);
+            padding = dataLabel.box ? 0 : (dataLabel.padding || 0),
+            horizontalAxis = this.xAxis?.horiz ? this.xAxis :
+                this.yAxis?.horiz ? this.yAxis : void 0;
 
         let { x = 0, y = 0 } = options,
             off,
@@ -865,7 +867,8 @@ namespace DataLabel {
         }
 
         // Off right
-        off = (alignAttr.x || 0) + bBox.width - padding;
+        off = (alignAttr.x || 0) + bBox.width - padding +
+            (horizontalAxis ? horizontalAxis.left - chart.plotLeft : 0);
         if (off > chart.plotWidth) {
             if (align === 'left' && x <= 0) {
                 options.align = 'right';


### PR DESCRIPTION
Fixed #20998, data labels overflowed the plot area when the axis position was different from default.