### PR TITLE
bugfix/22929-loading-two-annotations-files

### DIFF
--- a/ts/masters/modules/annotations-advanced.src.ts
+++ b/ts/masters/modules/annotations-advanced.src.ts
@@ -14,7 +14,11 @@
  */
 'use strict';
 import Highcharts from '../../Core/Globals.js';
-import './annotations.src.js';
+import Annotation from '../../Extensions/Annotations/Annotation.js';
+import NavigationBindings from '../../Extensions/Annotations/NavigationBindings.js';
+
+// Import all the advanced annotation types to make sure they are registered
+// when both annotations and annotations-advanced modules are loaded.
 import '../../Extensions/Annotations/Types/BasicAnnotation.js';
 import '../../Extensions/Annotations/Types/CrookedLine.js';
 import '../../Extensions/Annotations/Types/ElliottWave.js';
@@ -26,4 +30,22 @@ import '../../Extensions/Annotations/Types/FibonacciTimeZones.js';
 import '../../Extensions/Annotations/Types/Pitchfork.js';
 import '../../Extensions/Annotations/Types/VerticalLine.js';
 import '../../Extensions/Annotations/Types/Measure.js';
+const G: AnyRecord = Highcharts;
+
+// Ensure annotations module is initialized if not already loaded
+if (!G.Annotation) {
+    G.Annotation = Annotation;
+    G.NavigationBindings = G.NavigationBindings || NavigationBindings;
+    G.Annotation.compose(
+        G.Chart, G.NavigationBindings, G.Pointer, G.SVGRenderer
+    );
+}
+
+// Copy types from the imported Annotation to G.Annotation if they're
+// different instances. This ensures types registered on the imported
+// Annotation are available on G.Annotation.
+if (G.Annotation !== Annotation && Annotation.types) {
+    Object.assign(G.Annotation.types, Annotation.types);
+}
+
 export default Highcharts;


### PR DESCRIPTION
Fixed #22929, loading `modules/annotations.js` and `modules/annotations-advanced.js` at the same time didn't work