### PR TITLE
bugfix/21605-legend-symbol-font-not-centered

### DIFF
--- a/ts/Core/Legend/LegendSymbol.ts
+++ b/ts/Core/Legend/LegendSymbol.ts
@@ -112,7 +112,7 @@ namespace LegendSymbol {
             renderer = chart.renderer,
             legendItemGroup = legendItem.group,
             verticalCenter = baseline - Math.round(
-                symbolHeight *
+                (legend.fontMetrics?.b || symbolHeight) *
                 // Render line and marker slightly higher to make room for the
                 // area
                 (hasArea ? 0.4 : 0.3)


### PR DESCRIPTION
Fixed #21605, legend text was not vertically aligned with the symbol.