### PR TITLE
ci: update `upload-artifact` and `download-artifact` actions to v4

### DIFF
--- a/.github/workflows/dashboards-benchmark.yml
+++ b/.github/workflows/dashboards-benchmark.yml
@@ -65,7 +65,7 @@ jobs:
         run: cd test/ts-node-unit-tests && node --import tsx benchmark-compare.ts
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark-files
           path: |

--- a/.github/workflows/dashboards-lighthouse-test.yml
+++ b/.github/workflows/dashboards-lighthouse-test.yml
@@ -102,7 +102,7 @@ jobs:
           install: false
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tmp-files
           path: |

--- a/.github/workflows/dashboards-visual-test.yml
+++ b/.github/workflows/dashboards-visual-test.yml
@@ -138,7 +138,7 @@ jobs:
 
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: post-tests

--- a/.github/workflows/stock-benchmark.yml
+++ b/.github/workflows/stock-benchmark.yml
@@ -60,7 +60,7 @@ jobs:
         run: node --import tsx test/ts-node-unit-tests/benchmark-compare.ts
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark-files
           path: |

--- a/.github/workflows/visual-compare.yml
+++ b/.github/workflows/visual-compare.yml
@@ -165,7 +165,7 @@ jobs:
 
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: visual-test-results


### PR DESCRIPTION
v3 of `actions/upload-artifact` and `actions/download-artifact` will be fully deprecated by **30 January 2025**. Jobs that are scheduled to run during the brownout periods will also fail. See:

1. https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
2. https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/
3. https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#artifacts-v3-brownouts