### PR TITLE
bugfix/22263-plotline-across-panes

### DIFF
--- a/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
+++ b/samples/unit-tests/axis/plotlines-and-plotbands/demo.js
@@ -831,8 +831,7 @@ QUnit.test('#14254: plotBands.acrossPanes', function (assert) {
             },
             {
                 data: [1, 2, 3, 4],
-                yAxis: 1,
-                xAxis: 1
+                yAxis: 1
             }
         ],
         yAxis: [
@@ -858,10 +857,6 @@ QUnit.test('#14254: plotBands.acrossPanes', function (assert) {
                         acrossPanes: true
                     }
                 ],
-                height: '50%'
-            },
-            {
-                top: '50%',
                 height: '50%'
             }
         ]

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -921,7 +921,7 @@ class Tick {
                     lineWidth: gridLine.strokeWidth(),
                     force: 'pass',
                     old: old,
-                    acrossPanes: false // #18025
+                    acrossPanes: true // #18025 fix was wrong :)
                 }
             );
 

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -733,7 +733,6 @@ namespace StockChart {
             x2,
             y2,
             axes = [], // #3416 need a default array
-            axes2: Array<Axis>,
             uniqueAxes: Array<Axis>,
             transVal: number;
 
@@ -748,24 +747,6 @@ namespace StockChart {
 
             // Get the related axes based on series
             axes = getAxis(axis.coll);
-
-            // Get the related axes based options.*Axis setting #2810
-            axes2 = (axis.isXAxis ? chart.yAxis : chart.xAxis);
-            for (const A of axes2) {
-                if (!A.options.isInternal) {
-                    const a = (A.isXAxis ? 'yAxis' : 'xAxis'),
-                        relatedAxis: Axis = (
-                            defined((A.options as any)[a]) ?
-                                (chart as any)[a][(A.options as any)[a]] :
-                                (chart as any)[a][0]
-                        );
-
-                    if (axis === relatedAxis) {
-                        axes.push(A);
-                    }
-                }
-            }
-
 
             // Remove duplicates in the axes array. If there are no axes in the
             // axes array, we are adding an axis without data, so we need to


### PR DESCRIPTION
Fixed #22263, the gridlines were rendered across panes in the empty spots.