### PR TITLE
dash/datagrid2-code-cleanup-upgrades

### DIFF
--- a/css/datagrid/datagrid2.css
+++ b/css/datagrid/datagrid2.css
@@ -120,11 +120,16 @@
 .highcharts-dg-table thead th {
     color: var(--highcharts-neutral-color-100);
     position: relative;
+    border-left: 1px solid var(--highcharts-neutral-color-20);
+}
+
+.highcharts-dg-head-cell-content {
+    display: block;
     overflow: hidden;
     text-overflow: ellipsis;
     padding-right: 10px;
     padding-left: 3px;
-    border-left: 1px solid var(--highcharts-neutral-color-20);
+    width: 100%;
 }
 
 .highcharts-dg-table tbody {
@@ -180,8 +185,8 @@
 .highcharts-dg-col-resizer {
     position: absolute;
     top: 0;
-    width: 10px;
-    right: 0;
+    width: 16px;
+    right: -9px;
     height: 100%;
     cursor: col-resize;
     user-select: none;
@@ -193,15 +198,20 @@
     position: absolute;
     display: block;
     height: 20px;
-    width: 4px;
+    width: 7px;
     margin-top: -10px;
     top: 50%;
-    left: 0;
-    border-right: 2px solid var(--highcharts-neutral-color-20);
+    left: 2px;
 }
 
 .highcharts-dg-col-resizer:hover::after {
-    border-color: var(--highcharts-highlight-color-80);
+    border-left: 2px solid var(--highcharts-neutral-color-20);
+    border-right: 2px solid var(--highcharts-neutral-color-20);
+}
+
+.highcharts-dg-head-cell-resized .highcharts-dg-col-resizer::after {
+    border-left: 2px solid var(--highcharts-highlight-color-60);
+    border-right: 2px solid var(--highcharts-highlight-color-60);
 }
 
 .highcharts-dg-column {

--- a/css/datagrid/datagrid2.css
+++ b/css/datagrid/datagrid2.css
@@ -86,8 +86,9 @@
 }
 
 .highcharts-dg-container {
-    border: 1px solid var(--highcharts-neutral-color-20);
+    display: block;
     min-height: 100px;
+    border: 1px solid var(--highcharts-neutral-color-20);
     overflow: hidden;
 }
 

--- a/samples/data-grid/v2/benchmark/demo.css
+++ b/samples/data-grid/v2/benchmark/demo.css
@@ -1,7 +1,7 @@
 @import url("https://code.highcharts.com/datagrid/css/datagrid2.css");
 @import url("https://code.highcharts.com/datagrid/css/datagrid.css");
 
-#container-ah,
+#container,
 #container-sh {
     height: 400px;
 }

--- a/samples/data-grid/v2/benchmark/demo.html
+++ b/samples/data-grid/v2/benchmark/demo.html
@@ -10,7 +10,7 @@
       Datagrid 2.0 <i>(strictRowHeights: false): </i>
       <span id="render-new-ah"></span>
     </h2>
-    <div id="container-ah"></div>
+    <div id="container"></div>
   </div>
   <div>
     <h2>

--- a/samples/data-grid/v2/benchmark/demo.js
+++ b/samples/data-grid/v2/benchmark/demo.js
@@ -28,10 +28,7 @@ oldDatagridTimer.innerHTML =
 startTime = new Date().getTime();
 startPerfo = performance.now();
 DataGrid.dataGrid2('container', {
-    table: dataTable,
-    settings: {
-        rowBufferSize: 5
-    }
+    table: dataTable
 });
 endPerfo = performance.now();
 endTime = new Date().getTime();
@@ -45,7 +42,6 @@ startPerfo = performance.now();
 DataGrid.dataGrid2('container-sh', {
     table: dataTable,
     settings: {
-        rowBufferSize: 5,
         strictRowHeights: true
     }
 });

--- a/samples/data-grid/v2/benchmark/demo.js
+++ b/samples/data-grid/v2/benchmark/demo.js
@@ -15,8 +15,7 @@ const dataTable = new DataGrid.DataTable({
 
 let startTime = new Date().getTime();
 let startPerfo = performance.now();
-// eslint-disable-next-line
-const grid = new DataGrid.DataGrid('datagrid-old', {
+DataGrid.dataGrid('datagrid-old', {
     dataTable: dataTable
 });
 let endPerfo = performance.now();
@@ -28,8 +27,7 @@ oldDatagridTimer.innerHTML =
 // NEW (autoheight)
 startTime = new Date().getTime();
 startPerfo = performance.now();
-// eslint-disable-next-line no-unused-vars
-const newGridAH = new DataGrid.DataGrid2('container-ah', {
+DataGrid.dataGrid2('container', {
     table: dataTable,
     settings: {
         rowBufferSize: 5
@@ -44,8 +42,7 @@ newDatagridTimerAH.innerHTML =
 // NEW (strictheight)
 startTime = new Date().getTime();
 startPerfo = performance.now();
-// eslint-disable-next-line no-unused-vars
-const newGridSH = new DataGrid.DataGrid2('container-sh', {
+DataGrid.dataGrid2('container-sh', {
     table: dataTable,
     settings: {
         rowBufferSize: 5,

--- a/samples/data-grid/v2/column-options/demo.css
+++ b/samples/data-grid/v2/column-options/demo.css
@@ -1,0 +1,11 @@
+@import url("https://code.highcharts.com/datagrid/css/datagrid2.css");
+
+#container {
+    height: 250px;
+    margin: 8px;
+}
+
+.custom-column-class-name {
+    text-decoration: underline;
+    text-shadow: 2px 2px #f00;
+}

--- a/samples/data-grid/v2/column-options/demo.css
+++ b/samples/data-grid/v2/column-options/demo.css
@@ -5,7 +5,12 @@
     margin: 8px;
 }
 
+.highcharts-dg-column {
+    width: 20%;
+}
+
 .custom-column-class-name {
     text-decoration: underline;
     text-shadow: 2px 2px #f00;
+    width: 40%;
 }

--- a/samples/data-grid/v2/column-options/demo.html
+++ b/samples/data-grid/v2/column-options/demo.html
@@ -1,0 +1,3 @@
+<script src="https://code.highcharts.com/dashboards/datagrid.js"></script>
+
+<div id="container"></div>

--- a/samples/data-grid/v2/column-options/demo.js
+++ b/samples/data-grid/v2/column-options/demo.js
@@ -1,0 +1,19 @@
+DataGrid.dataGrid2('container', {
+    table: {
+        columns: {
+            product: ['Apples', 'Pears', 'Plums', 'Bananas'],
+            weight: [100, 40, 0.5, 200],
+            price: [1.5, 2.53, 5, 4.5],
+            metaData: ['a', 'b', 'c', 'd'],
+            icon: ['Apples URL', 'Pears URL', 'Plums URL', 'Bananas URL']
+        }
+    },
+    columns: {
+        weight: {
+            className: 'custom-column-class-name'
+        },
+        metaData: {
+            enabled: false
+        }
+    }
+});

--- a/samples/data-grid/v2/column-resizing-disabled/demo.css
+++ b/samples/data-grid/v2/column-resizing-disabled/demo.css
@@ -1,0 +1,14 @@
+@import url("https://code.highcharts.com/datagrid/css/datagrid2.css");
+
+#container {
+    height: 250px;
+    margin: 8px;
+}
+
+.highcharts-dg-column {
+    width: 15%;
+}
+
+.highcharts-dg-column[data-column-id="weight"] {
+    width: 40%;
+}

--- a/samples/data-grid/v2/column-resizing-disabled/demo.html
+++ b/samples/data-grid/v2/column-resizing-disabled/demo.html
@@ -1,0 +1,3 @@
+<script src="https://code.highcharts.com/dashboards/datagrid.js"></script>
+
+<div id="container"></div>

--- a/samples/data-grid/v2/column-resizing-disabled/demo.js
+++ b/samples/data-grid/v2/column-resizing-disabled/demo.js
@@ -1,0 +1,14 @@
+DataGrid.dataGrid2('container', {
+    table: {
+        columns: {
+            product: ['Apples', 'Pears', 'Plums', 'Bananas'],
+            weight: [100, 40, 0.5, 200],
+            price: [1.5, 2.53, 5, 4.5],
+            metaData: ['a', 'b', 'c', 'd'],
+            icon: ['Apples URL', 'Pears URL', 'Plums URL', 'Bananas URL']
+        }
+    },
+    settings: {
+        enableColumnResizing: false
+    }
+});

--- a/samples/data-grid/v2/destroy-datagrid/demo.js
+++ b/samples/data-grid/v2/destroy-datagrid/demo.js
@@ -1,4 +1,4 @@
-const dg = DataGrid.dataGrid2('container', {
+const options = {
     table: {
         columns: {
             product: ['Apples', 'Pears', 'Plums', 'Bananas'],
@@ -8,14 +8,15 @@ const dg = DataGrid.dataGrid2('container', {
             icon: ['Apples URL', 'Pears URL', 'Plums URL', 'Bananas URL']
         }
     }
-});
+};
+let dg = DataGrid.dataGrid2('container', options);
 
 document.getElementById('destroy-btn').addEventListener('click', () => {
     dg.destroy();
-    console.log(dg);
+    console.log('destroyed:', dg);
 });
 
 document.getElementById('load-btn').addEventListener('click', () => {
-    dg.load();
-    console.log(dg);
+    dg = new DataGrid.DataGrid2('container', options);
+    console.log('created:', dg);
 });

--- a/samples/data-grid/v2/destroy-datagrid/demo.js
+++ b/samples/data-grid/v2/destroy-datagrid/demo.js
@@ -17,6 +17,7 @@ document.getElementById('destroy-btn').addEventListener('click', () => {
 });
 
 document.getElementById('load-btn').addEventListener('click', () => {
+    dg.destroy();
     dg = new DataGrid.DataGrid2('container', options);
     console.log('created:', dg);
 });

--- a/samples/data-grid/v2/destroy-datagrid/demo.js
+++ b/samples/data-grid/v2/destroy-datagrid/demo.js
@@ -1,4 +1,4 @@
-const dg = new DataGrid.DataGrid2('container', {
+const dg = DataGrid.dataGrid2('container', {
     table: {
         columns: {
             product: ['Apples', 'Pears', 'Plums', 'Bananas'],

--- a/samples/data-grid/v2/fixed-distribution/demo.js
+++ b/samples/data-grid/v2/fixed-distribution/demo.js
@@ -16,7 +16,6 @@ DataGrid.dataGrid2('container', {
         }
     },
     settings: {
-        rowBufferSize: 5,
         columnDistribution: 'fixed'
     }
 });

--- a/samples/data-grid/v2/fixed-distribution/demo.js
+++ b/samples/data-grid/v2/fixed-distribution/demo.js
@@ -1,4 +1,4 @@
-const dg = new DataGrid.DataGrid2('container', {
+DataGrid.dataGrid2('container', {
     table: {
         columns: {
             product: [
@@ -20,5 +20,3 @@ const dg = new DataGrid.DataGrid2('container', {
         columnDistribution: 'fixed'
     }
 });
-
-console.log(dg);

--- a/samples/data-grid/v2/no-data/demo.js
+++ b/samples/data-grid/v2/no-data/demo.js
@@ -1,4 +1,4 @@
-const dg = new DataGrid.DataGrid2('container', {
+const dg = DataGrid.dataGrid2('container', {
     dataTable: {},
     rows: {
         bufferSize: 5

--- a/samples/data-grid/v2/no-data/demo.js
+++ b/samples/data-grid/v2/no-data/demo.js
@@ -1,11 +1,3 @@
-const dg = DataGrid.dataGrid2('container', {
-    dataTable: {},
-    rows: {
-        bufferSize: 5
-    },
-    columns: {
-        distribution: 'fixed'
-    }
+DataGrid.dataGrid2('container', {
+    dataTable: {}
 });
-
-console.log(dg);

--- a/samples/data-grid/v2/scroll-to-row/demo.js
+++ b/samples/data-grid/v2/scroll-to-row/demo.js
@@ -1,11 +1,13 @@
 const dg = new DataGrid.DataGrid2('container', {
     table: {
         columns: {
-            a: Array.from({ length: 1000 }, (_, i) => `A${i} loreum ipsum et`),
-            b: Array.from({ length: 1000 }, (_, i) => `B${i} long text test loreum ipsum et omnia dolores test width and height`), // eslint-disable-line
+            a: Array.from({ length: 1000 }, (_, i) => `A${i} lorem ipsum`),
+            b: Array.from({ length: 1000 }, (_, i) =>
+                `B${i} long text test lorem ipsum dolor sit amet, consectetur`
+            ),
             c: Array.from({ length: 1000 }, (_, i) => `C${i}`),
             d: Array.from({ length: 1000 }, (_, i) => `D${i}`),
-            'loreum ipsum': Array.from({ length: 1000 }, (_, i) => `E${i}`), // eslint-disable-line
+            'lorem ipsum': Array.from({ length: 1000 }, (_, i) => `E${i}`),
             f: Array.from({ length: 1000 }, (_, i) => `F${i}`)
         }
     },
@@ -13,7 +15,7 @@ const dg = new DataGrid.DataGrid2('container', {
         bufferSize: 5
     },
     title: {
-        text: 'Title of the new Datagrid. Loreum ipsum et omnia dolores, loreum ipsum et omnia dolores, loreum ipsum et omnia dolores, loreum ipsum et omnia dolores' // eslint-disable-line
+        text: 'Title of the new Datagrid.'
     },
     settings: {
         rowBufferSize: 5

--- a/samples/data-grid/v2/strict-row-heights/demo.js
+++ b/samples/data-grid/v2/strict-row-heights/demo.js
@@ -1,4 +1,4 @@
-const dg = new DataGrid.DataGrid2('container', {
+DataGrid.dataGrid2('container', {
     table: {
         columns: {
             a: Array.from({ length: 100 }, (_, i) => `A${i} quite a long text`),
@@ -14,5 +14,3 @@ const dg = new DataGrid.DataGrid2('container', {
         strictRowHeights: true
     }
 });
-
-console.log(dg);

--- a/samples/data-grid/v2/strict-row-heights/demo.js
+++ b/samples/data-grid/v2/strict-row-heights/demo.js
@@ -10,7 +10,6 @@ DataGrid.dataGrid2('container', {
         }
     },
     settings: {
-        rowBufferSize: 5,
         strictRowHeights: true
     }
 });

--- a/tools/gulptasks/dashboards/scripts-dts/datagrid.src.d.ts
+++ b/tools/gulptasks/dashboards/scripts-dts/datagrid.src.d.ts
@@ -7,6 +7,7 @@
 import Globals from "./es-modules/DataGrid/Globals";
 
 export { default as DataGrid } from "./es-modules/DataGrid/DataGrid";
+export { default as DataGrid2 } from "./es-modules/DataGrid/DataGrid2/DataGrid";
 
 export const win: typeof Globals.win;
 

--- a/ts/DataGrid/DataGrid2/Actions/ColumnsResizer.ts
+++ b/ts/DataGrid/DataGrid2/Actions/ColumnsResizer.ts
@@ -104,7 +104,7 @@ class ColumnsResizer {
      * Resizes the columns in the full distribution mode.
      *
      * @param diff
-     *        The X position difference in pixels.
+     * The X position difference in pixels.
      */
     private fullDistributionResize(diff: number): void {
         const vp = this.viewport;
@@ -144,7 +144,7 @@ class ColumnsResizer {
      * Resizes the columns in the fixed distribution mode.
      *
      * @param diff
-     *        The X position difference in pixels.
+     * The X position difference in pixels.
      */
     private fixedDistributionResize(diff: number): void {
         const column = this.draggedColumn;
@@ -167,7 +167,7 @@ class ColumnsResizer {
      * Handles the mouse move event on the document.
      *
      * @param e
-     *        The mouse event.
+     * The mouse event.
      */
     private onDocumentMouseMove = (e: MouseEvent): void => {
         if (!this.draggedResizeHandle || !this.draggedColumn) {
@@ -201,9 +201,10 @@ class ColumnsResizer {
      * Adds event listeners to the handle.
      *
      * @param handle
-     *        The handle element.
+     * The handle element.
+     *
      * @param column
-     *        The column the handle belongs to.
+     * The column the handle belongs to.
      */
     public addHandleListeners(
         handle: HTMLElement,

--- a/ts/DataGrid/DataGrid2/Actions/ColumnsResizer.ts
+++ b/ts/DataGrid/DataGrid2/Actions/ColumnsResizer.ts
@@ -190,6 +190,10 @@ class ColumnsResizer {
      * Handles the mouse up event on the document.
      */
     private onDocumentMouseUp = (): void => {
+        this.draggedColumn?.headElement?.classList.remove(
+            'highcharts-dg-head-cell-resized'
+        );
+
         this.dragStartX = void 0;
         this.draggedColumn = void 0;
         this.draggedResizeHandle = void 0;
@@ -217,6 +221,10 @@ class ColumnsResizer {
             this.columnStartWidth = column.getWidth();
             this.nextColumnStartWidth =
                 this.viewport.columns[column.index + 1]?.getWidth();
+
+            column.headElement?.classList.add(
+                'highcharts-dg-head-cell-resized'
+            );
         };
 
         this.handles.push([handle, onHandleMouseDown]);

--- a/ts/DataGrid/DataGrid2/Actions/RowsVirtualizer.ts
+++ b/ts/DataGrid/DataGrid2/Actions/RowsVirtualizer.ts
@@ -129,6 +129,9 @@ class RowsVirtualizer {
         this.adjustRowHeights();
     }
 
+    /**
+     * Method called on the viewport scroll event.
+     */
     public scroll(): void {
         const target = this.viewport.tbodyElement;
         const { defaultRowHeight: rowHeight } = this;

--- a/ts/DataGrid/DataGrid2/Actions/RowsVirtualizer.ts
+++ b/ts/DataGrid/DataGrid2/Actions/RowsVirtualizer.ts
@@ -97,8 +97,10 @@ class RowsVirtualizer {
         this.viewport = viewport;
         this.strictRowHeights =
             viewport.dataGrid.options.settings?.strictRowHeights as boolean;
-        this.buffer =
-            viewport.dataGrid.options.settings?.rowBufferSize as number;
+        this.buffer = Math.max(
+            viewport.dataGrid.options.settings?.rowBufferSize as number,
+            0
+        );
         this.defaultRowHeight = this.getDefaultRowHeight();
 
         if (this.strictRowHeights) {

--- a/ts/DataGrid/DataGrid2/Actions/RowsVirtualizer.ts
+++ b/ts/DataGrid/DataGrid2/Actions/RowsVirtualizer.ts
@@ -96,9 +96,9 @@ class RowsVirtualizer {
     constructor(viewport: DataGridTable) {
         this.viewport = viewport;
         this.strictRowHeights =
-            viewport.dataGrid.options.settings?.strictRowHeights as boolean;
+            viewport.dataGrid.options?.settings?.strictRowHeights as boolean;
         this.buffer = Math.max(
-            viewport.dataGrid.options.settings?.rowBufferSize as number,
+            viewport.dataGrid.options?.settings?.rowBufferSize as number,
             0
         );
         this.defaultRowHeight = this.getDefaultRowHeight();

--- a/ts/DataGrid/DataGrid2/DataGrid.ts
+++ b/ts/DataGrid/DataGrid2/DataGrid.ts
@@ -102,8 +102,6 @@ class DataGrid {
      * The options of the data grid.
      */
     constructor(renderTo: string|HTMLElement, options: DataGridOptions) {
-        this.destroy();
-
         this.userOptions = options;
         this.options = merge(DataGrid.defaultOptions, options);
 

--- a/ts/DataGrid/DataGrid2/DataGrid.ts
+++ b/ts/DataGrid/DataGrid2/DataGrid.ts
@@ -63,7 +63,7 @@ class DataGrid {
     /**
      * The container of the data grid.
      */
-    public container: HTMLElement;
+    public container?: HTMLElement;
 
     /**
      * The HTML element of the table.
@@ -73,12 +73,12 @@ class DataGrid {
     /**
      * The options of the data grid.
      */
-    public options: DataGridOptions;
+    public options?: DataGridOptions;
 
     /**
      * The user options of the data grid.
      */
-    public userOptions: DataGridOptions;
+    public userOptions?: DataGridOptions;
 
     /**
      * The table (viewport) element of the data grid.
@@ -102,29 +102,12 @@ class DataGrid {
      * The options of the data grid.
      */
     constructor(renderTo: string|HTMLElement, options: DataGridOptions) {
+        this.destroy();
+
         this.userOptions = options;
         this.options = merge(DataGrid.defaultOptions, options);
 
         this.container = DataGrid.initContainer(renderTo);
-
-        this.load();
-    }
-
-
-    /* *
-    *
-    *  Methods
-    *
-    * */
-
-    /**
-     * Loads & renders the data grid.
-     */
-    public load(): void {
-        if (this.tableElement) {
-            return;
-        }
-
         this.container.classList.add(Globals.classNames.container);
 
         this.tableElement = makeHTMLElement('table', {
@@ -147,14 +130,27 @@ class DataGrid {
         );
     }
 
+
+    /* *
+    *
+    *  Methods
+    *
+    * */
+
     /**
      * Destroys the data grid.
      */
     public destroy(): void {
         this.viewport?.destroy();
-        this.container.innerHTML = AST.emptyHTML;
-        this.container.classList.remove(Globals.classNames.container);
 
+        if (this.container) {
+            this.container.innerHTML = AST.emptyHTML;
+            this.container.classList.remove(Globals.classNames.container);
+        }
+
+        delete this.userOptions;
+        delete this.options;
+        delete this.container;
         delete this.viewport;
         delete this.tableElement;
     }

--- a/ts/DataGrid/DataGrid2/DataGrid.ts
+++ b/ts/DataGrid/DataGrid2/DataGrid.ts
@@ -95,8 +95,11 @@ class DataGrid {
     /**
      * Constructs a new data grid.
      *
-     * @param renderTo The render target (container) of the data grid.
-     * @param options The options of the data grid.
+     * @param renderTo
+     * The render target (container) of the data grid.
+     *
+     * @param options
+     * The options of the data grid.
      */
     constructor(renderTo: string|HTMLElement, options: DataGridOptions) {
         this.userOptions = options;
@@ -184,8 +187,11 @@ class DataGrid {
     /**
      * Initializes the container of the data grid.
      *
-     * @param renderTo The render target (html element or id) of the data grid.
-     * @returns The container element of the data grid.
+     * @param renderTo
+     * The render target (html element or id) of the data grid.
+     *
+     * @returns
+     * The container element of the data grid.
      */
     private static initContainer(renderTo: string|HTMLElement): HTMLElement {
         if (typeof renderTo === 'string') {

--- a/ts/DataGrid/DataGrid2/DataGrid.ts
+++ b/ts/DataGrid/DataGrid2/DataGrid.ts
@@ -85,6 +85,7 @@ class DataGrid {
      */
     public viewport?: DataGridTable;
 
+
     /* *
     *
     *  Constructor
@@ -105,6 +106,7 @@ class DataGrid {
 
         this.load();
     }
+
 
     /* *
     *
@@ -160,6 +162,24 @@ class DataGrid {
     *  Static Methods
     *
     * */
+
+    /**
+     * Creates a new data grid.
+     *
+     * @param renderTo
+     * The render target (html element or id) of the data grid.
+     *
+     * @param options
+     * The options of the data grid.
+     *
+     * @return The new data grid.
+     */
+    public static dataGrid(
+        renderTo: string|HTMLElement,
+        options: DataGridOptions
+    ): DataGrid {
+        return new DataGrid(renderTo, options);
+    }
 
     /**
      * Initializes the container of the data grid.

--- a/ts/DataGrid/DataGrid2/DataGridCell.ts
+++ b/ts/DataGrid/DataGrid2/DataGridCell.ts
@@ -77,8 +77,11 @@ class DataGridCell {
     /**
      * Constructs a cell in the data grid.
      *
-     * @param column The column of the cell.
-     * @param row The row of the cell.
+     * @param column
+     * The column of the cell.
+     *
+     * @param row
+     * The row of the cell.
      */
     constructor(column: DataGridColumn, row: DataGridRow) {
         this.htmlElement = document.createElement('td');

--- a/ts/DataGrid/DataGrid2/DataGridColumn.ts
+++ b/ts/DataGrid/DataGrid2/DataGridColumn.ts
@@ -173,12 +173,27 @@ class DataGridColumn {
     * */
 
     /**
+     * Sets the head element of the column.
+     *
+     * @param headElement The head element of the column.
+     */
+    public setHeadElement(headElement: HTMLElement): void {
+        this.headElement = headElement;
+        if (this.options.className) {
+            headElement.classList.add(this.options.className);
+        }
+    }
+
+    /**
      * Registers a cell in the column.
      *
      * @param cell The cell to register.
      */
     public registerCell(cell: DataGridCell): void {
         cell.htmlElement.setAttribute('data-column-id', this.id);
+        if (this.options.className) {
+            cell.htmlElement.classList.add(this.options.className);
+        }
         this.cells.push(cell);
     }
 

--- a/ts/DataGrid/DataGrid2/DataGridColumn.ts
+++ b/ts/DataGrid/DataGrid2/DataGridColumn.ts
@@ -146,8 +146,8 @@ class DataGridColumn {
         index: number
     ) {
         this.userOptions = merge(
-            viewport.dataGrid.options.defaults?.columns ?? {},
-            viewport.dataGrid.options.columns?.[id] ?? {}
+            viewport.dataGrid.options?.defaults?.columns ?? {},
+            viewport.dataGrid.options?.columns?.[id] ?? {}
         );
         this.options = merge(DataGridColumn.defaultOptions, this.userOptions);
 

--- a/ts/DataGrid/DataGrid2/DataGridColumn.ts
+++ b/ts/DataGrid/DataGrid2/DataGridColumn.ts
@@ -21,7 +21,7 @@
  *
  * */
 
-import type { ColumnOptions } from './DataGridOptions';
+import type { IndividualColumnOptions } from './DataGridOptions';
 
 import DataGridCell from './DataGridCell.js';
 import DataGridTable from './DataGridTable.js';
@@ -59,7 +59,7 @@ class DataGridColumn {
     /**
      * The default options of the column.
      */
-    public static readonly defaultOptions = {};
+    public static readonly defaultOptions: IndividualColumnOptions = {};
 
 
     /* *
@@ -109,12 +109,12 @@ class DataGridColumn {
     /**
      * The user options of the column.
      */
-    public readonly userOptions: ColumnOptions;
+    public readonly userOptions: IndividualColumnOptions;
 
     /**
      * The options of the column.
      */
-    public readonly options: ColumnOptions;
+    public readonly options: IndividualColumnOptions;
 
     /**
      * The index of the column in the viewport.
@@ -149,13 +149,16 @@ class DataGridColumn {
         this.id = id;
         this.index = index;
         this.viewport = viewport;
-        this.data = viewport.dataTable.getColumn(id);
+        this.data = viewport.dataTable.getColumn(id, true);
 
         // Set the initial width of the column.
         const mock = makeHTMLElement('div', {
             className: Globals.classNames.columnElement
         }, viewport.dataGrid.container);
         mock.setAttribute('data-column-id', id);
+        if (this.options.className) {
+            mock.classList.add(this.options.className);
+        }
 
         if (viewport.columnDistribution === 'full') {
             this.width = this.getInitialFullDistWidth(mock);
@@ -234,16 +237,14 @@ class DataGridColumn {
      */
     private getInitialFullDistWidth(mock: HTMLElement): number {
         const vp = this.viewport;
+        const columnsCount = vp.enabledColumns.length;
 
-        if (this.index < vp.allColumnsCount - 1) {
-            return (
-                vp.getRatioFromWidth(mock.offsetWidth) ||
-                1 / vp.allColumnsCount
-            );
+        if (this.index < columnsCount - 1) {
+            return vp.getRatioFromWidth(mock.offsetWidth) || 1 / columnsCount;
         }
 
         let allPreviousWidths = 0;
-        for (let i = 0, iEnd = vp.allColumnsCount - 1; i < iEnd; i++) {
+        for (let i = 0, iEnd = columnsCount - 1; i < iEnd; i++) {
             allPreviousWidths += vp.columns[i].width;
         }
 

--- a/ts/DataGrid/DataGrid2/DataGridColumn.ts
+++ b/ts/DataGrid/DataGrid2/DataGridColumn.ts
@@ -131,9 +131,14 @@ class DataGridColumn {
     /**
      * Constructs a column in the data grid.
      *
-     * @param viewport The viewport (table) the column belongs to.
-     * @param id The id of the column (`name` in the Data Table).
-     * @param index The index of the column.
+     * @param viewport
+     * The viewport (table) the column belongs to.
+     *
+     * @param id
+     * The id of the column (`name` in the Data Table).
+     *
+     * @param index
+     * The index of the column.
      */
     constructor(
         viewport: DataGridTable,
@@ -178,7 +183,8 @@ class DataGridColumn {
     /**
      * Sets the head element of the column.
      *
-     * @param headElement The head element of the column.
+     * @param headElement
+     * The head element of the column.
      */
     public setHeadElement(headElement: HTMLElement): void {
         this.headElement = headElement;
@@ -190,7 +196,8 @@ class DataGridColumn {
     /**
      * Registers a cell in the column.
      *
-     * @param cell The cell to register.
+     * @param cell
+     * The cell to register.
      */
     public registerCell(cell: DataGridCell): void {
         cell.htmlElement.setAttribute('data-column-id', this.id);
@@ -215,7 +222,8 @@ class DataGridColumn {
     /**
      * Sets the column hover state.
      *
-     * @param hovered Whether the column should be hovered.
+     * @param hovered
+     * Whether the column should be hovered.
      */
     public setHover(hovered: boolean): void {
         this.headElement?.classList[hovered ? 'add' : 'remove'](
@@ -233,7 +241,8 @@ class DataGridColumn {
      * The initial width of the column in the full distribution mode. The last
      * column in the viewport will have to fill the remaining space.
      *
-     * @param mock The mock element to measure the width.
+     * @param mock
+     * The mock element to measure the width.
      */
     private getInitialFullDistWidth(mock: HTMLElement): number {
         const vp = this.viewport;

--- a/ts/DataGrid/DataGrid2/DataGridDefaultOptions.ts
+++ b/ts/DataGrid/DataGrid2/DataGridDefaultOptions.ts
@@ -33,7 +33,8 @@ const DataGridDefaultOptions: DeepPartial<DataGridOptions> = {
     settings: {
         columnDistribution: 'full',
         rowBufferSize: 10,
-        strictRowHeights: false
+        strictRowHeights: false,
+        enableColumnResizing: true
     }
 };
 

--- a/ts/DataGrid/DataGrid2/DataGridOptions.d.ts
+++ b/ts/DataGrid/DataGrid2/DataGridOptions.d.ts
@@ -43,7 +43,7 @@ export interface DataGridOptions {
     /**
      * Data table to display in the grid structure.
      */
-    table: DataTable | DataTableOptions;
+    table?: DataTable | DataTableOptions;
 
     /**
      * Options to control the way DataGrid is rendered.
@@ -146,7 +146,7 @@ export interface TitleOptions {
     /**
      * The title of the datagrid grid.
      */
-    text: string;
+    text?: string;
 }
 
 

--- a/ts/DataGrid/DataGrid2/DataGridOptions.d.ts
+++ b/ts/DataGrid/DataGrid2/DataGridOptions.d.ts
@@ -61,7 +61,7 @@ export interface DataGridOptions {
     columnsIncluded?: Array<string>;
 
     /**
-     * Columns excluded from the grid structure.
+     * Options for individual columns.
      */
     columns?: Record<string, IndividualColumnOptions>;
 

--- a/ts/DataGrid/DataGrid2/DataGridOptions.d.ts
+++ b/ts/DataGrid/DataGrid2/DataGridOptions.d.ts
@@ -63,7 +63,7 @@ export interface DataGridOptions {
     /**
      * Columns excluded from the grid structure.
      */
-    columns?: Record<string, ColumnOptions>;
+    columns?: Record<string, IndividualColumnOptions>;
 
     /**
      * Contains options for title
@@ -133,20 +133,26 @@ export interface ColumnOptions {
     cellFormat?: string;
 
     /**
+     * The format of the column header.
+     */
+    headFormat?: string;
+}
+
+/**
+ * Column options that can be set for each column individually.
+ */
+export interface IndividualColumnOptions extends ColumnOptions {
+    /**
      * The custom CSS class name for the column.
      */
     className?: string;
 
     /**
      * Whether the column is enabled and should be displayed.
-     * @unimplemented
+     *
+     * @default true
      */
     enabled?: boolean;
-
-    /**
-     * The format of the column header.
-     */
-    headFormat?: string;
 }
 
 export interface TitleOptions {

--- a/ts/DataGrid/DataGrid2/DataGridOptions.d.ts
+++ b/ts/DataGrid/DataGrid2/DataGridOptions.d.ts
@@ -86,6 +86,13 @@ export interface DataGridSettings {
     columnDistribution?: ColumnDistribution;
 
     /**
+     * Whether the columns should be resizable.
+     *
+     * @default true
+     */
+    enableColumnResizing?: boolean;
+
+    /**
      * Buffer of rows to render outside the visible area from the top and from
      * the bottom while scrolling. The bigger the buffer, the less flicker will
      * be seen while scrolling, but the more rows will have to be rendered.

--- a/ts/DataGrid/DataGrid2/DataGridOptions.d.ts
+++ b/ts/DataGrid/DataGrid2/DataGridOptions.d.ts
@@ -90,7 +90,9 @@ export interface DataGridSettings {
      * the bottom while scrolling. The bigger the buffer, the less flicker will
      * be seen while scrolling, but the more rows will have to be rendered.
      *
-     * @default 5
+     * Cannot be lower than 0.
+     *
+     * @default 10
      */
     rowBufferSize?: number;
 

--- a/ts/DataGrid/DataGrid2/DataGridOptions.d.ts
+++ b/ts/DataGrid/DataGrid2/DataGridOptions.d.ts
@@ -133,6 +133,11 @@ export interface ColumnOptions {
     cellFormat?: string;
 
     /**
+     * The custom CSS class name for the column.
+     */
+    className?: string;
+
+    /**
      * Whether the column is enabled and should be displayed.
      * @unimplemented
      */

--- a/ts/DataGrid/DataGrid2/DataGridRow.ts
+++ b/ts/DataGrid/DataGrid2/DataGridRow.ts
@@ -169,7 +169,8 @@ class DataGridRow {
     /**
      * Sets the row hover state.
      *
-     * @param hovered Whether the row should be hovered.
+     * @param hovered
+     * Whether the row should be hovered.
      */
     public setHover(hovered: boolean): void {
         this.htmlElement.classList[hovered ? 'add' : 'remove'](

--- a/ts/DataGrid/DataGrid2/DataGridTable.ts
+++ b/ts/DataGrid/DataGrid2/DataGridTable.ts
@@ -219,7 +219,7 @@ class DataGridTable {
      */
     public reflow(): void {
         this.tbodyElement.style.height = this.tbodyElement.style.minHeight = `${
-            this.dataGrid.container?.clientHeight || 0 -
+            (this.dataGrid.container?.clientHeight || 0) -
             this.theadElement.offsetHeight -
             (this.titleElement?.offsetHeight || 0)
         }px`;

--- a/ts/DataGrid/DataGrid2/DataGridTable.ts
+++ b/ts/DataGrid/DataGrid2/DataGridTable.ts
@@ -261,7 +261,8 @@ class DataGridTable {
     /**
      * Scrolls the table to the specified row.
      *
-     * @param index The index of the row to scroll to.
+     * @param index
+     * The index of the row to scroll to.
      */
     public scrollToRow(index: number): void {
         this.tbodyElement.scrollTop =
@@ -273,7 +274,7 @@ class DataGridTable {
      * calculated based on the width of the viewport.
      *
      * @param width
-     *        The width in pixels.
+     * The width in pixels.
      *
      * @return The width ratio.
      */
@@ -286,7 +287,7 @@ class DataGridTable {
      * calculated based on the width of the viewport.
      *
      * @param ratio
-     *       The width ratio.
+     * The width ratio.
      *
      * @returns The width in pixels.
      */

--- a/ts/DataGrid/DataGrid2/DataGridTable.ts
+++ b/ts/DataGrid/DataGrid2/DataGridTable.ts
@@ -115,9 +115,9 @@ class DataGridTable {
     public rowsWidth?: number;
 
     /**
-     * The number of visible columns in the data grid.
+     * The list of IDs of columns displayed enabled in the data grid.
      */
-    public readonly allColumnsCount: number;
+    public readonly enabledColumns: string[];
 
     /**
      * Title of data grid
@@ -156,9 +156,7 @@ class DataGridTable {
         this.columnDistribution =
             dgOptions.settings?.columnDistribution as ColumnDistribution;
 
-        this.allColumnsCount =
-            dgOptions.columnsIncluded?.length ||
-            this.dataTable.getColumnNames().length;
+        this.enabledColumns = this.getEnabledColumnsIDs();
 
         this.renderTitle();
 
@@ -193,7 +191,7 @@ class DataGridTable {
         this.head = new DataGridTableHead(this);
         this.head.render();
 
-        if (this.allColumnsCount > 0) {
+        if (this.enabledColumns.length > 0) {
             this.rowsVirtualizer.initialRender();
         } else {
             this.renderNoResultRow();
@@ -207,13 +205,11 @@ class DataGridTable {
      * Loads the columns of the table.
      */
     private loadColumns(): void {
-        const columnsIncluded =
-            this.dataGrid.options.columnsIncluded ??
-            this.dataTable.getColumnNames();
-
-        for (let i = 0, iEnd = columnsIncluded.length; i < iEnd; ++i) {
+        let columnId: string;
+        for (let i = 0, iEnd = this.enabledColumns.length; i < iEnd; ++i) {
+            columnId = this.enabledColumns[i];
             this.columns.push(
-                new DataGridColumn(this, columnsIncluded[i], i)
+                new DataGridColumn(this, columnId, i)
             );
         }
     }
@@ -338,6 +334,24 @@ class DataGridTable {
         for (let i = 0, iEnd = this.rows.length; i < iEnd; ++i) {
             this.rows[i].destroy();
         }
+    }
+
+    private getEnabledColumnsIDs(): string[] {
+        const columnsOptions = this.dataGrid.options.columns;
+        const columnsIncluded =
+            this.dataGrid.options.columnsIncluded ??
+            this.dataTable.getColumnNames();
+
+        let columnName: string;
+        const result: string[] = [];
+        for (let i = 0, iEnd = columnsIncluded.length; i < iEnd; ++i) {
+            columnName = columnsIncluded[i];
+            if (columnsOptions?.[columnName]?.enabled !== false) {
+                result.push(columnName);
+            }
+        }
+
+        return result;
     }
 }
 

--- a/ts/DataGrid/DataGrid2/DataGridTable.ts
+++ b/ts/DataGrid/DataGrid2/DataGridTable.ts
@@ -154,7 +154,7 @@ class DataGridTable {
         const dgOptions = dataGrid.options;
 
         this.columnDistribution =
-            dgOptions.settings?.columnDistribution as ColumnDistribution;
+            dgOptions?.settings?.columnDistribution as ColumnDistribution;
 
         this.enabledColumns = this.getEnabledColumnsIDs();
 
@@ -218,9 +218,8 @@ class DataGridTable {
      * Reflows the table's content dimensions.
      */
     public reflow(): void {
-
         this.tbodyElement.style.height = this.tbodyElement.style.minHeight = `${
-            this.dataGrid.container.clientHeight -
+            this.dataGrid.container?.clientHeight || 0 -
             this.theadElement.offsetHeight -
             (this.titleElement?.offsetHeight || 0)
         }px`;
@@ -314,7 +313,7 @@ class DataGridTable {
      * Render title above the datagrid
      */
     public renderTitle(): void {
-        if (!this.dataGrid.options.title) {
+        if (!this.dataGrid.options?.title) {
             return;
         }
 
@@ -338,9 +337,9 @@ class DataGridTable {
     }
 
     private getEnabledColumnsIDs(): string[] {
-        const columnsOptions = this.dataGrid.options.columns;
+        const columnsOptions = this.dataGrid.options?.columns;
         const columnsIncluded =
-            this.dataGrid.options.columnsIncluded ??
+            this.dataGrid.options?.columnsIncluded ??
             this.dataTable.getColumnNames();
 
         let columnName: string;

--- a/ts/DataGrid/DataGrid2/DataGridTable.ts
+++ b/ts/DataGrid/DataGrid2/DataGridTable.ts
@@ -106,7 +106,7 @@ class DataGridTable {
     /**
      * The columns resizer instance that handles the columns resizing logic.
      */
-    public columnsResizer: ColumnsResizer;
+    public columnsResizer?: ColumnsResizer;
 
     /**
      * The width of each row in the table. Each of the rows has the same width.
@@ -164,7 +164,9 @@ class DataGridTable {
         this.tbodyElement = makeHTMLElement('tbody', {}, tableElement);
 
         this.rowsVirtualizer = new RowsVirtualizer(this);
-        this.columnsResizer = new ColumnsResizer(this);
+        if (dgOptions?.settings?.enableColumnResizing) {
+            this.columnsResizer = new ColumnsResizer(this);
+        }
 
         this.init();
 
@@ -329,7 +331,7 @@ class DataGridTable {
     public destroy(): void {
         this.tbodyElement.removeEventListener('scroll', this.onScroll);
         this.resizeObserver.disconnect();
-        this.columnsResizer.removeEventListeners();
+        this.columnsResizer?.removeEventListeners();
 
         for (let i = 0, iEnd = this.rows.length; i < iEnd; ++i) {
             this.rows[i].destroy();

--- a/ts/DataGrid/DataGrid2/DataGridTableHead.ts
+++ b/ts/DataGrid/DataGrid2/DataGridTableHead.ts
@@ -107,8 +107,7 @@ class DataGridTableHead {
             element.setAttribute('scope', 'col');
             element.setAttribute('data-column-id', this.columns[i].id);
 
-            // Set the column's head element.
-            column.headElement = element;
+            column.setHeadElement(element);
 
             if (
                 this.viewport.columnDistribution !== 'full' ||

--- a/ts/DataGrid/DataGrid2/DataGridTableHead.ts
+++ b/ts/DataGrid/DataGrid2/DataGridTableHead.ts
@@ -26,6 +26,7 @@ import DGUtils from './Utils.js';
 import DataGridColumn from './DataGridColumn.js';
 import DataGridTable from './DataGridTable.js';
 import F from '../../Core/Templating.js';
+import Globals from './Globals.js';
 
 const { makeHTMLElement } = DGUtils;
 const { format } = F;
@@ -99,11 +100,15 @@ class DataGridTableHead {
         let column: DataGridColumn;
         for (let i = 0, iEnd = this.columns.length; i < iEnd; ++i) {
             column = this.columns[i];
-            const element = makeHTMLElement('th', {
-                innerText: column.userOptions.headFormat ? (
-                    format(column.userOptions.headFormat, column)
-                ) : column.id
-            }, this.container);
+            const innerText = column.userOptions.headFormat ? (
+                format(column.userOptions.headFormat, column)
+            ) : column.id;
+
+            const element = makeHTMLElement('th', {}, this.container);
+            makeHTMLElement('span', {
+                innerText,
+                className: Globals.classNames.headCellContent
+            }, element);
 
             // Set the accessibility attributes.
             element.setAttribute('scope', 'col');

--- a/ts/DataGrid/DataGrid2/DataGridTableHead.ts
+++ b/ts/DataGrid/DataGrid2/DataGridTableHead.ts
@@ -165,7 +165,7 @@ class DataGridTableHead {
      * Scrolls the table head horizontally.
      *
      * @param scrollLeft
-     *        The left scroll position.
+     * The left scroll position.
      */
     public scrollHorizontally(scrollLeft: number): void {
         this.viewport.theadElement.style.transform =

--- a/ts/DataGrid/DataGrid2/DataGridTableHead.ts
+++ b/ts/DataGrid/DataGrid2/DataGridTableHead.ts
@@ -94,6 +94,8 @@ class DataGridTableHead {
      * Renders the table head content.
      */
     public render(): void {
+        const vp = this.viewport;
+
         let column: DataGridColumn;
         for (let i = 0, iEnd = this.columns.length; i < iEnd; ++i) {
             column = this.columns[i];
@@ -109,10 +111,10 @@ class DataGridTableHead {
 
             column.setHeadElement(element);
 
-            if (
-                this.viewport.columnDistribution !== 'full' ||
-                i < this.viewport.enabledColumns.length - 1
-            ) {
+            if (vp.columnsResizer && (
+                vp.columnDistribution !== 'full' ||
+                i < vp.enabledColumns.length - 1
+            )) {
                 // Render the drag handle for resizing columns.
                 this.renderColumnDragHandles(
                     column,
@@ -135,6 +137,7 @@ class DataGridTableHead {
             if (!td) {
                 continue;
             }
+
             // Set the width of the column. Max width is needed for the
             // overflow: hidden to work.
             td.style.width = td.style.maxWidth = column.getWidth() + 'px';
@@ -156,7 +159,7 @@ class DataGridTableHead {
             className: 'highcharts-dg-col-resizer'
         }, headElement);
 
-        this.viewport.columnsResizer.addHandleListeners(handle, column);
+        this.viewport.columnsResizer?.addHandleListeners(handle, column);
 
         return handle;
     }

--- a/ts/DataGrid/DataGrid2/DataGridTableHead.ts
+++ b/ts/DataGrid/DataGrid2/DataGridTableHead.ts
@@ -111,7 +111,7 @@ class DataGridTableHead {
 
             if (
                 this.viewport.columnDistribution !== 'full' ||
-                i < this.viewport.allColumnsCount - 1
+                i < this.viewport.enabledColumns.length - 1
             ) {
                 // Render the drag handle for resizing columns.
                 this.renderColumnDragHandles(

--- a/ts/DataGrid/DataGrid2/Globals.ts
+++ b/ts/DataGrid/DataGrid2/Globals.ts
@@ -76,7 +76,9 @@ namespace Globals {
         hoveredRow: classNamePrefix + 'hovered-row',
         odd: classNamePrefix + 'odd',
         noResultColumn: classNamePrefix + 'no-result-column',
-        rowsContentNowrap: classNamePrefix + 'rows-content-nowrap'
+        rowsContentNowrap: classNamePrefix + 'rows-content-nowrap',
+        headCellContent: classNamePrefix + 'head-cell-content',
+        headCellResized: classNamePrefix + 'head-cell-resized'
     };
 
     export const win = window;

--- a/ts/DataGrid/DataGrid2/Utils.ts
+++ b/ts/DataGrid/DataGrid2/Utils.ts
@@ -48,9 +48,14 @@ namespace DataGridUtils {
     /**
      * Creates a HTML element with the provided options.
      *
-     * @param tagName The tag name of the element.
-     * @param params The parameters of the element.
-     * @param parent The parent element.
+     * @param tagName
+     * The tag name of the element.
+     *
+     * @param params
+     * The parameters of the element.
+     *
+     * @param parent
+     * The parent element.
      */
     export function makeHTMLElement<T extends HTMLElement>(
         tagName: string,
@@ -88,8 +93,11 @@ namespace DataGridUtils {
     /**
      * Creates a div element with the provided class name and id.
      *
-     * @param className The class name of the
-     * @param id The id of the element.
+     * @param className
+     * The class name of the div.
+     *
+     * @param id
+     * The id of the element.
      */
     export function makeDiv(className: string, id?: string): HTMLElement {
         return makeHTMLElement('div', { className, id });
@@ -101,8 +109,7 @@ namespace DataGridUtils {
      * @param element
      * The element to get the translateY value from.
      *
-     * @returns
-     * The translateY value of the element.
+     * @returns The translateY value of the element.
      */
     export function getTranslateY(element: HTMLElement): number {
         const transform = element.style.transform;

--- a/ts/masters-datagrid/datagrid.src.ts
+++ b/ts/masters-datagrid/datagrid.src.ts
@@ -52,6 +52,7 @@ declare global {
         DataGrid: typeof _DataGrid;
         dataGrid: typeof _DataGrid.dataGrid;
         DataGrid2: typeof DataGrid2;
+        dataGrid2: typeof DataGrid2.dataGrid;
         DataCursor: typeof DataCursor;
         DataModifier: typeof DataModifier;
         DataConnector: typeof DataConnector;
@@ -80,6 +81,7 @@ G.DataCursor = DataCursor;
 G.DataGrid = _DataGrid;
 G.dataGrid = _DataGrid.dataGrid;
 G.DataGrid2 = DataGrid2;
+G.dataGrid2 = DataGrid2.dataGrid;
 G.DataModifier = DataModifier;
 G.DataPool = DataPool;
 G.DataTable = DataTable;


### PR DESCRIPTION
Minor fixes and improvements in the Datagrid2 code, after testing.

- [x] changed the way `destroy` works & removed `load`,
- [x] clamped the buffer size option to non negative numbers,
- [x] implemented `column.enabled`,
- [x] added `enabledColumnResizing` option,
- [x] restyled resize handlers,
- [x] standardized docklets,

and other micro changes...