### PR TITLE
tests/cy-ellipse-utils-edit

### DIFF
--- a/test/cypress/highcharts/integration/annotations/ellipse/ellipse.cy.js
+++ b/test/cypress/highcharts/integration/annotations/ellipse/ellipse.cy.js
@@ -157,8 +157,8 @@ describe('Stock tools Ellipse Annotation, #15008', () => {
     });
 
     it('Ellipse should keep its shape after popup edit.', () => {
-        cy.contains('Edit').click();
-        cy.contains('Save').click();
+        cy.get('.highcharts-popup').contains('Edit').click();
+        cy.get('.highcharts-popup').contains('Save').click();
         cy.chart().then(chart => {
 
             const ellipse = chart.annotations[0].shapes[0];


### PR DESCRIPTION
Fixed test after edit mode update for the utils.
The test was finding the first matching element which is now, after the utils edit mode update, a hidden GUI button for the edit.