### PR TITLE
grid/api-docs-missing-interfaces

### DIFF
--- a/tools/gulptasks/grid/api-docs.json
+++ b/tools/gulptasks/grid/api-docs.json
@@ -39,6 +39,7 @@
 
         "../../../ts/Grid/Pro/CellEditing/CellEditing.ts",
         "../../../ts/Grid/Pro/CellEditing/CellEditMode.d.ts",
+        "../../../ts/Grid/Pro/CellEditing/CellEditingComposition.ts",
         "../../../ts/Grid/Pro/Credits/CreditsPro.ts",
         "../../../ts/Grid/Pro/GridEvents.ts",
 


### PR DESCRIPTION
Added missing reference to interface defs.