### PR TITLE
Fixed #22393, Highcharts.dateTime didn't use html.lang attribute

### DIFF
--- a/samples/unit-tests/time/dateformat/demo.js
+++ b/samples/unit-tests/time/dateformat/demo.js
@@ -270,3 +270,49 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test('Global time object (#22393)', assert => {
+    const htmlLang = document.body.closest('[lang]')?.lang,
+        origLocale = Highcharts.defaultOptions.lang.locale;
+
+    if (htmlLang === 'en') {
+
+        Highcharts.setOptions({
+            lang: {
+                locale: undefined
+            }
+        });
+
+        assert.strictEqual(
+            Highcharts.pageLang,
+            htmlLang,
+            'The internal Highcharts `pageLang` property should be set'
+        );
+
+        assert.strictEqual(
+            Highcharts.dateFormat('%A', Date.UTC(2024, 11, 19, 12)),
+            'Thursday',
+            'The global `dateFormat` should use the global language'
+        );
+
+        Highcharts.setOptions({
+            lang: {
+                locale: 'es'
+            }
+        });
+
+        assert.strictEqual(
+            Highcharts.dateFormat('%A', Date.UTC(2024, 11, 19, 12)),
+            'jueves',
+            'Explicit locale, the global `dateFormat` should comply'
+        );
+
+        // Reset
+        Highcharts.setOptions({
+            lang: {
+                locale: origLocale
+            }
+        });
+
+    }
+});

--- a/samples/unit-tests/time/dateformat/demo.js
+++ b/samples/unit-tests/time/dateformat/demo.js
@@ -314,5 +314,7 @@ QUnit.test('Global time object (#22393)', assert => {
             }
         });
 
+    } else {
+        assert.expect(0);
     }
 });

--- a/ts/Core/Globals.ts
+++ b/ts/Core/Globals.ts
@@ -17,6 +17,7 @@
  * */
 
 import type ButtonThemeObject from './Renderer/SVG/ButtonThemeObject';
+import type { HTMLDOMElement } from './Renderer/DOMElementType';
 import type GlobalsLike from './GlobalsLike';
 
 /* *
@@ -204,6 +205,7 @@ namespace Globals {
                 doc.createElementNS(SVG_NS, 'svg') as SVGSVGElement
             ).createSVGRect
         ),
+        pageLang = (doc?.body.closest('[lang]') as HTMLDOMElement|null)?.lang,
         userAgent = (win.navigator && win.navigator.userAgent) || '',
         isChrome = win.chrome,
         isFirefox = userAgent.indexOf('Firefox') !== -1,

--- a/ts/Core/GlobalsLike.d.ts
+++ b/ts/Core/GlobalsLike.d.ts
@@ -50,6 +50,7 @@ export interface GlobalsLike {
     readonly marginNames: ReadonlyArray<string>;
     readonly nav: Navigator;
     readonly noop: (this: any, ...args: Array<any>) => any;
+    readonly pageLang?: string,
     readonly product: string;
     readonly seriesTypes: SeriesTypeRegistry;
     readonly supportsPassiveEvents: boolean;

--- a/ts/Core/Templating.ts
+++ b/ts/Core/Templating.ts
@@ -25,9 +25,8 @@ const {
 } = D;
 import G from './Globals.js';
 const {
-    doc
+    pageLang
 } = G;
-import type { HTMLDOMElement } from './Renderer/DOMElementType';
 import U from './Utilities.js';
 const {
     extend,
@@ -490,11 +489,7 @@ function numberFormat(
     const hasSeparators = thousandsSep || decimalPoint,
         locale = hasSeparators ?
             'en' :
-            (
-                (this as Chart)?.locale ||
-                lang.locale ||
-                (doc.body.closest('[lang]') as HTMLDOMElement|null)?.lang
-            ),
+            ((this as Chart)?.locale || lang.locale || pageLang),
         cacheKey = JSON.stringify(options) + locale,
         nf = numberFormatCache[cacheKey] ??=
             new Intl.NumberFormat(locale, options);

--- a/ts/Core/Time.ts
+++ b/ts/Core/Time.ts
@@ -21,6 +21,7 @@ import type TimeTicksInfoObject from './Axis/TimeTicksInfoObject';
 
 import H from './Globals.js';
 const {
+    pageLang,
     win
 } = H;
 import U from './Utilities.js';
@@ -319,7 +320,7 @@ class Time {
     private dateTimeFormat(
         options: Intl.DateTimeFormatOptions|string,
         timestamp?: number|Date,
-        locale: string|Array<string>|undefined = this.options.locale
+        locale: string|Array<string>|undefined = this.options.locale || pageLang
     ): string {
         const cacheKey = JSON.stringify(options) + locale;
         if (isString(options)) {


### PR DESCRIPTION
Fixed #22393, the global `Highcharts.dateTime` didn't pick the locale from the `html.lang` attribute