### PR TITLE
bugfix/23056-settings-disabled-new-component

### DIFF
--- a/test/cypress/dashboards/integration/edit-component.cy.js
+++ b/test/cypress/dashboards/integration/edit-component.cy.js
@@ -181,8 +181,9 @@ describe('Editable component options', () => {
 });
 
 describe('Toolbar settings disabled.', () => {
-    before(() => {
+    beforeEach(() => {
         cy.visit('/dashboards/edit-mode/settings-disabled');
+        cy.viewport(1200, 1000);
         cy.toggleEditMode();
         cy.get('.highcharts-dashboards-component').first().click();
     });
@@ -203,21 +204,5 @@ describe('Toolbar settings disabled.', () => {
         // Assert
         cy.get('.highcharts-dashboards-edit-overlay-active').should('not.exist');
         cy.get('.highcharts-dashboards-edit-sidebar').should('not.be.visible');
-        cy.get('.highcharts-dashboards-edit-toolbar-cell')
-            .parent()
-            .invoke('position')
-            .then((pos) => {
-                const initialX = pos.left;
-
-                // Act
-                cy.get('.highcharts-dashboards-component').first().click();
-
-                // Assert
-                cy.get('.highcharts-dashboards-edit-toolbar-cell')
-                    .parent()
-                    .invoke('position')
-                    .its('left')
-                    .should('be.lt', initialX);
-            });
     });
 });

--- a/ts/Dashboards/EditMode/ConfirmationPopup.ts
+++ b/ts/Dashboards/EditMode/ConfirmationPopup.ts
@@ -226,7 +226,7 @@ class ConfirmationPopup extends BaseForm {
         this.contentOptions = options;
         this.showPopup();
         this.renderContent();
-        this.editMode.setEditOverlay(false);
+        this.editMode.setEditOverlay();
     }
 
     /**

--- a/ts/Dashboards/EditMode/SidebarPopup.ts
+++ b/ts/Dashboards/EditMode/SidebarPopup.ts
@@ -437,25 +437,21 @@ class SidebarPopup extends BaseForm {
                             const newCell =
                                 components[i].onDrop(sidebar, dropContext);
 
+                            /* eslint-disable max-len */
                             const unbindLayoutChanged = addEvent(
                                 this.editMode,
                                 'layoutChanged',
                                 (e): void => {
                                     if (newCell && e.type === 'newComponent') {
-                                        const chart =
-                                            newCell.mountedComponent?.chart;
-                                        const settingsEnabled =
-                                            chart?.options.settings?.enabled;
+                                        const chart = newCell.mountedComponent?.chart;
+                                        const settingsEnabled = this.editMode.options.settings?.enabled;
 
                                         if (chart?.isDirtyBox) {
                                             const unbind = addEvent(
                                                 chart,
                                                 'render',
                                                 (): void => {
-                                                    sidebar.editMode
-                                                        .setEditCellContext(
-                                                            newCell
-                                                        );
+                                                    sidebar.editMode.setEditCellContext(newCell);
 
                                                     if (settingsEnabled) {
                                                         sidebar.show(newCell);
@@ -467,9 +463,7 @@ class SidebarPopup extends BaseForm {
                                                 }
                                             );
                                         } else {
-                                            sidebar.editMode.setEditCellContext(
-                                                newCell
-                                            );
+                                            sidebar.editMode.setEditCellContext(newCell);
                                             if (settingsEnabled) {
                                                 sidebar.show(newCell);
                                                 newCell.setHighlight();
@@ -479,6 +473,7 @@ class SidebarPopup extends BaseForm {
                                     }
                                 }
                             );
+                            /* eslint-enable max-len */
 
                             // Clean up event listener after drop is complete
                             document.removeEventListener(


### PR DESCRIPTION
Fixed #23056, the sidebar should not be visible when adding a new component and when the `settings` are disabled.