### PR TITLE
Fixed #22289: Dashboard Test workflow

### DIFF
--- a/.github/workflows/dashboards-test.yml
+++ b/.github/workflows/dashboards-test.yml
@@ -44,9 +44,12 @@ jobs:
 
       - name: Install Dependencies
         run: npm i
-
+        
       - name: Build Highcharts definitions
         run: npx gulp jsdoc-dts
+        
+      - name: Build Highcharts declarations
+        run: npx gulp dist
 
       - name: Run Dashboards Tests
         run: npx gulp dashboards/test


### PR DESCRIPTION
Fixes #22289 

Adds a `npx gulp dist` command to the workflow to prevent the Dashboard Test workflow from failing consistently