### PR TITLE
bugfix/21043-navigator-base-series-not-cleared

### DIFF
--- a/samples/unit-tests/scroller/multiple-navigator-series/demo.js
+++ b/samples/unit-tests/scroller/multiple-navigator-series/demo.js
@@ -47,6 +47,16 @@ QUnit.test('Setting base series on chart', function (assert) {
         2,
         'Navigator has two series'
     );
+
+    // #21043
+    while (chart.series.length > 0) {
+        chart.series[0].remove(false);
+    }
+    assert.strictEqual(
+        chart.navigator.baseSeries.length,
+        0,
+        'After series removal, baseSeries should be cleared too. (#21043)'
+    );
 });
 
 QUnit.test('Overriding base series option on chart', function (assert) {

--- a/ts/Stock/Navigator/Navigator.ts
+++ b/ts/Stock/Navigator/Navigator.ts
@@ -1781,6 +1781,9 @@ class Navigator {
                 base,
                 'remove',
                 function (): void {
+                    if (baseSeries) {
+                        erase(baseSeries, base); // #21043
+                    }
                     if (this.navigatorSeries) {
                         erase(navigator.series as any, this.navigatorSeries);
                         if (defined(this.navigatorSeries.options)) {


### PR DESCRIPTION
Fixed #21043, series references from `navigator.baseSeries` were not removed entirely after original series removal.




Consulted with the team, merging this branch does not affect the work in progress on #21194 and #21292.