### PR TITLE
 Update Example for Highcharts Highmaps Data Format

### DIFF
--- a/ts/Series/Map/MapSeriesDefaults.ts
+++ b/ts/Series/Map/MapSeriesDefaults.ts
@@ -381,11 +381,11 @@ const MapSeriesDefaults: MapSeriesOptions = {
  *    ```js
  *        data: [{
  *            value: 6,
- *            name: "Point2",
+ *            "hc-key": "in-mh",
  *            color: "#00FF00"
  *        }, {
  *            value: 6,
- *            name: "Point1",
+ *            "hc-key": "in-ka",
  *            color: "#FF00FF"
  *        }]
  *    ```


### PR DESCRIPTION
This PR updates the data format example for Highcharts Highmaps to align with the required `hc-key` usage instead of the `name `attribute. According to the [Highcharts documentation](https://api.highcharts.com/highmaps/series.map.data#:~:text=us%2Dak%27%2C%205%5D%0A%20%20%20%20%5D-,An%20array,-of%20objects%20with), (ref: Example 3rd option of  `series.map.data`) data is typically provided as an array of objects. In this context, the `hc-key` serves as the unique identifier for each map region.  However, in the actual example, they have used `name` instead of `hc-key`.

###  Changes Introduced:
The example provided in the existing documentation uses `name`, but in Highmaps configurations, dealing with geographic keys, `hc-key` is the correct identifier key rather than `name`. This change replaces the name property with `hc-key` to ensure compatibility with such configurations.

JS Fiddle link : https://jsfiddle.net/rohangore1999/yjdt9xf2/4/
```
const data = [
  { color: "#F48FB1", "name": "in-ut", value: 42 },
  { color: "#7986CB", "hc-key": "in-jh", value: 43 },
];
```
> **To see the color applied correctly, try changing the key from _"name"_ to _"hc-key"_. Once updated, the colors will begin reflecting properly on the map.**

### Example (3rd option of  `series.map.data`) Before:

```
data: [{
    value: 6,
    name: "Point2",
    color: "#00FF00"
}, {
    value: 6,
    name: "Point1",
    color: "#FF00FF"
}]
```

### Updated Example (3rd Option of  `series.map.data`):

```
data: [{
    value: 11,
    'hc-key': 'in-ka', // region name
    color: '#F7C4D6' // color to highlight
}, {
    value: 12,
    'hc-key': 'in-mh',  // region name
    color: '#E5A7FF'  // color to highlight
}]
```