### PR TITLE
bugfix/19944-event-target-documentmousemove

### DIFF
--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -1232,8 +1232,10 @@ class Pointer {
             !(
                 tooltip &&
                 tooltip.shouldStickOnContact(pEvt)
-            ) &&
-            !this.inClass(pEvt.target as any, 'highcharts-tracker')
+            ) && (
+                pEvt.target === chart.container.ownerDocument ||
+                !this.inClass(pEvt.target as any, 'highcharts-tracker')
+            )
         ) {
             this.reset();
         }


### PR DESCRIPTION
Fixed #19944, error message "getAttribute is not a function" appeared in certain edge cases in Firefox.