### PR TITLE
dash/layout-module-refs-fix

### DIFF
--- a/ts/Dashboards/Board.ts
+++ b/ts/Dashboards/Board.ts
@@ -381,11 +381,11 @@ class Board {
     /**
      * Inits creating a layouts and setup the EditMode tools.
      * @internal
-     *
      */
     private initEditMode(): void {
-        if (Dashboards.EditMode) {
-            this.editMode = new Dashboards.EditMode(
+        const { EditMode } = Globals.win.Dashboards;
+        if (EditMode) {
+            this.editMode = new EditMode(
                 this,
                 this.options.editMode
             );

--- a/ts/Dashboards/EditMode/EditMode.ts
+++ b/ts/Dashboards/EditMode/EditMode.ts
@@ -162,7 +162,7 @@ class EditMode {
             );
             this.isEditOverlayActive = false;
 
-            board.fullscreen = new Dashboards.Fullscreen(board);
+            board.fullscreen = new Globals.win.Dashboards.Fullscreen(board);
 
             if (this.customHTMLMode) {
                 board.container.classList.add(


### PR DESCRIPTION
Fixed refs to layout module classes so it works with CoD.

*Internal note: This solution is widely used in Dashboards at the moment, but in the future, when the `Dashboards` module will not always be located directly in the `window` object - then we also need to remember to load such things from modules directly, instead of through `window`.*
