### PR TITLE
bugfix/21268-standalone-navigator-height

### DIFF
--- a/samples/unit-tests/standalone-navigator/height/demo.details
+++ b/samples/unit-tests/standalone-navigator/height/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/standalone-navigator/height/demo.html
+++ b/samples/unit-tests/standalone-navigator/height/demo.html
@@ -5,4 +5,4 @@
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>
 
-<div id="navigator-container"></div>
+<div id="container"></div>

--- a/samples/unit-tests/standalone-navigator/height/demo.html
+++ b/samples/unit-tests/standalone-navigator/height/demo.html
@@ -1,0 +1,8 @@
+
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/navigator.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="navigator-container"></div>

--- a/samples/unit-tests/standalone-navigator/height/demo.js
+++ b/samples/unit-tests/standalone-navigator/height/demo.js
@@ -1,5 +1,5 @@
 QUnit.test('Standalone navigator height', function (assert) {
-    const navigator = Highcharts.navigator('navigator-container', {
+    const navigator = Highcharts.navigator('container', {
         height: 150,
         series: [{
             data: [1, 2, 3, 4]

--- a/samples/unit-tests/standalone-navigator/height/demo.js
+++ b/samples/unit-tests/standalone-navigator/height/demo.js
@@ -1,0 +1,25 @@
+QUnit.test('Standalone navigator height', function (assert) {
+    const navigator = Highcharts.navigator('navigator-container', {
+        height: 150,
+        series: [{
+            data: [1, 2, 3, 4]
+        }]
+    });
+
+    assert.strictEqual(
+        navigator.navigator.chart.container.offsetHeight,
+        150,
+        'Standalone navigator container should have correct height, #21268.'
+    );
+
+    navigator.update({
+        height: 200
+    });
+
+    assert.strictEqual(
+        navigator.navigator.chart.container.offsetHeight,
+        200,
+        `Standalone navigator container should have correct height after update,
+        #21268.`
+    );
+});

--- a/ts/Stock/Navigator/StandaloneNavigator.ts
+++ b/ts/Stock/Navigator/StandaloneNavigator.ts
@@ -117,6 +117,10 @@ class StandaloneNavigator {
             { navigator: userOptions }
         );
 
+        if (this.chartOptions.chart && userOptions.height) {
+            this.chartOptions.chart.height = userOptions.height;
+        }
+
         const chart = new Chart(element, this.chartOptions);
 
         chart.options = merge(
@@ -305,7 +309,11 @@ class StandaloneNavigator {
         newOptions: StandaloneNavigatorOptions,
         redraw?: boolean
     ): void {
-        this.chartOptions = merge(this.chartOptions, { navigator: newOptions });
+        this.chartOptions = merge(
+            this.chartOptions,
+            newOptions.height && { chart: { height: newOptions.height } },
+            { navigator: newOptions }
+        );
 
         this.navigator.chart.update(this.chartOptions, redraw);
     }


### PR DESCRIPTION
Fixed #21268, standalone navigator container height did not adjust correctly when a custom height was set.