### PR TITLE
bugfix/21205-offline-pdf-export-fail

### DIFF
--- a/ts/Extensions/OfflineExporting/OfflineExporting.ts
+++ b/ts/Extensions/OfflineExporting/OfflineExporting.ts
@@ -388,9 +388,12 @@ namespace OfflineExporting {
                     el.getElementsByClassName('highcharts-text-outline');
                 while (outlineElements.length > 0) {
                     const outline = outlineElements[0];
-                    outline.parentNode?.removeChild(outline);
+                    if (outline.parentNode) {
+                        outline.parentNode.removeChild(outline);
+                    }
                 }
             });
+
 
             const svgNode = dummySVGContainer.querySelector('svg');
             if (svgNode) {

--- a/ts/Extensions/OfflineExporting/OfflineExporting.ts
+++ b/ts/Extensions/OfflineExporting/OfflineExporting.ts
@@ -387,7 +387,8 @@ namespace OfflineExporting {
                 outlineElements =
                     el.getElementsByClassName('highcharts-text-outline');
                 while (outlineElements.length > 0) {
-                    el.removeChild(outlineElements[0]);
+                    const outline = outlineElements[0];
+                    outline.parentNode?.removeChild(outline);
                 }
             });
 


### PR DESCRIPTION
Fixed #21205, offline PDF exporting was broken by attempted erroneous child node removal when the chart contained text paths.

NOTE:
If you try to export a PDF from this PR, you will see that it does not display `textpath` elements.

This is a known limitation of the library we use for this, `svg2pdf`: https://github.com/yWorks/svg2pdf.js/issues/82 
(most recent issue regarding this: https://github.com/yWorks/svg2pdf.js/issues/298)

Reason export server does not have this issue is that [it uses puppeteer](https://github.com/highcharts/node-export-server/blob/e7409447ab621ef4df3da5da70e67edb7b9b1707/lib/export.js#L92)