### PR TITLE
docs/22966-tooltip-headerformat

### DIFF
--- a/docs/chart-concepts/templating.md
+++ b/docs/chart-concepts/templating.md
@@ -108,6 +108,7 @@ format: '{log}'
 * **multiply**. Multiply two numbers. For example `{multiply value 1000}`. [Demo](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/plotoptions/series-datalabels-format-subexpression).
 * **ne**. Not equal, JavaScript `!=`. Doubles as block helper and subexpression.
 * **subtract**. Subtract the second number from the first. Example `{subtract 5 2}` prints 3.
+* **ucfirst**. Uppercase the first character in a string. For example `{ucfirst point.key}`.
 * **#unless**. The inverse of `#if`. `{#unless point.isNull}The value is {point.y}{/unless}`.
 
 ## Limitations

--- a/docs/chart-concepts/tooltip.md
+++ b/docs/chart-concepts/tooltip.md
@@ -38,7 +38,7 @@ Tooltip formatting
 
 The tooltip's content is rendered from a subset of HTML that can be altered in a number of ways, all in all giving the implementer full control over the content. In addition to options on the [tooltip](https://api.highcharts.com/highcharts/tooltip) configuration object, you can set the options for how each series should be represented in the tooltip by [series.tooltip](https://api.highcharts.com/highcharts/plotOptions.series.tooltip). 
 
-*   The header part of the tooltip can be altered using the [tooltip.headerFormat](https://api.highcharts.com/highcharts/tooltip.headerFormat). In a shared tooltip, the first series' headerFormat is used.
+*   The header part of the tooltip can be altered using the [tooltip.headerFormat](https://api.highcharts.com/highcharts/tooltip.headerFormat). In a shared tooltip, the first series' headerFormat is used. In v12+, locale-aware date names for `point.key` follow the browser's casing (often lower-case), so use `{ucfirst point.key}` if you want a capitalized header.
 *   The listing of each series is given in the [tooltip.pointFormat](https://api.highcharts.com/highcharts/tooltip.pointFormat) option, or an individual pointFormat for each series. 
 *   The footer part can be set in the [tooltip.footerFormat](https://api.highcharts.com/highcharts/tooltip.footerFormat) option.
 *   All the options above can be overridden by the [tooltip.formatter](https://api.highcharts.com/highcharts/tooltip.formatter) callback for programmatic control.

--- a/tools/cspell/custom-words.txt
+++ b/tools/cspell/custom-words.txt
@@ -207,3 +207,4 @@ specific
 EMEA
 dendrogram
 datagrid
+ucfirst

--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -2694,6 +2694,9 @@ const defaultOptions: DefaultOptions = {
          * contains the category name, x value or datetime string depending on
          * the type of axis. For datetime axes, the `point.key` date format can
          * be set using `tooltip.xDateFormat`.
+         * In v12+, locale-aware date names follow the browser's casing and can
+         * be lower-case, so use the `ucfirst` helper (for example
+         * `{ucfirst point.key}`) if you want a capitalized header.
          *
          * @sample {highcharts} highcharts/tooltip/footerformat/
          *         An HTML table in the tooltip


### PR DESCRIPTION
Added info in docs about changes in tooltip.headerFormat, closes #22966.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210065924199668