### PR TITLE
Fixed #20988, wrong annotations references in options.

### DIFF
--- a/ts/Extensions/Annotations/EventEmitter.ts
+++ b/ts/Extensions/Annotations/EventEmitter.ts
@@ -382,14 +382,7 @@ abstract class EventEmitter {
      * Mouse up handler.
      */
     public onMouseUp(): void {
-        const chart = this.chart,
-            annotation = this.target as Annotation || this,
-            annotationsOptions = chart.options.annotations,
-            index = chart.annotations.indexOf(annotation);
-
         this.removeDocEvents();
-
-        annotationsOptions[index] = annotation.options;
     }
 
     abstract redraw(animation?: boolean): void;


### PR DESCRIPTION
Fixed #20988, exporting chart, then dragging an annotation and exporting again used to cause wrong annotation position in the subsequently exported charts.

___
Note: It might be just the tip of the iceberg. Exporting chart causes some mismatching references in options (`chart.annotation[].options` vs `chart.options.annotations[]`). Ideally, those should be different objects, not references to the same object. Not to mention `chart.userOptions.annotations[]` is also pointing to the same object.. This might require a bigger refactor somewhere in the future. But might as well not, since dragging annotation updates x&y values only and those are correctly set.