### PR TITLE
feature/21644-ts-add-missing-layout-values

### DIFF
--- a/ts/Core/Axis/Color/ColorAxis.ts
+++ b/ts/Core/Axis/Color/ColorAxis.ts
@@ -928,7 +928,7 @@ namespace ColorAxis {
 
     export interface Options extends ColorAxisLike.Options {
         dataClasses?: Array<DataClassesOptions>;
-        layout?: string;
+        layout?: 'horizontal'|'vertical';
         legend?: LegendOptions;
         marker?: MarkerOptions;
         showInLegend?: boolean;

--- a/ts/Core/Axis/Color/ColorAxisOptions.d.ts
+++ b/ts/Core/Axis/Color/ColorAxisOptions.d.ts
@@ -43,7 +43,7 @@ export interface ColorAxisMarkerOptions {
 export interface ColorAxisOptions extends AxisOptions {
     dataClassColor?: string;
     dataClasses?: Array<ColorAxisDataClassesOptions>;
-    layout?: string;
+    layout?: 'horizontal'|'vertical';
     legend?: LegendOptions;
     marker?: ColorAxisMarkerOptions;
     maxColor?: ColorType;

--- a/ts/Series/Item/ItemSeriesOptions.d.ts
+++ b/ts/Series/Item/ItemSeriesOptions.d.ts
@@ -181,7 +181,7 @@ export interface ItemSeriesOptions extends PieSeriesOptions {
      *
      * @type {string}
      */
-    layout?: string;
+    layout?: 'horizontal'|'vertical';
 
     /**
      * @extends plotOptions.series.marker


### PR DESCRIPTION
Closes #21644, added proper layout option types to `series.item` and `colorAxis` definitions.