### PR TITLE
dash/dg-min-visible-rows

### DIFF
--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -111,6 +111,7 @@
 }
 
 .highcharts-datagrid-container {
+    box-sizing: border-box;
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -296,7 +297,6 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
 
 .highcharts-datagrid-table.highcharts-datagrid-virtualization tbody {
     overflow: auto;
-    min-height: 20px;
     display: block;
     flex: 1;
     position: relative;

--- a/samples/data-grid/basic/overview/demo.js
+++ b/samples/data-grid/basic/overview/demo.js
@@ -18,6 +18,11 @@ DataGrid.dataGrid('container', {
     caption: {
         text: 'Fruit market'
     },
+    rendering: {
+        rows: {
+            minVisibleRows: 5
+        }
+    },
     columnDefaults: {
         cells: {
             editable: true

--- a/ts/DataGrid/DataGrid.ts
+++ b/ts/DataGrid/DataGrid.ts
@@ -149,7 +149,8 @@ class DataGrid {
     public container?: HTMLElement;
 
     /**
-     * The init container height
+     * The initial height of the container, defined in styles. Can be 0 also if
+     * not defined.
      */
     public initContainerHeight: number;
 
@@ -300,11 +301,8 @@ class DataGrid {
             `);
             return;
         }
-        this.initContainerHeight = getStyle(
-            container,
-            'height',
-            true
-        ) || 0;
+
+        this.initContainerHeight = getStyle(container, 'height', true) || 0;
 
         this.container = container;
         this.container.innerHTML = AST.emptyHTML;

--- a/ts/DataGrid/Defaults.ts
+++ b/ts/DataGrid/Defaults.ts
@@ -70,6 +70,7 @@ namespace Defaults {
             },
             rows: {
                 bufferSize: 10,
+                minVisibleRows: 2,
                 strictHeights: false,
                 virtualization: true
             },

--- a/ts/DataGrid/Options.ts
+++ b/ts/DataGrid/Options.ts
@@ -178,11 +178,24 @@ export interface RowsSettings {
      * the bottom while scrolling. The bigger the buffer, the less flicker will
      * be seen while scrolling, but the more rows will have to be rendered.
      *
-     * Cannot be lower than 0.
+     * Works only when `virtualization` is enabled. Cannot be lower than 0.
      *
      * @default 10
      */
     bufferSize?: number;
+
+    /**
+     * Defines the minimum height of the table body (`tbody`) based on the
+     * number of rows that should be visible without scrolling.
+     *
+     * If set to `null`, the minimum height will not be enforced.
+     *
+     * It's ignored when height of the container is set or the `min-height`
+     * style is set on the `tbody` by the user.
+     *
+     * @default 2
+     */
+    minVisibleRows?: number | null;
 
     /**
      * Whether the height of the rows should be calculated automatically based

--- a/ts/DataGrid/Table/Table.ts
+++ b/ts/DataGrid/Table/Table.ts
@@ -38,7 +38,7 @@ import Utils from '../../Core/Utilities.js';
 import CellEditing from './Actions/CellEditing.js';
 
 const { makeHTMLElement } = DGUtils;
-const { getStyle } = Utils;
+const { getStyle, defined } = Utils;
 
 /* *
  *
@@ -151,6 +151,7 @@ class Table {
      */
     public focusCursor?: [number, number];
 
+
     /* *
     *
     *  Constructor
@@ -188,6 +189,9 @@ class Table {
             this.theadElement = makeHTMLElement('thead', {}, tableElement);
         }
         this.tbodyElement = makeHTMLElement('tbody', {}, tableElement);
+        if (isVirtualization) {
+            tableElement.classList.add(Globals.classNames.virtualization);
+        }
 
 
         this.rowsVirtualizer = new RowsVirtualizer(this);
@@ -209,7 +213,6 @@ class Table {
 
         if (isVirtualization) {
             this.tbodyElement.addEventListener('scroll', this.onScroll);
-            tableElement.classList.add(Globals.classNames.virtualization);
         }
 
         if (isScrollable) {
@@ -229,6 +232,8 @@ class Table {
      * Initializes the data grid table.
      */
     private init(): void {
+        this.setTbodyMinHeight();
+
         // Load columns
         this.loadColumns();
 
@@ -243,6 +248,24 @@ class Table {
         // this.footer.render();
 
         this.rowsVirtualizer.initialRender();
+    }
+
+    /**
+     * Sets the minimum height of the table body.
+     */
+    private setTbodyMinHeight(): void {
+        const { options } = this.dataGrid;
+        const minVisibleRows = options?.rendering?.rows?.minVisibleRows;
+
+        const tbody = this.tbodyElement;
+        if (
+            defined(minVisibleRows) &&
+            !getStyle(tbody, 'min-height', true)
+        ) {
+            tbody.style.minHeight = (
+                minVisibleRows * this.rowsVirtualizer.defaultRowHeight
+            ) + 'px';
+        }
     }
 
     /**


### PR DESCRIPTION
An attempt to introduce a minimum height for the DataGrid tbody - `minVisibleRows` option.

Ultimately, this should only work when the container height is not set, so that the `tbody` height can be reduced when the user wants it. Unfortunately, even when container height is not set, `getStyle(container, 'height')` return always a value.