### PR TITLE
fix(grid): correct broken credits demo URL in JSDoc

### DIFF
--- a/ts/Grid/Pro/Credits/CreditsProComposition.ts
+++ b/ts/Grid/Pro/Credits/CreditsProComposition.ts
@@ -85,7 +85,7 @@ declare module '../../Core/Options' {
         /**
          * Options for the credits label.
          *
-         * Try it: {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/grid-pro/e2e/credits-pro | Credits options}
+         * Try it: {@link https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/grid-pro/basic/credits | Credits options}
          */
         credits?: CreditsOptions;
     }


### PR DESCRIPTION
## Problem

Fixes #24326

The JSDoc comment on the `Options.credits` property in `CreditsProComposition.ts` contains a `@link` pointing to a non-existent demo URL:

```
https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/grid-pro/credits
```

This URL returns a 404 error, as shown in the [API docs](https://api.highcharts.com/grid/credits).

## Fix

Updated the URL to point to the correct existing sample:

```
https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/grid-pro/e2e/credits-pro
```

## Changes

- **File:** `ts/Grid/Pro/Credits/CreditsProComposition.ts`
- - **Change:** One-line URL fix in a JSDoc `@link` comment 