### PR TITLE
dash/dg-long-header-title

### DIFF
--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -125,7 +125,7 @@
 }
 
 .highcharts-datagrid-table thead th .highcharts-datagrid-header-cell-content {
-    width: 100%;
+    width: calc(100% - 15px); /* 12px width of sorting icon, 3px padding */
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
Fixed overlapped sorting icon over the long header.