### PR TITLE
demo/arc-diagram-colour-update

### DIFF
--- a/samples/highcharts/demo/arc-diagram/demo.js
+++ b/samples/highcharts/demo/arc-diagram/demo.js
@@ -1,10 +1,5 @@
 Highcharts.chart('container', {
 
-    colors: [
-        '#293462', '#a64942', '#fe5f55', '#fff1c1', '#5bd1d7', '#ff502f',
-        '#004d61', '#ff8a5c', '#fff591', '#f5587b', '#fad3cf', '#a696c8',
-        '#5BE7C4', '#266A2E', '#593E1A'
-    ],
 
     title: {
         text: 'Main train connections in Europe'
@@ -25,7 +20,7 @@ Highcharts.chart('container', {
         keys: ['from', 'to', 'weight'],
         type: 'arcdiagram',
         name: 'Train connections',
-        linkWeight: 1,
+        linkWeight: 1.5,
         centeredLinks: true,
         dataLabels: {
             rotation: 90,


### PR DESCRIPTION
Reverted the colors of the diagram bak to the default colors to make the elements more visible. 
Increased the line width of the arches slightly to make them more visible.