### PR TITLE
bugfix/17393-duplicated-xAxis-labels

### DIFF
--- a/samples/unit-tests/series/setdata/demo.js
+++ b/samples/unit-tests/series/setdata/demo.js
@@ -1071,7 +1071,7 @@ QUnit.test('Point.update with only y value changed', function (assert) {
         // initialTickCount = xAxis.tickPositions.length,
         // initialLabelCount = xAxis.labelGroup.element.childNodes.length,
         point = series.points[0],
-        newY = data1[0][1] + 0.1;
+        newY = data1[0][1];
 
     // Update point with only y value changed
     point.update({ y: newY });

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -2438,6 +2438,16 @@ class Axis {
             }
 
         }
+
+        // Ensure the old ticks are removed and new ones added (#17393)
+        if (
+            !this.isDirty &&
+            tickPositions.length !==
+            this.tickPositions?.length
+        ) {
+            this.isDirty = true;
+        }
+
         this.tickPositions = tickPositions;
 
         // Get minorTickInterval

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -1292,16 +1292,6 @@ class Series {
             // Don't add new points since those configs are used above
             pointsToAdd.length = 0;
 
-            // Fix axis labels positioning (#17393).
-            // Mark axes as dirty.
-            if (this.xAxis) {
-                this.xAxis.isDirty = true;
-            }
-
-            if (this.yAxis) {
-                this.yAxis.isDirty = true;
-            }
-
         // Did not succeed in updating data
         } else {
             succeeded = false;


### PR DESCRIPTION
Fixed #17393, datetime axis had duplicated labels after updating data in some corner cases.