### PR TITLE
bugfix/21924-custom-size-img-marker-state

### DIFF
--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1514,7 +1514,7 @@ class Point {
                                         markerAttribs.y,
                                         markerAttribs.width,
                                         markerAttribs.height,
-                                        extend(
+                                        merge(
                                             markerOptions,
                                             markerStateOptions
                                         )

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1513,7 +1513,11 @@ class Point {
                                         markerAttribs.x,
                                         markerAttribs.y,
                                         markerAttribs.width,
-                                        markerAttribs.height
+                                        markerAttribs.height,
+                                        extend(
+                                            markerOptions,
+                                            markerStateOptions
+                                        )
                                     )
                                     .add(series.markerGroup);
                             stateMarkerGraphic.currentSymbol = newSymbol;


### PR DESCRIPTION
Fixed #21924, custom sizes in marker states did not work.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208444295941769