### PR TITLE
bugfix/22490-gantt-chart-in-styledmode-misses-progress-indication

### DIFF
--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -1300,3 +1300,8 @@ g.highcharts-series,
     stroke: var(--highcharts-neutral-color-20);
     stroke-width: 1px;
 }
+
+.highcharts-gantt-series .highcharts-partfill-overlay {
+    fill: hsla(0, 0%, 0%, 0.3);
+    stroke: hsla(0, 0%, 0%, 0.3);
+}


### PR DESCRIPTION
Fixed [#22490](https://github.com/highcharts/highcharts/issues/22490), styles for gantt progress inidicator bar for styled mode added