### PR TITLE
bugfix/getOptions-wrong-ref-nestedLayout

### DIFF
--- a/ts/Dashboards/Layout/Cell.ts
+++ b/ts/Dashboards/Layout/Cell.ts
@@ -226,7 +226,16 @@ class Cell extends GUIElement {
      *
      */
     public getOptions(): DeepPartial<Cell.Options> {
-        return this.options;
+        const cell = this;
+
+        if (cell.options.layout && cell.nestedLayout) {
+            return {
+                ...cell.options,
+                layout: cell.nestedLayout.getOptions()
+            };
+        }
+        
+        return cell.options;
     }
 
     protected changeVisibility(


### PR DESCRIPTION
Fixed #23952, wrong reference to nestedLayout.