### PR TITLE
bugfix/24102-export-img-boost

### DIFF
--- a/samples/unit-tests/exporting/getsvg/demo.html
+++ b/samples/unit-tests/exporting/getsvg/demo.html
@@ -1,5 +1,6 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/exporting.js"></script>
+<script src="https://code.highcharts.com/modules/boost.js"></script>
 
 
 <div id="qunit"></div>

--- a/samples/unit-tests/exporting/getsvg/demo.js
+++ b/samples/unit-tests/exporting/getsvg/demo.js
@@ -256,3 +256,23 @@ QUnit.test('getSVGForExport XHTML', async function (assert) {
         'Should export one self-closing <br /> for each point'
     );
 });
+
+QUnit.test('getSVG for boosted chart', async function (assert) {
+    const chart = Highcharts.chart('container', {
+        boost: {
+            useGPUTranslations: true
+        },
+
+        series: [{
+            data: Array.from({ length: 5000 }, (_, i) => i),
+            boostThreshold: 1
+        }]
+
+    });
+
+    assert.strictEqual(
+        chart.exporting.getSVG().indexOf('xlink:href="data:image'),
+        -1,
+        'Boost image href should not be replaced with xlink:href (#24102)'
+    );
+});

--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -679,6 +679,8 @@ class Exporting {
                 '<svg xmlns:xlink="http://www.w3.org/1999/xlink" '
             )
             .replace(/ (NS\d+\:)?href=/g, ' xlink:href=') // #3567
+            // #24102- restore href for image elements (boost)
+            .replace(/(<image[^>]*) xlink:href=/g, '$1 href=')
             .replace(/\n+/g, ' ')
 
             // Replace HTML entities, issue #347


### PR DESCRIPTION
Fixed #24102, a regression causing boosted series being invisible in online exports, when `exporting.local` was false.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213014952643940