### PR TITLE
Fixed Boost not rendering column series with a single point that is outside plot area

### DIFF
--- a/samples/unit-tests/boost/series-with-one-point/demo.js
+++ b/samples/unit-tests/boost/series-with-one-point/demo.js
@@ -1,41 +1,69 @@
 QUnit.test('No points in series with single point (#21897)', function (assert) {
+    // Check if the series has been included. It has not been included if the
+    // series segment ends at 0.
+    Highcharts.addEvent(Highcharts.Chart, 'testPushedBoostSeries', e => {
+        const chart = e.target;
+
+        const webGLRenderer = chart.boost.wgl;
+        const boostSeries = webGLRenderer.series[0];
+
+        const segment = boostSeries.segments[0];
+
+        const seriesType = boostSeries.series.type;
+
+        assert.strictEqual(
+            segment.from,
+            0,
+            `Segment (${seriesType}) should start at 0`
+        );
+
+        assert.notStrictEqual(
+            segment.to,
+            0,
+            `Segment (${seriesType}) should not end at 0`
+        );
+    });
+
+    // Override WGLRenderer.pushSeries to fire `testPushedBoostSeries` event
+    // before return. This is done because the WGLRenderer.series are flushed
+    // before any other events are fired.
+    Highcharts.addEvent(Highcharts.Series, 'renderCanvas', e => {
+        const chart = e.target.chart;
+        const webGLRenderer = chart.boost.wgl;
+
+        if (webGLRenderer.pushSeriesIsOverriden === true) {
+            return;
+        }
+
+        const pushSeriesBase = webGLRenderer.pushSeries;
+        webGLRenderer.pushSeriesIsOverriden = true;
+        webGLRenderer.pushSeries = (...args) => {
+            pushSeriesBase.apply(webGLRenderer, args);
+            Highcharts.fireEvent(chart, 'testPushedBoostSeries');
+        };
+    });
+
     const chart = Highcharts.chart('container', {
-        chart: {
-            type: 'scatter'
-        },
         boost: {
             seriesThreshold: 1
         },
+        yAxis: {
+            min: 0,
+            max: 80
+        },
+        // Boost should render scatter with single point (#21897)
         series: [{
+            type: 'scatter',
             data: [[1, 1]]
         }]
     });
 
-    const plotBox = chart.renderer.plotBox;
-    const seriesPoint = chart.series[0].points[0];
-    const webGLContext = chart.boost.wgl.gl;
-    const sampleWidth = 1;
-    const sampleHeight = 1;
+    chart.update({
+        // Boost should draw column with single point outside plot area (#22194)
+        series: [{
+            type: 'column',
+            data: [[1, 81]]
+        }]
+    });
 
-    const pixelBuffer = new Uint8Array(
-        sampleWidth * sampleHeight * 4
-    );
-
-    webGLContext.readPixels(
-        seriesPoint.plotX + plotBox.x,
-        chart.renderer.height - (seriesPoint.plotY + plotBox.y),
-        sampleWidth,
-        sampleHeight,
-        webGLContext.RGBA,
-        webGLContext.UNSIGNED_BYTE,
-        pixelBuffer
-    );
-
-    const pixelAlpha = pixelBuffer[3];
-
-    assert.strictEqual(
-        pixelAlpha,
-        255,
-        'Drawn image should have a visible point'
-    );
 });

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -887,7 +887,15 @@ class WGLRenderer {
             }
 
             // Cull points outside the extremes
-            if (y === null || (!isYInside && !nextInside && !prevInside)) {
+
+            // Continue if `sdata` has only one point as `nextInside` asserts
+            // whether the next point exists and will thus be false. (#22194)
+            if (
+                y === null || (
+                    !isYInside && sdata.length > 1 &&
+                    !nextInside && !prevInside
+                )
+            ) {
                 beginSegment();
                 continue;
             }


### PR DESCRIPTION
Fixed #22194, Boost not rendering column series with a single point that was outside plot area.

... 

I have tested the updated unit-test on v12.0.0 where it fails, like it should.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208833031136707