### PR TITLE
bugfix/22657-annotation-resize-with-flags-series

### DIFF
--- a/samples/unit-tests/stock-tools/stock-annotation-dragging/demo.js
+++ b/samples/unit-tests/stock-tools/stock-annotation-dragging/demo.js
@@ -55,15 +55,6 @@ QUnit.test('Dragging annotation', assert => {
                 dataGrouping: {
                     enabled: true
                 }
-            }, {
-                type: 'flags',
-                data: [{
-                    x: data[50][0]
-                }, {
-                    x: data[52][0]
-                }, {
-                    x: data[55][0]
-                }]
             }
         ]
     });
@@ -82,6 +73,17 @@ QUnit.test('Dragging annotation', assert => {
         1,
         `Annotation moved by ${diff} pixels`
     );
+
+    chart.addSeries({
+        type: 'flags',
+        data: [{
+            x: data[50][0]
+        }, {
+            x: data[52][0]
+        }, {
+            x: data[55][0]
+        }]
+    });
 
     testController.pan(
         [chart.plotLeft + newPlotX, 200],

--- a/samples/unit-tests/stock-tools/stock-annotation-dragging/demo.js
+++ b/samples/unit-tests/stock-tools/stock-annotation-dragging/demo.js
@@ -55,6 +55,15 @@ QUnit.test('Dragging annotation', assert => {
                 dataGrouping: {
                     enabled: true
                 }
+            }, {
+                type: 'flags',
+                data: [{
+                    x: data[50][0]
+                }, {
+                    x: data[52][0]
+                }, {
+                    x: data[55][0]
+                }]
             }
         ]
     });
@@ -72,6 +81,17 @@ QUnit.test('Dragging annotation', assert => {
         newPlotX,
         1,
         `Annotation moved by ${diff} pixels`
+    );
+
+    testController.pan(
+        [chart.plotLeft + newPlotX, 200],
+        [chart.plotLeft + newPlotX + 200, 200]
+    );
+    assert.close(
+        newPlotX + 200,
+        annotation.points[0].plotX,
+        1,
+        'Annotation should move freely over flags series, #22657.'
     );
 });
 

--- a/ts/Core/Axis/OrdinalAxis.ts
+++ b/ts/Core/Axis/OrdinalAxis.ts
@@ -1252,6 +1252,9 @@ namespace OrdinalAxis {
                 // Add the fake series to hold the full data, then apply
                 // processData to it
                 axis.series.forEach((series): void => {
+                    if ((series as FlagSeries).takeOrdinalPosition === false) {
+                        return; // #22657
+                    }
                     fakeSeries = {
                         xAxis: fakeAxis,
                         chart: chart,


### PR DESCRIPTION
Fixed #22657, annotation dragging and resizing over flags series was incorrect.

- [x] add test