### PR TITLE
dash/dg2-update-copy-argument

### DIFF
--- a/test/typescript-karma/Dashboards/DataGrid/datagrid.test.js
+++ b/test/typescript-karma/Dashboards/DataGrid/datagrid.test.js
@@ -30,7 +30,7 @@ test('DataGrid update methods', async function (assert) {
     }, true);
     dataGrid.viewport?.resizeObserver?.disconnect();
 
-    dataGrid.update({
+    const newOptionsObject = {
         columns: [{
             id: 'weight',
             cellFormat: 'after update'
@@ -40,7 +40,14 @@ test('DataGrid update methods', async function (assert) {
         }, {
             id: 'imaginary-column',
         }]
-    }, false);
+    }
+
+    dataGrid.update(newOptionsObject, false);
+
+    assert.ok(
+        newOptionsObject.columns,
+        'The update method should not mutate the options object passed as an argument.'
+    );
 
     assert.deepEqual(
         dataGrid.options.columns,

--- a/ts/DataGrid/DataGrid.ts
+++ b/ts/DataGrid/DataGrid.ts
@@ -295,6 +295,7 @@ class DataGrid {
         newOptions: Partial<Options>,
         oneToOne = false
     ): void {
+        // Operate on a copy of the options argument
         newOptions = merge(newOptions);
 
         if (newOptions.columns) {

--- a/ts/DataGrid/DataGrid.ts
+++ b/ts/DataGrid/DataGrid.ts
@@ -295,6 +295,8 @@ class DataGrid {
         newOptions: Partial<Options>,
         oneToOne = false
     ): void {
+        newOptions = merge(newOptions);
+
         if (newOptions.columns) {
             if (oneToOne) {
                 this.loadColumnOptionsOneToOne(newOptions.columns);


### PR DESCRIPTION
Prevented from modifying the options object provided as an argument to the DataGrid `update` method.