### PR TITLE
bugfix/21445-legenditemclick-type-declaration

### DIFF
--- a/ts/Core/Axis/Color/ColorAxisDefaults.ts
+++ b/ts/Core/Axis/Color/ColorAxisDefaults.ts
@@ -466,7 +466,7 @@ const colorAxisDefaults: DeepPartial<ColorAxis.Options> = {
      * **Note:** This option is deprecated in favor of
      * [legend.events.itemClick](#legend.events.itemClick).
      *
-     * @deprecated
+     * @deprecated 11.4.4
      * @type       {Function}
      * @product    highcharts highstock highmaps
      * @apioption  colorAxis.events.legendItemClick

--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -1872,7 +1872,7 @@ export default Legend;
  * **Note:** This option is deprecated in favor of
  * Highcharts.LegendItemClickCallbackFunction.
  *
- * @deprecated
+ * @deprecated 11.4.4
  * @callback Highcharts.PointLegendItemClickCallbackFunction
  *
  * @param {Highcharts.Point} this
@@ -1888,7 +1888,7 @@ export default Legend;
  * **Note:** This option is deprecated in favor of
  * Highcharts.LegendItemClickEventObject.
  *
- * @deprecated
+ * @deprecated 11.4.4
  * @interface Highcharts.PointLegendItemClickEventObject
  *//**
  * Related browser event.
@@ -1927,7 +1927,7 @@ export default Legend;
  * **Note:** This option is deprecated in favor of
  * Highcharts.LegendItemClickCallbackFunction.
  *
- * @deprecated
+ * @deprecated 11.4.4
  * @callback Highcharts.SeriesLegendItemClickCallbackFunction
  *
  * @param {Highcharts.Series} this
@@ -1943,7 +1943,7 @@ export default Legend;
  * **Note:** This option is deprecated in favor of
  * Highcharts.LegendItemClickEventObject.
  *
- * @deprecated
+ * @deprecated 11.4.4
  * @interface Highcharts.SeriesLegendItemClickEventObject
  *//**
  * Related browser event.

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -5166,7 +5166,7 @@ export default Series;
  * **Note:** This option is deprecated in favor of
  * Highcharts.LegendItemClickEventObject.
  *
- * @deprecated
+ * @deprecated 11.4.4
  * @interface Highcharts.SeriesLegendItemClickEventObject
  *//**
  * Related browser event.

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -5150,7 +5150,7 @@ export default Series;
  * **Note:** This option is deprecated in favor of
  * Highcharts.LegendItemClickCallbackFunction.
  *
- * @deprecated
+ * @deprecated 11.4.4
  * @callback Highcharts.SeriesLegendItemClickCallbackFunction
  *
  * @param {Highcharts.Series} this

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -969,7 +969,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
      * [legend.events.itemClick](#legend.events.itemClick).
      *
      * @type       {Highcharts.SeriesLegendItemClickCallbackFunction}
-     * @deprecated
+     * @deprecated 11.4.4
      * @context    Highcharts.Series
      * @apioption  plotOptions.series.events.legendItemClick
      */

--- a/ts/Series/Pie/PiePointOptions.d.ts
+++ b/ts/Series/Pie/PiePointOptions.d.ts
@@ -41,7 +41,7 @@ export interface PiePointEventsOptions extends PointEventsOptions {
      * **Note:** This option is deprecated in favor of
      * Highcharts.LegendItemClickEventObject.
      *
-     * @deprecated
+     * @deprecated 11.4.4
      *
      * @type {Highcharts.PointLegendItemClickCallbackFunction}
      *

--- a/ts/Series/Pie/PieSeriesDefaults.ts
+++ b/ts/Series/Pie/PieSeriesDefaults.ts
@@ -96,7 +96,7 @@ const PieSeriesDefaults: PlotOptionsOf<PieSeries> = {
      *  **Note:** This option is deprecated in favor of
      * [legend.events.itemClick](#legend.events.itemClick).
      *
-     * @deprecated
+     * @deprecated 11.4.4
      * @type       {Highcharts.PointLegendItemClickCallbackFunction}
      * @since      1.2.0
      * @product    highcharts highmaps


### PR DESCRIPTION
Fixed #21445, generated TypeScript declarations for deprecated option `series.events.legendItemClick`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207733936138345