### PR TITLE
Fixed #22188, zone clipping on zoomed category axis

### DIFF
--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -1585,9 +1585,9 @@ class Axis {
 
                         // The `minPointOffset` is the value padding to the left
                         // of the axis in order to make room for points with a
-                        // pointRange, typically columns. When the
-                        // pointPlacement option is 'between' or 'on', this
-                        // padding does not apply.
+                        // pointRange, typically columns, or line/scatter points
+                        // on a category axis. When the `pointPlacement` option
+                        // is 'between' or 'on', this padding does not apply.
                         minPointOffset = Math.max(
                             minPointOffset,
                             isPointPlacementAxis && isString(pointPlacement) ?

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -3170,7 +3170,12 @@ class Series {
 
             // Compute and apply the clips
             let lastLineClip: SVGPath = [],
-                lastTranslated = axis.toPixels(axis.getExtremes().min, true);
+                // Starting point of the first zone. Offset for category axis
+                // (#22188).
+                lastTranslated = axis.toPixels(
+                    axis.getExtremes().min - (axis.minPointOffset || 0),
+                    true
+                );
 
             zones.forEach((zone): void => {
                 const lineClip = zone.lineClip || [],
@@ -3223,7 +3228,8 @@ class Series {
                 }
 
                 /* Debug clip paths
-                chart.renderer.path(adaptivePath)
+                zone.path?.destroy();
+                zone.path = chart.renderer.path(adaptivePath)
                     .attr({
                         stroke: zone.color || this.color || 'gray',
                         'stroke-width': 1,


### PR DESCRIPTION
Fixed #22188, graphs were clipped at the left side when zooming on a series containing zones, and the x-axis was of type category.

---

* The OP demo with the fix applied: https://jsfiddle.net/highcharts/7zmcsqpL/1/
* The OP demo with a drop-in fix for Highcharts v11.4.8: https://jsfiddle.net/highcharts/7zmcsqpL/