### PR TITLE
bugfix/22228-breadcrumb-formatter-apidoc-mismatch

### DIFF
--- a/ts/Extensions/Breadcrumbs/Breadcrumbs.ts
+++ b/ts/Extensions/Breadcrumbs/Breadcrumbs.ts
@@ -918,9 +918,6 @@ export default Breadcrumbs;
  *
  * @callback Highcharts.BreadcrumbsFormatterCallbackFunction
  *
- * @param {Highcharts.Event} event
- * Event.
- *
  * @param {Highcharts.BreadcrumbOptions} options
  * Breadcrumb options.
  *


### PR DESCRIPTION
Fixed #22228, Removed docs about event param in Breadcrumb formatting callback.