### PR TITLE
Sample generator: no satisfies keyword

### DIFF
--- a/samples/highcharts/coloraxis/changed-default-color-key/demo.ts
+++ b/samples/highcharts/coloraxis/changed-default-color-key/demo.ts
@@ -26,4 +26,4 @@ Highcharts.chart('container', {
         ],
         keys: ['x', 'y', 'z', 'colorValue']
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/coloraxis/custom-color-key/demo.ts
+++ b/samples/highcharts/coloraxis/custom-color-key/demo.ts
@@ -26,4 +26,4 @@ Highcharts.chart('container', {
         ],
         keys: ['x', 'y', 'z', 'colorValue']
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/coloraxis/width-and-height/demo.ts
+++ b/samples/highcharts/coloraxis/width-and-height/demo.ts
@@ -15,4 +15,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/legend/align/demo.ts
+++ b/samples/highcharts/legend/align/demo.ts
@@ -20,4 +20,4 @@ Highcharts.chart('container', {
     }, {
         data: [4, 2, 5, 3]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/legend/backgroundcolor/demo.ts
+++ b/samples/highcharts/legend/backgroundcolor/demo.ts
@@ -14,4 +14,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/legend/bordercolor/config.ts
+++ b/samples/highcharts/legend/bordercolor/config.ts
@@ -4,7 +4,7 @@ import type {
 
 export default {
     paths: [
-        'legend.borderColor',
+        'legend.borderColor=#999999',
         'legend.borderWidth=2',
         'legend.borderRadius',
         'legend.backgroundColor=#aaaaaa40'

--- a/samples/highcharts/legend/bordercolor/demo.ts
+++ b/samples/highcharts/legend/bordercolor/demo.ts
@@ -16,4 +16,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/legend/enabled-false/demo.ts
+++ b/samples/highcharts/legend/enabled-false/demo.ts
@@ -14,4 +14,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/crosshair-both/demo.ts
+++ b/samples/highcharts/xaxis/crosshair-both/demo.ts
@@ -17,4 +17,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/crosshair-customized/demo.ts
+++ b/samples/highcharts/xaxis/crosshair-customized/demo.ts
@@ -24,4 +24,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/crosshair-dotted/demo.ts
+++ b/samples/highcharts/xaxis/crosshair-dotted/demo.ts
@@ -19,4 +19,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/crosshair-snap-false/demo.ts
+++ b/samples/highcharts/xaxis/crosshair-snap-false/demo.ts
@@ -23,4 +23,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/datetimelabelformats/demo.ts
+++ b/samples/highcharts/xaxis/datetimelabelformats/demo.ts
@@ -20,4 +20,4 @@ Highcharts.chart('container', {
         pointIntervalUnit: 'day',
         pointStart: '2010-01-01'
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/gridlineinterpolation/demo.ts
+++ b/samples/highcharts/xaxis/gridlineinterpolation/demo.ts
@@ -19,4 +19,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/gridzindex/demo.ts
+++ b/samples/highcharts/xaxis/gridzindex/demo.ts
@@ -13,4 +13,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/labels-align-left/demo.ts
+++ b/samples/highcharts/xaxis/labels-align-left/demo.ts
@@ -16,4 +16,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/labels-align-right/demo.ts
+++ b/samples/highcharts/xaxis/labels-align-right/demo.ts
@@ -16,4 +16,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/labels-allowoverlap-true/demo.ts
+++ b/samples/highcharts/xaxis/labels-allowoverlap-true/demo.ts
@@ -24,4 +24,4 @@ Highcharts.chart('container', {
             4, 2, 4, 5, 5
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/labels-autorotation-0-90/demo.ts
+++ b/samples/highcharts/xaxis/labels-autorotation-0-90/demo.ts
@@ -23,4 +23,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/labels-autorotation-default/demo.ts
+++ b/samples/highcharts/xaxis/labels-autorotation-default/demo.ts
@@ -20,4 +20,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/labels-autorotationlimit/demo.ts
+++ b/samples/highcharts/xaxis/labels-autorotationlimit/demo.ts
@@ -51,4 +51,4 @@ Highcharts.chart('container', {
             showInLegend: false
         }
     ]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/labels-enabled/demo.ts
+++ b/samples/highcharts/xaxis/labels-enabled/demo.ts
@@ -14,4 +14,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/labels-format-custom/demo.ts
+++ b/samples/highcharts/xaxis/labels-format-custom/demo.ts
@@ -25,4 +25,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/labels-reservespace-true/demo.ts
+++ b/samples/highcharts/xaxis/labels-reservespace-true/demo.ts
@@ -14,4 +14,4 @@ Highcharts.chart('container', {
     series: [{
         data: [5, 3, 4, 7, 2]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/labels-reservespace/demo.ts
+++ b/samples/highcharts/xaxis/labels-reservespace/demo.ts
@@ -34,4 +34,4 @@ Highcharts.chart('container', {
             enabled: true
         }
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/labels-rotation/demo.ts
+++ b/samples/highcharts/xaxis/labels-rotation/demo.ts
@@ -17,4 +17,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/labels-staggerlines/demo.ts
+++ b/samples/highcharts/xaxis/labels-staggerlines/demo.ts
@@ -17,4 +17,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/labels-step/demo.ts
+++ b/samples/highcharts/xaxis/labels-step/demo.ts
@@ -17,4 +17,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/labels-style/demo.ts
+++ b/samples/highcharts/xaxis/labels-style/demo.ts
@@ -21,4 +21,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/labels-x/demo.ts
+++ b/samples/highcharts/xaxis/labels-x/demo.ts
@@ -21,4 +21,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/minrange/demo.ts
+++ b/samples/highcharts/xaxis/minrange/demo.ts
@@ -19,4 +19,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/opposite/demo.ts
+++ b/samples/highcharts/xaxis/opposite/demo.ts
@@ -18,4 +18,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotbands-color/demo.ts
+++ b/samples/highcharts/xaxis/plotbands-color/demo.ts
@@ -19,4 +19,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotbands-from/demo.ts
+++ b/samples/highcharts/xaxis/plotbands-from/demo.ts
@@ -19,4 +19,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotbands-gauge/demo.ts
+++ b/samples/highcharts/xaxis/plotbands-gauge/demo.ts
@@ -26,4 +26,4 @@ Highcharts.chart('container', {
     series: [{
         data: [80]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotbands-label-align/demo.ts
+++ b/samples/highcharts/xaxis/plotbands-label-align/demo.ts
@@ -24,4 +24,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotbands-label-rotation/demo.ts
+++ b/samples/highcharts/xaxis/plotbands-label-rotation/demo.ts
@@ -24,4 +24,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotbands-label-style/demo.ts
+++ b/samples/highcharts/xaxis/plotbands-label-style/demo.ts
@@ -27,4 +27,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotbands-label-verticalalign/demo.ts
+++ b/samples/highcharts/xaxis/plotbands-label-verticalalign/demo.ts
@@ -24,4 +24,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotbands-label-y/demo.ts
+++ b/samples/highcharts/xaxis/plotbands-label-y/demo.ts
@@ -24,4 +24,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotbands-zindex-above-series/demo.ts
+++ b/samples/highcharts/xaxis/plotbands-zindex-above-series/demo.ts
@@ -23,4 +23,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotbands-zindex/demo.ts
+++ b/samples/highcharts/xaxis/plotbands-zindex/demo.ts
@@ -23,4 +23,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotlines-color/demo.ts
+++ b/samples/highcharts/xaxis/plotlines-color/demo.ts
@@ -22,4 +22,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotlines-dashstyle/demo.ts
+++ b/samples/highcharts/xaxis/plotlines-dashstyle/demo.ts
@@ -22,4 +22,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotlines-label-align-right/demo.ts
+++ b/samples/highcharts/xaxis/plotlines-label-align-right/demo.ts
@@ -28,4 +28,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotlines-label-style/demo.ts
+++ b/samples/highcharts/xaxis/plotlines-label-style/demo.ts
@@ -31,4 +31,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotlines-label-textalign/demo.ts
+++ b/samples/highcharts/xaxis/plotlines-label-textalign/demo.ts
@@ -27,4 +27,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotlines-label-verticalalign-middle/demo.ts
+++ b/samples/highcharts/xaxis/plotlines-label-verticalalign-middle/demo.ts
@@ -27,4 +27,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotlines-label-y/demo.ts
+++ b/samples/highcharts/xaxis/plotlines-label-y/demo.ts
@@ -27,4 +27,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotlines-zindex-above-all/demo.ts
+++ b/samples/highcharts/xaxis/plotlines-zindex-above-all/demo.ts
@@ -27,4 +27,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotlines-zindex-above/demo.ts
+++ b/samples/highcharts/xaxis/plotlines-zindex-above/demo.ts
@@ -27,4 +27,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/plotlines-zindex-behind/demo.ts
+++ b/samples/highcharts/xaxis/plotlines-zindex-behind/demo.ts
@@ -26,4 +26,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/reversedstacks/demo.ts
+++ b/samples/highcharts/xaxis/reversedstacks/demo.ts
@@ -14,4 +14,4 @@ Highcharts.chart('container', {
     }, {
         data: [4, 3, 5, 2]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/showfirstlabel-false/demo.ts
+++ b/samples/highcharts/xaxis/showfirstlabel-false/demo.ts
@@ -15,4 +15,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/showlastlabel-true/demo.ts
+++ b/samples/highcharts/xaxis/showlastlabel-true/demo.ts
@@ -15,4 +15,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/startofweek-monday/demo.ts
+++ b/samples/highcharts/xaxis/startofweek-monday/demo.ts
@@ -20,4 +20,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/startofweek-sunday/demo.ts
+++ b/samples/highcharts/xaxis/startofweek-sunday/demo.ts
@@ -20,4 +20,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/startontick-false/demo.ts
+++ b/samples/highcharts/xaxis/startontick-false/demo.ts
@@ -18,4 +18,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/startontick-true/demo.ts
+++ b/samples/highcharts/xaxis/startontick-true/demo.ts
@@ -18,4 +18,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/staticscale/demo.ts
+++ b/samples/highcharts/xaxis/staticscale/demo.ts
@@ -12,4 +12,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/tickcolor/demo.ts
+++ b/samples/highcharts/xaxis/tickcolor/demo.ts
@@ -19,4 +19,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/tickinterval-5/demo.ts
+++ b/samples/highcharts/xaxis/tickinterval-5/demo.ts
@@ -11,4 +11,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/ticklength/demo.ts
+++ b/samples/highcharts/xaxis/ticklength/demo.ts
@@ -21,4 +21,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/tickmarkplacement-between/demo.ts
+++ b/samples/highcharts/xaxis/tickmarkplacement-between/demo.ts
@@ -16,4 +16,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/tickmarkplacement-on/demo.ts
+++ b/samples/highcharts/xaxis/tickmarkplacement-on/demo.ts
@@ -16,4 +16,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/tickpixelinterval-50/demo.ts
+++ b/samples/highcharts/xaxis/tickpixelinterval-50/demo.ts
@@ -11,4 +11,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/tickposition-inside/demo.ts
+++ b/samples/highcharts/xaxis/tickposition-inside/demo.ts
@@ -11,4 +11,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/tickposition-outside/demo.ts
+++ b/samples/highcharts/xaxis/tickposition-outside/demo.ts
@@ -11,4 +11,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/tickwidth/demo.ts
+++ b/samples/highcharts/xaxis/tickwidth/demo.ts
@@ -11,4 +11,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/title-align-center/demo.ts
+++ b/samples/highcharts/xaxis/title-align-center/demo.ts
@@ -24,4 +24,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/title-align-high/demo.ts
+++ b/samples/highcharts/xaxis/title-align-high/demo.ts
@@ -24,4 +24,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/title-align-low/demo.ts
+++ b/samples/highcharts/xaxis/title-align-low/demo.ts
@@ -24,4 +24,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/title-margin/demo.ts
+++ b/samples/highcharts/xaxis/title-margin/demo.ts
@@ -20,4 +20,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/title-style/demo.ts
+++ b/samples/highcharts/xaxis/title-style/demo.ts
@@ -24,4 +24,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/title-text/demo.ts
+++ b/samples/highcharts/xaxis/title-text/demo.ts
@@ -22,4 +22,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/type-datetime/demo.ts
+++ b/samples/highcharts/xaxis/type-datetime/demo.ts
@@ -17,4 +17,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/type-linear/demo.ts
+++ b/samples/highcharts/xaxis/type-linear/demo.ts
@@ -11,4 +11,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/type-log-both/demo.ts
+++ b/samples/highcharts/xaxis/type-log-both/demo.ts
@@ -128,4 +128,4 @@ Highcharts.chart('container', {
         ],
         type: 'scatter'
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/uniquenames-false/demo.ts
+++ b/samples/highcharts/xaxis/uniquenames-false/demo.ts
@@ -49,4 +49,4 @@ Highcharts.chart('container', {
             showInLegend: false
         }
     ]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/uniquenames-true/demo.ts
+++ b/samples/highcharts/xaxis/uniquenames-true/demo.ts
@@ -49,4 +49,4 @@ Highcharts.chart('container', {
             showInLegend: false
         }
     ]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/visible/demo.ts
+++ b/samples/highcharts/xaxis/visible/demo.ts
@@ -15,4 +15,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/xaxis/zoomenabled/demo.ts
+++ b/samples/highcharts/xaxis/zoomenabled/demo.ts
@@ -26,4 +26,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/allowdecimals-false/demo.ts
+++ b/samples/highcharts/yaxis/allowdecimals-false/demo.ts
@@ -12,4 +12,4 @@ Highcharts.chart('container', {
     series: [{
         data: [0.5, 1.5, 1, 2]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/allowdecimals-true/demo.ts
+++ b/samples/highcharts/yaxis/allowdecimals-true/demo.ts
@@ -12,4 +12,4 @@ Highcharts.chart('container', {
     series: [{
         data: [0.5, 1.5, 1, 2]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/alternategridcolor/demo.ts
+++ b/samples/highcharts/yaxis/alternategridcolor/demo.ts
@@ -18,4 +18,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/angle/demo.ts
+++ b/samples/highcharts/yaxis/angle/demo.ts
@@ -28,4 +28,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/endontick-false/demo.ts
+++ b/samples/highcharts/yaxis/endontick-false/demo.ts
@@ -18,4 +18,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/endontick-log-false/demo.ts
+++ b/samples/highcharts/yaxis/endontick-log-false/demo.ts
@@ -19,4 +19,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/endontick/demo.ts
+++ b/samples/highcharts/yaxis/endontick/demo.ts
@@ -18,4 +18,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/floor-ceiling/demo.ts
+++ b/samples/highcharts/yaxis/floor-ceiling/demo.ts
@@ -20,4 +20,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/gridlinecolor/demo.ts
+++ b/samples/highcharts/yaxis/gridlinecolor/demo.ts
@@ -14,4 +14,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/gridlinedashstyle/demo.ts
+++ b/samples/highcharts/yaxis/gridlinedashstyle/demo.ts
@@ -15,4 +15,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/gridlineinterpolation/demo.ts
+++ b/samples/highcharts/yaxis/gridlineinterpolation/demo.ts
@@ -25,4 +25,4 @@ Highcharts.chart('container', {
     series: [{
         data: [29.9, 71.5, 106.4, 129.2, 144, 176, 135.6, 148.5]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/gridlinewidth/demo.ts
+++ b/samples/highcharts/yaxis/gridlinewidth/demo.ts
@@ -14,4 +14,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/labels-align-left/demo.ts
+++ b/samples/highcharts/yaxis/labels-align-left/demo.ts
@@ -17,4 +17,4 @@ Highcharts.chart('container', {
     series: [{
         data: [100, 300, 200, 400]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/labels-distance/demo.ts
+++ b/samples/highcharts/yaxis/labels-distance/demo.ts
@@ -37,4 +37,4 @@ Highcharts.chart('container', {
         radius: '100%',
         type: 'solidgauge'
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/labels-format/demo.ts
+++ b/samples/highcharts/yaxis/labels-format/demo.ts
@@ -16,4 +16,4 @@ Highcharts.chart('container', {
     series: [{
         data: [100, 300, 200, 400]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/linecolor/demo.ts
+++ b/samples/highcharts/yaxis/linecolor/demo.ts
@@ -15,4 +15,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/max-200/demo.ts
+++ b/samples/highcharts/yaxis/max-200/demo.ts
@@ -19,4 +19,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/max-logarithmic/demo.ts
+++ b/samples/highcharts/yaxis/max-logarithmic/demo.ts
@@ -20,4 +20,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/maxpadding-02/demo.ts
+++ b/samples/highcharts/yaxis/maxpadding-02/demo.ts
@@ -19,4 +19,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/maxpadding/demo.ts
+++ b/samples/highcharts/yaxis/maxpadding/demo.ts
@@ -19,4 +19,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/min-startontick-false/demo.ts
+++ b/samples/highcharts/yaxis/min-startontick-false/demo.ts
@@ -18,4 +18,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/min-startontick-true/demo.ts
+++ b/samples/highcharts/yaxis/min-startontick-true/demo.ts
@@ -18,4 +18,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/mincolor-maxcolor/demo.ts
+++ b/samples/highcharts/yaxis/mincolor-maxcolor/demo.ts
@@ -37,4 +37,4 @@ Highcharts.chart('container', {
     series: [{
         data: [30]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/minorgridlinecolor/demo.ts
+++ b/samples/highcharts/yaxis/minorgridlinecolor/demo.ts
@@ -16,4 +16,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/minorgridlinedashstyle/demo.ts
+++ b/samples/highcharts/yaxis/minorgridlinedashstyle/demo.ts
@@ -17,4 +17,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/minorgridlinewidth/demo.ts
+++ b/samples/highcharts/yaxis/minorgridlinewidth/demo.ts
@@ -18,4 +18,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/minortickcolor/demo.ts
+++ b/samples/highcharts/yaxis/minortickcolor/demo.ts
@@ -16,4 +16,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/minortickinterval-5/demo.ts
+++ b/samples/highcharts/yaxis/minortickinterval-5/demo.ts
@@ -17,4 +17,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/minortickinterval-log-auto/demo.ts
+++ b/samples/highcharts/yaxis/minortickinterval-log-auto/demo.ts
@@ -19,4 +19,4 @@ Highcharts.chart('container', {
         ],
         type: 'column'
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/minortickinterval-log/demo.ts
+++ b/samples/highcharts/yaxis/minortickinterval-log/demo.ts
@@ -18,4 +18,4 @@ Highcharts.chart('container', {
             54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/minorticklength/demo.ts
+++ b/samples/highcharts/yaxis/minorticklength/demo.ts
@@ -17,4 +17,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/minortickposition-inside/demo.ts
+++ b/samples/highcharts/yaxis/minortickposition-inside/demo.ts
@@ -17,4 +17,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/minortickposition-outside/demo.ts
+++ b/samples/highcharts/yaxis/minortickposition-outside/demo.ts
@@ -17,4 +17,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/minorticks-true/demo.ts
+++ b/samples/highcharts/yaxis/minorticks-true/demo.ts
@@ -14,4 +14,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/minortickspermajor/demo.ts
+++ b/samples/highcharts/yaxis/minortickspermajor/demo.ts
@@ -15,4 +15,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/minortickwidth/demo.ts
+++ b/samples/highcharts/yaxis/minortickwidth/demo.ts
@@ -15,4 +15,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/minpadding/demo.ts
+++ b/samples/highcharts/yaxis/minpadding/demo.ts
@@ -19,4 +19,4 @@ Highcharts.chart('container', {
             195.6, 154.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/offset/demo.ts
+++ b/samples/highcharts/yaxis/offset/demo.ts
@@ -19,4 +19,4 @@ Highcharts.chart('container', {
             95.6, 54.4
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/opposite/demo.ts
+++ b/samples/highcharts/yaxis/opposite/demo.ts
@@ -14,4 +14,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/reversed/demo.ts
+++ b/samples/highcharts/yaxis/reversed/demo.ts
@@ -14,4 +14,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/reversedstacks-false/demo.ts
+++ b/samples/highcharts/yaxis/reversedstacks-false/demo.ts
@@ -23,4 +23,4 @@ Highcharts.chart('container', {
     }, {
         data: [4, 2, 3, 1]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/showempty/demo.ts
+++ b/samples/highcharts/yaxis/showempty/demo.ts
@@ -18,4 +18,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/softmin-softmax/demo.ts
+++ b/samples/highcharts/yaxis/softmin-softmax/demo.ts
@@ -16,4 +16,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/stacklabels-align-center/demo.ts
+++ b/samples/highcharts/yaxis/stacklabels-align-center/demo.ts
@@ -35,4 +35,4 @@ Highcharts.chart('container', {
             106.4, 129.2
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/stacklabels-align-left/demo.ts
+++ b/samples/highcharts/yaxis/stacklabels-align-left/demo.ts
@@ -35,4 +35,4 @@ Highcharts.chart('container', {
             106.4, 129.2
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/stacklabels-align-right/demo.ts
+++ b/samples/highcharts/yaxis/stacklabels-align-right/demo.ts
@@ -35,4 +35,4 @@ Highcharts.chart('container', {
             106.4, 129.2
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/stacklabels-allowoverlap-false/demo.ts
+++ b/samples/highcharts/yaxis/stacklabels-allowoverlap-false/demo.ts
@@ -36,4 +36,4 @@ Highcharts.chart('container', {
             106.4, 129.2
         ]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/stacklabels-box/demo.ts
+++ b/samples/highcharts/yaxis/stacklabels-box/demo.ts
@@ -31,4 +31,4 @@ Highcharts.chart('container', {
     }, {
         data: [144, 176, 135.6, 148.5]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/stacklabels-enabled/demo.ts
+++ b/samples/highcharts/yaxis/stacklabels-enabled/demo.ts
@@ -26,4 +26,4 @@ Highcharts.chart('container', {
     }, {
         data: [144, 176, 135.6, 148.5]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/stacklabels-rotation/demo.ts
+++ b/samples/highcharts/yaxis/stacklabels-rotation/demo.ts
@@ -27,4 +27,4 @@ Highcharts.chart('container', {
     }, {
         data: [144, 176, 135.6, 148.5]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/stacklabels-style/demo.ts
+++ b/samples/highcharts/yaxis/stacklabels-style/demo.ts
@@ -32,4 +32,4 @@ Highcharts.chart('container', {
     }, {
         data: [144, 176, 135.6, 148.5]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/stacklabels-textalign-left/demo.ts
+++ b/samples/highcharts/yaxis/stacklabels-textalign-left/demo.ts
@@ -28,4 +28,4 @@ Highcharts.chart('container', {
     }, {
         data: [144, 176, 135.6, 148.5]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/stacklabels-verticalalign-bottom/demo.ts
+++ b/samples/highcharts/yaxis/stacklabels-verticalalign-bottom/demo.ts
@@ -27,4 +27,4 @@ Highcharts.chart('container', {
     }, {
         data: [144, 176, 135.6, 148.5]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/stacklabels-verticalalign-middle/demo.ts
+++ b/samples/highcharts/yaxis/stacklabels-verticalalign-middle/demo.ts
@@ -27,4 +27,4 @@ Highcharts.chart('container', {
     }, {
         data: [144, 176, 135.6, 148.5]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/stacklabels-verticalalign-top/demo.ts
+++ b/samples/highcharts/yaxis/stacklabels-verticalalign-top/demo.ts
@@ -27,4 +27,4 @@ Highcharts.chart('container', {
     }, {
         data: [144, 176, 135.6, 148.5]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/stacklabels-x/demo.ts
+++ b/samples/highcharts/yaxis/stacklabels-x/demo.ts
@@ -27,4 +27,4 @@ Highcharts.chart('container', {
     }, {
         data: [144, 176, 135.6, 148.5]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/stacklabels-y/demo.ts
+++ b/samples/highcharts/yaxis/stacklabels-y/demo.ts
@@ -27,4 +27,4 @@ Highcharts.chart('container', {
     }, {
         data: [144, 176, 135.6, 148.5]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/tickamount/demo.ts
+++ b/samples/highcharts/yaxis/tickamount/demo.ts
@@ -14,4 +14,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/title-offset/demo.ts
+++ b/samples/highcharts/yaxis/title-offset/demo.ts
@@ -17,4 +17,4 @@ Highcharts.chart('container', {
     series: [{
         data: [1, 3, 2, 4]
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/type-log-minorgrid/demo.ts
+++ b/samples/highcharts/yaxis/type-log-minorgrid/demo.ts
@@ -129,4 +129,4 @@ Highcharts.chart('container', {
         ],
         type: 'scatter'
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/highcharts/yaxis/type-log/demo.ts
+++ b/samples/highcharts/yaxis/type-log/demo.ts
@@ -128,4 +128,4 @@ Highcharts.chart('container', {
         ],
         type: 'scatter'
     }]
-} satisfies Highcharts.Options);
+});

--- a/samples/stock/xaxis/alternategridcolor/demo.ts
+++ b/samples/stock/xaxis/alternategridcolor/demo.ts
@@ -14,6 +14,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/crosshair-dashed/demo.ts
+++ b/samples/stock/xaxis/crosshair-dashed/demo.ts
@@ -16,6 +16,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/crosshair-interactive/demo.ts
+++ b/samples/stock/xaxis/crosshair-interactive/demo.ts
@@ -20,6 +20,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/crosshair-label/demo.ts
+++ b/samples/stock/xaxis/crosshair-label/demo.ts
@@ -20,6 +20,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/crosshairs-xy/demo.ts
+++ b/samples/stock/xaxis/crosshairs-xy/demo.ts
@@ -17,6 +17,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/datetimelabelformats/demo.ts
+++ b/samples/stock/xaxis/datetimelabelformats/demo.ts
@@ -22,6 +22,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/endontick/demo.ts
+++ b/samples/stock/xaxis/endontick/demo.ts
@@ -18,6 +18,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/gridlinecolor/demo.ts
+++ b/samples/stock/xaxis/gridlinecolor/demo.ts
@@ -14,6 +14,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/gridlinedashstyle/demo.ts
+++ b/samples/stock/xaxis/gridlinedashstyle/demo.ts
@@ -14,6 +14,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/gridlinewidth/demo.ts
+++ b/samples/stock/xaxis/gridlinewidth/demo.ts
@@ -14,6 +14,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/labels-enabled/demo.ts
+++ b/samples/stock/xaxis/labels-enabled/demo.ts
@@ -16,6 +16,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/labels-format/demo.ts
+++ b/samples/stock/xaxis/labels-format/demo.ts
@@ -16,6 +16,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/labels-staggerlines/demo.ts
+++ b/samples/stock/xaxis/labels-staggerlines/demo.ts
@@ -19,6 +19,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/linecolor/demo.ts
+++ b/samples/stock/xaxis/linecolor/demo.ts
@@ -14,6 +14,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/linewidth/demo.ts
+++ b/samples/stock/xaxis/linewidth/demo.ts
@@ -14,6 +14,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/min-max/demo.ts
+++ b/samples/stock/xaxis/min-max/demo.ts
@@ -15,6 +15,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/minorgridlinecolor/demo.ts
+++ b/samples/stock/xaxis/minorgridlinecolor/demo.ts
@@ -15,6 +15,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/minorgridlinedashstyle/demo.ts
+++ b/samples/stock/xaxis/minorgridlinedashstyle/demo.ts
@@ -17,6 +17,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/minorgridlinewidth/demo.ts
+++ b/samples/stock/xaxis/minorgridlinewidth/demo.ts
@@ -18,6 +18,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/minorticks/demo.ts
+++ b/samples/stock/xaxis/minorticks/demo.ts
@@ -19,6 +19,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/minpadding-maxpadding/demo.ts
+++ b/samples/stock/xaxis/minpadding-maxpadding/demo.ts
@@ -21,6 +21,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/offset/demo.ts
+++ b/samples/stock/xaxis/offset/demo.ts
@@ -21,6 +21,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/opposite/demo.ts
+++ b/samples/stock/xaxis/opposite/demo.ts
@@ -17,6 +17,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/ordinal-false/demo.ts
+++ b/samples/stock/xaxis/ordinal-false/demo.ts
@@ -28,6 +28,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/ordinal-true/demo.ts
+++ b/samples/stock/xaxis/ordinal-true/demo.ts
@@ -28,6 +28,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/overscroll-percent/demo.ts
+++ b/samples/stock/xaxis/overscroll-percent/demo.ts
@@ -14,6 +14,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/overscroll-pixel/demo.ts
+++ b/samples/stock/xaxis/overscroll-pixel/demo.ts
@@ -14,6 +14,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/plotbands-label/demo.ts
+++ b/samples/stock/xaxis/plotbands-label/demo.ts
@@ -26,6 +26,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/plotbands/demo.ts
+++ b/samples/stock/xaxis/plotbands/demo.ts
@@ -18,6 +18,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/plotlines/demo.ts
+++ b/samples/stock/xaxis/plotlines/demo.ts
@@ -22,6 +22,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/range/demo.ts
+++ b/samples/stock/xaxis/range/demo.ts
@@ -14,6 +14,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/reversed/demo.ts
+++ b/samples/stock/xaxis/reversed/demo.ts
@@ -15,6 +15,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/showfirstlabel/demo.ts
+++ b/samples/stock/xaxis/showfirstlabel/demo.ts
@@ -19,6 +19,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/startofweek-0/demo.ts
+++ b/samples/stock/xaxis/startofweek-0/demo.ts
@@ -20,6 +20,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/startofweek-1/demo.ts
+++ b/samples/stock/xaxis/startofweek-1/demo.ts
@@ -20,6 +20,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/tickinterval/demo.ts
+++ b/samples/stock/xaxis/tickinterval/demo.ts
@@ -14,6 +14,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/tickpixelinterval/demo.ts
+++ b/samples/stock/xaxis/tickpixelinterval/demo.ts
@@ -14,6 +14,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/ticks/demo.ts
+++ b/samples/stock/xaxis/ticks/demo.ts
@@ -17,6 +17,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/title-align/demo.ts
+++ b/samples/stock/xaxis/title-align/demo.ts
@@ -17,6 +17,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/xaxis/title-text/demo.ts
+++ b/samples/stock/xaxis/title-text/demo.ts
@@ -17,6 +17,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/yaxis/min-max/demo.ts
+++ b/samples/stock/yaxis/min-max/demo.ts
@@ -17,6 +17,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/yaxis/scrollbar/demo.ts
+++ b/samples/stock/yaxis/scrollbar/demo.ts
@@ -23,6 +23,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/samples/stock/yaxis/yaxis-reversed/demo.ts
+++ b/samples/stock/yaxis/yaxis-reversed/demo.ts
@@ -22,6 +22,6 @@
         series: [{
             data: data
         }]
-    } satisfies Highcharts.Options);
+    });
 
 })();

--- a/tools/sample-generator/index.ts
+++ b/tools/sample-generator/index.ts
@@ -882,9 +882,11 @@ export async function getDemoTS(
         ].join('\n') + '\n\n    ';
     }
 
+    // Build the TS. Would like to have `satisfies Highcharts.Options` here, but
+    // that breaks jsFiddle. Revisit later.
     ts += `Highcharts.${factory}('container', ${
         chartOptions
-    } satisfies Highcharts.Options);\n`
+    });\n`
         // Some cases, for example tooltip.borderWidth, have defaultValue as
         // "undefined" in tree.json
         .replace(/"undefined"/gu, 'undefined');


### PR DESCRIPTION
The demos failed in jsFiddle because its TypeScript mode didn't support `satisfies`

[Reported to jsFiddle](https://github.com/jsfiddle/jsfiddle-users/issues/2341).