### PR TITLE
Fixed #21131, navigator with boost was not visible after chart redraw.

### DIFF
--- a/samples/unit-tests/navigator/navigator-with-boost/demo.css
+++ b/samples/unit-tests/navigator/navigator-with-boost/demo.css
@@ -1,0 +1,4 @@
+#container {
+    width: 600px;
+    margin: 0 auto;
+}

--- a/samples/unit-tests/navigator/navigator-with-boost/demo.details
+++ b/samples/unit-tests/navigator/navigator-with-boost/demo.details
@@ -1,0 +1,6 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+ js_wrap: b
+...

--- a/samples/unit-tests/navigator/navigator-with-boost/demo.html
+++ b/samples/unit-tests/navigator/navigator-with-boost/demo.html
@@ -1,0 +1,7 @@
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
+<script src="https://code.highcharts.com/modules/boost.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/navigator/navigator-with-boost/demo.js
+++ b/samples/unit-tests/navigator/navigator-with-boost/demo.js
@@ -1,0 +1,45 @@
+QUnit.test(
+    'Navigator with Boost',
+    function (assert) {
+        const pointStart = Date.UTC(2024, 0, 1),
+            pointInterval = 36e5;
+        function getData(n) {
+            const arr = [];
+
+            for (let i = 0; i < n; i = i + 1) {
+                arr.push([
+                    pointStart + pointInterval * i,
+                    2 * Math.sin(i / 100) + Math.random()
+                ]);
+            }
+            return arr;
+        }
+        const n = 10000,
+            data = getData(n);
+
+        const chart = Highcharts.stockChart('container', {
+            navigator: {
+                enabled: true,
+                series: {
+                    type: 'line',
+                    dataGrouping: {
+                        enabled: false
+                    }
+                }
+            },
+            xAxis: {
+                type: 'datetime'
+            },
+            series: [{
+                data: data,
+                dataGrouping: {
+                    enabled: false
+                }
+            }]
+        });
+
+        // Chart redraw triggers the invisible navigator error.
+        chart.redraw();
+        assert.ok(true);
+    }
+);

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -512,6 +512,7 @@ function createAndAttachRenderer(
         // using panes, it is better to clip the target group, because then
         // we preserve clipping on touch- and mousewheel zoom preview.
         if (
+            !chart.navigator &&
             box.width === chart.clipBox.width &&
             box.height === chart.clipBox.height
         ) {


### PR DESCRIPTION
Fixed #21131, navigator with boost was not visible after chart redraw.

TODO: 

- [ ] Add assertion that will check if the navigator is visible