### PR TITLE
dash/datagrid-missing-dts

### DIFF
--- a/tools/gulptasks/dashboards/scripts-dts.js
+++ b/tools/gulptasks/dashboards/scripts-dts.js
@@ -74,6 +74,13 @@ async function scriptsDTS() {
             true,
             sourcePath => sourcePath.endsWith('.d.ts')
         );
+
+        fsLib.copyAllFiles(
+            path.join('ts', dtsFolder),
+            path.join(esModulesFolderDataGrid, dtsFolder),
+            true,
+            sourcePath => sourcePath.endsWith('.d.ts')
+        );
     }
 
     logLib.success('Copied stand-alone DTS');


### PR DESCRIPTION
Fixed missing `d.ts` files in DataGrid build.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208973536699124