### PR TITLE
bugfix/20382-navigator-axis-id

### DIFF
--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -4,7 +4,10 @@ QUnit.test(
         var chart = $('#container')
             .highcharts('StockChart', {
                 navigator: {
-                    height: 20
+                    height: 20,
+                    xAxis: {
+                        id: 'test'
+                    }
                 },
                 series: [
                     {
@@ -31,6 +34,11 @@ QUnit.test(
             chart.scroller.handles[0].zIndex >=
                 chart.scroller.xAxis.labelGroup.zIndex,
             'Labels no overlap handles'
+        );
+
+        assert.ok(
+            chart.get('test') !== undefined,
+            'Navigator xAxis should be accessed by custom id.'
         );
     }
 );

--- a/ts/Stock/Navigator/Navigator.ts
+++ b/ts/Stock/Navigator/Navigator.ts
@@ -1274,8 +1274,8 @@ class Navigator {
                 ordinal: baseXaxis.options.ordinal,
                 overscroll: baseXaxis.options.overscroll
             }, navigatorOptions.xAxis, {
-                id: 'navigator-x-axis',
-                yAxis: 'navigator-y-axis',
+                id: navigatorOptions.xAxis?.id || 'navigator-x-axis',
+                yAxis: navigatorOptions.yAxis?.id || 'navigator-y-axis',
                 type: 'datetime',
                 index: xAxisIndex,
                 isInternal: true,
@@ -1297,7 +1297,7 @@ class Navigator {
             navigator.yAxis = new Axis(chart, merge(
                 navigatorOptions.yAxis,
                 {
-                    id: 'navigator-y-axis',
+                    id: this.navigatorOptions.yAxis?.id || 'navigator-y-axis',
                     alignTicks: false,
                     offset: 0,
                     index: yAxisIndex,
@@ -1560,8 +1560,8 @@ class Navigator {
                 linkedTo: null, // #6734
                 group: 'nav', // For columns
                 padXAxis: false,
-                xAxis: 'navigator-x-axis',
-                yAxis: 'navigator-y-axis',
+                xAxis: this.navigatorOptions.xAxis?.id || 'navigator-x-axis',
+                yAxis: this.navigatorOptions.yAxis?.id || 'navigator-y-axis',
                 showInLegend: false,
                 stacking: void 0, // #4823
                 isInternal: true,


### PR DESCRIPTION
Fixed #20382: custom id on navigator axis returning undefined with `get()`.