### PR TITLE
Chores: Fixed JSON-sources issue since yesterday

### DIFF
--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -90,21 +90,6 @@ function resolveJSON(js) {
             filename,
             data;
 
-        // Look for aliases
-        const alias = aliases.find(item => item.url === src);
-        if (alias) {
-            filename = alias.filename;
-            data = fs.readFileSync(
-                path.join(
-                    __dirname,
-                    '..',
-                    'samples/data/json-sources',
-                    filename
-                ),
-                'utf8'
-            )
-        }
-
         // Look for sources that can be matched to samples/data
         innerMatch = src.match(
             /^(https:\/\/cdn\.jsdelivr\.net\/gh\/highcharts\/highcharts@[a-z0-9\.]+|https:\/\/www\.highcharts\.com)\/samples\/data\/([a-z0-9\-\.]+$)/
@@ -210,6 +195,24 @@ function handleDetails(path) {
 
 const browserStackBrowsers = require('./karma-bs.json');
 
+// Create JSONSources and write to a temporary file
+const JSONSources = {};
+aliases.forEach(alias => {
+    JSONSources[alias.url] = JSON.parse(fs.readFileSync(
+        path.join(
+            __dirname,
+            '..',
+            'samples/data/json-sources',
+            alias.filename
+        ),
+        'utf8'
+    ));
+});
+fs.writeFileSync(
+    path.join(__dirname, '../tmp/json-sources.js'),
+    `window.JSONSources = ${JSON.stringify(JSONSources)};`
+);
+
 
 module.exports = function (config) {
     const argv = require('yargs').argv;
@@ -294,6 +297,7 @@ module.exports = function (config) {
             'test/call-analyzer.js',
             'test/test-controller.js',
             'test/test-utilities.js',
+            'tmp/json-sources.js',
 
             // Highcharts
             ...files,

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -197,6 +197,9 @@ const browserStackBrowsers = require('./karma-bs.json');
 
 // Create JSONSources and write to a temporary file
 const JSONSources = {};
+if (!fs.existsSync(path.join(__dirname, '../tmp'))) {
+    fs.mkdirSync(path.join(__dirname, '../tmp'));
+}
 aliases.forEach(alias => {
     JSONSources[alias.url] = JSON.parse(fs.readFileSync(
         path.join(

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -30,8 +30,6 @@ document.body.appendChild(demoHTML);
 
 var currentTests = [];
 
-window.JSONSources = {};
-
 Highcharts.useSerialIds(true);
 
 // Disable animation over all.

--- a/test/typescript-karma/karma-conf.js
+++ b/test/typescript-karma/karma-conf.js
@@ -147,6 +147,7 @@ module.exports = function (config) {
             'vendor/require.js',
             'test/test-controller.js',
             'test/test-utilities.js',
+            'tmp/json-sources.js',
             'test/typescript-karma/karma-fetch.js',
             'test/typescript-karma/karma-setup.js',
             {

--- a/test/typescript-karma/karma-fetch.js
+++ b/test/typescript-karma/karma-fetch.js
@@ -8,7 +8,7 @@
  * and used from karma-setup.js.
  */
 window.JSONSources = {
-    ...(window.JSONSources || {}),
+    ...window.JSONSources,
     '/data/sine-data.csv': function () {
         const csv = [[ 'X', 'sin(n)', 'sin(-n)' ]];
 


### PR DESCRIPTION
[Yesterday's fix](https://github.com/highcharts/highcharts/pull/21868) failed to pick up use of `data.googleSpreadsheetKey` and failed on the `maps/demo/data-class-two-ranges` demo.