### PR TITLE
bugfix/23018-remove-board-custom-html

### DIFF
--- a/test/typescript-karma/Dashboards/Layout/tests.js
+++ b/test/typescript-karma/Dashboards/Layout/tests.js
@@ -368,3 +368,39 @@ test('IDs of rows, cells and layouts', function (assert) {
     assert.strictEqual(cell.getAttribute('id'), null, 'Cell\'s id should not exist');
     assert.strictEqual(row.getAttribute('id'), null, 'Row\'s id should not exist');
 })
+
+
+test('Board destroy with custom HTML', function (assert) {
+    // Prepare custom HTML for the board.
+    const container = setupContainer();
+    const chartContainer = document.createElement("div")
+    chartContainer.id = "chart-container"
+    document.getElementById("test-container").appendChild(chartContainer)
+
+    const component = {
+        renderTo: "chart-container",
+        type: "Highcharts",
+        chartOptions: {
+          series: [
+            {
+              type: "column",
+              data: [1, 2, 3],
+            },
+          ],
+        },
+    };
+    const board = Dashboards.board(container.id, {
+        components: [component],
+    });
+
+    assert.ok(board.mountedComponents.length === 1, "There should be one mounted component");
+    board.destroy();
+    assert.strictEqual(Object.keys(board).length, 0, "Board should be destroyed and empty");
+    assert.ok(chartContainer, "Chart container (custom HTML) should exist");
+
+    const board2 = Dashboards.board(container.id, {
+        components: [component],
+    });
+    assert.ok(board2.mountedComponents.length === 1, "There should be one mounted component");
+})
+

--- a/ts/Dashboards/Board.ts
+++ b/ts/Dashboards/Board.ts
@@ -418,15 +418,23 @@ class Board implements Serializable<Board, Board.JSON> {
         const board = this;
 
         // Destroy layouts.
-        for (let i = 0, iEnd = board.layouts?.length; i < iEnd; ++i) {
-            board.layouts[i].destroy();
+        if (this.guiEnabled) {
+            for (let i = 0, iEnd = board.layouts?.length; i < iEnd; ++i) {
+                board.layouts[i].destroy();
+            }
+        } else {
+            for (const mountedComponent of board.mountedComponents) {
+                mountedComponent.component.destroy();
+            }
         }
 
         // Remove resizeObserver from the board
         this.resizeObserver?.unobserve(board.container);
 
         // Destroy container.
-        board.container?.remove();
+        if (this.guiEnabled) {
+            board.container?.remove();
+        }
 
         // @ToDo Destroy bindings.
 


### PR DESCRIPTION
Fixed #23018, the board's `destroy` method removed the custom HTML layout.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210196758759053