### PR TITLE
grid/column-width-resizing-changes

### DIFF
--- a/docs/dashboards/grid-migration.md
+++ b/docs/dashboards/grid-migration.md
@@ -71,7 +71,9 @@ Some API options have been renamed or removed. For the full list, make sure to c
     }
     rendering: {
         columns: {
-            resizeMode: 'full'
+            resizing: {
+                mode: 'full'
+            }
         },
         rows: {
             bufferSize: 10,

--- a/docs/dashboards/grid-migration.md
+++ b/docs/dashboards/grid-migration.md
@@ -71,7 +71,7 @@ Some API options have been renamed or removed. For the full list, make sure to c
     }
     rendering: {
         columns: {
-            resizing: 'full'
+            resizeMode: 'full'
         },
         rows: {
             bufferSize: 10,

--- a/docs/dashboards/grid-migration.md
+++ b/docs/dashboards/grid-migration.md
@@ -71,7 +71,7 @@ Some API options have been renamed or removed. For the full list, make sure to c
     }
     rendering: {
         columns: {
-            distribution: 'full'
+            resizing: 'full'
         },
         rows: {
             bufferSize: 10,

--- a/docs/grid/columns.md
+++ b/docs/grid/columns.md
@@ -108,7 +108,7 @@ Use the mixed distribution when you want explicit control over individual column
 Grid.grid('container', {
   rendering: {
     columns: {
-      resizing: 'mixed'
+      resizeMode: 'mixed'
     }
   },
   columns: [{

--- a/docs/grid/columns.md
+++ b/docs/grid/columns.md
@@ -108,7 +108,9 @@ Use the mixed distribution when you want explicit control over individual column
 Grid.grid('container', {
   rendering: {
     columns: {
-      resizeMode: 'mixed'
+      resizing: {
+        mode: 'mixed'
+      }
     }
   },
   columns: [{

--- a/docs/grid/columns.md
+++ b/docs/grid/columns.md
@@ -108,7 +108,7 @@ Use the mixed distribution when you want explicit control over individual column
 Grid.grid('container', {
   rendering: {
     columns: {
-      distribution: 'mixed'
+      resizing: 'mixed'
     }
   },
   columns: [{

--- a/docs/grid/performance.md
+++ b/docs/grid/performance.md
@@ -41,20 +41,22 @@ By default, rows adjust their height to fit all content, which can reduce perfor
             enabled: false // default is true
         },
         columns: {
-            resizing: "fixed" // default is "full"
+            resizing: {
+                mode: "fixed"
+            }
         }
     }
 }
 ```
 These options can be used to configure how the table should be rendered.
 
-[`table.className`](https://api.highcharts.com/dashboards/#interfaces/Grid_Options.TableSettings#className) is appended to the `<table>` element.
+[`table.className`](https://api.highcharts.com/grid/#interfaces/Grid_Options.TableSettings#className) is appended to the `<table>` element.
 
-[`header.enabled: false`](https://api.highcharts.com/dashboards/#interfaces/Grid_Options.HeaderSettings#enabled) disables all [column headers](https://www.highcharts.com/docs/grid/header) by not rendering the `thead` element.
+[`header.enabled: false`](https://api.highcharts.com/grid/#interfaces/Grid_Options.HeaderSettings#enabled) disables all [column headers](https://www.highcharts.com/docs/grid/header) by not rendering the `thead` element.
 
-[`columns.resizing`](https://api.highcharts.com/dashboards/#interfaces/Grid_Options.ColumnsSettings#resizing) is used to configure initial column widths.
+[`columns.resizing.mode`](https://api.highcharts.com/grid/#interfaces/Grid_Core_Options.ResizingOptions#mode) is used to configure initial column widths.
 
-[`columns.resizing: "full"`](https://api.highcharts.com/dashboards/#interfaces/Grid_Options.ColumnsSettings#resizing) renders a full width (`width: 100%;`) responsive table with evenly distributed column widths. `columns.resizing: "fixed"` renders a table were columns have a fixed width in pixels. It should be set to support your specific use case.
+[`columns.resizing.mode: "full"`](https://api.highcharts.com/grid/#interfaces/Grid_Core_Options.ResizingOptions#mode) renders a full width (`width: 100%;`) responsive table with evenly distributed column widths. `columns.resizing.mode: "fixed"` renders a table were columns have a fixed width in pixels. It should be set to support your specific use case.
 
 
 

--- a/docs/grid/performance.md
+++ b/docs/grid/performance.md
@@ -41,7 +41,7 @@ By default, rows adjust their height to fit all content, which can reduce perfor
             enabled: false // default is true
         },
         columns: {
-            distribution: "fixed" // default is "full"
+            resizing: "fixed" // default is "full"
         }
     }
 }
@@ -52,9 +52,9 @@ These options can be used to configure how the table should be rendered.
 
 [`header.enabled: false`](https://api.highcharts.com/dashboards/#interfaces/Grid_Options.HeaderSettings#enabled) disables all [column headers](https://www.highcharts.com/docs/grid/header) by not rendering the `thead` element.
 
-[`columns.distribution`](https://api.highcharts.com/dashboards/#interfaces/Grid_Options.ColumnsSettings#distribution) is used to configure initial column widths.
+[`columns.resizing`](https://api.highcharts.com/dashboards/#interfaces/Grid_Options.ColumnsSettings#resizing) is used to configure initial column widths.
 
-[`columns.distribution: "full"`](https://api.highcharts.com/dashboards/#interfaces/Grid_Options.ColumnsSettings#distribution) renders a full width (`width: 100%;`) responsive table with evenly distributed column widths. `columns.distribution:"fixed"` renders a table were columns have a fixed width in pixels. It should be set to support your specific use case.
+[`columns.resizing: "full"`](https://api.highcharts.com/dashboards/#interfaces/Grid_Options.ColumnsSettings#resizing) renders a full width (`width: 100%;`) responsive table with evenly distributed column widths. `columns.resizing: "fixed"` renders a table were columns have a fixed width in pixels. It should be set to support your specific use case.
 
 
 

--- a/samples/grid-lite/basic/column-distribution/demo.js
+++ b/samples/grid-lite/basic/column-distribution/demo.js
@@ -10,7 +10,7 @@ Grid.grid('container', {
     },
     rendering: {
         columns: {
-            distribution: 'mixed'
+            resizing: 'mixed'
         }
     },
     columns: [{

--- a/samples/grid-lite/basic/column-distribution/demo.js
+++ b/samples/grid-lite/basic/column-distribution/demo.js
@@ -10,7 +10,7 @@ Grid.grid('container', {
     },
     rendering: {
         columns: {
-            resizing: 'mixed'
+            resizeMode: 'mixed'
         }
     },
     columns: [{

--- a/samples/grid-lite/basic/column-distribution/demo.js
+++ b/samples/grid-lite/basic/column-distribution/demo.js
@@ -10,7 +10,9 @@ Grid.grid('container', {
     },
     rendering: {
         columns: {
-            resizeMode: 'mixed'
+            resizing: {
+                mode: 'mixed'
+            }
         }
     },
     columns: [{

--- a/samples/grid-lite/basic/column-resizing-disabled/demo.js
+++ b/samples/grid-lite/basic/column-resizing-disabled/demo.js
@@ -8,7 +8,11 @@ Grid.grid('container', {
             icon: ['Apples URL', 'Pears URL', 'Plums URL', 'Bananas URL']
         }
     },
-    columnDefaults: {
-        resizing: false
+    rendering: {
+        columns: {
+            resizing: {
+                enabled: false
+            }
+        }
     }
 });

--- a/samples/grid-lite/basic/custom-column-distribution/demo.js
+++ b/samples/grid-lite/basic/custom-column-distribution/demo.js
@@ -32,7 +32,7 @@ Grid.grid('container', {
     },
     rendering: {
         columns: {
-            distribution: 'custom'
+            resizing: 'custom'
         }
     },
     columns: [{

--- a/samples/grid-lite/basic/custom-column-distribution/demo.js
+++ b/samples/grid-lite/basic/custom-column-distribution/demo.js
@@ -32,7 +32,9 @@ Grid.grid('container', {
     },
     rendering: {
         columns: {
-            resizeMode: 'custom'
+            resizing: {
+                mode: 'custom'
+            }
         }
     },
     columns: [{

--- a/samples/grid-lite/basic/custom-column-distribution/demo.js
+++ b/samples/grid-lite/basic/custom-column-distribution/demo.js
@@ -32,7 +32,7 @@ Grid.grid('container', {
     },
     rendering: {
         columns: {
-            resizing: 'custom'
+            resizeMode: 'custom'
         }
     },
     columns: [{

--- a/samples/grid-lite/cypress/column-distribution/demo.js
+++ b/samples/grid-lite/cypress/column-distribution/demo.js
@@ -24,7 +24,7 @@ document.getElementById('select-distr').addEventListener('change', e => {
     grid.update({
         rendering: {
             columns: {
-                distribution: e.target.value
+                resizing: e.target.value
             }
         }
     });

--- a/samples/grid-lite/cypress/wide-grid/demo.js
+++ b/samples/grid-lite/cypress/wide-grid/demo.js
@@ -60,7 +60,7 @@ Grid.grid('container', {
     }],
     rendering: {
         columns: {
-            distribution: 'fixed'
+            resizing: 'fixed'
         },
         rows: {
             strictHeights: true

--- a/samples/grid-lite/cypress/wide-grid/demo.js
+++ b/samples/grid-lite/cypress/wide-grid/demo.js
@@ -60,7 +60,9 @@ Grid.grid('container', {
     }],
     rendering: {
         columns: {
-            resizeMode: 'fixed'
+            resizing: {
+                mode: 'fixed'
+            }
         },
         rows: {
             strictHeights: true

--- a/samples/grid-lite/cypress/wide-grid/demo.js
+++ b/samples/grid-lite/cypress/wide-grid/demo.js
@@ -60,7 +60,7 @@ Grid.grid('container', {
     }],
     rendering: {
         columns: {
-            resizing: 'fixed'
+            resizeMode: 'fixed'
         },
         rows: {
             strictHeights: true

--- a/samples/grid-lite/demo/view-chart-data-using-grid/demo.js
+++ b/samples/grid-lite/demo/view-chart-data-using-grid/demo.js
@@ -139,7 +139,7 @@ function createGrid() {
         },
         rendering: {
             columns: {
-                distribution: 'mixed'
+                resizing: 'mixed'
             },
             theme: 'hcg-theme-default theme-custom'
         },

--- a/samples/grid-lite/demo/view-chart-data-using-grid/demo.js
+++ b/samples/grid-lite/demo/view-chart-data-using-grid/demo.js
@@ -139,7 +139,7 @@ function createGrid() {
         },
         rendering: {
             columns: {
-                resizing: 'mixed'
+                resizeMode: 'mixed'
             },
             theme: 'hcg-theme-default theme-custom'
         },

--- a/samples/grid-lite/demo/view-chart-data-using-grid/demo.js
+++ b/samples/grid-lite/demo/view-chart-data-using-grid/demo.js
@@ -139,7 +139,9 @@ function createGrid() {
         },
         rendering: {
             columns: {
-                resizeMode: 'mixed'
+                resizing: {
+                    mode: 'mixed'
+                }
             },
             theme: 'hcg-theme-default theme-custom'
         },

--- a/test/cypress/dashboards/integration/Components/Grid/GridComponent.cy.js
+++ b/test/cypress/dashboards/integration/Components/Grid/GridComponent.cy.js
@@ -139,7 +139,7 @@ describe('layout resize on window changes', () => {
             .find('input[type="checkbox"]')
             .should('be.checked');
 
-        cy.get('.highcharts-dashboards-edit-label-text').contains('Columns distribution').should('be.visible');
+        cy.get('.highcharts-dashboards-edit-label-text').contains('Columns resizing mode').should('be.visible');
         cy.get('.highcharts-dashboards-edit-dropdown.highcharts-dashboards-edit-collapsable-content-header')
             .eq(1)
             .find('.highcharts-dashboards-edit-dropdown-button-content > span')

--- a/test/typescript-dts/grid/grid-lite.ts
+++ b/test/typescript-dts/grid/grid-lite.ts
@@ -35,7 +35,7 @@ function test_grid() {
         }, 'hidden'],
         rendering: {
             columns: {
-                distribution: 'fixed'
+                resizing: 'fixed'
             }
         },
         columns: [{

--- a/test/typescript-dts/grid/grid-lite.ts
+++ b/test/typescript-dts/grid/grid-lite.ts
@@ -35,7 +35,7 @@ function test_grid() {
         }, 'hidden'],
         rendering: {
             columns: {
-                resizing: 'fixed'
+                resizeMode: 'fixed'
             }
         },
         columns: [{

--- a/test/typescript-dts/grid/grid-lite.ts
+++ b/test/typescript-dts/grid/grid-lite.ts
@@ -35,7 +35,9 @@ function test_grid() {
         }, 'hidden'],
         rendering: {
             columns: {
-                resizeMode: 'fixed'
+                resizing: {
+                    mode: 'fixed'
+                }
             }
         },
         columns: [{

--- a/ts/Dashboards/Components/DataGridComponent/DataGridComponentDefaults.ts
+++ b/ts/Dashboards/Components/DataGridComponent/DataGridComponentDefaults.ts
@@ -70,7 +70,8 @@ const DataGridComponentDefaults: Globals.DeepPartial<Options> = {
                                 'gridOptions',
                                 'rendering',
                                 'columns',
-                                'resizeMode'
+                                'resizing',
+                                'mode'
                             ],
                         type: 'select',
                         selectOptions: [{
@@ -97,8 +98,10 @@ const DataGridComponentDefaults: Globals.DeepPartial<Options> = {
                         propertyPath:
                             [
                                 'gridOptions',
-                                'columnDefaults',
-                                'resizing'
+                                'rendering',
+                                'columns',
+                                'resizing',
+                                'enabled'
                             ],
                         type: 'toggle'
                     }, {

--- a/ts/Dashboards/Components/DataGridComponent/DataGridComponentDefaults.ts
+++ b/ts/Dashboards/Components/DataGridComponent/DataGridComponentDefaults.ts
@@ -64,13 +64,13 @@ const DataGridComponentDefaults: Globals.DeepPartial<Options> = {
                         propertyPath: ['gridOptions', 'caption', 'text'],
                         type: 'input'
                     }, {
-                        name: 'Columns distribution',
+                        name: 'Columns resizing mode',
                         propertyPath:
                             [
                                 'gridOptions',
                                 'rendering',
                                 'columns',
-                                'distribution'
+                                'resizeMode'
                             ],
                         type: 'select',
                         selectOptions: [{

--- a/ts/Grid/Core/Defaults.ts
+++ b/ts/Grid/Core/Defaults.ts
@@ -74,13 +74,17 @@ namespace Defaults {
             header: {
                 enabled: true
             },
+            columns: {
+                resizing: {
+                    enabled: true
+                }
+            },
             theme: 'hcg-theme-default'
         },
         columnDefaults: {
             sorting: {
                 sortable: true
-            },
-            resizing: true
+            }
         }
     };
 

--- a/ts/Grid/Core/Options.ts
+++ b/ts/Grid/Core/Options.ts
@@ -156,7 +156,7 @@ export interface RenderingSettings {
 export interface ColumnsSettings {
     /**
      * @deprecated
-     * Use `resizing` instead.
+     * Use `resizeMode` instead.
      */
     distribution?: ColumnDistributionType;
 
@@ -187,7 +187,7 @@ export interface ColumnsSettings {
      *
      * @default undefined
      */
-    resizing?: ColumnDistributionType;
+    resizeMode?: ColumnDistributionType;
 }
 
 export interface RowsSettings {

--- a/ts/Grid/Core/Options.ts
+++ b/ts/Grid/Core/Options.ts
@@ -153,10 +153,13 @@ export interface RenderingSettings {
     theme?: string;
 }
 
+/**
+ * Options to control the columns rendering.
+ */
 export interface ColumnsSettings {
     /**
      * @deprecated
-     * Use `resizeMode` instead.
+     * Use `resizing.mode` instead.
      */
     distribution?: ColumnDistributionType;
 
@@ -173,6 +176,22 @@ export interface ColumnsSettings {
     included?: Array<string>;
 
     /**
+     * Options for the columns resizing.
+     */
+    resizing?: ResizingOptions;
+}
+
+/**
+ * Options to control the columns resizing.
+ */
+export interface ResizingOptions {
+    /**
+     * Whether the columns resizing is enabled. If `true`, the user can
+     * resize the columns by dragging the column header edges.
+     */
+    enabled?: boolean;
+
+    /**
      * Resizing mode of the columns. If `full`, the columns will be
      * distributed so that the first and the last column are at the edges of
      * the grid. If `fixed`, the columns will have a fixed width, only the
@@ -187,9 +206,12 @@ export interface ColumnsSettings {
      *
      * @default undefined
      */
-    resizeMode?: ColumnDistributionType;
+    mode?: ColumnDistributionType;
 }
 
+/**
+ * Options to control the rows rendering.
+ */
 export interface RowsSettings {
     /**
      * Buffer of rows to render outside the visible area from the top and from
@@ -299,16 +321,6 @@ export interface ColumnOptions {
      * Try it: {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/grid-pro/basic/sorting-options | Sorting options}
      */
     sorting?: ColumnSortingOptions;
-
-    /**
-     * Whether the columns should be resizable. It does not affect individual
-     * column settings.
-     *
-     * Try it: {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/grid-lite/basic/column-resizing-disabled | Column resize disabled}
-     *
-     * @default true
-     */
-    resizing?: boolean;
 
     /**
      * The width of the column. It can be set in pixels or as a percentage of
@@ -460,12 +472,6 @@ export interface IndividualColumnOptions extends ColumnOptions {
     id: string;
 
     sorting?: IndividualColumnSortingOptions;
-
-    /**
-     * @internal
-     * @private
-     */
-    resizing?: boolean;
 }
 
 export interface CaptionOptions {

--- a/ts/Grid/Core/Options.ts
+++ b/ts/Grid/Core/Options.ts
@@ -164,7 +164,7 @@ export interface ColumnsSettings {
     distribution?: ColumnDistributionType;
 
     /**
-     * Columns included in the grid structure- contains the columns IDs.
+     * Columns included in the grid structure - contains the columns IDs.
      * If not set, all columns will be included. Useful when many columns needs
      * to be excluded from the grid.
      *
@@ -188,6 +188,10 @@ export interface ResizingOptions {
     /**
      * Whether the columns resizing is enabled. If `true`, the user can
      * resize the columns by dragging the column header edges.
+     *
+     * Try it: {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/grid-lite/basic/column-resizing-disabled | Column resize disabled}
+     *
+     * @default true
      */
     enabled?: boolean;
 
@@ -321,6 +325,12 @@ export interface ColumnOptions {
      * Try it: {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/grid-pro/basic/sorting-options | Sorting options}
      */
     sorting?: ColumnSortingOptions;
+
+    /**
+     * @deprecated
+     * Use `rendering.columns.resizing.enabled` instead.
+     */
+    resizing?: boolean;
 
     /**
      * The width of the column. It can be set in pixels or as a percentage of
@@ -472,6 +482,14 @@ export interface IndividualColumnOptions extends ColumnOptions {
     id: string;
 
     sorting?: IndividualColumnSortingOptions;
+
+    /**
+     * @internal
+     * @private
+     * @deprecated
+     * It will be removed in the next major release.
+     */
+    resizing?: boolean;
 }
 
 export interface CaptionOptions {

--- a/ts/Grid/Core/Options.ts
+++ b/ts/Grid/Core/Options.ts
@@ -39,7 +39,7 @@ import type { LangOptionsCore } from '../../Shared/LangOptionsCore';
  * */
 
 /**
- * The distribution of the columns in the grid structure.
+ * The resizing strategy of the columns in the grid structure.
  */
 export type ColumnDistributionType = ColumnDistribution.StrategyType;
 
@@ -155,18 +155,8 @@ export interface RenderingSettings {
 
 export interface ColumnsSettings {
     /**
-     * The distribution of the columns. If `full`, the columns will be
-     * distributed so that the first and the last column are at the edges of
-     * the grid. If `fixed`, the columns will have a fixed width in pixels. If
-     * `mixed`, the column widths will be set according to the `width` option
-     * of each column - CSS styles will be ignored then.
-     *
-     * If `undefined`, the default column distribution will be used, which is
-     * `mixed`, if `width` is set for any column, otherwise `full`.
-     *
-     * Try it: {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/grid-lite/basic/column-distribution | Distribution overview}
-     *
-     * @default undefined
+     * @deprecated
+     * Use `resizing` instead.
      */
     distribution?: ColumnDistributionType;
 
@@ -181,6 +171,23 @@ export interface ColumnsSettings {
      * @private
      */
     included?: Array<string>;
+
+    /**
+     * Resizing mode of the columns. If `full`, the columns will be
+     * distributed so that the first and the last column are at the edges of
+     * the grid. If `fixed`, the columns will have a fixed width, only the
+     * resized column will be affected. If `mixed`, resizing will change the
+     * width of the neighboring columns, but the rest will remain in the same
+     * place.
+     *
+     * If `undefined`, the default column rensizing strategy will be used, which
+     * is `mixed`, if `width` is set for any column, otherwise `full`.
+     *
+     * Try it: {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/grid-lite/basic/column-distribution | Resizing overview}
+     *
+     * @default undefined
+     */
+    resizing?: ColumnDistributionType;
 }
 
 export interface RowsSettings {
@@ -308,11 +315,10 @@ export interface ColumnOptions {
      * the table width. If unset, the width is distributed evenly between all
      * columns.
      *
-     * This option works only when the `distribution` option is set to `mixed`.
+     * This option does not work with the `resizing` option set to `full`.
      *
-     * If the `distribution` option is undefined, it is set to `mixed` and the
-     * `width` option is used to set the width of the column. Other distribution
-     * modes work only with CSS-defined column widths.
+     * If the `resizing` option is undefined, it is set to `mixed` and the
+     * `width` option is used to set the width of the column.
      */
     width?: number | string;
 }

--- a/ts/Grid/Core/Table/ColumnDistribution/ColumnDistribution.ts
+++ b/ts/Grid/Core/Table/ColumnDistribution/ColumnDistribution.ts
@@ -59,7 +59,7 @@ namespace ColumnDistribution {
 
     /**
      * Returns the column distribution of the table according to the options:
-     * 1. If `columns.resizing` defined, use it. If not:
+     * 1. If `columns.resizeMode` defined, use it. If not:
      * 2. If any column has a width defined, use `mixed`. If not:
      * 3. Use `full`.
      *
@@ -69,7 +69,7 @@ namespace ColumnDistribution {
     function assumeDistributionType(viewport: Table): StrategyType {
         const { options } = viewport.grid;
         const result =
-            options?.rendering?.columns?.resizing ||
+            options?.rendering?.columns?.resizeMode ||
             options?.rendering?.columns?.distribution;
 
         if (result) {

--- a/ts/Grid/Core/Table/ColumnDistribution/ColumnDistribution.ts
+++ b/ts/Grid/Core/Table/ColumnDistribution/ColumnDistribution.ts
@@ -59,7 +59,7 @@ namespace ColumnDistribution {
 
     /**
      * Returns the column distribution of the table according to the options:
-     * 1. If `columns.resizeMode` defined, use it. If not:
+     * 1. If `columns.resizing.mode` defined, use it. If not:
      * 2. If any column has a width defined, use `mixed`. If not:
      * 3. Use `full`.
      *
@@ -69,7 +69,8 @@ namespace ColumnDistribution {
     function assumeDistributionType(viewport: Table): StrategyType {
         const { options } = viewport.grid;
         const colRendering = options?.rendering?.columns;
-        const result = colRendering?.resizeMode || colRendering?.distribution;
+        const result = colRendering?.resizing?.mode ||
+            colRendering?.distribution;
 
         if (result) {
             return result;

--- a/ts/Grid/Core/Table/ColumnDistribution/ColumnDistribution.ts
+++ b/ts/Grid/Core/Table/ColumnDistribution/ColumnDistribution.ts
@@ -59,7 +59,7 @@ namespace ColumnDistribution {
 
     /**
      * Returns the column distribution of the table according to the options:
-     * 1. If `columns.distribution` defined, use it. If not:
+     * 1. If `columns.resizing` defined, use it. If not:
      * 2. If any column has a width defined, use `mixed`. If not:
      * 3. Use `full`.
      *
@@ -68,7 +68,9 @@ namespace ColumnDistribution {
      */
     function assumeDistributionType(viewport: Table): StrategyType {
         const { options } = viewport.grid;
-        const result = options?.rendering?.columns?.distribution;
+        const result =
+            options?.rendering?.columns?.resizing ||
+            options?.rendering?.columns?.distribution;
 
         if (result) {
             return result;

--- a/ts/Grid/Core/Table/ColumnDistribution/ColumnDistribution.ts
+++ b/ts/Grid/Core/Table/ColumnDistribution/ColumnDistribution.ts
@@ -68,9 +68,8 @@ namespace ColumnDistribution {
      */
     function assumeDistributionType(viewport: Table): StrategyType {
         const { options } = viewport.grid;
-        const result =
-            options?.rendering?.columns?.resizeMode ||
-            options?.rendering?.columns?.distribution;
+        const colRendering = options?.rendering?.columns;
+        const result = colRendering?.resizeMode || colRendering?.distribution;
 
         if (result) {
             return result;

--- a/ts/Grid/Core/Table/ColumnDistribution/ColumnDistributionStrategy.ts
+++ b/ts/Grid/Core/Table/ColumnDistribution/ColumnDistributionStrategy.ts
@@ -221,6 +221,13 @@ abstract class ColumnDistributionStrategy {
     public validateOnUpdate(newOptions: Globals.DeepPartial<Options>): void {
         if (
             Object.hasOwnProperty.call(
+                newOptions.rendering?.columns || {}, 'resizing'
+            ) &&
+            newOptions.rendering?.columns?.resizing !== this.type
+        ) {
+            this.invalidated = true;
+        } else if (
+            Object.hasOwnProperty.call(
                 newOptions.rendering?.columns || {}, 'distribution'
             ) &&
             newOptions.rendering?.columns?.distribution !== this.type

--- a/ts/Grid/Core/Table/ColumnDistribution/ColumnDistributionStrategy.ts
+++ b/ts/Grid/Core/Table/ColumnDistribution/ColumnDistributionStrategy.ts
@@ -223,7 +223,7 @@ abstract class ColumnDistributionStrategy {
             Object.hasOwnProperty.call(
                 newOptions.rendering?.columns || {}, 'resizing'
             ) &&
-            newOptions.rendering?.columns?.resizing !== this.type
+            newOptions.rendering?.columns?.resizeMode !== this.type
         ) {
             this.invalidated = true;
         } else if (

--- a/ts/Grid/Core/Table/ColumnDistribution/ColumnDistributionStrategy.ts
+++ b/ts/Grid/Core/Table/ColumnDistribution/ColumnDistributionStrategy.ts
@@ -223,7 +223,7 @@ abstract class ColumnDistributionStrategy {
             Object.hasOwnProperty.call(
                 newOptions.rendering?.columns || {}, 'resizing'
             ) &&
-            newOptions.rendering?.columns?.resizeMode !== this.type
+            newOptions.rendering?.columns?.resizing?.mode !== this.type
         ) {
             this.invalidated = true;
         } else if (

--- a/ts/Grid/Core/Table/ColumnDistribution/FixedDistributionStrategy.ts
+++ b/ts/Grid/Core/Table/ColumnDistribution/FixedDistributionStrategy.ts
@@ -114,7 +114,7 @@ class FixedDistributionStrategy extends DistributionStrategy {
         }
 
         this.columnWidths[column.id] = Math.max(
-        	(resizer.columnStartWidth || 0) + diff,
+            (resizer.columnStartWidth || 0) + diff,
             DistributionStrategy.getMinWidth(column)
         );
         this.columnWidthUnits[column.id] = 0; // Always save in px

--- a/ts/Grid/Core/Table/ColumnDistribution/FixedDistributionStrategy.ts
+++ b/ts/Grid/Core/Table/ColumnDistribution/FixedDistributionStrategy.ts
@@ -71,8 +71,8 @@ class FixedDistributionStrategy extends DistributionStrategy {
      * */
 
     public override loadColumn(column: Column): void {
-        const raw = column.options.width;
-        if (!raw) {
+        const rawWidth = column.options.width;
+        if (!rawWidth) {
             this.columnWidths[column.id] = this.getInitialColumnWidth(column);
             this.columnWidthUnits[column.id] = 0;
             return;
@@ -81,12 +81,12 @@ class FixedDistributionStrategy extends DistributionStrategy {
         let value: number;
         let unitCode: number = 0;
 
-        if (typeof raw === 'number') {
-            value = raw;
+        if (typeof rawWidth === 'number') {
+            value = rawWidth;
             unitCode = 0;
         } else {
-            value = parseFloat(raw);
-            unitCode = raw.charAt(raw.length - 1) === '%' ? 1 : 0;
+            value = parseFloat(rawWidth);
+            unitCode = rawWidth.charAt(rawWidth.length - 1) === '%' ? 1 : 0;
         }
 
         this.columnWidthUnits[column.id] = unitCode;

--- a/ts/Grid/Core/Table/ColumnDistribution/MixedDistributionStrategy.ts
+++ b/ts/Grid/Core/Table/ColumnDistribution/MixedDistributionStrategy.ts
@@ -64,20 +64,20 @@ class MixedDistributionStrategy extends DistributionStrategy {
      * */
 
     public override loadColumn(column: Column): void {
-        const raw = column.options.width;
-        if (!raw) {
+        const rawWidth = column.options.width;
+        if (!rawWidth) {
             return;
         }
 
         let value: number;
         let unitCode: number = 0;
 
-        if (typeof raw === 'number') {
-            value = raw;
+        if (typeof rawWidth === 'number') {
+            value = rawWidth;
             unitCode = 0;
         } else {
-            value = parseFloat(raw);
-            unitCode = raw.charAt(raw.length - 1) === '%' ? 1 : 0;
+            value = parseFloat(rawWidth);
+            unitCode = rawWidth.charAt(rawWidth.length - 1) === '%' ? 1 : 0;
         }
 
         this.columnWidthUnits[column.id] = unitCode;

--- a/ts/Grid/Core/Table/Table.ts
+++ b/ts/Grid/Core/Table/Table.ts
@@ -181,7 +181,7 @@ class Table {
             );
         }
 
-        if (dgOptions?.columnDefaults?.resizing) {
+        if (dgOptions?.rendering?.columns?.resizing?.enabled) {
             this.columnsResizer = new ColumnsResizer(this);
         }
 

--- a/ts/Grid/Core/Table/Table.ts
+++ b/ts/Grid/Core/Table/Table.ts
@@ -181,7 +181,14 @@ class Table {
             );
         }
 
-        if (dgOptions?.rendering?.columns?.resizing?.enabled) {
+        // -- Backward compatibility ---
+        let resizingEnabled = dgOptions?.rendering?.columns?.resizing?.enabled;
+        if (!defined(resizingEnabled)) {
+            resizingEnabled = dgOptions?.columnDefaults?.resizing;
+        }
+        // ---
+
+        if (resizingEnabled) {
             this.columnsResizer = new ColumnsResizer(this);
         }
 

--- a/ts/Grid/Core/Table/Table.ts
+++ b/ts/Grid/Core/Table/Table.ts
@@ -181,14 +181,10 @@ class Table {
             );
         }
 
-        // -- Backward compatibility ---
-        let resizingEnabled = dgOptions?.rendering?.columns?.resizing?.enabled;
-        if (!defined(resizingEnabled)) {
-            resizingEnabled = dgOptions?.columnDefaults?.resizing;
-        }
-        // ---
-
-        if (resizingEnabled) {
+        if (!(
+            dgOptions?.rendering?.columns?.resizing?.enabled === false ||
+            dgOptions?.columnDefaults?.resizing === false
+        )) {
             this.columnsResizer = new ColumnsResizer(this);
         }
 


### PR DESCRIPTION
Added `rendering.columns.resizing.mode` option and deprecated `distribution`.
Added `rendering.columns.resizing.enabled` option and deprecated `columnDefaults.resizing`.
Added possibility to define `column.width` option for the `fixed` resizing strategy.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210379520936284