### PR TITLE
Fixed #23882, boost zones regression

### DIFF
--- a/samples/unit-tests/boost/general/demo.js
+++ b/samples/unit-tests/boost/general/demo.js
@@ -1120,3 +1120,68 @@ QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
         );
     }
 );
+
+QUnit[Highcharts.hasWebGLSupport() ? 'test' : 'skip'](
+    'Boost with zones',
+    async function (assert) {
+        const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'scatter'
+            },
+            title: {
+                text: 'Highcharts Zone Coloring with boost v12.4'
+            },
+            boost: {
+                enabled: true,
+                useGPUTranslations: true
+            },
+            plotOptions: {
+                series: {
+                    boostThreshold: 1,
+                    marker: { radius: 20 }
+                }
+            },
+            xAxis: { min: 0, max: 100 },
+            yAxis: { min: 0, max: 100 },
+            series: [{
+                name: 'Data',
+                data: [
+                    [10, 10], [20, 20], [30, 30], [40, 40], [50, 50],
+                    [60, 60], [70, 70], [80, 80], [90, 90]
+                ],
+                color: 'rgba(128, 128, 128, 0.5)',
+                zones: [{ // Red < 50
+                    value: 50,
+                    color: '#ff0000'
+                }, { // Blue >= 50
+                    color: '#0000ff'
+                }]
+            }]
+        });
+
+        const svg = chart.renderTo.querySelector('svg'),
+            imageEl = svg.querySelector('.highcharts-boost-canvas');
+
+        let x = chart.series[0].points[1].plotX + chart.plotLeft,
+            y = chart.series[0].points[1].plotY + chart.plotTop;
+        const { hex } =
+            await sampleImagePixelAtSVGPoint(svg, imageEl, x, y);
+
+        assert.strictEqual(
+            hex,
+            '#ff0000',
+            'The second point should be red.'
+        );
+
+        x = chart.series[0].points[8].plotX + chart.plotLeft;
+        y = chart.series[0].points[8].plotY + chart.plotTop;
+        const { hex: hex2 } =
+            await sampleImagePixelAtSVGPoint(svg, imageEl, x, y);
+
+        assert.strictEqual(
+            hex2,
+            '#0000ff',
+            'The last point should be blue.'
+        );
+    }
+);

--- a/ts/Extensions/Boost/WGLRenderer.ts
+++ b/ts/Extensions/Boost/WGLRenderer.ts
@@ -762,8 +762,9 @@ class WGLRenderer {
             // Handle the point.color option (#5999)
             const pointOptions = rawData && rawData[i];
             if (!useRaw) {
+                let rgba: Color.RGBA|undefined;
                 if (isObject(pointOptions, true) && pointOptions.color) {
-                    pcolor = color(pointOptions.color).rgba;
+                    rgba = color(pointOptions.color).rgba;
                 }
 
                 const colorKeyIndex = series.options.keys?.indexOf('color');
@@ -772,18 +773,20 @@ class WGLRenderer {
                     colorKeyIndex &&
                     typeof pointOptions[colorKeyIndex] === 'string'
                 ) {
-                    pcolor = color(pointOptions[colorKeyIndex]).rgba;
+                    rgba = color(pointOptions[colorKeyIndex]).rgba;
                 } else if (colorByPoint && chart.options.colors) {
                     colorIndex = colorIndex %
                         chart.options.colors.length;
 
-                    pcolor = color(chart.options.colors[colorIndex]).rgba;
+                    rgba = color(chart.options.colors[colorIndex]).rgba;
                 }
 
-                if (pcolor) {
-                    pcolor[0] /= 255.0;
-                    pcolor[1] /= 255.0;
-                    pcolor[2] /= 255.0;
+                if (rgba) {
+                    pcolor = rgba;
+                    pcolor[0] = rgba[0] / 255.0;
+                    pcolor[1] = rgba[1] / 255.0;
+                    pcolor[2] = rgba[2] / 255.0;
+                    pcolor[3] = rgba[3];
                 }
 
                 colorIndex++;


### PR DESCRIPTION
Fixed #23882, a regression in v12.4 causing zones not to work on a boosted series