### PR TITLE
bugfix/21698-tooltip outside-exceeds-viewport

### DIFF
--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1035,7 +1035,7 @@ class Tooltip {
 
         // Register the current series
         const currentSeries = point.series;
-        this.distance = pick(currentSeries.tooltipOptions.distance, 15);
+        this.distance = pick(currentSeries.tooltipOptions.distance, 16);
 
         // Update the inner HTML
         if (text === false) {

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1796,27 +1796,17 @@ class Tooltip {
                 pos.y += top - distance;
             }
 
-            let distanceMultiPlier, containerLeftOffset;
-
-            if (this.outside) {
-                containerLeftOffset = distanceMultiPlier = 1;
-            } else {
-                distanceMultiPlier = 1;
-                containerLeftOffset = 0;
-            }
-
             // Pad it by the border width and distance. Add 2 to make room for
             // the default shadow (#19314).
             pad = (
                 (options.borderWidth || 0) +
-                distanceMultiPlier *
+                2 *
                 distance +
-                2 -
-                containerLeftOffset
+                2
             );
 
             renderer.setSize(
-                width + pad,
+                Math.floor(width + pad) - (this.outside ? distance + 2 : 0),
                 height + pad,
                 false
             );

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1797,6 +1797,8 @@ class Tooltip {
                 pos.y += top - distance;
             }
 
+            // Pad it by the border width and distance. Add 2 to make room for
+            // the default shadow (#19314).
             pad = (options.borderWidth || 0) + 2 * distance + 2;
 
             renderer.setSize(

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1094,7 +1094,7 @@ class Tooltip {
                             x: clamp(
                                 label.x || 0,
                                 0,
-                                (this.getPlayingField().width) -
+                                this.getPlayingField().width -
                                 (label.width || 0)
                             )
                         });
@@ -1781,7 +1781,8 @@ class Tooltip {
                 width,
                 height,
                 point
-            );
+            ),
+            doc = H.doc;
 
         let anchorX = (point.plotX || 0) + chart.plotLeft,
             anchorY = (point.plotY || 0) + chart.plotTop,
@@ -1812,7 +1813,7 @@ class Tooltip {
                     baseWidth,
                     0,
                     // 'Outside' container always has 'left: 1px;'
-                    H.doc.documentElement.clientWidth - 1
+                    doc.documentElement.clientWidth - 1
                 ) :
                     baseWidth,
                 height + pad,

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1035,7 +1035,7 @@ class Tooltip {
 
         // Register the current series
         const currentSeries = point.series;
-        this.distance = pick(currentSeries.tooltipOptions.distance, 16);
+        this.distance = pick(currentSeries.tooltipOptions.distance, 15);
 
         // Update the inner HTML
         if (text === false) {
@@ -1796,9 +1796,24 @@ class Tooltip {
                 pos.y += top - distance;
             }
 
+            let distanceMultiPlier, containerLeftOffset;
+
+            if (this.outside) {
+                containerLeftOffset = distanceMultiPlier = 1;
+            } else {
+                distanceMultiPlier = 1;
+                containerLeftOffset = 0;
+            }
+
             // Pad it by the border width and distance. Add 2 to make room for
             // the default shadow (#19314).
-            pad = (options.borderWidth || 0) + 2 * distance + 2;
+            pad = (
+                (options.borderWidth || 0) +
+                distanceMultiPlier *
+                distance +
+                2 -
+                containerLeftOffset
+            );
 
             renderer.setSize(
                 width + pad,

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -571,7 +571,7 @@ class Tooltip {
                     body.offsetWidth,
                     documentElement.offsetWidth,
                     documentElement.clientWidth
-                ) - 2 * distance :
+                ) - (2 * distance) - 2 :
                 chart.chartWidth,
             height: outside ?
                 Math.max(
@@ -1094,8 +1094,8 @@ class Tooltip {
                             x: clamp(
                                 label.x || 0,
                                 0,
-                                this.getPlayingField().width -
-                                    (label.width || 0)
+                                (this.getPlayingField().width) -
+                                (label.width || 0)
                             )
                         });
                     }
@@ -1805,8 +1805,16 @@ class Tooltip {
                 2
             );
 
+            const baseWidth = width + pad;
+
             renderer.setSize(
-                Math.floor(width + pad) - (this.outside ? distance + 2 : 0),
+                this.outside ? clamp(
+                    baseWidth,
+                    0,
+                    // 'Outside' container always has 'left: 1px;'
+                    H.doc.documentElement.clientWidth - 1
+                ) :
+                    baseWidth,
                 height + pad,
                 false
             );

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1797,25 +1797,16 @@ class Tooltip {
                 pos.y += top - distance;
             }
 
-            // Pad it by the border width and distance. Add 2 to make room for
-            // the default shadow (#19314).
-            pad = (
-                (options.borderWidth || 0) +
-                2 *
-                distance +
-                2
-            );
-
-            const baseWidth = width + pad;
+            pad = (options.borderWidth || 0) + 2 * distance + 2;
 
             renderer.setSize(
-                this.outside ? clamp(
-                    baseWidth,
+                // Clamp width to keep tooltip in viewport (#21698)
+                // and subtract one since tooltip container has 'left: 1px;'
+                clamp(
+                    width + pad,
                     0,
-                    // 'Outside' container always has 'left: 1px;'
-                    doc.documentElement.clientWidth - 1
-                ) :
-                    baseWidth,
+                    doc.documentElement.clientWidth
+                ) - 1,
                 height + pad,
                 false
             );


### PR DESCRIPTION
Fixed #21698, tooltip with outside could exceed past the viewport.

Issue seems to be that when `text` is given to `tooltip label`, the resulting `bBox` is too large.