### PR TITLE
fix(a11y): align menuButtonLabel with visible "Options" text (WCAG 2.…

### DIFF
--- a/ts/Accessibility/Options/LangDefaults.ts
+++ b/ts/Accessibility/Options/LangDefaults.ts
@@ -387,7 +387,7 @@ const langOptions: DeepPartial<LangOptions> = {
          */
         exporting: {
             chartMenuLabel: 'Chart menu',
-            menuButtonLabel: 'View chart menu, {chartTitle}'
+            menuButtonLabel: 'Options, {chartTitle}'
         },
 
         /**


### PR DESCRIPTION
## Problem

Fixes #24304

The chart context menu button (visible label: **"Options"**) has its `aria-label` derived from the `lang.accessibility.exporting.menuButtonLabel` string, which was ''View chart menu, {chartTitle}''. Since this accessible name does not start with the visible label text "Options", it violates **WCAG 2.5.3 (Label in Name)**, causing screen readers (like Windows Narrator) to announce a name that doesn't match what sighted users see.

**Actual:** Screen reader announces _"View chart menu"_
**Expected:** Screen reader should announce _"Options"_ (matching the visible label)

## Changes

**File:** `ts/Accessibility/Options/LangDefaults.ts`

```diff
- menuButtonLabel: 'View chart menu, {chartTitle}'
+ menuButtonLabel: 'Options, {chartTitle}'
```

The new string starts with "Options" - matching the visible button text - which satisfies WCAG 2.5.3. The `{chartTitle}` context is preserved for additional clarity for screen reader users.

## Impact

- **docs/a11y change only** - one string in the lang defaults.
- No functional logic changed.
- Fixes the mismatch reported by the Windows Narrator with Accessibility Insights.