### PR TITLE
Fixed #22764, axis labels with useHTML got wrapped

### DIFF
--- a/samples/unit-tests/axis/labels-usehtml/demo.js
+++ b/samples/unit-tests/axis/labels-usehtml/demo.js
@@ -33,6 +33,11 @@ QUnit.test('Auto rotation and wrapping', function (assert) {
         'Initially not rotated'
     );
 
+    assert.ok(
+        xAxis.ticks[xAxis.tickPositions[2]].label.getBBox().height < 20,
+        'The label should not be wrapped (#22764)'
+    );
+
     chart.setSize(400, 300);
     assert.strictEqual(
         xAxis.ticks[xAxis.tickPositions[0]].label.rotation,

--- a/ts/Core/Axis/Tick.ts
+++ b/ts/Core/Axis/Tick.ts
@@ -387,6 +387,7 @@ class Tick {
     ): (SVGElement|undefined) {
         const axis = this.axis,
             { renderer, styledMode } = axis.chart,
+            whiteSpace = labelOptions.style.whiteSpace,
             label = defined(str) && labelOptions.enabled ?
                 renderer
                     .text(
@@ -400,13 +401,13 @@ class Tick {
 
         // Un-rotated length
         if (label) {
-            const whiteSpace = labelOptions.style.whiteSpace || 'normal';
-            // Without position absolute, IE export sometimes is wrong
             if (!styledMode) {
-                label.css(merge(labelOptions.style, { whiteSpace: 'nowrap' }));
+                label.css(merge(labelOptions.style));
             }
             label.textPxLength = label.getBBox().width;
-            if (!styledMode) {
+
+            // Apply the white-space setting after we read the full text width
+            if (!styledMode && whiteSpace) {
                 label.css({ whiteSpace });
             }
         }


### PR DESCRIPTION
Fixed #22764, a regression causing axis labels with `useHTML` to wrap when not needed