### PR TITLE
Fixed pie data label cut off at bottom

### DIFF
--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -186,6 +186,7 @@ namespace DataLabel {
     }
 
     export interface LabelConnectorPositionObject {
+        angle?: number;
         breakAt: CorePositionObject;
         touchingSliceAt: CorePositionObject;
     }

--- a/ts/Series/Pie/PieDataLabel.ts
+++ b/ts/Series/Pie/PieDataLabel.ts
@@ -193,7 +193,7 @@ namespace ColumnDataLabel {
         // If a large slice is crossing the lowest point, prefer rendering the
         // label on either side (#22100)
         if (distance > 0 && start < halfPI && end > halfPI) {
-            angle = angle < halfPI ? (start + halfPI) / 2 : (halfPI + end) / 2;
+            angle = angle <= halfPI ? (start + halfPI) / 2 : (halfPI + end) / 2;
         }
 
         const { center, options } = this,

--- a/ts/Series/Pie/PieDataLabel.ts
+++ b/ts/Series/Pie/PieDataLabel.ts
@@ -190,10 +190,22 @@ namespace ColumnDataLabel {
 
         let angle = point.angle || 0;
 
-        // If a large slice is crossing the lowest point, prefer rendering the
-        // label on either side (#22100)
-        if (distance > 0 && start < halfPI && end > halfPI) {
-            angle = angle <= halfPI ? (start + halfPI) / 2 : (halfPI + end) / 2;
+        // If a large slice is crossing the lowest point, prefer rendering it 45
+        // degrees out at either lower right or lower left. That's where there's
+        // most likely to be space available and avoid text being truncated
+        // (#22100). Technically this logic should also apply to the top point,
+        // but that is more of an edge case since the default start angle is at
+        // the top.
+        if (
+            distance > 0 &&
+            // Crossing the bottom
+            start < halfPI && end > halfPI &&
+            // Angle within the bottom quadrant
+            angle > halfPI / 2 && angle < halfPI * 1.5
+        ) {
+            angle = angle <= halfPI ?
+                Math.max(halfPI / 2, (start + halfPI) / 2) :
+                Math.min(halfPI * 1.5, (halfPI + end) / 2);
         }
 
         const { center, options } = this,

--- a/ts/Series/Pie/PiePoint.ts
+++ b/ts/Series/Pie/PiePoint.ts
@@ -293,7 +293,7 @@ extend(PiePoint.prototype, {
             connectorPosition: DataLabel.LabelConnectorPositionObject,
             options: PieDataLabelOptions
         ): SVGPath {
-            const { breakAt, touchingSliceAt } = connectorPosition,
+            const { angle = 0, breakAt, touchingSliceAt } = connectorPosition,
                 { series } = this,
                 [cx, cy, diameter] = series.center,
                 r = diameter / 2,
@@ -317,7 +317,7 @@ extend(PiePoint.prototype, {
             // and the extension of the label position.
             } else {
                 crookX = cx + (cy - y) * Math.tan(
-                    (this.angle || 0) - Math.PI / 2
+                    angle - Math.PI / 2
                 );
             }
 

--- a/ts/Series/Pie/PiePoint.ts
+++ b/ts/Series/Pie/PiePoint.ts
@@ -293,7 +293,11 @@ extend(PiePoint.prototype, {
             connectorPosition: DataLabel.LabelConnectorPositionObject,
             options: PieDataLabelOptions
         ): SVGPath {
-            const { angle = 0, breakAt, touchingSliceAt } = connectorPosition,
+            const {
+                    angle = this.angle || 0,
+                    breakAt,
+                    touchingSliceAt
+                } = connectorPosition,
                 { series } = this,
                 [cx, cy, diameter] = series.center,
                 r = diameter / 2,
@@ -316,9 +320,7 @@ extend(PiePoint.prototype, {
             // intersection between the radial line in the middle of the slice,
             // and the extension of the label position.
             } else {
-                crookX = cx + (cy - y) * Math.tan(
-                    angle - Math.PI / 2
-                );
+                crookX = cx + (cy - y) * Math.tan(angle - Math.PI / 2);
             }
 
             const path: SVGPath = [['M', x, y]];


### PR DESCRIPTION
Fixed #22100, pie data label was cut off in some cases when rendered at the bottom of the pie. Altered positioning logic by letting labels gravitate towards the sides when there is space available, which also leaves room for the pie to render larger in limited space.

Test case https://jsfiddle.net/highcharts/nt0qa289/ . 
