### PR TITLE
grid/dts-no-skip-lib-check

### DIFF
--- a/ts/Core/Time.ts
+++ b/ts/Core/Time.ts
@@ -284,7 +284,7 @@ namespace Time {
 
     export interface DateTimeFormatOptions extends Intl.DateTimeFormatOptions {
         dateStyle?: 'full'|'long'|'medium'|'short';
-        fractionalSecondDigits?: number;
+        fractionalSecondDigits?: 1|2|3;
         prefix?: string;
         suffix?: string;
         timeStyle?: 'full'|'long'|'medium'|'short';

--- a/ts/Grid/Pro/CellRendering/ContentTypes/SparklineContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/SparklineContent.ts
@@ -22,10 +22,9 @@
  *
  * */
 
-import type { DeepPartial } from '../../../../Shared/Types';
+import type { AnyRecord } from '../../../../Shared/Types';
 import type SparklineRenderer from '../Renderers/SparklineRenderer';
 import type TableCell from '../../../Core/Table/Body/TableCell';
-import type * as HighchartsNamespace from '../../highcharts';
 
 import CellContentPro from '../CellContentPro.js';
 import Globals from '../../../Core/Globals.js';
@@ -52,72 +51,78 @@ class SparklineContent extends CellContentPro {
      * This is set to `undefined` by default, and should be set to the
      * Highcharts namespace before using the Sparkline Renderer.
      */
-    public static H: undefined | typeof HighchartsNamespace;
+    public static H: undefined | AnyRecord;
 
     /**
      * The default chart options for the sparkline content.
      */
-    public static defaultChartOptions: DeepPartial<
-        HighchartsNamespace.Options
-    > = {
-            chart: {
-                height: 40,
-                margin: [5, 8, 5, 8],
-                backgroundColor: 'transparent',
-                skipClone: true
-            },
-            accessibility: {
-                enabled: false
-            },
-            tooltip: {
-                enabled: false
-            },
-            title: {
-                text: ''
-            },
-            credits: {
-                enabled: false
-            },
-            xAxis: {
-                visible: false
-            },
-            yAxis: {
-                visible: false
-            },
-            legend: {
-                enabled: false
-            },
-            plotOptions: {
-                series: {
-                    borderWidth: 0,
-                    marker: {
+    public static defaultChartOptions: AnyRecord = {
+        chart: {
+            height: 40,
+            margin: [5, 8, 5, 8],
+            backgroundColor: 'transparent',
+            skipClone: true
+        },
+        accessibility: {
+            enabled: false
+        },
+        tooltip: {
+            enabled: false
+        },
+        title: {
+            text: ''
+        },
+        credits: {
+            enabled: false
+        },
+        xAxis: {
+            visible: false
+        },
+        yAxis: {
+            visible: false
+        },
+        legend: {
+            enabled: false
+        },
+        plotOptions: {
+            series: {
+                borderWidth: 0,
+                marker: {
+                    enabled: false
+                },
+                states: {
+                    hover: {
                         enabled: false
                     },
-                    states: {
-                        hover: {
-                            enabled: false
-                        },
-                        inactive: {
-                            enabled: false
-                        }
-                    },
-                    animation: false,
-                    dataLabels: {
+                    inactive: {
                         enabled: false
                     }
                 },
-                pie: {
-                    slicedOffset: 0,
-                    borderRadius: 0
+                animation: false,
+                dataLabels: {
+                    enabled: false
                 }
+            },
+            pie: {
+                slicedOffset: 0,
+                borderRadius: 0
             }
-        };
+        }
+    };
 
 
     /**
      * The Highcharts chart instance.
      */
-    public chart?: HighchartsNamespace.Chart;
+    public chart?: {
+        update: (
+            options: AnyRecord,
+            force?: boolean,
+            redraw?: boolean,
+            animation?: boolean
+        ) => void;
+        destroy: () => void;
+    };
 
     /**
      * The parent element for the sparkline content.
@@ -204,13 +209,13 @@ class SparklineContent extends CellContentPro {
         );
     }
 
-    private getProcessedOptions(): Partial<HighchartsNamespace.Options> {
+    private getProcessedOptions(): Partial<AnyRecord> {
         const renderer = this.renderer as SparklineRenderer;
         const { chartOptions } = renderer.options;
 
-        let options: Partial<HighchartsNamespace.Options>;
+        let options: Partial<AnyRecord>;
         if (typeof chartOptions === 'function') {
-            options = chartOptions.call(
+            options = (chartOptions as Function).call(
                 this.cell,
                 this.cell.value
             );

--- a/ts/Grid/Pro/CellRendering/Renderers/SparklineRenderer.ts
+++ b/ts/Grid/Pro/CellRendering/Renderers/SparklineRenderer.ts
@@ -23,10 +23,10 @@
  *
  * */
 
+import type { AnyRecord } from '../../../../Shared/Types';
 import type Column from '../../../Core/Table/Column';
 import type TableCell from '../../../Core/Table/Body/TableCell';
 import type DataTable from '../../../../Data/DataTable';
-import type * as HighchartsNamespace from '../../highcharts';
 import type {
     EditModeRendererTypeName
 } from '../../CellEditing/CellEditingComposition';
@@ -58,7 +58,7 @@ class SparklineRenderer extends CellRenderer {
      * @param H
      * Highcharts namespace.
      */
-    public static useHighcharts(H: typeof HighchartsNamespace): void {
+    public static useHighcharts(H: AnyRecord): void {
         if (H && !SparklineContent.H) {
             SparklineContent.H = H;
         }
@@ -128,8 +128,8 @@ class SparklineRenderer extends CellRenderer {
 export interface SparklineRendererOptions extends CellRendererOptions {
     type: 'sparkline';
     chartOptions?: (
-        ((data: DataTable.CellType) => HighchartsNamespace.Options) |
-        HighchartsNamespace.Options
+        ((this: TableCell, data: DataTable.CellType) => AnyRecord) |
+        AnyRecord
     );
 }
 

--- a/ts/Grid/Pro/GridEvents.ts
+++ b/ts/Grid/Pro/GridEvents.ts
@@ -19,6 +19,7 @@
  *
  * */
 
+import type { AnyRecord } from '../../Shared/Types';
 import type Column from '../Core/Table/Column';
 import type TableCell from '../Core/Table/Body/TableCell';
 import type HeaderCell from '../Core/Table/Header/HeaderCell';

--- a/ts/Grid/Pro/highcharts.ts
+++ b/ts/Grid/Pro/highcharts.ts
@@ -1,7 +1,0 @@
-export { default as Axis } from '../../Core/Axis/Axis.js';
-export { default as AxisOptions } from '../../Core/Axis/AxisOptions.js';
-export { default as Chart } from '../../Core/Chart/Chart.js';
-export { default as Options } from '../../Core/Options.js';
-export { default as Point } from '../../Core/Series/Point.js';
-export { default as Series } from '../../Core/Series/Series.js';
-export { default as SeriesOptions } from '../../Core/Series/SeriesOptions.js';

--- a/ts/Shared/TimeBase.ts
+++ b/ts/Shared/TimeBase.ts
@@ -929,7 +929,7 @@ namespace TimeBase {
 
     export interface DateTimeFormatOptions extends Intl.DateTimeFormatOptions {
         dateStyle?: 'full'|'long'|'medium'|'short';
-        fractionalSecondDigits?: number;
+        fractionalSecondDigits?: 1|2|3;
         prefix?: string;
         suffix?: string;
         timeStyle?: 'full'|'long'|'medium'|'short';
@@ -1129,7 +1129,7 @@ export default TimeBase;
  * The number of fractional digits to use. 3 means milliseconds.
  *
  * @name Highcharts.DateTimeFormatOptions#fractionalSecondDigits
- * @type {number|undefined}
+ * @type {1|2|3|undefined}
  *//**
  * The representation of the time zone name.
  *

--- a/ts/masters-grid/grid-lite.src.ts
+++ b/ts/masters-grid/grid-lite.src.ts
@@ -96,6 +96,8 @@ export {
     DataModifier,
     DataPool,
     DataTable,
+    _Grid as Grid,
+    _Options as Options,
     Pagination,
     SvgIcons,
     Table,
@@ -104,7 +106,6 @@ export {
 
 export const {
     defaultOptions,
-    Grid,
     grid,
     grids,
     isHighContrastModeActive,

--- a/ts/masters-grid/grid-pro.src.ts
+++ b/ts/masters-grid/grid-pro.src.ts
@@ -15,7 +15,6 @@
  * */
 
 import type _Options from '../Grid/Core/Options';
-import type * as H from '../Grid/Pro/highcharts';
 
 import AST from '../Core/Renderer/HTML/AST.js';
 import Templating from '../Core/Templating.js';
@@ -158,7 +157,9 @@ export {
     DataModifier,
     DataPool,
     DataTable,
+    _Grid as Grid,
     HeaderCell,
+    _Options as Options,
     Pagination,
     Popup,
     SvgIcons,
@@ -170,7 +171,6 @@ export {
 export const {
     classNamePrefix,
     defaultOptions,
-    Grid,
     grid,
     grids,
     isHighContrastModeActive,
@@ -188,14 +188,9 @@ export const {
  *
  * */
 
-declare global {
-    interface Window {
-        Highcharts?: typeof H;
-    }
-}
-
-if (G.win.Highcharts) {
-    G.CellRendererRegistry.types.sparkline.useHighcharts(G.win.Highcharts);
+const wnd = G.win as { Highcharts?: unknown };
+if (wnd.Highcharts) {
+    G.CellRendererRegistry.types.sparkline.useHighcharts(wnd.Highcharts);
 }
 
 


### PR DESCRIPTION
Reduced the type dependency tree from Core so it's not needed anymore to use `"skipLibCheck": false` when using the library in typescript environment.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211783947894462