### PR TITLE
Fixed #23605, incomplete tooltip in xrange/gantt

### DIFF
--- a/ts/Series/XRange/XRangePoint.ts
+++ b/ts/Series/XRange/XRangePoint.ts
@@ -162,6 +162,7 @@ class XRangePoint extends ColumnPoint {
         super.applyOptions(options, x);
         this.x2 = this.series.chart.time.parse(this.x2);
         this.isNull = !this.isValid?.();
+        this.formatPrefix = this.isNull ? 'null' : 'point'; // #23605
         return this;
     }
 


### PR DESCRIPTION
Fixed #23605, incomplete tooltip in xrange and gantt series when the `x2` date was given as a string.