### PR TITLE
Use Point as context for tooltip and data label format(ter)s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@cypress-audit/lighthouse": "^1.4.2",
         "@highcharts/highcharts-assembler": "github:highcharts/highcharts-assembler#v1.5.6",
         "@highcharts/highcharts-declarations-generator": "github:highcharts/highcharts-declarations-generator#v1.2.0",
-        "@highcharts/highcharts-documentation-generators": "github:highcharts/highcharts-documentation-generators#v0.6.8",
+        "@highcharts/highcharts-documentation-generators": "github:highcharts/highcharts-documentation-generators#v0.6.9",
         "@highcharts/map-collection": "^2.2.0",
         "@octokit/rest": "^20.1.1",
         "@swc/core": "^1.5.25",

--- a/samples/highcharts/blog/corn-production/demo.js
+++ b/samples/highcharts/blog/corn-production/demo.js
@@ -73,7 +73,7 @@ const chart = Highcharts.chart('production', {
     tooltip: {
         formatter: function () {
             return '<b>Region: </b>' + this.series.name + '<br>' +
-                '<b>Year: </b>' + this.x + ' <br>' +
+                '<b>Year: </b>' + this.category + ' <br>' +
                 '<b>Production: </b>' +
                 Highcharts.numberFormat(this.y, 0, '.', ',') + ' tonnes<br>' +
                 '<b>Total: </b>' +

--- a/samples/highcharts/blog/corn-production/demo.js
+++ b/samples/highcharts/blog/corn-production/demo.js
@@ -73,7 +73,7 @@ const chart = Highcharts.chart('production', {
     tooltip: {
         formatter: function () {
             return '<b>Region: </b>' + this.series.name + '<br>' +
-                '<b>Year: </b>' + this.category + ' <br>' +
+                '<b>Year: </b>' + this.key + ' <br>' +
                 '<b>Production: </b>' +
                 Highcharts.numberFormat(this.y, 0, '.', ',') + ' tonnes<br>' +
                 '<b>Total: </b>' +

--- a/samples/highcharts/blog/dg-performance-comparison/demo.js
+++ b/samples/highcharts/blog/dg-performance-comparison/demo.js
@@ -45,7 +45,7 @@ Highcharts.chart('container', {
     tooltip: {
         shared: true,
         headerFormat: `<span style="font-size:11px">
-                        Chart loading time for {point.x} points: 
+                        Chart loading time for {category:,.0f} points: 
                         </span><br/>`
     },
     yAxis: {

--- a/samples/highcharts/blog/dg-performance-comparison/demo.js
+++ b/samples/highcharts/blog/dg-performance-comparison/demo.js
@@ -45,7 +45,7 @@ Highcharts.chart('container', {
     tooltip: {
         shared: true,
         headerFormat: `<span style="font-size:11px">
-                        Chart loading time for {category:,.0f} points: 
+                        Chart loading time for {category} points:
                         </span><br/>`
     },
     yAxis: {

--- a/samples/highcharts/blog/top-headline-phrases/demo.js
+++ b/samples/highcharts/blog/top-headline-phrases/demo.js
@@ -33,10 +33,7 @@ Highcharts.chart('container', {
         }
     },
     tooltip: {
-        formatter: function () {
-            return 'This trigrams "<b> ' + this.x + ' </b>" was used <b>' +
-                this.y + '</b>';
-        }
+        format: 'This trigrams "<b>{category}</b>" was used <b>{y}</b> times'
     },
     plotOptions: {
         bar: {

--- a/samples/highcharts/blog/top-headline-phrases/demo.js
+++ b/samples/highcharts/blog/top-headline-phrases/demo.js
@@ -33,7 +33,7 @@ Highcharts.chart('container', {
         }
     },
     tooltip: {
-        format: 'This trigrams "<b>{category}</b>" was used <b>{y}</b> times'
+        format: 'This trigrams "<b> {category} </b>" was used <b>{y}</b> times'
     },
     plotOptions: {
         bar: {

--- a/samples/highcharts/demo/column-stacked/demo.js
+++ b/samples/highcharts/demo/column-stacked/demo.js
@@ -35,7 +35,7 @@ Highcharts.chart('container', {
         shadow: false
     },
     tooltip: {
-        headerFormat: '<b>{point.x}</b><br/>',
+        headerFormat: '<b>{category}</b><br/>',
         pointFormat: '{series.name}: {point.y}<br/>Total: {point.stackTotal}'
     },
     plotOptions: {

--- a/samples/highcharts/demo/cylinder/demo.js
+++ b/samples/highcharts/demo/cylinder/demo.js
@@ -39,7 +39,7 @@ Highcharts.chart('container', {
         }
     },
     tooltip: {
-        headerFormat: '<b>Age: {point.x}</b><br>'
+        headerFormat: '<b>Age: {category}</b><br>'
     },
     plotOptions: {
         series: {

--- a/samples/highcharts/demo/wordcloud/demo.js
+++ b/samples/highcharts/demo/wordcloud/demo.js
@@ -50,7 +50,7 @@ Highcharts.chart('container', {
         align: 'left'
     },
     tooltip: {
-        headerFormat: '<span style="font-size: 16px"><b>{point.key}</b>' +
+        headerFormat: '<span style="font-size: 16px"><b>{point.name}</b>' +
             '</span><br>'
     }
 });

--- a/samples/highcharts/plotoptions/columnpyramid-stacked/demo.js
+++ b/samples/highcharts/plotoptions/columnpyramid-stacked/demo.js
@@ -34,7 +34,7 @@ Highcharts.chart('container', {
         shadow: false
     },
     tooltip: {
-        headerFormat: '<b>{point.x}</b><br/>',
+        headerFormat: '<b>{category}</b><br/>',
         pointFormat: '{series.name}: {point.y}<br/>Total: {point.stackTotal}'
     },
     plotOptions: {

--- a/samples/issues/highcharts-4.0.4/3329-tooltip-xdateformat/demo.js
+++ b/samples/issues/highcharts-4.0.4/3329-tooltip-xdateformat/demo.js
@@ -19,7 +19,7 @@ $(function () {
                     formatter: function () {
                         this.point.key = this.point.x;
                         return this.series.chart.tooltip
-                            .tooltipFooterHeaderFormatter(this.point);
+                            .headerFooterFormatter(this.point);
                     }
                 }
             }

--- a/samples/unit-tests/tooltip/header-format/demo.js
+++ b/samples/unit-tests/tooltip/header-format/demo.js
@@ -47,7 +47,7 @@ QUnit.test('Formats in tooltip header (#3238)', function (assert) {
     chart.tooltip.refresh([chart.series[0].points[0]]);
 
     assert.strictEqual(
-        chart.tooltip.tooltipFooterHeaderFormatter(
+        chart.tooltip.headerFooterFormatter(
             chart.series[0].points[0],
             false
         ),
@@ -65,7 +65,7 @@ QUnit.test('Formats in tooltip header (#3238)', function (assert) {
         'Keys in header should be replaced'
     );
     assert.strictEqual(
-        chart.tooltip.tooltipFooterHeaderFormatter(
+        chart.tooltip.headerFooterFormatter(
             chart.series[0].points[0],
             true
         ),

--- a/samples/unit-tests/tooltip/header-format/demo.js
+++ b/samples/unit-tests/tooltip/header-format/demo.js
@@ -18,7 +18,7 @@ QUnit.test('Formats in tooltip header (#3238)', function (assert) {
 
             series: [
                 {
-                    data: [1, 1, 1]
+                    data: [['Point name', 1], 1, 1]
                 },
                 {
                     data: [2, 2, 2]
@@ -28,7 +28,17 @@ QUnit.test('Formats in tooltip header (#3238)', function (assert) {
                 }
             ],
             tooltip: {
-                headerFormat: '{series.name} {point.total}<br>',
+                headerFormat: `
+                    point.x = {point.x},
+                    point.y = {point.y},
+                    point.color = {point.color},
+                    point.colorIndex = {point.colorIndex},
+                    point.key = {point.key},
+                    point.series.name = {point.series.name},
+                    point.point.name = {point.point.name},
+                    point.percentage = {point.percentage},
+                    point.total = {point.total}
+                `,
                 footerFormat: '{series.name} {point.total}<br>'
             }
         })
@@ -41,8 +51,18 @@ QUnit.test('Formats in tooltip header (#3238)', function (assert) {
             chart.series[0].points[0],
             false
         ),
-        'Series 1 5<br>',
-        'Keys in header are replaced'
+        `
+                    point.x = 0,
+                    point.y = 1,
+                    point.color = #2caffe,
+                    point.colorIndex = 0,
+                    point.key = Point name,
+                    point.series.name = Series 1,
+                    point.point.name = Point name,
+                    point.percentage = 20,
+                    point.total = 5
+                `,
+        'Keys in header should be replaced'
     );
     assert.strictEqual(
         chart.tooltip.tooltipFooterHeaderFormatter(

--- a/test/typescript-dts/highcharts-more/highcharts-more.ts
+++ b/test/typescript-dts/highcharts-more/highcharts-more.ts
@@ -53,7 +53,7 @@ function test_seriesAreaRange() {
         }],
         tooltip: {
             formatter: function() {
-                const high = this.point.options.high;
+                const high = this.options.high;
                 return '' + high;
             },
             shared: true,

--- a/test/typescript-dts/highmaps/highmaps.ts
+++ b/test/typescript-dts/highmaps/highmaps.ts
@@ -18,9 +18,9 @@ test_simple();
 function test_series() {
     const defaultOptions = Highcharts.getOptions();
     const tooltipFormatter = function(
-        this: Highcharts.TooltipFormatterContextObject
+        this: Highcharts.Point
     ) {
-        const point = this.point as any; // @todo make id, lat, lon public
+        const point = this as any; // @todo make id, lat, lon public
         return point.id + (
             point.lat ? `<br>Lat:${point.lat} Lon: ${point.lon}` : ''
         );

--- a/test/typescript-dts/modules/heatmap.ts
+++ b/test/typescript-dts/modules/heatmap.ts
@@ -9,13 +9,13 @@ function test() {
     const colors = Highcharts.getOptions().colors;
     const maxSafeInteger = 9007199254740991;
     const tooltipFormatter = function(
-        this: Highcharts.TooltipFormatterContextObject
+        this: Highcharts.Point
     ) {
-        const series = this.series as any; // @todo make Axis.categories public
+        const series = this.series;
         return (
-            `<b>${series.xAxis.categories[this.point.x]}</b> sold <br>
-            <b>${this.point.value}</b> items on <br>
-            <b>${series.yAxis.categories[this.point.y || maxSafeInteger]}</b>`
+            `<b>${series.xAxis.categories[this.x]}</b> sold <br>
+            <b>${this.value}</b> items on <br>
+            <b>${series.yAxis.categories[this.y || maxSafeInteger]}</b>`
         );
     };
     Highcharts.chart('container', {

--- a/test/typescript-dts/modules/map.ts
+++ b/test/typescript-dts/modules/map.ts
@@ -32,9 +32,9 @@ function test_simple() {
 function test_series() {
     const defaultOptions = Highcharts.getOptions();
     const tooltipFormatter = function(
-        this: Highcharts.TooltipFormatterContextObject
+        this: Highcharts.Point
     ) {
-        const point = this.point as any; // @todo make id, lat, lon public
+        const point = this as any; // @todo make id, lat, lon public
         return point.id + (
             point.lat ? `<br>Lat:${point.lat} Lon: ${point.lon}` : ''
         );

--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -2146,37 +2146,32 @@ const defaultOptions: DefaultOptions = {
          * attribute, but only text-related CSS, that is shared with SVG, is
          * handled.
          *
-         * The available data in the formatter differ a bit depending on whether
-         * the tooltip is shared or split, or belongs to a single point. In a
-         * shared/split tooltip, all properties except `x`, which is common for
-         * all points, are kept in an array, `this.points`.
+         * The context of the formatter (since v12) is the
+         * [Point](https://api.highcharts.com/class-reference/Highcharts.Point)
+         * instance. If the tooltip is shared or split, an array `this.points`
+         * contains all points of the hovered x-value.
          *
-         * Available data are:
+         * Common properties from the Point to use in the formatter include:
          *
-         * - **this.percentage (not shared) /**
-         *   **this.points[i].percentage (shared)**:
+         * - **Point.percentage**:
          *   Stacked series and pies only. The point's percentage of the total.
          *
-         * - **this.point (not shared) / this.points[i].point (shared)**:
-         *   The point object. The point name, if defined, is available through
-         *   `this.point.name`.
+         * - **Point.points**:
+         *   In a shared or split tooltip, this is an array containing all the
+         *   hovered points.
          *
-         * - **this.points**:
-         *   In a shared tooltip, this is an array containing all other
-         *   properties for each point.
-         *
-         * - **this.series (not shared) / this.points[i].series (shared)**:
+         * - **this.series**:
          *   The series object. The series name is available through
          *   `this.series.name`.
          *
-         * - **this.total (not shared) / this.points[i].total (shared)**:
-         *   Stacked series only. The total value at this point's x value.
+         * - **this.total**:
+         *   The total value at this point's x value in a stacked series, or the
+         *   sum of all slices in a pie series.
          *
          * - **this.x**:
-         *   The x value. This property is the same regardless of the tooltip
-         *   being shared or not.
+         *   The x value.
          *
-         * - **this.y (not shared) / this.points[i].y (shared)**:
+         * - **this.y**:
          *   The y value.
          *
          * @sample {highcharts} highcharts/tooltip/formatter-simple/
@@ -2581,13 +2576,14 @@ const defaultOptions: DefaultOptions = {
         snap: isTouchDevice ? 25 : 10,
 
         /**
-         * The HTML of the tooltip header line. Variables are enclosed by
-         * curly brackets. Available variables are `point.key`, `series.name`,
-         * `series.color` and other members from the `point` and `series`
-         * objects. The `point.key` variable contains the category name, x
-         * value or datetime string depending on the type of axis. For datetime
-         * axes, the `point.key` date format can be set using
-         * `tooltip.xDateFormat`.
+         * The HTML of the tooltip header line. The context is the
+         * [Point class](https://api.highcharts.com/class-reference/Highcharts.Point).
+         * Variables are enclosed in curly brackets. Examples of common
+         * variables to include are `x`, `y`, `series.name` and `series.color`
+         * and other properties on the same form. The `point.key` variable
+         * contains the category name, x value or datetime string depending on
+         * the type of axis. For datetime axes, the `point.key` date format can
+         * be set using `tooltip.xDateFormat`.
          *
          * @sample {highcharts} highcharts/tooltip/footerformat/
          *         An HTML table in the tooltip
@@ -2613,16 +2609,17 @@ const defaultOptions: DefaultOptions = {
          */
 
         /**
-         * The HTML of the point's line in the tooltip. Variables are enclosed
-         * by curly brackets. Available variables are `point.x`, `point.y`,
-         * `series.name` and `series.color` and other properties on the same
-         * form. Furthermore, `point.y` can be extended by the
-         * `tooltip.valuePrefix` and `tooltip.valueSuffix` variables. This can
-         * also be overridden for each series, which makes it a good hook for
-         * displaying units.
+         * The HTML of the point's line in the tooltip. The context is the
+         * [Point class](https://api.highcharts.com/class-reference/Highcharts.Point).
+         * Variables are enclosed in curly brackets. Examples of common
+         * variables to include are `x`, `y`, `series.name` and `series.color`
+         * and other properties on the same form. Furthermore, `y` can be
+         * extended by the `tooltip.valuePrefix` and `tooltip.valueSuffix`
+         * variables. This can also be overridden for each series, which makes
+         * it a good hook for displaying units.
          *
-         * In styled mode, the dot is colored by a class name rather
-         * than the point color.
+         * In styled mode, the dot is colored by a class name rather than the
+         * point color.
          *
          * @sample {highcharts} highcharts/tooltip/pointformat/
          *         A different point format with value suffix

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -599,8 +599,7 @@ namespace DataLabel {
                             style = {}
                         } = labelOptions;
 
-                    let labelConfig,
-                        formatString,
+                    let formatString,
                         labelText,
                         rotation,
                         attr: SVGAttributes = {},
@@ -619,15 +618,14 @@ namespace DataLabel {
                             labelOptions.format
                         );
 
-                        labelConfig = point.getLabelConfig();
                         labelText = defined(formatString) ?
-                            format(formatString, labelConfig, chart) :
+                            format(formatString, point, chart) :
                             (
                                 (labelOptions as any)[
                                     point.formatPrefix + 'Formatter'
                                 ] ||
                                 labelOptions.formatter
-                            ).call(labelConfig, labelOptions);
+                            ).call(point, labelOptions);
 
                         rotation = labelOptions.rotation;
 
@@ -1055,7 +1053,7 @@ export default DataLabel;
  *
  * @callback Highcharts.DataLabelsFormatterCallbackFunction
  *
- * @param {Highcharts.PointLabelObject} this
+ * @param {Highcharts.Point} this
  * Data label context to format
  *
  * @param {Highcharts.DataLabelsOptions} options

--- a/ts/Core/Series/DataLabelOptions.d.ts
+++ b/ts/Core/Series/DataLabelOptions.d.ts
@@ -50,7 +50,7 @@ export interface DataLabelFilterOptions {
 }
 
 export interface DataLabelFormatterCallback {
-    (this: Point.PointLabelObject): (number|string|null|undefined);
+    (this: Point): (number|string|null|undefined);
 }
 
 export interface DataLabelOptions {

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -951,22 +951,26 @@ class Point {
     public tooltipFormatter(pointFormat: string): string {
 
         // Insert options for valueDecimals, valuePrefix, and valueSuffix
-        const series = this.series,
-            seriesTooltipOptions = series.tooltipOptions,
-            valueDecimals = pick(seriesTooltipOptions.valueDecimals, ''),
-            valuePrefix = seriesTooltipOptions.valuePrefix || '',
-            valueSuffix = seriesTooltipOptions.valueSuffix || '';
-
+        const {
+                chart,
+                pointArrayMap = ['y'],
+                tooltipOptions
+            } = this.series,
+            {
+                valueDecimals = '',
+                valuePrefix = '',
+                valueSuffix = ''
+            } = tooltipOptions;
 
         // Replace default point style with class name
-        if (series.chart.styledMode) {
-            pointFormat =
-                (series.chart.tooltip as any).styledModeFormat(pointFormat);
+        if (chart.styledMode) {
+            pointFormat = chart.tooltip?.styledModeFormat(pointFormat) ||
+                pointFormat;
         }
 
         // Loop over the point array map and replace unformatted values with
         // sprintf formatting markup
-        (series.pointArrayMap || ['y']).forEach(function (key: string): void {
+        pointArrayMap.forEach((key: string): void => {
             key = '{point.' + key; // Without the closing bracket
             if (valuePrefix || valueSuffix) {
 
@@ -981,10 +985,7 @@ class Point {
             );
         });
 
-        return format(pointFormat, {
-            point: this,
-            series: this.series
-        }, series.chart);
+        return format(pointFormat, this, chart);
     }
 
     /**

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -125,11 +125,14 @@ class Point {
     public id!: string;
     public isNew?: boolean;
     public isNull?: boolean;
+    public key?: string|number;
     public marker?: PointMarkerOptions;
     public name!: string;
     public nonZonedColor?: ColorType;
     public options!: PointOptions;
     public percentage?: number;
+    public point: Point;
+    public points?: Array<Point>;
     public selected?: boolean;
     public series!: Series;
     public shapeArgs?: SVGAttributes;
@@ -171,6 +174,14 @@ class Point {
      *
      * @name Highcharts.Point#name
      * @type {string}
+     */
+
+    /**
+     * The point's name if it is defined, or its category in case of a category,
+     * otherwise the x value. Convenient for tooltip and data label formatting.
+     *
+     * @name Highcharts.Point#key
+     * @type {number|string}
      */
 
     /**
@@ -582,29 +593,6 @@ class Point {
     }
 
     /**
-     * Return the configuration hash needed for the data label and tooltip
-     * formatters.
-     *
-     * @function Highcharts.Point#getLabelConfig
-     *
-     * @return {Highcharts.PointLabelObject}
-     *         Abstract object used in formatters and formats.
-     */
-    public getLabelConfig(): Point.PointLabelObject {
-        return {
-            x: this.category,
-            y: this.y,
-            color: this.color,
-            colorIndex: this.colorIndex,
-            key: this.name || this.category,
-            series: this.series,
-            point: this as any,
-            percentage: this.percentage,
-            total: this.total || (this as any).stackTotal
-        };
-    }
-
-    /**
      * Returns the value of the point property for a given value.
      * @private
      */
@@ -689,6 +677,9 @@ class Point {
         options: (PointOptions|PointShortOptions),
         x?: number
     ) {
+        // For tooltip and data label formatting
+        this.point = this;
+
         this.series = series;
 
         this.applyOptions(options, x);
@@ -1654,17 +1645,6 @@ namespace Point {
         singular: Array<string>;
         plural: Array<string>;
     }
-    export interface PointLabelObject {
-        x?: (number|string);
-        y?: (number|null);
-        color?: ColorType;
-        colorIndex?: number;
-        key?: number|string;
-        series: Series;
-        point: Point;
-        percentage?: number;
-        total?: number;
-    }
     export interface SeriesPointsOptions {
         events?: PointEventsOptions;
     }
@@ -1712,52 +1692,6 @@ export default Point;
  * Clicked point.
  * @name Highcharts.PointClickEventObject#point
  * @type {Highcharts.Point}
- */
-
-/**
- * Configuration for the data label and tooltip formatters.
- *
- * @interface Highcharts.PointLabelObject
- *//**
- * The point's current color.
- * @name Highcharts.PointLabelObject#color
- * @type {Highcharts.ColorString|Highcharts.GradientColorObject|Highcharts.PatternObject|undefined}
- *//**
- * The point's current color index, used in styled mode instead of `color`. The
- * color index is inserted in class names used for styling.
- * @name Highcharts.PointLabelObject#colorIndex
- * @type {number}
- *//**
- * The name of the related point.
- * @name Highcharts.PointLabelObject#key
- * @type {string|undefined}
- *//**
- * The percentage for related points in a stacked series or pies.
- * @name Highcharts.PointLabelObject#percentage
- * @type {number}
- *//**
- * The related point. The point name, if defined, is available through
- * `this.point.name`.
- * @name Highcharts.PointLabelObject#point
- * @type {Highcharts.Point}
- *//**
- * The related series. The series name is available through `this.series.name`.
- * @name Highcharts.PointLabelObject#series
- * @type {Highcharts.Series}
- *//**
- * The total of values in either a stack for stacked series, or a pie in a pie
- * series.
- * @name Highcharts.PointLabelObject#total
- * @type {number|undefined}
- *//**
- * For categorized axes this property holds the category name for the point. For
- * other axes it holds the X value.
- * @name Highcharts.PointLabelObject#x
- * @type {number|string|undefined}
- *//**
- * The y value of the point.
- * @name Highcharts.PointLabelObject#y
- * @type {number|null|undefined}
  */
 
 /**

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -119,6 +119,7 @@ class Point {
     public dataLabels?: Array<SVGElement|SVGLabel>;
     public destroyed?: boolean;
     public formatPrefix: string = 'point';
+    public formattedValue?: string;
     public graphic?: SVGElement;
     public graphics?: Array<SVGElement|undefined>;
     public hiddenInDataClass?: boolean;

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2330,11 +2330,10 @@ class Series {
             // Negative points #19028
             point.negative = (point.y || 0) < (threshold || 0);
 
-            // Some API data
-            point.category = pick(
-                categories && categories[point.x],
-                point.x as any
-            );
+            // Set point properties for convenient access in tooltip and data
+            // labels
+            point.category = categories?.[point.x] ?? point.x;
+            point.key = point.name ?? point.category;
 
             // Determine auto enabling of markers (#3635, #5099)
             if (!point.isNull && point.visible !== false) {

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -1813,7 +1813,8 @@ class Series {
                 options.dataGrouping.groupAll ?
                     cropStart :
                     0
-            );
+            ),
+            categories = series.xAxis?.categories;
         let dataLength,
             cursor,
             point,
@@ -1879,6 +1880,12 @@ class Series {
                 point.index = hasGroupedData ?
                     (groupCropStartIndex + i) : cursor;
                 points[i] = point;
+
+                // Set point properties for convenient access in tooltip and
+                // data labels
+                point.category = categories?.[point.x] ?? point.x;
+                point.key = point.name ?? point.category;
+
             }
         }
 
@@ -2153,7 +2160,6 @@ class Series {
             options = series.options,
             stacking = options.stacking,
             xAxis = series.xAxis,
-            categories = xAxis.categories,
             enabledDataSorting = series.enabledDataSorting,
             yAxis = series.yAxis,
             points = series.points,
@@ -2329,11 +2335,6 @@ class Series {
 
             // Negative points #19028
             point.negative = (point.y || 0) < (threshold || 0);
-
-            // Set point properties for convenient access in tooltip and data
-            // labels
-            point.category = categories?.[point.x] ?? point.x;
-            point.key = point.name ?? point.category;
 
             // Determine auto enabling of markers (#3635, #5099)
             if (!point.isNull && point.visible !== false) {

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -1803,7 +1803,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
          *
          * @type {Highcharts.DataLabelsFormatterCallbackFunction}
          */
-        formatter: function (this: Point.PointLabelObject): string {
+        formatter: function (this: Point): string {
             const { numberFormatter } = this.series.chart;
             return typeof this.y !== 'number' ?
                 '' : numberFormatter(this.y, -1);

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1686,10 +1686,10 @@ class Tooltip {
             tooltipOptions = series.tooltipOptions,
             xAxis = series.xAxis,
             dateTime = xAxis && xAxis.dateTime,
-            e = {
-                isFooter: isFooter,
-                labelConfig: point
-            } as AnyRecord;
+            e: Tooltip.HeaderFormatterEventObject = {
+                isFooter,
+                point
+            };
         let xDateFormat = tooltipOptions.xDateFormat,
             formatString = tooltipOptions[
                 isFooter ? 'footerFormat' : 'headerFormat'
@@ -1697,7 +1697,7 @@ class Tooltip {
 
         fireEvent(this, 'headerFormatter', e, function (
             this: Tooltip,
-            e: AnyRecord
+            e: Tooltip.HeaderFormatterEventObject
         ): void {
 
             // Guess the best date format based on the closest point distance
@@ -1730,7 +1730,7 @@ class Tooltip {
             e.text = format(formatString, point, this.chart);
 
         });
-        return e.text;
+        return e.text || '';
     }
 
     /**
@@ -1848,6 +1848,12 @@ namespace Tooltip {
             this: Point,
             tooltip: Tooltip
         ): (false|string|Array<string>);
+    }
+
+    export interface HeaderFormatterEventObject {
+        isFooter?: boolean;
+        point: Point;
+        text?: string;
     }
 
     export interface PositionerCallbackFunction {

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -262,13 +262,13 @@ class Tooltip {
         let s: (string|Array<string>);
 
         // Build the header
-        s = [tooltip.tooltipFooterHeaderFormatter(hoverPoints[0])];
+        s = [tooltip.headerFooterFormatter(hoverPoints[0])];
 
         // Build the values
         s = s.concat(tooltip.bodyFormatter(hoverPoints));
 
         // Footer
-        s.push(tooltip.tooltipFooterHeaderFormatter(hoverPoints[0], true));
+        s.push(tooltip.headerFooterFormatter(hoverPoints[0], true));
 
         return s;
     }
@@ -1676,9 +1676,9 @@ class Tooltip {
      * #3397: abstraction to enable formatting of footer and header
      *
      * @private
-     * @function Highcharts.Tooltip#tooltipFooterHeaderFormatter
+     * @function Highcharts.Tooltip#headerFooterFormatter
      */
-    public tooltipFooterHeaderFormatter(
+    public headerFooterFormatter(
         point: Point,
         isFooter?: boolean
     ): string {

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1922,14 +1922,15 @@ export default Tooltip;
  * Callback function to format the text of the tooltip from scratch.
  *
  * In case of single or shared tooltips, a string should be returned. In case
- * of splitted tooltips, it should return an array where the first item is the
+ * of split tooltips, it should return an array where the first item is the
  * header, and subsequent items are mapped to the points. Return `false` to
  * disable tooltip for a specific point on series.
  *
  * @callback Highcharts.TooltipFormatterCallbackFunction
  *
- * @param {Highcharts.TooltipFormatterContextObject} this
- * Context to format
+ * @param {Highcharts.Point} this
+ * The formatter's context is the hovered `Point` instance. In case of shared or
+ * split tooltips, all points are available in `this.points`.
  *
  * @param {Highcharts.Tooltip} tooltip
  * The tooltip instance

--- a/ts/Extensions/Annotations/Controllables/ControllableLabel.ts
+++ b/ts/Extensions/Annotations/Controllables/ControllableLabel.ts
@@ -425,11 +425,7 @@ class ControllableLabel extends Controllable {
 
         label.attr({
             text: text ?
-                format(
-                    String(text),
-                    point.getLabelConfig(),
-                    this.annotation.chart
-                ) :
+                format(String(text), point, this.annotation.chart) :
                 (options.formatter as any).call(point, this)
         });
 

--- a/ts/Extensions/Annotations/MockPoint.ts
+++ b/ts/Extensions/Annotations/MockPoint.ts
@@ -316,21 +316,6 @@ class MockPoint {
     }
 
     /**
-     * Returns a label config object - the same as
-     * Highcharts.Point.prototype.getLabelConfig
-     * @private
-     * @return {Highcharts.AnnotationMockLabelOptionsObject}
-     * The point's label config
-     */
-    public getLabelConfig(): MockLabelConfigObject {
-        return {
-            x: this.x,
-            y: this.y,
-            point: this
-        };
-    }
-
-    /**
      * Get the point's options.
      * @private
      * @return {Highcharts.AnnotationMockPointOptionsObject}

--- a/ts/Extensions/Annotations/MockPoint.ts
+++ b/ts/Extensions/Annotations/MockPoint.ts
@@ -95,6 +95,8 @@ interface MockSeries {
  */
 class MockPoint {
 
+    point: MockPoint;
+
     /* *
      *
      *  Static Functions
@@ -201,6 +203,9 @@ class MockPoint {
         target: (ControlTarget|null),
         options: (MockPointOptions|Function)
     ) {
+        // Circular reference for formats and formatters
+        this.point = this;
+
         /**
          * A mock series instance imitating a real series from a real point.
          *

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -890,6 +890,7 @@ function getPoint(
             point.x, // @todo simplify
         point.x
     );
+    point.key = point.name ?? point.category;
 
     point.dist = boostPoint.dist;
     point.distX = boostPoint.distX;

--- a/ts/Extensions/DataGrouping/DataGrouping.ts
+++ b/ts/Extensions/DataGrouping/DataGrouping.ts
@@ -29,7 +29,6 @@ const { format } = F;
 import H from '../../Core/Globals.js';
 const { composed } = H;
 import U from '../../Core/Utilities.js';
-import Point from '../../Core/Series/Point';
 const {
     addEvent,
     extend,
@@ -71,20 +70,19 @@ function compose(
  */
 function onTooltipHeaderFormatter(
     this: Tooltip,
-    e: Event&AnyRecord
+    e: Event&Tooltip.HeaderFormatterEventObject
 ): void {
 
     const chart = this.chart,
         time = chart.time,
-        labelConfig = e.labelConfig,
-        series = labelConfig.series as Series,
-        point = labelConfig.point as Point,
+        point = e.point,
+        series = point.series,
         options = series.options,
         tooltipOptions = series.tooltipOptions,
         dataGroupingOptions = options.dataGrouping,
         xAxis = series.xAxis;
 
-    let xDateFormat = tooltipOptions.xDateFormat,
+    let xDateFormat = tooltipOptions.xDateFormat || '',
         xDateFormatEnd,
         currentDataGrouping: (TimeTicksInfoObject|undefined),
         dateTimeLabelFormats,
@@ -99,7 +97,7 @@ function onTooltipHeaderFormatter(
         xAxis &&
         xAxis.options.type === 'datetime' &&
         dataGroupingOptions &&
-        isNumber(labelConfig.key)
+        isNumber(point.key)
     ) {
 
         // Set variables
@@ -125,7 +123,7 @@ function onTooltipHeaderFormatter(
         // it, but if the least distance is one day, skip hours and minutes etc.
         } else if (!xDateFormat && dateTimeLabelFormats && xAxis.dateTime) {
             xDateFormat = xAxis.dateTime.getXDateFormat(
-                labelConfig.x,
+                point.x,
                 tooltipOptions.dateTimeLabelFormats
 
             );
@@ -133,14 +131,11 @@ function onTooltipHeaderFormatter(
 
         const groupStart = pick(
                 series.groupMap?.[point.index].groupStart,
-                labelConfig.key
+                point.key
             ),
-            groupEnd = groupStart + currentDataGrouping?.totalRange - 1;
+            groupEnd = groupStart + (currentDataGrouping?.totalRange || 0) - 1;
 
-        formattedKey = time.dateFormat(
-            xDateFormat as any,
-            groupStart
-        );
+        formattedKey = time.dateFormat(xDateFormat, groupStart);
         if (xDateFormatEnd) {
             formattedKey += time.dateFormat(
                 xDateFormatEnd,
@@ -156,7 +151,7 @@ function onTooltipHeaderFormatter(
         // Return the replaced format
         e.text = format(
             formatString, {
-                point: extend(labelConfig.point, { key: formattedKey }),
+                point: extend(point, { key: formattedKey }),
                 series: series
             },
             chart

--- a/ts/Extensions/ParallelCoordinates/ParallelSeries.ts
+++ b/ts/Extensions/ParallelCoordinates/ParallelSeries.ts
@@ -86,22 +86,6 @@ namespace ParallelSeries {
             );
             addEvent(CompoClass, 'bindAxes', onSeriesBindAxes);
             addEvent(CompoClass, 'destroy', onSeriesDestroy);
-
-            if (LinePointClass) {
-                wrap(
-                    LinePointClass.prototype,
-                    'getLabelConfig',
-                    wrapSeriesGetLabelConfig
-                );
-            }
-
-            if (SplinePointClass) {
-                wrap(
-                    SplinePointClass.prototype,
-                    'getLabelConfig',
-                    wrapSeriesGetLabelConfig
-                );
-            }
         }
 
     }
@@ -222,7 +206,7 @@ namespace ParallelSeries {
 
     /**
      * @private
-     */
+     * /
     function wrapSeriesGetLabelConfig(
         this: Point,
         proceed: Function
@@ -278,7 +262,7 @@ namespace ParallelSeries {
 
         return config;
     }
-
+    */
 }
 
 /* *

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -244,7 +244,7 @@ class BubbleSeries extends ScatterSeries {
 
         dataLabels: {
             formatter: function (
-                this: Point.PointLabelObject
+                this: Point
             ): string { // #2945
                 const { numberFormatter } = this.series.chart;
                 const { z } = (this.point as BubblePoint);

--- a/ts/Series/Map/MapSeriesDefaults.ts
+++ b/ts/Series/Map/MapSeriesDefaults.ts
@@ -67,7 +67,7 @@ const MapSeriesDefaults: MapSeriesOptions = {
             const { value } = this.point as MapPoint;
             return isNumber(value) ?
                 numberFormatter(value, -1) :
-                this.point.name; // #20231
+                (this.point.name || ''); // #20231
         },
         inside: true, // For the color
         overflow: false as any,

--- a/ts/Series/MapPoint/MapPointSeriesDefaults.ts
+++ b/ts/Series/MapPoint/MapPointSeriesDefaults.ts
@@ -48,7 +48,7 @@ const MapPointSeriesDefaults: MapPointSeriesOptions = {
         defer: false,
         enabled: true,
         formatter: function (
-            this: Point.PointLabelObject
+            this: Point
         ): (string|undefined) { // #2945
             return this.point.name;
         },

--- a/ts/Series/Networkgraph/NetworkgraphSeries.ts
+++ b/ts/Series/Networkgraph/NetworkgraphSeries.ts
@@ -607,36 +607,11 @@ export default NetworkgraphSeries;
  *
  * @callback Highcharts.SeriesNetworkgraphDataLabelsFormatterCallbackFunction
  *
- * @param {Highcharts.SeriesNetworkgraphDataLabelsFormatterContextObject|Highcharts.PointLabelObject} this
+ * @param {Highcharts.SeriesNetworkgraphDataLabelsFormatterContextObject|Highcharts.Point} this
  *        Data label context to format
  *
  * @return {string}
  *         Formatted data label text
- */
-
-/**
- * Context for the formatter function.
- *
- * @interface Highcharts.SeriesNetworkgraphDataLabelsFormatterContextObject
- * @extends Highcharts.PointLabelObject
- * @since 7.0.0
- *//**
- * The color of the node.
- * @name Highcharts.SeriesNetworkgraphDataLabelsFormatterContextObject#color
- * @type {Highcharts.ColorString}
- * @since 7.0.0
- *//**
- * The point (node) object. The node name, if defined, is available through
- * `this.point.name`. Arrays: `this.point.linksFrom` and `this.point.linksTo`
- * contains all nodes connected to this point.
- * @name Highcharts.SeriesNetworkgraphDataLabelsFormatterContextObject#point
- * @type {Highcharts.Point}
- * @since 7.0.0
- *//**
- * The ID of the node.
- * @name Highcharts.SeriesNetworkgraphDataLabelsFormatterContextObject#key
- * @type {string}
- * @since 7.0.0
  */
 
 /**

--- a/ts/Series/Networkgraph/NetworkgraphSeries.ts
+++ b/ts/Series/Networkgraph/NetworkgraphSeries.ts
@@ -278,6 +278,7 @@ class NetworkgraphSeries extends Series {
                 this.options.marker && this.options.marker.radius,
                 0
             );
+            node.key = node.name;
 
             // If node exists, but it's not available in nodeLookup,
             // then it's leftover from previous runs (e.g. setData)

--- a/ts/Series/Networkgraph/NetworkgraphSeries.ts
+++ b/ts/Series/Networkgraph/NetworkgraphSeries.ts
@@ -604,18 +604,6 @@ export default NetworkgraphSeries;
  * */
 
 /**
- * Formatter callback function.
- *
- * @callback Highcharts.SeriesNetworkgraphDataLabelsFormatterCallbackFunction
- *
- * @param {Highcharts.SeriesNetworkgraphDataLabelsFormatterContextObject|Highcharts.Point} this
- *        Data label context to format
- *
- * @return {string}
- *         Formatted data label text
- */
-
-/**
  * Callback that fires after the end of Networkgraph series simulation
  * when the layout is stable.
  *

--- a/ts/Series/Networkgraph/NetworkgraphSeriesDefaults.ts
+++ b/ts/Series/Networkgraph/NetworkgraphSeriesDefaults.ts
@@ -147,7 +147,6 @@ const NetworkgraphSeriesDefaults: NetworkgraphSeriesOptions = {
          * Note that if a `format` is defined, the format takes precedence
          * and the formatter is ignored.
          *
-         * @type  {Highcharts.SeriesNetworkgraphDataLabelsFormatterCallbackFunction}
          * @since 7.0.0
          */
         formatter: function (
@@ -173,7 +172,6 @@ const NetworkgraphSeriesDefaults: NetworkgraphSeriesOptions = {
          * The `linkFormat` option takes precedence over the
          * `linkFormatter`.
          *
-         * @type  {Highcharts.SeriesNetworkgraphDataLabelsFormatterCallbackFunction}
          * @since 7.1.0
          */
         linkFormatter: function (

--- a/ts/Series/Networkgraph/NetworkgraphSeriesDefaults.ts
+++ b/ts/Series/Networkgraph/NetworkgraphSeriesDefaults.ts
@@ -19,7 +19,6 @@
  * */
 
 import type {
-    NetworkgraphDataLabelsFormatterContextObject,
     NetworkgraphSeriesOptions
 } from './NetworkgraphSeriesOptions';
 import type NetworkgraphPoint from './NetworkgraphPoint';
@@ -152,16 +151,9 @@ const NetworkgraphSeriesDefaults: NetworkgraphSeriesOptions = {
          * @since 7.0.0
          */
         formatter: function (
-            this: (
-                NetworkgraphDataLabelsFormatterContextObject|
-                Point.PointLabelObject
-            )
+            this: Point|NetworkgraphPoint
         ): string {
-            return (
-                this as (
-                    NetworkgraphDataLabelsFormatterContextObject
-                )
-            ).key;
+            return String(this.key ?? '');
         },
 
         /**
@@ -185,15 +177,12 @@ const NetworkgraphSeriesDefaults: NetworkgraphSeriesOptions = {
          * @since 7.1.0
          */
         linkFormatter: function (
-            this: (
-                NetworkgraphDataLabelsFormatterContextObject|
-                Point.PointLabelObject
-            )
+            this: Point|NetworkgraphPoint
         ): string {
             return (
-                (this.point as NetworkgraphPoint).fromNode.name +
+                (this as NetworkgraphPoint).fromNode.name +
                 '<br>' +
-                (this.point as NetworkgraphPoint).toNode.name
+                (this as NetworkgraphPoint).toNode.name
             );
         },
 

--- a/ts/Series/Networkgraph/NetworkgraphSeriesOptions.d.ts
+++ b/ts/Series/Networkgraph/NetworkgraphSeriesOptions.d.ts
@@ -58,18 +58,7 @@ declare module '../../Core/Series/SeriesOptions' {
 }
 
 export interface NetworkgraphDataLabelsFormatterCallbackFunction {
-    (this: (
-        NetworkgraphDataLabelsFormatterContextObject|
-        Point.PointLabelObject
-    )): (number|string|null|undefined);
-}
-
-export interface NetworkgraphDataLabelsFormatterContextObject
-    extends Point.PointLabelObject {
-
-    color: ColorType;
-    key: string;
-    point: NetworkgraphPoint;
+    (this: Point|NetworkgraphPoint): (number|string|null|undefined);
 }
 
 export interface NetworkgraphDataLabelsOptions

--- a/ts/Series/Organization/OrganizationDataLabelOptions.d.ts
+++ b/ts/Series/Organization/OrganizationDataLabelOptions.d.ts
@@ -17,12 +17,11 @@
  * */
 
 import type OrganizationPoint from './OrganizationPoint';
-import type OrganizationSeries from './OrganizationSeries';
 import type Point from '../../Core/Series/Point';
 import type {
-    SankeyDataLabelFormatterContext,
     SankeyDataLabelOptions
 } from '../Sankey/SankeyDataLabelOptions';
+import type SankeyPoint from '../Sankey/SankeyPoint';
 
 /* *
  *
@@ -32,18 +31,10 @@ import type {
 
 export interface OrganizationDataLabelsFormatterCallbackFunction {
     (
-        this: (
-            OrganizationDataLabelFormatterContext|
-            SankeyDataLabelFormatterContext|
-            Point.PointLabelObject
-        )
+        this: (Point|OrganizationPoint|SankeyPoint)
     ): (string|undefined);
 }
 
-export interface OrganizationDataLabelFormatterContext extends SankeyDataLabelFormatterContext {
-    point: OrganizationPoint;
-    series: OrganizationSeries;
-}
 
 export interface OrganizationDataLabelOptions extends SankeyDataLabelOptions {
     nodeFormatter?: OrganizationDataLabelsFormatterCallbackFunction;

--- a/ts/Series/Organization/OrganizationSeriesDefaults.ts
+++ b/ts/Series/Organization/OrganizationSeriesDefaults.ts
@@ -19,11 +19,10 @@
  * */
 
 import type CSSObject from '../../Core/Renderer/CSSObject';
-import type { OrganizationDataLabelFormatterContext } from './OrganizationDataLabelOptions';
 import type OrganizationPoint from './OrganizationPoint';
 import type OrganizationSeriesOptions from './OrganizationSeriesOptions';
 import type Point from '../../Core/Series/Point';
-import type { SankeyDataLabelFormatterContext } from '../Sankey/SankeyDataLabelOptions';
+import type SankeyPoint from '../Sankey/SankeyPoint';
 
 import { Palette } from '../../Core/Color/Palettes.js';
 
@@ -162,11 +161,7 @@ const OrganizationSeriesDefaults: OrganizationSeriesOptions = {
          * @since 6.0.2
          */
         nodeFormatter: function (
-            this: (
-                Point.PointLabelObject|
-                OrganizationDataLabelFormatterContext|
-                SankeyDataLabelFormatterContext
-            )
+            this: (Point|OrganizationPoint|SankeyPoint)
         ): string {
             const outerStyle: CSSObject = {
                     width: '100%',
@@ -223,10 +218,7 @@ const OrganizationSeriesDefaults: OrganizationSeriesOptions = {
 
             // PhantomJS doesn't support flex, roll back to absolute
             // positioning
-            if (
-                (this as OrganizationDataLabelFormatterContext)
-                    .series.chart.renderer.forExport
-            ) {
+            if (this.series.chart.renderer.forExport) {
                 outerStyle.display = 'block';
                 innerStyle.position = 'absolute';
                 innerStyle.left = image ? '30%' : 0;

--- a/ts/Series/PackedBubble/PackedBubbleDataLabelOptions.d.ts
+++ b/ts/Series/PackedBubble/PackedBubbleDataLabelOptions.d.ts
@@ -28,14 +28,7 @@ import type Point from '../../Core/Series/Point';
  * */
 
 export interface PackedBubbleDataLabelsFormatterCallbackFunction {
-    (this: (
-        Point.PointLabelObject|
-        PackedBubbleDataLabelFormatterObject
-    )): (number|string|null|undefined);
-}
-
-export interface PackedBubbleDataLabelFormatterObject extends Point.PointLabelObject {
-    point: PackedBubblePoint;
+    (this: (Point|PackedBubblePoint)): (number|string|null|undefined);
 }
 
 export interface PackedBubbleDataLabelOptions extends DataLabelOptions {

--- a/ts/Series/PackedBubble/PackedBubbleSeries.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeries.ts
@@ -1344,29 +1344,5 @@ export default PackedBubbleSeries;
  *         Formatted data label text
  */
 
-/**
- * Context for the formatter function.
- *
- * @interface Highcharts.SeriesPackedBubbleDataLabelsFormatterContextObject
- * @extends Highcharts.PointLabelObject
- * @since 7.0.0
- *//**
- * The color of the node.
- * @name Highcharts.SeriesPackedBubbleDataLabelsFormatterContextObject#color
- * @type {Highcharts.ColorString}
- * @since 7.0.0
- *//**
- * The point (node) object. The node name, if defined, is available through
- * `this.point.name`. Arrays: `this.point.linksFrom` and `this.point.linksTo`
- * contains all nodes connected to this point.
- * @name Highcharts.SeriesPackedBubbleDataLabelsFormatterContextObject#point
- * @type {Highcharts.Point}
- * @since 7.0.0
- *//**
- * The ID of the node.
- * @name Highcharts.SeriesPackedBubbleDataLabelsFormatterContextObject#key
- * @type {string}
- * @since 7.0.0
- */
 
 ''; // Detach doclets above

--- a/ts/Series/PackedBubble/PackedBubbleSeries.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeries.ts
@@ -1325,24 +1325,3 @@ SeriesRegistry.registerSeriesType('packedbubble', PackedBubbleSeries);
  * */
 
 export default PackedBubbleSeries;
-
-/* *
- *
- *  API Declarations
- *
- * */
-
-/**
- * Formatter callback function.
- *
- * @callback Highcharts.SeriesPackedBubbleDataLabelsFormatterCallbackFunction
- *
- * @param {Highcharts.SeriesPackedBubbleDataLabelsFormatterContextObject} this
- *        Data label context to format
- *
- * @return {string}
- *         Formatted data label text
- */
-
-
-''; // Detach doclets above

--- a/ts/Series/PackedBubble/PackedBubbleSeriesDefaults.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeriesDefaults.ts
@@ -146,7 +146,6 @@ const PackedBubbleSeriesDefaults: PackedBubbleSeriesOptions = {
          * Note that if a `format` is defined, the format takes precedence
          * and the formatter is ignored.
          *
-         * @type  {Highcharts.SeriesPackedBubbleDataLabelsFormatterCallbackFunction}
          * @since 7.0.0
          */
         formatter: function (
@@ -166,7 +165,6 @@ const PackedBubbleSeriesDefaults: PackedBubbleSeriesOptions = {
 
         // eslint-disable-next-line valid-jsdoc
         /**
-         * @type  {Highcharts.SeriesPackedBubbleDataLabelsFormatterCallbackFunction}
          * @since 7.1.0
          */
         parentNodeFormatter: function (

--- a/ts/Series/PackedBubble/PackedBubbleSeriesDefaults.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeriesDefaults.ts
@@ -4,9 +4,6 @@
  *
  * */
 
-import type {
-    PackedBubbleDataLabelFormatterObject
-} from './PackedBubbleDataLabelOptions';
 import type PackedBubblePoint from './PackedBubblePoint';
 import type PackedBubbleSeriesOptions from './PackedBubbleSeriesOptions';
 import type Point from '../../Core/Series/Point';
@@ -153,10 +150,7 @@ const PackedBubbleSeriesDefaults: PackedBubbleSeriesOptions = {
          * @since 7.0.0
          */
         formatter: function (
-            this: (
-                Point.PointLabelObject|
-                PackedBubbleDataLabelFormatterObject
-            )
+            this: (Point|PackedBubblePoint)
         ): string {
             const { numberFormatter } = this.series.chart;
             const { value } = this.point as PackedBubblePoint;
@@ -176,12 +170,9 @@ const PackedBubbleSeriesDefaults: PackedBubbleSeriesOptions = {
          * @since 7.1.0
          */
         parentNodeFormatter: function (
-            this: (
-                Point.PointLabelObject|
-                PackedBubbleDataLabelFormatterObject
-            )
+            this: (Point|PackedBubblePoint)
         ): string {
-            return (this as any).name;
+            return this.name || '';
         },
 
         /**

--- a/ts/Series/Pie/PieSeriesDefaults.ts
+++ b/ts/Series/Pie/PieSeriesDefaults.ts
@@ -341,9 +341,9 @@ const PieSeriesDefaults: PlotOptionsOf<PieSeries> = {
          * @default function () { return this.point.isNull ? void 0 : this.point.name; }
          */
         formatter: function (
-            this: Point.PointLabelObject
+            this: Point
         ): (string|undefined) { // #2945
-            return this.point.isNull ? void 0 : this.point.name;
+            return this.isNull ? void 0 : this.name;
         },
 
         /**

--- a/ts/Series/Sankey/SankeyDataLabelOptions.d.ts
+++ b/ts/Series/Sankey/SankeyDataLabelOptions.d.ts
@@ -29,10 +29,7 @@ import type { DataLabelTextPathOptions } from '../../Core/Series/DataLabelOption
 
 export interface SankeyDataLabelFormatterCallback {
     (
-        this: (
-            SankeyDataLabelFormatterContext|
-            Point.PointLabelObject
-        )
+        this: (SankeyPoint|Point)
     ): (string|undefined);
 }
 

--- a/ts/Series/Sankey/SankeySeries.ts
+++ b/ts/Series/Sankey/SankeySeries.ts
@@ -876,23 +876,11 @@ export default SankeySeries;
  *
  * @callback Highcharts.SeriesSankeyDataLabelsFormatterCallbackFunction
  *
- * @param {Highcharts.SeriesSankeyDataLabelsFormatterContextObject|Highcharts.PointLabelObject} this
+ * @param {Highcharts.SankeyPoint|Highcharts.Point} this
  *        Data label context to format
  *
  * @return {string|undefined}
  *         Formatted data label text
- */
-
-/**
- * Context for the node formatter function.
- *
- * @interface Highcharts.SeriesSankeyDataLabelsFormatterContextObject
- * @extends Highcharts.PointLabelObject
- *//**
- * The node object. The node name, if defined, is available through
- * `this.point.name`.
- * @name Highcharts.SeriesSankeyDataLabelsFormatterContextObject#point
- * @type {Highcharts.SankeyNodeObject}
  */
 
 ''; // Detach doclets above

--- a/ts/Series/Sankey/SankeySeries.ts
+++ b/ts/Series/Sankey/SankeySeries.ts
@@ -876,7 +876,7 @@ export default SankeySeries;
  *
  * @callback Highcharts.SeriesSankeyDataLabelsFormatterCallbackFunction
  *
- * @param {Highcharts.SankeyPoint|Highcharts.Point} this
+ * @param {Highcharts.Point} this
  *        Data label context to format
  *
  * @return {string|undefined}

--- a/ts/Series/Sankey/SankeySeriesDefaults.ts
+++ b/ts/Series/Sankey/SankeySeriesDefaults.ts
@@ -20,7 +20,7 @@
 
 import type { PlotOptionsOf } from '../../Core/Series/SeriesOptions';
 import type Point from '../../Core/Series/Point';
-import type { SankeyDataLabelFormatterContext } from './SankeyDataLabelOptions';
+import type SankeyPoint from './SankeyPoint';
 import type SankeySeries from './SankeySeries';
 
 /* *
@@ -112,10 +112,7 @@ const SankeySeriesDefaults: PlotOptionsOf<SankeySeries> = {
          * @since 6.0.2
          */
         nodeFormatter: function (
-            this: (
-                SankeyDataLabelFormatterContext|
-                Point.PointLabelObject
-            )
+            this: (SankeyPoint|Point)
         ): (string|undefined) {
             return this.point.name;
         },

--- a/ts/Series/Timeline/TimelineDataLabelOptions.d.ts
+++ b/ts/Series/Timeline/TimelineDataLabelOptions.d.ts
@@ -25,7 +25,6 @@ import type {
 } from '../../Core/Series/DataLabelOptions';
 import type Point from '../../Core/Series/Point';
 import type TimelinePoint from './TimelinePoint';
-import type TimelineSeries from './TimelineSeries';
 
 /* *
  *
@@ -34,13 +33,7 @@ import type TimelineSeries from './TimelineSeries';
  * */
 
 export interface TimelineDataLabelFormatterCallback extends DataLabelFormatterCallback {
-    (this: (Point.PointLabelObject|TimelineDataLabelContextObject)): string;
-}
-
-export interface TimelineDataLabelContextObject extends Point.PointLabelObject {
-    key?: string;
-    point: TimelinePoint;
-    series: TimelineSeries;
+    (this: (Point|TimelinePoint)): string;
 }
 
 export interface TimelineDataLabelOptions extends DataLabelOptions {

--- a/ts/Series/Timeline/TimelineSeries.ts
+++ b/ts/Series/Timeline/TimelineSeries.ts
@@ -502,39 +502,3 @@ SeriesRegistry.registerSeriesType('timeline', TimelineSeries);
  * */
 
 export default TimelineSeries;
-
-/* *
- *
- *  API Declarations
- *
- * */
-
-/**
- * Callback JavaScript function to format the data label as a string. Note that
- * if a `format` is defined, the format takes precedence and the formatter is
- * ignored.
- *
- * @callback Highcharts.TimelineDataLabelsFormatterCallbackFunction
- *
- * @param {Highcharts.PointLabelObject|Highcharts.TimelineDataLabelsFormatterContextObject} this
- *        Data label context to format
- *
- * @return {number|string|null|undefined}
- *         Formatted data label text
- */
-
-/**
- * @interface Highcharts.TimelineDataLabelsFormatterContextObject
- * @extends Highcharts.PointLabelObject
- *//**
- * @name Highcharts.TimelineDataLabelsFormatterContextObject#key
- * @type {string|undefined}
- *//**
- * @name Highcharts.TimelineDataLabelsFormatterContextObject#point
- * @type {Highcharts.Point}
- *//**
- * @name Highcharts.TimelineDataLabelsFormatterContextObject#series
- * @type {Highcharts.Series}
- */
-
-''; // Dettach doclets above

--- a/ts/Series/Timeline/TimelineSeriesDefaults.ts
+++ b/ts/Series/Timeline/TimelineSeriesDefaults.ts
@@ -20,9 +20,8 @@
  *
  * */
 
-import type { TimelineDataLabelContextObject } from
-    './TimelineDataLabelOptions';
 import type Point from '../../Core/Series/Point';
+import type TimelinePoint from './TimelinePoint';
 import type TimelineSeriesOptions from './TimelineSeriesOptions';
 
 import { Palette } from '../../Core/Color/Palettes.js';
@@ -165,7 +164,7 @@ const TimelineSeriesDefaults: TimelineSeriesOptions = {
          * }
          */
         formatter: function (
-            this: (Point.PointLabelObject|TimelineDataLabelContextObject)
+            this: (Point|TimelinePoint)
         ): string {
             let format;
 
@@ -177,8 +176,8 @@ const TimelineSeriesDefaults: TimelineSeriesOptions = {
                     this.point.colorIndex + '">● </span>';
             }
             format += '<span class="highcharts-strong">' +
-                ((this as any).key || '') + '</span><br/>' +
-                ((this.point as any).label || '');
+                (this.key || '') + '</span><br/>' +
+                ((this as TimelinePoint).label || '');
             return format;
         },
 

--- a/ts/Series/Timeline/TimelineSeriesDefaults.ts
+++ b/ts/Series/Timeline/TimelineSeriesDefaults.ts
@@ -147,7 +147,6 @@ const TimelineSeriesDefaults: TimelineSeriesOptions = {
 
         // eslint-disable-next-line jsdoc/require-description
         /**
-         * @type    {Highcharts.TimelineDataLabelsFormatterCallbackFunction}
          * @default function () {
          *   let format;
          *

--- a/ts/Series/Treegraph/TreegraphSeriesOptions.d.ts
+++ b/ts/Series/Treegraph/TreegraphSeriesOptions.d.ts
@@ -99,10 +99,7 @@ export interface CollapseButtonOptions {
 
 export interface TreegraphDataLabelFormatterCallback {
     (
-        this: (
-            TreegraphDataLabelFormatterContext|
-            Point.PointLabelObject
-        )
+        this: (TreegraphPoint|Point)
     ): (string|undefined);
 }
 

--- a/ts/Series/XRange/XRangePoint.ts
+++ b/ts/Series/XRange/XRangePoint.ts
@@ -157,26 +157,6 @@ class XRangePoint extends ColumnPoint {
     }
 
     /**
-     * Add x2 and yCategory to the available properties for tooltip formats.
-     *
-     * @private
-     */
-    public getLabelConfig(): XRangePoint.XRangePointLabelObject {
-        const cfg = super.getLabelConfig.call(this) as
-                XRangePoint.XRangePointLabelObject,
-            yCats = this.series.yAxis.categories;
-
-        cfg.x2 = this.x2;
-        cfg.yCategory = this.yCategory = yCats && yCats[this.y as any];
-
-        // Use 'category' as 'key' to ensure tooltip datetime formatting.
-        // Use 'name' only when 'category' is undefined.
-        cfg.key = this.category || this.name;
-
-        return cfg;
-    }
-
-    /**
      * @private
      */
     public isValid(): boolean {
@@ -214,13 +194,6 @@ extend(XRangePoint.prototype, {
  *  Class Namespace
  *
  * */
-
-declare namespace XRangePoint {
-    interface XRangePointLabelObject extends Point.PointLabelObject {
-        x2?: XRangePoint['x2'];
-        yCategory?: XRangePoint['yCategory'];
-    }
-}
 
 /* *
  *

--- a/ts/Series/XRange/XRangeSeries.ts
+++ b/ts/Series/XRange/XRangeSeries.ts
@@ -461,6 +461,12 @@ class XRangeSeries extends ColumnSeries {
                 height: shapeArgs.height
             };
         }
+
+        // Add formatting keys for tooltip and data labels. Use 'category' as
+        // 'key' to ensure tooltip datetime formatting. Use 'name' only when
+        // 'category' is undefined.
+        point.key = point.category || point.name;
+        point.yCategory = yAxis.categories?.[point.y ?? -1];
     }
 
     /**

--- a/ts/Series/XRange/XRangeSeriesDefaults.ts
+++ b/ts/Series/XRange/XRangeSeriesDefaults.ts
@@ -97,7 +97,7 @@ const XRangeSeriesDefaults: XRangeSeriesOptions = {
 
     dataLabels: {
         formatter: function (): (string|undefined) {
-            let amount = (this.point as XRangePoint).partialFill;
+            let amount = (this as XRangePoint).partialFill;
 
             if (isObject(amount)) {
                 amount = (amount as any).amount;


### PR DESCRIPTION
Use Point instances as context for tooltip and data label formatters and formats.

#### Upgrade note
The [Point](https://api.highcharts.com/class-reference/Highcharts.Point) instances are now used as context for tooltip and data label formatters and format strings, instead of an abstract context object. In most cases this will cause no changes as the properties of the context object are now moved to the Point itself, but some changes may occur. Specifically the `{point.x}` key for points on a category axes will no longer return the category name. Instead, use `{category}`.

Closes #21514.