### PR TITLE
bugfix/24079-sankey-nodes-flow

### DIFF
--- a/samples/highcharts/demo/vertical-sankey/demo.js
+++ b/samples/highcharts/demo/vertical-sankey/demo.js
@@ -99,7 +99,7 @@ Highcharts.chart('container', {
         }, {
             id: 'Other power (non-steam)',
             column: 4,
-            offsetHorizontal: '700%',
+            offsetHorizontal: '900%',
             color: 'rgba(108, 221, 202, 0.8)'
         }, {
             id: 'To direct water services',
@@ -128,7 +128,7 @@ Highcharts.chart('container', {
             }
         }, {
             id: 'Electric water-related applications',
-            offsetHorizontal: '-250%',
+            offsetHorizontal: '-330%',
             color: 'rgba(255, 141, 100, 0.8)',
             dataLabels: {
                 rotation: -90,
@@ -138,18 +138,18 @@ Highcharts.chart('container', {
             }
         }, {
             id: 'Electric water heating',
-            offsetHorizontal: '-1100%',
+            offsetHorizontal: '-1600%',
             color: 'rgba(250, 183, 118, 0.8)'
         }, {
             id: 'Other',
-            offsetHorizontal: '-480%',
+            offsetHorizontal: '-700%',
             color: 'rgba(149, 155, 236, 0.8)',
             dataLabels: {
                 rotation: -90
             }
         }, {
             id: 'Direct water services',
-            offsetHorizontal: '-80%',
+            offsetHorizontal: '-680%',
             color: 'rgba(76, 175, 254, 0.8)',
             dataLabels: {
                 style: {

--- a/samples/highcharts/demo/vertical-sankey/demo.js
+++ b/samples/highcharts/demo/vertical-sankey/demo.js
@@ -99,7 +99,7 @@ Highcharts.chart('container', {
         }, {
             id: 'Other power (non-steam)',
             column: 4,
-            offsetHorizontal: '900%',
+            offsetHorizontal: '630%',
             color: 'rgba(108, 221, 202, 0.8)'
         }, {
             id: 'To direct water services',
@@ -128,7 +128,7 @@ Highcharts.chart('container', {
             }
         }, {
             id: 'Electric water-related applications',
-            offsetHorizontal: '-330%',
+            offsetHorizontal: '-250%',
             color: 'rgba(255, 141, 100, 0.8)',
             dataLabels: {
                 rotation: -90,
@@ -138,18 +138,18 @@ Highcharts.chart('container', {
             }
         }, {
             id: 'Electric water heating',
-            offsetHorizontal: '-1600%',
+            offsetHorizontal: '-1100%',
             color: 'rgba(250, 183, 118, 0.8)'
         }, {
             id: 'Other',
-            offsetHorizontal: '-700%',
+            offsetHorizontal: '-480%',
             color: 'rgba(149, 155, 236, 0.8)',
             dataLabels: {
                 rotation: -90
             }
         }, {
             id: 'Direct water services',
-            offsetHorizontal: '-680%',
+            offsetHorizontal: '-560%',
             color: 'rgba(76, 175, 254, 0.8)',
             dataLabels: {
                 style: {
@@ -159,11 +159,12 @@ Highcharts.chart('container', {
         }, {
             id: 'Indirect steam use',
             column: 7,
+            offsetHorizontal: '30%',
             color: 'rgba(181, 238, 228, 0.8)'
         }, {
             id: 'Direct steam use',
             column: 7,
-            offsetHorizontal: '200%',
+            offsetHorizontal: '480%',
             color: 'rgba(219, 239, 255, 0.8)',
             dataLabels: {
                 rotation: -90,

--- a/samples/highcharts/demo/vertical-sankey/demo.js
+++ b/samples/highcharts/demo/vertical-sankey/demo.js
@@ -99,7 +99,7 @@ Highcharts.chart('container', {
         }, {
             id: 'Other power (non-steam)',
             column: 4,
-            offsetHorizontal: '630%',
+            offsetHorizontal: '700%',
             color: 'rgba(108, 221, 202, 0.8)'
         }, {
             id: 'To direct water services',
@@ -149,7 +149,7 @@ Highcharts.chart('container', {
             }
         }, {
             id: 'Direct water services',
-            offsetHorizontal: '-560%',
+            offsetHorizontal: '-575%',
             color: 'rgba(76, 175, 254, 0.8)',
             dataLabels: {
                 style: {
@@ -164,7 +164,7 @@ Highcharts.chart('container', {
         }, {
             id: 'Direct steam use',
             column: 7,
-            offsetHorizontal: '480%',
+            offsetHorizontal: '440%',
             color: 'rgba(219, 239, 255, 0.8)',
             dataLabels: {
                 rotation: -90,

--- a/samples/unit-tests/series-sankey/sankey/demo.js
+++ b/samples/unit-tests/series-sankey/sankey/demo.js
@@ -593,10 +593,10 @@ QUnit.test('Sankey and circular data', function (assert) {
         .attr('d')
         .split(' ')
         .filter(item => item === 'C').length;
-    assert.ok(
-        numberOfCurves > 4,
-        'The link should have a complex, circular structure, ' +
-            'not direct (#12882)'
+    assert.strictEqual(
+        numberOfCurves,
+        2,
+        'The link should be a straight forward link (#24079)'
     );
 
     chart.series[0].setData([
@@ -1066,3 +1066,101 @@ QUnit.test('Sankey and point updates', assert => {
         `
     );
 });
+
+QUnit.test(
+    'Node column assignment with the right levels (#24079)',
+    function (assert) {
+        const chart = Highcharts.chart('container', {
+            series: [
+                {
+                    type: 'sankey',
+                    data: [
+                        {
+                            from: 'Root',
+                            to: 'A',
+                            weight: 1
+                        },
+                        {
+                            from: 'A',
+                            to: 'D',
+                            weight: 1
+                        },
+                        {
+                            from: 'Root',
+                            to: 'B',
+                            weight: 1
+                        },
+                        {
+                            from: 'B',
+                            to: 'C',
+                            weight: 1
+                        },
+                        {
+                            from: 'C',
+                            to: 'D',
+                            weight: 1
+                        }
+                    ]
+                }
+            ]
+        });
+
+        const series = chart.series[0],
+            nodeColumns = series.nodeColumns,
+            nodeLookup = series.nodeLookup;
+
+        assert.strictEqual(
+            nodeColumns.length,
+            4,
+            'There should be 4 columns - Root (0), A and B (1), C (2), D (3)'
+        );
+
+        assert.strictEqual(
+            nodeLookup.Root.column,
+            0,
+            'Root should be in column 0'
+        );
+
+        assert.strictEqual(
+            nodeLookup.A.column,
+            1,
+            'A should be in column 1'
+        );
+
+        assert.strictEqual(
+            nodeLookup.B.column,
+            1,
+            'B should be in column 1'
+        );
+
+        assert.strictEqual(
+            nodeLookup.C.column,
+            2,
+            'C should be in column 2'
+        );
+
+        assert.strictEqual(
+            nodeLookup.D.column,
+            3,
+            'D should be in column 3'
+        );
+
+        // Verify the C - D link renders correctly
+        const link = series.points.find(p => p.from === 'C' && p.to === 'D'),
+            path = link.shapeArgs?.d;
+
+        assert.ok(
+            path,
+            'The C - D link should have a rendered path'
+        );
+
+        // Check the start and end of the link
+        const startX = path[0][1],
+            endX = path[1][5];
+
+        assert.ok(
+            endX > startX,
+            'The C node should be rendered before the D node'
+        );
+    }
+);

--- a/ts/Series/Sankey/SankeySeries.ts
+++ b/ts/Series/Sankey/SankeySeries.ts
@@ -189,16 +189,29 @@ class SankeySeries extends ColumnSeries {
      * Order the nodes, starting with the root node(s). (#9818)
      * @private
      */
-    public order(node: SankeyPoint, level: number): void {
+    public order(
+        node: SankeyPoint,
+        level: number,
+        visited?: Set<SankeyPoint>
+    ): void {
         const series = this;
-        // Prevents circular recursion:
-        if (typeof node.level === 'undefined') {
+
+        // Watch the visited nodes
+        if (!visited) {
+            visited = new Set();
+        }
+
+        // Prevents circular recursion, but updates level if a longer
+        // path is found from a different branch
+        if (typeof node.level === 'undefined' || node.level < level) {
             node.level = level;
+            visited.add(node);
             for (const link of node.linksFrom) {
-                if (link.toNode) {
-                    series.order(link.toNode, level + 1);
+                if (link.toNode && !visited.has(link.toNode)) {
+                    series.order(link.toNode, level + 1, visited);
                 }
             }
+            visited.delete(node);
         }
     }
     /**


### PR DESCRIPTION
Fixed #24079, incorrect ordering of nodes in Sankey charts in some cases due to improper level assignment.