### PR TITLE
bugfix/22235-geoheatmap-decimal-issues

### DIFF
--- a/ts/Accessibility/HighContrastMode.ts
+++ b/ts/Accessibility/HighContrastMode.ts
@@ -61,6 +61,12 @@ declare module '../Core/Series/PointLike' {
  * @return {boolean} Returns true if the browser is in High Contrast mode.
  */
 function isHighContrastModeActive(): boolean {
+    // Use media query on Edge, but not on IE
+    const isEdge = /(Edg)/.test(win.navigator.userAgent);
+    if (win.matchMedia && isEdge) {
+        return win.matchMedia('(-ms-high-contrast: active)').matches;
+    }
+
     // Test BG image for IE
     if (isMS && win.getComputedStyle) {
         const testDiv = doc.createElement('div');

--- a/ts/Accessibility/HighContrastMode.ts
+++ b/ts/Accessibility/HighContrastMode.ts
@@ -61,12 +61,6 @@ declare module '../Core/Series/PointLike' {
  * @return {boolean} Returns true if the browser is in High Contrast mode.
  */
 function isHighContrastModeActive(): boolean {
-    // Use media query on Edge, but not on IE
-    const isEdge = /(Edg)/.test(win.navigator.userAgent);
-    if (win.matchMedia && isEdge) {
-        return win.matchMedia('(-ms-high-contrast: active)').matches;
-    }
-
     // Test BG image for IE
     if (isMS && win.getComputedStyle) {
         const testDiv = doc.createElement('div');

--- a/ts/Series/GeoHeatmap/GeoHeatmapSeries.ts
+++ b/ts/Series/GeoHeatmap/GeoHeatmapSeries.ts
@@ -340,12 +340,15 @@ class GeoHeatmapSeries extends MapSeries {
                 });
 
             if (canvas && ctx && colorAxis && topLeft && bottomRight) {
-                const dimensions = {
-                    x: topLeft.x,
-                    y: topLeft.y,
-                    width: bottomRight.x - topLeft.x,
-                    height: bottomRight.y - topLeft.y
-                };
+                const
+                    { x, y } = topLeft,
+                    [width, height] = [bottomRight.x - x, bottomRight.y - y],
+                    dimensions = {
+                        x,
+                        y,
+                        width,
+                        height
+                    };
 
                 if (
                     // Do not calculate new canvas if not necessary
@@ -355,27 +358,50 @@ class GeoHeatmapSeries extends MapSeries {
                     // Always calculate new canvas for Orthographic projection
                     mapView.projection.options.name === 'Orthographic'
                 ) {
-                    series.isDirtyCanvas = true;
                     const canvasWidth = canvas.width = ~~(360 / colsize) + 1,
                         canvasHeight = canvas.height = ~~(180 / rowsize) + 1,
                         canvasArea = canvasWidth * canvasHeight,
-                        pixelData = new Uint8ClampedArray(canvasArea * 4);
-                    series.directTouch = false; // Needed for tooltip
+                        pixelData = new Uint8ClampedArray(canvasArea * 4),
+                        // Guess if we have to round lon/lat with this data
+                        { lat = 0, lon = 0 } = points[0].options,
+                        getAdjustedLon = (
+                            lon - rowsize !== 0 ?
+                                (lon: number): number => (
+                                    Math.round(lon / rowsize) * rowsize
+                                ) :
+                                (lon: number): number => lon
+                        ),
+                        getAdjustedLat = (
+                            lat - colsize !== 0 ?
+                                (lat: number): number => (
+                                    Math.round(lat / colsize) * colsize
+                                ) :
+                                (lat: number): number => lat
+                        ),
+                        pointsLen = points.length;
+                        // SourceArr = new Uint8ClampedArray(4);
+
+                    // Needed for tooltip
+                    series.directTouch = false;
+                    series.isDirtyCanvas = true;
 
                     // First pixelData represents the geo coordinates
-                    for (let i = 0; i < points.length; i++) {
+                    for (let i = 0; i < pointsLen; i++) {
                         const p = points[i],
-                            sourceArr = new Uint8ClampedArray(
+                            /* SourceArr = new Uint8ClampedArray(
                                 colorFromPoint(p.value, p)
-                            ),
+                            ),*/
                             { lon, lat } = p.options;
-
                         if (isNumber(lon) && isNumber(lat)) {
                             pixelData.set(
-                                sourceArr,
+                                colorFromPoint(p.value, p),
                                 scaledPointPos(
-                                    lon, lat, canvasWidth, canvasHeight,
-                                    colsize, rowsize
+                                    getAdjustedLon(lon),
+                                    getAdjustedLat(lat),
+                                    canvasWidth,
+                                    canvasHeight,
+                                    colsize,
+                                    rowsize
                                 ) * 4
                             );
                         }
@@ -385,8 +411,8 @@ class GeoHeatmapSeries extends MapSeries {
                         blurFactor = blur === 0 ? 1 : blur * 11,
                         upscaledWidth = ~~(canvasWidth * blurFactor),
                         upscaledHeight = ~~(canvasHeight * blurFactor),
-                        projectedWidth = ~~dimensions.width,
-                        projectedHeight = ~~dimensions.height,
+                        projectedWidth = ~~width,
+                        projectedHeight = ~~height,
                         img =
                             new ImageData(pixelData, canvasWidth, canvasHeight);
 
@@ -405,32 +431,35 @@ class GeoHeatmapSeries extends MapSeries {
                     ctx.drawImage(
                         canvas,
                         0, 0, img.width, img.height, // Grab the ImageData
-                        0, 0, canvas.width, canvas.height // Scale it
+                        0, 0, upscaledWidth, upscaledHeight // Scale it
                     );
 
                     // Add projection to upscaled ImageData
-                    const cartesianImageData = ctx.getImageData(
-                            0, 0, canvas.width, canvas.height
-                        ),
+                    const
                         projectedPixelData = this.getProjectedImageData(
                             mapView,
                             projectedWidth,
                             projectedHeight,
-                            cartesianImageData,
+                            ctx.getImageData(
+                                0, 0, upscaledWidth, upscaledHeight
+                            ),
                             canvas,
-                            dimensions.x,
-                            dimensions.y
-                        ),
-                        projectedImg = new ImageData(
+                            x,
+                            y
+                        );
+
+                    canvas.width = projectedWidth;
+                    canvas.height = projectedHeight;
+
+                    ctx.putImageData(
+                        new ImageData(
                             projectedPixelData,
                             projectedWidth,
                             projectedHeight
-                        );
-
-                    ctx.globalCompositeOperation = 'copy';
-                    canvas.width = projectedWidth;
-                    canvas.height = projectedHeight;
-                    ctx.putImageData(projectedImg, 0, 0);
+                        ),
+                        0,
+                        0
+                    );
                 }
 
                 if (image) {
@@ -452,26 +481,27 @@ class GeoHeatmapSeries extends MapSeries {
                             now,
                             fx
                         ): void => {
+                            const pos = fx.pos;
                             image.attr({
                                 x: (
                                     startX + (
-                                        dimensions.x - startX
-                                    ) * fx.pos
+                                        x - startX
+                                    ) * pos
                                 ),
                                 y: (
                                     startY + (
-                                        dimensions.y - startY
-                                    ) * fx.pos
+                                        y - startY
+                                    ) * pos
                                 ),
                                 width: (
                                     startWidth + (
-                                        dimensions.width - startWidth
-                                    ) * fx.pos
+                                        width - startWidth
+                                    ) * pos
                                 ),
                                 height: (
                                     startHeight + (
-                                        dimensions.height - startHeight
-                                    ) * fx.pos
+                                        height - startHeight
+                                    ) * pos
                                 )
                             });
                         };

--- a/ts/Series/GeoHeatmap/GeoHeatmapSeries.ts
+++ b/ts/Series/GeoHeatmap/GeoHeatmapSeries.ts
@@ -51,6 +51,7 @@ const {
 import U from '../../Core/Utilities.js';
 const {
     addEvent,
+    error,
     extend,
     isNumber,
     isObject,
@@ -364,22 +365,30 @@ class GeoHeatmapSeries extends MapSeries {
                         pixelData = new Uint8ClampedArray(canvasArea * 4),
                         // Guess if we have to round lon/lat with this data
                         { lat = 0, lon = 0 } = points[0].options,
+                        unEvenLon = lon - rowsize !== 0,
+                        unEvenLat = lat - colsize !== 0,
                         getAdjustedLon = (
-                            lon - rowsize !== 0 ?
+                            unEvenLon ?
                                 (lon: number): number => (
                                     Math.round(lon / rowsize) * rowsize
                                 ) :
                                 (lon: number): number => lon
                         ),
                         getAdjustedLat = (
-                            lat - colsize !== 0 ?
+                            unEvenLat ?
                                 (lat: number): number => (
                                     Math.round(lat / colsize) * colsize
                                 ) :
                                 (lat: number): number => lat
                         ),
                         pointsLen = points.length;
-                        // SourceArr = new Uint8ClampedArray(4);
+
+                    if (unEvenLon || unEvenLat) {
+                        error(
+                            'For best performance, lon/lat datapoints should ' +
+                            'be spaced by a single colsize/rowsize'
+                        );
+                    }
 
                     // Needed for tooltip
                     series.directTouch = false;

--- a/ts/Series/GeoHeatmap/GeoHeatmapSeries.ts
+++ b/ts/Series/GeoHeatmap/GeoHeatmapSeries.ts
@@ -385,8 +385,15 @@ class GeoHeatmapSeries extends MapSeries {
 
                     if (unEvenLon || unEvenLat) {
                         error(
-                            'For best performance, lon/lat datapoints should ' +
-                            'be spaced by a single colsize/rowsize'
+                            'Highcharts Warning: For best performance,' +
+                            ' lon/lat datapoints should spaced by a single ' +
+                            'colsize/rowsize',
+                            false,
+                            series.chart,
+                            {
+                                colsize: String(colsize),
+                                rowsize: String(rowsize)
+                            }
                         );
                     }
 

--- a/ts/Series/GeoHeatmap/GeoHeatmapSeries.ts
+++ b/ts/Series/GeoHeatmap/GeoHeatmapSeries.ts
@@ -365,8 +365,8 @@ class GeoHeatmapSeries extends MapSeries {
                         pixelData = new Uint8ClampedArray(canvasArea * 4),
                         // Guess if we have to round lon/lat with this data
                         { lat = 0, lon = 0 } = points[0].options,
-                        unEvenLon = lon - rowsize !== 0,
-                        unEvenLat = lat - colsize !== 0,
+                        unEvenLon = lon % rowsize !== 0,
+                        unEvenLat = lat % colsize !== 0,
                         getAdjustedLon = (
                             unEvenLon ?
                                 (lon: number): number => (

--- a/ts/Series/GeoHeatmap/GeoHeatmapSeries.ts
+++ b/ts/Series/GeoHeatmap/GeoHeatmapSeries.ts
@@ -343,7 +343,8 @@ class GeoHeatmapSeries extends MapSeries {
             if (canvas && ctx && colorAxis && topLeft && bottomRight) {
                 const
                     { x, y } = topLeft,
-                    [width, height] = [bottomRight.x - x, bottomRight.y - y],
+                    width = bottomRight.x - x,
+                    height = bottomRight.y - y,
                     dimensions = {
                         x,
                         y,
@@ -404,9 +405,6 @@ class GeoHeatmapSeries extends MapSeries {
                     // First pixelData represents the geo coordinates
                     for (let i = 0; i < pointsLen; i++) {
                         const p = points[i],
-                            /* SourceArr = new Uint8ClampedArray(
-                                colorFromPoint(p.value, p)
-                            ),*/
                             { lon, lat } = p.options;
                         if (isNumber(lon) && isNumber(lat)) {
                             pixelData.set(


### PR DESCRIPTION
Fixed #22235, decimal lon/lat values were not handled correctly

Note that this doesnt "solve" the users problem by itself, he will still be required to set colsize/rowsize as suggested here: https://github.com/highcharts/highcharts/issues/22235#issuecomment-2616053253

This simply is intended to add the desired behavior as described in the post linked above.

It is still desirable to have a colsize/rowsize that is close to the spacing of the datapoints for this rounding to help things.

I have also attempted to optimize the rendering a bit, unsure if this has been noticably succesful, and might detract from readability.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208864527093775