### PR TITLE
bugfix/22892-packedbubble-hover-error

### DIFF
--- a/samples/unit-tests/series-packedbubble/update/demo.js
+++ b/samples/unit-tests/series-packedbubble/update/demo.js
@@ -157,11 +157,9 @@ QUnit.test('Testing hovering while updating', function (assert) {
         tc = new TestController(chart),
         interval = setInterval(() => {
             chart.update(getChartOptions(++count), true, true);
-
             tc.moveTo(hoverX, hoverY);
 
             if (count === 8) {
-                console.log(chart.hoverPoint.state);
                 assert.strictEqual(
                     chart.hoverPoint.state,
                     'hover',

--- a/samples/unit-tests/series-packedbubble/update/demo.js
+++ b/samples/unit-tests/series-packedbubble/update/demo.js
@@ -164,5 +164,5 @@ QUnit.test('Testing hovering while updating (#22892)', function (assert) {
                 clearInterval(interval);
                 done();
             }
-        }, 500);
+        }, 50);
 });

--- a/samples/unit-tests/series-packedbubble/update/demo.js
+++ b/samples/unit-tests/series-packedbubble/update/demo.js
@@ -114,7 +114,7 @@ QUnit.test('Series update', function (assert) {
 });
 
 
-QUnit.test('Testing hovering while updating (#22892)', function (assert) {
+QUnit.test('Testing hovering while updating, #22892', function (assert) {
     let count = 0;
 
     const getChartOptions = count => ({
@@ -159,7 +159,7 @@ QUnit.test('Testing hovering while updating (#22892)', function (assert) {
                 assert.strictEqual(
                     chart.hoverPoint.state,
                     'hover',
-                    'Hovering a changing packedbubble series should work'
+                    'Hovering a changing packed bubble series should work'
                 );
                 clearInterval(interval);
                 done();

--- a/samples/unit-tests/series-packedbubble/update/demo.js
+++ b/samples/unit-tests/series-packedbubble/update/demo.js
@@ -114,52 +114,48 @@ QUnit.test('Series update', function (assert) {
 });
 
 
-QUnit.test('Testing hovering while updating', function (assert) {
-    const done = assert.async();
-
+QUnit.test('Testing hovering while updating (#22892)', function (assert) {
     let count = 0;
 
-
     const getChartOptions = count => ({
-        chart: {
-            type: 'packedbubble',
-            animation: false
-        },
-        plotOptions: {
-            packedbubble: {
-                layoutAlgorithm: {
-                    enableSimulation: false,
-                    gravitationalConstant: 0.05,
-                    splitSeries: true,
-                    seriesInteraction: false,
-                    dragBetweenSeries: true,
-                    parentNodeLimit: true
-                }
-            }
-        },
-        series: [
-            {
-                name: 'Series',
+            chart: {
                 type: 'packedbubble',
-                data: Array.from({ length: count }).map((_, i) => ({
-                    name: '' + i,
-                    value: i
-                })),
-                layoutAlgorithm: {
-                    gravitationalConstant: 0.01
+                animation: false
+            },
+            plotOptions: {
+                packedbubble: {
+                    layoutAlgorithm: {
+                        enableSimulation: false,
+                        splitSeries: true
+                    }
                 }
-            }
-        ]
-    });
-    const chart = Highcharts.chart('container', getChartOptions(count)),
+            },
+            series: [{
+                data: (() => {
+                    const data = [];
+                    for (let i = count; i; --i) {
+                        data.push(i);
+                    }
+                    return data;
+                })()
+            }]
+        }),
+        done = assert.async(),
+        chart = Highcharts.chart('container', getChartOptions(count)),
         hoverX = chart.plotLeft + (chart.chartWidth / 2),
         hoverY = chart.plotTop + (chart.chartHeight / 2),
         tc = new TestController(chart),
+
+        // Change chart config while simulating mouse hovering
+        // the center of the series
         interval = setInterval(() => {
             chart.update(getChartOptions(++count), true, true);
+
+            // We know we will hit either a bubble or the parentBubble
             tc.moveTo(hoverX, hoverY);
 
             if (count === 8) {
+                // Check that hovering worked
                 assert.strictEqual(
                     chart.hoverPoint.state,
                     'hover',

--- a/samples/unit-tests/series-packedbubble/update/demo.js
+++ b/samples/unit-tests/series-packedbubble/update/demo.js
@@ -112,3 +112,63 @@ QUnit.test('Series update', function (assert) {
         chart plot height, #20264.`
     );
 });
+
+
+QUnit.test('Testing hovering while updating', function (assert) {
+    const done = assert.async();
+
+    let count = 0;
+
+
+    const getChartOptions = count => ({
+        chart: {
+            type: 'packedbubble',
+            animation: false
+        },
+        plotOptions: {
+            packedbubble: {
+                layoutAlgorithm: {
+                    enableSimulation: false,
+                    gravitationalConstant: 0.05,
+                    splitSeries: true,
+                    seriesInteraction: false,
+                    dragBetweenSeries: true,
+                    parentNodeLimit: true
+                }
+            }
+        },
+        series: [
+            {
+                name: 'Series',
+                type: 'packedbubble',
+                data: Array.from({ length: count }).map((_, i) => ({
+                    name: '' + i,
+                    value: i
+                })),
+                layoutAlgorithm: {
+                    gravitationalConstant: 0.01
+                }
+            }
+        ]
+    });
+    const chart = Highcharts.chart('container', getChartOptions(count)),
+        hoverX = chart.plotLeft + (chart.chartWidth / 2),
+        hoverY = chart.plotTop + (chart.chartHeight / 2),
+        tc = new TestController(chart),
+        interval = setInterval(() => {
+            chart.update(getChartOptions(++count), true, true);
+
+            tc.moveTo(hoverX, hoverY);
+
+            if (count === 8) {
+                console.log(chart.hoverPoint.state);
+                assert.strictEqual(
+                    chart.hoverPoint.state,
+                    'hover',
+                    'Hovering a changing packedbubble series should work'
+                );
+                clearInterval(interval);
+                done();
+            }
+        }, 500);
+});

--- a/samples/unit-tests/series-packedbubble/update/demo.js
+++ b/samples/unit-tests/series-packedbubble/update/demo.js
@@ -115,54 +115,62 @@ QUnit.test('Series update', function (assert) {
 
 
 QUnit.test('Testing hovering while updating, #22892', function (assert) {
-    let count = 0;
+    let count = 0,
+        clock = null;
 
-    const getChartOptions = count => ({
-            chart: {
-                type: 'packedbubble',
-                animation: false
-            },
-            plotOptions: {
-                packedbubble: {
-                    layoutAlgorithm: {
-                        enableSimulation: false,
-                        splitSeries: true
+    try {
+        clock = TestUtilities.lolexInstall();
+
+        const getChartOptions = count => ({
+                chart: {
+                    type: 'packedbubble',
+                    animation: false
+                },
+                plotOptions: {
+                    packedbubble: {
+                        layoutAlgorithm: {
+                            enableSimulation: false,
+                            splitSeries: true
+                        }
                     }
-                }
-            },
-            series: [{
-                data: (() => {
-                    const data = [];
-                    for (let i = count; i; --i) {
-                        data.push(i);
-                    }
-                    return data;
-                })()
-            }]
-        }),
-        done = assert.async(),
-        chart = Highcharts.chart('container', getChartOptions(count)),
-        hoverX = chart.plotLeft + (chart.chartWidth / 2),
-        hoverY = chart.plotTop + (chart.chartHeight / 2),
-        tc = new TestController(chart),
+                },
+                series: [{
+                    data: (() => {
+                        const data = [];
+                        for (let i = count; i; --i) {
+                            data.push(i);
+                        }
+                        return data;
+                    })()
+                }]
+            }),
+            done = assert.async(),
+            chart = Highcharts.chart('container', getChartOptions(count)),
+            hoverX = chart.plotLeft + (chart.chartWidth / 2),
+            hoverY = chart.plotTop + (chart.chartHeight / 2),
+            tc = new TestController(chart),
 
-        // Change chart config while simulating mouse hovering
-        // the center of the series
-        interval = setInterval(() => {
-            chart.update(getChartOptions(++count), true, true);
+            // Change chart config while simulating mouse hovering
+            // the center of the series
+            interval = setInterval(() => {
+                chart.update(getChartOptions(++count), true, true);
 
-            // We know we will hit either a bubble or the parentBubble
-            tc.moveTo(hoverX, hoverY);
+                // We know we will hit either a bubble or the parentBubble
+                tc.moveTo(hoverX, hoverY);
 
-            if (count === 8) {
+                if (count === 8) {
                 // Check that hovering worked
-                assert.strictEqual(
-                    chart.hoverPoint.state,
-                    'hover',
-                    'Hovering a changing packed bubble series should work'
-                );
-                clearInterval(interval);
-                done();
-            }
-        }, 50);
+                    assert.strictEqual(
+                        chart.hoverPoint.state,
+                        'hover',
+                        'Hovering a changing packed bubble series should work'
+                    );
+                    clearInterval(interval);
+                    done();
+                }
+            }, 50);
+        TestUtilities.lolexRunAndUninstall(clock);
+    } finally {
+        TestUtilities.lolexUninstall(clock);
+    }
 });

--- a/ts/Series/Bubble/BubblePoint.ts
+++ b/ts/Series/Bubble/BubblePoint.ts
@@ -72,13 +72,14 @@ class BubblePoint extends ScatterPoint {
 
         if (this.series.chart.inverted) {
             const pos = this.pos() || [0, 0],
-                { xAxis, yAxis, chart } = this.series;
+                { xAxis, yAxis, chart } = this.series,
+                diameter = computedSize * 2;
 
             return chart.renderer.symbols.circle(
-                xAxis.len - pos[1] - computedSize,
-                yAxis.len - pos[0] - computedSize,
-                computedSize * 2,
-                computedSize * 2
+                (xAxis?.len || 0) - pos[1] - computedSize,
+                (yAxis?.len || 0) - pos[0] - computedSize,
+                diameter,
+                diameter
             );
         }
 

--- a/ts/Series/PackedBubble/PackedBubblePoint.ts
+++ b/ts/Series/PackedBubble/PackedBubblePoint.ts
@@ -25,6 +25,7 @@ import type PackedBubbleSeries from './PackedBubbleSeries';
 import Chart from '../../Core/Chart/Chart.js';
 import Point from '../../Core/Series/Point.js';
 import SeriesRegistry from '../../Core/Series/SeriesRegistry.js';
+import { StatesOptionsKey } from '../../Core/Series/StatesOptions';
 const {
     seriesTypes: {
         bubble: {
@@ -144,6 +145,15 @@ class PackedBubblePoint extends BubblePoint implements DragNodesPoint {
             chart.getSelectedPoints = Chart.prototype.getSelectedPoints;
         } else {
             Point.prototype.select.apply(this, arguments);
+        }
+    }
+
+    public setState(
+        state?: (StatesOptionsKey|''),
+        move?: boolean
+    ): void {
+        if (this?.graphic?.parentGroup?.element) {
+            super.setState(state, move);
         }
     }
 

--- a/ts/Series/PackedBubble/PackedBubblePoint.ts
+++ b/ts/Series/PackedBubble/PackedBubblePoint.ts
@@ -21,11 +21,11 @@ import type { DragNodesPoint } from '../DragNodesComposition';
 import type NetworkgraphPoint from '../Networkgraph/NetworkgraphPoint';
 import type PackedBubblePointOptions from './PackedBubblePointOptions';
 import type PackedBubbleSeries from './PackedBubbleSeries';
+import type { StatesOptionsKey } from '../../Core/Series/StatesOptions';
 
 import Chart from '../../Core/Chart/Chart.js';
 import Point from '../../Core/Series/Point.js';
 import SeriesRegistry from '../../Core/Series/SeriesRegistry.js';
-import { StatesOptionsKey } from '../../Core/Series/StatesOptions';
 const {
     seriesTypes: {
         bubble: {
@@ -149,7 +149,7 @@ class PackedBubblePoint extends BubblePoint implements DragNodesPoint {
     }
 
     public setState(
-        state?: (StatesOptionsKey|''),
+        state?: StatesOptionsKey,
         move?: boolean
     ): void {
         if (this?.graphic?.parentGroup?.element) {


### PR DESCRIPTION
Fixed #22892 , hovering a changing packed bubble series could result in error thrown.


NOTE:
- The way to trigger this issue is to hover the chart while setInterval is continuously updating the chart, triggering a console error.
- How should a unit-test for this look?
- Should we do the setInterval thing while using testController to hover about the series?