### PR TITLE
bugfix/21130-rangeselector-input-tab-key

### DIFF
--- a/ts/Stock/RangeSelector/RangeSelector.ts
+++ b/ts/Stock/RangeSelector/RangeSelector.ts
@@ -1094,7 +1094,11 @@ class RangeSelector {
             keyDown = true;
 
             // Arrow keys
-            if (event.keyCode === 38 || event.keyCode === 40) {
+            if (
+                event.key === 'ArrowUp' ||
+                event.key === 'ArrowDown' ||
+                event.key === 'Tab'
+            ) {
                 updateExtremes();
             }
         };


### PR DESCRIPTION
Fixed #21130, `TAB` key was not updating the extremes in `rangeSelector` inputs.