### PR TITLE
Fixed #23392, changed docs default for sticky tracking

### DIFF
--- a/ts/Series/MapBubble/MapBubbleSeries.ts
+++ b/ts/Series/MapBubble/MapBubbleSeries.ts
@@ -253,7 +253,8 @@ class MapBubbleSeries extends BubbleSeries {
         joinBy: 'hc-key',
         tooltip: {
             pointFormat: '{point.name}: {point.z}'
-        }
+        },
+        stickyTracking: true
     } as MapBubbleSeriesOptions);
 
     /* *

--- a/ts/Series/MapPoint/MapPointSeriesDefaults.ts
+++ b/ts/Series/MapPoint/MapPointSeriesDefaults.ts
@@ -58,7 +58,8 @@ const MapPointSeriesDefaults: MapPointSeriesOptions = {
             color: Palette.neutralColor100
         }
     },
-    legendSymbol: 'lineMarker'
+    legendSymbol: 'lineMarker',
+    stickyTracking: true
 };
 
 /* *


### PR DESCRIPTION
Fixed #23392, changed docs default for `stickyTracking` from false to true for Map series mappoint and mapbubble.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210938732513747