### PR TITLE
tools/metadata-replacing

### DIFF
--- a/tools/gulptasks/scripts-watch.js
+++ b/tools/gulptasks/scripts-watch.js
@@ -98,5 +98,5 @@ require('./scripts-ts.js');
 
 gulp.task(
     'scripts-watch',
-    gulp.series('scripts-ts', 'scripts-css', 'scripts-js', task)
+    gulp.series('scripts-ts', 'scripts-css', 'scripts-js', 'scripts-code', task)
 );

--- a/tools/gulptasks/scripts-watch.js
+++ b/tools/gulptasks/scripts-watch.js
@@ -53,7 +53,7 @@ async function task() {
 
             if (newJsHash !== jsHash || argv.force || argv.dts) {
                 jsHash = newJsHash;
-                buildTasks.push('scripts-js');
+                buildTasks.push('scripts-js', 'scripts-code');
                 if (argv.dts) {
                     buildTasks.task('jsdoc-dts')();
                 }


### PR DESCRIPTION
Fixed #21277, metadata was not being replaced after building esm-modules