### PR TITLE
bugfix/21281-split-causes-wrong-tt-animation

### DIFF
--- a/samples/unit-tests/tooltip/split/demo.js
+++ b/samples/unit-tests/tooltip/split/demo.js
@@ -610,3 +610,43 @@ QUnit.test('Split tooltip, hideDelay set to 0 (#12994)', assert => {
         endTest();
     }, 1000);
 });
+
+QUnit.test('Split tooltip, hovering between series', assert => {
+    const chart = Highcharts.chart('container', {
+            tooltip: {
+                split: true,
+                animation: {
+                    // We need some time to catch the tooltip
+                    duration: 2000
+                }
+            },
+            series: [{
+                data: [0, 1, 3]
+            }, {
+                data: [[1, 2]],
+                type: 'scatter'
+            }]
+        }),
+        { plotLeft, plotTop, series } = chart,
+        startPoint = series[0].points[2],
+        endPoint =  series[1].points[0],
+        controller = new TestController(chart),
+        controlPos = endPoint.plotX + plotLeft;
+
+    controller.moveTo(
+        startPoint.plotX + plotLeft,
+        startPoint.plotY + plotTop
+    );
+    controller.moveTo(
+        controlPos,
+        endPoint.plotY + plotTop
+    );
+
+    setTimeout(function () {
+        assert.strictEqual(
+            true,
+            chart.tooltip.label.x > controlPos,
+            'Tooltip should travel from the right side.'
+        );
+    }, 500);
+});

--- a/samples/unit-tests/tooltip/split/demo.js
+++ b/samples/unit-tests/tooltip/split/demo.js
@@ -612,7 +612,8 @@ QUnit.test('Split tooltip, hideDelay set to 0 (#12994)', assert => {
 });
 
 QUnit.test('Split tooltip, hovering between series', assert => {
-    const chart = Highcharts.chart('container', {
+    const clock = TestUtilities.lolexInstall(),
+        chart = Highcharts.chart('container', {
             tooltip: {
                 split: true,
                 animation: {
@@ -651,4 +652,6 @@ QUnit.test('Split tooltip, hovering between series', assert => {
         );
         endTest();
     }, 1000);
+
+    TestUtilities.lolexRunAndUninstall(clock);
 });

--- a/samples/unit-tests/tooltip/split/demo.js
+++ b/samples/unit-tests/tooltip/split/demo.js
@@ -631,7 +631,8 @@ QUnit.test('Split tooltip, hovering between series', assert => {
         startPoint = series[0].points[2],
         endPoint =  series[1].points[0],
         controller = new TestController(chart),
-        controlPos = endPoint.plotX + plotLeft;
+        controlPos = endPoint.plotX + plotLeft,
+        endTest = assert.async();
 
     controller.moveTo(
         startPoint.plotX + plotLeft,
@@ -648,5 +649,6 @@ QUnit.test('Split tooltip, hovering between series', assert => {
             chart.tooltip.label.x > controlPos,
             'Tooltip should travel from the right side.'
         );
-    }, 500);
+        endTest();
+    }, 1000);
 });

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -409,7 +409,9 @@ class Tooltip {
      * @return {Highcharts.SVGElement}
      * Tooltip label
      */
-    public getLabel(x: number = 0, y: number = 0): SVGElement {
+    public getLabel(
+        { anchorX, anchorY }: Partial<SVGElement> = { anchorX: 0, anchorY: 0 }
+    ): SVGElement {
         const tooltip = this,
             styledMode = this.chart.styledMode,
             options = this.options,
@@ -486,8 +488,8 @@ class Tooltip {
                 this.label = renderer
                     .label(
                         '',
-                        x,
-                        y,
+                        anchorX,
+                        anchorY,
                         options.shape,
                         void 0,
                         void 0,
@@ -1057,17 +1059,9 @@ class Tooltip {
                             p.series.shouldShowTooltip(checkX, checkY)
                     )
                 ) {
-                    let label;
-
-                    if (wasShared && tooltip.tt) {
-                        const {
-                            anchorX = 0,
-                            anchorY = 0
-                        } = tooltip.tt;
-                        label = tooltip.getLabel(anchorX, anchorY);
-                    } else {
-                        label = tooltip.getLabel();
-                    }
+                    const label = tooltip.getLabel(
+                        wasShared && tooltip.tt || {}
+                    );
 
                     // Prevent the tooltip from flowing over the chart box
                     // (#6659)

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -409,7 +409,7 @@ class Tooltip {
      * @return {Highcharts.SVGElement}
      * Tooltip label
      */
-    public getLabel(): SVGElement {
+    public getLabel(x: number = 0, y: number = 0): SVGElement {
         const tooltip = this,
             styledMode = this.chart.styledMode,
             options = this.options,
@@ -486,8 +486,8 @@ class Tooltip {
                 this.label = renderer
                     .label(
                         '',
-                        0,
-                        0,
+                        x,
+                        y,
                         options.shape,
                         void 0,
                         void 0,
@@ -979,7 +979,8 @@ class Tooltip {
             formatString = options.format,
             formatter = options.formatter || tooltip.defaultFormatter,
             styledMode = chart.styledMode;
-        let formatterContext = {} as Tooltip.FormatterContextObject;
+        let formatterContext = {} as Tooltip.FormatterContextObject,
+            wasShared = tooltip.allowShared;
 
         if (!options.enabled || !point.series) { // #16820
             return;
@@ -994,6 +995,8 @@ class Tooltip {
             pointOrPoints.series &&
             pointOrPoints.series.noSharedTooltip
         );
+
+        wasShared = wasShared && !tooltip.allowShared;
 
         // Get the reference point coordinates (pie charts use tooltipPos)
         tooltip.followPointer = (
@@ -1054,7 +1057,17 @@ class Tooltip {
                             p.series.shouldShowTooltip(checkX, checkY)
                     )
                 ) {
-                    const label = tooltip.getLabel();
+                    let label;
+
+                    if (wasShared && tooltip.tt) {
+                        const {
+                            anchorX = 0,
+                            anchorY = 0
+                        } = tooltip.tt;
+                        label = tooltip.getLabel(anchorX, anchorY);
+                    } else {
+                        label = tooltip.getLabel();
+                    }
 
                     // Prevent the tooltip from flowing over the chart box
                     // (#6659)


### PR DESCRIPTION
Fixed #21281, hovering line with split tooltip, then scatter, caused tooltip animation to start in top-left.

Maybe there is a way to slim down this fix. Thoughts?