### PR TITLE
bugfix/14195-no-legend-maxwidth-option

### DIFF
--- a/samples/highcharts/legend/maxwidth/demo.css
+++ b/samples/highcharts/legend/maxwidth/demo.css
@@ -1,0 +1,5 @@
+#container {
+    height: 400px;
+    width: 480px;
+    margin: 0 auto;
+}

--- a/samples/highcharts/legend/maxwidth/demo.details
+++ b/samples/highcharts/legend/maxwidth/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Markus Knutson Barstad
+ js_wrap: b
+...

--- a/samples/highcharts/legend/maxwidth/demo.html
+++ b/samples/highcharts/legend/maxwidth/demo.html
@@ -1,0 +1,3 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+
+<div id="container"></div>

--- a/samples/highcharts/legend/maxwidth/demo.js
+++ b/samples/highcharts/legend/maxwidth/demo.js
@@ -1,0 +1,11 @@
+Highcharts.chart('container', {
+    legend: {
+        maxWidth: '7%', // Only allow legend to be up to 7% of chart width.
+        borderWidth: 1
+    },
+
+    series: [{
+        name: '123456789',
+        data: [0, 1, 2]
+    }]
+});

--- a/samples/unit-tests/legend/width/demo.js
+++ b/samples/unit-tests/legend/width/demo.js
@@ -1,61 +1,62 @@
 QUnit.test('Legend width', function (assert) {
-    var chart = Highcharts.chart('container', {
-        chart: {
-            width: 400
-        },
+    const chart = Highcharts.chart('container', {
+            chart: {
+                width: 400
+            },
 
-        legend: {
-            align: 'right',
-            verticalAlign: 'middle',
-            borderWidth: 1
-        },
+            legend: {
+                align: 'right',
+                verticalAlign: 'middle',
+                borderWidth: 1
+            },
 
-        series: [
-            {
-                data: [6, 4, 2],
-                name: 'First'
-            },
-            {
-                data: [7, 3, 2],
-                name: 'Second'
-            },
-            {
-                data: [9, 4, 8],
-                name: 'Third'
-            },
-            {
-                data: [1, 2, 6],
-                name: 'Fourth'
-            },
-            {
-                data: [4, 6, 4],
-                name: 'Fifth'
-            },
-            {
-                data: [1, 2, 7],
-                name: 'Sixth'
-            },
-            {
-                data: [4, 2, 5],
-                name: 'Seventh'
-            },
-            {
-                data: [8, 3, 2],
-                name: 'Eighth'
-            },
-            {
-                data: [4, 5, 6],
-                name: 'Ninth'
-            }
-        ]
-    });
+            series: [
+                {
+                    data: [6, 4, 2],
+                    name: 'First'
+                },
+                {
+                    data: [7, 3, 2],
+                    name: 'Second'
+                },
+                {
+                    data: [9, 4, 8],
+                    name: 'Third'
+                },
+                {
+                    data: [1, 2, 6],
+                    name: 'Fourth'
+                },
+                {
+                    data: [4, 6, 4],
+                    name: 'Fifth'
+                },
+                {
+                    data: [1, 2, 7],
+                    name: 'Sixth'
+                },
+                {
+                    data: [4, 2, 5],
+                    name: 'Seventh'
+                },
+                {
+                    data: [8, 3, 2],
+                    name: 'Eighth'
+                },
+                {
+                    data: [4, 5, 6],
+                    name: 'Ninth'
+                }
+            ]
+        }),
+        legend = chart.legend;
 
     assert.ok(
-        chart.legend.legendWidth < 300,
+        legend.legendWidth < 300,
         'The default legend width should not exceed half the chart width'
     );
 
-    chart.legend.update({
+    legend.update({
         title: {
             text: `This legend is long and caused overflow to both sides,
 which aside from being bad as of itself had an additional side-effect of
@@ -64,12 +65,20 @@ cropping the legend as well.`
     });
 
     assert.ok(
-        chart.legend.legendWidth < 300,
+        legend.legendWidth < 300,
         'The default legend width should not exceed half the chart width'
     );
 
     chart.legend.update({
         verticalAlign: 'bottom'
     });
-    assert.ok(chart.legend.legendWidth > 300, 'The legend has redrawn');
+    assert.ok(legend.legendWidth > 300, 'The legend has redrawn');
+
+    legend.update({ maxWidth: '1%' });
+
+    assert.strictEqual(
+        legend.legendWidth < 300,
+        true,
+        'Legend width should have decreased by \´maxWidth\´'
+    );
 });

--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -1311,6 +1311,17 @@ const defaultOptions: DefaultOptions = {
          */
 
         /**
+         * Maximum width for the legend. Can be a percentage of the chart width,
+         * or an integer representing how many pixels wide the legend can be.
+         *
+         * @sample {highcharts} highcharts/legend/maxwidth/
+         *         Max width set to 7%
+         *
+         * @type      {number|string}
+         * @apioption legend.maxWidth
+         */
+
+        /**
          * Maximum pixel height for the legend. When the maximum height is
          * extended, navigation will show.
          *

--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -774,11 +774,15 @@ class Legend {
         // Take care of max width and text overflow (#6659)
         if (chart.styledMode || !(itemStyle as any).width) {
             label.css({
-                width: ((
-                    options.itemWidth ||
-                    legend.widthOption ||
-                    chart.spacingBox.width
-                ) - itemExtraWidth) + 'px'
+                width: Math.min(
+                    (
+                        options.itemWidth ||
+                        legend.widthOption ||
+                        chart.spacingBox.width
+                    ) - itemExtraWidth,
+                    legend.maxLegendWidth
+                ) + 'px'
+
             });
         }
 
@@ -1072,6 +1076,7 @@ class Legend {
     public render(): void {
         const legend = this,
             chart = legend.chart,
+            chartSpacingBoxWidth = chart.spacingBox.width,
             renderer = chart.renderer,
             options = legend.options,
             padding = legend.padding,
@@ -1090,15 +1095,24 @@ class Legend {
         legend.lastItemY = 0;
         legend.widthOption = relativeLength(
             options.width as any,
-            chart.spacingBox.width - padding
+            chartSpacingBoxWidth - padding
         );
 
         // Compute how wide the legend is allowed to be
-        allowedWidth = chart.spacingBox.width - 2 * padding - options.x;
+        allowedWidth = chartSpacingBoxWidth - 2 * padding - options.x;
         if (['rm', 'lm'].indexOf(legend.getAlignment().substring(0, 2)) > -1) {
             allowedWidth /= 2;
         }
-        legend.maxLegendWidth = legend.widthOption || allowedWidth;
+
+        legend.maxLegendWidth = Math.min(
+            legend.widthOption ||
+            allowedWidth,
+            relativeLength(
+                options.maxWidth as any,
+                chartSpacingBoxWidth - padding
+            ) ||
+            Infinity
+        );
 
         if (!legendGroup) {
             /**

--- a/ts/Core/Legend/LegendOptions.d.ts
+++ b/ts/Core/Legend/LegendOptions.d.ts
@@ -75,6 +75,7 @@ export interface LegendOptions {
     /** @deprecated */
     lineHeight?: number;
     margin?: number;
+    maxWidth?: number;
     maxHeight?: number;
     navigation: LegendNavigationOptions;
     padding?: number;


### PR DESCRIPTION
Fixed #14195 , there was no `maxwidth` option for legend.

Due to some strange conflicts in the original branch I have moved the fix to this branch.