### PR TITLE
22169 only first zone is receiving shadow

### DIFF
--- a/ts/Series/Line/LineSeries.ts
+++ b/ts/Series/Line/LineSeries.ts
@@ -161,10 +161,8 @@ class LineSeries extends Series {
                 }
 
                 graph[verb](attribs)
-                // Add shadow to normal series (0) or to first
-                // zone (1) #3932
+                    // Add shadow to normal series as well as zones
                     .shadow(
-                        (i < 2) &&
                         options.shadow &&
                         // If shadow is defined, call function with
                         // `filterUnits: 'userSpaceOnUse'` to avoid known


### PR DESCRIPTION
Fixed #22169, only the first zone got shadow when `shadow` was `true`

Note: the reason was a workaround for an old bug #3932. This workaround can safely be removed since `negativeColor` and `shadow` play nice now: https://jsfiddle.net/mkb93/L8obxyq4/4/
