### PR TITLE
bugfix/21530-numbers-padding-categories

### DIFF
--- a/samples/unit-tests/series-bubble/minmaxsize/demo.js
+++ b/samples/unit-tests/series-bubble/minmaxsize/demo.js
@@ -70,6 +70,35 @@ QUnit.test(
                 );
             });
         });
+
+        chart.update({
+            chart: {
+                width: 200,
+                type: 'bubble'
+            },
+            xAxis: {
+                categories: ['a', 'b']
+            },
+            series: [
+                { data: [1, 2], maxSize: 600 }
+            ]
+        });
+
+        const xAxis = chart.series[0].xAxis,
+            { ticks, tickPositions } = xAxis;
+
+        for (const tickPos of tickPositions) {
+            const correctLabelState = tickPos === 0 ? 'inherit' : 'hidden';
+            assert.strictEqual(
+                ticks[tickPos].label.visibility,
+                correctLabelState,
+                `Label of tick-position ${
+                    tickPos
+                } should be \"${
+                    correctLabelState
+                }\"`
+            );
+        }
     }
 );
 QUnit.test(

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -225,7 +225,7 @@ class Tick {
         // The context value
         let value = this.parameters.category || (
             categories ?
-                pick(categories[pos], names[pos], '') :
+                pick(categories[pos], names[pos], pos) :
                 pos
         );
         if (log && isNumber(value)) {
@@ -821,6 +821,7 @@ class Tick {
             x = xy.x,
             y = xy.y,
             axisStart = axis.pos,
+            categories = axis.categories,
             axisEnd = axisStart + axis.len,
             pxPos = horiz ? x : y;
 
@@ -830,7 +831,14 @@ class Tick {
         if (
             !axis.chart.polar &&
             tick.isNew &&
-            (correctFloat(pxPos) < axisStart || pxPos > axisEnd)
+            (
+                correctFloat(pxPos) < axisStart ||
+                pxPos > axisEnd || (
+                    categories && categories.length ? !(
+                        pos >= 0 && pos < categories.length
+                    ) : false
+                )
+            )
         ) {
             opacity = 0;
         }

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -225,11 +225,7 @@ class Tick {
         // The context value
         let value = this.parameters.category || (
             categories ?
-                pick(
-                    categories[pos],
-                    names[pos],
-                    categories.length ? '' : pos
-                ) :
+                pick(categories[pos], names[pos], pos) :
                 pos
         );
         if (log && isNumber(value)) {

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -225,7 +225,7 @@ class Tick {
         // The context value
         let value = this.parameters.category || (
             categories ?
-                pick(categories[pos], names[pos], pos) :
+                pick(categories[pos], names[pos], '') :
                 pos
         );
         if (log && isNumber(value)) {

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -225,7 +225,11 @@ class Tick {
         // The context value
         let value = this.parameters.category || (
             categories ?
-                pick(categories[pos], names[pos], pos) :
+                pick(
+                    categories[pos],
+                    names[pos],
+                    categories.length ? '' : pos
+                ) :
                 pos
         );
         if (log && isNumber(value)) {
@@ -821,7 +825,6 @@ class Tick {
             x = xy.x,
             y = xy.y,
             axisStart = axis.pos,
-            categories = axis.categories,
             axisEnd = axisStart + axis.len,
             pxPos = horiz ? x : y;
 
@@ -831,14 +834,7 @@ class Tick {
         if (
             !axis.chart.polar &&
             tick.isNew &&
-            (
-                correctFloat(pxPos) < axisStart ||
-                pxPos > axisEnd || (
-                    categories && categories.length ? !(
-                        pos >= 0 && pos < categories.length
-                    ) : false
-                )
-            )
+            (correctFloat(pxPos) < axisStart || pxPos > axisEnd)
         ) {
             opacity = 0;
         }

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -182,6 +182,7 @@ function onAxisAfterRender(this: Axis): void {
     while (tickCount--) {
         const tick = ticks[tickPositions[tickCount]];
         if (
+            tick.pos &&
             tick.pos > (dataMax || 0) ||
             tick.pos < (dataMin || 0)
         ) {

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -187,26 +187,27 @@ function onAxisAfterRender(this: Axis): void {
             tickPositions,
             dataMin = 0,
             dataMax = 0,
-            categories,
-            options,
-            series
+            categories
         } = this,
-        type = options.type;
+        type = this.options.type;
 
-    if (series.find((s): boolean => s.bubblePadding === true)) {
-        if ((categories && categories.length) || type === 'category') {
-            let tickCount = tickPositions.length;
+    if (
+        ((categories && categories.length) || type === 'category') &&
+        this.series.find((s): boolean => s.bubblePadding === true)
+    ) {
 
-            while (tickCount--) {
-                const tick = ticks[tickPositions[tickCount]],
-                    pos = tick.pos || 0;
+        let tickCount = tickPositions.length;
+
+        while (tickCount--) {
+            const tick = ticks[tickPositions[tickCount]],
+                pos = tick.pos || 0;
 
 
-                if (tick.label && (pos > dataMax || pos < dataMin)) {
-                    tick.label.hide();
-                }
+            if (pos > dataMax || pos < dataMin) {
+                tick.label?.hide();
             }
         }
+
     }
 }
 

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -182,11 +182,12 @@ function onAxisAfterRender(this: Axis): void {
             dataMin = 0,
             dataMax = 0,
             categories,
-            options
+            options,
+            series
         } = this,
         type = options.type;
 
-    if (this.series.find((s): boolean => s.bubblePadding === true)) {
+    if (series.find((s): boolean => s.bubblePadding === true)) {
         if ((categories && categories.length) || type === 'category') {
             let tickCount = tickPositions.length;
 
@@ -195,10 +196,8 @@ function onAxisAfterRender(this: Axis): void {
                     pos = tick?.pos || 0;
 
 
-                if (tick?.label) {
-                    tick.label[
-                        (pos > dataMax || pos < dataMin) ? 'hide' : 'show'
-                    ]();
+                if (tick?.label && (pos > dataMax || pos < dataMin)) {
+                    tick.label.hide();
                 }
             }
         }

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -175,6 +175,23 @@ function onAxisFoundExtremes(
 
 }
 
+function onAxisAfterRender(this: Axis): void {
+    const { ticks, tickPositions, dataMin, dataMax } = this;
+    let tickCount = tickPositions.length;
+
+    while (tickCount--) {
+        const tick = ticks[tickPositions[tickCount]];
+        if (
+            tick.pos > (dataMax || 0) ||
+            tick.pos < (dataMin || 0)
+        ) {
+            if (tick.label) {
+                tick.label.hide();
+            }
+        }
+    }
+}
+
 /* *
  *
  *  Class
@@ -469,6 +486,11 @@ class BubbleSeries extends ScatterSeries {
 
         if (pushUnique(composed, 'Series.Bubble')) {
             addEvent(AxisClass, 'foundExtremes', onAxisFoundExtremes);
+            addEvent(
+                AxisClass,
+                'afterRender',
+                onAxisAfterRender
+            );
         }
 
     }

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -190,12 +190,10 @@ function onAxisAfterRender(this: Axis): void {
         let tickCount = tickPositions.length;
 
         while (tickCount--) {
-            const tick = ticks[tickPositions[tickCount]];
-            if (
-                tick.pos &&
-                tick.pos > (dataMax || 0) ||
-                tick.pos < (dataMin || 0)
-            ) {
+            const tick = ticks[tickPositions[tickCount]],
+                pos = tick['pos'] || 0;
+
+            if (pos > (dataMax || 0) || pos < (dataMin || 0)) {
                 if (tick.label) {
                     tick.label.hide();
                 }

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -194,7 +194,7 @@ function onAxisAfterRender(this: Axis): void {
                 pos = tick?.pos || 0;
 
 
-            if (tick.label) {
+            if (tick?.label) {
                 tick.label[
                     (pos > dataMax || pos < dataMin) ? 'hide' : 'show'
                 ]();

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -193,10 +193,11 @@ function onAxisAfterRender(this: Axis): void {
             const tick = ticks[tickPositions[tickCount]],
                 pos = tick?.pos || 0;
 
-            if (pos > dataMax || pos < dataMin) {
-                if (tick.label) {
-                    tick.label.hide();
-                }
+
+            if (tick.label) {
+                tick.label[
+                    (pos > dataMax || pos < dataMin) ? 'hide' : 'show'
+                ]();
             }
         }
     }

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -175,6 +175,11 @@ function onAxisFoundExtremes(
 
 }
 
+/**
+ * If a user has defined categories, it is necessary to retroactively hide any
+ * ticks added by the 'onAxisFoundExtremes' function above. Otherwise these
+ * ticks can show up on the axis, alongside user-defined categories.
+ */
 function onAxisAfterRender(this: Axis): void {
     const {
             ticks,

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -176,18 +176,29 @@ function onAxisFoundExtremes(
 }
 
 function onAxisAfterRender(this: Axis): void {
-    const { ticks, tickPositions, dataMin, dataMax } = this;
-    let tickCount = tickPositions.length;
+    const {
+            ticks,
+            tickPositions,
+            dataMin,
+            dataMax,
+            categories,
+            options
+        } = this,
+        type = options.type;
 
-    while (tickCount--) {
-        const tick = ticks[tickPositions[tickCount]];
-        if (
-            tick.pos &&
-            tick.pos > (dataMax || 0) ||
-            tick.pos < (dataMin || 0)
-        ) {
-            if (tick.label) {
-                tick.label.hide();
+    if ((categories && categories.length) || type === 'category') {
+        let tickCount = tickPositions.length;
+
+        while (tickCount--) {
+            const tick = ticks[tickPositions[tickCount]];
+            if (
+                tick.pos &&
+                tick.pos > (dataMax || 0) ||
+                tick.pos < (dataMin || 0)
+            ) {
+                if (tick.label) {
+                    tick.label.hide();
+                }
             }
         }
     }

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -177,8 +177,9 @@ function onAxisFoundExtremes(
 
 /**
  * If a user has defined categories, it is necessary to retroactively hide any
- * ticks added by the 'onAxisFoundExtremes' function above. Otherwise these
- * ticks can show up on the axis, alongside user-defined categories.
+ * ticks added by the 'onAxisFoundExtremes' function above (#21672).
+ *
+ * Otherwise they can show up on the axis, alongside user-defined categories.
  */
 function onAxisAfterRender(this: Axis): void {
     const {

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -186,18 +186,20 @@ function onAxisAfterRender(this: Axis): void {
         } = this,
         type = options.type;
 
-    if ((categories && categories.length) || type === 'category') {
-        let tickCount = tickPositions.length;
+    if (this.series.find((s): boolean => s.bubblePadding === true)) {
+        if ((categories && categories.length) || type === 'category') {
+            let tickCount = tickPositions.length;
 
-        while (tickCount--) {
-            const tick = ticks[tickPositions[tickCount]],
-                pos = tick?.pos || 0;
+            while (tickCount--) {
+                const tick = ticks[tickPositions[tickCount]],
+                    pos = tick?.pos || 0;
 
 
-            if (tick?.label) {
-                tick.label[
-                    (pos > dataMax || pos < dataMin) ? 'hide' : 'show'
-                ]();
+                if (tick?.label) {
+                    tick.label[
+                        (pos > dataMax || pos < dataMin) ? 'hide' : 'show'
+                    ]();
+                }
             }
         }
     }

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -179,8 +179,8 @@ function onAxisAfterRender(this: Axis): void {
     const {
             ticks,
             tickPositions,
-            dataMin,
-            dataMax,
+            dataMin = 0,
+            dataMax = 0,
             categories,
             options
         } = this,
@@ -191,9 +191,9 @@ function onAxisAfterRender(this: Axis): void {
 
         while (tickCount--) {
             const tick = ticks[tickPositions[tickCount]],
-                pos = tick['pos'] || 0;
+                pos = tick?.pos || 0;
 
-            if (pos > (dataMax || 0) || pos < (dataMin || 0)) {
+            if (pos > dataMax || pos < dataMin) {
                 if (tick.label) {
                     tick.label.hide();
                 }

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -192,8 +192,8 @@ function onAxisAfterRender(this: Axis): void {
         type = this.options.type;
 
     if (
-        ((categories && categories.length) || type === 'category') &&
-        this.series.find((s): boolean => s.bubblePadding === true)
+        (categories?.length || type === 'category') &&
+        this.series.find((s): boolean | undefined => s.bubblePadding)
     ) {
 
         let tickCount = tickPositions.length;

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -193,10 +193,10 @@ function onAxisAfterRender(this: Axis): void {
 
             while (tickCount--) {
                 const tick = ticks[tickPositions[tickCount]],
-                    pos = tick?.pos || 0;
+                    pos = tick.pos || 0;
 
 
-                if (tick?.label && (pos > dataMax || pos < dataMin)) {
+                if (tick.label && (pos > dataMax || pos < dataMin)) {
                     tick.label.hide();
                 }
             }


### PR DESCRIPTION
Fixed #21530, tick values were padded onto user-defined category axes

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207792651837956