### PR TITLE
grid/fix-lint-dts

### DIFF
--- a/tools/gulptasks/scripts-ts.js
+++ b/tools/gulptasks/scripts-ts.js
@@ -71,8 +71,24 @@ function removeHighcharts(removeFromCode = false, product = 'Highcharts') {
         pathsToDelete.push([...folder, 'Grid']);
     }
 
+    const preserveSvgDts = removeFromCode && product === 'Grid';
+    const svgRendererPath = fsLib.path([...folder, 'Core', 'Renderer', 'SVG']);
+
     for (const pathToDelete of pathsToDelete) {
-        fsLib.deleteDirectory(fsLib.path(pathToDelete));
+        const targetPath = fsLib.path(pathToDelete);
+
+        if (preserveSvgDts && targetPath === svgRendererPath) {
+            if (fsLib.isDirectory(targetPath)) {
+                for (const filePath of fsLib.getFilePaths(targetPath, true)) {
+                    if (!filePath.endsWith('.d.ts')) {
+                        fsLib.deleteFile(filePath);
+                    }
+                }
+            }
+            continue;
+        }
+
+        fsLib.deleteDirectory(targetPath);
     }
 }
 


### PR DESCRIPTION
Fix Grid dist d.ts lint by preserving SVG type declarations

  - Keep Core/Renderer/SVG/*.d.ts in Grid build cleanup so AST.d.ts can resolve
    SVGAttributes
  - Still remove SVG runtime code from Grid output