### PR TITLE
dash/api-wrong-doclet-fix

### DIFF
--- a/ts/Data/Connectors/JSONConnectorOptions.d.ts
+++ b/ts/Data/Connectors/JSONConnectorOptions.d.ts
@@ -73,9 +73,11 @@ export interface JSONConnectorOptions extends DataConnectorOptions {
     /**
      * Whether data is in columns or rows.
      *
-     * @default rows
+     * Try it:
      *
      * {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/data-tools/datapool-json-connector-orientation/ | JSON Connector orientation }
+     *
+     * @default 'rows'
      */
     orientation?: 'columns'|'rows';
 }


### PR DESCRIPTION
Fixed broken doclet for the `JSONConnectorOptions.orientation`.