### PR TITLE
docs/19991-thousands-separator

### DIFF
--- a/docs/chart-concepts/templating.md
+++ b/docs/chart-concepts/templating.md
@@ -8,18 +8,18 @@ Expressions in format strings are enclosed by `{single brackets}`. They can be s
 
 **Variables** and properties are inserted directly inside the bracket, for example `"The point value at {point.x} is {point.y}"`. Nested properties are supported using the dot notation. Arrays are also indexed using dot notation, for example `{series.xAxis.categories.0}`, or more practical, with a subexpression `{series.xAxis.categories.(point.x)}`
 
-**Numbers** are formatted with a subset of float formatting conventions from the C library function `sprintf`. The formatting is appended inside the expression, separated from the value by a colon. Note that even though a dot and a comma symbolizes the decimal point and the thousands separator respectively, how it is actually rendered depends on the browser locale, therefore will be displayed differently in different regions. To ensure identical number formatting across users set the desired format in [language settings](https://api.highcharts.com/highcharts/lang). For example:
+**Numbers** are formatted with a subset of float formatting conventions from the C library function `sprintf`. The formatting is appended inside the expression, separated from the value by a colon. Note that even though a dot and a comma symbolizes the decimal point and the thousands separator respectively, how it is actually rendered depends on the chart's [lang.locale](https://api.highcharts.com/highcharts/lang.locale) setting. The default for `lang.locale` is the browser's locate, but it can be overridden either with a HTML `lang` attribute, or with an explicit setting . Examples:
 
 *   Two decimal places:  `"{point.y:.2f}"` [[Demo](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/labels/two-decimal-places)]
 *   Default thousands separator from browser locale, no decimal places: `{point.y:,.0f}` [[Demo](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/labels/no-decimal-places)]
-*   Forced thousands separator with one decimal place after a comma: `{point.y:,.1f}` [[Demo, internationalized](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/labels/one-decimal-place)]
+*   Forced `de-DE` locale with one decimal place after a comma: `{point.y:,.1f}` [[Demo, internationalized](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/labels/one-decimal-place)]
 
 **Dates** allow, like numbers, the format to be appended behind a colon. The format conventions allowed are the same as those of [Highcharts.dateFormat()](https://api.highcharts.com/class-reference/Highcharts.Time#dateFormat). For example:
 
 *   Full date: `{value:%Y-%m-%d}` [[Demo](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/labels/full-date)]
 *   Locale-aware full date: `{value:%[Ymd]}` [[Demo](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/labels/full-date)]
 
-_Note: Locale-aware formats use names from the active locale.  
+_Note: Locale-aware formats use names from the active locale.
 To apply custom names from `lang.months`, `lang.weekdays`, etc., use non-locale-aware formats._
 
 For example, `{value:%b}` uses `lang.shortMonths`, while `{value:%[b]}` follows the locale.

--- a/samples/highcharts/labels/one-decimal-place/demo.js
+++ b/samples/highcharts/labels/one-decimal-place/demo.js
@@ -1,8 +1,7 @@
 Highcharts.setOptions({
 
     lang: {
-        decimalPoint: ',',
-        thousandsSep: ' '
+        locale: 'de-DE'
     }
 
 });


### PR DESCRIPTION
Fixed #19991, clear explanation of handling numbers formatting was missing.


Demos are fine, only docs correction was needed. If you would like test it on your side, you can switch Chrome browser locale by: https://stackoverflow.com/questions/37221494/how-to-change-the-locale-in-the-chrome-browser