### PR TITLE
Samples: some enhancemnts to live candlestick

### DIFF
--- a/samples/stock/demo/live-candlestick/demo.js
+++ b/samples/stock/demo/live-candlestick/demo.js
@@ -3,6 +3,10 @@ const options = {
         text: 'Dynamic data in Highcharts Stock'
     },
 
+    lang: {
+        locale: 'en-GB' // Keep compact 24h time format
+    },
+
     xAxis: {
         overscroll: 500000,
         range: 4 * 200000,
@@ -94,12 +98,17 @@ options.chart = {
                 // Different x-value, we need to add a new point
                 if (lastPoint[0] !== newPoint[0]) {
                     series.addPoint(newPoint);
-                } else {
-                // Existing point, update it
-                    series.options.data[data.length - 1] = newPoint;
 
+                // Series in data grouping mode, set the full data to regroup
+                } else if (series.currentDataGrouping) {
+                    series.options.data[data.length - 1] = newPoint;
                     series.setData(data);
+
+                // Existing point, update it
+                } else {
+                    series.points.at(-1).update(newPoint, true, false);
                 }
+
                 i++;
             }, 100);
         }


### PR DESCRIPTION
I found a couple of possible enhancements while working on the DataTable version of live candlestick:

1. At certain screen widths, US locale, the AM/PM style axis labels keep switching between one and two lines. Fixed it by setting the locale.

https://github.com/user-attachments/assets/70d97040-643a-4789-940d-34cc0c81c42c

2. Presumably it's inefficient to run the full `setData` for every update. Change it to do that only when data grouping is active.

