### PR TITLE
Fixed #22415, legend checkboxes disappeared after update

### DIFF
--- a/samples/unit-tests/legend/checkbox/demo.js
+++ b/samples/unit-tests/legend/checkbox/demo.js
@@ -1,17 +1,10 @@
 QUnit.test(
     'Legend items and checkboxes',
     function (assert) {
-        function countBoxes(legend) {
-            let count = 0;
-
-            legend.allItems.forEach(item => {
-                if (item.checkbox) {
-                    count++;
-                }
-            });
-
-            return count;
-        }
+        const countBoxes = legend =>
+            legend.allItems
+                .filter(item => item.checkbox?.parentElement)
+                .length;
 
         const chart = Highcharts.chart('container', {
             chart: {
@@ -97,6 +90,16 @@ QUnit.test(
             countBoxes(chart.legend),
             4,
             'Legend box contains checkboxes - 4 items'
+        );
+
+        chart.legend.update({
+            layout: 'vertical'
+        });
+
+        assert.strictEqual(
+            countBoxes(chart.legend),
+            4,
+            'Check boxes should survive legend.update (#22415)'
         );
     }
 );

--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -477,8 +477,7 @@ class Legend {
             Series|Point
         )
     ): void {
-        const checkbox = item.checkbox,
-            legendItem = item.legendItem || {};
+        const legendItem = item.legendItem || {};
 
         // Destroy SVG elements
         for (const key of ['group', 'label', 'line', 'symbol'] as const) {
@@ -487,9 +486,7 @@ class Legend {
             }
         }
 
-        if (checkbox) {
-            discardElement(checkbox);
-        }
+        item.checkbox = discardElement(item.checkbox);
 
         item.legendItem = void 0;
     }


### PR DESCRIPTION
Fixed #22415, legend checkboxes disappeared after responsive layout change or `legend.update`