### PR TITLE
Fixed #21262, relativeXValue didn't work when turboThreshold exceeded

### DIFF
--- a/samples/unit-tests/series/relativexvalue/demo.js
+++ b/samples/unit-tests/series/relativexvalue/demo.js
@@ -61,3 +61,39 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test(
+    'Relative X value with turboThreshold',
+    assert => {
+        const chart = Highcharts.chart('container', {
+            series: [{
+                data: [
+                    [0, 1],
+                    [1, 3],
+                    [2, 2],
+                    [3, 4]
+                ],
+                type: 'column',
+                relativeXValue: true,
+                turboThreshold: 1,
+                pointStart: '2025-05-23',
+                pointIntervalUnit: 'day'
+            }],
+            xAxis: {
+                type: 'datetime'
+            }
+        });
+
+        assert.strictEqual(
+            chart.xAxis[0].tickPositions[2],
+            Date.UTC(2025, 4, 25),
+            'X = 2, pointStart and interval unit should apply'
+        );
+
+        assert.strictEqual(
+            chart.series[0].points[2].x,
+            Date.UTC(2025, 4, 25),
+            'X = 2, pointStart and interval unit should apply'
+        );
+    }
+);

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -1401,7 +1401,11 @@ class Series {
             // all the rest are defined the same way. Although the 'for' loops
             // are similar, they are repeated inside each if-else conditional
             // for max performance.
-            let runTurbo = turboThreshold && dataLength > turboThreshold;
+            let runTurbo = (
+                turboThreshold &&
+                !options.relativeXValue &&
+                dataLength > turboThreshold
+            );
             if (runTurbo) {
 
                 const firstPoint = series.getFirstValidPoint(data),


### PR DESCRIPTION
Fixed #21262, data compression with `relativeXValue` didn't work when the data length exceeded the `turboThreshold`.