### PR TITLE
grid/sync-grids-hl-fixes

### DIFF
--- a/ts/Dashboards/Components/DataGridComponent/DataGridSyncs/DataGridHighlightSync.ts
+++ b/ts/Dashboards/Components/DataGridComponent/DataGridSyncs/DataGridHighlightSync.ts
@@ -71,7 +71,8 @@ const syncPair: Sync.SyncPair = {
                     type: 'position',
                     row: cell.row.id,
                     column: cell.column.id,
-                    state: 'point.mouseOver' + groupKey
+                    state: 'point.mouseOver' + groupKey,
+                    sourceId: this.id
                 });
             }
         };
@@ -84,7 +85,8 @@ const syncPair: Sync.SyncPair = {
                     type: 'position',
                     row: cell.row.id,
                     column: cell.column.id,
-                    state: 'point.mouseOut' + groupKey
+                    state: 'point.mouseOut' + groupKey,
+                    sourceId: this.id
                 });
             }
         };
@@ -130,7 +132,10 @@ const syncPair: Sync.SyncPair = {
 
         const handleCursor = (e: DataCursor.Event): void => {
             const cursor = e.cursor;
-            if (cursor.type !== 'position') {
+            if (
+                cursor.sourceId === component.id ||
+                cursor.type !== 'position'
+            ) {
                 return;
             }
 
@@ -155,9 +160,9 @@ const syncPair: Sync.SyncPair = {
             grid.syncColumn(column);
         };
 
-        const handleCursorOut = (): void => {
+        const handleCursorOut = (e: DataCursor.Event): void => {
             const { grid } = component;
-            if (grid) {
+            if (grid && e.cursor.sourceId !== component.id) {
                 grid.syncColumn();
                 grid.syncRow();
             }

--- a/ts/Dashboards/Components/DataGridComponent/DataGridSyncs/DataGridHighlightSync.ts
+++ b/ts/Dashboards/Components/DataGridComponent/DataGridSyncs/DataGridHighlightSync.ts
@@ -50,12 +50,12 @@ const syncPair: Sync.SyncPair = {
         }
         const component = this as DataGridComponent;
 
-        const { dataGrid, board } = component;
+        const { grid, board } = component;
         const highlightOptions = this.sync.syncConfig.highlight;
         const groupKey = highlightOptions.group ?
             ':' + highlightOptions.group : '';
 
-        if (!board || !dataGrid || !highlightOptions?.enabled) {
+        if (!board || !grid || !highlightOptions?.enabled) {
             return;
         }
 
@@ -71,32 +71,36 @@ const syncPair: Sync.SyncPair = {
                     type: 'position',
                     row: cell.row.id,
                     column: cell.column.id,
-                    state: 'dataGrid.hoverRow' + groupKey
+                    state: 'point.mouseOver' + groupKey
                 });
             }
         };
 
-        const onCellMouseOut = (): void => {
+        const onCellMouseOut = (e: TableCell.TableCellEvent): void => {
             if (table) {
+                const cell = e.target;
+
                 cursor.emitCursor(table, {
                     type: 'position',
-                    state: 'dataGrid.hoverOut' + groupKey
+                    row: cell.row.id,
+                    column: cell.column.id,
+                    state: 'point.mouseOut' + groupKey
                 });
             }
         };
 
-        addEvent(dataGrid, 'cellMouseOver', onCellHover);
-        addEvent(dataGrid, 'cellMouseOut', onCellMouseOut);
+        addEvent(grid, 'cellMouseOver', onCellHover);
+        addEvent(grid, 'cellMouseOut', onCellMouseOut);
 
         // Return a function that calls the callbacks
         return function (): void {
             removeEvent(
-                dataGrid.container,
+                grid.container,
                 'cellMouseOver',
                 onCellHover
             );
             removeEvent(
-                dataGrid.container,
+                grid.container,
                 'cellMouseOut',
                 onCellMouseOut
             );
@@ -131,8 +135,8 @@ const syncPair: Sync.SyncPair = {
             }
 
             const { row, column } = cursor;
-            const { dataGrid } = component;
-            const viewport = dataGrid?.viewport;
+            const { grid } = component;
+            const viewport = grid?.viewport;
 
             if (row === void 0 || !viewport) {
                 return;
@@ -147,15 +151,15 @@ const syncPair: Sync.SyncPair = {
                 viewport.scrollToRow(rowIndex);
             }
 
-            dataGrid.syncRow(rowIndex);
-            dataGrid.syncColumn(column);
+            grid.syncRow(rowIndex);
+            grid.syncColumn(column);
         };
 
         const handleCursorOut = (): void => {
-            const { dataGrid } = component;
-            if (dataGrid) {
-                dataGrid.syncColumn();
-                dataGrid.syncRow();
+            const { grid } = component;
+            if (grid) {
+                grid.syncColumn();
+                grid.syncRow();
             }
         };
 
@@ -178,16 +182,6 @@ const syncPair: Sync.SyncPair = {
                 'point.mouseOut' + groupKey,
                 handleCursorOut
             );
-            cursor.addListener(
-                table.id,
-                'dataGrid.hoverRow' + groupKey,
-                handleCursor
-            );
-            cursor.addListener(
-                table.id,
-                'dataGrid.hoverOut' + groupKey,
-                handleCursorOut
-            );
         };
 
         const unregisterCursorListeners = (): void => {
@@ -205,16 +199,6 @@ const syncPair: Sync.SyncPair = {
             cursor.removeListener(
                 table.id,
                 'point.mouseOut' + groupKey,
-                handleCursorOut
-            );
-            cursor.removeListener(
-                table.id,
-                'dataGrid.hoverRow' + groupKey,
-                handleCursor
-            );
-            cursor.removeListener(
-                table.id,
-                'dataGrid.hoverOut' + groupKey,
                 handleCursorOut
             );
         };

--- a/ts/Dashboards/Components/HighchartsComponent/HighchartsSyncs/HighchartsHighlightSync.ts
+++ b/ts/Dashboards/Components/HighchartsComponent/HighchartsSyncs/HighchartsHighlightSync.ts
@@ -397,13 +397,7 @@ const syncPair: Sync.SyncPair = {
                     table.id, 'point.mouseOver' + groupKey, handleCursor
                 );
                 cursor.addListener(
-                    table.id, 'dataGrid.hoverRow' + groupKey, handleCursor
-                );
-                cursor.addListener(
                     table.id, 'point.mouseOut' + groupKey, handleCursorOut
-                );
-                cursor.addListener(
-                    table.id, 'dataGrid.hoverOut' + groupKey, handleCursorOut
                 );
             }
         };
@@ -425,13 +419,7 @@ const syncPair: Sync.SyncPair = {
                     table.id, 'point.mouseOver' + groupKey, handleCursor
                 );
                 cursor.removeListener(
-                    table.id, 'dataGrid.hoverRow' + groupKey, handleCursor
-                );
-                cursor.removeListener(
                     table.id, 'point.mouseOut' + groupKey, handleCursorOut
-                );
-                cursor.removeListener(
-                    table.id, 'dataGrid.hoverOut' + groupKey, handleCursorOut
                 );
             }
         };

--- a/ts/Dashboards/Components/HighchartsComponent/HighchartsSyncs/HighchartsHighlightSync.ts
+++ b/ts/Dashboards/Components/HighchartsComponent/HighchartsSyncs/HighchartsHighlightSync.ts
@@ -105,7 +105,8 @@ const syncPair: Sync.SyncPair = {
                                 type: 'position',
                                 row: presTable.getOriginalRowIndex(this.index),
                                 column: columnName,
-                                state: 'point.mouseOver' + groupKey
+                                state: 'point.mouseOver' + groupKey,
+                                sourceId: component.id
                             });
                         },
                         mouseOut: function (): void {
@@ -113,7 +114,8 @@ const syncPair: Sync.SyncPair = {
                                 type: 'position',
                                 row: presTable.getOriginalRowIndex(this.index),
                                 column: columnName,
-                                state: 'point.mouseOut' + groupKey
+                                state: 'point.mouseOut' + groupKey,
+                                sourceId: component.id
                             });
                         }
                     }
@@ -243,7 +245,10 @@ const syncPair: Sync.SyncPair = {
             const highlightOptions = this.sync
                 .syncConfig.highlight as HighchartsHighlightSyncOptions;
 
-            if (!highlightOptions.enabled) {
+            if (
+                !highlightOptions.enabled ||
+                e.cursor.sourceId === component.id
+            ) {
                 return;
             }
 
@@ -303,7 +308,8 @@ const syncPair: Sync.SyncPair = {
 
             if (
                 !chart || !chart.series.length ||
-                !highlightOptions.enabled
+                !highlightOptions.enabled ||
+                e.cursor.sourceId === component.id
             ) {
                 return;
             }

--- a/ts/Dashboards/Components/Sync/Sync.ts
+++ b/ts/Dashboards/Components/Sync/Sync.ts
@@ -412,6 +412,8 @@ namespace Sync {
         ), undefined|boolean|OptionsEntry>
     );
 }
+
+
 /* *
  *
  *  Default Export

--- a/ts/Dashboards/SerializeHelper/DataCursorHelper.ts
+++ b/ts/Dashboards/SerializeHelper/DataCursorHelper.ts
@@ -131,6 +131,7 @@ namespace DataCursorHelper {
         column?: string;
         row?: number;
         state: DataCursor.State;
+        sourceId?: string;
         type: 'position';
     }
 
@@ -139,6 +140,7 @@ namespace DataCursorHelper {
         firstRow: number;
         lastRow: number;
         state: DataCursor.State;
+        sourceId?: string;
         type: 'range';
     }
 

--- a/ts/Data/DataCursor.ts
+++ b/ts/Data/DataCursor.ts
@@ -382,6 +382,7 @@ namespace DataCursor {
         column?: string;
         row?: number;
         state: State;
+        sourceId?: string;
     }
 
     export interface Range {
@@ -390,6 +391,7 @@ namespace DataCursor {
         firstRow: number;
         lastRow: number;
         state: State;
+        sourceId?: string;
     }
 
     export interface Event {


### PR DESCRIPTION
Removed unnecessary duplication of highlight events.
Prevented self-syncing.
