### PR TITLE
dash/api-links

### DIFF
--- a/ts/Dashboards/Components/HighchartsComponent/HighchartsComponentOptions.ts
+++ b/ts/Dashboards/Components/HighchartsComponent/HighchartsComponentOptions.ts
@@ -95,7 +95,9 @@ export interface Options extends Component.Options {
     /**
      * @deprecated
      * This option is deprecated and does not work anymore.
-     * Use [`connector.columnAssignment`](https://api.highcharts.com/dashboards/#interfaces/Dashboards_Plugins_HighchartsComponent_HighchartsComponentOptions.ConnectorOptions#columnAssignment) instead.
+     *
+     * Use [`connector.columnAssignment`](Dashboards_Components_HighchartsComponent_HighchartsComponentOptions.ConnectorOptions#columnAssignment) instead.
+     * 
     */
     columnAssignment?: Record<string, string | Record<string, string>>;
 

--- a/ts/Dashboards/Components/HighchartsComponent/HighchartsComponentOptions.ts
+++ b/ts/Dashboards/Components/HighchartsComponent/HighchartsComponentOptions.ts
@@ -97,7 +97,7 @@ export interface Options extends Component.Options {
      * This option is deprecated and does not work anymore.
      *
      * Use [`connector.columnAssignment`](Dashboards_Components_HighchartsComponent_HighchartsComponentOptions.ConnectorOptions#columnAssignment) instead.
-     * 
+     *
     */
     columnAssignment?: Record<string, string | Record<string, string>>;
 


### PR DESCRIPTION
Fixed the wrong link and redirection.

-----

I checked how it works in other parts of the API and it turns out that all links use internal redirects instead of `target=_top`.


It is also limited by the JSDoc to @see / @link or brackets option. It cannot be parametrized so the "open in new tab" option does not exist there.