### PR TITLE
Regressions in left-axis and spacing

### DIFF
--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3076,7 +3076,11 @@ class Axis {
             slotWidth = this.getSlotWidth(),
             innerWidth = Math.max(
                 1,
-                Math.round(slotWidth - 2 * (labelOptions.padding || 0))
+                Math.round(slotWidth - (
+                    horiz ?
+                        2 * (labelOptions.padding || 0) :
+                        (labelOptions.distance || 0) - 5
+                ))
             ),
             attr: SVGAttributes = {},
             labelMetrics = this.labelMetrics(),

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3079,6 +3079,9 @@ class Axis {
                 Math.round(slotWidth - (
                     horiz ?
                         2 * (labelOptions.padding || 0) :
+                        // #21172. Can't figure out where the constant 5 comes
+                        // from, but it's needed to make the labels render at
+                        // the `chart.spacing`.
                         (labelOptions.distance || 0) - 5
                 ))
             ),


### PR DESCRIPTION
The new axis padding default revealed a case when the `chart.spacing` was not respected: https://jsfiddle.net/highcharts/bgjad9nv/1/