### PR TITLE
bugfix/enabling-a11y

### DIFF
--- a/samples/highcharts/accessibility/accessible-dynamic-data/demo.css
+++ b/samples/highcharts/accessibility/accessible-dynamic-data/demo.css
@@ -1,0 +1,35 @@
+#container {
+    max-width: 800px;
+    height: 400px;
+    margin: 1em auto;
+}
+
+caption {
+    padding-bottom: 15px;
+    font-family: Verdana, sans-serif;
+    font-size: 1.2em;
+    color: #555;
+}
+
+table {
+    font-family: Verdana, sans-serif;
+    font-size: 12pt;
+    border-collapse: collapse;
+    border: 1px solid #ebebeb;
+    margin: 10px auto;
+    text-align: center;
+    width: 100%;
+}
+
+table tr:nth-child(odd) {
+    background-color: #fff;
+}
+
+table tr:nth-child(even) {
+    background-color: #fcf9f9;
+}
+
+th {
+    font-weight: 600;
+    padding: 10px;
+}

--- a/samples/highcharts/accessibility/accessible-dynamic-data/demo.details
+++ b/samples/highcharts/accessibility/accessible-dynamic-data/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Marita Vindedal
+ js_wrap: b
+...

--- a/samples/highcharts/accessibility/accessible-dynamic-data/demo.html
+++ b/samples/highcharts/accessibility/accessible-dynamic-data/demo.html
@@ -1,0 +1,10 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/modules/export-data.js"></script>
+<script src="https://code.highcharts.com/modules/accessibility.js"></script>
+<figure class="highcharts-figure">
+    <div id="container"></div>
+    <p class="highcharts-description">The following chart demonstrates a chart that animates quickly and is hidden from a screen reader.
+        If you pause the data, the Accessibility module is enabled and you are able to explore the data.</p>
+</figure>
+<button id="toggle">Start animating</button>

--- a/samples/highcharts/accessibility/accessible-dynamic-data/demo.js
+++ b/samples/highcharts/accessibility/accessible-dynamic-data/demo.js
@@ -1,0 +1,61 @@
+const chart = Highcharts.chart('container', {
+    title: {
+        text: 'Dynamic data'
+    },
+    subtitle: {
+        text: 'Click button to animate or explore chart'
+    },
+    accessibility: {
+        enabled: true
+    },
+    tooltip: {
+        dateTimeLabelFormats: {
+            day: '%H:%M',
+            hour: '%H:%M'
+        }
+    },
+    xAxis: {
+        type: 'datetime',
+        dateTimeLabelFormats: {
+            day: '%H:%M',
+            hour: '%H:%M'
+        }
+    },
+    plotOptions: {
+        series: {
+            pointStart: 0,
+            pointInterval: 1000 * 60 * 60
+        }
+    },
+    series: [{
+        name: 'Random data',
+        data: [1, 3, 4, 6, 7, 5, 3, 4, 8, 9, 7, 6, 4, 3]
+    }]
+});
+
+let intervalId;
+let isAnimating = false;
+
+const toggleButton = document.getElementById('toggle');
+toggleButton.onclick = function () {
+    if (isAnimating) {
+        clearInterval(intervalId);
+        chart.update({
+            accessibility: {
+                enabled: true
+            }
+        });
+        toggleButton.textContent = 'Start animating';
+    } else {
+        intervalId = setInterval(function () {
+            chart.series[0].addPoint(Math.round(Math.random() * 10));
+        }, 500);
+        chart.update({
+            accessibility: {
+                enabled: false
+            }
+        });
+        toggleButton.textContent = 'Stop animating';
+    }
+    isAnimating = !isAnimating;
+};

--- a/samples/unit-tests/accessibility/accessibility-options/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-options/demo.js
@@ -56,6 +56,29 @@ QUnit.test('Accessibility disabled', function (assert) {
         'img',
         'SVG root has img role'
     );
+
+    chart.update({
+        accessibility: {
+            enabled: true
+        }
+    });
+
+    assert.strictEqual(
+        chart.renderer.box.getAttribute('role'),
+        null,
+        'SVG root has no role after enabling a11y'
+    );
+
+    chart.update({
+        accessibility: {
+            enabled: false
+        }
+    });
+    assert.strictEqual(
+        chart.renderer.box.getAttribute('role'),
+        'img',
+        'SVG root has no img role after disabling a11y'
+    );
 });
 
 QUnit.test('Point hidden from AT', function (assert) {

--- a/ts/Accessibility/Accessibility.ts
+++ b/ts/Accessibility/Accessibility.ts
@@ -354,6 +354,7 @@ namespace Accessibility {
     export declare class ChartComposition extends Chart {
         options: Required<Options>;
         series: Array<SeriesComposition>;
+        wasAccessibilityEnabled?: boolean;
     }
 
     export declare class PointComposition extends Point {
@@ -459,7 +460,8 @@ namespace Accessibility {
         this: ChartComposition
     ): void {
         let a11y = this.accessibility;
-        const accessibilityOptions = this.options.accessibility;
+        const accessibilityOptions = this.options.accessibility,
+            svg = this.renderer.boxWrapper.element;
 
         if (accessibilityOptions && accessibilityOptions.enabled) {
             if (a11y && !a11y.zombie) {
@@ -469,6 +471,9 @@ namespace Accessibility {
                 if (a11y && !a11y.zombie) {
                     a11y.update();
                 }
+                // If a11y has been enabled = false, and is now enabled = true
+                svg.removeAttribute('role');
+                this.wasAccessibilityEnabled = true;
             }
         } else if (a11y) {
             // Destroy if after update we have a11y and it is disabled
@@ -479,7 +484,13 @@ namespace Accessibility {
         } else {
             // Just hide container
             this.renderTo.setAttribute('aria-hidden', true);
+
+            // If a11y has been enabled = true, and is now enabled = false
+            if (this.wasAccessibilityEnabled === false) {
+                svg.setAttribute('role', 'img');
+            }
         }
+        this.wasAccessibilityEnabled = false;
     }
 
     /**


### PR DESCRIPTION
When handling a complex dynamic chart, like #21221 it might be beneficial to be able to turn on and off `accessibility.enabled` . When dynamically setting it, `role="img"` for the SVG was not removed. So when pausing the chart, you were not able to explore the rest of the chart with a screen reader because of this.

How to test:
1. Verify that role="img" is removed from svg-element when stop button is clicked.
2. Verify that role="img" is there on the svg-element when start button is clicked.