### PR TITLE
bugfix/17450-annotations-afterUpdate-click

### DIFF
--- a/samples/unit-tests/annotations/annotations-events/demo.js
+++ b/samples/unit-tests/annotations/annotations-events/demo.js
@@ -127,8 +127,8 @@ QUnit.test('Annotations events - general', function (assert) {
 
     assert.strictEqual(
         circleAfterUpdateCalled,
-        1,
-        '#15952: afterUpdate event should fire when clicking control point'
+        0,
+        '#15952: afterUpdate event should not fire when clicking control point'
     );
 
     assert.strictEqual(

--- a/ts/Extensions/Annotations/EventEmitter.ts
+++ b/ts/Extensions/Annotations/EventEmitter.ts
@@ -365,13 +365,15 @@ abstract class EventEmitter {
                 }
 
                 emitter.cancelClick = emitter.hasDragged;
-                emitter.hasDragged = false;
                 emitter.chart.hasDraggedAnnotation = false;
-                // ControlPoints vs Annotation:
-                fireEvent(pick(
-                    annotation, // #15952
-                    emitter
-                ), 'afterUpdate');
+                if (emitter.hasDragged) {
+                    // ControlPoints vs Annotation:
+                    fireEvent(pick(
+                        annotation, // #15952
+                        emitter
+                    ), 'afterUpdate');
+                }
+                emitter.hasDragged = false;
                 emitter.onMouseUp();
             },
             isTouchDevice || firesTouchEvents ? { passive: false } : void 0


### PR DESCRIPTION
Fixed #17450, annotation click was firing unnecessary `afterUpdate` event.