### PR TITLE
Fixed #23432, could not drill down to added treemap nodes

### DIFF
--- a/samples/unit-tests/series-treemap/update/demo.js
+++ b/samples/unit-tests/series-treemap/update/demo.js
@@ -151,7 +151,6 @@ QUnit.test('Update and z-index', function (assert) {
     }
     function addData(newData) {
         const series = chart.series[0];
-        console.log(series.options.data);
         series.update({ data: [...series.userOptions.data, ...newData] }, true);
     }
 
@@ -165,7 +164,7 @@ QUnit.test('Update and z-index', function (assert) {
     assert.strictEqual(
         chart.get('id-6').graphic.element.parentNode
             .getAttribute('data-z-index'),
-        '996',
+        '-4',
         'Added nodes to traversed tree should have a static z-index (#23432)'
     );
 });

--- a/samples/unit-tests/series-treemap/update/demo.js
+++ b/samples/unit-tests/series-treemap/update/demo.js
@@ -75,3 +75,97 @@ QUnit.test('Treemap and updates', function (assert) {
         'throw'
     );
 });
+
+QUnit.test('Update and z-index', function (assert) {
+    // Sample data for the treemap
+    const data = [
+        {
+            name: 'Root',
+            id: 'id-0'
+        },
+        {
+            name: 'Child 1',
+            id: 'id-1',
+            parent: 'id-0',
+            value: 6
+        },
+        {
+            name: 'Child 2',
+            id: 'id-2',
+            parent: 'id-0',
+            value: 4
+        },
+        {
+            name: 'Grandchild 1',
+            id: 'id-3',
+            parent: 'id-1',
+            value: 2
+        },
+        {
+            name: 'Grandchild 2',
+            id: 'id-4',
+            parent: 'id-1',
+            value: 4
+        },
+        {
+            name: 'Grandchild 5',
+            id: 'id-5',
+            parent: 'id-2',
+            value: 4
+        }
+    ];
+
+    // Initialize the treemap
+    const chart = Highcharts.chart('container', {
+        series: [
+            {
+                type: 'treemap',
+                layoutAlgorithm: 'squarified',
+                data: data,
+                allowDrillToNode: true,
+                opacity: 1,
+                interactByLeaf: false,
+                dataLabels: {
+                    enabled: false
+                },
+                levelIsConstant: false,
+                breadcrumbs: {
+                    showFullPath: true
+                },
+                levels: [
+                    {
+                        level: 1,
+                        borderWidth: 5,
+                        dataLabels: {
+                            enabled: true
+                        }
+                    }
+                ]
+            }
+        ]
+    });
+
+    function navigateToNode(nodeId) {
+        const series = chart.series[0];
+        series.setRootNode(nodeId, true);
+    }
+    function addData(newData) {
+        const series = chart.series[0];
+        console.log(series.options.data);
+        series.update({ data: [...series.userOptions.data, ...newData] }, true);
+    }
+
+    navigateToNode('id-2');
+
+    addData([
+        { name: 'Added Node 1', id: 'id-6', parent: 'id-5', value: 5 },
+        { name: 'Added Node 2', id: 'id-7', parent: 'id-5', value: 2 }
+    ]);
+
+    assert.strictEqual(
+        chart.get('id-6').graphic.element.parentNode
+            .getAttribute('data-z-index'),
+        '996',
+        'Added nodes to traversed tree should have a static z-index (#23432)'
+    );
+});

--- a/ts/Series/Treemap/TreemapSeries.ts
+++ b/ts/Series/Treemap/TreemapSeries.ts
@@ -963,11 +963,9 @@ class TreemapSeries extends ScatterSeries {
                 if (!(series as any)[groupKey]) {
                     (series as any)[groupKey] = renderer.g(groupKey)
                         .attr({
-                            // @todo Set the zIndex based upon the number of
-                            // levels, instead of using 1000.
                             // Use the static level in order to retain z-index
                             // when data is updated (#23432).
-                            zIndex: 1000 - (point.node.level || 0)
+                            zIndex: -(point.node.level || 0)
                         })
                         .add(series.group);
                     (series as any)[groupKey].survive = true;

--- a/ts/Series/Treemap/TreemapSeries.ts
+++ b/ts/Series/Treemap/TreemapSeries.ts
@@ -919,8 +919,7 @@ class TreemapSeries extends ScatterSeries {
             allowTraversingTree = options.allowTraversingTree;
 
         for (const point of points) {
-            const levelDynamic = point.node.levelDynamic,
-                animatableAttribs: SVGAttributes = {},
+            const animatableAttribs: SVGAttributes = {},
                 attribs: SVGAttributes = {},
                 css: CSSObject = {},
                 groupKey = 'level-group-' + point.node.level,
@@ -965,8 +964,10 @@ class TreemapSeries extends ScatterSeries {
                     (series as any)[groupKey] = renderer.g(groupKey)
                         .attr({
                             // @todo Set the zIndex based upon the number of
-                            // levels, instead of using 1000
-                            zIndex: 1000 - (levelDynamic || 0)
+                            // levels, instead of using 1000.
+                            // Use the static level in order to retain z-index
+                            // when data is updated (#23432).
+                            zIndex: 1000 - (point.node.level || 0)
                         })
                         .add(series.group);
                     (series as any)[groupKey].survive = true;
@@ -1268,7 +1269,7 @@ class TreemapSeries extends ScatterSeries {
 
         if (series.options.allowTraversingTree) {
             series.eventsToUnbind.push(
-                addEvent(series, 'click', series.onClickDrillToNode as any)
+                addEvent(series, 'click', series.onClickDrillToNode)
             );
 
             series.eventsToUnbind.push(


### PR DESCRIPTION
Fixed #23432, could not drill down to treemap nodes when children were added dynamically

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211015355475410