### PR TITLE
bugfix/20599-align-labels-to-the-left-without-overlapping

### DIFF
--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3191,8 +3191,8 @@ class Axis {
         }
 
         // Set the explicit or automatic label alignment
-        this.labelAlign = labelOptions.align ||
-            this.autoLabelAlign(this.labelRotation as any);
+        this.labelAlign = (labelOptions.align ||
+            this.autoLabelAlign(this.labelRotation as any));
         if (this.labelAlign) {
             attr.align = this.labelAlign;
         }
@@ -3441,6 +3441,8 @@ class Axis {
             hasData = axis.hasData(),
             axisTitleOptions = options.title,
             labelOptions = options.labels,
+            labelOptionsAlign = labelOptions.align,
+            labelOptionsReserveSpace = labelOptions.reserveSpace,
             hasCrossing = isNumber(options.crossing),
             axisOffset = chart.axisOffset,
             clipOffset = chart.clipOffset,
@@ -3478,6 +3480,12 @@ class Axis {
                 side === 2 ||
                 ({ 1: 'left', 3: 'right' } as any)[side] === axis.labelAlign
             );
+
+            labelOptions.reserveSpace = !labelOptionsReserveSpace && (
+                (side === 3 && labelOptionsAlign === 'left') ||
+                (side === 1 && labelOptionsAlign === 'right')
+            ) || labelOptionsReserveSpace;
+
             if (pick(
                 labelOptions.reserveSpace,
                 hasCrossing ? false : null,

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -475,7 +475,7 @@ class Tick {
                                 ) :
                                 0
                         )
-                    ) - Math.max(((this.axis.labelOffset || 0)) - 14, 0),
+                    ),
                 y: horiz ?
                     (
                         (cHeight as any) -

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -475,8 +475,7 @@ class Tick {
                                 ) :
                                 0
                         )
-                    ),
-
+                    ) - Math.max(((this.axis.labelOffset || 0)) - 14, 0),
                 y: horiz ?
                     (
                         (cHeight as any) -
@@ -492,7 +491,6 @@ class Tick {
                         axis.transB
                     )
             };
-
         // Chrome workaround for #10516
         pos.y = clamp(pos.y, -1e5, 1e5);
 


### PR DESCRIPTION
Fixed #20599, labels were spilling out over the plot area

not entirely sure about this fix, should/are the axis labels positions optional?