### PR TITLE
Add 'viewBox' to HTML AST attributes

### DIFF
--- a/ts/Core/Renderer/HTML/AST.ts
+++ b/ts/Core/Renderer/HTML/AST.ts
@@ -172,6 +172,7 @@ class AST {
         'title',
         'type',
         'valign',
+        'viewBox',
         'width',
         'x',
         'x1',


### PR DESCRIPTION
You whitelisted `svg` elements, but not the `viewBox` attribute.
