### PR TITLE
boost/webgl-clip-poc

### DIFF
--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -504,19 +504,19 @@ function createAndAttachRenderer(
     boost.canvas.height = height;
 
     if (boost.clipRect) {
-        const box = getBoostClipRect(chart, target),
+        const box = getBoostClipRect(chart, target);
 
-            // When using panes, the image itself must be clipped. When not
-            // using panes, it is better to clip the target group, because then
-            // we preserve clipping on touch- and mousewheel zoom preview.
-            clippedElement = (
-                box.width === chart.clipBox.width &&
-                box.height === chart.clipBox.height
-            ) ? targetGroup :
-                (boost.targetFo || boost.target);
+        // When using panes, the image itself must be clipped. When not
+        // using panes, it is better to clip the target group, because then
+        // we preserve clipping on touch- and mousewheel zoom preview.
+        // clippedElement = (
+        //     box.width === chart.clipBox.width &&
+        //     box.height === chart.clipBox.height
+        // ) ? targetGroup :
+        //     (boost.targetFo || boost.target);
 
         boost.clipRect.attr(box);
-        clippedElement?.clip(boost.clipRect);
+        /// clippedElement?.clip(boost.clipRect);
     }
 
     boost.resize();

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -1238,6 +1238,7 @@ class WGLRenderer {
 
         shader.setUniform('xAxisTrans', axis.transA * pixelRatio);
         shader.setUniform('xAxisMin', axis.min as any);
+        shader.setUniform('xAxisMax', axis.max as any);
         shader.setUniform('xAxisMinPad', axis.minPixelPadding * pixelRatio);
         shader.setUniform('xAxisPointRange', axis.pointRange);
         shader.setUniform('xAxisLen', axis.len * pixelRatio);
@@ -1264,6 +1265,7 @@ class WGLRenderer {
 
         shader.setUniform('yAxisTrans', axis.transA * pixelRatio);
         shader.setUniform('yAxisMin', axis.min as any);
+        shader.setUniform('yAxisMax', axis.max as any);
         shader.setUniform('yAxisMinPad', axis.minPixelPadding * pixelRatio);
         shader.setUniform('yAxisPointRange', axis.pointRange);
         shader.setUniform('yAxisLen', axis.len * pixelRatio);

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -29,6 +29,8 @@ import type { SeriesZonesOptions } from '../../Core/Series/SeriesOptions';
 import type { WGLDrawModeValue } from './WGLDrawMode';
 import type WGLOptions from './WGLOptions';
 
+import BoostChart from './BoostChart';
+const { getBoostClipRect } = BoostChart;
 import Color from '../../Core/Color/Color.js';
 const { parse: color } = Color;
 import H from '../../Core/Globals.js';
@@ -1521,6 +1523,11 @@ class WGLRenderer {
             // Do the actual rendering
             // If the line width is < 0, skip rendering of the lines. See #7833.
             if (lineWidth > 0 || s.drawMode !== 'LINE_STRIP') {
+                const { x: cx, y: cy, width: cw, height: ch } =
+                    getBoostClipRect(chart, s.series);
+
+                gl.enable(gl.SCISSOR_TEST);
+                gl.scissor(cx, height - cy - ch, cw, ch);
                 for (sindex = 0; sindex < s.segments.length; sindex++) {
                     vbuffer.render(
                         s.segments[sindex].from,
@@ -1528,6 +1535,7 @@ class WGLRenderer {
                         s.drawMode
                     );
                 }
+                gl.disable(gl.SCISSOR_TEST);
             }
 
             if (s.hasMarkers && showMarkers) {

--- a/ts/Extensions/Boost/WGLShader.ts
+++ b/ts/Extensions/Boost/WGLShader.ts
@@ -98,6 +98,7 @@ const vertexShader = [
 
     'uniform float xAxisTrans;',
     'uniform float xAxisMin;',
+    'uniform float xAxisMax;',
     'uniform float xAxisMinPad;',
     'uniform float xAxisPointRange;',
     'uniform float xAxisLen;',
@@ -111,6 +112,7 @@ const vertexShader = [
 
     'uniform float yAxisTrans;',
     'uniform float yAxisMin;',
+    'uniform float yAxisMax;',
     'uniform float yAxisMinPad;',
     'uniform float yAxisPointRange;',
     'uniform float yAxisLen;',
@@ -122,6 +124,7 @@ const vertexShader = [
     'uniform bool  yAxisIsLog;',
     'uniform bool  yAxisReversed;',
 
+    'uniform bool  isCircle;',
     'uniform bool  isBubble;',
     'uniform bool  bubbleSizeByArea;',
     'uniform float bubbleZMin;',
@@ -218,6 +221,19 @@ const vertexShader = [
     '}',
 
     'void main(void) {',
+        // It's not working correctly on useGPUTranslations off, because we
+        // operate on pixel values then, not on axis values. Maybe we should
+        // just skip outer points before pushing them to the vertex buffer?
+        'if (!skipTranslation && isCircle && (',
+            'aVertexPosition.x < xAxisMin ||',
+            'aVertexPosition.x > xAxisMax ||',
+            'aVertexPosition.y < yAxisMin ||',
+            'aVertexPosition.y > yAxisMax',
+        ')) {',
+            'gl_Position = vec4(2.0, 2.0, 2.0, 1.0);',
+            'return;',
+        '}',
+
         'if (isBubble){',
             'gl_PointSize = bubbleRadius();',
         '} else {',

--- a/ts/Extensions/BoostCanvas.ts
+++ b/ts/Extensions/BoostCanvas.ts
@@ -429,7 +429,8 @@ namespace BoostCanvas {
             };
 
             boost.clipRect = chart.renderer.clipRect();
-            boost.target.clip(boost.clipRect);
+            // Debugging:
+            // boost.target.clip(boost.clipRect);
 
         } else if (!(target instanceof ChartConstructor)) {
             ///  ctx.clearRect(0, 0, width, height);


### PR DESCRIPTION
Proof-of-Concept solution for #9799:
- disabled the default clipping of the entire canvas,
- lines can be easily clipped using [gl.scissor](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/scissor),
- clipping markers can be achieved in the vertex shader (easy with GPU Translation enabled; if translation is skipped, another approach is needed - maybe it would be possible  to simply skip points outside the plot area before adding them to the vertex buffer)

**Testing sample:** https://jsfiddle.net/BlackLabel/xyrpv97g/
