### PR TITLE
Samples: Removed useHTML=true where not necessary

### DIFF
--- a/samples/dashboards/components/climate-all/demo.js
+++ b/samples/dashboards/components/climate-all/demo.js
@@ -293,8 +293,7 @@ async function setupBoard() {
                 },
                 tooltip: {
                     shape: 'rect',
-                    distance: -60,
-                    useHTML: true
+                    distance: -60
                 }
             }
         }, {

--- a/samples/dashboards/demo/accounting/demo.css
+++ b/samples/dashboards/demo/accounting/demo.css
@@ -95,6 +95,10 @@
     display: none;
 }
 
+.highcharts-gauge-series .highcharts-data-label text {
+    font-size: 1em;
+}
+
 .highcharts-gauge-series .highcharts-pivot,
 .highcharts-gauge-series .highcharts-dial {
     fill: var(--highcharts-neutral-color-60);

--- a/samples/dashboards/demo/accounting/demo.js
+++ b/samples/dashboards/demo/accounting/demo.js
@@ -49,7 +49,6 @@ const commonGaugeOptions = {
                 radius: 5
             },
             dataLabels: {
-                useHTML: true,
                 format: '${y}M'
             }
         }

--- a/samples/dashboards/demo/climate/demo.js
+++ b/samples/dashboards/demo/climate/demo.js
@@ -340,7 +340,6 @@ async function setupBoard() {
                 tooltip: {
                     shape: 'rect',
                     distance: -60,
-                    useHTML: true,
                     stickOnContact: true
                 },
                 lang: {

--- a/samples/highcharts/accessibility/accessible-keyboardnav/demo.js
+++ b/samples/highcharts/accessibility/accessible-keyboardnav/demo.js
@@ -12,7 +12,6 @@ Highcharts.chart('container', {
     },
 
     legend: {
-        useHTML: true,
         layout: 'proximate',
         align: 'right'
     },

--- a/samples/highcharts/accessibility/accessible-sparklines/demo.js
+++ b/samples/highcharts/accessibility/accessible-sparklines/demo.js
@@ -78,7 +78,6 @@ const defaultChartOptions = {
 
     tooltip: {
         outside: true,
-        useHTML: true,
         hideDelay: 100,
         backgroundColor: 'rgba(250, 250, 250, 0.95)',
         style: {

--- a/samples/highcharts/accessibility/accessible-venn/demo.js
+++ b/samples/highcharts/accessibility/accessible-venn/demo.js
@@ -67,7 +67,6 @@ const chart = Highcharts.chart('container', {
         },
         dataLabels: {
             enabled: false,
-            useHTML: true,
             style: {
                 textOutline: '0px contrast',
                 fontSize: '14px'

--- a/samples/highcharts/blog/bar-remember-information/demo.js
+++ b/samples/highcharts/blog/bar-remember-information/demo.js
@@ -6,7 +6,6 @@ Highcharts.chart('container', {
         text: 'How much information people will remember after 3 days'
     },
     subtitle: {
-        useHTML: true,
         text: 'Source: <a href="http://digitalsplashmedia.com/2012/03/picture-superiority-effect-video-explanation/">digitalsplashmedia.com</a>'
     },
     xAxis: {
@@ -23,13 +22,10 @@ Highcharts.chart('container', {
         }
     },
     tooltip: {
-        headerFormat: '<span style="font-size:10px">{point.key}</span><table>',
-        pointFormat: '<tr><td style="color:{series.color};padding:0">' +
-            '{series.name}: </td>' +
-            '<td style="padding:0"><b>{point.y:.1f} %</b></td></tr>',
-        footerFormat: '</table>',
-        shared: true,
-        useHTML: true
+        headerFormat: '<span style="font-size:10px">{point.key}</span><br>',
+        pointFormat: '<span style="color:{series.color};padding:0">' +
+            '{series.name}: </span>' +
+            '<b>{point.y:.1f} %</b>'
     },
     plotOptions: {
         column: {

--- a/samples/highcharts/blog/chart-inside-tooltip/demo.js
+++ b/samples/highcharts/blog/chart-inside-tooltip/demo.js
@@ -28,7 +28,6 @@ Highcharts.chart('container', {
         text: 'Chart inside tooltip demo'
     },
     tooltip: {
-        useHTML: true,
         headerFormat: '',
         pointFormat: '<div id="hc-tooltip"></div>'
     },

--- a/samples/highcharts/blog/chart-inside-tooltip/demo.js
+++ b/samples/highcharts/blog/chart-inside-tooltip/demo.js
@@ -28,6 +28,7 @@ Highcharts.chart('container', {
         text: 'Chart inside tooltip demo'
     },
     tooltip: {
+        useHTML: true,
         headerFormat: '',
         pointFormat: '<div id="hc-tooltip"></div>'
     },

--- a/samples/highcharts/blog/column-range-precipitation/demo.js
+++ b/samples/highcharts/blog/column-range-precipitation/demo.js
@@ -139,7 +139,6 @@ Highcharts.chart('container', {
     tooltip: {
         delayForDisplay: 10,
         shared: true,
-        useHTML: true,
         headerFormat: '<small>\n  {point.x: %b %d}\n  <br/>\n</small>'
     },
     xAxis: {

--- a/samples/highcharts/blog/column-range-precipitation/demo.js
+++ b/samples/highcharts/blog/column-range-precipitation/demo.js
@@ -137,9 +137,8 @@ Highcharts.chart('container', {
         enabledButtons: false
     },
     tooltip: {
-        delayForDisplay: 10,
         shared: true,
-        headerFormat: '<small>\n  {point.x: %b %d}\n  <br/>\n</small>'
+        headerFormat: '<small>{point.x: %b %d}</small><br/>'
     },
     xAxis: {
         type: 'datetime',

--- a/samples/highcharts/blog/column-range-with-axis-titles/demo.js
+++ b/samples/highcharts/blog/column-range-with-axis-titles/demo.js
@@ -138,7 +138,6 @@ Highcharts.chart('container', {
     tooltip: {
         delayForDisplay: 10,
         shared: true,
-        useHTML: true,
         headerFormat: '<small>\n  {point.x: %b %d}\n  <br/>\n</small>'
     },
     xAxis: {

--- a/samples/highcharts/blog/column-range-with-axis-titles/demo.js
+++ b/samples/highcharts/blog/column-range-with-axis-titles/demo.js
@@ -136,9 +136,8 @@ Highcharts.chart('container', {
         enabledButtons: false
     },
     tooltip: {
-        delayForDisplay: 10,
         shared: true,
-        headerFormat: '<small>\n  {point.x: %b %d}\n  <br/>\n</small>'
+        headerFormat: '<small>{point.x: %b %d}</small><br/>'
     },
     xAxis: {
         type: 'datetime',

--- a/samples/highcharts/blog/column-range-with-labels/demo.js
+++ b/samples/highcharts/blog/column-range-with-labels/demo.js
@@ -118,7 +118,6 @@ Highcharts.chart('container', {
     tooltip: {
         delayForDisplay: 10,
         shared: true,
-        useHTML: true,
         headerFormat: '<small>\n  {point.x: %b %d}\n  <br/>\n</small>'
     },
     xAxis: {

--- a/samples/highcharts/blog/column-range-with-labels/demo.js
+++ b/samples/highcharts/blog/column-range-with-labels/demo.js
@@ -116,9 +116,8 @@ Highcharts.chart('container', {
         enabledButtons: false
     },
     tooltip: {
-        delayForDisplay: 10,
         shared: true,
-        headerFormat: '<small>\n  {point.x: %b %d}\n  <br/>\n</small>'
+        headerFormat: '<small>{point.x: %b %d}</small><br/>'
     },
     xAxis: {
         type: 'datetime',

--- a/samples/highcharts/blog/column-range/demo.js
+++ b/samples/highcharts/blog/column-range/demo.js
@@ -118,7 +118,6 @@ Highcharts.chart('container', {
     tooltip: {
         delayForDisplay: 10,
         shared: true,
-        useHTML: true,
         headerFormat: '<small>\n  {point.x: %b %d}\n  <br/>\n</small>'
     },
     xAxis: {

--- a/samples/highcharts/blog/column-range/demo.js
+++ b/samples/highcharts/blog/column-range/demo.js
@@ -116,9 +116,8 @@ Highcharts.chart('container', {
         enabledButtons: false
     },
     tooltip: {
-        delayForDisplay: 10,
         shared: true,
-        headerFormat: '<small>\n  {point.x: %b %d}\n  <br/>\n</small>'
+        headerFormat: '<small>{point.x: %b %d}</small><br/>'
     },
     xAxis: {
         type: 'datetime',

--- a/samples/highcharts/blog/common-mistakes-map-2/demo.js
+++ b/samples/highcharts/blog/common-mistakes-map-2/demo.js
@@ -81,7 +81,6 @@ Highcharts.mapChart('container', {
             format: '{point.name}'
         },
         tooltip: {
-            useHTML: true,
             headerFormat: 'Name of the province:<br/>',
             pointFormat: '<b>{point.name} </b>'
         }
@@ -93,7 +92,6 @@ Highcharts.mapChart('container', {
         innerSize: '50%',
         tooltip: {
             valueSuffix: '%',
-            useHTML: true,
             headerFormat: '<b>{series.name}</b><br/>',
             pointFormat: '{point.name}: {point.y}'
         },

--- a/samples/highcharts/blog/common-mistakes-map/demo.js
+++ b/samples/highcharts/blog/common-mistakes-map/demo.js
@@ -83,7 +83,6 @@ Highcharts.mapChart('container', {
             format: '{point.name}'
         },
         tooltip: {
-            useHTML: true,
             headerFormat: 'Name of the province:<br/>',
             pointFormat: '<b>{point.name} </b>'
         }

--- a/samples/highcharts/blog/global-temp-column-range/demo.js
+++ b/samples/highcharts/blog/global-temp-column-range/demo.js
@@ -8,8 +8,7 @@ Highcharts.theme = {
     yAxis: {
         gridLineColor: '#B71C1C',
         labels: {
-            format: '{value} C',
-            useHTML: true
+            format: '{value} C'
         }
     },
     plotOptions: {

--- a/samples/highcharts/blog/global-temp-heatmap/demo.js
+++ b/samples/highcharts/blog/global-temp-heatmap/demo.js
@@ -8,8 +8,7 @@ Highcharts.theme = {
     yAxis: {
         gridLineColor: '#B71C1C',
         labels: {
-            format: '{value} C',
-            useHTML: true
+            format: '{value} C'
         }
     },
     plotOptions: {
@@ -35,8 +34,7 @@ Highcharts.chart('container', {
         reversed: true,
         tickPositions: false,
         labels: {
-            format: '{value}',
-            useHTML: true
+            format: '{value}'
         }
     },
     credits: {

--- a/samples/highcharts/blog/global-temp-time-series/demo.js
+++ b/samples/highcharts/blog/global-temp-time-series/demo.js
@@ -8,8 +8,7 @@ Highcharts.theme = {
     yAxis: {
         gridLineColor: '#B71C1C',
         labels: {
-            format: '{value} C',
-            useHTML: true
+            format: '{value} C'
         }
     },
     plotOptions: {

--- a/samples/highcharts/blog/line-average-rainfall-comparison/demo.js
+++ b/samples/highcharts/blog/line-average-rainfall-comparison/demo.js
@@ -3,7 +3,6 @@ Highcharts.chart('container', {
         text: 'Average Rainfall'
     },
     subtitle: {
-        useHTML: true,
         text: 'Source: <a href="http://www.worldclimate.com">worldclimate</a> '
     },
     xAxis: {

--- a/samples/highcharts/blog/line-average-rainfall/demo.js
+++ b/samples/highcharts/blog/line-average-rainfall/demo.js
@@ -3,7 +3,6 @@ Highcharts.chart('container', {
         text: 'Average Rainfall'
     },
     subtitle: {
-        useHTML: true,
         text: 'Source: <a href="http://www.worldclimate.com">worldclimate</a> '
     },
     xAxis: {

--- a/samples/highcharts/blog/line-success-by-attractiveness-female-sender/demo.js
+++ b/samples/highcharts/blog/line-success-by-attractiveness-female-sender/demo.js
@@ -5,7 +5,6 @@ Highcharts.chart('container', {
     },
 
     subtitle: {
-        useHTML: true,
         text: 'Source: <a href="https://theblog.okcupid.com/your-looks-and-your-inbox-8715c0f1561e">theblog.okcupid</a>'
     },
     xAxis: {

--- a/samples/highcharts/blog/line-success-by-attractiveness-male-sender/demo.js
+++ b/samples/highcharts/blog/line-success-by-attractiveness-male-sender/demo.js
@@ -3,7 +3,6 @@ Highcharts.chart('container', {
         text: 'Message Success By Attractiveness (Male Senders)'
     },
     subtitle: {
-        useHTML: true,
         text: 'Source: <a href="https://theblog.okcupid.com/your-looks-and-your-inbox-8715c0f1561e">theblog.okcupid</a>'
     },
     xAxis: {

--- a/samples/highcharts/blog/map-china-world-heritage/demo.js
+++ b/samples/highcharts/blog/map-china-world-heritage/demo.js
@@ -44,7 +44,6 @@
         },
 
         tooltip: {
-            useHTML: true,
             headerFormat: '{point.point.name}',
             pointFormat: '<br/><img src="{point.image}"/>'
         },

--- a/samples/highcharts/blog/map-china-world-heritage/demo.js
+++ b/samples/highcharts/blog/map-china-world-heritage/demo.js
@@ -44,6 +44,7 @@
         },
 
         tooltip: {
+            useHTML: true,
             headerFormat: '{point.point.name}',
             pointFormat: '<br/><img src="{point.image}"/>'
         },

--- a/samples/highcharts/blog/map-usa-hexagon/demo.js
+++ b/samples/highcharts/blog/map-usa-hexagon/demo.js
@@ -30,7 +30,6 @@ Highcharts.chart('container', {
         }
     },
     tooltip: {
-        useHTML: true,
         headerFormat: null,
         pointFormat: '- State of <b>{point.USstate}</b><br/> - The <b>' +
             '{point.region}</b> region<br/> <b>- {point.capital}</b> is the ' +

--- a/samples/highcharts/blog/movie-cummulative-income/demo.js
+++ b/samples/highcharts/blog/movie-cummulative-income/demo.js
@@ -36,7 +36,6 @@ Highcharts.chart('container', {
     },
     tooltip: {
         followPointer: false,
-        useHTML: true,
         headerFormat: '<small>{point.key} days sinsce release</small>'
     },
     yAxis: {

--- a/samples/highcharts/blog/nba-visualisation/demo.js
+++ b/samples/highcharts/blog/nba-visualisation/demo.js
@@ -25,7 +25,6 @@ Highcharts.chart('container', {
         dataLabels: {
             enabled: true,
             allowOverlap: true,
-            useHTML: true,
             y: 38,
             formatter: function () {
                 return '<span style="color:' + this.point.color + '">' +

--- a/samples/highcharts/blog/no-data-to-display/demo.js
+++ b/samples/highcharts/blog/no-data-to-display/demo.js
@@ -118,7 +118,6 @@ Highcharts.chart('container', {
     tooltip: {
         delayForDisplay: 10,
         shared: true,
-        useHTML: true,
         headerFormat: '<small>\n  {point.x: %b %d}\n  <br/>\n</small>'
     },
     xAxis: {

--- a/samples/highcharts/blog/no-data-to-display/demo.js
+++ b/samples/highcharts/blog/no-data-to-display/demo.js
@@ -116,9 +116,8 @@ Highcharts.chart('container', {
         enabledButtons: false
     },
     tooltip: {
-        delayForDisplay: 10,
         shared: true,
-        headerFormat: '<small>\n  {point.x: %b %d}\n  <br/>\n</small>'
+        headerFormat: '<small>{point.x: %b %d}</small><br/>'
     },
     xAxis: {
         type: 'datetime',

--- a/samples/highcharts/blog/packed-bubble-simple-demo/demo.js
+++ b/samples/highcharts/blog/packed-bubble-simple-demo/demo.js
@@ -10,7 +10,6 @@ Highcharts.chart('container', {
         text: 'Coffee consumption'
     },
     tooltip: {
-        useHTML: true,
         pointFormat: '<b>{point.name}:</b> {point.y}</sub>'
     },
     plotOptions: {

--- a/samples/highcharts/blog/polar-animation/demo.js
+++ b/samples/highcharts/blog/polar-animation/demo.js
@@ -8,8 +8,7 @@ Highcharts.theme = {
     yAxis: {
         gridLineColor: '#B71C1C',
         labels: {
-            format: '{value} C',
-            useHTML: true
+            format: '{value} C'
         }
     },
     plotOptions: {

--- a/samples/highcharts/blog/polar/demo.js
+++ b/samples/highcharts/blog/polar/demo.js
@@ -8,8 +8,7 @@ Highcharts.theme = {
     yAxis: {
         gridLineColor: '#B71C1C',
         labels: {
-            format: '{value} C',
-            useHTML: true
+            format: '{value} C'
         }
     },
     plotOptions: {

--- a/samples/highcharts/blog/scatter-regression/demo.js
+++ b/samples/highcharts/blog/scatter-regression/demo.js
@@ -9,7 +9,6 @@ Highcharts.chart('container', {
         text: 'GDP per capita vs Self-reported Life Satisfaction, 2015'
     },
     subtitle: {
-        useHTML: true,
         text: 'Source: <a href="http://data.worldbank.org/data-catalog/world-development-indicators">Worldbank</a>'
     },
     yAxis: {
@@ -24,7 +23,6 @@ Highcharts.chart('container', {
     },
 
     tooltip: {
-        useHTML: true,
         headerFormat: null,
         pointFormat: '<b>Country</b>: {point.name}<br><b>GDP per capita</b>: ' +
             '{point.x} $<br/><b>Life satisfaction</b>: {point.y}'

--- a/samples/highcharts/blog/seasonal-plot/demo.js
+++ b/samples/highcharts/blog/seasonal-plot/demo.js
@@ -8,8 +8,7 @@ Highcharts.theme = {
     yAxis: {
         gridLineColor: '#B71C1C',
         labels: {
-            format: '{value} C',
-            useHTML: true
+            format: '{value} C'
         }
     },
     plotOptions: {

--- a/samples/highcharts/chartchooser/categorical-composition-split-bubble-monochrome/demo.js
+++ b/samples/highcharts/chartchooser/categorical-composition-split-bubble-monochrome/demo.js
@@ -11,7 +11,6 @@ Highcharts.chart('container', {
         text: '(In October 2020)'
     },
     tooltip: {
-        useHTML: true,
         pointFormat: '<b>{point.name}:</b> {point.value} USD b$'
     },
     plotOptions: {

--- a/samples/highcharts/chartchooser/categorical-composition-split-bubble/demo.js
+++ b/samples/highcharts/chartchooser/categorical-composition-split-bubble/demo.js
@@ -10,7 +10,6 @@ Highcharts.chart('container', {
         text: '(In October 2020)'
     },
     tooltip: {
-        useHTML: true,
         pointFormat: '<b>{point.name}:</b> {point.value} USD b$'
     },
     plotOptions: {

--- a/samples/highcharts/chartchooser/categorical-hierarchy-organziation-monochrome/demo.js
+++ b/samples/highcharts/chartchooser/categorical-hierarchy-organziation-monochrome/demo.js
@@ -7,7 +7,6 @@ Highcharts.chart('container', {
     },
 
     title: {
-        useHTML: true,
         text: 'Statistics Division of United Nations'
     },
     accessibility: {

--- a/samples/highcharts/chartchooser/categorical-hierarchy-organziation/demo.js
+++ b/samples/highcharts/chartchooser/categorical-hierarchy-organziation/demo.js
@@ -5,7 +5,6 @@ Highcharts.chart('container', {
     },
 
     title: {
-        useHTML: true,
         text: 'Statistics Division of United Nations'
     },
     accessibility: {

--- a/samples/highcharts/chartchooser/categorical-hierarchy-treemap-monochrome/demo.js
+++ b/samples/highcharts/chartchooser/categorical-hierarchy-treemap-monochrome/demo.js
@@ -162,7 +162,6 @@ Highcharts.chart('container', {
       'Source:<a href="https://en.wikipedia.org/wiki/Local_government_in_Fiji">Wikipedia</a>'
     },
     tooltip: {
-        useHTML: true,
         pointFormat: '<b>{point.name}</b>: Population is <b>{point.value}</b>'
     }
 });

--- a/samples/highcharts/chartchooser/categorical-hierarchy-treemap/demo.js
+++ b/samples/highcharts/chartchooser/categorical-hierarchy-treemap/demo.js
@@ -161,7 +161,6 @@ Highcharts.chart('container', {
       'Source:<a href="https://en.wikipedia.org/wiki/Local_government_in_Fiji">Wikipedia</a>'
     },
     tooltip: {
-        useHTML: true,
         pointFormat: '<b>{point.name}</b>: Population is <b>{point.value}</b>'
     }
 });

--- a/samples/highcharts/chartchooser/categorical-relationship-map-bubble/demo.js
+++ b/samples/highcharts/chartchooser/categorical-relationship-map-bubble/demo.js
@@ -57,7 +57,6 @@ const dirDist50 = '#E8544E',
         },
 
         tooltip: {
-            useHTML: true,
             headerFormat: '',
             pointFormat: '<b>{point.id}</b>'
         },

--- a/samples/highcharts/chartchooser/continuous-trend-line-annotations/demo.js
+++ b/samples/highcharts/chartchooser/continuous-trend-line-annotations/demo.js
@@ -19,7 +19,6 @@ Highcharts.chart('container', {
         },
         plotLines: [
             {
-                useHTML: true,
                 color: '#f15c80',
                 dashStyle: 'dot',
                 width: 2,

--- a/samples/highcharts/demo/bar-race/demo.js
+++ b/samples/highcharts/demo/bar-race/demo.js
@@ -138,6 +138,7 @@ function getSubtitle() {
             floating: true,
             align: 'right',
             verticalAlign: 'middle',
+            useHTML: true,
             y: -80,
             x: -100
         },

--- a/samples/highcharts/demo/bar-race/demo.js
+++ b/samples/highcharts/demo/bar-race/demo.js
@@ -134,7 +134,6 @@ function getSubtitle() {
             align: 'left'
         },
         subtitle: {
-            useHTML: true,
             text: getSubtitle(),
             floating: true,
             align: 'right',

--- a/samples/highcharts/demo/combo-meteogram/demo.js
+++ b/samples/highcharts/demo/combo-meteogram/demo.js
@@ -340,7 +340,6 @@ Meteogram.prototype.getChartOptions = function () {
 
         tooltip: {
             shared: true,
-            useHTML: true,
             headerFormat:
                 '<small>{point.x:%A, %b %e, %H:%M} - ' +
                 '{point.point.to:%H:%M}</small><br>' +

--- a/samples/highcharts/demo/donut-race/demo.js
+++ b/samples/highcharts/demo/donut-race/demo.js
@@ -35,7 +35,6 @@ function getSubtitle() {
             align: 'center'
         },
         subtitle: {
-            useHTML: true,
             text: getSubtitle(),
             floating: true,
             verticalAlign: 'middle',

--- a/samples/highcharts/demo/donut-race/demo.js
+++ b/samples/highcharts/demo/donut-race/demo.js
@@ -37,6 +37,7 @@ function getSubtitle() {
         subtitle: {
             text: getSubtitle(),
             floating: true,
+            useHTML: true,
             verticalAlign: 'middle',
             y: 30
         },

--- a/samples/highcharts/demo/gauge-solid/demo.js
+++ b/samples/highcharts/demo/gauge-solid/demo.js
@@ -52,8 +52,7 @@ const gaugeOptions = {
             borderRadius: 3,
             dataLabels: {
                 y: 5,
-                borderWidth: 0,
-                useHTML: true
+                borderWidth: 0
             }
         }
     }

--- a/samples/highcharts/demo/packed-bubble-project-status/demo.js
+++ b/samples/highcharts/demo/packed-bubble-project-status/demo.js
@@ -10,7 +10,6 @@ Highcharts.chart('container', {
         text: 'Currently planned work for team'
     },
     tooltip: {
-        useHTML: true,
         pointFormat: '<b>{point.name}:</b> {point.value}'
     },
     plotOptions: {

--- a/samples/highcharts/demo/packed-bubble-project-status/demo.js~
+++ b/samples/highcharts/demo/packed-bubble-project-status/demo.js~
@@ -10,7 +10,6 @@ Highcharts.chart('container', {
         text: 'Currently planned work for team'
     },
     tooltip: {
-        useHTML: true,
         pointFormat: '<b>{point.name}:</b> {point.value}'
     },
     plotOptions: {

--- a/samples/highcharts/demo/packed-bubble-split/demo.js
+++ b/samples/highcharts/demo/packed-bubble-split/demo.js
@@ -12,7 +12,6 @@ Highcharts.chart('container', {
         align: 'left'
     },
     tooltip: {
-        useHTML: true,
         pointFormat: '<b>{point.name}:</b> {point.value}m CO<sub>2</sub>'
     },
     plotOptions: {

--- a/samples/highcharts/demo/polar-radial-bar/demo.js
+++ b/samples/highcharts/demo/polar-radial-bar/demo.js
@@ -25,7 +25,6 @@ Highcharts.chart('container', {
         tickInterval: 1,
         labels: {
             align: 'right',
-            useHTML: true,
             allowOverlap: true,
             step: 1,
             y: 3,

--- a/samples/highcharts/series-packedbubble/initial-radius/demo.js
+++ b/samples/highcharts/series-packedbubble/initial-radius/demo.js
@@ -7,7 +7,6 @@ Highcharts.chart('container', {
         text: 'Carbon emissions around the world (2014)'
     },
     tooltip: {
-        useHTML: true,
         pointFormat: '<b>{point.name}:</b> {point.y}m CO<sub>2</sub>'
     },
     plotOptions: {

--- a/samples/highcharts/series-packedbubble/initial-radius/demo.js
+++ b/samples/highcharts/series-packedbubble/initial-radius/demo.js
@@ -7,6 +7,7 @@ Highcharts.chart('container', {
         text: 'Carbon emissions around the world (2014)'
     },
     tooltip: {
+        useHTML: true,
         pointFormat: '<b>{point.name}:</b> {point.y}m CO<sub>2</sub>'
     },
     plotOptions: {

--- a/samples/highcharts/website/blog-landing-page/demo.js
+++ b/samples/highcharts/website/blog-landing-page/demo.js
@@ -968,7 +968,7 @@ const bubble = Highcharts.chart('soloBubble', {
     tooltip: {
         outside: true,
         enabled: true,
-        pointFormat: '<b>{point.name}:</b> {point.y}</sub>'
+        pointFormat: '<b>{point.name}:</b> {point.y}'
     },
     legend: {
         enabled: false

--- a/samples/highcharts/website/blog-landing-page/demo.js
+++ b/samples/highcharts/website/blog-landing-page/demo.js
@@ -966,7 +966,6 @@ const bubble = Highcharts.chart('soloBubble', {
         enabled: false
     },
     tooltip: {
-        useHTML: true,
         outside: true,
         enabled: true,
         pointFormat: '<b>{point.name}:</b> {point.y}</sub>'

--- a/samples/maps/demo/animated-mapline/demo.js
+++ b/samples/maps/demo/animated-mapline/demo.js
@@ -66,7 +66,6 @@
             enabled: false
         },
         tooltip: {
-            useHTML: true,
             headerFormat: '<b>{point.key}</b>:<br/>',
             pointFormat: '{point.info}'
         },

--- a/samples/maps/demo/pattern-fill-map/demo.js
+++ b/samples/maps/demo/pattern-fill-map/demo.js
@@ -112,7 +112,7 @@
             borderColor: '#aaa',
             headerFormat: '<b>{point.point.name}</b><br>',
             pointFormat: '<img style="width: 150px; height: 100px;" ' +
-                'src=\'{point.options.color.pattern.image}\'>'
+                'src="{point.options.color.pattern.image}">'
         },
 
         // Define the series

--- a/samples/maps/tooltip/usehtml/demo.js
+++ b/samples/maps/tooltip/usehtml/demo.js
@@ -40,8 +40,7 @@
             shadow: false,
             useHTML: true,
             pointFormat: '<span class="f32"><span class="flag {point.flag}">' +
-                '</span></span>' +
-                    ' {point.name}: <b>{point.value}</b>/km²'
+                '</span></span> {point.name}: <b>{point.value}</b>/km²'
         },
 
         colorAxis: {

--- a/samples/stock/demo/dark-candlestick-and-volume/demo.js
+++ b/samples/stock/demo/dark-candlestick-and-volume/demo.js
@@ -141,7 +141,6 @@
         tooltip: {
             shared: true,
             split: false,
-            useHTML: true,
             shadow: false,
             positioner: function () {
                 return { x: 50, y: 10 };


### PR DESCRIPTION
It's bad practice to set `useHTML: true` unless the string formats contain HTML that goes beyond the built-in HTML-to-SVG parser.