### PR TITLE
docs/changelog-format-update

### DIFF
--- a/changelog/changelog.html
+++ b/changelog/changelog.html
@@ -15179,6 +15179,34 @@ import &#39;highcharts/modules/accessibility&#39;;
           </div>
           <div class="changelog-container">
             <h3 class="release-header">
+              <a id="highcharts-dashboards-v4.0.0"></a>
+              <span>Highcharts Dashboards v4.0.0 (2025-10-29)</span>
+              <a class="release-header-hashtag" href="#highcharts-dashboards-v4.0.0">#</a>
+              <span class="download-link" ><a href="https://code.highcharts.com/dashboards/zips/Highcharts-Dashboards-4.0.0.zip" title="Download the zip archive for Highcharts Dashboards v4.0.0"><i class="fas fa-download"></i></a></span>
+            </h3>
+            <ul>
+              <li><code>Range Modifier</code> now defines the start-end slice of source table rows; all other range logic is covered by <code>Filter Modifier</code>.</li>
+            </ul>
+            <div class="accordion card-group">
+              <div class="card">
+                <div id="hd-heading-4-0-0-upgrade-notes" class="card-header">
+                  <h4 class="card-title">
+                    <button aria-label="Upgrade Notes Highcharts-dashboards v4.0.0" aria-expanded="false" class="btn btn-link collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#upgrade-notes-hd-4-0-0"><span> Upgrade notes </span></button>
+                  </h4>
+                </div>
+                <div id="upgrade-notes-hd-4-0-0" class="collapse" aria-labelledby="hd-heading-4-0-0-bug-fixes" data-parent=".accordion">
+                  <div class="card-body">
+                    <ul>
+                      <li><strong>Important Notice:</strong> <code>Datagrid</code> is now Grid Pro and no longer part of the Dashboards package. To use it as a component, you need to import it from an external library - either <code>Grid Pro</code> or <code>Grid Lite</code>. See the <a href="https://www.highcharts.com/docs/dashboards/grid-migration">Migration Guide</a> for more details.</li>
+                      <li>Any workflows relying on <code>Range Modifier</code> beyond simple row slicing by row index must be migrated to the <code>Filter Modifier</code>.</li>
+                    </ul>
+
+                  </div>
+                </div>
+
+              </div>
+            </div>
+            <h3 class="release-header">
               <a id="highcharts-dashboards-v3.6.0"></a>
               <span>Highcharts Dashboards v3.6.0 (2025-09-10)</span>
               <a class="release-header-hashtag" href="#highcharts-dashboards-v3.6.0">#</a>
@@ -15893,6 +15921,43 @@ import &#39;highcharts/modules/accessibility&#39;;
             <h2 id="highcharts-grid">Highcharts Grid</h2>
           </div>
           <div class="changelog-container">
+            <h3 class="release-header">
+              <a id="highcharts-grid-v2.0.0"></a>
+              <span>Highcharts Grid v2.0.0 (2025-10-29)</span>
+              <a class="release-header-hashtag" href="#highcharts-grid-v2.0.0">#</a>
+              <span class="download-link" ><a href="https://code.highcharts.com/grid/zips/Highcharts-Grid-2.0.0.zip" title="Download the zip archive for Highcharts Grid v2.0.0"><i class="fas fa-download"></i></a></span>
+            </h3>
+            <ul>
+              <li><strong>Grid:</strong> Sorting changed through header click or <code>setOrder</code> method updates the column options.</li>
+              <li><strong>Grid:</strong> Added column header toolbar and context menu.</li>
+              <li><strong>Grid:</strong> Added filtering functionality.</li>
+              <li><strong>Grid:</strong> Added pagination functionality.</li>
+              <li><strong>Grid:</strong> Replaced the old column distribution modes (<code>full</code>, <code>fixed</code>, <code>mixed</code>) with new column resizing modes (<code>adjacent</code>, <code>independent</code>, <code>distributed</code>).</li>
+              <li><strong>Grid:</strong> Removed previously deprecated <code>rendering.columns.distribution</code> option.</li>
+              <li><strong>Grid:</strong> Support for defining column widths via CSS has been removed.</li>
+            </ul>
+            <div class="accordion card-group">
+              <div class="card">
+                <div id="hGrid-heading-2-0-0-upgrade-notes" class="card-header">
+                  <h4 class="card-title">
+                    <button aria-label="Upgrade Notes Highcharts-grid v2.0.0" aria-expanded="false" class="btn btn-link collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#upgrade-notes-hGrid-2-0-0"><span> Upgrade notes </span></button>
+                  </h4>
+                </div>
+                <div id="upgrade-notes-hGrid-2-0-0" class="collapse" aria-labelledby="hGrid-heading-2-0-0-bug-fixes" data-parent=".accordion">
+                  <div class="card-body">
+                    <ul>
+                      <li><strong>Important Notice to Dashboards users:</strong> <code>Datagrid</code> is now Grid Pro and no longer part of the Dashboards package. To use Grid Pro as a standalone component, you need to import it from an external library - either <code>Grid Pro</code> or <code>Grid Lite</code>. See the <a href="https://www.highcharts.com/docs/dashboards/grid-migration">Migration Guide</a> for more details.</li>
+                      <li>The old column distribution modes (<code>full</code>, <code>fixed</code>, <code>mixed</code>) have been replaced with new column resizing modes (<code>adjacent</code>, <code>independent</code>, <code>distributed</code>).</li>
+                      <li>The previously deprecated <code>rendering.columns.distribution</code> option has been removed. To configure column resizing, use the new <code>rendering.columns.resizing.mode</code> option.</li>
+                      <li>If you used the resizing property in column definitions, move this logic to <code>rendering.columns.resizing.enabled</code> at the appropriate level.</li>
+                      <li>Review your project for any CSS rules targeting column widths and migrate those settings to the grid configuration options.</li>
+                    </ul>
+
+                  </div>
+                </div>
+
+              </div>
+            </div>
             <h3 class="release-header">
               <a id="highcharts-grid-v1.4.0"></a>
               <span>Highcharts Grid v1.4.0 (2025-09-10)</span>


### PR DESCRIPTION
We used the wrong format for titles initially, so this is the generation of the reverted change