### PR TITLE
dash/dg-loading-indicator

### DIFF
--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -699,8 +699,32 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
     position: absolute;
     width: 100%;
     height: 100%;
-    background: var(--highcharts-neutral-color-60);
+    background: var(--highcharts-neutral-color-0);
     opacity: 0.5;
+    gap: 10px;
+}
+
+.highcharts-datagrid-loading-wrapper .highcharts-datagrid-loading-message {
+    color: var(--highcharts-neutral-color-100);
+}
+
+.highcharts-datagrid-loading-wrapper .highcharts-datagrid-spinner {
+    border: 4px solid var(--highcharts-neutral-color-60);
+    border-top: 4px solid var(--highcharts-neutral-color-100);
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 /* End DataGrid CSS Helpers Classes */

--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -712,7 +712,8 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
     color: var(--highcharts-neutral-color-100);
 }
 
-.highcharts-datagrid-container:has(.highcharts-datagrid-loading-wrapper) .highcharts-datagrid-no-data {
+.highcharts-datagrid-container:has(.highcharts-datagrid-loading-wrapper) .highcharts-datagrid-no-data,
+.highcharts-datagrid-container:has(.highcharts-datagrid-loading-wrapper) .highcharts-datagrid-credits-container {
     opacity: 0;
 }
 

--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -270,6 +270,10 @@
     --idg-positive-border-size: var(--hcdg-positive-border-size, var(--idg-highlight-border-size));
     --idg-positive-background: var(--hcdg-positive-background, var(--idg-positive-default-background));
 
+    /* Loading indicator */
+    --idg-loading-wrapper-background: var(--hcdg-loading-wrapper-background, var(--idg-neutral-default-background));
+    --idg-loading-wrapper-border-size: var(--hcdg-loading-wrapper-border-size, 4px);
+
     position: relative;
     display: flex;
     flex-direction: column;
@@ -699,7 +703,7 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
     position: absolute;
     width: 100%;
     height: 100%;
-    background: var(--highcharts-neutral-color-0);
+    background: var(--idg-loading-wrapper-background);
     opacity: 0.5;
     gap: 10px;
 }
@@ -708,9 +712,13 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
     color: var(--highcharts-neutral-color-100);
 }
 
+.highcharts-datagrid-container:has(.highcharts-datagrid-loading-wrapper) .highcharts-datagrid-no-data {
+    opacity: 0;
+}
+
 .highcharts-datagrid-loading-wrapper .highcharts-datagrid-spinner {
-    border: 4px solid var(--highcharts-neutral-color-60);
-    border-top: 4px solid var(--highcharts-neutral-color-100);
+    border: var(--idg-loading-wrapper-border-size) solid var(--highcharts-neutral-color-60);
+    border-top: var(--idg-loading-wrapper-border-size) solid var(--highcharts-neutral-color-100);
     border-radius: 50%;
     width: 20px;
     height: 20px;

--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -270,6 +270,7 @@
     --idg-positive-border-size: var(--hcdg-positive-border-size, var(--idg-highlight-border-size));
     --idg-positive-background: var(--hcdg-positive-background, var(--idg-positive-default-background));
 
+    position: relative;
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -689,6 +690,17 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
 .highcharts-datagrid-table thead tr th.hcdg-left,
 .highcharts-datagrid-table tbody tr td.hcdg-left {
     text-align: left;
+}
+
+.highcharts-datagrid-loading-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background: var(--highcharts-neutral-color-60);
+    opacity: 0.5;
 }
 
 /* End DataGrid CSS Helpers Classes */

--- a/samples/data-grid/basic/loading-indicator/demo.css
+++ b/samples/data-grid/basic/loading-indicator/demo.css
@@ -1,0 +1,6 @@
+@import url("https://code.highcharts.com/dashboards/css/datagrid.css");
+
+#container {
+    height: 250px;
+    margin: 8px;
+}

--- a/samples/data-grid/basic/loading-indicator/demo.details
+++ b/samples/data-grid/basic/loading-indicator/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Dashboards Demo
+ authors:
+   - Karol Kolodziej
+ js_wrap: b
+...

--- a/samples/data-grid/basic/loading-indicator/demo.html
+++ b/samples/data-grid/basic/loading-indicator/demo.html
@@ -1,0 +1,4 @@
+<script src="https://code.highcharts.com/dashboards/datagrid.js"></script>
+
+<div id="container"></div>
+<button id="load">Load data</button>

--- a/samples/data-grid/basic/loading-indicator/demo.js
+++ b/samples/data-grid/basic/loading-indicator/demo.js
@@ -10,7 +10,7 @@ const dg = DataGrid.dataGrid('container', {
 
 document.getElementById('load').addEventListener('click', () => {
     // Show the loading indicator
-    dg.showLoading('Loading...');
+    dg.showLoading('Loading data...');
 
     // Simulate a get request
     setTimeout(() => {
@@ -18,10 +18,15 @@ document.getElementById('load').addEventListener('click', () => {
             dataTable: {
                 columns: {
                     product: ['Apples', 'Pears', 'Plums', 'Bananas'],
-                    weight: [100, 40, 0.5, 200],
-                    price: [1.5, 2.53, 5, 4.5]
+                    weight: Array.from({ length: 4 }, () =>
+                        Math.round(Math.random() * 100)
+                    ),
+                    price: Array.from({ length: 4 }, () =>
+                        Math.round(Math.random() * 10)
+                    )
                 }
             }
         });
-    }, 1000);
+        dg.hideLoading();
+    }, 2000);
 });

--- a/samples/data-grid/basic/loading-indicator/demo.js
+++ b/samples/data-grid/basic/loading-indicator/demo.js
@@ -1,0 +1,27 @@
+const dg = DataGrid.dataGrid('container', {
+    dataTable: {
+        columns: {
+            product: ['Apples', 'Pears', 'Plums', 'Bananas'],
+            weight: [],
+            price: []
+        }
+    }
+});
+
+document.getElementById('load').addEventListener('click', () => {
+    // Show the loading indicator
+    dg.showLoading('Loading...');
+
+    // Simulate a get request
+    setTimeout(() => {
+        dg.update({
+            dataTable: {
+                columns: {
+                    product: ['Apples', 'Pears', 'Plums', 'Bananas'],
+                    weight: [100, 40, 0.5, 200],
+                    price: [1.5, 2.53, 5, 4.5]
+                }
+            }
+        });
+    }, 1000);
+});

--- a/samples/data-grid/basic/loading-indicator/demo.js
+++ b/samples/data-grid/basic/loading-indicator/demo.js
@@ -8,7 +8,13 @@ const dg = DataGrid.dataGrid('container', {
     }
 });
 
+let isLoading = false;
 document.getElementById('load').addEventListener('click', () => {
+    if (isLoading) {
+        return;
+    }
+    isLoading = true;
+
     // Show the loading indicator
     dg.showLoading('Loading data...');
 
@@ -28,5 +34,6 @@ document.getElementById('load').addEventListener('click', () => {
             }
         });
         dg.hideLoading();
+        isLoading = false;
     }, 2000);
 });

--- a/test/cypress/data-grid/integration/loading-indicator.cy.js
+++ b/test/cypress/data-grid/integration/loading-indicator.cy.js
@@ -1,0 +1,22 @@
+describe('Loading indicator', () => {
+    before(() => {
+        cy.visit('/data-grid/cypress/datagrid-custom-class');
+    });
+
+    it('Loading indicator should be visible.', () => {
+        cy.grid().then((grid) => {
+            grid.showLoading('Loading test...');
+
+            cy.get('.highcharts-datagrid-loading-wrapper').should('be.visible');
+            cy.get('.highcharts-datagrid-loading-message').should('contain', 'Loading test...');
+        });
+    });
+
+    it('Loading indicator should be hidden.', () => {
+        cy.grid().then((grid) => {
+            grid.hideLoading();
+
+            cy.get('.highcharts-datagrid-loading-wrapper').should('not.exist');
+        });
+    });
+});

--- a/test/cypress/data-grid/integration/loading-indicator.cy.js
+++ b/test/cypress/data-grid/integration/loading-indicator.cy.js
@@ -19,4 +19,15 @@ describe('Loading indicator', () => {
             cy.get('.highcharts-datagrid-loading-wrapper').should('not.exist');
         });
     });
+
+    it('Only one indicator should be visible at a time.', () => {
+        cy.grid().then((grid) => {
+            grid.showLoading('Loading 1');
+            grid.showLoading('Loading 2');
+
+            cy.get('.highcharts-datagrid-loading-wrapper').should('be.visible');
+            cy.get('.highcharts-datagrid-loading-message').should('contain', 'Loading 1');
+            cy.get('.highcharts-datagrid-loading-wrapper').should('have.length', 1);
+        });
+    });
 });

--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -187,3 +187,10 @@ Cypress.Commands.add('dropComponent', (elementName) => {
     cy.get(elementName).first().trigger('mousemove', 'right', {force: true});
     cy.get(elementName).first().trigger('mouseup', 'right', {force: true});
 });
+
+Cypress.Commands.add('grid', () =>
+    cy.window().its('DataGrid.dataGrids').should('have.length.gte', 1).then(grids => {
+        const [grid] = grids;
+        return grid;
+    })
+);

--- a/ts/DataGrid/DataGrid.ts
+++ b/ts/DataGrid/DataGrid.ts
@@ -186,11 +186,6 @@ class DataGrid {
     public loadingWrapper?: HTMLElement;
 
     /**
-     * Whether the loading indicator is shown.
-     */
-    private loadingShown = false;
-
-    /**
      * The presentation table of the data grid. It contains a modified version
      * of the data table that is used for rendering the data grid content. If
      * not modified, just a reference to the original data table.
@@ -955,17 +950,15 @@ class DataGrid {
      * The message to display in the loading indicator.
      */
     public showLoading(message?: string): void {
-        if (this.loadingShown) {
+        if (this.loadingWrapper) {
             return;
         }
-
-        this.loadingShown = true;
 
         // Create loading wrapper.
         this.loadingWrapper = makeHTMLElement(
             'div',
             {
-                className: 'highcharts-datagrid-loading-wrapper',
+                className: Globals.classNames.loadingWrapper
             },
             this.contentWrapper
         )
@@ -974,7 +967,7 @@ class DataGrid {
         makeHTMLElement(
             'div',
             {
-                className: 'highcharts-datagrid-spinner'
+                className: Globals.classNames.loadingSpinner
             },
             this.loadingWrapper
         );
@@ -984,15 +977,15 @@ class DataGrid {
         const loadingSpan = makeHTMLElement(
             'span',
             {
-                className: 'highcharts-datagrid-loading-message'
+                className: Globals.classNames.loadingMessage
             },
             this.loadingWrapper
         );
 
-        AST.setElementHTML(
+        setHTMLContent(
             loadingSpan,
             pick(message, this.options?.lang?.loading, '')
-        );
+        )
     }
 
     /**
@@ -1000,8 +993,7 @@ class DataGrid {
      */
     public hideLoading(): void {
         this.loadingWrapper?.remove();
-        this.loadingWrapper = void 0;
-        this.loadingShown = false;
+        delete this.loadingWrapper;
     }
 
     /**

--- a/ts/DataGrid/DataGrid.ts
+++ b/ts/DataGrid/DataGrid.ts
@@ -186,6 +186,11 @@ class DataGrid {
     public loadingWrapper?: HTMLElement;
 
     /**
+     * Whether the loading indicator is shown.
+     */
+    private loadingShown = false;
+
+    /**
      * The presentation table of the data grid. It contains a modified version
      * of the data table that is used for rendering the data grid content. If
      * not modified, just a reference to the original data table.
@@ -950,6 +955,12 @@ class DataGrid {
      * The message to display in the loading indicator.
      */
     public showLoading(message?: string): void {
+        if (this.loadingShown) {
+            return;
+        }
+
+        this.loadingShown = true;
+
         // Create loading wrapper.
         this.loadingWrapper = makeHTMLElement(
             'div',
@@ -990,6 +1001,7 @@ class DataGrid {
     public hideLoading(): void {
         this.loadingWrapper?.remove();
         this.loadingWrapper = void 0;
+        this.loadingShown = false;
     }
 
     /**

--- a/ts/DataGrid/DataGrid.ts
+++ b/ts/DataGrid/DataGrid.ts
@@ -39,7 +39,7 @@ import QueryingController from './Querying/QueryingController.js';
 
 const { makeHTMLElement } = DataGridUtils;
 const { win } = Globals;
-const { merge, getStyle } = U;
+const { merge, getStyle, pick } = U;
 
 
 /* *
@@ -173,6 +173,16 @@ class DataGrid {
      * The description element of the data grid.
      */
     public descriptionElement?: HTMLElement;
+
+    /**
+     * The container element of the loading indicator overlaying the data grid.
+     */
+    public loadingWrapper?: HTMLElement;
+
+    /**
+     * The loading message span element.
+     */
+    public loadingSpan?: HTMLElement;
 
     /**
      * The presentation table of the data grid. It contains a modified version
@@ -901,6 +911,39 @@ class DataGrid {
         });
 
         DataGrid.dataGrids.splice(dgIndex, 1);
+    }
+
+    /**
+     * Grey out the data grid and show a loading indicator.
+     *
+     * @param message
+     * The message to display in the loading indicator.
+     */
+    public showLoading(message: string): void {
+        if (!this.loadingWrapper) {
+            this.loadingWrapper = makeHTMLElement(
+                'div',
+                {
+                    className: 'highcharts-datagrid-loading-wrapper',
+                },
+                this.contentWrapper
+            )
+        }
+
+        if (!this.loadingSpan) {
+            this.loadingSpan = makeHTMLElement(
+                'span',
+                {
+                    className: 'highcharts-datagrid-loading-message'
+                },
+                this.loadingWrapper
+            );
+        }
+
+        AST.setElementHTML(
+            this.loadingSpan,
+            pick(message, '')
+        );
     }
 
     /**

--- a/ts/DataGrid/DataGrid.ts
+++ b/ts/DataGrid/DataGrid.ts
@@ -180,11 +180,6 @@ class DataGrid {
     public loadingWrapper?: HTMLElement;
 
     /**
-     * The loading message span element.
-     */
-    public loadingSpan?: HTMLElement;
-
-    /**
      * The presentation table of the data grid. It contains a modified version
      * of the data table that is used for rendering the data grid content. If
      * not modified, just a reference to the original data table.
@@ -919,31 +914,47 @@ class DataGrid {
      * @param message
      * The message to display in the loading indicator.
      */
-    public showLoading(message: string): void {
-        if (!this.loadingWrapper) {
-            this.loadingWrapper = makeHTMLElement(
-                'div',
-                {
-                    className: 'highcharts-datagrid-loading-wrapper',
-                },
-                this.contentWrapper
-            )
-        }
+    public showLoading(message?: string): void {
+        // Create loading wrapper.
+        this.loadingWrapper = makeHTMLElement(
+            'div',
+            {
+                className: 'highcharts-datagrid-loading-wrapper',
+            },
+            this.contentWrapper
+        )
 
-        if (!this.loadingSpan) {
-            this.loadingSpan = makeHTMLElement(
-                'span',
-                {
-                    className: 'highcharts-datagrid-loading-message'
-                },
-                this.loadingWrapper
-            );
-        }
+        // Create spinner element.
+        makeHTMLElement(
+            'div',
+            {
+                className: 'highcharts-datagrid-spinner'
+            },
+            this.loadingWrapper
+        );
+
+
+        // Create loading message span element.
+        const loadingSpan = makeHTMLElement(
+            'span',
+            {
+                className: 'highcharts-datagrid-loading-message'
+            },
+            this.loadingWrapper
+        );
 
         AST.setElementHTML(
-            this.loadingSpan,
-            pick(message, '')
+            loadingSpan,
+            pick(message, this.options?.lang?.loading, '')
         );
+    }
+
+    /**
+     * Removes the loading indicator.
+     */
+    public hideLoading(): void {
+        this.loadingWrapper?.remove();
+        this.loadingWrapper = void 0;
     }
 
     /**

--- a/ts/DataGrid/Defaults.ts
+++ b/ts/DataGrid/Defaults.ts
@@ -66,6 +66,7 @@ namespace Defaults {
                     }
                 }
             },
+            loading: 'Loading...',
             noData: 'No data to display'
         },
         rendering: {

--- a/ts/DataGrid/Globals.ts
+++ b/ts/DataGrid/Globals.ts
@@ -101,7 +101,10 @@ namespace Globals {
         creditsContainer: classNamePrefix + 'credits-container',
         creditsText: classNamePrefix + 'credits',
         visuallyHidden: classNamePrefix + 'visually-hidden',
-        lastHeaderCellInRow: classNamePrefix + 'last-header-cell-in-row'
+        lastHeaderCellInRow: classNamePrefix + 'last-header-cell-in-row',
+        loadingWrapper: classNamePrefix + 'loading-wrapper',
+        loadingSpinner: classNamePrefix + 'spinner',
+        loadingMessage: classNamePrefix + 'loading-message'
     };
 
     export const win = window;

--- a/ts/DataGrid/Options.ts
+++ b/ts/DataGrid/Options.ts
@@ -643,6 +643,13 @@ export interface LangOptions {
     accessibility?: A11yOptions.LangAccessibilityOptions;
 
     /**
+     * The text to display when the loading indicator is shown.
+     *
+     * @default 'Loading...'
+     */
+    loading?: string;
+
+    /**
      * The text to display when there is no data to show.
      *
      * @default 'No data to display'


### PR DESCRIPTION
Implemented a loading indicator for the DataGrid, added the `showLoading` and `hideLoading` methods to manage the indicator's visibility, closes #22225.