### PR TITLE
bugfix/20354-navigator-scrollablePlotArea-grid-lines

### DIFF
--- a/samples/unit-tests/scrollable-plotarea/dynamics/demo.html
+++ b/samples/unit-tests/scrollable-plotarea/dynamics/demo.html
@@ -1,5 +1,7 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
+<script src="https://code.highcharts.com/stock/modules/stock.js"></script>
+
 
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>

--- a/samples/unit-tests/scrollable-plotarea/dynamics/demo.js
+++ b/samples/unit-tests/scrollable-plotarea/dynamics/demo.js
@@ -199,3 +199,25 @@ QUnit.test('#12517: Reset zoom button', assert => {
         'Reset zoom button should be within chart'
     );
 });
+
+QUnit.test('Navigator grid lines height in scrollablePlotArea chart.', assert => {
+    const chart = Highcharts.stockChart('container', {
+        chart: {
+            scrollablePlotArea: {
+                minHeight: 500
+            }
+        },
+        navigator: {
+            enabled: true
+        },
+        series: [{
+            data: [1, 2, 3, 4, 5]
+        }]
+    });
+
+    assert.ok(
+        chart.xAxis[1].gridGroup.getBBox().height,
+        chart.yAxis[1].height,
+        'Grid lines should not exceed navigator height, #20354'
+    );
+});

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1049,7 +1049,11 @@ class Axis {
                 force = false; // #7175, don't force it when path is invalid
             } else if (axis.horiz) {
                 y1 = axisTop;
-                y2 = cHeight - axis.bottom + (chart.scrollablePixelsY || 0);
+                y2 = cHeight - axis.bottom + (axis.options.isInternal ?
+                    0 :
+                    (chart.scrollablePixelsY || 0)
+                ); // #20354, scrollablePixelsY shouldn't be used for navigator
+
 
                 x1 = x2 = between(x1, axisLeft, axisLeft + axis.width);
 


### PR DESCRIPTION
Fixed #20354, navigator's grid lines were too long in a chart with a scrollable plot area.