### PR TITLE
Fixed #22394, bad alignment of text insize reset zoom button

### DIFF
--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -410,10 +410,7 @@ class SVGElement implements SVGElementLike {
         alignTo?: (string|BBoxObject),
         redraw: boolean = true
     ): this {
-        const attribs: SVGAttributes = {
-                'text-align': alignOptions?.align
-            },
-            renderer = this.renderer,
+        const renderer = this.renderer,
             alignedObjects = renderer.alignedObjects,
             initialAlignment = Boolean(alignOptions);
 
@@ -455,7 +452,10 @@ class SVGElement implements SVGElementLike {
             // Default: top align
             y = (alignToBox.y || 0) + (alignOptions.y || 0) +
                 ((alignToBox.height || 0) - (alignOptions.height || 0)) *
-                getAlignFactor(alignOptions.verticalAlign);
+                getAlignFactor(alignOptions.verticalAlign),
+            attribs: SVGAttributes = {
+                'text-align': alignOptions?.align
+            };
 
         attribs[alignByTranslate ? 'translateX' : 'x'] = Math.round(x);
         attribs[alignByTranslate ? 'translateY' : 'y'] = Math.round(y);

--- a/ts/Core/Renderer/SVG/SVGLabel.ts
+++ b/ts/Core/Renderer/SVG/SVGLabel.ts
@@ -394,7 +394,9 @@ class SVGLabel extends SVGElement {
     }
 
     public 'text-alignSetter'(value: string): void {
-        this.textAlign = value;
+        // The text-align variety is for the pre-animation getter. The code
+        // should be unified to either textAlign or text-align.
+        this.textAlign = this['text-align'] = value;
         this.updateTextPadding();
     }
 

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -345,9 +345,8 @@ namespace DataLabel {
             dataLabel.alignAttr.y += getAlignFactor(options.verticalAlign) *
                 (unrotatedbBox.height - bBox.height);
 
-            dataLabel.attr({
-                'text-align': dataLabel.alignAttr['text-align'] || 'center'
-            })[dataLabel.placed ? 'animate' : 'attr']({
+            dataLabel[dataLabel.placed ? 'animate' : 'attr']({
+                'text-align': dataLabel.alignAttr['text-align'] || 'center',
                 x: dataLabel.alignAttr.x +
                     (bBox.width - unrotatedbBox.width) / 2,
                 y: dataLabel.alignAttr.y +


### PR DESCRIPTION
Fixed #22394, a regression in v12.1.0 causing bad alignment of text inside the reset zoom button