### PR TITLE
bugfix/20549-empty-string-flag-title

### DIFF
--- a/samples/unit-tests/series-flags/color/demo.html
+++ b/samples/unit-tests/series-flags/color/demo.html
@@ -1,4 +1,4 @@
-<script src="https://code.highcharts.com/highstock.js"></script>
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/series-flags/general/demo.html
+++ b/samples/unit-tests/series-flags/general/demo.html
@@ -1,4 +1,4 @@
-<script src="https://code.highcharts.com/highstock.js"></script>
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/series-flags/general/demo.js
+++ b/samples/unit-tests/series-flags/general/demo.js
@@ -261,8 +261,8 @@ QUnit.test('Flag title values', function (assert) {
 
     assert.strictEqual(
         points[0].graphic.text.textStr,
-        'text',
-        'Title should be set from series.title if point.title is false.'
+        false,
+        'Title should equal false if point.title is false.'
     );
 
     assert.strictEqual(
@@ -287,13 +287,6 @@ QUnit.test('Flag title values', function (assert) {
             title: null
         }]
     });
-
-    assert.strictEqual(
-        points[0].graphic.text.textStr,
-        'A',
-        `If point.title is false and series.title is not defined, it should
-        yield default value.`
-    );
 
     assert.strictEqual(
         points[1].graphic.text.textStr,

--- a/samples/unit-tests/series-flags/general/demo.js
+++ b/samples/unit-tests/series-flags/general/demo.js
@@ -235,3 +235,77 @@ QUnit.test('Distributing the flag, #16041.)', function (assert) {
         and still have a positive x position.`
     );
 });
+
+QUnit.test('Flag title values', function (assert) {
+    const chart = Highcharts.chart('container', {
+        series: [{
+            type: 'flags',
+            title: 'text',
+            data: [{
+                x: 1,
+                title: false
+            }, {
+                x: 2,
+                title: undefined
+            }, {
+                x: 3,
+                title: null
+            }, {
+                x: 4,
+                title: ''
+            }]
+        }]
+    });
+
+    const points = chart.series[0].points;
+
+    assert.strictEqual(
+        points[0].graphic.text.textStr,
+        'text',
+        'Title should be set from series.title if point.title is false.'
+    );
+
+    assert.strictEqual(
+        points[1].graphic.text.textStr,
+        'text',
+        'Title should be set from series.title if point.title is undefined.'
+    );
+    assert.strictEqual(
+        points[2].graphic.text.textStr,
+        'text',
+        'Title should be set from series.title if point.title is null.'
+    );
+
+    assert.strictEqual(
+        points[3].graphic.text.textStr,
+        '',
+        'Empty string should be set as a flag title, #20549.'
+    );
+
+    chart.update({
+        series: [{
+            title: null
+        }]
+    });
+
+    assert.strictEqual(
+        points[0].graphic.text.textStr,
+        'A',
+        `If point.title is false and series.title is not defined, it should
+        yield default value.`
+    );
+
+    assert.strictEqual(
+        points[1].graphic.text.textStr,
+        'A',
+        `If point.title is undefined and series.title is not defined, it should
+        yield default value.`
+    );
+    assert.strictEqual(
+        points[2].graphic.text.textStr,
+        'A',
+        `If point.title is null and series.title is not defined, it should yield
+        default value.`
+    );
+
+});

--- a/samples/unit-tests/series-flags/max-distance/demo.html
+++ b/samples/unit-tests/series-flags/max-distance/demo.html
@@ -1,4 +1,4 @@
-<script src="https://code.highcharts.com/highstock.js"></script>
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/series-flags/onkey/demo.html
+++ b/samples/unit-tests/series-flags/onkey/demo.html
@@ -1,4 +1,4 @@
-<script src="https://code.highcharts.com/highstock.js"></script>
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/series-flags/position/demo.html
+++ b/samples/unit-tests/series-flags/position/demo.html
@@ -1,4 +1,4 @@
-<script src="https://code.highcharts.com/highstock.js"></script>
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/series-flags/tooltip/demo.html
+++ b/samples/unit-tests/series-flags/tooltip/demo.html
@@ -1,4 +1,4 @@
-<script src="https://code.highcharts.com/highstock.js"></script>
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/ts/Series/Flags/FlagsSeries.ts
+++ b/ts/Series/Flags/FlagsSeries.ts
@@ -43,7 +43,6 @@ const {
     defined,
     extend,
     isNumber,
-    isString,
     merge,
     objectEach,
     wrap
@@ -253,8 +252,7 @@ class FlagsSeries extends ColumnSeries {
                 }
                 graphic.attr({
                     // Allow empty string as a flag title (#20549)
-                    text: isString(point.options.title) ? point.options.title :
-                        isString(options.title) ? options.title : 'A'
+                    text: point.options.title ?? options.title ?? 'A'
                 })[graphic.isNew ? 'attr' : 'animate'](attribs);
 
                 // Rig for the distribute function

--- a/ts/Series/Flags/FlagsSeries.ts
+++ b/ts/Series/Flags/FlagsSeries.ts
@@ -43,6 +43,7 @@ const {
     defined,
     extend,
     isNumber,
+    isString,
     merge,
     objectEach,
     wrap
@@ -251,7 +252,9 @@ class FlagsSeries extends ColumnSeries {
                     attribs.anchorX = point.anchorX;
                 }
                 graphic.attr({
-                    text: point.options.title || options.title || 'A'
+                    // Allow empty string as a flag title (#20549)
+                    text: isString(point.options.title) ? point.options.title :
+                        isString(options.title) ? options.title : 'A'
                 })[graphic.isNew ? 'attr' : 'animate'](attribs);
 
                 // Rig for the distribute function


### PR DESCRIPTION
Fixed #20549, empty string in flag title resulted in default 'A' assigned.