### PR TITLE
bugfix/21050-missing-a11y-module-in-caption-text-demo

### DIFF
--- a/samples/highcharts/caption/text/demo.html
+++ b/samples/highcharts/caption/text/demo.html
@@ -1,4 +1,5 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/modules/accessibility.js"></script>
 
 <div id="container"></div>


### PR DESCRIPTION
Fixed #21050, missing a11y module from `caption/text` demo.