### PR TITLE
Border radius on subsequent arcs

### DIFF
--- a/samples/highcharts/demo/gauge-speedometer/demo.js
+++ b/samples/highcharts/demo/gauge-speedometer/demo.js
@@ -27,7 +27,7 @@ Highcharts.chart('container', {
         max: 200,
         tickPixelInterval: 72,
         tickPosition: 'inside',
-        tickColor: Highcharts.defaultOptions.chart.backgroundColor || '#FFFFFF',
+        tickColor: 'var(--highcharts-background-color, #FFFFFF)',
         tickLength: 20,
         tickWidth: 2,
         minorTickInterval: null,
@@ -40,21 +40,22 @@ Highcharts.chart('container', {
         lineWidth: 0,
         plotBands: [{
             from: 0,
-            to: 130,
+            to: 120,
             color: '#55BF3B', // green
-            thickness: 20,
-            borderRadius: '50%'
-        }, {
-            from: 150,
-            to: 200,
-            color: '#DF5353', // red
             thickness: 20,
             borderRadius: '50%'
         }, {
             from: 120,
             to: 160,
             color: '#DDDF0D', // yellow
-            thickness: 20
+            thickness: 20,
+            borderRadius: '50%'
+        }, {
+            from: 160,
+            to: 200,
+            color: '#DF5353', // red
+            thickness: 20,
+            borderRadius: '50%'
         }]
     },
 

--- a/samples/highcharts/demo/polar-radial-bar/demo.js
+++ b/samples/highcharts/demo/polar-radial-bar/demo.js
@@ -61,7 +61,10 @@ Highcharts.chart('container', {
             borderWidth: 0,
             pointPadding: 0,
             groupPadding: 0.15,
-            borderRadius: '50%'
+            borderRadius: {
+                radius: '50%',
+                where: 'all'
+            }
         }
     },
     series: [{

--- a/ts/Core/Axis/RadialAxis.ts
+++ b/ts/Core/Axis/RadialAxis.ts
@@ -513,12 +513,15 @@ namespace RadialAxis {
             },
             center = this.center,
             startAngleRad = this.startAngleRad,
+            borderRadius = options.borderRadius,
             fullRadius = center[2] / 2,
             offset = Math.min(this.offset, 0),
             left = this.left || 0,
             top = this.top || 0,
             percentRegex = /%$/,
-            isCircular = this.isCircular; // X axis in a polar chart
+            isCircular = this.isCircular, // X axis in a polar chart
+            trueBands = this.options.plotBands || [],
+            index = trueBands.indexOf(options);
 
         let start,
             end,
@@ -531,7 +534,19 @@ namespace RadialAxis {
                 fullRadius
             ),
             innerRadius = radiusToPixels(options.innerRadius),
-            thickness = pick(radiusToPixels(options.thickness), 10);
+            thickness = pick(radiusToPixels(options.thickness), 10),
+            brStart = true,
+            brEnd = true;
+
+        // Apply conditional border radius, only for ends of band stacks
+        if (borderRadius && index > -1) {
+            if (trueBands[index - 1] && trueBands[index - 1].to === from) {
+                brStart = false;
+            }
+            if (trueBands[index + 1] && trueBands[index + 1].from === to) {
+                brEnd = false;
+            }
+        }
 
         // Polygonal plot bands
         if (this.options.gridLineInterpolation === 'polygon') {
@@ -583,7 +598,9 @@ namespace RadialAxis {
                         outerRadius - thickness
                     ),
                     open,
-                    borderRadius: options.borderRadius
+                    borderRadius,
+                    brStart,
+                    brEnd
                 }
             );
 

--- a/ts/Extensions/BorderRadius.ts
+++ b/ts/Extensions/BorderRadius.ts
@@ -58,6 +58,9 @@ declare module '../Core/Renderer/SVG/SVGAttributes' {
         brBoxHeight?: number;
         /** The y position of the border-radius box  */
         brBoxY?: number;
+        /** Corresponding to the `borderRadius.where` option */
+        brEnd?: boolean;
+        brStart?: boolean;
     }
 }
 
@@ -66,6 +69,8 @@ declare module '../Core/Renderer/SVG/SymbolOptions' {
         borderRadius?: number|string;
         brBoxHeight?: number;
         brBoxY?: number;
+        brEnd?: boolean;
+        brStart?: boolean;
     }
 }
 
@@ -217,7 +222,14 @@ function arc(
     options: SymbolOptions = {}
 ): SVGPath {
     const path = oldArc(x, y, w, h, options),
-        { innerR = 0, r = w, start = 0, end = 0 } = options;
+        {
+            brStart = true,
+            brEnd = true,
+            innerR = 0,
+            r = w,
+            start = 0,
+            end = 0
+        } = options;
 
     if (options.open || !options.borderRadius) {
         return path;
@@ -244,6 +256,12 @@ function arc(
     // splicing in arc segments.
     let i = path.length - 1;
     while (i--) {
+        if (
+            (!brStart && (i === 0 || i === 3)) ||
+            (!brEnd && (i === 1 || i === 2))
+        ) {
+            continue;
+        }
         applyBorderRadius(
             path,
             i,
@@ -396,7 +414,9 @@ function compose(
         SVGElementClass.symbolCustomAttribs.push(
             'borderRadius',
             'brBoxHeight',
-            'brBoxY'
+            'brBoxY',
+            'brEnd',
+            'brStart'
         );
 
         oldArc = symbols.arc;

--- a/ts/Series/PolarComposition.ts
+++ b/ts/Series/PolarComposition.ts
@@ -659,7 +659,7 @@ function onSeriesAfterInit(
 }
 
 /**
- * Apply conditional rounding to stacked items
+ * Apply conditional rounding to polar bars
  */
 function onSeriesAfterColumnTranslate(
     this: Series
@@ -673,20 +673,21 @@ function onSeriesAfterColumnTranslate(
         const seriesDefault = defaultOptions.plotOptions
                 ?.[this.type]
                 ?.borderRadius,
-            borderRadius = optionsToObject(
+            { scope, where = 'end' } = optionsToObject(
                 options.borderRadius,
                 isObject(seriesDefault) ? seriesDefault : {}
             );
 
         for (const point of this.points) {
             const { shapeArgs } = point;
-            if (
-                point.shapeType === 'arc' &&
-                shapeArgs &&
-                borderRadius.scope === 'stack'
-            ) {
-                let brStart = point.stackY === point.y,
+            if (point.shapeType === 'arc' && shapeArgs) {
+                let brStart = where === 'all',
+                    brEnd = true;
+
+                if (options.stacking && scope === 'stack') {
+                    brStart = point.stackY === point.y && where === 'all',
                     brEnd = point.stackY === point.stackTotal;
+                }
 
                 if (yAxis.reversed) {
                     [brStart, brEnd] = [brEnd, brStart];

--- a/ts/Series/PolarComposition.ts
+++ b/ts/Series/PolarComposition.ts
@@ -45,6 +45,10 @@ import type Tick from '../Core/Axis/Tick';
 
 import A from '../Core/Animation/AnimationUtilities.js';
 const { animObject } = A;
+import BorderRadius from '../Extensions/BorderRadius.js';
+const { optionsToObject } = BorderRadius;
+import D from '../Core/Defaults.js';
+const { defaultOptions } = D;
 import H from '../Core/Globals.js';
 const { composed } = H;
 import Series from '../Core/Series/Series.js';
@@ -56,6 +60,7 @@ const {
     defined,
     find,
     isNumber,
+    isObject,
     merge,
     pick,
     pushUnique,
@@ -648,6 +653,47 @@ function onSeriesAfterInit(
             this.isRadialSeries = true;
             if (this.is('column')) {
                 this.isRadialBar = true;
+            }
+        }
+    }
+}
+
+/**
+ * Apply conditional rounding to stacked items
+ */
+function onSeriesAfterColumnTranslate(
+    this: Series
+): void {
+    const { chart, options, yAxis } = this;
+    if (
+        options.borderRadius &&
+        chart.polar &&
+        chart.inverted
+    ) {
+        const seriesDefault = defaultOptions.plotOptions
+                ?.[this.type]
+                ?.borderRadius,
+            borderRadius = optionsToObject(
+                options.borderRadius,
+                isObject(seriesDefault) ? seriesDefault : {}
+            );
+
+        for (const point of this.points) {
+            const { shapeArgs } = point;
+            if (
+                point.shapeType === 'arc' &&
+                shapeArgs &&
+                borderRadius.scope === 'stack'
+            ) {
+                let brStart = point.stackY === point.y,
+                    brEnd = point.stackY === point.stackTotal;
+
+                if (yAxis.reversed) {
+                    [brStart, brEnd] = [brEnd, brStart];
+                }
+
+                shapeArgs.brStart = brStart;
+                shapeArgs.brEnd = brEnd;
             }
         }
     }
@@ -1518,6 +1564,15 @@ class PolarAdditions {
             );
 
             addEvent(SeriesClass, 'afterInit', onSeriesAfterInit);
+            addEvent(
+                SeriesClass,
+                'afterColumnTranslate',
+                onSeriesAfterColumnTranslate,
+                {
+                    // After columnrange and polar column modifications
+                    order: 9
+                }
+            );
             addEvent(
                 SeriesClass,
                 'afterTranslate',


### PR DESCRIPTION
Implemented more granular border radius options on polar bar charts and radial gauge plot bands, see #23489.

Prior to this, polar bars would look like this:
<img width="715" height="662" alt="Skjermbilde 2025-08-25 kl  14 22 46" src="https://github.com/user-attachments/assets/97b45a6f-256b-4d5c-90b6-ae531da923c7" />

Plot bands on a gauge would look like this:
<img width="656" height="460" alt="Skjermbilde 2025-08-25 kl  14 24 20" src="https://github.com/user-attachments/assets/498240bc-a78c-4be5-8395-3ffb350e4810" />
