### PR TITLE
fix: update api docs for packed bubble chart

### DIFF
--- a/ts/Series/PackedBubble/PackedBubbleSeriesDefaults.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeriesDefaults.ts
@@ -33,7 +33,7 @@ const { isNumber } = U;
  * @excluding    boostThreshold, boostBlending,connectEnds, connectNulls,
  *               cropThreshold, dataSorting, dragDrop, jitter,
  *               legendSymbolColor, keys, pointPlacement, sizeByAbsoluteValue,
- *               step, xAxis, yAxis, zMax, zMin
+ *               step, xAxis, yAxis
  * @product      highcharts
  * @since        7.0.0
  * @requires     highcharts-more
@@ -79,6 +79,36 @@ const PackedBubbleSeriesDefaults: PackedBubbleSeriesOptions = {
     tooltip: {
         pointFormat: 'Value: {point.value}'
     },
+
+    /**
+     * The minimum for the Z value range. Defaults to the lowest Z value
+     * in the data.
+     *
+     * @see [zMax](#plotOptions.packedbubble.zMax)
+     *
+     * @sample {highcharts} highcharts/plotoptions/bubble-zmin-zmax/
+     *         Z has a possible range of 0-100
+     *
+     * @type      {number}
+     * @since     7.0.0
+     * @product   highcharts
+     * @apioption plotOptions.packedbubble.zMin
+     */
+
+    /**
+     * The maximum for the Z value range. Defaults to the highest Z value
+     * in the data.
+     *
+     * @see [zMin](#plotOptions.packedbubble.zMin)
+     *
+     * @sample {highcharts} highcharts/plotoptions/bubble-zmin-zmax/
+     *         Z has a possible range of 0-100
+     *
+     * @type      {number}
+     * @since     7.0.0
+     * @product   highcharts
+     * @apioption plotOptions.packedbubble.zMax
+     */
 
     /**
      * Flag to determine if nodes are draggable or not. Available for

--- a/ts/Series/PackedBubble/PackedBubbleSeriesOptions.d.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeriesOptions.d.ts
@@ -77,8 +77,7 @@ export interface PackedBubbleParentNodeOptions {
  *
  * @excluding connectEnds, connectNulls, cropThreshold, dragDrop, jitter,
  *            keys, pointPlacement, sizeByAbsoluteValue, step, xAxis,
- *            yAxis, zMax, zMin, dataSorting, boostThreshold,
- *            boostBlending
+ *            yAxis, dataSorting, boostThreshold, boostBlending
  *
  * @excluding cropThreshold, dataParser, dataSorting, dataURL, dragDrop, stack,
  *            boostThreshold, boostBlending
@@ -223,6 +222,36 @@ export interface PackedBubbleSeriesOptions
      * @since 7.1.0
      */
     useSimulation?: boolean;
+
+    /**
+     * The minimum for the Z value range. Defaults to the lowest Z value
+     * in the data.
+     *
+     * @see [zMax](#plotOptions.packedbubble.zMax)
+     *
+     * @sample {highcharts} highcharts/plotoptions/bubble-zmin-zmax/
+     *         Z has a possible range of 0-100
+     *
+     * @type      {number}
+     * @since     7.0.0
+     * @product   highcharts
+     */
+    zMin?: number;
+
+    /**
+     * The maximum for the Z value range. Defaults to the highest Z value
+     * in the data.
+     *
+     * @see [zMin](#plotOptions.packedbubble.zMin)
+     *
+     * @sample {highcharts} highcharts/plotoptions/bubble-zmin-zmax/
+     *         Z has a possible range of 0-100
+     *
+     * @type      {number}
+     * @since     7.0.0
+     * @product   highcharts
+     */
+    zMax?: number;
 
     zoneAxis?: ('x'|'y'|'z'|undefined);
 


### PR DESCRIPTION
### What I Fixed
Added missing API documentation for zMin and zMax properties in packed bubble charts.

### The Problem
- Properties worked in code but were hidden from API docs
- Developers couldn't find documentation despite properties being functional
---
### Files Changed
- PackedBubbleSeriesDefaults.ts
- PackedBubbleSeriesOptions.d.ts
---
### Result
After next build, documentation will appear at:
- plotOptions.packedbubble.zMin
- plotOptions.packedbubble.zMax
----
Fixes #24135 