### PR TITLE
bugfix/21213-axis-labels-padding-type

### DIFF
--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -1028,7 +1028,7 @@ namespace AxisDefaults {
              * The pixel padding for axis labels, to ensure white space between
              * them. Defaults to 4 for horizontal axes, 1 for vertical.
              *
-             * @type      {number|undefined}
+             * @type      {number}
              * @default   undefined
              * @product   highcharts gantt
              * @apioption xAxis.labels.padding

--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -1028,6 +1028,7 @@ namespace AxisDefaults {
              * The pixel padding for axis labels, to ensure white space between
              * them. Defaults to 4 for horizontal axes, 1 for vertical.
              *
+             * @type      {number|undefined}
              * @default   undefined
              * @product   highcharts gantt
              * @apioption xAxis.labels.padding


### PR DESCRIPTION
Fixed #21213, `yAxis.labels.padding` had incorrect type.