### PR TITLE
Fix formatting in understanding-grid.md

### DIFF
--- a/docs/grid/understanding-grid.md
+++ b/docs/grid/understanding-grid.md
@@ -84,8 +84,8 @@ For more information on the `caption` option, see the [API reference](https://ap
 {
     header: [
         {
-            columnId: "product"
-            format: "Fruit",
+            columnId: "product",
+            format: "Fruit"
         },
         "weight",
         "price"


### PR DESCRIPTION
Misplaced comma on an example in the understanding-grid.md file