### PR TITLE
grid/rows-empty-grid-reflow-error

### DIFF
--- a/ts/Grid/Core/Table/Actions/RowsVirtualizer.ts
+++ b/ts/Grid/Core/Table/Actions/RowsVirtualizer.ts
@@ -386,6 +386,9 @@ class RowsVirtualizer {
         const { rowCursor: cursor, defaultRowHeight: defaultH } = this;
         const { rows, tbodyElement } = this.viewport;
         const rowsLn = rows.length;
+        if (rowsLn < 1) {
+            return;
+        }
 
         let translateBuffer = rows[0].getDefaultTopOffset();
 


### PR DESCRIPTION
Fixed error thrown when adjusting row heights of empty grid.