### PR TITLE
Samples: generic font-family where missing

### DIFF
--- a/samples/dashboards/components/climate-all/demo.css
+++ b/samples/dashboards/components/climate-all/demo.css
@@ -2,6 +2,20 @@
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 @import url("https://code.highcharts.com/dashboards/css/dashboards.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 /* *
  *
  *  Colors

--- a/samples/dashboards/demo/accounting/demo.css
+++ b/samples/dashboards/demo/accounting/demo.css
@@ -2,6 +2,20 @@
 @import url("https://code.highcharts.com/dashboards/css/dashboards.css");
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 /* Dashboards */
 
 #container {

--- a/samples/dashboards/demo/axes-sync/demo.css
+++ b/samples/dashboards/demo/axes-sync/demo.css
@@ -1,6 +1,20 @@
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 @import url("https://code.highcharts.com/dashboards/css/dashboards.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 h1,
 a {
     text-align: center;

--- a/samples/dashboards/demo/climate/demo.css
+++ b/samples/dashboards/demo/climate/demo.css
@@ -2,6 +2,20 @@
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 @import url("https://code.highcharts.com/dashboards/css/dashboards.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 /**
  *
  *  Colors

--- a/samples/dashboards/demo/cloud-monitoring/demo.css
+++ b/samples/dashboards/demo/cloud-monitoring/demo.css
@@ -2,6 +2,20 @@
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 @import url("https://code.highcharts.com/dashboards/css/dashboards.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-description {
     padding: 0 20px;
 }

--- a/samples/dashboards/demo/grid-mathmodifier/demo.css
+++ b/samples/dashboards/demo/grid-mathmodifier/demo.css
@@ -2,6 +2,20 @@
 @import url("https://code.highcharts.com/css/highcharts.css");
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-description {
     padding: 0 20px;
 }

--- a/samples/dashboards/demo/grid-sync/demo.css
+++ b/samples/dashboards/demo/grid-sync/demo.css
@@ -1,6 +1,20 @@
 @import url("https://code.highcharts.com/dashboards/css/dashboards.css");
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-title {
     font-size: 1em;
     font-weight: normal;

--- a/samples/dashboards/demo/minimal-html/demo.css
+++ b/samples/dashboards/demo/minimal-html/demo.css
@@ -2,6 +2,20 @@
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 @import url("https://code.highcharts.com/dashboards/css/dashboards.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     padding: 10px;
     background-color: var(--highcharts-neutral-color-5);

--- a/samples/dashboards/demo/minimal/demo.css
+++ b/samples/dashboards/demo/minimal/demo.css
@@ -2,6 +2,20 @@
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 @import url("https://code.highcharts.com/dashboards/css/dashboards.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 h1#title {
     padding-top: 10px;
     margin: 0;

--- a/samples/dashboards/demo/personal-portfolio/demo.css
+++ b/samples/dashboards/demo/personal-portfolio/demo.css
@@ -2,6 +2,20 @@
 @import url("https://code.highcharts.com/dashboards/css/dashboards.css");
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 /* Dashboards */
 
 :root {

--- a/samples/dashboards/demo/project-management/demo.css
+++ b/samples/dashboards/demo/project-management/demo.css
@@ -1,5 +1,19 @@
 @import url("https://code.highcharts.com/css/highcharts.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 body {
     font-family:
         -apple-system,

--- a/samples/dashboards/demo/sync-cursor/demo.css
+++ b/samples/dashboards/demo/sync-cursor/demo.css
@@ -2,6 +2,20 @@
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 @import url("https://code.highcharts.com/dashboards/css/dashboards.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 h2,
 h3 {
     text-align: center;

--- a/samples/dashboards/demo/sync-extremes/demo.css
+++ b/samples/dashboards/demo/sync-extremes/demo.css
@@ -2,6 +2,20 @@
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 @import url("https://code.highcharts.com/dashboards/css/dashboards.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-background-color {
     fill: #f0f0f0;
 }

--- a/samples/dashboards/demo/sync/demo.css
+++ b/samples/dashboards/demo/sync/demo.css
@@ -1,5 +1,19 @@
 @import url("https://code.highcharts.com/css/highcharts.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure {
     max-width: 800px;
     margin: 1em auto;

--- a/samples/dashboards/demo/vertical/demo.css
+++ b/samples/dashboards/demo/vertical/demo.css
@@ -10,6 +10,20 @@
     }
 }
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 body {
     font-family:
         -apple-system,

--- a/samples/dashboards/sync/datacursor-sync/demo.css
+++ b/samples/dashboards/sync/datacursor-sync/demo.css
@@ -1,6 +1,20 @@
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 @import url("https://code.highcharts.com/dashboards/css/dashboards.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 /* LARGE */
 @media (max-width: 1200px) {
     #highcharts-dashboards-cell-a0,

--- a/samples/grid-lite/demo/grid-cell-format/demo.css
+++ b/samples/grid-lite/demo/grid-cell-format/demo.css
@@ -1,5 +1,19 @@
 @import url("https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     margin: 8px;
     padding: 20px;

--- a/samples/grid-lite/demo/grid-data-heavy/demo.css
+++ b/samples/grid-lite/demo/grid-data-heavy/demo.css
@@ -1,5 +1,19 @@
 @import url("https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 380px;
     padding: 8px;

--- a/samples/grid-lite/demo/grid-grouped-header/demo.css
+++ b/samples/grid-lite/demo/grid-grouped-header/demo.css
@@ -1,5 +1,19 @@
 @import url("https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 408px;
     padding: 20px;

--- a/samples/grid-lite/demo/grid-theming/demo.css
+++ b/samples/grid-lite/demo/grid-theming/demo.css
@@ -1,5 +1,19 @@
 @import url("https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     padding: 12px;
 }

--- a/samples/grid-lite/demo/html-in-cell/demo.css
+++ b/samples/grid-lite/demo/html-in-cell/demo.css
@@ -1,5 +1,19 @@
 @import url("https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .hcg-theme-default {
     --anchor-color: #007bff;
 }

--- a/samples/grid-lite/demo/internationalization/demo.css
+++ b/samples/grid-lite/demo/internationalization/demo.css
@@ -1,5 +1,19 @@
 @import url("https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .lang-options {
     display: flex;
     justify-content: end;

--- a/samples/grid-lite/demo/parse-data/demo.css
+++ b/samples/grid-lite/demo/parse-data/demo.css
@@ -1,5 +1,19 @@
 @import url("https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     padding: 8px;
 }

--- a/samples/grid-lite/demo/view-chart-data-using-grid/demo.css
+++ b/samples/grid-lite/demo/view-chart-data-using-grid/demo.css
@@ -1,5 +1,19 @@
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .content {
     padding: 8px;
 }

--- a/samples/grid-lite/demo/your-first-grid/demo.css
+++ b/samples/grid-lite/demo/your-first-grid/demo.css
@@ -1,5 +1,19 @@
 @import url("https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     padding: 8px;
 }

--- a/samples/grid-pro/demo/accessibility/demo.css
+++ b/samples/grid-pro/demo/accessibility/demo.css
@@ -1,5 +1,19 @@
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .demo {
     padding: 8px;
     font-family: Arial, Helvetica, sans-serif;

--- a/samples/grid-pro/demo/cell-editing/demo.css
+++ b/samples/grid-pro/demo/cell-editing/demo.css
@@ -1,5 +1,19 @@
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .content {
     padding: 8px;
 }

--- a/samples/grid-pro/demo/generate-chart-from-grid/demo.css
+++ b/samples/grid-pro/demo/generate-chart-from-grid/demo.css
@@ -1,5 +1,19 @@
 @import url("https://code.highcharts.com/dashboards/css/datagrid.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .content {
     padding: 8px;
 }

--- a/samples/highcharts/accessibility/accessible-annotations/demo.css
+++ b/samples/highcharts/accessibility/accessible-annotations/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #scrollable-container {
     width: 100%;
     overflow: scroll;

--- a/samples/highcharts/accessibility/accessible-avg-temp/demo.css
+++ b/samples/highcharts/accessibility/accessible-avg-temp/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/accessibility/accessible-bar/demo.css
+++ b/samples/highcharts/accessibility/accessible-bar/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure {
     margin: 0;
 }

--- a/samples/highcharts/accessibility/accessible-dynamic-data-animating/demo.css
+++ b/samples/highcharts/accessibility/accessible-dynamic-data-animating/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure {
     margin: 0;
 }

--- a/samples/highcharts/accessibility/accessible-line/demo.css
+++ b/samples/highcharts/accessibility/accessible-line/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 420px;
 }

--- a/samples/highcharts/accessibility/accessible-pie/demo.css
+++ b/samples/highcharts/accessibility/accessible-pie/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #patterns-enabled {
     width: 17px;
     height: 17px;

--- a/samples/highcharts/accessibility/accessible-simple-config/demo.css
+++ b/samples/highcharts/accessibility/accessible-simple-config/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure {
     margin: 0;
 }

--- a/samples/highcharts/accessibility/accessible-switch-theme-one/demo.css
+++ b/samples/highcharts/accessibility/accessible-switch-theme-one/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .btn1,
 .btn2 {
     display: inline-flex;

--- a/samples/highcharts/accessibility/accessible-switch-theme/demo.css
+++ b/samples/highcharts/accessibility/accessible-switch-theme/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 figure {
     margin: 0;
 }

--- a/samples/highcharts/accessibility/accessible-table/demo.css
+++ b/samples/highcharts/accessibility/accessible-table/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .chart-outer {
     display: flex;
 }

--- a/samples/highcharts/accessibility/advanced-accessible/demo.css
+++ b/samples/highcharts/accessibility/advanced-accessible/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 420px;
 }

--- a/samples/highcharts/accessibility/art-grants/demo.css
+++ b/samples/highcharts/accessibility/art-grants/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 420px;
 }

--- a/samples/highcharts/accessibility/before-chart-format/demo.css
+++ b/samples/highcharts/accessibility/before-chart-format/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 420px;
 }

--- a/samples/highcharts/accessibility/custom-dynamic/demo.css
+++ b/samples/highcharts/accessibility/custom-dynamic/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure {
     margin: 0;
 }

--- a/samples/highcharts/accessibility/expose-as-group-only/demo.css
+++ b/samples/highcharts/accessibility/expose-as-group-only/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure {
     margin: 0;
 }

--- a/samples/highcharts/accessibility/not-accessible-simple-config/demo.css
+++ b/samples/highcharts/accessibility/not-accessible-simple-config/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure {
     margin: 0;
 }

--- a/samples/highcharts/accessibility/point-description-enabled-threshold/demo.css
+++ b/samples/highcharts/accessibility/point-description-enabled-threshold/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure {
     margin: 0;
 }

--- a/samples/highcharts/accessibility/range-description-axis-description/demo.css
+++ b/samples/highcharts/accessibility/range-description-axis-description/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure {
     margin: 0;
 }

--- a/samples/highcharts/accessibility/value-description-format/demo.css
+++ b/samples/highcharts/accessibility/value-description-format/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 420px;
 }

--- a/samples/highcharts/blog/accessibility-tags/demo.css
+++ b/samples/highcharts/blog/accessibility-tags/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .penguins-figure {
     width: 100%;
     margin: 0;

--- a/samples/highcharts/blog/read-csv-data-from-html-table/demo.css
+++ b/samples/highcharts/blog/read-csv-data-from-html-table/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/chart/colors-css-variables/demo.css
+++ b/samples/highcharts/chart/colors-css-variables/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 body {
     font-family:
         -apple-system,

--- a/samples/highcharts/demo/3d-column-null-values/demo.css
+++ b/samples/highcharts/demo/3d-column-null-values/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/3d-column-stacking-grouping/demo.css
+++ b/samples/highcharts/demo/3d-column-stacking-grouping/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/3d-pie-donut/demo.css
+++ b/samples/highcharts/demo/3d-pie-donut/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/3d-pie/demo.css
+++ b/samples/highcharts/demo/3d-pie/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/3d-scatter-draggable/demo.css
+++ b/samples/highcharts/demo/3d-scatter-draggable/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/accessible-line/demo.css
+++ b/samples/highcharts/demo/accessible-line/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 420px;
 }

--- a/samples/highcharts/demo/accessible-pie/demo.css
+++ b/samples/highcharts/demo/accessible-pie/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #patterns-enabled {
     width: 17px;
     height: 17px;

--- a/samples/highcharts/demo/advanced-accessible/demo.css
+++ b/samples/highcharts/demo/advanced-accessible/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 420px;
 }

--- a/samples/highcharts/demo/area-chart/demo.css
+++ b/samples/highcharts/demo/area-chart/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/area-inverted/demo.css
+++ b/samples/highcharts/demo/area-inverted/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 410px;
 }

--- a/samples/highcharts/demo/area-missing/demo.css
+++ b/samples/highcharts/demo/area-missing/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/area-negative/demo.css
+++ b/samples/highcharts/demo/area-negative/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/area-stacked-percent/demo.css
+++ b/samples/highcharts/demo/area-stacked-percent/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/area-stacked/demo.css
+++ b/samples/highcharts/demo/area-stacked/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/arearange-line/demo.css
+++ b/samples/highcharts/demo/arearange-line/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/arearange/demo.css
+++ b/samples/highcharts/demo/arearange/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/areaspline/demo.css
+++ b/samples/highcharts/demo/areaspline/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/bar-chart/demo.css
+++ b/samples/highcharts/demo/bar-chart/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/bar-negative-stack/demo.css
+++ b/samples/highcharts/demo/bar-negative-stack/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/bar-race/demo.css
+++ b/samples/highcharts/demo/bar-race/demo.css
@@ -1,5 +1,19 @@
 @import url("https://netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure {
     margin: 0;
 }

--- a/samples/highcharts/demo/bar-stacked/demo.css
+++ b/samples/highcharts/demo/bar-stacked/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/bellcurve/demo.css
+++ b/samples/highcharts/demo/bellcurve/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/box-plot/demo.css
+++ b/samples/highcharts/demo/box-plot/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/bubble-3d/demo.css
+++ b/samples/highcharts/demo/bubble-3d/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/bubble/demo.css
+++ b/samples/highcharts/demo/bubble/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/bullet-graph/demo.css
+++ b/samples/highcharts/demo/bullet-graph/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container1 {
     height: 115px;
 }

--- a/samples/highcharts/demo/chart-update/demo.css
+++ b/samples/highcharts/demo/chart-update/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/column-basic/demo.css
+++ b/samples/highcharts/demo/column-basic/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/column-drilldown/demo.css
+++ b/samples/highcharts/demo/column-drilldown/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/column-negative/demo.css
+++ b/samples/highcharts/demo/column-negative/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/column-parsed/demo.css
+++ b/samples/highcharts/demo/column-parsed/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/column-placement/demo.css
+++ b/samples/highcharts/demo/column-placement/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/column-pyramid/demo.css
+++ b/samples/highcharts/demo/column-pyramid/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/column-rotated-labels/demo.css
+++ b/samples/highcharts/demo/column-rotated-labels/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/column-stacked-and-grouped/demo.css
+++ b/samples/highcharts/demo/column-stacked-and-grouped/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/column-stacked-percent/demo.css
+++ b/samples/highcharts/demo/column-stacked-percent/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/column-stacked/demo.css
+++ b/samples/highcharts/demo/column-stacked/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/columnrange/demo.css
+++ b/samples/highcharts/demo/columnrange/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/combo-dual-axes/demo.css
+++ b/samples/highcharts/demo/combo-dual-axes/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/combo-multi-axes/demo.css
+++ b/samples/highcharts/demo/combo-multi-axes/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/combo-regression/demo.css
+++ b/samples/highcharts/demo/combo-regression/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/combo/demo.css
+++ b/samples/highcharts/demo/combo/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/cylinder/demo.css
+++ b/samples/highcharts/demo/cylinder/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/dependency-wheel/demo.css
+++ b/samples/highcharts/demo/dependency-wheel/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/donut-chart/demo.css
+++ b/samples/highcharts/demo/donut-chart/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/dumbbell/demo.css
+++ b/samples/highcharts/demo/dumbbell/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/dynamic-click-to-add/demo.css
+++ b/samples/highcharts/demo/dynamic-click-to-add/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/dynamic-master-detail/demo.css
+++ b/samples/highcharts/demo/dynamic-master-detail/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/dynamic-update/demo.css
+++ b/samples/highcharts/demo/dynamic-update/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/error-bar/demo.css
+++ b/samples/highcharts/demo/error-bar/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/euler-diagram/demo.css
+++ b/samples/highcharts/demo/euler-diagram/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/fan-chart/demo.css
+++ b/samples/highcharts/demo/fan-chart/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/flame/demo.css
+++ b/samples/highcharts/demo/flame/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/funnel/demo.css
+++ b/samples/highcharts/demo/funnel/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/funnel3d/demo.css
+++ b/samples/highcharts/demo/funnel3d/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 420px;
 }

--- a/samples/highcharts/demo/gauge-clock/demo.css
+++ b/samples/highcharts/demo/gauge-clock/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/gauge-dual/demo.css
+++ b/samples/highcharts/demo/gauge-dual/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
 }

--- a/samples/highcharts/demo/gauge-multiple-kpi/demo.css
+++ b/samples/highcharts/demo/gauge-multiple-kpi/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     max-width: 400px;
     margin: 0 auto;

--- a/samples/highcharts/demo/gauge-solid/demo.css
+++ b/samples/highcharts/demo/gauge-solid/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure .chart-container {
     width: 300px;
     height: 200px;

--- a/samples/highcharts/demo/gauge-speedometer/demo.css
+++ b/samples/highcharts/demo/gauge-speedometer/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/gauge-vu-meter/demo.css
+++ b/samples/highcharts/demo/gauge-vu-meter/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/heatmap-canvas/demo.css
+++ b/samples/highcharts/demo/heatmap-canvas/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #csv {
     display: none;
 }

--- a/samples/highcharts/demo/heatmap/demo.css
+++ b/samples/highcharts/demo/heatmap/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 360px;

--- a/samples/highcharts/demo/histogram/demo.css
+++ b/samples/highcharts/demo/histogram/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/honeycomb-usa/demo.css
+++ b/samples/highcharts/demo/honeycomb-usa/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 360px;

--- a/samples/highcharts/demo/line-boost/demo.css
+++ b/samples/highcharts/demo/line-boost/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 360px;

--- a/samples/highcharts/demo/line-chart/demo.css
+++ b/samples/highcharts/demo/line-chart/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 360px;

--- a/samples/highcharts/demo/line-csv/demo.css
+++ b/samples/highcharts/demo/line-csv/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 360px;

--- a/samples/highcharts/demo/line-custom-entrance-animation/demo.css
+++ b/samples/highcharts/demo/line-custom-entrance-animation/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 360px;

--- a/samples/highcharts/demo/line-forecast/demo.css
+++ b/samples/highcharts/demo/line-forecast/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 360px;

--- a/samples/highcharts/demo/line-labels/demo.css
+++ b/samples/highcharts/demo/line-labels/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 360px;

--- a/samples/highcharts/demo/line-log-axis/demo.css
+++ b/samples/highcharts/demo/line-log-axis/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 360px;

--- a/samples/highcharts/demo/line-time-series/demo.css
+++ b/samples/highcharts/demo/line-time-series/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 360px;

--- a/samples/highcharts/demo/live-data/demo.css
+++ b/samples/highcharts/demo/live-data/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 360px;

--- a/samples/highcharts/demo/lollipop/demo.css
+++ b/samples/highcharts/demo/lollipop/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/network-graph/demo.css
+++ b/samples/highcharts/demo/network-graph/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/organization-chart/demo.css
+++ b/samples/highcharts/demo/organization-chart/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 360px;

--- a/samples/highcharts/demo/packed-bubble-split/demo.css
+++ b/samples/highcharts/demo/packed-bubble-split/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/packed-bubble/demo.css
+++ b/samples/highcharts/demo/packed-bubble/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/parallel-coordinates-polar/demo.css
+++ b/samples/highcharts/demo/parallel-coordinates-polar/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/parallel-coordinates/demo.css
+++ b/samples/highcharts/demo/parallel-coordinates/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/pareto/demo.css
+++ b/samples/highcharts/demo/pareto/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/parliament-chart/demo.css
+++ b/samples/highcharts/demo/parliament-chart/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/pie-chart/demo.css
+++ b/samples/highcharts/demo/pie-chart/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/pie-custom-entrance-animation/demo.css
+++ b/samples/highcharts/demo/pie-custom-entrance-animation/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/pie-donut/demo.css
+++ b/samples/highcharts/demo/pie-donut/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/pie-drilldown/demo.css
+++ b/samples/highcharts/demo/pie-drilldown/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/pie-gradient/demo.css
+++ b/samples/highcharts/demo/pie-gradient/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/pie-legend/demo.css
+++ b/samples/highcharts/demo/pie-legend/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/pie-monochrome/demo.css
+++ b/samples/highcharts/demo/pie-monochrome/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/pie-semi-circle/demo.css
+++ b/samples/highcharts/demo/pie-semi-circle/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/polar-radial-bar/demo.css
+++ b/samples/highcharts/demo/polar-radial-bar/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 600px;
 }

--- a/samples/highcharts/demo/polar-spider/demo.css
+++ b/samples/highcharts/demo/polar-spider/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/polar-wind-rose/demo.css
+++ b/samples/highcharts/demo/polar-wind-rose/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 360px;

--- a/samples/highcharts/demo/polar/demo.css
+++ b/samples/highcharts/demo/polar/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/polygon/demo.css
+++ b/samples/highcharts/demo/polygon/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 360px;

--- a/samples/highcharts/demo/pyramid/demo.css
+++ b/samples/highcharts/demo/pyramid/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 360px;

--- a/samples/highcharts/demo/pyramid3d/demo.css
+++ b/samples/highcharts/demo/pyramid3d/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/renderer/demo.css
+++ b/samples/highcharts/demo/renderer/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     width: 600px;
     height: 250px;

--- a/samples/highcharts/demo/responsive/demo.css
+++ b/samples/highcharts/demo/responsive/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/sankey-diagram/demo.css
+++ b/samples/highcharts/demo/sankey-diagram/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #csv {
     display: none;
 }

--- a/samples/highcharts/demo/scatter-boost/demo.css
+++ b/samples/highcharts/demo/scatter-boost/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/scatter/demo.css
+++ b/samples/highcharts/demo/scatter/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     max-width: 800px;
     margin: auto;

--- a/samples/highcharts/demo/sonification-navigation/demo.css
+++ b/samples/highcharts/demo/sonification-navigation/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure {
     max-width: 1000px;
     min-width: 320px;

--- a/samples/highcharts/demo/spline-inverted/demo.css
+++ b/samples/highcharts/demo/spline-inverted/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/spline-irregular-time/demo.css
+++ b/samples/highcharts/demo/spline-irregular-time/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/spline-plot-bands/demo.css
+++ b/samples/highcharts/demo/spline-plot-bands/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/spline-symbols/demo.css
+++ b/samples/highcharts/demo/spline-symbols/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/streamgraph/demo.css
+++ b/samples/highcharts/demo/streamgraph/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 600px;
 }

--- a/samples/highcharts/demo/styled-mode-column/demo.css
+++ b/samples/highcharts/demo/styled-mode-column/demo.css
@@ -1,5 +1,19 @@
 @import url("https://code.highcharts.com/css/highcharts.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/demo/styled-mode-pie/demo.css
+++ b/samples/highcharts/demo/styled-mode-pie/demo.css
@@ -1,5 +1,19 @@
 @import url("https://code.highcharts.com/css/highcharts.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-pie-series .highcharts-point {
     stroke: #ede;
     stroke-width: 2px;

--- a/samples/highcharts/demo/sunburst/demo.css
+++ b/samples/highcharts/demo/sunburst/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/synchronized-charts/demo.css
+++ b/samples/highcharts/demo/synchronized-charts/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/timeline/demo.css
+++ b/samples/highcharts/demo/timeline/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-strong {
     font-weight: bold;
 }

--- a/samples/highcharts/demo/treemap-coloraxis/demo.css
+++ b/samples/highcharts/demo/treemap-coloraxis/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/treemap-large-dataset/demo.css
+++ b/samples/highcharts/demo/treemap-large-dataset/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 body {
     font-family:
         -apple-system,

--- a/samples/highcharts/demo/treemap-with-levels/demo.css
+++ b/samples/highcharts/demo/treemap-with-levels/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/variable-radius-pie/demo.css
+++ b/samples/highcharts/demo/variable-radius-pie/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 500px;
 }

--- a/samples/highcharts/demo/variwide/demo.css
+++ b/samples/highcharts/demo/variwide/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 500px;
 }

--- a/samples/highcharts/demo/vector-plot/demo.css
+++ b/samples/highcharts/demo/vector-plot/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 500px;
 }

--- a/samples/highcharts/demo/vertical-sankey/demo.css
+++ b/samples/highcharts/demo/vertical-sankey/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure #container {
     min-width: 320px;
     max-width: 800px;

--- a/samples/highcharts/demo/waterfall/demo.css
+++ b/samples/highcharts/demo/waterfall/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/windbarb-series/demo.css
+++ b/samples/highcharts/demo/windbarb-series/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 370px;
 }

--- a/samples/highcharts/demo/wordcloud/demo.css
+++ b/samples/highcharts/demo/wordcloud/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/highcharts/demo/x-range/demo.css
+++ b/samples/highcharts/demo/x-range/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 300px;
 }

--- a/samples/highcharts/lang/i18n-arabic/demo.css
+++ b/samples/highcharts/lang/i18n-arabic/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 300px;
     max-width: 800px;

--- a/samples/highcharts/series-histogram/column/demo.css
+++ b/samples/highcharts/series-histogram/column/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 310px;

--- a/samples/highcharts/sonification/chart-earcon/demo.css
+++ b/samples/highcharts/sonification/chart-earcon/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .btn.btn-stop {
     background-color: #fff;
     border: 1px solid #25386f;

--- a/samples/highcharts/studies/tree-toggle/demo.css
+++ b/samples/highcharts/studies/tree-toggle/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 .highcharts-figure,
 .highcharts-data-table table {
     min-width: 320px;

--- a/samples/stock/demo/compare-etf/demo.css
+++ b/samples/stock/demo/compare-etf/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
     min-width: 310px;

--- a/samples/stock/demo/dark-candlestick-and-volume/demo.css
+++ b/samples/stock/demo/dark-candlestick-and-volume/demo.css
@@ -5,6 +5,20 @@
     --highcharts-neutral-color-3: rgba(0, 0, 0, 0);
 }
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 600px;
     min-width: 310px;

--- a/samples/stock/demo/drag-on-axis/demo.css
+++ b/samples/stock/demo/drag-on-axis/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 500px;
     min-width: 310px;

--- a/samples/stock/demo/neon-line-chart/demo.css
+++ b/samples/stock/demo/neon-line-chart/demo.css
@@ -1,5 +1,19 @@
 @import url("https://code.highcharts.com/css/highcharts.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 600px;
     min-width: 310px;

--- a/samples/stock/demo/step-line/demo.css
+++ b/samples/stock/demo/step-line/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
     min-width: 310px;

--- a/samples/stock/demo/stock-css-design/demo.css
+++ b/samples/stock/demo/stock-css-design/demo.css
@@ -2,6 +2,20 @@
 @import url("https://code.highcharts.com/css/stocktools/gui.css");
 @import url("https://code.highcharts.com/css/highcharts.css");
 
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 :root {
     --highcharts-background-color: #19191b;
     --highcharts-color-1: #9689e6;

--- a/samples/stock/demo/two-standalone-navigators/demo.css
+++ b/samples/stock/demo/two-standalone-navigators/demo.css
@@ -1,3 +1,17 @@
+* {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+}
+
 #container {
     height: 400px;
     min-width: 310px;


### PR DESCRIPTION
Some samples (with a description) missed generic font family. The demo pages has its own generic font, but in jsFiddle and utils, browser default serif fonts were used.