### PR TITLE
tools/editor-config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.html]
+insert_final_newline = true
+end_of_line = lf


### PR DESCRIPTION
Introduced new file `.editorconfig`
This file can be used for editor configurations that should apply to all developers.
In this PR, I added a rule for newline at the end of html files. We already have this for .ts, .js and .css files through linters