### PR TITLE
dash/emcl-create-tools-init

### DIFF
--- a/ts/Dashboards/Board.ts
+++ b/ts/Dashboards/Board.ts
@@ -382,13 +382,13 @@ class Board implements Serializable<Board, Board.JSON> {
      *
      */
     private initEditMode():void {
-        if (!Dashboards.EditMode) {
-            throw new Error('Missing layout.js module');
-        } else {
+        if (Dashboards.EditMode) {
             this.editMode = new Dashboards.EditMode(
                 this,
                 this.options.editMode
             );
+        } else if (this.editModeEnabled) {
+            throw new Error('Missing layout.js module');
         }
     }
 

--- a/ts/Dashboards/EditMode/EditMode.ts
+++ b/ts/Dashboards/EditMode/EditMode.ts
@@ -116,7 +116,10 @@ class EditMode {
         this.board = board;
         this.lang = merge({}, EditGlobals.lang, this.options.lang);
 
-        this.initLayout();
+        board.boardWrapper = board.container;
+        if (board.guiEnabled) {
+            this.initLayout();
+        }
 
         this.isInitialized = false;
         this.isContextDetectionActive = false;
@@ -410,9 +413,6 @@ class EditMode {
 
         // Clear the container from any content.
         board.container.innerHTML = '';
-
-        // Set the main wrapper container.
-        board.boardWrapper = board.container;
 
         // Add container for the board.
         board.container = createElement(
@@ -777,21 +777,30 @@ class EditMode {
      */
     public createTools(): void {
         const editMode = this;
-        const options = this.options;
+        const { board, options, tools } = editMode;
 
         // Create tools container
-        this.tools.container = document.createElement('div');
-        this.tools.container.classList.add(EditGlobals.classNames.editTools);
+        tools.container = document.createElement('div');
+        tools.container.classList.add(EditGlobals.classNames.editTools);
 
-        this.board.layoutsWrapper?.parentNode.insertBefore(
-            this.tools.container,
-            this.board.layoutsWrapper
-        );
+        if (board.layoutsWrapper) {
+            // For the generated layout
+            board.layoutsWrapper.parentNode.insertBefore(
+                tools.container,
+                board.layoutsWrapper
+            );
+        } else {
+            // For the custom layout
+            board.container.insertBefore(
+                tools.container,
+                board.container.firstChild
+            );
+        }
 
         // Create context menu button
         if (options.contextMenu && options.contextMenu.enabled) {
-            this.tools.contextButtonElement = EditRenderer.renderContextButton(
-                this.tools.container,
+            tools.contextButtonElement = EditRenderer.renderContextButton(
+                tools.container,
                 editMode
             );
 
@@ -813,7 +822,7 @@ class EditMode {
             const addIconURL = options.tools.addComponentBtn.icon;
 
             this.addComponentBtn = EditRenderer.renderButton(
-                this.tools.container,
+                tools.container,
                 {
                     className: EditGlobals.classNames.editToolsBtn,
                     icon: addIconURL,


### PR DESCRIPTION
It is now possible to initialize edit mode when generated gui is disabled. Tools container appears at the top of the board, before rows & cells. **(subtask)**

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207268774437530