### PR TITLE
Replace  deprecated `allowDrillToNode` with `allowTraversingTree` in Sunburst demo

### DIFF
--- a/samples/highcharts/demo/sunburst/demo.js
+++ b/samples/highcharts/demo/sunburst/demo.js
@@ -1397,7 +1397,7 @@ Highcharts.chart('container', {
         type: 'sunburst',
         data: data,
         name: 'Root',
-        allowDrillToNode: true,
+        allowTraversingTree: true,
         borderRadius: 3,
         cursor: 'pointer',
         dataLabels: {


### PR DESCRIPTION
[allowDrillToNode](https://api.highcharts.com/highcharts/series.sunburst.allowDrillToNode) is deprecated and replaced by [allowTraversingTree](https://api.highcharts.com/highcharts/plotOptions.sunburst.allowTraversingTree).