### PR TITLE
Added upload of *-latest.zip

### DIFF
--- a/tools/gulptasks/dist-upload-code.js
+++ b/tools/gulptasks/dist-upload-code.js
@@ -154,9 +154,17 @@ function uploadProductPackage(productProps, options = {}) {
         gfxFilesToVersionedDir = [...gfxFilesToVersionedDir, ...gfxFiles.map(file => toS3FilePath(file, localPath, cdnpath, versionPath))];
     });
 
+    // eslint-disable-next-line no-undef
+    const zipWithoutVersion = structuredClone(zipFile);
+    zipWithoutVersion.to =
+        zipWithoutVersion.to.replace('-' + version, '-latest');
+
     promises.push(uploadFiles({
         bucket: options.bucket,
-        files: [zipFile],
+        files: [
+            zipFile,
+            zipWithoutVersion
+        ],
         name: prettyName
     }));
 

--- a/tools/gulptasks/lib/uploadS3.js
+++ b/tools/gulptasks/lib/uploadS3.js
@@ -660,7 +660,7 @@ function getVersionPaths(version) {
  */
 async function uploadFiles(params) {
     const log = require('../../libs/log');
-    const { files, name, bucket, s3Params } = params;
+    const { files, name, bucket, s3Params, region } = params;
 
     params = Object.assign(
         {
@@ -672,7 +672,8 @@ async function uploadFiles(params) {
             callback: (from, to) => {
                 log.message(`Uploaded ${from} --> ${to}`);
             },
-            region: 'eu-west-1'
+            region: region ||
+                bucket.startsWith('staging') ? 'eu-central-1' : 'eu-west-1'
         },
         params
     );


### PR DESCRIPTION
## Test plan
1. Run `npx gulp dist`
2. Run `npx gulp dist-upload-code --bucket staging-code.highcharts.com`
3. `Highcharts-latest.zip` should be uploaded to AWS S3:
![image](https://github.com/highcharts/highcharts/assets/7478772/5431ae40-11d9-4934-9456-1831c07b2ec9)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207442874311194