### PR TITLE
bugfix/22919-background-transparent-color-affects-data-labels

### DIFF
--- a/samples/unit-tests/datalabels/contrast/demo.js
+++ b/samples/unit-tests/datalabels/contrast/demo.js
@@ -49,7 +49,7 @@ QUnit.test(
                 point.dataLabel.element.childNodes[0].style.fill
             ).get(),
             'rgb(0,0,0)',
-            `Contrast color should not be used when dataLabel does not collide  
+            `Contrast color should not be used when dataLabel does not collide
             with column (#6657).`
         );
 
@@ -110,7 +110,7 @@ QUnit.test(
                 'rgb(0,0,0)'
             ).get(),
             `If background of chart is dark, but plot background color is light
-            dataLabels outside the bar chart should get the contrast (black) 
+            dataLabels outside the bar chart should get the contrast (black)
             color (#17413).`
         );
 
@@ -166,6 +166,28 @@ QUnit.test(
             ).get(),
             `When the data label background color is set to 'auto', set the
             data label color by contrast to the point color. (#20007).`
+        );
+
+        chart.update({
+            chart: {
+                backgroundColor: 'transparent'
+            },
+            series: [{
+                data: [1],
+                dataLabels: {
+                    enabled: true
+                }
+            }]
+        });
+
+        const transparentLabelFill = chart.series[0].points[0]
+            .dataLabel.options.style.color;
+
+        assert.strictEqual(
+            Highcharts.color(transparentLabelFill).get(),
+            Highcharts.color('#000000').get(),
+            `When chart background is 'transparent', data label color should
+            fall back to black (#transparent-contrast).`
         );
     }
 );

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -664,6 +664,10 @@ class SVGRenderer implements SVGRendererLike {
      * The contrast color, either `#000000` or `#FFFFFF`.
      */
     public getContrast(color: ColorString): ColorString {
+
+        if (color === 'transparent') {
+            return '#000000';
+        }
         // #6216, #17273
         const rgba256 = Color.parse(color).rgba,
             // For each rgb channel, compute the luminosity based on all


### PR DESCRIPTION
Fixed [#22919,](https://github.com/highcharts/highcharts/issues/22919) added fallback value for `transparent` color setting so that data labels fill color is correct.