### PR TITLE
docs/23575-missing-annotations-options

### DIFF
--- a/samples/unit-tests/annotations/annotations-events/demo.js
+++ b/samples/unit-tests/annotations/annotations-events/demo.js
@@ -224,7 +224,8 @@ QUnit.test('Annotations events - general', function (assert) {
                     strokeWidth: [1, 'number']
                 }
             ],
-            type: 'basicAnnotation'
+            type: 'basicAnnotation',
+            typeOptions: {}
         },
         'Annotations\' popup should get correct config for fields (#11716)'
     );

--- a/samples/unit-tests/annotations/annotations-events/demo.js
+++ b/samples/unit-tests/annotations/annotations-events/demo.js
@@ -224,8 +224,7 @@ QUnit.test('Annotations events - general', function (assert) {
                     strokeWidth: [1, 'number']
                 }
             ],
-            type: 'basicAnnotation',
-            typeOptions: {}
+            type: 'basicAnnotation'
         },
         'Annotations\' popup should get correct config for fields (#11716)'
     );

--- a/ts/Extensions/Annotations/AnnotationDefaults.ts
+++ b/ts/Extensions/Annotations/AnnotationDefaults.ts
@@ -394,7 +394,7 @@ const AnnotationDefaults: AnnotationOptions = {
      *         Ellipse annotation
      *
      * @extends annotations.controlPointOptions
-     * @type {Array<Annotations.controlPointOptions>}
+     * @type {Array<AnnotationControlPointOptionsObject>}
      * @apioption annotations.labels.controlPoints
      */
 
@@ -436,7 +436,7 @@ const AnnotationDefaults: AnnotationOptions = {
      *         Controllable image annotation
      *
      * @extends annotations.controlPointOptions
-     * @type {Array<Annotations.controlPointOptions>}
+     * @type {Array<AnnotationControlPointOptionsObject>}
      * @apioption annotations.shapes.controlPoints
      */
 

--- a/ts/Extensions/Annotations/AnnotationDefaults.ts
+++ b/ts/Extensions/Annotations/AnnotationDefaults.ts
@@ -4,7 +4,7 @@
  *
  * */
 
-import type AnnotationOptions from './AnnotationOptions';
+import type { AnnotationOptions, AnnotationTypeOptions } from './AnnotationOptions';
 import type { AnnotationPoint } from './AnnotationSeries';
 import type ControlPointOptions from './ControlPointOptions';
 
@@ -718,6 +718,81 @@ const AnnotationDefaults: AnnotationOptions = {
      * @requires modules/annotations
      */
     events: {},
+
+    /**
+     *
+     * Additional options for an annotation with the type.
+     *
+     * @requires  modules/annotations
+     * @apioption annotations.typeOptions
+     */
+    typeOptions: {
+
+        /**
+         * Background shape options for the annotation.
+         *
+         * @extends annotations.shapeOptions
+         * @apioption annotations.typeOptions.background
+         */
+
+        /**
+         * Height of the annotation in pixels.
+         *
+         * @type {number}
+         * @apioption annotations.typeOptions.height
+         */
+
+        /**
+         * Line options.
+         *
+         * @extends annotations.shapeOptions
+         * @apioption annotations.typeOptions.line
+         */
+
+        /**
+         * A single point that the annotation is attached to. It can be either
+         * the point which exists in the series - it is referenced by the
+         * point's id - or a new point with defined x, y properties
+         * and optionally axes.
+         *
+         * @type {string|AnnotationMockPointFunction|AnnotationMockPointOptionsObject}
+         * @apioption annotations.typeOptions.point
+         */
+
+        /**
+         * An array of points that the annotation is attached to. Each point can
+         * the point which exists in the series - it is referenced by the
+         * point's id - or a new point with defined x, y properties
+         * and optionally axes.
+         *
+         * @type {Array<*>}
+         * @apioption annotations.typeOptions.points
+         */
+
+        /**
+         * The annotation type identifier.
+         *
+         * @type {string}
+         * @apioption annotations.typeOptions.type
+         */
+
+        /**
+         * This number defines which xAxis the point is connected to. It refers
+         * to either the axis id or the index of the axis in the xAxis array.
+         *
+         * @type {number}
+         * @apioption annotations.typeOptions.xAxis
+         */
+
+        /**
+         * This number defines which yAxis the point is connected to. It refers
+         * to either the axis id or the index of the axis in the xAxis array.
+         *
+         * @type {number}
+         * @apioption annotations.typeOptions.yAxis
+         */
+
+    } as AnnotationTypeOptions,
 
     /**
      * Option override for specific advanced annotation types. This collection

--- a/ts/Extensions/Annotations/AnnotationDefaults.ts
+++ b/ts/Extensions/Annotations/AnnotationDefaults.ts
@@ -388,6 +388,17 @@ const AnnotationDefaults: AnnotationOptions = {
      */
 
     /**
+     * The array of control points.
+     *
+     * @sample highcharts/annotations/ellipse
+     *         Ellipse annotation
+     *
+     * @extends annotations.controlPointOptions
+     * @type {Array<Annotations.controlPointOptions>}
+     * @apioption annotations.labels.controlPoints
+     */
+
+    /**
      * This option defines the point to which the label will be
      * connected. It can be either the point which exists in the
      * series - it is referenced by the point's id - or a new point
@@ -416,6 +427,17 @@ const AnnotationDefaults: AnnotationOptions = {
      * @type      {Array<*>}
      * @extends   annotations.shapeOptions
      * @apioption annotations.shapes
+     */
+
+    /**
+     * The array of control points.
+     *
+     * @sample highcharts/annotations-advanced/controllable-image
+     *         Controllable image annotation
+     *
+     * @extends annotations.controlPointOptions
+     * @type {Array<Annotations.controlPointOptions>}
+     * @apioption annotations.shapes.controlPoints
      */
 
     /**

--- a/ts/Extensions/Annotations/AnnotationDefaults.ts
+++ b/ts/Extensions/Annotations/AnnotationDefaults.ts
@@ -799,16 +799,18 @@ const AnnotationDefaults: AnnotationOptions = {
          */
 
         /**
-         * This number defines which xAxis the point is connected to. It refers
-         * to either the axis id or the index of the axis in the xAxis array.
+         * This number defines which `xAxis` the point is connected to.
+         * It refers to either the axis id or the index of the axis
+         * in the `xAxis` array.
          *
          * @type {number}
          * @apioption annotations.typeOptions.xAxis
          */
 
         /**
-         * This number defines which yAxis the point is connected to. It refers
-         * to either the axis id or the index of the axis in the xAxis array.
+         * This number defines which `yAxis` the point is connected to.
+         * It refers to either the axis id or the index of the axis
+         * in the `yAxis` array.
          *
          * @type {number}
          * @apioption annotations.typeOptions.yAxis

--- a/ts/Extensions/Annotations/AnnotationOptions.d.ts
+++ b/ts/Extensions/Annotations/AnnotationOptions.d.ts
@@ -72,6 +72,7 @@ export interface AnnotationTypeOptions {
     line?: Partial<ControllableShapeOptions>;
     point: MockPointOptions;
     points?: Array<AnnotationTypePointsOptions>;
+    type?: string;
     xAxis?: number;
     yAxis?: number;
 }

--- a/ts/Extensions/Annotations/NavigationBindings.ts
+++ b/ts/Extensions/Annotations/NavigationBindings.ts
@@ -1082,7 +1082,10 @@ class NavigationBindings {
         }
 
         objectEach(options, (option, key): void => {
-            if (key === 'typeOptions') {
+            if (
+                key === 'typeOptions' &&
+                visualOptions['type'] !== 'basicAnnotation' // #23575
+            ) {
                 visualOptions[key] = {};
                 objectEach(
                     options[key],

--- a/ts/Extensions/Annotations/Types/CrookedLine.ts
+++ b/ts/Extensions/Annotations/Types/CrookedLine.ts
@@ -47,10 +47,6 @@ if (defaultOptions.annotations) {
          * @apioption annotations.types.crookedLine.labelOptions
          */
 
-        /**
-         * @extends   annotations.shapeOptions
-         * @apioption annotations.types.crookedLine.shapeOptions
-         */
 
         /**
          * Additional options for an annotation with the type.
@@ -106,6 +102,7 @@ if (defaultOptions.annotations) {
 
         /**
          * @excluding positioner, events
+         * @extends annotations.controlPointOptions
          */
         controlPointOptions: {
             positioner: function (

--- a/ts/Extensions/Annotations/Types/Pitchfork.ts
+++ b/ts/Extensions/Annotations/Types/Pitchfork.ts
@@ -39,11 +39,14 @@ if (defaultOptions.annotations) {
          * @optionparent annotations.types.pitchfork
          */
         {
+            /**
+             * @excluding line
+             */
             typeOptions: {
                 /**
                  * Inner background options.
                  *
-                 * @extends   annotations.types.crookedLine.shapeOptions
+                 * @extends   annotations.shapeOptions
                  * @excluding height, r, type, width
                  */
                 innerBackground: {
@@ -53,7 +56,7 @@ if (defaultOptions.annotations) {
                 /**
                  * Outer background options.
                  *
-                 * @extends   annotations.types.crookedLine.shapeOptions
+                 * @extends   annotations.shapeOptions
                  * @excluding height, r, type, width
                  */
                 outerBackground: {

--- a/ts/Extensions/Annotations/Types/VerticalLine.ts
+++ b/ts/Extensions/Annotations/Types/VerticalLine.ts
@@ -78,7 +78,7 @@ if (defaultOptions.annotations) {
             /**
              * Connector options.
              *
-             * @extends   annotations.types.crookedLine.shapeOptions
+             * @extends   annotations.shapeOptions
              * @excluding height, r, type, width
              */
             connector: {


### PR DESCRIPTION
Fixed #23575, added missing API options for advanced annotations.