### PR TITLE
dash/docs-googleAPIKey-info

### DIFF
--- a/ts/Data/Connectors/GoogleSheetsConnectorOptions.d.ts
+++ b/ts/Data/Connectors/GoogleSheetsConnectorOptions.d.ts
@@ -53,8 +53,7 @@ export interface GoogleSheetsConnectorOptions extends DataConnectorOptions {
     firstRowAsNames?: boolean;
     /**
      * The API key for a Google Spreadsheet (user's credentials).
-     * See [general information on GS]
-     * (https://developers.google.com/sheets/api/guides/concepts).
+     * See [general information on GS](https://developers.google.com/sheets/api/quickstart/js#create_an_api_key).
      */
     googleAPIKey: string;
     /**


### PR DESCRIPTION
Closes #21236, updated link to googleAPIKey in Dashboards API.