### PR TITLE
bugfix/22052-drilldown-breadcrumb-label

### DIFF
--- a/samples/unit-tests/drilldown/highstock/demo.js
+++ b/samples/unit-tests/drilldown/highstock/demo.js
@@ -50,3 +50,81 @@ QUnit.test('Drilldown with Highcharts Stock (#5764)', function (assert) {
     chart.series[0].points[2].doDrilldown();
     assert.strictEqual(chart.series[0].name, 'Cars', 'Drilled');
 });
+
+QUnit.test(
+    'Drilldown with Highcharts Stock + Scrollbar (#22052)',
+    function (assert) {
+        var data = [];
+        var drilldownData = [];
+        for (var i = 0; i < 100; i++) {
+            data.push({
+                name: i.toString(),
+                y: i,
+                drilldown: i.toString()
+            });
+            drilldownData.push({
+                id: i.toString(),
+                data: [
+                    [i, i]
+                ]
+            });
+        }
+
+        const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'column',
+                animation: false
+            },
+            xAxis: {
+                type: 'category',
+                min: 0,
+                max: 20,
+                scrollbar: {
+                    enabled: true
+                }
+            },
+
+            legend: {
+                enabled: false
+            },
+
+            plotOptions: {
+                series: {
+                    borderWidth: 0,
+                    dataLabels: {
+                        enabled: true
+                    },
+                    animation: false
+                }
+            },
+
+            series: [{
+                name: 'Things',
+                colorByPoint: true,
+                data
+            }],
+            drilldown: {
+                series: drilldownData,
+                animation: false
+            }
+        },
+        chart => {
+            // Scroll to the side
+            chart.xAxis[0].setExtremes(79, 99);
+        });
+
+        chart.series[0].data.find(p => p && p.name === '88').doDrilldown();
+
+        const breadcrumbs = chart.breadcrumbs.elementList;
+        const lastBreadcrumb = breadcrumbs[
+            Object.keys(breadcrumbs).length - 1
+        ];
+        const breadcrumbText = lastBreadcrumb.button.text.textStr;
+
+        assert.strictEqual(
+            breadcrumbText,
+            '88',
+            'Breadcrumbs should show correct point after drilldown with ' +
+            'scrolling'
+        );
+    });

--- a/samples/unit-tests/drilldown/highstock/demo.js
+++ b/samples/unit-tests/drilldown/highstock/demo.js
@@ -113,18 +113,16 @@ QUnit.test(
             chart.xAxis[0].setExtremes(79, 99);
         });
 
-        chart.series[0].data.find(p => p && p.name === '88').doDrilldown();
+        chart.series[0].points.find(p => p && p.name === '88').doDrilldown();
 
-        const breadcrumbs = chart.breadcrumbs.elementList;
-        const lastBreadcrumb = breadcrumbs[
-            Object.keys(breadcrumbs).length - 1
-        ];
-        const breadcrumbText = lastBreadcrumb.button.text.textStr;
+        const breadcrumbs = chart.breadcrumbs.elementList,
+            lastBreadcrumb = breadcrumbs[Object.keys(breadcrumbs).length - 1],
+            breadcrumbText = lastBreadcrumb.button.text.textStr;
 
         assert.strictEqual(
             breadcrumbText,
             '88',
-            'Breadcrumbs should show correct point after drilldown with ' +
+            'Breadcrumbs should show correct point (88) after drilldown with ' +
             'scrolling'
         );
     });

--- a/ts/Extensions/Drilldown/Drilldown.ts
+++ b/ts/Extensions/Drilldown/Drilldown.ts
@@ -396,7 +396,7 @@ class ChartAdditions {
                 { colorIndex: pick(point.colorIndex, oldSeries.colorIndex) } :
                 { color: point.color || oldSeries.color },
             levelNumber = oldSeries.options._levelNumber || 0,
-            pointIndex = oldSeries.points.indexOf(point);
+            pointIndex = oldSeries.data.indexOf(point);
 
         if (!chart.drilldownLevels) {
             chart.drilldownLevels = [];

--- a/ts/Extensions/Drilldown/Drilldown.ts
+++ b/ts/Extensions/Drilldown/Drilldown.ts
@@ -395,8 +395,7 @@ class ChartAdditions {
             colorProp: SeriesOptions = chart.styledMode ?
                 { colorIndex: pick(point.colorIndex, oldSeries.colorIndex) } :
                 { color: point.color || oldSeries.color },
-            levelNumber = oldSeries.options._levelNumber || 0,
-            pointIndex = oldSeries.data.indexOf(point);
+            levelNumber = oldSeries.options._levelNumber || 0;
 
         if (!chart.drilldownLevels) {
             chart.drilldownLevels = [];
@@ -457,8 +456,8 @@ class ChartAdditions {
                 Color.parse(colorProp.color).setOpacity(0).get() :
                 colorProp.color,
             lowerSeriesOptions: ddOptions,
-            pointOptions: (oldSeries.options.data as any)[pointIndex],
-            pointIndex: pointIndex,
+            pointOptions: point.options,
+            pointIndex: point.index,
             oldExtremes: {
                 xMin: xAxis && xAxis.userMin,
                 xMax: xAxis && xAxis.userMax,


### PR DESCRIPTION
Fixed #22052, drilldown breadcrumb showed the wrong label when scrollbar was enabled

~~Fixed #22052, Drilling to wrong point when scrolled with scrollbar~~

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208629386042303