### PR TITLE
Fixed #22187, word wrap failed when markup at break

### DIFF
--- a/samples/unit-tests/svgrenderer/text/demo.js
+++ b/samples/unit-tests/svgrenderer/text/demo.js
@@ -152,6 +152,16 @@ QUnit.test('Text word wrap with markup', function (assert) {
         text.getBBox().width <= 100,
         'Text directly inside anchor should be wrapped (#16173)'
     );
+
+    text.attr({
+        text: 'Marked-up word <strong>finally</strong>'
+    });
+
+    assert.strictEqual(
+        text.element.querySelectorAll('tspan[x="100"]').length,
+        1,
+        'One line break should be applied (#22187)'
+    );
 });
 
 QUnit.module('whiteSpace: "nowrap"', hooks => {

--- a/ts/Core/Renderer/SVG/TextBuilder.ts
+++ b/ts/Core/Renderer/SVG/TextBuilder.ts
@@ -491,7 +491,7 @@ class TextBuilder {
 
         // Word wrap cannot be truncated to shorter than one word, ellipsis
         // text can be completely blank.
-        let minIndex = words ? 1 : 0;
+        let minIndex = words && !startAt ? 1 : 0;
         let maxIndex = (text || words || '').length;
         let currentIndex = maxIndex;
         let str;
@@ -517,7 +517,7 @@ class TextBuilder {
                         lengths[end] = startAt +
                             (parentNode as any).getSubStringLength(
                                 0,
-                                words ? end + 1 : end
+                                words && !startAt ? end + 1 : end
                             );
 
                     } catch (e) {


### PR DESCRIPTION
Fixed #22187, word wrap failed for SVG when a word with markup fell at the breaking point.