### PR TITLE
bugfix/21554-exitAnchor-got-shifted-above-highcharts-container

### DIFF
--- a/samples/unit-tests/accessibility/accessibility-exporting/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-exporting/demo.js
@@ -1,5 +1,3 @@
-const { container } = require('webpack');
-
 QUnit.test('Exporting button and menu HTML/ARIA markup', function (assert) {
     var chart = Highcharts.chart('container', {
             series: [{

--- a/samples/unit-tests/accessibility/accessibility-exporting/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-exporting/demo.js
@@ -1,3 +1,5 @@
+const { container } = require('webpack');
+
 QUnit.test('Exporting button and menu HTML/ARIA markup', function (assert) {
     var chart = Highcharts.chart('container', {
             series: [{
@@ -80,3 +82,33 @@ QUnit.test(
             'Title should replace `<` to `&lt;` for exporting, (#17753, #19002)'
         );
     });
+
+QUnit.test(
+    'Entering print menu should not disrupt position of screen reader divs',
+    function (assert) {
+        const chart = Highcharts.chart('container', {
+                chart: {
+                    width: 300
+                },
+                series: [{
+                    data: [
+                        1
+                    ]
+                }]
+            }),
+            containerChildren = chart.container.children,
+            controller = new TestController();
+
+        assert.strictEqual(
+            containerChildren[1].classList[0],
+            'highcharts-root',
+            'Root SVG should be the second child of container'
+        );
+        assert.strictEqual(
+            containerChildren[2].classList[0],
+            'highcharts-a11y-proxy-container-after',
+            '"proxy-container-after should "'
+        );
+    }
+
+);

--- a/samples/unit-tests/accessibility/accessibility-exporting/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-exporting/demo.js
@@ -84,7 +84,7 @@ QUnit.test(
     });
 
 QUnit.test(
-    'Entering print menu should not disrupt position of screen reader divs',
+    'Printing should preserve position of screen-reader divs (#21554)',
     function (assert) {
         const chart = Highcharts.chart('container', {
                 chart: {
@@ -96,19 +96,35 @@ QUnit.test(
                     ]
                 }]
             }),
-            containerChildren = chart.container.children,
-            controller = new TestController();
+            containerChildren = chart.renderTo.children;
 
-        assert.strictEqual(
-            containerChildren[1].classList[0],
-            'highcharts-root',
-            'Root SVG should be the second child of container'
-        );
-        assert.strictEqual(
-            containerChildren[2].classList[0],
-            'highcharts-a11y-proxy-container-after',
-            '"proxy-container-after should "'
-        );
+        // These two functions move "highcharts-container" when
+        // user selects printing
+        chart.beforePrint();
+        chart.afterPrint();
+
+        for (const [elementIndex, candidateId, testMessage]  of [
+            [
+                0,
+                'highcharts-screen-reader-region-before-0',
+                '"screen-reader-before" should be before "highcharts-container"'
+            ],
+            [
+                2,
+                'highcharts-container',
+                '"highcharts-container" should be between screen-reader divs'
+            ],
+            [
+                3,
+                'highcharts-screen-reader-region-after-0',
+                '"screen-reader-after" should be below "highcharts-container"'
+            ]
+        ]) {
+            assert.strictEqual(
+                containerChildren[elementIndex].id,
+                candidateId,
+                testMessage
+            );
+        }
     }
-
 );

--- a/samples/unit-tests/accessibility/accessibility-exporting/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-exporting/demo.js
@@ -94,7 +94,7 @@ QUnit.test(
                     ]
                 }]
             }),
-            containerChildren = chart.renderTo.children;
+            renderToChildren = chart.renderTo.children;
 
         // These two functions move "highcharts-container" when
         // user selects printing
@@ -109,7 +109,7 @@ QUnit.test(
             ],
             [
                 2,
-                'highcharts-container',
+                chart.container.id,
                 '"highcharts-container" should be between screen-reader divs'
             ],
             [
@@ -119,7 +119,7 @@ QUnit.test(
             ]
         ]) {
             assert.strictEqual(
-                containerChildren[elementIndex].id,
+                renderToChildren[elementIndex].id,
                 candidateId,
                 testMessage
             );

--- a/ts/Accessibility/Components/InfoRegionsComponent.ts
+++ b/ts/Accessibility/Components/InfoRegionsComponent.ts
@@ -288,6 +288,13 @@ class InfoRegionsComponent extends AccessibilityComponent {
             }
         });
 
+        // Needed when print logic in exporting does not trigger
+        // rerendering thus repositioning of screen reader DOM elements
+        // (#21554)
+        this.addEvent(chart, 'afterPrint', function (): void {
+            component.updateAllScreenReaderSections();
+        });
+
         this.announcer = new Announcer(chart, 'assertive');
     }
 
@@ -369,10 +376,13 @@ class InfoRegionsComponent extends AccessibilityComponent {
      * to get a11y info from series.
      */
     public onChartRender(): void {
-        const component = this;
-
         this.linkedDescriptionElement = this.getLinkedDescriptionElement();
         this.setLinkedDescriptionAttrs();
+        this.updateAllScreenReaderSections();
+    }
+
+    public updateAllScreenReaderSections(): void {
+        const component = this;
 
         Object.keys(this.screenReaderSections).forEach(function (
             regionKey: string
@@ -380,7 +390,6 @@ class InfoRegionsComponent extends AccessibilityComponent {
             component.updateScreenReaderSection(regionKey);
         });
     }
-
 
     /**
      * @private

--- a/ts/Accessibility/Components/InfoRegionsComponent.ts
+++ b/ts/Accessibility/Components/InfoRegionsComponent.ts
@@ -288,12 +288,14 @@ class InfoRegionsComponent extends AccessibilityComponent {
             }
         });
 
-        // Needed when print logic in exporting does not trigger
-        // rerendering thus repositioning of screen reader DOM elements
-        // (#21554)
-        this.addEvent(chart, 'afterPrint', function (): void {
-            component.updateAllScreenReaderSections();
-        });
+        if (chart.exporting) {
+            // Needed when print logic in exporting does not trigger
+            // rerendering thus repositioning of screen reader DOM elements
+            // (#21554)
+            this.addEvent(chart, 'afterPrint', function (): void {
+                component.updateAllScreenReaderSections();
+            });
+        }
 
         this.announcer = new Announcer(chart, 'assertive');
     }

--- a/ts/Accessibility/Components/MenuComponent.ts
+++ b/ts/Accessibility/Components/MenuComponent.ts
@@ -128,6 +128,20 @@ class MenuComponent extends AccessibilityComponent {
             component.onMenuHidden();
         });
 
+        this.addEvent(chart, 'afterPrint', function (): void {
+            const renderToChildren = chart.renderTo.children;
+            if (
+                chart.accessibility?.keyboardNavigation.exitAnchor &&
+                renderToChildren[renderToChildren.length - 1] !==
+                chart.accessibility?.keyboardNavigation.exitAnchor
+            ) {
+                chart.renderTo.insertBefore(
+                    chart.accessibility?.keyboardNavigation.exitAnchor,
+                    renderToChildren[renderToChildren.length - 1]
+                );
+            }
+        });
+
         this.createProxyGroup();
     }
 

--- a/ts/Accessibility/Components/MenuComponent.ts
+++ b/ts/Accessibility/Components/MenuComponent.ts
@@ -128,17 +128,16 @@ class MenuComponent extends AccessibilityComponent {
             component.onMenuHidden();
         });
 
+        // Needed when print logic in exporting does not trigger an update
+        // (#21554)
         this.addEvent(chart, 'afterPrint', function (): void {
-            const renderToChildren = chart.renderTo.children;
-            if (
-                chart.accessibility?.keyboardNavigation.exitAnchor &&
-                renderToChildren[renderToChildren.length - 1] !==
-                chart.accessibility?.keyboardNavigation.exitAnchor
-            ) {
-                chart.renderTo.insertBefore(
-                    chart.accessibility?.keyboardNavigation.exitAnchor,
-                    renderToChildren[renderToChildren.length - 1]
-                );
+            const infoRegionsComponent = chart
+                .accessibility
+                ?.components
+                .infoRegions;
+
+            if (infoRegionsComponent) {
+                infoRegionsComponent.updateScreenReaderSection('after');
             }
         });
 

--- a/ts/Accessibility/Components/MenuComponent.ts
+++ b/ts/Accessibility/Components/MenuComponent.ts
@@ -128,19 +128,6 @@ class MenuComponent extends AccessibilityComponent {
             component.onMenuHidden();
         });
 
-        // Needed when print logic in exporting does not trigger an update
-        // (#21554)
-        this.addEvent(chart, 'afterPrint', function (): void {
-            const infoRegionsComponent = chart
-                .accessibility
-                ?.components
-                .infoRegions;
-
-            if (infoRegionsComponent) {
-                infoRegionsComponent.updateScreenReaderSection('after');
-            }
-        });
-
         this.createProxyGroup();
     }
 


### PR DESCRIPTION
Fixed #21554, the exitAnchor-div was shifted above highcharts-container, causing tabbing to loop