### PR TITLE
bugfix/23385-nodes-dataLabels

### DIFF
--- a/samples/unit-tests/series-sankey/sankey/demo.js
+++ b/samples/unit-tests/series-sankey/sankey/demo.js
@@ -765,6 +765,18 @@ QUnit.test(
             'This node id(position) should not been have changed ' +
                 'after the update (#12453)'
         );
+
+        chart.series[0].update({
+            dataLabels: {
+                enabled: false
+            }
+        });
+
+        assert.strictEqual(
+            !!chart.series[0].nodes[0].dataLabel,
+            false,
+            'Node should not have the dataLabel after the update (#23385).'
+        );
     }
 );
 

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -4692,6 +4692,16 @@ class Series {
                     }
                 }
             }
+
+            // Also destroy node labels when data labels are disabled. Do not
+            // call resolveColor here to avoid reassigning colorByPoint colors.
+            if (kinds.dataLabel && this.nodes) { // #23385
+                for (const point of this.nodes) {
+                    if (point?.series) {
+                        point.destroyElements({ dataLabel: 1 });
+                    }
+                }
+            }
         }
 
         series.initialType = initialType;

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -4692,16 +4692,6 @@ class Series {
                     }
                 }
             }
-
-            // Also destroy node labels when data labels are disabled. Do not
-            // call resolveColor here to avoid reassigning colorByPoint colors.
-            if (kinds.dataLabel && this.nodes) { // #23385
-                for (const point of this.nodes) {
-                    if (point?.series) {
-                        point.destroyElements({ dataLabel: 1 });
-                    }
-                }
-            }
         }
 
         series.initialType = initialType;

--- a/ts/Series/NodesComposition.ts
+++ b/ts/Series/NodesComposition.ts
@@ -29,7 +29,14 @@ const {
         }
     }
 } = SeriesRegistry;
-import { defined, extend, find, merge, pick } from '../Shared/Utilities.js';
+import {
+    addEvent,
+    defined,
+    extend,
+    find,
+    merge,
+    pick
+} from '../Shared/Utilities.js';
 
 
 /* *
@@ -143,7 +150,21 @@ namespace NodesComposition {
         seriesProto.destroy = destroy;
         seriesProto.setData = setData;
 
+        addEvent(SeriesClass, 'afterUpdate', afterUpdate);
+
         return SeriesClass as (T&typeof SeriesComposition);
+    }
+
+    /**
+     * Destroy data labels on nodes.
+     * @private
+     */
+    function afterUpdate(this: Series): void {
+        if (!this.hasDataLabels?.() && this.nodes) { // #23385
+            for (const node of this.nodes) {
+                node.destroyElements({ dataLabel: 1 });
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Fixed #23385, `dataLabels` on sankey and dependency wheel nodes were not destroyed after update.