### PR TITLE
docs/uniqueNames-add-back

### DIFF
--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -2144,6 +2144,7 @@ namespace AxisDefaults {
          * @product   highcharts gantt
          * @type      {boolean}
          * @default   true
+         * @apioption xAxis.uniqueNames
          */
 
         /**


### PR DESCRIPTION
Added missing docs tag - `uniqueNames` was not showing in the API docs.