### PR TITLE
bugfix/13257-gantt-expanding-points

### DIFF
--- a/ts/Series/XRange/XRangeSeries.ts
+++ b/ts/Series/XRange/XRangeSeries.ts
@@ -230,7 +230,7 @@ class XRangeSeries extends ColumnSeries {
         const { id } = options;
         let pointIndex: (number|undefined);
 
-        if (id) {
+        if (id && this.yAxis.options.uniqueNames) {
             const point = find(points, (point): boolean => point.id === id);
             pointIndex = point ? point.index : void 0;
         }


### PR DESCRIPTION
Fixed #13257, expanding points would not render all points with same id.

I am a bit unsure here as I would think points ought to have unique id's but here is a fix for the users issue.