### PR TITLE
bugfix/23279-styled-mode-solidgauge-stops

### DIFF
--- a/samples/unit-tests/series-solidgauge/solidgauge-styled-series/demo.html
+++ b/samples/unit-tests/series-solidgauge/solidgauge-styled-series/demo.html
@@ -9,3 +9,5 @@
 <div id="qunit-fixture"></div>
 
 <div id="container"></div>
+
+<div id="container-without-stops"></div>

--- a/samples/unit-tests/series-solidgauge/solidgauge-styled-series/demo.js
+++ b/samples/unit-tests/series-solidgauge/solidgauge-styled-series/demo.js
@@ -70,6 +70,22 @@ QUnit.test('Solid gauge styled series color (#6350)', function (assert) {
         })
     );
 
+    var chartWithoutStops = Highcharts.chart(
+        'container-without-stops',
+        Highcharts.merge(gaugeOptions, {
+            yAxis: {
+                stops: null,
+                min: 0,
+                max: 200
+            },
+            series: [
+                {
+                    data: [{ y: 80 }, { y: 20, colorIndex: 2 }]
+                }
+            ]
+        })
+    );
+
     assert.strictEqual(
         chart.series[0].data[0].graphic.element.className.baseVal,
         'highcharts-point',
@@ -81,5 +97,24 @@ QUnit.test('Solid gauge styled series color (#6350)', function (assert) {
         chart.series[0].data[0].graphic.element.className.baseVal,
         'highcharts-point',
         'Color class should be updated (#8791)'
+    );
+
+    assert.strictEqual(
+        chartWithoutStops.series[0].data[0].graphic.element.className.baseVal,
+        'highcharts-point highcharts-color-0',
+        'Color classes are applied when stops are not defined.'
+    );
+
+    assert.strictEqual(
+        chartWithoutStops.series[0].data[1].graphic.element.className.baseVal,
+        'highcharts-point highcharts-color-2',
+        'Color classes are applied based on colorIndex.'
+    );
+
+    chartWithoutStops.series[0].points[0].update({ colorIndex: 1 });
+    assert.strictEqual(
+        chartWithoutStops.series[0].data[0].graphic.element.className.baseVal,
+        'highcharts-point highcharts-color-1',
+        'Color class should be updated when stops are not defined'
     );
 });

--- a/ts/Series/SolidGauge/SolidGaugeSeries.ts
+++ b/ts/Series/SolidGauge/SolidGaugeSeries.ts
@@ -31,6 +31,7 @@ const {
 } = SeriesRegistry.seriesTypes;
 import SolidGaugeAxis from '../../Core/Axis/SolidGaugeAxis.js';
 import SolidGaugeSeriesDefaults from './SolidGaugeSeriesDefaults.js';
+import { GradientColorStop } from '../../Core/Color/GradientColor';
 import U from '../../Core/Utilities.js';
 const {
     clamp,
@@ -255,7 +256,13 @@ class SolidGaugeSeries extends GaugeSeries {
                         stroke: options.borderColor || 'none',
                         'stroke-width': options.borderWidth || 0
                     });
-                } else if (series.yAxis?.stops) {
+                } else if (
+                    series.yAxis?.stops &&
+                    series.yAxis.stops.every(
+                        (stop: GradientColorStop): boolean =>
+                            stop.color?.get('rgb') !== ''
+                    )
+                ) {
                     className = className
                         .replace(/highcharts-color-\d/gm, '')
                         .trim();


### PR DESCRIPTION
Fixed #23279, color CSS classes were removed when neither stops nor minColor/maxColor were defined.

The stops options are always initialized either with the values provided through options or based on the `minColor`/`maxColor`. However, when neither of these value are defined through options, then the stops are initialized with invalid colors. This adds another check to ensure that the `highcharts-color-{n}` CSS classes are not removed when the stops don't contain valid colors.

The tests were added to the same file that was used for the other case, but it can be refactore to its own suite if so desired.