### PR TITLE
Fixed issue with visible background from empty data label

### DIFF
--- a/samples/unit-tests/datalabels/members/demo.js
+++ b/samples/unit-tests/datalabels/members/demo.js
@@ -68,8 +68,9 @@ QUnit.test('Series.drawDataLabels', function (assert) {
     drawDataLabels.call(series);
     assert.strictEqual(
         !!point.dataLabel,
-        true,
-        'Should create dataLabel when series.dataLabels.enabled=true'
+        false,
+        `Should create dataLabel when series.dataLabels.enabled=true, but not
+        if empty string`
     );
     assert.strictEqual(
         !!point.dataLabel.added,

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -601,8 +601,8 @@ namespace DataLabel {
                             style = {}
                         } = labelOptions;
 
-                    let formatString,
-                        labelText,
+                    let formatString: string|undefined,
+                        labelText: string|undefined,
                         rotation,
                         attr: SVGAttributes = {},
                         dataLabel: SVGElement|undefined =
@@ -729,7 +729,11 @@ namespace DataLabel {
                     // Individual labels are disabled if the are explicitly
                     // disabled in the point options, or if they fall outside
                     // the plot area.
-                    if (labelEnabled && defined(labelText)) {
+                    if (
+                        labelEnabled &&
+                        defined(labelText) &&
+                        labelText !== ''
+                    ) {
                         if (!dataLabel) {
                             // Create new label element
                             dataLabel = renderer.label(


### PR DESCRIPTION
When the data label format returned an empty string, backgrounds and borders would render.