### PR TITLE
dash/dg2-headerFormat

### DIFF
--- a/docs/datagrid/columns.md
+++ b/docs/datagrid/columns.md
@@ -45,12 +45,12 @@ Columns headers can be grouped into sections, so you can create your own multipl
 header: [{
   columnId: 'id'
 }, {
-  headerFormat: 'Product',
+  format: 'Product',
   columns: [{
-    headerFormat: 'Product name',
+    format: 'Product name',
     columnId: 'product'
   }, {
-    headerFormat: 'Units',
+    format: 'Units',
     columns: [{
       columnId: 'weight'
     }, {
@@ -58,9 +58,9 @@ header: [{
     }]
   }]
 }, {
-  headerFormat: 'Product info',
+  format: 'Product info',
   columns: [{
-    headerFormat: 'Meta',
+    format: 'Meta',
     columns: [{
       columnId: 'url'
     }, {

--- a/docs/datagrid/understanding-datagrid.md
+++ b/docs/datagrid/understanding-datagrid.md
@@ -37,7 +37,7 @@ Header
 
 The [table header](https://api.highcharts.com/dashboards/#interfaces/DataGrid_Options.Options-1#header) is a special row, always on the top, containing the column IDs.
 Cells in the `header` are called `headerCell`. Their contents can be edited using the
-[`header.headerFormat` option](https://api.highcharts.com/dashboards/#interfaces/DataGrid_DataGridOptions.ColumnOptions#headerFormat).
+[`header.format` option](https://api.highcharts.com/dashboards/#interfaces/DataGrid_DataGridOptions.ColumnOptions#format).
 
 The API allows you to group headers into sections.
 You can find more information about in our [Columns article](https://www.highcharts.com/docs/datagrid/columns).

--- a/samples/data-grid/basic/grouped-headers/demo.js
+++ b/samples/data-grid/basic/grouped-headers/demo.js
@@ -12,24 +12,24 @@ DataGrid.dataGrid('container', {
     header: [
         'id',
         {
-            headerFormat: 'Product',
+            format: 'Product',
             columns: [{
-                headerFormat: 'Product name',
+                format: 'Product name',
                 columnId: 'product'
             }, {
-                headerFormat: 'Units',
+                format: 'Units',
                 columns: [{
                     columnId: 'weight'
                 }, {
-                    headerFormat: 'Custom Price',
+                    format: 'Custom Price',
                     columnId: 'price'
                 }]
             }]
         },
         {
-            headerFormat: 'Product info',
+            format: 'Product info',
             columns: [{
-                headerFormat: 'Meta',
+                format: 'Meta',
                 columns: [{
                     columnId: 'url'
                 }, {

--- a/samples/data-grid/cypress/grouped-headers/demo.js
+++ b/samples/data-grid/cypress/grouped-headers/demo.js
@@ -12,20 +12,20 @@ window.dataGrid = DataGrid.dataGrid('container', {
     header: [
         'id',
         {
-            headerFormat: 'Product',
+            format: 'Product',
             columns: [{
-                headerFormat: 'Product name',
+                format: 'Product name',
                 columnId: 'product'
             }, {
-                headerFormat: 'Units',
+                format: 'Units',
                 columns: [{
                     columnId: 'weight'
                 }]
             }]
         }, {
-            headerFormat: 'Product info',
+            format: 'Product info',
             columns: [{
-                headerFormat: 'Meta',
+                format: 'Meta',
                 columns: [{
                     columnId: 'icon'
                 }]

--- a/ts/DataGrid/Options.ts
+++ b/ts/DataGrid/Options.ts
@@ -480,7 +480,7 @@ export interface GroupedHeaderOptions {
     /**
      * The format of the column header. Use `{id}` to display the column id.
      */
-    headerFormat?: string;
+    format?: string;
 
     /**
      * The custom CSS class name for the header.

--- a/ts/DataGrid/Table/Header/HeaderRow.ts
+++ b/ts/DataGrid/Table/Header/HeaderRow.ts
@@ -112,7 +112,7 @@ class HeaderRow extends Row {
                 column : column.columnId;
             const dataColumn = vp.getColumn(columnId || '');
             const headerFormat = (typeof column !== 'string') ?
-                column.headerFormat : void 0;
+                column.format : void 0;
             const className = (typeof column !== 'string') ?
                 column.className : void 0;
 


### PR DESCRIPTION
Replaced `headerFormat` with `format` for the multi level header.