### PR TITLE
Added `borderRadius` option to dependencywheel api docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@cypress-audit/lighthouse": "^1.4.2",
         "@highcharts/highcharts-assembler": "github:highcharts/highcharts-assembler#v1.5.6",
         "@highcharts/highcharts-declarations-generator": "github:highcharts/highcharts-declarations-generator#v1.2.0",
-        "@highcharts/highcharts-documentation-generators": "github:highcharts/highcharts-documentation-generators#v0.6.8",
+        "@highcharts/highcharts-documentation-generators": "github:highcharts/highcharts-documentation-generators#v0.6.9",
         "@highcharts/map-collection": "^2.2.0",
         "@octokit/rest": "^20.1.1",
         "@swc/core": "^1.5.25",

--- a/ts/Series/DependencyWheel/DependencyWheelSeriesDefaults.ts
+++ b/ts/Series/DependencyWheel/DependencyWheelSeriesDefaults.ts
@@ -105,6 +105,18 @@ const DependencyWheelSeriesDefaults: DependencyWheelSeriesOptions = {
     curveFactor: 0.6,
 
     /**
+     * The corner radius of the border surrounding each node. A number
+     * signifies pixels. A percentage string, like for example `50%`, signifies
+     * a relative size. For nodes this is relative to the node width.
+     *
+     * @type    {number|string|Highcharts.BorderRadiusOptionsObject}
+     * @default 3
+     * @product highcharts
+     * @since   11.0.0
+    */
+    borderRadius: 3,
+
+    /**
      * The start angle of the dependency wheel, in degrees where 0 is up.
      */
     startAngle: 0,

--- a/ts/Series/DependencyWheel/DependencyWheelSeriesDefaults.ts
+++ b/ts/Series/DependencyWheel/DependencyWheelSeriesDefaults.ts
@@ -43,6 +43,18 @@ import type DependencyWheelSeriesOptions from './DependencyWheelSeriesOptions';
 const DependencyWheelSeriesDefaults: DependencyWheelSeriesOptions = {
 
     /**
+     * The corner radius of the border surrounding each node. A number
+     * signifies pixels. A percentage string, like for example `50%`, signifies
+     * a relative size. For nodes this is relative to the node width.
+     *
+     * @type    {number|string|Highcharts.BorderRadiusOptionsObject}
+     * @default 3
+     * @product highcharts
+     * @since   11.0.0
+     * @apioption plotOptions.dependencywheel.borderRadius
+    */
+
+    /**
      * Distance between the data label and the center of the node.
      *
      * @type      {number}
@@ -103,18 +115,6 @@ const DependencyWheelSeriesDefaults: DependencyWheelSeriesOptions = {
     center: [null, null],
 
     curveFactor: 0.6,
-
-    /**
-     * The corner radius of the border surrounding each node. A number
-     * signifies pixels. A percentage string, like for example `50%`, signifies
-     * a relative size. For nodes this is relative to the node width.
-     *
-     * @type    {number|string|Highcharts.BorderRadiusOptionsObject}
-     * @default 3
-     * @product highcharts
-     * @since   11.0.0
-    */
-    borderRadius: 3,
 
     /**
      * The start angle of the dependency wheel, in degrees where 0 is up.

--- a/ts/Series/DependencyWheel/DependencyWheelSeriesOptions.d.ts
+++ b/ts/Series/DependencyWheel/DependencyWheelSeriesOptions.d.ts
@@ -16,6 +16,7 @@
  *
  * */
 
+import { BorderRadiusOptionsObject } from '../../Extensions/BorderRadius';
 import type DependencyWheelPointOptions from './DependencyWheelPointOptions';
 import type DependencyWheelSeries from './DependencyWheelSeries';
 import type {
@@ -63,6 +64,19 @@ interface DependencyWheelSeriesNodeOptions extends SankeySeriesNodeOptions {
  * @requires modules/sankey
  */
 export interface DependencyWheelSeriesOptions extends SankeySeriesOptions {
+
+    /**
+     * The corner radius of the border surrounding each node. A number
+     * signifies pixels. A percentage string, like for example `50%`, signifies
+     * a relative size. For nodes this is relative to the node width.
+     *
+     * @default 3
+     *
+     * @since 11.0.0
+     *
+     * @product highcharts
+     */
+    borderRadius?: (number|string|BorderRadiusOptionsObject);
 
     /**
      * The center of the wheel relative to the plot area. Can be


### PR DESCRIPTION
Fixed #21643, missing border radius option in dependency wheel api docs