### PR TITLE
bugfix/20662-rangeselector-dropdown-a11y

### DIFF
--- a/ts/Accessibility/Components/RangeSelectorComponent.ts
+++ b/ts/Accessibility/Components/RangeSelectorComponent.ts
@@ -457,10 +457,7 @@ class RangeSelectorComponent extends AccessibilityComponent {
                         e.preventDefault();
                         e.stopPropagation();
                         if (a11y) {
-                            a11y.keyboardNavigation.tabindexContainer.focus();
-                            a11y.keyboardNavigation.move(
-                                e.shiftKey ? -1 : 1
-                            );
+                            a11y.keyboardNavigation.move(e.shiftKey ? -1 : 1);
                         }
                     }
                 });


### PR DESCRIPTION
Fixed #20662, keyboard focus with `Tab` key was not working when `rangeSelector` dropdown was focused.