### PR TITLE
dash/dg-a11y-descriptions

### DIFF
--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -126,6 +126,7 @@
 
 .highcharts-datagrid-table thead th .highcharts-datagrid-header-cell-content {
     width: 100%;
+    display: block;
     overflow: hidden;
     text-overflow: ellipsis;
     padding-left: 3px;

--- a/samples/data-grid/accessibility/custom-accessibility/demo.js
+++ b/samples/data-grid/accessibility/custom-accessibility/demo.js
@@ -18,7 +18,6 @@ DataGrid.dataGrid('container', {
                 }
             },
             sorting: {
-                sortable: 'The column can be sorted.',
                 announcements: {
                     ascending: 'The column is sorted in ascending order.',
                     descending: 'The column is sorted in descending order.',

--- a/ts/DataGrid/Accessibility/A11yOptions.ts
+++ b/ts/DataGrid/Accessibility/A11yOptions.ts
@@ -74,7 +74,6 @@ namespace A11yOptions {
      * Accessibility options for the DataGrid sorting functionality.
      */
     export interface SortingLangA11yOptions {
-        sortable?: string;
         announcements?: {
             enabled?: boolean;
             ascending?: string;

--- a/ts/DataGrid/Accessibility/Accessibility.ts
+++ b/ts/DataGrid/Accessibility/Accessibility.ts
@@ -26,6 +26,9 @@ import type DataGrid from '../DataGrid';
 import type { ColumnSortingOrder } from '../Options';
 
 import Globals from '../Globals.js';
+import DGUtils from '../Utils.js';
+
+const { makeHTMLElement } = DGUtils;
 
 
 /**
@@ -55,16 +58,6 @@ class Accessibility {
     private announcerElement: HTMLElement;
 
     /**
-     * The HTML element of the description for the editable cell.
-     */
-    private editableCellDescriptionEl: HTMLElement;
-
-    /**
-     * The HTML element of the description for the sortable column.
-     */
-    private sortableColumnDescriptionEl: HTMLElement;
-
-    /**
      * The timeout for the announcer element removal.
      */
     private announcerTimeout?: number;
@@ -92,21 +85,6 @@ class Accessibility {
         this.announcerElement = document.createElement('p');
         this.announcerElement.setAttribute('aria-atomic', 'true');
         this.announcerElement.setAttribute('aria-hidden', 'false');
-
-        this.editableCellDescriptionEl = document.createElement('p');
-        this.sortableColumnDescriptionEl = document.createElement('p');
-        this.editableCellDescriptionEl.setAttribute('aria-hidden', true);
-        this.sortableColumnDescriptionEl.setAttribute('aria-hidden', true);
-
-        this.editableCellDescriptionEl.id =
-            Accessibility.decriptionElementIds.editableCell;
-        this.sortableColumnDescriptionEl.id =
-            Accessibility.decriptionElementIds.sortableColumn;
-
-        this.element.appendChild(this.editableCellDescriptionEl);
-        this.element.appendChild(this.sortableColumnDescriptionEl);
-
-        this.loadOptions();
     }
 
 
@@ -117,44 +95,23 @@ class Accessibility {
     * */
 
     /**
-     * Load the accessibility options.
-     */
-    public loadOptions(): void {
-        const lang = this.dataGrid.options?.lang?.accessibility;
-        if (!lang) {
-            return;
-        }
-
-        this.editableCellDescriptionEl.textContent =
-            lang.cellEditing?.editable || '';
-        this.sortableColumnDescriptionEl.textContent =
-            lang.sorting?.sortable || '';
-    }
-
-    /**
      * Add the description for the editable cell.
      *
      * @param cellElement
      * The cell element to add the description to.
      */
     public addEditableCellDescription(cellElement: HTMLElement): void {
-        cellElement.setAttribute(
-            'aria-describedby',
-            Accessibility.decriptionElementIds.editableCell
-        );
-    }
+        const description =
+            this.dataGrid.options?.lang?.accessibility?.cellEditing?.editable;
 
-    /**
-     * Add the description for the sortable column header.
-     *
-     * @param thElement
-     * The header cell element to add the description to.
-     */
-    public addSortableColumnDescription(thElement: HTMLElement): void {
-        thElement.setAttribute(
-            'aria-describedby',
-            Accessibility.decriptionElementIds.sortableColumn
-        );
+        if (!description) {
+            return;
+        }
+
+        makeHTMLElement('span', {
+            className: Globals.classNames.visuallyHidden,
+            innerText: ', ' + description
+        }, cellElement);
     }
 
     /**
@@ -294,14 +251,6 @@ namespace Accessibility {
      * The possible types of the edit message.
      */
     export type EditMsgType = 'started' | 'edited' | 'cancelled';
-
-    /**
-     * Dictionary of the IDs of the description elements.
-     */
-    export const decriptionElementIds = {
-        editableCell: 'highchartsdata-grid-editable-cell-description',
-        sortableColumn: 'highcharts-datagrid-sortable-column-description'
-    } as const;
 }
 
 

--- a/ts/DataGrid/DataGrid.ts
+++ b/ts/DataGrid/DataGrid.ts
@@ -480,7 +480,6 @@ class DataGrid {
         this.querying.loadOptions();
 
         if (render) {
-            this.accessibility?.loadOptions();
             await this.querying.proceed(newDataTable);
             this.renderViewport();
         }

--- a/ts/DataGrid/Defaults.ts
+++ b/ts/DataGrid/Defaults.ts
@@ -54,7 +54,6 @@ namespace Defaults {
                     }
                 },
                 sorting: {
-                    sortable: 'Sortable column header.',
                     announcements: {
                         enabled: true,
                         ascending: 'Sorted ascending.',

--- a/ts/DataGrid/Table/Actions/ColumnSorting.ts
+++ b/ts/DataGrid/Table/Actions/ColumnSorting.ts
@@ -88,10 +88,8 @@ class ColumnSorting {
                 },
                 headerCellElement
             ).setAttribute('aria-hidden', true);
+
             headerCellElement.classList.add(Globals.classNames.columnSortable);
-            column.viewport.dataGrid.accessibility
-                ?.addSortableColumnDescription(headerCellElement);
-            
             headerCellElement.setAttribute('role', 'button');
         }
     }

--- a/ts/DataGrid/Table/Actions/ColumnsResizer.ts
+++ b/ts/DataGrid/Table/Actions/ColumnsResizer.ts
@@ -169,6 +169,8 @@ class ColumnsResizer {
                 className: Globals.classNames.resizerHandles
             }, cell.htmlElement);
 
+            handle.setAttribute('aria-hidden', true);
+
             vp.columnsResizer?.addHandleListeners(
                 handle, column
             );

--- a/ts/DataGrid/Table/Content/TableCell.ts
+++ b/ts/DataGrid/Table/Content/TableCell.ts
@@ -91,11 +91,6 @@ class TableCell extends Cell {
     public override render(): void {
         super.render();
 
-        if (this.column.options.cells?.editable) {
-            this.row.viewport.dataGrid.accessibility
-                ?.addEditableCellDescription(this.htmlElement);
-        }
-
         // It may happen that `await` will be needed here in the future.
         void this.setValue(this.column.data?.[this.row.index], false);
     }
@@ -248,6 +243,12 @@ class TableCell extends Cell {
 
         this.htmlElement.setAttribute('data-value', this.value + '');
         this.setCustomClassName(this.column.options.cells?.className);
+
+        if (this.column.options.cells?.editable) {
+            vp.dataGrid.accessibility
+                ?.addEditableCellDescription(this.htmlElement);
+        }
+
         vp.dataGrid.options?.events?.cell?.afterSetValue?.call(this);
 
         if (!updateTable) {

--- a/ts/DataGrid/Table/Header/HeaderCell.ts
+++ b/ts/DataGrid/Table/Header/HeaderCell.ts
@@ -135,7 +135,7 @@ class HeaderCell extends Cell {
 
         // Render content of th element
         this.row.htmlElement.appendChild(this.htmlElement);
-        this.headerContent = makeHTMLElement('div', {
+        this.headerContent = makeHTMLElement('span', {
             className: Globals.classNames.headerCellContent
         }, this.htmlElement);
 


### PR DESCRIPTION
Removed sortable description because `role=button` should be enough.
Changed editable cell description to be a content of a `span` element after a value.
Added `aria-hidden: true` to the resize handler element.
Changed `headerContentEl` from `div` to `span` with `display: block`.