### PR TITLE
enhancement/19033-add-disabled-flag-series-stacking

### DIFF
--- a/samples/stock/plotoptions/stacking/demo.js
+++ b/samples/stock/plotoptions/stacking/demo.js
@@ -6,7 +6,7 @@ Highcharts.stockChart('container', {
 
     plotOptions: {
         series: {
-            stacking: 'normal'
+            stacking: 'disabled'
         }
     },
 

--- a/samples/unit-tests/series/stacking/demo.js
+++ b/samples/unit-tests/series/stacking/demo.js
@@ -766,4 +766,29 @@ QUnit.test('Date objects as X values, column', function (assert) {
                 should not affect the stack order.`
             );
         });
+
+    QUnit.test(
+        'Disable stacking via disabled flag, #19033',
+        function (assert) {
+            const chart = Highcharts.chart('container', {
+                chart: {
+                    type: 'column'
+                },
+                plotOptions: {
+                    series: {
+                        stacking: 'disabled'
+                    }
+                },
+                series: [{
+                    data: [1, 2, 3]
+                }]
+            });
+
+            assert.strictEqual(
+                chart.series[0].options.stacking,
+                'disabled',
+                'Stacking should be "disabled" when set in options.'
+            );
+        }
+    );
 }());

--- a/ts/Core/Axis/Stacking/StackingAxis.ts
+++ b/ts/Core/Axis/Stacking/StackingAxis.ts
@@ -143,7 +143,11 @@ function chartGetStacks(
     chart.series.forEach((series): void => {
         const xAxisOptions = series.xAxis?.options || {};
 
-        if (series.options.stacking && series.reserveSpace()) {
+        if (
+            series.options.stacking &&
+            series.options.stacking !== 'disabled' &&
+            series.reserveSpace()
+        ) {
             series.stackKey = [
                 series.type,
                 pick(series.options.stack, ''),
@@ -238,7 +242,9 @@ function seriesModifyStacks(
         processedXData = series.getColumn('x', true),
         stacking = series.options.stacking,
         stacker: (StackerFunction|undefined) =
-            (series as AnyRecord)[stacking + 'Stacker'];
+        stacking && stacking !== 'disabled' ?
+            (series as AnyRecord)[stacking + 'Stacker'] :
+            void 0;
 
     let stackIndicator: StackItemIndicatorObject;
 
@@ -332,7 +338,8 @@ function seriesSetStackedPoints(
     stackingParam?: string
 ): void {
 
-    const type = stackingParam || this.options.stacking;
+    const rawType = stackingParam || this.options.stacking,
+        type = rawType === 'disabled' ? void 0 : rawType;
 
     if (
         !type ||

--- a/ts/Core/Axis/Stacking/StackingOptions.d.ts
+++ b/ts/Core/Axis/Stacking/StackingOptions.d.ts
@@ -70,7 +70,7 @@ export interface StackLabelOptions {
 }
 
 export type StackOverflowValue = (
-    'normal'|'overlap'|'percent'|'stream'|'group'
+    'disabled'|'normal'|'overlap'|'percent'|'stream'|'group'
 );
 
 /* *

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -292,7 +292,10 @@ namespace DataLabel {
                     // that parts of the align box is inside the plot area
                     // (#12370). When stacking, it is always inside regardless
                     // of the option (#15148).
-                    pick(options.inside, !!this.options.stacking) &&
+                    pick(
+                        options.inside, this.options.stacking &&
+                        this.options.stacking !== 'disabled'
+                    ) &&
                     alignTo &&
                     chart.isInsidePlot(
                         plotX,
@@ -660,7 +663,10 @@ namespace DataLabel {
                                         labelOptions.inside
                                     ) ||
                                     pInt(distance || 0) < 0 ||
-                                    seriesOptions.stacking
+                                    (
+                                        seriesOptions.stacking &&
+                                        seriesOptions.stacking !== 'disabled'
+                                    )
                                 ) ?
                                     point.contrastColor :
                                     contrastColor;

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2253,6 +2253,7 @@ class Series {
             // Calculate the bottom y value for stacked series
             if (
                 stacking &&
+                stacking !== 'disabled' &&
                 series.visible &&
                 stacks &&
                 stacks[xValue]
@@ -4778,9 +4779,16 @@ class Series {
         series.isDirty = true;
 
         // In a stack, all other series are affected
-        if (series.options.stacking) {
+        if (
+            series.options.stacking &&
+            series.options.stacking !== 'disabled'
+        ) {
             chart.series.forEach((otherSeries): void => {
-                if (otherSeries.options.stacking && otherSeries.visible) {
+                if (
+                    otherSeries.options.stacking &&
+                    (otherSeries.options.stacking !== 'disabled') &&
+                    otherSeries.visible
+                ) {
                     otherSeries.isDirty = true;
                 }
             });

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2221,13 +2221,15 @@ class Series {
                 stackValues: (Array<number>|undefined),
                 yValue = point.y,
                 lowValue = point.low;
-            const stacks = stacking && yAxis.stacking?.stacks[(
-                series.negStacks &&
+            const stacks = stacking &&
+                stacking !== 'disabled' &&
+                yAxis.stacking?.stacks[(
+                    series.negStacks &&
                 (yValue as any) <
                 (stackThreshold ? 0 : (threshold as any)) ?
-                    '-' :
-                    ''
-            ) + series.stackKey];
+                        '-' :
+                        ''
+                ) + series.stackKey];
 
             plotX = xAxis.translate( // #3923
                 xValue, false, false, false, true, pointPlacement

--- a/ts/Core/Series/Series3D.ts
+++ b/ts/Core/Series/Series3D.ts
@@ -116,7 +116,8 @@ class Series3D extends Series {
             zAxis: ZAxis = pick(series.zAxis, (chart.options.zAxis as any)[0]),
             rawPoints = [] as Array<Position3DObject>,
             rawPointsX: Array<number> = [],
-            stack = seriesOptions.stacking ?
+            stack = seriesOptions.stacking &&
+                seriesOptions.stacking !== 'disabled' ?
                 (isNumber(seriesOptions.stack) ? seriesOptions.stack : 0) :
                 series.index || 0;
 

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -841,6 +841,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
      *         Area
      *
      * @type       {string}
+     * @default    disabled
      * @product    highcharts highstock
      * @validvalue ["disabled", "normal", "overlap", "percent", "stream"]
      * @apioption  plotOptions.series.stacking

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -804,7 +804,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
 
     /**
      * Whether to stack the values of each series on top of each other.
-     * Possible values are `undefined` to disable, `"normal"` to stack by
+     * Possible values are `disabled` to disable, `"normal"` to stack by
      * value or `"percent"`.
      *
      * When stacking is enabled, data must be sorted
@@ -842,7 +842,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
      *
      * @type       {string}
      * @product    highcharts highstock
-     * @validvalue ["normal", "overlap", "percent", "stream"]
+     * @validvalue ["disabled", "normal", "overlap", "percent", "stream"]
      * @apioption  plotOptions.series.stacking
      */
 

--- a/ts/Series/Area/AreaSeries.ts
+++ b/ts/Series/Area/AreaSeries.ts
@@ -214,6 +214,7 @@ class AreaSeries extends LineSeries {
             ): void {
                 const point = points[i],
                     stackedValues = stacking &&
+                        stacking !== 'disabled' &&
                         stacks[point.x as any].points[seriesIndex as any],
                     nullVal = (point as any)[side + 'Null'] || 0,
                     cliffVal = (point as any)[side + 'Cliff'] || 0;
@@ -232,7 +233,7 @@ class AreaSeries extends LineSeries {
                     isNull = !!nullVal;
 
                 } else if (
-                    !stacking &&
+                    (!stacking || stacking === 'disabled') &&
                     points[otherI] &&
                     points[otherI].isNull
                 ) {
@@ -267,21 +268,21 @@ class AreaSeries extends LineSeries {
         points = points || this.points;
 
         // Fill in missing points
-        if (stacking) {
+        if (stacking && stacking !== 'disabled') {
             points = this.getStackPoints(points);
         }
 
         for (let i = 0, iEnd = points.length; i < iEnd; ++i) {
 
             // Reset after series.update of stacking property (#12033)
-            if (!stacking) {
+            if (!stacking || stacking === 'disabled') {
                 points[i].leftCliff = points[i].rightCliff =
                     points[i].leftNull = points[i].rightNull = void 0;
             }
 
             isNull = points[i].isNull;
             plotX = pick(points[i].rectPlotX, points[i].plotX);
-            yBottom = stacking ?
+            yBottom = stacking && stacking !== 'disabled' ?
                 pick(points[i].yBottom, translatedThreshold) :
                 translatedThreshold;
 
@@ -292,7 +293,11 @@ class AreaSeries extends LineSeries {
                 }
                 // Skip null point when stacking is false and connectNulls
                 // true
-                if (!(isNull && !stacking && connectNulls)) {
+                if (
+                    !(isNull &&
+                    (!stacking || stacking === 'disabled') &&
+                    connectNulls)
+                ) {
                     graphPoints.push(points[i]);
                     bottomPoints.push({ // @todo make real point object
                         x: i,
@@ -327,6 +332,7 @@ class AreaSeries extends LineSeries {
         if (
             this.chart.series.length > 1 &&
             stacking &&
+            stacking !== 'disabled' &&
             graphPoints.some((point): boolean | undefined => point.isCliff)
         ) {
             areaPath.hasStackedCliffs = graphPath.hasStackedCliffs = true;
@@ -362,7 +368,7 @@ class AreaSeries extends LineSeries {
 
         points = points || this.points;
 
-        if (this.options.stacking) {
+        if (this.options.stacking && this.options.stacking !== 'disabled') {
 
             for (let i = 0; i < points.length; i++) {
                 // Reset after point update (#7326)

--- a/ts/Series/Area3D/Area3DSeries.ts
+++ b/ts/Series/Area3D/Area3DSeries.ts
@@ -79,7 +79,7 @@ function wrapAreaSeriesGetGraphPath(
         for (let i = 0; i < series.points.length; i++) {
             bottomPoints.push({
                 x: series.rawPointsX[i],
-                y: options.stacking ?
+                y: options.stacking && options.stacking !== 'disabled' ?
                     series.points[i].yBottom : translatedThreshold,
                 z: series.zPadding
             } as any);

--- a/ts/Series/Column/ColumnDataLabel.ts
+++ b/ts/Series/Column/ColumnDataLabel.ts
@@ -70,7 +70,8 @@ namespace ColumnDataLabel {
             below = (point as AreaRangePoint).below ?? // Range series
                 (point.plotY || 0) > (this.translatedThreshold ?? yLen),
             // Draw it inside the box?
-            inside = dlOptions.inside ?? !!options.stacking;
+            inside = dlOptions.inside ??
+            (options.stacking && options.stacking !== 'disabled');
 
         // Align to the column itself, or the top of it
         if (dlBox) { // Area range uses this method but not alignTo

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -274,6 +274,7 @@ class ColumnSeries extends Series {
                 ) { // #642, #2086
                     if (
                         otherOptions.stacking &&
+                        otherOptions.stacking !== 'disabled' &&
                         otherOptions.stacking !== 'group'
                     ) {
                         stackKey = otherSeries.stackKey;
@@ -449,7 +450,7 @@ class ColumnSeries extends Series {
                                     yStack = otherOptions.stacking &&
                                         otherOptions.stack;
 
-                                if (defined(yStack)) {
+                                if (defined(yStack) && yStack !== 'disabled') {
                                     if (isNumber(yStackMap[yStack])) {
                                         if (baseIndex === index) {
                                             baseIndex = yStackMap[yStack];

--- a/ts/Series/Column3D/Column3DComposition.ts
+++ b/ts/Series/Column3D/Column3DComposition.ts
@@ -106,7 +106,8 @@ function columnSeriesTranslate3dShapes(
         chart = series.chart,
         seriesOptions = series.options,
         depth = (seriesOptions as any).depth,
-        stack = seriesOptions.stacking ?
+        stack = seriesOptions.stacking &&
+        seriesOptions.stacking !== 'disabled' ?
             (seriesOptions.stack || 0) :
             series.index; // #4743
 
@@ -609,7 +610,12 @@ function wrapSeriesAlignDataLabel(
     ) {
         const series = this as ColumnSeries,
             seriesOptions: ColumnSeriesOptions = series.options,
-            inside = pick(options.inside, !!series.options.stacking),
+            inside = pick(
+                options.inside,
+                (series.options.stacking &&
+                series.options.stacking !== 'disabled'
+                )
+            ),
             options3d = chart.options.chart.options3d as any,
             xOffset = point.pointWidth / 2 || 0;
 

--- a/ts/Series/Funnel3D/Funnel3DSeries.ts
+++ b/ts/Series/Funnel3D/Funnel3DSeries.ts
@@ -115,7 +115,11 @@ class Funnel3DSeries extends ColumnSeries {
                 series.translatedThreshold,
                 series.yAxis.len
             ),
-            inside = pick(options.inside, !!series.options.stacking),
+            inside = pick(
+                options.inside, (series.options.stacking &&
+                series.options.stacking !== 'disabled'
+                )
+            ),
             dlBox: BBoxObject = {
                 x: dlBoxRaw.x,
                 y: dlBoxRaw.y,

--- a/ts/Series/Gantt/GanttSeries.ts
+++ b/ts/Series/Gantt/GanttSeries.ts
@@ -150,7 +150,9 @@ class GanttSeries extends XRangeSeries {
             shapeArgs: SVGAttributes = point.shapeArgs as any,
             plotY = point.plotY,
             state = point.selected && 'select',
-            cutOff = seriesOpts.stacking && !seriesOpts.borderRadius;
+            cutOff = seriesOpts.stacking &&
+            seriesOpts.stacking !== 'disabled' &&
+            !seriesOpts.borderRadius;
 
         let graphic = point.graphic,
             diamondShape: SVGPath;

--- a/ts/Series/PolarComposition.ts
+++ b/ts/Series/PolarComposition.ts
@@ -847,7 +847,11 @@ function wrapColumnSeriesAlignDataLabel(
     isNew?: boolean
 ): void {
     const chart = this.chart,
-        inside = pick(options.inside, !!this.options.stacking);
+        inside = pick(
+            options.inside,
+            (this.options.stacking && this.options.stacking !== 'disabled'
+            )
+        );
 
     let angle,
         shapeArgs,
@@ -995,7 +999,7 @@ function onAfterColumnTranslate(
             if (chart.inverted) {
                 point.plotY = yAxis.translate(pointY);
 
-                if (stacking && yAxis.stacking) {
+                if (stacking && stacking !== 'disabled' && yAxis.stacking) {
                     stack = yAxis.stacking.stacks[(pointY < 0 ? '-' : '') +
                         series.stackKey];
 

--- a/ts/Series/Variwide/VariwideSeries.ts
+++ b/ts/Series/Variwide/VariwideSeries.ts
@@ -288,7 +288,7 @@ addEvent(VariwideSeries, 'afterColumnTranslate', function (): void {
         }
     }
 
-    if (this.options.stacking) {
+    if (this.options.stacking && this.options.stacking !== 'disabled') {
         this.correctStackLabels();
     }
 

--- a/ts/Series/Waterfall/WaterfallSeries.ts
+++ b/ts/Series/Waterfall/WaterfallSeries.ts
@@ -203,7 +203,7 @@ class WaterfallSeries extends ColumnSeries {
         super.processData.call(this, force);
 
         // Record extremes only if stacking was not set:
-        if (!options.stacking) {
+        if (!options.stacking || options.stacking === 'disabled') {
             series.dataMin = dataMin + threshold;
             series.dataMax = dataMax;
         }
@@ -298,7 +298,7 @@ class WaterfallSeries extends ColumnSeries {
                 // stacked, yAxis is reversed and it also depends on point's
                 // value
                 let yPos: number;
-                if (stacking) {
+                if (stacking && stacking !== 'disabled') {
                     const connectorThreshold = prevStackX.connectorThreshold;
 
                     yPos = crisp(
@@ -340,7 +340,11 @@ class WaterfallSeries extends ColumnSeries {
                 prevBox &&
                 path.length &&
                 (
-                    (!stacking && prevY < 0 && !reversedYAxis) ||
+                    (
+                        (!stacking || stacking === 'disabled') &&
+                        prevY < 0 &&
+                        !reversedYAxis
+                    ) ||
                     (prevY > 0 && reversedYAxis)
                 )
             ) {
@@ -548,7 +552,7 @@ class WaterfallSeries extends ColumnSeries {
             stackedYNeg,
             stackedYPos;
 
-        if (stacking) {
+        if (stacking && stacking !== 'disabled') {
             yAxis = this.yAxis;
             waterfallStacks = yAxis.waterfall.stacks;
             stackedYNeg = this.stackedYNeg = [];
@@ -645,7 +649,7 @@ addEvent(WaterfallSeries, 'afterColumnTranslate', function (): void {
 
         // Code responsible for correct positions of stacked points
         // starts here
-        if (stacking) {
+        if (stacking && stacking !== 'disabled') {
             if (actualStack) {
                 const actualStackX = actualStack[i];
 


### PR DESCRIPTION
Implemented #19033, added 'disabled' flag as a default series stacking option.
Preserved undefined as a valid value for a backward compatibility.