### PR TITLE
bugfix/23498-org-chart-styled-mode-wrong-display

### DIFF
--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -755,7 +755,7 @@ circle.highcharts-legend-nav-inactive { /* tracker */
 }
 
 .highcharts-organization-series .highcharts-null-point {
-    --highcharts-neutral-color-3: transparent;
+    fill: transparent;
 }
 
 .highcharts-polygon-series .highcharts-graph {


### PR DESCRIPTION
Fixed #23498, wrong null points color fill in organization chart in styled mode.