### PR TITLE
bugfix/api-links-dash

### DIFF
--- a/changelog/highcharts-dashboards/2.3.0.md
+++ b/changelog/highcharts-dashboards/2.3.0.md
@@ -2,7 +2,7 @@
 
 - Added the possibility of setting toolbar visibility for individual components, closes [#20907](https://github.com/highcharts/highcharts/issues/20907).
 - Removed column aliases from `DataTable`, API documentation, and affected samples. Closes [#21485](https://github.com/highcharts/highcharts/issues/21485).
-- Added methods ([getLocalRowIndex](https://api.highcharts.com/dashboards/#classes/Data_DataTable.DataTable-1#getLocalRowIndex) & [getOriginalRowIndex](https://api.highcharts.com/dashboards/#classes/Data_DataTable.DataTable-1#getOriginalRowIndex)) for referencing between rows of original and modified data tables.
+- Added methods ([getLocalRowIndex](https://api.highcharts.com/dashboards/#classes/Data_DataTable.DataTable#getLocalRowIndex) & [getOriginalRowIndex](https://api.highcharts.com/dashboards/#classes/Data_DataTable.DataTable#getOriginalRowIndex)) for referencing between rows of original and modified data tables.
 - Changed the `layout` element in the Add component sidebar to a `row` and improved the look when added.
 - Added an `HTML` text field in the sidebar to control and edit the content of the HTML component.
 - Added support for the [beforeParse](https://api.highcharts.com/dashboards/data.beforeParse) callback in the `GoogleSheetsConnector` options. Closes [#21235](https://github.com/highcharts/highcharts/issues/21235).

--- a/docs/dashboards/grid-component.md
+++ b/docs/dashboards/grid-component.md
@@ -131,7 +131,7 @@ Dashboards.board('container', {
 ## Grid options
 
 See the [Grid documentation](https://www.highcharts.com/docs/grid/general) to read more about it
-or use [the API documentation](https://api.highcharts.com/grid/#interfaces/Grid_Core_Options.Options-1) to see the available options for the **Grid** component.
+or use [the API documentation](https://api.highcharts.com/grid/#interfaces/Grid_Core_Options.Options) to see the available options for the **Grid** component.
 
 ## Data modifiers
 

--- a/ts/Data/Connectors/DataConnector.ts
+++ b/ts/Data/Connectors/DataConnector.ts
@@ -127,7 +127,7 @@ abstract class DataConnector implements DataEvent.Emitter<DataConnector.Event> {
 
         if (options.options) {
             // eslint-disable-next-line no-console
-            console.error('The `DataConnectorOptions.options` property was removed in Dashboards v4.0.0. Check how to upgrade your connector to use the new options structure here: https://api.highcharts.com/dashboards/#interfaces/Data_DataTableOptions.DataTableOptions-1');
+            console.error('The `DataConnectorOptions.options` property was removed in Dashboards v4.0.0. Check how to upgrade your connector to use the new options structure here: https://api.highcharts.com/dashboards/#interfaces/Data_DataTableOptions.DataTableOptions');
         }
 
         if (dataTables && dataTables?.length > 0) {
@@ -141,9 +141,9 @@ abstract class DataConnector implements DataEvent.Emitter<DataConnector.Event> {
                     dataTableIndex++;
                 }
             }
-
-        // If user options dataTables is not defined, generate a default table.
         } else {
+            // If user options dataTables is not defined, generate a default
+            // table.
             this.dataTables[0] = new DataTable({
                 id: options.id // Required by DataTableCore
             });
@@ -199,7 +199,7 @@ abstract class DataConnector implements DataEvent.Emitter<DataConnector.Event> {
         const connector = this;
         const columnIds = Object.keys(columns);
 
-        let columnId: (string|undefined);
+        let columnId: (string | undefined);
 
         while (typeof (columnId = columnIds.pop()) === 'string') {
             connector.describeColumn(columnId, columns[columnId]);

--- a/ts/Data/Connectors/DataConnectorOptions.d.ts
+++ b/ts/Data/Connectors/DataConnectorOptions.d.ts
@@ -45,7 +45,7 @@ export interface DataConnectorOptions {
      * @deprecated
      * Removed in Dashboards v4.0.0
      *
-     * {@link https://api.highcharts.com/dashboards/#interfaces/Data_Connectors_DataConnectorOptions.DataConnectorOptions-1 | Check how to upgrade your connector to use the new options structure}
+     * {@link https://api.highcharts.com/dashboards/#interfaces/Data_Connectors_DataConnectorOptions.DataConnectorOptions | Check how to upgrade your connector to use the new options structure}
      */
     options?: never;
 }


### PR DESCRIPTION
Fixed broken links to API docs


We still had some broken links in Dash docs, changelog and in the code