### PR TITLE
Ensure centering of multiline text in data labels

### DIFF
--- a/samples/highcharts/demo/vertical-sankey/demo.js
+++ b/samples/highcharts/demo/vertical-sankey/demo.js
@@ -132,9 +132,7 @@ Highcharts.chart('container', {
             color: 'rgba(255, 141, 100, 0.8)',
             dataLabels: {
                 rotation: -90,
-                y: -55,
                 style: {
-                    textAnchor: 'middle',
                     width: '110px'
                 }
             }
@@ -154,9 +152,7 @@ Highcharts.chart('container', {
             offsetHorizontal: '-80%',
             color: 'rgba(76, 175, 254, 0.8)',
             dataLabels: {
-                x: 43,
                 style: {
-                    textAnchor: 'middle',
                     width: '90px'
                 }
             }

--- a/ts/Core/Renderer/HTML/HTMLElement.ts
+++ b/ts/Core/Renderer/HTML/HTMLElement.ts
@@ -396,8 +396,7 @@ class HTMLElement extends SVGElement {
                 ].join(','),
                 parentPadding = (this.parentGroup?.padding * -1) || 0;
 
-            let baseline,
-                hasBoxWidthChanged = false;
+            let baseline;
 
             // Update textWidth. Use the memoized textPxLength if possible, to
             // avoid the getTextPxLength function using elem.offsetWidth.
@@ -431,10 +430,8 @@ class HTMLElement extends SVGElement {
                         whiteSpace: whiteSpace || 'normal' // #3331
                     });
                     this.oldTextWidth = textWidth;
-                    hasBoxWidthChanged = true; // #8159
                 }
             }
-            this.hasBoxWidthChanged = hasBoxWidthChanged; // #8159
 
 
             // Do the calculations and DOM access only if properties changed

--- a/ts/Core/Renderer/SVG/SVGAttributes.d.ts
+++ b/ts/Core/Renderer/SVG/SVGAttributes.d.ts
@@ -114,6 +114,7 @@ export interface SVGAttributes {
     tabindex?: number;
     tableValues?: string;
     text?: string;
+    textAlign?: 'center'|'left'|'right';
     'text-align'?: 'center'|'left'|'right';
     'text-anchor'?: string;
     title?: string;

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -411,7 +411,7 @@ class SVGElement implements SVGElementLike {
         redraw: boolean = true
     ): this {
         const attribs: SVGAttributes = {
-                textAlign: alignOptions?.align
+                'text-align': alignOptions?.align
             },
             renderer = this.renderer,
             alignedObjects = renderer.alignedObjects,

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -411,7 +411,9 @@ class SVGElement implements SVGElementLike {
         alignTo?: (string|BBoxObject),
         redraw: boolean = true
     ): this {
-        const attribs: SVGAttributes = {},
+        const attribs: SVGAttributes = {
+                textAlign: alignOptions?.align
+            },
             renderer = this.renderer,
             alignedObjects = renderer.alignedObjects,
             initialAlignment = Boolean(alignOptions);

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -166,7 +166,6 @@ class SVGElement implements SVGElementLike {
     public fakeTS?: boolean;
     public firstLineMetrics?: FontMetricsObject;
     public handleZ?: boolean;
-    public hasBoxWidthChanged?: boolean;
     public height?: number;
     public imgwidth?: number;
     public imgheight?: number;

--- a/ts/Core/Renderer/SVG/SVGLabel.ts
+++ b/ts/Core/Renderer/SVG/SVGLabel.ts
@@ -393,7 +393,7 @@ class SVGLabel extends SVGElement {
         this.boxAttr(key, value);
     }
 
-    public textAlignSetter(value: string): void {
+    public 'text-alignSetter'(value: string): void {
         this.textAlign = value;
         this.updateTextPadding();
     }
@@ -495,7 +495,7 @@ class SVGLabel extends SVGElement {
      * is changed.
      */
     public updateTextPadding(): void {
-        const text = this.text;
+        const { text, textAlign } = this;
         if (!text.textPath) {
 
             this.updateBoxSize();
@@ -503,12 +503,15 @@ class SVGLabel extends SVGElement {
             // Determine y based on the baseline
             const textY = this.baseline ? 0 : this.baselineOffset,
                 textX = (this.paddingLeft ?? this.padding) +
-                    getAlignFactor(this.textAlign) * this.bBox.width;
+                    // Compensate for alignment
+                    getAlignFactor(textAlign) * (
+                        this.widthSetting ?? this.bBox.width
+                    );
 
             // Update if anything changed
             if (textX !== text.x || textY !== text.y) {
                 text.attr({
-                    align: this.textAlign,
+                    align: textAlign,
                     x: textX
                 });
 

--- a/ts/Core/Renderer/SVG/SVGLabel.ts
+++ b/ts/Core/Renderer/SVG/SVGLabel.ts
@@ -503,13 +503,6 @@ class SVGLabel extends SVGElement {
             // Determine y based on the baseline
             const textY = this.baseline ? 0 : this.baselineOffset,
                 textX = (this.paddingLeft ?? this.padding) +
-                    // Compensate for alignment
-                    (
-                        (defined(this.widthSetting) && this.bBox) ?
-                            getAlignFactor(this.textAlign) *
-                                (this.widthSetting - this.bBox.width) :
-                            0
-                    ) +
                     getAlignFactor(this.textAlign) * this.bBox.width;
 
             // Update if anything changed

--- a/ts/Core/Renderer/SVG/SVGLabel.ts
+++ b/ts/Core/Renderer/SVG/SVGLabel.ts
@@ -165,6 +165,7 @@ class SVGLabel extends SVGElement {
 
     public alignSetter(value: AlignValue): void {
         const alignFactor = getAlignFactor(value);
+        this.textAlign = value;
         if (alignFactor !== this.alignFactor) {
             this.alignFactor = alignFactor;
             // Bounding box exists, means we're dynamically changing
@@ -392,8 +393,9 @@ class SVGLabel extends SVGElement {
         this.boxAttr(key, value);
     }
 
-    public 'text-alignSetter'(value: string): void {
+    public textAlignSetter(value: string): void {
         this.textAlign = value;
+        this.updateTextPadding();
     }
 
     public textSetter(text?: string): void {
@@ -507,11 +509,15 @@ class SVGLabel extends SVGElement {
                             getAlignFactor(this.textAlign) *
                                 (this.widthSetting - this.bBox.width) :
                             0
-                    );
+                    ) +
+                    getAlignFactor(this.textAlign) * this.bBox.width;
 
             // Update if anything changed
             if (textX !== text.x || textY !== text.y) {
-                text.attr('x', textX);
+                text.attr({
+                    align: this.textAlign,
+                    x: textX
+                });
                 // #8159 - prevent misplaced data labels in treemap
                 // (useHTML: true)
                 if (text.hasBoxWidthChanged) {

--- a/ts/Core/Renderer/SVG/SVGLabel.ts
+++ b/ts/Core/Renderer/SVG/SVGLabel.ts
@@ -511,11 +511,7 @@ class SVGLabel extends SVGElement {
                     align: this.textAlign,
                     x: textX
                 });
-                // #8159 - prevent misplaced data labels in treemap
-                // (useHTML: true)
-                if (text.hasBoxWidthChanged) {
-                    this.bBox = text.getBBox(true);
-                }
+
                 if (typeof textY !== 'undefined') {
                     text.attr('y', textY);
                 }

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -346,7 +346,7 @@ namespace DataLabel {
                 (unrotatedbBox.height - bBox.height);
 
             dataLabel[dataLabel.placed ? 'animate' : 'attr']({
-                textAlign: dataLabel.alignAttr.textAlign || 'center',
+                'text-align': dataLabel.alignAttr['text-align'] || 'center',
                 x: dataLabel.alignAttr.x +
                     (bBox.width - unrotatedbBox.width) / 2,
                 y: dataLabel.alignAttr.y +

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -346,6 +346,7 @@ namespace DataLabel {
                 (unrotatedbBox.height - bBox.height);
 
             dataLabel[dataLabel.placed ? 'animate' : 'attr']({
+                textAlign: dataLabel.alignAttr.textAlign || 'center',
                 x: dataLabel.alignAttr.x +
                     (bBox.width - unrotatedbBox.width) / 2,
                 y: dataLabel.alignAttr.y +


### PR DESCRIPTION
Fixed #22357, multiline text was not centered within data labels.

---

Demo: https://jsfiddle.net/highcharts/ehcdbwqk/ . Although the text is centered, which is evident from the short labels, the long multiline text doesn't center.
