### PR TITLE
dash/bugfix-board-destroy-polling-stop

### DIFF
--- a/test/cypress/dashboards/integration/Components/general.cy.js
+++ b/test/cypress/dashboards/integration/Components/general.cy.js
@@ -84,3 +84,25 @@ describe('Data polling restarting', () => {
     });
   });
 });
+
+describe('Data polling stop', () => {
+  before(() => {
+    cy.visit('dashboards/cypress/connector-polling');
+  });
+
+  it('Should stop connector polling after the board is destroyed.', () => {
+    cy.board().then(dashboard => {
+      const CONNECTOR_ID = 'fetched-data';
+      const dataPool = dashboard.dataPool;
+
+      // Let the connector to load synchronously.
+      dataPool.getConnector(CONNECTOR_ID);
+      // Destroy the dashboard before the connector gets loaded.
+      dashboard.destroy();
+      // Expect request to be aborted.
+      expect(
+        dataPool.connectors[CONNECTOR_ID].pollingController.signal.aborted
+      ).to.be.true;
+    });
+  });
+});

--- a/test/cypress/dashboards/integration/Components/general.cy.js
+++ b/test/cypress/dashboards/integration/Components/general.cy.js
@@ -90,7 +90,7 @@ describe('Data polling stop', () => {
     cy.visit('dashboards/cypress/connector-polling');
   });
 
-  it('Should stop connector polling after the board is destroyed.', () => {
+  it('Connector polling is stopped after the unloaded board is destroyed.', () => {
     cy.board().then(dashboard => {
       const CONNECTOR_ID = 'fetched-data';
       const dataPool = dashboard.dataPool;

--- a/ts/Dashboards/Board.ts
+++ b/ts/Dashboards/Board.ts
@@ -417,6 +417,9 @@ class Board implements Serializable<Board, Board.JSON> {
     public destroy(): void {
         const board = this;
 
+        // Cancel all data connectors pending requests.
+        this.dataPool.cancelPendingRequests();
+
         // Destroy layouts.
         if (this.guiEnabled) {
             for (let i = 0, iEnd = board.layouts?.length; i < iEnd; ++i) {

--- a/ts/Dashboards/Components/ConnectorHandler.ts
+++ b/ts/Dashboards/Components/ConnectorHandler.ts
@@ -98,7 +98,7 @@ class ConnectorHandler {
      * destroyed, used to check and prevent further operations if the connector
      * handler has been destroyed during asynchronous functions.
      *
-     * @private
+     * @internal
      */
     private destroyed?: boolean;
 

--- a/ts/Dashboards/Components/ConnectorHandler.ts
+++ b/ts/Dashboards/Components/ConnectorHandler.ts
@@ -93,6 +93,14 @@ class ConnectorHandler {
      * @internal
      */
     public presentationTable?: DataTable;
+    /**
+     * Helper flag for detecting whether the connector handler has been
+     * destroyed, used to check and prevent further operations if the connector
+     * handler has been destroyed during asynchronous functions.
+     *
+     * @private
+     */
+    private destroyed?: boolean;
 
 
     /* *
@@ -149,7 +157,12 @@ class ConnectorHandler {
             }
 
             const connector = await dataPool.getConnector(connectorId);
-            this.setConnector(connector);
+
+            // The connector shouldn't be set if the handler was destroyed
+            // during its creation.
+            if (!this.destroyed) {
+                this.setConnector(connector);
+            }
         }
 
         return component;
@@ -382,6 +395,7 @@ class ConnectorHandler {
      * @internal
      */
     public destroy(): void {
+        this.destroyed = true;
         this.removeConnectorAssignment();
         this.removeTableEvents();
     }

--- a/ts/Dashboards/Components/ConnectorHandler.ts
+++ b/ts/Dashboards/Components/ConnectorHandler.ts
@@ -97,8 +97,6 @@ class ConnectorHandler {
      * Helper flag for detecting whether the connector handler has been
      * destroyed, used to check and prevent further operations if the connector
      * handler has been destroyed during asynchronous functions.
-     *
-     * @internal
      */
     private destroyed?: boolean;
 

--- a/ts/Data/Connectors/DataConnector.ts
+++ b/ts/Data/Connectors/DataConnector.ts
@@ -143,6 +143,11 @@ abstract class DataConnector implements DataEvent.Emitter {
      */
     public pollingController?: AbortController;
 
+    /**
+     * Helper flag for detecting whether the data connector is loaded.
+     */
+    public loaded: boolean = false;
+
     /* *
      *
      *  Functions
@@ -380,10 +385,13 @@ abstract class DataConnector implements DataEvent.Emitter {
     }
 
     /**
-     * Stops polling data.
+     * Stops polling data. Shouldn't be performed if polling is already stopped.
      */
     public stopPolling(): void {
         const connector = this;
+        if (!connector.polling) {
+            return;
+        }
 
         // Abort the existing request.
         connector?.pollingController?.abort();

--- a/ts/Data/Connectors/DataConnector.ts
+++ b/ts/Data/Connectors/DataConnector.ts
@@ -145,6 +145,7 @@ abstract class DataConnector implements DataEvent.Emitter {
 
     /**
      * Helper flag for detecting whether the data connector is loaded.
+     * @internal
      */
     public loaded: boolean = false;
 

--- a/ts/Data/Connectors/HTMLTableConnector.ts
+++ b/ts/Data/Connectors/HTMLTableConnector.ts
@@ -94,7 +94,7 @@ class HTMLTableConnector extends DataConnector {
     /**
      * The attached parser, which can be replaced in the constructor
      */
-    public readonly converter: HTMLTableConverter;
+    public converter: HTMLTableConverter;
 
     /**
      * The table element to create the connector from. Is either supplied

--- a/ts/Data/DataPool.ts
+++ b/ts/Data/DataPool.ts
@@ -309,9 +309,7 @@ class DataPool implements DataEvent.Emitter {
                 .load()
                 .then(({ converter, dataTables }): void => {
                     connector.dataTables = dataTables;
-                    if (converter) {
-                        connector.converter = converter;
-                    }
+                    connector.converter = converter;
                     connector.loaded = true;
 
                     this.emit<DataPool.Event>({


### PR DESCRIPTION
Fixed #23095, cancel data polling requests after destroying a board.