### PR TITLE
bugfix/20494-reset-responsive-config

### DIFF
--- a/samples/unit-tests/responsive/responsive/demo.js
+++ b/samples/unit-tests/responsive/responsive/demo.js
@@ -33,7 +33,8 @@ QUnit.test('Adapt height', function (assert) {
                     },
                     chartOptions: {
                         chart: {
-                            height: '100%'
+                            height: 200,
+                            backgroundColor: 'red'
                         }
                     }
                 }
@@ -55,6 +56,20 @@ QUnit.test('Adapt height', function (assert) {
 
     assert.strictEqual(chart.chartWidth, 200, 'Width updated');
     assert.strictEqual(chart.chartHeight, 200, 'Percentage height updated');
+
+    assert.strictEqual(
+        chart.options.chart.backgroundColor,
+        'red',
+        'Chart should have red background'
+    );
+
+    chart.setSize(400);
+
+    assert.strictEqual(
+        chart.options.chart.backgroundColor,
+        '#ffffff',
+        'Chart should have default background'
+    );
 });
 
 QUnit.test('Callback', function (assert) {

--- a/ts/Core/Responsive.ts
+++ b/ts/Core/Responsive.ts
@@ -81,6 +81,7 @@ namespace Responsive {
         ): void;
         /** @requires Core/Responsive */
         setResponsive(redraw?: boolean, reset?: boolean): void;
+        updatingResponsive: boolean;
     }
 
     export interface CurrentObject {
@@ -224,7 +225,10 @@ namespace Responsive {
             // Undo previous rules. Before we apply a new set of rules, we
             // need to roll back completely to base options (#6291).
             if (currentResponsive) {
+                this.currentResponsive = void 0;
+                this.updatingResponsive = true;
                 this.update(currentResponsive.undoOptions, redraw, true);
+                this.updatingResponsive = false;
             }
 
             if (ruleIds) {
@@ -243,9 +247,9 @@ namespace Responsive {
                     mergedOptions: mergedOptions,
                     undoOptions: undoOptions
                 };
-
-                this.update(mergedOptions, redraw, true);
-
+                if (!this.updatingResponsive) {
+                    this.update(mergedOptions, redraw, true);
+                }
             } else {
                 this.currentResponsive = void 0;
             }


### PR DESCRIPTION
Fixed #20494, chart did not switch back to default config upon exiting responsive conditions