### PR TITLE
Typesafed the splat utility function

### DIFF
--- a/ts/Core/Axis/ZAxis.ts
+++ b/ts/Core/Axis/ZAxis.ts
@@ -46,7 +46,7 @@ declare module './AxisType' {
 declare module '../Chart/ChartLike'{
     interface ChartLike {
         zAxis?: Array<ZAxis>;
-        addZAxis(options: AxisOptions): Axis;
+        addZAxis(options: DeepPartial<AxisOptions>): Axis;
     }
 }
 
@@ -70,7 +70,7 @@ declare module '../Options' {
  */
 function chartAddZAxis(
     this: Chart,
-    options: AxisOptions
+    options: DeepPartial<AxisOptions>
 ): Axis {
     return new ZAxis(this, options);
 }

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -653,10 +653,10 @@ class Chart {
 
             // Item options should be reflected in chart.options.series,
             // chart.options.yAxis etc
-            optionsArray = this.options[coll] = splat(this.options[coll])
+            optionsArray = this.options[coll] = splat(this.options[coll] as any)
                 .slice(),
             userOptionsArray = this.userOptions[coll] = this.userOptions[coll] ?
-                splat(this.userOptions[coll]).slice() :
+                splat(this.userOptions[coll] as any).slice() :
                 [];
 
         if (this.hasRendered) {
@@ -1054,7 +1054,7 @@ class Chart {
         fireEvent(this, 'getAxes');
 
         for (const coll of ['xAxis', 'yAxis'] as Array<'xAxis'|'yAxis'>) {
-            const arr: Array<AxisOptions> = options[coll] = splat(
+            const arr = options[coll] = splat(
                 options[coll] || {}
             );
             for (const axisOptions of arr) {

--- a/ts/Core/Chart/GanttChart.ts
+++ b/ts/Core/Chart/GanttChart.ts
@@ -169,8 +169,8 @@ class GanttChart extends Chart {
 
         // Apply Y axis options to both single and multi y axes
         options.yAxis = (splat(userOptions.yAxis || {})).map((
-            yAxisOptions: YAxisOptions
-        ): YAxisOptions => merge(
+            yAxisOptions
+        ): DeepPartial<YAxisOptions> => merge(
             // Defaults
             {
                 grid: {
@@ -186,7 +186,7 @@ class GanttChart extends Chart {
                 // undefined
                 type: yAxisOptions.categories ? yAxisOptions.type : 'treegrid'
 
-            } as YAxisOptions,
+            },
             // User options
             yAxisOptions
         ));

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -299,8 +299,8 @@ class StockChart extends Chart {
 
         // Apply X axis options to both single and multi y axes
         options.xAxis = splat(userOptions.xAxis || {}).map((
-            xAxisOptions: AxisOptions
-        ): AxisOptions => merge(
+            xAxisOptions
+        ): DeepPartial<AxisOptions> => merge(
             getDefaultAxisOptions(
                 'xAxis',
                 xAxisOptions,
@@ -313,8 +313,8 @@ class StockChart extends Chart {
 
         // Apply Y axis options to both single and multi y axes
         options.yAxis = splat(userOptions.yAxis || {}).map((
-            yAxisOptions: YAxisOptions
-        ): YAxisOptions => merge(
+            yAxisOptions
+        ): DeepPartial<YAxisOptions> => merge(
             getDefaultAxisOptions(
                 'yAxis',
                 yAxisOptions,

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -201,20 +201,20 @@ class Tooltip {
      * @private
      * @function Highcharts.Tooltip#bodyFormatter
      */
-    public bodyFormatter(items: Array<Point>): Array<string> {
-        return items.map(function (item): string {
-            const tooltipOptions = (item as any).series.tooltipOptions;
+    public bodyFormatter(
+        items: Array<Tooltip.FormatterContextObject>
+    ): Array<string> {
+        return items.map((item): string => {
+            const tooltipOptions = item.series.tooltipOptions,
+                point = item.point,
+                formatPrefix = point.formatPrefix || 'point';
 
             return (
-                (tooltipOptions as any)[
-                    ((item as any).point.formatPrefix || 'point') + 'Formatter'
-                ] ||
-                (item as any).point.tooltipFormatter
+                (tooltipOptions as any)[formatPrefix + 'Formatter'] ||
+                point.tooltipFormatter
             ).call(
-                (item as any).point,
-                tooltipOptions[
-                    ((item as any).point.formatPrefix || 'point') + 'Format'
-                ] || ''
+                point,
+                (tooltipOptions as any)[formatPrefix + 'Format'] || ''
             );
         });
     }

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -728,7 +728,7 @@ function attr(
  * @return {Array}
  *         The produced or original array.
  */
-function splat(obj: any): Array<any> {
+function splat<T>(obj: T|Array<T>): Array<T> {
     return isArray(obj) ? obj : [obj];
 }
 

--- a/ts/Extensions/Annotations/Annotation.ts
+++ b/ts/Extensions/Annotations/Annotation.ts
@@ -116,23 +116,19 @@ function getLabelsAndShapesOptions(
     (['labels', 'shapes'] as Array<('labels'|'shapes')>).forEach((
         name
     ): void => {
-        const someBaseOptions = baseOptions[name];
+        const someBaseOptions = baseOptions[name],
+            newOptionsValue = newOptions[name];
+
+        type ControllableOptions = (
+            ControllableLabelOptions|
+            ControllableShapeOptions
+        );
 
         if (someBaseOptions) {
-            if (newOptions[name]) {
-                mergedOptions[name] = splat(newOptions[name]).map(
-                    function (
-                        basicOptions: (
-                            ControllableLabelOptions|
-                            ControllableShapeOptions
-                        ),
-                        i: number
-                    ): (
-                        ControllableLabelOptions|
-                        ControllableShapeOptions
-                        ) {
-                        return merge(someBaseOptions[i], basicOptions);
-                    }
+            if (newOptionsValue) {
+                mergedOptions[name] = splat(newOptionsValue).map(
+                    (basicOptions, i): ControllableOptions =>
+                        merge(someBaseOptions[i], basicOptions)
                 ) as any;
             } else {
                 mergedOptions[name] = baseOptions[name] as any;

--- a/ts/Gantt/Pathfinder.ts
+++ b/ts/Gantt/Pathfinder.ts
@@ -27,7 +27,7 @@ import type SVGElement from '../Core/Renderer/SVG/SVGElement';
 import Connection from './Connection.js';
 import Chart from '../Core/Chart/Chart.js';
 import PathfinderAlgorithms from './PathfinderAlgorithms.js';
-import PathfinderComposition from './PathfinderComposition.js';
+import PathfinderComposition, { PointConnectOptionsObject } from './PathfinderComposition.js';
 import Point from '../Core/Series/Point.js';
 import U from '../Core/Utilities.js';
 const {
@@ -301,21 +301,23 @@ class Pathfinder {
                             .dependency;
                     }
 
-                    const connects = (
-                        point.options?.connect &&
-                        splat(point.options.connect)
-                    );
+                    const connects = point.options?.connect ?
+                        splat(point.options.connect) :
+                        [];
 
                     let to: (Axis|Series|Point|undefined);
 
-                    if (point.visible && point.isInside !== false && connects) {
-                        connects.forEach(function (
-                            connect: (string|Record<string, string>)
-                        ): void {
-                            to = chart.get(
-                                typeof connect === 'string' ?
-                                    connect : connect.to
-                            );
+                    if (point.visible && point.isInside !== false) {
+                        connects.forEach((
+                            connect
+                        ): void => {
+                            const toId = typeof connect === 'string' ?
+                                connect :
+                                (connect as PointConnectOptionsObject).to;
+
+                            if (toId) {
+                                to = chart.get(toId);
+                            }
                             if (
                                 to instanceof Point &&
                                 to.series.visible &&

--- a/ts/Series/Funnel/FunnelSeries.ts
+++ b/ts/Series/Funnel/FunnelSeries.ts
@@ -252,7 +252,7 @@ class FunnelSeries extends PieSeries {
      */
     public drawDataLabels(): void {
         (
-            splat(this.options.dataLabels)[0].inside ?
+            splat(this.options.dataLabels || {})[0].inside ?
                 ColumnSeries :
                 PieSeries
         ).prototype.drawDataLabels.call(this);

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -918,9 +918,11 @@ class MapSeries extends ScatterSeries {
         if (options.joinBy === null) {
             joinBy = '_i';
         }
-        joinBy = this.joinBy = splat(joinBy);
-        if (!joinBy[1]) {
-            joinBy[1] = joinBy[0];
+        if (joinBy) {
+            this.joinBy = splat(joinBy);
+            if (!this.joinBy[1]) {
+                this.joinBy[1] = this.joinBy[0];
+            }
         }
 
         return options;

--- a/ts/Series/PolarComposition.ts
+++ b/ts/Series/PolarComposition.ts
@@ -374,7 +374,7 @@ function onChartGetAxes(
     if (!this.pane) {
         this.pane = [];
     }
-    this.options.pane = splat(this.options.pane);
+    this.options.pane = splat(this.options.pane || {});
     this.options.pane.forEach((paneOptions): void => {
         new Pane( // eslint-disable-line no-new
             paneOptions,

--- a/ts/Series/Treegraph/TreegraphSeries.ts
+++ b/ts/Series/Treegraph/TreegraphSeries.ts
@@ -144,7 +144,10 @@ class TreegraphSeries extends TreemapSeries {
                 const linkLabels = [];
 
                 // Check links for overlap
-                if (!splat(series.options.dataLabels)[0].allowOverlap) {
+                if (
+                    series.options.dataLabels &&
+                    !splat(series.options.dataLabels)[0].allowOverlap
+                ) {
 
                     for (const link of series.links) {
                         if (link.dataLabel) {
@@ -495,9 +498,10 @@ class TreegraphSeries extends TreemapSeries {
             // Set dataLabel width to the width of the point shape.
             if (
                 point.shapeArgs &&
-                !splat(series.options.dataLabels)[0].style.width
+                series.options.dataLabels &&
+                !splat(series.options.dataLabels)[0].style?.width
             ) {
-                (options.style as any).width = point.shapeArgs.width;
+                options.style.width = `${point.shapeArgs.width || 0}px`;
                 if (point.dataLabel) {
                     point.dataLabel.css({
                         width: point.shapeArgs.width + 'px'

--- a/ts/Stock/Indicators/SMA/SMAIndicator.ts
+++ b/ts/Stock/Indicators/SMA/SMAIndicator.ts
@@ -445,7 +445,9 @@ class SMAIndicator extends LineSeries {
                     croppedDataValues.push([
                         croppedData.xData[i]
                     ].concat(
-                        splat(croppedData.yData[i])
+                        // Note: allowing new any here because this code
+                        // will be removed with the Series/DataTable refactor
+                        splat(croppedData.yData[i]) as any
                     ));
                 }
 

--- a/ts/Stock/RangeSelector/RangeSelector.ts
+++ b/ts/Stock/RangeSelector/RangeSelector.ts
@@ -239,7 +239,7 @@ class RangeSelector {
                     baseAxis.max as any, pick(dataMax, baseAxis.max as any)
                 )
             ), // #1568
-            baseXAxisOptions: AxisOptions,
+            baseXAxisOptions: DeepPartial<AxisOptions>,
             range = rangeOptions._range,
             rangeMin: (number|undefined),
             ctx: Axis,
@@ -365,7 +365,7 @@ class RangeSelector {
             // Axis not yet instantiated. Temporarily set min and range
             // options and axes once defined and remove them on
             // chart load (#4317 & #20529).
-            baseXAxisOptions = splat(chart.options.xAxis)[0];
+            baseXAxisOptions = splat(chart.options.xAxis || {})[0];
             const axisRangeUpdateEvent = addEvent(
                 chart,
                 'afterGetAxes',


### PR DESCRIPTION
Typesafed the `splat` function, I came over it by coincidence and noted it always returned `Array<any>`.

@bre1470 I'd be happy to receive input on this part:

https://github.com/highcharts/highcharts/blob/3151aff99ea84775b732a38729bf7132ba07553d/ts/Core/Chart/Chart.ts#L656-L660

Since `this.options[coll]` can be either Series or Axis options, TypeScript complains because we can write Series options to an Axis and the other way around. I couldn't think of a way to deal with this typing, though the logic itself is clear; it passes the same objects back, splatted, so that in reality Series options are always set to Series and Axis to Axis.