### PR TITLE
bugfix/20969-tooltip-not-destroyed

### DIFF
--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1950,8 +1950,14 @@ class Pointer {
             hoverChart &&
             hoverChart !== chart
         ) {
+            const relatedTargetObj = { relatedTarget: chart.container };
+
+            if (e && !e?.relatedTarget) {
+                e = { ...e, ...relatedTargetObj };
+            }
+
             hoverChart.pointer?.onContainerMouseLeave(
-                e || { relatedTarget: chart.container } as any
+                e || relatedTargetObj as any
             );
         }
 

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1953,7 +1953,7 @@ class Pointer {
             const relatedTargetObj = { relatedTarget: chart.container };
 
             if (e && !e?.relatedTarget) {
-                e = { ...e, ...relatedTargetObj };
+                e = { ...relatedTargetObj, ...e };
             }
 
             hoverChart.pointer?.onContainerMouseLeave(

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1098,21 +1098,15 @@ class Pointer {
      * @function Highcharts.Pointer#onContainerMouseLeave
      */
     public onContainerMouseLeave(e: MouseEvent): void {
-        const {
-            pointer,
-            tooltip
-        } = charts[pick(Pointer.hoverChartIndex, -1)] || {};
+        const { pointer } = charts[pick(Pointer.hoverChartIndex, -1)] || {};
 
         e = this.normalize(e);
 
-        if (tooltip && !tooltip.isHidden) {
-            this.onContainerMouseMove(e);
-        }
+        this.onContainerMouseMove(e);
 
         // #4886, MS Touch end fires mouseleave but with no related target
         if (
             pointer &&
-            e.relatedTarget &&
             !this.inClass(e.relatedTarget as any, 'highcharts-tooltip')
         ) {
             pointer.reset();

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1098,11 +1098,16 @@ class Pointer {
      * @function Highcharts.Pointer#onContainerMouseLeave
      */
     public onContainerMouseLeave(e: MouseEvent): void {
-        const { pointer } = charts[pick(Pointer.hoverChartIndex, -1)] || {};
+        const {
+            pointer,
+            tooltip
+        } = charts[pick(Pointer.hoverChartIndex, -1)] || {};
 
         e = this.normalize(e);
 
-        this.onContainerMouseMove(e);
+        if (tooltip && !tooltip.isHidden) {
+            this.onContainerMouseMove(e);
+        }
 
         // #4886, MS Touch end fires mouseleave but with no related target
         if (


### PR DESCRIPTION
Fixed #20969, tooltip did not dissappear when hovering from one chart to another