### PR TITLE
21596 gs conn escape url options

### DIFF
--- a/ts/Data/Connectors/GoogleSheetsConnector.ts
+++ b/ts/Data/Connectors/GoogleSheetsConnector.ts
@@ -11,6 +11,7 @@
  *  - Gøran Slettemark
  *  - Wojciech Chmiel
  *  - Sophie Bremer
+ *  - Jomar Hønsi
  *
  * */
 
@@ -168,6 +169,8 @@ class GoogleSheetsConnector extends DataConnector {
                 connector.options
             );
 
+        const urlObj = new URL(url);
+
         connector.emit<GoogleSheetsConnector.Event>({
             type: 'load',
             detail: eventDetail,
@@ -176,7 +179,7 @@ class GoogleSheetsConnector extends DataConnector {
         });
 
 
-        return fetch(url)
+        return fetch(urlObj.href)
             .then((
                 response
             ): Promise<GoogleSheetsConverter.GoogleSpreadsheetJSON> => (
@@ -228,7 +231,6 @@ class GoogleSheetsConnector extends DataConnector {
                 throw error;
             });
     }
-
 }
 
 /* *
@@ -336,7 +338,6 @@ namespace GoogleSheetsConnector {
             )
         );
     }
-
 }
 
 /* *

--- a/ts/Data/Connectors/GoogleSheetsConnector.ts
+++ b/ts/Data/Connectors/GoogleSheetsConnector.ts
@@ -169,8 +169,6 @@ class GoogleSheetsConnector extends DataConnector {
                 connector.options
             );
 
-        const urlObj = new URL(url);
-
         connector.emit<GoogleSheetsConnector.Event>({
             type: 'load',
             detail: eventDetail,
@@ -178,8 +176,11 @@ class GoogleSheetsConnector extends DataConnector {
             url
         });
 
+        if (!URL.canParse(url)) {
+            throw new Error('Invalid URL: ' + url);
+        }
 
-        return fetch(urlObj.href)
+        return fetch(url)
             .then((
                 response
             ): Promise<GoogleSheetsConverter.GoogleSpreadsheetJSON> => (
@@ -247,7 +248,7 @@ namespace GoogleSheetsConnector {
      *
      * */
 
-    export type Event = (ErrorEvent|LoadEvent);
+    export type Event = (ErrorEvent | LoadEvent);
 
     export type ErrorEvent = DataConnector.ErrorEvent;
 
@@ -264,7 +265,7 @@ namespace GoogleSheetsConnector {
      * GoogleSheetsConnector.
      */
     export type UserOptions = (
-        Types.DeepPartial<GoogleSheetsConnectorOptions>&
+        Types.DeepPartial<GoogleSheetsConnectorOptions> &
         GoogleSheetsConverter.UserOptions
     );
 
@@ -289,26 +290,26 @@ namespace GoogleSheetsConnector {
     export function buildFetchURL(
         apiKey: string,
         sheetKey: string,
-        options: Partial<(FetchURLOptions&GoogleSheetsConnectorOptions)> = {}
+        options: Partial<(FetchURLOptions & GoogleSheetsConnectorOptions)> = {}
     ): string {
-        return (
-            `https://sheets.googleapis.com/v4/spreadsheets/${sheetKey}/values/` +
-            (
-                options.onlyColumnNames ?
-                    'A1:Z1' :
-                    buildQueryRange(options)
-            ) +
-            '?alt=json' +
-            (
-                options.onlyColumnNames ?
-                    '' :
-                    '&dateTimeRenderOption=FORMATTED_STRING' +
-                    '&majorDimension=COLUMNS' +
-                    '&valueRenderOption=UNFORMATTED_VALUE'
-            ) +
-            '&prettyPrint=false' +
-            `&key=${apiKey}`
-        );
+        const url = new URL(`https://sheets.googleapis.com/v4/spreadsheets/${sheetKey}/values/`);
+
+        const range = options.onlyColumnNames ?
+            'A1:Z1' : buildQueryRange(options);
+        url.pathname += range;
+
+        const searchParams = url.searchParams;
+        searchParams.set('alt', 'json');
+
+        if (!options.onlyColumnNames) {
+            searchParams.set('dateTimeRenderOption', 'FORMATTED_STRING');
+            searchParams.set('majorDimension', 'COLUMNS');
+            searchParams.set('valueRenderOption', 'UNFORMATTED_VALUE');
+        }
+        searchParams.set('prettyPrint', 'false');
+        searchParams.set('key', apiKey);
+
+        return url.href;
     }
 
     /**


### PR DESCRIPTION
Fixed #21596, used `URL.searchParams` to build URL for fetching Google Sheet.