### PR TITLE
bugfix/22295-tooltip-anchor-animation

### DIFF
--- a/samples/unit-tests/tooltip/shared/demo.js
+++ b/samples/unit-tests/tooltip/shared/demo.js
@@ -324,7 +324,7 @@ QUnit.test('Shared tooltip with multiple axes', assert => {
             data: [2, 6, 4],
             type: 'column'
         }, {
-            data: [4, 7, 9],
+            data: [4, 7, 9, 1],
             type: 'column',
             yAxis: 1
         }],
@@ -342,12 +342,38 @@ QUnit.test('Shared tooltip with multiple axes', assert => {
     });
 
     const controller = new TestController(chart);
-    const point = chart.series[2].points[0];
+    let point = chart.series[2].points[0];
     const axis = chart.yAxis[1];
 
     controller.moveTo(axis.left + point.plotX, axis.top + point.plotY + 5);
     assert.notOk(
         chart.tooltip.isHidden,
         '#16004: Tooltip should be visible'
+    );
+
+    // Move to a single point
+    point = chart.series[2].points[3];
+    controller.moveTo(axis.left + point.plotX, axis.top + point.plotY + 5);
+
+    assert.ok(
+        !!chart.tooltip.label.anchorX,
+        'Tooltip should have anchorX for a single point'
+    );
+    assert.ok(
+        !!chart.tooltip.label.anchorY,
+        'Tooltip should have anchorY for a single point'
+    );
+
+    // Move from a single point to multiple points
+    point = chart.series[2].points[2];
+    controller.moveTo(axis.left + point.plotX, axis.top + point.plotY + 5);
+
+    assert.ok(
+        !chart.tooltip.label.anchorX,
+        'Tooltip should NOT have anchorX for multiple points'
+    );
+    assert.ok(
+        !chart.tooltip.label.anchorY,
+        'Tooltip should NOT have anchorY for multiple points'
     );
 });

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -961,8 +961,8 @@ class Tooltip {
             attr.anchorX = anchorX;
             attr.anchorY = anchorY;
         } else {
-            // Clear the previous anchor position (#22295)
-            attr.anchorX = attr.anchorY = void 0;
+            // Clear anchor with NaN to prevent animation (#22295)
+            attr.anchorX = attr.anchorY = NaN;
         }
 
         animation.step = (): void => tooltip.drawTracker();

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -960,6 +960,9 @@ class Tooltip {
         if (!skipAnchor) {
             attr.anchorX = anchorX;
             attr.anchorY = anchorY;
+        } else {
+            // Clear the previous anchor position (#22295)
+            attr.anchorX = attr.anchorY = void 0;
         }
 
         animation.step = (): void => tooltip.drawTracker();


### PR DESCRIPTION
Fixed #22295, shared tooltip anchor position was not animated correctly between a single and multiple points.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208914157601454