### PR TITLE
Make `svgContainerLabel` empty by default

### DIFF
--- a/ts/Accessibility/Options/LangDefaults.ts
+++ b/ts/Accessibility/Options/LangDefaults.ts
@@ -72,7 +72,7 @@ const langOptions: DeepPartial<LangOptions> = {
          * Accessible label for the chart SVG element.
          * `{chartTitle}` refers to the chart title.
          */
-        svgContainerLabel: 'Interactive chart',
+        svgContainerLabel: '',
 
         /**
          * Accessible label for the drill-up button.


### PR DESCRIPTION
Fixes #20064 

As specified in the issue, I have made the `svgContainerLabel` in the `ts/Accessibility/Options/LangDefaults.ts` file as empty by default.

I was wondering if I needed to include something else within this change?