### PR TITLE
bugfix/23771-boost-point-missing-values

### DIFF
--- a/samples/unit-tests/boost/tooltip/demo.js
+++ b/samples/unit-tests/boost/tooltip/demo.js
@@ -150,3 +150,118 @@ QUnit.test(
         );
     }
 );
+
+QUnit.test(
+    'Scatter with boost should keep `keys` values after zoom (#23771)',
+    function (assert) {
+        const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'scatter',
+                zooming: {
+                    type: 'x'
+                }
+            },
+            boost: {
+                usePreAllocated: true
+            },
+            xAxis: {
+                min: 0,
+                max: 100
+            },
+            yAxis: {
+                min: 0,
+                max: 10
+            },
+            series: [{
+                boostThreshold: 1,
+                cropThreshold: 1,
+                keys: ['x', 'y', 'label'],
+                data: [
+                    [0, 1],
+                    [20, 2],
+                    [40, 3, 'C'],
+                    [60, 4, 'D'],
+                    [80, 5, 'E'],
+                    [100, 6, 'F']
+                ]
+            }]
+        });
+        const series = chart.series[0];
+
+        assert.strictEqual(
+            series.boost.getPoint(series.points[2]).label,
+            'C',
+            'The keyed value should be available before zoom'
+        );
+
+        chart.xAxis[0].setExtremes(40, 100);
+
+        assert.strictEqual(
+            series.boost.getPoint(series.points[0]).label,
+            'C',
+            'The keyed value should stay mapped after zoom'
+        );
+    }
+);
+
+QUnit.test(
+    'Scatter boost should keep remapped keys after zoom (#23771, user demo)',
+    function (assert) {
+        const size = 18;
+        const data = [];
+        let at = 0;
+
+        for (let i = 1; i <= size; i++) {
+            for (let j = 1; j <= size; j++) {
+                data.push([i, j, i + j, at++]);
+            }
+        }
+
+        const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'scatter',
+                zooming: {
+                    type: 'xy'
+                }
+            },
+            xAxis: {
+                min: 1,
+                max: size
+            },
+            yAxis: {
+                min: 1,
+                max: size
+            },
+            series: [{
+                boostThreshold: 200,
+                cropThreshold: 1,
+                keys: ['y', 'x', 'sum', 'at'],
+                data
+            }]
+        });
+        const series = chart.series[0];
+        const beforeZoomPoint = series.boost.getPoint(series.points[0]);
+
+        assert.strictEqual(
+            beforeZoomPoint.sum,
+            beforeZoomPoint.x + beforeZoomPoint.y,
+            'The remapped key should be available before zoom'
+        );
+
+        chart.xAxis[0].setExtremes(10, 18);
+        chart.yAxis[0].setExtremes(10, 18);
+
+        const afterZoomPoint = series.boost.getPoint(series.points[0]);
+
+        assert.strictEqual(
+            afterZoomPoint.sum,
+            afterZoomPoint.x + afterZoomPoint.y,
+            'The remapped key should stay mapped after zoom'
+        );
+        assert.strictEqual(
+            ((afterZoomPoint.y - 1) * size) + (afterZoomPoint.x - 1),
+            afterZoomPoint.at,
+            'The keyed value should stay aligned with x/y after zoom'
+        );
+    }
+);

--- a/ts/Extensions/Boost/BoostSeries.ts
+++ b/ts/Extensions/Boost/BoostSeries.ts
@@ -112,6 +112,7 @@ interface BoostPointMockup {
     plotX: number;
     plotY: number;
     i: number;
+    dataIndex?: number;
     percentage: number;
 }
 
@@ -119,6 +120,7 @@ interface BoostPointMockup {
 interface BoostSeriesAdditions extends BoostTargetAdditions {
     altered?: Array<BoostAlteredObject>;
     getPoint(boostPoint: (BoostPointMockup|Point)): BoostPointComposition;
+    pointDataIndices?: Array<number>;
 }
 
 /** @internal */
@@ -939,7 +941,8 @@ function getPoint(
             false
         ),
         pointIndex = boostPoint.i,
-        pointColor = (data?.[pointIndex] as { color?: string } | undefined)
+        dataIndex = pick(boostPoint.dataIndex, pointIndex),
+        pointColor = (data?.[dataIndex] as { color?: string } | undefined)
             ?.color,
         point = new PointClass(
             series as BoostSeriesComposition,
@@ -955,16 +958,19 @@ function getPoint(
         isScatter &&
         seriesOptions?.keys?.length
     ) {
-        const keys = seriesOptions.keys;
+        const keys = seriesOptions.keys,
+            pointData = (data as any)?.[dataIndex];
 
-        // Don't reassign X and Y properties as they're already handled above
-        for (
-            let keysIndex = keys.length - 1;
-            keysIndex > -1;
-            keysIndex--
-        ) {
-            (point as any)[keys[keysIndex]] =
-                (data as any)[pointIndex][keysIndex];
+        if (isArray(pointData)) {
+            // Don't reassign X and Y properties as they're already handled
+            // above
+            for (
+                let keysIndex = keys.length - 1;
+                keysIndex > -1;
+                keysIndex--
+            ) {
+                (point as any)[keys[keysIndex]] = pointData[keysIndex];
+            }
         }
     }
 
@@ -980,7 +986,7 @@ function getPoint(
     point.distX = boostPoint.distX;
     point.plotX = boostPoint.plotX;
     point.plotY = boostPoint.plotY;
-    point.index = pointIndex;
+    point.index = dataIndex;
     point.percentage = boostPoint.percentage;
     point.isInside = series.isPointInside(point);
     if (pointColor) {
@@ -1026,6 +1032,10 @@ function scatterProcessData(
         yMax = yExtremes.max ?? Number.MAX_VALUE,
         yMin = yExtremes.min ?? -Number.MAX_VALUE;
 
+    if (series.boost) {
+        delete series.boost.pointDataIndices;
+    }
+
     // Skip processing in non-boost zoom
     if (
         !series.boosted &&
@@ -1064,9 +1074,10 @@ function scatterProcessData(
     }
 
     // Filter unsorted scatter data for ranges
-    const processedData: Array<PointOptions> = [],
+    const processedData: Array<(PointOptions|PointShortOptions)> = [],
         processedXData: Array<number> = [],
         processedYData: Array<number> = [],
+        processedDataIndices: Array<number> = [],
         xRangeNeeded = !(isNumber(xExtremes.max) || isNumber(xExtremes.min)),
         yRangeNeeded = !(isNumber(yExtremes.max) || isNumber(yExtremes.min));
 
@@ -1086,9 +1097,14 @@ function scatterProcessData(
             x >= xMin && x <= xMax &&
             y >= yMin && y <= yMax
         ) {
-            processedData.push({ x, y });
+            processedData.push(
+                typeof options.data?.[i] !== 'undefined' ?
+                    options.data[i] :
+                    { x, y }
+            );
             processedXData.push(x);
             processedYData.push(y);
+            processedDataIndices.push(i);
             if (xRangeNeeded) {
                 xDataMax = Math.max(xDataMax, x);
                 xDataMin = Math.min(xDataMin, x);
@@ -1124,6 +1140,9 @@ function scatterProcessData(
         x: processedXData,
         y: processedYData
     });
+    if (series.boost && cropped) {
+        series.boost.pointDataIndices = processedDataIndices;
+    }
 
     if (!getSeriesBoosting(series, processedXData)) {
         series.processedData = processedData; // For un-boosted points rendering
@@ -1164,6 +1183,9 @@ function seriesRenderCanvas(this: Series): void {
         isStacked = !!options.stacking,
         cropStart = this.cropStart || 0,
         requireSorting = this.requireSorting,
+        pointDataIndices = !requireSorting ?
+            seriesBoost?.pointDataIndices :
+            void 0,
         useRaw = !xData,
         compareX = options.findNearestPointBy === 'x',
         xDataFull = (
@@ -1280,7 +1302,8 @@ function seriesRenderCanvas(this: Series): void {
             i: number,
             percentage: number
         ): void => {
-            const x = xDataFull ? xDataFull[cropStart + i] : false,
+            const dataIndex = pointDataIndices?.[i] ?? (cropStart + i),
+                x = xDataFull ? xDataFull[dataIndex] : false,
                 pushPoint = (plotX: number): void => {
                     if (chart.inverted) {
                         plotX = xAxis.len - plotX;
@@ -1294,6 +1317,7 @@ function seriesRenderCanvas(this: Series): void {
                         plotX: plotX,
                         plotY: plotY,
                         i: cropStart + i,
+                        dataIndex: dataIndex,
                         percentage: percentage
                     });
                 };


### PR DESCRIPTION
Fixed #23771, boosted points were missing keyed values after zoom.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211807966725143