### PR TITLE
Fixed #22262, responsive range selector without inputs

### DIFF
--- a/samples/unit-tests/rangeselector/dropdown/demo.js
+++ b/samples/unit-tests/rangeselector/dropdown/demo.js
@@ -107,6 +107,7 @@ QUnit.test('RangeSelector.dropdown', assert => {
         'Dropdown label should be visible'
     );
 
+    // Responsive dropdown
     chart.update({
         rangeSelector: {
             dropdown: 'responsive'
@@ -128,9 +129,57 @@ QUnit.test('RangeSelector.dropdown', assert => {
         'Dropdown label should be visible'
     );
 
+    // Responsive dropdown, no inputs
+    chart.update({
+        chart: {
+            width: 200
+        },
+        rangeSelector: {
+            inputEnabled: false
+        }
+    });
+
+    assert.ok(
+        chart.rangeSelector.buttons.every(b => b.visibility === 'hidden'),
+        '200px + resonsive: Every button should be hidden'
+    );
+    assert.notStrictEqual(
+        chart.rangeSelector.dropdown.style.visibility,
+        'hidden',
+        'Dropdown select should be visible'
+    );
+    assert.notStrictEqual(
+        chart.rangeSelector.dropdownLabel.visibility,
+        'hidden',
+        'Dropdown label should be visible'
+    );
+
+    chart.update({
+        chart: {
+            width: 400
+        }
+    });
+
+    assert.ok(
+        chart.rangeSelector.buttons.every(b => b.visibility !== 'hidden'),
+        '400px + resonsive: Every button should be visible'
+    );
+    assert.strictEqual(
+        chart.rangeSelector.dropdown.style.visibility,
+        'hidden',
+        'Dropdown select should be hidden'
+    );
+    assert.strictEqual(
+        chart.rangeSelector.dropdownLabel.visibility,
+        'hidden',
+        'Dropdown label should be hidden'
+    );
+
+    // Never dropdown
     chart.update({
         rangeSelector: {
-            dropdown: 'never'
+            dropdown: 'never',
+            inputEnabled: true
         }
     });
 

--- a/ts/Stock/RangeSelector/RangeSelector.ts
+++ b/ts/Stock/RangeSelector/RangeSelector.ts
@@ -1957,7 +1957,8 @@ class RangeSelector {
         const {
             chart,
             buttonGroup,
-            inputGroup
+            inputGroup,
+            initialButtonGroupWidth
         } = this;
 
         const {
@@ -1986,7 +1987,7 @@ class RangeSelector {
                 moveInputsDown();
 
                 if (
-                    this.initialButtonGroupWidth >
+                    initialButtonGroupWidth >
                     chart.plotWidth + xOffsetForExportButton - 20
                 ) {
                     this.collapseButtons();
@@ -1994,7 +1995,7 @@ class RangeSelector {
                     this.expandButtons();
                 }
             } else if (
-                this.initialButtonGroupWidth -
+                initialButtonGroupWidth -
                 xOffsetForExportButton +
                 inputGroup.getBBox().width >
                 chart.plotWidth
@@ -2007,7 +2008,14 @@ class RangeSelector {
             } else {
                 this.expandButtons();
             }
+        } else if (buttonGroup && dropdown === 'responsive') {
+            if (initialButtonGroupWidth > chart.plotWidth) {
+                this.collapseButtons();
+            } else {
+                this.expandButtons();
+            }
         }
+
         // Forced states
         if (buttonGroup) {
             if (dropdown === 'always') {


### PR DESCRIPTION
Fixed #22262, a regression since v12.0.2 causing range selector buttons not to be responsive if the `inputEnabled` was false.