### PR TITLE
Docs: Wrong description and @see reference in mapbubble.zMax

### DIFF
--- a/ts/Series/MapBubble/MapBubbleSeries.ts
+++ b/ts/Series/MapBubble/MapBubbleSeries.ts
@@ -200,10 +200,10 @@ class MapBubbleSeries extends BubbleSeries {
          */
 
         /**
-         * The minimum for the Z value range. Defaults to the highest Z
-         * value in the data.
+         * The maximum for the Z value range. Defaults to the highest Z value in
+         * the data.
          *
-         * @see [zMax](#plotOptions.mapbubble.zMin)
+         * @see [zMin](#plotOptions.mapbubble.zMin)
          *
          * @sample {highmaps} highcharts/plotoptions/bubble-zmin-zmax/
          *         Z has a possible range of 0-100


### PR DESCRIPTION
 Fixed wrong description and @see reference in `mapbubble.zMax`

Closes #21739