### PR TITLE
grid/a11y-pagination

### DIFF
--- a/ts/Grid/Core/Accessibility/A11yOptions.ts
+++ b/ts/Grid/Core/Accessibility/A11yOptions.ts
@@ -73,6 +73,11 @@ export interface LangAccessibilityOptions {
      * Language options for the accessibility descriptions in sorting.
      */
     sorting?: SortingLangA11yOptions;
+
+    /**
+     * Language options for the accessibility descriptions in pagination.
+     */
+    pagination?: PaginationLangA11yOptions;
 }
 
 /**
@@ -116,6 +121,29 @@ export interface SortingLangA11yOptions {
     }
 }
 
+/**
+ * Accessibility options for the Grid pagination functionality.
+ */
+export interface PaginationLangA11yOptions {
+    /**
+     * Language options for the accessibility descriptions in pagination.
+     */
+    announcements?: {
+        /**
+         * The message when the page size was changed.
+         *
+         * @default 'Page size changed to.'
+         */
+        pageSizeChange?: string;
+
+        /**
+         * The message when the page was changed.
+         *
+         * @default 'Page changed to.'
+         */
+        pageChange?: string;
+    }
+}
 /**
  * Accessibility options for the Grid header cell.
  */

--- a/ts/Grid/Core/Defaults.ts
+++ b/ts/Grid/Core/Defaults.ts
@@ -56,6 +56,12 @@ namespace Defaults {
                         descending: 'Sorted descending.',
                         none: 'Not sorted.'
                     }
+                },
+                pagination: {
+                    announcements: {
+                        pageSizeChange: 'Page size changed to.',
+                        pageChange: 'Page changed to.'
+                    }
                 }
             },
             loading: 'Loading...',

--- a/ts/Grid/Core/Defaults.ts
+++ b/ts/Grid/Core/Defaults.ts
@@ -59,8 +59,8 @@ namespace Defaults {
                 },
                 pagination: {
                     announcements: {
-                        pageSizeChange: 'Page size changed to.',
-                        pageChange: 'Page changed to.'
+                        pageSizeChange: 'Page size changed to',
+                        pageChange: 'Page changed to'
                     }
                 }
             },

--- a/ts/Grid/Core/Pagination/Pagination.ts
+++ b/ts/Grid/Core/Pagination/Pagination.ts
@@ -872,6 +872,7 @@ class Pagination {
      */
     public async setPageSize(newPageSize: number): Promise<void> {
         const pageSize = this.currentPageSize;
+        const langAccessibility = this.grid.options?.lang?.accessibility;
 
         fireEvent(
             this,
@@ -900,6 +901,12 @@ class Pagination {
         // Update row count for a11y
         this.updateA11yRowsCount(this.currentPageSize);
 
+        // Announce the page size change
+        this.grid.accessibility?.announce(
+            langAccessibility?.pagination?.announcements?.pageSizeChange +
+                ' ' + newPageSize
+        );
+
         // Update mobile page size selector if it exists
         if (this.mobilePageSizeSelector) {
             this.mobilePageSizeSelector.value = this.currentPageSize.toString();
@@ -922,6 +929,8 @@ class Pagination {
      * The page number to navigate to.
      */
     public async goToPage(pageNumber: number): Promise<void> {
+        const langAccessibility = this.grid.options?.lang?.accessibility;
+
         if (
             pageNumber < 1 ||
             pageNumber > this.totalPages ||
@@ -948,6 +957,13 @@ class Pagination {
         this.updatePageInfo();
         this.updatePageNumbers();
         this.updateButtonStates();
+
+
+        // Announce the page change
+        this.grid.accessibility?.announce(
+            langAccessibility?.pagination?.announcements?.pageChange +
+                ' ' + this.currentPage
+        );
 
         fireEvent(
             this,

--- a/ts/Grid/Core/Pagination/Pagination.ts
+++ b/ts/Grid/Core/Pagination/Pagination.ts
@@ -260,15 +260,33 @@ class Pagination {
      */
     public render(): void {
         const position = this.options.position;
+        const grid = this.grid;
 
-        if (position === 'footer') {
-            this.renderFooter();
-        } else if (typeof position === 'string' && position.startsWith('#')) {
+        // Set row count for a11y
+        grid.tableElement?.setAttribute('aria-current', 'page');
+        this.updateA11yRowsCount(this.currentPageSize);
+
+        // Render pagination container
+        if (typeof position === 'string' && position.startsWith('#')) {
             this.renderCustomContainer(position);
         } else {
-            this.contentWrapper = makeHTMLElement('div', {
-                className: Globals.getClassName('paginationWrapper')
-            }, this.grid.contentWrapper);
+            if (position === 'footer') {
+                this.renderFooter();
+            }
+
+            this.contentWrapper = makeHTMLElement(
+                'nav',
+                {
+                    className: Globals.getClassName('paginationWrapper')
+                },
+                position === 'footer' ?
+                    this.paginationContainer : grid.contentWrapper
+            );
+
+            this.contentWrapper.setAttribute(
+                'aria-label',
+                'Results pagination'
+            );
         }
 
         // Update total pages first to ensure correct calculations
@@ -306,11 +324,6 @@ class Pagination {
         );
 
         this.reflow();
-
-        // Set content wrapper to the tfoot cell
-        this.contentWrapper = makeHTMLElement('div', {
-            className: Globals.getClassName('paginationWrapper')
-        }, this.paginationContainer);
     }
 
     /**
@@ -432,6 +445,7 @@ class Pagination {
             return;
         }
 
+        // Create first button
         this.firstButton = makeHTMLElement('button', {
             innerHTML: Icons.first,
             className: Globals.getClassName('paginationButton') + ' ' +
@@ -439,6 +453,13 @@ class Pagination {
         }, container);
         this.firstButton.title = this.lang.firstPage;
 
+        // Set aria-label for a11y
+        this.firstButton.setAttribute(
+            'aria-label',
+            this.lang.firstPage
+        );
+
+        // Add click event
         this.firstButton.addEventListener('click', (): void => {
             void this.goToPage(1);
         });
@@ -464,6 +485,7 @@ class Pagination {
             return;
         }
 
+        // Create previous button
         this.prevButton = makeHTMLElement('button', {
             innerHTML: Icons.previous,
             className: Globals.getClassName('paginationButton') + ' ' +
@@ -471,6 +493,13 @@ class Pagination {
         }, container);
         this.prevButton.title = this.lang.previousPage;
 
+        // Set aria-label for a11y
+        this.prevButton.setAttribute(
+            'aria-label',
+            this.lang.previousPage
+        );
+
+        // Add click event
         this.prevButton.addEventListener('click', (): void => {
             void this.goToPage(this.currentPage - 1);
         });
@@ -496,6 +525,7 @@ class Pagination {
             return;
         }
 
+        // Create next button
         this.nextButton = makeHTMLElement('button', {
             innerHTML: Icons.next,
             className: Globals.getClassName('paginationButton') + ' ' +
@@ -503,6 +533,13 @@ class Pagination {
         }, container);
         this.nextButton.title = this.lang.nextPage;
 
+        // Set aria-label for a11y
+        this.nextButton.setAttribute(
+            'aria-label',
+            this.lang.nextPage
+        );
+
+        // Add click event
         this.nextButton.addEventListener('click', (): void => {
             void this.goToPage(this.currentPage + 1);
         });
@@ -528,6 +565,7 @@ class Pagination {
             return;
         }
 
+        // Create last button
         this.lastButton = makeHTMLElement('button', {
             innerHTML: Icons.last,
             className: Globals.getClassName('paginationButton') + ' ' +
@@ -535,6 +573,13 @@ class Pagination {
         }, container);
         this.lastButton.title = this.lang.lastPage;
 
+        // Set aria-label for a11y
+        this.lastButton.setAttribute(
+            'aria-label',
+            this.lang.lastPage
+        );
+
+        // Add click event
         this.lastButton.addEventListener('click', (): void => {
             void this.goToPage(this.totalPages);
         });
@@ -737,6 +782,13 @@ class Pagination {
             { page: pageNumber }
         );
 
+        // Set aria-label for a11y
+        button.setAttribute(
+            'aria-label',
+            this.formatText(this.lang.pageNumber, { page: pageNumber })
+        );
+
+        // Add click event
         button.addEventListener('click', (): void => {
             void this.goToPage(pageNumber);
         });
@@ -755,6 +807,9 @@ class Pagination {
             className: Globals.getClassName('paginationEllipsis')
         }, this.pageNumbersContainer);
         ellipsisElement.title = this.lang.ellipsis;
+
+        // Set aria-label for a11y
+        ellipsisElement.setAttribute('aria-hidden', true);
     }
 
     /**
@@ -841,6 +896,9 @@ class Pagination {
         this.updatePageInfo();
         this.updatePageNumbers();
         this.updateButtonStates();
+
+        // Update row count for a11y
+        this.updateA11yRowsCount(this.currentPageSize);
 
         // Update mobile page size selector if it exists
         if (this.mobilePageSizeSelector) {
@@ -1121,6 +1179,20 @@ class Pagination {
                 parseInt(this.mobilePageSizeSelector.value, 10)
             );
         });
+    }
+
+    /**
+     * Update the row count for a11y.
+     *
+     * @param currentPageSize
+     * The current page size.
+     */
+    public updateA11yRowsCount(currentPageSize: number): void {
+        const grid = this.grid;
+        grid.tableElement?.setAttribute(
+            'aria-rowcount',
+            currentPageSize || grid.dataTable?.getRowCount() || 0
+        );
     }
 }
 

--- a/ts/Grid/Core/Table/ColumnResizing/ResizingMode.ts
+++ b/ts/Grid/Core/Table/ColumnResizing/ResizingMode.ts
@@ -144,7 +144,7 @@ abstract class ResizingMode {
 
         if (!defined(widthValue)) {
             const tbody = vp.tbodyElement;
-            const freeWidth = 
+            const freeWidth =
                 tbody.getBoundingClientRect().width -
                 this.calculateOccupiedWidth() -
                 tbody.offsetWidth + tbody.clientWidth;


### PR DESCRIPTION
Added a11y to the pagination module.

---- 
- [x] - Pagination is in a <nav> with a unique label (e.g., aria-label="Results pagination").
- [x] - Current page has aria-current="page".
- [x] - Prev/Next/First/Last have clear labels (e.g., aria-label="Next page"); unusable controls are truly disabled (disabled or aria-disabled="true").
- [x] - Page numbers are announced clearly (visible “Page 3” or aria-label="Page 3"), not just “3”.
- [x] - Ellipsis (…) is non-interactive and hidden from AT (aria-hidden="true").
- [x] - Annoucements
- [x] - Focus is visible on every control and not obscured by sticky UI.