### PR TITLE
New version of formatting demo

### DIFF
--- a/samples/grid-lite/demo/grid-cell-format/demo.css
+++ b/samples/grid-lite/demo/grid-cell-format/demo.css
@@ -1,69 +1,76 @@
 @import url("https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid.css");
 
-:root {
-    --hcg-background: #fff;
-}
-
-.custom-theme {
-    --hcg-padding: 10px;
-    --hcg-header-background: #dfdfdf;
-    --hcg-header-font-weight: 500;
-    --hcg-row-border-width: 1px;
-    --hcg-row-border-color: #d9d9d9;
-    --hcg-row-even-background: #f9f9f9;
-    --highlight-cell: #f0f2ca;
-    --high-color: #348700;
-    --low-color: #d8003a;
-    --over-30: #152fc2;
-}
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        --hcg-background: #333;
-    }
-
-    .custom-theme {
-        --hcg-header-background: #333;
-        --hcg-row-border-color: #333;
-        --hcg-row-even-background: #4f4f4f;
-        --hcg-row-background: #4f4f4f;
-        --highlight-cell: #404c2f;
-        --high-color: #98d76a;
-        --low-color: #ffa8a8;
-        --over-30: #b1befb;
-    }
-}
-
 #container {
-    background-color: var(--hcg-background);
-    margin: 8px;
+  margin: 8px;
+  padding: 20px;
 }
 
 .highcharts-description {
-    padding-left: 10px;
+  padding-left: 10px;
 }
 
-.hcg-table thead th.bold-header span,
-.hcg-table tbody tr td.bold-column {
-    font-weight: bold;
-    text-align: center;
+.custom-theme {
+  /* This starts of by defining some custom color variabled */
+  --highlight-color: #e2e2e2;
+  --highlight-border-color: #cec184;
+  --high-color: #348700;
+  --low-color: #d8003a;
+
+  /* The custom variables are then applied to the included theming --hcg variables */
+  --hcg-padding: 10px;
+  --hcg-header-row-border-width: 2px;
+  --hcg-header-row-border-color: var(--highlight-color);
+  --hcg-row-border-width: 1px;
+  --hcg-row-border-color: var(--highlight-color);
+
+  --hcg-cell-hovered-background: var(--highlight-color);
+  --hcg-cell-hovered-column-border-width: 1px;
+  --hcg-cell-hovered-column-border-color: var(--highlight-color);
 }
 
-.hcg-table tbody tr:has(.highlight-cell) td {
-    background-color: var(--highlight-cell) !important;
+@media (prefers-color-scheme: dark) {
+  #container {
+    background-color: #333;
+  }
+
+  .custom-theme {
+    /* In most cases you only want to change colors for dark mode, so no need to repeat any --hcg variables in dark mode */
+    --highlight-color: #4c4c4c;
+    --highlight-border-color: #7d754c;
+    --high-color: #98d76a;
+    --low-color: #ffa8a8;
+  }
 }
 
-.hcg-table tbody td.high-color {
-    font-weight: bold;
-    color: var(--high-color) !important;
+.hcg-table th.bold span,
+.hcg-table td.bold {
+  font-weight: bold;
 }
 
-.hcg-table tbody td.low-color {
-    font-weight: bold;
-    color: var(--low-color) !important;
+/* We also reuse the custom CSS variables inside the custom CSS classes, and append !important to make sure formatting is kept regardless of any hover states etc. */
+.hcg-table tr:has(.highlight-color) td {
+  background: var(--highlight-color) !important;
 }
 
-.hcg-table tbody td.over-30 {
-    font-weight: bold;
-    color: var(--over-30) !important;
+.hcg-table td.high-color {
+  color: var(--high-color) !important;
+}
+
+.hcg-table td.low-color {
+  color: var(--low-color) !important;
+}
+
+/* We put ALL numbers inside a span to ensure that they all have the same padding, for vertical alignment */
+.hcg-table span.box {
+  font-weight: inherit;
+  display: inline-block;
+  padding: 2px 5px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+}
+
+/* Only numbers greater than 50 receives a background and border */
+.hcg-table span.highlight {
+  background: var(--highlight-color);
+  border-color: var(--highlight-border-color);
 }

--- a/samples/grid-lite/demo/grid-cell-format/demo.css
+++ b/samples/grid-lite/demo/grid-cell-format/demo.css
@@ -1,76 +1,77 @@
 @import url("https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid.css");
 
 #container {
-  margin: 8px;
-  padding: 20px;
+    margin: 8px;
+    padding: 20px;
 }
 
 .highcharts-description {
-  padding-left: 10px;
+    padding-left: 10px;
 }
 
 .custom-theme {
-  /* This starts of by defining some custom color variabled */
-  --highlight-color: #e2e2e2;
-  --highlight-border-color: #cec184;
-  --high-color: #348700;
-  --low-color: #d8003a;
+    /* This starts of by defining some custom color variabled */
+    --highlight-color: #e2e2e2;
+    --highlight-border-color: #cec184;
+    --high-color: #348700;
+    --low-color: #d8003a;
 
-  /* The custom variables are then applied to the included theming --hcg variables */
-  --hcg-padding: 10px;
-  --hcg-header-row-border-width: 2px;
-  --hcg-header-row-border-color: var(--highlight-color);
-  --hcg-row-border-width: 1px;
-  --hcg-row-border-color: var(--highlight-color);
-
-  --hcg-cell-hovered-background: var(--highlight-color);
-  --hcg-cell-hovered-column-border-width: 1px;
-  --hcg-cell-hovered-column-border-color: var(--highlight-color);
+    /* The custom variables are then applied to the included theming --hcg variables */
+    --hcg-padding: 10px;
+    --hcg-header-row-border-width: 2px;
+    --hcg-header-row-border-color: var(--highlight-color);
+    --hcg-row-border-width: 1px;
+    --hcg-row-border-color: var(--highlight-color);
+    --hcg-cell-hovered-background: var(--highlight-color);
+    --hcg-cell-hovered-column-border-width: 1px;
+    --hcg-cell-hovered-column-border-color: var(--highlight-color);
 }
 
 @media (prefers-color-scheme: dark) {
-  #container {
-    background-color: #333;
-  }
+    #container {
+        background-color: #333;
+    }
 
-  .custom-theme {
-    /* In most cases you only want to change colors for dark mode, so no need to repeat any --hcg variables in dark mode */
-    --highlight-color: #4c4c4c;
-    --highlight-border-color: #7d754c;
-    --high-color: #98d76a;
-    --low-color: #ffa8a8;
-  }
+    .custom-theme {
+        /* In most cases you only want to change colors for dark mode,
+        so no need to repeat any --hcg variables in dark mode */
+        --highlight-color: #4c4c4c;
+        --highlight-border-color: #7d754c;
+        --high-color: #98d76a;
+        --low-color: #ffa8a8;
+    }
 }
 
 .hcg-table th.bold span,
 .hcg-table td.bold {
-  font-weight: bold;
+    font-weight: bold;
 }
 
-/* We also reuse the custom CSS variables inside the custom CSS classes, and append !important to make sure formatting is kept regardless of any hover states etc. */
+/* We also reuse the custom CSS variables inside the custom CSS classes, and append !important to make sure
+formatting is kept regardless of any hover states etc. */
 .hcg-table tr:has(.highlight-color) td {
-  background: var(--highlight-color) !important;
+    background: var(--highlight-color) !important;
 }
 
 .hcg-table td.high-color {
-  color: var(--high-color) !important;
+    color: var(--high-color) !important;
 }
 
 .hcg-table td.low-color {
-  color: var(--low-color) !important;
+    color: var(--low-color) !important;
 }
 
 /* We put ALL numbers inside a span to ensure that they all have the same padding, for vertical alignment */
 .hcg-table span.box {
-  font-weight: inherit;
-  display: inline-block;
-  padding: 2px 5px;
-  border: 1px solid transparent;
-  border-radius: 5px;
+    font-weight: inherit;
+    display: inline-block;
+    padding: 2px 5px;
+    border: 1px solid transparent;
+    border-radius: 5px;
 }
 
 /* Only numbers greater than 50 receives a background and border */
 .hcg-table span.highlight {
-  background: var(--highlight-color);
-  border-color: var(--highlight-border-color);
+    background: var(--highlight-color);
+    border-color: var(--highlight-border-color);
 }

--- a/samples/grid-lite/demo/grid-cell-format/demo.details
+++ b/samples/grid-lite/demo/grid-cell-format/demo.details
@@ -1,5 +1,5 @@
 ---
-name: Advanced cell formatting
+name: Cell formatting
 authors:
   - Karol Kolodziej
 js_wrap: b

--- a/samples/grid-lite/demo/grid-cell-format/demo.html
+++ b/samples/grid-lite/demo/grid-cell-format/demo.html
@@ -2,12 +2,12 @@
 
 <div id="container"></div>
 <p class="highcharts-description">
-    A simple Grid with a custom cell format. Some of the changes:
+    A simple Grid with custom cell formatting, using the <code>className</code>, <code>format</code> and <code>formatter</code> API options. See comments in the source code to learn more. 
     <ul>
-        <li>The salary is formatted to a currency string with `k` abbreviation.</li>
-        <li>The entire row is highlighted if the salary is greater than 50k.</li>
-        <li>The performance value is highlighted green if it is greater than 80 and red if it is less than 80.</li>
-        <li>Change font-weight and alignment in first column</li>
-        <li>Any cell that has a value greater than 30 is highlighted blue.</li>
+        <li>Salary column is formatted to a currency string with `k` abbreviation.</li>
+        <li>The entire row is highlighted if salary is greater than 80k.</li>
+        <li>The performance value is highlighted green if greater than 80 and red if less than 75.</li>
+        <li>Content in first and last column is centered, and values in the Name column are always bold.</li>
+        <li>Any numeric value in the entire grid, except for ID and Salary, that are greater than 50 is put inside a box.</li>
     </ul>
 </p>

--- a/samples/grid-lite/demo/grid-cell-format/demo.html
+++ b/samples/grid-lite/demo/grid-cell-format/demo.html
@@ -7,7 +7,7 @@
         <li>Salary column is formatted to a currency string with `k` abbreviation.</li>
         <li>The entire row is highlighted if salary is greater than 80k.</li>
         <li>The performance value is highlighted green if greater than 80 and red if less than 75.</li>
-        <li>Content in first and last column is centered, and values in the Name column are always bold.</li>
+        <li>Content in first column is centered, and values in the Name column are always bold.</li>
         <li>Any numeric value in the entire grid, except for ID and Salary, that are greater than 50 is put inside a box.</li>
     </ul>
 </p>

--- a/samples/grid-lite/demo/grid-cell-format/demo.js
+++ b/samples/grid-lite/demo/grid-cell-format/demo.js
@@ -1,86 +1,100 @@
-Grid.grid("container", {
-  dataTable: {
-    columns: {
-      ID: [1, 2, 3, 4, 5, 6],
-      Name: ["Alice", "Bob", "Charlie", "David", "Eve", "John"],
-      Age: [28, 51, 40, 60, 53, 39],
-      Department: ["HR", "Engineering", "Sales", "Marketing", "Finance", "Finance"],
-      Salary: [50000, 75000, 55000, 85000, 65000, 83000],
-      PerformanceScore: [85, 49, 95, 40, 88, 73],
+Grid.grid('container', {
+    dataTable: {
+        columns: {
+            ID: [1, 2, 3, 4, 5, 6],
+            Name: ['Alice', 'Bob', 'Charlie', 'David', 'Eve', 'John'],
+            Age: [28, 51, 40, 60, 53, 39],
+            Department: [
+                'HR',
+                'Engineering',
+                'Sales',
+                'Marketing',
+                'Finance',
+                'Finance'
+            ],
+            Salary: [50000, 75000, 55000, 85000, 65000, 83000],
+            PerformanceScore: [85, 49, 95, 40, 88, 73]
+        }
     },
-  },
-  columnDefaults: {
-    cells: {
-      /* 
-      Use the formatter callback function only when needed, for more complex formatting.
-      This example wraps numeric values, except the first column, inside a span. If
-      value > 50 a highlight CSS class is appended. Since inside columnDefaults this applies to all
-      columns in the grid. See also CSS comment.
-      */
-      formatter: function () {
-        const value = this.value;
-        const id = this.column.id;
-        if (typeof value !== "number" || id === "ID") return value;
-        const className = value > 50 ? "highlight" : "";
-        return `<span class="box ${className}">${value}</span>`;
-      },
+    columnDefaults: {
+        cells: {
+            /*
+            Use the formatter callback function only when needed, for more
+            complex formatting. This example wraps numeric values, except the
+            first column, inside a span. If value > 50 a highlight CSS class is
+            appended. Since inside columnDefaults this applies to all columns in
+            the grid. See also CSS comment.
+            */
+            formatter: function () {
+                const value = this.value;
+                const id = this.column.id;
+
+                if (typeof value !== 'number' || id === 'ID') {
+                    return value;
+                }
+
+                const className = value > 50 ? 'highlight' : '';
+                return `<span class="box ${className}">${value}</span>`;
+            }
+        }
     },
-  },
-  rendering: {
-    theme: "custom-theme",
-  },
-  description: {
-    text: "* Performance Score",
-  },
-  columns: [
-    /* 
-    The included hcg-center, hcg-left and hc-right CSS classes can be used for text alignment
-    in headers and cells. Observe that column headers can be removed by passing an empty string
-    in the columns[].header.format API option.
-    */
-    {
-      id: "ID",
-      cells: {
-        className: "hcg-center",
-      },
-      header: {
-        format: "",
-      },
+    rendering: {
+        theme: 'custom-theme'
     },
-    /* 
-    In the Name column a custom CSS class is applied to all cells. See CSS.
-    */
-    {
-      id: "Name",
-      cells: {
-        className: "bold",
-      },
+    description: {
+        text: '* Performance Score'
     },
-    /* 
-    For simpler formatting with less logic use the format API option instead of formatter (see above).
-    Highcharts Grid use the same templating engine as Highcharts Core, so read more at https://www.highcharts.com/docs/chart-concepts/templating.
-    Note that format, formatter and className options in columns[] overrides any values set in columnDefaults, 
-    so the Salary column will in this example not contain that <span> we injected earlier.
-    */
-    {
-      id: "Salary",
-      cells: {
-        className: "{#if (gt value 80000)}highlight-color{/if}",
-        format: "${(divide value 1000):.0f}k",
-      },
-    },
-    /* 
-    This example uses conditional formatting for only part of the className template
-    */
-    {
-      id: "PerformanceScore",
-      cells: {
-        className: "{#if (gt value 75)}high{else}low{/if}-color bold hcg-center",
-      },
-      header: {
-        className: "hcg-center",
-        format: "PS (0-100) *",
-      },
-    },
-  ],
+    columns: [
+        /*
+        The included hcg-center, hcg-left and hc-right CSS classes can be used
+        for text alignment in headers and cells. Observe that column headers can
+        be removed by passing an empty string in the columns[].header.format.
+        */
+        {
+            id: 'ID',
+            cells: {
+                className: 'hcg-center'
+            },
+            header: {
+                format: ''
+            }
+        },
+        /*
+        In the Name column a custom CSS class is applied to all cells. See CSS.
+        */
+        {
+            id: 'Name',
+            cells: {
+                className: 'bold'
+            }
+        },
+        /*
+        For simpler formatting with less logic use the format API option instead
+        of formatter (see above). Highcharts Grid use the same templating engine
+        as Highcharts Core, so read more at https://www.highcharts.com/docs/chart-concepts/templating.
+        Note that format, formatter and className options in columns[] overrides
+        any values set in columnDefaults, so the Salary column will in this
+        example not contain that <span> we injected earlier.
+        */
+        {
+            id: 'Salary',
+            cells: {
+                className: '{#if (gt value 80000)}highlight-color{/if}',
+                format: '${(divide value 1000):.0f}k'
+            }
+        },
+        /*
+        This example uses conditional formatting for only part of
+        the className template
+        */
+        {
+            id: 'PerformanceScore',
+            cells: {
+                className: '{#if (gt value 75)}high{else}low{/if}-color bold'
+            },
+            header: {
+                format: 'PS (0-100) *'
+            }
+        }
+    ]
 });

--- a/samples/grid-lite/demo/grid-cell-format/demo.js
+++ b/samples/grid-lite/demo/grid-cell-format/demo.js
@@ -1,46 +1,86 @@
-Grid.grid('container', {
-    dataTable: {
-        columns: {
-            ID: [1, 2, 3, 4, 5],
-            Name: ['Alice', 'Bob', 'Charlie', 'David', 'Eve'],
-            Age: [28, 35, 40, 23, 30],
-            Department: ['HR', 'Engineering', 'Sales', 'Marketing', 'Finance'],
-            Salary: [50000, 75000, 55000, 45000, 65000],
-            PerformanceScore: [85, 70, 95, 60, 88]
-        }
+Grid.grid("container", {
+  dataTable: {
+    columns: {
+      ID: [1, 2, 3, 4, 5, 6],
+      Name: ["Alice", "Bob", "Charlie", "David", "Eve", "John"],
+      Age: [28, 51, 40, 60, 53, 39],
+      Department: ["HR", "Engineering", "Sales", "Marketing", "Finance", "Finance"],
+      Salary: [50000, 75000, 55000, 85000, 65000, 83000],
+      PerformanceScore: [85, 49, 95, 40, 88, 73],
     },
-    columnDefaults: {
-        cells: {
-            className: '{#if (gt value 30)}over-30{/if}'
-        }
+  },
+  columnDefaults: {
+    cells: {
+      /* 
+      Use the formatter callback function only when needed, for more complex formatting.
+      This example wraps numeric values, except the first column, inside a span. If
+      value > 50 a highlight CSS class is appended. Since inside columnDefaults this applies to all
+      columns in the grid. See also CSS comment.
+      */
+      formatter: function () {
+        const value = this.value;
+        const id = this.column.id;
+        if (typeof value !== "number" || id === "ID") return value;
+        const className = value > 50 ? "highlight" : "";
+        return `<span class="box ${className}">${value}</span>`;
+      },
     },
-    rendering: {
-        theme: 'custom-theme',
-        rows: {
-            minVisibleRows: 5
-        }
+  },
+  rendering: {
+    theme: "custom-theme",
+  },
+  description: {
+    text: "* Performance Score",
+  },
+  columns: [
+    /* 
+    The included hcg-center, hcg-left and hc-right CSS classes can be used for text alignment
+    in headers and cells. Observe that column headers can be removed by passing an empty string
+    in the columns[].header.format API option.
+    */
+    {
+      id: "ID",
+      cells: {
+        className: "hcg-center",
+      },
+      header: {
+        format: "",
+      },
     },
-    columns: [{
-        id: 'ID',
-        cells: {
-            className: 'bold-column'
-        },
-        header: {
-            className: 'bold-header'
-        }
-    }, {
-        id: 'Salary',
-        cells: {
-            className: '{#if (gt value 50000)}highlight-cell{/if}',
-            format: '${(divide value 1000):.0f}k'
-        }
-    }, {
-        id: 'PerformanceScore',
-        cells: {
-            className: '{#if (gt value 80)}high{else}low{/if}-color'
-        },
-        header: {
-            format: 'Performance score (0-100)'
-        }
-    }]
+    /* 
+    In the Name column a custom CSS class is applied to all cells. See CSS.
+    */
+    {
+      id: "Name",
+      cells: {
+        className: "bold",
+      },
+    },
+    /* 
+    For simpler formatting with less logic use the format API option instead of formatter (see above).
+    Highcharts Grid use the same templating engine as Highcharts Core, so read more at https://www.highcharts.com/docs/chart-concepts/templating.
+    Note that format, formatter and className options in columns[] overrides any values set in columnDefaults, 
+    so the Salary column will in this example not contain that <span> we injected earlier.
+    */
+    {
+      id: "Salary",
+      cells: {
+        className: "{#if (gt value 80000)}highlight-color{/if}",
+        format: "${(divide value 1000):.0f}k",
+      },
+    },
+    /* 
+    This example uses conditional formatting for only part of the className template
+    */
+    {
+      id: "PerformanceScore",
+      cells: {
+        className: "{#if (gt value 75)}high{else}low{/if}-color bold hcg-center",
+      },
+      header: {
+        className: "hcg-center",
+        format: "PS (0-100) *",
+      },
+    },
+  ],
 });


### PR DESCRIPTION
Modified this demo so that, IMO, it's easier to see what's going, the design is more "pleasant" and also contains example of `formatter` in addition to `format`. Shows combination of HTML formatting and CSS formatting. Reintroduced simple hover style that doesn't conflict with other highlighting. Commented code so easier for beginners to understand what's happening.