### PR TITLE
Fixed #22807, SVGRenderer.fontMetrics throw exception with number input.

### DIFF
--- a/samples/unit-tests/svgrenderer/text/demo.js
+++ b/samples/unit-tests/svgrenderer/text/demo.js
@@ -874,15 +874,6 @@ QUnit.test('Text height', function (assert) {
             },
             'Number should be supported by fontMetrics.'
         );
-        assert.deepEqual(
-            renderer.fontMetrics('24px'),
-            {
-                h: 29,
-                b: 23,
-                f: 24
-            },
-            'String should be supported by fontMetrics.'
-        );
 
         // Highcharts 4.1.1, Issue #3842:
         // Bar dataLabels positions in 4.1.x - Firefox, Internet Explorer

--- a/samples/unit-tests/svgrenderer/text/demo.js
+++ b/samples/unit-tests/svgrenderer/text/demo.js
@@ -864,6 +864,26 @@ QUnit.test('Text height', function (assert) {
             })
             .add();
 
+        // Backwards compatibility, #22807
+        assert.deepEqual(
+            renderer.fontMetrics(14),
+            {
+                h: 17,
+                b: 14,
+                f: 14
+            },
+            'Number should be supported by fontMetrics.'
+        );
+        assert.deepEqual(
+            renderer.fontMetrics('24px'),
+            {
+                h: 29,
+                b: 23,
+                f: 24
+            },
+            'String should be supported by fontMetrics.'
+        );
+
         // Highcharts 4.1.1, Issue #3842:
         // Bar dataLabels positions in 4.1.x - Firefox, Internet Explorer
         assert.equal(

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -1726,13 +1726,12 @@ class SVGRenderer implements SVGRendererLike {
      *
      * @function Highcharts.SVGRenderer#fontMetrics
      *
-     * @param {Highcharts.SVGElement|Highcharts.SVGDOMElement|number|string} [ref]
-     *        The element to inspect for a current font size. If a number or
-     *        string is given, it's used as a fall back for direct font size in
-     *        pixels.
+     * @param {Highcharts.SVGElement|Highcharts.SVGDOMElement|number|string} ref
+     * The element to inspect for a current font size. If a number or string is
+     * given, it's used as a fall back for direct font size in pixels.
      *
      * @return {Highcharts.FontMetricsObject}
-     *         The font metrics.
+     * The font metrics.
      */
     public fontMetrics(
         ref: (DOMElementType|SVGElement|number|string)

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -1726,18 +1726,21 @@ class SVGRenderer implements SVGRendererLike {
      *
      * @function Highcharts.SVGRenderer#fontMetrics
      *
-     * @param {Highcharts.SVGElement|Highcharts.SVGDOMElement|number} [element]
-     *        The element to inspect for a current font size. If a number is
-     *        given, it's used as a fall back for direct font size in pixels.
+     * @param {Highcharts.SVGElement|Highcharts.SVGDOMElement|number|string} [ref]
+     *        The element to inspect for a current font size. If a number or
+     *        string is given, it's used as a fall back for direct font size in
+     *        pixels.
      *
      * @return {Highcharts.FontMetricsObject}
      *         The font metrics.
      */
     public fontMetrics(
-        element: (DOMElementType|SVGElement)
+        ref: (DOMElementType|SVGElement|number|string)
     ): FontMetricsObject {
         const f = pInt(
-            SVGElement.prototype.getStyle.call(element, 'font-size') || 0
+            isObject(ref) ?
+                (SVGElement.prototype.getStyle.call(ref, 'font-size') || 0) :
+                ref
         );
 
         // Empirical values found by comparing font size and bounding box

--- a/ts/Core/Renderer/SVG/SVGRenderer.ts
+++ b/ts/Core/Renderer/SVG/SVGRenderer.ts
@@ -1726,20 +1726,18 @@ class SVGRenderer implements SVGRendererLike {
      *
      * @function Highcharts.SVGRenderer#fontMetrics
      *
-     * @param {Highcharts.SVGElement|Highcharts.SVGDOMElement|number|string} ref
-     * The element to inspect for a current font size. If a number or string is
-     * given, it's used as a fall back for direct font size in pixels.
+     * @param {Highcharts.SVGElement|Highcharts.SVGDOMElement|number} ref
+     * The element to inspect for a current font size. If a number is given,
+     * it's used as a fall back for direct font size in pixels.
      *
      * @return {Highcharts.FontMetricsObject}
      * The font metrics.
      */
     public fontMetrics(
-        ref: (DOMElementType|SVGElement|number|string)
+        ref: (DOMElementType|SVGElement|number)
     ): FontMetricsObject {
-        const f = pInt(
-            isObject(ref) ?
-                (SVGElement.prototype.getStyle.call(ref, 'font-size') || 0) :
-                ref
+        const f = isNumber(ref) ? ref : pInt(
+            (SVGElement.prototype.getStyle.call(ref, 'font-size') || 0)
         );
 
         // Empirical values found by comparing font size and bounding box


### PR DESCRIPTION
Fixed #22807, `SVGRenderer.fontMetrics` did not support numeric arguments.