### PR TITLE
bugfix/22380-arc-start-angle

### DIFF
--- a/samples/unit-tests/svgrenderer/symbol/demo.js
+++ b/samples/unit-tests/svgrenderer/symbol/demo.js
@@ -169,6 +169,46 @@ QUnit.test('Arc', assert => {
         0,
         '#15382: Y radius should be 0'
     );
+
+    const ren = new Highcharts.Renderer(
+            document.getElementById('container'),
+            400,
+            400
+        ),
+        arcBox = ren.path({
+            d: ren.symbols.arc(150, 150, 150, 150, {
+                r: 150,
+                end: Math.PI * 2 - 1.1,
+                start: -1.1
+            })
+        }).attr({
+            stroke: 'black'
+        }).add().getBBox();
+
+    assert.close(
+        arcBox.y,
+        0,
+        0.001,
+        'Arc with changed start and end angle should create a correct circle.'
+    );
+    assert.close(
+        arcBox.x,
+        0,
+        0.001,
+        'Arc with changed start and end angle should create a correct circle.'
+    );
+    assert.close(
+        arcBox.width,
+        300,
+        0.001,
+        'Arc with changed start and end angle should create a correct circle.'
+    );
+    assert.close(
+        arcBox.height,
+        300,
+        0.001,
+        'Arc with changed start and end angle should create a correct circle.'
+    );
 });
 
 QUnit.test('Square/rect', assert => {

--- a/ts/Core/Renderer/SVG/Symbols.ts
+++ b/ts/Core/Renderer/SVG/Symbols.ts
@@ -48,22 +48,29 @@ function arc(
     const arc: SVGPath = [];
 
     if (options) {
-        const start = options.start || 0,
-            rx = pick(options.r, w),
+        let start = options.start || 0,
+            end = options.end || 0;
+
+        const rx = pick(options.r, w),
             ry = pick(options.r, h || w),
             // Subtract a small number to prevent cos and sin of start and end
             // from becoming equal on 360 arcs (#1561). The size of the circle
             // affects the constant, therefore the division by `rx`. If the
             // proximity is too small, the arc disappears. If it is too great, a
             // gap appears. This can be seen in the animation of the official
-            // bubble demo (#20586).
+            // bubble demo (#20585).
             proximity = 0.0002 / (options.borderRadius ? 1 : Math.max(rx, 1)),
             fullCircle = (
-                Math.abs((options.end || 0) - start - 2 * Math.PI) <
+                Math.abs(end - start - 2 * Math.PI) <
                 proximity
-            ),
-            end = (options.end || 0) - (fullCircle ? proximity : 0),
-            innerRadius = options.innerR,
+            );
+
+        if (fullCircle) {
+            start = 0;
+            end = 2 * Math.PI - proximity;
+        }
+
+        const innerRadius = options.innerR,
             open = pick(options.open, fullCircle),
             cosStart = Math.cos(start),
             sinStart = Math.sin(start),


### PR DESCRIPTION
Fixed #22380, circles were misaligned in a polar chart when `pane.startAngle` was set to a non-zero value.