### PR TITLE
grid/responsive-rules-2nd-render

### DIFF
--- a/ts/Grid/Core/Grid.ts
+++ b/ts/Grid/Core/Grid.ts
@@ -1379,19 +1379,20 @@ export class Grid {
      */
     public async renderViewport(): Promise<void> {
         const viewportMeta = this.viewport?.getStateMeta();
-        const pagination = this.pagination;
-        const paginationPosition = pagination?.options?.position;
-
-        this.enabledColumns = await this.getEnabledColumnIDs();
 
         this.credits?.destroy();
 
         this.viewport?.destroy();
         delete this.viewport;
 
+        fireEvent(this, 'beforeRenderViewport');
+
         this.resetContentWrapper();
 
-        fireEvent(this, 'beforeRenderViewport');
+        this.enabledColumns = await this.getEnabledColumnIDs();
+
+        const pagination = this.pagination;
+        const paginationPosition = pagination?.options?.position;
 
         this.renderCaption();
 

--- a/ts/Grid/Core/Responsive/ResponsiveComposition.ts
+++ b/ts/Grid/Core/Responsive/ResponsiveComposition.ts
@@ -74,6 +74,33 @@ function initResizeObserver(this: Grid): void {
 
     this.activeRules = new Set();
 
+    // Synchronously evaluate responsive rules so the first render already
+    // uses the correct options (avoids a redundant second render).
+    if (!this.updatingResponsive) {
+        const rules = this.options?.responsive?.rules || [];
+        if (rules.length > 0) {
+            const { clientWidth: width, clientHeight: height } =
+                this.container;
+            const fakeEntry = {
+                contentRect: { width, height }
+            } as ResizeObserverEntry;
+            const matchingRules: RuleOptions[] = [];
+
+            for (const rule of rules) {
+                if (typeof rule._id === 'undefined') {
+                    rule._id = uniqueKey();
+                }
+
+                if (matchResponsiveRule.call(this, rule, fakeEntry)) {
+                    matchingRules.push(rule);
+                }
+            }
+
+            this.activeRules = new Set(matchingRules);
+            setResponsive.call(this, matchingRules, false);
+        }
+    }
+
     this.resizeObserver = new ResizeObserver((entries): void => {
         onResize.call(this, entries[0]);
     });
@@ -132,22 +159,36 @@ function matchResponsiveRule(
  *
  * @param matchingRules
  * Active responsive rules.
+ *
+ * @param redraw
+ * Whether to redraw the grid. Default is `true`.
  */
-function setResponsive(this: Grid, matchingRules: RuleOptions[]): void {
+function setResponsive(
+    this: Grid,
+    matchingRules: RuleOptions[],
+    redraw = true
+): void {
     const ruleIds = matchingRules.map((rule): string => rule._id as string);
     const ruleIdsString = (ruleIds.toString() || void 0);
     const currentRuleIds = this.currentResponsive?.ruleIds;
 
-    if (ruleIdsString === currentRuleIds) {
+    if (ruleIdsString === currentRuleIds || this.updatingResponsive) {
         return;
     }
+
+    this.updatingResponsive = true;
+
+    let lastUpdate: Promise<void> | undefined;
 
     if (this.currentResponsive) {
         const undoOptions = this.currentResponsive.undoOptions;
         this.currentResponsive = void 0;
-        this.updatingResponsive = true;
-        void this.update(undoOptions as Options, true);
-        this.updatingResponsive = false;
+
+        if (redraw) {
+            lastUpdate = this.update(undoOptions as Options, true);
+        } else {
+            this.update(undoOptions as Options, false);
+        }
     }
 
     if (ruleIdsString) {
@@ -177,9 +218,21 @@ function setResponsive(this: Grid, matchingRules: RuleOptions[]): void {
             undoOptions
         };
 
-        if (!this.updatingResponsive) {
-            void this.update(mergedOptions as Options, true);
+        if (redraw) {
+            lastUpdate = this.update(mergedOptions as Options, true);
+        } else {
+            this.update(mergedOptions as Options, false);
         }
+    }
+
+    // Keep the flag alive until the last queued update finishes so that
+    // ResizeObserver callbacks arriving in the meantime are ignored.
+    if (lastUpdate !== void 0) {
+        void lastUpdate.then((): void => {
+            this.updatingResponsive = false;
+        });
+    } else {
+        this.updatingResponsive = false;
     }
 }
 
@@ -286,7 +339,7 @@ function syncColumnIds(
  * The resize observer entry.
  */
 function onResize(this: Grid, entry: ResizeObserverEntry): void {
-    if (!this.activeRules) {
+    if (!this.activeRules || this.updatingResponsive) {
         return;
     }
 


### PR DESCRIPTION
Fixed double initial render when using `responsive.rules`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213476299103473