### PR TITLE
bugfix/19740-marker-clusters-datetime

### DIFF
--- a/tests/highcharts/series/series-marker-clusters.spec.ts
+++ b/tests/highcharts/series/series-marker-clusters.spec.ts
@@ -1,4 +1,60 @@
+import type { Page } from '@playwright/test';
+
 import { test, expect, createChart } from '~/fixtures.ts';
+
+async function getClusterStateAfterDatetimeMsGridClustering(
+    page: Page,
+    xAxisReversed: boolean
+): Promise<{
+    hasClustersArray: boolean;
+    clustersLength: number | null;
+}> {
+    const options: Highcharts.Options = {
+        chart: {
+            width: 800
+        },
+        title: {
+            text: ''
+        },
+        xAxis: {
+            type: 'datetime',
+            reversed: xAxisReversed
+        },
+        series: [{
+            type: 'scatter',
+            data: [
+                { x: 1694561823000, y: 1 },
+                { x: 1694561823000 + 1, y: 1 }
+            ],
+            cluster: {
+                enabled: true,
+                animation: false
+            }
+        }]
+    };
+
+    const chart = await createChart(page, options, {
+        modules: ['modules/marker-clusters.js']
+    });
+
+    // Ensure the page event loop is responsive right after chart creation.
+    // A blocked main thread would prevent the timer from firing.
+    await page.evaluate(() => new Promise<void>(resolve => {
+        window.setTimeout(() => resolve(), 0);
+    }));
+
+    return chart.evaluate(c => {
+        const series = c.series[0];
+        const markerClusterInfo = series.markerClusterInfo;
+        const clusters =
+            markerClusterInfo && markerClusterInfo.clusters;
+
+        return {
+            hasClustersArray: Array.isArray(clusters),
+            clustersLength: clusters ? clusters.length : null
+        };
+    });
+}
 
 test.describe('series/marker-clusters', {
     annotation: [
@@ -219,55 +275,23 @@ test.describe('series/marker-clusters', {
 
     test('Grid algorithm should not hang on datetime data', async ({ page }) => {
         // Related to #19740
-        // If the grid clustering algorithm regresses into a infinite loop,
+        // If the grid clustering algorithm regresses into an infinite loop,
         // this test should fail quickly by hitting the timeout below.
-        test.setTimeout(2000);
-
-        const options: Highcharts.Options = {
-            chart: {
-                width: 800
-            },
-            title: {
-                text: ''
-            },
-            xAxis: {
-                type: 'datetime'
-            },
-            series: [{
-                type: 'scatter',
-                data: [
-                    { x: 1694561823000, y: 1 },
-                    { x: 1694561823000 + 1, y: 1 }
-                ],
-                cluster: {
-                    enabled: true,
-                    animation: false
-                }
-            }]
-        };
-
-        const chart = await createChart(page, options, {
-            modules: ['modules/marker-clusters.js']
-        });
-
-        // Ensure the page event loop is responsive right after chart creation.
-        // A blocked main thread would prevent the timer from firing.
-        await page.evaluate(() => new Promise<void>(resolve => {
-            window.setTimeout(() => resolve(), 0);
-        }));
-
+        test.setTimeout(15000);
         expect(
-            await chart.evaluate(c => {
-                const series = c.series[0];
-                const markerClusterInfo = series.markerClusterInfo;
-                const clusters =
-                    markerClusterInfo && markerClusterInfo.clusters;
+            await getClusterStateAfterDatetimeMsGridClustering(page, false),
+            'Clustering should complete and keep browser responsive.'
+        ).toEqual({
+            hasClustersArray: true,
+            clustersLength: 0
+        });
+    });
 
-                return {
-                    hasClustersArray: Array.isArray(clusters),
-                    clustersLength: clusters ? clusters.length : null
-                };
-            }),
+    test('Grid algorithm should not hang on datetime data with reversed xAxis', async ({ page }) => {
+        // Related to #19740 — reversed axis can change grid math paths.
+        test.setTimeout(15000);
+        expect(
+            await getClusterStateAfterDatetimeMsGridClustering(page, true),
             'Clustering should complete and keep browser responsive.'
         ).toEqual({
             hasClustersArray: true,

--- a/tests/highcharts/series/series-marker-clusters.spec.ts
+++ b/tests/highcharts/series/series-marker-clusters.spec.ts
@@ -216,4 +216,62 @@ test.describe('series/marker-clusters', {
             '18.00'
         );
     });
+
+    test('Grid algorithm should not hang on datetime data', async ({ page }) => {
+        // Related to #19740
+        // If the grid clustering algorithm regresses into a infinite loop,
+        // this test should fail quickly by hitting the timeout below.
+        test.setTimeout(2000);
+
+        const options: Highcharts.Options = {
+            chart: {
+                width: 800
+            },
+            title: {
+                text: ''
+            },
+            xAxis: {
+                type: 'datetime'
+            },
+            series: [{
+                type: 'scatter',
+                data: [
+                    { x: 1694561823000, y: 1 },
+                    { x: 1694561823000 + 1, y: 1 }
+                ],
+                cluster: {
+                    enabled: true,
+                    animation: false
+                }
+            }]
+        };
+
+        const chart = await createChart(page, options, {
+            modules: ['modules/marker-clusters.js']
+        });
+
+        // Ensure the page event loop is responsive right after chart creation.
+        // A blocked main thread would prevent the timer from firing.
+        await page.evaluate(() => new Promise<void>(resolve => {
+            window.setTimeout(() => resolve(), 0);
+        }));
+
+        expect(
+            await chart.evaluate(c => {
+                const series = c.series[0];
+                const markerClusterInfo = series.markerClusterInfo;
+                const clusters =
+                    markerClusterInfo && markerClusterInfo.clusters;
+
+                return {
+                    hasClustersArray: Array.isArray(clusters),
+                    clustersLength: clusters ? clusters.length : null
+                };
+            }),
+            'Clustering should complete and keep browser responsive.'
+        ).toEqual({
+            hasClustersArray: true,
+            clustersLength: 0
+        });
+    });
 });

--- a/ts/Extensions/MarkerClusters/MarkerClusterScatter.ts
+++ b/ts/Extensions/MarkerClusters/MarkerClusterScatter.ts
@@ -1484,8 +1484,8 @@ function seriesGetScaledGridSize(
         xAxis.toPixels(series.gridValueSize) - xAxis.toPixels(0);
 
     // Fix, #19740: Prevent division by zero error.
-    const scale = gridSize > 0 ?
-        +(processedGridSize / gridSize).toFixed(14) : 1;
+    const scale = gridSize !== 0 ?
+        Math.abs(+(processedGridSize / gridSize).toFixed(14)) : 1;
 
     // Find the level and its divider.
     while (search && scale !== 1) {

--- a/ts/Extensions/MarkerClusters/MarkerClusterScatter.ts
+++ b/ts/Extensions/MarkerClusters/MarkerClusterScatter.ts
@@ -1482,7 +1482,10 @@ function seriesGetScaledGridSize(
     const gridSize = mapView ?
         series.gridValueSize * mapView.getScale() :
         xAxis.toPixels(series.gridValueSize) - xAxis.toPixels(0);
-    const scale = +(processedGridSize / gridSize).toFixed(14);
+
+    // Fix, #19740: Prevent division by zero error.
+    const scale = gridSize > 0 ?
+        +(processedGridSize / gridSize).toFixed(14) : 1;
 
     // Find the level and its divider.
     while (search && scale !== 1) {


### PR DESCRIPTION
Fixed #19740, marker clusters with datetime axes froze the browser when x values were millisecond timestamps.