### PR TITLE
Fixed SelectEventObject.preventDefault.

### DIFF
--- a/test/typescript-dts/highcharts/highcharts.ts
+++ b/test/typescript-dts/highcharts/highcharts.ts
@@ -9,6 +9,7 @@
 import * as Highcharts from "highcharts";
 
 test_legend();
+test_selectEvent();
 test_seriesArea();
 test_seriesBar();
 test_seriesColumn();
@@ -31,6 +32,21 @@ function test_legend() {
                     return JSON.stringify(series.legendItem as Record<string, SVGElement>);
                 }
                 return '';
+            }
+        }
+    });
+}
+
+/**
+ * Tests type of select event.
+ */
+function test_selectEvent() {
+    Highcharts.chart('container', {
+        chart: {
+            events: {
+                selection: function (e: Highcharts.SelectEventObject): undefined {
+                    e.preventDefault();
+                }
             }
         }
     });

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -2293,6 +2293,10 @@ export default Pointer;
  * @name Highcharts.SelectEventObject#originalEvent
  * @type {global.Event}
  *//**
+ * Prevents the default action for the event, if called.
+ * @name Highcharts.SelectEventObject#preventDefault
+ * @type {Function}
+ *//**
  * Indicates a reset event to restore default state.
  * @name Highcharts.SelectEventObject#resetSelection
  * @type {boolean|undefined}


### PR DESCRIPTION
Fixed #19326, SelectEventObject.preventDefault

---

- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206610910008454