### PR TITLE
bugfix/20877-ordinal-panning

### DIFF
--- a/samples/unit-tests/axis/extremes/demo.js
+++ b/samples/unit-tests/axis/extremes/demo.js
@@ -637,11 +637,30 @@ QUnit.test('Touch panning falls back to data range (#3104)', function (assert) {
         touchPointX = (chart.plotSizeX + chart.plotLeft) / 2,
         touchPointY = (chart.plotSizeY + chart.plotTop) / 2;
 
+    function slide(xAxis, x, y) {
+        const extremes = xAxis.getExtremes();
+
+        controller.slide(
+            [x + 200, y],
+            [x - 100, y]
+        );
+
+        assert.notStrictEqual(
+            extremes.min,
+            xAxis.min,
+            'Ordinal xAxis min should change after touch sliding (#20877).'
+        );
+
+        assert.notStrictEqual(
+            extremes.max,
+            xAxis.max,
+            'Ordinal xAxis max should change after touch sliding (#20877).'
+        );
+    }
+
     controller.slide(
         [touchPointX, touchPointY],
-        [touchPointX + 100, touchPointY],
-        undefined,
-        true
+        [touchPointX + 100, touchPointY]
     );
 
     var tickPositionsAfterSlide = chart.axes[0].tickPositions;
@@ -651,6 +670,48 @@ QUnit.test('Touch panning falls back to data range (#3104)', function (assert) {
         tickPositionsAfterSlide,
         'Tick positions has changed after touch sliding'
     );
+
+    // Reset user-extremes
+    chart.xAxis[0].setExtremes();
+
+    chart.update({
+        chart: {
+            zoomType: '',
+            panning: {
+                enabled: true,
+                type: 'x'
+            }
+        },
+        xAxis: {
+            type: 'datetime',
+            ordinal: true,
+            range: 5
+        },
+        tooltip: {
+            followTouchMove: false
+        },
+        series: [{
+            data: [
+                [0, 1],
+                [1, 4],
+                [4, 1],
+                [5, 4],
+                [6, 5],
+                [7, 5],
+                [8, 4],
+                [9, 1],
+                [10, 4],
+                [11, 5],
+                [12, 5],
+                [13, 4]
+            ]
+        }]
+    });
+
+    // First slide: test if panning + ordinal works
+    slide(chart.xAxis[0], touchPointX, touchPointY);
+    // Second slide: test if we zoom into different range
+    slide(chart.xAxis[0], touchPointX, touchPointY);
 });
 
 QUnit.test('Column zooming and Y axis extremes (#9944)', assert => {

--- a/samples/unit-tests/axis/extremes/demo.js
+++ b/samples/unit-tests/axis/extremes/demo.js
@@ -192,7 +192,9 @@ QUnit.test(
             chart = new Highcharts.StockChart({
                 chart: {
                     renderTo: 'container',
-                    zoomType: 'x'
+                    zooming: {
+                        type: 'x'
+                    }
                 },
 
                 series: [
@@ -331,7 +333,9 @@ QUnit.test('getSeriesExtremes', function (assert) {
 QUnit.test('Zooming', function (assert) {
     var chart = Highcharts.chart('container', {
             chart: {
-                zoomType: 'x'
+                zooming: {
+                    type: 'x'
+                }
             },
             xAxis: {
                 minRange: 0.5
@@ -525,7 +529,9 @@ QUnit.test('Touch pan categories (#3075)', function (assert) {
         'highcharts/area',
         {
             chart: {
-                zoomType: 'x'
+                zooming: {
+                    type: 'x'
+                }
             },
 
             xAxis: {
@@ -613,7 +619,9 @@ QUnit.test('Touch panning falls back to data range (#3104)', function (assert) {
         'container',
         {
             chart: {
-                zoomType: 'x'
+                zooming: {
+                    type: 'x'
+                }
             },
             xAxis: {
                 min: 0,
@@ -676,7 +684,9 @@ QUnit.test('Touch panning falls back to data range (#3104)', function (assert) {
 
     chart.update({
         chart: {
-            zoomType: '',
+            zooming: {
+                type: ''
+            },
             panning: {
                 enabled: true,
                 type: 'x'

--- a/samples/unit-tests/axis/extremes/demo.js
+++ b/samples/unit-tests/axis/extremes/demo.js
@@ -685,7 +685,8 @@ QUnit.test('Touch panning falls back to data range (#3104)', function (assert) {
         xAxis: {
             type: 'datetime',
             ordinal: true,
-            range: 5
+            min: 0,
+            max: 5
         },
         tooltip: {
             followTouchMove: false
@@ -698,8 +699,6 @@ QUnit.test('Touch panning falls back to data range (#3104)', function (assert) {
                 [5, 4],
                 [6, 5],
                 [7, 5],
-                [8, 4],
-                [9, 1],
                 [10, 4],
                 [11, 5],
                 [12, 5],

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -169,6 +169,7 @@ namespace OrdinalAxis {
             );
 
             addEvent(ChartClass, 'pan', onChartPan);
+            addEvent(ChartClass, 'touchpan', onChartPan);
 
             addEvent(SeriesClass, 'updatedData', onSeriesUpdatedData);
         }

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1300,6 +1300,7 @@ class Pointer {
         if (e.type === 'touchstart') {
             pointer.pinchDown = touches;
             pointer.res = true; // Reset on next move
+            chart.mouseDownX = e.chartX;
 
         // Optionally move the tooltip on touchmove
         } else if (followTouchMove) {


### PR DESCRIPTION
Fixed #20877, panning using one finger on touch devices didn't work correctly with a dispersed dataset.
___
The "after-refactor" fix. On mobile devices, previously we scaled grouped visually and created a mock selection marker. Then on touchend event, we apply new extremes. In the current implementation, we update extremes "live", so OrdinalAxis needs to connect to both `pan` and `touchpan` events. 

Extra change to store `mouseDownX` on touchstart since it's the base for panning in OrdinalAxis to compare with how many units we moved away. 