### PR TITLE
bugfix/23723-mapView-not-clipped

### DIFF
--- a/samples/unit-tests/maps/mapview-inset/demo.js
+++ b/samples/unit-tests/maps/mapview-inset/demo.js
@@ -213,4 +213,22 @@ QUnit.test('MapView Inset', assert => {
         'Translation inside what was previously the inset should change'
     );
 
+    const insetClip = chart.mapView.groupClipRect.element;
+
+    assert.deepEqual(
+        [
+            +insetClip.getAttribute('x'),
+            +insetClip.getAttribute('y'),
+            +insetClip.getAttribute('width'),
+            +insetClip.getAttribute('height')
+        ],
+        [
+            chart.plotLeft,
+            chart.plotTop,
+            chart.plotWidth,
+            chart.plotHeight
+        ],
+        'The map-view group clip should match the plot area (#23723)'
+    );
+
 });

--- a/ts/Maps/MapView.ts
+++ b/ts/Maps/MapView.ts
@@ -412,6 +412,9 @@ class MapView {
     public group?: SVGElement;
 
     /** @internal */
+    public groupClipRect?: SVGElement;
+
+    /** @internal */
     public insets: MapViewInset[] = [];
 
     /** @internal */
@@ -1304,12 +1307,17 @@ class MapView {
 
     /** @internal */
     public render(): void {
+        const chart = this.chart;
 
-        // We need a group for the insets
+        // We need a group and clip for the group for the insets
         if (!this.group) {
-            this.group = this.chart.renderer.g('map-view')
+            this.groupClipRect = chart.renderer.clipRect(chart.plotBox);
+            this.group = chart.renderer.g('map-view')
                 .attr({ zIndex: 4 })
+                .clip(this.groupClipRect)
                 .add();
+        } else if (this.groupClipRect) {
+            this.groupClipRect.animate(chart.plotBox);
         }
     }
 


### PR DESCRIPTION
Fixed #23723, `mapView` inset borders were not clipped correctly.