### PR TITLE
Dash: dataGrid factory

### DIFF
--- a/samples/dashboards/cypress/datagrid-hidden/demo.js
+++ b/samples/dashboards/cypress/datagrid-hidden/demo.js
@@ -9,7 +9,7 @@ const columns = {
 };
 
 
-const grid = new DataGrid.DataGrid('container', {
+DataGrid.dataGrid('container', {
     dataTable: new DataTable({ columns })
 });
 

--- a/ts/DataGrid/DataGrid.ts
+++ b/ts/DataGrid/DataGrid.ts
@@ -83,7 +83,7 @@ class DataGrid {
     public static dataGrid(
         container: (string | HTMLElement),
         options: Globals.DeepPartial<DataGridOptions>
-    ) {
+    ): DataGrid {
         return new DataGrid(container, options);
     }
 

--- a/ts/DataGrid/DataGrid.ts
+++ b/ts/DataGrid/DataGrid.ts
@@ -71,6 +71,22 @@ class DataGrid {
      */
     public static readonly defaultOptions = DataGridDefaults;
 
+    /**
+     * Factory function for data grid instances.
+     *
+     * @param container
+     * Element or element ID to create the grid structure into.
+     *
+     * @param options
+     * Options to create the grid structure.
+     */
+    public static dataGrid(
+        container: (string | HTMLElement),
+        options: Globals.DeepPartial<DataGridOptions>
+    ) {
+        return new DataGrid(container, options);
+    }
+
     /* *
      *
      *  Properties

--- a/ts/masters-datagrid/datagrid.src.ts
+++ b/ts/masters-datagrid/datagrid.src.ts
@@ -47,6 +47,7 @@ declare global {
     interface DataGridNamespace {
         win: typeof Globals.win;
         DataGrid: typeof _DataGrid;
+        dataGrid: typeof _DataGrid.dataGrid;
         DataCursor: typeof DataCursor;
         DataModifier: typeof DataModifier;
         DataConnector: typeof DataConnector;
@@ -72,6 +73,7 @@ const G = Globals as unknown as DataGridNamespace;
 G.DataConnector = DataConnector;
 G.DataCursor = DataCursor;
 G.DataGrid = _DataGrid;
+G.dataGrid = _DataGrid.dataGrid;
 G.DataModifier = DataModifier;
 G.DataPool = DataPool;
 G.DataTable = DataTable;


### PR DESCRIPTION
Added `DataGrid.dataGrid` factory so that a grid can be constructed without the `new` keyword.

This change is for consistency, to follow the established pattern of:
* `new Highcharts.Chart` = `Highcharts.chart`
* `new Dashboards.Board` = `Dashboards.board`
* `new Highcharts.StockChart` = `Highcharts.stockChart`
* etc