### PR TITLE
dash/dg-row-data-as-object

### DIFF
--- a/ts/DataGrid/Table/Content/TableRow.ts
+++ b/ts/DataGrid/Table/Content/TableRow.ts
@@ -51,7 +51,7 @@ class TableRow extends Row {
     /**
      * The row values from the data table in the original column order.
      */
-    public data: DataTable.Row = [];
+    public data: DataTable.RowObject = {};
 
     /**
      * The local index of the row in the presentation data table.
@@ -107,7 +107,7 @@ class TableRow extends Row {
      * Loads the row data from the data table.
      */
     private loadData(): void {
-        const data = this.viewport.dataTable.getRow(this.index);
+        const data = this.viewport.dataTable.getRowObject(this.index);
         if (!data) {
             return;
         }


### PR DESCRIPTION
Changed DataGrid `row.data` to be an object instead of an array of values.

Example: https://jsfiddle.net/BlackLabel/4qLogsh0/

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209137369236068