### PR TITLE
bugfix/21220-multiple-axis-resize

### DIFF
--- a/ts/Extensions/DragPanes/AxisResizer.ts
+++ b/ts/Extensions/DragPanes/AxisResizer.ts
@@ -369,7 +369,7 @@ class AxisResizer {
                         plotHeight
                     ));
 
-                if (!isFirst) {
+                if (!isFirst && axesGroup === nextAxes) {
                     // Try to change height first. yDelta could had changed
                     yDelta = chartY - resizer.lastPos;
 


### PR DESCRIPTION
Fixed #21220, resizing panes with multiple axes was resulting in incorrect axis height.