### PR TITLE
docs/cumulative-sum-linebreak

### DIFF
--- a/docs/stock/cumulative-sum.md
+++ b/docs/stock/cumulative-sum.md
@@ -4,6 +4,7 @@ Cumulative Sum
 The Cumulative Sum tool sums (cumulates) all the previous values with the current value in a visible range.
 
 For the following data: `[10, 8, 15, 20, 8, 15]` the Cumulative Sum returns `[10, 18, 33, 53, 61, 76]` (see the graph below):
+
 ![cumulative-sum.png](cumulative-sum.png)
 
 The `cumulative` can be enabled in the chart's options using the [series.cumulative](https://api.highcharts.com/highstock/plotOptions.series.cumulative) property or enabled/disabled by the [series.setCumulative()](https://api.highcharts.com/class-reference/Highcharts.Series#setCumulative) method or on all the series belonging to a specific y-axis by the [yAxis.setCumulative()](https://api.highcharts.com/class-reference/Highcharts.Axis#setCumulative) method.


### PR DESCRIPTION
Added a missing line break for cumulative sum doc.

To test it locally, open up the .md file in VSCode, and click the preview icon on the right hand side. <img width="35" alt="image" src="https://github.com/highcharts/highcharts/assets/105275628/56c74631-fe3f-4d0e-9b44-8253ec5563d9">
