### PR TITLE
Fixed #24163, redundant redraws when chart update

### DIFF
--- a/ts/Core/Axis/Color/ColorAxis.ts
+++ b/ts/Core/Axis/Color/ColorAxis.ts
@@ -368,13 +368,6 @@ class ColorAxis extends Axis implements ColorAxisBase {
             legend.render();
             this.chart.getMargins(true);
 
-            // If not drilling down/up
-            if (!this.chart.series.some((series): boolean | undefined =>
-                series.isDrilling
-            )) {
-                axis.isDirty = true; // Flag to fire drawChartBox
-            }
-
             // First time only
             if (!axis.added) {
                 axis.added = true;


### PR DESCRIPTION
Fixed #24163, redundant redraws when running `chart.update`, causing poor performance in charts with a color axis.

There are still cases where `Chart.isDirtyBox` is set to true even though a chart box layout is not needed, for example any `series.update` call. A proper cleanup should probably be done, to evaluate which updates actually require new box computation and which do not. For example any color updates do not.