### PR TITLE
dash/22720-component-destroy-mispositioned-resize-buttons

### DIFF
--- a/ts/Dashboards/EditMode/Toolbar/CellEditToolbar.ts
+++ b/ts/Dashboards/EditMode/Toolbar/CellEditToolbar.ts
@@ -285,9 +285,7 @@ class CellEditToolbar extends EditToolbar {
             toolbar.editMode.hideToolbars(['cell', 'row']);
 
             // Disable resizer.
-            if (toolbar.editMode.resizer) {
-                toolbar.editMode.resizer.disableResizer();
-            }
+            toolbar.editMode.resizer?.disableResizer();
 
             // Call cellResize dashboard event.
             if (row && row.cells && row.cells.length) {

--- a/ts/Dashboards/EditMode/Toolbar/CellEditToolbar.ts
+++ b/ts/Dashboards/EditMode/Toolbar/CellEditToolbar.ts
@@ -274,12 +274,20 @@ class CellEditToolbar extends EditToolbar {
             const row = toolbar.cell.row;
             const cellId = toolbar.cell.id;
 
+            // Disable row highlight.
+            toolbar.cell.row.setHighlight();
+
             toolbar.resetEditedCell();
             toolbar.cell.destroy();
             toolbar.cell = void 0;
 
             // Hide row and cell toolbars.
             toolbar.editMode.hideToolbars(['cell', 'row']);
+
+            // Disable resizer.
+            if (toolbar.editMode.resizer) {
+                toolbar.editMode.resizer.disableResizer();
+            }
 
             // Call cellResize dashboard event.
             if (row && row.cells && row.cells.length) {


### PR DESCRIPTION
Fixed #22720, component destroy mispositioned resize buttons.