### PR TITLE
bugfix/20322-color-axis-wordcloud

### DIFF
--- a/samples/unit-tests/series-wordcloud/color-axis/demo.css
+++ b/samples/unit-tests/series-wordcloud/color-axis/demo.css
@@ -1,0 +1,4 @@
+#container {
+    height: 500px;
+    width: 1000px;
+}

--- a/samples/unit-tests/series-wordcloud/color-axis/demo.details
+++ b/samples/unit-tests/series-wordcloud/color-axis/demo.details
@@ -1,0 +1,5 @@
+---
+ resources:
+   - https://code.jquery.com/qunit/qunit-2.0.1.js
+   - https://code.jquery.com/qunit/qunit-2.0.1.css
+...

--- a/samples/unit-tests/series-wordcloud/color-axis/demo.html
+++ b/samples/unit-tests/series-wordcloud/color-axis/demo.html
@@ -1,0 +1,8 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/wordcloud.js"></script>
+<script src="https://code.highcharts.com/modules/coloraxis.js"></script>
+
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+
+<div id="container"></div>

--- a/samples/unit-tests/series-wordcloud/color-axis/demo.js
+++ b/samples/unit-tests/series-wordcloud/color-axis/demo.js
@@ -1,0 +1,30 @@
+QUnit.test('Color axis should be supported for wordcloud', function (assert) {
+    const chart = Highcharts.chart('container', {
+        colorAxis: {
+            minColor: '#0f0',
+            maxColor: '#f00'
+        },
+        series: [
+            {
+                type: 'wordcloud',
+                data: [
+                    { name: 'value-5', y: 5, weight: 5 },
+                    { name: 'value-50', y: 50, weight: 50 },
+                    { name: 'value-100', y: 100, weight: 100 }
+                ]
+            }
+        ]
+    });
+
+    assert.strictEqual(
+        chart.series[0].points[0].color,
+        'rgb(13,242,0)',
+        'First point should be green'
+    );
+
+    assert.strictEqual(
+        chart.series[0].points[2].color,
+        'rgb(255,0,0)',
+        'Third point should be red'
+    );
+});

--- a/ts/Core/Axis/Color/ColorAxisDefaults.ts
+++ b/ts/Core/Axis/Color/ColorAxisDefaults.ts
@@ -54,7 +54,7 @@ import { Palette } from '../../Color/Palettes.js';
  * convenient to add each category to a separate series.
  *
  * Color axis does not work with: `sankey`, `sunburst`, `dependencywheel`,
- * `networkgraph`, `wordcloud`, `venn`, `gauge` and `solidgauge` series
+ * `networkgraph`, `venn`, `gauge` and `solidgauge` series
  * types.
  *
  * Since v7.2.0 `colorAxis` can also be an array of options objects.

--- a/ts/Core/Axis/Color/ColorAxisOptions.ts
+++ b/ts/Core/Axis/Color/ColorAxisOptions.ts
@@ -138,7 +138,7 @@ export interface ColorAxisMarkerOptions {
  * convenient to add each category to a separate series.
  *
  * Color axis does not work with: `sankey`, `sunburst`, `dependencywheel`,
- * `networkgraph`, `wordcloud`, `venn`, `gauge` and `solidgauge` series
+ * `networkgraph`, `venn`, `gauge` and `solidgauge` series
  * types.
  *
  * Since v7.2.0 `colorAxis` can also be an array of options objects.

--- a/ts/Series/Wordcloud/WordcloudSeriesDefaults.ts
+++ b/ts/Series/Wordcloud/WordcloudSeriesDefaults.ts
@@ -80,6 +80,8 @@ const WordcloudSeriesDefaults: WordcloudSeriesOptions = {
 
     cropThreshold: Infinity,
 
+    colorKey: 'weight',
+
     /**
      * A threshold determining the minimum font size that can be applied to
      * a word.


### PR DESCRIPTION
Fixed #20322, the color axis did not work with wordcloud.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206210828828940