### PR TITLE
Show negative values in dotplot chart type

### DIFF
--- a/samples/highcharts/studies/dotplot-negative-values/demo.css
+++ b/samples/highcharts/studies/dotplot-negative-values/demo.css
@@ -1,0 +1,5 @@
+#container {
+    min-width: 300px;
+    max-width: 800px;
+    margin: 1em auto;
+}

--- a/samples/highcharts/studies/dotplot-negative-values/demo.details
+++ b/samples/highcharts/studies/dotplot-negative-values/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Kulbir Kainth
+ js_wrap: b
+...

--- a/samples/highcharts/studies/dotplot-negative-values/demo.html
+++ b/samples/highcharts/studies/dotplot-negative-values/demo.html
@@ -1,0 +1,4 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/dotplot.js"></script>
+
+<div id="container"></div>

--- a/samples/highcharts/studies/dotplot-negative-values/demo.js
+++ b/samples/highcharts/studies/dotplot-negative-values/demo.js
@@ -1,0 +1,41 @@
+Highcharts.chart('container', {
+    chart: {
+        type: 'dotplot'
+    },
+    title: {
+        text: 'Stortinget'
+    },
+    xAxis: {
+        type: 'category',
+        offset: 5
+    },
+    yAxis: {
+        visible: false
+    },
+    legend: {
+        enabled: false
+    },
+    series: [{
+        keys: ['name', 'y', 'color'],
+        data: [
+            ['R', 1, '#9c0014'],
+            ['SV', 11, '#da47bb'],
+            ['AP', 49, '#e90031'],
+            ['SP', -19, '#a8cd4d'],
+            ['MDG', 1, '#3e8720'],
+            ['KrF', -8, '#f4b436'],
+            ['V', 8, '#14b48f'],
+            ['H', 45, '#00bbef'],
+            ['FrP', 27, '#005996']
+        ],
+        name: 'Seats',
+        colorByPoint: true,
+        dataLabels: {
+            enabled: true,
+            style: {
+                fontSize: '1em',
+                fontWeight: 'normal'
+            }
+        }
+    }]
+});

--- a/ts/Series/DotPlot/DotPlotSeries.ts
+++ b/ts/Series/DotPlot/DotPlotSeries.ts
@@ -94,7 +94,7 @@ class DotPlotSeries extends ColumnSeries {
             renderer = series.chart.renderer,
             seriesMarkerOptions = options.marker,
             total = this.points.reduce(
-                (acc, point): number => acc + (point.y || 0),
+                (acc, point): number => acc + Math.abs(point.y || 0),
                 0
             ),
             totalHeight = this.points.reduce(
@@ -140,11 +140,14 @@ class DotPlotSeries extends ColumnSeries {
                 startX = (shapeArgs.x || 0) + (
                     (shapeArgs.width || 0) -
                     slotsPerBar * width
-                ) / 2;
+                ) / 2,
+                positiveYValue = Math.abs(point.y ?? 0),
+                shapeY = (shapeArgs.y || 0),
+                shapeHeight = (shapeArgs.height || 0);
 
             let graphics: Array<SVGElement|undefined>,
                 x = startX,
-                y = (shapeArgs.y || 0) + (shapeArgs.height || 0) - height,
+                y = point.negative ? shapeY : shapeY + shapeHeight - height,
                 slotColumn = 0;
 
             point.graphics = graphics = point.graphics || [];
@@ -169,7 +172,7 @@ class DotPlotSeries extends ColumnSeries {
                     point.graphic = renderer.g('point').add(series.group);
                 }
 
-                for (let val = 0; val < point.y || 0; val++) {
+                for (let val = 0; val < positiveYValue; val++) {
                     const attr = {
                         x: x + width * itemPadding,
                         y: y + height * itemPadding,
@@ -195,7 +198,7 @@ class DotPlotSeries extends ColumnSeries {
                     if (slotColumn >= slotsPerBar) {
                         slotColumn = 0;
                         x = startX;
-                        y -= height;
+                        y = point.negative ? y + height : y - height;
                     }
                 }
             }


### PR DESCRIPTION
Show negative values in the dotplot chart type. They would previously not get shown in the chart and any of the bars that did show would not reflect correctly against the yAxis. I've created a demo in the repo as well to test against.