### PR TITLE
bugfix/24067-remove-old-cols

### DIFF
--- a/ts/Dashboards/Components/GridComponent/GridComponent.ts
+++ b/ts/Dashboards/Components/GridComponent/GridComponent.ts
@@ -136,10 +136,10 @@ class GridComponent extends Component {
                 grid.update({
                     dataTable: table?.getModified()
                 }, false);
-            }
-
-            // #24067 Update the dataTable in the options if it has changed
-            if (options.gridOptions?.dataTable && this.options.gridOptions) {
+            } else if ( // #24067 -Update the dataTable in the options if it has changed
+                options.gridOptions?.dataTable &&
+                this.options.gridOptions
+            ) { 
                 this.options.gridOptions.dataTable =
                     options.gridOptions.dataTable;
             }


### PR DESCRIPTION
Fixed #24067, dataTable was not saved in gridOptions on update.