### PR TITLE
grid/api-validation-notifs

### DIFF
--- a/docs/grid/editing/validation.md
+++ b/docs/grid/editing/validation.md
@@ -61,24 +61,22 @@ columns: [{
 }]
 ```
 
-Custom error messages for each validation rule can be set using the root `lang` API option:
+Custom notifications for each validation rule can be set using the root `lang` API option:
 
 ```js
 lang: {
-    validationErrors: {
-        notEmpty: {
-            notification: 'Custom error message for empty cells'
-        },
-        number: {
-            notification: 'Custom error message for NaN'
-        }
+    validationNotifications: {
+        notEmpty: 'Custom notification for empty cells',
+        number: 'Custom notification for NaN'
     }
 }
 ```
 
+Each value can be a string or a callback function returning a string.
+
 ## Custom validation rules
 
-You can define custom validation rules and error messages directly in the column options:
+You can define custom validation rules and notifications directly in the column options:
 
 ```ts
 columns: [{

--- a/samples/grid-pro/basic/cell-editing/demo.js
+++ b/samples/grid-pro/basic/cell-editing/demo.js
@@ -21,19 +21,12 @@ Grid.grid('container', {
         }
     },
     lang: {
-        validationErrors: {
-            notEmpty: {
-                notification: 'New value cannot be empty.'
-            },
-            number: {
-                notification: 'New value has to be a number.'
-            },
-            boolean: {
-                notification: 'New value has to be a boolean.'
-            },
-            ignoreCaseUnique: {
-                notification: 'New value has to be unique (case-sensitive).'
-            }
+        validationNotifications: {
+            notEmpty: 'New value cannot be empty.',
+            number: 'New value has to be a number.',
+            boolean: 'New value has to be a boolean.',
+            ignoreCaseUnique:
+                'New value has to be unique (case-sensitive).'
         }
     },
     rendering: {
@@ -56,7 +49,7 @@ Grid.grid('container', {
         dataType: 'string',
         cells: {
             editMode: {
-                // Gets default error message text or from lang (if defined)
+                // Gets default notification text or from lang (if defined)
                 validationRules: ['notEmpty', 'ignoreCaseUnique']
             }
         }

--- a/samples/grid-pro/e2e/cell-editing/demo.js
+++ b/samples/grid-pro/e2e/cell-editing/demo.js
@@ -39,13 +39,9 @@ Grid.grid('container', {
         }
     },
     lang: {
-        validationErrors: {
-            notEmpty: {
-                notification: 'New value cannot be empty.'
-            },
-            number: {
-                notification: 'New value has to be a number.'
-            }
+        validationNotifications: {
+            notEmpty: 'New value cannot be empty.',
+            number: 'New value has to be a number.'
         }
     },
     rendering: {
@@ -74,7 +70,7 @@ Grid.grid('container', {
         dataType: 'string',
         cells: {
             editMode: {
-                // Gets default error message text or from lang (if defined)
+                // Gets default notification text or from lang (if defined)
                 validationRules: ['notEmpty', 'ignoreCaseUnique']
             }
         }

--- a/tools/gulptasks/grid/api-docs.js
+++ b/tools/gulptasks/grid/api-docs.js
@@ -458,7 +458,7 @@ function postProcessSitemap(gridDir) {
  * Path to the Grid API docs output directory.
  *
  * @param {string|undefined} gridVersion
- * Grid version string (e.g. "v2.2.0") for the navbar.
+ * Grid version string (e.g. "v2.2.0").
  */
 function postProcessHTML(gridDir, gridVersion) {
     const fs = require('fs');
@@ -552,7 +552,7 @@ function postProcessHTML(gridDir, gridVersion) {
         ],
         [
             /Highcharts Core (v[\d.]+)/gu,
-            'Highcharts Grid $1'
+            `Highcharts Grid ${gridVersion || '$1'}`
         ],
 
         // Fix og:url to use /grid/ instead of /highcharts/
@@ -728,7 +728,7 @@ async function apiDocs() {
     log.message('Post-processing HTML for Grid branding...');
     const gridVersion = await fetchGridVersion();
     if (gridVersion) {
-        log.message('Using Grid version', gridVersion, 'for navbar.');
+        log.message('Using Grid version', gridVersion, 'for navbar and footer.');
     } else {
         log.warn(
             'Could not read Grid version from build-properties.json. ' +

--- a/ts/Grid/Pro/ColumnTypes/Validator.ts
+++ b/ts/Grid/Pro/ColumnTypes/Validator.ts
@@ -244,8 +244,8 @@ class Validator {
         errors: string[] = []
     ): boolean {
         const { options, dataType } = cell.column;
-        const validationErrors =
-            cell.row.viewport.grid.options?.lang?.validationErrors;
+        const validationNotifications =
+            cell.row.viewport.grid.options?.lang?.validationNotifications;
         const rendererType = cell.column.options?.cells?.renderer?.type;
         let rules = Array.from(options?.cells?.editMode?.validationRules || []);
 
@@ -281,11 +281,11 @@ class Validator {
 
         for (const rule of rules) {
             let ruleDef: RuleDefinition;
-            let err;
+            let err: ValidationNotification|undefined;
 
             if (typeof rule === 'string') {
                 ruleDef = Validator.rulesRegistry[rule];
-                err = validationErrors?.[rule]?.notification;
+                err = validationNotifications?.[rule];
             } else {
                 ruleDef = rule;
             }
@@ -309,7 +309,9 @@ class Validator {
                 editModeContent &&
                 !validateFn.call(cell, editModeContent)
             ) {
-                if (typeof ruleDef.notification === 'function') {
+                if (typeof err === 'function') {
+                    err = err.call(cell, editModeContent);
+                } else if (typeof ruleDef.notification === 'function') {
                     err = ruleDef.notification.call(cell, editModeContent);
                 }
                 errors.push((err || ruleDef.notification) as string);
@@ -452,20 +454,45 @@ export type ValidateFunction = (
 ) => boolean;
 
 /**
- * Callback function that returns a error message.
+ * Callback function that returns a validation notification.
  */
-export type ValidationErrorFunction = (
+export type ValidationNotificationFunction = (
     this: TableCell,
     content?: EditModeContent
 ) => string;
 
 /**
- * Definition of the validation rule that should container validate method
- * and error message displayed in notification.
+ * Validation notification content.
+ */
+export type ValidationNotification =
+    string|ValidationNotificationFunction;
+
+/**
+ * Definition of the validation rule that should contain validate method
+ * and validation notification.
  */
 export interface RuleDefinition {
+    /**
+     * Validation logic for the rule.
+     *
+     * Use a built-in rule key to reuse one of the predefined validators, or
+     * provide a custom callback function.
+     */
     validate: RuleKey|ValidateFunction;
-    notification: string|ValidationErrorFunction;
+
+    /**
+     * Notification displayed when the validation fails.
+     *
+     * Can be defined as a static string or a callback function returning a
+     * string.
+     *
+     * When `validate` references one of the predefined rule keys, this
+     * property overrides that rule's built-in notification.
+     *
+     * Localized notifications for predefined rules configured directly by key
+     * can be customized through `lang.validationNotifications`.
+     */
+    notification: ValidationNotification;
 }
 
 /**
@@ -481,6 +508,80 @@ export interface RulesRegistryType {
     arrayNumber: RuleDefinition;
     json: RuleDefinition;
     sparkline: RuleDefinition;
+}
+
+/**
+ * Definition of localized validation notifications keyed by validator name.
+ *
+ * Built-in validator names are listed below, and custom validators can be
+ * addressed by their registry key as well.
+ */
+export interface ValidationNotificationsType
+    extends Record<string, ValidationNotification|undefined> {
+
+    // Built-in validator names listed here to be included in the api docs.
+    /**
+     * Notification text for the `boolean` validator.
+     *
+     * @default 'Value has to be a boolean.'
+     */
+    boolean?: ValidationNotification;
+
+    /**
+     * Notification text for the `datetime` validator.
+     *
+     * @default 'Value has to be parsed to a valid timestamp.'
+     */
+    datetime?: ValidationNotification;
+
+    /**
+     * Notification text for the `notEmpty` validator.
+     *
+     * @default 'Value cannot be empty.'
+     */
+    notEmpty?: ValidationNotification;
+
+    /**
+     * Notification text for the `number` validator.
+     *
+     * @default 'Value has to be a number.'
+     */
+    number?: ValidationNotification;
+
+    /**
+     * Notification text for the `ignoreCaseUnique` validator.
+     *
+     * @default 'Value must be unique within this column (case-insensitive).'
+     */
+    ignoreCaseUnique?: ValidationNotification;
+
+    /**
+     * Notification text for the `unique` validator.
+     *
+     * @default 'Value must be unique within this column (case-sensitive).'
+     */
+    unique?: ValidationNotification;
+
+    /**
+     * Notification text for the `arrayNumber` validator.
+     *
+     * @default 'Value should be a list of numbers separated by commas.'
+     */
+    arrayNumber?: ValidationNotification;
+
+    /**
+     * Notification text for the `json` validator.
+     *
+     * @default 'Value should be a valid JSON.'
+     */
+    json?: ValidationNotification;
+
+    /**
+     * Notification text for the `sparkline` validator.
+     *
+     * @default 'Value should be a valid JSON or a list of numbers separated by commas.'
+     */
+    sparkline?: ValidationNotification;
 }
 
 /**

--- a/ts/Grid/Pro/ColumnTypes/ValidatorComposition.ts
+++ b/ts/Grid/Pro/ColumnTypes/ValidatorComposition.ts
@@ -26,7 +26,7 @@ import type Table from '../../Core/Table/Table';
 import type {
     RuleKey,
     RuleDefinition,
-    RulesRegistryType
+    ValidationNotificationsType
 } from './Validator';
 
 import Validator from './Validator.js';
@@ -106,12 +106,10 @@ declare module '../../Pro/CellEditing/CellEditingComposition' {
 declare module '../../Core/Options' {
     interface LangOptions {
         /**
-         * Validation options for the column.
-         *
-         * If not set, the validation rules are applied according to the data
-         * type.
+         * Localized validation notifications for predefined rules or custom
+         * validators.
          */
-        validationErrors?: RulesRegistryType;
+        validationNotifications?: ValidationNotificationsType;
     }
 }
 


### PR DESCRIPTION
Changed Grid validation notifications to use `lang.validationNotifications` with flattened predefined rule entries.

#### Upgrade note

- Replaced `lang.validationErrors` with `lang.validationNotifications`.
- Flattened predefined rule overrides under `lang.validationNotifications`, so `lang.validationNotifications.number.notification` should now be written as `lang.validationNotifications.number`.
