### PR TITLE
dash/23859-datatable-clone-medtata

### DIFF
--- a/test/typescript-karma/Data/DataTable.test.js
+++ b/test/typescript-karma/Data/DataTable.test.js
@@ -558,12 +558,11 @@ QUnit.test('DataTable.setRow insert argument', function (assert) {
     );
 });
 
-QUnit.test('Metadata in a cloned table', function (assert) {
+QUnit.test('Metadata in a cloned table should be a shallow copy', function (assert) {
     // Arrange
     const table = new DataTable({
         columns: {
-            ID: [1, 2, 3],
-            Name: ['John', 'Jane', 'Alice']
+            ID: [1, 2, 3]
         },
         metadata: {
             ID: {
@@ -576,9 +575,19 @@ QUnit.test('Metadata in a cloned table', function (assert) {
     const tableClone = table.clone();
 
     // Assert
+    assert.notStrictEqual(
+        tableClone.metadata,
+        table.metadata,
+        'Metadata object should be a new shallow copy.'
+    );
+    assert.strictEqual(
+        tableClone.metadata.ID,
+        table.metadata.ID,
+        'Nested metadata objects should still reference the same object.'
+    );
     assert.deepEqual(
         tableClone.metadata,
         table.metadata,
-        'Cloned table should have the same metadata.'
+        'Cloned metadata should have equal structure and values.'
     );
 });

--- a/ts/Data/DataTable.ts
+++ b/ts/Data/DataTable.ts
@@ -143,7 +143,7 @@ class DataTable extends DataTableCore implements DataEvent.Emitter<DataTable.Eve
             tableClone.localRowIndexes = table.localRowIndexes;
         }
 
-        tableClone.metadata = table.metadata;
+        tableClone.metadata = { ...table.metadata };
 
         table.emit({
             type: 'afterCloneTable',


### PR DESCRIPTION
Fixed #23859, the `metadata` was not cloned in the data table.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212003423590804