### PR TITLE
Remove use of `series.name` in Pie chart with custom entrance animation demo

### DIFF
--- a/samples/highcharts/demo/pie-custom-entrance-animation/demo.js
+++ b/samples/highcharts/demo/pie-custom-entrance-animation/demo.js
@@ -86,7 +86,10 @@ Highcharts.chart('container', {
         align: 'left'
     },
     tooltip: {
-        pointFormat: '{series.name}: <b>{point.percentage:.1f}%</b>'
+        headerFormat: '',
+        pointFormat: 
+            '<span style="color:{point.color}">\u25cf</span> ' +
+            '{point.name}: <b>{point.percentage:.1f}%</b>'
     },
     accessibility: {
         point: {


### PR DESCRIPTION
On the [Pie chart with custom entrance animation](https://www.highcharts.com/demo/highcharts/pie-custom-entrance-animation), in the tooltip, `series.name` will render as 'Series 1' for all slices.
I replaced it with `point.name` which is what is intended here I think.