### PR TITLE
bugfix/22563-ms-high-contrast-deprecated

### DIFF
--- a/ts/Accessibility/HighContrastMode.ts
+++ b/ts/Accessibility/HighContrastMode.ts
@@ -61,12 +61,6 @@ declare module '../Core/Series/PointLike' {
  * @return {boolean} Returns true if the browser is in High Contrast mode.
  */
 function isHighContrastModeActive(): boolean {
-    // Use media query on Edge, but not on IE
-    const isEdge = /(Edg)/.test(win.navigator.userAgent);
-    if (win.matchMedia && isEdge) {
-        return win.matchMedia('(-ms-high-contrast: active)').matches;
-    }
-
     // Test BG image for IE
     if (isMS && win.getComputedStyle) {
         const testDiv = doc.createElement('div');


### PR DESCRIPTION
Fixed #22563 , checking for 'ms-high-contrast' generated a warning

"forced-colors" works now for Edge as well so no need to specifically detect edge and 'ms-high-contrast'

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209225113782221