### PR TITLE
Fixed #22423, error when loading highcharts.js from head

### DIFF
--- a/ts/Core/Globals.ts
+++ b/ts/Core/Globals.ts
@@ -205,7 +205,9 @@ namespace Globals {
                 doc.createElementNS(SVG_NS, 'svg') as SVGSVGElement
             ).createSVGRect
         ),
-        pageLang = (doc?.body.closest('[lang]') as HTMLDOMElement|null)?.lang,
+        pageLang = (
+            doc?.documentElement?.closest('[lang]') as HTMLDOMElement|null
+        )?.lang,
         userAgent = (win.navigator && win.navigator.userAgent) || '',
         isChrome = win.chrome,
         isFirefox = userAgent.indexOf('Firefox') !== -1,


### PR DESCRIPTION
Fixed #22423, a regression in v12.1.1 causing Highcharts to crash when loaded from a script tag in the head section.