### PR TITLE
Allow user to scroll on map when map not zooming

### DIFF
--- a/ts/Maps/MapNavigation.ts
+++ b/ts/Maps/MapNavigation.ts
@@ -417,10 +417,14 @@ class MapNavigation {
                         e.target as any,
                         'highcharts-no-mousewheel'
                     )) {
+                        const initialZoom = chart.mapView?.zoom;
                         chart.pointer.onContainerMouseWheel(e);
-                        // Issue #5011, returning false from non-jQuery event
-                        // does not prevent default
-                        stopEvent(e as Event);
+
+                        // If the zoom level changed, prevent the default action
+                        // which is to scroll the page
+                        if (initialZoom !== chart.mapView?.zoom) {
+                            stopEvent(e as Event);
+                        }
                     }
                     return false;
                 }


### PR DESCRIPTION
Prevent mousewheel capture on maps if they are all zoomed out, so that the user can scroll normally down the page.

Test case: https://jsfiddle.net/highcharts/3b97gvzj/