### PR TITLE
dash/dg-even-odd-rows

### DIFF
--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -324,7 +324,7 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
     background: var(--highcharts-background-color);
 }
 
-.highcharts-datagrid-table tbody tr.highcharts-datagrid-row.highcharts-datagrid-row-odd {
+.highcharts-datagrid-table tbody tr.highcharts-datagrid-row.highcharts-datagrid-row-even {
     background-color: var(--highcharts-neutral-color-3);
 }
 
@@ -334,7 +334,7 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
 }
 
 .highcharts-datagrid-table tbody tr.highcharts-datagrid-hovered-row,
-.highcharts-datagrid-table tbody tr.highcharts-datagrid-row.highcharts-datagrid-row-odd.highcharts-datagrid-hovered-row {
+.highcharts-datagrid-table tbody tr.highcharts-datagrid-row.highcharts-datagrid-row-even.highcharts-datagrid-hovered-row {
     background-color: var(--highcharts-highlight-color-10);
 }
 

--- a/test/cypress/data-grid/integration/general.cy.js
+++ b/test/cypress/data-grid/integration/general.cy.js
@@ -10,4 +10,9 @@ describe('Remove the dashboard.', () => {
         // Assert
         cy.get('tr').should('have.length', 5);
     });
+
+    it('Rows should have even and odd classes.', () => {
+        cy.get('tbody tr').eq(0).should('have.class', 'highcharts-datagrid-row-odd');
+        cy.get('tbody tr').eq(1).should('have.class', 'highcharts-datagrid-row-even');
+    });
 });

--- a/ts/DataGrid/Globals.ts
+++ b/ts/DataGrid/Globals.ts
@@ -71,6 +71,7 @@ namespace Globals {
         theadElement: classNamePrefix + 'thead',
         tbodyElement: classNamePrefix + 'tbody',
         rowElement: classNamePrefix + 'row',
+        rowEven: classNamePrefix + 'row-even',
         rowOdd: classNamePrefix + 'row-odd',
         hoveredRow: classNamePrefix + 'hovered-row',
         columnElement: classNamePrefix + 'column',

--- a/ts/DataGrid/Table/Content/TableRow.ts
+++ b/ts/DataGrid/Table/Content/TableRow.ts
@@ -130,7 +130,10 @@ class TableRow extends Row {
             idx + (this.viewport.header?.levels ?? 1) + 1
         );
 
-        if (idx % 2 === 1) {
+        // Indexing from 0, so rows with even index are odd.
+        if (idx % 2) {
+            el.classList.add(Globals.classNames.rowEven);
+        } else {
             el.classList.add(Globals.classNames.rowOdd);
         }
 

--- a/ts/DataGrid/Table/Content/TableRow.ts
+++ b/ts/DataGrid/Table/Content/TableRow.ts
@@ -131,11 +131,7 @@ class TableRow extends Row {
         );
 
         // Indexing from 0, so rows with even index are odd.
-        if (idx % 2) {
-            el.classList.add(Globals.classNames.rowEven);
-        } else {
-            el.classList.add(Globals.classNames.rowOdd);
-        }
+        el.classList.add(Globals.classNames[idx % 2 ? 'rowEven' : 'rowOdd']);
 
         if (this.viewport.dataGrid.hoveredRowIndex === idx) {
             el.classList.add(Globals.classNames.hoveredRow);


### PR DESCRIPTION
Fixed an issue where even rows had the `highcharts-datagrid-row-odd` class. Now, odd rows have the proper class, and even rows have a new `highcharts-datagrid-row-even` class.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208723823472437