### PR TITLE
Bugfix/21341 svg label update height

### DIFF
--- a/samples/unit-tests/svgrenderer/label/demo.js
+++ b/samples/unit-tests/svgrenderer/label/demo.js
@@ -670,6 +670,16 @@ QUnit.test('Label padding', assert => {
             'Padding should increase width by 20'
         );
     });
+
+    label.attr({
+        height: 100
+    });
+
+    assert.strictEqual(
+        label.getBBox().height,
+        100,
+        'Height should be updated'
+    );
 });
 
 QUnit.test('Label callout tests', assert => {

--- a/ts/Core/Renderer/SVG/SVGLabel.ts
+++ b/ts/Core/Renderer/SVG/SVGLabel.ts
@@ -320,8 +320,8 @@ class SVGLabel extends SVGElement {
      * This method is executed in the end of `attr()`, after setting all
      * attributes in the hash. In can be used to efficiently consolidate
      * multiple attributes in one SVG property -- e.g., translate, rotate and
-     * scale are merged in one "transform" attribute in the SVG node. Also
-     * Updating height or width needs to be updated.
+     * scale are merged in one "transform" attribute in the SVG node.
+     * Also updating height or width should trigger update of the box size.
      *
      * @private
      * @function Highcharts.SVGLabel#afterSetters

--- a/ts/Core/Renderer/SVG/SVGLabel.ts
+++ b/ts/Core/Renderer/SVG/SVGLabel.ts
@@ -311,6 +311,16 @@ class SVGLabel extends SVGElement {
 
     public heightSetter(value: number): void {
         this.heightSetting = value;
+        this.doUpdate = true;
+    }
+
+
+    public afterSetters(): void {
+        super.afterSetters();
+        if (this.doUpdate) {
+            this.updateBoxSize();
+            this.doUpdate = false;
+        }
     }
 
     /*

--- a/ts/Core/Renderer/SVG/SVGLabel.ts
+++ b/ts/Core/Renderer/SVG/SVGLabel.ts
@@ -153,6 +153,7 @@ class SVGLabel extends SVGElement {
     public paddingRightSetter = this.paddingSetter;
     public text: SVGElement;
     public textStr: string;
+    public doUpdate = false;
     public x: number;
 
     /* *
@@ -315,6 +316,16 @@ class SVGLabel extends SVGElement {
     }
 
 
+    /**
+     * This method is executed in the end of `attr()`, after setting all
+     * attributes in the hash. In can be used to efficiently consolidate
+     * multiple attributes in one SVG property -- e.g., translate, rotate and
+     * scale are merged in one "transform" attribute in the SVG node. Also
+     * Updating height or width needs to be updated.
+     *
+     * @private
+     * @function Highcharts.SVGLabel#afterSetters
+     */
     public afterSetters(): void {
         super.afterSetters();
         if (this.doUpdate) {
@@ -528,6 +539,7 @@ class SVGLabel extends SVGElement {
     public widthSetter(value: (number|string)): void {
         // `width:auto` => null
         this.widthSetting = isNumber(value) ? value : void 0;
+        this.doUpdate = true;
     }
 
     public getPaddedWidth(): number {


### PR DESCRIPTION
Fixed #21341, updating the height of a `SVGLabel` didn't occur immediately. 