### PR TITLE
bugfix/20611-variwide-linear

### DIFF
--- a/samples/unit-tests/series-variwide/variwide/demo.js
+++ b/samples/unit-tests/series-variwide/variwide/demo.js
@@ -127,6 +127,17 @@ QUnit.test('variwide', function (assert) {
         true,
         'The width of the first point should not be less than 1px (#11510)'
     );
+
+    chart.xAxis[0].setExtremes(void 0, void 0, false);
+
+    chart.series[0].setData([[0, 5, 2], [2, 7, 1], [3, 9, 9]]);
+
+    const lastPoint = chart.series[0].points[chart.series[0].points.length - 1];
+
+    assert.ok(
+        chart.xAxis[0].max > lastPoint.x + lastPoint.z,
+        'Linear x-axis extremes should include z-value of last point, #20611'
+    );
 });
 
 QUnit.test('variwide null points', function (assert) {

--- a/ts/Series/Variwide/VariwideSeries.ts
+++ b/ts/Series/Variwide/VariwideSeries.ts
@@ -19,6 +19,8 @@
  * */
 
 import type StackingAxis from '../../Core/Axis/Stacking/StackingAxis';
+import type Types from '../../Shared/Types';
+import type RangeSelector from '../../Stock/RangeSelector/RangeSelector';
 import type VariwideSeriesOptions from './VariwideSeriesOptions';
 
 import SeriesRegistry from '../../Core/Series/SeriesRegistry.js';
@@ -31,6 +33,8 @@ import VariwideSeriesDefaults from './VariwideSeriesDefaults.js';
 import U from '../../Core/Utilities.js';
 const {
     addEvent,
+    arrayMin,
+    arrayMax,
     crisp,
     extend,
     merge,
@@ -234,6 +238,18 @@ class VariwideSeries extends ColumnSeries {
                 }
             }
         }
+    }
+
+    public getXExtremes(
+        xData: Array<number>|Types.TypedArray
+    ): RangeSelector.RangeObject {
+        const max = arrayMax(xData),
+            maxZ = this.getColumn('z')[xData.indexOf(max)];
+
+        return {
+            min: arrayMin(xData),
+            max: max + (!this.xAxis.categories ? maxZ : 0)
+        };
     }
 }
 

--- a/ts/Series/Variwide/VariwideSeries.ts
+++ b/ts/Series/Variwide/VariwideSeries.ts
@@ -248,7 +248,7 @@ class VariwideSeries extends ColumnSeries {
 
         return {
             min: arrayMin(xData),
-            max: max + (!this.xAxis.categories ? maxZ : 0)
+            max: max + (this.xAxis.categories ? 0 : maxZ)
         };
     }
 }


### PR DESCRIPTION
Fixed #20611, wrong linear x-axis extremes for variwide series.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206580038320331