### PR TITLE
Tests: Fixed failing one for dense ticks.

### DIFF
--- a/samples/unit-tests/drilldown/drilldown-general/demo.js
+++ b/samples/unit-tests/drilldown/drilldown-general/demo.js
@@ -2633,7 +2633,7 @@ QUnit.test('Named categories (#6704)', function (assert) {
     });
 
     assert.strictEqual(
-        chart.xAxis[0].tickPositions.length,
+        chart.xAxis[0].names.length,
         20,
         'Initial category length'
     );


### PR DESCRIPTION
Changed check from `tickPositions` to `names`. Ticks are too dense to render them all, thus checking internal `names` property