### PR TITLE
bugfix/demo-thumbnails-empty

### DIFF
--- a/samples/highcharts/demo/dendrogram/demo.css
+++ b/samples/highcharts/demo/dendrogram/demo.css
@@ -1,4 +1,4 @@
-* {
+body {
     font-family:
         -apple-system,
         BlinkMacSystemFont,
@@ -10,6 +10,8 @@
         "Segoe UI Emoji",
         "Segoe UI Symbol",
         sans-serif;
+    background: var(--highcharts-background-color);
+    color: var(--highcharts-neutral-color-100);
 }
 
 .highcharts-figure {

--- a/samples/highcharts/demo/dendrogram/demo.html
+++ b/samples/highcharts/demo/dendrogram/demo.html
@@ -8,16 +8,16 @@
 <figure class="highcharts-figure">
     <div id="container"></div>
 
+    <p class="highcharts-description">
+        A dendrogram is a tree-like diagram that visualizes the results of a hierarchical clustering analysis, showing the relationships and similarity levels among a group of entities. Objects are merged into branches (clusters) based on their similarities, with the height of the branches indicating the level of similarity or distance at which those clusters were formed.
+    </p>
+
     <div class="button-row">
         <label>Link type</label>
         <button class="highcharts-demo-button active" data-value="orthogonal">Orthogonal</button>
         <button class="highcharts-demo-button" data-value="straight">Straight</button>
         <button class="highcharts-demo-button" data-value="curved">Curved</button>
     </div>
-
-    <p class="highcharts-description">
-        A dendrogram is a tree-like diagram that visualizes the results of a hierarchical clustering analysis, showing the relationships and similarity levels among a group of entities. Objects are merged into branches (clusters) based on their similarities, with the height of the branches indicating the level of similarity or distance at which those clusters were formed.
-   </p>
 </figure>
 
 <pre class="hidden">

--- a/samples/highcharts/demo/network-graph/demo.js
+++ b/samples/highcharts/demo/network-graph/demo.js
@@ -63,6 +63,7 @@ Highcharts.chart('container', {
         networkgraph: {
             keys: ['from', 'to'],
             layoutAlgorithm: {
+                maxIterations: 72,
                 enableSimulation: true,
                 friction: -0.9,
                 gravitationalConstant:


### PR DESCRIPTION
- CSS in dendrogram were missing some styles to prevent black text on dark background;
- higher maxIterations prevents small thumbnail due to the default value of 10
- a11y requires highcharts-description to be the next sibling of the chart container

Unresolved missing SVG images in labels are to be continued in https://github.com/highcharts/highcharts/issues/24097

Skipping changelog intentionally - I just named the branch wrongly with `bugfix`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212935433325373