### PR TITLE
bugfix/22296-drillup-missing-tick

### DIFF
--- a/samples/unit-tests/drilldown/drillup/demo.js
+++ b/samples/unit-tests/drilldown/drillup/demo.js
@@ -224,6 +224,53 @@ QUnit.test('Drill up failed on top level (#3544)', function (assert) {
         undefined,
         'Column element is undefined after drillUp'
     );
+
+    chart.update({
+        xAxis: {
+            type: 'datetime'
+        },
+        drilldown: {
+            series: [
+                {
+                    id: 'first',
+                    data: [
+                        [1672704000000, 11],
+                        [1683158400000, 12]
+                    ],
+                    name: 'series_1'
+                }
+            ]
+        }
+    }, false);
+
+    chart.series[0].setData([
+        {
+            x: 1672704000000,
+            y: 10,
+            drilldown: 'first'
+        }
+    ]);
+
+    let label = chart.xAxis[0].ticks[chart.xAxis[0].tickPositions[0]].label;
+
+    const labelParametersBefore = {
+        text: label.textStr,
+        pos: label.xy
+    };
+
+    chart.series[0].points[0].doDrilldown();
+    chart.drillUp();
+
+    label = chart.xAxis[0].ticks[chart.xAxis[0].tickPositions[0]].label;
+
+    assert.deepEqual(
+        labelParametersBefore,
+        {
+            text: label.textStr,
+            pos: label.xy
+        },
+        'After drilling up, the label should not be changed or hidden, #22206.'
+    );
 });
 
 // Highcharts 4.0.4, Issue #3579

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -215,7 +215,7 @@ class Axis {
     public bottom!: number;
     public categories?: Array<string>;
     public chart!: Chart;
-    public closestPointRange!: number;
+    public closestPointRange?: number;
     public coll!: AxisCollectionKey;
     public cross?: SVGElement;
     public crosshair?: AxisCrosshairOptions;
@@ -1638,7 +1638,7 @@ class Axis {
             // The `closestPointRange` is the closest distance between points.
             // In columns it is mostly equal to pointRange, but in lines
             // pointRange is 0 while closestPointRange is some other value
-            if (isXAxis && closestPointRange) {
+            if (isXAxis) {
                 axis.closestPointRange = closestPointRange;
             }
         }
@@ -1959,7 +1959,11 @@ class Axis {
             !axis.series.some((s): boolean|undefined => !s.sorted) ?
                 axis.closestPointRange : 0
         );
-        if (!tickIntervalOption && axis.tickInterval < minTickInterval) {
+        if (
+            !tickIntervalOption &&
+            minTickInterval &&
+            axis.tickInterval < minTickInterval
+        ) {
             axis.tickInterval = minTickInterval;
         }
 

--- a/ts/Core/Time.ts
+++ b/ts/Core/Time.ts
@@ -1082,7 +1082,7 @@ class Time {
      *         The optimal date format for a point.
      */
     public getDateFormat(
-        range: number,
+        range: number | undefined,
         timestamp: number,
         startOfWeek: number,
         dateTimeLabelFormats: Time.DateTimeLabelFormatsOption
@@ -1105,6 +1105,7 @@ class Time {
             // If the range is exactly one week and we're looking at a
             // Sunday/Monday, go for the week format
             if (
+                range &&
                 range === timeUnits.week &&
                 +this.dateFormat('%w', timestamp) === startOfWeek &&
                 dateStr.substr(6) === blank.substr(6)
@@ -1114,7 +1115,7 @@ class Time {
             }
 
             // The first format that is too great for the range
-            if (timeUnits[n] > range) {
+            if (range && timeUnits[n] > range) {
                 n = lastN;
                 break;
             }


### PR DESCRIPTION
Fixed #22296, missing tick after drill-up when parent series had a single point

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208914511776884