### PR TITLE
samples/minor-controls-fixes 

### DIFF
--- a/samples/highcharts/tooltip/fixed/demo.css
+++ b/samples/highcharts/tooltip/fixed/demo.css
@@ -20,6 +20,7 @@
 .highcharts-controls-wrapper {
     max-width: 800px;
     margin: 1em auto;
+    padding: 0 10px;
 }
 
 highcharts-controls {

--- a/samples/highcharts/tooltip/fixed/demo.html
+++ b/samples/highcharts/tooltip/fixed/demo.html
@@ -1,5 +1,5 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@highcharts/controls@0.4.0" type="module"></script>
+<script src="https://cdn.jsdelivr.net/npm/@highcharts/controls@0.7.0" type="module"></script>
 
 <figure class="highcharts-figure">
     <div id="container"></div>
@@ -7,20 +7,22 @@
 
 <div class="highcharts-controls-wrapper">
     <highcharts-controls>
-        <highcharts-control path="tooltip.fixed"></highcharts-control>
-        <highcharts-control path="tooltip.position.align" value="left"
-            options="left,center,right"></highcharts-control>
-        <highcharts-control path="tooltip.position.verticalAlign"
-            value="top" options="top,middle,bottom"></highcharts-control>
-        <highcharts-control path="tooltip.position.relativeTo" value="pane"
-            options="pane,chart,plotBox,spacingBox"></highcharts-control>
-        <highcharts-control path="tooltip.position.x"></highcharts-control>
-        <highcharts-control path="tooltip.position.y"></highcharts-control>
-        <highcharts-control path="tooltip.split"
-            type="boolean" value="false"></highcharts-control>
-        <highcharts-control path="tooltip.shared"
-            type="boolean" value="false"></highcharts-control>
-        <highcharts-control path="tooltip.outside"
-            type="boolean" value="false"></highcharts-control>
+        <highcharts-group header="Update options">
+            <highcharts-control path="tooltip.fixed"></highcharts-control>
+            <highcharts-control path="tooltip.position.align" value="left"
+                options="left,center,right"></highcharts-control>
+            <highcharts-control path="tooltip.position.verticalAlign"
+                value="top" options="top,middle,bottom"></highcharts-control>
+            <highcharts-control path="tooltip.position.relativeTo" value="pane"
+                options="pane,chart,plotBox,spacingBox"></highcharts-control>
+            <highcharts-control path="tooltip.position.x"></highcharts-control>
+            <highcharts-control path="tooltip.position.y"></highcharts-control>
+            <highcharts-control path="tooltip.split"
+                type="boolean" value="false"></highcharts-control>
+            <highcharts-control path="tooltip.shared"
+                type="boolean" value="false"></highcharts-control>
+            <highcharts-control path="tooltip.outside"
+                type="boolean" value="false"></highcharts-control>
+        </highcharts-group>
     </highcharts-controls>
 </div>

--- a/samples/highcharts/xaxis/datetimelabelformats/config.ts
+++ b/samples/highcharts/xaxis/datetimelabelformats/config.ts
@@ -7,6 +7,7 @@ export default {
         path: 'xAxis.dateTimeLabelFormats.day',
         value: '%e of %b'
     }],
+    templates: [],
     chartOptionsExtra: {
         xAxis: {
             type: 'datetime'

--- a/samples/highcharts/xaxis/datetimelabelformats/demo.ts
+++ b/samples/highcharts/xaxis/datetimelabelformats/demo.ts
@@ -1,12 +1,8 @@
 Highcharts.chart('container', {
-    chart: {
-        type: 'column'
-    },
     title: {
         text: 'Demo of <em>xAxis.dateTimeLabelFormats.day</em>'
     },
     xAxis: {
-        categories: ['Apples', 'Bananas', 'Oranges', 'Pears'],
         dateTimeLabelFormats: {
             day: '%e of %b'
         },


### PR DESCRIPTION
Samples: Fixed xAxis.dateTimeLabelFormats and tooltip.fixed samples.

In xAxis.dateTimeLabelFormats demo used categories and datetime at the same time, as a result format did not work (we can fix this in the lib). 

In tooltip.fixed the HTML and CSS used to look strange (no code-formatting, missing title etc).