### PR TITLE
bugfix/22907-misplaced-tooltip-anchor

### DIFF
--- a/ts/Core/Renderer/SVG/SVGLabel.ts
+++ b/ts/Core/Renderer/SVG/SVGLabel.ts
@@ -549,17 +549,29 @@ class SVGLabel extends SVGElement {
 
     public xSetter(value: number): void {
         this.x = value; // For animation getter
+
         if (this.alignFactor) {
             value -= this.alignFactor * this.getPaddedWidth();
 
             // Force animation even when setting to the same value (#7898)
             this['forceAnimate:x'] = true;
         }
+
+        if (this.anchorX) {
+            // #22907, force anchorX to animate after x set
+            this['forceAnimate:anchorX'] = true;
+        }
+
         this.xSetting = Math.round(value);
         this.attr('translateX', this.xSetting);
     }
 
     public ySetter(value: number): void {
+        if (this.anchorY) {
+            // #22907, force anchorY to animate after y set
+            this['forceAnimate:anchorY'] = true;
+        }
+
         this.ySetting = this.y = Math.round(value);
         this.attr('translateY', this.ySetting);
     }


### PR DESCRIPTION
Fixed #22907, the tooltip anchor was misplaced in some cases when hovering close to the edge of the chart

Unable to add unit test due to wrong anchor animation.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209930695497056