### PR TITLE
bugfix/20877-mobile-touch-panning

### DIFF
--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3655,8 +3655,8 @@ class Chart {
                 } = axis,
                 wh = horiz ? 'width' : 'height',
                 xy = horiz ? 'x' : 'y',
-                toLength = to[wh] || axis.len,
-                fromLength = from[wh] || axis.len,
+                toLength = pick(to[wh], axis.len),
+                fromLength = pick(from[wh], axis.len),
                 // If fingers pinched very close on this axis, treat as pan
                 scale = Math.abs(toLength) < 10 ?
                     1 :


### PR DESCRIPTION
Fixed #20877, a regression in v11.3.0 causing mobile touch panning not to work correctly.

The PR doesn't include any tests because current controller touch methods doesn't trigger touch event correctly.