### PR TITLE
dash/fix-layout-module-d-ts

### DIFF
--- a/tools/gulptasks/dashboards/scripts-dts/modules/layout.src.d.ts
+++ b/tools/gulptasks/dashboards/scripts-dts/modules/layout.src.d.ts
@@ -7,7 +7,7 @@
 import * as _Dashboards from "../dashboards.src";
 
 import _EditMode from "../es-modules/Dashboards/EditMode/EditMode";
-import _FullScreen from "../es-modules/Dashboards/EditMode/FullScreen";
+import _FullScreen from "../es-modules/Dashboards/EditMode/Fullscreen";
 
 import "../es-modules/Dashboards/EditMode/EditMode";
 import "../es-modules/Dashboards/EditMode/FullScreen";


### PR DESCRIPTION
Fixed typo in `Fullscreen` es-module import which caused an error when importing the `layout` module.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207316633264443