### PR TITLE
Fixed #21125, wrong position of inverted bubbles

### DIFF
--- a/samples/highcharts/plotoptions/bubble-radialgradient/demo.js
+++ b/samples/highcharts/plotoptions/bubble-radialgradient/demo.js
@@ -2,6 +2,7 @@ Highcharts.chart('container', {
 
     chart: {
         type: 'bubble',
+        inverted: true,
         plotBorderWidth: 1,
         zooming: {
             type: 'xy'

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -519,23 +519,32 @@ class BubbleSeries extends ScatterSeries {
             this.points.length < (this.options.animationLimit as any) // #8099
         ) {
             this.points.forEach(function (point): void {
-                const { graphic } = point;
+                const { graphic, plotX = 0, plotY = 0 } = point;
 
                 if (graphic && graphic.width) { // URL symbols don't have width
 
                     // Start values
                     if (!this.hasRendered) {
                         graphic.attr({
-                            x: point.plotX,
-                            y: point.plotY,
+                            x: plotX,
+                            y: plotY,
                             width: 1,
                             height: 1
                         });
                     }
 
-                    // Run animation
+                    // Run animation. Cannot use `markerAttribs` directly
+                    // because the bubble markers are rendered into
+                    // `series.group`, which may be inverted, as opposed to the
+                    // default `series.markerGroup` (#21125).
+                    const { width = 0, height = 0 } = this.markerAttribs(point);
                     graphic.animate(
-                        this.markerAttribs(point),
+                        {
+                            x: plotX - width / 2,
+                            y: plotY - width / 2,
+                            width,
+                            height
+                        },
                         this.options.animation
                     );
                 }

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -688,10 +688,10 @@ class BubbleSeries extends ScatterSeries {
         // Bubble needs a specific `markerAttribs` override because the markers
         // are rendered into the potentially inverted `series.group`. Unlike
         // regular markers, which are rendered into the `markerGroup` (#21125).
-        return extend(attr, {
+        return this.chart.inverted ? extend(attr, {
             x: (point.plotX || 0) - width / 2,
             y: (point.plotY || 0) - height / 2
-        });
+        }) : attr;
     }
 
     /**

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -533,18 +533,8 @@ class BubbleSeries extends ScatterSeries {
                         });
                     }
 
-                    // Run animation. Cannot use `markerAttribs` directly
-                    // because the bubble markers are rendered into
-                    // `series.group`, which may be inverted, as opposed to the
-                    // default `series.markerGroup` (#21125).
-                    const { width = 0, height = 0 } = this.markerAttribs(point);
                     graphic.animate(
-                        {
-                            x: plotX - width / 2,
-                            y: plotY - width / 2,
-                            width,
-                            height
-                        },
+                        this.markerAttribs(point),
                         this.options.animation
                     );
                 }
@@ -688,6 +678,25 @@ class BubbleSeries extends ScatterSeries {
     /**
      * @private
      */
+    public markerAttribs(
+        point: Point,
+        state?: StatesOptionsKey
+    ): SVGAttributes {
+        const attr = super.markerAttribs(point, state),
+            { height = 0, width = 0 } = attr;
+
+        // Bubble needs a specific `markerAttribs` override because the markers
+        // are rendered into the potentially inverted `series.group`. Unlike
+        // regular markers, which are rendered into the `markerGroup` (#21125).
+        return extend(attr, {
+            x: (point.plotX || 0) - width / 2,
+            y: (point.plotY || 0) - height / 2
+        });
+    }
+
+    /**
+     * @private
+     */
     public pointAttribs(
         point?: BubblePoint,
         state?: StatesOptionsKey
@@ -726,8 +735,8 @@ class BubbleSeries extends ScatterSeries {
         let i = data.length;
 
         while (i--) {
-            const point = data[i];
-            const radius = radii ? radii[i] : 0; // #1737
+            const point = data[i],
+                radius = radii ? radii[i] : 0; // #1737
 
             // Negative points means negative z values (#9728)
             if (this.zoneAxis === 'z') {


### PR DESCRIPTION
Fixed #21125, a regression causing wrong positioning of bubbles in an inverted bubble chart.

Note to reviewers: Unit test is skipped in favor of a visual test. An existing sample was altered to double as a visual test.