### PR TITLE
bugfix/23728-axis-breaks-outside-data-range

### DIFF
--- a/samples/unit-tests/axis/breaks/demo.js
+++ b/samples/unit-tests/axis/breaks/demo.js
@@ -1004,7 +1004,7 @@ QUnit.test('Axis breaks with scatter series', function (assert) {
 });
 
 QUnit.test('Axis breaks on Y axis', function (assert) {
-    var chart = Highcharts.chart('container', {
+    const chart = Highcharts.chart('container', {
         yAxis: {
             breaks: [
                 {
@@ -1026,6 +1026,27 @@ QUnit.test('Axis breaks on Y axis', function (assert) {
         chart.yAxis[0].toPixels(50),
         chart.yAxis[0].toPixels(100),
         '50 and 100 translate to the same axis position'
+    );
+
+    chart.update({
+        yAxis: {
+            tickInterval: 5,
+            min: 0,
+            max: 90,
+            breaks: [{
+                from: 20,
+                to: 62
+            }]
+        },
+        series: [{
+            data: [2, 6, 3]
+        }]
+    });
+
+    assert.strictEqual(
+        chart.yAxis[0].toPixels(20),
+        chart.yAxis[0].toPixels(62),
+        '20 and 62 translate to the same axis position, #23728.'
     );
 });
 

--- a/ts/Core/Axis/BrokenAxis.ts
+++ b/ts/Core/Axis/BrokenAxis.ts
@@ -908,21 +908,8 @@ namespace BrokenAxis {
                             repeat: number,
                             min = axis.userMin ?? axis.min,
                             max = axis.userMax ?? axis.max,
-                            dataMin = axis.dataMin ?? min,
-                            dataMax = axis.dataMax ?? max,
                             start: (number|undefined),
                             i: number;
-
-                        if (isNumber(axis.threshold)) {
-                            dataMin = Math.min(
-                                dataMin ?? axis.threshold,
-                                axis.threshold
-                            );
-                            dataMax = Math.max(
-                                dataMax ?? axis.threshold,
-                                axis.threshold
-                            );
-                        }
 
                         // Min & max check (#4247) but not for gantt (#13898)
                         if (!axis.treeGrid?.tree) {
@@ -948,21 +935,31 @@ namespace BrokenAxis {
                         }
 
                         // Construct an array holding all breaks in the axis
-                        // for the current data range.
-                        if (isNumber(dataMin) && isNumber(dataMax)) {
+                        // for the current data range. Use min and max instead
+                        // of dataMin and dataMax to ensure that the breaks are
+                        // constructed correctly even if break happens outside
+                        // the data range, #23728.
+                        if (isNumber(min) && isNumber(max)) {
                             breaks.forEach(
                                 function (brk): void {
                                     start = brk.from;
                                     repeat = brk.repeat || Infinity;
 
-                                    while (start - repeat > dataMin) {
+                                    while (
+                                        isNumber(min) &&
+                                        start - repeat > min
+                                    ) {
                                         start -= repeat;
                                     }
-                                    while (start < dataMin) {
+                                    while (isNumber(min) && start < min) {
                                         start += repeat;
                                     }
 
-                                    for (i = start; i < dataMax; i += repeat) {
+                                    for (
+                                        i = start;
+                                        isNumber(max) && i < max;
+                                        i += repeat
+                                    ) {
                                         breakArrayTemp.push({
                                             value: i,
                                             move: 'in'
@@ -993,7 +990,7 @@ namespace BrokenAxis {
 
                         // Simplify the breaks
                         inBrk = 0;
-                        start = dataMin;
+                        start = min;
 
                         breakArrayTemp.forEach(
                             (brk: AxisBreakBorderObject): void => {

--- a/ts/Core/Axis/BrokenAxis.ts
+++ b/ts/Core/Axis/BrokenAxis.ts
@@ -940,26 +940,21 @@ namespace BrokenAxis {
                         // constructed correctly even if break happens outside
                         // the data range, #23728.
                         if (isNumber(min) && isNumber(max)) {
+                            const minVal = min,
+                                maxVal = max;
                             breaks.forEach(
                                 function (brk): void {
                                     start = brk.from;
                                     repeat = brk.repeat || Infinity;
 
-                                    while (
-                                        isNumber(min) &&
-                                        start - repeat > min
-                                    ) {
+                                    while (start - repeat > minVal) {
                                         start -= repeat;
                                     }
-                                    while (isNumber(min) && start < min) {
+                                    while (start < minVal) {
                                         start += repeat;
                                     }
 
-                                    for (
-                                        i = start;
-                                        isNumber(max) && i < max;
-                                        i += repeat
-                                    ) {
+                                    for (i = start; i < maxVal; i += repeat) {
                                         breakArrayTemp.push({
                                             value: i,
                                             move: 'in'

--- a/ts/Core/Axis/BrokenAxis.ts
+++ b/ts/Core/Axis/BrokenAxis.ts
@@ -911,6 +911,15 @@ namespace BrokenAxis {
                             start: (number|undefined),
                             i: number;
 
+                        // Extend range to include visible breaks outside of
+                        // series data.
+                        const dataMin = isNumber(min) ?
+                                Math.min(axis.dataMin ?? min, min) :
+                                (axis.dataMin ?? min),
+                            dataMax = isNumber(max) ?
+                                Math.max(axis.dataMax ?? max, max) :
+                                (axis.dataMax ?? max);
+
                         // Min & max check (#4247) but not for gantt (#13898)
                         if (!axis.treeGrid?.tree) {
                             breaks.forEach(
@@ -935,26 +944,21 @@ namespace BrokenAxis {
                         }
 
                         // Construct an array holding all breaks in the axis
-                        // for the current data range. Use min and max instead
-                        // of dataMin and dataMax to ensure that the breaks are
-                        // constructed correctly even if break happens outside
-                        // the data range, #23728.
-                        if (isNumber(min) && isNumber(max)) {
-                            const minVal = min,
-                                maxVal = max;
+                        // for the current data range.
+                        if (isNumber(dataMin) && isNumber(dataMax)) {
                             breaks.forEach(
                                 function (brk): void {
                                     start = brk.from;
                                     repeat = brk.repeat || Infinity;
 
-                                    while (start - repeat > minVal) {
+                                    while (start - repeat > dataMin) {
                                         start -= repeat;
                                     }
-                                    while (start < minVal) {
+                                    while (start < dataMin) {
                                         start += repeat;
                                     }
 
-                                    for (i = start; i < maxVal; i += repeat) {
+                                    for (i = start; i < dataMax; i += repeat) {
                                         breakArrayTemp.push({
                                             value: i,
                                             move: 'in'
@@ -985,7 +989,7 @@ namespace BrokenAxis {
 
                         // Simplify the breaks
                         inBrk = 0;
-                        start = min;
+                        start = dataMin;
 
                         breakArrayTemp.forEach(
                             (brk: AxisBreakBorderObject): void => {


### PR DESCRIPTION
Fixed #23728, axis breaks were rendered incorrectly when there were no points in them.