### PR TITLE
feature/remove download pdf

### DIFF
--- a/samples/highcharts/exporting/menuitemdefinitions/demo.js
+++ b/samples/highcharts/exporting/menuitemdefinitions/demo.js
@@ -56,7 +56,7 @@ Highcharts.chart('container', {
         },
         buttons: {
             contextButton: {
-                menuItems: ['downloadPNG', 'downloadSVG', 'separator', 'label']
+                menuItems: ['downloadPNG', 'downloadPDF', 'separator', 'label']
             }
         }
     }

--- a/ts/Extensions/Exporting/ExportingDefaults.ts
+++ b/ts/Extensions/Exporting/ExportingDefaults.ts
@@ -467,7 +467,7 @@ const exporting: ExportingOptions = {
              *         Menu item definitions
              *
              * @type    {Array<string>}
-             * @default ["viewFullscreen", "printChart", "separator", "downloadPNG", "downloadJPEG", "downloadPDF", "downloadSVG"]
+             * @default ["viewFullscreen", "printChart", "separator", "downloadPNG", "downloadJPEG", "downloadSVG"]
              * @since   2.0
              */
             menuItems: [
@@ -476,7 +476,6 @@ const exporting: ExportingOptions = {
                 'separator',
                 'downloadPNG',
                 'downloadJPEG',
-                'downloadPDF',
                 'downloadSVG'
             ]
 


### PR DESCRIPTION
Removed "Download PDF" from the default exporting menu.

#### Upgrade note
The "Download PDF" menu item was removed from the default exporting menu, in preparation for a future update where exporting is done on the client side by default. The future update will require PDF download to either run via the export server like before, or to load a third party script. To re-enable the PDF download in the menu, add `downloadPDF` in the [contextButton.menuItems](https://api.highcharts.com/highcharts/exporting.buttons.contextButton.menuItems).
