### PR TITLE
bugfix/20470-nested-props-exporting-data

### DIFF
--- a/samples/unit-tests/export-data/basics/demo.js
+++ b/samples/unit-tests/export-data/basics/demo.js
@@ -1593,3 +1593,22 @@ QUnit.test('Exporting duplicated points (#17639)', function (assert) {
         should be same as actual, #17639.`
     );
 });
+
+
+QUnit.test('Dot notation in exporting data (#20470)', function (assert) {
+    const chart = Highcharts.chart('container', {
+            series: [{
+                data: [
+                    [5, 10]
+                ],
+                keys: ['y', 'custom.test']
+            }]
+        }),
+        csv = '"Category","Series 1 (y)","Series 1 (custom.test)"\n0,5,10';
+
+    assert.strictEqual(
+        chart.getCSV(),
+        csv,
+        'Key notation values should be visible in exported data, #20470.'
+    );
+});

--- a/ts/Extensions/ExportData/ExportData.ts
+++ b/ts/Extensions/ExportData/ExportData.ts
@@ -603,7 +603,7 @@ function chartGetDataRows(
                 while (j < valueCount) {
                     prop = pointArrayMap[j]; // `y`, `z` etc
                     val = series.pointClass.prototype.getNestedProperty.apply(
-                        mockPoint as any,
+                        mockPoint,
                         [prop]
                     ) as number; // Allow values from nested properties (#20470)
                     rows[key][i + j] = pick(

--- a/ts/Extensions/ExportData/ExportData.ts
+++ b/ts/Extensions/ExportData/ExportData.ts
@@ -602,7 +602,10 @@ function chartGetDataRows(
 
                 while (j < valueCount) {
                     prop = pointArrayMap[j]; // `y`, `z` etc
-                    val = (mockPoint as any)[prop];
+                    val = series.pointClass.prototype.getNestedProperty.apply(
+                        mockPoint as any,
+                        [prop]
+                    ) as number; // Allow values from nested properties (#20470)
                     rows[key][i + j] = pick(
                         // Y axis category if present
                         categoryAndDatetimeMap.categoryMap[prop][val],


### PR DESCRIPTION
Fixed #20470, allow values from nested properties in exported data.