### PR TITLE
bugfix/24274-fullscreen-label

### DIFF
--- a/ts/Extensions/Exporting/Fullscreen.ts
+++ b/ts/Extensions/Exporting/Fullscreen.ts
@@ -26,6 +26,7 @@
  * */
 
 import type Chart from '../../Core/Chart/Chart';
+import type { LangOptions } from '../../Core/Options';
 
 import AST from '../../Core/Renderer/HTML/AST.js';
 import H from '../../Core/Globals.js';
@@ -433,13 +434,17 @@ class Fullscreen {
                 menuItems.indexOf('viewFullscreen')
             ];
             if (exportDivElement) {
+                const definition =
+                    exportingOptions.menuItemDefinitions.viewFullscreen;
+                const textKey = definition?.textKey || 'viewFullscreen';
+                const translated = lang[textKey as keyof LangOptions];
                 AST.setElementHTML(
                     exportDivElement,
                     !this.isOpen ?
                         (
-                            exportingOptions.menuItemDefinitions.viewFullscreen
-                                ?.textKey ||
-                            lang.viewFullscreen
+                            typeof translated === 'string' ?
+                                translated :
+                                lang.viewFullscreen
                         ) : lang.exitFullscreen
                 );
             }


### PR DESCRIPTION
Fixed #24274 

- Fixes a regression where the "View in fullscreen" exporting menu item label changed to the raw key `viewFullscreen` after exiting fullscreen.

## Changes

- Resolve the fullscreen menu item label using `LangOptions` and the configured `textKey`, with a safe fallback to `lang.viewFullscreen`.
