### PR TITLE
feature/23798-navigator-live-redraw

### DIFF
--- a/ts/Stock/Navigator/Navigator.ts
+++ b/ts/Stock/Navigator/Navigator.ts
@@ -1135,9 +1135,8 @@ class Navigator {
             }
             if (
                 navigator.hasDragged &&
-                navigator.scrollbar &&
                 pick(
-                    navigator.scrollbar.options.liveRedraw,
+                    navigator.scrollbarOptions?.liveRedraw,
 
                     // By default, don't run live redraw on touch
                     // devices or if the chart is in boost.

--- a/ts/Stock/Navigator/Navigator.ts
+++ b/ts/Stock/Navigator/Navigator.ts
@@ -1084,7 +1084,7 @@ class Navigator {
         // In iOS, a mousemove event with e.pageX === 0 is fired when holding
         // the finger down in the center of the scrollbar. This should be
         // ignored.
-        if (!(e as any).touches || (e as any).touches[0].pageX !== 0) { // #4696
+        if (!e.touches || e.touches[0].pageX !== 0) { // #4696
 
             e = chart.pointer?.normalize(e) || e;
             chartX = e.chartX;
@@ -1114,23 +1114,23 @@ class Navigator {
                     chartX - left
                 );
             // Drag scrollbar or open area in navigator
-            } else if (navigator.grabbedCenter) {
+            } else if (navigator.grabbedCenter && dragOffset) {
                 navigator.hasDragged = true;
-                if (chartX < (dragOffset as any)) { // Outside left
+                if (chartX < dragOffset) { // Outside left
                     chartX = dragOffset;
                 // Outside right
                 } else if (
                     chartX >
-                    navigatorSize + (dragOffset as any) - range
+                    navigatorSize + dragOffset - range
                 ) {
-                    chartX = navigatorSize + (dragOffset as any) - range;
+                    chartX = navigatorSize + dragOffset - range;
                 }
 
                 navigator.render(
                     0,
                     0,
-                    (chartX as any) - (dragOffset as any),
-                    (chartX as any) - (dragOffset as any) + range
+                    chartX - dragOffset,
+                    chartX - dragOffset + range
                 );
             }
             if (

--- a/ts/Stock/Scrollbar/ScrollbarDefaults.ts
+++ b/ts/Stock/Scrollbar/ScrollbarDefaults.ts
@@ -100,7 +100,8 @@ const ScrollbarDefaults: ScrollbarOptions = {
     /**
      * Whether to redraw the main chart as the scrollbar or the navigator
      * zoomed window is moved. Defaults to `true` for modern browsers and
-     * `false` for legacy IE browsers as well as mobile devices.
+     * `false` for legacy IE browsers as well as mobile devices. This option
+     * works regardless of whether the scrollbar is enabled or not.
      *
      * @sample stock/scrollbar/liveredraw
      *         Setting live redraw to false


### PR DESCRIPTION
Added navigator supports for live redraw without scrollbar, see #23798.

#### Upgrade note
Navigator with disabled scrollbar now supports the [live redraw option](https://api.highcharts.com/highstock/scrollbar.liveRedraw). To enable or disable live redraw on the navigator, even with disabled scrollbar, use `scrollbar.liveRedraw`.