### PR TITLE
DO NOT MERGE YET: Fixed #13049, reordered DOM elements in maps

### DIFF
--- a/samples/unit-tests/series-heatmap/members/demo.js
+++ b/samples/unit-tests/series-heatmap/members/demo.js
@@ -208,10 +208,10 @@ QUnit.test('seriesTypes.heatmap.pointClass.setState', function (assert) {
             .pointClass.prototype.setState;
 
     setState.call(point, '');
-    assert.strictEqual(
-        point.graphic.zIndex,
-        0,
-        'When state:normal zIndex is 0'
+    assert.notEqual(
+        point.series.stateMarkerGraphic.element.getAttribute('href'),
+        `${chart.renderer.url}#${point.graphic.element.id}`,
+        'State is normal, state marker graphic should not refer to the point'
     );
     assert.strictEqual(
         point.graphic.d.split(' ')[1] - point.graphic.getBBox().x,
@@ -221,7 +221,11 @@ QUnit.test('seriesTypes.heatmap.pointClass.setState', function (assert) {
     );
 
     setState.call(point, 'hover');
-    assert.strictEqual(point.graphic.zIndex, 1, 'When state:hover zIndex is 1');
+    assert.strictEqual(
+        point.series.stateMarkerGraphic.attr('href'),
+        `${chart.renderer.url}#${point.graphic.element.id}`,
+        'State is hover, state marker graphic should refer to the point'
+    );
     assert.strictEqual(
         point.graphic.d.split(' ')[1] - point.graphic.getBBox().x,
         point.series.options.borderRadius,
@@ -230,10 +234,10 @@ QUnit.test('seriesTypes.heatmap.pointClass.setState', function (assert) {
     );
 
     setState.call(point, 'select');
-    assert.strictEqual(
-        point.graphic.zIndex,
-        0,
-        'When state:select zIndex is 0'
+    assert.notEqual(
+        point.series.stateMarkerGraphic.element.getAttribute('href'),
+        `${chart.renderer.url}#${point.graphic.element.id}`,
+        'State is select, state marker graphic should not refer to the point'
     );
 
     setState.call(point, '');

--- a/samples/unit-tests/series-map/members/demo.js
+++ b/samples/unit-tests/series-map/members/demo.js
@@ -38,18 +38,22 @@ QUnit.test('seriesTypes.map.pointClass.setState', function (assert) {
             .pointClass.prototype.setState;
 
     setState.call(point, '');
-    assert.strictEqual(
-        point.graphic.zIndex,
-        0,
-        'When state:normal zIndex is 0'
+    assert.notEqual(
+        point.series.stateMarkerGraphic.element.getAttribute('href'),
+        `${chart.renderer.url}#${point.graphic.element.id}`,
+        'State is normal, state marker graphic should not refer to the point'
     );
     setState.call(point, 'hover');
-    assert.strictEqual(point.graphic.zIndex, 1, 'When state:hover zIndex is 1');
-    setState.call(point, 'select');
     assert.strictEqual(
-        point.graphic.zIndex,
-        0,
-        'When state:select zIndex is 0'
+        point.series.stateMarkerGraphic.attr('href'),
+        `${chart.renderer.url}#${point.graphic.element.id}`,
+        'State is hover, state marker graphic should refer to the point'
+    );
+    setState.call(point, 'select');
+    assert.notEqual(
+        point.series.stateMarkerGraphic.element.getAttribute('href'),
+        `${chart.renderer.url}#${point.graphic.element.id}`,
+        'State is select, state marker graphic should not refer to the point'
     );
 });
 

--- a/ts/Series/ColorMapComposition.ts
+++ b/ts/Series/ColorMapComposition.ts
@@ -26,6 +26,7 @@ import SeriesRegistry from '../Core/Series/SeriesRegistry.js';
 const {
     column: { prototype: columnProto }
 } = SeriesRegistry.seriesTypes;
+import SVGElement from '../Core/Renderer/SVG/SVGElement.js';
 import U from '../Core/Utilities.js';
 const {
     addEvent,
@@ -136,12 +137,34 @@ namespace ColorMapComposition {
         this: Point,
         e?: Record<string, any>
     ): void {
-        const point = this as PointComposition;
+        const point = this as PointComposition,
+            series = point.series,
+            renderer = series.chart.renderer;
 
         if (point.moveToTopOnHover && point.graphic) {
-            point.graphic.attr({
-                zIndex: e && e.state === 'hover' ? 1 : 0
-            });
+            if (!series.stateMarkerGraphic) {
+                // Create a `use` element and add it to the end of the group,
+                // which would make it appear on top of the other elements. This
+                // deals with z-index without reordering DOM elements (#13049).
+                series.stateMarkerGraphic = new SVGElement(renderer, 'use')
+                    .add(point.graphic.parentGroup);
+            }
+            if (e?.state === 'hover') {
+                // Give the graphic DOM element the same id as the Point
+                // instance
+                point.graphic.attr({
+                    id: this.id
+                });
+
+                series.stateMarkerGraphic.attr({
+                    href: `${renderer.url}#${this.id}`,
+                    visibility: 'visible'
+                });
+            } else {
+                series.stateMarkerGraphic.attr({
+                    href: ''
+                });
+            }
         }
     }
 

--- a/ts/Series/ColorMapComposition.ts
+++ b/ts/Series/ColorMapComposition.ts
@@ -147,6 +147,9 @@ namespace ColorMapComposition {
                 // which would make it appear on top of the other elements. This
                 // deals with z-index without reordering DOM elements (#13049).
                 series.stateMarkerGraphic = new SVGElement(renderer, 'use')
+                    .css({
+                        pointerEvents: 'none'
+                    })
                     .add(point.graphic.parentGroup);
             }
             if (e?.state === 'hover') {


### PR DESCRIPTION
Fixed #13049, hovering reordered DOM elements in maps and heatmaps, causing problems for screen readers.

Resolved by adding a `use` element last in the series group instead of moving the hovered element to the top.

**Note to reviewers**: The visual diffs comes from the fact that now both the real element and the `use` element are rendered on top of each other. Which is fine, except when the opacity is less than 1, the color will be aggregated which is a bit unpredictable. I'm willing to live with that though. I tried hiding the real element and keeping the `use` element visible, but that doesn't work. Apparently the `use` element takes all attributes of its reference element.