### PR TITLE
feature/23118-tooltippos-public

### DIFF
--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -141,6 +141,7 @@ class Point {
     public shapeType?: string;
     public startXPos?: number;
     public state?: StatesOptionsKey;
+    public tooltipPos?: Array<number>;
     public total?: number;
     public visible: boolean = true;
     public x!: number;
@@ -231,6 +232,16 @@ class Point {
      * @readonly
      * @name Highcharts.Point#shapeArgs
      * @type {Readonly<Highcharts.SVGAttributes>|undefined}
+     */
+
+    /**
+     * Defines the tooltip's position for a data point in a chart. It is an
+     * array of numbers representing the coordinates for the tooltip's
+     * placement, allowing for precise control over its location.
+     *
+     * @readonly
+     * @name Highcharts.Point#tooltipPos
+     * @type {Readonly<Array<number>>|undefined}
      */
 
     /**

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -79,7 +79,6 @@ declare module './Chart/ChartLike' {
 declare module './Series/PointLike' {
     interface PointLike {
         isHeader?: boolean;
-        tooltipPos?: Array<number>;
     }
 }
 


### PR DESCRIPTION
Fixed #23118, made `tooltipPos` public to expose point position for pie and donut charts

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210404383957859