### PR TITLE
Fix #24382: Zero-value columns render visible lines when borderWidth > 0

### DIFF
--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -737,6 +737,17 @@ class ColumnSeries extends Series {
             opacity = pick(stateOptions.opacity, opacity);
         }
 
+        // #24382: If the point has a value of 0 and the height is 0,
+        // don't render a border that would be visible.
+        if (
+            point &&
+            point.y === 0 &&
+            point.shapeArgs &&
+            point.shapeArgs.height === 0
+        ) {
+            strokeWidth = 0;
+        }
+
         const ret: SVGAttributes = {
             fill: fill as any,
             stroke: stroke,


### PR DESCRIPTION
Closes #24382

## Summary
Fixes a regression introduced in v11.4.2 where zero-value columns render a visible horizontal line when `borderWidth > 0`.

## Problem
Zero-value points result in SVG `rect` elements with `height: 0`. Despite having no height, the stroke is still rendered, causing unwanted horizontal lines at the baseline.

## Expected Behavior
Zero-height columns should remain visually hidden, consistent with behavior prior to v11.4.2.

## Solution
Updated `pointAttribs` in `ts/Series/Column/ColumnSeries.ts` to conditionally disable the stroke when:
- point value is `0`
- computed column height is `0`

This ensures no border is rendered for zero-height columns.

## Notes
- Does not affect cases where `minPointLength` is set, since those columns have non-zero height and should render borders as expected.
- Change is limited in scope and does not impact non-zero values.

## Impact
Restores expected rendering behavior without affecting existing features.