### PR TITLE
feat/21519-rename-get-axes

### DIFF
--- a/samples/highcharts/demo/flame/demo.js
+++ b/samples/highcharts/demo/flame/demo.js
@@ -54,7 +54,7 @@ const colors = Highcharts.getOptions().colors,
         value: 33116,
         color: colors[2]
     }, {
-        name: 'getAxes',
+        name: 'createAxes',
         id: '30',
         parent: '20',
         value: 33116,
@@ -891,7 +891,7 @@ const colors = Highcharts.getOptions().colors,
         low: 330456,
         high: 397316
     }, {
-        name: 'getAxes',
+        name: 'createAxes',
         id: '30',
         value: 33116,
         color: colors[0],

--- a/ts/Core/Axis/Color/ColorAxisComposition.ts
+++ b/ts/Core/Axis/Color/ColorAxisComposition.ts
@@ -127,7 +127,7 @@ namespace ColorAxisComposition {
                 chartProto.addColorAxis
             ];
 
-            addEvent(ChartClass, 'afterGetAxes', onChartAfterGetAxes);
+            addEvent(ChartClass, 'afterCreateAxes', onChartAfterCreateAxes);
 
             wrapChartCreateAxis(ChartClass);
 
@@ -168,10 +168,10 @@ namespace ColorAxisComposition {
     }
 
     /**
-     * Extend the chart getAxes method to also get the color axis.
+     * Extend the chart createAxes method to also make the color axis.
      * @private
      */
-    function onChartAfterGetAxes(
+    function onChartAfterCreateAxes(
         this: Chart
     ): void {
         const { userOptions } = this;

--- a/ts/Core/Axis/ZAxis.ts
+++ b/ts/Core/Axis/ZAxis.ts
@@ -79,7 +79,7 @@ function chartAddZAxis(
  * Get the Z axis in addition to the default X and Y.
  * @private
  */
-function onChartAfterGetAxes(this: Chart): void {
+function onChartAfterCreateAxes(this: Chart): void {
     const zAxisOptions = this.options.zAxis = splat(this.options.zAxis || {});
 
     if (!this.is3d()) {
@@ -127,7 +127,7 @@ class ZAxis extends Axis implements AxisLike {
             chartProto.collectionsWithInit.zAxis = [chartProto.addZAxis];
             chartProto.collectionsWithUpdate.push('zAxis');
 
-            addEvent(ChartClass, 'afterGetAxes', onChartAfterGetAxes);
+            addEvent(ChartClass, 'afterCreateAxes', onChartAfterCreateAxes);
         }
 
     }

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -1044,14 +1044,14 @@ class Chart {
      * Create the Axis instances based on the config options.
      *
      * @private
-     * @function Highcharts.Chart#getAxes
-     * @emits Highcharts.Chart#event:afterGetAxes
-     * @emits Highcharts.Chart#event:getAxes
+     * @function Highcharts.Chart#createAxes
+     * @emits Highcharts.Chart#event:afterCreateAxes
+     * @emits Highcharts.Chart#event:createAxes
      */
-    public getAxes(): void {
+    public createAxes(): void {
         const options = this.userOptions;
 
-        fireEvent(this, 'getAxes');
+        fireEvent(this, 'createAxes');
 
         for (const coll of ['xAxis', 'yAxis'] as Array<'xAxis'|'yAxis'>) {
             const arr = options[coll] = splat(
@@ -1063,7 +1063,7 @@ class Chart {
             }
         }
 
-        fireEvent(this, 'afterGetAxes');
+        fireEvent(this, 'afterCreateAxes');
     }
 
     /**
@@ -2727,7 +2727,7 @@ class Chart {
         chart.propFromSeries();
 
         // Get axes
-        chart.getAxes();
+        chart.createAxes();
 
         // Initialize the series
         const series = isArray(options.series) ? options.series : [];

--- a/ts/Series/PolarComposition.ts
+++ b/ts/Series/PolarComposition.ts
@@ -367,7 +367,7 @@ function onChartAfterInit(event: any): void {
 /**
  *
  */
-function onChartGetAxes(
+function onChartCreateAxes(
     this: Chart
 ): void {
 
@@ -1495,7 +1495,7 @@ class PolarAdditions {
                 seriesProto = SeriesClass.prototype;
 
             addEvent(ChartClass, 'afterDrawChartBox', onChartAfterDrawChartBox);
-            addEvent(ChartClass, 'getAxes', onChartGetAxes);
+            addEvent(ChartClass, 'createAxes', onChartCreateAxes);
             addEvent(ChartClass, 'init', onChartAfterInit);
 
             wrap(chartProto, 'get', wrapChartGet);

--- a/ts/Stock/RangeSelector/RangeSelector.ts
+++ b/ts/Stock/RangeSelector/RangeSelector.ts
@@ -371,7 +371,7 @@ class RangeSelector {
             baseXAxisOptions = splat(chart.options.xAxis || {})[0];
             const axisRangeUpdateEvent = addEvent(
                 chart,
-                'afterGetAxes',
+                'afterCreateAxes',
                 function (): void {
                     const xAxis = chart.xAxis[0];
                     xAxis.range = xAxis.options.range = range;


### PR DESCRIPTION
Fixed #21519, renamed the internal `Chart.getAxes` to `Chart.createAxes`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207784939095843