### PR TITLE
22088 tooltip outside spilling over

### DIFF
--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1096,7 +1096,8 @@ class Tooltip {
                                 label.x || 0,
                                 0,
                                 this.getPlayingField().width -
-                                (label.width || 0)
+                                (label.width || 0) -
+                                1
                             )
                         });
                     }


### PR DESCRIPTION
Fixed #22088, tooltip could spill over at certain widths.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208746924695349