### PR TITLE
Tools: Fixed nested es-modules/masters/esm issue.

### DIFF
--- a/tools/gulptasks/jsdoc-dts.js
+++ b/tools/gulptasks/jsdoc-dts.js
@@ -46,11 +46,11 @@ function jsDocESMDTS() {
         .getFilePaths('code', true)
         .filter(file => (
             file.endsWith('.d.ts') &&
-            !file.includes('dashboards') &&
-            !file.includes('datagrid') &&
-            !file.includes('es-modules') &&
-            !file.includes('esm') &&
-            !file.includes('grid')
+            !file.split(path.sep).includes('dashboards') &&
+            !file.split(path.sep).includes('datagrid') &&
+            !file.split(path.sep).includes('es-modules') &&
+            !file.split(path.sep).includes('esm') &&
+            !file.split(path.sep).includes('grid')
         ));
     const argv = require('yargs').argv;
     const promises = [];
@@ -61,7 +61,7 @@ function jsDocESMDTS() {
             if (
                 // Skip compiled DTS for es-modules/masters
                 !dtsFile.endsWith('.src.d.ts') &&
-                folder.includes('masters')
+                folder.split(path.sep).includes('masters')
             ) {
                 continue;
             }

--- a/ts/Core/Renderer/SVG/TextBuilder.ts
+++ b/ts/Core/Renderer/SVG/TextBuilder.ts
@@ -400,7 +400,7 @@ class TextBuilder {
     /**
      * Get the rendered line height of a <text>, <tspan> or pure text node.
      * @private
-     * @param {DOMElementType|Text} node The node to check for
+     * @param {Highcharts.DOMElementType|Text} node The node to check for
      * @return {number} The rendered line height
      */
     private getLineHeight(node: DOMElementType|Text): number {


### PR DESCRIPTION
If you run `npm x gulp jsdoc-dts` multiple times, you ended up with nested ESM folders.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211704264578751