### PR TITLE
dash/firefox-drag

### DIFF
--- a/ts/Dashboards/EditMode/SidebarPopup.ts
+++ b/ts/Dashboards/EditMode/SidebarPopup.ts
@@ -362,7 +362,7 @@ class SidebarPopup extends BaseForm {
                     sidebar.editMode.dragDrop.onDragStart(
                         e as PointerEvent,
                         void 0,
-                        (dropContext: Cell | Row): void => {
+                        (dropContext: Cell|Row): void => {
                             // Add component if there is no layout yet.
                             if (this.editMode.board.layouts.length === 0) {
                                 const board = this.editMode.board,

--- a/ts/Dashboards/EditMode/Toolbar/CellEditToolbar.ts
+++ b/ts/Dashboards/EditMode/Toolbar/CellEditToolbar.ts
@@ -67,6 +67,8 @@ class CellEditToolbar extends EditToolbar {
                             .parent as CellEditToolbar;
                         const dragDrop = cellEditToolbar.editMode.dragDrop;
 
+                        e.preventDefault();
+
                         if (dragDrop && cellEditToolbar.cell) {
                             dragDrop.onDragStart(e, cellEditToolbar.cell);
                         }

--- a/ts/Dashboards/EditMode/Toolbar/RowEditToolbar.ts
+++ b/ts/Dashboards/EditMode/Toolbar/RowEditToolbar.ts
@@ -67,6 +67,8 @@ class RowEditToolbar extends EditToolbar {
                                 .parent as RowEditToolbar,
                             dragDrop = rowEditToolbar.editMode.dragDrop;
 
+                        e.preventDefault();
+
                         if (dragDrop && rowEditToolbar.row) {
                             dragDrop.onDragStart(e, rowEditToolbar.row);
                         }


### PR DESCRIPTION
Fixed #21189, dragging and dropping elements from the sidebar and inside the dashboard was impossible in Firefox.


- [x] sidebar
- [x] context detection 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207355996450120