### PR TITLE
tools/npm-audit-fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -329,51 +329,51 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.616.0.tgz",
-      "integrity": "sha512-3yli0rchw7FuI8CmxUKW5z6TzrAJzBm9x+Se20Gqm0idXc2X2RT4Z8axtni5umBu8+4QWgNDZAr/WG6bR/JUGA==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.650.0.tgz",
+      "integrity": "sha512-ng9Ta7emTgIAnUW52wi2KcNbAudGQPiXuPKJwtw67WQei3gHMpxvgCCRXP7AiB+LyB/fBURxraDkO5N+sPZp0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.616.0",
-        "@aws-sdk/client-sts": "3.616.0",
-        "@aws-sdk/core": "3.616.0",
-        "@aws-sdk/credential-provider-node": "3.616.0",
-        "@aws-sdk/middleware-host-header": "3.616.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.616.0",
-        "@aws-sdk/middleware-user-agent": "3.616.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.7",
-        "@smithy/fetch-http-handler": "^3.2.2",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.4",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.10",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/client-sso-oidc": "3.650.0",
+        "@aws-sdk/client-sts": "3.650.0",
+        "@aws-sdk/core": "3.649.0",
+        "@aws-sdk/credential-provider-node": "3.650.0",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.10",
-        "@smithy/util-defaults-mode-node": "^3.0.10",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -382,69 +382,69 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.617.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.617.0.tgz",
-      "integrity": "sha512-0f954CU42BhPFVRQCCBc1jAvV9N4XW9I3D4h7tJ8tzxft7fS62MSJkgxRIXNKgWKLeGR7DUbz+XGZ1R5e7pyjA==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.650.0.tgz",
+      "integrity": "sha512-6ZfkDu2FMOtYPV1ah5vWMqFKNKEqlBQ3/NOVvLGscU1dR0ybbOwwm4ywWofZmz72uOts5NGqe12kzohb/AsGAA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.616.0",
-        "@aws-sdk/client-sts": "3.616.0",
-        "@aws-sdk/core": "3.616.0",
-        "@aws-sdk/credential-provider-node": "3.616.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.616.0",
-        "@aws-sdk/middleware-expect-continue": "3.616.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.616.0",
-        "@aws-sdk/middleware-host-header": "3.616.0",
-        "@aws-sdk/middleware-location-constraint": "3.609.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.616.0",
-        "@aws-sdk/middleware-sdk-s3": "3.617.0",
-        "@aws-sdk/middleware-signing": "3.616.0",
-        "@aws-sdk/middleware-ssec": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.616.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/signature-v4-multi-region": "3.617.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@aws-sdk/xml-builder": "3.609.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.7",
-        "@smithy/eventstream-serde-browser": "^3.0.4",
-        "@smithy/eventstream-serde-config-resolver": "^3.0.3",
-        "@smithy/eventstream-serde-node": "^3.0.4",
-        "@smithy/fetch-http-handler": "^3.2.2",
-        "@smithy/hash-blob-browser": "^3.1.2",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/hash-stream-node": "^3.1.2",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/md5-js": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.4",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.10",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/client-sso-oidc": "3.650.0",
+        "@aws-sdk/client-sts": "3.650.0",
+        "@aws-sdk/core": "3.649.0",
+        "@aws-sdk/credential-provider-node": "3.650.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.649.0",
+        "@aws-sdk/middleware-expect-continue": "3.649.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.649.0",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-location-constraint": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-sdk-s3": "3.649.0",
+        "@aws-sdk/middleware-ssec": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/signature-v4-multi-region": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@aws-sdk/xml-builder": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/eventstream-serde-browser": "^3.0.7",
+        "@smithy/eventstream-serde-config-resolver": "^3.0.4",
+        "@smithy/eventstream-serde-node": "^3.0.6",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-blob-browser": "^3.1.3",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/hash-stream-node": "^3.1.3",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/md5-js": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.10",
-        "@smithy/util-defaults-mode-node": "^3.0.10",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-stream": "^3.1.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
+        "@smithy/util-stream": "^3.1.4",
         "@smithy/util-utf8": "^3.0.0",
-        "@smithy/util-waiter": "^3.1.2",
+        "@smithy/util-waiter": "^3.1.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -452,48 +452,48 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.616.0.tgz",
-      "integrity": "sha512-hwW0u1f8U4dSloAe61/eupUiGd5Q13B72BuzGxvRk0cIpYX/2m0KBG8DDl7jW1b2QQ+CflTLpG2XUf2+vRJxGA==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.650.0.tgz",
+      "integrity": "sha512-YKm14gCMChD/jlCisFlsVqB8HJujR41bl4Fup2crHwNJxhD/9LTnzwMiVVlBqlXr41Sfa6fSxczX2AMP8NM14A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.616.0",
-        "@aws-sdk/middleware-host-header": "3.616.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.616.0",
-        "@aws-sdk/middleware-user-agent": "3.616.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.7",
-        "@smithy/fetch-http-handler": "^3.2.2",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.4",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.10",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/core": "3.649.0",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.10",
-        "@smithy/util-defaults-mode-node": "^3.0.10",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -502,49 +502,49 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.616.0.tgz",
-      "integrity": "sha512-YY1hpYS/G1uRGjQf88dL8VLHkP/IjGxKeXdhy+JnzMdCkAWl3V9j0fEALw40NZe0x79gr6R2KUOUH/IKYQfUmg==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.650.0.tgz",
+      "integrity": "sha512-6J7IS0f8ovhvbIAZaynOYP+jPX8344UlTjwHxjaXHgFvI8axu3+NslKtEEV5oHLhgzDvrKbinsu5lgE2n4Sqng==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.616.0",
-        "@aws-sdk/credential-provider-node": "3.616.0",
-        "@aws-sdk/middleware-host-header": "3.616.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.616.0",
-        "@aws-sdk/middleware-user-agent": "3.616.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.7",
-        "@smithy/fetch-http-handler": "^3.2.2",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.4",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.10",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/core": "3.649.0",
+        "@aws-sdk/credential-provider-node": "3.650.0",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.10",
-        "@smithy/util-defaults-mode-node": "^3.0.10",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -552,54 +552,54 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.616.0"
+        "@aws-sdk/client-sts": "^3.650.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.616.0.tgz",
-      "integrity": "sha512-FP7i7hS5FpReqnysQP1ukQF1OUWy8lkomaOnbu15H415YUrfCp947SIx6+BItjmx+esKxPkEjh/fbCVzw2D6hQ==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.650.0.tgz",
+      "integrity": "sha512-ISK0ZQYA7O5/WYgslpWy956lUBudGC9d7eL0FFbiL0j50N80Gx3RUv22ezvZgxJWE0W3DqNr4CE19sPYn4Lw8g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.616.0",
-        "@aws-sdk/core": "3.616.0",
-        "@aws-sdk/credential-provider-node": "3.616.0",
-        "@aws-sdk/middleware-host-header": "3.616.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.616.0",
-        "@aws-sdk/middleware-user-agent": "3.616.0",
-        "@aws-sdk/region-config-resolver": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.614.0",
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/core": "^2.2.7",
-        "@smithy/fetch-http-handler": "^3.2.2",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.4",
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.10",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/node-http-handler": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@aws-sdk/client-sso-oidc": "3.650.0",
+        "@aws-sdk/core": "3.649.0",
+        "@aws-sdk/credential-provider-node": "3.650.0",
+        "@aws-sdk/middleware-host-header": "3.649.0",
+        "@aws-sdk/middleware-logger": "3.649.0",
+        "@aws-sdk/middleware-recursion-detection": "3.649.0",
+        "@aws-sdk/middleware-user-agent": "3.649.0",
+        "@aws-sdk/region-config-resolver": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@aws-sdk/util-user-agent-browser": "3.649.0",
+        "@aws-sdk/util-user-agent-node": "3.649.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/core": "^2.4.1",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/hash-node": "^3.0.4",
+        "@smithy/invalid-dependency": "^3.0.4",
+        "@smithy/middleware-content-length": "^3.0.6",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.10",
-        "@smithy/util-defaults-mode-node": "^3.0.10",
-        "@smithy/util-endpoints": "^2.0.5",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
+        "@smithy/util-defaults-mode-browser": "^3.0.16",
+        "@smithy/util-defaults-mode-node": "^3.0.16",
+        "@smithy/util-endpoints": "^2.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -608,18 +608,21 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.616.0.tgz",
-      "integrity": "sha512-O/urkh2kECs/IqZIVZxyeyHZ7OR2ZWhLNK7btsVQBQvJKrEspLrk/Fp20Qfg5JDerQfBN83ZbyRXLJOOucdZpw==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.649.0.tgz",
+      "integrity": "sha512-dheG/X2y25RHE7K+TlS32kcy7TgDg1OpWV44BQRoE0OBPAWmFR1D1qjjTZ7WWrdqRPKzcnDj1qED8ncyncOX8g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^2.2.7",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/signature-v4": "^4.0.0",
-        "@smithy/smithy-client": "^3.1.8",
-        "@smithy/types": "^3.3.0",
-        "fast-xml-parser": "4.2.5",
+        "@smithy/core": "^2.4.1",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/signature-v4": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -627,16 +630,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.616.0.tgz",
-      "integrity": "sha512-bcsf36gdGY2SpvTmoxd7t2235q+Rjg6xnTeCiKs9YuzbNezZ4FosqSORs7/vu2CvyaXWwV28909Q1boZ76v4TA==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.650.0.tgz",
+      "integrity": "sha512-QwtRKWKE6vv78Be3Lm5GmFkSl2DGWSOXPZYgkbo8GsD6SP0ParUvJvUE8wsPS5c4tUXC9KuvJAwYAYNFN10Fnw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.616.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/client-cognito-identity": "3.650.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -644,15 +647,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
-      "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.649.0.tgz",
+      "integrity": "sha512-tViwzM1dauksA3fdRjsg0T8mcHklDa8EfveyiQKK6pUJopkqV6FQx+X5QNda0t/LrdEVlFZvwHNdXqOEfc83TA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -660,20 +663,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.616.0.tgz",
-      "integrity": "sha512-1rgCkr7XvEMBl7qWCo5BKu3yAxJs71dRaZ55Xnjte/0ZHH6Oc93ZrHzyYy6UH6t0nZrH+FAuw7Yko2YtDDwDeg==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.649.0.tgz",
+      "integrity": "sha512-ODAJ+AJJq6ozbns6ejGbicpsQ0dyMOpnGlg0J9J0jITQ05DKQZ581hdB8APDOZ9N8FstShP6dLZflSj8jb5fNA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/fetch-http-handler": "^3.2.2",
-        "@smithy/node-http-handler": "^3.1.3",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.8",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.1.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-stream": "^3.1.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -681,49 +684,49 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.616.0.tgz",
-      "integrity": "sha512-5gQdMr9cca3xV7FF2SxpxWGH2t6+t4o+XBGiwsHm8muEjf4nUmw7Ij863x25Tjt2viPYV0UStczSb5Sihp7bkA==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.650.0.tgz",
+      "integrity": "sha512-x2M9buZxIsKuUbuDgkGHhAKYBpn0/rYdKlwuFuOhXyyAcnhvPj0lgNF2KE4ld/GF1mKr7FF/uV3G9lM6PFaYmA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.616.0",
-        "@aws-sdk/credential-provider-process": "3.614.0",
-        "@aws-sdk/credential-provider-sso": "3.616.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/credential-provider-env": "3.649.0",
+        "@aws-sdk/credential-provider-http": "3.649.0",
+        "@aws-sdk/credential-provider-process": "3.649.0",
+        "@aws-sdk/credential-provider-sso": "3.650.0",
+        "@aws-sdk/credential-provider-web-identity": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/credential-provider-imds": "^3.2.1",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.616.0"
+        "@aws-sdk/client-sts": "^3.650.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.616.0.tgz",
-      "integrity": "sha512-Se+u6DAxjDPjKE3vX1X2uxjkWgGq69BTo0uTB0vDUiWwBVgh16s9BsBhSAlKEH1CCbbJHvOg4YdTrzjwzqyClg==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.650.0.tgz",
+      "integrity": "sha512-uBra5YjzS/gWSekAogfqJfY6c+oKQkkou7Cjc4d/cpMNvQtF1IBdekJ7NaE1RfsDEz3uH1+Myd07YWZAJo/2Qw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.616.0",
-        "@aws-sdk/credential-provider-ini": "3.616.0",
-        "@aws-sdk/credential-provider-process": "3.614.0",
-        "@aws-sdk/credential-provider-sso": "3.616.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/credential-provider-env": "3.649.0",
+        "@aws-sdk/credential-provider-http": "3.649.0",
+        "@aws-sdk/credential-provider-ini": "3.650.0",
+        "@aws-sdk/credential-provider-process": "3.649.0",
+        "@aws-sdk/credential-provider-sso": "3.650.0",
+        "@aws-sdk/credential-provider-web-identity": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/credential-provider-imds": "^3.2.1",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -731,16 +734,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.614.0.tgz",
-      "integrity": "sha512-Q0SI0sTRwi8iNODLs5+bbv8vgz8Qy2QdxbCHnPk/6Cx6LMf7i3dqmWquFbspqFRd8QiqxStrblwxrUYZi09tkA==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.649.0.tgz",
+      "integrity": "sha512-6VYPQpEVpU+6DDS/gLoI40ppuNM5RPIEprK30qZZxnhTr5wyrGOeJ7J7wbbwPOZ5dKwta290BiJDU2ipV8Y9BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -748,18 +751,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.616.0.tgz",
-      "integrity": "sha512-3rsWs9GBi8Z8Gps5ROwqguxtw+J6OIg1vawZMLRNMqqZoBvbOToe9wEnpid8ylU+27+oG8uibJNlNuRyXApUjw==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.650.0.tgz",
+      "integrity": "sha512-069nkhcwximbvyGiAC6Fr2G+yrG/p1S3NQ5BZ2cMzB1hgUKo6TvgFK7nriYI4ljMQ+UWxqPwIdTqiUmn2iJmhg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.616.0",
-        "@aws-sdk/token-providers": "3.614.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/client-sso": "3.650.0",
+        "@aws-sdk/token-providers": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -767,46 +770,46 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
-      "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.649.0.tgz",
+      "integrity": "sha512-XVk3WsDa0g3kQFPmnCH/LaCtGY/0R2NDv7gscYZSXiBZcG/fixasglTprgWSp8zcA0t7tEIGu9suyjz8ZwhymQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
+        "@aws-sdk/client-sts": "^3.649.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.617.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.617.0.tgz",
-      "integrity": "sha512-ZXzdnHI7Tfsk7Y2hezlhxFHlG2VM5tTWQPZ0qZ/cYCzZxyZfsmSFr/rMi6wJGB2J6ZDbbAohEoOWrEblHVq7Cw==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.650.0.tgz",
+      "integrity": "sha512-e99xHtzfL3fwS5j2gzMXRikoux/vNO3JKlxYSTnz/yfcReYRtRIz4iNrbqOzYFIQFlPS11ToXXXcwl6FOzNM7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.616.0",
-        "@aws-sdk/client-sso": "3.616.0",
-        "@aws-sdk/client-sts": "3.616.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.616.0",
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.616.0",
-        "@aws-sdk/credential-provider-ini": "3.616.0",
-        "@aws-sdk/credential-provider-node": "3.616.0",
-        "@aws-sdk/credential-provider-process": "3.614.0",
-        "@aws-sdk/credential-provider-sso": "3.616.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/client-cognito-identity": "3.650.0",
+        "@aws-sdk/client-sso": "3.650.0",
+        "@aws-sdk/client-sts": "3.650.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.650.0",
+        "@aws-sdk/credential-provider-env": "3.649.0",
+        "@aws-sdk/credential-provider-http": "3.649.0",
+        "@aws-sdk/credential-provider-ini": "3.650.0",
+        "@aws-sdk/credential-provider-node": "3.650.0",
+        "@aws-sdk/credential-provider-process": "3.649.0",
+        "@aws-sdk/credential-provider-sso": "3.650.0",
+        "@aws-sdk/credential-provider-web-identity": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/credential-provider-imds": "^3.2.1",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -814,17 +817,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.616.0.tgz",
-      "integrity": "sha512-KZv78s8UE7+s3qZCfG3pE9U9XV5WTP478aNWis5gDXmsb5LF7QWzEeR8kve5dnjNlK6qVQ33v+mUZa6lR5PwMw==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.649.0.tgz",
+      "integrity": "sha512-ZdDICtUU4YZkrVllTUOH1Fj/F3WShLhkfNKJE3HJ/yj6pS8JS9P2lWzHiHkHiidjrHSxc6NuBo6vuZ+182XLbw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/types": "3.649.0",
         "@aws-sdk/util-arn-parser": "3.568.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
         "@smithy/util-config-provider": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -833,15 +836,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.616.0.tgz",
-      "integrity": "sha512-IM1pfJPm7pDUXa55js9bnGjS8o3ldzDwf95mL9ZAYdEsm10q6i0ZxZbbro2gTq25Ap5ykdeeS34lOSzIqPiW1A==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.649.0.tgz",
+      "integrity": "sha512-pW2id/mWNd+L0/hZKp5yL3J+8rTwsamu9E69Hc5pM3qTF4K4DTZZ+A0sQbY6duIvZvc8IbQHbSMulBOLyWNP3A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -849,18 +852,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.616.0.tgz",
-      "integrity": "sha512-Mrco/dURoTXVqwcnYRcyrFaPTIg36ifg2PK0kUYfSVTGEOClZOQXlVG5zYCZoo3yEMgy/gLT907FjUQxwoifIw==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.649.0.tgz",
+      "integrity": "sha512-8mzMBEA+Tk6rbrS8iqnXX119C6z+Id84cuzvUc6dAiYcbnOVbus8M4XKKsAFzGGXHCRc2gMwYhKdnoVz2ijaFA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
-        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/types": "3.649.0",
         "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -869,15 +872,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.616.0.tgz",
-      "integrity": "sha512-mhNfHuGhCDZwYCABebaOvTgOM44UCZZRq2cBpgPZLVKP0ydAv5aFHXv01goexxXHqgHoEGx0uXWxlw0s2EpFDg==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.649.0.tgz",
+      "integrity": "sha512-PjAe2FocbicHVgNNwdSZ05upxIO7AgTPFtQLpnIAmoyzMcgv/zNB5fBn3uAnQSAeEPPCD+4SYVEUD1hw1ZBvEg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -885,14 +888,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.609.0.tgz",
-      "integrity": "sha512-xzsdoTkszGVqGVPjUmgoP7TORiByLueMHieI1fhQL888WPdqctwAx3ES6d/bA9Q/i8jnc6hs+Fjhy8UvBTkE9A==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.649.0.tgz",
+      "integrity": "sha512-O9AXhaFUQx34UTnp/cKCcaWW/IVk4mntlWfFjsIxvRatamKaY33b5fOiakGG+J1t0QFK0niDBSvOYUR1fdlHzw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -900,14 +903,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
-      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.649.0.tgz",
+      "integrity": "sha512-qdqRx6q7lYC6KL/NT9x3ShTL0TBuxdkCczGzHzY3AnOoYUjnCDH7Vlq867O6MAvb4EnGNECFzIgtkZkQ4FhY5w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -915,15 +918,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.616.0.tgz",
-      "integrity": "sha512-LQKAcrZRrR9EGez4fdCIVjdn0Ot2HMN12ChnoMGEU6oIxnQ2aSC7iASFFCV39IYfeMh7iSCPj7Wopqw8rAouzg==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.649.0.tgz",
+      "integrity": "sha512-IPnO4wlmaLRf6IYmJW2i8gJ2+UPXX0hDRv1it7Qf8DpBW+lGyF2rnoN7NrFX0WIxdGOlJF1RcOr/HjXb2QeXfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -931,21 +934,24 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.617.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.617.0.tgz",
-      "integrity": "sha512-zVOS6sNGcLGhq7i+5POmVqmSPNmrQYDFsynpnWMSLsNaej+xvkdSOnytLrUvag3Du4kAxfO5NNIC0GuNj9lcCg==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.649.0.tgz",
+      "integrity": "sha512-3H8735xTAD7IxNdreT6qv2YRk4CGOGfz8ufZo5pROJYZ4N5rfcdDMvb8szMSLvQHegqS4v1DqO9nrOPgc0I2Qg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
+        "@aws-sdk/core": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
         "@aws-sdk/util-arn-parser": "3.568.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/signature-v4": "^4.0.0",
-        "@smithy/smithy-client": "^3.1.8",
-        "@smithy/types": "^3.3.0",
+        "@smithy/core": "^2.4.1",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/signature-v4": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-stream": "^3.1.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-stream": "^3.1.4",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -953,34 +959,15 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.616.0.tgz",
-      "integrity": "sha512-wwzZFlXyURwo40oz1NmufreQa5DqwnCF8hR8tIP5+oKCyhbkmlmv8xG4Wn51bzY2WEbQhvFebgZSFTEvelCoCg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/signature-v4": "^4.0.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.609.0.tgz",
-      "integrity": "sha512-GZSD1s7+JswWOTamVap79QiDaIV7byJFssBW68GYjyRS5EBjNfwA/8s+6uE6g39R3ojyTbYOmvcANoZEhSULXg==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.649.0.tgz",
+      "integrity": "sha512-r/WBIpX+Kcx+AV5vJ+LbdDOuibk7spBqcFK2LytQjOZKPksZNRAM99khbFe9vr9S1+uDmCLVjAVkIfQ5seJrOw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -988,16 +975,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.616.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.616.0.tgz",
-      "integrity": "sha512-iMcAb4E+Z3vuEcrDsG6T2OBNiqWAquwahP9qepHqfmnmJqHr1mSHtXDYTGBNid31+621sUQmneUQ+fagpGAe4w==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.649.0.tgz",
+      "integrity": "sha512-q6sO10dnCXoxe9thobMJxekhJumzd1j6dxcE1+qJdYKHJr6yYgWbogJqrLCpWd30w0lEvnuAHK8lN2kWLdJxJw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.614.0",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.649.0",
+        "@aws-sdk/util-endpoints": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1005,17 +992,17 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
-      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.649.0.tgz",
+      "integrity": "sha512-xURBvdQXvRvca5Du8IlC5FyCj3pkw8Z75+373J3Wb+vyg8GjD14HfKk1Je1HCCQDyIE9VB/scYDcm9ri0ppePw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/types": "^3.4.0",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1023,17 +1010,17 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.617.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.617.0.tgz",
-      "integrity": "sha512-kGbLs9q0/ziuzA1huf0BBh05ChxDeZ8ZWc/kedb80ocq6izOLaGgeqqUR8oB0ianwjel4AQq/iv1fsOIt3wmAA==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.649.0.tgz",
+      "integrity": "sha512-feJfSHtCarFmTMZSE5k7/A+m4FrdCrmotljc/AmXArWy3wl8XFyxE5tFVW/PiUgbgeoVDN+ZLt3YYtItHfNUWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.617.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/signature-v4": "^4.0.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/middleware-sdk-s3": "3.649.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/signature-v4": "^4.1.1",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1041,33 +1028,33 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
-      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.649.0.tgz",
+      "integrity": "sha512-ZBqr+JuXI9RiN+4DSZykMx5gxpL8Dr3exIfFhxMiwAP3DQojwl0ub8ONjMuAjq9OvmX6n+jHZL6fBnNgnNFC8w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.614.0"
+        "@aws-sdk/client-sso-oidc": "^3.649.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
-      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.649.0.tgz",
+      "integrity": "sha512-PuPw8RysbhJNlaD2d/PzOTf8sbf4Dsn2b7hwyGh7YVG3S75yTpxSAZxrnhKsz9fStgqFmnw/jUfV/G+uQAeTVw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1088,15 +1075,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.614.0.tgz",
-      "integrity": "sha512-wK2cdrXHH4oz4IomV/yrGkftU9A+ITB6nFL+rxxyO78is2ifHJpFdV4aqk4LSkXYPi6CXWNru/Dqc7yiKXgJPw==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.649.0.tgz",
+      "integrity": "sha512-bZI1Wc3R/KibdDVWFxX/N4AoJFG4VJ92Dp4WYmOrVD6VPkb8jPz7ZeiYc7YwPl8NoDjYyPneBV0lEoK/V8OKAA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-endpoints": "^2.0.5",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-endpoints": "^2.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1117,28 +1104,28 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
-      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.649.0.tgz",
+      "integrity": "sha512-IY43r256LhKAvdEVQO/FPdUyVpcZS5EVxh/WHVdNzuN1bNLoUK2rIzuZqVA0EGguvCxoXVmQv9m50GvG7cGktg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/types": "^3.4.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.614.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
-      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.649.0.tgz",
+      "integrity": "sha512-x5DiLpZDG/AJmCIBnE3Xhpwy35QIo3WqNiOpw6ExVs1NydbM/e90zFPSfhME0FM66D/WorigvluBxxwjxDm/GA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@aws-sdk/types": "3.649.0",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1154,13 +1141,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.609.0.tgz",
-      "integrity": "sha512-l9XxNcA4HX98rwCC2/KoiWcmEiRfZe4G+mYwDbCFT87JIMj6GBhLDkAzr/W8KAaA2IDr8Vc6J8fZPgVulxxfMA==",
+      "version": "3.649.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.649.0.tgz",
+      "integrity": "sha512-XVESKkK7m5LdCVzZ3NvAja40BEyCrfPqtaiFAAhJIvW2U1Edyugf2o3XikuQY62crGT6BZagxJFgOiLKvuTiTg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4044,13 +4031,13 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
-      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.2.tgz",
+      "integrity": "sha512-b5g+PNujlfqIib9BjkNB108NyO5aZM/RXjfOCXRCqXQ1oPnIkfvdORrztbGgCZdPe/BN/MKDlrGA7PafKPM2jw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4079,16 +4066,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.5.tgz",
-      "integrity": "sha512-SkW5LxfkSI1bUC74OtfBbdz+grQXYiPYolyu8VfpLIjEoN/sHVBlLeGXMQ1vX4ejkgfv6sxVbQJ32yF2cl1veA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.6.tgz",
+      "integrity": "sha512-j7HuVNoRd8EhcFp0MzcUb4fG40C7BcyshH+fAd3Jhd8bINNFvEQYBrZoS/SK6Pun9WPlfoI8uuU2SMz8DsEGlA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/types": "^3.4.0",
         "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4096,19 +4083,21 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.8.tgz",
-      "integrity": "sha512-1Y0XX0Ucyg0LWTfTVLWpmvSRtFRniykUl3dQ0os1sTd03mKDudR6mVyX+2ak1phwPXx2aEWMAAdW52JNi0mc3A==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.1.tgz",
+      "integrity": "sha512-7cts7/Oni7aCHebHGiBeWoz5z+vmH+Vx2Z/UW3XtXMslcxI3PEwBZxNinepwZjixS3n12fPc247PHWmjU7ndsQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.11",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/smithy-client": "^3.1.9",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-retry": "^3.0.16",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4116,16 +4105,16 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.4.tgz",
-      "integrity": "sha512-NKyH01m97Xa5xf3pB2QOF3lnuE8RIK0hTVNU5zvZAwZU8uspYO4DHQVlK+Y5gwSrujTfHvbfd1D9UFJAc0iYKQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.1.tgz",
+      "integrity": "sha512-4z/oTWpRF2TqQI3aCM89/PWu3kim58XU4kOCTtuTJnoaS4KT95cPWMxbQfTN2vzcOe96SOKO8QouQW/+ESB1fQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4133,27 +4122,27 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.2.tgz",
-      "integrity": "sha512-0mBcu49JWt4MXhrhRAlxASNy0IjDRFU+aWNDRal9OtUJvJNiwDuyKMUONSOjLjSCeGwZaE0wOErdqULer8r7yw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-3.1.3.tgz",
+      "integrity": "sha512-mKBrmhg6Zd3j07G9dkKTGmrU7pdJGTNz8LbZtIOR3QoodS5yDNqEqoXU4Eg38snZcnCAh7NPBsw5ndxtJPLiCg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "@smithy/util-hex-encoding": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.5.tgz",
-      "integrity": "sha512-dEyiUYL/ekDfk+2Ra4GxV+xNnFoCmk1nuIXg+fMChFTrM2uI/1r9AdiTYzPqgb72yIv/NtAj6C3dG//1wwgakQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.7.tgz",
+      "integrity": "sha512-UC4RQqyM8B0g5cX/xmWtsNgSBmZ13HrzCqoe5Ulcz6R462/egbIdfTXnayik7jkjvwOrCPL1N11Q9S+n68jPLA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/eventstream-serde-universal": "^3.0.6",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4161,13 +4150,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.3.tgz",
-      "integrity": "sha512-NVTYjOuYpGfrN/VbRQgn31x73KDLfCXCsFdad8DiIc3IcdxL+dYA9zEQPyOP7Fy2QL8CPy2WE4WCUD+ZsLNfaQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.0.4.tgz",
+      "integrity": "sha512-saIs5rtAMpifqL7u7nc5YeE/6gkenzXpSz5NwEyhIesRWtHK+zEuYn9KY8SArZEbPSHyGxvvgKk1z86VzfUGHw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4175,14 +4164,14 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.4.tgz",
-      "integrity": "sha512-mjlG0OzGAYuUpdUpflfb9zyLrBGgmQmrobNT8b42ZTsGv/J03+t24uhhtVEKG/b2jFtPIHF74Bq+VUtbzEKOKg==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.6.tgz",
+      "integrity": "sha512-gRKGBdZah3EjZZgWcsTpShq4cZ4Q4JTTe1OPob+jrftmbYj6CvpeydZbH0roO5SvBG8SI3aBZIet9TGN3zUxUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/eventstream-serde-universal": "^3.0.6",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4190,14 +4179,14 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.4.tgz",
-      "integrity": "sha512-Od9dv8zh3PgOD7Vj4T3HSuox16n0VG8jJIM2gvKASL6aCtcS8CfHZDWe1Ik3ZXW6xBouU+45Q5wgoliWDZiJ0A==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.6.tgz",
+      "integrity": "sha512-1jvXd4sFG+zKaL6WqrJXpL6E+oAMafuM5GPd4qF0+ccenZTX3DZugoCCjlooQyTh+TZho2FpdVYUf5J/bB/j6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^3.1.2",
-        "@smithy/types": "^3.3.0",
+        "@smithy/eventstream-codec": "^3.1.3",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4205,40 +4194,40 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.2.tgz",
-      "integrity": "sha512-3LaWlBZObyGrOOd7e5MlacnAKEwFBmAeiW/TOj2eR9475Vnq30uS2510+tnKbxrGjROfNdOhQqGo5j3sqLT6bA==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.5.tgz",
+      "integrity": "sha512-DjRtGmK8pKQMIo9+JlAKUt14Z448bg8nAN04yKIvlrrpmpRSG57s5d2Y83npks1r4gPtTRNbAFdQCoj9l3P2KQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/querystring-builder": "^3.0.3",
-        "@smithy/types": "^3.3.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/querystring-builder": "^3.0.4",
+        "@smithy/types": "^3.4.0",
         "@smithy/util-base64": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.2.tgz",
-      "integrity": "sha512-hAbfqN2UbISltakCC2TP0kx4LqXBttEv2MqSPE98gVuDFMf05lU+TpC41QtqGP3Ff5A3GwZMPfKnEy0VmEUpmg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.3.tgz",
+      "integrity": "sha512-im9wAU9mANWW0OP0YGqwX3lw0nXG0ngyIcKQ8V/MUz1r7A6uO2lpPqKmAsH4VPGNLP2JPUhj4aW/m5UKkxX/IA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/chunked-blob-reader": "^3.0.0",
         "@smithy/chunked-blob-reader-native": "^3.0.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
-      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.4.tgz",
+      "integrity": "sha512-6FgTVqEfCr9z/7+Em8BwSkJKA2y3krf1em134x3yr2NHWVCo2KYI8tcA53cjeO47y41jwF84ntsEE0Pe6pNKlg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -4248,13 +4237,13 @@
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.2.tgz",
-      "integrity": "sha512-PBgDMeEdDzi6JxKwbfBtwQG9eT9cVwsf0dZzLXoJF4sHKHs5HEo/3lJWpn6jibfJwT34I1EBXpBnZE8AxAft6g==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-3.1.3.tgz",
+      "integrity": "sha512-Tz/eTlo1ffqYn+19VaMjDDbmEWqYe4DW1PAWaS8HvgRdO6/k9hxNPt8Wv5laXoilxE20YzKugiHvxHyO6J7kGA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -4263,13 +4252,13 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
-      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.4.tgz",
+      "integrity": "sha512-MJBUrojC4SEXi9aJcnNOE3oNAuYNphgCGFXscaCj2TA/59BTcXhzHACP8jnnEU3n4yir/NSLKzxqez0T4x4tjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       }
     },
@@ -4287,26 +4276,26 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.3.tgz",
-      "integrity": "sha512-O/SAkGVwpWmelpj/8yDtsaVe6sINHLB1q8YE/+ZQbDxIw3SRLbTZuRaI10K12sVoENdnHqzPp5i3/H+BcZ3m3Q==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-3.0.4.tgz",
+      "integrity": "sha512-qSlqr/+hybufIJgxQW2gYzGE6ywfOxkjjJVojbbmv4MtxfdDFfzRew+NOIOXcYgazW0f8OYBTIKsmNsjxpvnng==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.4.tgz",
-      "integrity": "sha512-wySGje/KfhsnF8YSh9hP16pZcl3C+X6zRsvSfItQGvCyte92LliilU3SD0nR7kTlxnAJwxY8vE/k4Eoezj847Q==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.6.tgz",
+      "integrity": "sha512-AFyHCfe8rumkJkz+hCOVJmBagNBj05KypyDwDElA4TgMSA4eYDZRjVePFZuyABrJZFDc7uVj3dpFIDCEhf59SA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4314,18 +4303,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.5.tgz",
-      "integrity": "sha512-V4acqqrh5tDxUEGVTOgf2lYMZqPQsoGntCrjrJZEeBzEzDry2d2vcI1QCXhGltXPPY+BMc6eksZMguA9fIY8vA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.1.tgz",
+      "integrity": "sha512-Irv+soW8NKluAtFSEsF8O3iGyLxa5oOevJb/e1yNacV9H7JP/yHyJuKST5YY2ORS1+W34VR8EuUrOF+K29Pl4g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/middleware-serde": "^3.0.4",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
+        "@smithy/url-parser": "^3.0.4",
+        "@smithy/util-middleware": "^3.0.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4333,19 +4322,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.11.tgz",
-      "integrity": "sha512-/TIRWmhwMpv99JCGuMhJPnH7ggk/Lah7s/uNDyr7faF02BxNsyD/fz9Tw7pgCf9tYOKgjimm2Qml1Aq1pbkt6g==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.16.tgz",
+      "integrity": "sha512-08kI36p1yB4CWO3Qi+UQxjzobt8iQJpnruF0K5BkbZmA/N/sJ51A1JJGJ36GgcbFyPfWw2FU48S5ZoqXt0h0jw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/smithy-client": "^3.1.9",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/service-error-classification": "^3.0.4",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-middleware": "^3.0.4",
+        "@smithy/util-retry": "^3.0.4",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -4354,13 +4343,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
-      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.4.tgz",
+      "integrity": "sha512-1lPDB2O6IJ50Ucxgn7XrvZXbbuI48HmPCcMTuSoXT1lDzuTUfIuBjgAjpD8YLVMfnrjdepi/q45556LA51Pubw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4368,13 +4357,13 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
-      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.4.tgz",
+      "integrity": "sha512-sLMRjtMCqtVcrOqaOZ10SUnlFE25BSlmLsi4bRSGFD7dgR54eqBjfqkVkPBQyrKBortfGM0+2DJoUPcGECR+nQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4382,15 +4371,15 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.4.tgz",
-      "integrity": "sha512-YvnElQy8HR4vDcAjoy7Xkx9YT8xZP4cBXcbJSgm/kxmiQu08DwUwj8rkGnyoJTpfl/3xYHH+d8zE+eHqoDCSdQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.5.tgz",
+      "integrity": "sha512-dq/oR3/LxgCgizVk7in7FGTm0w9a3qM4mg3IIXLTCHeW3fV+ipssSvBZ2bvEx1+asfQJTyCnVLeYf7JKfd9v3Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/shared-ini-file-loader": "^3.1.5",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4398,16 +4387,16 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.3.tgz",
-      "integrity": "sha512-UiKZm8KHb/JeOPzHZtRUfyaRDO1KPKPpsd7iplhiwVGOeVdkiVJ5bVe7+NhWREMOKomrDIDdSZyglvMothLg0Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.0.tgz",
+      "integrity": "sha512-5TFqaABbiY7uJMKbqR4OARjwI/l4TRoysDJ75pLpVQyO3EcmeloKYwDGyCtgB9WJniFx3BMkmGCB9+j+QiB+Ww==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/querystring-builder": "^3.0.3",
-        "@smithy/types": "^3.3.0",
+        "@smithy/abort-controller": "^3.1.2",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/querystring-builder": "^3.0.4",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4415,13 +4404,13 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
-      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.4.tgz",
+      "integrity": "sha512-BmhefQbfkSl9DeU0/e6k9N4sT5bya5etv2epvqLUz3eGyfRBhtQq60nDkc1WPp4c+KWrzK721cUc/3y0f2psPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4429,13 +4418,13 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.4.tgz",
-      "integrity": "sha512-fAA2O4EFyNRyYdFLVIv5xMMeRb+3fRKc/Rt2flh5k831vLvUmNFXcydeg7V3UeEhGURJI4c1asmGJBjvmF6j8Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.1.tgz",
+      "integrity": "sha512-Fm5+8LkeIus83Y8jTL1XHsBGP8sPvE1rEVyKf/87kbOPTbzEDMcgOlzcmYXat2h+nC3wwPtRy8hFqtJS71+Wow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4443,13 +4432,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
-      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.4.tgz",
+      "integrity": "sha512-NEoPAsZPdpfVbF98qm8i5k1XMaRKeEnO47CaL5ja6Y1Z2DgJdwIJuJkTJypKm/IKfp8gc0uimIFLwhml8+/pAw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "@smithy/util-uri-escape": "^3.0.0",
         "tslib": "^2.6.2"
       },
@@ -4458,13 +4447,13 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
-      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.4.tgz",
+      "integrity": "sha512-7CHPXffFcakFzhO0OZs/rn6fXlTHrSDdLhIT6/JIk1u2bvwguTL3fMCc1+CfcbXA7TOhjWXu3TcB1EGMqJQwHg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4472,26 +4461,26 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.4.tgz",
+      "integrity": "sha512-KciDHHKFVTb9A1KlJHBt2F26PBaDtoE23uTZy5qRvPzHPqrooXFi6fmx98lJb3Jl38PuUTqIuCUmmY3pacuMBQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0"
+        "@smithy/types": "^3.4.0"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.5.tgz",
+      "integrity": "sha512-6jxsJ4NOmY5Du4FD0enYegNJl4zTSuKLiChIMqIkh+LapxiP7lmz5lYUNLE9/4cvA65mbBmtdzZ8yxmcqM5igg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4499,16 +4488,17 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.0.0.tgz",
-      "integrity": "sha512-ervYjQ+ZvmNG51Ui77IOTPri7nOyo8Kembzt9uwwlmtXJPmFXvslOahbA1blvAVs7G0KlYMiOBog1rAt7RVXxg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.1.tgz",
+      "integrity": "sha512-SH9J9be81TMBNGCmjhrgMWu4YSpQ3uP1L06u/K9SDrE2YibUix1qxedPCxEQu02At0P0SrYDjvz+y91vLG0KRQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/types": "^3.3.0",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
         "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-middleware": "^3.0.4",
         "@smithy/util-uri-escape": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -4518,17 +4508,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.9.tgz",
-      "integrity": "sha512-My2RaInZ4gSwJUPMaiLR/Nk82+c4LlvqpXA+n7lonGYgCZq23Tg+/xFhgmiejJ6XPElYJysTPyV90vKyp17+1g==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.3.0.tgz",
+      "integrity": "sha512-H32nVo8tIX82kB0xI2LBrIcj8jx/3/ITotNLbeG1UL0b3b440YPR/hUvqjFJiaB24pQrMjRbU8CugqH5sV0hkw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/protocol-http": "^4.0.4",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.1.1",
+        "@smithy/middleware-endpoint": "^3.1.1",
+        "@smithy/middleware-stack": "^3.0.4",
+        "@smithy/protocol-http": "^4.1.1",
+        "@smithy/types": "^3.4.0",
+        "@smithy/util-stream": "^3.1.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4536,9 +4526,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.0.tgz",
+      "integrity": "sha512-0shOWSg/pnFXPcsSU8ZbaJ4JBHZJPPzLCJxafJvbMVFo9l1w81CqpgUqjlKGNHVrVB7fhIs+WS82JDTyzaLyLA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4549,14 +4539,14 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
-      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.4.tgz",
+      "integrity": "sha512-XdXfObA8WrloavJYtDuzoDhJAYc5rOt+FirFmKBRKaihu7QtU/METAxJgSo7uMK6hUkx0vFnqxV75urtRaLkLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^3.0.3",
-        "@smithy/types": "^3.3.0",
+        "@smithy/querystring-parser": "^3.0.4",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       }
     },
@@ -4626,15 +4616,15 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.11.tgz",
-      "integrity": "sha512-O3s9DGb3bmRvEKmT8RwvSWK4A9r6svfd+MnJB+UMi9ZcCkAnoRtliulOnGF0qCMkKF9mwk2tkopBBstalPY/vg==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.16.tgz",
+      "integrity": "sha512-Os8ddfNBe7hmc5UMWZxygIHCyAqY0aWR8Wnp/aKbti3f8Df/r0J9ttMZIxeMjsFgtVjEryB0q7SGcwBsHk8WEw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.1.9",
-        "@smithy/types": "^3.3.0",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -4643,18 +4633,18 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.11.tgz",
-      "integrity": "sha512-qd4a9qtyOa/WY14aHHOkMafhh9z8D2QTwlcBoXMTPnEwtcY+xpe1JyFm9vya7VsB8hHsfn3XodEtwqREiu4ygQ==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.16.tgz",
+      "integrity": "sha512-rNhFIYRtrOrrhRlj6RL8jWA6/dcwrbGYAmy8+OAHjjzQ6zdzUBB1P+3IuJAgwWN6Y5GxI+mVXlM/pOjaoIgHow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^3.0.5",
-        "@smithy/credential-provider-imds": "^3.1.4",
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.1.9",
-        "@smithy/types": "^3.3.0",
+        "@smithy/config-resolver": "^3.0.6",
+        "@smithy/credential-provider-imds": "^3.2.1",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/property-provider": "^3.1.4",
+        "@smithy/smithy-client": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4662,14 +4652,14 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
-      "integrity": "sha512-ReQP0BWihIE68OAblC/WQmDD40Gx+QY1Ez8mTdFMXpmjfxSyz2fVQu3A4zXRfQU9sZXtewk3GmhfOHswvX+eNg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.0.tgz",
+      "integrity": "sha512-ilS7/0jcbS2ELdg0fM/4GVvOiuk8/U3bIFXUW25xE1Vh1Ol4DP6vVHQKqM40rCMizCLmJ9UxK+NeJrKlhI3HVA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/node-config-provider": "^3.1.5",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4690,13 +4680,13 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
-      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.4.tgz",
+      "integrity": "sha512-uSXHTBhstb1c4nHdmQEdkNMv9LiRNaJ/lWV2U/GO+5F236YFpdPw+hyWI9Zc0Rp9XKzwD9kVZvhZmEgp0UCVnA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4704,14 +4694,14 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.4.tgz",
+      "integrity": "sha512-JJr6g0tO1qO2tCQyK+n3J18r34ZpvatlFN5ULcLranFIBZPxqoivb77EPyNTVwTGMEvvq2qMnyjm4jMIxjdLFg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
+        "@smithy/service-error-classification": "^3.0.4",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4719,15 +4709,15 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.1.tgz",
-      "integrity": "sha512-EhRnVvl3AhoHAT2rGQ5o+oSDRM/BUSMPLZZdRJZLcNVUsFAjOs4vHaPdNQivTSzRcFxf5DA4gtO46WWU2zimaw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.4.tgz",
+      "integrity": "sha512-txU3EIDLhrBZdGfon6E9V6sZz/irYnKFMblz4TLVjyq8hObNHNS2n9a2t7GIrl7d85zgEPhwLE0gANpZsvpsKg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^3.2.2",
-        "@smithy/node-http-handler": "^3.1.3",
-        "@smithy/types": "^3.3.0",
+        "@smithy/fetch-http-handler": "^3.2.5",
+        "@smithy/node-http-handler": "^3.2.0",
+        "@smithy/types": "^3.4.0",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-hex-encoding": "^3.0.0",
@@ -4766,14 +4756,14 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.2.tgz",
-      "integrity": "sha512-4pP0EV3iTsexDx+8PPGAKCQpd/6hsQBaQhqWzU4hqKPHN5epPsxKbvUTIiYIHTxaKt6/kEaqPBpu/ufvfbrRzw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.3.tgz",
+      "integrity": "sha512-OU0YllH51/CxD8iyr3UHSMwYqTGTyuxFdCMH/0F978t+iDmJseC/ttrWPb22zmYkhkrjqtipzC1xaMuax5QKIA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.1",
-        "@smithy/types": "^3.3.0",
+        "@smithy/abort-controller": "^3.1.2",
+        "@smithy/types": "^3.4.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5073,28 +5063,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/eslint": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
-      "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -6782,9 +6750,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6796,7 +6764,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -6822,22 +6790,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/bowser": {
       "version": "2.11.0",
@@ -9386,9 +9338,9 @@
       "license": "ISC"
     },
     "node_modules/elliptic": {
-      "version": "6.5.6",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.6.tgz",
-      "integrity": "sha512-mpzdtpeCLuS3BmE3pO3Cpp5bbjlOPY2Q0PgoF+Od1XZrHLYI28Xe3ossCmYCQt11FQKEYd9+PF8jymTvtWJSHQ==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10371,38 +10323,38 @@
       }
     },
     "node_modules/express": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -10423,28 +10375,22 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/express/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/express/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -10586,18 +10532,18 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
       "dev": true,
       "funding": [
         {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
-        {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "license": "MIT",
@@ -10688,14 +10634,14 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -10714,6 +10660,16 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/finalhandler/node_modules/ms": {
@@ -15655,11 +15611,14 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -15703,9 +15662,9 @@
       "license": "MIT"
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16873,9 +16832,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
       "dev": true,
       "license": "MIT"
     },
@@ -17563,9 +17522,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.3.tgz",
-      "integrity": "sha512-AWJm14H1vVaO/iNZ4/hO+HyaTehuy9nRqVdkTqlJt0HWvBiBIEXFmb4C0DGeYo3Xes9rrEW+TxHsaigCbN5ICQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -18721,9 +18680,9 @@
       }
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18793,19 +18752,29 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-static/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/set-blocking": {
@@ -21889,13 +21858,12 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.93.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
-      "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
+      "version": "5.94.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
+      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
         "@webassemblyjs/wasm-edit": "^1.12.1",
@@ -21904,7 +21872,7 @@
         "acorn-import-attributes": "^1.9.5",
         "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",


### PR DESCRIPTION
Fixed some dependency issues via npm audit fix.

Reduced dev environment vulnerabilities (when running e.g. `npm audit` or `npm i`) from:
`34 vulnerabilities (1 low, 8 moderate, 25 high)`
to:
`14 vulnerabilities (4 moderate, 10 high)`.

Most (if not all) that is left, doesn't seem to directly affect what is being done - those are some potential issues that will be detected anyway via memory or other crashes as far as I can tell after the initial investigation.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205567700961437