### PR TITLE
ON HOLD: enhancement/colorAxis-reversed-default-update

### DIFF
--- a/ts/Core/Axis/Color/ColorAxis.ts
+++ b/ts/Core/Axis/Color/ColorAxis.ts
@@ -223,7 +223,7 @@ class ColorAxis extends Axis implements AxisLike {
                 legend.layout !== 'vertical';
 
         axis.side = userOptions.side || horiz ? 2 : 1;
-        axis.reversed = userOptions.reversed || false;
+        axis.reversed = userOptions.reversed;
         axis.opposite = !horiz;
 
         super.init(chart, userOptions, 'colorAxis');

--- a/ts/Core/Axis/Color/ColorAxis.ts
+++ b/ts/Core/Axis/Color/ColorAxis.ts
@@ -223,7 +223,7 @@ class ColorAxis extends Axis implements AxisLike {
                 legend.layout !== 'vertical';
 
         axis.side = userOptions.side || horiz ? 2 : 1;
-        axis.reversed = userOptions.reversed || !horiz;
+        axis.reversed = userOptions.reversed || false;
         axis.opposite = !horiz;
 
         super.init(chart, userOptions, 'colorAxis');

--- a/ts/Core/Axis/Color/ColorAxisDefaults.ts
+++ b/ts/Core/Axis/Color/ColorAxisDefaults.ts
@@ -444,11 +444,10 @@ const colorAxisDefaults: DeepPartial<ColorAxis.Options> = {
 
     /**
      * Whether to reverse the axis so that the highest number is closest
-     * to the origin. Defaults to `false` in a horizontal legend and
-     * `true` in a vertical legend, where the smallest value starts on
-     * top.
+     * to the origin. Defaults to `false`.
      *
      * @type      {boolean}
+     * @default   false
      * @product   highcharts highstock highmaps
      * @apioption colorAxis.reversed
      */


### PR DESCRIPTION
Changed the default `colorAxis.reversed` value to always be false, regardless of vertical or horizontal layout. In a vertical layout, higher values are expected to be at the top.

#### Upgrade notes
The default value for `colorAxis.reversed` changed from true to false for vertical color axes.

---

Changed the default specification of colorAxis so that the default value of colorAxis.inverted is always false, previously false when axis is horizontal, and true when axis vertical.
The default value should be the same irrespective of the axis orientation.