### PR TITLE
grid/fixed-types-renderers

### DIFF
--- a/test/typescript-dts/dashboards/dashboards.ts
+++ b/test/typescript-dts/dashboards/dashboards.ts
@@ -57,6 +57,11 @@ function test_grid() {
         dataTable: {
             columns: {
                 a: new Float32Array([1, 2, 3]),
+                sparklines: [
+                    '1, 3, 2',
+                    '2, 1, 3',
+                    '3, 2, 1'
+                ]
             }
         },
         columnDefaults: {
@@ -66,11 +71,34 @@ function test_grid() {
                 }
             }
         },
+        credits: {
+            enabled: false
+        },
         columns: [{
             id: 'a',
             cells: {
                 editMode: {
                     enabled: true
+                }
+            }
+        }, {
+            id: 'sparklines',
+            dataType: 'string',
+            cells: {
+                renderer: {
+                    type: 'sparkline',
+                    chartOptions: {
+                        chart: {
+                            type: 'line'
+                        }
+                    }
+                },
+                editMode: {
+                    renderer: {
+                        type: 'textInput',
+                        disabled: true
+                    },
+                    validationRules: ['notEmpty']
                 }
             }
         }],

--- a/test/typescript-dts/dashboards/tsconfig.json
+++ b/test/typescript-dts/dashboards/tsconfig.json
@@ -8,7 +8,7 @@
             "highcharts/*": ["code/*"],
             "@highcharts/dashboards/datagrid": ["code/datagrid/datagrid.src"],
             "@highcharts/dashboards/datagrid/*": ["code/datagrid/*"],
-
-        }
+        },
+        "skipLibCheck": true
     }
 }

--- a/tools/gulptasks/dashboards/scripts-dts/datagrid.src.d.ts
+++ b/tools/gulptasks/dashboards/scripts-dts/datagrid.src.d.ts
@@ -19,6 +19,7 @@ import './es-modules/Grid/Pro/CellRendering/Renderers/CheckboxRenderer';
 import './es-modules/Grid/Pro/CellRendering/Renderers/SelectRenderer';
 import './es-modules/Grid/Pro/CellRendering/Renderers/TextInputRenderer';
 import './es-modules/Grid/Pro/CellRendering/Renderers/DateInputRenderer';
+import './es-modules/Grid/Pro/CellRendering/Renderers/SparklineRenderer';
 
 export { /** @deprecated Use `Grid` instead. */ default as DataGrid } from './es-modules/Grid/Core/Grid.js';
 export { default as Grid } from './es-modules/Grid/Core/Grid.js';

--- a/ts/masters-datagrid/datagrid.src.ts
+++ b/ts/masters-datagrid/datagrid.src.ts
@@ -73,6 +73,7 @@ import '../Grid/Pro/Dash3Compatibility.js';
 import '../Grid/Pro/Credits/CreditsProComposition.js';
 
 // Cell Renderers
+import '../Grid/Pro/CellRendering/CellRenderersComposition.js';
 import '../Grid/Pro/CellRendering/Renderers/TextRenderer.js';
 import '../Grid/Pro/CellRendering/Renderers/CheckboxRenderer.js';
 import '../Grid/Pro/CellRendering/Renderers/SelectRenderer.js';


### PR DESCRIPTION
Fixed missing imports for renderer and sparkline option types in master `.d.ts`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210714820027096