### PR TITLE
X datestring: first commit

### DIFF
--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -356,8 +356,24 @@ class Point {
             } else {
                 point.x = x;
             }
+
         } else if (isNumber(options.x) && series.options.relativeXValue) {
             point.x = series.autoIncrement(options.x);
+
+        // If x is a string, try to parse it to a datetime
+        } else if (typeof point.x === 'string') {
+            x = Date.parse(point.x);
+            if (isNumber(x)) {
+                // Unless the string contains time zone information, convert
+                // from the local time result of `Date.parse` via UTC into the
+                // current timezone of the time object.
+                if (!/[+-][0-9]{2}:[0-9]{2}|Z$/.test(point.x)) {
+                    const tsUTC = x - new Date(x).getTimezoneOffset() * 60000;
+
+                    x = tsUTC + series.chart.time.getTimezoneOffset(tsUTC);
+                }
+                point.x = x;
+            }
         }
 
         point.isNull = this.isValid && !this.isValid();


### PR DESCRIPTION
Added support for date strings as [data.x](https://api.highcharts.com/highcharts/series.line.data.x) values.

Example:
```js
    series: [{
        data: [
            ['2024-01-01', 1],
            ['2024-01-02', 3],
            ['2024-01-03', 2],
            ['2024-01-04', 4]
        ],
        keys: ['x', 'y']
    }],
```

Basic test: https://jsfiddle.net/highcharts/qo3b6g57/
Performance test: https://jsfiddle.net/highcharts/mho57a6b/3/

#### To do
 - [ ] Also allow date strings for related options like `pointStart`.
 - [ ] Refactor out the [time zone correction](https://github.com/highcharts/highcharts/blob/5d01daf8231d3deacb5a8b4c9684f06bf12426db/ts/Core/Series/Point.ts#L370-L374) of the parser. Create a `parse` function on the Time object. Use this also for the `RangeSelector.defaultInputDataParser`.
 - [ ] Verify the regex for checking the string for time zone information. Test against all valid formats of ISO8601.
 - [ ] Work on the performance of time zone corrections. Related to the performance to-do's of #21233.
 - [ ] Tests. Check specifically the time around local DST crossovers.
 - [ ] Demos. Update all public demos to use string formats rather than `Date.UTC` (check also for raw timestamps).
 - [ ] Docs.