### PR TITLE
Fixed TreemapSeries not working with Boost

### DIFF
--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -1558,7 +1558,11 @@ function wrapSeriesProcessData(
                 firstPoint = series.getFirstValidPoint(
                     series.options.data
                 );
-                if (!isNumber(firstPoint) && !isArray(firstPoint)) {
+                if (
+                    !isNumber(firstPoint) &&
+                    !isArray(firstPoint) &&
+                    !series.is('treemap')
+                ) {
                     error(12, false, series.chart);
                 }
             }

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -670,6 +670,7 @@ function enterBoost(
     // Destroy existing points after zoom out
     if (
         series.is('scatter') &&
+        !series.is('treemap') &&
         series.data.length
     ) {
         for (const point of series.data) {
@@ -1506,8 +1507,11 @@ function wrapSeriesProcessData(
 
     if (boostEnabled(this.chart) && BoostableMap[this.type]) {
         const series = this as BoostSeriesComposition,
+            // Flag for code that should run for ScatterSeries and its
+            // subclasses, apart from the enlisted exceptions.
             isScatter = series.is('scatter') &&
                 !series.is('bubble') &&
+                !series.is('treemap') &&
                 !series.is('heatmap');
         // If there are no extremes given in the options, we also need to
         // process the data to read the data extremes. If this is a heatmap,
@@ -1516,6 +1520,7 @@ function wrapSeriesProcessData(
             // First pass with options.data:
             !getSeriesBoosting(series, dataToMeasure) ||
             isScatter ||
+            series.is('treemap') ||
             // Use processedYData for the stack (#7481):
             series.options.stacking ||
             !hasExtremes(series, true)


### PR DESCRIPTION
Fixed #21863, a regression causing the Boost module to fail with treemap series


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208339061077327