### PR TITLE
dash/23935-set-connector-options

### DIFF
--- a/ts/Data/DataPool.ts
+++ b/ts/Data/DataPool.ts
@@ -337,8 +337,6 @@ class DataPool implements DataEventEmitter<Event> {
      * @param update
      * Whether to update the existing connector with the new options and reload
      * it (`true`) or replace it with a new connector instance (`false`).
-     *
-     * @default true
      */
     public async setConnectorOptions(
         options: DataConnectorTypeOptions,


### PR DESCRIPTION
Added `update` argument to DataPool's `setConnectorOptions` method. See #23935.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212402891359301