### PR TITLE
bugfix/22316 tooltip format

### DIFF
--- a/samples/unit-tests/datalabels/anchor/demo.js
+++ b/samples/unit-tests/datalabels/anchor/demo.js
@@ -55,7 +55,10 @@ QUnit.test(
     function (assert) {
         var chart = Highcharts.chart('container', {
             chart: {
-                inverted: true
+                inverted: true,
+                style: {
+                    fontFamily: 'Helvetica, Arial, sans-serif'
+                }
             },
             xAxis: {
                 height: 100,

--- a/samples/unit-tests/gantt/grid-axis/demo.js
+++ b/samples/unit-tests/gantt/grid-axis/demo.js
@@ -851,7 +851,10 @@ QUnit.test('Horizontal axis tick labels centered', function (assert) {
     chart = Highcharts.chart('container', {
         chart: {
             type: 'scatter',
-            width: 800
+            width: 800,
+            style: {
+                fontFamily: 'Helvetica, Arial, sans-serif'
+            }
         },
         xAxis: [
             {

--- a/samples/unit-tests/rangeselector/position-antycollision/demo.js
+++ b/samples/unit-tests/rangeselector/position-antycollision/demo.js
@@ -70,7 +70,10 @@ QUnit.test('Inputs and buttons aligning.', function (assert) {
 
     chart = Highcharts.stockChart('container', {
         chart: {
-            spacing: [10, 21, 10, 52]
+            spacing: [10, 21, 10, 52],
+            style: {
+                fontFamily: 'Helvetica, Arial, sans-serif'
+            }
         },
         yAxis: {
             title: {

--- a/samples/unit-tests/scrollbar/positions/demo.js
+++ b/samples/unit-tests/scrollbar/positions/demo.js
@@ -297,6 +297,11 @@ QUnit.test('Overlapping scrollbars', assert => {
 
 QUnit.test('Positioning the scrollbar (opposite), #16017.', function (assert) {
     const chart = Highcharts.chart('container', {
+        chart: {
+            style: {
+                fontFamily: 'Helvetica, Arial, sans-serif'
+            }
+        },
         xAxis: {
             min: 0,
             max: 5,

--- a/samples/unit-tests/utilities/format/demo.js
+++ b/samples/unit-tests/utilities/format/demo.js
@@ -538,6 +538,34 @@ QUnit.module('Format', () => {
             'Date formatting with string output should be preserved'
         );
 
+        assert.strictEqual(
+            format(
+                'Hello {"World"}',
+                {}
+            ),
+            'Hello World',
+            'Immediate string literal should resolve'
+        );
+
+        assert.strictEqual(
+            format(
+                'Hello {(key)}',
+                { key: 'World' }
+            ),
+            'Hello World',
+            'Immediate parenthesis should resolve'
+        );
+
+        assert.strictEqual(
+            format(
+                '<span>{(point.key:%a %d.%m.%y %H:%M)}</span><br>',
+                { point: { key: Date.UTC(2024, 11, 11) } }
+            ),
+            '<span>Wed 11.12.24 00:00</span><br>',
+            'Date formatting with parens and colon inside string should ' +
+                'resolve (#22316)'
+        );
+
     });
 
     QUnit.test('Error handling', assert => {

--- a/ts/Core/Templating.ts
+++ b/ts/Core/Templating.ts
@@ -35,6 +35,7 @@ const {
     isArray,
     isNumber,
     isObject,
+    isString,
     pick,
     ucfirst
 } = U;
@@ -90,6 +91,9 @@ const numberFormatCache: Record<string, Intl.NumberFormat> = {};
  *  Functions
  *
  * */
+
+// Internal convenience function
+const isQuotedString = (str: string): boolean => /^["'].+["']$/.test(str);
 
 /**
  * Formats a JavaScript date timestamp (milliseconds since Jan 1st 1970) into a
@@ -204,7 +208,7 @@ function format(str = '', ctx: any, chart?: Chart): string {
         if ((n = Number(key)).toString() === key) {
             return n;
         }
-        if (/^["'].+["']$/.test(key)) {
+        if (isQuotedString(key)) {
             return key.slice(1, -1);
         }
 
@@ -355,7 +359,8 @@ function format(str = '', ctx: any, chart?: Chart): string {
 
         // Simple variable replacement
         } else {
-            const valueAndFormat = expression.split(':');
+            const valueAndFormat = isQuotedString(expression) ?
+                [expression] : expression.split(':');
 
             replacement = resolveProperty(valueAndFormat.shift() || '');
 
@@ -379,13 +384,13 @@ function format(str = '', ctx: any, chart?: Chart): string {
                     }
                 } else {
                     replacement = time.dateFormat(segment, replacement);
-
-                    // Use string literal in order to be preserved in the outer
-                    // expression
-                    if (hasSub) {
-                        replacement = `"${replacement}"`;
-                    }
                 }
+            }
+
+            // Use string literal in order to be preserved in the outer
+            // expression
+            if (hasSub && isString(replacement)) {
+                replacement = `"${replacement}"`;
             }
         }
         str = str.replace(match.find, pick(replacement, ''));


### PR DESCRIPTION
- Samples: Fixed some failing samples in Firefox
- Fixed #22316, some tooltip date formats were not correctly replaced.
