### PR TITLE
Fixed #23631, SeriesRegistry unavailable in custom ESM bundle.

### DIFF
--- a/ts/Core/Series/SeriesRegistry.ts
+++ b/ts/Core/Series/SeriesRegistry.ts
@@ -138,10 +138,11 @@ namespace SeriesRegistry {
 
         // Create the class
         delete seriesTypes[type];
-        const parentClass =
-                seriesTypes[parent] as typeof Series || (H as any).Series,
-            childClass =
-                extendClass(parentClass, seriesProto) as typeof Series;
+        const parentClass = (
+                seriesTypes[parent] as typeof Series ||
+                (H as unknown as { Series: typeof Series }).Series
+            ),
+            childClass = extendClass(parentClass, seriesProto) as typeof Series;
 
         registerSeriesType(type, childClass);
         seriesTypes[type].prototype.type = type;


### PR DESCRIPTION
Fixed #23631, `SeriesRegistry` was unavailable in custom ESM bundle because of circular import.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211518749676060