### PR TITLE
grid/validator-raw-parsed-value 

### DIFF
--- a/samples/grid-pro/basic/cell-editing/demo.js
+++ b/samples/grid-pro/basic/cell-editing/demo.js
@@ -68,16 +68,11 @@ Grid.grid('container', {
         dataType: 'number',
         cells: {
             editMode: {
-                validationRules: [{
-                    validate: 'notEmpty',
-                    notification: function () {
-                        return 'Not empty formatter';
-                    }
-                }, {
+                validationRules: ['notEmpty', {
                     validate: 'number',
-                    notification: function (content) {
+                    notification: function ({ rawValue }) {
                         return `New value <strong>${
-                            content.getStringValue()
+                            rawValue
                         }</strong> should be number`;
                     }
                 }]
@@ -125,8 +120,8 @@ Grid.grid('container', {
             },
             editMode: {
                 validationRules: ['notEmpty', {
-                    validate: function (content) {
-                        return content.getStringValue().indexOf('URL') !== -1;
+                    validate: function ({ rawValue }) {
+                        return rawValue.indexOf('URL') !== -1;
                     },
                     notification: 'The value must contain "URL"'
                 }]

--- a/samples/grid-pro/cypress/cell-editing/demo.js
+++ b/samples/grid-pro/cypress/cell-editing/demo.js
@@ -72,9 +72,9 @@ Grid.grid('container', {
                     }
                 }, {
                     validate: 'number',
-                    notification: function (value) {
+                    notification: function ({ rawValue }) {
                         return `New value <strong>${
-                            value
+                            rawValue
                         }</strong> should be number`;
                     }
                 }]
@@ -116,8 +116,8 @@ Grid.grid('container', {
         cells: {
             editMode: {
                 validationRules: ['notEmpty', {
-                    validate: function (value) {
-                        return value.indexOf('URL') !== -1;
+                    validate: function ({ rawValue }) {
+                        return rawValue.indexOf('URL') !== -1;
                     },
                     notification: 'The value must contain "URL"'
                 }]

--- a/ts/Grid/Pro/CellEditing/CellEditMode.d.ts
+++ b/ts/Grid/Pro/CellEditing/CellEditMode.d.ts
@@ -45,15 +45,14 @@ export interface EditModeContent<
     getMainElement(): E;
 
     /**
-     * Returns the value of the cell in the edit mode, parsed according to the
-     * column type.
+     * Value of the edit mode cell content, parsed according to the column type.
      */
-    getValue(): DataTable.CellType;
+    readonly value: DataTable.CellType;
 
     /**
-     * Returns the raw value of the cell in the edit mode, in a string format.
+     * Raw value of the edit mode cell content, in a string format.
      */
-    getStringValue(): string;
+    readonly rawValue: string;
 
     /**
      * Destroys the edit mode content, removing all event listeners
@@ -91,7 +90,7 @@ export interface EditModeContent<
     /**
      * Indicates whether the edit mode should finish after a change event.
      */
-    finishAfterChange: boolean;
+    readonly finishAfterChange: boolean;
 }
 
 /**

--- a/ts/Grid/Pro/CellEditing/CellEditing.ts
+++ b/ts/Grid/Pro/CellEditing/CellEditing.ts
@@ -132,7 +132,7 @@ class CellEditing {
 
         const { column } = cell;
         const vp = column.viewport;
-        const newValue = emContent.getValue();
+        const newValue = emContent.value;
 
         if (submit) {
             const validationErrors: string[] = [];
@@ -206,18 +206,15 @@ class CellEditing {
             return;
         }
 
-        const valueIsDifferent = this.editedCell?.value !==
-            this.editModeContent?.getValue();
-
         if (key === 'Enter') {
             if (
-                this.editModeContent?.finishAfterChange && valueIsDifferent
+                this.editModeContent?.finishAfterChange
             ) {
                 this.onInputChange();
                 return;
             }
 
-            this.stopEditing(valueIsDifferent);
+            this.stopEditing();
         }
     };
 

--- a/ts/Grid/Pro/CellRendering/ContentTypes/CheckboxContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/CheckboxContent.ts
@@ -95,11 +95,11 @@ class CheckboxContent extends CellContentPro implements EditModeContent {
         return this.input;
     }
 
-    public getStringValue(): string {
+    public get rawValue(): string {
         return this.input.checked ? 'true' : 'false';
     }
 
-    public getValue(): DataTable.CellType {
+    public get value(): DataTable.CellType {
         const val = this.input.checked;
         switch (this.cell.column.dataType) {
             case 'datetime':
@@ -134,7 +134,7 @@ class CheckboxContent extends CellContentPro implements EditModeContent {
         if (this.changeHandler) {
             this.changeHandler(e);
         } else {
-            void this.cell.setValue(this.getValue(), true);
+            void this.cell.setValue(this.value, true);
         }
     };
 

--- a/ts/Grid/Pro/CellRendering/ContentTypes/DateInputContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/DateInputContent.ts
@@ -91,11 +91,11 @@ class DateInputContent extends CellContentPro implements EditModeContent {
         return this.input;
     }
 
-    public getStringValue(): string {
+    public get rawValue(): string {
         return this.input.value;
     }
 
-    public getValue(): number {
+    public get value(): number {
         return new Date(this.input.value).getTime();
     }
 
@@ -145,7 +145,7 @@ class DateInputContent extends CellContentPro implements EditModeContent {
 
         if (e.key === 'Enter') {
             this.cell.htmlElement.focus();
-            void this.cell.setValue(this.getValue(), true);
+            void this.cell.setValue(this.value, true);
         }
     };
 
@@ -155,7 +155,7 @@ class DateInputContent extends CellContentPro implements EditModeContent {
             return;
         }
 
-        void this.cell.setValue(this.getValue(), true);
+        void this.cell.setValue(this.value, true);
     };
 
     private readonly onCellKeyDown = (e: KeyboardEvent): void => {

--- a/ts/Grid/Pro/CellRendering/ContentTypes/SelectContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/SelectContent.ts
@@ -128,11 +128,11 @@ class SelectContent extends CellContentPro implements EditModeContent {
         select.remove();
     }
 
-    public getStringValue(): string {
+    public get rawValue(): string {
         return this.select.value;
     }
 
-    public getValue(): DataTable.CellType {
+    public get value(): DataTable.CellType {
         const val = this.select.value;
         switch (this.cell.column.dataType) {
             case 'datetime':
@@ -154,7 +154,7 @@ class SelectContent extends CellContentPro implements EditModeContent {
             this.changeHandler(e);
         } else {
             this.cell.htmlElement.focus();
-            void this.cell.setValue(this.getValue(), true);
+            void this.cell.setValue(this.value, true);
         }
     };
 

--- a/ts/Grid/Pro/CellRendering/ContentTypes/TextInputContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/TextInputContent.ts
@@ -97,22 +97,22 @@ class TextInputContent extends CellContentPro implements EditModeContent {
         return this.input;
     }
 
-    public getStringValue(): string {
+    public get rawValue(): string {
         return this.input.value;
     }
 
-    public getValue(): DataTable.CellType {
+    public get value(): DataTable.CellType {
         const val = this.input.value;
         switch (this.cell.column.dataType) {
             case 'datetime':
             case 'number':
                 return val === '' ? null : +val;
             case 'boolean':
-                if (val === 'false' || +val === 0) {
-                    return false;
-                }
                 if (val === '') {
                     return null;
+                }
+                if (val === 'false' || +val === 0) {
+                    return false;
                 }
                 return true;
             case 'string':

--- a/ts/Grid/Pro/ColumnTypes/Validator.ts
+++ b/ts/Grid/Pro/ColumnTypes/Validator.ts
@@ -349,26 +349,20 @@ namespace Validator {
      */
     export const rulesRegistry: RulesRegistryType = {
         notEmpty: {
-            validate: (emContent): boolean => (
-                defined(emContent.getValue()) &&
-                emContent.getStringValue().length > 0
+            validate: ({ value, rawValue }): boolean => (
+                defined(value) && rawValue.length > 0
             ),
             notification: 'Value cannot be empty.'
         },
         number: {
-            validate: (emContent): boolean => (
-                !isNaN(+emContent.getStringValue())
-            ),
+            validate: ({ rawValue }): boolean => !isNaN(+rawValue),
             notification: 'Value has to be a number.'
         },
         'boolean': {
-            validate: (emContent): boolean => {
-                const rawValue = emContent.getStringValue();
-                return (
-                    rawValue === 'true' || rawValue === 'false' ||
-                    Number(rawValue) === 1 || Number(rawValue) === 0
-                );
-            },
+            validate: ({ rawValue }): boolean => (
+                rawValue === 'true' || rawValue === 'false' ||
+                Number(rawValue) === 1 || Number(rawValue) === 0
+            ),
             notification: 'Value has to be a boolean.'
         }
     };


### PR DESCRIPTION
The first argument of the validator and notification callback is now edit mode content, instead of parsed value, so that we can refer to parsed and raw in string format.

Is this intuitive enough? Maybe instead of `getValue()` and `getStringValue` we should use getters (e.g. `value` and `rawValue`)?