### PR TITLE
bugfix/24031-negative-values-in-compare

### DIFF
--- a/samples/unit-tests/series/compare/demo.js
+++ b/samples/unit-tests/series/compare/demo.js
@@ -1,17 +1,21 @@
-QUnit.test('Compare to negative (#4661)', function (assert) {
-    var chart = $('#container')
-        .highcharts('StockChart', {
-            series: [
-                {
-                    data: [-100, -150, -125, -300, -250],
-                    compare: 'percent'
-                }
-            ]
-        })
-        .highcharts();
+QUnit.test('Compare to negative (#4661, #24031)', function (assert) {
+    const chart = Highcharts.stockChart('container', {
+        series: [
+            {
+                data: [-100, -150, -125, -300, -250],
+                compare: 'percent'
+            }
+        ]
+    });
 
     assert.strictEqual(typeof chart.yAxis[0].min, 'number', 'Has a minimum');
     assert.strictEqual(typeof chart.yAxis[0].max, 'number', 'Has a maximum');
+
+    assert.ok(
+        chart.series[0].dataModify.modifyValue(-150, 0) < 0,
+        `If parent series points values are decreasing, the compare percent
+        series modified values should also decrease. (#24031)`
+    );
 });
 
 QUnit.test('Compare in candlesticks', function (assert) {

--- a/ts/Series/DataModifyComposition.ts
+++ b/ts/Series/DataModifyComposition.ts
@@ -635,7 +635,7 @@ namespace DataModifyComposition {
                     } else {
                         const compareBase = this.series.options.compareBase;
 
-                        value = 100 * (value / compareValue) -
+                        value = 100 * (value / Math.abs(compareValue)) -
                             (compareBase === 100 ? 0 : 100);
                     }
 


### PR DESCRIPTION
Fixed #24031, compare percent values calculation was not correct for negative points.