### PR TITLE
dash/fullsreen-for-component

### DIFF
--- a/gfx/dashboards-icons/fullscreen.svg
+++ b/gfx/dashboards-icons/fullscreen.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" standalone="no"?>
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="512" height="512" viewBox="0 0 32 32" id="i-fullscreen" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentcolor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+    <path d="M4 12 L4 4 12 4 M20 4 L28 4 28 12 M4 20 L4 28 12 28 M28 20 L28 28 20 28"/>
+</svg>

--- a/samples/dashboards/demo/minimal-html/demo.js
+++ b/samples/dashboards/demo/minimal-html/demo.js
@@ -24,7 +24,8 @@ Dashboards.board('container', {
     editMode: {
         enabled: true,
         contextMenu: {
-            enabled: true
+            enabled: true,
+            items: ['editMode', 'viewFullscreen']
         }
     },
     components: [{

--- a/samples/dashboards/demo/minimal/demo.js
+++ b/samples/dashboards/demo/minimal/demo.js
@@ -24,7 +24,8 @@ Dashboards.board('container', {
     editMode: {
         enabled: true,
         contextMenu: {
-            enabled: true
+            enabled: true,
+            items: ['editMode', 'viewFullscreen']
         }
     },
     gui: {

--- a/samples/dashboards/edit-mode/toolbars-options/demo.js
+++ b/samples/dashboards/edit-mode/toolbars-options/demo.js
@@ -2,7 +2,8 @@ Dashboards.board('container', {
     editMode: {
         enabled: true,
         contextMenu: {
-            enabled: true
+            enabled: true,
+            items: ['editMode', 'viewFullscreen']
         }
     },
     gui: {
@@ -24,6 +25,9 @@ Dashboards.board('container', {
                                 enabled: false
                             },
                             settings: {
+                                enabled: false
+                            },
+                            viewFullscreen: {
                                 enabled: false
                             }
                         }

--- a/ts/Dashboards/EditMode/Fullscreen.ts
+++ b/ts/Dashboards/EditMode/Fullscreen.ts
@@ -56,23 +56,27 @@ class Fullscreen {
 
     /**
      * Toggles displaying the board in fullscreen mode.
+     *
+     * @param container
+     * The container to be displayed in fullscreen mode.
      */
-    public toggle(): void {
+    public toggle(container?: HTMLElement): void {
         const fullscreen = this,
             isOpen = this.isOpen;
 
-        fullscreen[isOpen ? 'close' : 'open']();
+        fullscreen[isOpen ? 'close' : 'open'](container);
     }
 
     /**
      * Display board in fullscreen.
      */
-    public open(): void {
+    public open(container?: HTMLElement): void {
         if (this.isOpen) {
             return;
         }
-        const fullscreen = this,
-            board = fullscreen.board;
+        const fullscreen = this;
+        const board = fullscreen.board;
+        const elementToFullscreen = container || board.boardWrapper;
 
         // Handle exitFullscreen() method when user clicks 'Escape' button.
         const unbindChange = addEvent(
@@ -93,7 +97,7 @@ class Fullscreen {
             unbindChange();
         };
 
-        const promise = board.boardWrapper.requestFullscreen();
+        const promise = elementToFullscreen.requestFullscreen();
 
         promise['catch']((): void => {
             throw new Error('Full screen is not supported.');
@@ -104,8 +108,8 @@ class Fullscreen {
      * Stops displaying the dashboard in fullscreen mode.
      */
     public close(): void {
-        const fullscreen = this,
-            board = fullscreen.board;
+        const fullscreen = this;
+        const board = fullscreen.board;
 
         // Don't fire exitFullscreen() when user exited using 'Escape' button.
         if (

--- a/ts/Dashboards/EditMode/Toolbar/CellEditToolbar.ts
+++ b/ts/Dashboards/EditMode/Toolbar/CellEditToolbar.ts
@@ -135,6 +135,23 @@ class CellEditToolbar extends EditToolbar {
             }
         });
 
+        items.push({
+            id: 'viewFullscreen',
+            type: 'icon',
+            className: EditGlobals.classNames.viewFullscreen,
+            icon: iconURLPrefix + 'fullscreen.svg',
+            events: {
+                click: function (this: MenuItem): void {
+                    const fullScreen = this.menu.parent.editMode.board.fullscreen;
+                    const container = this.menu.parent.cell.container;
+
+                    if (fullScreen) {
+                        fullScreen.toggle(container);
+                    }
+                }
+            }
+        })
+
         return items;
     }
 

--- a/ts/Dashboards/Layout/Cell.ts
+++ b/ts/Dashboards/Layout/Cell.ts
@@ -499,7 +499,7 @@ namespace Cell {
                     enabled?: boolean;
                 };
                 /**
-                 * Options for the `settings` toolbar item.
+                 * Options for the `drag` toolbar item.
                  */
                 drag: {
                     enabled?: boolean;
@@ -508,6 +508,12 @@ namespace Cell {
                  * Options for the `settings` toolbar item.
                  */
                 settings: {
+                    enabled?: boolean;
+                };
+                /**
+                 * Options for the `viewFullscreen` toolbar item.
+                 */
+                viewFullscreen: {
                     enabled?: boolean;
                 };
             }

--- a/ts/Dashboards/Layout/CellHTML.ts
+++ b/ts/Dashboards/Layout/CellHTML.ts
@@ -170,7 +170,7 @@ namespace CellHTML {
                     enabled?: boolean;
                 };
                 /**
-                 * Options for the `settings` toolbar item.
+                 * Options for the `drag` toolbar item.
                  */
                 drag: {
                     enabled?: boolean;
@@ -179,6 +179,12 @@ namespace CellHTML {
                  * Options for the `settings` toolbar item.
                  */
                 settings: {
+                    enabled?: boolean;
+                };
+                /**
+                 * Options for the `viewFullscreen` toolbar item.
+                 */
+                viewFullscreen: {
                     enabled?: boolean;
                 };
             }

--- a/ts/Dashboards/Layout/Row.ts
+++ b/ts/Dashboards/Layout/Row.ts
@@ -446,7 +446,7 @@ namespace Row {
              **/
             toolbarItems?: {
                 /**
-                 * Options for the `destroy` toolbar item.
+                 * Options for the `drag` toolbar item.
                  */
                 destroy: {
                     enabled?: boolean;


### PR DESCRIPTION
Add the possibility to full-screen individual dashboard components, see #23547.

Todo:
- [ ] Restore component size when exiting from fullscreen mode