### PR TITLE
grid/sparkline-default-pie-donut

### DIFF
--- a/samples/grid-pro/demo/sparklines/demo.js
+++ b/samples/grid-pro/demo/sparklines/demo.js
@@ -304,6 +304,7 @@ const grid = Grid.grid('container', {
                             type: 'pie'
                         },
                         series: [{
+                            innerSize: '50%',
                             data: [{
                                 name: 'Used',
                                 y: data,

--- a/ts/Grid/Pro/CellRendering/ContentTypes/SparklineContent.ts
+++ b/ts/Grid/Pro/CellRendering/ContentTypes/SparklineContent.ts
@@ -105,8 +105,7 @@ class SparklineContent extends CellContentPro {
             },
             pie: {
                 slicedOffset: 0,
-                borderRadius: 0,
-                innerSize: '50%'
+                borderRadius: 0
             }
         }
     };


### PR DESCRIPTION
Defined default `innerSize: 50%` for pie sparklines in [the sparklines demo](http://localhost:3030/samples/#view/grid-pro/demo/sparklines).


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212964240385696