### PR TITLE
dash/dg-sortable-arrows

### DIFF
--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -177,22 +177,27 @@
     cursor: pointer;
 }
 
-.highcharts-datagrid-header-cell-content::after {
+th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-icon {
     right: 10px;
     top: calc(50% - 10px);
     bottom: 50%;
     position: absolute;
-    display: inline-block;
+    display: none;
     width: 12px;
     height: 12px;
+    user-select: none;
+    pointer-events: none;
 }
 
-.highcharts-datagrid-column-sortable.highcharts-datagrid-column-sorted-asc .highcharts-datagrid-header-cell-content::after {
-    content: "▲";
+.highcharts-datagrid-column-sortable.highcharts-datagrid-column-sorted-asc .highcharts-datagrid-column-sortable-icon,
+.highcharts-datagrid-column-sortable.highcharts-datagrid-column-sorted-desc .highcharts-datagrid-column-sortable-icon {
+    display: inline-block;
 }
 
-.highcharts-datagrid-column-sortable.highcharts-datagrid-column-sorted-desc .highcharts-datagrid-header-cell-content::after {
-    content: "▼";
+.highcharts-datagrid-column-sortable.highcharts-datagrid-column-sorted-desc .highcharts-datagrid-column-sortable-icon {
+    transform: rotate(180deg);
+    top: calc(50%);
+    right: 6px;
 }
 
 .highcharts-datagrid-container:has(.highcharts-datagrid-no-data) {

--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -187,6 +187,7 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
     height: 12px;
     user-select: none;
     pointer-events: none;
+    color: var(--highcharts-neutral-color-60);
 }
 
 .highcharts-datagrid-column-sortable.highcharts-datagrid-column-sorted-asc .highcharts-datagrid-column-sortable-icon,
@@ -196,8 +197,8 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
 
 .highcharts-datagrid-column-sortable.highcharts-datagrid-column-sorted-desc .highcharts-datagrid-column-sortable-icon {
     transform: rotate(180deg);
-    top: calc(50%);
-    right: 6px;
+    top: calc(50% - 3px);
+    right: 7px;
 }
 
 .highcharts-datagrid-container:has(.highcharts-datagrid-no-data) {

--- a/ts/DataGrid/Globals.ts
+++ b/ts/DataGrid/Globals.ts
@@ -85,6 +85,7 @@ namespace Globals {
         noData: classNamePrefix + 'no-data',
         columnFirst: classNamePrefix + 'column-first',
         columnSortable: classNamePrefix + 'column-sortable',
+        columnSortableIcon: classNamePrefix + 'column-sortable-icon',
         columnSortedAsc: classNamePrefix + 'column-sorted-asc',
         columnSortedDesc: classNamePrefix + 'column-sorted-desc',
         resizerHandles: classNamePrefix + 'column-resizer',

--- a/ts/DataGrid/Table/Actions/ColumnSorting.ts
+++ b/ts/DataGrid/Table/Actions/ColumnSorting.ts
@@ -26,6 +26,9 @@ import type { ColumnSortingOrder } from '../../Options.js';
 
 import Column from '../Column.js';
 import Globals from '../../Globals.js';
+import DGUtils from '../../Utils.js';
+
+const { makeHTMLElement } = DGUtils;
 
 /* *
  *
@@ -77,6 +80,14 @@ class ColumnSorting {
         this.addHeaderElementAttributes();
 
         if (column.options.sorting?.sortable) {
+            makeHTMLElement(
+                'span',
+                {
+                    className: Globals.classNames.columnSortableIcon,
+                    innerText: '▲'
+                },
+                headerCellElement
+            ).setAttribute('aria-hidden', true);
             headerCellElement.classList.add(Globals.classNames.columnSortable);
             column.viewport.dataGrid.accessibility
                 ?.addSortableColumnDescription(headerCellElement);


### PR DESCRIPTION
Hidden the DataGrid column sorting arrow elements for the screen readers.