### PR TITLE
dash/spreadsheets-demo-fix 

### DIFF
--- a/samples/dashboards/basic/google-spreadsheets/demo.css
+++ b/samples/dashboards/basic/google-spreadsheets/demo.css
@@ -22,6 +22,11 @@ body {
     position: relative;
     margin: 10px;
     background-clip: border-box;
+    height: 250px;
+}
+
+.highcharts-datagrid-container {
+    min-height: auto;
 }
 
 .highcharts-dashboards-component-title {


### PR DESCRIPTION
Fixed DataGrid Component's height styles in Google Spreadsheets demo.
