### PR TITLE
bugfix/22943-gantt-styled-labels

### DIFF
--- a/samples/unit-tests/gantt/grid-axis/demo.css
+++ b/samples/unit-tests/gantt/grid-axis/demo.css
@@ -1,3 +1,5 @@
+@import url("https://code.highcharts.com/css/highcharts.css");
+
 #container {
     max-width: 800px;
     height: 400px;

--- a/samples/unit-tests/gantt/grid-axis/demo.js
+++ b/samples/unit-tests/gantt/grid-axis/demo.js
@@ -2304,4 +2304,48 @@ QUnit.test('slotWidth', assert => {
         `For inverted chart, grid x-axis should be closed from both sides
         with two ticks.`
     );
+
+    const chartOptions = {
+        chart: {
+            styledMode: false
+        },
+        yAxis: {
+            labels: {
+                useHTML: true,
+                formatter: function () {
+                    return `<div>${this.value} 123abc<div>`;
+                }
+            }
+        },
+        series: [
+            {
+                data: [
+                    {
+                        start: 1753488000000,
+                        end: 1755648000000
+                    }
+                ]
+            }
+        ]
+    };
+
+    chart = Highcharts.ganttChart('container', chartOptions);
+
+    const normalLabelWidth = chart.yAxis[0].ticks[0].label.getBBox().width;
+
+    chart = Highcharts.ganttChart('container', {
+        ...chartOptions,
+        chart: {
+            styledMode: true
+        }
+    });
+
+    const styledLabelWidth = chart.yAxis[0].ticks[0].label.getBBox().width;
+
+    assert.close(
+        normalLabelWidth,
+        styledLabelWidth,
+        10,
+        'Non-styled and styled mode labels width should be the similar, #22943'
+    );
 });

--- a/ts/Core/Renderer/HTML/HTMLElement.ts
+++ b/ts/Core/Renderer/HTML/HTMLElement.ts
@@ -429,7 +429,8 @@ class HTMLElement extends SVGElement {
             if (textWidth !== oldTextWidth) { // #983, #1254
                 const textPxLength = getTextPxLength(),
                     textWidthNum = textWidth || 0,
-                    willOverWrap = element.style.textOverflow === '' &&
+                    willOverWrap = !renderer.styledMode &&
+                        element.style.textOverflow === '' &&
                         element.style.webkitLineClamp;
                 if (
                     (


### PR DESCRIPTION
Fixed #22943, tree axes labels with styled mode had the wrong width.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210003683381628