### PR TITLE
dash/datagrid-release-files

### DIFF
--- a/tools/gulptasks/dashboards/dist-release.js
+++ b/tools/gulptasks/dashboards/dist-release.js
@@ -71,6 +71,11 @@ async function distRelease() {
     );
 
     fsLib.deleteDirectory(
+        path.join(distRepository, 'es-modules', 'DataGrid'),
+        true
+    );
+
+    fsLib.deleteDirectory(
         path.join(distRepository, 'css', 'dashboards'),
         true
     );


### PR DESCRIPTION
Updated datagrid tools that did not remove es-modules properly.