### PR TITLE
feature/add helper methods to Board class

### DIFF
--- a/samples/dashboards/demo/election/demo.js
+++ b/samples/dashboards/demo/election/demo.js
@@ -65,6 +65,7 @@ async function setupDashboard() {
             title: 'Electoral College Results'
         }, {
             renderTo: 'election-map',
+            id: 'election-map',
             type: 'Highcharts',
             chartConstructor: 'mapChart',
             title: 'Popular Vote Results', // Populated by election year
@@ -365,7 +366,7 @@ async function setupDashboard() {
         'change',
         function () {
             const selectedOption = this.options[this.selectedIndex];
-            const mapChart = getComponent(board, 'election-map').chart;
+            const mapChart = board.getComponentByCellId('election-map').chart;
 
             // Choose a different election year
             onYearClicked(board, selectedOption.value);
@@ -677,11 +678,6 @@ async function getElectionTable(board, year) {
 }
 
 
-function getComponent(board, id) {
-    return board.mountedComponents.find(c => c.cell.id === id).component;
-}
-
-
 async function updateResultComponent(electionTable, year) {
     // Candidate names
     const candDem = electionData[year].candDem;
@@ -832,8 +828,8 @@ async function onStateClicked(board, state) {
     const yearSelector = document.getElementById('election-year');
 
     // Update chart title
-    const comp = getComponent(board, 'election-chart');
-    const barComponent = getComponent(board, 'election-chart-national');
+    const comp = board.getComponentByCellId('election-chart');
+    const barComponent = board.getComponentByCellId('election-chart-national');
 
     // Election data for current state
     const stateSeries = getHistoricalElectionSeries(state);
@@ -866,9 +862,9 @@ async function onStateClicked(board, state) {
 // Update board after changing data set (state or election year)
 async function onYearClicked(board, year) {
     // Dashboards components
-    const mapComponent = getComponent(board, 'election-map');
-    const gridComponent = getComponent(board, 'election-grid');
-    const barComponent = getComponent(board, 'election-chart-national');
+    const mapComponent = board.getComponentByCellId('election-map');
+    const gridComponent = board.getComponentByCellId('election-grid');
+    const barComponent = board.getComponentByCellId('election-chart-national');
 
     // Get election data
     const electionTable = await getElectionTable(board, year);

--- a/samples/dashboards/demo/election/demo.js
+++ b/samples/dashboards/demo/election/demo.js
@@ -65,7 +65,6 @@ async function setupDashboard() {
             title: 'Electoral College Results'
         }, {
             renderTo: 'election-map',
-            id: 'election-map',
             type: 'Highcharts',
             chartConstructor: 'mapChart',
             title: 'Popular Vote Results', // Populated by election year

--- a/test/typescript-karma/Dashboards/Component/helpers.js
+++ b/test/typescript-karma/Dashboards/Component/helpers.js
@@ -1,0 +1,45 @@
+//@ts-check
+import Dashboards from '../../../../code/dashboards/es-modules/masters/dashboards.src.js';
+import EditMode from '../../../../code/dashboards/es-modules/masters/modules/layout.src.js';
+
+const { test } = QUnit;
+
+
+test('Component helpers', async function (assert) {
+    const container = document.createElement('div');
+    container.id = 'container';
+
+    const dashboard = await Dashboards.board('container', {
+        gui: {
+            layouts: [{
+                rows: [{
+                    cells: [{
+                        id: 'dashboard-cell-1'
+                    }]
+                }]
+            }]
+        },
+        components: [{
+            renderTo: 'dashboard-cell-1',
+            type: 'KPI',
+            title: 'Value',
+            value: 1
+        }]
+    }, true),
+        kpi = dashboard.mountedComponents[0].component;
+
+    // @ts-ignore
+    assert.notOk(kpi.chart, 'KPI Component should be loaded without a chart.');
+
+    kpi.update({
+        value: 2,
+        chartOptions: {
+            series: [{
+                data: [1, 2, 3]
+            }]
+        }
+    });
+
+    // @ts-ignore
+    assert.ok(kpi.chart, 'KPI Component should have a chart after update.');
+});

--- a/test/typescript-karma/Dashboards/Component/helpers.js
+++ b/test/typescript-karma/Dashboards/Component/helpers.js
@@ -1,6 +1,5 @@
-//@ts-check
+// @ts-ignore
 import Dashboards from '../../../../code/dashboards/es-modules/masters/dashboards.src.js';
-import EditMode from '../../../../code/dashboards/es-modules/masters/modules/layout.src.js';
 
 const { test } = QUnit;
 
@@ -15,6 +14,8 @@ test('Component helpers', async function (assert) {
                 rows: [{
                     cells: [{
                         id: 'dashboard-cell-1'
+                    }, {
+                        id: 'dashboard-cell-2'
                     }]
                 }]
             }]
@@ -23,23 +24,41 @@ test('Component helpers', async function (assert) {
             renderTo: 'dashboard-cell-1',
             type: 'KPI',
             title: 'Value',
-            value: 1
-        }]
-    }, true),
-        kpi = dashboard.mountedComponents[0].component;
-
-    // @ts-ignore
-    assert.notOk(kpi.chart, 'KPI Component should be loaded without a chart.');
-
-    kpi.update({
-        value: 2,
-        chartOptions: {
-            series: [{
-                data: [1, 2, 3]
+            value: 1,
+            chartOptions: {
+                series: [{
+                    data: [1, 2, 3]
+                }]
+            }
+        }, {
+            renderTo: 'dashboard-cell-2',
+            id: 'html-component',
+            type: 'HTML',
+            elements: [{
+                tagName: 'h1',
+                textContent: 'HTML from elements'
             }]
-        }
-    });
+        }]
+    }, true);
 
-    // @ts-ignore
-    assert.ok(kpi.chart, 'KPI Component should have a chart after update.');
+    // Old way of getting components
+    const kpi = dashboard.mountedComponents[0].component;
+    const html = dashboard.mountedComponents[1].component;
+
+    assert.ok(kpi.chart, 'KPI Component direct lookup.');
+    assert.ok(html.element, 'HTML Component direct lookup.');
+
+    // Getting components by ID
+    let kpi1 = dashboard.getComponentByCellId('dashboard-cell-1');
+    let html1 = dashboard.getComponentById('html-component');
+
+    assert.ok(html1.element, 'HTML Component via helper.');
+    assert.ok(kpi1.chart, 'KPI Component via helper.');
+
+    // Getting components by ID, expected failures
+    let comp = dashboard.getComponentById('dashboard-cell-2');
+    assert.notOk(comp, 'Component with wrong id.');
+
+    comp = dashboard.getComponentByCellId('junk-cell-id');
+    assert.notOk(comp, 'Component with wrong cell id.');
 });

--- a/ts/Dashboards/Board.ts
+++ b/ts/Dashboards/Board.ts
@@ -596,7 +596,7 @@ class Board implements Serializable<Board, Board.JSON> {
      */
     public getComponentById(id: string): ComponentType | undefined {
         return this.mountedComponents.find(
-            (c) :boolean => c.component.id === id
+            (c): boolean => c.component.id === id
         )?.component;
     }
 
@@ -611,7 +611,7 @@ class Board implements Serializable<Board, Board.JSON> {
      */
     public getComponentByCellId(id: string): ComponentType | undefined {
         return this.mountedComponents.find(
-            (c) :boolean => c.cell.id === id
+            (c): boolean => c.cell.id === id
         )?.component;
     }
 }
@@ -827,8 +827,7 @@ namespace Board {
                 return Serializable
                     .fromJSON(JSON.parse(dashboardJSON)) as Board;
             } catch (e) {
-                // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-                throw new Error(`${e}`);
+                throw new Error('' + e);
             }
         }
     }

--- a/ts/Dashboards/Board.ts
+++ b/ts/Dashboards/Board.ts
@@ -587,7 +587,7 @@ class Board implements Serializable<Board, Board.JSON> {
 
     /**
      * Get a Dashboards component by its identifier.
-     * 
+     *
      * @param id
      * The identifier of the requsted component.
      *
@@ -827,6 +827,7 @@ namespace Board {
                 return Serializable
                     .fromJSON(JSON.parse(dashboardJSON)) as Board;
             } catch (e) {
+                // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
                 throw new Error(`${e}`);
             }
         }

--- a/ts/Dashboards/Board.ts
+++ b/ts/Dashboards/Board.ts
@@ -104,7 +104,7 @@ class Board implements Serializable<Board, Board.JSON> {
      * undefined, the function returns the dashboard instance.
      */
     public static board(
-        renderTo: (string|globalThis.HTMLElement),
+        renderTo: (string | globalThis.HTMLElement),
         options: Board.Options,
         async?: boolean
     ): Board;
@@ -123,17 +123,17 @@ class Board implements Serializable<Board, Board.JSON> {
      * function returns a promise that resolves with the dashboard instance.
      */
     public static board(
-        renderTo: (string|globalThis.HTMLElement),
+        renderTo: (string | globalThis.HTMLElement),
         options: Board.Options,
         async: true
     ): Promise<Board>;
 
     // Implementation:
     public static board(
-        renderTo: (string|globalThis.HTMLElement),
+        renderTo: (string | globalThis.HTMLElement),
         options: Board.Options,
         async?: boolean
-    ): (Board|Promise<Board>) {
+    ): (Board | Promise<Board>) {
         return new Board(renderTo, options).init(async);
     }
 
@@ -155,7 +155,7 @@ class Board implements Serializable<Board, Board.JSON> {
      * The options for the dashboard.
      */
     protected constructor(
-        renderTo: (string|HTMLElement),
+        renderTo: (string | HTMLElement),
         options: Board.Options
     ) {
         this.options = merge(Board.defaultOptions, options);
@@ -324,7 +324,7 @@ class Board implements Serializable<Board, Board.JSON> {
     protected init(async: true): Promise<Board>;
 
     // Implementation:
-    protected init(async?: boolean): (Board|Promise<Board>) {
+    protected init(async?: boolean): (Board | Promise<Board>) {
         const options = this.options;
 
         const componentPromises = (options.components) ?
@@ -365,7 +365,7 @@ class Board implements Serializable<Board, Board.JSON> {
      * @param renderTo
      * The DOM element to render to, or its id.
      */
-    private initContainer(renderTo: (string|HTMLElement)): void {
+    private initContainer(renderTo: (string | HTMLElement)): void {
         const board = this;
 
         if (typeof renderTo === 'string') {
@@ -385,7 +385,7 @@ class Board implements Serializable<Board, Board.JSON> {
      * @internal
      *
      */
-    private initEditMode():void {
+    private initEditMode(): void {
         if (!Dashboards.EditMode) {
             throw new Error('Missing layout.js module');
         } else {
@@ -406,7 +406,7 @@ class Board implements Serializable<Board, Board.JSON> {
      */
     public setComponents(
         components: Array<Partial<ComponentType['options']>>
-    ): Array<Promise<Component|void>> {
+    ): Array<Promise<Component | void>> {
         const promises = [];
         const board = this;
         for (let i = 0, iEnd = components.length; i < iEnd; ++i) {
@@ -463,7 +463,7 @@ class Board implements Serializable<Board, Board.JSON> {
      *
      * @returns Returns the imported layout.
      */
-    public importLayoutLocal(id: string): Layout|undefined {
+    public importLayoutLocal(id: string): Layout | undefined {
         return Layout.importLocal(id, this);
     }
 
@@ -534,7 +534,7 @@ class Board implements Serializable<Board, Board.JSON> {
             dataCursor: DataCursorHelper.toJSON(board.dataCursor),
             options: {
                 containerId: board.container.id,
-                dataPool: board.options.dataPool as DataPoolOptions&JSON.Object,
+                dataPool: board.options.dataPool as DataPoolOptions & JSON.Object,
                 guiEnabled: board.guiEnabled,
                 layouts: layouts,
                 componentOptions: board.options.componentOptions as
@@ -582,6 +582,26 @@ class Board implements Serializable<Board, Board.JSON> {
         }
 
         return options;
+    }
+
+    /**
+     * Get a Dashboards component by its id.
+     *
+     * @returns
+     * The component with the given id.
+     */
+    public getComponentById(id: string): ComponentType | undefined {
+        return this.mountedComponents.find(c => c.component.id === id)?.component;
+    }
+
+    /**
+     * Get a Dashboards component by its cell id.
+     *
+     * @returns
+     * The component with the given cell id.
+     */
+    public getComponentByCellId(id: string): ComponentType | undefined {
+        return this.mountedComponents.find(c => c.cell.id === id)?.component;
     }
 }
 
@@ -673,7 +693,7 @@ namespace Board {
         /**
          * Data pool with all of the connectors.
          **/
-        dataPool?: DataPoolOptions&JSON.Object;
+        dataPool?: DataPoolOptions & JSON.Object;
         /**
          * An array of serialized layouts options and their elements to add to
          * the board.
@@ -785,7 +805,7 @@ namespace Board {
      *
      * @returns Returns the Dashboard instance or undefined.
      */
-    export function importLocal(): (Board|undefined) {
+    export function importLocal(): (Board | undefined) {
         const dashboardJSON = localStorage.getItem(
             // Dashboard.prefix + this.id,
             Globals.classNamePrefix + '1' // Temporary for demo test

--- a/ts/Dashboards/Board.ts
+++ b/ts/Dashboards/Board.ts
@@ -534,7 +534,8 @@ class Board implements Serializable<Board, Board.JSON> {
             dataCursor: DataCursorHelper.toJSON(board.dataCursor),
             options: {
                 containerId: board.container.id,
-                dataPool: board.options.dataPool as DataPoolOptions & JSON.Object,
+                dataPool: board.options.dataPool as
+                    DataPoolOptions & JSON.Object,
                 guiEnabled: board.guiEnabled,
                 layouts: layouts,
                 componentOptions: board.options.componentOptions as
@@ -591,7 +592,9 @@ class Board implements Serializable<Board, Board.JSON> {
      * The component with the given id.
      */
     public getComponentById(id: string): ComponentType | undefined {
-        return this.mountedComponents.find(c => c.component.id === id)?.component;
+        return this.mountedComponents.find(
+            (c) :boolean => c.component.id === id
+        )?.component;
     }
 
     /**
@@ -601,7 +604,9 @@ class Board implements Serializable<Board, Board.JSON> {
      * The component with the given cell id.
      */
     public getComponentByCellId(id: string): ComponentType | undefined {
-        return this.mountedComponents.find(c => c.cell.id === id)?.component;
+        return this.mountedComponents.find(
+            (c) :boolean => c.cell.id === id
+        )?.component;
     }
 }
 

--- a/ts/Dashboards/Board.ts
+++ b/ts/Dashboards/Board.ts
@@ -586,10 +586,13 @@ class Board implements Serializable<Board, Board.JSON> {
     }
 
     /**
-     * Get a Dashboards component by its id.
+     * Get a Dashboards component by its identifier.
+     * 
+     * @param id
+     * The identifier of the requsted component.
      *
      * @returns
-     * The component with the given id.
+     * The component with the given identifier.
      */
     public getComponentById(id: string): ComponentType | undefined {
         return this.mountedComponents.find(
@@ -598,10 +601,13 @@ class Board implements Serializable<Board, Board.JSON> {
     }
 
     /**
-     * Get a Dashboards component by its cell id.
+     * Get a Dashboards component by its cell identifier.
+     *
+     * @param id
+     * The identifier of the cell that contains the requested component.
      *
      * @returns
-     * The component with the given cell id.
+     * The component with the given cell identifier.
      */
     public getComponentByCellId(id: string): ComponentType | undefined {
         return this.mountedComponents.find(


### PR DESCRIPTION
Added the methods `getComponentById `and `getComponentByCellId` to the `Board` class. Addressing feature request [#21378](https://github.com/highcharts/highcharts/issues/21378).