### PR TITLE
grid/display-inline-responsive-rules

### DIFF
--- a/docs/grid/responsive-grid.md
+++ b/docs/grid/responsive-grid.md
@@ -88,13 +88,6 @@ The optional `callback` gives full control over rule matching:
 - Active rules are merged in order, so later matching rules can override earlier matching rules.
 - The responsive check is based on the Grid container size, not the browser window size.
 
-> **Note:** Responsive rules rely on the browser's
-> [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver)
-> API, which does not observe elements with `display: inline` or
-> `display: none`. Make sure the Grid container uses a block-level
-> display value (e.g. `block`, `inline-block`, `flex`, or `grid`)
-> for responsive rules to work correctly.
-
 ## Typical use cases
 
 Typical responsive use cases in Grid include:

--- a/ts/Grid/Core/Responsive/ResponsiveComposition.ts
+++ b/ts/Grid/Core/Responsive/ResponsiveComposition.ts
@@ -68,17 +68,8 @@ export function compose(
  */
 function initResizeObserver(this: Grid): void {
     destroyResizeObserver.call(this);
-    if (!this.container) {
+    if (!this.contentWrapper) {
         return;
-    }
-
-    const display = getComputedStyle(this.container).display;
-    if (display === 'inline' || display === 'none') {
-        console.warn( // eslint-disable-line no-console
-            'Highcharts Grid: Responsive rules rely on ResizeObserver, ' +
-            'which does not observe elements with display: ' + display +
-            '. Use a block-level display value instead.'
-        );
     }
 
     this.activeRules = new Set();
@@ -87,7 +78,7 @@ function initResizeObserver(this: Grid): void {
         onResize.call(this, entries[0]);
     });
 
-    this.resizeObserver.observe(this.container);
+    this.resizeObserver.observe(this.contentWrapper);
 }
 
 /**


### PR DESCRIPTION
Fixed #24370, responsive rules not reacting when the Grid container has `display: inline`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213779130762387
  - https://app.asana.com/0/0/1213775241017507