### PR TITLE
grid/cell-content-update 

### DIFF
--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -830,8 +830,12 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
     right: 0;
     width: 100%;
     height: 100%;
-    padding: inherit;
+    padding-left: inherit;
     z-index: 1;
+    background: #b7d4ff;
+    box-shadow: inset 0 0 0 1px #0000ed;
+    display: flex;
+    align-items: center;
 }
 
 .hcg-table tbody td.hcg-edited-cell input:not(.hcg-field-auto-width),
@@ -851,9 +855,8 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
     outline: none;
     float: left;
     font: var(--ig-font);
-    box-shadow: inset 0 0 0 1px #0000ed;
-    padding: var(--ig-padding);
-    background: #b7d4ff;
+    padding-left: inherit;
+    background: transparent;
 }
 
 .highcharts-datagrid-table tbody td.hcg-edited-cell-error input:not(.highcharts-datagrid-field-auto-width),

--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -823,6 +823,17 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
     width: 100%;
 }
 
+.highcharts-datagrid-cell-editing-container,
+.hcg-cell-editing-container {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    padding: inherit;
+    z-index: 1;
+}
+
 .hcg-table tbody td.hcg-edited-cell input:not(.hcg-field-auto-width),
 .highcharts-datagrid-table tbody td.highcharts-datagrid-edited-cell input:not(.highcharts-datagrid-field-auto-width),
 .hcg-table tbody td.hcg-edited-cell input:not(.hcg-field-auto-width):focus,

--- a/samples/grid-pro/demo/cell-editing/demo.js
+++ b/samples/grid-pro/demo/cell-editing/demo.js
@@ -27,8 +27,11 @@ Grid.grid('container', {
         id: 'available',
         dataType: 'boolean',
         cells: {
-            renderer: {
-                type: 'checkbox'
+            format: '{#if value}✓{else}✗{/if}',
+            editMode: {
+                renderer: {
+                    type: 'checkbox'
+                }
             }
         }
     }, {
@@ -48,19 +51,37 @@ Grid.grid('container', {
     }, {
         id: 'country',
         dataType: 'string',
-        renderer: {
-            type: 'select',
-            options: [
-                { value: 'PL', label: 'Poland' },
-                { value: 'NL', label: 'Netherlands' },
-                { value: 'RO', label: 'Romania' },
-                { value: 'EC', label: 'Ecuador' },
-                { value: 'ES', label: 'Spain' },
-                { value: 'IT', label: 'Italy' },
-                { value: 'DE', label: 'Germany' },
-                { value: 'TR', label: 'Turkey' },
-                { value: 'BR', label: 'Brazil' }
-            ]
+        cells: {
+            formatter: function () {
+                const countryNames = {
+                    PL: 'Poland',
+                    NL: 'Netherlands',
+                    RO: 'Romania',
+                    EC: 'Ecuador',
+                    ES: 'Spain',
+                    IT: 'Italy',
+                    DE: 'Germany',
+                    TR: 'Turkey',
+                    BR: 'Brazil'
+                };
+                return countryNames[this.value] || this.value;
+            },
+            editMode: {
+                renderer: {
+                    type: 'select',
+                    options: [
+                        { value: 'PL', label: 'Poland' },
+                        { value: 'NL', label: 'Netherlands' },
+                        { value: 'RO', label: 'Romania' },
+                        { value: 'EC', label: 'Ecuador' },
+                        { value: 'ES', label: 'Spain' },
+                        { value: 'IT', label: 'Italy' },
+                        { value: 'DE', label: 'Germany' },
+                        { value: 'TR', label: 'Turkey' },
+                        { value: 'BR', label: 'Brazil' }
+                    ]
+                }
+            }
         }
     }]
 });

--- a/samples/grid-pro/studies/sparkline/demo.html
+++ b/samples/grid-pro/studies/sparkline/demo.html
@@ -1,4 +1,4 @@
-<script src="https://code.highcharts.com/dashboards/datagrid.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/dashboards/datagrid.js"></script>
 
 <div id="container"></div>

--- a/samples/grid-pro/studies/sparkline/demo.js
+++ b/samples/grid-pro/studies/sparkline/demo.js
@@ -18,60 +18,12 @@ Grid.grid('container', {
             strictHeights: true
         }
     },
-
-    events: {
-        cell: {
-            afterSetValue: function () {
-                if (this.column.id !== 'd') {
-                    return;
-                }
-                const rowIndex = this.row.index;
-
-                Highcharts.chart(this.htmlElement, {
-                    chart: {
-                        height: 40,
-                        animation: false,
-                        margin: [0, 0, 0, 0],
-                        events: {
-                            load: function () {
-                                console.log('I am loaded', rowIndex);
-                            }
-                        }
-                    },
-                    tooltip: {
-                        outside: true
-                    },
-                    title: {
-                        text: ''
-                    },
-                    credits: {
-                        enabled: false
-                    },
-                    xAxis: {
-                        visible: false
-                    },
-                    yAxis: {
-                        visible: false
-                    },
-                    legend: {
-                        enabled: false
-                    },
-                    plotOptions: {
-                        series: {
-                            marker: {
-                                enabled: false
-                            },
-                            animation: false
-                        }
-                    },
-                    series: [
-                        {
-                            type: 'spline',
-                            data: this.value
-                        }
-                    ]
-                });
+    columns: [{
+        id: 'd',
+        cells: {
+            renderer: {
+                type: 'sparkline'
             }
         }
-    }
+    }]
 });

--- a/ts/Grid/Core/Table/Actions/RowsVirtualizer.ts
+++ b/ts/Grid/Core/Table/Actions/RowsVirtualizer.ts
@@ -279,9 +279,9 @@ class RowsVirtualizer {
 
         if (!rows.length) {
             const last = new TableRow(vp, vp.dataTable.getRowCount() - 1);
+            vp.tbodyElement.appendChild(last.htmlElement);
             last.render();
             rows.push(last);
-            vp.tbodyElement.appendChild(last.htmlElement);
 
             if (isVirtualization) {
                 last.setTranslateY(last.getDefaultTopOffset());
@@ -333,11 +333,11 @@ class RowsVirtualizer {
 
         for (let i = 0, iEnd = rows.length; i < iEnd; ++i) {
             if (!rows[i].rendered) {
-                rows[i].render();
                 vp.tbodyElement.insertBefore(
                     rows[i].htmlElement,
                     vp.tbodyElement.lastChild
                 );
+                rows[i].render();
             }
         }
 
@@ -471,9 +471,8 @@ class RowsVirtualizer {
         mockRow.htmlElement.style.position = 'absolute';
         mockRow.htmlElement.classList.add(Globals.getClassName('mockedRow'));
 
-        mockRow.render();
-
         this.viewport.tbodyElement.appendChild(mockRow.htmlElement);
+        mockRow.render();
 
         const defaultRowHeight = mockRow.htmlElement.offsetHeight;
 

--- a/ts/Grid/Core/Table/Body/TableCell.ts
+++ b/ts/Grid/Core/Table/Body/TableCell.ts
@@ -239,14 +239,16 @@ class TableCell extends Cell {
 
         const vp = this.column.viewport;
 
-        this.content?.destroy();
-        this.content = this.column.createCellContent(this);
+        if (this.content) {
+            this.content.update();
+        } else {
+            this.content = this.column.createCellContent(this);
+        }
+
         this.htmlElement.setAttribute('data-value', this.value + '');
         this.setCustomClassName(this.column.options.cells?.className);
 
-        fireEvent(this, 'afterRender', {
-            target: this
-        });
+        fireEvent(this, 'afterRender', { target: this });
 
         if (!updateTable) {
             return;

--- a/ts/Grid/Core/Table/Cell.ts
+++ b/ts/Grid/Core/Table/Cell.ts
@@ -221,6 +221,7 @@ abstract class Cell {
      */
     public render(): void {
         this.row.htmlElement.appendChild(this.htmlElement);
+        this.reflow();
     }
 
     /**

--- a/ts/Grid/Core/Table/CellContent/CellContent.ts
+++ b/ts/Grid/Core/Table/CellContent/CellContent.ts
@@ -60,6 +60,11 @@ abstract class CellContent {
      * Destroy the cell content.
      */
     public abstract destroy(): void;
+
+    /**
+     * Updates the cell content without re-rendering it.
+     */
+    public abstract update(): void;
 }
 
 

--- a/ts/Grid/Core/Table/CellContent/TextContent.ts
+++ b/ts/Grid/Core/Table/CellContent/TextContent.ts
@@ -34,8 +34,7 @@ const {
 
 import Utils from '../../../../Core/Utilities.js';
 const {
-    defined,
-    fireEvent
+    defined
 } = Utils;
 
 
@@ -65,7 +64,6 @@ class TextContent extends CellContent {
 
     public override update(): void {
         setHTMLContent(this.cell.htmlElement, this.format());
-        fireEvent(this.cell, 'afterContentCreated', { target: this });
     }
 
     /**

--- a/ts/Grid/Core/Table/CellContent/TextContent.ts
+++ b/ts/Grid/Core/Table/CellContent/TextContent.ts
@@ -34,7 +34,8 @@ const {
 
 import Utils from '../../../../Core/Utilities.js';
 const {
-    defined
+    defined,
+    fireEvent
 } = Utils;
 
 
@@ -55,11 +56,16 @@ class TextContent extends CellContent {
     }
 
     protected override add(): void {
-        setHTMLContent(this.cell.htmlElement, this.format());
+        this.update();
     }
 
     public override destroy(): void {
         this.cell.htmlElement.innerHTML = AST.emptyHTML;
+    }
+
+    public override update(): void {
+        setHTMLContent(this.cell.htmlElement, this.format());
+        fireEvent(this.cell, 'afterContentCreated', { target: this });
     }
 
     /**

--- a/ts/Grid/Core/Table/Row.ts
+++ b/ts/Grid/Core/Table/Row.ts
@@ -111,7 +111,6 @@ abstract class Row {
             const cell = this.createCell(columns[i]);
             cell.render();
         }
-
         this.rendered = true;
 
         if (this.viewport.grid.options?.rendering?.rows?.virtualization) {

--- a/ts/Grid/Core/Table/Table.ts
+++ b/ts/Grid/Core/Table/Table.ts
@@ -188,6 +188,7 @@ class Table {
         if (customClassName) {
             tableElement.classList.add(...customClassName.split(/\s+/g));
         }
+        tableElement.classList.add(Globals.getClassName('scrollableContent'));
 
         // Load columns
         this.loadColumns();
@@ -201,8 +202,6 @@ class Table {
         // Add event listeners
         this.resizeObserver = new ResizeObserver(this.onResize);
         this.resizeObserver.observe(tableElement);
-
-        tableElement.classList.add(Globals.getClassName('scrollableContent'));
 
         this.tbodyElement.addEventListener('scroll', this.onScroll);
         this.tbodyElement.addEventListener('focus', this.onTBodyFocus);

--- a/ts/Grid/Pro/CellEditing/CellEditMode.d.ts
+++ b/ts/Grid/Pro/CellEditing/CellEditMode.d.ts
@@ -103,6 +103,10 @@ export interface EditModeRenderer {
      *
      * @param cell
      * The cell to render the edit mode content for.
+     *
+     * @param parent
+     * Optional parent element to append the rendered content to. If not
+     * provided, the content will be rendered in the cell's main element.
      */
-    render(cell: TableCell): EditModeContent;
+    render(cell: TableCell, parent?: HTMLElement): EditModeContent;
 }

--- a/ts/Grid/Pro/CellEditing/CellEditing.ts
+++ b/ts/Grid/Pro/CellEditing/CellEditing.ts
@@ -270,8 +270,13 @@ class CellEditing {
  *  Namespace
  *
  * */
+
+
 namespace CellEditing {
 
+    /**
+     * The class names used by the CellEditing functionality.
+     */
     export const classNames = {
         cellEditingContainer: Globals.classNamePrefix + 'cell-editing-container'
     } as const;

--- a/ts/Grid/Pro/CellEditing/CellEditing.ts
+++ b/ts/Grid/Pro/CellEditing/CellEditing.ts
@@ -160,12 +160,15 @@ class CellEditing {
 
         cell.htmlElement.focus();
 
+        const isValueChanged = cell.value !== newValue;
         void cell.setValue(
             submit ? newValue : cell.value,
-            submit && cell.value !== newValue
+            submit && isValueChanged
         );
 
-        fireEvent(cell, 'stoppedEditing', { submit });
+        if (isValueChanged) {
+            fireEvent(cell, 'stoppedEditing', { submit });
+        }
 
         delete this.editedCell;
 

--- a/ts/Grid/Pro/CellEditing/CellEditing.ts
+++ b/ts/Grid/Pro/CellEditing/CellEditing.ts
@@ -69,6 +69,12 @@ class CellEditing {
      */
     public editModeContent?: EditModeContent;
 
+    /**
+     * The container element for the cell edit mode, which is used to
+     * position the edit mode content correctly within the cell.
+     */
+    private containerElement?: HTMLDivElement;
+
 
     /* *
      *
@@ -225,10 +231,16 @@ class CellEditing {
             return;
         }
 
-        this.editModeContent = cell.column.editModeRenderer?.render(cell);
-        const element = this.editModeContent.getMainElement();
-        element.style.zIndex = '1';
-        element.focus();
+        this.containerElement = this.containerElement ||
+            document.createElement('div');
+        this.containerElement.className =
+            CellEditing.classNames.cellEditingContainer;
+        this.editedCell?.htmlElement.appendChild(this.containerElement);
+
+        this.editModeContent = cell.column.editModeRenderer?.render(
+            cell, this.containerElement
+        );
+        this.editModeContent.getMainElement().focus();
 
         this.editModeContent.blurHandler = this.onInputBlur;
         this.editModeContent.changeHandler = this.onInputChange;
@@ -244,8 +256,23 @@ class CellEditing {
         }
 
         this.editModeContent.destroy();
+        this.containerElement?.remove();
         delete this.editModeContent;
+        delete this.containerElement;
     }
+}
+
+/* *
+ *
+ *  Namespace
+ *
+ * */
+namespace CellEditing {
+
+    export const classNames = {
+        cellEditingContainer: Globals.classNamePrefix + 'cell-editing-container'
+    } as const;
+
 }
 
 

--- a/ts/Grid/Pro/CellEditing/CellEditing.ts
+++ b/ts/Grid/Pro/CellEditing/CellEditing.ts
@@ -104,12 +104,7 @@ class CellEditing {
         }
 
         this.editedCell = cell;
-        const cellElement = cell.htmlElement;
-
-        cell.content?.destroy();
-        delete cell.content;
-
-        cellElement.classList.add(Globals.getClassName('editedCell'));
+        cell.htmlElement.classList.add(Globals.getClassName('editedCell'));
 
         this.render();
         fireEvent(cell, 'startedEditing');
@@ -231,7 +226,9 @@ class CellEditing {
         }
 
         this.editModeContent = cell.column.editModeRenderer?.render(cell);
-        this.editModeContent.getMainElement().focus();
+        const element = this.editModeContent.getMainElement();
+        element.style.zIndex = '1';
+        element.focus();
 
         this.editModeContent.blurHandler = this.onInputBlur;
         this.editModeContent.changeHandler = this.onInputChange;

--- a/ts/Grid/Pro/CellEditing/CellEditing.ts
+++ b/ts/Grid/Pro/CellEditing/CellEditing.ts
@@ -105,6 +105,8 @@ class CellEditing {
         const cellElement = cell.htmlElement;
 
         cell.content?.destroy();
+        delete cell.content;
+
         cellElement.classList.add(Globals.getClassName('editedCell'));
 
         this.render();

--- a/ts/Grid/Pro/CellEditing/CellEditingComposition.ts
+++ b/ts/Grid/Pro/CellEditing/CellEditingComposition.ts
@@ -112,11 +112,7 @@ namespace CellEditingComposition {
         addEvent(TableClass, 'beforeInit', initTable);
         addEvent(TableCellClass, 'keyDown', onCellKeyDown);
         addEvent(TableCellClass, 'dblClick', onCellDblClick);
-        addEvent(
-            TableCellClass,
-            'afterContentCreated',
-            addEditableCellA11yHint
-        );
+        addEvent(TableCellClass, 'afterRender', addEditableCellA11yHint);
         addEvent(TableCellClass, 'startedEditing', function (): void {
             announceA11yUserEditedCell(this, 'started');
         });
@@ -234,7 +230,7 @@ namespace CellEditingComposition {
      */
     function addEditableCellA11yHint(this: TableCell): void {
         const a11y = this.row.viewport.grid.accessibility;
-        if (!a11y) {
+        if (!a11y || this.a11yEditableHint?.isConnected) {
             return;
         }
 
@@ -251,7 +247,8 @@ namespace CellEditingComposition {
             return;
         }
 
-        makeHTMLElement('span', {
+
+        this.a11yEditableHint = makeHTMLElement('span', {
             className: Globals.getClassName('visuallyHidden'),
             innerText: ', ' + editableLang
         }, this.htmlElement);
@@ -369,6 +366,15 @@ declare module '../../Core/Table/Column' {
          * The edit mode renderer for the column.
          */
         editModeRenderer?: EditModeRendererType;
+    }
+}
+
+declare module '../../Core/Table/Body/TableCell' {
+    export default interface TableCell {
+        /**
+         * The HTML span element that contains the 'editable' hint for the cell.
+         */
+        a11yEditableHint?: HTMLSpanElement;
     }
 }
 

--- a/ts/Grid/Pro/CellEditing/CellEditingComposition.ts
+++ b/ts/Grid/Pro/CellEditing/CellEditingComposition.ts
@@ -112,7 +112,11 @@ namespace CellEditingComposition {
         addEvent(TableClass, 'beforeInit', initTable);
         addEvent(TableCellClass, 'keyDown', onCellKeyDown);
         addEvent(TableCellClass, 'dblClick', onCellDblClick);
-        addEvent(TableCellClass, 'afterRender', addEditableCellA11yHint);
+        addEvent(
+            TableCellClass,
+            'afterContentCreated',
+            addEditableCellA11yHint
+        );
         addEvent(TableCellClass, 'startedEditing', function (): void {
             announceA11yUserEditedCell(this, 'started');
         });

--- a/ts/Grid/Pro/CellRendering/ContentTypes/CheckboxContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/CheckboxContent.ts
@@ -28,10 +28,6 @@ import type TableCell from '../../../Core/Table/Body/TableCell';
 
 import CellContentPro from '../CellContentPro.js';
 import Globals from '../../../Core/Globals.js';
-import U from '../../../../Core/Utilities.js';
-const {
-    fireEvent
-} = U;
 
 
 /* *
@@ -95,7 +91,6 @@ class CheckboxContent extends CellContentPro implements EditModeContent {
         this.input.addEventListener('blur', this.onBlur);
         this.cell.htmlElement.addEventListener('keydown', this.onCellKeyDown);
 
-        fireEvent(this.cell, 'afterContentCreated', { target: this });
         return this.input;
     }
 

--- a/ts/Grid/Pro/CellRendering/ContentTypes/CheckboxContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/CheckboxContent.ts
@@ -28,6 +28,10 @@ import type TableCell from '../../../Core/Table/Body/TableCell';
 
 import CellContentPro from '../CellContentPro.js';
 import Globals from '../../../Core/Globals.js';
+import U from '../../../../Core/Utilities.js';
+const {
+    fireEvent
+} = U;
 
 
 /* *
@@ -75,14 +79,13 @@ class CheckboxContent extends CellContentPro implements EditModeContent {
 
     protected override add(): HTMLInputElement {
         const cell = this.cell;
-        const { options } = this.renderer as CheckboxRenderer;
 
         this.input = document.createElement('input');
         this.input.tabIndex = -1;
         this.input.type = 'checkbox';
-        this.input.checked = !!cell.value;
         this.input.name = cell.column.id + '-' + cell.row.id;
-        this.input.disabled = !!options.disabled;
+
+        this.update();
 
         this.cell.htmlElement.appendChild(this.input);
         this.input.classList.add(Globals.classNamePrefix + 'field-auto-width');
@@ -92,7 +95,17 @@ class CheckboxContent extends CellContentPro implements EditModeContent {
         this.input.addEventListener('blur', this.onBlur);
         this.cell.htmlElement.addEventListener('keydown', this.onCellKeyDown);
 
+        fireEvent(this.cell, 'afterContentCreated', { target: this });
         return this.input;
+    }
+
+    public override update(): void {
+        const cell = this.cell;
+        const input = this.input;
+        const { options } = this.renderer as CheckboxRenderer;
+
+        input.checked = !!cell.value;
+        input.disabled = !!options.disabled;
     }
 
     public getValue(): DataTable.CellType {

--- a/ts/Grid/Pro/CellRendering/ContentTypes/CheckboxContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/CheckboxContent.ts
@@ -61,9 +61,13 @@ class CheckboxContent extends CellContentPro implements EditModeContent {
      *
      * */
 
-    constructor(cell: TableCell, renderer: CheckboxRenderer) {
+    constructor(
+        cell: TableCell,
+        renderer: CheckboxRenderer,
+        parentElement?: HTMLElement
+    ) {
         super(cell, renderer);
-        this.input = this.add();
+        this.input = this.add(parentElement);
     }
 
 
@@ -73,7 +77,9 @@ class CheckboxContent extends CellContentPro implements EditModeContent {
      *
      * */
 
-    protected override add(): HTMLInputElement {
+    protected override add(
+        parentElement: HTMLElement = this.cell.htmlElement
+    ): HTMLInputElement {
         const cell = this.cell;
 
         this.input = document.createElement('input');
@@ -83,7 +89,7 @@ class CheckboxContent extends CellContentPro implements EditModeContent {
 
         this.update();
 
-        this.cell.htmlElement.appendChild(this.input);
+        parentElement.appendChild(this.input);
         this.input.classList.add(Globals.classNamePrefix + 'field-auto-width');
 
         this.input.addEventListener('change', this.onChange);

--- a/ts/Grid/Pro/CellRendering/ContentTypes/DateInputContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/DateInputContent.ts
@@ -26,10 +26,6 @@ import type { EditModeContent } from '../../CellEditing/CellEditMode';
 import type TableCell from '../../../Core/Table/Body/TableCell';
 
 import CellContentPro from '../CellContentPro.js';
-import U from '../../../../Core/Utilities.js';
-const {
-    fireEvent
-} = U;
 
 
 /* *
@@ -92,7 +88,6 @@ class DateInputContent extends CellContentPro implements EditModeContent {
         input.addEventListener('blur', this.onBlur);
         this.cell.htmlElement.addEventListener('keydown', this.onCellKeyDown);
 
-        fireEvent(this.cell, 'afterContentCreated', { target: this });
         return this.input;
     }
 

--- a/ts/Grid/Pro/CellRendering/ContentTypes/DateInputContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/DateInputContent.ts
@@ -26,6 +26,11 @@ import type { EditModeContent } from '../../CellEditing/CellEditMode';
 import type TableCell from '../../../Core/Table/Body/TableCell';
 
 import CellContentPro from '../CellContentPro.js';
+import U from '../../../../Core/Utilities.js';
+const {
+    fireEvent
+} = U;
+
 
 /* *
  *
@@ -72,23 +77,31 @@ class DateInputContent extends CellContentPro implements EditModeContent {
 
     public override add(): HTMLInputElement {
         const cell = this.cell;
-        const { options } = this.renderer as DateInputRenderer;
+        const input = this.input = document.createElement('input');
 
-        this.input = document.createElement('input');
-        this.input.tabIndex = -1;
-        this.input.type = 'date';
-        this.input.value = this.convertToInputValue();
-        this.input.name = cell.column.id + '-' + cell.row.id;
-        this.input.disabled = !!options.disabled;
+        input.tabIndex = -1;
+        input.type = 'date';
+        input.name = cell.column.id + '-' + cell.row.id;
+
+        this.update();
 
         this.cell.htmlElement.appendChild(this.input);
 
-        this.input.addEventListener('change', this.onChange);
-        this.input.addEventListener('keydown', this.onKeyDown);
-        this.input.addEventListener('blur', this.onBlur);
+        input.addEventListener('change', this.onChange);
+        input.addEventListener('keydown', this.onKeyDown);
+        input.addEventListener('blur', this.onBlur);
         this.cell.htmlElement.addEventListener('keydown', this.onCellKeyDown);
 
+        fireEvent(this.cell, 'afterContentCreated', { target: this });
         return this.input;
+    }
+
+    public override update(): void {
+        const input = this.input;
+        const { options } = this.renderer as DateInputRenderer;
+
+        input.value = this.convertToInputValue();
+        input.disabled = !!options.disabled;
     }
 
     public getValue(): number {

--- a/ts/Grid/Pro/CellRendering/ContentTypes/DateInputContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/DateInputContent.ts
@@ -87,7 +87,7 @@ class DateInputContent extends CellContentPro implements EditModeContent {
 
         this.update();
 
-        parentElement.appendChild(this.input);
+        parentElement.appendChild(input);
 
         input.addEventListener('change', this.onChange);
         input.addEventListener('keydown', this.onKeyDown);

--- a/ts/Grid/Pro/CellRendering/ContentTypes/DateInputContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/DateInputContent.ts
@@ -59,9 +59,13 @@ class DateInputContent extends CellContentPro implements EditModeContent {
      *
      * */
 
-    constructor(cell: TableCell, renderer: DateInputRenderer) {
+    constructor(
+        cell: TableCell,
+        renderer: DateInputRenderer,
+        parentElement?: HTMLElement
+    ) {
         super(cell, renderer);
-        this.input = this.add();
+        this.input = this.add(parentElement);
     }
 
 
@@ -71,7 +75,9 @@ class DateInputContent extends CellContentPro implements EditModeContent {
      *
      * */
 
-    public override add(): HTMLInputElement {
+    public override add(
+        parentElement: HTMLElement = this.cell.htmlElement
+    ): HTMLInputElement {
         const cell = this.cell;
         const input = this.input = document.createElement('input');
 
@@ -81,7 +87,7 @@ class DateInputContent extends CellContentPro implements EditModeContent {
 
         this.update();
 
-        this.cell.htmlElement.appendChild(this.input);
+        parentElement.appendChild(this.input);
 
         input.addEventListener('change', this.onChange);
         input.addEventListener('keydown', this.onKeyDown);

--- a/ts/Grid/Pro/CellRendering/ContentTypes/SelectContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/SelectContent.ts
@@ -66,9 +66,13 @@ class SelectContent extends CellContentPro implements EditModeContent {
      *
      * */
 
-    public constructor(cell: TableCell, renderer: SelectRenderer) {
+    public constructor(
+        cell: TableCell,
+        renderer: SelectRenderer,
+        parentElement?: HTMLElement
+    ) {
         super(cell, renderer);
-        this.select = this.add();
+        this.select = this.add(parentElement);
     }
 
 
@@ -78,7 +82,9 @@ class SelectContent extends CellContentPro implements EditModeContent {
      *
      * */
 
-    protected override add(): HTMLSelectElement {
+    protected override add(
+        parentElement: HTMLElement = this.cell.htmlElement
+    ): HTMLSelectElement {
         const cell = this.cell;
 
         const select = this.select = document.createElement('select');
@@ -87,7 +93,7 @@ class SelectContent extends CellContentPro implements EditModeContent {
 
         this.update();
 
-        this.cell.htmlElement.appendChild(this.select);
+        parentElement.appendChild(this.select);
 
         select.addEventListener('change', this.onChange);
         select.addEventListener('keydown', this.onKeyDown);

--- a/ts/Grid/Pro/CellRendering/ContentTypes/SelectContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/SelectContent.ts
@@ -28,10 +28,6 @@ import type TableCell from '../../../Core/Table/Body/TableCell';
 
 import CellContentPro from '../CellContentPro.js';
 import AST from '../../../../Core/Renderer/HTML/AST.js';
-import U from '../../../../Core/Utilities.js';
-const {
-    fireEvent
-} = U;
 
 
 /* *
@@ -98,7 +94,6 @@ class SelectContent extends CellContentPro implements EditModeContent {
         select.addEventListener('blur', this.onBlur);
         this.cell.htmlElement.addEventListener('keydown', this.onCellKeyDown);
 
-        fireEvent(this.cell, 'afterContentCreated', { target: this });
         return select;
     }
 

--- a/ts/Grid/Pro/CellRendering/ContentTypes/SparklineContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/SparklineContent.ts
@@ -113,9 +113,13 @@ class SparklineContent extends CellContentPro {
      *
      * */
 
-    constructor(cell: TableCell, renderer: SparklineRenderer) {
+    constructor(
+        cell: TableCell,
+        renderer: SparklineRenderer,
+        parentElement?: HTMLElement
+    ) {
         super(cell, renderer);
-        this.add();
+        this.add(parentElement);
     }
 
 
@@ -125,15 +129,17 @@ class SparklineContent extends CellContentPro {
      *
      * */
 
-    protected override add(): void {
+    protected override add(
+        parentElement: HTMLElement = this.cell.htmlElement
+    ): void {
         const H = SparklineContent.H;
         if (!H || !defined(this.cell.value)) {
             return;
         }
 
         this.chartContainer = document.createElement('div');
-        this.cell.htmlElement.classList.add(Globals.getClassName('noPadding'));
-        this.cell.htmlElement.appendChild(this.chartContainer);
+        parentElement.classList.add(Globals.getClassName('noPadding'));
+        parentElement.appendChild(this.chartContainer);
 
         this.chart = H.Chart.chart(this.chartContainer, merge(
             SparklineContent.defaultChartOptions,

--- a/ts/Grid/Pro/CellRendering/ContentTypes/SparklineContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/SparklineContent.ts
@@ -136,8 +136,6 @@ class SparklineContent extends CellContentPro {
         this.cell.htmlElement.classList.add(Globals.getClassName('noPadding'));
         this.cell.htmlElement.appendChild(this.chartContainer);
 
-        this.cell.reflow();
-
         this.chart = H.Chart.chart(this.chartContainer, merge(
             SparklineContent.defaultChartOptions,
             this.getProcessedOptions()

--- a/ts/Grid/Pro/CellRendering/ContentTypes/SparklineContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/SparklineContent.ts
@@ -91,7 +91,7 @@ class SparklineContent extends CellContentPro {
                             enabled: false
                         }
                     },
-                    /// animation: false,
+                    animation: false,
                     dataLabels: {
                         enabled: false
                     }
@@ -133,9 +133,10 @@ class SparklineContent extends CellContentPro {
         }
 
         this.chartContainer = document.createElement('div');
+        this.cell.htmlElement.classList.add(Globals.getClassName('noPadding'));
         this.cell.htmlElement.appendChild(this.chartContainer);
 
-        this.cell.htmlElement.classList.add(Globals.getClassName('noPadding'));
+        this.cell.reflow();
 
         this.chart = H.Chart.chart(this.chartContainer, merge(
             SparklineContent.defaultChartOptions,
@@ -148,7 +149,7 @@ class SparklineContent extends CellContentPro {
     }
 
     public override update(): void {
-        this.chart?.update(this.getProcessedOptions(), true, false, true);
+        this.chart?.update(this.getProcessedOptions(), true, false);
     }
 
     public override destroy(): void {

--- a/ts/Grid/Pro/CellRendering/ContentTypes/SparklineContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/SparklineContent.ts
@@ -91,7 +91,7 @@ class SparklineContent extends CellContentPro {
                             enabled: false
                         }
                     },
-                    animation: false,
+                    /// animation: false,
                     dataLabels: {
                         enabled: false
                     }
@@ -148,7 +148,7 @@ class SparklineContent extends CellContentPro {
     }
 
     public override update(): void {
-        this.chart?.update(this.getProcessedOptions(), true, false);
+        this.chart?.update(this.getProcessedOptions(), true, false, true);
     }
 
     public override destroy(): void {

--- a/ts/Grid/Pro/CellRendering/ContentTypes/SparklineContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/SparklineContent.ts
@@ -30,7 +30,6 @@ import Globals from '../../../Core/Globals.js';
 import U from '../../../../Core/Utilities.js';
 const {
     defined,
-    fireEvent,
     merge
 } = U;
 
@@ -142,8 +141,6 @@ class SparklineContent extends CellContentPro {
         ));
 
         this.chartContainer.addEventListener('click', this.onKeyDown);
-
-        fireEvent(this.cell, 'afterContentCreated', { target: this });
     }
 
     public override update(): void {

--- a/ts/Grid/Pro/CellRendering/ContentTypes/TextInputContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/TextInputContent.ts
@@ -65,9 +65,13 @@ class TextInputContent extends CellContentPro implements EditModeContent {
      *
      * */
 
-    constructor(cell: TableCell, renderer: TextInputRenderer) {
+    constructor(
+        cell: TableCell,
+        renderer: TextInputRenderer,
+        parentElement?: HTMLElement
+    ) {
         super(cell, renderer);
-        this.input = this.add();
+        this.input = this.add(parentElement);
     }
 
 
@@ -77,7 +81,9 @@ class TextInputContent extends CellContentPro implements EditModeContent {
      *
      * */
 
-    public override add(): HTMLInputElement {
+    public override add(
+        parentElement: HTMLElement = this.cell.htmlElement
+    ): HTMLInputElement {
         const cell = this.cell;
         const input = this.input = document.createElement('input');
 
@@ -86,7 +92,7 @@ class TextInputContent extends CellContentPro implements EditModeContent {
 
         this.update();
 
-        this.cell.htmlElement.appendChild(this.input);
+        parentElement.appendChild(this.input);
 
         input.addEventListener('change', this.onChange);
         input.addEventListener('keydown', this.onKeyDown);

--- a/ts/Grid/Pro/CellRendering/ContentTypes/TextInputContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/TextInputContent.ts
@@ -30,8 +30,7 @@ import CellContentPro from '../CellContentPro.js';
 import U from '../../../../Core/Utilities.js';
 
 const {
-    defined,
-    fireEvent
+    defined
 } = U;
 
 
@@ -94,7 +93,6 @@ class TextInputContent extends CellContentPro implements EditModeContent {
         input.addEventListener('blur', this.onBlur);
         this.cell.htmlElement.addEventListener('keydown', this.onCellKeyDown);
 
-        fireEvent(this.cell, 'afterContentCreated', { target: this });
         return input;
     }
 

--- a/ts/Grid/Pro/CellRendering/ContentTypes/TextInputContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/TextInputContent.ts
@@ -30,7 +30,8 @@ import CellContentPro from '../CellContentPro.js';
 import U from '../../../../Core/Utilities.js';
 
 const {
-    defined
+    defined,
+    fireEvent
 } = U;
 
 
@@ -79,22 +80,28 @@ class TextInputContent extends CellContentPro implements EditModeContent {
 
     public override add(): HTMLInputElement {
         const cell = this.cell;
-        const { options } = this.renderer as TextInputRenderer;
+        const input = this.input = document.createElement('input');
 
-        this.input = document.createElement('input');
-        this.input.tabIndex = -1;
-        this.input.value = this.convertToInputValue();
-        this.input.name = cell.column.id + '-' + cell.row.id;
-        this.input.disabled = !!options.disabled;
+        input.tabIndex = -1;
+        input.name = cell.column.id + '-' + cell.row.id;
+
+        this.update();
 
         this.cell.htmlElement.appendChild(this.input);
 
-        this.input.addEventListener('change', this.onChange);
-        this.input.addEventListener('keydown', this.onKeyDown);
-        this.input.addEventListener('blur', this.onBlur);
+        input.addEventListener('change', this.onChange);
+        input.addEventListener('keydown', this.onKeyDown);
+        input.addEventListener('blur', this.onBlur);
         this.cell.htmlElement.addEventListener('keydown', this.onCellKeyDown);
 
-        return this.input;
+        fireEvent(this.cell, 'afterContentCreated', { target: this });
+        return input;
+    }
+
+    public override update(): void {
+        const { options } = this.renderer as TextInputRenderer;
+        this.input.value = this.convertToInputValue();
+        this.input.disabled = !!options.disabled;
     }
 
     public getValue(): DataTable.CellType {

--- a/ts/Grid/Pro/CellRendering/Renderers/CheckboxRenderer.ts
+++ b/ts/Grid/Pro/CellRendering/Renderers/CheckboxRenderer.ts
@@ -83,8 +83,11 @@ class CheckboxRenderer extends CellRenderer implements EditModeRenderer {
      *
      * */
 
-    public override render(cell: TableCell): CheckboxContent {
-        return new CheckboxContent(cell, this);
+    public override render(
+        cell: TableCell,
+        parentElement?: HTMLElement
+    ): CheckboxContent {
+        return new CheckboxContent(cell, this, parentElement);
     }
 }
 

--- a/ts/Grid/Pro/CellRendering/Renderers/DateInputRenderer.ts
+++ b/ts/Grid/Pro/CellRendering/Renderers/DateInputRenderer.ts
@@ -84,8 +84,11 @@ class DateInputRenderer extends CellRenderer implements EditModeRenderer {
      *
      * */
 
-    public override render(cell: TableCell): DateInputContent {
-        return new DateInputContent(cell, this);
+    public override render(
+        cell: TableCell,
+        parentElement?: HTMLElement
+    ): DateInputContent {
+        return new DateInputContent(cell, this, parentElement);
     }
 
 }

--- a/ts/Grid/Pro/CellRendering/Renderers/SelectRenderer.ts
+++ b/ts/Grid/Pro/CellRendering/Renderers/SelectRenderer.ts
@@ -84,8 +84,11 @@ class SelectRenderer extends CellRenderer implements EditModeRenderer {
      *
      * */
 
-    public override render(cell: TableCell): SelectContent {
-        return new SelectContent(cell, this);
+    public override render(
+        cell: TableCell,
+        parentElement?: HTMLElement
+    ): SelectContent {
+        return new SelectContent(cell, this, parentElement);
     }
 
 }

--- a/ts/Grid/Pro/CellRendering/Renderers/TextInputRenderer.ts
+++ b/ts/Grid/Pro/CellRendering/Renderers/TextInputRenderer.ts
@@ -90,8 +90,11 @@ class TextInputRenderer extends CellRenderer implements EditModeRenderer {
      *
      * */
 
-    public override render(cell: TableCell): TextInputContent {
-        return new TextInputContent(cell, this);
+    public override render(
+        cell: TableCell,
+        parentElement?: HTMLElement
+    ): TextInputContent {
+        return new TextInputContent(cell, this, parentElement);
     }
 
 }

--- a/ts/Grid/Pro/ColumnTypes/Validator.ts
+++ b/ts/Grid/Pro/ColumnTypes/Validator.ts
@@ -284,14 +284,14 @@ class Validator {
 namespace Validator {
 
     /**
-     * Global validation CSS classes.
+     * The class names used by the validator functionality.
      */
     export const classNames = {
         notifContainer: Globals.classNamePrefix + 'notification',
         notifError: Globals.classNamePrefix + 'notification-error',
         notifAnimation: Globals.classNamePrefix + 'notification-animation',
         editedCellError: Globals.classNamePrefix + 'edited-cell-error'
-    };
+    } as const;
 
     /* *
      *


### PR DESCRIPTION
Optimized cell content rendering.
Fixed sparkline initial rendering width glitch.

**Sample for testing:** https://jsfiddle.net/BlackLabel/mdve8tqL/

---

**Description:**
- `update` methods have been added to the CellContent's child classes, which allow cell to be re-rendered after their value has changed without having to remove and re-add them to the DOM.
- The order of rendering rows has been changed - first we add the container to the DOM, only then we render cells. Additionally, when rendering cells we immediately specify their width using `reflow`. This solves the problem of sparkline glitch.
- Starting cell edit mode doesn't destroy the previous cell content. Now it just covers it up.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210533397046502