### PR TITLE
bugfix/21375 last label hidden

### DIFF
--- a/samples/unit-tests/axis/ticks/demo.js
+++ b/samples/unit-tests/axis/ticks/demo.js
@@ -1279,13 +1279,11 @@ QUnit.test('Tick and label overflow (#16307)', assert => {
         '... but the last tick label should be visible (#20375)'
     );
 
-    /*
     chart.redraw();
     assert.strictEqual(
         chart.xAxis[0].ticks['11'].mark.opacity,
         0,
         'After redraw, the last tick mark should still not be visible'
     );
-    */
 
 });

--- a/samples/unit-tests/axis/ticks/demo.js
+++ b/samples/unit-tests/axis/ticks/demo.js
@@ -1239,3 +1239,53 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test('Tick and label overflow (#16307)', assert => {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            width: 600,
+            marginRight: 50
+        },
+        xAxis: {
+            categories: [
+                'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep',
+                'Oct', 'Nov', 'Dec'
+            ],
+            tickLength: 10,
+            tickWidth: 1
+        },
+        series: [{
+            data: [
+                29.9, 71.5, 106.4, 129.2, 144.0,
+                176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4
+            ]
+        }],
+        plotOptions: {
+            series: {
+                pointPlacement: 'on'
+            }
+        }
+    });
+
+    assert.strictEqual(
+        chart.xAxis[0].ticks['11'].mark.opacity,
+        0,
+        'The last tick mark should not be visible (#20166)'
+    );
+
+    assert.strictEqual(
+        chart.xAxis[0].ticks['11'].label.opacity,
+        1,
+        '... but the last tick label should be visible (#20375)'
+    );
+
+    /*
+    chart.redraw();
+    assert.strictEqual(
+        chart.xAxis[0].ticks['11'].mark.opacity,
+        0,
+        'After redraw, the last tick mark should still not be visible'
+    );
+    */
+
+});

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -822,6 +822,12 @@ class Tick {
             axisEnd = axisStart + axis.len,
             pxPos = horiz ? x : y;
 
+        const labelOpacity = pick(
+            opacity,
+            tick.label?.newOpacity, // #15528
+            1
+        );
+
         // Anything that is not between `axis.pos` and `axis.pos + axis.length`
         // should not be visible (#20166). The `correctFloat` is for reversed
         // axes in Safari.
@@ -833,12 +839,7 @@ class Tick {
             opacity = 0;
         }
 
-        const labelOpacity = pick(
-            opacity,
-            tick.label?.newOpacity, // #15528
-            1
-        );
-        opacity = pick(opacity, 1);
+        opacity ??= 1;
         this.isActive = true;
 
         // Create the grid line

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -833,7 +833,6 @@ class Tick {
         // axes in Safari.
         if (
             !axis.chart.polar &&
-            tick.isNew &&
             (correctFloat(pxPos) < axisStart || pxPos > axisEnd)
         ) {
             opacity = 0;


### PR DESCRIPTION
Fixed #21375, a regression causing the last axis label missing when `pointPlacement` was `on`


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207652309390848