### PR TITLE
Added length check for polygon

### DIFF
--- a/ts/Extensions/TextPath.ts
+++ b/ts/Extensions/TextPath.ts
@@ -292,7 +292,9 @@ function setPolygon(this: SVGElement, event: any): BBoxObject {
         }
 
         // Close it
-        polygon.push(polygon[0].slice() as [number, number]);
+        if (polygon.length) {
+            polygon.push(polygon[0].slice() as [number, number]);
+        }
 
         bBox.polygon = polygon;
     }


### PR DESCRIPTION
Seems to have fixed failing tests in the nightly Safari run, see https://github.com/highcharts/highcharts/actions/runs/9770808976 vs https://github.com/highcharts/highcharts/actions/runs/9773547513

(http://localhost:3030/samples/#test/unit-tests/series-networkgraph/networkgraph failed previously trying to access the first item of an empty array)