### PR TITLE
dash/dg-a11y-focus-anchor-reset

### DIFF
--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -312,16 +312,6 @@
     user-select: none; /* Standard syntax */
 }
 
-.highcharts-datagrid-table thead th button.highcharts-datagrid-header-cell-content {
-    border: none;
-    background: transparent;
-    cursor: pointer;
-}
-
-.highcharts-datagrid-table thead th button.highcharts-datagrid-header-cell-content:hover {
-    background: transparent;
-}
-
 .highcharts-datagrid-table thead th .highcharts-datagrid-header-cell-content span {
     flex: 1;
     overflow: hidden;

--- a/ts/DataGrid/Accessibility/A11yOptions.ts
+++ b/ts/DataGrid/Accessibility/A11yOptions.ts
@@ -122,6 +122,14 @@ namespace A11yOptions {
     export interface SortingLangA11yOptions {
 
         /**
+         * An additional hint (a visually hidden span) read by the voice over
+         * after the column name.
+         *
+         * @default 'Sortable.'
+         */
+        sortable?: string;
+
+        /**
          * Accessibility lang options for the sorting announcements.
          */
         announcements?: {

--- a/ts/DataGrid/Accessibility/Accessibility.ts
+++ b/ts/DataGrid/Accessibility/Accessibility.ts
@@ -115,6 +115,26 @@ class Accessibility {
     }
 
     /**
+     * Add the 'sortable' hint span element for the sortable column.
+     *
+     * @param element
+     * The element to add the description to.
+     */
+    public addSortableColumnHint(element: HTMLElement): void {
+        const sortableLang =
+            this.dataGrid.options?.lang?.accessibility?.sorting?.sortable;
+
+        if (!sortableLang) {
+            return;
+        }
+
+        makeHTMLElement('span', {
+            className: Globals.classNames.visuallyHidden,
+            innerText: ', ' + sortableLang
+        }, element);
+    }
+
+    /**
      * Add the description to the header cell.
      *
      * @param thElement

--- a/ts/DataGrid/Defaults.ts
+++ b/ts/DataGrid/Defaults.ts
@@ -57,6 +57,7 @@ namespace Defaults {
                     }
                 },
                 sorting: {
+                    sortable: 'Sortable.',
                     announcements: {
                         ascending: 'Sorted ascending.',
                         descending: 'Sorted descending.',

--- a/ts/DataGrid/Table/Actions/RowsVirtualizer.ts
+++ b/ts/DataGrid/Table/Actions/RowsVirtualizer.ts
@@ -358,6 +358,8 @@ class RowsVirtualizer {
             }
         }
 
+        // Reset the focus anchor cell
+        this.focusAnchorCell?.htmlElement.setAttribute('tabindex', '-1');
         const firstVisibleRow = rows[rowCursor - rows[0].index];
         this.focusAnchorCell = firstVisibleRow?.cells[0];
         this.focusAnchorCell?.htmlElement.setAttribute('tabindex', '0');

--- a/ts/DataGrid/Table/Header/HeaderCell.ts
+++ b/ts/DataGrid/Table/Header/HeaderCell.ts
@@ -137,17 +137,9 @@ class HeaderCell extends Cell {
         // Render content of th element
         this.row.htmlElement.appendChild(this.htmlElement);
 
-        this.headerContent = makeHTMLElement(
-            isSortableData ? 'button' : 'span',
-            {
-                className: Globals.classNames.headerCellContent
-            },
-            this.htmlElement
-        );
-
-        if (isSortableData) {
-            this.headerContent.setAttribute('type', 'button');
-        }
+        this.headerContent = makeHTMLElement('span', {
+            className: Globals.classNames.headerCellContent
+        }, this.htmlElement);
 
         if (isHTML(this.value)) {
             this.renderHTMLCellContent(
@@ -156,6 +148,12 @@ class HeaderCell extends Cell {
             );
         } else {
             this.headerContent.innerText = this.value;
+        }
+
+        if (isSortableData) {
+            column.viewport.dataGrid.accessibility?.addSortableColumnHint(
+                this.headerContent
+            );
         }
 
         this.htmlElement.setAttribute('scope', 'col');


### PR DESCRIPTION
Changed sortable column header content from `button` to `span`, added a hidden description (default: `'Sortable.'`).
Added focus anchor resetting every row render.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208964674187827