### PR TITLE
bugfix/22599-fix-FormatterCallbackFunction--typing

### DIFF
--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1864,7 +1864,7 @@ namespace Tooltip {
         (
             this: Point,
             tooltip: Tooltip
-        ): (false|string|Array<string>);
+        ): (false|string|Array<(boolean | string)>);
     }
 
     export interface HeaderFormatterEventObject {


### PR DESCRIPTION
Fixed #22599, added boolean array to formatter callback function interface return type