### PR TITLE
Fix axis label direction when position3d="flap" and X/Z axes are reversed.

### DIFF
--- a/ts/Core/Axis/Axis3DComposition.ts
+++ b/ts/Core/Axis/Axis3DComposition.ts
@@ -611,9 +611,6 @@ class Axis3DAdditions {
                 let sin = Math.sin(alpha);
                 const cos = Math.cos(alpha);
 
-                if (axis.opposite) {
-                    sin = -sin;
-                }
                 if (reverseFlap) {
                     sin = -sin;
                 }


### PR DESCRIPTION
I most likely left this bug when I originally wrote the position3d flag a few years ago -- #6929.

Turns out that my app didn't really use reversed axes, and the handling for it was wrong/unnecessary

Reproduction: https://jsfiddle.net/bgc2rqjo/ -- Note how the X/Z Axes labels seem to be tilted to the front.

Before: 
![3d-draggable-chart](https://github.com/user-attachments/assets/0638398a-3f51-4d74-91e2-bbb899088fa8)

After fix:
![3d-draggable-chart (1)](https://github.com/user-attachments/assets/eec0e1a0-1560-4a3a-bb5f-bc3b45f68691)
