### PR TITLE
Fixed double rounding for  of x-axis grid lines on stock charts

### DIFF
--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -792,7 +792,7 @@ namespace StockChart {
 
                         y1 = axis2.pos;
                         y2 = y1 + axis2.len;
-                        x1 = x2 = Math.round(transVal + axis.transB);
+                        x1 = x2 = transVal + axis.transB;
 
                         // Outside plot area
                         if (


### PR DESCRIPTION
Fixed #23399, double rounding of the pixel position for x-axis grid lines on stock charts.

Like #23025, but for horizontal axes. Since the result is [generally crisped later](https://github.com/highcharts/highcharts/blob/67ef87331fea010d2026ccb837b556a1acb10445/ts/Core/Chart/StockChart.ts#L846), `Math.round` is redundant and produces unwanted results.