### PR TITLE
Added chart.update with open slots for series and axis

### DIFF
--- a/samples/unit-tests/chart/chart-update/demo.js
+++ b/samples/unit-tests/chart/chart-update/demo.js
@@ -184,6 +184,28 @@
             'ProximaNova, Arial, \'Helvetica Neue\', Helvetica, sans-serif',
             '#16153: fontFamily should not reset when updating chart.style'
         );
+
+        // Update collection with empty item
+        Highcharts.addEvent(chart.series[0], 'update', () => {
+            assert.notOk(
+                true,
+                'Update should not be called when updating with empty item'
+            );
+        });
+        chart.update({
+            series: [undefined, { color: 'green' }]
+        });
+
+        assert.strictEqual(
+            chart.series[0].color,
+            '#68266f',
+            'First series color should not be affected by empty item in update'
+        );
+        assert.strictEqual(
+            chart.series[1].color,
+            'green',
+            'Second series color should be updated to green'
+        );
     });
 
     QUnit.test('Loading update', function (assert) {

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -3831,14 +3831,17 @@ class Chart {
         // update the first series in the chart. Setting two series without
         // an id will update the first and the second respectively (#6019)
         // chart.update and responsive.
-        this.collectionsWithUpdate.forEach(function (coll: string): void {
+        this.collectionsWithUpdate.forEach((coll: string): void => {
 
             if ((options as any)[coll]) {
 
-                splat((options as any)[coll]).forEach(function (
+                splat((options as any)[coll]).forEach((
                     newOptions,
                     i
-                ): void {
+                ): void => {
+                    if (!newOptions) {
+                        return;
+                    }
                     const hasId = defined(newOptions.id);
                     let item: (Axis|Series|Point|undefined);
 
@@ -3892,7 +3895,7 @@ class Chart {
 
                 // Add items for removal
                 if (oneToOne) {
-                    (chart as any)[coll].forEach(function (item: any): void {
+                    (chart as any)[coll].forEach((item: any): void => {
                         if (!item.touched && !item.options.isInternal) {
                             itemsForRemoval.push(item);
                         } else {
@@ -3905,7 +3908,7 @@ class Chart {
             }
         });
 
-        itemsForRemoval.forEach(function (item: any): void {
+        itemsForRemoval.forEach((item: any): void => {
             if (item.chart && item.remove) { // #9097, avoid removing twice
                 item.remove(false);
             }


### PR DESCRIPTION
Fixed issue when running `Chart.update` with empty items for `series`, `xAxis` and `yAxis`. 

Preparation for Controls, where undefined slots are inserted for existing items.