### PR TITLE
Samples: missing padding on Dash demo

### DIFF
--- a/samples/dashboards/demo/light-dark-theme/demo.js
+++ b/samples/dashboards/demo/light-dark-theme/demo.js
@@ -54,11 +54,11 @@ Dashboards.board('container', {
             },
             accessibility: {
                 typeDescription: 'Packed bubble chart with 5 points.',
-                description: `The chart displays points in the form of 
-                different-sized bubbles, representing types of food, the 
+                description: `The chart displays points in the form of
+                different-sized bubbles, representing types of food, the
                 size of which corresponds to their vitamin A content.`,
                 point: {
-                    descriptionFormat: `Vitamin A content in {name}: 
+                    descriptionFormat: `Vitamin A content in {name}:
                     {value} micrograms`
                 }
             },
@@ -67,9 +67,7 @@ Dashboards.board('container', {
             },
             chart: {
                 animation: false,
-                type: 'packedbubble',
-                margin: 0,
-                spacing: [0, 10, 10, 10]
+                type: 'packedbubble'
             },
             tooltip: {
                 stickOnContact: true


### PR DESCRIPTION
Fixed title overlap and missing padding in dashboards demo.

#### Before:
![Skjermbilde 2024-05-02 kl  12 44 33](https://github.com/highcharts/highcharts/assets/227836/c735cff4-6c56-47bd-b9e9-120b4b601446)

#### After:
![Skjermbilde 2024-05-02 kl  12 44 57](https://github.com/highcharts/highcharts/assets/227836/2c8835ed-bd97-4f79-a34c-55845b069185)
