### PR TITLE
bugfix/23465-styled-mode-tooltip-box

### DIFF
--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -334,11 +334,6 @@
     fill: var(--highcharts-background-color);
 }
 
-.highcharts-tooltip-box {
-    stroke-width: 0;
-    fill: var(--highcharts-background-color);
-}
-
 .highcharts-tooltip-box .highcharts-label-box {
     fill: var(--highcharts-background-color);
 }


### PR DESCRIPTION
Fixed #23465, CSS for tooltip box was overwritten.