### PR TITLE
Fixed text-align of HTML text

### DIFF
--- a/ts/Core/Renderer/HTML/HTMLElement.ts
+++ b/ts/Core/Renderer/HTML/HTMLElement.ts
@@ -466,6 +466,7 @@ class HTMLElement extends SVGElement {
                 styles: CSSObject = {
                     left: `${x + xCorr}px`,
                     top: `${y + yCorr}px`,
+                    textAlign,
                     transformOrigin: `${rotOriginX}px ${rotOriginY}px`
                 };
             css(element, styles);


### PR DESCRIPTION
Fixed #22143, titles with center alignment rendered left-aligned with `useHTML`.

Reproductions:
* With `useHTML` subtitle: https://jsfiddle.net/highcharts/1w7xrk89/
* With clean SVGRenderer, SVG vs HTML: https://jsfiddle.net/highcharts/07dLm58y/