### PR TITLE
bugfix/22709-dumbbell-syntax-error

### DIFF
--- a/ts/Series/Dumbbell/DumbbellSeries.ts
+++ b/ts/Series/Dumbbell/DumbbellSeries.ts
@@ -322,7 +322,10 @@ class DumbbellSeries extends AreaRangeSeries {
                 (upperGraphic.element as any).point = point;
                 upperGraphic.addClass('highcharts-lollipop-high');
             }
-            (point.connector?.element as any).point = point;
+
+            if (point.connector) {
+                (point.connector.element as any).point = point;
+            }
 
             if (lowerGraphic) {
                 zoneColor = point.zone && point.zone.color;


### PR DESCRIPTION
Fixed #22709, optional chaining threw a syntax error in dumbbell module.