### PR TITLE
bugfix/21176-boost-multiple-axes-point-flickers

### DIFF
--- a/samples/unit-tests/boost/general/demo.js
+++ b/samples/unit-tests/boost/general/demo.js
@@ -563,5 +563,64 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
             2,
             'The y-axis should have more than two ticks'
         );
+
+        chart.update({
+            chart: {
+                animation: true
+            },
+            boost: {
+                enabled: true,
+                useGPUTranslations: false,
+                usePreallocated: false
+            },
+            yAxis: [{
+                id: 'a'
+            }, {
+                id: 'b',
+                height: '10%',
+                top: '90%'
+            }],
+            plotOptions: {
+                series: {
+                    animation: true,
+                    states: {
+                        hover: {
+                            halo: {
+                                size: 50
+                            }
+                        }
+                    }
+                }
+            },
+            series: [{
+                type: 'line',
+                yAxis: 'a',
+                data: [8, 6, 4],
+                boostThreshold: 1,
+                stickyTracking: false
+            }, {
+                data: [4, 5, 7],
+                yAxis: 'b',
+                boostThreshold: 1,
+                stickyTracking: false
+            }]
+        }, true, true);
+
+        const controller = new TestController(chart);
+        controller.moveTo(
+            chart.plotLeft + chart.series[1].points[1].plotX,
+            chart.plotTop + chart.plotHeight - chart.series[1].points[1].plotY
+        );
+        controller.moveTo(
+            chart.plotLeft + chart.series[0].points[1].plotX,
+            chart.plotTop + chart.plotHeight - chart.series[0].points[1].plotY
+        );
+
+        assert.strictEqual(
+            chart.series[1].halo.visibility,
+            'hidden',
+            `Halo shouldn't be rendered in wrong position between hovering
+            points from multiple series on multiple y-axes, #21176.`
+        );
     }
 );

--- a/ts/Extensions/Boost/BoostChart.ts
+++ b/ts/Extensions/Boost/BoostChart.ts
@@ -28,6 +28,7 @@ import type Chart from '../../Core/Chart/Chart';
 import type Series from '../../Core/Series/Series';
 import type SeriesOptions from '../../Core/Series/SeriesOptions';
 import type SVGElement from '../../Core/Renderer/SVG/SVGElement';
+import type Pointer from '../../Core/Pointer';
 
 import BoostableMap from './BoostableMap.js';
 import H from '../../Core/Globals.js';
@@ -322,29 +323,40 @@ function onChartCallback(
     let prevX = -1;
     let prevY = -1;
 
-    addEvent(chart.pointer, 'afterGetHoverData', (): void => {
-        const series = chart.hoverSeries;
+    addEvent(
+        chart.pointer,
+        'afterGetHoverData',
+        (e: Pointer.EventArgsObject): void => {
+            const series = e.hoverPoint?.series;
 
-        chart.boost = chart.boost || {};
+            chart.boost = chart.boost || {};
 
-        if (chart.boost.markerGroup && series) {
-            const xAxis = chart.inverted ? series.yAxis : series.xAxis;
-            const yAxis = chart.inverted ? series.xAxis : series.yAxis;
+            if (chart.boost.markerGroup && series) {
+                const xAxis = chart.inverted ? series.yAxis : series.xAxis;
+                const yAxis = chart.inverted ? series.xAxis : series.yAxis;
 
-            if (
-                (xAxis && xAxis.pos !== prevX) ||
-                (yAxis && yAxis.pos !== prevY)
-            ) {
-                // #10464: Keep the marker group position in sync with the
-                // position of the hovered series axes since there is only
-                // one shared marker group when boosting.
-                chart.boost.markerGroup.translate(xAxis.pos, yAxis.pos);
+                if (
+                    (xAxis && xAxis.pos !== prevX) ||
+                    (yAxis && yAxis.pos !== prevY)
+                ) {
+                    // #21176: If the axis is changed, hide teh halo without
+                    // animation  to prevent flickering of halos sharing the
+                    // same marker group
+                    chart.series.forEach((s): void => {
+                        s.halo?.hide();
+                    });
 
-                prevX = xAxis.pos;
-                prevY = yAxis.pos;
+                    // #10464: Keep the marker group position in sync with the
+                    // position of the hovered series axes since there is only
+                    // one shared marker group when boosting.
+                    chart.boost.markerGroup.translate(xAxis.pos, yAxis.pos);
+
+                    prevX = xAxis.pos;
+                    prevY = yAxis.pos;
+                }
             }
         }
-    });
+    );
 }
 
 /**


### PR DESCRIPTION
Fixed #21176, in boosted charts, the halo was wrongly animated for multiple series with multiple axes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207336752644298