### PR TITLE
demo/ichimoku-tooltip-spelling-fix

### DIFF
--- a/samples/stock/demo/dark-candlestick-and-volume/demo.js
+++ b/samples/stock/demo/dark-candlestick-and-volume/demo.js
@@ -179,19 +179,19 @@
                 pointFormat: `<br/>
                     <span style="color: #666666;">IKH</span>
                     <br/>
-                    tenkan sen: <span
+                    Tenkan-sen: <span
                     style="color:{series.options.tenkanLine.styles.lineColor}">
-                    {point.tenkanSen:.3f}</span><br/>' +
-                    kijun sen: <span
+                    {point.tenkanSen:.3f}</span><br/>
+                    Kijun-sen: <span
                     style="color:{series.options.kijunLine.styles.lineColor}">
                     {point.kijunSen:.3f}</span><br/>
-                    chikou span: <span
+                    Chikou span: <span
                     style="color:{series.options.chikouLine.styles.lineColor}">
                     {point.chikouSpan:.3f}</span><br/>
-                    senkou span A: <span
+                    Senkou span A: <span
                     style="color:{series.options.senkouSpanA.styles.lineColor}">
                     {point.senkouSpanA:.3f}</span><br/>
-                    senkou span B: <span
+                    Senkou span B: <span
                     style="color:{series.options.senkouSpanB.styles.lineColor}">
                     {point.senkouSpanB:.3f}</span><br/>`
             },


### PR DESCRIPTION
Fixed Ichimoku lines names in tooltip, according to [Wikipedia](https://en.wikipedia.org/wiki/Ichimoku_Kink%C5%8D_Hy%C5%8D)