### PR TITLE
Better fix for label and spacing

### DIFF
--- a/samples/unit-tests/axis/labels-usehtml/demo.js
+++ b/samples/unit-tests/axis/labels-usehtml/demo.js
@@ -131,7 +131,10 @@ QUnit.test('Reset text with with useHTML (#4928)', function (assert) {
     });
 
     var labelLength = chart.xAxis[0].ticks[0].label.element.offsetWidth;
-    assert.ok(labelLength > 20, 'Label has length');
+    assert.ok(
+        labelLength > 15,
+        `Label length should be more than 15px, got ${labelLength}`
+    );
 
     chart.setSize(600, 400, false);
 

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3079,10 +3079,7 @@ class Axis {
                 Math.round(slotWidth - (
                     horiz ?
                         2 * (labelOptions.padding || 0) :
-                        // #21172. Can't figure out where the constant 5 comes
-                        // from, but it's needed to make the labels render at
-                        // the `chart.spacing`.
-                        (labelOptions.distance || 0) - 5
+                        labelOptions.distance || 0 // #21172
                 ))
             ),
             attr: SVGAttributes = {},


### PR DESCRIPTION
Better fix for #21172, got rid of the 5px constant offset, which was just a coincidence.

Drag the slider here and observe how the left-side axis labels never overflow the 10px spacing helper line: https://jsfiddle.net/highcharts/bgjad9nv/