### PR TITLE
 bugfix/21584-navigator-series-remove

### DIFF
--- a/samples/unit-tests/navigator/navigator/demo.js
+++ b/samples/unit-tests/navigator/navigator/demo.js
@@ -386,6 +386,38 @@ QUnit.test('General Navigator tests', function (assert) {
         chart.xAxis[0].options.maxPadding,
         'Navigator should inherit the maxPadding property from the main axis.'
     );
+
+    // #21584
+    const start = +new Date();
+
+    const lineSeries = {
+        type: 'line',
+        showInNavigator: true,
+        data: Array.from({ length: 10 }, (_, i) => [start + 60000 * i, i])
+    };
+    const lineSeries2 = {
+        type: 'line',
+        showInNavigator: true,
+        data: Array.from({ length: 10 }, (_, i) => [start + 60000 * i, 2 * i])
+    };
+
+    const options = {
+        navigator: {
+            enabled: true
+        },
+        series: [lineSeries, lineSeries2]
+    };
+
+    chart = Highcharts.stockChart('container', options);
+
+    // Update the chart
+    options.series = [lineSeries];
+    options.navigator.enabled = false;
+    chart.update(options, true, true, false);
+    assert.ok(
+        true,
+        `Updating the chart with oneToOne should not throw an error in the
+        navigator, #21584.`);
 });
 
 QUnit.test('Reversed xAxis with navigator', function (assert) {

--- a/ts/Stock/Navigator/Navigator.ts
+++ b/ts/Stock/Navigator/Navigator.ts
@@ -1894,8 +1894,8 @@ class Navigator {
                     if (baseSeries) {
                         erase(baseSeries, base); // #21043
                     }
-                    if (this.navigatorSeries) {
-                        erase(navigator.series as any, this.navigatorSeries);
+                    if (this.navigatorSeries && navigator.series) {
+                        erase(navigator.series, this.navigatorSeries);
                         if (defined(this.navigatorSeries.options)) {
                             this.navigatorSeries.remove(false);
                         }


### PR DESCRIPTION
Fixed #21584, navigator series was not removed correctly, causing `chart.update` to fail under some conditions.