### PR TITLE
grid/fix-samples-desc-urls

### DIFF
--- a/samples/grid-pro/demo/cell-editing/demo.html
+++ b/samples/grid-pro/demo/cell-editing/demo.html
@@ -9,9 +9,9 @@
         and observe how the <code>afterEdit</code> event is used to log the updated values. Cell editing, Validation and Events are
         Pro features.<br /><br />
         Check out the
-        <a href="https://www.highcharts.com/demo/grid/custom-input-validation">demo on custom input validation</a> as
+        <a href="https://www.highcharts.com/demo/grid/validation" target="_blank">demo on custom input validation</a> as
         well, and
-        <a href="https://www.highcharts.com/docs/grid/cell-editing#validation">read the documentation article</a> on the
+        <a href="https://www.highcharts.com/docs/grid/cell-editing#validation" target="_blank">read the documentation article</a> on the
         topic.
     </p>
 </div>


### PR DESCRIPTION
Fixed urls in cell-editing demo.

Additionally, it seems that links with `target="_blank"` and `target="_top"` attributes are not working on the demo pages. @KamilKubik Can you verify this?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211793117039715