### PR TITLE
docs/missing-lastprice-options

### DIFF
--- a/ts/Extensions/PriceIndication.ts
+++ b/ts/Extensions/PriceIndication.ts
@@ -457,4 +457,27 @@ export default PriceIndication;
  *
  */
 
+/**
+ * Name of the dash style to use for the line of last price.
+ *
+ * @sample {highstock} highcharts/plotoptions/series-dashstyle-all/
+ *         Possible values demonstrated
+ *
+ * @type      {Highcharts.DashStyleValue}
+ * @product   highstock
+ * @default   Solid
+ * @apioption plotOptions.series.lastPrice.dashStyle
+ *
+ */
+
+/**
+ * Width of the last price line.
+ *
+ * @type      {number}
+ * @product   highstock
+ * @default   1
+ * @apioption plotOptions.series.lastPrice.width
+ *
+ */
+
 ''; // Keeps doclets above in JS file

--- a/ts/Extensions/PriceIndication.ts
+++ b/ts/Extensions/PriceIndication.ts
@@ -220,6 +220,39 @@ export default PriceIndication;
  */
 
 /**
+ * The color of the line of last visible price.
+ * By default, color is not applied and the line is not visible.
+ *
+ * @type      {string}
+ * @product   highstock
+ * @apioption plotOptions.series.lastVisiblePrice.color
+ *
+ */
+
+/**
+ * Name of the dash style to use for the line of last visible price.
+ *
+ * @sample {highstock} highcharts/plotoptions/series-dashstyle-all/
+ *         Possible values demonstrated
+ *
+ * @type      {Highcharts.DashStyleValue}
+ * @product   highstock
+ * @default   Solid
+ * @apioption plotOptions.series.lastVisiblePrice.dashStyle
+ *
+ */
+
+/**
+ * Width of the last visible price line.
+ *
+ * @type      {number}
+ * @product   highstock
+ * @default   1
+ * @apioption plotOptions.series.lastVisiblePrice.width
+ *
+ */
+
+/**
  * Enable or disable the indicator.
  *
  * @type      {boolean}


### PR DESCRIPTION
Fixed #22302, added width and dashStyle options to `lastPrice` docs.