### PR TITLE
Tools: Fixed dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3159,8 +3159,8 @@
       }
     },
     "node_modules/@highcharts/highcharts-assembler": {
-      "version": "1.5.4",
-      "resolved": "git+ssh://git@github.com/highcharts/highcharts-assembler.git#7e899ed09ad03c75030295a2b21717752cf9baa7",
+      "version": "1.5.5",
+      "resolved": "git+ssh://git@github.com/highcharts/highcharts-assembler.git#358daaddefaf1dfdf9788b612bd937c8ce247d52",
       "dev": true
     },
     "node_modules/@highcharts/highcharts-declarations-generator": {
@@ -11151,8 +11151,8 @@
     },
     "node_modules/highcharts-assembler": {
       "name": "@highcharts/highcharts-assembler",
-      "version": "1.5.4",
-      "resolved": "git+ssh://git@github.com/highcharts/highcharts-assembler.git#7e899ed09ad03c75030295a2b21717752cf9baa7",
+      "version": "1.5.5",
+      "resolved": "git+ssh://git@github.com/highcharts/highcharts-assembler.git#358daaddefaf1dfdf9788b612bd937c8ce247d52",
       "dev": true
     },
     "node_modules/highsoft-websearch": {


### PR DESCRIPTION
Forgot version number increase and dependency update for `highcharts-assembler`.