### PR TITLE
dash/non-virtualized-scrolling

### DIFF
--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -198,6 +198,7 @@
 
 .highcharts-datagrid-resizer-content thead,
 .highcharts-datagrid-resizer-content tbody {
+    display: block;
     margin-left: calc(var(--border-spacing) * -1);
 }
 

--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -128,10 +128,6 @@
 }
 
 /* Table Header */
-.highcharts-datagrid-table.highcharts-datagrid-virtualization thead {
-    display: block;
-}
-
 .highcharts-datagrid-table thead tr {
     height: 32px;
 }
@@ -202,8 +198,6 @@
 
 .highcharts-datagrid-resizer-content thead,
 .highcharts-datagrid-resizer-content tbody {
-    display: block;
-    overflow-y: auto;
     margin-left: calc(var(--border-spacing) * -1);
 }
 
@@ -280,12 +274,22 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
 }
 
 /* Table body */
+.highcharts-datagrid-table.highcharts-datagrid-scrollable-content tbody,
+.highcharts-datagrid-table.highcharts-datagrid-scrollable-content thead {
+    display: block;
+    position: relative;   
+}
+
+.highcharts-datagrid-table.highcharts-datagrid-scrollable-content tbody {
+    overflow-y: auto;
+}
+
 .highcharts-datagrid-table.highcharts-datagrid-virtualization tbody {
     overflow: auto;
     height: 100%;
     min-height: 100%;
-    display: block;
-    position: relative;
+    /* display: block;
+    position: relative; */
 }
 
 .highcharts-datagrid-table tbody tr {

--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -35,7 +35,7 @@
     --row-border: 1px;
     --inset: 1px; /* We recommend inset for hightlight borders to avoid content shifting. */
     --padding: 8px;
-    --border-spacing: 10px; /* This is the big one, allowing for more "decorative" tables. */
+    --border-spacing: 0px; /* This is the big one, allowing for more "decorative" tables. */
     --cell-border-radius: 0px; /* Best suited if border-spacing > 0. We need for <table> as well. */
 }
 

--- a/ts/DataGrid/DataGrid.ts
+++ b/ts/DataGrid/DataGrid.ts
@@ -39,7 +39,7 @@ import QueryingController from './Querying/QueryingController.js';
 
 const { makeHTMLElement } = DataGridUtils;
 const { win } = Globals;
-const { merge } = U;
+const { merge, getStyle } = U;
 
 
 /* *
@@ -149,6 +149,11 @@ class DataGrid {
     public container?: HTMLElement;
 
     /**
+     * The init container height
+     */
+    public initContainerHeight: number;
+
+    /**
      * The content container of the data grid.
      */
     public contentWrapper?: HTMLElement;
@@ -242,7 +247,7 @@ class DataGrid {
         this.loadUserOptions(options);
 
         this.querying = new QueryingController(this);
-
+        this.initContainerHeight = 0;
         this.initContainers(renderTo);
         this.initAccessibility();
         this.loadDataTable(this.options?.dataTable);
@@ -295,7 +300,11 @@ class DataGrid {
             `);
             return;
         }
-
+        this.initContainerHeight = getStyle(
+            container,
+            'height',
+            true
+        ) || 0;
         this.container = container;
         this.container.innerHTML = AST.emptyHTML;
         this.contentWrapper = makeHTMLElement('div', {

--- a/ts/DataGrid/DataGrid.ts
+++ b/ts/DataGrid/DataGrid.ts
@@ -305,6 +305,7 @@ class DataGrid {
             'height',
             true
         ) || 0;
+
         this.container = container;
         this.container.innerHTML = AST.emptyHTML;
         this.contentWrapper = makeHTMLElement('div', {

--- a/ts/DataGrid/Globals.ts
+++ b/ts/DataGrid/Globals.ts
@@ -80,6 +80,7 @@ namespace Globals {
         editedCell: classNamePrefix + 'edited-cell',
         rowsContentNowrap: classNamePrefix + 'rows-content-nowrap',
         virtualization: classNamePrefix + 'virtualization',
+        scrollableContent: classNamePrefix + 'scrollable-content',
         headerCell: classNamePrefix + 'header-cell',
         headerCellContent: classNamePrefix + 'header-cell-content',
         headerRow: classNamePrefix + 'head-row-content',

--- a/ts/DataGrid/Table/Actions/ColumnsResizer.ts
+++ b/ts/DataGrid/Table/Actions/ColumnsResizer.ts
@@ -83,6 +83,10 @@ class ColumnsResizer {
      */
     private handles: Array<[HTMLElement, (e: MouseEvent) => void]> = [];
 
+    /**
+     * Determinates that columns are resized.
+     */
+    public resizedColumns?: boolean;
 
     /* *
      *
@@ -220,7 +224,7 @@ class ColumnsResizer {
             this.fixedDistributionResize(diff);
         }
 
-        vp.reflow(true);
+        vp.reflow();
 
         if (vp.dataGrid.options?.rendering?.rows?.virtualization) {
             vp.rowsVirtualizer.adjustRowHeights();
@@ -267,7 +271,7 @@ class ColumnsResizer {
                     Globals.classNames.resizerWrapper
                 );
                 // Apply widths before resizing
-                this.viewport.reflow(true);
+                this.viewport.reflow();
             }
 
             this.dragStartX = e.pageX;
@@ -280,6 +284,8 @@ class ColumnsResizer {
             column.header?.htmlElement.classList.add(
                 Globals.classNames.resizedColumn
             );
+
+            this.resizedColumns = true;
         };
 
         this.handles.push([handle, onHandleMouseDown]);

--- a/ts/DataGrid/Table/Actions/ColumnsResizer.ts
+++ b/ts/DataGrid/Table/Actions/ColumnsResizer.ts
@@ -266,6 +266,8 @@ class ColumnsResizer {
         const onHandleMouseDown = (e: MouseEvent): void => {
             const vp = column.viewport;
 
+            this.resizedColumns = true;
+
             if (!vp.dataGrid.options?.rendering?.rows?.virtualization) {
                 vp.dataGrid.contentWrapper?.classList.add(
                     Globals.classNames.resizerWrapper
@@ -284,8 +286,6 @@ class ColumnsResizer {
             column.header?.htmlElement.classList.add(
                 Globals.classNames.resizedColumn
             );
-
-            this.resizedColumns = true;
         };
 
         this.handles.push([handle, onHandleMouseDown]);

--- a/ts/DataGrid/Table/Header/HeaderCell.ts
+++ b/ts/DataGrid/Table/Header/HeaderCell.ts
@@ -124,6 +124,7 @@ class HeaderCell extends Cell {
         const column = this.column;
         const options = merge(column.options, this.options); // ??
         const headerCellOptions = options.header || {};
+        const isSortableData = options.sorting?.sortable && column.data;
 
         if (headerCellOptions.formatter) {
             this.value = headerCellOptions.formatter.call(this).toString();
@@ -137,12 +138,16 @@ class HeaderCell extends Cell {
         this.row.htmlElement.appendChild(this.htmlElement);
 
         this.headerContent = makeHTMLElement(
-            options.sorting?.sortable && column.data ? 'button' : 'span',
+            isSortableData ? 'button' : 'span',
             {
                 className: Globals.classNames.headerCellContent
             },
             this.htmlElement
         );
+
+        if (isSortableData) {
+            this.headerContent.setAttribute('type', 'button');
+        }
 
         if (isHTML(this.value)) {
             this.renderHTMLCellContent(

--- a/ts/DataGrid/Table/Table.ts
+++ b/ts/DataGrid/Table/Table.ts
@@ -151,7 +151,6 @@ class Table {
      */
     public focusCursor?: [number, number];
 
-
     /* *
     *
     *  Constructor
@@ -278,12 +277,8 @@ class Table {
 
     /**
      * Reflows the table's content dimensions.
-     *
-     * @param reflowColumns
-     * Force reflow columns and recalculate widths.
-     *
      */
-    public reflow(reflowColumns: boolean = false): void {
+    public reflow(): void {
         const tableEl = this.dataGrid.tableElement;
         const isVirtualization =
             this.dataGrid.options?.rendering?.rows?.virtualization;
@@ -316,7 +311,11 @@ class Table {
             this.rowsWidth = rowsWidth;
         }
 
-        if (isVirtualization || reflowColumns) {
+        if (
+            isVirtualization ||
+            this.dataGrid.initContainerHeight ||
+            this.columnsResizer?.resizedColumns
+        ) {
             // Reflow the head
             this.header?.reflow();
 
@@ -342,7 +341,7 @@ class Table {
      * Handles the resize event.
      */
     private onResize = (): void => {
-        this.reflow(true);
+        this.reflow();
     };
 
     /**

--- a/ts/DataGrid/Table/Table.ts
+++ b/ts/DataGrid/Table/Table.ts
@@ -176,6 +176,9 @@ class Table {
 
         const dgOptions = dataGrid.options;
         const customClassName = dgOptions?.rendering?.table?.className;
+        const isVirtualization = dgOptions?.rendering?.rows?.virtualization;
+        const isScrollable =
+            this.dataGrid.initContainerHeight || isVirtualization;
 
         this.columnDistribution =
             dgOptions?.rendering?.columns?.distribution as ColumnDistribution;
@@ -205,9 +208,13 @@ class Table {
         this.resizeObserver = new ResizeObserver(this.onResize);
         this.resizeObserver.observe(tableElement);
 
-        if (dgOptions?.rendering?.rows?.virtualization) {
+        if (isVirtualization) {
             this.tbodyElement.addEventListener('scroll', this.onScroll);
             tableElement.classList.add(Globals.classNames.virtualization);
+        }
+
+        if (isScrollable) {
+            tableElement.classList.add(Globals.classNames.scrollableContent);
         }
 
         this.tbodyElement.addEventListener('focus', this.onTBodyFocus);
@@ -289,14 +296,15 @@ class Table {
             )
         ) : 0;
 
-        if (isVirtualization) {
-            this.tbodyElement.style.height = this.tbodyElement.style.minHeight = `${
-                (this.dataGrid.container?.clientHeight || 0) -
-                (this.theadElement?.offsetHeight || 0) -
-                (this.captionElement?.offsetHeight || 0) -
-                (this.dataGrid.credits?.getHeight() || 0) -
-                borderWidth
-            }px`;
+        if (isVirtualization || this.dataGrid.initContainerHeight) {
+            this.tbodyElement.style.height =
+                this.tbodyElement.style.minHeight = `${
+                    (this.dataGrid.container?.clientHeight || 0) -
+                    (this.theadElement?.offsetHeight || 0) -
+                    (this.captionElement?.offsetHeight || 0) -
+                    (this.dataGrid.credits?.getHeight() || 0) -
+                    borderWidth
+                }px`;
         }
 
         // Get the width of the rows.


### PR DESCRIPTION
Added scrolling to non-virtualized DataGrid

---- 

- [x] - refactoring CSS class
- [x] - set `tbody` height and overflow 
- [x] - apply new styling to resizing
- [x] - clear inline widths when update virtualization param
