### PR TITLE
bugfix/light-dark-credits

### DIFF
--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -987,6 +987,22 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
 }
 
 /* Credits */
+.highcharts-datagrid-credits:empty {
+    display: block;
+    width: 114px;
+    height: 20px;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-image: url("https://assets.highcharts.com/grid/logo_light.png");
+}
+
+.highcharts-light .highcharts-datagrid-credits:empty {
+    background-image: url("https://assets.highcharts.com/grid/logo_light.png");
+}
+
+.highcharts-dark .highcharts-datagrid-credits:empty {
+    background-image: url("https://assets.highcharts.com/grid/logo_dark.png");
+}
 
 .hcg-credits-container.hcg-credits-pro,
 .highcharts-datagrid-credits-container.highcharts-datagrid-credits-pro {
@@ -1089,6 +1105,10 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
     .highcharts-datagrid-theme-default {
         --hcg-color: var(--highcharts-neutral-color-100, #ffffff);
         --hcg-background: var(--highcharts-background-color, #141414);
+    }
+
+    .highcharts-datagrid-credits:empty {
+        background-image: url("https://assets.highcharts.com/grid/logo_dark.png");
     }
 }
 

--- a/css/datagrid/datagrid.css
+++ b/css/datagrid/datagrid.css
@@ -993,15 +993,30 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
     height: 20px;
     background-size: contain;
     background-repeat: no-repeat;
-    background-image: url("https://assets.highcharts.com/grid/logo_light.png");
+    background-image:
+        image-set(
+            /* stylelint-disable-next-line function-comma-newline-after */
+            url("https://assets.highcharts.com/grid/logo_light.png") 1x,
+            url("https://assets.highcharts.com/grid/logo_lightx2.png") 2x
+        );
 }
 
 .highcharts-light .highcharts-datagrid-credits:empty {
-    background-image: url("https://assets.highcharts.com/grid/logo_light.png");
+    background-image:
+        image-set(
+            /* stylelint-disable-next-line function-comma-newline-after */
+            url("https://assets.highcharts.com/grid/logo_light.png") 1x,
+            url("https://assets.highcharts.com/grid/logo_lightx2.png") 2x
+        );
 }
 
 .highcharts-dark .highcharts-datagrid-credits:empty {
-    background-image: url("https://assets.highcharts.com/grid/logo_dark.png");
+    background-image:
+        image-set(
+            /* stylelint-disable-next-line function-comma-newline-after */
+            url("https://assets.highcharts.com/grid/logo_dark.png") 1x,
+            url("https://assets.highcharts.com/grid/logo_darkx2.png") 2x
+        );
 }
 
 .hcg-credits-container.hcg-credits-pro,
@@ -1108,7 +1123,12 @@ th.highcharts-datagrid-column-sortable > .highcharts-datagrid-column-sortable-ic
     }
 
     .highcharts-datagrid-credits:empty {
-        background-image: url("https://assets.highcharts.com/grid/logo_dark.png");
+        background-image:
+            image-set(
+                /* stylelint-disable-next-line function-comma-newline-after */
+                url("https://assets.highcharts.com/grid/logo_dark.png") 1x,
+                url("https://assets.highcharts.com/grid/logo_darkx2.png") 2x
+            );
     }
 }
 

--- a/css/grid/grid.css
+++ b/css/grid/grid.css
@@ -791,15 +791,30 @@ th.hcg-column-sortable > .hcg-column-sortable-icon {
     height: 20px;
     background-size: contain;
     background-repeat: no-repeat;
-    background-image: url("https://assets.highcharts.com/grid/logo_light.png");
+    background-image:
+        image-set(
+            /* stylelint-disable-next-line function-comma-newline-after */
+            url("https://assets.highcharts.com/grid/logo_light.png") 1x,
+            url("https://assets.highcharts.com/grid/logo_lightx2.png") 2x
+        );
 }
 
 .highcharts-light .hcg-credits {
-    background-image: url("https://assets.highcharts.com/grid/logo_light.png");
+    background-image:
+        image-set(
+            /* stylelint-disable-next-line function-comma-newline-after */
+            url("https://assets.highcharts.com/grid/logo_light.png") 1x,
+            url("https://assets.highcharts.com/grid/logo_lightx2.png") 2x
+        );
 }
 
 .highcharts-dark .hcg-credits {
-    background-image: url("https://assets.highcharts.com/grid/logo_dark.png");
+    background-image:
+        image-set(
+            /* stylelint-disable-next-line function-comma-newline-after */
+            url("https://assets.highcharts.com/grid/logo_dark.png") 1x,
+            url("https://assets.highcharts.com/grid/logo_darkx2.png") 2x
+        );
 }
 
 .hcg-credits-container.hcg-credits-pro {
@@ -949,7 +964,12 @@ th.hcg-column-sortable > .hcg-column-sortable-icon {
     }
 
     .hcg-credits {
-        background-image: url("https://assets.highcharts.com/grid/logo_dark.png");
+        background-image:
+            image-set(
+                /* stylelint-disable-next-line function-comma-newline-after */
+                url("https://assets.highcharts.com/grid/logo_dark.png") 1x,
+                url("https://assets.highcharts.com/grid/logo_darkx2.png") 2x
+            );
     }
 }
 

--- a/css/grid/grid.css
+++ b/css/grid/grid.css
@@ -785,6 +785,23 @@ th.hcg-column-sortable > .hcg-column-sortable-icon {
 
 /* Credits */
 
+.hcg-credits {
+    display: block;
+    width: 114px;
+    height: 20px;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-image: url("https://assets.highcharts.com/grid/logo_light.png");
+}
+
+.highcharts-light .hcg-credits {
+    background-image: url("https://assets.highcharts.com/grid/logo_light.png");
+}
+
+.highcharts-dark .hcg-credits {
+    background-image: url("https://assets.highcharts.com/grid/logo_dark.png");
+}
+
 .hcg-credits-container.hcg-credits-pro {
     text-align: var(--ig-credits-text-align);
     padding: var(--ig-credits-padding);
@@ -929,6 +946,10 @@ th.hcg-column-sortable > .hcg-column-sortable-icon {
     .hcg-theme-default {
         --hcg-color: var(--highcharts-neutral-color-100, #ffffff);
         --hcg-background: var(--highcharts-background-color, #141414);
+    }
+
+    .hcg-credits {
+        background-image: url("https://assets.highcharts.com/grid/logo_dark.png");
     }
 }
 

--- a/samples/grid-pro/cypress/credits-pro/demo.js
+++ b/samples/grid-pro/cypress/credits-pro/demo.js
@@ -9,8 +9,6 @@ window.grid = Grid.grid('container', {
     },
     credits: {
         enabled: true,
-        position: 'top',
-        text: 'overwriteText',
-        href: 'https://customurl.com'
+        position: 'top'
     }
 });

--- a/test/cypress/grid/integration/grid-lite/credits.cy.js
+++ b/test/cypress/grid/integration/grid-lite/credits.cy.js
@@ -1,9 +1,9 @@
 describe('Credits.', () => {
     it('Credits are default and not configurable.', () => {
         cy.visit('/grid-lite/cypress/credits/');
-        cy.get('.hcg-credits')
-            .should('not.contain', 'overwriteText')
-            .find('img').should('exist'); // Default Highcharts icon
+        cy.get('a.hcg-credits')
+            .should('have.attr', 'href', 'https://www.highcharts.com')
+            .should('exist');
 
         cy.window().its('Grid').then((grid) => {
             grid.grids[0].update({
@@ -12,8 +12,9 @@ describe('Credits.', () => {
                 }
             });
 
-            cy.get('.hcg-credits')
-                .find('img').should('exist'); // Default Highcharts icon
+        cy.get('a.hcg-credits')
+            .should('have.attr', 'href', 'https://www.highcharts.com')
+            .should('exist');
         });
     });
 });

--- a/test/cypress/grid/integration/grid-lite/credits.cy.js
+++ b/test/cypress/grid/integration/grid-lite/credits.cy.js
@@ -12,6 +12,14 @@ describe('Credits.', () => {
                 }
             });
 
+        cy.grid().then((grid) => {
+            grid.update({
+            credits: {
+                    enabled: false
+                }
+            });
+        });
+
         cy.get('a.hcg-credits')
             .should('have.attr', 'href', 'https://www.highcharts.com')
             .should('exist');

--- a/test/cypress/grid/integration/grid-pro/credits.cy.js
+++ b/test/cypress/grid/integration/grid-pro/credits.cy.js
@@ -1,18 +1,40 @@
 describe('Credits.', () => {
-    it('Credits can be configurable.', () => {
+    beforeEach(() => {
         cy.visit('/grid-pro/cypress/credits-pro/');
-        cy.get('.highcharts-datagrid-credits')
-            .should('contain', 'overwriteText')
-            .find('img').should('not.exist'); // Default Highcharts icon
+    });
 
-        cy.window().its('Grid').then((grid) => {
-            grid.grids[0].update({
+    it('Default credits should be displayed.', () => {
+        cy.get('.highcharts-datagrid-credits')
+            .should('have.css', 'background-image')
+            .then((bg) => {
+                expect(bg).to.contain('https://assets.highcharts.com/grid/logo_light.png');
+            });
+    });
+
+    it('Credits should be configurable.', () => {
+        cy.grid().then((grid) => {
+            grid.update({
+                credits: {
+                    enabled: true,
+                    position: 'top',
+                    text: 'overwriteText',
+                    href: 'https://customurl.com'
+                }
+            });
+        });
+
+        cy.get('.highcharts-datagrid-credits').should('contain', 'overwriteText');
+        cy.get('.highcharts-datagrid-credits').should('have.css', 'background-image', 'none');
+    });
+
+    it('Disabled credits should not be displayed.', () => {
+        cy.grid().then((grid) => {
+            grid.update({
                 credits: {
                     enabled: false
                 }
             });
         });
-
         cy.get('.highcharts-datagrid-credits').should('not.exist');
     });
 });

--- a/ts/Grid/Core/Credits.ts
+++ b/ts/Grid/Core/Credits.ts
@@ -52,11 +52,7 @@ class Credits {
      */
     public static defaultOptions: CreditsOptions = {
         enabled: true,
-        // eslint-disable-next-line no-console
-        text: `<picture class="hcg-logo-wrapper">
-            <source srcset="https://assets.highcharts.com/grid/logo_darkx2.png 2x, https://assets.highcharts.com/grid/logo_dark.png 1x" media="(prefers-color-scheme: dark)">
-            <img src="https://assets.highcharts.com/grid/logo_light.png" srcset="https://assets.highcharts.com/grid/logo_lightx2.png 2x, https://assets.highcharts.com/grid/logo_light.png 1x" alt="Highcharts logo" style="height: 20px !important; width: auto !important; display: inline-block !important;">
-        </picture>`,
+        text: '',
         href: 'https://www.highcharts.com',
         position: 'bottom'
     };
@@ -141,8 +137,10 @@ class Credits {
             this.textElement = this.renderAnchor();
         }
 
-        if (text && href) {
+        if (text) {
             setHTMLContent(this.textElement, text);
+        }
+        if (href) {
             this.textElement.setAttribute('href', href || '');
         }
 
@@ -162,6 +160,7 @@ class Credits {
         }, this.containerElement);
 
         anchorElement.setAttribute('target', '_blank');
+        anchorElement.setAttribute('alt', 'Highcharts logo');
 
         return anchorElement;
     }

--- a/ts/Grid/Lite/Credits/CreditsLiteComposition.ts
+++ b/ts/Grid/Lite/Credits/CreditsLiteComposition.ts
@@ -58,13 +58,15 @@ namespace CreditsLiteComposition {
         const containerStyle = credits.containerElement.style;
 
         // Apply static styles
-        containerStyle.setProperty('display', 'inline-block', 'important');
+        containerStyle.setProperty('display', 'flex', 'important');
         containerStyle.setProperty('padding', '5px 5px 0px 5px', 'important');
-        containerStyle.setProperty('text-align', 'right', 'important');
+        containerStyle.setProperty(
+            'flex-direction', 'row-reverse', 'important'
+        );
 
         // Create an observer that check credits modifications
         creditsObserver = new MutationObserver((): void => {
-            if (!credits.containerElement.querySelector('.hcg-logo-wrapper')) {
+            if (!credits.containerElement.querySelector('.hcg-credits')) {
                 credits.render();
             }
         });


### PR DESCRIPTION
Fixed, the credits logo was incorrect when the `highcharts-dark` or `highcharts-light` class was added to the parent container.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210685696487063