### PR TITLE
Fix: Mark series dirty when disabling accessibility

### DIFF
--- a/ts/Accessibility/Components/SeriesComponent/ForcedMarkers.ts
+++ b/ts/Accessibility/Components/SeriesComponent/ForcedMarkers.ts
@@ -261,6 +261,8 @@ namespace ForcedMarkersComposition {
 
         } else if (series.a11yMarkersForced) {
             delete series.a11yMarkersForced;
+            // Mark series dirty to ensure marker graphics are cleaned up
+            series.isDirty = true;
             unforceSeriesMarkerOptions(series);
             if (options.marker && options.marker.enabled === false) { // #23329
                 delete series.resetA11yMarkerOptions; // #16624


### PR DESCRIPTION
Fixes #23783

## Description
Fixes issue where accessibility marker graphics persist after disabling the accessibility module.

## Solution
Mark all series as `isDirty = true` before destroying the accessibility module, but only when the module was actively running (not in zombie mode). This ensures:
- Marker graphics are properly destroyed
- Unnecessary redraws are avoided (zombie check)
- Performance impact is minimal