### PR TITLE
bugfix/20405-drag-node-follow

### DIFF
--- a/samples/unit-tests/series-networkgraph/networkgraph/demo.js
+++ b/samples/unit-tests/series-networkgraph/networkgraph/demo.js
@@ -1,5 +1,5 @@
 QUnit.test('Network Graph', function (assert) {
-    var chart = Highcharts.chart('container', {
+    const chart = Highcharts.chart('container', {
         chart: {
             type: 'networkgraph'
         },
@@ -15,7 +15,6 @@ QUnit.test('Network Graph', function (assert) {
             }
         }
     });
-    var point;
 
     assert.notStrictEqual(
         chart.container.querySelector('.highcharts-no-data'),
@@ -70,6 +69,34 @@ QUnit.test('Network Graph', function (assert) {
         'No-data label should NOT display when there is data (#9801)'
     );
 
+    // Addition for bug #20405
+    const controller = new TestController(chart);
+
+    const firstNode = chart.series[0].nodes[0],
+        secondNodePosX = chart.series[0].nodes[1].plotX;
+
+    // Simulate dragging of the first node
+    controller.moveTo(
+        chart.plotLeft + firstNode.plotX,
+        chart.plotTop + firstNode.plotY
+    );
+    controller.mouseDown(
+        chart.plotLeft + firstNode.plotX,
+        chart.plotTop + firstNode.plotY
+    );
+    controller.moveTo(
+        chart.plotLeft + firstNode.plotX + 100,
+        chart.plotTop + firstNode.plotY
+    );
+    controller.mouseUp();
+
+    assert.notStrictEqual(
+        secondNodePosX,
+        chart.series[0].nodes[1].plotX,
+        'The second node should follow so its position should be changed.'
+    );
+    // End of #20405 test
+
     chart.series[0].nodes[0].update({
         marker: {
             fillColor: 'red'
@@ -97,7 +124,7 @@ QUnit.test('Network Graph', function (assert) {
         'Custom series.nodes.color is correct'
     );
 
-    point = chart.series[1].points[1];
+    const point = chart.series[1].points[1];
 
     assert.strictEqual(
         point.graphic.element.getAttribute('stroke').toUpperCase(),

--- a/ts/Series/Networkgraph/ReingoldFruchtermanLayout.ts
+++ b/ts/Series/Networkgraph/ReingoldFruchtermanLayout.ts
@@ -645,7 +645,7 @@ class ReingoldFruchtermanLayout {
 
         for (const node of nodes) {
             if (node.fixedPosition) {
-                return;
+                continue;
             }
 
             this.integration.integrate(this, node);


### PR DESCRIPTION
Fixed #20405, when dragging networkgraph node, others didn't follow.

The regression was made when refactoring `forEach` to `for`, see https://github.com/highcharts/highcharts/commit/bcfd51fb17c0d73856906c5692107d3513c825ce. I added regression test.