### PR TITLE
bugfix/23296

### DIFF
--- a/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
+++ b/ts/Core/Axis/PlotLineOrBand/PlotLineOrBand.ts
@@ -360,7 +360,7 @@ class PlotLineOrBand {
                     // default options for plot lines and bands, default to the
                     // title color. If we expose the palette, we should use that
                     // instead.
-                    color: axis.chart.options.title?.style.color,
+                    color: axis.chart.options.title?.style?.color,
                     fontSize: '0.8em',
                     textOverflow: (isBand && !inside) ? '' : 'ellipsis'
                 }, optionsLabel.style));


### PR DESCRIPTION
Fixed #23296, a regression causing an error when title options were incomplete.

----

This is a fix in the code that will probably be changed into palette usage in the next version or so, so I'm adding only the minimal fix.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210678982066685