### PR TITLE
Fixed #23677, alignThreshold not always working after zooming

### DIFF
--- a/samples/unit-tests/chart/alignthresholds/demo.js
+++ b/samples/unit-tests/chart/alignthresholds/demo.js
@@ -232,3 +232,42 @@ QUnit.test('alignThresholds', function (assert) {
         '#17314: alignThresholds and stacking should place columns correctly.'
     );
 });
+
+QUnit.test('Align thresholds and zooming', function (assert) {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'column',
+            alignThresholds: true,
+            width: 600
+        },
+        yAxis: [
+            {},
+            {
+                opposite: true
+            }
+        ],
+        series: [
+            {
+                data: [-18, 11, 7, -13, -6, 1, 0, 17, -1, 10, 14]
+            },
+            {
+                data: [-18, 11, 7, -13, -6, 1, 0, 17, -1, 10, 14],
+                yAxis: 1
+            }
+        ]
+    });
+
+    assert.strictEqual(
+        chart.yAxis[0].tickPositions.indexOf(0),
+        chart.yAxis[1].tickPositions.indexOf(0),
+        'Thresholds should be aligned initially'
+    );
+
+    chart.xAxis[0].setExtremes(7, 10);
+
+    assert.strictEqual(
+        chart.yAxis[0].tickPositions.indexOf(0),
+        chart.yAxis[1].tickPositions.indexOf(0),
+        'Thresholds should be aligned after zooming (setExtremes)'
+    );
+});

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -2349,9 +2349,10 @@ class Axis {
             !isNumber(this.dataMin) ||
             (
                 this !== callerAxis &&
-                this.series.some((s): boolean|undefined => (
-                    s.isDirty || s.isDirtyData
-                ))
+                this.series.some((s): boolean|undefined =>
+                    // The xAxis.isDirty check is for setExtremes (#23677)
+                    s.isDirty || s.isDirtyData || s.xAxis?.isDirty
+                )
             )
         ) {
             this.getSeriesExtremes();


### PR DESCRIPTION
Fixed #23677, the `chart.alignThreshold` option did not always take effect after zooming