### PR TITLE
bugfix/21302-ts-tooltip-constructor

### DIFF
--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -122,6 +122,9 @@ interface BoxObject extends R.BoxObject {
  *
  * @param {Highcharts.TooltipOptions} options
  * Tooltip options.
+ *
+ * @param {Highcharts.Pointer} pointer
+ * The pointer instance.
  */
 class Tooltip {
 


### PR DESCRIPTION
Fixed #21302, added the description to all arguments in the Tooltip constructor.