### PR TITLE
More forgiving turboThreshold

### DIFF
--- a/samples/dashboards/studies/sun-horizon/demo.js
+++ b/samples/dashboards/studies/sun-horizon/demo.js
@@ -620,8 +620,7 @@ const createBoard = async () => {
                             inactive: {
                                 enabled: false
                             }
-                        },
-                        turboThreshold: Infinity
+                        }
                     },
                     flags: {
                         borderRadius: 3,

--- a/samples/gantt/gantt/bigdata/demo.js
+++ b/samples/gantt/gantt/bigdata/demo.js
@@ -52253,8 +52253,7 @@ Highcharts.ganttChart('container', {
 
     plotOptions: {
         series: {
-            grouping: false,
-            turboThreshold: 0
+            grouping: false
         }
     },
 

--- a/samples/highcharts/boost/heatmap/demo.js
+++ b/samples/highcharts/boost/heatmap/demo.js
@@ -87,8 +87,7 @@ Highcharts.chart('container', {
             headerFormat: 'Temperature<br/>',
             pointFormat: '{point.x:%e %b, %Y} {point.y}:00: <b>{point.value} ' +
                 '℃</b>'
-        },
-        turboThreshold: Number.MAX_VALUE // #3404, remove after 4.0.5 release
+        }
     }]
 
 });

--- a/samples/highcharts/boost/line-series-heavy-dynamic/demo.js
+++ b/samples/highcharts/boost/line-series-heavy-dynamic/demo.js
@@ -22,7 +22,6 @@ function getSeries(n, s) {
             animation: false,
             lineWidth: 2,
             boostThreshold: 1,
-            turboThreshold: 1,
             showInNavigator: true,
             requireSorting: false
         });

--- a/samples/highcharts/boost/line-series-heavy-stock/demo.js
+++ b/samples/highcharts/boost/line-series-heavy-stock/demo.js
@@ -43,7 +43,6 @@ function getSeries(n, s) {
             },
             lineWidth: 2,
             boostThreshold: 1,
-            turboThreshold: 1,
             showInNavigator: true
         });
     }

--- a/samples/highcharts/boost/line-series-heavy/demo.js
+++ b/samples/highcharts/boost/line-series-heavy/demo.js
@@ -35,8 +35,7 @@ function getSeries(n, s) {
         r.push({
             data: getData(n),
             lineWidth: 2,
-            boostThreshold: 1,
-            turboThreshold: 1
+            boostThreshold: 1
         });
     }
 

--- a/samples/highcharts/chartchooser/categorical-comparison-treemap-monochrome/demo.js
+++ b/samples/highcharts/chartchooser/categorical-comparison-treemap-monochrome/demo.js
@@ -27,7 +27,6 @@
                 type: 'treemap',
                 layoutAlgorithm: 'squarified',
                 allowDrillToNode: true,
-                turboThreshold: dataJson.length,
                 dataLabels: {
                     enabled: false
                 },

--- a/samples/highcharts/chartchooser/categorical-comparison-treemap/demo.js
+++ b/samples/highcharts/chartchooser/categorical-comparison-treemap/demo.js
@@ -39,7 +39,6 @@
                 type: 'treemap',
                 layoutAlgorithm: 'squarified',
                 allowDrillToNode: true,
-                turboThreshold: Infinity,
                 dataLabels: {
                     enabled: false,
                     crop: true

--- a/samples/highcharts/demo/heatmap-canvas/demo.js
+++ b/samples/highcharts/demo/heatmap-canvas/demo.js
@@ -81,8 +81,7 @@ Highcharts.chart('container', {
             headerFormat: 'Temperature<br/>',
             pointFormat: '{point.x:%e %b, %Y} {point.y}:00: <b>{point.value} ' +
                 '℃</b>'
-        },
-        turboThreshold: Number.MAX_VALUE // #3404, remove after 4.0.5 release
+        }
     }]
 
 });

--- a/samples/highcharts/series-networkgraph/forces/demo.js
+++ b/samples/highcharts/series-networkgraph/forces/demo.js
@@ -8,7 +8,6 @@ Highcharts.chart('container', {
     },
     plotOptions: {
         networkgraph: {
-            turboThreshold: 0,
             keys: ['from', 'to', 'color']
         }
     },

--- a/samples/maps/demo/lightning/demo.js
+++ b/samples/maps/demo/lightning/demo.js
@@ -163,7 +163,6 @@ const displayTime = time => {
             name: 'Lightning strike',
             id: 'lightnings',
             type: 'mapbubble',
-            turboThreshold: Infinity,
             animation: false,
             data: getInitialData(currentTime),
             tooltip: {

--- a/samples/stock/members/series-update/demo.js
+++ b/samples/stock/members/series-update/demo.js
@@ -39,8 +39,7 @@
         series: [{
             name: 'AAPL Stock Price',
             data: data,
-            threshold: null,
-            turboThreshold: 2000 // to accept point object configuration
+            threshold: null
         }]
     });
 

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -351,11 +351,7 @@ class Point {
             point.x = series.xAxis.nameToX(point);
         }
         if (typeof point.x === 'undefined' && series) {
-            if (typeof x === 'undefined') {
-                point.x = series.autoIncrement();
-            } else {
-                point.x = x;
-            }
+            point.x = x ?? series.autoIncrement();
         } else if (isNumber(options.x) && series.options.relativeXValue) {
             point.x = series.autoIncrement(options.x);
         }

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -1400,8 +1400,9 @@ class Series {
                     lastPoint = series.getFirstValidPoint(
                         data, dataLength - 1, -1
                     ),
-                    isNumericArray = (a: unknown): a is Array<number> =>
-                        isArray(a) && isNumber(a[0]);
+                    isShortArray = (a: unknown): a is Array<unknown> => Boolean(
+                        isArray(a) && (keys || isNumber(a[0]))
+                    );
 
                 // Assume all points are numbers
                 if (isNumber(firstPoint) && isNumber(lastPoint)) {
@@ -1412,8 +1413,8 @@ class Series {
 
                 // Assume all points are arrays when first point is
                 } else if (
-                    isNumericArray(firstPoint) &&
-                    isNumericArray(lastPoint)
+                    isShortArray(firstPoint) &&
+                    isShortArray(lastPoint)
                 ) {
                     if (valueCount) { // [x, low, high] or [x, o, h, l, c]
                         if (firstPoint.length === valueCount) {

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -1337,7 +1337,6 @@ class Series {
             updatedData,
             indexOfX = 0,
             indexOfY = 1,
-            firstPoint = null,
             copiedData;
 
         if (!chart.options.chart.allowMutatingData) { // #4259
@@ -1389,23 +1388,33 @@ class Series {
                 (series as any)[key + 'Data'].length = 0;
             });
 
-            // In turbo mode, only one- or twodimensional arrays of numbers
-            // are allowed. The first value is tested, and we assume that
-            // all the rest are defined the same way. Although the 'for'
-            // loops are similar, they are repeated inside each if-else
-            // conditional for max performance.
-            if (turboThreshold && dataLength > turboThreshold) {
+            // In turbo mode, look for one- or twodimensional arrays of numbers.
+            // The first and the last valid value are tested, and we assume that
+            // all the rest are defined the same way. Although the 'for' loops
+            // are similar, they are repeated inside each if-else conditional
+            // for max performance.
+            let runTurbo = turboThreshold && dataLength > turboThreshold;
+            if (runTurbo) {
 
-                firstPoint = series.getFirstValidPoint(data);
+                const firstPoint = series.getFirstValidPoint(data),
+                    lastPoint = series.getFirstValidPoint(
+                        data, dataLength - 1, -1
+                    ),
+                    isNumericArray = (a: unknown): a is Array<number> =>
+                        isArray(a) && isNumber(a[0]);
 
-                if (isNumber(firstPoint)) { // Assume all points are numbers
+                // Assume all points are numbers
+                if (isNumber(firstPoint) && isNumber(lastPoint)) {
                     for (i = 0; i < dataLength; i++) {
                         (xData as any)[i] = this.autoIncrement();
                         (yData as any)[i] = data[i];
                     }
 
                 // Assume all points are arrays when first point is
-                } else if (isArray(firstPoint)) {
+                } else if (
+                    isNumericArray(firstPoint) &&
+                    isNumericArray(lastPoint)
+                ) {
                     if (valueCount) { // [x, low, high] or [x, o, h, l, c]
                         if (firstPoint.length === valueCount) {
                             for (i = 0; i < dataLength; i++) {
@@ -1449,9 +1458,11 @@ class Series {
                 } else {
                     // Highcharts expects configs to be numbers or arrays in
                     // turbo mode
-                    error(12, false, chart);
+                    runTurbo = false;
                 }
-            } else {
+            }
+
+            if (!runTurbo) {
                 for (i = 0; i < dataLength; i++) {
                     pt = { series: series };
                     series.pointClass.prototype.applyOptions.apply(
@@ -2091,26 +2102,31 @@ class Series {
     }
 
     /**
-     * Find and return the first non null point in the data
+     * Find and return the first non nullish point in the data
      *
      * @private
      * @function Highcharts.Series.getFirstValidPoint
      * @param {Array<Highcharts.PointOptionsType>} data
-     * Array of options for points
+     *        Array of options for points
+     * @param {number} [start=0]
+     *        Index to start searching from
+     * @param {number} [increment=1]
+     *        Index increment, set -1 to search backwards
      */
     public getFirstValidPoint(
-        data: Array<(PointOptions|PointShortOptions)>
-    ): (PointOptions|PointShortOptions) {
+        data: Array<(PointOptions|PointShortOptions)>,
+        start = 0,
+        increment = 1
+    ): (PointOptions|PointShortOptions|undefined) {
         const dataLength = data.length;
-        let i = 0,
-            firstPoint = null;
+        let i = start;
 
-        while (firstPoint === null && i < dataLength) {
-            firstPoint = data[i];
-            i++;
+        while (i >= 0 && i < dataLength) {
+            if (defined(data[i])) {
+                return data[i];
+            }
+            i += increment;
         }
-
-        return firstPoint;
     }
 
     /**

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -2386,15 +2386,20 @@ const seriesDefaults: PlotOptionsOf<Series> = {
      */
 
     /**
-     * When a series contains a data array that is longer than this, only
-     * one dimensional arrays of numbers, or two dimensional arrays with
-     * x and y values are allowed. Also, only the first point is tested,
-     * and the rest are assumed to be the same format. This saves expensive
-     * data checking and indexing in long series. Set it to `0` disable.
+     * When a series contains a `data` array that is longer than this, the
+     * Series class looks for data configurations of plain numbers or arrays of
+     * numbers. The first and last valid points are checked. If found, the rest
+     * of the data is assumed to be the same. This saves expensive data checking
+     * and indexing in long series, and makes data-heavy charts render faster.
+     *
+     * Set it to `0` disable.
      *
      * Note:
-     * In boost mode turbo threshold is forced. Only array of numbers or
-     * two dimensional arrays are allowed.
+     * - In boost mode turbo threshold is forced. Only array of numbers or two
+     *   dimensional arrays are allowed.
+     * - In version 11.4.3 and earlier, if object configurations were passed
+     *   beyond the turbo threshold, a warning was logged in the console and the
+     *   data series didn't render.
      *
      * @since   2.2
      * @product highcharts highstock gantt


### PR DESCRIPTION
Refactored the `series.turboThreshold` option to be more forgiving. Instead of failing with a warning message, the Series class now silently skips the fast looping of raw numbers and processes the object configuration instead, at a slight performance cost.