### PR TITLE
Bugfix: Fix partial hidden markers under axis in boost. #9799

### DIFF
--- a/samples/highcharts/boost/line-markers/demo.js
+++ b/samples/highcharts/boost/line-markers/demo.js
@@ -24,7 +24,7 @@ const chart = Highcharts.chart('container', {
 });
 chart.series[0].remove(); // test boost refresh after empty series array
 chart.addSeries({
-    data: [1, 3, 2, 4, 5, 3]
+    data: [1, 0, 0, 4, 5, 3]
 });
 chart.addSeries({
     data: [6, 5, 7, 6, 8, 4]

--- a/samples/highcharts/boost/line-markers/demo.js
+++ b/samples/highcharts/boost/line-markers/demo.js
@@ -24,7 +24,8 @@ const chart = Highcharts.chart('container', {
 });
 chart.series[0].remove(); // test boost refresh after empty series array
 chart.addSeries({
-    data: [1, 0, 0, 4, 5, 3]
+    data: [1, 0, 0, 4, 5, 3],
+    type: 'scatter'
 });
 chart.addSeries({
     data: [6, 5, 7, 6, 8, 4]

--- a/samples/highcharts/boost/line-markers/demo.js
+++ b/samples/highcharts/boost/line-markers/demo.js
@@ -18,7 +18,7 @@ const chart = Highcharts.chart('container', {
     },
 
     series: [{
-        data: [11, 10, 12, 11, 10, 13],
+        data: [0, 10, 12, 11, 10, 13],
         type: 'scatter'
     }]
 

--- a/samples/highcharts/boost/line-markers/demo.js
+++ b/samples/highcharts/boost/line-markers/demo.js
@@ -18,15 +18,14 @@ const chart = Highcharts.chart('container', {
     },
 
     series: [{
-        data: [11, 10, 12, 0, 0, 13],
+        data: [11, 10, 12, 11, 10, 13],
         type: 'scatter'
     }]
 
 });
 chart.series[0].remove(); // test boost refresh after empty series array
 chart.addSeries({
-    data: [1, 0, 0, 4, 5, 3],
-    type: 'scatter'
+    data: [1, 3, 2, 4, 5, 3]
 });
 chart.addSeries({
     data: [6, 5, 7, 6, 8, 4]
@@ -35,6 +34,6 @@ chart.addSeries({
     data: [9, 8, 9, 8, 7, 9]
 });
 chart.addSeries({
-    data: [11, 10, 12, 11, 10, 13],
+    data: [11, 10, 0, 0, 10, 13],
     type: 'scatter'
 });

--- a/samples/highcharts/boost/line-markers/demo.js
+++ b/samples/highcharts/boost/line-markers/demo.js
@@ -18,7 +18,8 @@ const chart = Highcharts.chart('container', {
     },
 
     series: [{
-        data: [11, 10, 12, 11, 10, 13]
+        data: [11, 10, 12, 0, 0, 13],
+        type: 'scatter'
     }]
 
 });

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -506,17 +506,17 @@ function createAndAttachRenderer(
     if (boost.clipRect) {
         const box = getBoostClipRect(chart, target);
 
+        boost.clipRect.attr(box);
+
         // When using panes, the image itself must be clipped. When not
         // using panes, it is better to clip the target group, because then
         // we preserve clipping on touch- and mousewheel zoom preview.
-        // clippedElement = (
-        //     box.width === chart.clipBox.width &&
-        //     box.height === chart.clipBox.height
-        // ) ? targetGroup :
-        //     (boost.targetFo || boost.target);
-
-        boost.clipRect.attr(box);
-        /// clippedElement?.clip(boost.clipRect);
+        if (
+            box.width === chart.clipBox.width &&
+            box.height === chart.clipBox.height
+        ) {
+            targetGroup?.clip(boost.clipRect);
+        }
     }
 
     boost.resize();

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -515,7 +515,14 @@ function createAndAttachRenderer(
             box.width === chart.clipBox.width &&
             box.height === chart.clipBox.height
         ) {
-            targetGroup?.clip(boost.clipRect);
+            targetGroup?.clip(chart.renderer.clipRect(
+                box.x - 4,
+                box.y,
+                box.width + 4,
+                box.height + 4
+            )); // #9799
+        } else {
+            (boost.targetFo || boost.target).clip(boost.clipRect);
         }
     }
 

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -504,19 +504,19 @@ function createAndAttachRenderer(
     boost.canvas.height = height;
 
     if (boost.clipRect) {
-        const box = getBoostClipRect(chart, target),
+        const box = getBoostClipRect(chart, target);
 
-            // When using panes, the image itself must be clipped. When not
-            // using panes, it is better to clip the target group, because then
-            // we preserve clipping on touch- and mousewheel zoom preview.
-            clippedElement = (
-                box.width === chart.clipBox.width &&
-                box.height === chart.clipBox.height
-            ) ? targetGroup :
-                (boost.targetFo || boost.target);
+        // When using panes, the image itself must be clipped. When not
+        // using panes, it is better to clip the target group, because then
+        // we preserve clipping on touch- and mousewheel zoom preview.
+        // clippedElement = (
+        //     box.width === chart.clipBox.width &&
+        //     box.height === chart.clipBox.height
+        // ) ? targetGroup :
+        //     (boost.targetFo || boost.target);
 
         boost.clipRect.attr(box);
-        clippedElement?.clip(boost.clipRect);
+        /// clippedElement?.clip(boost.clipRect);
     }
 
     boost.resize();

--- a/ts/Extensions/Boost/BoostTargetObject.d.ts
+++ b/ts/Extensions/Boost/BoostTargetObject.d.ts
@@ -17,7 +17,7 @@ import type WGLRenderer from './WGLRenderer';
 export interface BoostTargetAdditions {
     canvas?: HTMLCanvasElement;
     clipRect?: SVGElement;
-    target?: (HTMLElement|SVGElement);
+    target?: SVGElement;
     targetCtx?: CanvasRenderingContext2D;
     targetFo?: SVGElement;
     wgl?: WGLRenderer;

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -1238,6 +1238,7 @@ class WGLRenderer {
 
         shader.setUniform('xAxisTrans', axis.transA * pixelRatio);
         shader.setUniform('xAxisMin', axis.min as any);
+        shader.setUniform('xAxisMax', axis.max as any);
         shader.setUniform('xAxisMinPad', axis.minPixelPadding * pixelRatio);
         shader.setUniform('xAxisPointRange', axis.pointRange);
         shader.setUniform('xAxisLen', axis.len * pixelRatio);
@@ -1264,6 +1265,7 @@ class WGLRenderer {
 
         shader.setUniform('yAxisTrans', axis.transA * pixelRatio);
         shader.setUniform('yAxisMin', axis.min as any);
+        shader.setUniform('yAxisMax', axis.max as any);
         shader.setUniform('yAxisMinPad', axis.minPixelPadding * pixelRatio);
         shader.setUniform('yAxisPointRange', axis.pointRange);
         shader.setUniform('yAxisLen', axis.len * pixelRatio);

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -29,6 +29,8 @@ import type { SeriesZonesOptions } from '../../Core/Series/SeriesOptions';
 import type { WGLDrawModeValue } from './WGLDrawMode';
 import type WGLOptions from './WGLOptions';
 
+import BoostChart from './BoostChart';
+const { getBoostClipRect } = BoostChart;
 import Color from '../../Core/Color/Color.js';
 const { parse: color } = Color;
 import H from '../../Core/Globals.js';
@@ -1521,6 +1523,11 @@ class WGLRenderer {
             // Do the actual rendering
             // If the line width is < 0, skip rendering of the lines. See #7833.
             if (lineWidth > 0 || s.drawMode !== 'LINE_STRIP') {
+                const { x: cx, y: cy, width: cw, height: ch } =
+                    getBoostClipRect(chart, s.series);
+
+                gl.enable(gl.SCISSOR_TEST);
+                gl.scissor(cx, height - cy - ch, cw, ch);
                 for (sindex = 0; sindex < s.segments.length; sindex++) {
                     vbuffer.render(
                         s.segments[sindex].from,
@@ -1528,6 +1535,7 @@ class WGLRenderer {
                         s.drawMode
                     );
                 }
+                gl.disable(gl.SCISSOR_TEST);
             }
 
             if (s.hasMarkers && showMarkers) {

--- a/ts/Extensions/Boost/WGLShader.ts
+++ b/ts/Extensions/Boost/WGLShader.ts
@@ -98,6 +98,7 @@ const vertexShader = [
 
     'uniform float xAxisTrans;',
     'uniform float xAxisMin;',
+    'uniform float xAxisMax;',
     'uniform float xAxisMinPad;',
     'uniform float xAxisPointRange;',
     'uniform float xAxisLen;',
@@ -111,6 +112,7 @@ const vertexShader = [
 
     'uniform float yAxisTrans;',
     'uniform float yAxisMin;',
+    'uniform float yAxisMax;',
     'uniform float yAxisMinPad;',
     'uniform float yAxisPointRange;',
     'uniform float yAxisLen;',
@@ -122,6 +124,7 @@ const vertexShader = [
     'uniform bool  yAxisIsLog;',
     'uniform bool  yAxisReversed;',
 
+    'uniform bool  isCircle;',
     'uniform bool  isBubble;',
     'uniform bool  bubbleSizeByArea;',
     'uniform float bubbleZMin;',
@@ -218,6 +221,19 @@ const vertexShader = [
     '}',
 
     'void main(void) {',
+        // It's not working correctly on useGPUTranslations off, because we
+        // operate on pixel values then, not on axis values. Maybe we should
+        // just skip outer points before pushing them to the vertex buffer?
+        'if (!skipTranslation && isCircle && (',
+            'aVertexPosition.x < xAxisMin ||',
+            'aVertexPosition.x > xAxisMax ||',
+            'aVertexPosition.y < yAxisMin ||',
+            'aVertexPosition.y > yAxisMax',
+        ')) {',
+            'gl_Position = vec4(2.0, 2.0, 2.0, 1.0);',
+            'return;',
+        '}',
+
         'if (isBubble){',
             'gl_PointSize = bubbleRadius();',
         '} else {',

--- a/ts/Extensions/Boost/WGLShader.ts
+++ b/ts/Extensions/Boost/WGLShader.ts
@@ -221,6 +221,14 @@ const vertexShader = [
     '}',
 
     'void main(void) {',
+        'if (isBubble){',
+            'gl_PointSize = bubbleRadius();',
+        '} else {',
+            'gl_PointSize = pSize;',
+        '}',
+        // 'gl_PointSize = 10.0;',
+        'vColor = aColor;',
+
         // It's not working correctly on useGPUTranslations off, because we
         // operate on pixel values then, not on axis values. Maybe we should
         // just skip outer points before pushing them to the vertex buffer?
@@ -230,19 +238,8 @@ const vertexShader = [
             'aVertexPosition.y < yAxisMin ||',
             'aVertexPosition.y > yAxisMax',
         ')) {',
-            'gl_Position = vec4(2.0, 2.0, 2.0, 1.0);',
-            'return;',
-        '}',
-
-        'if (isBubble){',
-            'gl_PointSize = bubbleRadius();',
-        '} else {',
-            'gl_PointSize = pSize;',
-        '}',
-        // 'gl_PointSize = 10.0;',
-        'vColor = aColor;',
-
-        'if (skipTranslation && isInverted) {',
+            'gl_Position = uPMatrix * vec4(2.0, 2.0, 2.0, 1.0);',
+        '} else if (skipTranslation && isInverted) {',
             // If we get translated values from JS, just swap them (x, y)
             'gl_Position = uPMatrix * vec4(aVertexPosition.y + yAxisPos, aVertexPosition.x + xAxisPos, 0.0, 1.0);',
         '} else if (isInverted) {',

--- a/ts/Extensions/BoostCanvas.ts
+++ b/ts/Extensions/BoostCanvas.ts
@@ -149,8 +149,6 @@ namespace BoostCanvas {
      *
      * */
 
-    let ChartConstructor: typeof Chart;
-
     let destroyLoadingDiv: number;
 
     /* *
@@ -232,7 +230,6 @@ namespace BoostCanvas {
                 scatter: ScatterSeries
             } = seriesTypes;
 
-            ChartConstructor = ChartClass;
             ChartClass.prototype.callbacks.push((chart): void => {
                 addEvent(chart, 'predraw', onChartClear);
                 addEvent(chart, 'render', onChartCanvasToSVG);
@@ -429,11 +426,7 @@ namespace BoostCanvas {
             };
 
             boost.clipRect = chart.renderer.clipRect();
-            // Debugging:
-            // boost.target.clip(boost.clipRect);
-
-        } else if (!(target instanceof ChartConstructor)) {
-            ///  ctx.clearRect(0, 0, width, height);
+            boost.target.clip(boost.clipRect);
         }
 
         if (boost.canvas.width !== width) {

--- a/ts/Extensions/BoostCanvas.ts
+++ b/ts/Extensions/BoostCanvas.ts
@@ -429,7 +429,8 @@ namespace BoostCanvas {
             };
 
             boost.clipRect = chart.renderer.clipRect();
-            boost.target.clip(boost.clipRect);
+            // Debugging:
+            // boost.target.clip(boost.clipRect);
 
         } else if (!(target instanceof ChartConstructor)) {
             ///  ctx.clearRect(0, 0, width, height);


### PR DESCRIPTION
Fixed #9799, in boost mode, markers on axis were partially clipped.

Might also solve #22949; clipping issue with resize after legend toggle.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208639853541968