### PR TITLE
bugfix/21884-measure-annotation-border

### DIFF
--- a/samples/unit-tests/annotations/annotations-measure/demo.js
+++ b/samples/unit-tests/annotations/annotations-measure/demo.js
@@ -130,3 +130,41 @@ QUnit.test('#13664 - annotation measure on yAxis', function (assert) {
         'The annotation should stay in the same place after update, #19121.'
     );
 });
+
+QUnit.test('Measure annotation border', function (assert) {
+    const WIDTH = 400;
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'column'
+        },
+        annotations: [
+            {
+                type: 'measure',
+                typeOptions: {
+                    point: {
+                        x: 0
+                    },
+                    selectType: 'x',
+                    background: {
+                        width: `${WIDTH}px`,
+                        fill: 'lightblue',
+                        stroke: 'red',
+                        strokeWidth: 20
+                    }
+                }
+            }
+        ],
+        series: [
+            {
+                data: [1, 2, 3, 4, 5, 6, 7, 8]
+            }
+        ]
+    });
+    const measure = chart.annotations[0];
+    const { width } = measure.shapes[2].graphic.getBBox();
+    assert.equal(
+        width + measure.shapes[2].options.strokeWidth,
+        WIDTH,
+        'StrokeWidth should be taken into account when drawing annotation'
+    );
+});

--- a/ts/Extensions/Annotations/Types/Measure.ts
+++ b/ts/Extensions/Annotations/Types/Measure.ts
@@ -842,6 +842,35 @@ class Measure extends Annotation {
         this.redrawItems(this.shapes, animation);
         this.redrawItems(this.labels, animation);
 
+        const backgroundOptions = this.options.typeOptions.background;
+        if (
+            backgroundOptions?.strokeWidth &&
+                this.shapes[2]?.graphic
+        ) {
+            const offset = (backgroundOptions.strokeWidth) / 2;
+            const background = this.shapes[2];
+            const path = background.graphic.pathArray as SVGPath;
+            const p1 = path[0];
+            const p2 = path[1];
+            const p3 = path[2];
+            const p4 = path[3];
+
+            p1[1] = (p1[1] || 0) + offset;
+            p2[1] = (p2[1] || 0) - offset;
+            p3[1] = (p3[1] || 0) - offset;
+            p4[1] = (p4[1] || 0) + offset;
+
+            p1[2] = (p1[2] || 0) + offset;
+            p2[2] = (p2[2] || 0) + offset;
+            p3[2] = (p3[2] || 0) - offset;
+            p4[2] = (p4[2] || 0) - offset;
+
+            background.graphic.attr({
+                d: path
+            });
+        }
+
+
         // Redraw control point to run positioner
         this.controlPoints.forEach((controlPoint): void =>
             controlPoint.redraw()

--- a/ts/Extensions/Annotations/Types/Measure.ts
+++ b/ts/Extensions/Annotations/Types/Measure.ts
@@ -497,7 +497,10 @@ class Measure extends Annotation {
                 y: this.yAxisMax,
                 xAxis: xAxis,
                 yAxis: yAxis
-            }
+            },
+            {
+                command: 'Z'
+            } as MockPointOptions
         ];
     }
 
@@ -620,7 +623,7 @@ class Measure extends Annotation {
             extend<Partial<ControllableShapeOptions>>(
                 {
                     type: 'path',
-                    points: this.shapePointsOptions(),
+                    points: shapePoints,
                     className: 'highcharts-measure-background'
                 },
                 this.options.typeOptions.background
@@ -1179,6 +1182,7 @@ namespace Measure {
         xAxis: number;
         yAxis: number;
     }
+
 }
 
 /* *

--- a/ts/Stock/StockTools/StockToolsBindings.ts
+++ b/ts/Stock/StockTools/StockToolsBindings.ts
@@ -905,7 +905,8 @@ const StockToolsBindings: Record<string, NavigationBindingsOptions> = {
                             background: {
                                 width: 0,
                                 height: 0,
-                                strokeWidth: 10
+                                strokeWidth: 0,
+                                stroke: Palette.backgroundColor
                             },
                             crosshairX: {
                                 strokeWidth: 1,


### PR DESCRIPTION
Fixed #21884, rendering issues with the borders of the Measure annotation.

Measure annotation's border was missing on 1 side, and the size of measure's rectangle didn't take into account the border, and also the border's dimension wasn't included in size calculation.