### PR TITLE
bugfix/21319-resetZoomButton-visile-while-panning

### DIFF
--- a/samples/unit-tests/chart/panning/demo.js
+++ b/samples/unit-tests/chart/panning/demo.js
@@ -232,7 +232,7 @@ QUnit.test('Zoom and pan key', function (assert) {
     );
 });
 
-QUnit.test('Stock (ordinal axis) panning (#6276)', function (assert) {
+QUnit.test('Stock panning (#6276, #21319)', function (assert) {
     var chart = Highcharts.stockChart('container', {
         chart: {
             width: 600
@@ -291,8 +291,8 @@ QUnit.test('Stock (ordinal axis) panning (#6276)', function (assert) {
     assert.strictEqual(chart.xAxis[0].max, 1514505600000, 'Initial max');
 
     // Pan
-    controller.mouseDown(100, 200, { shiftKey: true }, true);
-    controller.mouseMove(300, 200, { shiftKey: true }, true);
+    controller.mouseDown(100, 200, { shiftKey: true });
+    controller.mouseMove(300, 200, { shiftKey: true });
     controller.mouseUp();
 
     assert.ok(chart.xAxis[0].min < initialMin, 'Has panned');
@@ -338,6 +338,20 @@ QUnit.test('Stock (ordinal axis) panning (#6276)', function (assert) {
         oldExtremes,
         chart.xAxis[0].getExtremes(),
         '#20809, panning outside chart extremes should not do anything.'
+    );
+
+    // #21319
+    chart.update({
+        xAxis: {
+            ordinal: false
+        }
+    });
+    controller.pan([300, 200], [100, 200]);
+    assert.strictEqual(
+        chart.resetZoomButton,
+        undefined,
+        `resetZoomButton should not be rendered while panning on non-ordinal
+        axes. (#21319)`
     );
 });
 

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3641,7 +3641,8 @@ class Chart {
             { inverted } = this;
 
         let hasZoomed = false,
-            displayButton: boolean|undefined;
+            displayButton: boolean|undefined,
+            isAnyAxisPanning = false;
 
         // Remove active points for shared tooltip
         this.hoverPoints?.forEach((point): void => point.setState());
@@ -3822,6 +3823,10 @@ class Chart {
                         // operation has finished.
                         axis.isPanning = trigger !== 'zoom';
 
+                        if (axis.isPanning && !isAnyAxisPanning) {
+                            isAnyAxisPanning = true;
+                        }
+
                         axis.setExtremes(
                             reset ? void 0 : newMin,
                             reset ? void 0 : newMax,
@@ -3868,8 +3873,7 @@ class Chart {
                 // Show or hide the Reset zoom button, but not while panning
                 if (
                     displayButton &&
-                    !this.xAxis[0].isPanning && // #21319
-                    !this.yAxis[0].isPanning && // #21319
+                    !isAnyAxisPanning &&
                     !this.resetZoomButton
                 ) {
                     this.showResetZoom();

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3865,8 +3865,13 @@ class Chart {
                 );
             } else {
 
-                // Show or hide the Reset zoom button
-                if (displayButton && !this.resetZoomButton) {
+                // Show or hide the Reset zoom button, but not while panning
+                if (
+                    displayButton &&
+                    !this.xAxis[0].isPanning && // #21319
+                    !this.yAxis[0].isPanning && // #21319
+                    !this.resetZoomButton
+                ) {
                     this.showResetZoom();
                 } else if (!displayButton && this.resetZoomButton) {
                     this.resetZoomButton = this.resetZoomButton.destroy();

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3642,7 +3642,7 @@ class Chart {
 
         let hasZoomed = false,
             displayButton: boolean|undefined,
-            isAnyAxisPanning = false;
+            isAnyAxisPanning: true|undefined;
 
         // Remove active points for shared tooltip
         this.hoverPoints?.forEach((point): void => point.setState());
@@ -3823,8 +3823,8 @@ class Chart {
                         // operation has finished.
                         axis.isPanning = trigger !== 'zoom';
 
-                        if (axis.isPanning && !isAnyAxisPanning) {
-                            isAnyAxisPanning = true;
+                        if (axis.isPanning) {
+                            isAnyAxisPanning = true; // #21319
                         }
 
                         axis.setExtremes(


### PR DESCRIPTION
Fixed #21319, a regression since v11.4.0, `resetZoomButton` was visible while panning on non-ordinal axes.