### PR TITLE
dash/minimal-html-demo-title-dark-mode

### DIFF
--- a/samples/dashboards/demo/minimal-html/demo.css
+++ b/samples/dashboards/demo/minimal-html/demo.css
@@ -58,11 +58,9 @@
 }
 
 h1#title {
-    padding-top: 10px;
     margin: 0;
-    background-color: #3d3d3d;
+    padding: 10px 0;
     text-align: center;
-    color: #fff;
 }
 
 #kpi-vitamin-a .highcharts-dashboards-component-title::before,


### PR DESCRIPTION
Fixed the minimal-html dashboard demo title in dark mode.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210684939296228