### PR TITLE
tools/new export url

### DIFF
--- a/samples/unit-tests/exporting/url/demo.js
+++ b/samples/unit-tests/exporting/url/demo.js
@@ -2,7 +2,7 @@ QUnit.test('Exporting module is compatible with https', function (assert) {
     var defaultOptions = Highcharts.getOptions();
     assert.strictEqual(
         defaultOptions.exporting.url,
-        'https://export.highcharts.com/',
-        'exporting.url default value is https://export.highcharts.com/'
+        'https://export-svg.highcharts.com/',
+        'exporting.url default value should be https://export-svg.highcharts.com/'
     );
 });

--- a/ts/Extensions/Exporting/ExportingDefaults.ts
+++ b/ts/Extensions/Exporting/ExportingDefaults.ts
@@ -264,7 +264,7 @@ const exporting: ExportingOptions = {
      *
      * @since 2.0
      */
-    url: 'https://export.highcharts.com/',
+    url: 'https://export-svg.highcharts.com/',
 
     /**
      * Settings for a custom font for the exported PDF, when using the


### PR DESCRIPTION
Changed default `exporting.url` to a more stable server, dedicated to SVG export only.