### PR TITLE
Add support for CSS :host selector in stylesheets

### DIFF
--- a/css/annotations/popup.css
+++ b/css/annotations/popup.css
@@ -1,5 +1,6 @@
 /* Colors, using same names and values as in highcharts.css */
-:root {
+:root,
+:host {
     --highcharts-background-color: #ffffff;
     --highcharts-neutral-color-100: #000000;
     --highcharts-neutral-color-80: #333333;

--- a/css/dashboards/dashboards.css
+++ b/css/dashboards/dashboards.css
@@ -7,6 +7,7 @@
  */
 
 :root,
+:host,
 .highcharts-light {
     /* Neutral colors */
     --highcharts-neutral-color-100: #000000;
@@ -44,7 +45,8 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    :root {
+    :root,
+    :host {
         /* UI colors */
         --highcharts-background-color: #333333;
 

--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -7,6 +7,7 @@
  */
 
 :root,
+:host,
 .highcharts-light {
     --highcharts-background-color: #ffffff;
 
@@ -29,7 +30,8 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    :root {
+    :root,
+    :host {
         /* UI colors */
         --highcharts-background-color: #333333;
 

--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -7,6 +7,7 @@
  */
 
 :root,
+:host,
 .highcharts-light {
     /* Colors for data series and points */
     --highcharts-color-0: #2caffe;
@@ -81,7 +82,8 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    :root {
+    :root,
+    :host {
         /* UI colors */
         --highcharts-background-color: rgb(48, 48, 48);
 

--- a/css/themes/dark-unica.css
+++ b/css/themes/dark-unica.css
@@ -2,7 +2,8 @@
 @import url("https://fonts.googleapis.com/css?family=Unica+One");
 @import url("../highcharts.css");
 
-:root {
+:root,
+:host {
     /* Chart background, point stroke for markers and columns etc */
     --highcharts-background-color: #2a2a2b;
 

--- a/css/themes/grid-light.css
+++ b/css/themes/grid-light.css
@@ -2,7 +2,8 @@
 @import url("https://fonts.googleapis.com/css?family=Dosis:400,600");
 @import url("../highcharts.css");
 
-:root {
+:root,
+:host {
     /* Colors for data series and points. */
     --highcharts-color-0: #7cb5ec;
     --highcharts-color-1: #f7a35c;

--- a/css/themes/sand-signika.css
+++ b/css/themes/sand-signika.css
@@ -2,7 +2,8 @@
 @import url("https://fonts.googleapis.com/css?family=Signika:400,700");
 @import url("../highcharts.css");
 
-:root {
+:root,
+:host {
     --highcharts-background-color: none;
 
     /* Colors for data series and points. */


### PR DESCRIPTION
Adds CSS `:host` selector to main Highcharts stylesheet, themed stylesheets, and other non-demo-related stylesheets.

Importing the default Highcharts styles as-is into the shadow root of a web component - such as one with styled mode turned on - results in broken styles since the `:root` selector does not declare CSS variables in the shadow root context, where `:host` is required.