### PR TITLE
fix/19663-packedbubble-datalabels-opacity

### DIFF
--- a/samples/unit-tests/series-packedbubble/packedbubble/demo.js
+++ b/samples/unit-tests/series-packedbubble/packedbubble/demo.js
@@ -1,5 +1,30 @@
 QUnit.test('Packed Bubble layouts operations', function (assert) {
-    const chart = Highcharts.chart('container', {
+    let chart = Highcharts.chart('container', {
+        chart: {
+            type: 'packedbubble',
+            height: '100%'
+        },
+        plotOptions: {
+            packedbubble: {
+                useSimulation: false,
+                dataLabels: {
+                    enabled: true
+                }
+            }
+        },
+        series: [{
+            data: [7]
+        }]
+    });
+
+    assert.notEqual(
+        chart.series[0].dataLabelsGroup.opacity,
+        0,
+        `Series data labels groups is visible from the start, at init of the
+        chart #19663.`
+    );
+
+    chart = Highcharts.chart('container', {
         chart: {
             type: 'packedbubble',
             height: '100%'

--- a/ts/Series/SimulationSeriesUtilities.ts
+++ b/ts/Series/SimulationSeriesUtilities.ts
@@ -74,6 +74,13 @@ function initDataLabels(this: SimulationSeries): SVGElement {
         dataLabelsGroup.attr({ opacity: 0 });
 
         if (series.visible) { // #2597, #3023, #3024
+            // #19663, initial data labels animation
+            if (series.options.animation && dlOptions?.animation) {
+                dataLabelsGroup.animate({ opacity: 1 }, dlOptions?.animation);
+            } else {
+                dataLabelsGroup.attr({ opacity: 1 });
+            }
+
             dataLabelsGroup.show();
         }
 


### PR DESCRIPTION
Fixed #19663, packed bubble data labels group had wrong initial opacity.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210657626037078