### PR TITLE
Fixed #20967, errors in series-on-point

### DIFF
--- a/samples/unit-tests/series/update/demo.html
+++ b/samples/unit-tests/series/update/demo.html
@@ -1,5 +1,6 @@
 <script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/modules/boost.js"></script>
+<script src="https://code.highcharts.com/modules/series-on-point.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/series/update/demo.js
+++ b/samples/unit-tests/series/update/demo.js
@@ -757,6 +757,13 @@ QUnit.test(
             chart.series[1].group.attr('visibility') !== 'hidden',
             'Series should be visible'
         );
+
+        chart.addSeries({
+            data: [20, 30, 40],
+            visible: false
+        });
+        chart.series[2].show();
+        assert.ok(true, 'No errors should occur on showing a series (#20967)');
     }
 );
 

--- a/ts/Series/SeriesOnPointComposition.ts
+++ b/ts/Series/SeriesOnPointComposition.ts
@@ -366,7 +366,7 @@ namespace SeriesOnPointComposition {
             const allSeries = this.chart.series;
 
             // When toggling a series visibility, loop through all points
-            this.points.forEach((point): void => {
+            this.points?.forEach((point): void => {
                 // Find all series that are on toggled points
                 const series = find(allSeries, (series): boolean => {
                     const id = ((series.onPoint || {}).options || {}).id;


### PR DESCRIPTION
Fixed #20967, the `Chart.addSeries()` function with a hidden series caused an error with the series-on-point module