### PR TITLE
Fixed #21793, templating with sub expressions inside nested if

### DIFF
--- a/samples/unit-tests/utilities/format/demo.js
+++ b/samples/unit-tests/utilities/format/demo.js
@@ -242,6 +242,24 @@ QUnit.module('Format', () => {
             'Nested conditions'
         );
 
+        const f = `
+        {#if (lt value 3)}
+            Green
+        {else}
+            {#if (lt value 7)}
+                Yellow
+            {else}
+                Red
+            {/if}
+        {/if}
+        `;
+
+        assert.deepEqual(
+            [2, 5, 8].map(value => format(f, { value }).trim()),
+            ['Green', 'Yellow', 'Red'],
+            'Nested conditions with sub expression'
+        );
+
     });
 
     QUnit.test('each helper', assert => {
@@ -329,6 +347,7 @@ QUnit.module('Format', () => {
     });
 
     QUnit.test('Relational helpers', assert => {
+
         assert.strictEqual(
             format(
                 '{#if (lt one 2)}true{/if}',

--- a/ts/Core/Templating.ts
+++ b/ts/Core/Templating.ts
@@ -210,7 +210,8 @@ function format(str = '', ctx: any, chart?: Chart): string {
     while ((match = regex.exec(str)) !== null) {
         // When a sub expression is found, it is evaluated first, and the
         // results recursively evaluated until no subexpression exists.
-        const subMatch = subRegex.exec(match[1]);
+        const mainMatch = match,
+            subMatch = subRegex.exec(match[1]);
         if (subMatch) {
             match = subMatch;
             hasSub = true;
@@ -228,7 +229,9 @@ function format(str = '', ctx: any, chart?: Chart): string {
         }
 
         // Identify helpers
-        const fn = match[1].split(' ')[0].replace('#', '');
+        const fn = (
+            currentMatch.isBlock ? mainMatch : match
+        )[1].split(' ')[0].replace('#', '');
         if (helpers[fn]) {
 
             // Block helper, only 0 level is handled


### PR DESCRIPTION
Fixed #21793, templating did not correctly parse sub expressions inside nested ifs.

Switch-like structure with the fix applied: https://jsfiddle.net/highcharts/dvxkafr0/