### PR TITLE
Fixed #23787, suboptimal tick distribution in some cases with alignThresholds

### DIFF
--- a/samples/unit-tests/chart/alignthresholds/demo.js
+++ b/samples/unit-tests/chart/alignthresholds/demo.js
@@ -231,6 +231,18 @@ QUnit.test('alignThresholds', function (assert) {
         point2Box.y + point2Box.height,
         '#17314: alignThresholds and stacking should place columns correctly.'
     );
+
+    // #23787
+    chart.series[0].setData([1, 3, -1]);
+    chart.series[1].setData([2, -2, 2]);
+    chart.setSize(undefined, 300);
+
+    assert.strictEqual(
+        chart.yAxis[0].tickPositions.indexOf(0),
+        1,
+        'Top-heavy data, zero should be the second tick on first axis'
+    );
+
 });
 
 QUnit.test('Align thresholds and zooming', function (assert) {

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -2461,10 +2461,17 @@ class Axis {
         // tick index. Unless `thresholdAlignment` is exactly 0 or 1, avoid the
         // first or last tick because that would lead to series being clipped.
         if (isNumber(thresholdAlignment)) {
-            thresholdTickIndex = thresholdAlignment < 0.5 ?
-                Math.ceil(thresholdAlignment * (tickAmount - 1)) :
-                Math.floor(thresholdAlignment * (tickAmount - 1));
-
+            thresholdTickIndex = thresholdAlignment === 0 ? 0 :
+                thresholdAlignment === 1 ? tickAmount - 1 :
+                    // Get the closest integer between 1 and
+                    // `tickAmount - 2` (#23787)
+                    Math.round(
+                        clamp(
+                            thresholdAlignment * (tickAmount - 1),
+                            1,
+                            tickAmount - 2
+                        )
+                    );
             if (options.reversed) {
                 thresholdTickIndex = tickAmount - 1 - thresholdTickIndex;
             }


### PR DESCRIPTION
Fixed #23787, suboptimal tick distribution in some cases with `chart.alignThresholds`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211837516845373