### PR TITLE
Added option to assign className in navigation.bindings.

### DIFF
--- a/samples/unit-tests/stock-tools/bindings/demo.js
+++ b/samples/unit-tests/stock-tools/bindings/demo.js
@@ -31,6 +31,15 @@ QUnit.test('Bindings general tests', function (assert) {
                 gui: {
                     enabled: true
                 }
+            },
+            navigation: {
+                bindings: {
+                    segment: {
+                        annotationsOptions: {
+                            className: 'custom-annotation-class-name'
+                        }
+                    }
+                }
             }
         }),
         plotLeft = chart.plotLeft,
@@ -196,6 +205,13 @@ QUnit.test('Bindings general tests', function (assert) {
     controller.mouseUp(
         chart.plotLeft + chart.plotWidth / 2,
         chart.plotTop + chart.plotHeight / 2 + 10
+    );
+
+    assert.ok(
+        chart.annotations[3].graphic.element.classList.contains(
+            'custom-annotation-class-name'
+        ),
+        'Annotation should have a custom class name, #22902.'
     );
 
     assert.close(

--- a/ts/Extensions/Annotations/Annotation.ts
+++ b/ts/Extensions/Annotations/Annotation.ts
@@ -649,6 +649,7 @@ class Annotation extends EventEmitter implements ControlTarget {
 
         this.graphic = renderer
             .g('annotation')
+            .addClass(this.options.className || '')
             .attr({
                 opacity: 0,
                 zIndex: this.options.zIndex,
@@ -657,10 +658,6 @@ class Annotation extends EventEmitter implements ControlTarget {
                     'hidden'
             })
             .add();
-
-        if (this.options.className) {
-            this.graphic.addClass(this.options.className);
-        }
 
         this.shapesGroup = renderer
             .g('annotation-shapes')

--- a/ts/Extensions/Annotations/Annotation.ts
+++ b/ts/Extensions/Annotations/Annotation.ts
@@ -658,6 +658,10 @@ class Annotation extends EventEmitter implements ControlTarget {
             })
             .add();
 
+        if (this.options.className) {
+            this.graphic.addClass(this.options.className);
+        }
+
         this.shapesGroup = renderer
             .g('annotation-shapes')
             .add(this.graphic);

--- a/ts/Extensions/Annotations/AnnotationOptions.d.ts
+++ b/ts/Extensions/Annotations/AnnotationOptions.d.ts
@@ -47,6 +47,7 @@ export interface AnnotationEventsOptions {
 
 export interface AnnotationOptions extends ControlTargetOptions {
     animation: Partial<AnimationOptions>;
+    className?: string;
     controlPointOptions: ControlPointOptions;
     crop: boolean;
     draggable: AnnotationDraggableValue;


### PR DESCRIPTION
Fixed #22902, added `className` option in `navigation.bindings` to allow for CSS customizations of annotations.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209894444449682