### PR TITLE
bugfix/22450-es5-errors

### DIFF
--- a/ts/Core/Globals.ts
+++ b/ts/Core/Globals.ts
@@ -201,9 +201,11 @@ namespace Globals {
         svg = !!(
             doc?.createElementNS?.(SVG_NS, 'svg') as SVGSVGElement|undefined
         )?.createSVGRect,
-        pageLang = (
-            doc?.documentElement?.closest('[lang]') as HTMLDOMElement|null
-        )?.lang,
+        // Notice: optimizing pageLang might cause ES5 build error (#22450).
+        pageLang = typeof doc?.documentElement?.closest === 'function' &&
+            (
+                doc.documentElement.closest('[lang]') as HTMLDOMElement|null
+            )?.lang,
         userAgent = win.navigator?.userAgent || '',
         isChrome = win.chrome,
         isFirefox = userAgent.indexOf('Firefox') !== -1,

--- a/ts/Core/Globals.ts
+++ b/ts/Core/Globals.ts
@@ -201,11 +201,9 @@ namespace Globals {
         svg = !!(
             doc?.createElementNS?.(SVG_NS, 'svg') as SVGSVGElement|undefined
         )?.createSVGRect,
-        // Notice: optimizing pageLang might cause ES5 build error (#22450).
-        pageLang = typeof doc?.documentElement?.closest === 'function' &&
-            (
-                doc.documentElement.closest('[lang]') as HTMLDOMElement|null
-            )?.lang,
+        pageLang = (
+            doc?.documentElement?.closest('[lang]') as HTMLDOMElement|null
+        )?.lang,
         userAgent = win.navigator?.userAgent || '',
         isChrome = win.chrome,
         isFirefox = userAgent.indexOf('Firefox') !== -1,

--- a/ts/Core/Templating.ts
+++ b/ts/Core/Templating.ts
@@ -177,11 +177,12 @@ function dateFormat(
  */
 function format(str = '', ctx: any, chart?: Chart): string {
 
-    const regex = /\{([\p{L}\d:\.,;\-\/<>\[\]%_@+"'’= #\(\)]+)\}/gu,
+    // Notice: using u flag will require a refactor for ES5 (#22450).
+    const regex = /\{([a-zA-Z\u00C0-\u017F\d:\.,;\-\/<>\[\]%_@+"'’= #\(\)]+)\}/g, // eslint-disable-line max-len
         // The sub expression regex is the same as the top expression regex,
         // but except parens and block helpers (#), and surrounded by parens
         // instead of curly brackets.
-        subRegex = /\(([\p{L}\d:\.,;\-\/<>\[\]%_@+"'= ]+)\)/gu,
+        subRegex = /\(([a-zA-Z\u00C0-\u017F\d:\.,;\-\/<>\[\]%_@+"'= ]+)\)/g,
         matches = [],
         floatRegex = /f$/,
         decRegex = /\.(\d)/,

--- a/ts/masters-es5/polyfills.ts
+++ b/ts/masters-es5/polyfills.ts
@@ -56,6 +56,35 @@ if (!Object.values) {
     };
 }
 
+const ElementPrototype = window.Element.prototype;
+
+if (typeof ElementPrototype.matches !== 'function') {
+    ElementPrototype.matches = function matches(selector: string): boolean {
+        let element = this;
+        const elements = element.ownerDocument.querySelectorAll(selector);
+        let index = 0;
+        while (elements[index] && elements[index] !== element) {
+            ++index;
+        }
+        return Boolean(elements[index]);
+    };
+}
+
+if (typeof ElementPrototype.closest !== 'function') {
+    ElementPrototype.closest = function closest(
+        selector: keyof HTMLElementTagNameMap
+    ): Element | null {
+        let element: Element | null = this;
+        while (element && element.nodeType === 1) {
+            if (element?.matches(selector)) {
+                return element;
+            }
+            element = (element.parentNode as Element | null) || null;
+        }
+        return null;
+    };
+}
+
 (function () {
     if (typeof window.CustomEvent === "function") return false;
 


### PR DESCRIPTION
Fixed #22450, ES5 build failed in legacy browsers due to Unicode property escape used in regex

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209061945761312