### PR TITLE
feature/cumulative-start-option

### DIFF
--- a/samples/stock/plotoptions/series-cumulativestart/demo.css
+++ b/samples/stock/plotoptions/series-cumulativestart/demo.css
@@ -1,0 +1,4 @@
+#container {
+    height: 400px;
+    min-width: 600px;
+}

--- a/samples/stock/plotoptions/series-cumulativestart/demo.details
+++ b/samples/stock/plotoptions/series-cumulativestart/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Stock Cumulative start option demo
+ authors:
+   - Pawel Lysy
+ js_wrap: b
+...

--- a/samples/stock/plotoptions/series-cumulativestart/demo.html
+++ b/samples/stock/plotoptions/series-cumulativestart/demo.html
@@ -1,0 +1,4 @@
+<div id="container"></div>
+
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+<script src="https://code.highcharts.com/stock/modules/exporting.js"></script>

--- a/samples/stock/plotoptions/series-cumulativestart/demo.js
+++ b/samples/stock/plotoptions/series-cumulativestart/demo.js
@@ -1,0 +1,40 @@
+const day = 1000 * 60 * 60 * 24;
+
+// Create the chart
+Highcharts.stockChart('container', {
+
+    title: {
+        text: 'CumulativeStart'
+    },
+
+    plotOptions: {
+        series: {
+            cumulative: true,
+            pointStart: Date.UTC(2021, 0, 1),
+            pointInterval: day
+        }
+    },
+
+    rangeSelector: {
+        enabled: false
+    },
+
+    tooltip: {
+        pointFormat: '<span style="color:{series.color}">{series.name}</span>' +
+            ': <b>{point.y}</b> ({point.cumulativeSum})<br/>',
+        changeDecimals: 2,
+        valueDecimals: 2
+    },
+
+    xAxis: {
+        minRange: day * 3,
+        max: Date.UTC(2021, 0, 6)
+    },
+
+    series: [{
+        data: [1, 2, 5, 10, 20, 50, 100, -100, 100, -100],
+        cumulativeStart: true
+    }, {
+        data: [100, -50, -15, 15, -50, -20, -30, 100, -100, 100]
+    }]
+});

--- a/samples/stock/plotoptions/series-cumulativestart/demo.js
+++ b/samples/stock/plotoptions/series-cumulativestart/demo.js
@@ -28,13 +28,13 @@ Highcharts.stockChart('container', {
 
     xAxis: {
         minRange: day * 3,
-        max: Date.UTC(2021, 0, 6)
+        min: Date.UTC(2021, 0, 2)
     },
 
     series: [{
-        data: [1, 2, 5, 10, 20, 50, 100, -100, 100, -100],
+        data: [10, 2, 5, 10, 12, 13, 3, 2, 5],
         cumulativeStart: true
     }, {
-        data: [100, -50, -15, 15, -50, -20, -30, 100, -100, 100]
+        data: [10, 2, 5, 10, 12, 13, 3, 2, 5]
     }]
 });

--- a/samples/unit-tests/series/cumulative/demo.js
+++ b/samples/unit-tests/series/cumulative/demo.js
@@ -100,5 +100,58 @@ QUnit.test('Stock: general tests for the Cumulative Sum', function (assert) {
         `Default approximation when dataGrouping
         is enabled should be equal to sum, #18974.`
     );
+});
 
+QUnit.test('cumulative start option', function (assert) {
+    const data = [1, 1, 1, 1, 1];
+    const chart = Highcharts.stockChart('container', {
+        plotOptions: {
+            series: {
+                cumulative: true
+            }
+        },
+        xAxis: {
+            tickInterval: 1,
+            labels: {
+                format: '{value}'
+            },
+
+            min: 1.1
+        },
+        series: [
+            {
+                cumulativeStart: true,
+                data
+            },
+            {
+                data
+            }
+        ]
+    });
+
+    const series = chart.series,
+        point1 = series[0].points[1],
+        point2 = series[1].points[1];
+
+    assert.notEqual(
+        point1.plotY,
+        point2.plotY,
+        'Points should have different position'
+    );
+
+    chart.xAxis[0].setExtremes(2.1, null);
+
+    assert.notEqual(
+        series[0].points[2].plotY,
+        series[1].points[2].plotY,
+        'Points should have different position'
+    );
+
+    chart.xAxis[0].setExtremes(1.1, null);
+
+    assert.notEqual(
+        point1,
+        chart.yAxis[0].toPixels(0),
+        'Frist Point should start at 0'
+    );
 });

--- a/ts/Series/DataModifyComposition.ts
+++ b/ts/Series/DataModifyComposition.ts
@@ -76,6 +76,7 @@ declare module '../Core/Series/SeriesOptions' {
         compareBase?: (0|100);
         compareStart?: boolean;
         cumulative?: boolean;
+        cumulativeStart?: boolean;
     }
 }
 
@@ -666,8 +667,19 @@ namespace DataModifyComposition {
                     // Record for tooltip etc.
                     const point = this.series.points[index];
 
+                    const cumulativeStart =
+                            point.series.options.cumulativeStart,
+                        withinRange =
+                            point.x <= this.series.xAxis.max! &&
+                            point.x >= this.series.xAxis.min!;
+
+
                     if (point) {
-                        point.cumulativeSum = value;
+                        if (!cumulativeStart || withinRange) {
+                            point.cumulativeSum = value;
+                        } else {
+                            point.cumulativeSum = void 0;
+                        }
                     }
 
                     return value;
@@ -771,6 +783,24 @@ export default DataModifyComposition;
  * @since 9.3.0
  * @product   highstock
  * @apioption plotOptions.series.cumulative
+ */
+
+/**
+ * Defines if cumulation should start from the first point within the visible
+ * range or should start from the first point **before** the range.
+ *
+ * In other words, this flag determines if first point within the visible range
+ * will start at 0 (`cumulativeStart=true`) or should have been already calculated
+ * according to the previous point (`cumulativeStart=false`).
+ *
+ * @sample {highstock} stock/plotoptions/series-cumulativestart/
+ *         Cumulative Start
+ *
+ * @type      {boolean}
+ * @default   false
+ * @since     next
+ * @product   highstock
+ * @apioption plotOptions.series.cumulativeStart
  */
 
 ''; // Keeps doclets above in transpiled file

--- a/ts/Series/DataModifyComposition.ts
+++ b/ts/Series/DataModifyComposition.ts
@@ -732,7 +732,7 @@ export default DataModifyComposition;
 
 /**
  * Defines if comparison should start from the first point within the visible
- * range or should start from the first point **before** the range.
+ * range or should start from the last point **before** the range.
  *
  * In other words, this flag determines if first point within the visible range
  * will have 0% (`compareStart=true`) or should have been already calculated
@@ -787,7 +787,7 @@ export default DataModifyComposition;
 
 /**
  * Defines if cumulation should start from the first point within the visible
- * range or should start from the first point **before** the range.
+ * range or should start from the last point **before** the range.
  *
  * In other words, this flag determines if first point within the visible range
  * will start at 0 (`cumulativeStart=true`) or should have been already calculated


### PR DESCRIPTION
Added new option, [series.cumulativeStart](https://api.highcharts.com/highstock/series.line.cumulativeStart). See #19050.
Closes #19050. 