### PR TITLE
bugfix/20940-gantt-rangeSelector-not-fixed

### DIFF
--- a/samples/unit-tests/gantt/gantt/demo.js
+++ b/samples/unit-tests/gantt/gantt/demo.js
@@ -825,4 +825,47 @@
                 'There should be no errors in the console.'
             );
         });
+
+    QUnit.test(
+        'Gantt rangeSelector with scrollablePlotArea is fixed, #20940',
+        function (assert) {
+
+            const chart = Highcharts.ganttChart('container', {
+                chart: {
+                    scrollablePlotArea: {
+                        minHeight: 500
+                    }
+                },
+                rangeSelector: {
+                    enabled: true
+                },
+                series: [
+                    {
+                        data: [
+                            {
+                                name: 'Task 1',
+                                start: 2,
+                                end: 3
+                            },
+                            {
+                                name: 'Task 2',
+                                start: 3,
+                                end: 4
+                            },
+                            {
+                                name: 'Task 3',
+                                start: 1,
+                                end: 2
+                            }
+                        ]
+                    }
+                ]
+            });
+
+            assert.ok(
+                chart.rangeSelector.buttonGroup
+                    .element.closest('.highcharts-fixed'),
+                'rangeSelector is a part of fixed elements.'
+            );
+        });
 }());

--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -186,6 +186,25 @@ class ScrollablePlotArea {
         }
     }
 
+    static fixedSelectors: string[] = [
+        '.highcharts-breadcrumbs-group',
+        '.highcharts-contextbutton',
+        '.highcharts-caption',
+        '.highcharts-credits',
+        '.highcharts-drillup-button',
+        '.highcharts-legend',
+        '.highcharts-legend-checkbox',
+        '.highcharts-navigator-series',
+        '.highcharts-navigator-xaxis',
+        '.highcharts-navigator-yaxis',
+        '.highcharts-navigator',
+        '.highcharts-range-selector-group',
+        '.highcharts-reset-zoom',
+        '.highcharts-scrollbar',
+        '.highcharts-subtitle',
+        '.highcharts-title'
+    ];
+
     public chart: Chart;
     public fixedDiv: HTMLDOMElement;
     public fixedRenderer: SVGRenderer;
@@ -425,23 +444,7 @@ class ScrollablePlotArea {
                 scrollablePixelsY
             } = this.chart,
             fixedRenderer = this.fixedRenderer,
-            fixedSelectors = [
-                '.highcharts-breadcrumbs-group',
-                '.highcharts-contextbutton',
-                '.highcharts-caption',
-                '.highcharts-credits',
-                '.highcharts-legend',
-                '.highcharts-legend-checkbox',
-                '.highcharts-navigator-series',
-                '.highcharts-navigator-xaxis',
-                '.highcharts-navigator-yaxis',
-                '.highcharts-navigator',
-                '.highcharts-reset-zoom',
-                '.highcharts-drillup-button',
-                '.highcharts-scrollbar',
-                '.highcharts-subtitle',
-                '.highcharts-title'
-            ];
+            fixedSelectors = ScrollablePlotArea.fixedSelectors;
 
         let axisClass: (string|undefined);
 


### PR DESCRIPTION
Fixed #20940, `rangeSelector` wasn't a part of fixed elements in Gantt.
Extracted `fixedSelectors` list as a static property inside `ScrollablePlotArea` class.