### PR TITLE
bugfix/boost-point-click-differs-from-non-boost

### DIFF
--- a/ts/Extensions/Boost/Boost.ts
+++ b/ts/Extensions/Boost/Boost.ts
@@ -26,6 +26,7 @@ import type HTMLElement from '../../Core/Renderer/HTML/HTMLElement';
 import type Series from '../../Core/Series/Series';
 import type SeriesRegistry from '../../Core/Series/SeriesRegistry';
 import type SVGElement from '../../Core/Renderer/SVG/SVGElement';
+import type Point from '../../Core/Series/Point';
 
 import BoostChart from './BoostChart.js';
 import BoostSeries from './BoostSeries.js';
@@ -68,6 +69,7 @@ function compose(
     AxisClass: typeof Axis,
     SeriesClass: typeof Series,
     seriesTypes: typeof SeriesRegistry.seriesTypes,
+    PointClass: typeof Point,
     ColorClass?: typeof Color
 ): void {
     const wglMode = hasWebGLSupport();
@@ -91,7 +93,7 @@ function compose(
     // WebGL support is alright, and we're good to go.
 
     BoostChart.compose(ChartClass, wglMode);
-    BoostSeries.compose(SeriesClass, seriesTypes, wglMode);
+    BoostSeries.compose(SeriesClass, seriesTypes, PointClass, wglMode);
 
     // Handle zooming by touch/pinch or mouse wheel. Assume that boosted charts
     // are too slow for a live preview while dragging. Instead, just scale the

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -445,8 +445,7 @@ function createAndAttachRenderer(
                     pointerEvents: hasClickHandler ? void 0 : 'none',
                     mixedBlendMode: 'normal',
                     opacity: alpha
-                })
-                .addClass(hasClickHandler ? 'highcharts-tracker' : '');
+                });
 
             if (target instanceof ChartClass) {
                 target.boost?.markerGroup?.translate(

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -201,6 +201,7 @@ function boostEnabled(chart: Chart): boolean {
 function compose<T extends typeof Series>(
     SeriesClass: T,
     seriesTypes: typeof SeriesRegistry.seriesTypes,
+    PointClass: typeof Point,
     wglMode?: boolean
 ): (T&typeof BoostSeriesComposition) {
     if (pushUnique(composed, 'Boost.Series')) {
@@ -234,6 +235,27 @@ function compose<T extends typeof Series>(
             )>
         ).forEach((method): void =>
             wrapSeriesFunctions(seriesProto, seriesTypes, method)
+        );
+
+        wrap(
+            PointClass.prototype,
+            'firePointEvent',
+            function (this: typeof PointClass.prototype, proceed): boolean {
+                const eType = arguments[1];
+                const event = arguments[2];
+                if (
+                    event &&
+                    eType === 'click' &&
+                    event
+                        .target
+                        ?.className
+                        ?.baseVal
+                        .includes('highcharts-tracker')
+                ) {
+                    return false;
+                }
+                return proceed.apply(this, [].slice.call(arguments, 1));
+            }
         );
 
         // Set default options

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -241,17 +241,18 @@ function compose<T extends typeof Series>(
             'firePointEvent',
             function (
                 this: typeof PointClass.prototype,
-                proceed, type, e
+                proceed,
+                type,
+                e
             ): boolean | undefined {
                 if (type === 'click' && this.series.boosted) {
-                    const point = e.point,
-                        { xAxis, yAxis } = point.series,
-                        distance = Math.sqrt(
-                            Math.pow(point.plotX + xAxis.pos - e.chartX, 2) +
-                            Math.pow(point.plotY + yAxis.pos - e.chartY, 2)
-                        );
+                    const point = e.point;
 
-                    if (distance > 10) {
+                    if (
+                        (point.dist || point.distX) >= (
+                            point.series.options.marker?.radius ?? 10
+                        )
+                    ) {
                         return;
                     }
                 }

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -243,7 +243,7 @@ function compose<T extends typeof Series>(
                 this: typeof PointClass.prototype,
                 proceed, type, e
             ): boolean | undefined {
-                if (type === 'click') {
+                if (type === 'click' && this.series.boosted) {
                     const point = e.point,
                         { xAxis, yAxis } = point.series,
                         distance = Math.sqrt(

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -445,7 +445,8 @@ function createAndAttachRenderer(
                     pointerEvents: hasClickHandler ? void 0 : 'none',
                     mixedBlendMode: 'normal',
                     opacity: alpha
-                });
+                })
+                .addClass(hasClickHandler ? 'highcharts-tracker' : '');
 
             if (target instanceof ChartClass) {
                 target.boost?.markerGroup?.translate(

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -236,27 +236,27 @@ function compose<T extends typeof Series>(
         ).forEach((method): void =>
             wrapSeriesFunctions(seriesProto, seriesTypes, method)
         );
-
         wrap(
             PointClass.prototype,
             'firePointEvent',
-            function (this: typeof PointClass.prototype, proceed): boolean {
-                const eType = arguments[1];
-                const event = arguments[2];
-                if (
-                    event &&
-                    eType === 'click' &&
-                    event
-                        ?.target
-                        ?.className
-                        ?.baseVal
-                        ?.includes('highcharts-tracker')
-                ) {
-                    return false;
+            function (
+                this: typeof PointClass.prototype,
+                proceed, type, e
+            ): boolean | undefined {
+                if (type === 'click') {
+                    const point = e.point,
+                        { xAxis, yAxis } = point.series,
+                        distance = Math.sqrt(
+                            Math.pow(point.plotX + xAxis.pos - e.chartX, 2) +
+                            Math.pow(point.plotY + yAxis.pos - e.chartY, 2)
+                        );
+
+                    if (distance > 10) {
+                        return;
+                    }
                 }
                 return proceed.apply(this, [].slice.call(arguments, 1));
-            }
-        );
+            });
 
         // Set default options
         Boostables.forEach((type: string): void => {

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -247,10 +247,10 @@ function compose<T extends typeof Series>(
                     event &&
                     eType === 'click' &&
                     event
-                        .target
+                        ?.target
                         ?.className
                         ?.baseVal
-                        .includes('highcharts-tracker')
+                        ?.includes('highcharts-tracker')
                 ) {
                     return false;
                 }

--- a/ts/Series/PackedBubble/PackedBubbleLayout.ts
+++ b/ts/Series/PackedBubble/PackedBubbleLayout.ts
@@ -160,31 +160,21 @@ class PackedBubbleLayout extends ReingoldFruchtermanLayout {
             box = layout.box,
             nodes = layout.nodes as Array<PackedBubblePoint>,
             nodesLength = nodes.length + 1,
-            angle = 2 * Math.PI / nodesLength;
+            angle = 2 * Math.PI / nodesLength,
+            radius = layout.options.initialPositionRadius;
 
         let centerX: number,
             centerY: number,
-            index = 0,
-            radius = layout.options.initialPositionRadius;
+            index = 0;
 
         for (const node of nodes) {
-            const isParentNode = node.isParentNode;
             if (
                 layout.options.splitSeries &&
-                !isParentNode
+                !node.isParentNode
             ) {
                 centerX = (node.series.parentNode as any).plotX;
                 centerY = (node.series.parentNode as any).plotY;
             } else {
-                if (isParentNode) {
-                    radius = node
-                        .series
-                        .options
-                        ?.layoutAlgorithm
-                        ?.initialPositionRadius ||
-                        radius;
-                }
-
                 centerX = box.width / 2;
                 centerY = box.height / 2;
             }

--- a/ts/Series/PackedBubble/PackedBubbleLayout.ts
+++ b/ts/Series/PackedBubble/PackedBubbleLayout.ts
@@ -160,21 +160,31 @@ class PackedBubbleLayout extends ReingoldFruchtermanLayout {
             box = layout.box,
             nodes = layout.nodes as Array<PackedBubblePoint>,
             nodesLength = nodes.length + 1,
-            angle = 2 * Math.PI / nodesLength,
-            radius = layout.options.initialPositionRadius;
+            angle = 2 * Math.PI / nodesLength;
 
         let centerX: number,
             centerY: number,
-            index = 0;
+            index = 0,
+            radius = layout.options.initialPositionRadius;
 
         for (const node of nodes) {
+            const isParentNode = node.isParentNode;
             if (
                 layout.options.splitSeries &&
-                !node.isParentNode
+                !isParentNode
             ) {
                 centerX = (node.series.parentNode as any).plotX;
                 centerY = (node.series.parentNode as any).plotY;
             } else {
+                if (isParentNode) {
+                    radius = node
+                        .series
+                        .options
+                        ?.layoutAlgorithm
+                        ?.initialPositionRadius ||
+                        radius;
+                }
+
                 centerX = box.width / 2;
                 centerY = box.height / 2;
             }

--- a/ts/masters/modules/boost.src.ts
+++ b/ts/masters/modules/boost.src.ts
@@ -25,6 +25,7 @@ Boost.compose(
     G.Axis,
     G.Series,
     G.seriesTypes,
+    G.Point,
     G.Color
 );
 


### PR DESCRIPTION
Fixed #22515, boosted points had different click-events from non-boost

FYI: I have removed `highcharts-tracker` class from `boost.target`. This feels like a radical move, and I'm not totally sure what may break because of this :grimacing: