### PR TITLE
moving-demos-to-trees-and-networks

### DIFF
--- a/samples/highcharts/demo/organization-chart/demo.details
+++ b/samples/highcharts/demo/organization-chart/demo.details
@@ -6,5 +6,5 @@ js_wrap: b
 tags:
   - Highcharts demo
 categories:
-  - More chart types
+  - Trees and networks
 ...

--- a/samples/highcharts/demo/organization-hanging/demo.details
+++ b/samples/highcharts/demo/organization-hanging/demo.details
@@ -6,5 +6,5 @@ js_wrap: b
 tags:
   - Highcharts demo
 categories:
-  - More chart types
+  - Trees and networks
 ...

--- a/samples/highcharts/demo/sankey-diagram/demo.details
+++ b/samples/highcharts/demo/sankey-diagram/demo.details
@@ -6,5 +6,5 @@ js_wrap: b
 tags:
   - Highcharts demo
 categories:
-  - More chart types
+  - Trees and networks
 ...

--- a/samples/highcharts/demo/sunburst/demo.details
+++ b/samples/highcharts/demo/sunburst/demo.details
@@ -6,5 +6,5 @@ js_wrap: b
 tags:
   - Highcharts demo
 categories:
-  - More chart types
+  - Trees and networks
 ...

--- a/samples/highcharts/demo/treegraph-boxes/demo.details
+++ b/samples/highcharts/demo/treegraph-boxes/demo.details
@@ -6,5 +6,5 @@ js_wrap: b
 tags:
   - Highcharts demo
 categories:
-  - More chart types
+  - Trees and networks
 ...

--- a/samples/highcharts/demo/treegraph-chart/demo.details
+++ b/samples/highcharts/demo/treegraph-chart/demo.details
@@ -7,5 +7,5 @@ use_png_thumbnail: true
 tags:
   - Highcharts demo
 categories:
-  - More chart types
+  - Trees and networks
 ...

--- a/samples/highcharts/demo/treegraph-inverted/demo.details
+++ b/samples/highcharts/demo/treegraph-inverted/demo.details
@@ -6,5 +6,5 @@ js_wrap: b
 tags:
   - Highcharts demo
 categories:
-  - More chart types
+  - Trees and networks
 ...


### PR DESCRIPTION
Moved treegraph, treemap, sunburst, sankey, and organization demos from `More chart types` to `Trees and networks`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207019700111296