### PR TITLE
bugfix/21131-boost-navigator-clip

### DIFF
--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -486,7 +486,7 @@ function createAndAttachRenderer(
             // When using panes, the image itself must be clipped. When not
             // using panes, it is better to clip the target group, because then
             // we preserve clipping on touch- and mousewheel zoom preview.
-            clippedElement = (
+            clippedElement = !navigator || (
                 box.width === chart.clipBox.width &&
                 box.height === chart.clipBox.height
             ) ? targetGroup :


### PR DESCRIPTION
Fixed #21131, missing navigator series after zooming in boost mode.
___
A follow-up to https://github.com/highcharts/highcharts/issues/21131 :

> I bisected it to [ed32adb](https://github.com/highcharts/highcharts/commit/ed32adb20b6e9495bff70f2323bc7532ed1597eb) . Apparently something similar is going on in the main pane in some of the close commits, but at least this gives us a starting point.

It comes from this commit. Tested by reverting changes and solved the issue. Why it happens? Because we have just one pane and navigator. Code executes twice, for each series:
- the main pane/series: the condition is met (width and heights are equal to the clipbox), applying clip to the parent (`<group>`)
- navigator: height is different, applying clipbox to the series (`<image>`)

The problem is: navigator series is still rendered in the series-group. That means it has two clip-rects, it's own and one leaked from main pane/series:
![Zrzut ekranu 2024-05-22 o 16 05 48](https://github.com/highcharts/highcharts/assets/1453926/7035d22e-3f60-452f-856a-1830fb8dab40)

I don't quite understand why it's better to clip the target group @TorsteinHonsi - what is a mousewheel zoom preview? Something in HC Maps? If we don't want to revert the changes, then my suggestion is this PR: make an exception when the navigator exists. The condition is not perfect, for example, Navigator can exist in a form of a solo Scrollbar (and zero series), but is good enough.
