### PR TITLE
regression/rangeselector-collapse

### DIFF
--- a/ts/Stock/RangeSelector/RangeSelector.ts
+++ b/ts/Stock/RangeSelector/RangeSelector.ts
@@ -1646,9 +1646,8 @@ class RangeSelector {
 
                 // Skip animation
                 inputGroup.placed = chart.hasLoaded;
-                this.handleCollision(xOffsetForExportButton);
             }
-
+            this.handleCollision(xOffsetForExportButton);
 
             // Vertical align
             group.align({


### PR DESCRIPTION
Fixed #22262, a regression causing range selector buttons not collapse on narrow screens when there was no input.