### PR TITLE
dash/datagid-useHTML

### DIFF
--- a/ts/DataGrid/DataGridOptions.d.ts
+++ b/ts/DataGrid/DataGridOptions.d.ts
@@ -77,6 +77,11 @@ export interface DataGridOptions {
     editable?: boolean;
 
     /**
+     * Events attached to the row : `click`.
+     */
+    events?: DataGridEvents
+
+    /**
      * Switch to make the column sizes editable ('true') or fixed ('false').
      *
      * @default true
@@ -84,9 +89,12 @@ export interface DataGridOptions {
     resizableColumns?: boolean;
 
     /**
-     * Events attached to the row : `click`.
+     * Weather to use HTML to render the cell content. When enabled, other
+     * elements than text can be added to the cell ie. images.
+     *
+     * @default false
      */
-    events?: DataGridEvents
+    useHTML?: boolean;
 }
 
 /**

--- a/ts/masters-datagrid/datagrid.src.ts
+++ b/ts/masters-datagrid/datagrid.src.ts
@@ -18,6 +18,7 @@
  * */
 
 
+import AST from '../Core/Renderer/HTML/AST.js';
 import DataConnector from '../Data/Connectors/DataConnector.js';
 import DataCursor from '../Data/DataCursor.js';
 import _DataGrid from '../DataGrid/DataGrid.js';
@@ -46,6 +47,7 @@ import '../Data/Modifiers/SortModifier.js';
 declare global {
     interface DataGridNamespace {
         win: typeof Globals.win;
+        AST: typeof AST;
         DataGrid: typeof _DataGrid;
         dataGrid: typeof _DataGrid.dataGrid;
         DataCursor: typeof DataCursor;
@@ -70,6 +72,7 @@ declare global {
 
 const G = Globals as unknown as DataGridNamespace;
 
+G.AST = AST;
 G.DataConnector = DataConnector;
 G.DataCursor = DataCursor;
 G.DataGrid = _DataGrid;


### PR DESCRIPTION
Added option to use valid HTML inside the DataGrid cell, along with that the `useHTML` option was added, see #20634.