### PR TITLE
bugfix/21245-boxplot-multiple-series-position

### DIFF
--- a/samples/unit-tests/series-boxplot/boxplot/demo.js
+++ b/samples/unit-tests/series-boxplot/boxplot/demo.js
@@ -187,7 +187,7 @@ QUnit.test(
 QUnit.test(
     'Individual dash styles for box, median, stem and whisker lines (#13065)',
     function (assert) {
-        var chart = Highcharts.chart('container', {
+        const chart = Highcharts.chart('container', {
             chart: {
                 type: 'boxplot'
             },
@@ -223,7 +223,7 @@ QUnit.test(
             ]
         });
 
-        var series = chart.series[0],
+        const series = chart.series[0],
             firstPoint = series.points[0],
             secondPoint = series.points[1];
 
@@ -260,6 +260,42 @@ QUnit.test(
             secondPoint.stem.attr('stroke-dasharray'),
             '4,3,1,3',
             'DashDot dashStyle should be applied to the second point\'s stem.'
+        );
+
+        chart.series[0].update({
+            dashStyle: 'normal',
+            medianDashStyle: 'normal',
+            whiskerDashStyle: 'normal',
+            data: [{
+                low: 194.0,
+                q1: 205.52,
+                median: 207.36,
+                q3: 209.08,
+                high: 317.58
+            }]
+        }, false);
+
+        chart.addSeries({
+            data: [{
+                low: 195.64,
+                q1: 204.16,
+                median: 205.72,
+                q3: 207.48,
+                high: 275.4
+            }]
+        });
+
+        const whiskersBox = chart.series[0].points[0].whiskers.getBBox(),
+            whiskersCenter = whiskersBox.x + (whiskersBox.width / 2),
+            { shapeArgs } = chart.series[0].points[0],
+            pointCenter = shapeArgs.x + (shapeArgs.width / 2);
+
+        assert.close(
+            whiskersCenter,
+            pointCenter,
+            0.501,
+            `Whiskers and stem should be placed correctly in the center of point
+            for multiple boxplot series, #21245.`
         );
     }
 );

--- a/ts/Series/BoxPlot/BoxPlotSeries.ts
+++ b/ts/Series/BoxPlot/BoxPlotSeries.ts
@@ -261,7 +261,11 @@ class BoxPlotSeries extends ColumnSeries {
                 let d: SVGPath;
 
                 // The stem
-                const stemX = crisp(point.plotX || 0, point.stem.strokeWidth());
+                const stemX = crisp(
+                    (point.plotX || 0) + (series.pointXOffset || 0) +
+                        ((series.barW || 0) / 2),
+                    point.stem.strokeWidth()
+                );
                 d = [
                     // Stem up
                     ['M', stemX, q3Plot],


### PR DESCRIPTION
Fixed #21245, points were wrongly positioned for multiple boxplot series.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207445117851437