### PR TITLE
dash/dg-height-updating

### DIFF
--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -93,8 +93,6 @@
 
 .highcharts-datagrid-container {
     display: block;
-    min-height: 200px;
-    font-family: 1em;
     overflow: hidden;
 }
 
@@ -106,7 +104,7 @@
 .highcharts-datagrid-table {
     width: 100%;
     table-layout: fixed;
-    border-collapse: collapse;
+    border-collapse: separate;
     border-spacing: 0;
     overflow: hidden;
 }

--- a/samples/data-grid/basic/container-height/demo.css
+++ b/samples/data-grid/basic/container-height/demo.css
@@ -1,6 +1,5 @@
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 
 #container {
-    /* height: 250px; */
-    margin: 8px;
+    border: 2px solid red;
 }

--- a/samples/data-grid/basic/container-height/demo.details
+++ b/samples/data-grid/basic/container-height/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Dashboards Demo
+ authors:
+   - Dawid Dragula
+ js_wrap: b
+...

--- a/samples/data-grid/basic/container-height/demo.html
+++ b/samples/data-grid/basic/container-height/demo.html
@@ -1,0 +1,12 @@
+<script src="https://code.highcharts.com/dashboards/datagrid.js"></script>
+
+<div>
+    <input type="checkbox" id="defined-height-cbx" name="defined-height-cbx" />
+    <label for="defined-height-cbx">Defined container height</label>
+</div>
+<div>
+    <input type="range" id="height-slider" name="height-slider" min="0" max="400" disabled />
+    <label for="height-slider" id="height-slider-label">auto</label>
+</div>
+
+<div id="container"></div>

--- a/samples/data-grid/basic/container-height/demo.js
+++ b/samples/data-grid/basic/container-height/demo.js
@@ -1,0 +1,30 @@
+const container = document.getElementById('container');
+const definedHeightCbx = document.getElementById('defined-height-cbx');
+const heightSlider = document.getElementById('height-slider');
+const heightSliderLabel = document.getElementById('height-slider-label');
+
+DataGrid.dataGrid(container, {
+    dataTable: {
+        columns: {
+            product: ['Apples', 'Pears', 'Plums', 'Bananas'],
+            weight: [100, 40, 0.5, 200],
+            price: [1.5, 2.53, 5, 4.5],
+            metaData: ['a', 'b', 'c', 'd'],
+            icon: ['Apples URL', 'Pears URL', 'Plums URL', 'Bananas URL']
+        }
+    },
+    columnDefaults: {
+        resizing: false
+    }
+});
+
+definedHeightCbx.addEventListener('change', () => {
+    const unchecked = heightSlider.disabled = !definedHeightCbx.checked;
+    heightSliderLabel.textContent = container.style.height =
+        unchecked ? 'auto' : `${heightSlider.value}px`;
+});
+
+heightSlider.addEventListener('input', () => {
+    heightSliderLabel.textContent =
+        container.style.height = `${heightSlider.value}px`;
+});

--- a/ts/DataGrid/Table/Table.ts
+++ b/ts/DataGrid/Table/Table.ts
@@ -270,11 +270,15 @@ class Table {
     public reflow(): void {
         const tableEl = this.dataGrid.tableElement;
         const borderWidth = tableEl ? (
-            (getStyle(tableEl, 'border-top-width', true) || 0) +
-            (getStyle(tableEl, 'border-bottom-width', true) || 0)
+            parseFloat(
+                '' + (getStyle(tableEl, 'border-top-width', false) || 0)
+            ) +
+            parseFloat(
+                '' + (getStyle(tableEl, 'border-bottom-width', false) || 0)
+            )
         ) : 0;
 
-        this.tbodyElement.style.height = this.tbodyElement.style.minHeight = `${
+        this.tbodyElement.style.height = `${
             (this.dataGrid.container?.clientHeight || 0) -
             (this.theadElement?.offsetHeight || 0) -
             (this.captionElement?.offsetHeight || 0) -


### PR DESCRIPTION
An attempt to rebuild the DataGrid dimensioning method to get rid of ResizeObserver loops and prepare it for the 3 rendering types (virtualized, non-virtualized, non-virtualized without scrolling).