### PR TITLE
bugfix/16915-minPadding-navigator-ignored

### DIFF
--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -334,6 +334,31 @@ QUnit.test('General Navigator tests', function (assert) {
         'Navigator position should be updated when scrollbar ' +
             'disabled and navigator.baseSeries not set (#13114).'
     );
+
+    chart = Highcharts.stockChart('container', {
+        xAxis: {
+            ordinal: false,
+            minPadding: 0.05,
+            maxPadding: 0.05
+        },
+        series: [
+            {
+                data: [1, 2, 3]
+            }
+        ]
+    });
+
+    assert.strictEqual(
+        chart.navigator.xAxis.options.minPadding,
+        chart.xAxis[0].options.minPadding,
+        'Navigator should inherit the minPadding property from the main axis.'
+    );
+
+    assert.strictEqual(
+        chart.navigator.xAxis.options.maxPadding,
+        chart.xAxis[0].options.maxPadding,
+        'Navigator should inherit the maxPadding property from the main axis.'
+    );
 });
 
 QUnit.test('Reversed xAxis with navigator', function (assert) {

--- a/ts/Stock/Navigator/Navigator.ts
+++ b/ts/Stock/Navigator/Navigator.ts
@@ -1282,8 +1282,11 @@ class Navigator {
                 keepOrdinalPadding: true, // #2436
                 startOnTick: false,
                 endOnTick: false,
-                minPadding: 0,
-                maxPadding: 0,
+                // Inherit base xAxis' padding when ordinal is false (#16915).
+                minPadding: baseXaxis.options.ordinal ? 0 :
+                    baseXaxis.options.minPadding,
+                maxPadding: baseXaxis.options.ordinal ? 0 :
+                    baseXaxis.options.maxPadding,
                 zoomEnabled: false
             }, chart.inverted ? {
                 offsets: [scrollButtonSize, 0, -scrollButtonSize, 0],
@@ -1292,7 +1295,6 @@ class Navigator {
                 offsets: [0, -scrollButtonSize, 0, scrollButtonSize],
                 height: height
             }), 'xAxis') as NavigatorAxisComposition;
-
             navigator.yAxis = new Axis(chart, merge(
                 navigatorOptions.yAxis,
                 {


### PR DESCRIPTION
Fixed #16915, the navigator should inherit the base x-axis padding when `ordinal` is false.