### PR TITLE
docs/stickoncontact-links

### DIFF
--- a/docs/chart-concepts/tooltip.md
+++ b/docs/chart-concepts/tooltip.md
@@ -45,6 +45,8 @@ The tooltip's content is rendered from a subset of HTML that can be altered in a
 
 By default the tooltip only allows a subset of HTML because the HTML is parsed and rendered using SVG. By setting the [useHTML](https://api.highcharts.com/highcharts/tooltip.useHTML) option to true, the renderer switches to full HTML, which allows for instance table layouts or images inside the tooltip.
 
+For clickable links inside the tooltip, use [tooltip.stickOnContact](https://api.highcharts.com/highcharts/tooltip.stickOnContact) together with `useHTML`. This keeps the tooltip visible when moving the pointer from the point to the tooltip content. On touch devices, set [tooltip.followTouchMove](https://api.highcharts.com/highcharts/tooltip.followTouchMove) to `false` so users can tap links more reliably. See [an example](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/tooltip/stickoncontact-anchor-link/).
+
 ```js
 tooltip: {
     format: 'The value for <b>{x}</b> is <b>{y}</b>, in series {series.name}'

--- a/docs/chart-concepts/tooltip.md
+++ b/docs/chart-concepts/tooltip.md
@@ -45,7 +45,7 @@ The tooltip's content is rendered from a subset of HTML that can be altered in a
 
 By default the tooltip only allows a subset of HTML because the HTML is parsed and rendered using SVG. By setting the [useHTML](https://api.highcharts.com/highcharts/tooltip.useHTML) option to true, the renderer switches to full HTML, which allows for instance table layouts or images inside the tooltip.
 
-For clickable links inside the tooltip, use [tooltip.stickOnContact](https://api.highcharts.com/highcharts/tooltip.stickOnContact) together with `useHTML`. This keeps the tooltip visible when moving the pointer from the point to the tooltip content. On touch devices, set [tooltip.followTouchMove](https://api.highcharts.com/highcharts/tooltip.followTouchMove) to `false` so users can tap links more reliably. See [an example](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/tooltip/stickoncontact-anchor-link/).
+For clickable links inside the tooltip, use [tooltip.stickOnContact](https://api.highcharts.com/highcharts/tooltip.stickOnContact). This keeps the tooltip visible when moving the pointer from the point to the tooltip content. See [an example](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/tooltip/stickoncontact-anchor-link/).
 
 ```js
 tooltip: {

--- a/samples/highcharts/tooltip/stickoncontact-anchor-link/demo.css
+++ b/samples/highcharts/tooltip/stickoncontact-anchor-link/demo.css
@@ -1,0 +1,5 @@
+#container {
+    max-width: 800px;
+    min-width: 320px;
+    margin: 0 auto;
+}

--- a/samples/highcharts/tooltip/stickoncontact-anchor-link/demo.details
+++ b/samples/highcharts/tooltip/stickoncontact-anchor-link/demo.details
@@ -1,0 +1,6 @@
+---
+ name: Highcharts Demo
+ authors:
+   - Torstein Hønsi
+ js_wrap: b
+...

--- a/samples/highcharts/tooltip/stickoncontact-anchor-link/demo.html
+++ b/samples/highcharts/tooltip/stickoncontact-anchor-link/demo.html
@@ -1,0 +1,5 @@
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/accessibility.js"></script>
+<script src="https://code.highcharts.com/themes/adaptive.js"></script>
+
+<div id="container"></div>

--- a/samples/highcharts/tooltip/stickoncontact-anchor-link/demo.js
+++ b/samples/highcharts/tooltip/stickoncontact-anchor-link/demo.js
@@ -1,0 +1,45 @@
+Highcharts.chart('container', {
+    title: {
+        text: 'Tooltip with clickable anchor links'
+    },
+
+    subtitle: {
+        text: 'Use stickOnContact to keep the tooltip open while hovering links'
+    },
+
+    tooltip: {
+        followTouchMove: false,
+        stickOnContact: true,
+        useHTML: true
+    },
+
+    xAxis: {
+        categories: ['A', 'B', 'C']
+    },
+
+    series: [{
+        tooltip: {
+            headerFormat: '',
+            hideDelay: 5000,
+            pointFormat:
+                '{point.y} <a href="{point.custom.url}" ' +
+                'target="_blank" rel="noopener">Link</a>'
+        },
+        data: [{
+            y: 1,
+            custom: {
+                url: 'https://www.highcharts.com/#1'
+            }
+        }, {
+            y: 3,
+            custom: {
+                url: 'https://www.highcharts.com/#2'
+            }
+        }, {
+            y: 2,
+            custom: {
+                url: 'https://www.highcharts.com/#3'
+            }
+        }]
+    }]
+});

--- a/samples/highcharts/tooltip/stickoncontact-anchor-link/demo.js
+++ b/samples/highcharts/tooltip/stickoncontact-anchor-link/demo.js
@@ -8,9 +8,7 @@ Highcharts.chart('container', {
     },
 
     tooltip: {
-        followTouchMove: false,
-        stickOnContact: true,
-        useHTML: true
+        stickOnContact: true
     },
 
     xAxis: {
@@ -20,7 +18,6 @@ Highcharts.chart('container', {
     series: [{
         tooltip: {
             headerFormat: '',
-            hideDelay: 5000,
             pointFormat:
                 '{point.y} <a href="{point.custom.url}" ' +
                 'target="_blank" rel="noopener">Link</a>'

--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -2810,6 +2810,8 @@ const defaultOptions: DefaultOptions = {
          *
          * @sample highcharts/tooltip/stickoncontact/
          *         Tooltip sticks on pointer contact
+         * @sample highcharts/tooltip/stickoncontact-anchor-link/
+         *         Tooltip with clickable links
          *
          * @type      {boolean}
          * @since     8.0.1

--- a/ts/Core/TooltipOptions.ts
+++ b/ts/Core/TooltipOptions.ts
@@ -664,6 +664,8 @@ export interface TooltipOptions {
      *
      * @sample highcharts/tooltip/stickoncontact/
      *         Tooltip sticks on pointer contact
+     * @sample highcharts/tooltip/stickoncontact-anchor-link/
+     *         Tooltip with clickable links
      *
      * @since     8.0.1
      */


### PR DESCRIPTION
Added tooltip docs and sample for clickable links with `stickOnContact`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213418101501240