### PR TITLE
bugfix/temporary-vis-test-fix

### DIFF
--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -412,6 +412,9 @@ module.exports = function (config) {
             'samples/highcharts/demo/pareto/demo.js',
             'samples/highcharts/demo/pyramid3d/demo.js',
             'samples/highcharts/demo/synchronized-charts/demo.js',
+
+            // Visual test fails due to external library used
+            'samples/highcharts/demo/combo-regression',
         ],
         reporters: ['progress'],
         port: 9876,  // karma web server port


### PR DESCRIPTION
Test broken because of usage of an external library. Temporarily excluding the test until a fix can be implemented