### PR TITLE
bugfix/20359-scrollbar-same-extremes

### DIFF
--- a/samples/unit-tests/scrollbar/extremes/demo.js
+++ b/samples/unit-tests/scrollbar/extremes/demo.js
@@ -174,7 +174,7 @@ QUnit.test(
     });
 
 QUnit.test(
-    '#10733 - scrollbar had wrong range when extremes was the same.',
+    '#10733, #20359 - scrollbar had wrong range when extremes was the same.',
     function (assert) {
         var H = Highcharts,
             chart = H.chart('container', {
@@ -199,6 +199,30 @@ QUnit.test(
             H.isNumber(scrollbar.from) && H.isNumber(scrollbar.to),
             true,
             'Scrollbar starts from left button.'
+        );
+
+        // Chart should display one category at a time and allow scrolling.
+        // The category should be placed within x-axis extremes. (#20359)
+        chart.update({
+            xAxis: {
+                min: 1,
+                max: 1
+            },
+            series: {
+                type: 'column',
+                data: [1, 2, 3, 4]
+            }
+        });
+
+        assert.equal(
+            chart.xAxis[0].scrollbar.from,
+            0.25,
+            'Scrollbar should start at 0.25.'
+        );
+        assert.equal(
+            chart.xAxis[0].scrollbar.to,
+            0.50,
+            'Scrollbar should end at 0.55.'
         );
     }
 );

--- a/ts/Core/Axis/ScrollbarAxis.ts
+++ b/ts/Core/Axis/ScrollbarAxis.ts
@@ -321,12 +321,26 @@ namespace ScrollbarAxis {
                 isNaN(scrollMax) ||
                 !defined(axis.min) ||
                 !defined(axis.max) ||
-                axis.min === axis.max // #10733
+                axis.dataMin === axis.dataMax // #10733
             ) {
-                // Default action: when extremes are the same or there is
+                // Default action: when data extremes are the same or there is
                 // not extremes on the axis, but scrollbar exists, make it
                 // full size
+
                 scrollbar.setRange(0, 1);
+            } else if (axis.min === axis.max) { // #20359
+                // When the extremes are the same, set the scrollbar to a point
+                // within the extremes range. Utilize pointRange to perform the
+                // calculations. (#20359)
+
+                const interval: number = axis.pointRange / (
+                    axis.dataMax as number +
+                    1
+                );
+                from = interval * axis.min;
+                to = interval * (axis.max + 1);
+
+                scrollbar.setRange(from, to);
             } else {
                 from = (
                     ((axis.min as any) - scrollMin) /


### PR DESCRIPTION
Fixed #20359, scrollbar was not working when x-axis extremes were the same.