### PR TITLE
Fixed #23564, false overlap detection on responsive data labels

### DIFF
--- a/samples/unit-tests/datalabels/overlapping/demo.js
+++ b/samples/unit-tests/datalabels/overlapping/demo.js
@@ -227,3 +227,61 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test('Overlapping labels with responsive rotation (#23564)', assert => {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            width: 120,
+            margin: 0
+        },
+        title: {
+            text: ''
+        },
+        yAxis: {
+            visible: false
+        },
+        xAxis: {
+            categories: [
+                'Apples',
+                'Pears',
+                'Oranges',
+                'Bananas',
+                'Avocados',
+                'Grapes'
+            ],
+            visible: false
+        },
+        series: [{
+            data: [3, 4, 3, 5, 4, 5],
+            type: 'column',
+            dataLabels: {
+                enabled: true,
+                format: '{point.category}',
+                align: 'right',
+                inside: true,
+                padding: 0
+            }
+        }],
+        responsive: {
+            rules: [{
+                condition: {
+                    maxWidth: 500
+                },
+                chartOptions: {
+                    series: [{
+                        dataLabels: {
+                            rotation: 90
+                        }
+                    }]
+                }
+            }]
+        }
+    });
+
+    assert.ok(
+        chart.series[0].points.every(
+            point => point.dataLabel.opacity === 1
+        ),
+        'All dataLabels should be visible (#23564).'
+    );
+});

--- a/samples/unit-tests/datalabels/usehtml/demo.js
+++ b/samples/unit-tests/datalabels/usehtml/demo.js
@@ -171,11 +171,6 @@ QUnit.test('#10765: rotated dataLabels support useHTML', function (assert) {
         unrotated, #20685.`
     );
 
-    assert.ok(
-        rotatedBLBox.y < unrotatedDLBox.y,
-        'Rotated data label box should be placed higher that unrotated, #20685.'
-    );
-
     const htmlLabel = chart.renderer.label(
             'Label', 0, 0, undefined,
             undefined, undefined, true

--- a/ts/Core/Renderer/SVG/SVGElement.ts
+++ b/ts/Core/Renderer/SVG/SVGElement.ts
@@ -1644,19 +1644,21 @@ class SVGElement implements SVGElementLike {
             boxWidth = Math.max(aX, bX, cX, dX) - x,
             boxHeight = Math.max(aY, bY, cY, dY) - y;
 
-        /* Uncomment to debug boxes
-        this.renderer.path([
+        /* Uncomment to visualize boxes
+        this.bBoxViz ??= this.renderer.path()
+            .attr({
+                stroke: 'red',
+                'stroke-width': 1,
+                zIndex: 20
+            })
+            .add();
+        this.bBoxViz.attr('d', [
             ['M', aX, aY],
             ['L', bX, bY],
             ['L', cX, cY],
             ['L', dX, dY],
             ['Z']
-        ])
-            .attr({
-                stroke: 'red',
-                'stroke-width': 1
-            })
-            .add();
+        ]);
         // */
 
         return {

--- a/ts/Core/Renderer/SVG/SVGLabel.ts
+++ b/ts/Core/Renderer/SVG/SVGLabel.ts
@@ -269,7 +269,11 @@ class SVGLabel extends SVGElement {
         // If we have a text string and the DOM bBox was 0, it typically means
         // that the label was first rendered hidden, so we need to update the
         // bBox (#15246)
-        if (this.textStr && this.bBox.width === 0 && this.bBox.height === 0) {
+        if (
+            (
+                this.textStr && this.bBox.width === 0 && this.bBox.height === 0
+            ) || this.rotation
+        ) {
             this.updateBoxSize();
         }
         const {


### PR DESCRIPTION
Fixed #23564, false positive overlap detection on responsive data labels with rotation