### PR TITLE
tools/docs-next-deprecated

### DIFF
--- a/tools/gulptasks/prep-release.js
+++ b/tools/gulptasks/prep-release.js
@@ -81,11 +81,14 @@ function prepareRelease() {
         buildProperties.date = new Date().toISOString().split('T')[0];
         fs.writeFileSync('build-properties.json', JSON.stringify(buildProperties, null, 2));
 
-        // replace occurences of @ since next in docs with @since x.y.z, first checking if xargs is on gnu (linux) or bsd (osx).
+        // replace occurences of @ since next in docs with @ since x.y.z, and the same for @ deprecated,
+        // first checking if xargs is on gnu (linux) or bsd (osx).
         const isGNU = ChildProcess.execSync('xargs --version 2>&1 |grep -s GNU >/dev/null && echo true || echo false').toString().replace('\n', '') === 'true';
-        ChildProcess.execSync(`grep -Rl --exclude=*.bak --exclude-dir=node_modules --exclude-dir=code "@since\\s\\+next" . | xargs ${isGNU ? '-r' : ''} sed -i'.bak' -e 's/@since *next/@since ${nextVersion}/'`);
-        // replace "next" in tag deprecated with the next version "x.y.z"
-        ChildProcess.execSync(`grep -Rl --exclude=*.bak --exclude-dir=node_modules --exclude-dir=code "@deprecated\\s\\+next" . | xargs ${isGNU ? '-r' : ''} sed -i'.bak' -e 's/@deprecated *next/@deprecated ${nextVersion}/'`);
+        ChildProcess.execSync(
+            'grep -Rl --exclude=*.bak --exclude-dir=node_modules --exclude-dir=code -e "@since\\s\\+next" -e "@deprecated\\s\\+next" . | ' +
+            `xargs ${isGNU ? '-r' : ''} ` +
+            `sed -i'.bak' -e 's/@since *next/@since ${nextVersion}/; s/@deprecated *next/@deprecated ${nextVersion}/'`
+        );
 
         LogLib.success('Updated version in package.json, bower.json, build-properties.json' +
                         ' and replaced next in @ since and @ deprecated in the docs.' +

--- a/tools/gulptasks/prep-release.js
+++ b/tools/gulptasks/prep-release.js
@@ -84,9 +84,12 @@ function prepareRelease() {
         // replace occurences of @ since next in docs with @since x.y.z, first checking if xargs is on gnu (linux) or bsd (osx).
         const isGNU = ChildProcess.execSync('xargs --version 2>&1 |grep -s GNU >/dev/null && echo true || echo false').toString().replace('\n', '') === 'true';
         ChildProcess.execSync(`grep -Rl --exclude=*.bak --exclude-dir=node_modules --exclude-dir=code "@since\\s\\+next" . | xargs ${isGNU ? '-r' : ''} sed -i'.bak' -e 's/@since *next/@since ${nextVersion}/'`);
+        // replace "next" in tag deprecated with the next version "x.y.z"
+        ChildProcess.execSync(`grep -Rl --exclude=*.bak --exclude-dir=node_modules --exclude-dir=code "@deprecated\\s\\+next" . | xargs ${isGNU ? '-r' : ''} sed -i'.bak' -e 's/@deprecated *next/@deprecated ${nextVersion}/'`);
 
-        LogLib.success('Updated version in package.json, bower.json, build-properties.json and replaced @ since next' +
-                        ' in the docs. Please review changes and commit & push when ready.');
+        LogLib.success('Updated version in package.json, bower.json, build-properties.json' +
+                        ' and replaced next in @ since and @ deprecated in the docs.' +
+                        ' Please review changes and commit & push when ready.');
         resolve();
     });
 }

--- a/ts/Core/Axis/Color/ColorAxisDefaults.ts
+++ b/ts/Core/Axis/Color/ColorAxisDefaults.ts
@@ -479,7 +479,7 @@ const colorAxisDefaults: DeepPartial<ColorAxis.Options> = {
      *            Percentage width and pixel height for color axis
      *
      * @type      {number|string}
-     * @since     @next
+     * @since     11.3.0
      * @product   highcharts highstock highmaps
      * @apioption colorAxis.width
      */
@@ -495,7 +495,7 @@ const colorAxisDefaults: DeepPartial<ColorAxis.Options> = {
      *            Percentage width and pixel height for color axis
      *
      * @type      {number|string}
-     * @since     @next
+     * @since     11.3.0
      * @product   highcharts highstock highmaps
      * @apioption colorAxis.height
      */

--- a/ts/Core/Chart/ChartDefaults.ts
+++ b/ts/Core/Chart/ChartDefaults.ts
@@ -447,7 +447,7 @@ const ChartDefaults: ChartOptions = {
      *
      * @type      {number}
      * @default   2
-     * @since     @next
+     * @since     11.3.0
      * @apioption chart.axisLayoutRuns
      */
 

--- a/ts/Extensions/Data.ts
+++ b/ts/Extensions/Data.ts
@@ -2472,10 +2472,10 @@ export default Data;
  * @sample {highmaps} highcharts/data/column-types-map/
  *         Map chart created with fips from CSV
  *
- * @type      {Array<'string'|'number'|'float'|'date'>}
- * @since     @next
+ * @type       {Array<'string'|'number'|'float'|'date'>}
+ * @since      11.3.0
  * @validvalue ["string", "number", "float", "date"]
- * @apioption data.columnTypes
+ * @apioption  data.columnTypes
  */
 
 /**

--- a/ts/Maps/MapView.ts
+++ b/ts/Maps/MapView.ts
@@ -776,7 +776,7 @@ class MapView {
      *
      * @function Highcharts.MapView#recommendMapView
      *
-     * @since @next
+     * @since 11.4.0
      *
      * @param {Highcharts.Chart} chart
      *        Chart object

--- a/ts/Series/GeoHeatmap/GeoHeatmapSeries.ts
+++ b/ts/Series/GeoHeatmap/GeoHeatmapSeries.ts
@@ -160,9 +160,6 @@ class GeoHeatmapSeries extends MapSeries {
              * @sample maps/demo/geoheatmap-europe/
              *         1 by default, set to 5
              *
-             * @type      {number}
-             * @default   1
-             * @since 11.0.0
              * @product   highmaps
              * @apioption plotOptions.geoheatmap.colsize
              */
@@ -175,7 +172,6 @@ class GeoHeatmapSeries extends MapSeries {
              * default value is pulled from the [options.colors](#colors) array.
              *
              * @type      {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
-             * @since 11.0.0
              * @product   highmaps
              * @apioption plotOptions.geoheatmap.color
              */
@@ -187,9 +183,6 @@ class GeoHeatmapSeries extends MapSeries {
              * @sample maps/demo/geoheatmap-europe/
              *         1 by default, set to 5
              *
-             * @type      {number}
-             * @default   1
-             * @since 11.0.0
              * @product   highmaps
              * @apioption plotOptions.geoheatmap.rowsize
              */
@@ -206,14 +199,14 @@ class GeoHeatmapSeries extends MapSeries {
              *         datasets
              *
              * @type      {boolean|Highcharts.InterpolationOptionsObject}
-             * @since     @next
+             * @since     11.2.0
              * @product   highmaps
              */
             interpolation: {
                 /**
                  * Enable or disable the interpolation of the geoheatmap series.
                  *
-                 * @since     @next
+                 * @since 11.2.0
                  */
                 enabled: false,
                 /**
@@ -228,7 +221,7 @@ class GeoHeatmapSeries extends MapSeries {
                  * @sample maps/series-geoheatmap/turkey-fire-areas
                  *         Simple demo of GeoHeatmap interpolation
                  *
-                 * @since     @next
+                 * @since  11.2.0
                  */
                 blur: 1
             }

--- a/ts/Series/Organization/OrganizationSeriesDefaults.ts
+++ b/ts/Series/Organization/OrganizationSeriesDefaults.ts
@@ -484,7 +484,7 @@ const OrganizationSeriesDefaults: OrganizationSeriesOptions = {
  * Layout for the node's children. If `hanging`, this node's children will hang
  * below their parent, allowing a tighter packing of nodes in the diagram.
  *
- * Note: Since @next version, the `hanging` layout is set by default for
+ * Note: Since version 10.0.0, the `hanging` layout is set by default for
  * children of a parent using `hanging` layout.
  *
  * @sample highcharts/demo/organization-chart

--- a/ts/Series/Sankey/SankeySeriesDefaults.ts
+++ b/ts/Series/Sankey/SankeySeriesDefaults.ts
@@ -227,7 +227,7 @@ const SankeySeriesDefaults: PlotOptionsOf<SankeySeries> = {
      *         Sankey diagram with gradients and explanation
      *
      * @type      {('from'|'gradient'|'to')}
-     * @since     @next
+     * @since     11.2.0
      */
     linkColorMode: 'from',
 


### PR DESCRIPTION
Added replace for `@deprecated next` on release, so `next` could be used for the `@deprecated`.
Wrongly used `@next` instead of `next` that were used are now fixed - replaced with the relevant version number.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207286207694047