### PR TITLE
bugfix/23503-popper-broken-by-overflow

### DIFF
--- a/css/dashboards/dashboards.css
+++ b/css/dashboards/dashboards.css
@@ -353,7 +353,6 @@
     background-color: var(--highcharts-background-color);
     background-clip: border-box;
     border-radius: var(--highcharts-dashboards-border-radius);
-    overflow: hidden;
 }
 
 .highcharts-dashboards-cell > .highcharts-dashboards-component .highcharts-dashboards-component-kpi-chart-container {


### PR DESCRIPTION
Fixed #23503, popper broken by overflow


Looked at most demos after `overflow: hidden` was removed, and things looked fine