### PR TITLE
Fixed #22277, timezone option didn't work when undefined

### DIFF
--- a/samples/unit-tests/axis/datetime-ticks/demo.js
+++ b/samples/unit-tests/axis/datetime-ticks/demo.js
@@ -39,7 +39,7 @@ QUnit.test(
         // Reset
         Highcharts.setOptions({
             time: {
-                timezone: undefined
+                timezone: 'UTC'
             }
         });
     }
@@ -89,7 +89,7 @@ QUnit.test('Time zone with small interval (#4951)', function (assert) {
     // Reset
     Highcharts.setOptions({
         time: {
-            timezone: undefined
+            timezone: 'UTC'
         }
     });
 });
@@ -160,7 +160,7 @@ QUnit.test('Time zone with bigger interval (#4951)', function (assert) {
     // Reset
     Highcharts.setOptions({
         time: {
-            timezone: undefined
+            timezone: 'UTC'
         }
     });
 });

--- a/samples/unit-tests/global/timezone/demo.js
+++ b/samples/unit-tests/global/timezone/demo.js
@@ -79,7 +79,7 @@ QUnit.test('Crossing DST with a wide pointRange (#7432)', function (assert) {
 
     Highcharts.setOptions({
         time: {
-            timezone: undefined
+            timezone: 'UTC'
         }
     });
 });

--- a/samples/unit-tests/series/pointintervalunit/demo.js
+++ b/samples/unit-tests/series/pointintervalunit/demo.js
@@ -123,7 +123,7 @@ QUnit.test('Point interval unit across DST (#4958)', function (assert) {
     // Reset
     Highcharts.setOptions({
         time: {
-            timezone: undefined
+            timezone: 'UTC'
         }
     });
 });

--- a/samples/unit-tests/time/timezone/demo.js
+++ b/samples/unit-tests/time/timezone/demo.js
@@ -177,10 +177,27 @@ QUnit.test('timezone', function (assert) {
         'Non full-hour timezone - UTC midnight should render 05:45 in Katmandu'
     );
 
+    chart.update({
+        time: {
+            timezone: undefined
+        }
+    });
+    assert.equal(
+        chart.time.timezone,
+        undefined,
+        'Undefined time zone should be supported and fall back to local'
+    );
+    const ts = Date.UTC(2024, 11, 5, 6, 7);
+    assert.equal(
+        chart.time.dateFormat('%k:00', ts),
+        new Date(ts).getHours() + ':00',
+        'Undefined timezone should fall back to local time'
+    );
+
     // Tear down
     Highcharts.setOptions({
         time: {
-            timezone: undefined,
+            timezone: 'UTC',
             getTimezoneOffset: undefined
         }
     });

--- a/ts/Core/Time.ts
+++ b/ts/Core/Time.ts
@@ -158,7 +158,9 @@ class Time {
      *
      * */
 
-    public options: Time.TimeOptions = {};
+    public options: Time.TimeOptions = {
+        timezone: 'UTC'
+    };
 
     public timezone?: string;
 
@@ -195,8 +197,6 @@ class Time {
         options: Time.TimeOptions = {}
     ): void {
 
-        let timezone: string|undefined = options.timezone ?? 'UTC';
-
         this.dTLCache = {};
         this.options = options = merge(true, this.options, options);
 
@@ -205,6 +205,8 @@ class Time {
         // Allow using a different Date class
         this.Date = options.Date || win.Date || Date;
 
+        // Assign the time zone. Handle the legacy, deprecated `useUTC` option.
+        let timezone = options.timezone;
         if (defined(useUTC)) {
             timezone = useUTC ? 'UTC' : void 0;
         }
@@ -776,7 +778,7 @@ class Time {
         } else if (isObject(format)) {
             const tzHours = (this.getTimezoneOffset(timestamp) || 0) /
                     (60000 * 60),
-                timeZone = this.options.timezone || (
+                timeZone = this.timezone || (
                     'Etc/GMT' + (tzHours >= 0 ? '+' : '') + tzHours
                 ),
                 { prefix = '', suffix = '' } = format;


### PR DESCRIPTION
Fixed #22277, setting the `time.timezone` option explicitly to `undefined` didn't work as described.