### PR TITLE
Fixed #20687, series.update with keys did not work

### DIFF
--- a/samples/unit-tests/series/update/demo.js
+++ b/samples/unit-tests/series/update/demo.js
@@ -621,6 +621,25 @@ QUnit.test('Series.update and setData', function (assert) {
         true,
         'Custom property should be available in options after update (#11244)'
     );
+
+    chart.series[0].update({
+        keys: ['x', 'name', 'y'],
+        data: [
+            [0, 'First', 20]
+        ]
+    });
+
+    assert.strictEqual(
+        chart.series[0].points[0].y,
+        20,
+        'The point value should be updated when using keys'
+    );
+
+    assert.strictEqual(
+        chart.series[0].points[0].name,
+        'First',
+        'The point name should be updated when using keys'
+    );
 });
 
 QUnit.test(

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -4232,6 +4232,7 @@ class Series {
             // New type requires new point classes
             (newType && newType !== this.type) ||
             // New options affecting how the data points are built
+            typeof options.keys !== 'undefined' ||
             typeof options.pointStart !== 'undefined' ||
             typeof options.pointInterval !== 'undefined' ||
             typeof options.relativeXValue !== 'undefined' ||


### PR DESCRIPTION
Fixed #20687, `series.update` with `keys` did not work