### PR TITLE
Added check for existance of demo.details file in demo directories

### DIFF
--- a/samples/demo-config.js
+++ b/samples/demo-config.js
@@ -51,7 +51,7 @@ module.exports = {
     },
     'Highcharts Dashboards': {
         categories: ['Basic', 'Advanced'],
-        filter: { tags: ['Highcharts dashboards demo'] },
+        filter: { tags: ['Highcharts Dashboards demo'] },
         path: '/dashboards/'
     }
 };

--- a/tools/gulptasks/test.js
+++ b/tools/gulptasks/test.js
@@ -97,8 +97,17 @@ function checkDemosConsistency() {
     const FSLib = require('../libs/fs.js');
     const LogLib = require('../libs/log');
     const yaml = require('js-yaml');
+    const assert = require('node:assert');
+    const { existsSync } = require('node:fs');
 
     let errors = 0;
+
+
+    glob.sync(
+        FSLib.path(process.cwd() + '/samples/*/demo/*', true)
+    ).forEach(p => {
+        assert(existsSync(FSLib.path(p + '/demo.details')), `Missing demo.details file at ${p}`);
+    });
 
     glob.sync(
         FSLib.path(process.cwd() + '/samples/+(highcharts|stock|maps|gantt)/*/*/demo.details', true)

--- a/tools/gulptasks/test.js
+++ b/tools/gulptasks/test.js
@@ -110,11 +110,11 @@ function checkDemosConsistency() {
     });
 
     glob.sync(
-        FSLib.path(process.cwd() + '/samples/+(highcharts|stock|maps|gantt)/*/*/demo.details', true)
+        FSLib.path(process.cwd() + '/samples/*/*/*/demo.details', true)
     ).forEach(detailsFile => {
         detailsFile = FSLib.path(detailsFile, true);
 
-        if (/\/samples\/(highcharts|stock|maps|gantt)\/demo\//u.test(detailsFile)) {
+        if (/\/samples\/(\w+)\/demo\//u.test(detailsFile)) {
             try {
                 const details = yaml.load(
                     fs.readFileSync(detailsFile, 'utf-8')
@@ -150,34 +150,11 @@ function checkDemosConsistency() {
                     }
                 }
 
-            } catch (e) {
+            } catch {
                 LogLib.failure('File not found:', detailsFile);
                 errors++;
             }
 
-        } else {
-            try {
-                const details = yaml.load(
-                    fs.readFileSync(detailsFile, 'utf-8')
-                );
-
-                if (typeof details === 'object') {
-                    if (details.categories) {
-                        LogLib.failure(
-                            'categories should not be used in demo.details outside demo folder',
-                            detailsFile
-                        );
-                        errors++;
-                    } else if (details.tags) {
-                        LogLib.failure(
-                            'tags should not be used in demo.details outside demo folder',
-                            detailsFile
-                        );
-                        errors++;
-                    }
-                }
-            // eslint-disable-next-line
-            } catch (e) {}
         }
     });
 


### PR DESCRIPTION
Adds an explicit check for `demo.details` files in `samples/*/demo` folders. Adjusted regex to cover more products. 

Removed check for usage of `categories` outside demo folders, which is not necessary from a demo building perspective

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208577670050822