### PR TITLE
bugfix/21804 respecting crisp false to allow decimal values

### DIFF
--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -488,7 +488,9 @@ class ColumnSeries extends Series {
             dataMin = series.dataMin,
             dataMax = series.dataMax,
             translatedThreshold = series.translatedThreshold =
-                yAxis.getThreshold(threshold as any);
+                yAxis.getThreshold(threshold as any),
+            isCrisp = series.options.crisp !== false;
+
         // Postprocessed for border width
         let seriesBarW = series.barW =
                 Math.max(seriesPointWidth, 1 + 2 * borderWidth);
@@ -497,7 +499,7 @@ class ColumnSeries extends Series {
         // tightly, so we allow individual columns to have individual sizes.
         // When pointPadding is greater, we strive for equal-width columns
         // (#2694).
-        if (options.pointPadding) {
+        if (options.pointPadding && isCrisp) {
             seriesBarW = Math.ceil(seriesBarW);
         }
 

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -488,8 +488,7 @@ class ColumnSeries extends Series {
             dataMin = series.dataMin,
             dataMax = series.dataMax,
             translatedThreshold = series.translatedThreshold =
-                yAxis.getThreshold(threshold as any),
-            isCrisp = series.options.crisp !== false;
+                yAxis.getThreshold(threshold as any);
 
         // Postprocessed for border width
         let seriesBarW = series.barW =
@@ -499,7 +498,7 @@ class ColumnSeries extends Series {
         // tightly, so we allow individual columns to have individual sizes.
         // When pointPadding is greater, we strive for equal-width columns
         // (#2694).
-        if (options.pointPadding && isCrisp) {
+        if (options.pointPadding && options.crisp) {
             seriesBarW = Math.ceil(seriesBarW);
         }
 

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -489,7 +489,6 @@ class ColumnSeries extends Series {
             dataMax = series.dataMax,
             translatedThreshold = series.translatedThreshold =
                 yAxis.getThreshold(threshold as any);
-
         // Postprocessed for border width
         let seriesBarW = series.barW =
                 Math.max(seriesPointWidth, 1 + 2 * borderWidth);


### PR DESCRIPTION
Fixed #21804, columns were crisped to full pixel width even when the `crisp` option was explicitly false.
___

This fixes #21804
- Skipping rounding off of series pointWidth value if crisp is false explicitly
- The point.shapeArgs are calculated correctly to render fractional pixels