### PR TITLE
tools/gha-node-version

### DIFF
--- a/.github/workflows/dashboards-benchmark.yml
+++ b/.github/workflows/dashboards-benchmark.yml
@@ -23,9 +23,9 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        node-version: [lts/iron]
+        node-version: [lts/*]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: master
 
@@ -47,7 +47,7 @@ jobs:
         run: cd test/ts-node-unit-tests && node --import tsx bench.ts --context base --pattern Dashboards/
 
       - name: Checkout current branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            clean: false # do not remove files from previous run
       - run: npm i
@@ -72,7 +72,7 @@ jobs:
             tmp/benchmarks
 
       - name: Comment on PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.PR_COMMENT_TOKEN}}
           script: |

--- a/.github/workflows/dashboards-lighthouse-test.yml
+++ b/.github/workflows/dashboards-lighthouse-test.yml
@@ -25,9 +25,9 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        node-version: [lts/iron]
+        node-version: [lts/*]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: master
 
@@ -77,7 +77,7 @@ jobs:
         run: kill $(lsof -t -i:3030)
 
       - name: Checkout current branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            clean: false # do not remove files from previous run
 
@@ -125,7 +125,7 @@ jobs:
           cat ./tmp/lighthousetable.md >> $GITHUB_STEP_SUMMARY
 
       - name: Comment on PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: ${{ always() }}
         with:
           github-token: ${{secrets.PR_COMMENT_TOKEN}}

--- a/.github/workflows/dashboards-test.yml
+++ b/.github/workflows/dashboards-test.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [lts/iron]
+        node-version: [lts/*]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/dashboards-visual-test.yml
+++ b/.github/workflows/dashboards-visual-test.yml
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [lts/iron]
+        node-version: [lts/*]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: master
 
@@ -72,7 +72,7 @@ jobs:
         run: kill $(lsof -t -i:3030)
 
       - name: Checkout current branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           clean: false
 

--- a/.github/workflows/highcharts-browserstack.yml
+++ b/.github/workflows/highcharts-browserstack.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/iron'
+          node-version: 'lts/*'
           cache: 'npm'
 
       - name: Install Dependencies

--- a/.github/workflows/highcharts-headless.yml
+++ b/.github/workflows/highcharts-headless.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/iron'
+          node-version: 'lts/*'
           cache: 'npm'
 
       - name: Install Dependencies
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/iron'
+          node-version: 'lts/*'
           cache: 'npm'
 
       - name: Install dependencies
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/iron'
+          node-version: 'lts/*'
           cache: 'npm'
       # browser-actions/setup-chrome installs chrome at a separate location
       # which setup-chromedriver does not pick up, so doing it manually
@@ -149,7 +149,7 @@ jobs:
   #     - uses: actions/checkout@v3
   #     - uses: actions/setup-node@v4
   #       with:
-  #         node-version: 'lts/iron'
+  #         node-version: 'lts/*'
   #         cache: 'npm'
   #     - name: Install Dependencies
   #       run: npm i

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [lts/iron]
+        node-version: [lts/*]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [lts/iron]
+        node-version: [lts/*]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
     needs: lint_hc
     strategy:
       matrix:
-        node-version: [lts/iron]
+        node-version: [lts/*]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [lts/iron]
+        node-version: [lts/*]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/iron'
+          node-version: 'lts/*'
           cache: 'npm'
 
       - name: Install Dependencies
@@ -164,7 +164,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/iron'
+          node-version: 'lts/*'
           cache: 'npm'
           cache-dependency-path: ./highcharts/package-lock.json
 

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -25,10 +25,10 @@ jobs:
       AWS_REGION: ${{secrets.VISUAL_TESTS_AWS_REGION}}
       BROWSER_COUNT: 2
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/iron'
+          node-version: 'lts/*'
           cache: 'npm'
 
       - run: echo ${{github.ref_name}}

--- a/.github/workflows/stock-benchmark.yml
+++ b/.github/workflows/stock-benchmark.yml
@@ -23,9 +23,9 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        node-version: [lts/iron]
+        node-version: [lts/*]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: master
 
@@ -45,7 +45,7 @@ jobs:
         run: node --import tsx test/ts-node-unit-tests/bench.ts --context base --pattern Stock/
 
       - name: Checkout current branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            clean: false # do not remove files from previous run
       - run: npm i
@@ -67,7 +67,7 @@ jobs:
             tmp/benchmarks
 
       - name: Comment on PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.PR_COMMENT_TOKEN}}
           script: |

--- a/.github/workflows/visual-compare.yml
+++ b/.github/workflows/visual-compare.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           ref: master
 
-      - name: Use Node.js lts/iron
+      - name: Use Node.js lts/*
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/iron'
+          node-version: 'lts/*'
           cache: 'npm'
 
       - name: Install dependencies
@@ -51,10 +51,10 @@ jobs:
           clean: false
           fetch-depth: 0
 
-      - name: Use Node.js lts/iron
+      - name: Use Node.js lts/*
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/iron'
+          node-version: 'lts/*'
           cache: 'npm'
 
       - name: Install dependencies
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [lts/iron]
+        node-version: [lts/*]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Seems Node has fixed their imports, so we can use the latest Node LTS now instead of a specific old one