### PR TITLE
Softer default text outline

### DIFF
--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -3260,7 +3260,7 @@ namespace AxisDefaults {
                 /** @internal */
                 fontWeight: 'bold',
                 /** @internal */
-                textOutline: '1px contrast'
+                textOutline: '2px contrast'
             }
         },
         gridLineWidth: 1,

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -558,12 +558,12 @@ class SVGElement implements SVGElementLike {
      * @example
      * // Specific color
      * text.css({
-     *    textOutline: '1px black'
+     *    textOutline: '2px black'
      * });
      * // Automatic contrast
      * text.css({
      *    color: '#000000', // black text
-     *    textOutline: '1px contrast' // => white outline
+     *    textOutline: '2px contrast' // => white outline
      * });
      *
      * @private
@@ -615,6 +615,8 @@ class SVGElement implements SVGElementLike {
             attr(outline, {
                 'class': 'highcharts-text-outline',
                 fill: color,
+                // Just enough to comply to WCAG text contrast requirements
+                opacity: 0.65,
                 stroke: color,
                 'stroke-width': strokeWidth as any,
                 'stroke-linejoin': 'round'

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -1974,7 +1974,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
             /** @internal */
             color: 'contrast',
             /** @internal */
-            textOutline: '1px contrast'
+            textOutline: '2px contrast'
         },
 
         /**


### PR DESCRIPTION
Changed the default text outline for data labels to be softer and semi-opaque.

- Increased default width to 2px
- Set opacity to 0.65