### PR TITLE
dash/adding-hc-component

### DIFF
--- a/test/cypress/dashboards/integration/EditMode/empty-board-interction.cy.js
+++ b/test/cypress/dashboards/integration/EditMode/empty-board-interction.cy.js
@@ -12,4 +12,11 @@ describe('Empty board interaction', () => {
 
         cy.get('.highcharts-dashboards-edit-resize-snap').should('be.visible');
     });
+
+    it('When adding Highcharts component to an empty board, sidebar should be visible.', () => {
+        cy.grabComponent('Highcharts');
+        cy.dropComponent('#container');
+
+        cy.get('.highcharts-dashboards-edit-sidebar').should('be.visible');
+    });
 });

--- a/ts/Dashboards/EditMode/SidebarPopup.ts
+++ b/ts/Dashboards/EditMode/SidebarPopup.ts
@@ -436,8 +436,9 @@ class SidebarPopup extends BaseForm {
                                 'layoutChanged',
                                 (e): void => {
                                     if (newCell && e.type === 'newComponent') {
+                                        const chart = newCell.mountedComponent.chart;
 
-                                        if (newCell.mountedComponent.chart) {
+                                        if (chart && chart.isDirtyBox) {
                                             const unbind = addEvent(
                                                 newCell.mountedComponent.chart,
                                                 'render',


### PR DESCRIPTION
Fix, the sidebar was not visible when adding the Highcharts component to an empty board.