### PR TITLE
bugfix/23162-heatmap-dataclass-missing-tooltip

### DIFF
--- a/samples/unit-tests/series-heatmap/members/demo.js
+++ b/samples/unit-tests/series-heatmap/members/demo.js
@@ -261,6 +261,27 @@ QUnit.test('seriesTypes.heatmap.pointClass.setState', function (assert) {
         chart.series[0].color,
         'Point\'s stroke should be set on hover, #17856.'
     );
+
+    chart.update({
+        colorAxis: {
+            dataClasses: [{ to: 2 }]
+        }
+    }, true, true);
+
+    chart.legend.allItems[0].setVisible(false);
+    chart.legend.allItems[0].setVisible(true);
+
+    const controller = new TestController(chart);
+
+    controller.moveTo(100, 100);
+
+    assert.strictEqual(
+        chart.hoverPoint,
+        point,
+        `Tooltip should be visible on point hover after toggling data class
+        visibility, #23162.`
+    );
+
 });
 
 QUnit.test(

--- a/ts/Series/Heatmap/HeatmapSeries.ts
+++ b/ts/Series/Heatmap/HeatmapSeries.ts
@@ -531,6 +531,9 @@ class HeatmapSeries extends ScatterSeries {
 addEvent(HeatmapSeries, 'afterDataClassLegendClick', function (): void {
     this.isDirtyCanvas = true;
     this.drawPoints();
+    if (this.options.enableMouseTracking) {
+        this.drawTracker(); // #23162, set tracker again after points redraw
+    }
 });
 
 /* *


### PR DESCRIPTION
Fixed #23162, tooltip not rendering for heatmap cell on hover after `dataClass` legend toggle.