### PR TITLE
bugfix/24199-datetimeformat-intl

### DIFF
--- a/tests/highcharts/time/timezone.spec.ts
+++ b/tests/highcharts/time/timezone.spec.ts
@@ -51,6 +51,17 @@ async function setupPage(page: import('@playwright/test').Page, needsMoment = fa
     }
 }
 
+test('dateTimeFormat returns empty string for NaN (#24199)', async ({ page }) => {
+    await setupPage(page, false);
+
+    const result = await page.evaluate(() => {
+        const time = new (window as any).Highcharts.Time({});
+        return time.dateTimeFormat({}, NaN);
+    });
+
+    expect(result).toBe('');
+});
+
 for (const tz of TIMEZONES) {
     test.describe(`Timezone: ${tz}`, () => {
         test.use({ timezoneId: tz });

--- a/ts/Shared/TimeBase.ts
+++ b/ts/Shared/TimeBase.ts
@@ -358,6 +358,17 @@ class TimeBase {
 
         this.dTLCache[cacheKey] = dTL;
 
+        // Guard against non-finite timestamps (e.g. from spacing: undefined)
+        // Intl.DateTimeFormat.format() throws RangeError on NaN/Infinity
+        if (
+            defined(timestamp) &&
+            !Number.isFinite(
+                timestamp instanceof Date ? timestamp.getTime() : timestamp
+            )
+        ) {
+            return '';
+        }
+
         return dTL?.format(timestamp) || '';
     }
 


### PR DESCRIPTION
Fixed #24199, `dateTimeFormat` caused error when formatting non-finite timestamps.