### PR TITLE
dash/samples-validator-test

### DIFF
--- a/test/cypress/grid/config.mjs
+++ b/test/cypress/grid/config.mjs
@@ -1,11 +1,28 @@
 import { defineConfig } from 'cypress';
 
 import defaultConfig from '../../../cypress.config.mjs';
+import { readdirSync } from 'node:fs';
+
+const gridLiteDir = '../../../samples/grid-lite/';
+const gridProDir =  '../../../samples/grid-pro/';
+
+function getDemoFiles(dir) {
+    return readdirSync(dir,{ recursive: true })
+        .filter((file) => file.endsWith('.html'))
+        .map((file) => file.replace('\/demo.html', ''));
+}
 
 export default defineConfig({
     ...defaultConfig,
     e2e: {
         ...defaultConfig.e2e,
-        specPattern: 'test/cypress/grid/integration/**/*.cy.{js,jsx,ts,tsx}'
+        specPattern: 'test/cypress/grid/integration/**/*.cy.{js,jsx,ts,tsx}',
+        setupNodeEvents(on, config) {
+            config.env.demoPaths = {
+                gridLitePaths: getDemoFiles(gridLiteDir),
+                gridProPaths: getDemoFiles(gridProDir)
+            };
+            return config;
+        }
     }
 });

--- a/test/cypress/grid/integration/demos.cy.js
+++ b/test/cypress/grid/integration/demos.cy.js
@@ -1,0 +1,55 @@
+const { gridLitePaths, gridProPaths } = Cypress.env('demoPaths') || [];
+const gridLiteDir = '/grid-lite/';
+const gridProDir = '/grid-pro/';
+
+describe('Grid Lite demos', () => {
+    gridLitePaths.forEach((demoPath) => {
+        it(`should not have console errors in ${demoPath}`, () => {
+            let errorMessages = [];
+            cy.on('window:before:load', (win) => {
+                cy.stub(win.console, 'error').callsFake((msg) => {
+                    errorMessages.push(msg);
+                });
+                win.onerror = function (msg) {
+                    errorMessages.push(msg);
+                };
+                win.addEventListener('unhandledrejection', (event) => {
+                    errorMessages.push(event.reason);
+                });
+            });
+            cy.visit(gridLiteDir + demoPath);
+            cy.then(() => {
+                expect(
+                    errorMessages,
+                    `Console errors in ${demoPath}`
+                ).to.be.empty;
+            });
+        });
+    });
+});
+
+describe('Grid Pro demos', () => {
+    gridProPaths.forEach((demoPath) => {
+        it(`should not have console errors in ${demoPath}`, () => {
+            let errorMessages = [];
+            cy.on('window:before:load', (win) => {
+                cy.stub(win.console, 'error').callsFake((msg) => {
+                    errorMessages.push(msg);
+                });
+                win.onerror = function (msg) {
+                    errorMessages.push(msg);
+                };
+                win.addEventListener('unhandledrejection', (event) => {
+                    errorMessages.push(event.reason);
+                });
+            });
+            cy.visit(gridProDir + demoPath);
+            cy.then(() => {
+                expect(
+                    errorMessages,
+                    `Console errors in ${demoPath}`
+                ).to.be.empty;
+            });
+        });
+    });
+});


### PR DESCRIPTION
Added a test for checking errors in demos and samples.

---- 
Should be run with Cypress Grid config: `npx cypress open --config-file test/cypress/grid/config.mjs`