### PR TITLE
bugfix/24135-update-api-packed-bubble

### DIFF
--- a/ts/Series/PackedBubble/PackedBubbleSeriesDefaults.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeriesDefaults.ts
@@ -33,7 +33,7 @@ const { isNumber } = U;
  * @excluding    boostThreshold, boostBlending,connectEnds, connectNulls,
  *               cropThreshold, dataSorting, dragDrop, jitter,
  *               legendSymbolColor, keys, pointPlacement, sizeByAbsoluteValue,
- *               step, xAxis, yAxis, zMax, zMin
+ *               step, xAxis, yAxis
  * @product      highcharts
  * @since        7.0.0
  * @requires     highcharts-more

--- a/ts/Series/PackedBubble/PackedBubbleSeriesOptions.d.ts
+++ b/ts/Series/PackedBubble/PackedBubbleSeriesOptions.d.ts
@@ -77,7 +77,7 @@ export interface PackedBubbleParentNodeOptions {
  *
  * @excluding connectEnds, connectNulls, cropThreshold, dragDrop, jitter,
  *            keys, pointPlacement, sizeByAbsoluteValue, step, xAxis,
- *            yAxis, zMax, zMin, dataSorting, boostThreshold,
+ *            yAxis, dataSorting, boostThreshold,
  *            boostBlending
  *
  * @excluding cropThreshold, dataParser, dataSorting, dataURL, dragDrop, stack,


### PR DESCRIPTION
Fixed #24135, updated API with `plotOptions.zMax` and `plotOptions.zMin` for packed bubble chart.