### PR TITLE
Fixed master issue with karma tests and templating-like code in HTML

### DIFF
--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -68,7 +68,10 @@ function getHTML(path) {
         .replace(
             /<link[a-z"=:\.\/ ]+(fonts\.googleapis.com|fonts\.gstatic.com)[^>]+>/gi,
             ''
-        );
+        )
+
+        // Escape ${...} template strings
+        .replace(/\$\{/g, '\\${');
 
     return html + '\n';
 }


### PR DESCRIPTION
The following command failed:

`npx karma start test/karma-conf.js --tests "highcharts/xaxis/labels-format-custom" --reference --browsercount 1 --no-fail-on-empty-test-suite`

.. because we have JS templating-like strings in the HTML:

`<highcharts-control type="text" path="yAxis.labels.format" value="${value:.2f} USD"></highcharts-control>`