### PR TITLE
Fixed #22402, regression decimalPoint and thousandsSep

### DIFF
--- a/samples/unit-tests/utilities/format/demo.js
+++ b/samples/unit-tests/utilities/format/demo.js
@@ -61,6 +61,19 @@ QUnit.module('Format', () => {
             'Localized format'
         );
 
+        // European thousands separator and decimal point
+        Highcharts.setOptions({
+            lang: {
+                decimalPoint: ',',
+                thousandsSep: '.'
+            }
+        });
+        assert.strictEqual(
+            '12.345,68',
+            format('{point.long:,.2f}', { point: point }),
+            'European format (#22402)'
+        );
+
         // default thousands separator and decimal point
         Highcharts.setOptions({
             lang: {
@@ -200,12 +213,8 @@ QUnit.module('Format', () => {
         );
 
         // Reset
-        Highcharts.setOptions({
-            lang: {
-                decimalPoint: '.',
-                thousandsSep: ' '
-            }
-        });
+        delete Highcharts.defaultOptions.lang.decimalPoint;
+        delete Highcharts.defaultOptions.lang.thousandsSep;
     });
 
     QUnit.test('if helper', assert => {

--- a/samples/unit-tests/utilities/utilities/demo.js
+++ b/samples/unit-tests/utilities/utilities/demo.js
@@ -399,13 +399,13 @@
         assertEquals(
             assert,
             'Rounding negative (#4573)',
-            '-342 000.00',
+            '-342,000.00',
             numberFormat(-342000, 2)
         );
         assertEquals(
             assert,
             'String decimal count',
-            '2 016',
+            '2,016',
             numberFormat(2016, '0')
         );
         assertEquals(assert, 'Rounding', '2.0', numberFormat(1.96, 1));

--- a/ts/Core/Templating.ts
+++ b/ts/Core/Templating.ts
@@ -505,8 +505,10 @@ function numberFormat(
     // format with string replacement for the separators.
     if (hasSeparators) {
         ret = ret
-            .replace(/\,/g, thousandsSep ?? ',')
-            .replace('.', decimalPoint ?? '.');
+            // Preliminary step to avoid re-swapping (#22402)
+            .replace(/([,\.])/g, '_$1')
+            .replace(/_\,/g, thousandsSep ?? ',')
+            .replace('_.', decimalPoint ?? '.');
     }
 
     if (


### PR DESCRIPTION
Fixed #22402, a regression in v12 causing wrong number formatting with `lang.decimalPoint` and `lang.thousandsSep` set to `,` and `.` respectively (European style).