### PR TITLE
bugfix/21581-highmaps-credits-href

### DIFF
--- a/samples/highcharts/credits/href/demo.js
+++ b/samples/highcharts/credits/href/demo.js
@@ -2,7 +2,7 @@ Highcharts.chart('container', {
 
     credits: {
         text: 'Example.com',
-        href: 'http://www.example.com'
+        href: 'https://www.example.com'
     },
 
     xAxis: {

--- a/samples/unit-tests/maps/credits-maptext/demo.js
+++ b/samples/unit-tests/maps/credits-maptext/demo.js
@@ -122,6 +122,21 @@ QUnit.test('Credits', function (assert) {
         'precedence'
     );
 
+    const href = 'www.example.com';
+
+    chart.update({
+        credits: {
+            href
+        }
+    });
+
+    assert.strictEqual(
+        chart.options.credits.href,
+        href,
+        `Setting credits.href in MapChart should work and shouldn't be removed,
+        #21581.`
+    );
+
     // Reset
     delete Highcharts.defaultOptions.credits.mapText;
     delete Highcharts.defaultOptions.credits.mapTextFull;

--- a/ts/Maps/GeoJSONComposition.ts
+++ b/ts/Maps/GeoJSONComposition.ts
@@ -547,13 +547,6 @@ namespace GeoJSONComposition {
     ): void {
 
         credits = merge(true, this.options.credits, credits);
-
-        // Disable credits link if map credits enabled. This to allow for
-        // in-text anchors.
-        if (this.mapCredits) {
-            credits.href = void 0;
-        }
-
         proceed.call(this, credits);
 
         // Add full map credits to hover


### PR DESCRIPTION
Fixed #21581, the `credits.href` setting wasn't respected in Map charts.