### PR TITLE
grid/styles-api-option

### DIFF
--- a/css/grid/grid-lite.css
+++ b/css/grid/grid-lite.css
@@ -454,12 +454,19 @@
     --ig-header-column-color: var(--hcg-column-color, var(--hcg-cell-color, var(--ig-color, inherit)));
     --ig-header-base-color: var(--hcg-header-color, var(--ig-header-column-color));
     --ig-header-current-color: var(--ig-header-base-color);
+    --ig-header-font-weight: var(--hcg-header-font-weight, var(--hcg-cell-font-weight, var(--ig-font-weight)));
+    --ig-header-font-size: var(--hcg-header-font-size, var(--hcg-cell-font-size, var(--ig-font-size)));
+    --ig-header-font-family: var(--hcg-header-font-family, var(--hcg-cell-font-family, var(--ig-font-family)));
+    --ig-header-font: var(--ig-header-font-weight) var(--ig-header-font-size) var(--ig-header-font-family);
+    --ig-header-text-align: var(--hcg-header-text-align, var(--hcg-cell-text-align, var(--ig-text-align)));
 
     border-right: var(--ig-header-column-border);
     border-bottom: var(--ig-header-row-border);
     padding: var(--ig-header-padding);
     background: var(--ig-header-background);
     color: var(--ig-header-current-color);
+    font: var(--ig-header-font);
+    text-align: var(--ig-header-text-align);
 }
 
 .hcg-table thead th:nth-child(even) {
@@ -471,14 +478,8 @@
 }
 
 .hcg-table thead th .hcg-header-cell-content {
-    --ig-header-font-weight: var(--hcg-header-font-weight, var(--hcg-cell-font-weight, var(--ig-font-weight)));
-    --ig-header-font-size: var(--hcg-header-font-size, var(--hcg-cell-font-size, var(--ig-font-size)));
-    --ig-header-font-family: var(--hcg-header-font-family, var(--hcg-cell-font-family, var(--ig-font-family)));
-    --ig-header-font: var(--ig-header-font-weight) var(--ig-header-font-size) var(--ig-header-font-family);
-    --ig-header-text-align: var(--hcg-header-text-align, var(--hcg-cell-text-align, var(--ig-text-align)));
-
-    font: var(--ig-header-font);
-    text-align: var(--ig-header-text-align);
+    font: inherit;
+    text-align: inherit;
 }
 
 .hcg-table thead tr:first-of-type th:first-child {

--- a/samples/grid-lite/basic/style-options/demo.css
+++ b/samples/grid-lite/basic/style-options/demo.css
@@ -1,0 +1,18 @@
+@import url("https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid-lite.css");
+
+body {
+    font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        sans-serif;
+    background: var(--highcharts-background-color);
+    color: var(--highcharts-neutral-color-100);
+}
+
+#container {
+    padding: 8px;
+}

--- a/samples/grid-lite/basic/style-options/demo.details
+++ b/samples/grid-lite/basic/style-options/demo.details
@@ -1,0 +1,6 @@
+---
+name: Grid Style Options
+authors:
+  - Dawid Dragula
+js_wrap: b
+...

--- a/samples/grid-lite/basic/style-options/demo.html
+++ b/samples/grid-lite/basic/style-options/demo.html
@@ -1,0 +1,3 @@
+<script src="https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/grid-lite.js"></script>
+
+<div id="container"></div>

--- a/samples/grid-lite/basic/style-options/demo.js
+++ b/samples/grid-lite/basic/style-options/demo.js
@@ -1,0 +1,96 @@
+Grid.grid('container', {
+    dataTable: {
+        columns: {
+            product: [
+                'Apples',
+                'Pears',
+                'Plums',
+                'Bananas',
+                'Oranges',
+                'Grapes'
+            ],
+            stock: [120, 55, 25, 10, 0, 80],
+            margin: [38, 22, 14, 8, 4, 31]
+        }
+    },
+    columnDefaults: {
+        header: {
+            style: {
+                fontWeight: '700'
+            }
+        }
+    },
+    columns: [
+        {
+            id: 'product',
+            style: {
+                fontWeight: '100'
+            },
+            header: {
+                style: {
+                    backgroundColor: 'rgba(51, 65, 85, 0.85)',
+                    color: '#f8fafc'
+                }
+            }
+        },
+        {
+            id: 'stock',
+            style: function () {
+                return {
+                    textAlign: 'right'
+                };
+            },
+            header: {
+                style: function () {
+                    return {
+                        backgroundColor: 'rgba(15, 118, 110, 0.85)',
+                        color: '#f8fafc'
+                    };
+                }
+            },
+            cells: {
+                style: function () {
+                    if (this.value >= 50) {
+                        return { color: '#22c55e', fontWeight: '700' };
+                    }
+                    if (this.value >= 20) {
+                        return { color: '#f59e0b', fontWeight: '700' };
+                    }
+                    return {
+                        color: '#ef4444',
+                        fontWeight: '700'
+                    };
+                }
+            }
+        },
+        {
+            id: 'margin',
+            cells: {
+                style: function () {
+                    const value = this.value;
+
+                    if (value >= 25) {
+                        return { color: '#22c55e', fontWeight: '700' };
+                    }
+                    if (value >= 10) {
+                        return { color: '#f59e0b', fontWeight: '700' };
+                    }
+
+                    return {
+                        color: '#ef4444',
+                        fontWeight: '700'
+                    };
+                }
+            },
+            header: {
+                style: {
+                    backgroundColor: 'rgba(124, 45, 18, 0.85)',
+                    color: '#f8fafc'
+                }
+            }
+        }
+    ],
+    caption: {
+        text: 'Column style options with simple high/medium/low thresholds'
+    }
+});

--- a/ts/Grid/Core/Options.ts
+++ b/ts/Grid/Core/Options.ts
@@ -42,6 +42,7 @@ import type { LangOptionsCore } from '../../Shared/LangOptionsCore';
 import type {
     Condition as ColumnFilteringCondition
 } from './Table/Actions/ColumnFiltering/FilteringTypes';
+import type CSSObject from '../../Core/Renderer/CSSObject';
 
 
 /* *
@@ -61,6 +62,16 @@ export type CellFormatterCallback = (this: Cell) => string;
  * formatted header's string.
  */
 export type HeaderFormatterCallback = (this: Column) => string;
+
+/**
+ * Callback function to resolve dynamic style for a grid entity.
+ */
+export type StyleCallback<T> = (this: T, target: T) => CSSObject;
+
+/**
+ * A static style object or a callback that returns one.
+ */
+export type StyleValue<T> = CSSObject | StyleCallback<T>;
 
 /**
  * Column sorting order type.
@@ -461,6 +472,12 @@ export interface ColumnOptions {
      * Filtering options for the column.
      */
     filtering?: ColumnFilteringOptions;
+
+    /**
+     * CSS styles for the whole column, applied to the header and body cells.
+     * Can be a static style object or a callback that returns one.
+     */
+    style?: StyleValue<Column>;
 }
 
 /**
@@ -508,6 +525,12 @@ export interface ColumnCellOptions {
      * context menu will be shown on right-click.
      */
     contextMenu?: CellContextMenuOptions;
+
+    /**
+     * CSS styles for table body cells in the column.
+     * Can be a static style object or a callback that returns one.
+     */
+    style?: StyleValue<Cell>;
 }
 
 /**
@@ -537,6 +560,12 @@ export interface ColumnHeaderOptions {
      * A string to be set as a header cell's content.
      */
     formatter?: HeaderFormatterCallback;
+
+    /**
+     * CSS styles for the column header cells.
+     * Can be a static style object or a callback that returns one.
+     */
+    style?: StyleValue<Column>;
 }
 
 /**

--- a/ts/Grid/Core/Table/Body/TableCell.ts
+++ b/ts/Grid/Core/Table/Body/TableCell.ts
@@ -23,12 +23,14 @@
  * */
 
 import type { CellType as DataTableCellType } from '../../../../Data/DataTable';
+import type CSSObject from '../../../../Core/Renderer/CSSObject';
 import type Column from '../Column';
 import type TableRow from './TableRow';
 
 import Globals from '../../Globals.js';
 import Cell from '../Cell.js';
 import CellContent from '../CellContent/CellContent.js';
+import { mergeStyleValues } from '../../GridUtils.js';
 
 import Utils from '../../../../Core/Utilities.js';
 const {
@@ -162,7 +164,31 @@ class TableCell extends Cell {
         // Add custom class name from column options
         this.setCustomClassName(this.column.options.cells?.className);
 
+        this.setCustomStyles(this.getCellStyles());
+
         fireEvent(this, 'afterRender', { target: this });
+    }
+
+    /**
+     * Returns merged styles from defaults and current column options.
+     */
+    private getCellStyles(): CSSObject {
+        const { grid } = this.column.viewport;
+        const rawColumnOptions =
+            grid.columnOptionsMap?.[this.column.id]?.options;
+
+        return {
+            ...mergeStyleValues(
+                this.column,
+                grid.options?.columnDefaults?.style,
+                rawColumnOptions?.style
+            ),
+            ...mergeStyleValues(
+                this,
+                grid.options?.columnDefaults?.cells?.style,
+                rawColumnOptions?.cells?.style
+            )
+        };
     }
 
     /**

--- a/ts/Grid/Core/Table/Header/HeaderCell.ts
+++ b/ts/Grid/Core/Table/Header/HeaderCell.ts
@@ -25,22 +25,24 @@
 
 import type { GroupedHeaderOptions } from '../../Options';
 import type { NoIdColumnOptions } from '../Column';
+import type CSSObject from '../../../../Core/Renderer/CSSObject';
 
 import Cell from '../Cell.js';
 import Column from '../Column';
 import Row from '../Row';
-import GridUtils from '../../GridUtils.js';
+import {
+    makeHTMLElement,
+    setHTMLContent,
+    createOptionsProxy,
+    resolveStyleValue,
+    mergeStyleValues
+} from '../../GridUtils.js';
 import ColumnSorting from '../Actions/ColumnSorting.js';
 import Globals from '../../Globals.js';
 import Utilities from '../../../../Core/Utilities.js';
 import TableHeader from './TableHeader.js';
 import ColumnToolbar from './ColumnToolbar/ColumnToolbar.js';
 
-const {
-    makeHTMLElement,
-    setHTMLContent,
-    createOptionsProxy
-} = GridUtils;
 const {
     fireEvent,
     isString
@@ -243,7 +245,37 @@ class HeaderCell extends Cell {
         // Add custom class name from column options
         this.setCustomClassName(options.header?.className);
 
+        this.setCustomStyles(this.getColumnStyles());
+
         fireEvent(this, 'afterRender', { column });
+    }
+
+    /**
+     * Returns merged header styles from defaults and current column options.
+     *
+     */
+    private getColumnStyles(): (CSSObject | undefined) {
+        const { column } = this;
+
+        if (!column) {
+            return resolveStyleValue(this.superColumnOptions.header?.style);
+        }
+
+        const { grid } = this.row.viewport;
+        const rawColumnOptions = grid.columnOptionsMap?.[column.id]?.options;
+
+        return {
+            ...mergeStyleValues(
+                column,
+                grid.options?.columnDefaults?.style,
+                rawColumnOptions?.style
+            ),
+            ...mergeStyleValues(
+                column,
+                grid.options?.columnDefaults?.header?.style,
+                rawColumnOptions?.header?.style
+            )
+        };
     }
 
     public override reflow(): void {


### PR DESCRIPTION
Added `columns[].style`, `columns[].cells.style`, and `columns[].header.style` to apply dynamic or static inline styles to whole columns, body cells, and header cells.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213096793041591