### PR TITLE
Fixed #21109, tooltip animation was not smooth

### DIFF
--- a/samples/unit-tests/chart/reflow/demo.js
+++ b/samples/unit-tests/chart/reflow/demo.js
@@ -240,9 +240,9 @@ QUnit.test(
         assert.ok(
             !chart.tooltip.isHidden &&
         Math.round(point.plotX + chart.plotLeft) ===
-        chart.tooltip.now.anchorX &&
+        chart.tooltip.label.anchorX &&
         Math.round(point.plotY + chart.plotTop) ===
-        chart.tooltip.now.anchorY,
+        chart.tooltip.label.anchorY,
             'Tooltip should be visible and in the correct position'
         );
 
@@ -258,9 +258,9 @@ QUnit.test(
         assert.ok(
             !chart.tooltip.isHidden &&
         Math.round(point.plotX + chart.plotLeft) ===
-        chart.tooltip.now.anchorX &&
+        chart.tooltip.label.anchorX &&
         Math.round(point.plotY + chart.plotTop) ===
-        chart.tooltip.now.anchorY,
+        chart.tooltip.label.anchorY,
             'Tooltip should be visible and in the correct position'
         );
 

--- a/samples/unit-tests/series-column/axis-multiple/demo.js
+++ b/samples/unit-tests/series-column/axis-multiple/demo.js
@@ -140,7 +140,7 @@ QUnit.test('Wrong datalabel position (#3648)', function (assert) {
 
     assert.notOk(chart.tooltip.isHidden, 'Tooltip is hidden');
 
-    var tooltipXPos = chart.tooltip.now.x;
+    var tooltipXPos = chart.tooltip.label.x;
 
     assert.ok(
         firstSeriesColumnX < tooltipXPos && secondSeriesColumnX > tooltipXPos,
@@ -148,7 +148,7 @@ QUnit.test('Wrong datalabel position (#3648)', function (assert) {
     );
 
     controller.mouseOver(secondSeriesCenterX, seriesCenterY);
-    tooltipXPos = chart.tooltip.now.x;
+    tooltipXPos = chart.tooltip.label.x;
     assert.ok(
         secondSeriesColumnX < tooltipXPos,
         'The position of the tooltip is wrong'

--- a/samples/unit-tests/tooltip/outside/demo.js
+++ b/samples/unit-tests/tooltip/outside/demo.js
@@ -81,13 +81,14 @@ QUnit.test('Outside tooltip styling and correct position', function (assert) {
         '#11494: Setting tooltip.style.zIndex should also work'
     );
 
-    const tooltipAbsolute = tooltip.now.x + tooltip.now.anchorX,
+    const tooltipAbsolute = tooltip.label.x + tooltip.label.anchorX,
         pointerLeft = chart.pointer.getChartPosition().left,
         pointX = point.plotX + chart.plotLeft + pointerLeft;
 
-    assert.strictEqual(
-        Math.round(tooltipAbsolute),
-        Math.round(pointX),
+    assert.close(
+        tooltipAbsolute,
+        pointX,
+        5,
         '#16944: Tooltip position should appear at point with outside true'
     );
 
@@ -101,9 +102,10 @@ QUnit.test('Outside tooltip styling and correct position', function (assert) {
 
     tooltip.refresh(point);
 
-    assert.strictEqual(
-        Math.round(tooltipAbsolute),
-        Math.round(pointX),
+    assert.close(
+        tooltipAbsolute,
+        pointX,
+        5,
         'Tooltip position should appear at point with sets margin for chart ' +
         'and container'
     );

--- a/samples/unit-tests/tooltip/outside/demo.js
+++ b/samples/unit-tests/tooltip/outside/demo.js
@@ -88,7 +88,7 @@ QUnit.test('Outside tooltip styling and correct position', function (assert) {
     assert.close(
         tooltipAbsolute,
         pointX,
-        5,
+        8,
         '#16944: Tooltip position should appear at point with outside true'
     );
 
@@ -105,7 +105,7 @@ QUnit.test('Outside tooltip styling and correct position', function (assert) {
     assert.close(
         tooltipAbsolute,
         pointX,
-        5,
+        8,
         'Tooltip position should appear at point with sets margin for chart ' +
         'and container'
     );

--- a/samples/unit-tests/tooltip/position/demo.js
+++ b/samples/unit-tests/tooltip/position/demo.js
@@ -39,7 +39,7 @@ QUnit.test(
         chart.tooltip.refresh(chart.series[0].points[0]);
 
         assert.strictEqual(
-            chart.tooltip.now.anchorY,
+            chart.tooltip.label.anchorY,
             Math.round(chart.series[0].points[0].plotY) + chart.plotTop,
             'Tooltip points to the middle of the top side of fist column ' +
             '(#7242)'
@@ -50,7 +50,7 @@ QUnit.test(
         chart.tooltip.refresh(chart.series[0].points[5]);
 
         assert.strictEqual(
-            chart.tooltip.now.anchorY,
+            chart.tooltip.label.anchorY,
             Math.round(chart.series[0].points[5].plotY) + chart.plotTop,
             'Tooltip points to the middle of the top side of last column ' +
             '(#7242)'
@@ -71,14 +71,15 @@ QUnit.test(
         );
 
         chart.tooltip.refresh(chart.series[1].points[0]);
-        const distanceBefore = chart.tooltip.now.x - chart.tooltip.now.anchorX;
+        const distanceBefore = chart.tooltip.label.x -
+            chart.tooltip.label.anchorX;
 
         chart.renderTo.style.transform = 'scale(1.5)';
         chart.reflow();
 
         chart.tooltip.refresh(chart.series[1].points[0]);
         assert.strictEqual(
-            chart.tooltip.now.x - chart.tooltip.now.anchorX,
+            chart.tooltip.label.x - chart.tooltip.label.anchorX,
             distanceBefore,
             '#12031: Distance should be the same before and after scaling'
         );
@@ -185,7 +186,7 @@ QUnit.test('Wrong tooltip pos for column (#424)', function (assert) {
 
     controller.moveTo(chart.plotLeft + 1, tooltipYPos);
     assert.close(
-        chart.tooltip.now.anchorY,
+        chart.tooltip.label.anchorY,
         Math.round(tooltipYPos),
         1.1,
         'Tooltip position should be correct when bar chart xAxis has top and ' +
@@ -212,7 +213,7 @@ QUnit.test('Wrong tooltip pos for column (#424)', function (assert) {
 
     controller.moveTo(chart.plotLeft + 1, tooltipYPos);
     assert.close(
-        chart.tooltip.now.anchorY,
+        chart.tooltip.label.anchorY,
         Math.round(tooltipYPos),
         1.1,
         'Tooltip position should be correct when bar chart xAxis has top and ' +
@@ -311,7 +312,7 @@ QUnit.test('Tooltip position with inverted multiple axes', assert => {
 
     point1.onMouseOver();
     assert.close(
-        chart.tooltip.now.anchorX,
+        chart.tooltip.label.anchorX,
         chart.series[0].yAxis.width + chart.plotLeft - point1.plotY,
         0.5,
         'Tooltip position on inverted chart with multiple axes should appear ' +
@@ -334,13 +335,13 @@ QUnit.test('Tooltip position for inverted polar chart.', assert => {
     point1.onMouseOver();
 
     assert.equal(
-        chart.tooltip.now.anchorX,
+        chart.tooltip.label.anchorX,
         Math.round(point1.plotX + chart.plotLeft),
         'Tooltip x position should be valid.'
     );
 
     assert.equal(
-        chart.tooltip.now.anchorY,
+        chart.tooltip.label.anchorY,
         Math.round(point1.plotY + chart.plotTop),
         'Tooltip y position should be valid.'
     );

--- a/samples/unit-tests/tooltip/shared/demo.js
+++ b/samples/unit-tests/tooltip/shared/demo.js
@@ -309,7 +309,7 @@ QUnit.test('Shared tooltip with pointPlacement and stickOnContact', assert => {
 
     assert.close(
         predictedTooltipX,
-        chart.tooltip.now.x,
+        chart.tooltip.getLabel().x,
         1,
         `#17948: Tooltip should be displayed at the end of the bar,
             when reversedStacks is set to false.`

--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -22,8 +22,7 @@ import type Legend from './Legend/Legend';
 import ChartDefaults from './Chart/ChartDefaults.js';
 import H from './Globals.js';
 const {
-    isTouchDevice,
-    svg
+    isTouchDevice
 } = H;
 import { Palette } from './Color/Palettes.js';
 import Palettes from './Color/Palettes.js';
@@ -2304,11 +2303,14 @@ const defaultOptions: DefaultOptions = {
         /**
          * Enable or disable animation of the tooltip.
          *
-         * @type       {boolean}
-         * @default    true
+         * @type       {boolean|Partial<Highcharts.AnimationOptionsObject>}
          * @since      2.3.0
          */
-        animation: svg,
+        animation: {
+            duration: 300,
+            // EaseOutCirc
+            easing: (x: number): number => Math.sqrt(1 - Math.pow(x - 1, 2))
+        },
 
         /**
          * The radius of the rounded border corners.

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -28,6 +28,8 @@ import type SVGElement from './Renderer/SVG/SVGElement';
 import type SVGRenderer from './Renderer/SVG/SVGRenderer';
 import type TooltipOptions from './TooltipOptions';
 
+import A from './Animation/AnimationUtilities.js';
+const { animObject } = A;
 import F from './Templating.js';
 const { format } = F;
 import H from './Globals.js';
@@ -166,8 +168,6 @@ class Tooltip {
 
     public len?: number;
 
-    public now: Record<string, number> = {};
-
     public options: TooltipOptions = {} as any;
 
     public outside: boolean = false;
@@ -179,8 +179,6 @@ class Tooltip {
     public shared?: boolean;
 
     public split?: boolean;
-
-    public tooltipTimeout?: number;
 
     public tracker?: SVGElement;
 
@@ -294,7 +292,6 @@ class Tooltip {
             discardElement(this.container);
         }
         U.clearTimeout(this.hideTimer as any);
-        U.clearTimeout(this.tooltipTimeout as any);
     }
 
     /**
@@ -868,16 +865,6 @@ class Tooltip {
         this.crosshairs = [];
 
         /**
-         * Current values of x and y when animating.
-         *
-         * @private
-         * @readonly
-         * @name Highcharts.Tooltip#now
-         * @type {Highcharts.PositionObject}
-         */
-        this.now = { x: 0, y: 0 };
-
-        /**
          * Tooltips are initially hidden.
          *
          * @private
@@ -955,46 +942,20 @@ class Tooltip {
      */
     public move(x: number, y: number, anchorX: number, anchorY: number): void {
         const tooltip = this,
-            now = tooltip.now,
-            animate = tooltip.options.animation !== false &&
-                !tooltip.isHidden &&
-                // When we get close to the target position, abort animation and
-                // land on the right place (#3056)
-                (Math.abs(x - now.x) > 1 || Math.abs(y - now.y) > 1),
-            skipAnchor = tooltip.followPointer || (tooltip.len as any) > 1;
+            animation = animObject(
+                !tooltip.isHidden && tooltip.options.animation
+            ),
+            skipAnchor = tooltip.followPointer || (tooltip.len || 0) > 1,
+            attr: SVGAttributes = { x, y };
 
-        // Get intermediate values for animation
-        extend(now, {
-            x: animate ? (2 * now.x + x) / 3 : x,
-            y: animate ? (now.y + y) / 2 : y,
-            anchorX: skipAnchor ?
-                void 0 :
-                animate ? (2 * now.anchorX + anchorX) / 3 : anchorX,
-            anchorY: skipAnchor ?
-                void 0 :
-                animate ? (now.anchorY + anchorY) / 2 : anchorY
-        });
-
-        // Move to the intermediate value
-        tooltip.getLabel().attr(now);
-        tooltip.drawTracker();
-
-        // Run on next tick of the mouse tracker
-        if (animate) {
-
-            // Never allow two timeouts
-            U.clearTimeout(this.tooltipTimeout as any);
-
-            // Set the fixed interval ticking for the smooth tooltip
-            this.tooltipTimeout = setTimeout(function (): void {
-                // The interval function may still be running during destroy,
-                // so check that the chart is really there before calling.
-                if (tooltip) {
-                    tooltip.move(x, y, anchorX, anchorY);
-                }
-            }, 32) as any;
-
+        if (!skipAnchor) {
+            attr.anchorX = anchorX;
+            attr.anchorY = anchorY;
         }
+
+        animation.step = (): void => tooltip.drawTracker();
+
+        tooltip.getLabel().animate(attr, animation);
     }
 
     /**

--- a/ts/Core/TooltipOptions.d.ts
+++ b/ts/Core/TooltipOptions.d.ts
@@ -14,6 +14,7 @@
  *
  * */
 
+import type AnimationOptions from './Animation/AnimationOptions';
 import type ColorType from './Color/ColorType';
 import type CSSObject from './Renderer/CSSObject';
 import type F from './Templating';
@@ -41,7 +42,7 @@ declare module './Series/SeriesOptions' {
 }
 
 export interface TooltipOptions {
-    animation: boolean;
+    animation: boolean|Partial<AnimationOptions>;
     backgroundColor: ColorType;
     borderColor?: ColorType;
     borderRadius: number;


### PR DESCRIPTION
Fixed #21109, tooltip animation was not smooth. Added the option to set [tooltip.animation](https://api.highcharts.com/highcharts/tooltip.animation) as an animation object, not just a boolean as previously.

___

OP demo with the fix applied: https://jsfiddle.net/highcharts/6b1Ln5gq/

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207228969713195