### PR TITLE
docs/20717-negativeFillColor-missing-zones-info

### DIFF
--- a/ts/Series/Area/AreaSeries.ts
+++ b/ts/Series/Area/AreaSeries.ts
@@ -162,7 +162,8 @@ class AreaSeries extends LineSeries {
          */
 
         /**
-         * A separate color for the negative part of the area.
+         * A separate color for the negative part of the area. Note that `zones`
+         * takes precedence over the negative fill color.
          *
          * In styled mode, a negative color is set with the
          * `.highcharts-negative` class name.


### PR DESCRIPTION
Closes #20717, added missing note about `series.zones` precedence over `negativeFillColor` for area series.