### PR TITLE
dash/22241-component-editable-options-connector-name

### DIFF
--- a/tools/gulptasks/dashboards/api-docs.json
+++ b/tools/gulptasks/dashboards/api-docs.json
@@ -22,6 +22,7 @@
         "../../../ts/Dashboards/EditMode/Toolbar/RowEditToolbar.ts",
         "../../../ts/Dashboards/EditMode/Toolbar/SidebarEditToolbar.ts",
         "../../../ts/Dashboards/EditMode/SidebarPopup.ts",
+        "../../../ts/Dashboards/EditMode/EditGlobals.ts",
 
         // Components
         "../../../ts/Dashboards/Components/Component.ts",

--- a/ts/Dashboards/Components/EditableOptions.ts
+++ b/ts/Dashboards/Components/EditableOptions.ts
@@ -61,7 +61,11 @@ class EditableOptions {
 
         for (let i = 0, iEnd = options.length; i < iEnd; i++) {
             const option = options[i];
-            if (option.name === 'connectorName') {
+            if (
+                option.propertyPath?.some(
+                    (path): boolean => path === 'connector'
+                )
+            ) {
                 const board = this.component.board;
                 const selectOptions = !board ?
                     [] :

--- a/ts/Dashboards/EditMode/EditGlobals.ts
+++ b/ts/Dashboards/EditMode/EditGlobals.ts
@@ -20,9 +20,6 @@ import DG from '../Globals.js';
 
 const PREFIX = DG.classNamePrefix + 'edit-';
 
-/**
- * @internal
- */
 const EditGlobals: EditGlobals = {
     classNames: {
         resizeSnap: PREFIX + 'resize-snap',
@@ -164,9 +161,6 @@ const EditGlobals: EditGlobals = {
     }
 };
 
-/**
- * @internal
- */
 interface EditGlobals {
     classNames: EditGlobals.ClassNamesOptions;
     lang: EditGlobals.LangOptions;


### PR DESCRIPTION
Fixed https://github.com/highcharts/highcharts/issues/22241, could not change the sidebar accordions names.