### PR TITLE
bugfix/22281-Point.points-d.ts-missing

### DIFF
--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -211,6 +211,13 @@ class Point {
      */
 
     /**
+     * Array of all hovered points when using shared tooltips.
+     *
+     * @name Highcharts.Point#points
+     * @type {Array<Highcharts.Point>|undefined}
+     */
+
+    /**
      * The series object associated with the point.
      *
      * @name Highcharts.Point#series


### PR DESCRIPTION
Fixed #22281, Added doc-comment for Point.points

----

Some additional things that me and Kacper found. It doesn't seem the typescript declarations builds correctly on Windows as the Point class seems to be missing entirely from the highcharts.d.ts (and src.d.ts), so if someone on mac could build and test to see if it's there and contains `points?: Array<Point>` as part of the review process that would be great.

As far as me and kacper could see the array is defined and properly referenced in the types so not entirely sure why it's not being picked up.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208902000821056