### PR TITLE
Added GITHUB_TOKEN to setup-geckodriver step

### DIFF
--- a/.github/workflows/highcharts-headless.yml
+++ b/.github/workflows/highcharts-headless.yml
@@ -114,6 +114,8 @@ jobs:
         with:
           firefox-version: latest-esr
       - uses: browser-actions/setup-geckodriver@latest
+        with:
+            token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Display
         run: |
           chromedriver --url-base=/wd/hub &


### PR DESCRIPTION
Should help avoid [rate limiting](https://github.com/highcharts/highcharts/actions/runs/16410811175/job/46365161966?pr=23140)