### PR TITLE
Fixed #22329, a regression causing wrong tooltip with date formats

### DIFF
--- a/samples/unit-tests/utilities/format/demo.js
+++ b/samples/unit-tests/utilities/format/demo.js
@@ -595,6 +595,22 @@ QUnit.module('Format', () => {
             'String properties inside deep objects should resolve'
         );
 
+        // Format %O as timezone offset to local time (#22329)
+        Highcharts.dateFormats.O = () => '+0100';
+        assert.strictEqual(
+            format(
+                '{ucfirst (point.key:%d.%m.%Y %H:%M:%S %O)}',
+                {
+                    point: {
+                        key: Date.UTC(2024, 11, 11)
+                    }
+                }
+            ),
+            '11.12.2024 00:00:00 +0100',
+            'Custom date format with plus sign'
+        );
+        delete Highcharts.dateFormats.O;
+
     });
 
     QUnit.test('Error handling', assert => {

--- a/ts/Core/Templating.ts
+++ b/ts/Core/Templating.ts
@@ -178,11 +178,11 @@ function dateFormat(
  */
 function format(str = '', ctx: any, chart?: Chart): string {
 
-    const regex = /\{([\p{L}\d:\.,;\-\/<>\[\]%_@"'’= #\(\)]+)\}/gu,
+    const regex = /\{([\p{L}\d:\.,;\-\/<>\[\]%_@+"'’= #\(\)]+)\}/gu,
         // The sub expression regex is the same as the top expression regex,
         // but except parens and block helpers (#), and surrounded by parens
         // instead of curly brackets.
-        subRegex = /\(([\p{L}\d:\.,;\-\/<>\[\]%_@"'= ]+)\)/gu,
+        subRegex = /\(([\p{L}\d:\.,;\-\/<>\[\]%_@+"'= ]+)\)/gu,
         matches = [],
         floatRegex = /f$/,
         decRegex = /\.(\d)/,


### PR DESCRIPTION
Fixed #22329, a regression causing wrong tooltip header with plus sign in date formats