### PR TITLE
bugfix/boost-rendering-outside-axis

### DIFF
--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -823,6 +823,10 @@ class WGLRenderer {
                 }
             }
 
+            if (x > xMax || x < xMin || y > yMax || y < yMin) {
+                continue;
+            }
+
             if (!connectNulls && (x === null || y === null)) {
                 beginSegment();
                 continue;


### PR DESCRIPTION
Fixed #21185, series in full boosted charts rendered points outside axis bounds