### PR TITLE
Fixed #23576, wrong annotion mock point function arg.

### DIFF
--- a/ts/Extensions/Annotations/MockPoint.ts
+++ b/ts/Extensions/Annotations/MockPoint.ts
@@ -635,8 +635,8 @@ export default MockPoint;
  *
  * @callback Highcharts.AnnotationMockPointFunction
  *
- * @param  {Highcharts.Annotation} annotation
- *         An annotation instance.
+ * @param {Highcharts.AnnotationControllable} controllable
+ *        Controllable shape or label.
  *
  * @return {Highcharts.AnnotationMockPointOptionsObject}
  *         Annotations shape point.


### PR DESCRIPTION
Fixed #23576, wrong annotation mock point function argument type. 

The better fit would be to use the `ControllableType` for the argument type, but somehow even when explicitly declaring it as an interface for the JSDoc, it didn't make it into built d.ts file: https://github.com/highcharts/highcharts/blob/master/ts/Extensions/Annotations/Controllables/ControllableType.d.ts

The `Highcharts.AnnotationControllable` type is also being used in the annotations positioner function for target, and since in both callback functions the context is the same, I've opted to use it here as the more general type:
https://github.com/highcharts/highcharts/blob/2268785055ae27f2ad1a50fc5473fc95af7ab5ff/ts/Extensions/Annotations/Controllables/Controllable.ts#L367-L387