### PR TITLE
bugfix/21316-panning-with-overscroll

### DIFF
--- a/samples/unit-tests/axis/overscroll/demo.js
+++ b/samples/unit-tests/axis/overscroll/demo.js
@@ -61,8 +61,8 @@
         'Ordinal: ' + ordinal + ' - Extremes from rangeSelector buttons' +
         ' + panning.',
         function (assert) {
-            let options = getOptions(),
-                xAxis;
+            const options = getOptions();
+            let xAxis;
 
             xAxis = Highcharts.stockChart('container', options).xAxis[0];
 
@@ -71,8 +71,6 @@
                 options.rangeSelector.buttons[0].count,
                 'Correct range with preselected button (1s)'
             );
-
-            options = getOptions();
             options.rangeSelector.selected = null;
 
             const chart = Highcharts.stockChart('container', options),

--- a/samples/unit-tests/axis/overscroll/demo.js
+++ b/samples/unit-tests/axis/overscroll/demo.js
@@ -58,9 +58,10 @@
     }
 
     QUnit.test(
-        'Ordinal: ' + ordinal + ' - Extremes from rangeSelector buttons',
+        'Ordinal: ' + ordinal + ' - Extremes from rangeSelector buttons' +
+        ' + panning.',
         function (assert) {
-            var options = getOptions(),
+            let options = getOptions(),
                 xAxis;
 
             xAxis = Highcharts.stockChart('container', options).xAxis[0];
@@ -74,7 +75,10 @@
             options = getOptions();
             options.rangeSelector.selected = null;
 
-            xAxis = Highcharts.stockChart('container', options).xAxis[0];
+            const chart = Highcharts.stockChart('container', options),
+                controller = new TestController(chart);
+
+            xAxis = chart.xAxis[0];
 
             assert.strictEqual(
                 xAxis.max - xAxis.min,
@@ -82,6 +86,15 @@
                     1 +
                     xAxis.options.overscroll,
                 'Correct range with ALL'
+            );
+
+            xAxis.setExtremes(10, null);
+            controller.pan([100, 200], [300, 200]);
+            assert.close(
+                xAxis.min,
+                9.5,
+                0.5,
+                'Panning should work with overscroll option, #21316'
             );
         }
     );

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3782,7 +3782,12 @@ class Chart {
             // It is not necessary to calculate extremes on ordinal axis,
             // because they are already calculated, so we don't want to override
             // them.
-            if (!axis.isOrdinal || scale !== 1 || reset) {
+            if (
+                !axis.isOrdinal ||
+                !axis.ordinal?.getExtendedPositions() || // #21316
+                scale !== 1 ||
+                reset
+            ) {
                 // If the new range spills over, either to the min or max,
                 // adjust it.
                 if (newMin < floor) {

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3784,7 +3784,7 @@ class Chart {
             // them.
             if (
                 !axis.isOrdinal ||
-                !axis.ordinal?.getExtendedPositions() || // #21316
+                axis.options.overscroll || // #21316
                 scale !== 1 ||
                 reset
             ) {


### PR DESCRIPTION
Fixed #21316, panning on axes with overscroll was not possible.