### PR TITLE
bugfix/22999-remove-added-component

### DIFF
--- a/test/cypress/dashboards/integration/component-add.cy.js
+++ b/test/cypress/dashboards/integration/component-add.cy.js
@@ -249,4 +249,4 @@ describe('Edit mode with add component button disabled', () => {
     it('Add component button should not exist.', () => {
         cy.get('.highcharts-dashboards-edit-tools-btn').should('not.exist');
     });
- });
+});

--- a/test/cypress/dashboards/integration/component-add.cy.js
+++ b/test/cypress/dashboards/integration/component-add.cy.js
@@ -89,6 +89,22 @@ describe('Add components through UI', () => {
         cy.get('.highcharts-dashboards-edit-menu.highcharts-dashboards-edit-toolbar-cell').children().should('be.visible')
     });
 
+    it('Board should not crash when removing added component', function() {
+        // Act- add HTML component
+        cy.grabComponent('HTML');
+        cy.dropComponent('#dashboard-col-2');
+        cy.hideSidebar();
+        // Remove HTML component
+        cy.get('.highcharts-dashboards-edit-menu-destroy').first().click();
+        cy.get('.highcharts-dashboards-edit-confirmation-popup-confirm-btn').click({ force: true, multiple: true });
+        // Act- add HTML component again
+        cy.grabComponent('HTML');
+        cy.dropComponent('#dashboard-col-1');
+
+        // Assert
+        cy.get('.highcharts-dashboards-edit-sidebar').should('exist');
+    });
+
     it('should be able to add a chart component and resize it', function() {
         // Act
         cy.grabComponent('chart');
@@ -233,4 +249,4 @@ describe('Edit mode with add component button disabled', () => {
     it('Add component button should not exist.', () => {
         cy.get('.highcharts-dashboards-edit-tools-btn').should('not.exist');
     });
-});
+ });

--- a/ts/Dashboards/EditMode/SidebarPopup.ts
+++ b/ts/Dashboards/EditMode/SidebarPopup.ts
@@ -461,8 +461,8 @@ class SidebarPopup extends BaseForm {
                                             );
                                             sidebar.show(newCell);
                                             newCell.setHighlight();
+                                            unbindLayoutChanged();
                                         }
-
                                     }
                                 }
                             );


### PR DESCRIPTION
Fixed #22999, the board froze when re-adding a previously removed component.


Internal note:
The `layoutChanged` event was not removed after the code execution. 
The `addEvent` returns a callback function to remove the event, so by calling `unbindLayoutChanged` we remove this event.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210173399513424