### PR TITLE
grid/fix-header-background

### DIFF
--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -381,6 +381,10 @@
     display: block;
 }
 
+.highcharts-datagrid-table thead {
+    background-color: var(--ig-header-background);
+}
+
 .hcg-table thead th,
 .highcharts-datagrid-table thead th {
     position: relative;
@@ -1065,7 +1069,7 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
 .highcharts-light .highcharts-datagrid-theme-default {
     /* Primary colors */
     --hcg-color: var(--highcharts-neutral-color-100, #000000);
-    --hcg-background: var(--highcharts-background-color, #ffffff);
+    --hcg-background: var(--highcharts-neutral-color-5, #ffffff);
 
     /* Other properties */
     --hcg-border-radius: 5px;

--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -381,6 +381,7 @@
     display: block;
 }
 
+.hcg-table thead,
 .highcharts-datagrid-table thead {
     background-color: var(--ig-header-background);
 }

--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -1069,7 +1069,7 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
 .highcharts-light .highcharts-datagrid-theme-default {
     /* Primary colors */
     --hcg-color: var(--highcharts-neutral-color-100, #000000);
-    --hcg-background: var(--highcharts-neutral-color-5, #ffffff);
+    --hcg-background: var(--highcharts-background-color, #ffffff);
 
     /* Other properties */
     --hcg-border-radius: 5px;

--- a/css/grid/grid.css
+++ b/css/grid/grid.css
@@ -348,6 +348,10 @@
     display: block;
 }
 
+.hcg-table thead {
+    background-color: var(--ig-header-background);
+}
+
 .hcg-table thead th {
     position: relative;
     border-right: var(--ig-header-column-border);


### PR DESCRIPTION
Fixed Grid table header background colour

In certain situations, the header row will not extend all the way, in these cases, the `thead` background will show. So we need it to have the same background colour as the header row

Task https://app.asana.com/1/222651295669536/project/1203234853779882/task/1210684939296220?focus=true