### PR TITLE
bugfix/22907-misplaced-tooltip

### DIFF
--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1822,7 +1822,7 @@ class Tooltip {
                 pointer,
                 renderer
             } = this,
-            label = this.getLabel(),
+            label = (this.label || this.getLabel()),
             {
                 height = 0,
                 width = 0


### PR DESCRIPTION
Fixed #22907 , tooltip could be misplaced in area chart.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209930695497056