### PR TITLE
tools/karma-browser-count-properties

### DIFF
--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -255,7 +255,10 @@ module.exports = function (config) {
         browsers = Object.keys(browserStackBrowsers);
     }
 
-    const browserCount = argv.browsercount || (Math.max(1, os.cpus().length - 2));
+    // Set karma.browsercount to bypass disconnection problem on Windows
+    const browserCount = Number(getProperties()['karma.browsercount']) ||
+        argv.browsercount || (Math.max(1, os.cpus().length - 2));
+
     if (!argv.browsers && browserCount && !isNaN(browserCount) && browserCount > 1) {
         // Sharding / splitting tests across multiple browser instances
         frameworks = [...frameworks, 'sharding'];

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -255,7 +255,7 @@ module.exports = function (config) {
         browsers = Object.keys(browserStackBrowsers);
     }
 
-    // Set karma.browsercount to bypass disconnection problem on Windows
+    // Adjust karma.browsercount number to bypass disconnect problem on Windows
     const browserCount = Number(getProperties()['karma.browsercount']) ||
         argv.browsercount || (Math.max(1, os.cpus().length - 2));
 


### PR DESCRIPTION
Allow setting `browsercount` number in a `git-ignore-me.properties` file. Setting a lower number allows to complete the tests without disconnection problems, which can happen on Windows (e.g. with `browsercount` > 10).

## Usage
Open or create the file `/git-ignore-me.properties` in the _highcharts_ repo root, and add this
```
# Karma tests
karma.browsercount=6
``` 