### PR TITLE
bugfix/22516-boost-state-inactive

### DIFF
--- a/samples/unit-tests/halo/integration/demo.js
+++ b/samples/unit-tests/halo/integration/demo.js
@@ -47,25 +47,31 @@ QUnit.test('visibility', assert => {
     );
 });
 
-QUnit.test('Halo with boost module, #12870', assert => {
+QUnit.test('Halo with boost module', assert => {
     const chart = Highcharts.chart('container', {
-        xAxis: {
-            min: -5,
-            max: 5
-        },
-        series: [
-            {
-                boostThreshold: 1,
-                marker: {
-                    radius: 75
-                },
-                data: [2]
-            }
-        ]
-    });
+            xAxis: {
+                min: -5,
+                max: 5
+            },
+            plotOptions: {
+                series: {
+                    boostThreshold: 2,
+                    marker: {
+                        radius: 20
+                    }
+                }
+            },
+            series: [{
+                data: [2, 3]
+            }, {
+                data: [3, 2]
+            }, {
+                data: [2.5]
+            }]
+        }),
+        series = chart.series[0],
+        controller = new TestController(chart);
 
-    const series = chart.series[0];
-    const controller = new TestController(chart);
     controller.mouseMove(
         series.points[0].plotX + chart.plotLeft,
         series.points[0].plotY + chart.plotTop
@@ -73,6 +79,18 @@ QUnit.test('Halo with boost module, #12870', assert => {
 
     assert.ok(
         !!series.halo,
-        'Should have created a halo object on Series after hover'
+        'Should have created a halo object on Series after hover (#12870)'
+    );
+
+    assert.strictEqual(
+        series.markerGroup.element.getAttribute('opacity'),
+        '1',
+        'Boosted series sharing markerGroup should not be inactive on hover'
+    );
+
+    assert.notEqual(
+        +chart.series[2].markerGroup.element.getAttribute('opacity'),
+        1,
+        'Series not sharing markerGroup should be inactive on hover'
     );
 });

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -185,13 +185,12 @@ class Pointer {
      * @param {Array<Highcharts.Point>} points
      * Currently hovered points
      */
-    public applyInactiveState(points: Array<Point>): void {
-        let activeSeries = [] as Array<Series>,
-            series: Series;
+    public applyInactiveState(points: Array<Point> = []): void {
+        let activeSeries: Array<Series> = [];
 
         // Get all active series from the hovered points
-        (points || []).forEach(function (item): void {
-            series = item.series;
+        points.forEach((item): void => {
+            const series = item.series;
 
             // Include itself
             activeSeries.push(series);
@@ -212,15 +211,24 @@ class Pointer {
             if (series.navigatorSeries) {
                 activeSeries.push(series.navigatorSeries);
             }
+
+            // Include boosed series when they share markerGroup
+            if (series.boosted && series.markerGroup) {
+                activeSeries = activeSeries.concat(
+                    this.chart.series.filter(function (otherSeries): boolean {
+                        return otherSeries.markerGroup === series.markerGroup;
+                    })
+                );
+            }
         });
         // Now loop over all series, filtering out active series
-        this.chart.series.forEach(function (inactiveSeries): void {
-            if (activeSeries.indexOf(inactiveSeries) === -1) {
+        this.chart.series.forEach(function (series): void {
+            if (activeSeries.indexOf(series) === -1) {
                 // Inactive series
-                inactiveSeries.setState('inactive', true);
-            } else if (inactiveSeries.options.inactiveOtherPoints) {
+                series.setState('inactive', true);
+            } else if (series.options.inactiveOtherPoints) {
                 // Active series, but other points should be inactivated
-                inactiveSeries.setAllPointsToState('inactive');
+                series.setAllPointsToState('inactive');
             }
         });
     }
@@ -1496,7 +1504,7 @@ class Pointer {
 
     /**
      * Reset the tracking by hiding the tooltip, the hover series state and the
-     * hover point
+     * hover point.
      *
      * @function Highcharts.Pointer#reset
      *
@@ -1505,6 +1513,7 @@ class Pointer {
      * possible.
      *
      * @param {number} [delay]
+     * The tooltip hide delay in ms.
      */
     public reset(allowMove?: boolean, delay?: number): void {
         const pointer = this,

--- a/ts/Core/Pointer.ts
+++ b/ts/Core/Pointer.ts
@@ -186,7 +186,7 @@ class Pointer {
      * Currently hovered points
      */
     public applyInactiveState(points: Array<Point> = []): void {
-        let activeSeries: Array<Series> = [];
+        const activeSeries: Array<Series> = [];
 
         // Get all active series from the hovered points
         points.forEach((item): void => {
@@ -202,9 +202,7 @@ class Pointer {
 
             // Include all child series
             if (series.linkedSeries) {
-                activeSeries = activeSeries.concat(
-                    series.linkedSeries
-                );
+                activeSeries.push.apply(activeSeries, series.linkedSeries);
             }
 
             // Include navigator series
@@ -214,15 +212,16 @@ class Pointer {
 
             // Include boosed series when they share markerGroup
             if (series.boosted && series.markerGroup) {
-                activeSeries = activeSeries.concat(
-                    this.chart.series.filter(function (otherSeries): boolean {
-                        return otherSeries.markerGroup === series.markerGroup;
-                    })
+                activeSeries.push.apply(
+                    activeSeries,
+                    this.chart.series.filter((otherSeries): boolean =>
+                        otherSeries.markerGroup === series.markerGroup
+                    )
                 );
             }
         });
         // Now loop over all series, filtering out active series
-        this.chart.series.forEach(function (series): void {
+        this.chart.series.forEach((series): void => {
             if (activeSeries.indexOf(series) === -1) {
                 // Inactive series
                 series.setState('inactive', true);


### PR DESCRIPTION
Fixed #22516, prevented inactive state for series with shared `markerGroup` when hovering a boosted series.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209142462125420