### PR TITLE
Fixed dropdown state on changing the range.

### DIFF
--- a/samples/unit-tests/rangeselector/dropdown/demo.js
+++ b/samples/unit-tests/rangeselector/dropdown/demo.js
@@ -151,10 +151,23 @@ QUnit.test('RangeSelector.dropdown', assert => {
 
     chart.update({
         rangeSelector: {
-            buttons: [],
             dropdown: 'always'
         }
     });
+    chart.xAxis[0].setExtremes(0, Date.UTC(1970, 0, 8));
+
+    assert.strictEqual(
+        chart.rangeSelector.dropdown.selectedIndex,
+        -1,
+        'There should be no option selected'
+    );
+
+    chart.update({
+        rangeSelector: {
+            buttons: []
+        }
+    });
+
     assert.ok(
         true, '#15124: Attempting to collapse with no buttons should ' +
         'not throw'

--- a/ts/Stock/RangeSelector/RangeSelector.ts
+++ b/ts/Stock/RangeSelector/RangeSelector.ts
@@ -663,9 +663,15 @@ class RangeSelector {
         if (selectedIndex !== null) {
             buttonStates[selectedIndex] = 2;
             rangeSelector.setSelected(selectedIndex);
+            if (this.dropdown) {
+                this.dropdown.selectedIndex = selectedIndex + 1;
+            }
         } else {
             rangeSelector.setSelected();
 
+            if (this.dropdown) {
+                this.dropdown.selectedIndex = -1;
+            }
             if (dropdownLabel) {
                 dropdownLabel.setState(0);
                 dropdownLabel.attr({


### PR DESCRIPTION
Fixed #22269, select element didn't update the selected index when range changed in `rangeSelector`.