### PR TITLE
Testing array-safe DeepPartial

### DIFF
--- a/ts/Core/Axis/GridAxis.ts
+++ b/ts/Core/Axis/GridAxis.ts
@@ -936,10 +936,13 @@ function onAfterSetOptions(
                             isNumber(unitIdx) && units[unitIdx + 1]
                         );
                         if (unit) {
-                            unitName = unit[0] || 'year';
+                            if (typeof unit[0] === 'string') {
+                                unitName = unit[0];
+                            }
                             const counts = unit[1];
-                            count = counts?.[0] || 1;
-
+                            if (typeof counts?.[0] === 'number') {
+                                count = counts[0] || 1;
+                            }
                         // In case the base X axis shows years, make the
                         // secondary axis show ten times the years (#11427)
                         } else if (parentInfo.unitName === 'year') {

--- a/ts/Maps/MapView.ts
+++ b/ts/Maps/MapView.ts
@@ -371,7 +371,8 @@ class MapView {
                         this.zoom = this.userOptions.zoom;
                     }
                     if (this.userOptions.center) {
-                        merge(true, this.center, this.userOptions.center);
+                        this.center[0] = this.userOptions.center[0];
+                        this.center[1] = this.userOptions.center[1];
                     }
                 }
             })

--- a/ts/Shared/Types.d.ts
+++ b/ts/Shared/Types.d.ts
@@ -28,7 +28,12 @@ export type AnyRecord = Record<string, any>;
  * optional.
  */
 export type DeepPartial<T> = {
-    [K in keyof T]?: (T[K]|DeepPartial<T[K]>);
+    [K in keyof T]?: (
+        T[K] extends Array<infer U>
+            // Arrays stay as-is with DeepPartial elements
+            ? Array<DeepPartial<U>>
+            : T[K]|DeepPartial<T[K]>
+    );
 };
 
 /**


### PR DESCRIPTION
Testing out a version of DeepPartial where arrays are kept as-is with deep partial elements.

Note: The changes in MapView seems to be a bad use of `merge` in the first place, merging two tuples. It probably worked by chance, but is not how `merge` was intended.