### PR TITLE
bugfix/21804 respecting crisp false to allow decimal values

### DIFF
--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -497,7 +497,11 @@ class ColumnSeries extends Series {
         // tightly, so we allow individual columns to have individual sizes.
         // When pointPadding is greater, we strive for equal-width columns
         // (#2694).
-        if (options.pointPadding) {
+        if (
+            options.pointPadding &&
+            !defined(this.options.pointWidth) &&
+            !this.options.crisp
+        ) {
             seriesBarW = Math.ceil(seriesBarW);
         }
 
@@ -562,9 +566,8 @@ class ColumnSeries extends Series {
             // Handle point.options.pointWidth
             // @todo Handle grouping/stacking too. Calculate offset properly
             if (defined(point.options.pointWidth)) {
-                pointWidth = barW =
-                    Math.ceil(point.options.pointWidth as any);
-                barX -= Math.round((pointWidth - seriesPointWidth) / 2);
+                pointWidth = barW = point.options.pointWidth;
+                barX -= (pointWidth - seriesPointWidth) / 2;
             }
 
             // Adjust for null or missing points


### PR DESCRIPTION
This fixes #21804
- Skpping rounding off of series pointWidth value if crisp is false and if pointWidth is passed explicitly
- The point.shapeArgs are calculated correctly to render fractional pixels.