### PR TITLE
dash/missing-light-mode-color-var

### DIFF
--- a/css/dashboards/dashboards.css
+++ b/css/dashboards/dashboards.css
@@ -13,6 +13,7 @@
     --highcharts-neutral-color-80: #333333;
     --highcharts-neutral-color-60: #666666;
     --highcharts-neutral-color-20: #cccccc;
+    --highcharts-neutral-color-10: #e6e6e6;
     --highcharts-neutral-color-5: #f2f2f2;
     --highcharts-neutral-color-3: #f7f7f7;
     --highcharts-neutral-color-0: #ffffff;


### PR DESCRIPTION
Fixed styling, added the missing light-mode `--highcharts-neutral-color-10` CSS variable override.