### PR TITLE
dash/dist-gulptask-refactor

### DIFF
--- a/tools/gulptasks/scripts-clean.js
+++ b/tools/gulptasks/scripts-clean.js
@@ -50,11 +50,11 @@ function task() {
     return new Promise((resolve, reject) => {
         try {
             if (skipBuildClean) {
-                log.message('Preserving build directory (dashboards-all sequence).');
+                log.message('Preserving build directory (with-deps sequence).');
             }
 
             if (skipCodeClean) {
-                log.message('Preserving code directory (dashboards-all sequence).');
+                log.message('Preserving code directory (with-deps sequence).');
             }
 
             for (const ptd of pathsToDelete) {


### PR DESCRIPTION
- renamed the command to be a bit more descriptive `npx gulp dist --dashboards-all` -> `npx gulp dist --dashboards-with-deps`
- Skipped compress step for libs that should not end up in `/dist` when running the command