### PR TITLE
Locale-aware numberFormat

### DIFF
--- a/samples/unit-tests/axis/labels/demo.js
+++ b/samples/unit-tests/axis/labels/demo.js
@@ -675,7 +675,7 @@ QUnit.test('Label formatting(#4291)', function (assert) {
 
     assert.strictEqual(
         chart.yAxis[0].ticks['79962.57'].label.textStr,
-        '79 962.57',
+        '79,962.57',
         'Preserved decimals'
     );
 });

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -695,18 +695,17 @@ class Axis {
                     numericSymbols[i] !== null &&
                     value !== 0
                 ) { // #5480
-                    ret = numberFormatter(
-                        value / multi, -1, chart
-                    ) + numericSymbols[i];
+                    ret = numberFormatter(value / multi, -1) +
+                        numericSymbols[i];
                 }
             }
         }
 
         if (typeof ret === 'undefined') {
             if (Math.abs(value) >= 10000) { // Add thousands separators
-                ret = numberFormatter(value, -1, chart);
+                ret = numberFormatter(value, -1);
             } else { // Small numbers
-                ret = numberFormatter(value, -1, chart, ''); // #2466
+                ret = numberFormatter(value, -1, void 0, ''); // #2466
             }
         }
 

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -696,7 +696,7 @@ class Axis {
                     value !== 0
                 ) { // #5480
                     ret = numberFormatter(
-                        value / multi, -1
+                        value / multi, -1, chart
                     ) + numericSymbols[i];
                 }
             }
@@ -704,9 +704,9 @@ class Axis {
 
         if (typeof ret === 'undefined') {
             if (Math.abs(value) >= 10000) { // Add thousands separators
-                ret = numberFormatter(value, -1);
+                ret = numberFormatter(value, -1, chart);
             } else { // Small numbers
-                ret = numberFormatter(value, -1, void 0, ''); // #2466
+                ret = numberFormatter(value, -1, chart, ''); // #2466
             }
         }
 

--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -3225,10 +3225,7 @@ namespace AxisDefaults {
              * @product highcharts
              */
             formatter: function (this: StackItem): string {
-                const chart = this.axis.chart,
-                    { numberFormatter } = chart;
-                /* eslint-enable valid-jsdoc */
-                return numberFormatter(this.total || 0, -1, chart);
+                return this.axis.chart.numberFormatter(this.total || 0, -1);
             },
 
             /**

--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -3225,9 +3225,10 @@ namespace AxisDefaults {
              * @product highcharts
              */
             formatter: function (this: StackItem): string {
-                const { numberFormatter } = this.axis.chart;
+                const chart = this.axis.chart,
+                    { numberFormatter } = chart;
                 /* eslint-enable valid-jsdoc */
-                return numberFormatter(this.total || 0, -1);
+                return numberFormatter(this.total || 0, -1, chart);
             },
 
             /**

--- a/ts/Core/Axis/Color/ColorAxis.ts
+++ b/ts/Core/Axis/Color/ColorAxis.ts
@@ -765,17 +765,13 @@ class ColorAxis extends Axis implements AxisLike {
                     name = '> ';
                 }
                 if (typeof from !== 'undefined') {
-                    name += numberFormatter(
-                        from, valueDecimals, chart
-                    ) + valueSuffix;
+                    name += numberFormatter(from, valueDecimals) + valueSuffix;
                 }
                 if (typeof from !== 'undefined' && typeof to !== 'undefined') {
                     name += ' - ';
                 }
                 if (typeof to !== 'undefined') {
-                    name += numberFormatter(
-                        to, valueDecimals, chart
-                    ) + valueSuffix;
+                    name += numberFormatter(to, valueDecimals) + valueSuffix;
                 }
                 // Add a mock object to the legend items
                 legendItems.push(extend<ColorAxis.LegendItemObject>(

--- a/ts/Core/Axis/Color/ColorAxis.ts
+++ b/ts/Core/Axis/Color/ColorAxis.ts
@@ -765,13 +765,17 @@ class ColorAxis extends Axis implements AxisLike {
                     name = '> ';
                 }
                 if (typeof from !== 'undefined') {
-                    name += numberFormatter(from, valueDecimals) + valueSuffix;
+                    name += numberFormatter(
+                        from, valueDecimals, chart
+                    ) + valueSuffix;
                 }
                 if (typeof from !== 'undefined' && typeof to !== 'undefined') {
                     name += ' - ';
                 }
                 if (typeof to !== 'undefined') {
-                    name += numberFormatter(to, valueDecimals) + valueSuffix;
+                    name += numberFormatter(
+                        to, valueDecimals, chart
+                    ) + valueSuffix;
                 }
                 // Add a mock object to the legend items
                 legendItems.push(extend<ColorAxis.LegendItemObject>(

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -537,7 +537,9 @@ class Chart {
              * @name Highcharts.Chart#numberFormatter
              * @type {Highcharts.NumberFormatterCallbackFunction}
              */
-            this.numberFormatter = optionsChart.numberFormatter || numberFormat;
+            this.numberFormatter = (
+                optionsChart.numberFormatter || numberFormat
+            ).bind(this);
 
             /**
              * Whether the chart is in styled mode, meaning all presentational

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -332,6 +332,7 @@ class Chart {
     public loadingDiv?: HTMLDOMElement;
     public loadingShown?: boolean;
     public loadingSpan?: HTMLDOMElement;
+    public locale?: string|Array<string>;
     public margin!: Array<number>;
     public marginBottom?: number;
     public numberFormatter!: NumberFormatterCallbackFunction;
@@ -502,6 +503,9 @@ class Chart {
              */
             this.series = [];
 
+            this.locale = options.lang.locale ??
+                (this.renderTo.closest('[lang]') as HTMLDOMElement|null)?.lang;
+
             /**
              * The `Time` object associated with the chart. Since v6.0.5,
              * time settings can be applied individually for each chart. If
@@ -514,14 +518,16 @@ class Chart {
             this.time = new Time(extend(
                 options.time || {},
                 {
-                    locale: (
-                        options.lang.locale ??
-                        (this.renderTo.closest('[lang]') as HTMLDOMElement|null)
-                            ?.lang
-                    )
+                    locale: this.locale
                 }
             ));
             options.time = this.time.options;
+
+            // Detect the number format of the locale and set the lang settings
+            // eslint-disable-next-line new-cap
+            const numString = Intl.NumberFormat(this.locale).format(10000.1);
+            options.lang.thousandsSep ??= numString[2];
+            options.lang.decimalPoint ??= numString[6];
 
             /**
              * Callback function to override the default function that formats

--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -228,11 +228,12 @@ const defaultOptions: DefaultOptions = {
 
         /**
          * The default decimal point used in the `Highcharts.numberFormat`
-         * method unless otherwise specified in the function arguments.
+         * method unless otherwise specified in the function arguments. Defaults
+         * to the locale decimal point as determined by `lang.locale`.
          *
          * @since 1.2.2
          */
-        decimalPoint: '.',
+        decimalPoint: void 0,
 
         /**
          * [Metric prefixes](https://en.wikipedia.org/wiki/Metric_prefix) used
@@ -282,14 +283,11 @@ const defaultOptions: DefaultOptions = {
         /**
          * The default thousands separator used in the `Highcharts.numberFormat`
          * method unless otherwise specified in the function arguments. Defaults
-         * to a single space character, which is recommended in
-         * [ISO 31-0](https://en.wikipedia.org/wiki/ISO_31-0#Numbers) and works
-         * across Anglo-American and continental European languages.
+         * to the locale decimal point as determined by `lang.locale`.
          *
-         * @default \u0020
          * @since   1.2.2
          */
-        thousandsSep: ' '
+        thousandsSep: void 0
     },
 
     /**

--- a/ts/Core/Options.d.ts
+++ b/ts/Core/Options.d.ts
@@ -14,6 +14,7 @@
  *
  * */
 
+import type Chart from './Chart/Chart';
 import type ColorString from './Color/ColorString';
 import type CSSObject from './Renderer/CSSObject';
 import type { SeriesTypePlotOptions } from './Series/SeriesType';
@@ -31,7 +32,7 @@ export interface LabelsItemsOptions {
 }
 
 export interface LangOptions {
-    decimalPoint: string;
+    decimalPoint?: string;
     invalidDate?: string;
     loading: string;
     locale?: string|Array<string>;
@@ -42,7 +43,7 @@ export interface LangOptions {
     resetZoomTitle: string;
     shortMonths?: Array<string>;
     shortWeekdays?: Array<string>;
-    thousandsSep: string;
+    thousandsSep?: string;
     weekdays?: Array<string>;
     zoomIn?: string;
     zoomOut?: string;
@@ -59,7 +60,7 @@ export interface NumberFormatterCallbackFunction {
     (
         number: number,
         decimals: number,
-        decimalPoint?: string,
+        decimalPoint?: string|Chart,
         thousandsSep?: string
     ): string;
 }

--- a/ts/Core/Options.d.ts
+++ b/ts/Core/Options.d.ts
@@ -58,9 +58,10 @@ export interface LoadingOptions {
 
 export interface NumberFormatterCallbackFunction {
     (
+        this: Chart|Object|void,
         number: number,
         decimals: number,
-        decimalPoint?: string|Chart,
+        decimalPoint?: string,
         thousandsSep?: string
     ): string;
 }

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -1807,10 +1807,8 @@ const seriesDefaults: PlotOptionsOf<Series> = {
          * @type {Highcharts.DataLabelsFormatterCallbackFunction}
          */
         formatter: function (this: Point.PointLabelObject): string {
-            const chart = this.series.chart,
-                { numberFormatter } = chart;
             return typeof this.y !== 'number' ?
-                '' : numberFormatter(this.y, -1, chart);
+                '' : this.series.chart.numberFormatter(this.y, -1);
         },
 
         /**

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -1807,9 +1807,10 @@ const seriesDefaults: PlotOptionsOf<Series> = {
          * @type {Highcharts.DataLabelsFormatterCallbackFunction}
          */
         formatter: function (this: Point.PointLabelObject): string {
-            const { numberFormatter } = this.series.chart;
+            const chart = this.series.chart,
+                { numberFormatter } = chart;
             return typeof this.y !== 'number' ?
-                '' : numberFormatter(this.y, -1);
+                '' : numberFormatter(this.y, -1, chart);
         },
 
         /**

--- a/ts/Core/Templating.ts
+++ b/ts/Core/Templating.ts
@@ -415,9 +415,10 @@ function format(str = '', ctx: any, chart?: Chart): string {
  *         The formatted number.
  */
 function numberFormat(
+    this: Chart|Object|void,
     number: number,
     decimals: number,
-    decimalPoint?: string|Chart,
+    decimalPoint?: string,
     thousandsSep?: string
 ): string {
     number = +number || 0;
@@ -426,8 +427,7 @@ function numberFormat(
     let ret,
         fractionDigits;
 
-    const chart = isObject(decimalPoint) ? decimalPoint : void 0,
-        lang = chart?.options.lang || defaultOptions.lang,
+    const lang = (this as Chart)?.options?.lang || defaultOptions.lang,
         origDec = (number.toString().split('.')[1] || '').split('e')[0].length,
         exponent = number.toString().split('e'),
         firstDecimals = decimals;

--- a/ts/Core/Templating.ts
+++ b/ts/Core/Templating.ts
@@ -30,6 +30,7 @@ const {
     isArray,
     isNumber,
     isObject,
+    isString,
     pick,
     pInt,
     ucfirst
@@ -176,7 +177,7 @@ function format(str = '', ctx: any, chart?: Chart): string {
         matches = [],
         floatRegex = /f$/,
         decRegex = /\.(\d)/,
-        lang = defaultOptions.lang,
+        lang = chart?.options.lang || defaultOptions.lang,
         time = chart && chart.time || defaultTime,
         numberFormatter = chart && chart.numberFormatter || numberFormat;
 
@@ -416,7 +417,7 @@ function format(str = '', ctx: any, chart?: Chart): string {
 function numberFormat(
     number: number,
     decimals: number,
-    decimalPoint?: string,
+    decimalPoint?: string|Chart,
     thousandsSep?: string
 ): string {
     number = +number || 0;
@@ -425,7 +426,8 @@ function numberFormat(
     let ret,
         fractionDigits;
 
-    const lang = defaultOptions.lang,
+    const chart = isObject(decimalPoint) ? decimalPoint : void 0,
+        lang = chart?.options.lang || defaultOptions.lang,
         origDec = (number.toString().split('.')[1] || '').split('e')[0].length,
         exponent = number.toString().split('e'),
         firstDecimals = decimals;
@@ -473,8 +475,10 @@ function numberFormat(
     const thousands = strinteger.length > 3 ? strinteger.length % 3 : 0;
 
     // Language
-    decimalPoint = pick(decimalPoint, lang.decimalPoint);
-    thousandsSep = pick(thousandsSep, lang.thousandsSep);
+    if (!isString(decimalPoint)) {
+        decimalPoint = lang.decimalPoint ?? '.';
+    }
+    thousandsSep ??= lang.thousandsSep ?? ' ';
 
     // Start building the return
     ret = number < 0 ? '-' : '';

--- a/ts/Series/Bubble/BubbleLegendItem.ts
+++ b/ts/Series/Bubble/BubbleLegendItem.ts
@@ -530,11 +530,10 @@ class BubbleLegendItem {
         const options = this.options,
             formatter = (options.labels as any).formatter,
             format = (options.labels as any).format;
-        const { numberFormatter } = this.chart;
 
         return format ? F.format(format, range) :
             formatter ? formatter.call(range) :
-                numberFormatter(range.value, 1, this.chart);
+                this.chart.numberFormatter(range.value, 1);
     }
 
     /**

--- a/ts/Series/Bubble/BubbleLegendItem.ts
+++ b/ts/Series/Bubble/BubbleLegendItem.ts
@@ -534,7 +534,7 @@ class BubbleLegendItem {
 
         return format ? F.format(format, range) :
             formatter ? formatter.call(range) :
-                numberFormatter(range.value, 1);
+                numberFormatter(range.value, 1, this.chart);
     }
 
     /**

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -245,10 +245,11 @@ class BubbleSeries extends ScatterSeries {
             formatter: function (
                 this: Point.PointLabelObject
             ): string { // #2945
-                const { numberFormatter } = this.series.chart;
                 const { z } = (this.point as BubblePoint);
 
-                return isNumber(z) ? numberFormatter(z, -1) : '';
+                return isNumber(z) ?
+                    this.series.chart.numberFormatter(z, -1) :
+                    '';
             },
             inside: true,
             verticalAlign: 'middle'

--- a/ts/Series/DataModifyComposition.ts
+++ b/ts/Series/DataModifyComposition.ts
@@ -228,14 +228,16 @@ namespace DataModifyComposition {
      */
     function tooltipFormatter(this: Point, pointFormat: string): string {
         const point: any = this,
-            { numberFormatter } = point.series.chart,
+            chart = point.series.chart,
+            { numberFormatter } = chart,
             replace = function (value: string): void {
                 pointFormat = pointFormat.replace(
                     '{point.' + value + '}',
                     (point[value] > 0 && value === 'change' ? '+' : '') +
                         numberFormatter(
                             point[value],
-                            pick(point.series.tooltipOptions.changeDecimals, 2)
+                            pick(point.series.tooltipOptions.changeDecimals, 2),
+                            chart
                         )
                 );
             };

--- a/ts/Series/Heatmap/HeatmapSeriesDefaults.ts
+++ b/ts/Series/Heatmap/HeatmapSeriesDefaults.ts
@@ -149,10 +149,11 @@ const HeatmapSeriesDefaults: HeatmapSeriesOptions = {
 
     dataLabels: {
         formatter: function (): string { // #2945
-            const { numberFormatter } = this.series.chart;
-            const { value } = this.point as HeatmapPoint;
+            const chart = this.series.chart,
+                { numberFormatter } = chart,
+                { value } = this.point as HeatmapPoint;
 
-            return isNumber(value) ? numberFormatter(value, -1) : '';
+            return isNumber(value) ? numberFormatter(value, -1, chart) : '';
         },
         inside: true,
         verticalAlign: 'middle',

--- a/ts/Series/Heatmap/HeatmapSeriesDefaults.ts
+++ b/ts/Series/Heatmap/HeatmapSeriesDefaults.ts
@@ -150,10 +150,9 @@ const HeatmapSeriesDefaults: HeatmapSeriesOptions = {
     dataLabels: {
         formatter: function (): string { // #2945
             const chart = this.series.chart,
-                { numberFormatter } = chart,
                 { value } = this.point as HeatmapPoint;
 
-            return isNumber(value) ? numberFormatter(value, -1, chart) : '';
+            return isNumber(value) ? chart.numberFormatter(value, -1) : '';
         },
         inside: true,
         verticalAlign: 'middle',

--- a/ts/Series/Map/MapSeriesDefaults.ts
+++ b/ts/Series/Map/MapSeriesDefaults.ts
@@ -64,11 +64,10 @@ const MapSeriesDefaults: MapSeriesOptions = {
         crop: false,
         formatter: function (): string { // #2945
             const chart = this.series.chart,
-                { numberFormatter } = chart,
-                { value } = this.point as MapPoint;
+                { name, value } = this.point as MapPoint;
             return isNumber(value) ?
-                numberFormatter(value, -1, chart) :
-                this.point.name; // #20231
+                chart.numberFormatter(value, -1) :
+                name; // #20231
         },
         inside: true, // For the color
         overflow: false as any,

--- a/ts/Series/Map/MapSeriesDefaults.ts
+++ b/ts/Series/Map/MapSeriesDefaults.ts
@@ -63,10 +63,11 @@ const MapSeriesDefaults: MapSeriesOptions = {
     dataLabels: {
         crop: false,
         formatter: function (): string { // #2945
-            const { numberFormatter } = this.series.chart;
-            const { value } = this.point as MapPoint;
+            const chart = this.series.chart,
+                { numberFormatter } = chart,
+                { value } = this.point as MapPoint;
             return isNumber(value) ?
-                numberFormatter(value, -1) :
+                numberFormatter(value, -1, chart) :
                 this.point.name; // #20231
         },
         inside: true, // For the color

--- a/ts/Series/PackedBubble/PackedBubbleSeriesDefaults.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeriesDefaults.ts
@@ -159,10 +159,9 @@ const PackedBubbleSeriesDefaults: PackedBubbleSeriesOptions = {
             )
         ): string {
             const chart = this.series.chart,
-                { numberFormatter } = chart,
                 { value } = this.point as PackedBubblePoint;
 
-            return isNumber(value) ? numberFormatter(value, -1, chart) : '';
+            return isNumber(value) ? chart.numberFormatter(value, -1) : '';
         },
 
         /**

--- a/ts/Series/PackedBubble/PackedBubbleSeriesDefaults.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeriesDefaults.ts
@@ -158,10 +158,11 @@ const PackedBubbleSeriesDefaults: PackedBubbleSeriesOptions = {
                 PackedBubbleDataLabelFormatterObject
             )
         ): string {
-            const { numberFormatter } = this.series.chart;
-            const { value } = this.point as PackedBubblePoint;
+            const chart = this.series.chart,
+                { numberFormatter } = chart,
+                { value } = this.point as PackedBubblePoint;
 
-            return isNumber(value) ? numberFormatter(value, -1) : '';
+            return isNumber(value) ? numberFormatter(value, -1, chart) : '';
         },
 
         /**


### PR DESCRIPTION
Made the `lang.decimalPoint` and `lang.thousandsSep` default to, in prioritized order: the current `lang.locale` setting, page `html.lang` attribute, or the browser default language.

#### Upgrade note
Decimal points and thousands separators now default to the page or browser language setting. To stick to the previous defaults, set `lang.decimalPoint` to `.` and `lang.thousandsSep` to ` ` (a single space). You can also use the new `lang.locale` option to specify the preferred language for number and date formatting.

___

This is a simpler and probably good enough alternative to #21855.