### PR TITLE
docs: add missing property allowOverlap on plotLines

### DIFF
--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -991,7 +991,7 @@ export default PlotLineOrBand;
  */
 
 /**
- * Text labels for the plot bands
+ * Text labels for the plot lines
  *
  * @apioption xAxis.plotLines.label
  */
@@ -1009,6 +1009,15 @@ export default PlotLineOrBand;
  * @default    left
  * @since      2.1
  * @apioption  xAxis.plotLines.label.align
+ */
+
+/**
+ * Whether or not the label can be hidden if it overlaps with another label.
+ *
+ * @type      {boolean}
+ * @default   undefined
+ * @since     11.4.8
+ * @apioption xAxis.plotBands.label.allowOverlap
  */
 
 /**


### PR DESCRIPTION
In a recent upgrade from 9 to 12, plotLines started situationally rendering, due to overlapping with data labels. 

The behaviour makes sense. But we wanted to limit disruption to users as much as possible, so continue to render plotLines despite colliding with data labels.

The option for `allowOverlap` is [documented in the API](https://api.highcharts.com/highcharts/xAxis.plotBands.label.allowOverlap) for plotBands but not for plotLines. 

Giving it a go anyway it does appear to work, just undocumented
![image](https://github.com/user-attachments/assets/59280b05-1641-4e97-b99e-aeaf940ae0ed)

This also causes typescript issues when trying to apply the property

![image](https://github.com/user-attachments/assets/e193cee2-2676-4602-9582-9446b5853fea)
