### PR TITLE
dash/dg-rows-per-page-fix

### DIFF
--- a/ts/DataGrid/Table/Actions/RowsVirtualizer.ts
+++ b/ts/DataGrid/Table/Actions/RowsVirtualizer.ts
@@ -261,7 +261,8 @@ class RowsVirtualizer {
         const { viewport: vp, buffer } = this;
         const isVirtualization = this.rowSettings?.virtualization;
         const rowsPerPage = isVirtualization ? Math.ceil(
-            vp.tbodyElement.offsetHeight / this.defaultRowHeight
+            (vp.dataGrid.tableElement?.clientHeight || 0) /
+            this.defaultRowHeight
         ) : Infinity; // Need to be refactored when add pagination
 
         let rows = vp.rows;


### PR DESCRIPTION
Fixed a bug where too few rows were displayed in a tall table.

![image](https://github.com/user-attachments/assets/fbf60993-1e52-4f90-b3a5-2bf120a451f0)
