### PR TITLE
Replaced gifencoder with gifenc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-security": "^2.1.1",
         "fs-extra": "^11.2.0",
-        "gifencoder": "^2.0.1",
+        "gifenc": "^1.0.3",
         "glob": "^10.4.1",
         "gulp": "^5.0.0",
         "gulp-jsdoc3": "^3.0.0",
@@ -3988,6 +3988,8 @@
       "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -6094,7 +6096,8 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
       "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -6412,7 +6415,9 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/arch": {
       "version": "2.2.0",
@@ -6452,6 +6457,8 @@
       "deprecated": "This package is no longer supported.",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
@@ -6466,6 +6473,8 @@
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -7696,6 +7705,8 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "nan": "^2.17.0",
@@ -7846,6 +7857,8 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8473,7 +8486,9 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/constants-browserify": {
       "version": "1.0.0",
@@ -9503,6 +9518,8 @@
       "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "mimic-response": "^2.0.0"
       },
@@ -9613,7 +9630,9 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -9686,6 +9705,8 @@
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11729,6 +11750,8 @@
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -11742,6 +11765,8 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -11754,7 +11779,9 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/fs-mkdirp-stream": {
       "version": "2.0.1",
@@ -11809,6 +11836,8 @@
       "deprecated": "This package is no longer supported.",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.2",
@@ -11960,15 +11989,12 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "node_modules/gifencoder": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/gifencoder/-/gifencoder-2.0.1.tgz",
-      "integrity": "sha512-x19DcyWY10SkshBpokqFOo/HBht9GB75evRYvaLMbez9p+yB/o+kt0fK9AwW59nFiAMs2UUQsjv1lX/hvu9Ong==",
+    "node_modules/gifenc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gifenc/-/gifenc-1.0.3.tgz",
+      "integrity": "sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "canvas": "^2.2.0"
-      }
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.4.5",
@@ -12783,7 +12809,9 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/hash-base": {
       "version": "3.0.4",
@@ -16365,6 +16393,8 @@
       "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -16460,6 +16490,8 @@
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -16474,6 +16506,8 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -16486,7 +16520,9 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/mitt": {
       "version": "3.0.0",
@@ -16593,7 +16629,9 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
       "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -16744,6 +16782,8 @@
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -16797,6 +16837,8 @@
       "deprecated": "This package is no longer supported.",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "are-we-there-yet": "^2.0.0",
         "console-control-strings": "^1.1.0",
@@ -19323,7 +19365,9 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -19496,6 +19540,8 @@
       "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
@@ -20930,6 +20976,8 @@
       "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -20972,6 +21020,8 @@
       "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -20982,6 +21032,8 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -20994,7 +21046,9 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/teex": {
       "version": "1.0.1",
@@ -22596,6 +22650,8 @@
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-security": "^2.1.1",
     "fs-extra": "^11.2.0",
-    "gifencoder": "^2.0.1",
+    "gifenc": "^1.0.3",
     "glob": "^10.4.1",
     "gulp": "^5.0.0",
     "gulp-jsdoc3": "^3.0.0",

--- a/test/karma-imagecapture-reporter.js
+++ b/test/karma-imagecapture-reporter.js
@@ -27,39 +27,40 @@ function ImageCaptureReporter(baseReporterDecorator, config, logger, emitter) {
         referenceRun = false
     } = config;
 
+
     /**
-     * Create an animated gif of the reference and the candidata image, in order to
-     * see the differences.
-     * @param  {String} filename
-     *         The file name
-     * @param  {Array}  frames
-     *         The image data of the GIF frames
-     * @param {number} width
-     *          Width of the created gif
-     * @param {number} height
-     *          Height of the created gif
-     * @return {void}
+     * Create an animated GIF from the provided frames.
+     * @param {String} filename The output file name.
+     * @param {Array} frames An array of frame data (Uint8Array) in RGBA format.
+     * @param {number} width The width of the GIF.
+     * @param {number} height The height of the GIF.
      */
     function createAnimatedGif(filename, frames, width, height) {
-        var GIFEncoder = require('gifencoder');
+        const { GIFEncoder: gifenc, quantize, applyPalette } = require('gifenc');
+        // Quantize the first frame to get the global palette
+        const palette = quantize(frames[0], 256);
 
-        var encoder = new GIFEncoder(width, height);
-        encoder.start();
-        // 0 for repeat, -1 for no-repeat
-        encoder.setRepeat(0);
-        // frame delay in ms
-        encoder.setDelay(500);
-        // image quality. 10 is default.
-        encoder.setQuality(10);
+        // Create a new GIF encoder
+        const gif = gifenc();
 
+        // Add each frame to the GIF
         frames.forEach(frame => {
-            encoder.addFrame(frame);
+        // Apply the palette to the frame
+            const indexedFrame = applyPalette(frame, palette);
+            // Add the frame to the GIF with a 500ms delay
+            gif.writeFrame(indexedFrame, width, height, { palette, delay: 500 });
         });
-        encoder.finish();
 
-        var buf = encoder.out.getData();
+        // Finalize the GIF
+        gif.finish();
+
+        // Get the GIF as a Uint8Array
+        const gifData = gif.bytes();
+
         pendingFileWritings++;
-        fs.writeFile(filename, buf, function (err) {
+
+        // Write the GIF to a file
+        fs.writeFile(filename, Buffer.from(gifData), err => {
             if (err) {
                 throw err;
             }

--- a/test/karma-setup.js
+++ b/test/karma-setup.js
@@ -759,6 +759,8 @@ function compareToReference(chart, path) { // eslint-disable-line no-unused-vars
                 var diff = compare(referencePixels, candidatePixels);
 
                 if (diff !== 0) {
+                    saveSVGSnapshot(candidateSVG, path + '/candidate.svg');
+
                     __karma__.info({
                         filename: './samples/' + path + '/diff.gif',
                         canvasWidth: CANVAS_WIDTH,
@@ -768,7 +770,6 @@ function compareToReference(chart, path) { // eslint-disable-line no-unused-vars
                             candidatePixels
                         ]
                     });
-                    saveSVGSnapshot(candidateSVG, path + '/candidate.svg');
                 }
                 resolve(diff);
             })


### PR DESCRIPTION
Replaced gifencoder dependency with [gifenc](https://www.npmjs.com/package/gifenc), which has no dependencies.

## Test plan
1. Run `npx karma start test/karma-conf.js --tests "highcharts/demo/line-chart" --single-run --browsercount 1 --reference`
2. Make a change in `samples/highcharts/demo/line-chart/demo.js` that should produce a visual diff
3.  Run `npx karma start test/karma-conf.js --tests "highcharts/demo/line-chart" --single-run --browsercount 1 --visualcompare`
4. There should be a `samples/highcharts/demo/line-chart/diff.gif` containing the visual changes