### PR TITLE
dash/dg2-comp-options-export

### DIFF
--- a/docs/datagrid/general.md
+++ b/docs/datagrid/general.md
@@ -84,7 +84,7 @@ Using [`columns`](https://api.highcharts.com/dashboards/#interfaces/DataGrid_Dat
 Example:
 ```js
 DataGrid.dataGrid('container', {
-    dataTable: { columns },
+    table: { columns },
     caption: {
         text: 'Fruit market'
     },

--- a/docs/datagrid/general.md
+++ b/docs/datagrid/general.md
@@ -20,6 +20,94 @@ By incorporating this component, users can effectively interact with data in a s
     ```
     Then import the module like this:
 
-    ```typescript
+    ```ts
     import * as DataGrid from '@highcharts/dashboards/datagrid';
     ```
+
+## Usage
+The DataGrid can be added as a standalone component or as a part of a dashboard.
+The following example demonstrates how to use the DataGrid as a standalone component.
+
+First you need to create a container for the DataGrid:
+
+```js
+<div id="container"></div>
+```
+
+Then you can create the DataGrid instance and add it to the container.
+Note that the DataGrid requires data to be in form of a data table or a data table options object.
+Check [the data documentation](https://www.highcharts.com/docs/dashboards/data-handling) to read more about data handling.
+
+Data Table Options:
+```js
+import DataGrid from '@highcharts/dashboards/datagrid';
+DataGrid.dataGrid('container', {
+    table: {
+        columns: {
+            product: ['Apples', 'Pears', 'Plums', 'Bananas'],
+            price: [1.5, 2.53, 5, 4.5],
+        }
+    }
+});
+```
+
+Data Table Instance:
+```ts
+import DataGrid from '@highcharts/dashboards/datagrid';
+const grid = new DataGrid.DataGrid('container', {
+    table: new DataGrid.DataTable({
+        columns: {
+            product: ['Apples', 'Pears', 'Plums', 'Bananas'],
+            price: [1.5, 2.53, 5, 4.5],
+        }
+    })
+});
+```
+
+## Styles
+The DataGrid component requires the following styles to be imported in your main CSS file:
+
+```css
+@import url("https://code.highcharts.com/dashboards/css/datagrid.css");
+```
+
+
+## Options
+<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/data-grid/basic/overview" allow="fullscreen"></iframe>
+
+The DataGrid has a number of options that can be used to customize the appearance and behavior of the table.
+
+For example using the [`editable`](https://api.highcharts.com/dashboards/#interfaces/DataGrid_DataGridOptions.DataGridOptions-1#editable) option you can make all the cells in a DataGrid editable (`true`) or read-only (`false`):
+
+Using [`columns`](https://api.highcharts.com/dashboards/#interfaces/DataGrid_DataGridOptions.DataGridOptions-1#columns), you can format data and headers in cells, e.g. adding units to them. The key is the column name and the value is the object with the column-specific options.
+
+Example:
+```js
+DataGrid.dataGrid('container', {
+    dataTable: { columns },
+    caption: {
+        text: 'Fruit market'
+    },
+    columns: {
+        product: {
+            cellFormat: '{text} No. 1',
+            headerFormat: '{text} name'
+        },
+        weight: {
+            cellFormat: '{value} kg',
+            headerFormat: '{text} (kg)'
+        },
+        price: {
+            cellFormat: '{value} $',
+            headerFormat: '($) {text}'
+        },
+        metaData: {
+            enabled: false
+        }
+    }
+});
+```
+
+A complete list of the API options can be found [here](https://api.highcharts.com/dashboards/typedoc/interfaces/DataGrid_DataGridOptions.DataGridOptions-1.html).
+
+Go [here](https://www.highcharts.com/docs/datagrid/understanding-datagrid) to read more about the DataGrid structure.

--- a/docs/datagrid/general.md
+++ b/docs/datagrid/general.md
@@ -110,4 +110,4 @@ DataGrid.dataGrid('container', {
 
 A complete list of the API options can be found [here](https://api.highcharts.com/dashboards/typedoc/interfaces/DataGrid_DataGridOptions.DataGridOptions-1.html).
 
-Go [here](https://www.highcharts.com/docs/datagrid/understanding-datagrid) to read more about the DataGrid structure.
+[Go to the next article](https://www.highcharts.com/docs/datagrid/understanding-datagrid) to read more about the DataGrid structure.

--- a/docs/datagrid/understanding-datagrid.md
+++ b/docs/datagrid/understanding-datagrid.md
@@ -9,12 +9,12 @@ Defaults
 ---------
 Default options for all rows or all columns.
 
-```
-    defaults: {
-        columns: {
-            editable: true
-        }
+```js
+defaults: {
+    columns: {
+        editable: true
     }
+}
 ```
 
 For more information on `default` options see the [API reference]().
@@ -24,10 +24,10 @@ Caption
 
 The caption of the datagrid grid.
 
-```
-    caption: {
-        text: 'Your title of datagrid'
-    }
+```js
+caption: {
+    text: 'Your title of datagrid'
+}
 ```
 
 For more information on `caption` options see the [API reference]().
@@ -35,77 +35,89 @@ For more information on `caption` options see the [API reference]().
 Head
 ---------
 
-The table header row contains the column names.
+The [table head](https://api.highcharts.com/dashboards/#classes/DataGrid_DataGridTableHead.DataGridTableHead-1) is a special, always top row, containing the column IDs.
+Cells in the `head` are called `headers`. Their content can be edited using the
+[`headerFormat` option](https://api.highcharts.com/dashboards/#interfaces/DataGrid_DataGridOptions.ColumnOptions#headerFormat).
 
 
 Row
 ---------
 
-Represents a row in the data grid.
+Represents a [row](https://api.highcharts.com/dashboards/#classes/DataGrid_DataGridRow.DataGridRow-1) in the data grid.
 
-```
-    defaults: {
-        rows: {
-            bufferSize: 5
-        }
+```js
+settings: {
+    rows: {
+        bufferSize: 5,
+        strictHeights: true
     }
+}
 ```
 
-For more information on row options see the [API reference](https://api.highcharts.com/dashboards/typedoc/interfaces/DataGrid_DataGridOptions.CaptionOptions.html).
+For more information on row settings see the [API reference](https://api.highcharts.com/dashboards/#interfaces/DataGrid_DataGridOptions.RowsSettings).
 
 Column resizer
 ---------
 
-Allows you to resize the entire column. The functionality is enabled by default,
-but you can disable it in the settings option.
+Allows you to resize the entire [column](https://api.highcharts.com/dashboards/#classes/DataGrid_DataGridColumn.DataGridColumn-1). The functionality is enabled by default,
+but you can disable it in the [settings option](https://api.highcharts.com/dashboards/#interfaces/DataGrid_DataGridOptions.ColumnsSettings).
 
+```js
+settings: {
+    columns: {
+        resizing: false
+    }
+}
 ```
-    settings: {
-        columns: {
-            resizing: false
+
+For more information on the column resizer see the [API reference](https://api.highcharts.com/dashboards/#classes/DataGrid_Actions_ColumnsResizer.ColumnsResizer).
+
+Column
+---------
+
+Represents a column in the data grid. Options for a column often apply to all cells it contains. See the [column options API docs](https://api.highcharts.com/dashboards/typedoc/interfaces/DataGrid_DataGridOptions.IndividualColumnOptions.html).
+
+```js
+defaults: {
+    columns: {
+        useHTML: true
+    }
+},
+columns: {
+    column1: {
+        cellFormat: '<h3>{value}</h3>'
+    },
+    column2: {
+        cellFormatter: function () {
+            return '<a href="' + this.value + '">URL</a>';
         }
     }
+}
 ```
 
-For more information on resizer options see the [API reference](https://api.highcharts.com/dashboards/typedoc/interfaces/DataGrid_DataGridOptions.ColumnsSettings.html#resizing).
+For more information on the column element see the [API reference](https://api.highcharts.com/dashboards/typedoc/classes/DataGrid_DataGridColumn.DataGridColumn-1.html).
+
 
 Cell
 ---------
 
-The basic element in the DataGrid can be formatted by `cellFormat` or `cellFormatter`.
-You can also set the `useHTML` option and apply the custom HTML in formatters.
+The basic element in the DataGrid can be formatted by [`cellFormat`](https://api.highcharts.com/dashboards/#interfaces/DataGrid_DataGridOptions.ColumnOptions#cellFormat) or [`cellFormatter`](https://api.highcharts.com/dashboards/#interfaces/DataGrid_DataGridOptions.ColumnOptions#cellFormatter).
+You can also set the [`useHTML`](https://api.highcharts.com/dashboards/typedoc/interfaces/DataGrid_DataGridOptions.IndividualColumnOptions.html#useHTML) option and apply the custom HTML in formatters.
 
-```
-    defaults: {
-        columns: {
-            useHTML: true
-        }
-    },
-    columns: {
-        column1: {
-            cellFormat: '<h3>{value}</h3>'
-        },
-        column2: {
-            cellFormatter: function () {
-                return '<a href="' + this.value + '">URL</a>';
-            }
-        }
-    }
-```
+For more information on the cell element see the [API reference](https://api.highcharts.com/dashboards/typedoc/classes/DataGrid_DataGridCell.DataGridCell-1.html).
 
-For more information on column options see the [API reference](https://api.highcharts.com/dashboards/typedoc/interfaces/DataGrid_DataGridOptions.IndividualColumnOptions.html).
 
 Value editor
 ---------
 
 Allows you to edit the main value of the cell.
 
-```
-    defaults: {
-        columns: {
-            editable: true
-        }
+```js
+defaults: {
+    columns: {
+        editable: true
     }
+}
 ```
 
 Click on a cell and change the value.

--- a/samples/dashboards/components/climate-all/demo.js
+++ b/samples/dashboards/components/climate-all/demo.js
@@ -670,13 +670,13 @@ async function setupBoard() {
                         enabled: false
                     },
                     FD: {
-                        headFormat: 'Days with Frost'
+                        headerFormat: 'Days with Frost'
                     },
                     ID: {
-                        headFormat: 'Days with Ice'
+                        headerFormat: 'Days with Ice'
                     },
                     RR1: {
-                        headFormat: 'Days with Rain'
+                        headerFormat: 'Days with Rain'
                     },
                     TN: {
                         enabled: false
@@ -685,20 +685,20 @@ async function setupBoard() {
                         enabled: false
                     },
                     TNC: {
-                        headFormat: 'Average Temperature °C',
+                        headerFormat: 'Average Temperature °C',
                         cellFormat: '{value:.1f}'
                     },
                     TNF: {
-                        headFormat: 'Average Temperature °F',
+                        headerFormat: 'Average Temperature °F',
                         cellFormat: '{value:.1f}',
                         enabled: false
                     },
                     TXC: {
-                        headFormat: 'Maximal Temperature °C',
+                        headerFormat: 'Maximal Temperature °C',
                         cellFormat: '{value:.1f}'
                     },
                     TXF: {
-                        headFormat: 'Maximal Temperature °F',
+                        headerFormat: 'Maximal Temperature °F',
                         cellFormat: '{value:.1f}',
                         enabled: false
                     }

--- a/samples/dashboards/components/component-datagrid/demo.js
+++ b/samples/dashboards/components/component-datagrid/demo.js
@@ -45,7 +45,7 @@ Dashboards.board('container', {
         dataGridOptions: {
             columns: {
                 Revenue: {
-                    headFormat: '{id} (€)'
+                    headerFormat: '{id} (€)'
                 },
                 Category: {
                     enabled: false

--- a/samples/dashboards/components/custom-component-data-connector/demo.js
+++ b/samples/dashboards/components/custom-component-data-connector/demo.js
@@ -116,7 +116,7 @@ Dashboards.board('container', {
         dataGridOptions: {
             columns: {
                 Revenue: {
-                    headFormat: '{id} (€)'
+                    headerFormat: '{id} (€)'
                 },
                 Category: {
                     enabled: false

--- a/samples/dashboards/datagrid-component/datagrid-options/demo.js
+++ b/samples/dashboards/datagrid-component/datagrid-options/demo.js
@@ -30,7 +30,7 @@ Dashboards.board('container', {
         dataGridOptions: {
             columns: {
                 'Vitamin A': {
-                    headFormat: '{id} [mg]'
+                    headerFormat: '{id} [mg]'
                 }
             }
         }

--- a/samples/dashboards/demo/climate/demo.js
+++ b/samples/dashboards/demo/climate/demo.js
@@ -469,13 +469,13 @@ async function setupBoard() {
                         enabled: false
                     },
                     FD: {
-                        headFormat: 'Days with frost'
+                        headerFormat: 'Days with frost'
                     },
                     ID: {
-                        headFormat: 'Days with ice'
+                        headerFormat: 'Days with ice'
                     },
                     RR1: {
-                        headFormat: 'Days with rain'
+                        headerFormat: 'Days with rain'
                     },
                     TN: {
                         enabled: false
@@ -484,20 +484,20 @@ async function setupBoard() {
                         enabled: false
                     },
                     TNC: {
-                        headFormat: 'Average temperature °C',
+                        headerFormat: 'Average temperature °C',
                         cellFormat: '{value:.1f}'
                     },
                     TNF: {
-                        headFormat: 'Average temperature °F',
+                        headerFormat: 'Average temperature °F',
                         cellFormat: '{value:.1f}',
                         enabled: false
                     },
                     TXC: {
-                        headFormat: 'Maximum temperature °C',
+                        headerFormat: 'Maximum temperature °C',
                         cellFormat: '{value:.1f}'
                     },
                     TXF: {
-                        headFormat: 'Maximum temperature °F',
+                        headerFormat: 'Maximum temperature °F',
                         cellFormat: '{value:.1f}',
                         enabled: false
                     }

--- a/samples/dashboards/demo/cloud-monitoring/demo.js
+++ b/samples/dashboards/demo/cloud-monitoring/demo.js
@@ -648,16 +648,16 @@ const setupDashboard = instanceId => {
                 },
                 columns: {
                     InstanceId: {
-                        headFormat: 'ID'
+                        headerFormat: 'ID'
                     },
                     InstanceType: {
-                        headFormat: 'Type'
+                        headerFormat: 'Type'
                     },
                     PublicIpAddress: {
-                        headFormat: 'Public IP'
+                        headerFormat: 'Public IP'
                     },
                     HealthIndicator: {
-                        headFormat: 'Health',
+                        headerFormat: 'Health',
                         useHTML: true,
                         cellFormatter: function () {
                             const val = this.value;

--- a/samples/dashboards/demo/election/demo.js
+++ b/samples/dashboards/demo/election/demo.js
@@ -324,16 +324,16 @@ async function setupDashboard() {
                 ],
                 columns: {
                     state: {
-                        headFormat: 'State'
+                        headerFormat: 'State'
                     },
                     demVoteSummary: {
-                        headFormat: 'Dem. votes'
+                        headerFormat: 'Dem. votes'
                     },
                     repVoteSummary: {
-                        headFormat: 'Rep. votes'
+                        headerFormat: 'Rep. votes'
                     },
                     totalVotes: {
-                        headFormat: 'Total votes',
+                        headerFormat: 'Total votes',
                         cellFormatter: function () {
                             return Number(this.value).toLocaleString('en-US');
                         }
@@ -778,10 +778,10 @@ async function updateGridComponent(component, year) {
         dataGridOptions: {
             columns: {
                 repColVotes: {
-                    headFormat: candRep + ' (Republican)'
+                    headerFormat: candRep + ' (Republican)'
                 },
                 demColVotes: {
-                    headFormat: candDem + ' (Democrat)'
+                    headerFormat: candDem + ' (Democrat)'
                 }
             }
         }

--- a/samples/dashboards/demo/light-dark-theme/demo.js
+++ b/samples/dashboards/demo/light-dark-theme/demo.js
@@ -104,7 +104,7 @@ Dashboards.board('container', {
         dataGridOptions: {
             columns: {
                 'Vitamin A': {
-                    headFormat: '{text} μg'
+                    headerFormat: '{text} μg'
                 }
             }
         }

--- a/samples/dashboards/demo/live-weather/demo.js
+++ b/samples/dashboards/demo/live-weather/demo.js
@@ -536,7 +536,7 @@ async function setupDashboard() {
                 dataGridOptions: {
                     columns: {
                         time: {
-                            headFormat: 'Time UTC',
+                            headerFormat: 'Time UTC',
                             cellFormatter: function () {
                                 return Highcharts.dateFormat(
                                     '%H:%M', this.value
@@ -544,23 +544,23 @@ async function setupDashboard() {
                             }
                         },
                         temperature: {
-                            headFormat: paramConfig.getColumnHeader(
+                            headerFormat: paramConfig.getColumnHeader(
                                 'temperature'
                             ),
                             cellFormat: '{value:.1f}'
                         },
                         wind: {
-                            headFormat: paramConfig.getColumnHeader('wind'),
+                            headerFormat: paramConfig.getColumnHeader('wind'),
                             cellFormat: '{value:.1f}'
                         },
                         windDir: {
-                            headFormat: paramConfig.getColumnHeader(
+                            headerFormat: paramConfig.getColumnHeader(
                                 'windDir'
                             ),
                             cellFormat: '{value:.0f}'
                         },
                         precipitation: {
-                            headFormat: paramConfig.getColumnHeader(
+                            headerFormat: paramConfig.getColumnHeader(
                                 'precipitation'
                             ),
                             cellFormat: '{value:.1f}'

--- a/samples/dashboards/studies/sun-horizon/demo.js
+++ b/samples/dashboards/studies/sun-horizon/demo.js
@@ -989,7 +989,7 @@ const createBoard = async () => {
             type: 'DataGrid',
             dataGridOptions: {
                 columns: [{
-                    headFormat: 'Celestial event',
+                    headerFormat: 'Celestial event',
                     cellFormatter: function () {
                         const str = this.value
                             .replace(/([A-Z])/g, ' $1')
@@ -998,7 +998,7 @@ const createBoard = async () => {
                     }
                 },
                 {
-                    headFormat: 'Time',
+                    headerFormat: 'Time',
                     // @todo Fix after #20444
                     // cellFormat: '{value:%H:%M}'
                     cellFormatter: function () {

--- a/samples/data-grid/basic/cell-formatting/demo.js
+++ b/samples/data-grid/basic/cell-formatting/demo.js
@@ -17,7 +17,7 @@ DataGrid.dataGrid('container', {
     },
     columns: {
         date: {
-            headFormat: 'Date of purchase',
+            headerFormat: 'Date of purchase',
             cellFormatter: function () {
                 return new Date(this.value)
                     .toISOString()
@@ -25,7 +25,7 @@ DataGrid.dataGrid('container', {
             }
         },
         product: {
-            headFormat: '{id} name'
+            headerFormat: '{id} name'
         },
         weight: {
             className: 'custom-column-class-name',

--- a/samples/data-grid/basic/no-data/demo.js
+++ b/samples/data-grid/basic/no-data/demo.js
@@ -1,3 +1,3 @@
 DataGrid.dataGrid('container', {
-    dataTable: {}
+    table: {}
 });

--- a/samples/data-grid/basic/overview/demo.css
+++ b/samples/data-grid/basic/overview/demo.css
@@ -1,0 +1,6 @@
+@import url("https://code.highcharts.com/dashboards/css/datagrid.css");
+
+#container {
+    height: 250px;
+    margin: 8px;
+}

--- a/samples/data-grid/basic/overview/demo.html
+++ b/samples/data-grid/basic/overview/demo.html
@@ -1,0 +1,3 @@
+<script src="https://code.highcharts.com/dashboards/datagrid.js"></script>
+
+<div id="container"></div>

--- a/samples/data-grid/basic/overview/demo.js
+++ b/samples/data-grid/basic/overview/demo.js
@@ -1,0 +1,43 @@
+DataGrid.dataGrid('container', {
+    table: {
+        columns: {
+            product: [
+                'Apples', 'Pears', 'Plums', 'Bananas', 'Oranges', 'Grapes',
+                'Strawberries', 'Blueberries', 'Cherries', 'Mangoes'
+            ],
+            weight: [100, 40, 0.5, 200, 150, 120, 50, 30, 25, 200],
+            price: [1.5, 2.53, 5, 4.5, 3, 2.8, 6, 4.2, 7, 3.5],
+            metaData: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
+            icon: [
+                'Apples URL', 'Pears URL', 'Plums URL', 'Bananas URL',
+                'Oranges URL', 'Grapes URL', 'Strawberries URL',
+                'Blueberries URL', 'Cherries URL', 'Mangoes URL'
+            ]
+        }
+    },
+    defaults: {
+        columns: {
+            editable: false
+        }
+    },
+    caption: {
+        text: 'Fruit market'
+    },
+    columns: {
+        product: {
+            cellFormat: '{value} No. 1',
+            headerFormat: '{text} name'
+        },
+        weight: {
+            cellFormat: '{value} kg',
+            headerFormat: '{text} (kg)'
+        },
+        price: {
+            cellFormat: '{value} $',
+            headerFormat: '($) {text}'
+        },
+        metaData: {
+            enabled: false
+        }
+    }
+});

--- a/samples/data-grid/basic/scroll-to-row/demo.js
+++ b/samples/data-grid/basic/scroll-to-row/demo.js
@@ -21,13 +21,13 @@ const dataGrid = new DataGrid.DataGrid('container', {
     },
     defaults: {
         columns: {
-            headFormat: 'Col-{id}',
+            headerFormat: 'Col-{id}',
             cellFormat: 'V: {value}'
         }
     },
     columns: {
         d: {
-            headFormat: 'Col D',
+            headerFormat: 'Col D',
             cellFormat: '{row.index}%'
         }
     }

--- a/ts/Dashboards/Components/Component.ts
+++ b/ts/Dashboards/Components/Component.ts
@@ -808,7 +808,9 @@ abstract class Component {
          * TODO: Should perhaps set an `isActive` flag to false.
          */
 
-        this.sync.stop();
+        if (this.sync.isSyncing) {
+            this.sync.stop();
+        }
 
         while (this.element.firstChild) {
             this.element.firstChild.remove();

--- a/ts/Dashboards/Components/DataGridComponent/DataGridComponent.ts
+++ b/ts/Dashboards/Components/DataGridComponent/DataGridComponent.ts
@@ -220,9 +220,20 @@ class DataGridComponent extends Component {
      *
      * @internal
      */
-    public getOptions(): Partial<Options> {
+    public override getOptions(): Partial<Options> {
+
+        // Remove the table from the options copy if the connector is set.
+        const optionsCopy = merge(this.options);
+        if (optionsCopy.connector?.id) {
+            delete optionsCopy.dataGridOptions?.table;
+        } else if (optionsCopy.dataGridOptions?.table?.id) {
+            optionsCopy.dataGridOptions.table = {
+                columns: optionsCopy.dataGridOptions.table.columns
+            };
+        }
+
         return {
-            ...diffObjects(this.options, DataGridComponent.defaultOptions),
+            ...diffObjects(optionsCopy, DataGridComponent.defaultOptions),
             type: 'DataGrid'
         };
     }
@@ -231,6 +242,7 @@ class DataGridComponent extends Component {
      * Destroys the data grid component.
      */
     public override destroy(): void {
+        this.sync.stop();
         this.dataGrid?.destroy();
         super.destroy();
     }

--- a/ts/Data/README.md
+++ b/ts/Data/README.md
@@ -167,7 +167,7 @@ to retrieve the original order.
 
 ```TypeScript
 const dataGrid = new DataGrid('container', {
-    dataTable: new DataTable({
+    table: new DataTable({
         columns: {
             Value: [ 12.34, 45.67, 78.90 ],
             Currency: [ 'EUR', 'DKK', 'NOK' ]
@@ -180,7 +180,7 @@ If a row reference is needed, an index column has to be part of the table:
 
 ```TypeScript
 const dataGrid = new DataGrid('container', {
-    dataTable: new DataTable({
+    table: new DataTable({
         columns: {
             '': [1, 2, 3],
             Value: [ 12.34, 45.67, 78.90 ],
@@ -188,7 +188,7 @@ const dataGrid = new DataGrid('container', {
         }
     }
 });
-dataGrid.table.getRow(dataGrid.table.getRowIndexBy('', 2));
+dataGrid.dataTable.getRow(dataGrid.table.getRowIndexBy('', 2));
 ```
 
 

--- a/ts/DataGrid/Actions/ColumnsResizer.ts
+++ b/ts/DataGrid/Actions/ColumnsResizer.ts
@@ -190,7 +190,7 @@ class ColumnsResizer {
      * Handles the mouse up event on the document.
      */
     private onDocumentMouseUp = (): void => {
-        this.draggedColumn?.headElement?.classList.remove(
+        this.draggedColumn?.headerElement?.classList.remove(
             'highcharts-datagrid-head-cell-resized'
         );
 
@@ -222,7 +222,7 @@ class ColumnsResizer {
             this.nextColumnStartWidth =
                 this.viewport.columns[column.index + 1]?.getWidth();
 
-            column.headElement?.classList.add(
+            column.headerElement?.classList.add(
                 'highcharts-datagrid-head-cell-resized'
             );
         };

--- a/ts/DataGrid/DataGridColumn.ts
+++ b/ts/DataGrid/DataGridColumn.ts
@@ -103,9 +103,9 @@ class DataGridColumn {
     public type?: DataGridColumn.Type;
 
     /**
-     * The head element of the column.
+     * The header element of the column (the proper cell in the table head).
      */
-    public headElement?: HTMLElement;
+    public headerElement?: HTMLElement;
 
     /**
      * The user options of the column.
@@ -176,15 +176,15 @@ class DataGridColumn {
     * */
 
     /**
-     * Sets the head element of the column.
+     * Sets the header element of the column.
      *
-     * @param headElement
+     * @param headerElement
      * The head element of the column.
      */
-    public setHeadElement(headElement: HTMLElement): void {
-        this.headElement = headElement;
+    public setHeaderElement(headerElement: HTMLElement): void {
+        this.headerElement = headerElement;
         if (this.options.className) {
-            headElement.classList.add(this.options.className);
+            headerElement.classList.add(this.options.className);
         }
     }
 
@@ -239,7 +239,7 @@ class DataGridColumn {
      * Whether the column should be hovered.
      */
     public setHoveredState(hovered: boolean): void {
-        this.headElement?.classList[hovered ? 'add' : 'remove'](
+        this.headerElement?.classList[hovered ? 'add' : 'remove'](
             Globals.classNames.hoveredColumn
         );
 

--- a/ts/DataGrid/DataGridOptions.d.ts
+++ b/ts/DataGrid/DataGridOptions.d.ts
@@ -40,6 +40,11 @@ export type ColumnDistribution = 'full' | 'fixed';
  */
 export type DataGridCellEventCallback = (this: DataGridCell) => void;
 
+/**
+ * Returns a formatted call's string.
+ */
+export type CellFormatterCallback = (this: DataGridCell) => string;
+
 
 /**
  * Options to control the content and the user experience of a grid structure.
@@ -165,35 +170,18 @@ export interface ColumnOptions {
     cellFormat?: string;
 
     /**
-     * The format of the column header. Use `{id}` to display the column id.
-     */
-    headFormat?: string;
-}
-
-/**
- * Column options that can be set for each column individually.
- */
-export interface IndividualColumnOptions extends ColumnOptions {
-    /**
-     * The custom CSS class name for the column.
-     */
-    className?: string;
-
-    /**
-     * Whether the column is enabled and should be displayed.
-     *
-     * @default true
-     */
-    enabled?: boolean;
-
-    /**
      * Callback function for formatting cells within the given column of the
      * DataGrid.
      *
-     * @return {string}
+     * @return
      * A string to be concatenated in to the common cell's text.
      */
     cellFormatter?: CellFormatterCallback;
+
+    /**
+     * The format of the column header. Use `{id}` to display the column id.
+     */
+    headerFormat?: string;
 
     /**
      * Weather to use HTML to render the cell content. When enabled, other
@@ -219,18 +207,28 @@ export interface IndividualColumnOptions extends ColumnOptions {
     sorting?: boolean;
 }
 
+/**
+ * Column options that can be set for each column individually.
+ */
+export interface IndividualColumnOptions extends ColumnOptions {
+    /**
+     * The custom CSS class name for the column.
+     */
+    className?: string;
+
+    /**
+     * Whether the column is enabled and should be displayed.
+     *
+     * @default true
+     */
+    enabled?: boolean;
+}
+
 export interface CaptionOptions {
     /**
      * The caption of the datagrid grid.
      */
     text?: string;
-}
-
-/**
- * Returns a formatted call's string.
- */
-export interface CellFormatterCallback {
-    (this: DataGridCell): string;
 }
 
 /**

--- a/ts/DataGrid/DataGridTableHead.ts
+++ b/ts/DataGrid/DataGridTableHead.ts
@@ -41,7 +41,8 @@ const { format } = Templating;
  * */
 
 /**
- * Represents a table header row containing the column names.
+ * Represents a table header row containing the cells (headers) with
+ * column names.
  */
 class DataGridTableHead {
 
@@ -104,8 +105,8 @@ class DataGridTableHead {
         let column: DataGridColumn;
         for (let i = 0, iEnd = this.columns.length; i < iEnd; ++i) {
             column = this.columns[i];
-            const innerText = column.userOptions.headFormat ? (
-                format(column.userOptions.headFormat, column)
+            const innerText = column.userOptions.headerFormat ? (
+                format(column.userOptions.headerFormat, column)
             ) : column.id;
 
             const element = makeHTMLElement('th', {}, this.container);
@@ -118,7 +119,7 @@ class DataGridTableHead {
             element.setAttribute('scope', 'col');
             element.setAttribute('data-column-id', this.columns[i].id);
 
-            column.setHeadElement(element);
+            column.setHeaderElement(element);
 
             // Resizing
             if (vp.columnsResizer && (
@@ -148,7 +149,7 @@ class DataGridTableHead {
 
         for (let i = 0, iEnd = this.columns.length; i < iEnd; ++i) {
             const column = this.columns[i];
-            const td = column.headElement;
+            const td = column.headerElement;
             if (!td) {
                 continue;
             }


### PR DESCRIPTION
Fixed stack overflow error in board options exporting with the new DataGrid.

Fixed error on the DataGrid Component destroy.

Updated DataGrid docs articles.

The `head` and `header` naming convention has been changed. `header` is now a cell (`th`) in `head`. For this reason, `headFormat` was changed to `headerFormat`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207865896899659