### PR TITLE
fix: Fix script error when using Highcharts in Salesforce LWC

### DIFF
--- a/ts/Core/Globals.ts
+++ b/ts/Core/Globals.ts
@@ -219,27 +219,37 @@ namespace Globals {
             'plotLeft'
         ],
         noop = function (): void {},
-        supportsPassiveEvents = (function (): boolean {
-            // Checks whether the browser supports passive events, (#11353).
+        checkSupportPassiveEvent = function (el: EventTarget = win) : boolean {
             let supportsPassive = false;
 
-            // Object.defineProperty doesn't work on IE as well as passive
-            // events - instead of using polyfill, we can exclude IE totally.
             if (!isMS) {
-                const opts = Object.defineProperty({}, 'passive', {
-                    get: function (): void {
-                        supportsPassive = true;
-                    }
-                });
+                // eslint-disable-next-line no-console
+                const originalConsoleError = console.error;
+                // eslint-disable-next-line no-console
+                console.error = function () : void {};
+                try {
+                    const opts = Object.defineProperty({}, 'passive', {
+                        get() : boolean {
+                            supportsPassive = true;
+                            return true;
+                        }
+                    });
 
-                if (win.addEventListener && win.removeEventListener) {
-                    win.addEventListener('testPassive', noop, opts);
-                    win.removeEventListener('testPassive', noop, opts);
+                    if (el.addEventListener && el.removeEventListener) {
+                        el.addEventListener('testPassive', noop, opts);
+                        el.removeEventListener('testPassive', noop, opts);
+                    }
+                } catch {
+                    supportsPassive = false;
+                } finally {
+                    // eslint-disable-next-line no-console
+                    console.error = originalConsoleError;
                 }
             }
 
             return supportsPassive;
-        }());
+        },
+        supportsPassiveEvents = checkSupportPassiveEvent();
 
     /**
      * An array containing the current chart objects in the page. A chart's

--- a/ts/Core/GlobalsLike.d.ts
+++ b/ts/Core/GlobalsLike.d.ts
@@ -55,6 +55,7 @@ export interface GlobalsLike {
     readonly pageLang?: string,
     readonly product: string;
     readonly seriesTypes: SeriesTypeRegistry;
+    checkSupportPassiveEvent: Function;
     readonly supportsPassiveEvents: boolean;
     readonly svg: boolean;
     readonly symbolSizes: Record<string, SizeObject>;

--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -1720,17 +1720,23 @@ function addEvent<T>(
     // If the browser supports passive events, add it to improve performance
     // on touch events (#11353).
     const addEventListener = (el as any).addEventListener;
+    let supportsPassiveEvents = H.supportsPassiveEvents;
+    if (addEventListener !== Element.prototype.addEventListener) {
+        supportsPassiveEvents = H.checkSupportPassiveEvent(el);
+    }
+
     if (addEventListener) {
-        addEventListener.call(
-            el,
-            type,
-            fn,
-            H.supportsPassiveEvents ? {
+        const args: any[] = [type, fn];
+
+        if (supportsPassiveEvents) {
+            args.push({
                 passive: options.passive === void 0 ?
                     type.indexOf('touch') !== -1 : options.passive,
                 capture: false
-            } : false
-        );
+            });
+        }
+
+        addEventListener.apply(el, args);
     }
 
     if (!events[type]) {


### PR DESCRIPTION
this PR fix issue #23458.

<img width="941" height="331" alt="image" src="https://github.com/user-attachments/assets/379648f6-ff3e-43fe-83fc-7688c54f262c" />

As can be seen in the image, custom tags in Salesforce LWC such as `lightning-card` and `lightning-tab` do not use the standard browser `addEventListener` as-is, but instead override it. In this case, if the options parameter is passed to `addEventListener`, a script error occurs.

```js
let parent = this.chart.renderTo.parentElement;
while (parent && parent.tagName !== 'BODY') {
    this.eventsToUnbind.push(addEvent(parent, 'scroll', (): void => {
        delete this.chartPosition;
    }));
    parent = parent.parentElement;
}
```

Inside Highcharts, there is code that registers a scroll event starting from the element where the Highchart is rendered, up to the body. In an LWC environment, if a parent element includes a Lightning Element lie `<lightning-card>` `<lightning-tab>`, it attempts to register the scroll event by calling the `addEvent` function.

```js
const addEventListener = (el as any).addEventListener;
if (addEventListener) {
    addEventListener.call(
        el,
        type,
        fn,
        H.supportsPassiveEvents ? {
            passive: options.passive === void 0 ?
                type.indexOf('touch') !== -1 : options.passive,
            capture: false
        } : false
    );
}
```
```js
supportsPassiveEvents = (function (): boolean {
    // Checks whether the browser supports passive events, (#11353).
    let supportsPassive = false;

    // Object.defineProperty doesn't work on IE as well as passive
    // events - instead of using polyfill, we can exclude IE totally.
    if (!isMS) {
        const opts = Object.defineProperty({}, 'passive', {
            get: function (): void {
                supportsPassive = true;
            }
        });

        if (win.addEventListener && win.removeEventListener) {
            win.addEventListener('testPassive', noop, opts);
            win.removeEventListener('testPassive', noop, opts);
        }
    }

    return supportsPassive;
}());
```

When the `addEvent` function is called, it checks the global variable `supportsPassiveEvents` to determine whether the options setting can be used, and if so, assigns the options variable. **The problem is that this `supportsPassiveEvents` variable checks passive support based on the browser’s standard addEventListener, but since the `addEventListener` of a Lightning Element is not the standard browser implementation to begin with, the check does not work correctly.**

```js
const addEventListener = (el as any).addEventListener;
let supportsPassiveEvents = H.supportsPassiveEvents;
if (addEventListener !== Element.prototype.addEventListener) {
    supportsPassiveEvents = H.checkSupportPassiveEvent(el);
}

if (addEventListener) {
    const args: any[] = [type, fn];

    if (supportsPassiveEvents) {
        args.push({
            passive: options.passive === void 0 ?
                type.indexOf('touch') !== -1 : options.passive,
            capture: false
        });
    }

    addEventListener.apply(el, args);
}
```

Therefore, whether a lightning elements `addEventListener` supports passive events or not should not be determined based on the browser’s standard `addEventListener`. So, I modified the code so that if the `addEventListener` of the element registering the event is not the same as `Element.prototype.addEventListener`, it checks again for passive support based on that element, and if it does not support passive events, the options parameter is not passed.
