### PR TITLE
bugfix/pad-range-error

### DIFF
--- a/test/ts-node-unit-tests/tests/pad.test.ts
+++ b/test/ts-node-unit-tests/tests/pad.test.ts
@@ -1,0 +1,35 @@
+import { loadHCWithModules } from '../test-utils';
+import { strictEqual } from 'node:assert';
+import { describe, it } from 'node:test';
+
+describe('Highcharts.pad', () => {
+    const Highcharts = loadHCWithModules();
+    const pad = Highcharts.pad as (number: number, length?: number, padder?: string) => string;
+
+    it('should pad a single digit number to two digits (default)', () => {
+        strictEqual(pad(1), '01');
+    });
+
+    it('should pad a single digit number to three digits', () => {
+        strictEqual(pad(1, 3), '001');
+    });
+
+    it('should not pad if the number is already the requested length', () => {
+        strictEqual(pad(10, 2), '10');
+    });
+
+    it('should not pad (and NOT CRASH) if the number is longer than the requested length', () => {
+        strictEqual(pad(100, 2), '100');
+        strictEqual(pad(1000, 2), '1000');
+    });
+
+    it('should use a custom padder', () => {
+        strictEqual(pad(5, 2, ' '), ' 5');
+    });
+
+    it('should handle negative numbers by padding before the sign (existing behavior)', () => {
+        // Based on the implementation: new Array(...).join(padder) + number
+        // pad(-1, 2) -> "0-1"
+        strictEqual(pad(-1, 2), '0-1');
+    });
+});

--- a/ts/Shared/Utilities.ts
+++ b/ts/Shared/Utilities.ts
@@ -1410,11 +1410,14 @@ export function offset(el: Element): OffsetObject {
  */
 export function pad(number: number, length?: number, padder?: string): string {
     return new Array(
-        (length || 2) +
-        1 -
-        String(number)
-            .replace('-', '')
-            .length
+        Math.max(
+            0,
+            (length || 2) +
+            1 -
+            String(number)
+                .replace('-', '')
+                .length
+        )
     ).join(padder || '0') + number;
 }
 


### PR DESCRIPTION
Fixed issue with `Highcharts.pad` throwing a `RangeError` when input numbers were longer than the requested padding.

### Description
This PR fixes a `RangeError: Invalid array length` in the `Highcharts.pad` utility function. 

The error occurred when a number with more digits than the requested padding length was passed (e.g., `Highcharts.pad(1000, 2)`), resulting in a negative array length calculation.

### Changes
- Wrapped the array length calculation in `Math.max(0, ...)` to safely handle cases where the input is already longer than the desired padding.
- Added unit tests in `test/ts-node-unit-tests/tests/pad.test.ts` covering basic padding, edge cases with long numbers, and custom padders.

### Verification
Verified with standalone Node.js script and added unit tests:
- `pad(1, 2)` -> `"01"`
- `pad(100, 2)` -> `"100"` (fixed)
- `pad(1000, 2)` -> `"1000"` (fixed)" -f