### PR TITLE
bugfix/19335-ally-focusindicator-wrongly-displayed

### DIFF
--- a/samples/unit-tests/accessibility/accessibility-options/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-options/demo.js
@@ -547,9 +547,10 @@ QUnit.test('Focus border', function (assert) {
         stroke: 'blue',
         strokeWidth: 1
     };
+    const padding = 2;
 
     const regularText = ren.text('regular text', 50, 50).add();
-    regularText.addFocusBorder(2, style);
+    regularText.addFocusBorder(padding, style);
 
     const wordcloudText = ren
         .text('wordcloud text', 100, 100)
@@ -562,7 +563,7 @@ QUnit.test('Focus border', function (assert) {
             whiteSpace: 'nowrap'
         })
         .add();
-    wordcloudText.addFocusBorder(2, style);
+    wordcloudText.addFocusBorder(padding, style);
 
     const regularRotatedText = ren
         .text('regular rotated text', 150, 150)
@@ -570,7 +571,7 @@ QUnit.test('Focus border', function (assert) {
             rotation: 90
         })
         .add();
-    regularRotatedText.addFocusBorder(2, style);
+    regularRotatedText.addFocusBorder(padding, style);
 
     const wordcloudRotatedText = ren
         .text('wordcloud rotated text', 200, 200)
@@ -584,7 +585,7 @@ QUnit.test('Focus border', function (assert) {
             whiteSpace: 'nowrap'
         })
         .add();
-    wordcloudRotatedText.addFocusBorder(2, style);
+    wordcloudRotatedText.addFocusBorder(padding, style);
 
     const labelText = ren
         .label('label', 250, 250)
@@ -592,7 +593,7 @@ QUnit.test('Focus border', function (assert) {
             color: 'blue'
         })
         .add();
-    labelText.addFocusBorder(2, style);
+    labelText.addFocusBorder(padding, style);
 
     const labelRotatedText = ren
         .label('rotated label', 300, 300)
@@ -603,7 +604,7 @@ QUnit.test('Focus border', function (assert) {
             color: 'blue'
         })
         .add();
-    labelRotatedText.addFocusBorder(2, style);
+    labelRotatedText.addFocusBorder(padding, style);
 
     // Comparing the midpoint of the border with the midpoint of the text.
     assert.close(
@@ -614,11 +615,12 @@ QUnit.test('Focus border', function (assert) {
         'should be correctly applied for text horizontally.'
     );
 
+    const lineHeight = ren.fontMetrics(regularText).h;
     assert.close(
         regularText.focusBorder.getBBox().y +
-            regularText.focusBorder.getBBox().height / 2,
-        regularText.attr('y') - (regularText.getBBox().height / 2) * 0.5,
-        0.1,
+        (regularText.focusBorder.getBBox().height / 2),
+        regularText.attr('y') - (lineHeight / 4),
+        1,
         'should be correctly applied for text vertically.'
     );
 

--- a/ts/Accessibility/FocusBorder.ts
+++ b/ts/Accessibility/FocusBorder.ts
@@ -321,10 +321,10 @@ namespace FocusBorderComposition {
                 borderPosX = attrX - (bb.width * correction.x) - pad;
             }
             if (!isNaN(attrY)) {
+                // Correct by line height if "text-achor" == "start", #19335.
                 const dim = this.attr('text-anchor') === 'start' ?
                     lineHeight :
                     bb.height;
-                // Correct by line height if "text-achor" == "start", #19335.
                 borderPosY = attrY - (dim * correction.y) - pad;
             }
 

--- a/ts/Accessibility/FocusBorder.ts
+++ b/ts/Accessibility/FocusBorder.ts
@@ -271,7 +271,8 @@ namespace FocusBorderComposition {
             scaleY = this.scaleY || parent && parent.scaleY,
             oneDefined = scaleX ? !scaleY : scaleY,
             scaleBoth = oneDefined ? Math.abs(scaleX || scaleY || 1) :
-                (Math.abs(scaleX || 1) + Math.abs(scaleY || 1)) / 2;
+                (Math.abs(scaleX || 1) + Math.abs(scaleY || 1)) / 2,
+            lineHeight = this.renderer.fontMetrics(this).h;
 
         bb.x += this.translateX ? this.translateX : 0;
         bb.y += this.translateY ? this.translateY : 0;
@@ -320,7 +321,11 @@ namespace FocusBorderComposition {
                 borderPosX = attrX - (bb.width * correction.x) - pad;
             }
             if (!isNaN(attrY)) {
-                borderPosY = attrY - (bb.height * correction.y) - pad;
+                const dim = this.attr('text-anchor') === 'start' ?
+                    lineHeight :
+                    bb.height;
+                // Correct by line height if "text-achor" == "start", #19335.
+                borderPosY = attrY - (dim * correction.y) - pad;
             }
 
             if (isLabel && isRotated) {


### PR DESCRIPTION
Fixed #19335, accessibility focus border was incorrectly positioned in some edge cases

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208416598183382