### PR TITLE
bugfix/21501-chromium-remove-temp-fix

### DIFF
--- a/tools/gulptasks/test-docs.js
+++ b/tools/gulptasks/test-docs.js
@@ -11,6 +11,7 @@ const gulp = require('gulp');
  */
 async function checkDocsConsistency() {
     const FS = require('fs');
+    const FSLib = require('../libs/fs');
     const glob = require('glob');
     const LogLib = require('../libs/log');
 
@@ -23,6 +24,7 @@ async function checkDocsConsistency() {
         );
     }
     tsFiles.forEach(file => {
+        file = FSLib.path(file, true);
         const md = FS.readFileSync(file),
             demoPattern = /(https:\/\/jsfiddle.net\/gh\/get\/library\/pure\/highcharts\/highcharts\/tree\/master\/samples|https:\/\/www.highcharts.com\/samples\/embed)\/([a-z0-9\-]+\/[a-z0-9\-]+\/[a-z0-9\-]+)/gu,
             requiresPattern = /@requires[ ]*([a-z0-9\-\/\.:]+)/gu,

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -1555,11 +1555,7 @@ class Chart {
 
         // Allow table cells and flex-boxes to shrink without the chart blocking
         // them out (#6427)
-        css(renderTo, {
-            overflow: 'hidden',
-            // #21144, retest and remove in future version of Chrome
-            pointerEvents: H.isChrome ? 'fill' : 'auto'
-        });
+        css(renderTo, { overflow: 'hidden' });
 
         // Create the inner container
         if (!chart.styledMode) {


### PR DESCRIPTION
Fixed #21501, #21547 and #21569, removed temporary `pointerEvents` fix for Chromium.

Tested locally on Windows 11 with Edge and Chrome, seems to work correctly.