### PR TITLE
demo/line-chart-tag

### DIFF
--- a/samples/highcharts/demo/line-chart/demo.details
+++ b/samples/highcharts/demo/line-chart/demo.details
@@ -8,7 +8,6 @@ alt_text: >-
   employment growth areas over time.
 tags:
   - Highcharts demo
-  - Annotations
 categories:
   - Line charts:
       priority: 1


### PR DESCRIPTION
Removed unnecessary tag from line chart demo, reported by Demo pages team.