### PR TITLE
grid/non-contain-filtering-serverside

### DIFF
--- a/ts/Grid/Pro/Data/DataSourceHelper.ts
+++ b/ts/Grid/Pro/Data/DataSourceHelper.ts
@@ -50,9 +50,11 @@ const filterOperatorMap: Record<string, string> = {
     '<': 'lessThan',
     '<=': 'lessThanOrEqualTo',
     contains: 'contains',
+    notContains: 'doesNotContain',
     startsWith: 'beginsWith',
     endsWith: 'endsWith',
-    empty: 'empty'
+    empty: 'empty',
+    notEmpty: 'notEmpty'
 };
 
 /**
@@ -77,21 +79,31 @@ function extractFilterConditions(
     }
 
     if (condition.operator === 'and' || condition.operator === 'or') {
-        // Logical condition - extract from nested conditions
         if (condition.conditions) {
             for (const subCondition of condition.conditions) {
                 extractFilterConditions(subCondition, filterColumns);
             }
         }
-    } else if (condition.columnId) {
-        // Single condition
-        const mappedOperator =
-            filterOperatorMap[condition.operator] || condition.operator;
-        filterColumns.push({
-            id: condition.columnId,
-            condition: mappedOperator,
-            value: condition.value
-        });
+    } else if (condition.columnId || condition.condition?.columnId) {
+        const conditionToUse = condition.columnId ?
+            condition : (condition.condition as FilterConditionLike);
+        let key = conditionToUse.operator;
+
+        if (condition.operator === 'not') {
+            key = condition.operator +
+                conditionToUse.operator.charAt(0).toUpperCase() +
+                conditionToUse.operator.slice(1);
+        }
+
+        const mapped = filterOperatorMap[key] || conditionToUse.operator;
+
+        if (conditionToUse.columnId) {
+            filterColumns.push({
+                id: conditionToUse.columnId,
+                condition: mapped,
+                value: conditionToUse.value
+            });
+        }
     }
 
     return filterColumns;
@@ -389,6 +401,7 @@ interface FilterConditionLike {
     operator: string;
     columnId?: string;
     value?: unknown;
+    condition?: FilterConditionLike;
     conditions?: FilterConditionLike[];
 }
 


### PR DESCRIPTION
Fixed missing server filtering for `not` filter.