### PR TITLE
bugfix/22397-add-title-attr-in-accessibility

### DIFF
--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -461,6 +461,7 @@ class LegendComponent extends AccessibilityComponent {
 
         if (
             ellipsis &&
+            // Unicode character (U+2026) for ellipsis (…)
             (legendLabelEl.textContent || '').indexOf('\u2026') !== -1
         ) {
             attribs.title = legendItemLabel?.textStr;

--- a/ts/Accessibility/Components/LegendComponent.ts
+++ b/ts/Accessibility/Components/LegendComponent.ts
@@ -431,6 +431,11 @@ class LegendComponent extends AccessibilityComponent {
         item: Legend.Item
     ): void {
         const legendItem = item.legendItem || {};
+        const legendItemLabel = item.legendItem?.label;
+        const legendLabelEl = legendItemLabel?.element;
+        const ellipsis = Boolean(
+            legendItem.label?.styles?.textOverflow === 'ellipsis'
+        );
 
         if (!legendItem.label || !legendItem.group) {
             return;
@@ -450,8 +455,17 @@ class LegendComponent extends AccessibilityComponent {
         const attribs = {
             tabindex: -1,
             'aria-pressed': item.visible,
-            'aria-label': itemLabel
+            'aria-label': itemLabel,
+            title: ''
         };
+
+        if (
+            ellipsis &&
+            (legendLabelEl.textContent || '').indexOf('\u2026') !== -1
+        ) {
+            attribs.title = legendItemLabel?.textStr;
+        }
+
         // Considers useHTML
         const proxyPositioningElement = legendItem.group.div ?
             legendItem.label :


### PR DESCRIPTION
Fixed #22397, native element tooltips were not visible for legend items with long text when `accessibility.enabled` was true.

~~Fixed #22397, tooltips were not visible for legend items with long text when accessibility.enabled was set to true in pie chart configurations.~~