### PR TITLE
data/range-modifier-rework

### DIFF
--- a/samples/dashboards/components/crossfilter-affecting-navigators/demo.css
+++ b/samples/dashboards/components/crossfilter-affecting-navigators/demo.css
@@ -9,3 +9,7 @@ h2 {
 #csv {
     display: none;
 }
+
+#bottom {
+    height: 400px;
+}

--- a/samples/dashboards/components/crossfilter-affecting-navigators/demo.js
+++ b/samples/dashboards/components/crossfilter-affecting-navigators/demo.js
@@ -107,7 +107,7 @@ Dashboards.board('container', {
         }
     }, {
         renderTo: 'bottom',
-        type: 'DataGrid',
+        type: 'Grid',
         connector: {
             id: 'Economy'
         },

--- a/test/typescript-karma/Dashboards/Component/highcharts.js
+++ b/test/typescript-karma/Dashboards/Component/highcharts.js
@@ -873,7 +873,7 @@ test('Crossfilter with string values', async function (assert) {
         const table = e.connector.table;
 
         // Assert only on the last event
-        if (table?.modifier?.options?.ranges?.length > 1) {
+        if (table?.modifier?.options?.condition?.conditions?.length > 2) {
 
             assert.equal(
                 countPoints(stringsNavigator.chart.series[0]),

--- a/ts/Dashboards/Components/NavigatorComponent/NavigatorComponent.ts
+++ b/ts/Dashboards/Components/NavigatorComponent/NavigatorComponent.ts
@@ -32,14 +32,17 @@ import type {
     Options
 } from './NavigatorComponentOptions';
 import type {
-    RangeModifierOptions, RangeModifierRangeOptions
-} from '../../../Data/Modifiers/RangeModifierOptions';
+    FilterModifierOptions
+} from '../../../Data/Modifiers/FilterModifierOptions';
+
 
 import Component from '../Component.js';
 import Globals from '../../Globals.js';
 import NavigatorComponentDefaults from './NavigatorComponentDefaults.js';
 import DataTable from '../../../Data/DataTable.js';
 import NavigatorSyncs from './NavigatorSyncs/NavigatorSyncs.js';
+import NavigatorSyncUtils from './NavigatorSyncs/NavigatorSyncUtils.js';
+
 import U from '../../../Core/Utilities.js';
 const {
     diffObjects,
@@ -423,16 +426,22 @@ class NavigatorComponent extends Component {
         let filteredValues: (number | string)[];
 
         const modifierOptions = table.getModifier()?.options;
-        if (crossfilterOptions.affectNavigator && modifierOptions) {
-            const appliedRanges: RangeModifierRangeOptions[] = [],
-                rangedColumns: DataTable.Column[] = [],
-                { ranges } = (modifierOptions as RangeModifierOptions);
+
+        if (
+            crossfilterOptions.affectNavigator &&
+            modifierOptions?.type === 'Filter'
+        ) {
+            const appliedRanges: NavigatorSyncUtils.Range[] = [];
+            const rangedColumns: DataTable.Column[] = [];
+            const ranges = NavigatorSyncUtils.toRange(
+                modifierOptions as FilterModifierOptions
+            );
 
             for (let i = 0, iEnd = ranges.length; i < iEnd; i++) {
-                if (ranges[i].column !== this.getColumnAssignment()[0]) {
+                if (ranges[i].columnName !== this.getColumnAssignment()[0]) {
                     appliedRanges.push(ranges[i]);
                     rangedColumns.push(table.getColumn(
-                        ranges[i].column, true
+                        ranges[i].columnName, true
                     ) || []);
                 }
             }

--- a/ts/Dashboards/Components/NavigatorComponent/NavigatorSyncs/NavigatorCrossfilterSync.ts
+++ b/ts/Dashboards/Components/NavigatorComponent/NavigatorSyncs/NavigatorCrossfilterSync.ts
@@ -32,7 +32,7 @@ import DataModifier from '../../../../Data/Modifiers/DataModifier.js';
 import NavigatorSyncUtils from './NavigatorSyncUtils.js';
 import U from '../../../../Core/Utilities.js';
 
-const { Range: RangeModifier } = DataModifier.types;
+const { Filter: FilterModifier } = DataModifier.types;
 const { addEvent } = U;
 
 
@@ -66,20 +66,27 @@ const syncPair: Sync.SyncPair = {
 
                 let modifier = table.getModifier();
 
-                if (modifier instanceof RangeModifier) {
+                if (modifier instanceof FilterModifier) {
                     NavigatorSyncUtils.setRangeOptions(
-                        modifier.options.ranges,
+                        modifier.options,
                         filterColumn,
                         min,
                         max
                     );
                 } else {
-                    modifier = new RangeModifier({
-                        ranges: [{
-                            column: filterColumn,
-                            maxValue: max,
-                            minValue: min
-                        }]
+                    modifier = new FilterModifier({
+                        condition: {
+                            operator: 'and',
+                            conditions: [{
+                                columnName: filterColumn,
+                                operator: 'ge',
+                                value: min
+                            }, {
+                                columnName: filterColumn,
+                                operator: 'le',
+                                value: max
+                            }]
+                        }
                     });
                 }
 
@@ -116,7 +123,9 @@ const syncPair: Sync.SyncPair = {
             'afterSetExtremes',
             function (extremes: Axis.ExtremesObject): void {
                 clearTimeout(delay);
-                delay = setTimeout(afterSetExtremes, 50, this, extremes);
+                delay = setTimeout((): void => {
+                    void afterSetExtremes(extremes);
+                }, 50);
             }
         );
     },
@@ -129,4 +138,5 @@ const syncPair: Sync.SyncPair = {
 *  Default export
 *
 * */
+
 export default { defaultOptions, syncPair };

--- a/ts/Dashboards/Components/NavigatorComponent/NavigatorSyncs/NavigatorExtremesSync.ts
+++ b/ts/Dashboards/Components/NavigatorComponent/NavigatorSyncs/NavigatorExtremesSync.ts
@@ -30,7 +30,7 @@ import NavigatorComponent from '../NavigatorComponent.js';
 import NavigatorSyncUtils from './NavigatorSyncUtils.js';
 import U from '../../../../Core/Utilities.js';
 
-const { Range: RangeModifier } = DataModifier.types;
+const { Filter: FilterModifier } = DataModifier.types;
 const { addEvent, pick, defined } = U;
 
 
@@ -138,23 +138,20 @@ const syncPair: Sync.SyncPair = {
 
             if (
                 typeof extremesColumn === 'string' &&
-                modifier instanceof RangeModifier
+                modifier instanceof FilterModifier
             ) {
-                const ranges = modifier.options.ranges,
-                    min = table.getCell(extremesColumn, minIndex),
-                    max = table.getCell(extremesColumn, maxIndex);
+                const min = table.getCell(extremesColumn, minIndex);
+                const max = table.getCell(extremesColumn, maxIndex);
 
                 if (defined(max) && defined(min)) {
-                    NavigatorSyncUtils.unsetRangeOptions(
-                        ranges, extremesColumn
+                    NavigatorSyncUtils.setRangeOptions(
+                        modifier.options,
+                        extremesColumn,
+                        min,
+                        max
                     );
 
-                    ranges.unshift({
-                        column: extremesColumn,
-                        maxValue: max,
-                        minValue: min
-                    });
-                    table.setModifier(modifier);
+                    void table.setModifier(modifier);
                 }
             }
         };

--- a/ts/Dashboards/Components/NavigatorComponent/NavigatorSyncs/NavigatorSyncUtils.ts
+++ b/ts/Dashboards/Components/NavigatorComponent/NavigatorSyncs/NavigatorSyncUtils.ts
@@ -21,8 +21,12 @@
  * */
 
 import type {
-    RangeModifierRangeOptions
-} from '../../../../Data/Modifiers/RangeModifierOptions';
+    FilterModifierOptions,
+    LogicalMultipleCondition
+} from '../../../../Data/Modifiers/FilterModifierOptions';
+
+import U from '../../../../Core/Utilities.js';
+const { defined } = U;
 
 
 /* *
@@ -41,50 +45,180 @@ namespace NavigatorSyncUtils {
 
     /**
      * Adds or updates range options for a specific column.
-     * @param ranges Array of range options (will be modified).
+     * @param filterOptions Filter modifier options object reference.
      * @param column Column name.
      * @param minValue Minimum value.
      * @param maxValue Maximum value.
      * @internal
      */
     export function setRangeOptions(
-        ranges: Array<RangeModifierRangeOptions>,
+        filterOptions: FilterModifierOptions,
         column: string,
         minValue: (boolean | number | string),
         maxValue: (boolean | number | string)
     ): void {
-        let changed = false;
+        let changedMin = false;
+        let changedMax = false;
 
-        for (let i = 0, iEnd = ranges.length; i < iEnd; ++i) {
-            if (ranges[i].column === column) {
-                ranges[i].maxValue = maxValue;
-                ranges[i].minValue = minValue;
-                changed = true;
-                break;
+        if (
+            typeof filterOptions.condition !== 'object' ||
+            filterOptions.condition.operator !== 'and'
+        ) {
+            filterOptions.condition = {
+                operator: 'and',
+                conditions: []
+            };
+        }
+
+        const { conditions } = filterOptions.condition;
+
+        for (let i = 0, iEnd = conditions.length; i < iEnd; ++i) {
+            const condition = conditions[i];
+            if (
+                !condition ||
+                typeof condition !== 'object' ||
+                !(condition.operator === 'le' || condition.operator === 'ge') ||
+                condition.columnName !== column
+            ) {
+                continue;
+            }
+
+            if (condition.operator === 'le') {
+                condition.value = maxValue;
+                changedMax = true;
+            } else {
+                condition.value = minValue;
+                changedMin = true;
+            }
+
+            if (changedMin && changedMax) {
+                return;
             }
         }
 
-        if (!changed) {
-            ranges.push({ column, maxValue, minValue });
+        if (!changedMax) {
+            conditions.push({
+                operator: 'le',
+                columnName: column,
+                value: maxValue
+            });
+        }
+
+        if (!changedMin) {
+            conditions.push({
+                operator: 'ge',
+                columnName: column,
+                value: minValue
+            });
         }
     }
 
 
     /**
      * Removes range options for a specific column.
-     * @param ranges Array of range options (will be modified).
+     * @param filterOptions Filter modifier options object reference.
      * @param column Column name.
      * @internal
      */
     export function unsetRangeOptions(
-        ranges: Array<RangeModifierRangeOptions>,
+        filterOptions: FilterModifierOptions,
         column: string
-    ): (RangeModifierRangeOptions | undefined) {
-        for (let i = 0, iEnd = ranges.length; i < iEnd; ++i) {
-            if (ranges[i].column === column) {
-                return ranges.splice(i, 1)[0];
+    ): void {
+        if (
+            typeof filterOptions.condition !== 'object' ||
+            filterOptions.condition.operator !== 'and'
+        ) {
+            return;
+        }
+
+        const { conditions } = filterOptions.condition;
+
+        for (let i = 0, iEnd = conditions.length; i < iEnd; ++i) {
+            const condition = conditions[i];
+
+            if (
+                !condition ||
+                typeof condition !== 'object' ||
+                !(condition.operator === 'le' || condition.operator === 'ge') ||
+                condition.columnName !== column
+            ) {
+                continue;
+            }
+
+            conditions.splice(i, 1)[0];
+        }
+    }
+
+    /**
+     * Converts filter options to ranges array.
+     *
+     * @param filterOptions
+     * Filter modifier options object reference.
+     */
+    export function toRange(filterOptions: FilterModifierOptions): Range[] {
+        const rangesMap: Record<string, Range> = {};
+
+        if (
+            typeof filterOptions.condition !== 'object' ||
+            filterOptions.condition.operator !== 'and'
+        ) {
+            return [];
+        }
+
+        const { conditions } =
+            filterOptions.condition as LogicalMultipleCondition;
+
+        for (let i = 0, iEnd = conditions.length; i < iEnd; ++i) {
+            const condition = conditions[i];
+
+            if (
+                !condition ||
+                typeof condition !== 'object' ||
+                !(condition.operator === 'le' || condition.operator === 'ge') ||
+                typeof condition.columnName !== 'string' ||
+                !defined(condition.value)
+            ) {
+                continue;
+            }
+
+            const colName = condition.columnName;
+            if (!rangesMap[colName]) {
+                rangesMap[colName] = {
+                    maxValue: Infinity,
+                    minValue: -Infinity,
+                    columnName: colName
+                };
+            }
+
+            if (condition.operator === 'le') {
+                rangesMap[colName].maxValue = condition.value;
+            } else {
+                rangesMap[colName].minValue = condition.value;
             }
         }
+
+        return Object.values(rangesMap);
+    }
+
+    /**
+     * Helper interface for translating filter options to range options.
+     * @internal
+     */
+    export interface Range {
+        /**
+         * Column containing the values to filter.
+         */
+        columnName: string;
+
+        /**
+         * Maximum including value (`<=` operator).
+         */
+        maxValue: (boolean|number|string);
+
+        /**
+         * Minimum including value (`>=` operator).
+         */
+        minValue: (boolean|number|string);
     }
 }
 
@@ -94,4 +228,5 @@ namespace NavigatorSyncUtils {
  *  Default Export
  *
  * */
+
 export default NavigatorSyncUtils;


### PR DESCRIPTION
Range Modifier now only defines the start–end slice of source table rows; all other range logic is covered by **Filter Modifier**.

#### Upgrade note

Any workflows relying on **Range Modifier** for must be migrated to **Filter Modifier**.
