### PR TITLE
Avoid visual test failure with arearange demo on Firefox/Ubuntu

### DIFF
--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -392,6 +392,7 @@ module.exports = function (config) {
             'samples/highcharts/blog/map-europe-electricity-price/demo.js', // strange fails, remove this later
 
             // Unknown error
+            'samples/highcharts/boost/arearange/demo.js',
             'samples/highcharts/boost/scatter-smaller/demo.js',
             'samples/highcharts/data/google-spreadsheet/demo.js',
 


### PR DESCRIPTION
Couldn't reproduce the error locally or on BrowserStack, so I just exclude the sample. Not ideal, but coverage should be okay with local visual testing.