### PR TITLE
Fixed scaling issues on mobile

### DIFF
--- a/samples/dashboards/demo/election/demo.css
+++ b/samples/dashboards/demo/election/demo.css
@@ -767,12 +767,6 @@ text.highcharts-data-label {
     #election-grid .highcharts-datagrid-cell:nth-child(6) {
         display: none;
     }
-
-    #eleciton-chart-national .datalabels-wrapper {
-        display: inline-block;
-        white-space: normal;
-        width: 70px;
-    }
 }
 
 /* SMALL */
@@ -823,8 +817,11 @@ text.highcharts-data-label {
         padding-left: 3px;
     }
 
-    #election-chart-national .highcharts-data-label {
-        font-size: 0.5em;
+    #election-chart-national .datalabels-wrapper {
+        font-size: 0.75em;
+        display: inline-block;
+        white-space: normal;
+        width: 100px;
     }
 
     #election-chart-national .highcharts-axis-labels {

--- a/samples/dashboards/demo/election/demo.css
+++ b/samples/dashboards/demo/election/demo.css
@@ -266,6 +266,7 @@ text.highcharts-data-label {
     height: var(--progress-bar-height);
     background-color: var(--highcharts-color-0);
     border-radius: 5px 0 0 5px;
+    transition: width 0.5s;
 }
 
 #bar-line {
@@ -291,6 +292,7 @@ text.highcharts-data-label {
     height: var(--progress-bar-height);
     background-color: var(--highcharts-color-1);
     border-radius: 0 5px 5px 0;
+    transition: width 0.5s;
 }
 
 #election-result .info {

--- a/samples/dashboards/demo/election/demo.css
+++ b/samples/dashboards/demo/election/demo.css
@@ -21,7 +21,7 @@
     --color-background: var(--highcharts-neutral-color-3);
     --color-link: #339;
 
-    /* components */
+    /* Components */
     --color-title: #000;
     --component-background: var(--highcharts-neutral-color-0);
     --component-background-optional: var(--highcharts-neutral-color-5);
@@ -165,8 +165,38 @@ body {
     border-radius: var(--component-rounded-corners);
 }
 
+.highcharts-map-series .highcharts-point,
+.highcharts-column-series path.highcharts-point,
+.highcharts-bar-series path.highcharts-point {
+    stroke: #fff;
+}
+
+.highcharts-data-label text,
+text.highcharts-data-label {
+    fill: #000;
+}
+
 .dataGrid-container {
     background: none;
+}
+
+.democrat {
+    color: var(--highcharts-color-0);
+    font-weight: bold;
+}
+
+.republican {
+    color: var(--highcharts-color-1);
+    font-weight: bold;
+}
+
+/* Storage for application meta data */
+#app-data {
+    display: none;
+}
+
+#demo-description {
+    padding: 15px;
 }
 
 /* *
@@ -373,9 +403,8 @@ body {
  *
  * */
 
-#election-map .highcharts-background,
-.highcharts-background {
-    /* fill: var(--component-background); */
+#election-map {
+    height: 805px;
 }
 
 .highcharts-background {
@@ -466,17 +495,13 @@ body {
 
 /* *
  *
- *  Election chart (history)
+ *  Election chart (national and history)
  *
  * */
 
-#election-map {
-    height: 805px;
-}
-
 #election-chart-national,
 #election-chart {
-    height: 200px;
+    min-height: 200px;
 }
 
 #election-chart-national h2 {
@@ -546,9 +571,16 @@ body {
 }
 
 #election-chart-national .highcharts-axis-labels {
-    color: #000;
     font-size: 1.3em;
     font-weight: bold;
+}
+
+#election-chart .highcharts-data-label text,
+#election-chart text.highcharts-data-label {
+    paint-order: stroke;
+    stroke-width: 2px;
+    fill: #000;
+    stroke: #fff;
 }
 
 /* *
@@ -652,17 +684,6 @@ body {
     stroke-width: 2px;
 }
 
-.highcharts-map-series .highcharts-point,
-.highcharts-column-series path.highcharts-point,
-.highcharts-bar-series path.highcharts-point {
-    stroke: #fff;
-}
-
-.highcharts-data-label text,
-text.highcharts-data-label {
-    fill: #000;
-}
-
 /* Dashboards layout */
 
 /* LARGE */
@@ -757,6 +778,10 @@ text.highcharts-data-label {
         width: 100%;
     }
 
+    #election-map {
+        height: 400px;
+    }
+
     #info-dem1,
     #info-rep1 {
         font-size: 12px;
@@ -780,39 +805,29 @@ text.highcharts-data-label {
         margin-right: -20px;
     }
 
+    #info-to-win {
+        padding: 0;
+        font-size: 12px;
+    }
+
     #election-grid .highcharts-datagrid-cell {
         font-size: 12px;
         padding-left: 3px;
     }
-}
 
-/* *
- *
- *  Page-wide styles
- *
- * */
+    #election-chart-national .highcharts-data-label {
+        font-size: 0.5em;
+    }
 
-.democrat {
-    color: var(--highcharts-color-0);
-    font-weight: bold;
-}
+    #election-chart-national .highcharts-axis-labels {
+        font-size: 0.9em;
+    }
 
-.republican {
-    color: var(--highcharts-color-1);
-    font-weight: bold;
-}
+    #html-control-div #election-description {
+        text-align: justify;
+    }
 
-/* Storage for application meta data */
-#app-data {
-    display: none;
-}
-
-/* *
- *
- *  Demo description
- *
- * */
-
-#demo-description {
-    padding: 15px;
+    #html-control-div #election-description-container h1 {
+        font-size: 18px;
+    }
 }

--- a/samples/dashboards/demo/election/demo.css
+++ b/samples/dashboards/demo/election/demo.css
@@ -767,6 +767,12 @@ text.highcharts-data-label {
     #election-grid .highcharts-datagrid-cell:nth-child(6) {
         display: none;
     }
+
+    #eleciton-chart-national .datalabels-wrapper {
+        display: inline-block;
+        white-space: normal;
+        width: 70px;
+    }
 }
 
 /* SMALL */

--- a/samples/dashboards/demo/election/demo.js
+++ b/samples/dashboards/demo/election/demo.js
@@ -209,7 +209,7 @@ async function setupDashboard() {
                             useHTML: true,
                             enabled: true,
                             inside: true,
-                            format: '{point.votes}'
+                            format: '<span class="datalabels-wrapper">{point.votes}</span>'
                         }
                     }
                 },

--- a/samples/dashboards/demo/election/demo.js
+++ b/samples/dashboards/demo/election/demo.js
@@ -73,7 +73,7 @@ async function setupDashboard() {
                     type: 'map',
                     map: mapData,
                     styledMode: false,
-                    animation: false,
+                    animation: true,
                     events: {
                         click: function () {
                             // Clicked outside map
@@ -263,8 +263,7 @@ async function setupDashboard() {
                 },
                 legend: {
                     enabled: true,
-                    floating: true,
-                    verticalAlign: 'top',
+                    verticalAlign: 'bottom',
                     align: 'right'
                 },
                 tooltip: {
@@ -622,8 +621,10 @@ function resetMap(mapChart) {
 }
 
 
-function formatVotes(votes, percent) {
-    return `${votes.toLocaleString('en-US')} (${percent}%) Total Votes`;
+function formatVotes(votes, percent, text = 'Votes') {
+    const voteStr = votes.toLocaleString('en-US');
+
+    return `${voteStr} (${percent}%) ${text}`;
 }
 
 
@@ -710,12 +711,12 @@ async function updateResultComponent(electionTable, year) {
     let el = document.getElementById('info-dem1');
     el.innerHTML = `${candDem}: ${demColVotes}`;
     el = document.getElementById('info-dem2');
-    el.innerHTML = formatVotes(demVotes, demPercent);
+    el.innerHTML = formatVotes(demVotes, demPercent, 'Total Votes');
 
     el = document.getElementById('info-rep1');
     el.innerHTML = `${candRep}: ${repColVotes}`;
     el = document.getElementById('info-rep2');
-    el.innerHTML = formatVotes(repVotes, repPercent);
+    el.innerHTML = formatVotes(repVotes, repPercent, 'Total Votes');
 
     // Result bar
     el = document.getElementById('bar-dem');


### PR DESCRIPTION
Fixed scaling issues for 'history' and 'national' charts.
Re-enabled animation for map.
Moved legend for 'History chart' to bottom (avoids messing up on mobile).
Added white stroke to data label on history chart, this improves visibility when label in inside chart.
Reduced map height on mobile to avoid excessive horizontal padding.
Moved some elements in the CSS file.
