### PR TITLE
bugfix/20560-arearange-hover-destroy

### DIFF
--- a/samples/unit-tests/chart/destroy/demo.js
+++ b/samples/unit-tests/chart/destroy/demo.js
@@ -135,4 +135,24 @@ QUnit.test('Destroy in own callback and recreate (#3600)', function (assert) {
         `Destroy chart with highchare-more during mouse over the point,
         console should be clear #20572.`
     );
+
+    newChart = Highcharts.chart('container', {
+        series: [{
+            type: 'line',
+            data: [1.5, 2.5]
+        }, {
+            type: 'arearange',
+            data: [[1, 2], [2, 3]]
+        }]
+    });
+
+    newChart.series[1].points[1].onMouseOver();
+    newChart.series[0].points[0].onMouseOver();
+    newChart.destroy();
+
+    assert.ok(
+        true,
+        `Chart destroy should be possible without any errors even if the user
+        hovers over points during destroy #20560.`
+    );
 });

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1583,9 +1583,7 @@ class Point {
             }
 
         } else if (
-            halo &&
-            halo.point &&
-            halo.point.haloPath &&
+            halo?.point?.haloPath &&
             !halo.point.destroyed
         ) {
             // Animate back to 0 on the current halo point (#6055)

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1582,7 +1582,12 @@ class Point {
                 ));
             }
 
-        } else if (halo && halo.point && halo.point.haloPath) {
+        } else if (
+            halo &&
+            halo.point &&
+            halo.point.haloPath &&
+            !halo.point.destroyed
+        ) {
             // Animate back to 0 on the current halo point (#6055)
             halo.animate(
                 { d: halo.point.haloPath(0) },


### PR DESCRIPTION
Fixed #20560, destroyed points in the area range series were wrongly used during mouse hover.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206503029059347