### PR TITLE
bugfix/20435-points-events-update-regression

### DIFF
--- a/samples/unit-tests/series/update/demo.js
+++ b/samples/unit-tests/series/update/demo.js
@@ -382,6 +382,40 @@ QUnit.test('Series.update and mouse interaction', function (assert) {
         'Data labels should not be enabled.'
     );
 
+    const color = '#ff0000';
+
+    chart.series[0].update({
+        point: {
+            events: {
+                mouseOver: function () {
+                    this.update({
+                        color: color
+                    });
+                },
+                mouseOut: function () {
+                    this.update({
+                        color: void 0
+                    });
+                }
+            }
+        }
+    });
+
+    chart.series[0].points[0].onMouseOver();
+    assert.strictEqual(
+        chart.series[0].points[0].options.color,
+        color,
+        `Color should be set on mouse over - updated callback should work
+        correctly (#20435).`
+    );
+    assert.notEqual(
+        chart.series[0].points[0].options.dataLabels &&
+            chart.series[0].points[0].options.dataLabels.enabled,
+        true,
+        `Data labels should not be enabled - callback before update shouldn't
+        work (#20435).`
+    );
+
     chart.series[0].update({
         point: {
             events: {

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -71,7 +71,7 @@ declare module './PointLike' {
     interface PointLike {
         className?: string;
         events?: PointEventsOptions;
-        hasImportedEvents?: boolean;
+        importedUserEvent?: Function;
         selected?: boolean;
         selectedStaging?: boolean;
         state?: string;
@@ -1321,14 +1321,13 @@ class Point {
         ) {
             // While updating the existing callback event the old one should be
             // removed
-            if (point.hasImportedEvents) {
-                removeEvent(point, eventType);
+            if (point.importedUserEvent) {
+                point.importedUserEvent();
             }
 
-            addEvent(point, eventType, userEvent);
-            point.hasImportedEvents = true;
+            point.importedUserEvent = addEvent(point, eventType, userEvent);
         } else if (
-            point.hasImportedEvents &&
+            point.importedUserEvent &&
             !userEvent &&
             point.hcEvents?.[eventType]
         ) {
@@ -1336,7 +1335,7 @@ class Point {
             delete point.hcEvents[eventType];
 
             if (!Object.keys(point.hcEvents)) {
-                point.hasImportedEvents = false;
+                delete point.importedUserEvent;
             }
         }
     }

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1321,9 +1321,7 @@ class Point {
         ) {
             // While updating the existing callback event the old one should be
             // removed
-            if (point.importedUserEvent) {
-                point.importedUserEvent();
-            }
+            point.importedUserEvent?.();
 
             point.importedUserEvent = addEvent(point, eventType, userEvent);
         } else if (

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1319,6 +1319,12 @@ class Point {
                     .indexOf(userEvent) === -1
             )
         ) {
+            // While updating the existing callback event the old one should be
+            // removed
+            if (point.hasImportedEvents) {
+                removeEvent(point, eventType);
+            }
+
             addEvent(point, eventType, userEvent);
             point.hasImportedEvents = true;
         } else if (


### PR DESCRIPTION
Fixed regression after fix #20435, updating of existing point event didn't remove the old event.