### PR TITLE
dash/datagrid2-different-row-heights

### DIFF
--- a/css/datagrid/datagrid2.css
+++ b/css/datagrid/datagrid2.css
@@ -117,6 +117,10 @@
     height: 36px;
 }
 
+.highcharts-dg-row.highcharts-dg-odd {
+    background-color: #fafafa;
+}
+
 .highcharts-dg-table td {
     height: inherit;
     border-right: 1px solid #00ff00;

--- a/css/datagrid/datagrid2.css
+++ b/css/datagrid/datagrid2.css
@@ -110,10 +110,11 @@
     position: relative;
 }
 
-.highcharts-dg-table tr {
-    border-bottom: 1px solid #0000ff;
+.highcharts-dg-row {
+    border-top: 1px solid #0000ff;
     position: absolute;
     overflow: hidden;
+    height: 36px;
 }
 
 .highcharts-dg-table td {

--- a/samples/data-grid/basic/data-grid-2-benchmark/demo.css
+++ b/samples/data-grid/basic/data-grid-2-benchmark/demo.css
@@ -16,3 +16,7 @@
 .highcharts-dg-table thead th {
     height: 49px;
 }
+
+.highcharts-dg-row {
+    height: 49px;
+}

--- a/samples/data-grid/basic/data-grid-2-benchmark/demo.js
+++ b/samples/data-grid/basic/data-grid-2-benchmark/demo.js
@@ -29,7 +29,6 @@ var t2 = performance.now();
 const newgrid = new DataGrid.DataGrid2('container', {
     dataTable: dataTable,
     rowOptions: {
-        height: 49,
         bufferSize: 2
     }
 });

--- a/samples/data-grid/basic/data-grid-2/demo.css
+++ b/samples/data-grid/basic/data-grid-2/demo.css
@@ -14,7 +14,42 @@
     height: 100px;
 }
 
+.highcharts-dg-row[row-index="3"] {
+    background-color: #afa;
+    height: 100px;
+}
+
+.highcharts-dg-row[row-index="6"] {
+    background-color: #afa;
+    height: 100px;
+}
+
 .highcharts-dg-row[row-index="100"] {
     background-color: #f0a;
+    height: 200px;
+}
+
+.highcharts-dg-row[row-index="150"] {
+    background-color: #aff;
+    height: 10px;
+}
+
+.highcharts-dg-row[row-index="152"] {
+    background-color: #aff;
+    height: 10px;
+}
+
+.highcharts-dg-row[row-index="154"] {
+    background-color: #aff;
+    height: 10px;
+}
+
+.highcharts-dg-row[row-index="6"] {
+    background-color: #afa;
+    height: 100px;
+}
+
+.highcharts-dg-row[row-index="99999"] {
+    background-color: #ff0;
     height: 200px;
 }

--- a/samples/data-grid/basic/data-grid-2/demo.css
+++ b/samples/data-grid/basic/data-grid-2/demo.css
@@ -8,3 +8,13 @@
     margin-bottom: 15px;
     height: 400px;
 }
+
+.highcharts-dg-row[row-index="1"] {
+    background-color: #afa;
+    height: 100px;
+}
+
+.highcharts-dg-row[row-index="100"] {
+    background-color: #f0a;
+    height: 200px;
+}

--- a/samples/data-grid/basic/data-grid-2/demo.js
+++ b/samples/data-grid/basic/data-grid-2/demo.js
@@ -1,14 +1,17 @@
 const dg = new DataGrid.DataGrid2('container', {
     dataTable: new DataGrid.DataTable({
         columns: {
-            a: Array.from({ length: 10e4 }, (_, i) => `A${i}`),
-            b: Array.from({ length: 10e4 }, (_, i) => `B${i}`),
-            c: Array.from({ length: 10e4 }, (_, i) => `C${i}`),
-            d: Array.from({ length: 10e4 }, (_, i) => `D${i}`),
-            e: Array.from({ length: 10e4 }, (_, i) => `E${i}`),
-            f: Array.from({ length: 10e4 }, (_, i) => `F${i}`)
+            a: Array.from({ length: 1000 }, (_, i) => `A${i}`),
+            b: Array.from({ length: 1000 }, (_, i) => `B${i}`),
+            c: Array.from({ length: 1000 }, (_, i) => `C${i}`),
+            d: Array.from({ length: 1000 }, (_, i) => `D${i}`),
+            e: Array.from({ length: 1000 }, (_, i) => `E${i}`),
+            f: Array.from({ length: 1000 }, (_, i) => `F${i}`)
         }
-    })
+    }),
+    rowOptions: {
+        bufferSize: 5
+    }
 });
 
 document.getElementById('scroll').addEventListener('submit', e => {

--- a/ts/DataGrid/DataGrid2/DataGridCell.ts
+++ b/ts/DataGrid/DataGrid2/DataGridCell.ts
@@ -79,12 +79,8 @@ class DataGridCell {
         this.row = row;
         this.row.registerCell(this);
 
-        this.htmlElement.addEventListener(
-            'mouseenter', this.onMouseEnter.bind(this)
-        );
-        this.htmlElement.addEventListener(
-            'mouseout', this.onMouseOut.bind(this)
-        );
+        this.htmlElement.addEventListener('mouseenter', this.onMouseEnter);
+        this.htmlElement.addEventListener('mouseout', this.onMouseOut);
     }
 
 
@@ -115,14 +111,29 @@ class DataGridCell {
         this.htmlElement.style.width = this.column.getWidth() + 'px';
     }
 
-    private onMouseEnter(): void {
+    /**
+     * Sets the hover state of the cell and its row and column.
+     */
+    private readonly onMouseEnter = (): void => {
         this.row.setHover(true);
         this.column.setHover(true);
-    }
+    };
 
-    private onMouseOut(): void {
+    /**
+     * Unsets the hover state of the cell and its row and column.
+     */
+    private readonly onMouseOut = (): void => {
         this.row.setHover(false);
         this.column.setHover(false);
+    };
+
+    /**
+     * Destroys the cell.
+     */
+    public destroy(): void {
+        this.htmlElement.removeEventListener('mouseenter', this.onMouseEnter);
+        this.htmlElement.removeEventListener('mouseout', this.onMouseOut);
+        this.htmlElement.remove();
     }
 
     /* *

--- a/ts/DataGrid/DataGrid2/DataGridDefaultOptions.ts
+++ b/ts/DataGrid/DataGrid2/DataGridDefaultOptions.ts
@@ -31,8 +31,7 @@ import type DataGridOptions from './DataGridOptions';
 
 const DataGridDefaultOptions: DeepPartial<DataGridOptions> = {
     rowOptions: {
-        bufferSize: 5,
-        height: 36
+        bufferSize: 5
     }
 };
 

--- a/ts/DataGrid/DataGrid2/DataGridOptions.d.ts
+++ b/ts/DataGrid/DataGrid2/DataGridOptions.d.ts
@@ -20,7 +20,7 @@
  * */
 
 import type DataTable from '../../Data/DataTable';
-import type DataGridRow from './DataGridRow';
+
 
 /* *
  *
@@ -58,22 +58,6 @@ export interface RowOptions {
      */
     bufferSize?: number;
 
-    /**
-     * Default height of each row in pixels. This is used to calculate the
-     * amount of visible rows in a container and the size of the scrollbar.
-     *
-     * @default 36
-     */
-    height?: number;
-
-    /**
-     * Calls to set the height of a row in render time. This is useful for
-     * dynamic row heights. If set, the height option is ignored.
-     *
-     * @param row The row to set height for.
-     * @returns The height of the row in pixels or undefined if the default height should be used.
-     */
-    setHeight?: ((row: DataGridRow) => number | undefined);
 }
 
 

--- a/ts/DataGrid/DataGrid2/DataGridRow.ts
+++ b/ts/DataGrid/DataGrid2/DataGridRow.ts
@@ -149,6 +149,10 @@ class DataGridRow {
             return;
         }
 
+        for (let i = 0, iEnd = this.cells.length; i < iEnd; ++i) {
+            this.cells[i].destroy();
+        }
+
         this.htmlElement.remove();
         this.destroyed = true;
     }
@@ -176,7 +180,7 @@ class DataGridRow {
     }
 
     public getDefaultTopOffset(): number {
-        return this.index * this.viewport.defaultRowHeight;
+        return this.index * this.viewport.rowsVirtualizer.defaultRowHeight;
     }
 
 

--- a/ts/DataGrid/DataGrid2/DataGridRow.ts
+++ b/ts/DataGrid/DataGrid2/DataGridRow.ts
@@ -100,6 +100,10 @@ class DataGridRow {
         this.htmlElement.setAttribute('row-index', index);
         this.htmlElement.setAttribute('aria-rowindex', index);
         this.htmlElement.setAttribute('row-id', index);
+
+        if (index % 2 === 1) {
+            this.htmlElement.classList.add(Globals.classNames.odd);
+        }
     }
 
 
@@ -167,8 +171,8 @@ class DataGridRow {
         );
     }
 
-    public getHeight(): number {
-        return this.htmlElement.offsetHeight;
+    public getCurrentHeight(): number {
+        return this.htmlElement.clientHeight;
     }
 
     public getDefaultTopOffset(): number {

--- a/ts/DataGrid/DataGrid2/DataGridRow.ts
+++ b/ts/DataGrid/DataGrid2/DataGridRow.ts
@@ -24,10 +24,9 @@
 import DataGridCell from './DataGridCell.js';
 import DataGridTable from './DataGridTable.js';
 import Globals from './Globals.js';
-import Utils from './Utils.js';
-import DataGrid from './DataGrid.js';
+import DGUtils from './Utils.js';
 
-const { makeHTMLElement } = Utils;
+const { makeHTMLElement } = DGUtils;
 
 /* *
  *
@@ -57,11 +56,6 @@ class DataGridRow {
     public htmlElement: HTMLTableRowElement;
 
     /**
-     * The dataGrid instance which the row belongs to.
-     */
-    public dataGrid: DataGrid;
-
-    /**
      * The index of the row in the data table.
      */
     public index: number;
@@ -74,7 +68,7 @@ class DataGridRow {
     /**
      * The viewport the row belongs to.
      */
-    public viewport?: DataGridTable;
+    public viewport: DataGridTable;
 
 
     /* *
@@ -86,18 +80,20 @@ class DataGridRow {
     /**
      * Constructs a row in the data grid.
      *
-     * @param dataGrid The data grid instance which the row belongs to.
-     * @param index The index of the row in the data table.
+     * @param viewport
+     * The Data Grid Table instance which the row belongs to.
+     *
+     * @param index
+     * The index of the row in the data table.
      */
-    constructor(dataGrid: DataGrid, index: number) {
-        this.dataGrid = dataGrid;
+    constructor(viewport: DataGridTable, index: number) {
+        this.viewport = viewport;
         this.index = index;
 
-        const rowHeight = dataGrid.options.rowOptions?.height as number;
         this.htmlElement = makeHTMLElement('tr', {
+            className: Globals.classNames.rowElement,
             style: {
-                height: rowHeight + 'px',
-                transform: `translateY(${index * rowHeight}px)`
+                transform: `translateY(${this.getDefaultTopOffset()}px)`
             }
         });
 
@@ -169,6 +165,14 @@ class DataGridRow {
         this.htmlElement.classList[hovered ? 'add' : 'remove'](
             Globals.classNames.hoveredRow
         );
+    }
+
+    public getHeight(): number {
+        return this.htmlElement.offsetHeight;
+    }
+
+    public getDefaultTopOffset(): number {
+        return this.index * this.viewport.defaultRowHeight;
     }
 
 

--- a/ts/DataGrid/DataGrid2/DataGridTable.ts
+++ b/ts/DataGrid/DataGrid2/DataGridTable.ts
@@ -27,7 +27,7 @@ import DataGridRow from './DataGridRow.js';
 import DataGridColumn from './DataGridColumn.js';
 import DataGridTableHead from './DataGridTableHead.js';
 import DataGrid from './DataGrid.js';
-import Globals from './Globals.js';
+import RowsVirtualizer from './Virtualization/RowsVirtualizer.js';
 
 const { makeHTMLElement } = DGUtils;
 
@@ -94,19 +94,10 @@ class DataGridTable {
     public resizeObserver: ResizeObserver;
 
     /**
-     * The default height of a row.
+     * The rows virtualizer instance that handles the rows rendering &
+     * dimensioning logic.
      */
-    public defaultRowHeight: number;
-
-    /**
-     * The index of the first visible row.
-     */
-    public rowCursor: number = 0;
-
-    /**
-     * The initial height of the top row.
-     */
-    private topRowInitialHeight?: number;
+    public rowsVirtualizer: RowsVirtualizer;
 
 
     /* *
@@ -130,13 +121,13 @@ class DataGridTable {
         this.theadElement = makeHTMLElement('thead', {}, tableElement);
         this.tbodyElement = makeHTMLElement('tbody', {}, tableElement);
 
-        this.defaultRowHeight = this.getDefaultRowHeight();
+        this.rowsVirtualizer = new RowsVirtualizer(this);
 
         this.init();
 
+        // Add event listeners
         this.resizeObserver = new ResizeObserver(this.onResize.bind(this));
         this.resizeObserver.observe(tableElement);
-
         this.tbodyElement.addEventListener('scroll', this.onScroll.bind(this));
     }
 
@@ -163,12 +154,7 @@ class DataGridTable {
         this.head = new DataGridTableHead(this.theadElement, this.columns);
         this.head.render();
 
-        // Initial reflow to set the viewport height
-        this.reflow();
-
-        // Load & render rows
-        this.renderRows(this.rowCursor);
-        this.adjustRowDimensions();
+        this.rowsVirtualizer.initialRender();
 
         // Refresh element dimensions after initial rendering
         this.reflow();
@@ -188,67 +174,7 @@ class DataGridTable {
         }
 
         // Reflow rows
-        for (let i = 0, iEnd = this.rows.length; i < iEnd; ++i) {
-            this.rows[i].reflow();
-        }
-    }
-
-    /**
-     * Renders rows in the specified range. Removes rows that are out of the
-     * range except the last row.
-     *
-     * @param rowCursor
-     * The index of the first visible row.
-     */
-    private renderRows(rowCursor: number): void {
-        const buffer = this.dataGrid.options.rowOptions?.bufferSize as number;
-        const rowsPerPage = Math.ceil(
-            this.tbodyElement.offsetHeight / this.defaultRowHeight
-        );
-
-        const rows = this.rows;
-
-        if (!rows.length) {
-            const last = new DataGridRow(
-                this,
-                this.dataTable.getRowCount() - 1
-            );
-            last.render(this);
-            rows.push(last);
-            this.tbodyElement.appendChild(last.htmlElement);
-        }
-
-        const from = Math.max(rowCursor - buffer, 0);
-        const to = Math.min(
-            rowCursor + rowsPerPage + buffer,
-            rows[rows.length - 1].index - 1
-        );
-
-        const alwaysLastRow = rows.pop();
-
-        for (let i = 0, iEnd = rows.length; i < iEnd; ++i) {
-            rows[i].destroy();
-        }
-        rows.length = 0;
-
-        for (let i = from; i <= to; ++i) {
-            const newRow = new DataGridRow(this, i);
-            newRow.render(this);
-            this.tbodyElement.insertBefore(
-                newRow.htmlElement,
-                this.tbodyElement.lastChild
-            );
-
-            rows.push(newRow);
-        }
-
-        if (alwaysLastRow) {
-            rows.push(alwaysLastRow);
-        }
-
-        const bof = rowCursor - buffer < 0 ? buffer - rowCursor : 0;
-        this.topRowInitialHeight =
-            this.rows[buffer - bof].htmlElement.clientHeight;
+        this.rowsVirtualizer.reflowRows();
     }
 
     /**
@@ -262,17 +188,7 @@ class DataGridTable {
      * Handles the scroll event.
      */
     private onScroll(): void {
-        const target = this.tbodyElement;
-        const { defaultRowHeight: rowHeight } = this;
-
-        // Vertical virtual scrolling
-        const rowCursor = Math.floor(target.scrollTop / rowHeight);
-        if (this.rowCursor !== rowCursor) {
-            this.renderRows(rowCursor);
-        }
-        this.rowCursor = rowCursor;
-
-        this.adjustRowDimensions();
+        this.rowsVirtualizer.scroll();
     }
 
     /**
@@ -281,83 +197,9 @@ class DataGridTable {
      * @param index The index of the row to scroll to.
      */
     public scrollToRow(index: number): void {
-        this.tbodyElement.scrollTop = index * this.defaultRowHeight;
+        this.tbodyElement.scrollTop =
+            index * this.rowsVirtualizer.defaultRowHeight;
     }
-
-    public getDefaultRowHeight(): number {
-        const mockRow = makeHTMLElement('tr', {
-            className: Globals.classNames.rowElement
-        }, this.tbodyElement);
-
-        const defaultRowHeight = mockRow.clientHeight;
-        mockRow.remove();
-
-        return defaultRowHeight;
-    }
-
-    public adjustRowDimensions(): void {
-        let translateBuffer = this.rows[0].getDefaultTopOffset();
-        const rowLen = this.rows.length;
-
-        for (let i = 0; i < rowLen; ++i) {
-            const row = this.rows[i];
-            const cursor = this.rowCursor;
-
-            if (row.index > cursor) {
-                break;
-            }
-
-            const element = row.htmlElement;
-            const defaultH = this.defaultRowHeight;
-            const borderH = element.offsetHeight - element.clientHeight;
-
-            if (row.index < cursor) {
-                row.htmlElement.style.height = defaultH + borderH + 'px';
-            } else if (
-                row.getCurrentHeight() > defaultH &&
-                this.topRowInitialHeight
-            ) {
-                const ratio = this.tbodyElement.scrollTop / defaultH - cursor;
-                const diff = this.topRowInitialHeight - defaultH;
-
-                row.htmlElement.style.height =
-                    this.topRowInitialHeight - diff * ratio + 'px';
-            }
-        }
-
-        for (let i = 1, iEnd = rowLen - 1; i < iEnd; ++i) {
-            translateBuffer += this.rows[i - 1].getCurrentHeight();
-            this.rows[i].htmlElement.style.transform =
-                `translateY(${translateBuffer}px)`;
-        }
-
-        if (this.rows[rowLen - 2].index + 1 === this.rows[rowLen - 1].index) {
-            translateBuffer += this.rows[rowLen - 2].getCurrentHeight();
-            this.rows[rowLen - 1].htmlElement.style.transform =
-                `translateY(${translateBuffer}px)`;
-        } else {
-            this.rows[rowLen - 1].htmlElement.style.transform =
-                `translateY(${this.rows[rowLen - 1].getDefaultTopOffset()}px)`;
-        }
-    }
-
-    /* *
-    *
-    *  Static Methods
-    *
-    * */
-
-}
-
-
-/* *
- *
- *  Class Namespace
- *
- * */
-
-namespace DataGridTable {
-
 }
 
 

--- a/ts/DataGrid/DataGrid2/Globals.ts
+++ b/ts/DataGrid/DataGrid2/Globals.ts
@@ -68,6 +68,7 @@ namespace Globals {
         tableElement: classNamePrefix + 'table',
         theadElement: classNamePrefix + 'thead',
         tbodyElement: classNamePrefix + 'tbody',
+        rowElement: classNamePrefix + 'row',
         hoveredCell: classNamePrefix + 'hovered-cell',
         hoveredColumn: classNamePrefix + 'hovered-column',
         hoveredRow: classNamePrefix + 'hovered-row'

--- a/ts/DataGrid/DataGrid2/Globals.ts
+++ b/ts/DataGrid/DataGrid2/Globals.ts
@@ -71,7 +71,8 @@ namespace Globals {
         rowElement: classNamePrefix + 'row',
         hoveredCell: classNamePrefix + 'hovered-cell',
         hoveredColumn: classNamePrefix + 'hovered-column',
-        hoveredRow: classNamePrefix + 'hovered-row'
+        hoveredRow: classNamePrefix + 'hovered-row',
+        odd: classNamePrefix + 'odd'
     };
 
     export const win = window;

--- a/ts/DataGrid/DataGrid2/Virtualization/RowsVirtualizer.ts
+++ b/ts/DataGrid/DataGrid2/Virtualization/RowsVirtualizer.ts
@@ -1,0 +1,271 @@
+/* *
+ *
+ *  Data Grid Rows Renderer class.
+ *
+ *  (c) 2020-2024 Highsoft AS
+ *
+ *  License: www.highcharts.com/license
+ *
+ *  !!!!!!! SOURCE GETS TRANSPILED BY TYPESCRIPT. EDIT TS FILE ONLY. !!!!!!!
+ *
+ *  Authors:
+ *  - Dawid Dragula
+ *
+ * */
+
+'use strict';
+
+
+/* *
+ *
+ *  Imports
+ *
+ * */
+
+import DataGridTable from '../DataGridTable.js';
+import DGUtils from '../Utils.js';
+import Globals from '../Globals.js';
+import DataGridRow from '../DataGridRow.js';
+
+const { makeHTMLElement } = DGUtils;
+
+
+/* *
+ *
+ *  Class
+ *
+ * */
+
+/**
+ * Represents a virtualized rows renderer for the data grid.
+ */
+class RowsVirtualizer {
+
+    /* *
+    *
+    *  Properties
+    *
+    * */
+
+    /**
+     * The default height of a row.
+     */
+    public defaultRowHeight: number;
+
+    /**
+     * The index of the first visible row.
+     */
+    public rowCursor: number = 0;
+
+    /**
+     * The viewport (table) of the data grid.
+     */
+    public viewport: DataGridTable;
+
+    /**
+     * The initial height of the top row.
+     */
+    private topRowInitialHeight?: number;
+
+    /**
+     * Size of the row buffer - how many rows should be rendered outside of the
+     * viewport from the top and the bottom.
+     */
+    private buffer: number;
+
+
+    /* *
+    *
+    *  Constructor
+    *
+    * */
+
+    /**
+     * Constructs an instance of the rows virtualizer.
+     *
+     * @param viewport
+     * The viewport of the data grid to render rows in.
+     */
+    constructor(viewport: DataGridTable) {
+        this.viewport = viewport;
+        this.defaultRowHeight = this.getDefaultRowHeight();
+        this.buffer =
+            viewport.dataGrid.options.rowOptions?.bufferSize as number;
+    }
+
+
+    /* *
+    *
+    *  Functions
+    *
+    * */
+
+    /**
+     * Renders the rows in the viewport for the first time.
+     */
+    public initialRender(): void {
+        // Initial reflow to set the viewport height
+        this.viewport.reflow();
+
+        // Load & render rows
+        this.renderRows(this.rowCursor);
+        this.adjustRowHeights();
+    }
+
+    public scroll(): void {
+        const target = this.viewport.tbodyElement;
+        const { defaultRowHeight: rowHeight } = this;
+
+        // Do vertical virtual scrolling
+        const rowCursor = Math.floor(target.scrollTop / rowHeight);
+        if (this.rowCursor !== rowCursor) {
+            this.renderRows(rowCursor);
+        }
+        this.rowCursor = rowCursor;
+        // -----------------------------
+
+        this.adjustRowHeights();
+    }
+
+    /**
+     * Renders rows in the specified range. Removes rows that are out of the
+     * range except the last row.
+     *
+     * @param rowCursor
+     * The index of the first visible row.
+     */
+    private renderRows(rowCursor: number): void {
+        const { viewport: vp, buffer } = this;
+        const rowsPerPage = Math.ceil(
+            vp.tbodyElement.offsetHeight / this.defaultRowHeight
+        );
+
+        const rows = vp.rows;
+
+        if (!rows.length) {
+            const last = new DataGridRow(vp, vp.dataTable.getRowCount() - 1);
+            last.render(vp);
+            rows.push(last);
+            vp.tbodyElement.appendChild(last.htmlElement);
+        }
+
+        const from = Math.max(rowCursor - buffer, 0);
+        const to = Math.min(
+            rowCursor + rowsPerPage + buffer,
+            rows[rows.length - 1].index - 1
+        );
+
+        const alwaysLastRow = rows.pop();
+
+        for (let i = 0, iEnd = rows.length; i < iEnd; ++i) {
+            rows[i].destroy();
+        }
+        rows.length = 0;
+
+        for (let i = from; i <= to; ++i) {
+            const newRow = new DataGridRow(vp, i);
+            newRow.render(vp);
+            vp.tbodyElement.insertBefore(
+                newRow.htmlElement,
+                vp.tbodyElement.lastChild
+            );
+
+            rows.push(newRow);
+        }
+
+        if (alwaysLastRow) {
+            rows.push(alwaysLastRow);
+        }
+
+        const bof = buffer - (rowCursor - buffer < 0 ? buffer - rowCursor : 0);
+        this.topRowInitialHeight = vp.rows[bof].htmlElement.clientHeight;
+    }
+
+    /**
+     * Adjusts the heights of the rows based on the current scroll position.
+     * It handles the possibility of the rows having different heights than
+     * the default height.
+     */
+    public adjustRowHeights(): void {
+        const { rows, tbodyElement } = this.viewport;
+        const rowsLn = rows.length;
+
+        let translateBuffer = rows[0].getDefaultTopOffset();
+
+        for (let i = 0; i < rowsLn; ++i) {
+            const row = rows[i];
+            const cursor = this.rowCursor;
+
+            if (row.index > cursor) {
+                break;
+            }
+
+            const element = row.htmlElement;
+            const defaultH = this.defaultRowHeight;
+            const borderH = element.offsetHeight - element.clientHeight;
+
+            if (row.index < cursor) {
+                row.htmlElement.style.height = defaultH + borderH + 'px';
+            } else if (
+                row.getCurrentHeight() > defaultH &&
+                this.topRowInitialHeight
+            ) {
+                const ratio = tbodyElement.scrollTop / defaultH - cursor;
+                const diff = this.topRowInitialHeight - defaultH;
+
+                row.htmlElement.style.height =
+                    this.topRowInitialHeight - diff * ratio + 'px';
+            }
+        }
+
+        for (let i = 1, iEnd = rowsLn - 1; i < iEnd; ++i) {
+            translateBuffer += rows[i - 1].getCurrentHeight();
+            rows[i].htmlElement.style.transform =
+                `translateY(${translateBuffer}px)`;
+        }
+
+        if (rows[rowsLn - 2].index + 1 === rows[rowsLn - 1].index) {
+            translateBuffer += rows[rowsLn - 2].getCurrentHeight();
+            rows[rowsLn - 1].htmlElement.style.transform =
+                `translateY(${translateBuffer}px)`;
+        } else {
+            rows[rowsLn - 1].htmlElement.style.transform =
+                `translateY(${rows[rowsLn - 1].getDefaultTopOffset()}px)`;
+        }
+    }
+
+    /**
+     * Reflow the rendered rows content dimensions.
+     */
+    public reflowRows(): void {
+        const rows = this.viewport.rows;
+
+        for (let i = 0, iEnd = rows.length; i < iEnd; ++i) {
+            rows[i].reflow();
+        }
+    }
+
+    /**
+     * Returns the default height of a row. This method should be called only
+     * once on initialization.
+     */
+    private getDefaultRowHeight(): number {
+        const mockRow = makeHTMLElement('tr', {
+            className: Globals.classNames.rowElement
+        }, this.viewport.tbodyElement);
+
+        const defaultRowHeight = mockRow.clientHeight;
+        mockRow.remove();
+
+        return defaultRowHeight;
+    }
+}
+
+
+/* *
+ *
+ *  Default Export
+ *
+ * */
+
+export default RowsVirtualizer;


### PR DESCRIPTION
Added individual row sizing in virtual scroll using CSS.

TODO:
- [x] Add the ability to set the height of individual rows in virtual scrolling (fully in CSS).
- [x] Add smooth scrolling for rows with different heights (no table jumping if high rows go beyond buffer.).
- [x] Separate the row rendering code into a new class `RowsVirtualizer`.