### PR TITLE
dash/force-ligth-mode-docs

### DIFF
--- a/docs/dashboards/custom-component.md
+++ b/docs/dashboards/custom-component.md
@@ -3,7 +3,7 @@
 ## Custom HTML Component
 The basic HTML component described in the [Types of Components](https://www.highcharts.com/docs/dashboards/types-of-components) doesn't allow the reuse of the HTML code, which is already present in the DOM. To overcome this limitation, you can create a custom HTML component, which will allow you to reference the HTML element by its `id` attribute or pass the HTML as a string to the `html` property.
 
-<iframe style="width: 100%; height: 590px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/components/custom-html-component" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 590px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/components/custom-html-component?force-light-theme" allow="fullscreen"></iframe>
 
 This custom component will extend the basic HTML component, so we must import the `HTMLComponent` class. The easiest way is through the `ComponentRegistry`, as shown below. We will also use the `Dashboards.AST` class, which will be used to parse the string-type HTML into an AST-like object. In case something is missing in the AST class, you can extend it the same way as in Highcharts. See the documentation for [AST](https://api.highcharts.com/class-reference/Highcharts.AST).
 
@@ -83,7 +83,7 @@ Dashboards.board('container', {
 ## Custom Threshold Component
 Sometimes, you may want to create a component that works as if it changes its type and/or options depending on certain conditions. Such a condition may be, for example, value. The example below shows how to program a custom so-called Threshold Component.
 
-<iframe style="width: 100%; height: 700px; border: none;" src='https://www.highcharts.com/samples/embed/dashboards/components/custom-threshold-component' allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 700px; border: none;" src='https://www.highcharts.com/samples/embed/dashboards/components/custom-threshold-component?force-light-theme' allow="fullscreen"></iframe>
 
 Such a component can be implemented very similarly to the previously described `YouTubeComponent`, except that you need to consider replacing the default cell content with the child component. This can be achieved by overriding the render method with the code for clearing the cell content and then the logic for creating and updating a new component like this:
 
@@ -256,7 +256,7 @@ The example below shows how to develop a custom component that fetches data from
 
 The custom component is created by extending the `HTMLComponent` class, which displays the total revenue.
 
-<iframe style="width: 100%; height: 700px; border: none;" src='https://www.highcharts.com/samples/embed/dashboards/components/custom-component-data-connector' allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 700px; border: none;" src='https://www.highcharts.com/samples/embed/dashboards/components/custom-component-data-connector?force-light-theme' allow="fullscreen"></iframe>
 
 The DataConnector is registered on the `load`, so we need to execute and await the `super.load()` method first to ensure that the `DataConnector` is registered. An important part is that the `load` method is `async` because we need to wait for the data to be fetched and processed.
 
@@ -318,7 +318,7 @@ components: [{
 ## Custom YouTube Component
 This article shows how to create a custom **Dashboards** Component. In this example, we create a YouTube Component.
 
-<iframe style="width: 100%; height: 590px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/components/custom-component" allow="fullscreen" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 590px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/components/custom-component?force-light-theme" allow="fullscreen" allow="fullscreen"></iframe>
 
 Note that to create the custom component, we are using ES6 and using the `class` and `extends` keywords, which makes creating a custom class much easier.
 

--- a/docs/dashboards/data-modifiers.md
+++ b/docs/dashboards/data-modifiers.md
@@ -136,7 +136,7 @@ Every modified table contains two methods that allow you to manage the relations
 You can check the modifiers in action with the following demos:
 
 ### Grid with MathModifier
-<iframe style="width: 100%; height: 700px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/demo/grid-mathmodifier" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 700px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/demo/grid-mathmodifier?force-light-theme" allow="fullscreen"></iframe>
 
 ### CSV data with RangeModifier
-<iframe style="width: 100%; height: 733px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/data/csv-modifiers" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 733px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/data/csv-modifiers?force-light-theme" allow="fullscreen"></iframe>

--- a/docs/dashboards/data-pool-and-connectors.md
+++ b/docs/dashboards/data-pool-and-connectors.md
@@ -132,7 +132,7 @@ Spreadsheet key: **1U17c4GljMWpgk1bcTvUzIuWT8vdOnlCBHTm5S8Jh8tw**
 
 ### Basic demo
 
-<iframe style="width: 100%; height: 450px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/data/googlesheets-tutorial" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 450px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/data/googlesheets-tutorial?force-light-theme" allow="fullscreen"></iframe>
 
 
 ## HTMLTableConnector
@@ -303,4 +303,4 @@ The `MQTTConnector` can be reused for other applications by copying the entire c
 MQTTConnector.registerType('MQTT', MQTTConnector);
 ```
 
-<iframe style="width: 100%; height: 450px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/data/mqtt-connector" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 450px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/data/mqtt-connector?force-light-theme" allow="fullscreen"></iframe>

--- a/docs/dashboards/edit-mode.md
+++ b/docs/dashboards/edit-mode.md
@@ -159,7 +159,7 @@ items: [{
 ## Edit mode live example
 
 Use the context menu on the upper-right corner to enable and explore the edit mode.
-<iframe style="width: 100%; height: 600px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/edit-mode/ctx-enabled" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 600px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/edit-mode/ctx-enabled?force-light-theme" allow="fullscreen"></iframe>
 
 
 ## Edit mode events

--- a/docs/dashboards/get-options.md
+++ b/docs/dashboards/get-options.md
@@ -3,7 +3,7 @@
 **Dashboards** allows you to convert the current state of the dashboard's options into
 JSON. Please note that the [getOptions()](https://api.highcharts.com/dashboards/#classes/Dashboards_Board.Board-1#getOptions) function does not support converting functions or events into a JSON object.
 
-<iframe style="width: 100%; height: 700px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/exporting/export-to-json" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 700px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/exporting/export-to-json?force-light-theme" allow="fullscreen"></iframe>
 
 ## How to use `getOptions()`
 In the example below, the [getOptions()](https://api.highcharts.com/dashboards/#classes/Dashboards_Board.Board-1#getOptions)

--- a/docs/dashboards/grid-component.md
+++ b/docs/dashboards/grid-component.md
@@ -2,7 +2,7 @@
 
 **Highcharts Grid Pro** can be placed as a component inside a dashboard's cell to allow users to visualize the data a tabular format.
 
-<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/grid-component/grid-options" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/grid-component/grid-options?force-light-theme" allow="fullscreen"></iframe>
 
 ## How to start
 
@@ -166,7 +166,7 @@ Note that you also need to import modules to use the appropriate modifiers. For 
 
 One of the many available options for the **Grid Component** is the [`sync` option](https://api.highcharts.com/dashboards/#interfaces/Dashboards_Components_DataGridComponent_DataGridComponentOptions.Options#sync), which allows setting the synchronization of component states with each other. You can find more information about it in the [sync article](https://www.highcharts.com/docs/dashboards/synchronize-components).
 
-<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/component-options/sync-highlight" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/component-options/sync-highlight?force-light-theme" allow="fullscreen"></iframe>
 
 The sync can be an object configuration containing: `highlight`, `visibility` and `extremes`, which allow enabling or disabling the types of synchronization by passing the value `true` or `false`.
 
@@ -193,5 +193,5 @@ If you want to scroll the **Grid Component** automatically to a highlighted row,
 the [`autoScroll`](https://api.highcharts.com/dashboards/#interfaces/Dashboards_Components_DataGridComponent_DataGridComponentOptions.DataGridHighlightSyncOptions) option.
 
 Demo:
-<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/sync/grid-highlight-sync-autoscroll" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/sync/grid-highlight-sync-autoscroll?force-light-theme" allow="fullscreen"></iframe>
 

--- a/docs/dashboards/highcharts-component.md
+++ b/docs/dashboards/highcharts-component.md
@@ -2,7 +2,7 @@
 
 The **Highcharts** Component allows the end-user to define a chart in the dashboard. Charts are generally used to visualize changing data.
 
-<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/components/component-highcharts" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/components/component-highcharts?force-light-theme" allow="fullscreen"></iframe>
 
 ## How to start
 We need to load the JavaScript and CSS files in the following order to get started.
@@ -151,7 +151,7 @@ columnAssignment: [{
     data: 'myData'
 }]
 ```
-<iframe style="width: 100%; height: 600px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/components/highcharts-column-assignment-1d-data" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 600px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/components/highcharts-column-assignment-1d-data?force-light-theme" allow="fullscreen"></iframe>
 
 ### 2. `string[]` two-dimensional
 Names of the columns that data will be used in the two-dimensional format.
@@ -161,7 +161,7 @@ columnAssignment: [{
     data: ['myX', 'myY']
 }]
 ```
-<iframe style="width: 100%; height: 600px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/components/highcharts-column-assignment-2d-data" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 600px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/components/highcharts-column-assignment-2d-data?force-light-theme" allow="fullscreen"></iframe>
 
 ### 3. `Record<string, string>`
 Object with the keys as series data key names and column names that will be used for the key-defined two-dimensional series data.
@@ -184,7 +184,7 @@ columnAssignment: [{
     }
 }]
 ```
-<iframe style="width: 100%; height: 600px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/components/highcharts-column-assignment-keys-data" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 600px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/components/highcharts-column-assignment-keys-data?force-light-theme" allow="fullscreen"></iframe>
 
 ### Multiple connectors
 
@@ -205,14 +205,14 @@ components: [{
 ```
 
 Example:
-<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/highcharts-components/multiple-connectors" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/highcharts-components/multiple-connectors?force-light-theme" allow="fullscreen"></iframe>
 
 
 ## Components synchronization
 
 One of the many available options for the Highcharts Component is the [`sync` option](https://api.highcharts.com/dashboards/#interfaces/Dashboards_Components_HighchartsComponent_HighchartsComponentOptions.Options#sync), which allows setting the synchronization of component states with each other. You can find more information about it in the [sync article](https://www.highcharts.com/docs/dashboards/synchronize-components).
 
-<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/component-options/sync-highlight" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/component-options/sync-highlight?force-light-theme" allow="fullscreen"></iframe>
 
 The sync can be an object configuration containing: `highlight`, `visibility` and `extremes`, which allow enabling or disabling the types of synchronization by passing the value `true` or `false`.
 
@@ -240,12 +240,12 @@ sync: {
 If you want to force highlight sync to always affect one specific series, use the [`affectedSeriesId`](https://api.highcharts.com/dashboards/#interfaces/Dashboards_Components_HighchartsComponent_HighchartsComponentOptions.HighchartsHighlightSyncOptions#affectedSeriesId) option in the argument specifying the ID of that series. When undefined, empty or set to null, option assignment works by default based on the hovered column and column assignment.
 
 Demo:
-<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/sync/highcharts-highlight-affected-series" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/sync/highcharts-highlight-affected-series?force-light-theme" allow="fullscreen"></iframe>
 
 If you want to determine how the highlight of points on the chart should work (i.e. whether the hover state should be set for a marker, whether the crosshair should be synced and whether the tooltip should be shown), use the `highlightPoint`, `showCrosshair` and `showTooltip` options. Read more in the [API docs](https://api.highcharts.com/dashboards/#interfaces/Dashboards_Components_HighchartsComponent_HighchartsComponentOptions.HighchartsHighlightSyncOptions#affectedSeriesId).
 
 Demo:
-<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/sync/sync-highlight-options" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/sync/sync-highlight-options?force-light-theme" allow="fullscreen"></iframe>
 
 
 

--- a/docs/dashboards/html-component.md
+++ b/docs/dashboards/html-component.md
@@ -2,7 +2,7 @@
 
 The HTML Component serves as a fundamental building block in dashboards. It offers the versatility to incorporate diverse HTML content. It is a simple yet potent tool for constructing dashboards with dynamic content. The configuration structure resembles an Abstract Syntax Tree (AST), enabling definition of tag names, attributes, and nested elements or can be defined as a string representing the HTML code.
 
-<iframe style="width: 100%; height: 470px; border: none;" src='https://www.highcharts.com/samples/embed/dashboards/components/component-html' allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 470px; border: none;" src='https://www.highcharts.com/samples/embed/dashboards/components/component-html?force-light-theme' allow="fullscreen"></iframe>
 
 ## Using the HTML component
 

--- a/docs/dashboards/kpi-component.md
+++ b/docs/dashboards/kpi-component.md
@@ -2,7 +2,7 @@
 
 The KPI component allows you to visualize *key performance indicators*.
 
-<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/components/component-kpi" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/components/component-kpi?force-light-theme" allow="fullscreen"></iframe>
 
 ## How to start
 

--- a/docs/dashboards/layout-description.md
+++ b/docs/dashboards/layout-description.md
@@ -42,7 +42,7 @@ Each row can have its own style defined, and its cells can be defined as a JS ob
 Each row consists of at least one cell, but there can be many cells in the same row. These cells are the containers for the components or the nested layout.
 
 ## Nested layout demo
-<iframe style="width: 100%; height: 600px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/gui/nested-layout" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 600px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/gui/nested-layout?force-light-theme" allow="fullscreen"></iframe>
 
 ## How the dashboard layout engine makes your dashboard responsive
 The layout calculates the position of the components. Generally, each row is placed in columns, and cells are placed in rows. When dealing with the resizer module, things get more complicated, which lets you change the width and height of the row and cell. The dashboard layout engine is based on Flexbox, and by setting width and height in percentage values, cell and row sizes are adjusted dynamically when the outer container resizes. This can happen in nested layouts when several rows are positioned inside a cell, which can also be resized.

--- a/docs/dashboards/navigator-component.md
+++ b/docs/dashboards/navigator-component.md
@@ -55,7 +55,7 @@ Read more about components synchronization [here](https://www.highcharts.com/doc
 
 ### Crossfilter Example
 
-<iframe style="width: 100%; height: 600px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/demo/crossfilter" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 600px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/demo/crossfilter?force-light-theme" allow="fullscreen"></iframe>
 
 In the [crossfilter demo](https://highcharts.com/demo/dashboards/crossfilter)
 you see the setup to limit the amount of data points. You have to define column

--- a/docs/dashboards/style-by-css.md
+++ b/docs/dashboards/style-by-css.md
@@ -222,7 +222,7 @@ Custom classes and IDs can be used to style the dashboard:
 
 The final result might look like:
 
-<iframe src="https://www.highcharts.com/samples/embed/dashboards/demo/personal-finance" allow="fullscreen"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/dashboards/demo/personal-finance?force-light-theme" allow="fullscreen"></iframe>
 
 ## Edit Mode classes
 You can also change how the Edit Mode looks like. The Edit mode is based on the

--- a/docs/dashboards/synchronize-components.md
+++ b/docs/dashboards/synchronize-components.md
@@ -2,7 +2,7 @@
 
 In addition to sharing data via the data pool, **Dashboards** components can use the synchronization mechanism to aid visualization, navigation and highlighting of specific data.
 
-<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/demo/minimal" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 470px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/demo/minimal?force-light-theme" allow="fullscreen"></iframe>
 
 ## How to synchronize Dashboards components?
 
@@ -128,7 +128,7 @@ sync: {
 ```
 
 Demo:
-<iframe style="width: 100%; height: 651px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/sync/groups" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 651px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/sync/groups?force-light-theme" allow="fullscreen"></iframe>
 
 
 ## Custom synchronization
@@ -198,4 +198,4 @@ class CustomComponent extends Component {
 ```
 
 The below example shows how [custom sync](https://www.highcharts.com/docs/dashboards/synchronize-components) between a [Highcharts Component](https://www.highcharts.com/docs/dashboards/highcharts-component) and a [custom component](https://www.highcharts.com/docs/dashboards/custom-component) works:
-<iframe style="width: 100%; height: 651px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/sync/custom-component-sync" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 651px; border: none;" src="https://www.highcharts.com/samples/embed/dashboards/sync/custom-component-sync?force-light-theme" allow="fullscreen"></iframe>

--- a/docs/dashboards/your-first-dashboard.md
+++ b/docs/dashboards/your-first-dashboard.md
@@ -99,4 +99,4 @@ components: [{
 ## View the result
 With the above configuration, your dashboard should look like this:
 
-<iframe src="https://www.highcharts.com/samples/embed/dashboards/basic/your-first-dashboard"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/dashboards/basic/your-first-dashboard?force-light-theme"></iframe>

--- a/docs/grid/columns.md
+++ b/docs/grid/columns.md
@@ -188,6 +188,6 @@ The data type determines how the cell content is rendered. For example, setting 
 
 If this property is not defined, the data type is automatically inferred from the first cell in the column.
 
-<iframe src="https://www.highcharts.com/samples/embed/grid/basic/column-data-type" allow="fullscreen"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/grid/basic/column-data-type?force-light-theme" allow="fullscreen"></iframe>
 
 For more details on customizing cell content, refer to the [cell content section](https://www.highcharts.com/docs/grid/cell-renderers).

--- a/docs/grid/events.md
+++ b/docs/grid/events.md
@@ -110,4 +110,4 @@ columns: [{
 ```
 
 Live example:
-<iframe src="https://www.highcharts.com/samples/embed/grid-pro/basic/cell-events" allow="fullscreen"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/grid-pro/basic/cell-events?force-light-theme" allow="fullscreen"></iframe>

--- a/docs/grid/general.md
+++ b/docs/grid/general.md
@@ -88,6 +88,6 @@ Add an HTML element to the `body` with the ID you specified as the first argumen
 
 With the configuration above, your Grid should look like this:
 
-<iframe src="https://www.highcharts.com/samples/embed/grid/demo/your-first-grid" allow="fullscreen"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/grid/demo/your-first-grid?force-light-theme" allow="fullscreen"></iframe>
 
 Go to [Understanding Grid](https://www.highcharts.com/docs/grid/understanding-grid) to read more about Grid structure and configuration options.

--- a/docs/grid/header.md
+++ b/docs/grid/header.md
@@ -66,7 +66,7 @@ You can group headers however deep you want by nesting the `columns[]` option ar
 
 This example shows deeper nesting of `columns[]`:
 
-<iframe src="https://www.highcharts.com/samples/embed/grid/basic/grouped-headers" allow="fullscreen"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/grid/basic/grouped-headers?force-light-theme" allow="fullscreen"></iframe>
 
 ## Summary
 

--- a/docs/grid/sparklines.md
+++ b/docs/grid/sparklines.md
@@ -123,5 +123,5 @@ You can configure the sparkline using the `chartOptions` API option, that suppor
 ## Performance
 Sparkline supports all standard Highcharts chart options and is optimized for speed, including virtual scrolling for large datasets.
 
-<iframe src="https://www.highcharts.com/samples/embed/grid/basic/sparklines" allow="fullscreen"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/grid/basic/sparklines?force-light-theme" allow="fullscreen"></iframe>
 


### PR DESCRIPTION
Force light mode in the docs article demos.


The only demo that stays without the light mode is here: https://www.highcharts.com/docs/dashboards/light-dark-theme

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210685696487057