### PR TITLE
docs/20391-exclude-dragdrop-networkgraph

### DIFF
--- a/ts/Series/Networkgraph/NetworkgraphSeriesDefaults.ts
+++ b/ts/Series/Networkgraph/NetworkgraphSeriesDefaults.ts
@@ -508,7 +508,7 @@ export default NetworkgraphSeriesDefaults;
  *
  * @type      {Array<Object|Array|number>}
  * @extends   series.line.data
- * @excluding drilldown,marker,x,y,draDrop
+ * @excluding drilldown,marker,x,y,dragDrop
  * @sample    {highcharts} highcharts/chart/reflow-true/
  *            Numerical values
  * @sample    {highcharts} highcharts/series/data-array-of-arrays/


### PR DESCRIPTION
Fixed #20391, exclude networkgraph drag drop from default options.