### PR TITLE
bugfix/22045-sorting-moves-rows-outside-tbody 

### DIFF
--- a/samples/highcharts/accessibility/accessible-annotations/demo.css
+++ b/samples/highcharts/accessibility/accessible-annotations/demo.css
@@ -43,7 +43,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/accessibility/accessible-avg-temp/demo.css
+++ b/samples/highcharts/accessibility/accessible-avg-temp/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/accessibility/accessible-line/demo.css
+++ b/samples/highcharts/accessibility/accessible-line/demo.css
@@ -38,7 +38,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/accessibility/accessible-pie/demo.css
+++ b/samples/highcharts/accessibility/accessible-pie/demo.css
@@ -54,7 +54,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/accessibility/accessible-table/demo.css
+++ b/samples/highcharts/accessibility/accessible-table/demo.css
@@ -38,7 +38,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/accessibility/advanced-accessible/demo.css
+++ b/samples/highcharts/accessibility/advanced-accessible/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/accessibility/art-grants/demo.css
+++ b/samples/highcharts/accessibility/art-grants/demo.css
@@ -39,7 +39,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/accessibility/before-chart-format/demo.css
+++ b/samples/highcharts/accessibility/before-chart-format/demo.css
@@ -38,7 +38,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/accessibility/value-description-format/demo.css
+++ b/samples/highcharts/accessibility/value-description-format/demo.css
@@ -38,7 +38,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/annotations/include-in-data-export/demo.css
+++ b/samples/highcharts/annotations/include-in-data-export/demo.css
@@ -38,7 +38,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/blog/cognitive-impairment-no-labels/demo.css
+++ b/samples/highcharts/blog/cognitive-impairment-no-labels/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/blog/cognitive-impairment/demo.css
+++ b/samples/highcharts/blog/cognitive-impairment/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/blog/line-chart/demo.css
+++ b/samples/highcharts/blog/line-chart/demo.css
@@ -38,7 +38,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/categorical-composition-split-bubble-monochrome/demo.css
+++ b/samples/highcharts/chartchooser/categorical-composition-split-bubble-monochrome/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/categorical-composition-split-bubble/demo.css
+++ b/samples/highcharts/chartchooser/categorical-composition-split-bubble/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/categorical-composition-stacked-bar-monochrome/demo.css
+++ b/samples/highcharts/chartchooser/categorical-composition-stacked-bar-monochrome/demo.css
@@ -39,7 +39,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/categorical-composition-stacked-bar-pattern/demo.css
+++ b/samples/highcharts/chartchooser/categorical-composition-stacked-bar-pattern/demo.css
@@ -39,7 +39,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/categorical-composition-stacked-bar/demo.css
+++ b/samples/highcharts/chartchooser/categorical-composition-stacked-bar/demo.css
@@ -39,7 +39,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/continuous-comparison-scatter-trend-line/demo.css
+++ b/samples/highcharts/chartchooser/continuous-comparison-scatter-trend-line/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/continuous-comparison-scatter/demo.css
+++ b/samples/highcharts/chartchooser/continuous-comparison-scatter/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/continuous-composition-stacked-area-monochrome/demo.css
+++ b/samples/highcharts/chartchooser/continuous-composition-stacked-area-monochrome/demo.css
@@ -40,7 +40,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/continuous-composition-stacked-area/demo.css
+++ b/samples/highcharts/chartchooser/continuous-composition-stacked-area/demo.css
@@ -40,7 +40,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/continuous-distribution-bell-curve-standard-deviation/demo.css
+++ b/samples/highcharts/chartchooser/continuous-distribution-bell-curve-standard-deviation/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/continuous-distribution-bell-curve/demo.css
+++ b/samples/highcharts/chartchooser/continuous-distribution-bell-curve/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/continuous-distribution-bubble-patterns/demo.css
+++ b/samples/highcharts/chartchooser/continuous-distribution-bubble-patterns/demo.css
@@ -41,7 +41,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/continuous-distribution-bubble/demo.css
+++ b/samples/highcharts/chartchooser/continuous-distribution-bubble/demo.css
@@ -41,7 +41,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/continuous-flow-streamgraph-monochrome/demo.css
+++ b/samples/highcharts/chartchooser/continuous-flow-streamgraph-monochrome/demo.css
@@ -38,7 +38,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/continuous-flow-streamgraph/demo.css
+++ b/samples/highcharts/chartchooser/continuous-flow-streamgraph/demo.css
@@ -38,7 +38,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/continuous-relationship-line/demo.css
+++ b/samples/highcharts/chartchooser/continuous-relationship-line/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/continuous-relationship-scatte-trend-line/demo.css
+++ b/samples/highcharts/chartchooser/continuous-relationship-scatte-trend-line/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/continuous-relationship-scatter/demo.css
+++ b/samples/highcharts/chartchooser/continuous-relationship-scatter/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/continuous-trend-area-range/demo.css
+++ b/samples/highcharts/chartchooser/continuous-trend-area-range/demo.css
@@ -38,7 +38,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/continuous-trend-line-annotations/demo.css
+++ b/samples/highcharts/chartchooser/continuous-trend-line-annotations/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/chartchooser/continuous-trend-line/demo.css
+++ b/samples/highcharts/chartchooser/continuous-trend-line/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/3d-column-null-values/demo.css
+++ b/samples/highcharts/demo/3d-column-null-values/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/3d-column-stacking-grouping/demo.css
+++ b/samples/highcharts/demo/3d-column-stacking-grouping/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/3d-pie-donut/demo.css
+++ b/samples/highcharts/demo/3d-pie-donut/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/3d-pie/demo.css
+++ b/samples/highcharts/demo/3d-pie/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/3d-scatter-draggable/demo.css
+++ b/samples/highcharts/demo/3d-scatter-draggable/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/accessible-line/demo.css
+++ b/samples/highcharts/demo/accessible-line/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/accessible-pie/demo.css
+++ b/samples/highcharts/demo/accessible-pie/demo.css
@@ -55,7 +55,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/advanced-accessible/demo.css
+++ b/samples/highcharts/demo/advanced-accessible/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/annotations/demo.css
+++ b/samples/highcharts/demo/annotations/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/area-chart/demo.css
+++ b/samples/highcharts/demo/area-chart/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/area-inverted/demo.css
+++ b/samples/highcharts/demo/area-inverted/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/area-missing/demo.css
+++ b/samples/highcharts/demo/area-missing/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/area-negative/demo.css
+++ b/samples/highcharts/demo/area-negative/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/area-stacked-inverted/demo.css
+++ b/samples/highcharts/demo/area-stacked-inverted/demo.css
@@ -40,7 +40,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/area-stacked-percent/demo.css
+++ b/samples/highcharts/demo/area-stacked-percent/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/area-stacked/demo.css
+++ b/samples/highcharts/demo/area-stacked/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/arearange-line/demo.css
+++ b/samples/highcharts/demo/arearange-line/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/arearange/demo.css
+++ b/samples/highcharts/demo/arearange/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/areaspline/demo.css
+++ b/samples/highcharts/demo/areaspline/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/bar-chart/demo.css
+++ b/samples/highcharts/demo/bar-chart/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/bar-negative-stack/demo.css
+++ b/samples/highcharts/demo/bar-negative-stack/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/bar-stacked/demo.css
+++ b/samples/highcharts/demo/bar-stacked/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/bellcurve/demo.css
+++ b/samples/highcharts/demo/bellcurve/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/box-plot/demo.css
+++ b/samples/highcharts/demo/box-plot/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/bubble-3d/demo.css
+++ b/samples/highcharts/demo/bubble-3d/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/bubble/demo.css
+++ b/samples/highcharts/demo/bubble/demo.css
@@ -41,7 +41,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/bullet-graph/demo.css
+++ b/samples/highcharts/demo/bullet-graph/demo.css
@@ -47,7 +47,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/chart-update/demo.css
+++ b/samples/highcharts/demo/chart-update/demo.css
@@ -41,7 +41,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/column-basic/demo.css
+++ b/samples/highcharts/demo/column-basic/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/column-drilldown/demo.css
+++ b/samples/highcharts/demo/column-drilldown/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/column-negative/demo.css
+++ b/samples/highcharts/demo/column-negative/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/column-placement/demo.css
+++ b/samples/highcharts/demo/column-placement/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/column-pyramid/demo.css
+++ b/samples/highcharts/demo/column-pyramid/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/column-rotated-labels/demo.css
+++ b/samples/highcharts/demo/column-rotated-labels/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/column-stacked-and-grouped/demo.css
+++ b/samples/highcharts/demo/column-stacked-and-grouped/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/column-stacked-percent/demo.css
+++ b/samples/highcharts/demo/column-stacked-percent/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/column-stacked/demo.css
+++ b/samples/highcharts/demo/column-stacked/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/columnrange/demo.css
+++ b/samples/highcharts/demo/columnrange/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/combo-dual-axes/demo.css
+++ b/samples/highcharts/demo/combo-dual-axes/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/combo-meteogram/demo.css
+++ b/samples/highcharts/demo/combo-meteogram/demo.css
@@ -59,7 +59,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/combo-multi-axes/demo.css
+++ b/samples/highcharts/demo/combo-multi-axes/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/combo-regression/demo.css
+++ b/samples/highcharts/demo/combo-regression/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/combo-timeline/demo.css
+++ b/samples/highcharts/demo/combo-timeline/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/combo/demo.css
+++ b/samples/highcharts/demo/combo/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/cylinder/demo.css
+++ b/samples/highcharts/demo/cylinder/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/dependency-wheel/demo.css
+++ b/samples/highcharts/demo/dependency-wheel/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/donut-chart/demo.css
+++ b/samples/highcharts/demo/donut-chart/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/dumbbell/demo.css
+++ b/samples/highcharts/demo/dumbbell/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/dynamic-click-to-add/demo.css
+++ b/samples/highcharts/demo/dynamic-click-to-add/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/dynamic-master-detail/demo.css
+++ b/samples/highcharts/demo/dynamic-master-detail/demo.css
@@ -44,7 +44,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/dynamic-update/demo.css
+++ b/samples/highcharts/demo/dynamic-update/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/error-bar/demo.css
+++ b/samples/highcharts/demo/error-bar/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/euler-diagram/demo.css
+++ b/samples/highcharts/demo/euler-diagram/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/fan-chart/demo.css
+++ b/samples/highcharts/demo/fan-chart/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/flame/demo.css
+++ b/samples/highcharts/demo/flame/demo.css
@@ -86,7 +86,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/funnel/demo.css
+++ b/samples/highcharts/demo/funnel/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/funnel3d/demo.css
+++ b/samples/highcharts/demo/funnel3d/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/gauge-clock/demo.css
+++ b/samples/highcharts/demo/gauge-clock/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/gauge-dual/demo.css
+++ b/samples/highcharts/demo/gauge-dual/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/gauge-multiple-kpi/demo.css
+++ b/samples/highcharts/demo/gauge-multiple-kpi/demo.css
@@ -38,7 +38,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/gauge-solid/demo.css
+++ b/samples/highcharts/demo/gauge-solid/demo.css
@@ -38,7 +38,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/gauge-speedometer/demo.css
+++ b/samples/highcharts/demo/gauge-speedometer/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/gauge-vu-meter/demo.css
+++ b/samples/highcharts/demo/gauge-vu-meter/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/heatmap-canvas/demo.css
+++ b/samples/highcharts/demo/heatmap-canvas/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/heatmap/demo.css
+++ b/samples/highcharts/demo/heatmap/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/histogram/demo.css
+++ b/samples/highcharts/demo/histogram/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/honeycomb-usa/demo.css
+++ b/samples/highcharts/demo/honeycomb-usa/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/line-boost/demo.css
+++ b/samples/highcharts/demo/line-boost/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/line-chart/demo.css
+++ b/samples/highcharts/demo/line-chart/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/line-csv/demo.css
+++ b/samples/highcharts/demo/line-csv/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/line-custom-entrance-animation/demo.css
+++ b/samples/highcharts/demo/line-custom-entrance-animation/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/line-forecast/demo.css
+++ b/samples/highcharts/demo/line-forecast/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/line-labels/demo.css
+++ b/samples/highcharts/demo/line-labels/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/line-log-axis/demo.css
+++ b/samples/highcharts/demo/line-log-axis/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/line-time-series/demo.css
+++ b/samples/highcharts/demo/line-time-series/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/live-data/demo.css
+++ b/samples/highcharts/demo/live-data/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/lollipop/demo.css
+++ b/samples/highcharts/demo/lollipop/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/network-graph/demo.css
+++ b/samples/highcharts/demo/network-graph/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/organization-chart/demo.css
+++ b/samples/highcharts/demo/organization-chart/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/packed-bubble-split/demo.css
+++ b/samples/highcharts/demo/packed-bubble-split/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/packed-bubble/demo.css
+++ b/samples/highcharts/demo/packed-bubble/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/parallel-coordinates-polar/demo.css
+++ b/samples/highcharts/demo/parallel-coordinates-polar/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/parallel-coordinates/demo.css
+++ b/samples/highcharts/demo/parallel-coordinates/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/pareto/demo.css
+++ b/samples/highcharts/demo/pareto/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/parliament-chart/demo.css
+++ b/samples/highcharts/demo/parliament-chart/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/pie-chart/demo.css
+++ b/samples/highcharts/demo/pie-chart/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/pie-custom-entrance-animation/demo.css
+++ b/samples/highcharts/demo/pie-custom-entrance-animation/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/pie-donut/demo.css
+++ b/samples/highcharts/demo/pie-donut/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/pie-drilldown/demo.css
+++ b/samples/highcharts/demo/pie-drilldown/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/pie-gradient/demo.css
+++ b/samples/highcharts/demo/pie-gradient/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/pie-legend/demo.css
+++ b/samples/highcharts/demo/pie-legend/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/pie-monochrome/demo.css
+++ b/samples/highcharts/demo/pie-monochrome/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/pie-semi-circle/demo.css
+++ b/samples/highcharts/demo/pie-semi-circle/demo.css
@@ -41,7 +41,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/polar-radial-bar/demo.css
+++ b/samples/highcharts/demo/polar-radial-bar/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/polar-spider/demo.css
+++ b/samples/highcharts/demo/polar-spider/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/polar-wind-rose/demo.css
+++ b/samples/highcharts/demo/polar-wind-rose/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/polar/demo.css
+++ b/samples/highcharts/demo/polar/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/polygon/demo.css
+++ b/samples/highcharts/demo/polygon/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/pyramid/demo.css
+++ b/samples/highcharts/demo/pyramid/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/pyramid3d/demo.css
+++ b/samples/highcharts/demo/pyramid3d/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/renderer/demo.css
+++ b/samples/highcharts/demo/renderer/demo.css
@@ -39,7 +39,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/responsive/demo.css
+++ b/samples/highcharts/demo/responsive/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/sankey-diagram/demo.css
+++ b/samples/highcharts/demo/sankey-diagram/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/scatter-boost/demo.css
+++ b/samples/highcharts/demo/scatter-boost/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/scatter/demo.css
+++ b/samples/highcharts/demo/scatter/demo.css
@@ -38,7 +38,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/spline-inverted/demo.css
+++ b/samples/highcharts/demo/spline-inverted/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/spline-irregular-time/demo.css
+++ b/samples/highcharts/demo/spline-irregular-time/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/spline-plot-bands/demo.css
+++ b/samples/highcharts/demo/spline-plot-bands/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/spline-symbols/demo.css
+++ b/samples/highcharts/demo/spline-symbols/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/streamgraph/demo.css
+++ b/samples/highcharts/demo/streamgraph/demo.css
@@ -38,7 +38,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/styled-mode-column/demo.css
+++ b/samples/highcharts/demo/styled-mode-column/demo.css
@@ -35,7 +35,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/styled-mode-pie/demo.css
+++ b/samples/highcharts/demo/styled-mode-pie/demo.css
@@ -46,7 +46,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/sunburst/demo.css
+++ b/samples/highcharts/demo/sunburst/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/synchronized-charts/demo.css
+++ b/samples/highcharts/demo/synchronized-charts/demo.css
@@ -41,7 +41,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/timeline/demo.css
+++ b/samples/highcharts/demo/timeline/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/treemap-coloraxis/demo.css
+++ b/samples/highcharts/demo/treemap-coloraxis/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/treemap-with-levels/demo.css
+++ b/samples/highcharts/demo/treemap-with-levels/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/variable-radius-pie/demo.css
+++ b/samples/highcharts/demo/variable-radius-pie/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/variwide/demo.css
+++ b/samples/highcharts/demo/variwide/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/vector-plot/demo.css
+++ b/samples/highcharts/demo/vector-plot/demo.css
@@ -41,7 +41,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/vertical-sankey/demo.css
+++ b/samples/highcharts/demo/vertical-sankey/demo.css
@@ -39,7 +39,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/waterfall/demo.css
+++ b/samples/highcharts/demo/waterfall/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/windbarb-series/demo.css
+++ b/samples/highcharts/demo/windbarb-series/demo.css
@@ -41,7 +41,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/wordcloud/demo.css
+++ b/samples/highcharts/demo/wordcloud/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/demo/x-range/demo.css
+++ b/samples/highcharts/demo/x-range/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/export-data/join-annotations/demo.css
+++ b/samples/highcharts/export-data/join-annotations/demo.css
@@ -38,7 +38,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/export-data/multilevel-table/demo.css
+++ b/samples/highcharts/export-data/multilevel-table/demo.css
@@ -32,7 +32,7 @@
     padding: 0.5em;
 }
 
-.highcharts-data-table tr:nth-child(even),
+.highcharts-data-table tbody tr:nth-child(even),
 .highcharts-data-table thead tr {
     background: #f8f8f8;
 }

--- a/samples/highcharts/export-data/showtable/demo.css
+++ b/samples/highcharts/export-data/showtable/demo.css
@@ -26,7 +26,7 @@
     padding: 0.5em;
 }
 
-.highcharts-data-table tr:nth-child(even),
+.highcharts-data-table tbody tr:nth-child(even),
 .highcharts-data-table thead tr {
     background: #f8f8f8;
 }

--- a/samples/highcharts/series-histogram/column/demo.css
+++ b/samples/highcharts/series-histogram/column/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/series-venn/point-legend/demo.css
+++ b/samples/highcharts/series-venn/point-legend/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/series/legend-symbol-color/demo.css
+++ b/samples/highcharts/series/legend-symbol-color/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/studies/parliament-improved/demo.css
+++ b/samples/highcharts/studies/parliament-improved/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/studies/tree-toggle/demo.css
+++ b/samples/highcharts/studies/tree-toggle/demo.css
@@ -33,7 +33,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/highcharts/website/themes-demo/demo.css
+++ b/samples/highcharts/website/themes-demo/demo.css
@@ -37,7 +37,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/samples/unit-tests/export-data/basics/demo.js
+++ b/samples/unit-tests/export-data/basics/demo.js
@@ -1358,46 +1358,53 @@ QUnit.test('Sortable table (#16972)', function (assert) {
     });
 
     chart.dataTableDiv.children[0].children[1].children[0].children[0].click();
-
     assert.strictEqual(
-        chart.dataTableDiv.children[0].children[3].children[0].innerText,
+        chart.dataTableDiv.children[0].children[2].children[0].children[0]
+            .innerText,
         'BE',
         'After clicking on the row header, table content should be sorted.'
     );
     assert.strictEqual(
-        chart.dataTableDiv.children[0].children[3].children[1].innerText,
+        chart.dataTableDiv.children[0].children[2].children[0].children[1]
+            .innerText,
         '50',
         'After sorting, values should correspond to the one on the chart.'
     );
     assert.strictEqual(
-        chart.dataTableDiv.children[0].children[4].children[0].innerText,
+        chart.dataTableDiv.children[0].children[2].children[1].children[0]
+            .innerText,
         'DE',
         'After clicking on the row header, table content should be sorted.'
     );
     assert.strictEqual(
-        chart.dataTableDiv.children[0].children[4].children[1].innerText,
+        chart.dataTableDiv.children[0].children[2].children[1].children[1]
+            .innerText,
         '60',
         'After sorting, values should correspond to the one on the chart.'
     );
 
     chart.dataTableDiv.children[0].children[1].children[0].children[0].click();
     assert.strictEqual(
-        chart.dataTableDiv.children[0].children[3].children[0].innerText,
+        chart.dataTableDiv.children[0].children[2].children[0].children[0]
+            .innerText,
         'NO',
         'After clicking on the row header, table content should be resorted.'
     );
     assert.strictEqual(
-        chart.dataTableDiv.children[0].children[3].children[1].innerText,
+        chart.dataTableDiv.children[0].children[2].children[0].children[1]
+            .innerText,
         '70',
         'After sorting, values should correspond to the one on the chart.'
     );
     assert.strictEqual(
-        chart.dataTableDiv.children[0].children[4].children[0].innerText,
+        chart.dataTableDiv.children[0].children[2].children[1].children[0]
+            .innerText,
         'NL',
         'After clicking on the row header, table content should be resorted.'
     );
     assert.strictEqual(
-        chart.dataTableDiv.children[0].children[4].children[1].innerText,
+        chart.dataTableDiv.children[0].children[2].children[1].children[1]
+            .innerText,
         '100',
         'After sorting, values should correspond to the one on the chart.'
     );

--- a/samples/unit-tests/export-data/multilevel-table/demo.css
+++ b/samples/unit-tests/export-data/multilevel-table/demo.css
@@ -44,7 +44,7 @@
 }
 
 .highcharts-data-table thead tr,
-.highcharts-data-table tr:nth-child(even) {
+.highcharts-data-table tbody tr:nth-child(even) {
     background: #f8f8f8;
 }
 

--- a/ts/Extensions/ExportData/ExportData.ts
+++ b/ts/Extensions/ExportData/ExportData.ts
@@ -1283,7 +1283,7 @@ function onChartAfterViewData(
         const row = dataTableDiv.querySelector('thead tr');
         if (row) {
             row.childNodes.forEach((th: any): void => {
-                const table = th.closest('table');
+                const tableBody = dataTableDiv.querySelector('tbody');
 
                 th.addEventListener('click', function (): void {
                     const rows = [...dataTableDiv.querySelectorAll(
@@ -1298,7 +1298,7 @@ function onChartAfterViewData(
                                 !chart.ascendingOrderInTable
                         )
                     ).forEach((tr: HTMLDOMElement): void => {
-                        table.appendChild(tr);
+                        tableBody?.appendChild(tr);
                     });
 
                     headers.forEach((th): void => {


### PR DESCRIPTION
Fixed #22045, sorting the data export table broke the DOM structure, affecting styling.