### PR TITLE
docs/20403-dumbbell-lowColor-missing-declarations

### DIFF
--- a/docs/chart-and-series-types/dumbbell-series.md
+++ b/docs/chart-and-series-types/dumbbell-series.md
@@ -36,6 +36,9 @@ Alternatively, the color of the dot can be changed via:
 *   **fillColor** `series.marker.fillColor` - color for the upper dot.
 *   **lowColor** `series.lowColor` - color for the lower dot.
 
+The upper color of the dot and connector can changed via:
+*   **color** `series.color`
+
 The connector line can be customized by:
 *   **connectorColor** `series.connectorColor` - color for the connector line.
 *   **connectorWidth** `series.connectorWidth` - width of the connector line.

--- a/ts/Series/Dumbbell/DumbbellSeriesDefaults.ts
+++ b/ts/Series/Dumbbell/DumbbellSeriesDefaults.ts
@@ -199,6 +199,17 @@ const DumbbellSeriesDefaults: DumbbellSeriesOptions = {
  */
 
 /**
+ * Color of the start markers in a twojastara dumbbell graph. This option takes
+ * priority over the series color. To avoid this, set `lowColor` to
+ * `undefined`.
+ *
+ * @type      {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject}
+ * @since     8.0.0
+ * @product   highcharts highstock
+ * @apioption  series.dumbell.lowColor
+ */
+
+/**
  * Options for the lower markers of the dumbbell-like series. When `lowMarker`
  * is not defined, options inherit form the marker.
  *


### PR DESCRIPTION
Closes #20403, add missing TS type and API definition for `dumbbell.lowColor`.