### PR TITLE
grid/pro-transition-period

### DIFF
--- a/.github/workflows/dashboards-lighthouse-test.yml
+++ b/.github/workflows/dashboards-lighthouse-test.yml
@@ -1,4 +1,4 @@
-name: Dashboards lighthouse tests
+name: Dashboards and Grid lighthouse tests
 on:
   pull_request:
     branches:
@@ -45,6 +45,8 @@ jobs:
 
       - name: Build Highcharts
         run: npx gulp scripts
+      - name: Build Grid
+        run: npx gulp scripts --product Grid
       - name: Build Dashboards
         run: npx gulp dashboards/scripts
 
@@ -87,6 +89,9 @@ jobs:
 
       - name: Build Highcharts
         run: npx gulp scripts
+
+      - name: Build Grid
+        run: npx gulp scripts --product Grid
 
       - name: Build Dashboards
         run: npx gulp dashboards/scripts

--- a/.github/workflows/dashboards-test.yml
+++ b/.github/workflows/dashboards-test.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Dashboards Test
+name: Dashboards and Grid Test
 
 # Controls when the workflow will run
 on:
@@ -47,6 +47,9 @@ jobs:
 
       - name: Build Highcharts definitions
         run: npx gulp jsdoc-dts
+
+      - name: Build Grid
+        run: npx gulp scripts --product Grid
 
       - name: Run Dashboards Tests
         run: npx gulp dashboards/test

--- a/css/grid/grid.css
+++ b/css/grid/grid.css
@@ -1,5 +1,5 @@
 /**
- * @license Highcharts Dashboards v@product.version@
+ * @license Highcharts Grid v@product.version@
  *
  * (c) 2009-2023 Highsoft AS
  *
@@ -82,7 +82,7 @@
     --highcharts-highlight-color-10: rgb(58, 63, 71);
 }
 
-/*  ==== Start DataGrid Color Scheme  ==== */
+/*  ==== Start Grid Color Scheme  ==== */
 .hcg-container {
     --idg-default-color: #000000;
     --idg-negative-default-border-color: hsl(0, 100%, 50%);
@@ -105,11 +105,11 @@
     }
 }
 
-/*  ==== End DataGrid Color Scheme  ==== */
+/*  ==== End Grid Color Scheme  ==== */
 
 /* stylelint-disable max-line-length */
 
-/* ==== Start DataGrid Variables ==== */
+/* ==== Start Grid Variables ==== */
 .hcg-container {
     --idg-table-border-radius: var(--hcdg-border-radius, 0);
 
@@ -282,7 +282,7 @@
     box-sizing: border-box;
 }
 
-/* ==== End DataGrid Variables ==== */
+/* ==== End Grid Variables ==== */
 
 .hcg-container * {
     box-sizing: border-box;
@@ -662,7 +662,7 @@ th.hcg-column-sortable > .hcg-column-sortable-icon {
     padding: var(--idg-credits-padding);
 }
 
-/* Start DataGrid CSS Helpers Classes */
+/* Start Grid CSS Helpers Classes */
 .hcg-table tbody tr td.hcdg-negative,
 .hcg-table tbody tr:has(.hcdg-negative-row) td {
     box-shadow: inset 0 0 0 var(--idg-negative-border-size) var(--idg-negative-border-color) !important;
@@ -737,10 +737,10 @@ th.hcg-column-sortable > .hcg-column-sortable-icon {
     }
 }
 
-/* End DataGrid CSS Helpers Classes */
+/* End Grid CSS Helpers Classes */
 
-/* Start DataGrid Default Theme */
-.hcdg-theme-default {
+/* Start Grid Default Theme */
+.hcg-theme-default {
     --hcdg-border-radius: 5px;
     --hcdg-color: var(--highcharts-neutral-color-100);
     --hcdg-padding: 8px;
@@ -762,4 +762,4 @@ th.hcg-column-sortable > .hcg-column-sortable-icon {
     --hcdg-header-cell-hovered-background: var(--highcharts-highlight-color-20);
 }
 
-/* End DataGrid Default Theme */
+/* End Grid Default Theme */

--- a/test/typescript-dts/dashboards/dashboards.ts
+++ b/test/typescript-dts/dashboards/dashboards.ts
@@ -7,6 +7,7 @@
  * */
 
 import * as Dashboards from "@highcharts/dashboards";
+import * as Grid from '@highcharts/dashboards/datagrid';
 
 test_board();
 

--- a/test/typescript-dts/dashboards/dashboards.ts
+++ b/test/typescript-dts/dashboards/dashboards.ts
@@ -10,6 +10,7 @@ import * as Dashboards from "@highcharts/dashboards";
 import * as Grid from '@highcharts/dashboards/datagrid';
 
 test_board();
+test_grid();
 
 /**
  * Tests board options.
@@ -45,6 +46,37 @@ function test_board() {
                 }
             }
         }]
+    });
+}
+
+/**
+ * Tests grid options.
+ */
+function test_grid() {
+    Grid.grid('container', {
+        dataTable: {
+            columns: {
+                a: new Float32Array([1, 2, 3]),
+            }
+        },
+        columnDefaults: {
+            cells: {
+                editable: true
+            }
+        },
+        columns: [{
+            id: 'a',
+            cells: {
+                editable: true
+            }
+        }],
+        events: {
+            column: {
+                afterResize: function () {
+                    console.log(this.viewport.dataGrid);
+                }
+            }
+        }
     });
 }
 

--- a/tools/gulptasks/dashboards/lint.js
+++ b/tools/gulptasks/dashboards/lint.js
@@ -14,7 +14,7 @@ const { lintDTS } = require('../lint-dts');
 const { lintTS } = require('../lint-ts');
 
 gulp.task('dashboards/lint', gulp.series(
-    () => lintTS({ datagrid: true }),
+    () => lintTS({ product: 'Grid' }),
     () => lintTS({ dashboards: true }),
     () => lintDTS({ dashboards: true })
 ));

--- a/tools/gulptasks/dashboards/scripts-dts/datagrid.src.d.ts
+++ b/tools/gulptasks/dashboards/scripts-dts/datagrid.src.d.ts
@@ -4,9 +4,13 @@
  *
  *!*/
 
-import Grid from "./es-modules/Grid/Core/Grid";
-import Globals from "./es-modules/Grid/Core/Globals";
-import Defaults from "./es-modules/Grid/Core/Defaults";
+import Grid from './es-modules/Grid/Core/Grid';
+import Globals from './es-modules/Grid/Core/Globals';
+import Defaults from './es-modules/Grid/Core/Defaults';
+
+import './es-modules/Grid/Pro/GridEvents';
+import './es-modules/Grid/Pro/CellEditing/CellEditingComposition';
+import './es-modules/Grid/Pro/Dash3Compatibility';
 
 export { /** @deprecated Use `Grid` instead. */ default as DataGrid } from './es-modules/Grid/Core/Grid.js';
 export { default as Grid } from './es-modules/Grid/Core/Grid.js';
@@ -15,13 +19,13 @@ export { default as TableRow } from './es-modules/Grid/Core/Table/Content/TableR
 export { default as TableCell } from './es-modules/Grid/Core/Table/Content/TableCell.js';
 export { default as Options } from './es-modules/Grid/Core/Options.js';
 
-export { default as DataConnector } from "./es-modules/Data/Connectors/DataConnector";
-export { default as DataConverter } from "./es-modules/Data/Converters/DataConverter";
-export { default as DataCursor } from "./es-modules/Data/DataCursor";
-export { default as DataEvent } from "./es-modules/Data/DataEvent";
-export { default as DataModifier } from "./es-modules/Data/Modifiers/DataModifier";
-export { default as DataPool } from "./es-modules/Data/DataPool";
-export { default as DataTable } from "./es-modules/Data/DataTable";
+export { default as DataConnector } from './es-modules/Data/Connectors/DataConnector';
+export { default as DataConverter } from './es-modules/Data/Converters/DataConverter';
+export { default as DataCursor } from './es-modules/Data/DataCursor';
+export { default as DataEvent } from './es-modules/Data/DataEvent';
+export { default as DataModifier } from './es-modules/Data/Modifiers/DataModifier';
+export { default as DataPool } from './es-modules/Data/DataPool';
+export { default as DataTable } from './es-modules/Data/DataTable';
 
 /** @deprecated Use `grid` instead. */
 export const dataGrid: typeof Grid.grid;

--- a/tools/gulptasks/dashboards/scripts-dts/datagrid.src.d.ts
+++ b/tools/gulptasks/dashboards/scripts-dts/datagrid.src.d.ts
@@ -4,11 +4,12 @@
  *
  *!*/
 
-import DataGrid from "./es-modules/Grid/Pro/GridPro";
-import Globals from "./es-modules/Grid/Pro/GridProGlobals";
+import Grid from "./es-modules/Grid/Core/Grid";
+import Globals from "./es-modules/Grid/Core/Globals";
 import Defaults from "./es-modules/Grid/Core/Defaults";
 
-export { default as DataGrid } from './es-modules/Grid/Pro/GridPro.js';
+export { /** @deprecated Use `Grid` instead. */ default as DataGrid } from './es-modules/Grid/Core/Grid.js';
+export { default as Grid } from './es-modules/Grid/Core/Grid.js';
 export { default as Column } from './es-modules/Grid/Core/Table/Column.js';
 export { default as TableRow } from './es-modules/Grid/Core/Table/Content/TableRow.js';
 export { default as TableCell } from './es-modules/Grid/Core/Table/Content/TableCell.js';
@@ -22,10 +23,17 @@ export { default as DataModifier } from "./es-modules/Data/Modifiers/DataModifie
 export { default as DataPool } from "./es-modules/Data/DataPool";
 export { default as DataTable } from "./es-modules/Data/DataTable";
 
-export const dataGrid: typeof DataGrid.grid;
-export const dataGrids: typeof DataGrid.grids;
+/** @deprecated Use `grid` instead. */
+export const dataGrid: typeof Grid.grid;
+/** @deprecated Use `grids` instead. */
+export const dataGrids: typeof Grid.grids;
+export const grid: typeof Grid.grid;
+export const grids: typeof Grid.grids;
+export const product: 'Grid Pro';
 export const defaultOptions: typeof Defaults.defaultOptions;
 export const setOptions: typeof Defaults.setOptions;
 export const win: typeof Globals.win;
 
+/** @deprecated Use `Grid` instead. */
 export as namespace DataGrid;
+export as namespace Grid;

--- a/tools/gulptasks/lint-ts.js
+++ b/tools/gulptasks/lint-ts.js
@@ -43,9 +43,6 @@ function lintTS(argv) {
         if (argv.dashboards) {
             product = 'Dashboards';
             productTSFolder = './ts/Dashboards';
-        } else if (argv.datagrid) {
-            product = 'DataGrid';
-            productTSFolder = './ts/DataGrid';
         } else if (product === 'Grid') {
             productTSFolder = './ts/Grid';
         }

--- a/ts/Grid/Core/Credits.ts
+++ b/ts/Grid/Core/Credits.ts
@@ -49,17 +49,17 @@ class Credits {
     /**
      * The Grid instance which the credits belong to.
      */
-    public grid: Grid;
+    public readonly grid: Grid;
 
     /**
      * The credits container HTML element.
      */
-    public containerElement: HTMLElement;
+    public readonly containerElement: HTMLElement;
 
     /**
      * The credits content HTML element.
      */
-    public textElement: HTMLElement;
+    public readonly textElement: HTMLElement;
 
     /**
      * The options for the credits.

--- a/ts/Grid/Core/Grid.ts
+++ b/ts/Grid/Core/Grid.ts
@@ -134,6 +134,7 @@ class Grid {
 
     /**
      * An array containing the current Grid objects in the page.
+     * @internal
      */
     public static readonly grids: Array<(Grid|undefined)> = [];
 

--- a/ts/Grid/Core/Options.ts
+++ b/ts/Grid/Core/Options.ts
@@ -307,15 +307,6 @@ export interface ColumnCellOptions {
     className?: string;
 
     /**
-     * Whether to make the column cells editable `true`, or read-only `false`.
-     *
-     * Try it: {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/grid/basic/overview | Editable columns disabled}
-     *
-     * @default true
-     */
-    editable?: boolean;
-
-    /**
      * The format of the cell content within the given column of the grid.
      * Applied only to cell that are in the table, not in the column header.
      *

--- a/ts/Grid/Pro/CellEditing/CellEditingComposition.ts
+++ b/ts/Grid/Pro/CellEditing/CellEditingComposition.ts
@@ -289,6 +289,19 @@ declare module '../../Core/Accessibility/A11yOptions' {
     }
 }
 
+declare module '../../Core/Options' {
+    interface ColumnCellOptions {
+        /**
+         * Whether to make the column cells editable `true`, or read-only `false`.
+         *
+         * Try it: {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/grid/basic/overview | Editable columns disabled}
+         *
+         * @default true
+         */
+        editable?: boolean;
+    }
+}
+
 /**
  * The possible types of the edit message.
  */

--- a/ts/Grid/Pro/CellEditing/CellEditingComposition.ts
+++ b/ts/Grid/Pro/CellEditing/CellEditingComposition.ts
@@ -167,7 +167,10 @@ namespace CellEditingComposition {
         const editableLang = this.row.viewport.grid.options
             ?.lang?.accessibility?.cellEditing?.editable;
 
-        if (!editableLang) {
+        if (
+            !this.column.options.cells?.editable ||
+            !editableLang
+        ) {
             return;
         }
 

--- a/ts/Grid/Pro/Dash3Compatibility.ts
+++ b/ts/Grid/Pro/Dash3Compatibility.ts
@@ -1,0 +1,87 @@
+/* *
+ *
+ *  (c) 2020-2024 Highsoft AS
+ *
+ *  License: www.highcharts.com/license
+ *
+ *  !!!!!!! SOURCE GETS TRANSPILED BY TYPESCRIPT. EDIT TS FILE ONLY. !!!!!!!
+ *
+ *  Authors:
+ *  - Dawid Dragula
+ *
+ * */
+
+'use strict';
+
+/* *
+ *
+ *  Imports
+ *
+ * */
+
+import type Grid from '../Core/Grid';
+import type Table from '../Core/Table/Table';
+
+import U from '../../Core/Utilities.js';
+import Globals from '../../Core/Globals.js';
+
+const {
+    pushUnique
+} = U;
+
+
+/* *
+ *
+ *  Functions
+ *
+ * */
+
+/**
+ * Composition to add compatibility with the old `dataGrid` property.
+ *
+ * @param TableClass
+ * The class to extend.
+ */
+function compose(
+    TableClass: typeof Table
+): void {
+
+    if (!pushUnique(Globals.composed, 'Dash3Compatibility')) {
+        return;
+    }
+
+    Object.defineProperty(TableClass.prototype, 'dataGrid', {
+        get: function (this: Table): Grid {
+            return this.grid;
+        },
+        configurable: true,
+        enumerable: false
+    });
+
+}
+
+
+/* *
+ *
+ *  Declarations
+ *
+ * */
+
+declare module '../Core/Table/Table' {
+    export default interface Table {
+        /**
+         * Deprecated. Use `grid` instead.
+         * @deprecated
+         */
+        readonly dataGrid: Grid;
+    }
+}
+
+
+/* *
+ *
+ *  Default Export
+ *
+ * */
+
+export default { compose };

--- a/ts/Grid/Pro/GridEvents.ts
+++ b/ts/Grid/Pro/GridEvents.ts
@@ -19,8 +19,8 @@
  *
  * */
 
-import Column from '../Core/Table/Column';
-import TableCell from '../Core/Table/Content/TableCell';
+import type Column from '../Core/Table/Column';
+import type TableCell from '../Core/Table/Content/TableCell';
 import type HeaderCell from '../Core/Table/Header/HeaderCell';
 import type { GridEvent } from '../Core/GridUtils';
 
@@ -67,7 +67,7 @@ declare module '../Core/Options' {
  * @param TableCellClass
  * The class to extend.
  *
- * @private
+ * @internal
  */
 function compose(
     ColumnClass: typeof Column,

--- a/ts/masters-datagrid/datagrid.src.ts
+++ b/ts/masters-datagrid/datagrid.src.ts
@@ -37,6 +37,7 @@ import TableCell from '../Grid/Core/Table/Content/TableCell.js';
 
 import GridEvents from '../Grid/Pro/GridEvents.js';
 import CellEditingComposition from '../Grid/Pro/CellEditing/CellEditingComposition.js';
+import Dash3Compatibility from '../Grid/Pro/Dash3Compatibility.js';
 
 // Fill registries
 import '../Data/Connectors/CSVConnector.js';
@@ -135,6 +136,7 @@ G.TableCell = G.TableCell || TableCell;
 
 GridEvents.compose(G.Column, G.HeaderCell, G.TableCell);
 CellEditingComposition.compose(G.Table, G.TableCell);
+Dash3Compatibility.compose(G.Table);
 
 
 /* *

--- a/ts/masters-datagrid/datagrid.src.ts
+++ b/ts/masters-datagrid/datagrid.src.ts
@@ -61,9 +61,21 @@ declare global {
         product: 'Grid Pro';
         AST: typeof AST;
         classNamePrefix: typeof Globals.classNamePrefix;
+        /**
+         * @deprecated Use `Grid` instead.
+         */
         DataGrid: typeof _Grid;
+        /**
+         * @deprecated Use `grid` instead.
+         */
         dataGrid: typeof _Grid.grid;
+        /**
+         * @deprecated Use `grids` instead.
+         */
         dataGrids: Array<(_Grid|undefined)>;
+        Grid: typeof _Grid;
+        grid: typeof _Grid.grid;
+        grids: Array<(_Grid|undefined)>;
         DataConverter: typeof DataConverter;
         DataCursor: typeof DataCursor;
         DataModifier: typeof DataModifier;
@@ -79,9 +91,12 @@ declare global {
         TableCell: typeof TableCell;
     }
     interface Window {
+        /**
+         * @deprecated Use `Grid` instead.
+         */
         DataGrid: DataGridNamespace;
+        Grid: DataGridNamespace;
     }
-    let DataGrid: DataGridNamespace;
 }
 
 
@@ -102,6 +117,9 @@ G.DataConverter = DataConverter;
 G.DataGrid = _Grid;
 G.dataGrid = _Grid.grid;
 G.dataGrids = _Grid.grids;
+G.Grid = _Grid;
+G.grid = _Grid.grid;
+G.grids = _Grid.grids;
 G.DataModifier = DataModifier;
 G.DataPool = DataPool;
 G.DataTable = DataTable;
@@ -128,6 +146,10 @@ CellEditingComposition.compose(G.Table, G.TableCell);
 
 if (!G.win.DataGrid) {
     G.win.DataGrid = G;
+}
+
+if (!G.win.Grid) {
+    G.win.Grid = G;
 }
 
 


### PR DESCRIPTION
Made improvements focusing on Grid Pro and its integration with Dashboards (keeping the DataGridComponent naming). Added Grid aliases to the Grid Pro Dashboards package, deprecated references to dataGrid that are not directly related to Dashboards. Updated Github Actions for Dashboards to also build the Grid Lite.