### PR TITLE
bugfix/20564-signed-zeros

### DIFF
--- a/samples/unit-tests/utilities/format/demo.js
+++ b/samples/unit-tests/utilities/format/demo.js
@@ -314,6 +314,11 @@ QUnit.module('Format', () => {
             '',
             'Division by zero'
         );
+        assert.strictEqual(
+            Highcharts.numberFormat(-0.4999999, 0, '.', ''),
+            '0',
+            'numberFormat should return zero without singed minus, #20564.'
+        );
     });
 
     QUnit.test('Relational helpers', assert => {

--- a/ts/Core/Templating.ts
+++ b/ts/Core/Templating.ts
@@ -445,7 +445,7 @@ function numberFormat(
     // number 42 000 000, this line adds 42.
     ret += thousands ? strinteger.substr(0, thousands) + thousandsSep : '';
 
-    if (+exponent[1] < 0 && !firstDecimals) {
+    if ((+exponent[1] < 0 && !firstDecimals)) {
         ret = '0';
     } else {
         // Add the remaining thousands groups, joined by the thousands separator
@@ -458,6 +458,8 @@ function numberFormat(
     if (decimals) {
         // Get the decimal component
         ret += decimalPoint + roundedNumber.slice(-decimals);
+    } else if (+ret === 0) { // Remove signed minus #20564
+        ret = '0';
     }
 
     if (exponent[1] && +ret !== 0) {

--- a/ts/Core/Templating.ts
+++ b/ts/Core/Templating.ts
@@ -445,7 +445,7 @@ function numberFormat(
     // number 42 000 000, this line adds 42.
     ret += thousands ? strinteger.substr(0, thousands) + thousandsSep : '';
 
-    if ((+exponent[1] < 0 && !firstDecimals)) {
+    if (+exponent[1] < 0 && !firstDecimals) {
         ret = '0';
     } else {
         // Add the remaining thousands groups, joined by the thousands separator


### PR DESCRIPTION
Fixed #20564, minus sign was displayed for the number zero if it was rounded from a negative value.