### PR TITLE
tools/fix-benchmark-ts-interop

### DIFF
--- a/.github/workflows/dashboards-benchmark.yml
+++ b/.github/workflows/dashboards-benchmark.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Benchmark
         continue-on-error: true
-        run: cd test/ts-node-unit-tests && node -r ts-node/register bench.ts --context base --pattern Dashboards/
+        run: cd test/ts-node-unit-tests && node --import tsx bench.ts --context base --pattern Dashboards/
 
       - name: Checkout current branch
         uses: actions/checkout@v3
@@ -59,10 +59,10 @@ jobs:
         run: npx gulp dashboards/scripts
 
       - name: Benchmark
-        run: cd test/ts-node-unit-tests && node -r ts-node/register bench.ts --context actual --pattern Dashboards/
+        run: cd test/ts-node-unit-tests && node --import tsx bench.ts --context actual --pattern Dashboards/
 
       - name: Benchmark comparison
-        run: cd test/ts-node-unit-tests && node -r ts-node/register benchmark-compare.ts
+        run: cd test/ts-node-unit-tests && node --import tsx benchmark-compare.ts
 
       - name: Store artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/stock-benchmark.yml
+++ b/.github/workflows/stock-benchmark.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Benchmark
         continue-on-error: true
-        run: cd test/ts-node-unit-tests && node -r ts-node/register bench.ts --context base --pattern Stock/
+        run: node --import tsx test/ts-node-unit-tests/bench.ts --context base --pattern Stock/
 
       - name: Checkout current branch
         uses: actions/checkout@v3
@@ -54,10 +54,10 @@ jobs:
         run: npx gulp scripts
 
       - name: Benchmark
-        run: cd test/ts-node-unit-tests && node -r ts-node/register bench.ts --context actual --pattern Stock/
+        run: node --import tsx test/ts-node-unit-tests/bench.ts --context actual --pattern Stock/
 
       - name: Benchmark comparison
-        run: cd test/ts-node-unit-tests && node -r ts-node/register benchmark-compare.ts
+        run: node --import tsx test/ts-node-unit-tests/benchmark-compare.ts
 
       - name: Store artifacts
         uses: actions/upload-artifact@v3

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "prepare": "husky install",
     "postinstall": "npx gulp update-vendor && npx gulp patch-ink-docstrap",
     "reset": "npx gulp reset-clone && npm i",
-    "benchmark": "cd test/ts-node-unit-tests && node -r ts-node/register bench.ts",
-    "benchmark-compare": "cd test/ts-node-unit-tests && node -r ts-node/register benchmark-compare.ts"
+    "benchmark": "tsx test/ts-node-unit-tests/bench.ts",
+    "benchmark-compare": "tsx test/ts-node-unit-tests/benchmark-compare.ts"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.592.0",

--- a/test/ts-node-unit-tests/.gitignore
+++ b/test/ts-node-unit-tests/.gitignore
@@ -1,2 +1,3 @@
 tests/**/*.js
 test-data
+*.tmp.mjs

--- a/test/ts-node-unit-tests/benchmark-compare.ts
+++ b/test/ts-node-unit-tests/benchmark-compare.ts
@@ -6,8 +6,6 @@ import { join, resolve } from 'node:path';
 
 const TMP_FILE_PATH = resolve(__dirname, '../../tmp/benchmarks');
 
-console.log(TMP_FILE_PATH)
-
 function regression (yValues: number[], xValues: number[]){
     const yMean = yValues.reduce((a, b) => a + b) / yValues.length;
     const xMean = xValues.reduce((a, b) => a + b) / xValues.length;

--- a/test/ts-node-unit-tests/benchmark-compare.ts
+++ b/test/ts-node-unit-tests/benchmark-compare.ts
@@ -4,7 +4,9 @@ import { opendir, readFile, appendFile, writeFile } from 'node:fs/promises';
 import type { Dir } from 'fs';
 import { join, resolve } from 'node:path';
 
-const TMP_FILE_PATH = '../../tmp/benchmarks';
+const TMP_FILE_PATH = resolve(__dirname, '../../tmp/benchmarks');
+
+console.log(TMP_FILE_PATH)
 
 function regression (yValues: number[], xValues: number[]){
     const yMean = yValues.reduce((a, b) => a + b) / yValues.length;

--- a/test/ts-node-unit-tests/index.ts
+++ b/test/ts-node-unit-tests/index.ts
@@ -7,7 +7,7 @@ import { run as runGulp } from '../../tools/gulptasks/lib/gulp';
 import '../../gulpfile.js';
 
 import * as glob from 'glob';
-const files = glob.sync(join(__dirname, 'tests') + '/**/*.test.ts');
+const files = glob.sync(join(__dirname , 'tests') + '/**/*.test.ts');
 
 (async ()=> {
     await runGulp('scripts');


### PR DESCRIPTION
Added transpilation of the worker file, as well as import enhancements using tsx within the worker file. Fixes issues that may be caused by changes in recent node versions.

Comparison fails as master does not work. But see the second "benchmark" step in https://github.com/highcharts/highcharts/actions/runs/11838739571/job/32988565766?pr=22156 to see it working on this branch