### PR TITLE
bugfix/23525-variablepie-missing-z-option

### DIFF
--- a/ts/Series/VariablePie/VariablePiePointOptions.d.ts
+++ b/ts/Series/VariablePie/VariablePiePointOptions.d.ts
@@ -25,7 +25,15 @@ import type PiePointOptions from '../Pie/PiePointOptions';
  * */
 
 export interface VariablePiePointOptions extends PiePointOptions {
-    // Nothing to add yet
+    /**
+     * The z value of the point.
+     *
+     * @type {number}
+     *
+     * @product highcharts
+     *
+     * @apioption series.variablepie.data.z
+     */
 }
 
 /* *

--- a/ts/Series/VariablePie/VariablePieSeriesDefaults.ts
+++ b/ts/Series/VariablePie/VariablePieSeriesDefaults.ts
@@ -180,6 +180,16 @@ const VariablePieSeriesDefaults: VariablePieSeriesOptions = {
  * @apioption series.variablepie.data
  */
 
+/**
+* The z value of the point.
+*
+* @type {(number| null)}
+*
+* @product highcharts
+*
+* @apioption series.variablepie.data.z
+*/
+
 ''; // Keeps doclets above separate
 
 /* *


### PR DESCRIPTION
Fixed #23525, added missing z option to variablepie api docs.