### PR TITLE
Fixed default font

### DIFF
--- a/css/grid/grid-lite.css
+++ b/css/grid/grid-lite.css
@@ -112,9 +112,10 @@
     /* Fonts */
 
     /* Global fonts */
+    --ig-default-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
     --ig-font-weight: var(--hcg-font-weight, normal);
     --ig-font-size: var(--hcg-font-size, 1rem);
-    --ig-font-family: var(--hcg-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif);
+    --ig-font-family: var(--hcg-font-family, var(--ig-default-font-family));
     --ig-color: var(--hcg-color, var(--ig-default-color));
     --ig-font: var(--ig-font-weight) var(--ig-font-size) var(--ig-font-family);
     --ig-text-align: var(--hcg-text-align, left);


### PR DESCRIPTION
Inspector complained about `--ig-font-family`. According to GPT and other findings it was correct, but it still complained. This fix removes the complaining. 

How to verify:

Currently font-sizes in demopages is slightly smaller than in jsfiddle and utils. If fix is successful they should be the same. Not sure how to verify demos outside of utils.