### PR TITLE
tools/test-node-version

### DIFF
--- a/.github/workflows/dashboards-benchmark.yml
+++ b/.github/workflows/dashboards-benchmark.yml
@@ -23,7 +23,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        node-version: [lts/*]
+        node-version: [lts/iron]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/dashboards-lighthouse-test.yml
+++ b/.github/workflows/dashboards-lighthouse-test.yml
@@ -25,7 +25,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        node-version: [lts/*]
+        node-version: [lts/iron]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/dashboards-test.yml
+++ b/.github/workflows/dashboards-test.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [lts/*]
+        node-version: [lts/iron]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/dashboards-visual-test.yml
+++ b/.github/workflows/dashboards-visual-test.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [lts/*]
+        node-version: [lts/iron]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/highcharts-browserstack.yml
+++ b/.github/workflows/highcharts-browserstack.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 'lts/iron'
           cache: 'npm'
 
       - name: Install Dependencies

--- a/.github/workflows/highcharts-headless.yml
+++ b/.github/workflows/highcharts-headless.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 'lts/iron'
           cache: 'npm'
 
       - name: Install Dependencies

--- a/.github/workflows/highcharts-headless.yml
+++ b/.github/workflows/highcharts-headless.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 'lts/iron'
           cache: 'npm'
 
       - name: Install dependencies
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 'lts/iron'
           cache: 'npm'
       # browser-actions/setup-chrome installs chrome at a separate location
       # which setup-chromedriver does not pick up, so doing it manually
@@ -149,7 +149,7 @@ jobs:
   #     - uses: actions/checkout@v3
   #     - uses: actions/setup-node@v4
   #       with:
-  #         node-version: 'lts/*'
+  #         node-version: 'lts/iron'
   #         cache: 'npm'
   #     - name: Install Dependencies
   #       run: npm i

--- a/.github/workflows/highcharts-webpack.yml
+++ b/.github/workflows/highcharts-webpack.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 'lts/iron'
           cache: 'npm'
       - uses: browser-actions/setup-firefox@latest
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [lts/*]
+        node-version: [lts/iron]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
     needs: lint_hc
     strategy:
       matrix:
-        node-version: [lts/*]
+        node-version: [lts/iron]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [lts/*]
+        node-version: [lts/iron]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 'lts/iron'
           cache: 'npm'
 
       - name: Install Dependencies
@@ -164,7 +164,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 'lts/iron'
           cache: 'npm'
           cache-dependency-path: ./highcharts/package-lock.json
 

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 'lts/iron'
           cache: 'npm'
 
       - run: echo ${{github.ref_name}}

--- a/.github/workflows/stock-benchmark.yml
+++ b/.github/workflows/stock-benchmark.yml
@@ -23,7 +23,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        node-version: [lts/*]
+        node-version: [lts/iron]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/visual-compare.yml
+++ b/.github/workflows/visual-compare.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           ref: master
 
-      - name: Use Node.js lts/*
+      - name: Use Node.js lts/iron
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 'lts/iron'
           cache: 'npm'
 
       - name: Install dependencies
@@ -51,10 +51,10 @@ jobs:
           clean: false
           fetch-depth: 0
 
-      - name: Use Node.js lts/*
+      - name: Use Node.js lts/iron
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 'lts/iron'
           cache: 'npm'
 
       - name: Install dependencies
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [lts/*]
+        node-version: [lts/iron]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Workflows are currently failing due to missing prebuilds for node-canvas for the latest Node LTS. https://github.com/Automattic/node-canvas/issues/2448