### PR TITLE
docs/grid-sample-urls

### DIFF
--- a/docs/grid/cell-renderers.md
+++ b/docs/grid/cell-renderers.md
@@ -265,7 +265,7 @@ If you want your custom renderer to be usable in cell edit mode, you need to imp
 
 This section demonstrates how to create a custom **Textarea** cell renderer for the Grid. The custom renderer will display a `<textarea>` element inside the cell, allowing for multi-line text editing.
 
-<iframe style="width: 100%; height: 590px; border: none;" src="https://www.highcharts.com/samples/embed/grid-pro/basic/custom-renderer?force-light-theme" allow="fullscreen"></iframe>
+<iframe style="width: 100%; height: 590px; border: none;" src="https://www.highcharts.com/samples/embed/grid/basic/custom-renderer?force-light-theme" allow="fullscreen"></iframe>
 
 1. We start by importing the default [`CellRenderer`](https://api.highcharts.com/grid/#classes/Grid_Pro_CellRendering_CellRenderer.CellRenderer-1) and `CellContentPro` classes and [`CellRendererRegistry`](https://api.highcharts.com/grid/#modules/Grid_Pro_CellRendering_CellRendererRegistry.CellRendererRegistry) from the `Grid` namespace.
 

--- a/docs/grid/column-filtering.md
+++ b/docs/grid/column-filtering.md
@@ -326,4 +326,4 @@ Here's a complete example showing column filtering in action:
 
 This example creates a grid with filtering enabled for all columns through `columnDefaults`. The grid displays various fruit data with different data types including strings, numbers, booleans, and dates. The weight column has an initial filter set to show only items weighing more than 1000 units, demonstrating how to pre-configure filtering conditions. The grouped header structure shows how filtering works with complex column layouts.
 
-<iframe src="https://www.highcharts.com/samples/embed/grid-lite/basic/column-filtering?force-light-theme" allow="fullscreen"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/grid/basic/column-filtering?force-light-theme" allow="fullscreen"></iframe>

--- a/docs/grid/events.md
+++ b/docs/grid/events.md
@@ -169,4 +169,4 @@ pagination: {
 ```
 
 Live example:
-<iframe src="https://www.highcharts.com/samples/embed/grid-pro/basic/cell-events?force-light-theme" allow="fullscreen"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/grid/basic/cell-events?force-light-theme" allow="fullscreen"></iframe>

--- a/docs/grid/pagination.md
+++ b/docs/grid/pagination.md
@@ -248,4 +248,4 @@ Highcharts Grid Pro provides pagination events that allow you to respond to page
 
 For detailed information about pagination events and how to use them, see the [Events article](https://www.highcharts.com/docs/grid/events).
 
-<iframe src="https://www.highcharts.com/samples/embed/grid-lite/basic/pagination?force-light-theme" allow="fullscreen"></iframe>
+<iframe src="https://www.highcharts.com/samples/embed/grid/basic/pagination?force-light-theme" allow="fullscreen"></iframe>


### PR DESCRIPTION
the demo builder tool does not push to `grid-lite/` and `grid-pro/` only `grid/`