### PR TITLE
Samples: fixed #24203 color-parser example

### DIFF
--- a/samples/highcharts/chart/colors-parsers/demo.js
+++ b/samples/highcharts/chart/colors-parsers/demo.js
@@ -1,5 +1,6 @@
 Highcharts.Color.parsers.push({
-    regex: /^hsl\s+(-?\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)$/u,
+    // eslint-disable-next-line max-len
+    regex: /^hsl\(\s*(-?\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)%\s*,\s*(\d+(?:\.\d+)?)%\s*\)$/u,
     parse: result => {
         const hue = ((Number.parseFloat(result[1]) % 360) + 360) % 360;
         const saturation = Math.max(
@@ -54,12 +55,12 @@ Highcharts.chart('container', {
         text: 'HSL colors'
     },
     colors: [
-        'hsl 0 100 50',
-        'hsl 30 100 50',
-        'hsl 120 60 45',
-        'hsl 210 70 50',
-        'hsl 275 55 45',
-        'hsl 15 45 35'
+        'hsl(0, 100%, 50%)',
+        'hsl(30, 100%, 50%)',
+        'hsl(120, 60%, 45%)',
+        'hsl(210, 70%, 50%)',
+        'hsl(275, 55%, 45%)',
+        'hsl(15, 45%, 35%)'
     ],
     xAxis: {
         categories: [

--- a/samples/highcharts/demo/contour-mountain/demo.ts
+++ b/samples/highcharts/demo/contour-mountain/demo.ts
@@ -164,56 +164,11 @@
             type: 'scatter'
         }],
         tooltip: {
-            pointFormat: '\n                Latitude: <strong>{point.x:.2f} ' +
-                   'ºE</strong>,<br/>\n ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   'Longitude: ' +
-                   '<strong>{point.y:.2f} ' +
-                   'ºN</strong>,<br/>\n ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   'Elevation: ' +
-                   '<strong>{point.value} ' +
-                   'm</strong>\n ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ' ' +
-                   ''
+            pointFormat: `
+                Latitude: <strong>{point.x:.2f} ºE</strong>,<br/>
+                Longitude: <strong>{point.y:.2f} ºN</strong>,<br/>
+                Elevation: <strong>{point.value} m</strong>
+            `
         }
     });
 


### PR DESCRIPTION
Fixed the sample to use initial colors that the browser can read natively. HC only calls color parsers for modifying the brightness on hover.