### PR TITLE
tools/postinstall-cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ts-compile:test": "npx tsc -p test && npx tsc -p samples",
     "gulp": "npx gulp",
     "utils": "highcharts-utils",
-    "prepare": "husky install && npm run clean",
+    "prepare": "husky install",
     "postinstall": "npx gulp update-vendor && npx gulp patch-ink-docstrap",
     "reset": "npx gulp reset-clone && npm i",
     "benchmark": "tsx test/ts-node-unit-tests/bench.ts",

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,15 @@ for more information.
 ## Build and debug
 If you want to do modifications to Highcharts or fix issues, you may build your own files. Highcharts uses Gulp as the build system. After `npm install` in the root folder, run `gulp`, which will set up a watch task for the JavaScript and CSS files. Now any changes in the files of the `/js` or `/css` folders will result in new files being built and saved in the `code` folder. Other tasks are also available, like `gulp lint`.
 
+`npm install` no longer removes generated local folders such as `build`, `code`,
+`js`, or `vendor`. It still runs the `postinstall` setup that prepares
+`vendor/` assets and applies the temporary `ink-docstrap` compatibility patch.
+
+If you need a full local reset, use the manual recovery commands instead:
+
+- `npm run clean` deletes generated folders and recreates `vendor/`
+- `npm run reset` resets the clone state and reinstalls dependencies
+
 ```
 npm install
 gulp


### PR DESCRIPTION
## Summary
- stop running `npm run clean` from the `prepare` lifecycle hook
- keep `postinstall` unchanged so vendor assets and the `ink-docstrap` patch are still applied
- update the README to clarify the new install behavior and document `clean`/`reset` as manual recovery commands

## Testing
- `npm install`
- `npx gulp scripts`
- `npx gulp jsdoc-classes`
- `npm run clean`