### PR TITLE
bugfix/20482-crosshair-cut-off

### DIFF
--- a/samples/unit-tests/axis/crosshairs/demo.js
+++ b/samples/unit-tests/axis/crosshairs/demo.js
@@ -664,3 +664,49 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test(
+    'Crosshairs label should be correctly justified.',
+    function (assert) {
+        const chart = Highcharts.chart('container', {
+            xAxis: {
+                crosshair: true
+            },
+
+            tooltip: {
+                enabled: false
+            },
+            yAxis: {
+                title: '',
+                opposite: false,
+                crosshair: {
+                    label: {
+                        enabled: true,
+                        format: '{value:.2f}'
+                    }
+                },
+                labels: {
+                    align: 'left',
+                    format: '{value:.2f}',
+                    y: 6,
+                    x: 2
+                }
+            },
+
+            series: [
+                {
+                    data: [1, 2, 34, 23, 43, 3]
+                }
+            ]
+        });
+
+        chart.series[0].points[3].onMouseOver();
+
+        const yAxis = chart.yAxis[0];
+        assert.equal(
+            yAxis.crossLabel.x >= 0,
+            true,
+            'Crosshair label is justified'
+        );
+    }
+);

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -426,12 +426,12 @@ namespace StockChart {
 
         // Check if the label has to be drawn
         if (
-            !axis.crosshair ||
-            !axis.crosshair.label ||
-            !axis.crosshair.label.enabled ||
-            !axis.cross ||
-            !isNumber(axis.min) ||
-            !isNumber(axis.max)
+            !(
+                axis.crosshair?.label?.enabled &&
+                axis.cross &&
+                isNumber(axis.min) &&
+                isNumber(axis.max)
+            )
         ) {
             return;
         }
@@ -446,7 +446,7 @@ namespace StockChart {
             width = axis.width,
             tickInside = axis.options.tickPosition === 'inside',
             snap = axis.crosshair.snap !== false,
-            e = event.e || (axis.cross && axis.cross.e),
+            e = event.e || (axis.cross?.e),
             point = event.point;
 
         let crossLabel = axis.crossLabel, // The svgElement
@@ -601,8 +601,8 @@ namespace StockChart {
 
         // Show the crosslabel
         crossLabel.attr({
-            x: posx + offset,
-            y: posy,
+            x: Math.max(0, posx + offset),
+            y: Math.max(0, posy),
             // First set x and y, then anchorX and anchorY, when box is actually
             // calculated, #5702
             anchorX: horiz ?


### PR DESCRIPTION
Fixed #20482,  crosshair's label was cut off in certain label config.