### PR TITLE
Added more precise api documentation for `CSSObject.fontSize`

### DIFF
--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -1160,7 +1160,17 @@ namespace AxisDefaults {
                 color: Palette.neutralColor80,
                 /** @internal */
                 cursor: 'default',
-                /** @internal */
+
+                /**
+                 * The font size to use for text. If a number is set, it
+                 * translates to pixels. You may also use a string and specify
+                 * the unit to use, like `px`, `em` or `%` to name a few.
+                 *
+                 * If `useHTML` is true, you need to provide a string with
+                 * the unit.
+                 *
+                 * @type {number|string}
+                 */
                 fontSize: '0.8em'
             }
         },
@@ -2085,7 +2095,17 @@ namespace AxisDefaults {
             style: {
                 /** @internal */
                 color: Palette.neutralColor60,
-                /** @internal */
+
+                /**
+                 * The font size to use for text. If a number is set, it
+                 * translates to pixels. You may also use a string and specify
+                 * the unit to use, like `px`, `em` or `%` to name a few.
+                 *
+                 * If `useHTML` is true, you need to provide a string with
+                 * the unit.
+                 *
+                 * @type {number|string}
+                 */
                 fontSize: '0.8em'
             }
         },
@@ -3228,7 +3248,16 @@ namespace AxisDefaults {
             style: {
                 /** @internal */
                 color: Palette.neutralColor100,
-                /** @internal */
+                /**
+                 * The font size to use for text. If a number is set, it
+                 * translates to pixels. You may also use a string and specify
+                 * the unit to use, like `px`, `em` or `%` to name a few.
+                 *
+                 * If `useHTML` is true, you need to provide a string with
+                 * the unit.
+                 *
+                 * @type {number|string}
+                 */
                 fontSize: '0.7em',
                 /** @internal */
                 fontWeight: 'bold',

--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -889,6 +889,17 @@ const defaultOptions: DefaultOptions = {
          */
         style: {
             color: Palette.neutralColor60,
+
+            /**
+             * The font size to use for the subtitle. If a number is set, it
+             * translates to pixels. You may also use a string and specify
+             * the unit to use, like `px`, `em` or `%` to name a few.
+             *
+             * If `useHTML` is true, you need to provide a string with
+             * the unit.
+             *
+             * @type {number|string}
+             */
             fontSize: '0.8em'
         },
 
@@ -996,6 +1007,17 @@ const defaultOptions: DefaultOptions = {
          */
         style: {
             color: Palette.neutralColor60,
+
+            /**
+             * The font size to use for the caption. If a number is set, it
+             * translates to pixels. You may also use a string and specify
+             * the unit to use, like `px`, `em` or `%` to name a few.
+             *
+             * If `useHTML` is true, you need to provide a string with
+             * the unit.
+             *
+             * @type {number|string}
+             */
             fontSize: '0.8em'
         },
 
@@ -1453,6 +1475,16 @@ const defaultOptions: DefaultOptions = {
              * @apioption legend.navigation.style
              */
             style: {
+                /**
+                 * The font size to use for text. If a number is set, it
+                 * translates to pixels. You may also use a string and specify
+                 * the unit to use, like `px`, `em` or `%` to name a few.
+                 *
+                 * If `useHTML` is true, you need to provide a string with
+                 * the unit.
+                 *
+                 * @type {number|string}
+                 */
                 fontSize: '0.8em'
             },
 
@@ -2731,7 +2763,17 @@ const defaultOptions: DefaultOptions = {
             color: Palette.neutralColor80,
             /** @internal */
             cursor: 'default',
-            /** @internal */
+
+            /**
+             * The font size to use for text. If a number is set, it
+             * translates to pixels. You may also use a string and specify
+             * the unit to use, like `px`, `em` or `%` to name a few.
+             *
+             * If `useHTML` is true, you need to provide a string with
+             * the unit.
+             *
+             * @type {number|string}
+             */
             fontSize: '0.8em'
         },
 
@@ -2850,7 +2892,17 @@ const defaultOptions: DefaultOptions = {
             cursor: 'pointer',
             /** @internal */
             color: Palette.neutralColor40,
-            /** @internal */
+
+            /**
+             * The font size to use for text. If a number is set, it
+             * translates to pixels. You may also use a string and specify
+             * the unit to use, like `px`, `em` or `%` to name a few.
+             *
+             * If `useHTML` is true, you need to provide a string with
+             * the unit.
+             *
+             * @type {number|string}
+             */
             fontSize: '0.6em'
         },
 

--- a/ts/Extensions/SeriesLabel/SeriesLabelDefaults.ts
+++ b/ts/Extensions/SeriesLabel/SeriesLabelDefaults.ts
@@ -125,7 +125,16 @@ const SeriesLabelDefaults: SeriesLabelOptions = {
      * @type {Highcharts.CSSObject}
      */
     style: {
-        /** @internal */
+        /**
+         * The font size to use for the label. If a number is set, it
+         * translates to pixels. You may also use a string and specify
+         * the unit to use, like `px`, `em` or `%` to name a few.
+         *
+         * If `useHTML` is true, you need to provide a string with
+         * the unit.
+         *
+         * @type {number|string}
+         */
         fontSize: '0.8em',
         /** @internal */
         fontWeight: 'bold'


### PR DESCRIPTION
Fixed #21624, discrepancy in api documentation regarding type of the fontSize option.