### PR TITLE
bugfix/24138-bubble-zMin

### DIFF
--- a/samples/unit-tests/series-bubble/minmaxsize/demo.js
+++ b/samples/unit-tests/series-bubble/minmaxsize/demo.js
@@ -301,3 +301,28 @@ QUnit.test('Set min/max size', function (assert) {
         by the previous series that has been removed, #17486.`
     );
 });
+
+QUnit.test('Bubble zMin update, #24138.', function (assert) {
+    var chart = Highcharts.chart('container', {
+            chart: {
+                type: 'bubble'
+            },
+            series: [{
+                zMin: 0,
+                data: [
+                    [1, 1, 5],
+                    [2, 2, 10],
+                    [3, 3, 15]
+                ]
+            }]
+        }),
+        radiusBefore = chart.series[0].data[0].marker.radius;
+
+    chart.series[0].update({ zMin: 10 });
+
+    assert.notStrictEqual(
+        chart.series[0].data[0].marker.radius,
+        radiusBefore,
+        'Radius should update after zMin change.'
+    );
+});

--- a/ts/Series/Bubble/BubbleSeries.ts
+++ b/ts/Series/Bubble/BubbleSeries.ts
@@ -47,6 +47,7 @@ const {
     arrayMax,
     arrayMin,
     clamp,
+    defined,
     extend,
     isNumber,
     merge,
@@ -780,14 +781,16 @@ class BubbleSeries extends ScatterSeries {
                 point.negative = (point.z || 0) < (options.zThreshold || 0);
             }
 
-            if (isNumber(radius) && radius >= minPxSize / 2) {
-                // Shape arguments
+            // #24138: Always update marker to reflect current calculated radius
+            if (isNumber(radius)) {
                 point.marker = extend(point.marker, {
                     radius,
                     width: 2 * radius,
                     height: 2 * radius
                 });
+            }
 
+            if (isNumber(radius) && radius >= minPxSize / 2) {
                 // Alignment box for the data label
                 point.dlBox = {
                     x: (point.plotX as any) - radius,
@@ -944,6 +947,15 @@ addEvent(BubbleSeries, 'updatedData', (e): void => {
 // After removing series, delete the chart-level Z extremes cache, #17502.
 addEvent(BubbleSeries, 'remove', (e): void => {
     delete e.target.chart.bubbleZExtremes;
+});
+
+// Before updating series, delete the chart-level Z extremes cache if zMin or
+// zMax options are being changed, #24138.
+addEvent(BubbleSeries, 'update', (e): void => {
+    const bubbleOptions = e.target.options as BubbleSeriesOptions;
+    if (defined(bubbleOptions.zMin) || defined(bubbleOptions.zMax)) {
+        delete e.target.chart.bubbleZExtremes;
+    }
 });
 
 /* *


### PR DESCRIPTION
Fixed #24138, `zMin` for bubble series was not changed on `series.update()`.