### PR TITLE
bugfix/22981-stock-axis-plotline-misalignment

### DIFF
--- a/samples/unit-tests/axis/gridlines/demo.js
+++ b/samples/unit-tests/axis/gridlines/demo.js
@@ -144,8 +144,6 @@ QUnit.test('Position of grid lines and tick marks (#22981)', function (assert) {
 
     for (const pos in ticks) {
         if (Object.hasOwnProperty.call(ticks, pos)) {
-            console.log(ticks[pos].mark.attr('d').split(' ')[2]);
-            console.log(ticks[pos].gridLine.attr('d').split(' ')[2]);
             assert.strictEqual(
                 ticks[pos].mark.attr('d').split(' ')[2],
                 ticks[pos].gridLine.attr('d').split(' ')[2],

--- a/samples/unit-tests/axis/gridlines/demo.js
+++ b/samples/unit-tests/axis/gridlines/demo.js
@@ -127,3 +127,31 @@ QUnit.test('Animation of grid lines and tick marks', function (assert) {
 
     TestUtilities.lolexUninstall(clock);
 });
+
+
+QUnit.test('Position of grid lines and tick marks (#22981)', function (assert) {
+    const chart = Highcharts.chart('container', {
+        yAxis: [{
+            tickWidth: 1,
+            gridLineColor: 'red',
+            tickAmount: 4
+        }],
+        series: [{
+            data: [1, 2, 3, 4, 5]
+        }]
+    });
+    const ticks = chart.yAxis[0].ticks;
+
+    for (const pos in ticks) {
+        if (Object.hasOwnProperty.call(ticks, pos)) {
+            console.log(ticks[pos].mark.attr('d').split(' ')[2]);
+            console.log(ticks[pos].gridLine.attr('d').split(' ')[2]);
+            assert.strictEqual(
+                ticks[pos].mark.attr('d').split(' ')[2],
+                ticks[pos].gridLine.attr('d').split(' ')[2],
+                `Tick ${pos} mark and grid line should have the same y
+                position.`
+            );
+        }
+    }
+});

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -819,7 +819,7 @@ namespace StockChart {
 
                         x1 = axis2.pos;
                         x2 = x1 + axis2.len;
-                        y1 = y2 = Math.round(axisTop + axis.height - transVal);
+                        y1 = y2 = axisTop + axis.height - transVal;
 
                         // Outside plot area
                         if (


### PR DESCRIPTION
Fixed #22981, rounding of y-values for the plot lines with Highcharts Stock resulted in misaligned grid lines.