### PR TITLE
bugfix/21263-flag-series-allow-classname

### DIFF
--- a/samples/unit-tests/series-flags/color/demo.js
+++ b/samples/unit-tests/series-flags/color/demo.js
@@ -29,3 +29,34 @@ QUnit.test(
         );
     }
 );
+
+
+QUnit.test(
+    'Custom className should be correctly added to the flag (#21263).',
+    assert => {
+        const chart = Highcharts.stockChart('container', {
+            series: [
+                {
+                    data: [10, 20, 30]
+                },
+                {
+                    type: 'flags',
+                    data: [
+                        {
+                            x: 1,
+                            title: 'F',
+                            text: 'FlagText',
+                            className: 'custom-flag'
+                        }
+                    ]
+                }
+            ]
+        });
+
+        assert.strictEqual(
+            chart.series[1].points[0].getClassName().split(' ')[2],
+            'custom-flag',
+            'Correct className is applied to the flag point.'
+        );
+    }
+);

--- a/ts/Series/Flags/FlagsSeries.ts
+++ b/ts/Series/Flags/FlagsSeries.ts
@@ -211,7 +211,7 @@ class FlagsSeries extends ColumnSeries {
                         void 0,
                         options.useHTML
                     )
-                        .addClass('highcharts-point')
+                        .addClass(point.getClassName())
                         .add(series.markerGroup);
 
                     // Add reference to the point for tracker (#6303)

--- a/ts/Series/Line/LineSeries.ts
+++ b/ts/Series/Line/LineSeries.ts
@@ -490,7 +490,7 @@ export default LineSeries;
  *
  * @type      {string}
  * @since     5.0.0
- * @product   highcharts gantt
+ * @product   highcharts highstock gantt
  * @apioption series.line.data.className
  */
 


### PR DESCRIPTION
Fixed #21263, `className` were not applied to flag points.

This PR also add `series.data.className` information for Highcharts Stock API, which was excluded beforehand.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209638668930915
  - https://app.asana.com/0/0/1211160185100251