### PR TITLE
dash/dg2-formatter-wrong-return-type

### DIFF
--- a/test/typescript-karma/Dashboards/DataGrid/columnOptions.test.js
+++ b/test/typescript-karma/Dashboards/DataGrid/columnOptions.test.js
@@ -1,0 +1,35 @@
+import DataGrid from '/base/code/datagrid/es-modules/masters/datagrid.src.js';
+
+const { test } = QUnit;
+
+test('DataGrid formatter options', async function (assert) {
+    const parentElement = document.getElementById('container');
+    if (!parentElement) {
+        return;
+    }
+
+    const dataGrid = await DataGrid.dataGrid(parentElement, {
+        dataTable: {
+            columns: {
+                product: ['Apples', 'Pears', 'Plums', 'Bananas'],
+                weight: [100, 40, 0.5, 200],
+                price: [1.5, 2.53, 5, 4.5]
+            }
+        },
+        columnDefaults: {
+            header: {
+                formatter: function() {
+                    return 1; // Should not throw an error even if wrong type
+                }
+            },
+            cells: {
+                formatter: function() {
+                    return 2; // Should not throw an error even if wrong type
+                }
+            }
+        }
+    }, true);
+    dataGrid.viewport?.resizeObserver?.disconnect();
+
+    assert.ok(dataGrid, 'Formatter returns the wrong type, but it can be stringified without causing an error.');
+});

--- a/test/typescript-karma/Dashboards/DataGrid/datagrid.test.js
+++ b/test/typescript-karma/Dashboards/DataGrid/datagrid.test.js
@@ -1,7 +1,7 @@
 //@ts-check
 import DataGrid from '/base/code/datagrid/es-modules/masters/datagrid.src.js';
 
-const { test, skip } = QUnit;
+const { test } = QUnit;
 
 //@ts-ignore
 test('DataGrid update methods', async function (assert) {

--- a/ts/DataGrid/Table/Content/TableCell.ts
+++ b/ts/DataGrid/Table/Content/TableCell.ts
@@ -261,7 +261,7 @@ class TableCell extends Cell {
         let cellContent = '';
 
         if (formatter) {
-            cellContent = formatter.call(this);
+            cellContent = formatter.call(this).toString();
         } else {
             cellContent = (
                 format ? this.format(format) : value + ''

--- a/ts/DataGrid/Table/Header/HeaderCell.ts
+++ b/ts/DataGrid/Table/Header/HeaderCell.ts
@@ -74,6 +74,12 @@ class HeaderCell extends Cell {
      */
     private isMain: boolean;
 
+    /**
+     * Content value of the header cell.
+     */
+    public override value: string = '';
+
+
     /* *
     *
     *  Constructor
@@ -120,11 +126,11 @@ class HeaderCell extends Cell {
         const headerCellOptions = options.header || {};
 
         if (headerCellOptions.formatter) {
-            this.value = headerCellOptions.formatter.call(this);
+            this.value = headerCellOptions.formatter.call(this).toString();
         } else if (headerCellOptions.format) {
             this.value = column.format(headerCellOptions.format);
         } else {
-            this.value = column.id;
+            this.value = this.column.id;
         }
 
         // Render content of th element


### PR DESCRIPTION
Fixed `formatter` options to handle incorrect return types without throwing an error.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208270120603048