### PR TITLE
samples/fix-legend-custom-symbol-demo

### DIFF
--- a/samples/highcharts/studies/legend-custom-symbol/demo.js
+++ b/samples/highcharts/studies/legend-custom-symbol/demo.js
@@ -1,19 +1,19 @@
 // Override the legend symbol creator function
 Highcharts.wrap(
     Highcharts.Series.prototype,
-    'drawLegendSymbol', function (proceed, legend) {
-        proceed.call(this, legend);
+    'drawLegendSymbol', function (proceed, legend, item) {
+        proceed.call(this, legend, item);
 
-        this.legendItem.line.attr({
+        item.legendItem.line.attr({
             d: ['M', 0, 10, 'L', 5, 5, 8, 10]
         });
-        this.negativeLine = this.chart.renderer
+        item.legendItem.negativeLine = this.chart.renderer
             .path(['M', 8, 10, 'L', 11, 15, 16, 10])
             .attr({
                 stroke: this.options.negativeColor,
                 'stroke-width': this.options.lineWidth
             })
-            .add(this.legendItem.group);
+            .add(item.legendItem.group);
     });
 
 // Create the chart


### PR DESCRIPTION
Fixed error in `legend-custom-symbol` demo and adjusted to latest changes.

Note for review: Moved assignment of `negativeLine` to `item.legendItem` as it seemed more suitable.