### PR TITLE
regression/22311-missing-rangeselector

### DIFF
--- a/samples/unit-tests/rangeselector/input-range/demo.js
+++ b/samples/unit-tests/rangeselector/input-range/demo.js
@@ -712,6 +712,18 @@ QUnit.test('Input types', assert => {
                 'text',
                 'Format with milliseconds should result in text input'
             );
+            chart.update({
+                rangeSelector: {
+                    inputDateFormat: '%[ebY]'
+                }
+            });
+
+            assert.strictEqual(
+                input().type,
+                'date',
+                'default format should result in date input'
+            );
         }
+
     });
 });

--- a/ts/Stock/RangeSelector/RangeSelector.ts
+++ b/ts/Stock/RangeSelector/RangeSelector.ts
@@ -101,6 +101,8 @@ declare module './RangeSelectorOptions' {
  * @function preferredInputType
  */
 function preferredInputType(format: Time.DateTimeFormat): string {
+    const hasTimeKey = (char: string): boolean =>
+        new RegExp(`%[\[a-zA-Z]*${char}`).test(format as string);
     const ms = isString(format) ?
         format.indexOf('%L') !== -1 :
         // Implemented but not typed as of 2024
@@ -112,16 +114,11 @@ function preferredInputType(format: Time.DateTimeFormat): string {
 
     const date = isString(format) ?
         ['a', 'A', 'd', 'e', 'w', 'b', 'B', 'm', 'o', 'y', 'Y']
-            .some((char: string): boolean =>
-                format.indexOf('%' + char) !== -1
-            ) :
+            .some(hasTimeKey) :
         format.dateStyle || format.day || format.month || format.year;
 
     const time = isString(format) ?
-        ['H', 'k', 'I', 'l', 'M', 'S']
-            .some((char: string): boolean =>
-                format.indexOf('%' + char) !== -1
-            ) :
+        ['H', 'k', 'I', 'l', 'M', 'S'].some(hasTimeKey) :
         format.timeStyle || format.hour || format.minute || format.second;
 
     if (date && time) {
@@ -450,7 +447,6 @@ class RangeSelector {
             blurInputs = function (): void {
                 const minInput = rangeSelector.minInput,
                     maxInput = rangeSelector.maxInput;
-
                 // #3274 in some case blur is not defined
                 if (minInput && !!minInput.blur) {
                     fireEvent(minInput, 'blur');


### PR DESCRIPTION
Fixed #22311, calendar was missing for `rangeSelector`'s input.