### PR TITLE
grid/jsdelivr-code-www

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -356,7 +356,7 @@ and Highcharts plugin form.</p>
 
 <section id="grid-lite">
 <h2 id="highcharts-grid-lite">Highcharts Grid Lite</h2>
-<p>Highcharts Grid Lite files are hosted on <a href="https://www.jsdelivr.com/" target="_blank">jsDelivr</a> and can be accessed via the <a href="https://www.jsdelivr.com/package/npm/@highcharts/dashboards" target="_blank">@highcharts/grid-lite</a> npm package.</p>
+<p>Highcharts Grid Lite files are hosted on <a href="https://www.jsdelivr.com/" target="_blank">jsDelivr</a> and can be accessed via the <a href="https://www.jsdelivr.com/package/npm/@highcharts/grid-lite" target="_blank">@highcharts/grid-lite</a> npm package.</p>
 
 <h4>Specific version</h4>
 <p>To use a specific version of Highcharts Grid Lite, specify the package version in the URL:</p>

--- a/www/index.html
+++ b/www/index.html
@@ -109,7 +109,7 @@
 
         // Handle other products
         updateLinks('Highcharts Dashboards', '#dashboards a', '@dashboards-minor', '@dashboards-patch');
-        updateLinks('Highcharts Grid Lite', '#grid a', '@grid-lite-minor', '@grid-lite-patch');
+        updateLinks('Highcharts Grid Lite', '#grid-lite a', '@grid-lite-minor', '@grid-lite-patch');
     });
 </script>
 </head>
@@ -354,27 +354,27 @@ and Highcharts plugin form.</p>
 </ul>
 </section>
 
-<section id="grid">
-<h2 id="highcharts-grid">Highcharts Grid</h2>
-<p>Highcharts Grid files are available under the <strong>/grid</strong> subfolder.</p>
+<section id="grid-lite">
+<h2 id="highcharts-grid-lite">Highcharts Grid Lite</h2>
+<p>Highcharts Grid Lite files are hosted on <a href="https://www.jsdelivr.com/" target="_blank">jsDelivr</a> and can be accessed via the <a href="https://www.jsdelivr.com/package/npm/@highcharts/dashboards" target="_blank">@highcharts/grid-lite</a> npm package.</p>
 
 <h4>Specific version</h4>
-<p>You'll find a specific Highcharts Grid version by appending the version number to the <strong>/grid</strong> folder:</p>
+<p>To use a specific version of Highcharts Grid Lite, specify the package version in the URL:</p>
 <ul>
-<li><a href="grid/@grid-lite-patch/grid-lite.js">https://code.highcharts.com/grid/@grid-lite-patch/grid-lite.js</a></li>
-<li><a href="grid/@grid-lite-patch/css/grid.css">https://code.highcharts.com/grid/@grid-lite-patch/css/grid.css</a></li>
+<li><a href="https://cdn.jsdelivr.net/npm/@highcharts/grid-lite@@grid-lite-patch/grid-lite.js">https://cdn.jsdelivr.net/npm/@highcharts/grid-lite@@grid-lite-patch/grid-lite.js</a></li>
+<li><a href="https://cdn.jsdelivr.net/npm/@highcharts/grid-lite@@grid-lite-patch/css/grid.js">https://cdn.jsdelivr.net/npm/@highcharts/grid-lite@@grid-lite-patch/css/grid.css</a></li>
 </ul>
 
 <h4>Truncated versions</h4>
 <ul>
-<li><a href="grid/@grid-lite-minor/grid-lite.js">https://code.highcharts.com/grid/@grid-lite-minor/grid-lite.js</a></li>
-<li><a href="grid/@grid-lite-minor/css/grid.css">https://code.highcharts.com/grid/@grid-lite-minor/css/grid.css</a></li>
+<li><a href="https://cdn.jsdelivr.net/npm/@highcharts/grid-lite@@grid-lite-minor/grid-lite.js">https://cdn.jsdelivr.net/npm/@highcharts/grid-lite@@grid-lite-minor/grid-lite.js</a></li>
+<li><a href="https://cdn.jsdelivr.net/npm/@highcharts/grid-lite@@grid-lite-minor/css/grid.css">https://cdn.jsdelivr.net/npm/@highcharts/grid-lite@@grid-lite-minor/css/grid.css</a></li>
 </ul>
 
 <h4>Latest stable</h4>
 <ul>
-<li><a href="grid/grid-lite.js">https://code.highcharts.com/grid/grid-lite.js</a></li>
-<li><a href="grid/css/grid.css">https://code.highcharts.com/grid/css/grid.css</a></li>
+<li><a href="https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/grid-lite.js">https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/grid-lite.js</a></li>
+<li><a href="https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid.css">https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid.css</a></li>
 </ul>
 </section>
 


### PR DESCRIPTION
Changed Grid Lite links on code.highcharts.com homepage to jsDelivr.