### PR TITLE
bugfix/23964-spline-datalabel-contrast-over-columns

### DIFF
--- a/samples/unit-tests/datalabels/contrast/demo.js
+++ b/samples/unit-tests/datalabels/contrast/demo.js
@@ -227,23 +227,6 @@ QUnit.test(
     'Spline dataLabels should use overlapping column contrast (#23964).',
     function (assert) {
         const chart = Highcharts.chart('container', {
-                chart: {
-                    animation: false
-                },
-                plotOptions: {
-                    spline: {
-                        dataLabels: {
-                            allowOverlap: true,
-                            enabled: true,
-                            style: {
-                                textOutline: 'none'
-                            }
-                        }
-                    }
-                },
-                yAxis: {
-                    max: 6
-                },
                 series: [{
                     type: 'column',
                     data: [{
@@ -255,7 +238,14 @@ QUnit.test(
                     }]
                 }, {
                     type: 'spline',
-                    data: [2.5, 2.5]
+                    data: [2.5, 2.5],
+                    dataLabels: {
+                        defer: false,
+                        enabled: true,
+                        style: {
+                            textOutline: 'none'
+                        }
+                    }
                 }]
             }),
             points = chart.series[1].points;

--- a/samples/unit-tests/datalabels/contrast/demo.js
+++ b/samples/unit-tests/datalabels/contrast/demo.js
@@ -222,3 +222,58 @@ QUnit.test('Pie dataLabels and contrast', function (assert) {
         '(#11140).'
     );
 });
+
+QUnit.test(
+    'Spline dataLabels should use overlapping column contrast (#23964).',
+    function (assert) {
+        const chart = Highcharts.chart('container', {
+                chart: {
+                    animation: false
+                },
+                plotOptions: {
+                    spline: {
+                        dataLabels: {
+                            allowOverlap: true,
+                            enabled: true,
+                            style: {
+                                textOutline: 'none'
+                            }
+                        }
+                    }
+                },
+                yAxis: {
+                    max: 6
+                },
+                series: [{
+                    type: 'column',
+                    data: [{
+                        color: '#111111',
+                        y: 5
+                    }, {
+                        color: '#f0f0f0',
+                        y: 5
+                    }]
+                }, {
+                    type: 'spline',
+                    data: [2.5, 2.5]
+                }]
+            }),
+            points = chart.series[1].points;
+
+        assert.strictEqual(
+            Highcharts.color(
+                points[0].dataLabel.element.childNodes[0].style.fill
+            ).get(),
+            Highcharts.color(chart.renderer.getContrast('#111111')).get(),
+            'Spline dataLabel over a dark column should be light.'
+        );
+
+        assert.strictEqual(
+            Highcharts.color(
+                points[1].dataLabel.element.childNodes[0].style.fill
+            ).get(),
+            Highcharts.color(chart.renderer.getContrast('#f0f0f0')).get(),
+            'Spline dataLabel over a light column should be dark.'
+        );
+    }
+);

--- a/ts/Core/Series/DataLabel.ts
+++ b/ts/Core/Series/DataLabel.ts
@@ -674,7 +674,112 @@ namespace DataLabel {
             seriesDlOptions = mergedDataLabelOptions(series);
 
         let pointOptions: Array<DataLabelOptions>,
-            dataLabelsGroup: SVGElement;
+            dataLabelsGroup: SVGElement,
+            contrastCandidatesByX: Map<number, Array<{
+                bottom: number;
+                color: ColorString;
+                left: number;
+                right: number;
+                top: number;
+            }>>|undefined;
+
+        const getOverlappingShapeContrastColor = (
+            point: Point
+        ): (ColorString|undefined) => {
+            const { plotX, plotY, x } = point;
+
+            if (
+                typeof plotX !== 'number' ||
+                typeof plotY !== 'number' ||
+                typeof x !== 'number'
+            ) {
+                return;
+            }
+
+            if (!contrastCandidatesByX) {
+                contrastCandidatesByX = new Map();
+                const contrastLookup = contrastCandidatesByX;
+
+                chart.series.forEach((otherSeries): void => {
+                    if (
+                        otherSeries === series ||
+                        !otherSeries.visible ||
+                        otherSeries.xAxis !== series.xAxis
+                    ) {
+                        return;
+                    }
+
+                    (otherSeries.points || []).forEach((otherPoint): void => {
+                        const { shapeArgs } = otherPoint,
+                            shapeX = shapeArgs?.x,
+                            shapeY = shapeArgs?.y,
+                            shapeWidth = shapeArgs?.width,
+                            shapeHeight = shapeArgs?.height,
+                            fill = pick(
+                                isString(otherPoint.color) ?
+                                    otherPoint.color :
+                                    void 0,
+                                isString(otherSeries.color) ?
+                                    otherSeries.color :
+                                    void 0
+                            );
+
+                        if (
+                            otherPoint.isNull ||
+                            otherPoint.visible === false ||
+                            (
+                                otherPoint.shapeType !== 'rect' &&
+                                otherPoint.shapeType !== 'roundedRect'
+                            ) ||
+                            typeof otherPoint.x !== 'number' ||
+                            typeof shapeX !== 'number' ||
+                            typeof shapeY !== 'number' ||
+                            typeof shapeWidth !== 'number' ||
+                            typeof shapeHeight !== 'number' ||
+                            !fill
+                        ) {
+                            return;
+                        }
+
+                        const candidatesAtX =
+                            contrastLookup.get(otherPoint.x) || [];
+
+                        candidatesAtX.push({
+                            bottom: Math.max(shapeY, shapeY + shapeHeight),
+                            color: fill,
+                            left: Math.min(shapeX, shapeX + shapeWidth),
+                            right: Math.max(shapeX, shapeX + shapeWidth),
+                            top: Math.min(shapeY, shapeY + shapeHeight)
+                        });
+                        contrastLookup.set(
+                            otherPoint.x,
+                            candidatesAtX
+                        );
+                    });
+                });
+            }
+
+            const contrastLookup = contrastCandidatesByX;
+            if (!contrastLookup) {
+                return;
+            }
+            const candidatesAtX = contrastLookup.get(x);
+
+            if (candidatesAtX) {
+                for (let i = candidatesAtX.length - 1; i >= 0; --i) {
+                    const candidate = candidatesAtX[i];
+
+                    if (
+                        plotX >= candidate.left &&
+                        plotX <= candidate.right &&
+                        plotY >= candidate.top &&
+                        plotY <= candidate.bottom
+                    ) {
+                        return candidate.color;
+                    }
+                }
+            }
+        };
 
         // Resolve the animation
         const { animation, defer } = seriesDlOptions[0],
@@ -778,7 +883,7 @@ namespace DataLabel {
                                     (isString(pointColor) ? pointColor : '')
                                 );
 
-                                style.color = (
+                                const usePointContrast = (
                                     labelBgColor || // #20007
                                     (
                                         !defined(distance) &&
@@ -786,9 +891,22 @@ namespace DataLabel {
                                     ) ||
                                     pInt(distance || 0) < 0 ||
                                     seriesOptions.stacking
-                                ) ?
-                                    point.contrastColor :
-                                    contrastColor;
+                                );
+
+                                if (usePointContrast) {
+                                    style.color = point.contrastColor;
+                                } else {
+                                    const overlappingShapeColor =
+                                        getOverlappingShapeContrastColor(
+                                            point
+                                        );
+
+                                    style.color = overlappingShapeColor ?
+                                        renderer.getContrast(
+                                            overlappingShapeColor
+                                        ) :
+                                        contrastColor;
+                                }
                             } else {
                                 delete point.contrastColor;
                             }


### PR DESCRIPTION
Fixed #23964, spline datalabels did not take other series' colors into account


Unsure about the visual diff here, in the case of that demo it doesnt look like any new color for the label should be necessary in the screenshot in the visual diff checker, but if you check out the demo in utils, stuff looks alright to me (http://localhost:3030/samples/#view/highcharts/plotoptions/animation-defer) 🤔 
