### PR TITLE
Added .highcharts-styled-mode CSS class

### DIFF
--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -704,7 +704,7 @@ circle.highcharts-legend-nav-inactive { /* tracker */
 }
 
 /* Plot bands and polar pane backgrounds */
-.highcharts-plot-band,
+.highcharts-styled-mode .highcharts-plot-band,
 .highcharts-pane {
     fill: var(--highcharts-neutral-color-100);
     fill-opacity: 0.05;

--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -248,7 +248,7 @@
     font-size: 0.8em;
 }
 
-.highcharts-styled-mode .highcharts-axis-labels {
+.highcharts-axis-labels text {
     fill: var(--highcharts-neutral-color-80);
     cursor: default;
     font-size: 0.8em;

--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -248,7 +248,7 @@
     font-size: 0.8em;
 }
 
-.highcharts-axis-labels {
+.highcharts-styled-mode .highcharts-axis-labels {
     fill: var(--highcharts-neutral-color-80);
     cursor: default;
     font-size: 0.8em;

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -227,7 +227,9 @@ class SVGRenderer implements SVGRendererLike {
                 }),
             element = boxWrapper.element as SVGDOMElement;
 
-        if (!styledMode) {
+        if (styledMode) {
+            boxWrapper.addClass('highcharts-styled-mode');
+        } else {
             boxWrapper.css(this.getStyle(style || {}));
         }
 


### PR DESCRIPTION
Added a top-level class `.highcharts-styled-mode` for better control of CSS, allowing rules to apply only when `chart.styledMode` is true.

Potentially fixes #22688 and similar.