### PR TITLE
bugfix/22658-last-price-visibility-on-series-toggle

### DIFF
--- a/samples/unit-tests/indicator-current-price/recalculations/demo.js
+++ b/samples/unit-tests/indicator-current-price/recalculations/demo.js
@@ -101,6 +101,9 @@ QUnit.test(
                     ]
                 }
             },
+            legend: {
+                enabled: true
+            },
             series: [{
                 compare: 'percent',
                 data: [100, 1, 1, 10, 1],
@@ -166,10 +169,27 @@ QUnit.test(
 
         chart.series[0].hide();
         assert.strictEqual(
-            lvpLabel.visibility,
-            'hidden',
-            'Last visible price label should be hidden on series hide, #22658.'
+            lvpLabel.visibility && lpLabel.visibility === 'hidden',
+            true,
+            'Both labels should be hidden after series hide, #22658.'
         );
         chart.series[0].show();
+
+        chart.addSeries({
+            data: [100],
+            visible: false,
+            lastPrice: {
+                enabled: true,
+                label: {
+                    enabled: true
+                }
+            }
+        });
+        assert.strictEqual(
+            chart.series[1].lastPriceLabel && chart.series[1].lastPrice,
+            undefined,
+            `Last price label should be hidden when series is not visible on
+            first render, #22658.`
+        );
     }
 );

--- a/samples/unit-tests/indicator-current-price/recalculations/demo.js
+++ b/samples/unit-tests/indicator-current-price/recalculations/demo.js
@@ -163,5 +163,13 @@ QUnit.test(
             `Last visible price label value should be equal to last inside point
             value, #18528.`
         );
+
+        chart.series[0].hide();
+        assert.strictEqual(
+            lvpLabel.visibility,
+            'hidden',
+            'Last visible price label should be hidden on series hide, #22658.'
+        );
+        chart.series[0].show();
     }
 );

--- a/samples/unit-tests/indicator-current-price/recalculations/demo.js
+++ b/samples/unit-tests/indicator-current-price/recalculations/demo.js
@@ -101,9 +101,6 @@ QUnit.test(
                     ]
                 }
             },
-            legend: {
-                enabled: true
-            },
             series: [{
                 compare: 'percent',
                 data: [100, 1, 1, 10, 1],

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -4778,8 +4778,14 @@ class Series {
                 'dataLabelsGroup',
                 'markerGroup',
                 'tracker',
-                'tt'
-            ] as ('group'|'dataLabelsGroup'|'markerGroup'|'tracker'|'tt')[]
+                'tt',
+                'lastPrice',
+                'lastPriceLabel',
+                'lastVisiblePrice',
+                'lastVisiblePriceLabel'
+            ] as ('group'|'dataLabelsGroup'|'markerGroup'|'tracker'|'tt'|
+                'lastPrice'|'lastPriceLabel'|'lastVisiblePrice'|
+                'lastVisiblePriceLabel')[]
         ).forEach((key): void => {
             series[key]?.[showOrHide]();
         });

--- a/ts/Extensions/PriceIndication.ts
+++ b/ts/Extensions/PriceIndication.ts
@@ -94,7 +94,8 @@ function onSeriesAfterRender(
 
     if (
         (lastVisiblePrice || lastPrice) &&
-         seriesOptions.id !== 'highcharts-navigator-series'
+         seriesOptions.id !== 'highcharts-navigator-series' &&
+         series.visible
     ) {
         const xAxis = series.xAxis,
             yAxis = series.yAxis,


### PR DESCRIPTION
Fixed #22658, last price indicator was not hidden with parent series.