### PR TITLE
Added new option, dataLabels.alignTo

### DIFF
--- a/samples/highcharts/series-bar/datalabels-alignto/demo.css
+++ b/samples/highcharts/series-bar/datalabels-alignto/demo.css
@@ -1,0 +1,5 @@
+#container {
+    min-width: 320px;
+    max-width: 600px;
+    margin: 0 auto;
+}

--- a/samples/highcharts/series-bar/datalabels-alignto/demo.details
+++ b/samples/highcharts/series-bar/datalabels-alignto/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Data labels align to
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+...

--- a/samples/highcharts/series-bar/datalabels-alignto/demo.html
+++ b/samples/highcharts/series-bar/datalabels-alignto/demo.html
@@ -1,0 +1,3 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="container"></div>

--- a/samples/highcharts/series-bar/datalabels-alignto/demo.js
+++ b/samples/highcharts/series-bar/datalabels-alignto/demo.js
@@ -1,0 +1,29 @@
+Highcharts.chart('container', {
+    chart: {
+        type: 'bar'
+    },
+    title: {
+        text: 'Data labels aligned to plot edges'
+    },
+    xAxis: {
+        categories: ['Apples', 'Pears', 'Bananas', 'Oranges', 'Carrots']
+    },
+    yAxis: {
+        title: {
+            text: null
+        }
+    },
+    legend: {
+        enabled: false
+    },
+    series: [{
+        name: 'Fruit consumption',
+        data: [112, 2345, 3245, 6321, 6870],
+        dataLabels: {
+            align: 'right',
+            alignTo: 'plotEdges',
+            enabled: true
+        },
+        colorByPoint: true
+    }]
+});

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -69,6 +69,7 @@ const {
     objectEach,
     pick,
     pInt,
+    pushUnique,
     replaceNested,
     syncTimeout,
     uniqueKey
@@ -156,7 +157,7 @@ class SVGElement implements SVGElementLike {
     // @todo public alignAttr?: SVGAttributes;
     public alignByTranslate?: boolean;
     public alignOptions?: AlignObject;
-    public alignTo?: string;
+    public alignTo?: BBoxObject|string;
     public alignValue?: ('left'|'center'|'right');
     public clipPath?: SVGElement;
     // @todo public d?: number;
@@ -203,7 +204,6 @@ class SVGElement implements SVGElementLike {
     public visibility?: 'hidden'|'inherit'|'visible';
     public width?: number;
     public x?: number;
-    public xAlign?: number;
     public y?: number;
     // @todo public zIndex?: number;
 
@@ -394,7 +394,7 @@ class SVGElement implements SVGElementLike {
      * @param {boolean} [alignByTranslate]
      *        Align element by translation.
      *
-     * @param {string|Highcharts.BBoxObject} [box]
+     * @param {string|Highcharts.BBoxObject} [alignTo]
      *        The box to align to, needs a width and height. When the box is a
      *        string, it refers to an object in the Renderer. For example, when
      *        box is `spacingBox`, it refers to `Renderer.spacingBox` which
@@ -409,17 +409,16 @@ class SVGElement implements SVGElementLike {
     public align(
         alignOptions?: AlignObject,
         alignByTranslate?: boolean,
-        box?: (string|BBoxObject),
+        alignTo?: (string|BBoxObject),
         redraw: boolean = true
     ): this {
         const attribs: SVGAttributes = {},
             renderer = this.renderer,
-            alignedObjects = renderer.alignedObjects;
+            alignedObjects = renderer.alignedObjects,
+            initialAlignment = Boolean(alignOptions);
 
         let x: number,
             y: number,
-            animateX = true,
-            alignTo: string|undefined,
             alignFactor: number|undefined,
             vAlignFactor: number|undefined;
 
@@ -427,13 +426,7 @@ class SVGElement implements SVGElementLike {
         if (alignOptions) {
             this.alignOptions = alignOptions;
             this.alignByTranslate = alignByTranslate;
-            if (!box || isString(box)) {
-                this.alignTo = alignTo = box || 'renderer';
-                // Prevent duplicates, like legendGroup after resize
-                erase(alignedObjects, this);
-                alignedObjects.push(this);
-                box = void 0; // Reassign it below
-            }
+            this.alignTo = alignTo;
 
         // When called on resize, no arguments are supplied
         } else {
@@ -442,19 +435,31 @@ class SVGElement implements SVGElementLike {
             alignTo = this.alignTo;
         }
 
-        box = pick(
-            box,
-            (renderer as any)[alignTo as any],
-            renderer as any
+        const alignToKey = !alignTo || isString(alignTo) ?
+            alignTo || 'renderer' :
+            void 0;
+        // When aligned to a key, automatically re-align on redraws
+        if (alignToKey) {
+            // Prevent duplicates, like legendGroup after resize
+            if (initialAlignment) {
+                pushUnique(alignedObjects, this);
+            }
+            alignTo = void 0; // Do not use the box
+        }
+
+        const alignToBox: BBoxObject = pick(
+            alignTo,
+            (renderer as any)[alignToKey as any],
+            renderer
         );
 
         // Assign variables
         const align = alignOptions.align,
             vAlign = alignOptions.verticalAlign;
         // Default: left align
-        x = ((box as any).x || 0) + (alignOptions.x || 0);
+        x = (alignToBox.x || 0) + (alignOptions.x || 0);
         // Default: top align
-        y = ((box as any).y || 0) + (alignOptions.y || 0);
+        y = (alignToBox.y || 0) + (alignOptions.y || 0);
 
         // Align
         if (align === 'right') {
@@ -463,10 +468,7 @@ class SVGElement implements SVGElementLike {
             alignFactor = 2;
         }
         if (alignFactor) {
-            animateX = x !== this.xAlign;
-            this.xAlign = x;
-
-            x += ((box as any).width - (alignOptions.width || 0)) /
+            x += ((alignToBox.width || 0) - (alignOptions.width || 0)) /
                 alignFactor;
         }
         attribs[alignByTranslate ? 'translateX' : 'x'] = Math.round(x);
@@ -479,18 +481,10 @@ class SVGElement implements SVGElementLike {
             vAlignFactor = 2;
         }
         if (vAlignFactor) {
-            y += ((box as any).height - (alignOptions.height || 0)) /
+            y += ((alignToBox.height || 0) - (alignOptions.height || 0)) /
                 vAlignFactor;
         }
         attribs[alignByTranslate ? 'translateY' : 'y'] = Math.round(y);
-
-        // Right- and center-aligned labels should not animate when we're only
-        // changing the text (#20965)
-        if (!animateX) {
-            this.attr({
-                [alignByTranslate ? 'translateX' : 'x']: x
-            });
-        }
 
         // Animate only if already placed
         if (redraw) {
@@ -498,7 +492,6 @@ class SVGElement implements SVGElementLike {
             this.placed = true;
         }
         this.alignAttr = attribs;
-
         return this;
     }
 
@@ -1288,7 +1281,7 @@ class SVGElement implements SVGElementLike {
         }
 
         // Remove from alignObjects
-        if (wrapper.alignTo) {
+        if (wrapper.alignOptions) {
             erase(renderer.alignedObjects, wrapper);
         }
 
@@ -1813,6 +1806,21 @@ class SVGElement implements SVGElementLike {
     }
 
     /**
+     * Re-align an aligned text or label after setting the text.
+     *
+     * @private
+     * @function Highcharts.SVGElement#reAlign
+     *
+     */
+    protected reAlign(): void {
+        if (this.alignOptions?.width && this.alignOptions.align !== 'left') {
+            this.alignOptions.width = this.getBBox().width;
+            this.placed = false; // Block animation
+            this.align();
+        }
+    }
+
+    /**
      * Remove a class name from the element.
      *
      * @function Highcharts.SVGElement#removeClass
@@ -2188,8 +2196,10 @@ class SVGElement implements SVGElementLike {
 
             this.textStr = value;
             if (this.added) {
-                this.renderer.buildText(this as any);
+                this.renderer.buildText(this);
             }
+
+            this.reAlign();
         }
     }
 

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -484,16 +484,16 @@ class SVGElement implements SVGElementLike {
         }
         attribs[alignByTranslate ? 'translateY' : 'y'] = Math.round(y);
 
+        // Right- and center-aligned labels should not animate when we're only
+        // changing the text (#20965)
+        if (!animateX) {
+            this.attr({
+                [alignByTranslate ? 'translateX' : 'x']: x
+            });
+        }
+
         // Animate only if already placed
         if (redraw) {
-
-            // Right- and center-aligned labels should not animate when we're
-            // only changing the text (#20965)
-            if (!animateX) {
-                this.attr({
-                    [alignByTranslate ? 'translateX' : 'x']: x
-                });
-            }
             this[this.placed ? 'animate' : 'attr'](attribs);
             this.placed = true;
         }

--- a/ts/Core/Renderer/SVG/SVGLabel.ts
+++ b/ts/Core/Renderer/SVG/SVGLabel.ts
@@ -380,6 +380,8 @@ class SVGLabel extends SVGElement {
             this.text.attr({ text });
         }
         this.updateTextPadding();
+
+        this.reAlign();
     }
 
     /*

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -238,9 +238,8 @@ namespace DataLabel {
         isNew?: boolean
     ): void {
         const series = this,
-            chart = this.chart,
+            { chart, enabledDataSorting } = this,
             inverted = this.isCartesian && chart.inverted,
-            enabledDataSorting = this.enabledDataSorting,
             plotX = point.plotX,
             plotY = point.plotY,
             rotation = options.rotation || 0,
@@ -275,33 +274,33 @@ namespace DataLabel {
         // Math.round for rounding errors (#2683), alignTo to allow column
         // labels (#2700)
         let visible =
-                this.visible &&
-                point.visible !== false &&
-                defined(plotX) &&
+            this.visible &&
+            point.visible !== false &&
+            defined(plotX) &&
+            (
+                point.series.forceDL ||
+                (enabledDataSorting && !justify) ||
+                isInsidePlot ||
                 (
-                    point.series.forceDL ||
-                    (enabledDataSorting && !justify) ||
-                    isInsidePlot ||
-                    (
-                        // If the data label is inside the align box, it is
-                        // enough that parts of the align box is inside the
-                        // plot area (#12370). When stacking, it is always
-                        // inside regardless of the option (#15148).
-                        pick(options.inside, !!this.options.stacking) &&
-                        alignTo &&
-                        chart.isInsidePlot(
-                            plotX,
-                            inverted ?
-                                alignTo.x + 1 :
-                                alignTo.y + alignTo.height - 1,
-                            {
-                                inverted,
-                                paneCoordinates: true,
-                                series
-                            }
-                        )
+                    // If the data label is inside the align box, it is enough
+                    // that parts of the align box is inside the plot area
+                    // (#12370). When stacking, it is always inside regardless
+                    // of the option (#15148).
+                    pick(options.inside, !!this.options.stacking) &&
+                    alignTo &&
+                    chart.isInsidePlot(
+                        plotX,
+                        inverted ?
+                            alignTo.x + 1 :
+                            alignTo.y + alignTo.height - 1,
+                        {
+                            inverted,
+                            paneCoordinates: true,
+                            series
+                        }
                     )
-                );
+                )
+            );
 
         const pos = point.pos();
         if (visible && pos) {
@@ -323,6 +322,12 @@ namespace DataLabel {
                 width: 0,
                 height: 0
             }, alignTo || {});
+
+            // Align to plot edges
+            if (options.alignTo === 'plotEdges') {
+                alignTo[inverted ? 'x' : 'y'] = 0;
+                alignTo[inverted ? 'width' : 'height'] = this.yAxis?.len || 0;
+            }
 
             // Add the text size for alignment calculation
             extend<DataLabelOptions|BBoxObject>(options, {

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -324,7 +324,7 @@ namespace DataLabel {
             }, alignTo || {});
 
             // Align to plot edges
-            if (options.alignTo === 'plotEdges') {
+            if (options.alignTo === 'plotEdges' && series.isCartesian) {
                 alignTo[inverted ? 'x' : 'y'] = 0;
                 alignTo[inverted ? 'width' : 'height'] = this.yAxis?.len || 0;
             }

--- a/ts/Core/Series/DataLabelOptions.d.ts
+++ b/ts/Core/Series/DataLabelOptions.d.ts
@@ -56,6 +56,7 @@ export interface DataLabelFormatterCallback {
 export interface DataLabelOptions {
     animation?: (boolean|Partial<AnimationOptions>);
     align?: AlignValue;
+    alignTo?: 'connectors'|'plotEdges';
     allowOverlap?: boolean;
     backgroundColor?: ColorType;
     borderColor?: ColorType;

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -1558,6 +1558,22 @@ const seriesDefaults: PlotOptionsOf<Series> = {
         align: 'center',
 
         /**
+         * Alignment method for data labels. If set to `plotEdges`, the labels
+         * are aligned within the plot area in the direction of the y-axis. So
+         * in a regular column chart, the labels are aligned vertically
+         * according to the `verticalAlign` setting. In a bar chart, which is
+         * inverted, the labels are aligned horizontally according to the
+         * `align` setting. Applies to cartesian series only.
+         *
+         * @sample {highcharts} highcharts/series-bar/datalabels-alignto/
+         *         Align to plot edges
+         *
+         * @type      {string}
+         * @since     next
+         * @apioption plotOptions.series.dataLabels.alignTo
+         */
+
+        /**
          * Whether to allow data labels to overlap. To make the labels less
          * sensitive for overlapping, the
          * [dataLabels.padding](#plotOptions.series.dataLabels.padding)

--- a/ts/Series/Pie/PieDataLabelOptions.d.ts
+++ b/ts/Series/Pie/PieDataLabelOptions.d.ts
@@ -25,7 +25,6 @@ import type DataLabelOptions from '../../Core/Series/DataLabelOptions';
  * */
 
 export interface PieDataLabelOptions extends DataLabelOptions {
-    alignTo?: string;
     connectorColor?: ColorType;
     connectorPadding?: number;
     connectorShape?: (string|DataLabel.ConnectorShapeFunction);


### PR DESCRIPTION
Added new option, [dataLabels.alignTo](https://api.highcharts.com/highcharts/series.dataLabels.alignTo). Previously this option was available for pie series only, now `alignTo: 'plotEdges'` can be used for cartesian series as well. 

### To do
 - [x] Sample
 - [x] API doclet
 - [x] Test with non-cartesian series like sankey, sunburst etc. Remove from their API if possible.
 - [x] Should it be called `pane` instead of `plotEdges`? In that case, change pie too, with a legacy fallback.
 - [x] Reconsider the `animateX` fix, check if we should update the `x` in `textSetter` instead.