### PR TITLE
Fixed #23643; legend event type was missing defaultPrevented property.

### DIFF
--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -1905,6 +1905,10 @@ export default Legend;
  * @name Highcharts.PointLegendItemClickEventObject#browserEvent
  * @type {Highcharts.PointerEvent}
  *//**
+ * Whether the default action has been prevented (`true`) or not.
+ * @name Highcharts.PointLegendItemClickEventObject#defaultPrevented
+ * @type {boolean|undefined}
+ *//**
  * Prevent the default action of toggle the visibility of the point.
  * @name Highcharts.PointLegendItemClickEventObject#preventDefault
  * @type {Function}
@@ -1959,6 +1963,10 @@ export default Legend;
  * Related browser event.
  * @name Highcharts.SeriesLegendItemClickEventObject#browserEvent
  * @type {Highcharts.PointerEvent}
+ *//**
+ * Whether the default action has been prevented (`true`) or not.
+ * @name Highcharts.SeriesLegendItemClickEventObject#defaultPrevented
+ * @type {boolean|undefined}
  *//**
  * Prevent the default action of toggle the visibility of the series.
  * @name Highcharts.SeriesLegendItemClickEventObject#preventDefault

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -5227,6 +5227,10 @@ export default Series;
  * @name Highcharts.SeriesLegendItemClickEventObject#browserEvent
  * @type {global.PointerEvent}
  *//**
+ * Whether the default action has been prevented (`true`) or not.
+ * @name Highcharts.SeriesLegendItemClickEventObject#defaultPrevented
+ * @type {boolean|undefined}
+ *//**
  * Prevent the default action of toggle the visibility of the series.
  * @name Highcharts.SeriesLegendItemClickEventObject#preventDefault
  * @type {Function}

--- a/ts/Extensions/Drilldown/Drilldown.ts
+++ b/ts/Extensions/Drilldown/Drilldown.ts
@@ -967,6 +967,7 @@ namespace Drilldown {
 
     export interface EventObject {
         category?: number;
+        defaultPrevented?: boolean;
         originalEvent?: Event;
         point: Point;
         points?: Array<(boolean|Point)>;


### PR DESCRIPTION
Fixed #23643; legend event types were missing `defaultPrevented` property.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211542923517284