### PR TITLE
bugfix/23611-border-radius-wrong-types

### DIFF
--- a/ts/Core/Utilities.ts
+++ b/ts/Core/Utilities.ts
@@ -412,7 +412,7 @@ export interface ErrorMessageEventObject {
  *//**
  * Radius of the element border.
  * @name Highcharts.CSSObject#borderRadius
- * @type {number|undefined}
+ * @type {string|undefined}
  *//**
  * Color used in the element. The 'contrast' option is a Highcharts custom
  * property that results in black or white, depending on the background of the
@@ -431,7 +431,7 @@ export interface ErrorMessageEventObject {
  *//**
  * Font size of the element text.
  * @name Highcharts.CSSObject#fontSize
- * @type {string|undefined}
+ * @type {number|string|undefined}
  *//**
  * Font weight of the element text.
  * @name Highcharts.CSSObject#fontWeight


### PR DESCRIPTION
Fixed #23611, updated CSS object interface typing for `fontSize` and `borderRadius`.