### PR TITLE
dash/editmode-html-sidebar

### DIFF
--- a/samples/dashboards/components/component-html/demo.js
+++ b/samples/dashboards/components/component-html/demo.js
@@ -1,4 +1,10 @@
 Dashboards.board('container', {
+    editMode: {
+        enabled: true,
+        contextMenu: {
+            enabled: true
+        }
+    },
     gui: {
         layouts: [{
             rows: [{

--- a/samples/dashboards/cypress/component-html/demo.mjs
+++ b/samples/dashboards/cypress/component-html/demo.mjs
@@ -2,6 +2,12 @@ import Dashboards from '../../../../code/dashboards/es-modules/masters/dashboard
 import EditMode from '../../../../code/dashboards/es-modules/masters/modules/layout.src.js';
 
 Dashboards.board('container', {
+    editMode: {
+        enabled: true,
+        contextMenu: {
+            enabled: true
+        }
+    },
     gui: {
         layouts: [{
             rows: [{

--- a/test/cypress/dashboards/integration/Components/HTML/HTMLComponent.cy.js
+++ b/test/cypress/dashboards/integration/Components/HTML/HTMLComponent.cy.js
@@ -34,4 +34,27 @@ describe('Updating HTML component.', () => {
             );
         })
     });
+
+    it('Should edit the HTML component with sidebar.', () => {
+        // Arrange- open sidebar
+        cy.toggleEditMode();
+        cy.openCellEditSidebar('#dashboard-2');
+
+        // Act- edit the HTML component
+        cy.get('.highcharts-dashboards-edit-accordion-header-btn')
+            .contains('span', 'HTML')
+            .closest('.highcharts-dashboards-edit-collapsable-content-header')
+            .click();
+        cy.get('textarea').clear().type('<h1>New title</h1>');
+
+        // Assert- confirm the changes in dashboard and sidebar
+        cy.get('.highcharts-dashboards-edit-confirmation-popup-confirm-btn').click();
+        cy.get('#dashboard-2').should('contain', 'New title');
+        cy.openCellEditSidebar('#dashboard-2');
+        cy.get('.highcharts-dashboards-edit-accordion-header-btn')
+            .contains('span', 'HTML')
+            .closest('.highcharts-dashboards-edit-collapsable-content-header')
+            .click();
+        cy.get('textarea').should('have.value', '<h1>New title</h1>');
+    });
 });

--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -70,7 +70,13 @@ Cypress.Commands.add('hideSidebar', () =>
 
 Cypress.Commands.add('openCellEditSidebar', (cellId) => {
     cy.get(cellId).click();
-    cy.get('.highcharts-dashboards-edit-toolbar-cell').children().eq(0).click();
+    cy.get('.highcharts-dashboards-edit-menu-item > div')
+        .each(($el) => {
+            const backgroundImage = $el.css('background-image');
+            if (backgroundImage.includes('/code/dashboards/gfx/dashboards-icons/settings.svg')) {
+                cy.wrap($el).click();
+            }
+        });
 });
 
 Cypress.Commands.add('chart', () =>

--- a/ts/Dashboards/Components/HTMLComponent/HTMLComponent.ts
+++ b/ts/Dashboards/Components/HTMLComponent/HTMLComponent.ts
@@ -427,12 +427,16 @@ class HTMLComponent extends Component {
         let html = `<${node.tagName}`;
 
         if (attributes) {
-            (Object.keys(attributes) as Array<keyof typeof attributes>)
-                .forEach((key): void => {
-                    const value = attributes[key];
-                    html += ` ${key}="${value}"`;
-                });
+            for (const key in attributes) {
+                if (Object.prototype.hasOwnProperty.call(attributes, key)) {
+                    const value = attributes[key as keyof typeof attributes];
+                    if (value !== void 0) {
+                        html += ` ${key}="${value}"`;
+                    }
+                }
+            }
         }
+
         html += '>';
 
         html += node.textContent || '';

--- a/ts/Dashboards/Components/HTMLComponent/HTMLComponent.ts
+++ b/ts/Dashboards/Components/HTMLComponent/HTMLComponent.ts
@@ -261,11 +261,19 @@ class HTMLComponent extends Component {
 
     /**
      * Handles updating via options.
+     *
      * @param options
      * The options to apply.
      */
-    public async update(options: Partial<Options>): Promise<void> {
-        await super.update(options);
+    public async update(options: Partial<Options>, shouldRerender: boolean = true): Promise<void> {
+        if (options.html) {
+            this.elements = this.getElementsFromString(options.html);
+
+            this.constructTree();
+        }
+
+        await super.update(options, shouldRerender);
+
         this.emit({ type: 'afterUpdate' });
     }
 

--- a/ts/Dashboards/Components/HTMLComponent/HTMLComponentDefaults.ts
+++ b/ts/Dashboards/Components/HTMLComponent/HTMLComponentDefaults.ts
@@ -24,6 +24,8 @@
 import type Globals from '../../Globals';
 import type Options from './HTMLComponentOptions';
 
+import Component from '../Component.js';
+
 /* *
  *
  *  Constants
@@ -32,7 +34,15 @@ import type Options from './HTMLComponentOptions';
 
 const HTMLComponentDefaults: Globals.DeepPartial<Options> = {
     type: 'HTML',
-    elements: []
+    elements: [],
+    editableOptions: [
+        ...Component.defaultOptions.editableOptions || [],
+        {
+            name: 'htmlInput',
+            propertyPath: ['html'],
+            type: 'textarea'
+        }
+    ]
 };
 
 /* *

--- a/ts/Dashboards/Components/HTMLComponent/HTMLComponentOptions.ts
+++ b/ts/Dashboards/Components/HTMLComponent/HTMLComponentOptions.ts
@@ -56,7 +56,7 @@ export interface Options extends Component.Options {
      * {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/dashboards/html-component/nested-elements/ | HTML component with nested images.}
      *
      */
-    elements?: (AST.Node | string)[];
+    elements?: (AST.Node)[];
 
     /**
      * The HTML content of the component. If the `elements` option is set, the

--- a/ts/Dashboards/EditMode/AccordionMenu.ts
+++ b/ts/Dashboards/EditMode/AccordionMenu.ts
@@ -23,6 +23,7 @@
 import type Component from '../Components/Component';
 import type EditableOptions from '../Components/EditableOptions';
 import type Globals from '../Globals';
+import type { Options as HTMLOptions } from '../Components/HTMLComponent/HTMLComponentOptions';
 
 import EditRenderer from './EditRenderer.js';
 import U from '../../Core/Utilities.js';
@@ -375,6 +376,10 @@ class AccordionMenu {
             await component.update({
                 chartOptions: this.chartOptionsJSON
             } as any);
+        } else if (component.type === 'HTML') {
+            const options = this.changedOptions as HTMLOptions;
+
+            await component.update(options, true);
         }
 
         fireEvent(

--- a/ts/Dashboards/EditMode/EditGlobals.ts
+++ b/ts/Dashboards/EditMode/EditGlobals.ts
@@ -142,6 +142,7 @@ const EditGlobals: EditGlobals = {
         editMode: 'Edit mode',
         errorMessage: 'Something went wrong',
         exitFullscreen: 'Exit full screen',
+        htmlInput: 'HTML',
         id: 'Id',
         off: 'off',
         on: 'on',


### PR DESCRIPTION
Added an `HTML` text field in the sidebar to control and edit the content of the HTML component.


Tasks:
- [x] Show default in the sidebar
- [x] Handle update
- [x] Test

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207420047763483