### PR TITLE
dash/21615-DataGrid-recursion-useHTML

### DIFF
--- a/ts/DataGrid/DataGrid.ts
+++ b/ts/DataGrid/DataGrid.ts
@@ -992,6 +992,7 @@ class DataGrid {
     ): void {
         const formattedNodes = new AST(cellContent);
 
+        parentElement.innerHTML = '';
         formattedNodes.addToDOM(parentElement);
     }
 


### PR DESCRIPTION
Fixed #21615, when the `useHTML` was enabled, content in a cell was not rendered correctly when scrolling.