### PR TITLE
dash/dg2-padding-on-td

### DIFF
--- a/docs/datagrid/style-by-css.md
+++ b/docs/datagrid/style-by-css.md
@@ -28,7 +28,7 @@ The CSS is not included in the library by default, but you can import it like be
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 ```
 
-## Row/Cell height
+## Row height
 The height of each row is dynamic and based on the tallest cell. This allows for dynamic row height changes when adjusting column width. However, this can impact performance. You can disable this feature by setting the [settings.rows.strictHeights](https://api.highcharts.com/dashboards/#interfaces/DataGrid_DataGridOptions.ColumnsSettings#strictHeights) option to `true`.
 
 ```js
@@ -39,13 +39,15 @@ settings: {
 }
 ```
 
-The default row height for the DataGrid with strict row heights turned on is then determined by the height value set for `.highcharts-datagrid-table tbody tr`, which is `36px` by default. If you need to change it, use CSS to override it:
+The default row height for the DataGrid with strict row heights enabled is determined by the `height` parameter set for `.highcharts-datagrid-table tbody tr`, which is `36px` by default. If you need to change it, you can override it using CSS:
 
 ```css
 .highcharts-datagrid-table tbody tr {
     height: 50px;
 }
 ```
+
+The text in the cell will not wrap then, and anything that exceeds the width will be truncated and replaced with an ellipsis. If you use content that causes the cell height to exceed the declared row height, the row will not automatically expand. This will only happen if the `row.strictHeights` option is disabled.
 
 
 ## General classes

--- a/docs/datagrid/style-by-css.md
+++ b/docs/datagrid/style-by-css.md
@@ -29,7 +29,7 @@ The CSS is not included in the library by default, but you can import it like be
 ```
 
 ## Row height
-The height of each row is dynamic and based on the tallest cell. This allows for dynamic row height changes when adjusting column width. However, this can impact performance. You can disable this feature by setting the [settings.rows.strictHeights](https://api.highcharts.com/dashboards/#interfaces/DataGrid_DataGridOptions.ColumnsSettings#strictHeights) option to `true`.
+The height of each row is dynamic and based on the highest cell. It allows adjust row height when changing the column width. However, this can impact performance. You can disable this feature by setting the [settings.rows.strictHeights](https://api.highcharts.com/dashboards/#interfaces/DataGrid_DataGridOptions.ColumnsSettings#strictHeights) option to `true`.
 
 ```js
 settings: {

--- a/docs/datagrid/style-by-css.md
+++ b/docs/datagrid/style-by-css.md
@@ -29,8 +29,7 @@ The CSS is not included in the library by default, but you can import it like be
 ```
 
 ## Row/Cell height
-For performance reasons the height of every row, and hence cell, is static and long texts are truncated with an ellipsis.
-However, you can disable this by setting the [settings.rows.strictHeights](https://api.highcharts.com/dashboards/#interfaces/DataGrid_DataGridOptions.ColumnsSettings#strictHeights) option to `true`
+The height of each row is dynamic and based on the tallest cell. This allows for dynamic row height changes when adjusting column width. However, this can impact performance. You can disable this feature by setting the [settings.rows.strictHeights](https://api.highcharts.com/dashboards/#interfaces/DataGrid_DataGridOptions.ColumnsSettings#strictHeights) option to `true`.
 
 ```js
 settings: {
@@ -39,6 +38,15 @@ settings: {
     }
 }
 ```
+
+The default row height for the DataGrid with strict row heights turned on is then determined by the height value set for `.highcharts-datagrid-table tbody tr`, which is `36px` by default. If you need to change it, use CSS to override it:
+
+```css
+.highcharts-datagrid-table tbody tr {
+    height: 50px;
+}
+```
+
 
 ## General classes
 Each of the class name contains a prefix `highcharts-datagrid` and a suffix that


### PR DESCRIPTION
Fixed & expanded the `Row/cell height` docs article.

As of now, the documentation explains why this happens. It's a result of the specifics of `strictHeights` and for that reason, I'm not in favor of fixing it further - we can just turn off the `strictHeights` and use no-wrap in CSS if we still want to have an ellipsis or increase the row height.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208026151504865