### PR TITLE
dash/bugfix-redundant-JSON-connector-data-default-option

### DIFF
--- a/ts/Data/Connectors/JSONConnector.ts
+++ b/ts/Data/Connectors/JSONConnector.ts
@@ -48,7 +48,6 @@ class JSONConnector extends DataConnector {
      * */
 
     protected static readonly defaultOptions: JSONConnectorOptions = {
-        data: [],
         enablePolling: false,
         dataRefreshRate: 0,
         firstRowAsNames: true,

--- a/ts/Data/Converters/JSONConverter.ts
+++ b/ts/Data/Converters/JSONConverter.ts
@@ -53,7 +53,6 @@ class JSONConverter extends DataConverter {
      */
     protected static readonly defaultOptions: JSONConverter.Options = {
         ...DataConverter.defaultOptions,
-        data: [],
         orientation: 'rows'
     };
 
@@ -276,7 +275,7 @@ namespace JSONConverter {
      */
     export interface Options extends DataConverter.Options {
         columnNames?: Array<string>|ColumnNamesOptions;
-        data: Data;
+        data?: Data;
         orientation: 'columns'|'rows';
     }
 


### PR DESCRIPTION
Closed #23447, Removed the redundant JSON connector data default option.