### PR TITLE
Fixed #18494, styledMode not being passed in ScrollPlotArea fixedRenderer

### DIFF
--- a/ts/Extensions/ScrollablePlotArea.ts
+++ b/ts/Extensions/ScrollablePlotArea.ts
@@ -289,7 +289,12 @@ class ScrollablePlotArea {
                 fixedDiv,
                 chart.chartWidth,
                 chart.chartHeight,
-                chartOptions.style
+                chartOptions.style,
+                // eslint-disable-next-line no-undefined
+                undefined,
+                // eslint-disable-next-line no-undefined
+                undefined,
+                chart.styledMode
             );
 
         // Mask


### PR DESCRIPTION
Fixed #18494, styledMode not being passed in ScrollPlotArea fixedRenderer

Before:
![highcharts_before](https://github.com/user-attachments/assets/6f211167-3ff3-4642-b0e2-214d9dc6ddf2)
After:
![highcharts_after](https://github.com/user-attachments/assets/10c0541d-b031-48ff-a2a4-53a7c7e0f2ac)
