### PR TITLE
bugfix/21840 ScatterSeries depends on ColumnSeries and LineSeries

### DIFF
--- a/ts/Series/Scatter/ScatterSeries.ts
+++ b/ts/Series/Scatter/ScatterSeries.ts
@@ -19,6 +19,10 @@
 import type ScatterPoint from './ScatterPoint';
 import type ScatterSeriesOptions from './ScatterSeriesOptions';
 
+// ScatterSeries depends on ColumnSeries and LineSeries, so we must ensure they are loaded
+import '../Column/ColumnSeries.js';
+import '../Line/LineSeries.js';
+
 import ScatterSeriesDefaults from './ScatterSeriesDefaults.js';
 import SeriesRegistry from '../../Core/Series/SeriesRegistry.js';
 const {


### PR DESCRIPTION
We must ensure that our series dependencies are actually loaded. Otherwise, bundlers such as vite will produce a broken bundle that fails at runtime.

This typically allows the following to work properly with vite:

```html
<!doctype html>
<html lang="en">
<body>
<script type="module">
    import 'highcharts/es-modules/masters/highcharts.src.js';
    import 'highcharts/es-modules/masters/highcharts-3d.src.js';

    document.querySelector('body').innerHTML = 'Working ! ' + new Date().toISOString();
</script>
</body>
</html>
```

Fixes #21840