### PR TITLE
bugfix/17890-timeline-in-stock-chart

### DIFF
--- a/samples/unit-tests/series-timeline/datetime-axis/demo.html
+++ b/samples/unit-tests/series-timeline/datetime-axis/demo.html
@@ -1,4 +1,4 @@
-<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/modules/timeline.js"></script>
 
 <div id="qunit"></div>

--- a/samples/unit-tests/series-timeline/datetime-axis/demo.js
+++ b/samples/unit-tests/series-timeline/datetime-axis/demo.js
@@ -241,4 +241,30 @@ QUnit.test('Timeline: General tests.', function (assert) {
         false,
         'The third point is hidden, when it\'s outside of plot area.'
     );
+
+
+    chart = Highcharts.stockChart('container', {
+        series: [{
+            type: 'timeline',
+            data: [{
+                x: Date.UTC(2009, 10, 1),
+                name: 'A'
+            }, {
+                x: Date.UTC(2009, 10, 27),
+                name: 'B'
+            }, {
+                x: Date.UTC(2010, 10, 20),
+                name: 'C'
+            }, {
+                x: Date.UTC(2011, 3, 19),
+                name: 'D'
+            }]
+        }]
+    });
+
+    assert.strictEqual(
+        chart.series[0].points.length,
+        4,
+        'Timeline series is rendered with stock chart constructor, #17890'
+    );
 });

--- a/tools/gulptasks/test-docs.js
+++ b/tools/gulptasks/test-docs.js
@@ -11,6 +11,7 @@ const gulp = require('gulp');
  */
 async function checkDocsConsistency() {
     const FS = require('fs');
+    const FSLib = require('../libs/fs');
     const glob = require('glob');
     const LogLib = require('../libs/log');
 
@@ -23,6 +24,7 @@ async function checkDocsConsistency() {
         );
     }
     tsFiles.forEach(file => {
+        file = FSLib.path(file, true);
         const md = FS.readFileSync(file),
             demoPattern = /(https:\/\/jsfiddle.net\/gh\/get\/library\/pure\/highcharts\/highcharts\/tree\/master\/samples|https:\/\/www.highcharts.com\/samples\/embed)\/([a-z0-9\-]+\/[a-z0-9\-]+\/[a-z0-9\-]+)/gu,
             requiresPattern = /@requires[ ]*([a-z0-9\-\/\.:]+)/gu,

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -1264,6 +1264,11 @@ namespace OrdinalAxis {
                         xData: (series.xData as any).slice(),
                         chart: chart,
                         groupPixelWidth: series.groupPixelWidth,
+                        data: series.type === 'timeline' ? series.data : null,
+                        yData: series.type === 'timeline' ? series.yData : null,
+                        getVisibilityMap: series.type === 'timeline' ?
+                            Series.types.timeline.prototype.getVisibilityMap :
+                            null, // #17890
                         destroyGroupedData: H.noop,
                         getProcessedData: Series.prototype.getProcessedData,
                         applyGrouping: Series.prototype.applyGrouping,


### PR DESCRIPTION
Fixed #17890, added timeline series props to ordinal axis `fakeSeries`.