### PR TITLE
bugfix/22334-incorrect-overscroll-with-rangeselector

### DIFF
--- a/samples/unit-tests/axis/overscroll/demo.js
+++ b/samples/unit-tests/axis/overscroll/demo.js
@@ -295,3 +295,57 @@
         }
     );
 });
+
+QUnit.test('Overscroll with rangeSelector (#22334)', function (assert) {
+    const overscrollPixelValue = 200,
+        overscrollPercentageValue = 25;
+
+    const chart = Highcharts.stockChart('container', {
+        chart: {
+            width: 820 // Gives us axis.len of 800px
+        },
+
+        xAxis: {
+            overscroll: overscrollPixelValue + 'px'
+        },
+
+        rangeSelector: {
+            selected: 1
+        },
+
+        series: [{
+            pointStart: '2017-01-01',
+            pointInterval: 1000 * 60 * 60 * 24, // 1 day
+            data: (function () {
+                const data = [];
+
+                for (let i = 0; i <= 1000; i += 1) {
+                    data.push(
+                        Math.round(Math.random() * 100)
+                    );
+                }
+                return data;
+            }())
+        }]
+    });
+
+    const points = chart.series[0].points,
+        lastPoint = points[points.length - 1];
+
+    assert.strictEqual(
+        lastPoint.plotX,
+        chart.xAxis[0].width - overscrollPixelValue,
+        'Pixel overscroll correct range with rangeSelector enabled'
+    );
+
+    chart.xAxis[0].update({
+        overscroll: overscrollPercentageValue + '%'
+    });
+
+    assert.strictEqual(
+        lastPoint.plotX,
+        chart.xAxis[0].width -
+            (chart.xAxis[0].len * overscrollPercentageValue / 100),
+        'Percent overscroll correct range with rangeSelector enabled'
+    );
+});

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -1517,7 +1517,7 @@ namespace OrdinalAxis {
         }
 
         /**
-         * If overscroll is pixel or pecentage value, convert it to axis range.
+         * If overscroll is pixel or percentage value, convert it to axis range.
          *
          * @private
          * @param {number | string} overscroll
@@ -1542,6 +1542,20 @@ namespace OrdinalAxis {
 
             if (isString(overscroll)) {
                 const overscrollValue = parseInt(overscroll, 10);
+                let isFullRange;
+
+                // #22334
+                if (
+                    defined(axis.min) && defined(axis.max) &&
+                    defined(axis.dataMin) && defined(axis.dataMax)
+                ) {
+                    isFullRange =
+                        axis.max - axis.min === axis.dataMax - axis.dataMin;
+
+                    if (!isFullRange) {
+                        this.originalOrdinalRange = axis.max - axis.min;
+                    }
+                }
 
                 if (/%$/.test(overscroll)) {
                     // If overscroll is percentage
@@ -1559,7 +1573,8 @@ namespace OrdinalAxis {
                         pixelToPercent = limitedOverscrollValue / axis.len;
 
                     return calculateOverscroll(
-                        pixelToPercent / (1 - pixelToPercent)
+                        pixelToPercent /
+                        (isFullRange ? (1 - pixelToPercent) : 1)
                     );
                 }
 


### PR DESCRIPTION
Fixed #22334, overscroll values were incorrect with `rangeSelector` enabled.