### PR TITLE
bugfix/20948-map-bubblelegend-unexpected-ticks

### DIFF
--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -2430,6 +2430,7 @@ class Chart {
                 { labels } = options;
 
             if (
+                chart.hasCartesianSeries &&
                 axis.horiz &&
                 axis.visible &&
                 labels.enabled &&


### PR DESCRIPTION
Fixed #20948, bubble legend created unexpected ticks in Map Charts.