### PR TITLE
bugfix/grid-afterRedraw-event

### DIFF
--- a/ts/Grid/Core/Grid.ts
+++ b/ts/Grid/Core/Grid.ts
@@ -860,7 +860,9 @@ export class Grid {
         const flags = this.dirtyFlags;
 
         if (flags.has('grid')) {
-            return await this.render();
+            await this.render();
+            fireEvent(this, 'afterRedraw');
+            return;
         }
 
         const { viewport: vp, pagination } = this;


### PR DESCRIPTION
The afterRender events was not triggered when grid rerender.