### PR TITLE
Fixed #21734, minor ticks distribution wrong with tickAmount

### DIFF
--- a/samples/unit-tests/axis/minortickinterval/demo.js
+++ b/samples/unit-tests/axis/minortickinterval/demo.js
@@ -216,21 +216,37 @@ QUnit.test('Typed - auto, linear', function (assert) {
     chart = Highcharts.chart('container', {
         chart: {
             width: 600,
-            height: 250
+            height: 400
         },
         yAxis: {
             minorTicks: true
         },
         series: [
             {
-                data: [1, 2, 3, 4]
+                data: [1, 5, 2, 4, 3, 6]
             }
         ]
     });
     assert.strictEqual(
         Object.keys(chart.yAxis[0].minorTicks).length,
-        15,
+        35,
         'Auto'
+    );
+
+    chart.update({
+        yAxis: {
+            tickAmount: 5
+        }
+    });
+    assert.strictEqual(
+        Object.keys(chart.yAxis[0].ticks).length,
+        5,
+        'The major tick amount should match `tickAmount` option'
+    );
+    assert.strictEqual(
+        Object.keys(chart.yAxis[0].minorTicks).length,
+        20,
+        'The minor tick amount should match `tickAmount` option'
     );
 });
 

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1991,14 +1991,6 @@ class Axis {
             this.tickInterval === 1
         ) ? 0.5 : 0; // #3202
 
-
-        // Get minorTickInterval
-        this.minorTickInterval =
-            minorTickIntervalOption === 'auto' &&
-            this.tickInterval ?
-                this.tickInterval / options.minorTicksPerMajor :
-                (minorTickIntervalOption as any);
-
         // When there is only one point, or all points have the same value on
         // this axis, then min and max are equal and tickPositions.length is 0
         // or 1. In this case, add some padding in order to center the point,
@@ -2123,6 +2115,13 @@ class Axis {
 
         }
         this.tickPositions = tickPositions;
+
+
+        // Get minorTickInterval
+        this.minorTickInterval =
+            minorTickIntervalOption === 'auto' && this.tickInterval ?
+                this.tickInterval / options.minorTicksPerMajor :
+                (minorTickIntervalOption as any);
 
 
         // Reset min/max or remove extremes based on start/end on tick


### PR DESCRIPTION
Fixed #21734, minor ticks were wrongly distributed with multiple axes or when `tickAmount` was set.