### PR TITLE
dash/editable-cell  

### DIFF
--- a/css/datagrid/datagrid2.css
+++ b/css/datagrid/datagrid2.css
@@ -235,3 +235,17 @@
     justify-content: center;
     align-items: center;
 }
+
+td.highcharts-dg-focused-cell {
+    padding-left: 0px;
+    padding-right: 0px;
+}
+
+.highcharts-dg-focused-cell input,
+.highcharts-dg-focused-cell input:focus {
+    border: 1px solid #0000ed;
+    border-radius: 0px;
+    background-color: #b7d4ff;
+    width: 100%;
+    outline: none;
+}

--- a/samples/data-grid/v2/column-options/demo.js
+++ b/samples/data-grid/v2/column-options/demo.js
@@ -8,6 +8,11 @@ DataGrid.dataGrid2('container', {
             icon: ['Apples URL', 'Pears URL', 'Plums URL', 'Bananas URL']
         }
     },
+    defaults: {
+        columns: {
+            editable: true
+        }
+    },
     columns: {
         weight: {
             className: 'custom-column-class-name'

--- a/samples/data-grid/v2/column-options/demo.js
+++ b/samples/data-grid/v2/column-options/demo.js
@@ -15,7 +15,10 @@ DataGrid.dataGrid2('container', {
     },
     columns: {
         weight: {
-            className: 'custom-column-class-name'
+            className: 'custom-column-class-name',
+            cellFormatter: function () {
+                return 'V: ' + this.value;
+            }
         },
         metaData: {
             enabled: false

--- a/samples/data-grid/v2/custom-html/demo.js
+++ b/samples/data-grid/v2/custom-html/demo.js
@@ -23,12 +23,11 @@ DataGrid.dataGrid2('container', {
     },
     defaults: {
         columns: {
-            // useHTML: true
+            useHTML: true
         }
     },
     columns: {
         Header: {
-            // useHTML: true
             cellFormat: '<h3>{value}</h3>'
         },
         List: {

--- a/samples/data-grid/v2/custom-html/demo.js
+++ b/samples/data-grid/v2/custom-html/demo.js
@@ -23,11 +23,14 @@ DataGrid.dataGrid2('container', {
     },
     defaults: {
         columns: {
-            useHTML: true
+            // useHTML: true
+            editable: true
         }
     },
     columns: {
-        useHTML: true,
+        Description: {
+            editable: true
+        },
         Header: {
             // useHTML: true
             cellFormat: '<h3>{value}</h3>'

--- a/samples/data-grid/v2/custom-html/demo.js
+++ b/samples/data-grid/v2/custom-html/demo.js
@@ -24,13 +24,9 @@ DataGrid.dataGrid2('container', {
     defaults: {
         columns: {
             // useHTML: true
-            editable: true
         }
     },
     columns: {
-        Description: {
-            editable: true
-        },
         Header: {
             // useHTML: true
             cellFormat: '<h3>{value}</h3>'

--- a/ts/DataGrid/DataGrid2/DataGridCell.ts
+++ b/ts/DataGrid/DataGrid2/DataGridCell.ts
@@ -226,7 +226,7 @@ class DataGridCell {
         // Replace cell contents with an input element
         cellElement.innerHTML = '';
         cellElement.classList.add(Globals.classNames.focusedCell);
-        
+
         this.column.viewport.editedCell = cell;
 
         // create an input
@@ -236,14 +236,22 @@ class DataGridCell {
         input.value = value || '';
         input.focus();
         input.addEventListener('keydown', (e: any) => {
+
             if (cell.column.id && cell.row.index > -1 && editedCell) {
+                let newValue = e.target?.value || value;
+
                 cell.column.viewport.dataTable.setCell(
                     cell.column.id,
                     cell.row.index,
-                    e.target?.value || value
+                    newValue
                 );
 
-                editedCell.value = cell.value = e.target?.value || value;
+                editedCell.value = cell.value = newValue;
+            }
+
+            // Enter / Escape
+            if (e.keyCode === 13 || e.keyCode === 27) {
+                cell.removeCellInputElement();
             }
         });
 

--- a/ts/DataGrid/DataGrid2/DataGridCell.ts
+++ b/ts/DataGrid/DataGrid2/DataGridCell.ts
@@ -280,7 +280,13 @@ class DataGridCell {
     }
 
     /**
-     * 
+     * Handle the formatting content of the cell.
+     *
+     * @internal
+     *
+     * @param value
+     * The value of cell
+     *
      */
     public formatCell(value: string | number | boolean): string {
         const {

--- a/ts/DataGrid/DataGrid2/DataGridCell.ts
+++ b/ts/DataGrid/DataGrid2/DataGridCell.ts
@@ -247,17 +247,16 @@ class DataGridCell {
      * Remove the <input> overlay and update the cell value
      * @internal
      */
-    private removeCellInputElement(): void {
+    public removeCellInputElement(): void {
         const editedCell = this.column.viewport.editedCell;
+        const parentNode = editedCell?.cellInputEl?.parentNode;
 
-        if (!editedCell) {
+        if (!editedCell || !parentNode) {
             return;
         }
+        let cellValue = editedCell.value as string;
 
-        const parentNode = editedCell.cellInputEl.parentNode;
-        let cellValue = editedCell.value;
-
-        editedCell.cellInputEl.remove();
+        editedCell.cellInputEl?.remove();
         delete this.column.viewport.editedCell;
 
         parentNode.classList.remove(Globals.classNames.focusedCell);

--- a/ts/DataGrid/DataGrid2/DataGridCell.ts
+++ b/ts/DataGrid/DataGrid2/DataGridCell.ts
@@ -225,23 +225,21 @@ class DataGridCell {
 
         // Replace cell contents with an input element
         cellElement.innerHTML = '';
+        cellElement.classList.add(Globals.classNames.focusedCell);
+        
+        this.column.viewport.editedCell = cell;
 
         // create an input
         const input = this.cellInputEl =
             makeHTMLElement('input', {}, cellElement);
         input.style.height = (cellElement.clientHeight - 1) + 'px';
-        cellElement.classList.add(Globals.classNames.focusedCell);
-        input.focus();
         input.value = value || '';
-
-        this.column.viewport.editedCell = this;
-        const _self = this;
-
+        input.focus();
         input.addEventListener('keydown', (e: any) => {
-            if (_self.column.id && _self.row.index > -1 && editedCell) {
+            if (cell.column.id && cell.row.index > -1 && editedCell) {
                 cell.column.viewport.dataTable.setCell(
-                    _self.column.id,
-                    _self.row.index,
+                    cell.column.id,
+                    cell.row.index,
                     e.target?.value || value
                 );
 

--- a/ts/DataGrid/DataGrid2/DataGridCell.ts
+++ b/ts/DataGrid/DataGrid2/DataGridCell.ts
@@ -123,9 +123,8 @@ class DataGridCell {
         if (!this.column.data) {
             return;
         }
+
         const {
-            cellFormat,
-            cellFormatter,
             useHTML,
             editable
         } = this.column.userOptions;
@@ -136,16 +135,8 @@ class DataGridCell {
 
         this.value = this.column.data[this.row.index];
 
-        if (cellFormatter) {
-            cellContent = cellFormatter.call({
-                value: this.value
-            });
-        } else {
-            cellContent = (
-                    cellFormat ?
-                        format(cellFormat, this) :
-                        this.value + ''
-                );
+        if (this.value) {
+            cellContent = this.formatCell(this.value);
         }
 
         if (editable) {
@@ -213,8 +204,11 @@ class DataGridCell {
      *
      * @internal
      *
-     * @param cellEl
-     * The clicked cell.
+     * @param cellElement
+     * The clicked cell's HTML element.
+     * 
+     * @param value
+     * The value of cell
      *
      */
     private onCellClick(cellElement: HTMLElement, value: string): void {
@@ -256,7 +250,7 @@ class DataGridCell {
     public removeCellInputElement(): void {
         const editedCell = this.column.viewport.editedCell;
         const parentNode = editedCell?.cellInputEl?.parentNode;
-
+        
         if (!editedCell || !parentNode) {
             return;
         }
@@ -280,9 +274,33 @@ class DataGridCell {
         delete this.column.viewport.editedCell;
 
         parentNode.classList.remove(Globals.classNames.focusedCell);
-        parentNode.innerHTML = cellValue;
+        parentNode.innerHTML = this.formatCell(cellValue);
 
         fireEvent(parentNode, 'cellUpdated');
+    }
+
+    /**
+     * 
+     */
+    public formatCell(value: string | number | boolean): string {
+        const {
+            cellFormat,
+            cellFormatter
+        } = this.column.userOptions;
+
+        let cellContent = '';
+
+        if (cellFormatter) {
+            cellContent = cellFormatter.call({
+                value: value
+            });
+        } else {
+            cellContent = (
+                cellFormat ? format(cellFormat, this) :  value + ''
+            );
+        }
+
+        return cellContent;
     }
 
     /**

--- a/ts/DataGrid/DataGrid2/DataGridOptions.d.ts
+++ b/ts/DataGrid/DataGrid2/DataGridOptions.d.ts
@@ -172,6 +172,13 @@ export interface ColumnOptions {
      * @default false
      */
     useHTML?: boolean;
+
+    /**
+     * Switch to make the column cells editable ('true') or read-only ('false').
+     *
+     * @default true
+     */
+    editable?: boolean;
 }
 
 /**

--- a/ts/DataGrid/DataGrid2/DataGridTable.ts
+++ b/ts/DataGrid/DataGrid2/DataGridTable.ts
@@ -33,6 +33,7 @@ import RowsVirtualizer from './Actions/RowsVirtualizer.js';
 import ColumnsResizer from './Actions/ColumnsResizer.js';
 import Globals from './Globals.js';
 import Utils from '../../Core/Utilities.js';
+import DataGridCell from './DataGridCell';
 
 const { makeHTMLElement } = DGUtils;
 const { getStyle } = Utils;
@@ -125,7 +126,7 @@ class DataGridTable {
      * The input element of a cell after mouse focus.
      * @internal
      */
-    public editedCell?: any;
+    public editedCell?: DataGridCell;
 
 
     /* *
@@ -342,13 +343,14 @@ class DataGridTable {
      * Related mouse event.
      */
     private onDocumentClick(e: MouseEvent): void {
-        const cellInputEl = this.editedCell.cellInputEl;
+        const editedCell = this.editedCell;
+        const cellInputEl = editedCell?.cellInputEl;
 
-        if (cellInputEl && e.target) {
+        if (editedCell && cellInputEl && e.target) {
             const cellEl = cellInputEl.parentNode;
             const isClickInInput = cellEl && cellEl.contains(e.target as Node);
             if (!isClickInInput) {
-                this.editedCell.removeCellInputElement();
+                editedCell.removeCellInputElement();
             }
         }
     }

--- a/ts/DataGrid/DataGrid2/DataGridTable.ts
+++ b/ts/DataGrid/DataGrid2/DataGridTable.ts
@@ -121,6 +121,12 @@ class DataGridTable {
      */
     public captionElement?: HTMLElement;
 
+    /**
+     * The input element of a cell after mouse focus.
+     * @internal
+     */
+    public editedCell?: any;
+
 
     /* *
     *
@@ -169,6 +175,10 @@ class DataGridTable {
         this.resizeObserver = new ResizeObserver(this.onResize);
         this.resizeObserver.observe(tableElement);
         this.tbodyElement.addEventListener('scroll', this.onScroll);
+
+        document.addEventListener('click', (e): void => {
+            this.onDocumentClick(e);
+        });
     }
 
     /* *
@@ -320,6 +330,26 @@ class DataGridTable {
 
         for (let i = 0, iEnd = this.rows.length; i < iEnd; ++i) {
             this.rows[i].destroy();
+        }
+    }
+
+    /**
+     * Handle the user clicking somewhere outside the grid.
+     *
+     * @internal
+     *
+     * @param e
+     * Related mouse event.
+     */
+    private onDocumentClick(e: MouseEvent): void {
+        const cellInputEl = this.editedCell.cellInputEl;
+
+        if (cellInputEl && e.target) {
+            const cellEl = cellInputEl.parentNode;
+            const isClickInInput = cellEl && cellEl.contains(e.target as Node);
+            if (!isClickInInput) {
+                this.editedCell.removeCellInputElement();
+            }
         }
     }
 }

--- a/ts/DataGrid/DataGrid2/Globals.ts
+++ b/ts/DataGrid/DataGrid2/Globals.ts
@@ -72,6 +72,7 @@ namespace Globals {
         rowElement: classNamePrefix + 'row',
         columnElement: classNamePrefix + 'column',
         hoveredCell: classNamePrefix + 'hovered-cell',
+        focusedCell: classNamePrefix + 'focused-cell',
         hoveredColumn: classNamePrefix + 'hovered-column',
         hoveredRow: classNamePrefix + 'hovered-row',
         odd: classNamePrefix + 'odd',


### PR DESCRIPTION
Added the editing option for a cell.

----

- [x] - API option + docs
- [x] - replace content with the input
- [x] - styles
- [x] - remove other inputs when changing the cell
- [x] - click outside the cell
- [x] - emit events
- [x] - update value
- [x] - "enter" / "esc"- close input
- [x] - click on cell - cannot set a coursor 
- [x] - cache problem when switching inputs
