### PR TITLE
bugfix/21507-annotation-remove-in-exporting

### DIFF
--- a/samples/unit-tests/annotations/annotations-dynamic/demo.js
+++ b/samples/unit-tests/annotations/annotations-dynamic/demo.js
@@ -257,6 +257,35 @@ QUnit.test('Annotation\'s dynamic methods', function (assert) {
         2,
         '#16011: Shapes should not disappear on update'
     );
+
+    const textAnnotation = chart.addAnnotation({
+        labels: [{
+            point: {
+                xAxis: 0,
+                yAxis: 0,
+                x: 0,
+                y: 100000
+            },
+            text: 'Label text',
+            className: 'text-annotation'
+        }]
+    });
+
+    textAnnotation.update({
+        labels: {
+            style: {
+                color: 'yellow'
+            }
+        }
+    });
+
+    chart.removeAnnotation(textAnnotation);
+
+    assert.strictEqual(
+        chart.getSVG().indexOf('text-annotation'),
+        -1,
+        'Annotation is not visible in exported chart after removing (#21507).'
+    );
 });
 
 QUnit.test(

--- a/tools/gulptasks/test-docs.js
+++ b/tools/gulptasks/test-docs.js
@@ -11,6 +11,7 @@ const gulp = require('gulp');
  */
 async function checkDocsConsistency() {
     const FS = require('fs');
+    const FSLib = require('../libs/fs');
     const glob = require('glob');
     const LogLib = require('../libs/log');
 
@@ -23,6 +24,7 @@ async function checkDocsConsistency() {
         );
     }
     tsFiles.forEach(file => {
+        file = FSLib.path(file, true);
         const md = FS.readFileSync(file),
             demoPattern = /(https:\/\/jsfiddle.net\/gh\/get\/library\/pure\/highcharts\/highcharts\/tree\/master\/samples|https:\/\/www.highcharts.com\/samples\/embed)\/([a-z0-9\-]+\/[a-z0-9\-]+\/[a-z0-9\-]+)/gu,
             requiresPattern = /@requires[ ]*([a-z0-9\-\/\.:]+)/gu,

--- a/ts/Extensions/Annotations/Annotation.ts
+++ b/ts/Extensions/Annotations/Annotation.ts
@@ -868,8 +868,8 @@ class Annotation extends EventEmitter implements ControlTarget {
         this.destroy();
         this.initProperties(chart, options);
         this.init(chart, options);
-        // Update options in chart options, used in exporting (#9767):
-        chart.options.annotations[userOptionsIndex] = options;
+        // Update options in chart options, used in exporting (#9767, #21507):
+        chart.options.annotations[userOptionsIndex] = this.options;
 
         this.isUpdating = true;
         if (pick(redraw, true)) {


### PR DESCRIPTION
Fixed #21507, removed annotation was still visible in exported chart.