### PR TITLE
bugfix/23493-crosshair-label-styled-mode-too-big

### DIFF
--- a/css/highcharts.css
+++ b/css/highcharts.css
@@ -954,7 +954,7 @@ input.highcharts-range-selector {
 
 .highcharts-crosshair-label text {
     fill: var(--highcharts-background-color);
-    font-size: 1.7em;
+    font-size: 1em;
 }
 
 .highcharts-crosshair-label .highcharts-label-box {


### PR DESCRIPTION
Fixed #23493, font size of crosshair label in `styledMode` was too large.