### PR TITLE
bugfix/21274-plotbands-on-navigator

### DIFF
--- a/samples/unit-tests/plotbandslines/plotbandslines/demo.js
+++ b/samples/unit-tests/plotbandslines/plotbandslines/demo.js
@@ -290,3 +290,32 @@ QUnit.test('Plotbands in stock', assert => {
         'The plotBand on navigator should be positioned on corresponding yAxis'
     );
 });
+
+QUnit.test('PlotBand on main axis when navigator yAxis has id', assert => {
+
+    const chart = Highcharts.stockChart('container', {
+        xAxis: {
+            plotBands: [{
+                from: 5,
+                to: 10,
+                color: 'yellow'
+            }]
+        },
+        navigator: {
+            yAxis: {
+                id: 'nav-ABC'
+            }
+        },
+
+        series: [{
+            data: Array.from({ length: 15 }, () => 1)
+        }]
+    });
+    const xAxis = chart.xAxis[0];
+
+    assert.strictEqual(
+        xAxis.plotLinesAndBands[0].svgElem.pathArray.length,
+        5,
+        'The plotband should only have 1 box'
+    );
+});

--- a/samples/unit-tests/plotbandslines/plotbandslines/demo.js
+++ b/samples/unit-tests/plotbandslines/plotbandslines/demo.js
@@ -259,3 +259,34 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test('Plotbands in stock', assert => {
+
+    const chart = Highcharts.stockChart('container', {
+        series: [{
+            data: Array.from({ length: 50 }, () => 1),
+            showInNavigator: false
+        }],
+        xAxis: {
+            min: 10,
+            max: 30
+        },
+        navigator: {
+            xAxis: {
+                min: 0,
+                max: 50,
+                plotBands: [{
+                    from: 10,
+                    to: 14,
+                    color: 'red'
+                }]
+            }
+        }
+    });
+    const xAxis = chart.xAxis[1];
+    assert.strictEqual(
+        xAxis.plotLinesAndBands[0].svgElem.pathArray[0][2],
+        xAxis.top,
+        'The plotBand on navigator should be positioned on corresponding yAxis'
+    );
+});

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -752,19 +752,15 @@ namespace StockChart {
             // Get the related axes based options.*Axis setting #2810
             axes2 = (axis.isXAxis ? chart.yAxis : chart.xAxis);
             for (const A of axes2) {
-                if (
-                    defined(A.options.id) ?
-                        A.options.id.indexOf('navigator') === -1 :
-                        true
-                ) {
+                if (!A.options.isInternal) {
                     const a = (A.isXAxis ? 'yAxis' : 'xAxis'),
-                        rax = (
+                        relatedAxis: Axis = (
                             defined((A.options as any)[a]) ?
                                 (chart as any)[a][(A.options as any)[a]] :
                                 (chart as any)[a][0]
                         );
 
-                    if (axis === rax) {
+                    if (axis === relatedAxis) {
                         axes.push(A);
                     }
                 }

--- a/ts/Stock/Navigator/Navigator.ts
+++ b/ts/Stock/Navigator/Navigator.ts
@@ -1360,6 +1360,7 @@ class Navigator {
                 overscroll: baseXaxis.options.overscroll
             }, navigatorOptions.xAxis, {
                 type: 'datetime',
+                yAxis: navigatorOptions.yAxis?.id,
                 index: xAxisIndex,
                 isInternal: true,
                 offset: 0,


### PR DESCRIPTION
Fixed https://github.com/highcharts/highcharts/issues/21274,  `plotBands` were assigned to the wrong `yAxis` when there was no series in navigator.