### PR TITLE
bugfix/21177-packedBubble-setData-when-hidden

### DIFF
--- a/ts/Series/PackedBubble/PackedBubblePoint.ts
+++ b/ts/Series/PackedBubble/PackedBubblePoint.ts
@@ -109,7 +109,7 @@ class PackedBubblePoint extends BubblePoint implements DragNodesPoint {
      * @private
      */
     public destroy(): void {
-        if (this.series.layout) {
+        if (this.series?.layout) {
             this.series.layout.removeElementFromCollection(
                 this,
                 this.series.layout.nodes as Array<PackedBubblePoint>


### PR DESCRIPTION
Fixed #21177, setting data to a hidden packed bubble series would throw error