### PR TITLE
bugfix/21666-gantt-drillup

### DIFF
--- a/samples/unit-tests/gantt/gantt/demo.js
+++ b/samples/unit-tests/gantt/gantt/demo.js
@@ -911,4 +911,60 @@
                 'Array-based points are loaded into the chart'
             );
         });
+
+    QUnit.test(
+        'labelIcon toggles on series visibility (#21666, #21532)',
+        function (assert) {
+            const chart = Highcharts.ganttChart('container', {
+                yAxis: {
+                    type: 'treegrid'
+                },
+                series: [
+                    {
+                        name: 'Project',
+                        data: [{
+                            id: 'project',
+                            name: 'Project',
+                            start: Date.UTC(2014, 10, 17),
+                            end: Date.UTC(2014, 10, 18),
+                            isParent: true,
+                            pointWidth: 0
+                        }]
+                    },
+                    {
+                        name: 'Task2',
+                        data: [{
+                            id: 'task001',
+                            name: 'Task2',
+                            start: Date.UTC(2014, 10, 17),
+                            end: Date.UTC(2014, 10, 18),
+                            y: 1,
+                            parent: 'project'
+                        }]
+                    }
+                ]
+            });
+
+            const tick = chart.yAxis[0].ticks[0];
+
+            assert.ok(
+                tick.treeGrid?.labelIcon && !tick.treeGrid.labelIcon.destroyed,
+                'Icon exists initially'
+            );
+
+            chart.series[1].hide();
+
+            assert.strictEqual(
+                tick.treeGrid.labelIcon,
+                undefined,
+                'Icon removed after hiding child series'
+            );
+
+            chart.series[1].show();
+
+            assert.ok(
+                tick.treeGrid.labelIcon && !tick.treeGrid.labelIcon.destroyed,
+                'Icon restored after showing series'
+            );
+        });
 }());

--- a/ts/Core/Axis/TreeGrid/TreeGridTick.ts
+++ b/ts/Core/Axis/TreeGrid/TreeGridTick.ts
@@ -352,6 +352,7 @@ function wrapRenderLabel(
         removeEvent(labelElement);
         label?.css({ cursor: 'default' });
         icon.destroy();
+        tickGrid.labelIcon = void 0;
     }
 }
 


### PR DESCRIPTION
Fixed #21532, #21666, tree grid label icon was not properly refreshed when toggling series visibility.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/1/222651295669536/project/1204879359430251/task/1208054844449655?focus=true
  - https://app.asana.com/1/222651295669536/project/1204879359430251/task/1207791401644877?focus=true