### PR TITLE
Fixed API option name parsing bug

### DIFF
--- a/tools/api-docs/grid-options.ts
+++ b/tools/api-docs/grid-options.ts
@@ -146,7 +146,7 @@ function addTreeNode(
         return;
     }
 
-    _fullname = getGridOptionName(_fullname);
+    _fullname = getGridTreeNodeName(info, _fullname);
 
     if (_fullname.startsWith('_')) {
         return;
@@ -1428,6 +1428,27 @@ function autoCompleteGridInfos(): void {
                 }
             }
         }
+    }
+}
+
+
+/**
+ * Convert a code entity name to the grid option tree node name.
+ *
+ * Real option keys declared as properties/variables must keep their source
+ * name verbatim, while interface/type-style names still use the Grid
+ * `...Options` normalization.
+ */
+function getGridTreeNodeName(
+    info: TSLib.CodeInfo,
+    name: string
+): string {
+    switch (info.kind) {
+        case 'Property':
+        case 'Variable':
+            return name;
+        default:
+            return getGridOptionName(name);
     }
 }
 


### PR DESCRIPTION
The string `Options` was stripped from all types, including the rendered API keys in tree view. Fixed so that it is not stripped from `Property` and `Variable` types.

Observe bug in prod: https://api.highcharts.com/grid/responsive.rules.grid (should be `gridOptions`)