### PR TITLE
dash/connector-data-polling-abort-controller

### DIFF
--- a/test/cypress/dashboards/integration/Components/general.cy.js
+++ b/test/cypress/dashboards/integration/Components/general.cy.js
@@ -48,7 +48,7 @@ describe('Data polling restarting', () => {
   it('Should restart the connector polling.', () => {
     cy.board().then(async dashboard => {
       const connector = await dashboard.dataPool.getConnector('fetched-data');
-      const signal = connector.abortController.signal;
+      const signal = connector.pollingController.signal;
       // Component reference should be initially added to the connector.
       expect(connector.components).not.be.empty;
       // Expect request not to be aborted.
@@ -78,7 +78,7 @@ describe('Data polling restarting', () => {
       // Component reference should be added to the connector.
       expect(connector.components).not.be.empty;
       // Expect request not to be aborted.
-      expect(connector.abortController.signal.aborted).to.be.false;
+      expect(connector.pollingController.signal.aborted).to.be.false;
       // Connector polling should be run again.
       expect(connector.polling).to.be.true;
     });

--- a/test/cypress/dashboards/integration/Components/general.cy.js
+++ b/test/cypress/dashboards/integration/Components/general.cy.js
@@ -48,10 +48,13 @@ describe('Data polling restarting', () => {
   it('Should restart the connector polling.', () => {
     cy.board().then(async dashboard => {
       const connector = await dashboard.dataPool.getConnector('fetched-data');
+      const signal = connector.abortController.signal;
       // Component reference should be initially added to the connector.
       expect(connector.components).not.be.empty;
       // Connector polling should be run initially.
       expect(connector.polling).to.be.true;
+      // Expect request not to be aborted.
+      expect(signal.aborted).to.be.false;
 
       // Destroy the component.
       const component = dashboard.mountedComponents[0].component;
@@ -59,6 +62,8 @@ describe('Data polling restarting', () => {
 
       // Component reference should be removed from the connector.
       expect(connector.components).be.undefined;
+      // Expect request to be aborted.
+      expect(signal.aborted).to.be.true;
       // Connector polling should be stopped.
       expect(connector.polling).to.be.false;
 
@@ -74,6 +79,8 @@ describe('Data polling restarting', () => {
       expect(connector.components).not.be.empty;
       // Connector polling should be run again.
       expect(connector.polling).to.be.true;
+      // Expect request not to be aborted.
+      expect(connector.abortController.signal.aborted).to.be.false;
     });
   });
 });

--- a/test/cypress/dashboards/integration/Components/general.cy.js
+++ b/test/cypress/dashboards/integration/Components/general.cy.js
@@ -51,10 +51,10 @@ describe('Data polling restarting', () => {
       const signal = connector.abortController.signal;
       // Component reference should be initially added to the connector.
       expect(connector.components).not.be.empty;
-      // Connector polling should be run initially.
-      expect(connector.polling).to.be.true;
       // Expect request not to be aborted.
       expect(signal.aborted).to.be.false;
+      // Connector polling should be run initially.
+      expect(connector.polling).to.be.true;
 
       // Destroy the component.
       const component = dashboard.mountedComponents[0].component;
@@ -77,10 +77,10 @@ describe('Data polling restarting', () => {
       const connector = await dashboard.dataPool.getConnector('fetched-data');
       // Component reference should be added to the connector.
       expect(connector.components).not.be.empty;
-      // Connector polling should be run again.
-      expect(connector.polling).to.be.true;
       // Expect request not to be aborted.
       expect(connector.abortController.signal.aborted).to.be.false;
+      // Connector polling should be run again.
+      expect(connector.polling).to.be.true;
     });
   });
 });

--- a/ts/Data/Connectors/CSVConnector.ts
+++ b/ts/Data/Connectors/CSVConnector.ts
@@ -140,7 +140,9 @@ class CSVConnector extends DataConnector {
         return Promise
             .resolve(
                 csvURL ?
-                    fetch(csvURL).then(
+                    fetch(csvURL, {
+                        signal: connector?.abortController?.signal
+                    }).then(
                         (response): Promise<string> => response.text()
                     ) :
                     csv || ''

--- a/ts/Data/Connectors/CSVConnector.ts
+++ b/ts/Data/Connectors/CSVConnector.ts
@@ -141,7 +141,7 @@ class CSVConnector extends DataConnector {
             .resolve(
                 csvURL ?
                     fetch(csvURL, {
-                        signal: connector?.abortController?.signal
+                        signal: connector?.pollingController?.signal
                     }).then(
                         (response): Promise<string> => response.text()
                     ) :

--- a/ts/Data/Connectors/DataConnector.ts
+++ b/ts/Data/Connectors/DataConnector.ts
@@ -100,6 +100,12 @@ abstract class DataConnector implements DataEvent.Emitter {
      */
     public readonly table: DataTable;
 
+    /**
+     * The corresponding request abort controller, which gets assigned when data
+     * polling starts. Used to abort the request when data polling stops.
+     */
+    public abortController?: AbortController;
+
 
     /* *
      *
@@ -286,6 +292,10 @@ abstract class DataConnector implements DataEvent.Emitter {
     ): void {
         const connector = this;
 
+        // Assign a new abort controller.
+        this.abortController = new AbortController();
+
+        // Clear the polling timeout.
         window.clearTimeout(connector._polling);
 
         connector._polling = window.setTimeout(
@@ -312,8 +322,11 @@ abstract class DataConnector implements DataEvent.Emitter {
     public stopPolling(): void {
         const connector = this;
 
-        window.clearTimeout(connector._polling);
+        // Abort the existing request.
+        connector?.abortController?.abort();
 
+        // Clear the polling timeout.
+        window.clearTimeout(connector._polling);
         delete connector._polling;
     }
 

--- a/ts/Data/Connectors/DataConnector.ts
+++ b/ts/Data/Connectors/DataConnector.ts
@@ -101,10 +101,10 @@ abstract class DataConnector implements DataEvent.Emitter {
     public readonly table: DataTable;
 
     /**
-     * The corresponding request abort controller, which gets assigned when data
-     * polling starts. Used to abort the request when data polling stops.
+     * The polling controller used to abort the request when data polling stops.
+     * It gets assigned when data polling starts.
      */
-    public abortController?: AbortController;
+    public pollingController?: AbortController;
 
 
     /* *
@@ -293,7 +293,7 @@ abstract class DataConnector implements DataEvent.Emitter {
         const connector = this;
 
         // Assign a new abort controller.
-        this.abortController = new AbortController();
+        this.pollingController = new AbortController();
 
         // Clear the polling timeout.
         window.clearTimeout(connector._polling);
@@ -323,7 +323,7 @@ abstract class DataConnector implements DataEvent.Emitter {
         const connector = this;
 
         // Abort the existing request.
-        connector?.abortController?.abort();
+        connector?.pollingController?.abort();
 
         // Clear the polling timeout.
         window.clearTimeout(connector._polling);

--- a/ts/Data/Connectors/GoogleSheetsConnector.ts
+++ b/ts/Data/Connectors/GoogleSheetsConnector.ts
@@ -179,7 +179,7 @@ class GoogleSheetsConnector extends DataConnector {
             throw new Error('Invalid URL: ' + url);
         }
 
-        return fetch(url)
+        return fetch(url, { signal: connector?.abortController?.signal })
             .then((
                 response
             ): Promise<GoogleSheetsConverter.GoogleSpreadsheetJSON> => (

--- a/ts/Data/Connectors/GoogleSheetsConnector.ts
+++ b/ts/Data/Connectors/GoogleSheetsConnector.ts
@@ -179,7 +179,7 @@ class GoogleSheetsConnector extends DataConnector {
             throw new Error('Invalid URL: ' + url);
         }
 
-        return fetch(url, { signal: connector?.abortController?.signal })
+        return fetch(url, { signal: connector?.pollingController?.signal })
             .then((
                 response
             ): Promise<GoogleSheetsConverter.GoogleSpreadsheetJSON> => (

--- a/ts/Data/Connectors/JSONConnector.ts
+++ b/ts/Data/Connectors/JSONConnector.ts
@@ -132,7 +132,7 @@ class JSONConnector extends DataConnector {
             .resolve(
                 dataUrl ?
                     fetch(dataUrl, {
-                        signal: connector?.abortController?.signal
+                        signal: connector?.pollingController?.signal
                     }).then(
                         (response): Promise<any> => response.json()
                     )['catch']((error): void => {

--- a/ts/Data/Connectors/JSONConnector.ts
+++ b/ts/Data/Connectors/JSONConnector.ts
@@ -131,7 +131,9 @@ class JSONConnector extends DataConnector {
         return Promise
             .resolve(
                 dataUrl ?
-                    fetch(dataUrl).then(
+                    fetch(dataUrl, {
+                        signal: connector?.abortController?.signal
+                    }).then(
                         (response): Promise<any> => response.json()
                     )['catch']((error): void => {
                         connector.emit<JSONConnector.Event>({


### PR DESCRIPTION
Fixed #22982, added the data connector request abort controller.