### PR TITLE
bugfix/21521-overlapping-plotband-and-plotline-labels

### DIFF
--- a/samples/highcharts/xaxis/plotbands-label-allowoverlap/demo.css
+++ b/samples/highcharts/xaxis/plotbands-label-allowoverlap/demo.css
@@ -1,0 +1,3 @@
+#container {
+    height: 400px;
+}

--- a/samples/highcharts/xaxis/plotbands-label-allowoverlap/demo.details
+++ b/samples/highcharts/xaxis/plotbands-label-allowoverlap/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+...

--- a/samples/highcharts/xaxis/plotbands-label-allowoverlap/demo.html
+++ b/samples/highcharts/xaxis/plotbands-label-allowoverlap/demo.html
@@ -1,0 +1,3 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="container"></div>

--- a/samples/highcharts/xaxis/plotbands-label-allowoverlap/demo.js
+++ b/samples/highcharts/xaxis/plotbands-label-allowoverlap/demo.js
@@ -1,0 +1,27 @@
+Highcharts.chart('container', {
+    title: {
+        text: 'Plotband labels overlapping'
+    },
+
+    xAxis: {
+        plotBands: [{
+            color: 'cyan',
+            from: 1,
+            to: 3,
+            label: {
+                text: 'This label is overlapping with another one',
+                allowOverlap: true
+            }
+        }, {
+            color: 'lime',
+            from: 2,
+            to: 4,
+            label: {
+                text: 'This label is overlapping with another one'
+            }
+        }]
+    },
+    series: [{
+        data: [0, 1, 2, 3, 4, 5]
+    }]
+});

--- a/samples/highcharts/xaxis/plotbands-label-textwidth/demo.css
+++ b/samples/highcharts/xaxis/plotbands-label-textwidth/demo.css
@@ -1,0 +1,3 @@
+#container {
+    width: 600px;
+}

--- a/samples/highcharts/xaxis/plotbands-label-textwidth/demo.details
+++ b/samples/highcharts/xaxis/plotbands-label-textwidth/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Markus Knutson Barstad
+ js_wrap: b
+...

--- a/samples/highcharts/xaxis/plotbands-label-textwidth/demo.html
+++ b/samples/highcharts/xaxis/plotbands-label-textwidth/demo.html
@@ -1,0 +1,3 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="container"></div>

--- a/samples/highcharts/xaxis/plotbands-label-textwidth/demo.js
+++ b/samples/highcharts/xaxis/plotbands-label-textwidth/demo.js
@@ -1,0 +1,38 @@
+Highcharts.chart('container', {
+    xAxis: {
+        plotBands: [{
+            from: 1,
+            to: 2,
+
+            // Set 'inside' to 'false' to display the full text
+            label: {
+                text: 'One to two plotband',
+                inside: false
+            }
+        }, {
+            from: 3,
+            to: 4,
+
+            // 'inside' defaults to 'true' and adds ellipsis by default
+            label: {
+                text: 'Three to four plotband'
+            }
+        }, {
+            from: 5,
+            to: 6,
+
+            // 'inside' defaults to 'true'..
+            label: {
+                text: 'Five to six plotband',
+
+                style: {
+                    // Set 'textOverflow' to 'none' to make the text wrap
+                    textOverflow: 'none'
+                }
+            }
+        }]
+    },
+    series: [{
+        data: [0, 1, 2, 3, 4, 5, 6, 7]
+    }]
+});

--- a/samples/highcharts/xaxis/plotbands-label-textwidth/demo.js
+++ b/samples/highcharts/xaxis/plotbands-label-textwidth/demo.js
@@ -9,7 +9,7 @@ Highcharts.chart('container', {
 
             // Set 'inside' to 'false' to display the full text
             label: {
-                text: 'One to two plotband',
+                text: 'This label overflows',
                 inside: false
             }
         }, {
@@ -18,7 +18,7 @@ Highcharts.chart('container', {
 
             // 'inside' defaults to 'true' and adds ellipsis by default
             label: {
-                text: 'Three to four plotband'
+                text: 'Ellipsis by default'
             }
         }, {
             from: 5,
@@ -26,7 +26,7 @@ Highcharts.chart('container', {
 
             // 'inside' defaults to 'true'..
             label: {
-                text: 'Five to six plotband',
+                text: 'This label wraps to multiple lines',
 
                 style: {
                     // Set 'textOverflow' to 'none' to make the text wrap
@@ -39,7 +39,7 @@ Highcharts.chart('container', {
 
             // The boundaries of the text can be configured with 'width'
             label: {
-                text: 'Seven to eight plotband',
+                text: 'Fixed width',
 
                 style: {
                     width: 30

--- a/samples/highcharts/xaxis/plotbands-label-textwidth/demo.js
+++ b/samples/highcharts/xaxis/plotbands-label-textwidth/demo.js
@@ -1,4 +1,7 @@
 Highcharts.chart('container', {
+    title: {
+        text: 'Overflowing text of plotband labels'
+    },
     xAxis: {
         plotBands: [{
             from: 1,
@@ -30,9 +33,21 @@ Highcharts.chart('container', {
                     textOverflow: 'none'
                 }
             }
+        }, {
+            from: 7,
+            to: 8,
+
+            // The boundaries of the text can be configured with 'width'
+            label: {
+                text: 'Seven to eight plotband',
+
+                style: {
+                    width: 30
+                }
+            }
         }]
     },
     series: [{
-        data: [0, 1, 2, 3, 4, 5, 6, 7]
+        data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     }]
 });

--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
@@ -850,3 +850,57 @@ QUnit.test('#14254: plotBands.acrossPanes', function (assert) {
         'plotBand with acrossPanes = true has greater height'
     );
 });
+
+QUnit.test(
+    '#21521: Hiding overlapping plotBand/plotLine labels ',
+    function (assert) {
+        const chart = Highcharts.chart('container', {
+                xAxis: {
+                    plotLines: [{
+                        value: 1,
+                        label: {
+                            text: '0000000000000000'
+                        }
+                    },
+                    {
+                        value: 1,
+                        label: {
+                            text: '================'
+                        }
+                    },
+                    {
+                        value: 1.01,
+                        label: {
+                            text: '%%%%%%%%%%%%%%%%'
+                        }
+                    }]
+                },
+
+                series: [{
+                    data: [1, 2, 3]
+                }]
+            }),
+            xAxis = chart.series[0].xAxis,
+            opacityTester = vals => {
+                const plotLinesAndBands = xAxis.plotLinesAndBands;
+
+                for (let i = 0; i < 3; i++) {
+                    assert.strictEqual(
+                        plotLinesAndBands[i].label.opacity,
+                        vals[i],
+                        `Opacity of label number ${i} should be ${vals[i]}`
+                    );
+                }
+            };
+
+        opacityTester([1, 0, 0]);
+
+        chart.series[0].xAxis.update({
+            labels: {
+                allowOverlap: true
+            }
+        });
+
+        opacityTester([1, 1, 1]);
+    }
+);

--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
@@ -858,20 +858,23 @@ QUnit.test(
     function (assert) {
         const chart = Highcharts.chart('container', {
                 xAxis: {
-                    plotLines: [{
-                        value: 1,
+                    plotBands: [{
+                        from: 0,
+                        to: 1,
                         label: {
                             text: '0000000000000000'
                         }
                     },
                     {
-                        value: 1,
+                        from: 0,
+                        to: 1,
                         label: {
                             text: '================'
                         }
                     },
                     {
-                        value: 1.01,
+                        from: 0,
+                        to: 1,
                         label: {
                             text: '%%%%%%%%%%%%%%%%'
                         }
@@ -898,9 +901,29 @@ QUnit.test(
         opacityTester([1, 0, 0]);
 
         chart.series[0].xAxis.update({
-            labels: {
-                allowOverlap: true
-            }
+            plotBands: [{
+                from: 0,
+                to: 1,
+                label: {
+                    text: '0000000000000000',
+                    allowOverlap: true
+                }
+            },
+            {
+                from: 0,
+                to: 1,
+                label: {
+                    text: '================',
+                    allowOverlap: true
+                }
+            },
+            {
+                from: 0,
+                to: 1,
+                label: {
+                    text: '%%%%%%%%%%%%%%%%'
+                }
+            }]
         });
 
         opacityTester([1, 1, 1]);

--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
@@ -513,7 +513,8 @@ QUnit.test('#6521 - missing labels for narrow bands', function (assert) {
                     to: Date.UTC(2016, 0, 18, 4, 20),
                     label: {
                         rotation: 90,
-                        text: 'Wide Enough'
+                        text: 'Wide Enough',
+                        inside: false
                     }
                 },
                 {
@@ -522,7 +523,8 @@ QUnit.test('#6521 - missing labels for narrow bands', function (assert) {
                     to: Date.UTC(2016, 0, 25, 8),
                     label: {
                         rotation: 90,
-                        text: 'Too Narrow'
+                        text: 'Too Narrow',
+                        inside: false
                     }
                 }
             ]

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -595,7 +595,7 @@ class Axis {
      *
      * @function Highcharts.Axis#createCollector
      *
-     * @return {Highcharts.LabelCollectorFunction}
+     * @return {Function}
      * A function which returns labels.
      */
     public createCollector(): Chart.LabelCollectorFunction {

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3940,15 +3940,25 @@ class Axis {
 
             // Custom plot lines and bands
             if (!axis._addedPlotLB) { // Only first time
+                const labels: (SVGElement | undefined)[] = [];
+
                 axis._addedPlotLB = true;
+
                 (options.plotLines || [])
                     .concat((options.plotBands as any) || [])
                     .forEach(
                         function (plotLineOptions: any): void {
-                            (axis as unknown as PlotLineOrBand.Axis)
-                                .addPlotBandOrLine(plotLineOptions);
+                            labels.push(
+                                (axis as unknown as PlotLineOrBand.Axis)
+                                    .addPlotBandOrLine(plotLineOptions)
+                                    ?.label
+                            );
                         }
                     );
+
+                chart.labelCollectors.push(
+                    (): (SVGElement | undefined)[] => labels
+                );
             }
 
         } // End if hasData

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3940,19 +3940,17 @@ class Axis {
 
             // Custom plot lines and bands
             if (!axis._addedPlotLB) { // Only first time
-                const labels: (SVGElement | undefined)[] = [];
-
                 axis._addedPlotLB = true;
 
-                (options.plotLines || [])
+                const labels = (options.plotLines || [])
                     .concat((options.plotBands as any) || [])
-                    .forEach(
-                        function (plotLineOptions: any): void {
-                            labels.push(
-                                (axis as unknown as PlotLineOrBand.Axis)
-                                    .addPlotBandOrLine(plotLineOptions)
-                                    ?.label
-                            );
+                    .map(
+                        function (
+                            plotLineOptions: any
+                        ): SVGElement | undefined {
+                            return (axis as unknown as PlotLineOrBand.Axis)
+                                .addPlotBandOrLine(plotLineOptions)
+                                ?.label;
                         }
                     );
 

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -493,15 +493,6 @@ class Axis {
         // List of plotLines/Bands
         axis.plotLinesAndBands = [];
 
-        // Creating labelCollector for plotLines/Bands
-        const collectors = chart.labelCollectors;
-
-        // Only add the collector function if it is not present
-        if (!collectors.some((f): boolean => f.name === 'axisLabelCollector')) {
-            const axisLabelCollector = axis.createCollector();
-            collectors.push(axisLabelCollector);
-        }
-
         // Alternate bands
         axis.alternateBands = {};
 
@@ -588,38 +579,6 @@ class Axis {
         registerEventOptions(axis, options);
 
         fireEvent(this, 'afterInit');
-    }
-    /**
-     * Overridable function which creates a function collecting labels.
-     * The returned function is used for detecting overlapping labels.
-     *
-     * @function Highcharts.Axis#createCollector
-     *
-     * @return {Function}
-     * A function which returns labels.
-     */
-    public createCollector(): Chart.LabelCollectorFunction {
-        const axis = this;
-        return (): (SVGElement | undefined)[] => {
-
-            // It is possible that plotLinesAndBands and options
-            // is/becomes undefined.
-            const plotLinesAndBands = (
-                !axis?.options?.labels?.allowOverlap &&
-                axis?.plotLinesAndBands
-            );
-
-            if (plotLinesAndBands) {
-                const labels: (SVGElement | undefined)[] = [];
-
-                for (const { label } of plotLinesAndBands) {
-                    labels.push(label);
-                }
-                return labels;
-            }
-
-            return [];
-        };
     }
 
     /**

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -494,32 +494,12 @@ class Axis {
         axis.plotLinesAndBands = [];
 
         // Creating labelCollector for plotLines/Bands
-        const collectors = chart.labelCollectors,
-            plotBandCollector = (
-                function (): (SVGElement | undefined)[] {
-                    // It is possible that plotLinesAndBands and options
-                    // is/becomes undefined.
-                    const plotLinesAndBands = (
-                        !axis.options?.labels?.allowOverlap &&
-                        axis.plotLinesAndBands
-                    );
-
-                    if (plotLinesAndBands) {
-                        const labels: (SVGElement | undefined)[] = [];
-
-                        for (const { label } of plotLinesAndBands) {
-                            labels.push(label);
-                        }
-                        return labels;
-                    }
-
-                    return [];
-                }
-            );
+        const collectors = chart.labelCollectors;
 
         // Only add the collector function if it is not present
-        if (!collectors.some((f): boolean => f.name === 'plotBandCollector')) {
-            collectors.push(plotBandCollector);
+        if (!collectors.some((f): boolean => f.name === 'axisLabelCollector')) {
+            const axisLabelCollector = axis.createCollector();
+            collectors.push(axisLabelCollector);
         }
 
         // Alternate bands
@@ -608,6 +588,38 @@ class Axis {
         registerEventOptions(axis, options);
 
         fireEvent(this, 'afterInit');
+    }
+    /**
+     * Overridable function which creates a function collecting labels.
+     * The returned function is used for detecting overlapping labels.
+     *
+     * @function Highcharts.Axis#createCollector
+     *
+     * @return {Highcharts.LabelCollectorFunction}
+     * A function which returns labels.
+     */
+    public createCollector(): Chart.LabelCollectorFunction {
+        const axis = this;
+        return (): (SVGElement | undefined)[] => {
+
+            // It is possible that plotLinesAndBands and options
+            // is/becomes undefined.
+            const plotLinesAndBands = (
+                !axis?.options?.labels?.allowOverlap &&
+                axis?.plotLinesAndBands
+            );
+
+            if (plotLinesAndBands) {
+                const labels: (SVGElement | undefined)[] = [];
+
+                for (const { label } of plotLinesAndBands) {
+                    labels.push(label);
+                }
+                return labels;
+            }
+
+            return [];
+        };
     }
 
     /**

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -498,7 +498,7 @@ class Axis {
             plotBandCollector = (
                 function (): (SVGElement | undefined)[] {
                     // It is possible that plotLinesAndBands and options
-                    // is undefined.
+                    // is/becomes undefined.
                     const plotLinesAndBands = (
                         !axis.options?.labels?.allowOverlap &&
                         axis.plotLinesAndBands

--- a/ts/Core/Axis/PlotLineOrBand/PlotBandOptions.d.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotBandOptions.d.ts
@@ -35,6 +35,7 @@ export interface PlotBandLabelOptions {
     className?: string;
     clip?: boolean;
     formatter?: Templating.FormatterCallback<PlotLineOrBand>;
+    inside?: boolean;
     rotation?: number;
     style?: CSSObject;
     text?: string;

--- a/ts/Core/Axis/PlotLineOrBand/PlotBandOptions.d.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotBandOptions.d.ts
@@ -32,6 +32,7 @@ import type PlotLineOrBand from './PlotLineOrBand';
 
 export interface PlotBandLabelOptions {
     align?: AlignValue;
+    allowOverlap?: boolean,
     className?: string;
     clip?: boolean;
     formatter?: Templating.FormatterCallback<PlotLineOrBand>;

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -80,13 +80,17 @@ class PlotLineOrBand {
         addEvent(ChartClass, 'afterInit', function (): void {
             this.labelCollectors.push((): SVGElement[] => {
                 const labels: SVGElement[] = [];
+
                 this.axes.forEach((axis): void => {
-                    axis.plotLinesAndBands.forEach(({ label }): void => {
-                        if (label) {
-                            labels.push(label);
-                        }
-                    });
+                    if (!axis.options.labels.allowOverlap) {
+                        axis.plotLinesAndBands.forEach(({ label }): void => {
+                            if (label) {
+                                labels.push(label);
+                            }
+                        });
+                    }
                 });
+
                 return labels;
             });
         });

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -187,6 +187,15 @@ class PlotLineOrBand {
                     attribs.stroke = (options as PlotBandOptions).borderColor;
                     attribs['stroke-width'] = borderWidth;
                 }
+
+                if (
+                    optionsLabel &&
+                    !defined((optionsLabel as PlotBandLabelOptions).inside) &&
+                    options.label
+                ) {
+                    (optionsLabel as PlotBandLabelOptions).inside =
+                    (options.label as PlotBandLabelOptions).inside = true;
+                }
             }
         }
 
@@ -357,7 +366,11 @@ class PlotLineOrBand {
             width: bBoxWidth,
             height: arrayMax(yBounds) - y
         });
-        if (!label.alignValue || label.alignValue === 'left') {
+        if (
+            !label.alignValue ||
+            label.alignValue === 'left' ||
+            defined(inside)
+        ) {
             label.css({
                 width: (
                     optionsLabel.style?.width || (

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -15,7 +15,7 @@
  *  Imports
  *
  * */
-
+import type Chart from '../../Chart/Chart';
 import type Templating from '../../Templating';
 import type {
     PlotBandLabelOptions,
@@ -34,6 +34,7 @@ import { Palette } from '../../Color/Palettes.js';
 import PlotLineOrBandAxis from './PlotLineOrBandAxis.js';
 import U from '../../Utilities.js';
 const {
+    addEvent,
     arrayMax,
     arrayMin,
     defined,
@@ -72,8 +73,25 @@ class PlotLineOrBand {
      * */
 
     public static compose<T extends typeof Axis>(
+        ChartClass: Chart,
         AxisClass: T
     ): ReturnType<typeof PlotLineOrBandAxis.compose> {
+
+        addEvent(ChartClass, 'afterInit', function (): void {
+            this.labelCollectors.push((): SVGElement[] => {
+                const labels: SVGElement[] = [];
+                this.axes.forEach((axis): void => {
+                    axis.plotLinesAndBands.forEach(({ label }): void => {
+                        if (label) {
+                            labels.push(label);
+                        }
+                    });
+                });
+                return labels;
+            });
+        });
+
+
         return PlotLineOrBandAxis.compose(PlotLineOrBand, AxisClass);
     }
 

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -359,8 +359,8 @@ class PlotLineOrBand {
         if (!label.alignValue || label.alignValue === 'left') {
             const width = (
                 (optionsLabel as PlotBandLabelOptions).style?.width || (
-                    !(
-                        isBand &&
+                    (
+                        !isBand ||
                         (optionsLabel as PlotBandLabelOptions).inside
                     ) ? (
                             label.rotation === 90 ?

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -81,15 +81,13 @@ class PlotLineOrBand {
             this.labelCollectors.push((): SVGElement[] => {
                 const labels: SVGElement[] = [];
 
-                this.axes.forEach((axis): void => {
-                    if (!axis.options.labels.allowOverlap) {
-                        axis.plotLinesAndBands.forEach(({ label }): void => {
-                            if (label) {
-                                labels.push(label);
-                            }
-                        });
+                for (const axis of this.axes) {
+                    for (const { label } of axis.plotLinesAndBands) {
+                        if (label) {
+                            labels.push(label);
+                        }
                     }
-                });
+                }
 
                 return labels;
             });

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -358,7 +358,7 @@ class PlotLineOrBand {
         });
         if (!label.alignValue || label.alignValue === 'left') {
             const width = (
-                (optionsLabel as PlotBandLabelOptions).style?.width || (
+                optionsLabel.style?.width || (
                     (
                         !isBand ||
                         (optionsLabel as PlotBandLabelOptions).inside

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -361,22 +361,25 @@ class PlotLineOrBand {
         if (
             !label.alignValue ||
             label.alignValue === 'left' ||
-            inside
+            defined(inside)
         ) {
             label.css({
                 width: (
                     optionsLabel.style?.width || (
-                        !isBand ? (
-                            label.rotation === 90 ?
-                                axis.height - (
-                                    label.alignAttr.y -
+                        (
+                            !isBand ||
+                            !inside
+                        ) ? (
+                                label.rotation === 90 ?
+                                    axis.height - (
+                                        label.alignAttr.y -
                                         axis.top
-                                ) : (
-                                    optionsLabel.clip ?
-                                        axis.width :
-                                        axis.chart.chartWidth
-                                ) - (label.alignAttr.x - axis.left)
-                        ) :
+                                    ) : (
+                                        optionsLabel.clip ?
+                                            axis.width :
+                                            axis.chart.chartWidth
+                                    ) - (label.alignAttr.x - axis.left)
+                            ) :
                             bBoxWidth
                     )
                 ) + 'px'

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -357,28 +357,26 @@ class PlotLineOrBand {
             width: bBoxWidth,
             height: arrayMax(yBounds) - y
         });
+
         if (
             !label.alignValue ||
             label.alignValue === 'left' ||
-            defined(inside)
+            inside
         ) {
             label.css({
                 width: (
                     optionsLabel.style?.width || (
-                        (
-                            !isBand ||
-                            !inside
-                        ) ? (
-                                label.rotation === 90 ?
-                                    axis.height - (
-                                        label.alignAttr.y -
+                        !isBand ? (
+                            label.rotation === 90 ?
+                                axis.height - (
+                                    label.alignAttr.y -
                                         axis.top
-                                    ) : (
-                                        optionsLabel.clip ?
-                                            axis.width :
-                                            axis.chart.chartWidth
-                                    ) - (label.alignAttr.x - axis.left)
-                            ) :
+                                ) : (
+                                    optionsLabel.clip ?
+                                        axis.width :
+                                        axis.chart.chartWidth
+                                ) - (label.alignAttr.x - axis.left)
+                        ) :
                             bBoxWidth
                     )
                 ) + 'px'

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -303,7 +303,8 @@ class PlotLineOrBand {
     ): void {
         const plotLine = this,
             axis = plotLine.axis,
-            renderer = axis.chart.renderer;
+            renderer = axis.chart.renderer,
+            inside = (optionsLabel as PlotBandLabelOptions).inside;
 
         let label = plotLine.label;
 
@@ -333,7 +334,7 @@ class PlotLineOrBand {
             if (!axis.chart.styledMode) {
                 label.css(merge({
                     fontSize: '0.8em',
-                    textOverflow: 'ellipsis'
+                    textOverflow: (isBand && !inside) ? '' : 'ellipsis'
                 }, optionsLabel.style));
             }
 
@@ -357,26 +358,26 @@ class PlotLineOrBand {
             height: arrayMax(yBounds) - y
         });
         if (!label.alignValue || label.alignValue === 'left') {
-            const width = (
-                optionsLabel.style?.width || (
-                    (
-                        !isBand ||
-                        (optionsLabel as PlotBandLabelOptions).inside
-                    ) ? (
-                            label.rotation === 90 ?
-                                axis.height - (label.alignAttr.y - axis.top) :
-                                (
-                                    optionsLabel.clip ?
-                                        axis.width :
-                                        axis.chart.chartWidth
-                                ) - (label.alignAttr.x - axis.left)
-                        ) :
-                        bBoxWidth
-                )
-            );
-
             label.css({
-                width: width + 'px'
+                width: (
+                    optionsLabel.style?.width || (
+                        (
+                            !isBand ||
+                            !inside
+                        ) ? (
+                                label.rotation === 90 ?
+                                    axis.height - (
+                                        label.alignAttr.y -
+                                        axis.top
+                                    ) : (
+                                        optionsLabel.clip ?
+                                            axis.width :
+                                            axis.chart.chartWidth
+                                    ) - (label.alignAttr.x - axis.left)
+                            ) :
+                            bBoxWidth
+                    )
+                ) + 'px'
             });
         }
 

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -83,11 +83,11 @@ class PlotLineOrBand {
 
                 for (const axis of this.axes) {
 
-                    if (!axis.options.labels.allowOverlap) {
-                        for (const { label } of axis.plotLinesAndBands) {
-                            if (label) {
-                                labels.push(label);
-                            }
+                    for (const { label, options } of axis.plotLinesAndBands) {
+                        if (label && !(
+                            options as PlotBandOptions)?.label?.allowOverlap
+                        ) {
+                            labels.push(label);
                         }
                     }
                 }
@@ -699,6 +699,18 @@ export default PlotLineOrBand;
  * @default   center
  * @since     2.1
  * @apioption xAxis.plotBands.label.align
+ */
+
+/**
+ * Whether or not the label can be hidden if it overlaps with another label.
+ *
+ * @sample {highcharts} highcharts/xaxis/plotbands-label-allowoverlap/
+ *         A Plotband label overlapping another
+ *
+ * @type      {boolean}
+ * @default   undefined
+ * @since     11.4.8
+ * @apioption xAxis.plotBands.label.allowOverlap
  */
 
 /**

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -679,6 +679,19 @@ export default PlotLineOrBand;
  */
 
 /**
+ * Wether or not the text of the label can exceed the width of the label.
+ *
+ * @type      {boolean}
+ * @product   highcharts highstock gantt
+ * @sample {highcharts} highcharts/xaxis/plotbands-label-textwidth/
+ *         Displaying text with text-wrapping/ellipsis, or the full text.
+ *
+ * @default   true
+ * @since     11.4.6
+ * @apioption xAxis.plotBands.label.inside
+ */
+
+/**
  * Rotation of the text label in degrees .
  *
  * @sample {highcharts} highcharts/xaxis/plotbands-label-rotation/

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -82,9 +82,12 @@ class PlotLineOrBand {
                 const labels: SVGElement[] = [];
 
                 for (const axis of this.axes) {
-                    for (const { label } of axis.plotLinesAndBands) {
-                        if (label) {
-                            labels.push(label);
+
+                    if (!axis.options.labels.allowOverlap) {
+                        for (const { label } of axis.plotLinesAndBands) {
+                            if (label) {
+                                labels.push(label);
+                            }
                         }
                     }
                 }

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -275,7 +275,8 @@ class PlotLineOrBand {
                 x: horiz ? !isBand && 4 : 10,
                 verticalAlign: !horiz && isBand ? 'middle' : void 0,
                 y: horiz ? isBand ? 16 : 10 : isBand ? 6 : -4,
-                rotation: horiz && !isBand ? 90 : 0
+                rotation: horiz && !isBand ? 90 : 0,
+                ...(isBand ? { inside: true } : {})
             } as PlotLineLabelOptions, optionsLabel);
 
             this.renderLabel(optionsLabel, path, isBand, zIndex);
@@ -346,24 +347,36 @@ class PlotLineOrBand {
             yBounds = path.yBounds ||
                 [path[0][2], path[1][2], (isBand ? path[2][2] : path[0][2])],
             x = arrayMin(xBounds),
-            y = arrayMin(yBounds);
+            y = arrayMin(yBounds),
+            bBoxWidth = arrayMax(xBounds) - x;
 
         label.align(optionsLabel, false, {
             x,
             y,
-            width: arrayMax(xBounds) - x,
+            width: bBoxWidth,
             height: arrayMax(yBounds) - y
         });
         if (!label.alignValue || label.alignValue === 'left') {
-            const width = optionsLabel.clip ?
-                axis.width : axis.chart.chartWidth;
+            const width = (
+                (optionsLabel as PlotBandLabelOptions).style?.width || (
+                    !(
+                        isBand &&
+                        (optionsLabel as PlotBandLabelOptions).inside
+                    ) ? (
+                            label.rotation === 90 ?
+                                axis.height - (label.alignAttr.y - axis.top) :
+                                (
+                                    optionsLabel.clip ?
+                                        axis.width :
+                                        axis.chart.chartWidth
+                                ) - (label.alignAttr.x - axis.left)
+                        ) :
+                        bBoxWidth
+                )
+            );
 
             label.css({
-                width: (
-                    label.rotation === 90 ?
-                        axis.height - (label.alignAttr.y - axis.top) :
-                        width - (label.alignAttr.x - axis.left)
-                ) + 'px'
+                width: width + 'px'
             });
         }
 

--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -187,15 +187,6 @@ class PlotLineOrBand {
                     attribs.stroke = (options as PlotBandOptions).borderColor;
                     attribs['stroke-width'] = borderWidth;
                 }
-
-                if (
-                    optionsLabel &&
-                    !defined((optionsLabel as PlotBandLabelOptions).inside) &&
-                    options.label
-                ) {
-                    (optionsLabel as PlotBandLabelOptions).inside =
-                    (options.label as PlotBandLabelOptions).inside = true;
-                }
             }
         }
 

--- a/ts/masters/highcharts.src.ts
+++ b/ts/masters/highcharts.src.ts
@@ -104,7 +104,7 @@ Legend.compose(G.Chart);
 LogarithmicAxis.compose(G.Axis);
 OverlappingDataLabels.compose(G.Chart);
 PieDataLabel.compose(G.Series.types.pie);
-PlotLineOrBand.compose(G.Axis);
+PlotLineOrBand.compose(G.Chart, G.Axis);
 Pointer.compose(G.Chart);
 Responsive.compose(G.Chart);
 ScrollablePlotArea.compose(G.Axis, G.Chart, G.Series);


### PR DESCRIPTION
Fixed #21521, plot band labels and plot line labels would overlap if positioned too close. Added `inside` and `allowOverlap` options to the [Axis.plotBands.label](https://api.highcharts.com/highcharts/xAxis.plotBands.label) options.