### PR TITLE
bugfix/17854-incorrect-fillopacity-in-boost

### DIFF
--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -1406,15 +1406,6 @@ class WGLRenderer {
                 scolor[3] = 1.0;
             }
 
-            // This is very much temporary
-            if (
-                s.drawMode === 'LINES' &&
-                settings.useAlpha &&
-                (scolor[3] as any) < 1
-            ) {
-                (scolor[3] as any) /= 10;
-            }
-
             // Blending
             if (options.boostBlending === 'add') {
                 gl.blendFunc(gl.SRC_ALPHA, gl.ONE);


### PR DESCRIPTION
Fixed #17854 , `fillOpacity` was too strong in boosted series