### PR TITLE
bugfix/api-types

### DIFF
--- a/ts/Accessibility/Components/SeriesComponent/ForcedMarkers.ts
+++ b/ts/Accessibility/Components/SeriesComponent/ForcedMarkers.ts
@@ -122,9 +122,7 @@ namespace ForcedMarkersComposition {
     function getPointMarkerOpacity(
         pointOptions: PointOptions
     ): number|undefined {
-        return (pointOptions.marker as any).states &&
-            (pointOptions.marker as any).states.normal &&
-            (pointOptions.marker as any).states.normal.opacity;
+        return pointOptions.marker?.states?.normal?.opacity;
     }
 
 

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1631,8 +1631,7 @@ class Point {
             series = point.series,
             previousState = point.state,
             stateOptions = (
-                (series.options.states as any)[state || 'normal'] ||
-                {}
+                series.options.states?.[state || 'normal'] || {}
             ),
             markerOptions = (
                 (defaultOptions.plotOptions as any)[
@@ -1676,9 +1675,7 @@ class Point {
             // Individual point marker's state options is disabled
             (
                 state &&
-                pointMarker.states &&
-                (pointMarker.states as any)[state] &&
-                (pointMarker.states as any)[state].enabled === false
+                pointMarker.states?.[state]?.enabled === false
             ) // #1610
 
         ) {
@@ -1707,7 +1704,7 @@ class Point {
                 pointAttribsAnimation = pick(
                     chart.options.chart.animation,
                     stateOptions.animation
-                );
+                ) as AnimationOptions;
                 const opacity = pointAttribs.opacity;
 
                 // Some inactive points (e.g. slices in pie) should apply
@@ -1818,7 +1815,8 @@ class Point {
         }
 
         // Show me your halo
-        const haloOptions = stateOptions.halo;
+        const haloOptions = typeof stateOptions.halo === 'object' ?
+            stateOptions.halo : void 0;
         const markerGraphic = (point.graphic || stateMarkerGraphic);
         const markerVisibility = markerGraphic?.visibility || 'inherit';
 

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1814,8 +1814,8 @@ class Point {
             }
         }
 
-        // Show me your halo
-        const haloOptions = typeof stateOptions.halo === 'object' ?
+        // Show me your halo (object config only; false/true handled elsewhere)
+        const haloOptions = isObject(stateOptions.halo, true) ?
             stateOptions.halo : void 0;
         const markerGraphic = (point.graphic || stateMarkerGraphic);
         const markerVisibility = markerGraphic?.visibility || 'inherit';

--- a/ts/Core/Series/PointOptions.ts
+++ b/ts/Core/Series/PointOptions.ts
@@ -15,19 +15,14 @@
  *
  * */
 
-import type AnimationOptions from '../Animation/AnimationOptions';
 import type ColorType from '../Color/ColorType';
-import type { DeepPartial } from '../../Shared/Types';
 import type { EventCallback } from '../Callback';
 import type Point from './Point';
 import type PointerEvent from '../PointerEvent';
 import type { PointTypeOptions } from './PointType';
 import type {
     StateGenericOptions,
-    StateHoverOptions,
-    StateInactiveOptions,
-    StateNormalOptions,
-    StateSelectOptions,
+    StateOptions,
     StatesOptions
 } from './StatesOptions';
 import type { SymbolKey } from '../Renderer/SVG/SymbolType';
@@ -591,187 +586,27 @@ export type PointShortOptions = (
     null
 );
 
-export interface PointMarkerStateHoverOptions extends StateHoverOptions {
-    /**
-     * Animation when hovering over the marker.
-     *
-     * @default {"duration":150}
-     */
-    animation?: (boolean|DeepPartial<AnimationOptions>);
-
-    /**
-     * Enable or disable the point marker.
-     *
-     * @sample {highcharts} highcharts/plotoptions/series-marker-states-hover-enabled/
-     * Disabled hover state
-     *
-     * @default true
-     */
-    enabled?: boolean;
-
-    /**
-     * The fill color of the marker in hover state. When
-     * `undefined`, the series' or point's fillColor for normal
-     * state is used.
-     */
-    fillColor?: ColorType;
-
-    /**
-     * The color of the point marker's outline. When
-     * `undefined`, the series' or point's lineColor for normal
-     * state is used.
-     *
-     * @sample {highcharts} highcharts/plotoptions/series-marker-states-hover-linecolor/
-     * White fill color, black line color
-     */
-    lineColor?: ColorType;
-
-    /**
-     * The width of the point marker's outline. When
-     * `undefined`, the series' or point's lineWidth for normal
-     * state is used.
-     *
-     * @sample {highcharts} highcharts/plotoptions/series-marker-states-hover-linewidth/
-     * 3px line width
-     */
-    lineWidth?: number;
-
-    /**
-     * The additional line width for a hovered point.
-     *
-     * @sample {highcharts} highcharts/plotoptions/series-states-hover-linewidthplus/
-     * 2 pixels wider on hover
-     *
-     * @sample {highstock} highcharts/plotoptions/series-states-hover-linewidthplus/
-     * 2 pixels wider on hover
-     *
-     * @since 4.0.3
-     * @default 1
-     */
-    lineWidthPlus?: number;
-
-    /** @internal */
-    opacity?: number;
-
-    /**
-     * The radius of the point marker. In hover state, it
-     * defaults to the normal state's radius + 2 as per the
-     * [radiusPlus](#plotOptions.series.marker.states.hover.radiusPlus)
-     * option.
-     *
-     * @sample {highcharts} highcharts/plotoptions/series-marker-states-hover-radius/
-     * 10px radius
-     */
-    radius?: number;
-
-    /**
-     * The number of pixels to increase the radius of the hovered point.
-     *
-     * @sample {highcharts} highcharts/plotoptions/series-states-hover-linewidthplus/
-     * 5 pixels greater radius on hover
-     * @sample {highstock} highcharts/plotoptions/series-states-hover-linewidthplus/
-     * 5 pixels greater radius on hover
-     *
-     * @since 4.0.3
-     * @default 2
-     */
-    radiusPlus?: number;
-}
-
-export interface PointMarkerStateInactiveOptions extends StateInactiveOptions {
-    /** @internal */
-    opacity?: number;
-}
-
-export interface PointMarkerStateNormalOptions extends StateNormalOptions {
-    /**
-     * Animation when returning to normal state after hovering.
-     *
-     * @default true
-     */
-    animation?: (boolean|DeepPartial<AnimationOptions>);
-
-    /** @internal */
-    opacity?: number;
-}
-
 export interface PointMarkerStatesOptions<T extends PointMarkerOptions> extends StatesOptions {
     /**
      * The hover state for a single point marker.
      */
-    hover?: PointMarkerStateHoverOptions & StateGenericOptions<T>;
+    hover?: StateOptions & StateGenericOptions<T>;
 
     // Implemented only for networkgraph.
     /** @internal */
-    inactive?: PointMarkerStateInactiveOptions & StateGenericOptions<T>;
+    inactive?: StateOptions & StateGenericOptions<T>;
 
     /**
-     * The normal state of a single point marker. Currently only
-     * used for setting animation when returning to normal state
-     * from hover.
+     * The normal state of a single point marker. Currently only used for
+     * setting animation when returning to normal state from hover.
      */
-    normal?: PointMarkerStateNormalOptions & StateGenericOptions<T>;
+    normal?: StateOptions & StateGenericOptions<T>;
 
     /**
      * The appearance of the point marker when selected. In order to allow a
      * point to be selected, set the `series.allowPointSelect` option to true.
      */
-    select?: PointMarkerStateSelectOptions & StateGenericOptions<T>;
-}
-
-export interface PointMarkerStateSelectOptions extends StateSelectOptions {
-    /**
-     * Enable or disable visible feedback for selection.
-     *
-     * @sample {highcharts} highcharts/plotoptions/series-marker-states-select-enabled/
-     * Disabled select state
-     *
-     * @default true
-     */
-    enabled?: boolean;
-
-    /**
-     * The fill color of the point marker.
-     *
-     * @sample {highcharts} highcharts/plotoptions/series-marker-states-select-fillcolor/
-     * Solid red discs for selected points
-     *
-     * @default ${palette.neutralColor20}
-     */
-    fillColor?: ColorType;
-
-    /**
-     * The color of the point marker's outline. When
-     * `undefined`, the series' or point's color is used.
-     *
-     * @sample {highcharts} highcharts/plotoptions/series-marker-states-select-linecolor/
-     * Red line color for selected points
-     *
-     * @default ${palette.neutralColor100}
-     */
-    lineColor?: ColorType;
-
-    /**
-     * The width of the point marker's outline.
-     *
-     * @sample {highcharts} highcharts/plotoptions/series-marker-states-select-linewidth/
-     * 3px line width for selected points
-     *
-     * @default 2
-     */
-    lineWidth?: number;
-
-    /** @internal */
-    opacity?: number;
-
-    /**
-     * The radius of the point marker. In hover state, it defaults to the normal
-     * state's radius + 2.
-     *
-     * @sample {highcharts} highcharts/plotoptions/series-marker-states-select-radius/
-     * 10px radius for selected points
-     */
-    radius?: number;
+    select?: StateOptions & StateGenericOptions<T>;
 }
 
 /* *

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -3138,11 +3138,10 @@ class Series {
         state = state || 'normal';
         if (state) {
             seriesStateOptions = (
-                (seriesMarkerOptions as any).states[state] || {}
+                seriesMarkerOptions?.states?.[state] || {}
             );
             pointStateOptions = (
-                pointMarkerOptions.states &&
-                (pointMarkerOptions.states as any)[state]
+                pointMarkerOptions.states?.[state]
             ) || {};
             strokeWidth = pick(
                 pointStateOptions.lineWidth,

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -1215,7 +1215,16 @@ const seriesDefaults: PlotOptionsOf<Series> = {
         /**
          * States for a single point marker.
          *
+         * In addition to the options documented for each marker state, you can
+         * set any option from
+         * [plotOptions.series.marker](#plotOptions.series.marker) except nested
+         * `states`. Those values override the base marker options while the
+         * marker is in that state.
+         *
          * @declare Highcharts.PointStatesOptionsObject
+         *
+         * @product highcharts highstock highmaps gantt
+         * @apioption plotOptions.series.marker.states
          */
         states: {
 
@@ -2170,7 +2179,20 @@ const seriesDefaults: PlotOptionsOf<Series> = {
     /**
      * A collection of options for different series states.
      *
+     * In addition to the options documented under each state (`hover`,
+     * `inactive`, `normal`, `select`), you can set any option from the parent
+     * series type except `data` and nested `states`. Those values override the
+     * base series options while the series is in that state—for example
+     * `lineWidth` under
+     * [plotOptions.series.states.hover](#plotOptions.series.states.hover), or
+     * `borderColor` and `borderWidth` under
+     * [plotOptions.pie.states.inactive](#plotOptions.pie.states.inactive) for
+     * pie series.
+     *
      * @declare Highcharts.SeriesStatesOptionsObject
+     *
+     * @product highcharts highstock highmaps gantt
+     * @apioption plotOptions.series.states
      */
     states: {
 

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -1240,6 +1240,8 @@ const seriesDefaults: PlotOptionsOf<Series> = {
                  * Animation when returning to normal state after hovering.
                  *
                  * @type {boolean|Partial<Highcharts.AnimationOptionsObject>}
+                 * @default true
+                 * @apioption plotOptions.series.marker.states.normal.animation
                  */
                 animation: true
             },
@@ -1255,8 +1257,12 @@ const seriesDefaults: PlotOptionsOf<Series> = {
                  * Animation when hovering over the marker.
                  *
                  * @type {boolean|Partial<Highcharts.AnimationOptionsObject>}
+                 * @apioption plotOptions.series.marker.states.hover.animation
                  */
                 animation: {
+                    /**
+                     * @apioption plotOptions.series.marker.states.hover.animation.duration
+                     */
                     duration: 150
                 },
 
@@ -1265,25 +1271,56 @@ const seriesDefaults: PlotOptionsOf<Series> = {
                  *
                  * @sample {highcharts} highcharts/plotoptions/series-marker-states-hover-enabled/
                  *         Disabled hover state
+                 *
+                 * @default true
+                 * @apioption plotOptions.series.marker.states.hover.enabled
                  */
                 enabled: true,
 
                 /**
-                 * The fill color of the marker in hover state. When
-                 * `undefined`, the series' or point's fillColor for normal
-                 * state is used.
+                 * Used by hover and inactive states. Brightness adjustment
+                 * applied to the series or point color, e.g. for column, pie
+                 * and map series.
+                 *
+                 * @apioption plotOptions.series.marker.states.hover.brightness
+                 */
+                brightness: void 0,
+
+                /**
+                 * Used by hover, inactive, and select states. The color of
+                 * the series or point marker in this state.
+                 *
+                 * @apioption plotOptions.series.marker.states.hover.color
+                 */
+                color: void 0,
+
+                /**
+                 * Used by hover, inactive, and select states. The dash
+                 * style of the series line in this state.
+                 *
+                 * @apioption plotOptions.series.marker.states.hover.dashStyle
+                 */
+                dashStyle: void 0,
+
+                /**
+                 * Used by hover and select states (marker). The fill color
+                 * of the point marker in this state. When `undefined`, the
+                 * series' or point's color is used.
+                 *
+                 * @sample {highcharts} highcharts/plotoptions/series-marker-states-select-fillcolor/
+                 * Solid red discs for selected points
                  *
                  * @type      {Highcharts.ColorType}
                  * @apioption plotOptions.series.marker.states.hover.fillColor
                  */
 
                 /**
-                 * The color of the point marker's outline. When
-                 * `undefined`, the series' or point's lineColor for normal
-                 * state is used.
+                 * Used by hover and select states (marker). The color of the
+                 * point marker's outline in this state. When `undefined`, the
+                 * series' or point's color is used.
                  *
                  * @sample {highcharts} highcharts/plotoptions/series-marker-states-hover-linecolor/
-                 *         White fill color, black line color
+                 * White fill color, black line color
                  *
                  * @type      {Highcharts.ColorType}
                  * @apioption plotOptions.series.marker.states.hover.lineColor
@@ -1315,8 +1352,8 @@ const seriesDefaults: PlotOptionsOf<Series> = {
                  */
 
                 /**
-                 * The number of pixels to increase the radius of the
-                 * hovered point.
+                 * Used by hover state (marker). The number of pixels to add
+                 * to the marker radius on hover.
                  *
                  * @sample {highcharts} highcharts/plotoptions/series-states-hover-linewidthplus/
                  *         5 pixels greater radius on hover
@@ -1324,11 +1361,15 @@ const seriesDefaults: PlotOptionsOf<Series> = {
                  *         5 pixels greater radius on hover
                  *
                  * @since 4.0.3
+                 * @default 2
+                 * @apioption plotOptions.series.marker.states.hover.radiusPlus
                  */
                 radiusPlus: 2,
 
                 /**
-                 * The additional line width for a hovered point.
+                 * Used by hover state (series and marker). The additional
+                 * line width for the graph or marker outline relative to the
+                 * normal state.
                  *
                  * @sample {highcharts} highcharts/plotoptions/series-states-hover-linewidthplus/
                  *         2 pixels wider on hover
@@ -1336,8 +1377,19 @@ const seriesDefaults: PlotOptionsOf<Series> = {
                  *         2 pixels wider on hover
                  *
                  * @since 4.0.3
+                 * @default 1
+                 * @apioption plotOptions.series.marker.states.hover.lineWidthPlus
                  */
-                lineWidthPlus: 1
+                lineWidthPlus: 1,
+
+                /**
+                 * Used by hover and inactive states (series and marker). The
+                 * opacity of the series or marker elements. In the inactive
+                 * state this defaults to `0.2` for series.
+                 *
+                 * @apioption plotOptions.series.marker.states.hover.opacity
+                 */
+                opacity: void 0
             },
 
             /**
@@ -1346,6 +1398,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
              * `series.allowPointSelect` option to true.
              *
              * @declare Highcharts.PointStatesSelectOptionsObject
+             * @extends   plotOptions.series.marker.states.hover
              */
             select: {
 
@@ -1378,6 +1431,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
                  *         Solid red discs for selected points
                  *
                  * @type {Highcharts.ColorType}
+                 * @apioption plotOptions.series.marker.states.select.fillColor
                  */
                 fillColor: Palette.neutralColor20,
 
@@ -1389,6 +1443,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
                  *         Red line color for selected points
                  *
                  * @type {Highcharts.ColorType}
+                 * @apioption plotOptions.series.marker.states.select.lineColor
                  */
                 lineColor: Palette.neutralColor100,
 
@@ -1397,6 +1452,8 @@ const seriesDefaults: PlotOptionsOf<Series> = {
                  *
                  * @sample {highcharts} highcharts/plotoptions/series-marker-states-select-linewidth/
                  *         3px line width for selected points
+                 *
+                 * @apioption plotOptions.series.marker.states.select.lineWidth
                  */
                 lineWidth: 2
             }
@@ -2208,6 +2265,8 @@ const seriesDefaults: PlotOptionsOf<Series> = {
              * Animation when returning to normal state after hovering.
              *
              * @type {boolean|Partial<Highcharts.AnimationOptionsObject>}
+             * @default true
+             * @apioption plotOptions.series.states.normal.animation
              */
             animation: true
         },
@@ -2244,6 +2303,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
              * @type {boolean|Partial<Highcharts.AnimationOptionsObject>}
              * @since   5.0.8
              * @product highcharts highstock
+             * @apioption plotOptions.series.states.hover.animation
              */
             animation: {
 
@@ -2251,6 +2311,8 @@ const seriesDefaults: PlotOptionsOf<Series> = {
                  * The duration of the hover animation in milliseconds. By
                  * default the hover state animates quickly in, and slowly
                  * back to normal.
+                 *
+                 * @apioption plotOptions.series.states.hover.animation.duration
                  */
                 duration: 150
             },
@@ -2278,8 +2340,96 @@ const seriesDefaults: PlotOptionsOf<Series> = {
              *
              * @since   4.0.3
              * @product highcharts highstock
+             * @default 1
+             * @apioption plotOptions.series.states.hover.lineWidthPlus
              */
             lineWidthPlus: 1,
+
+            /**
+             * Used by hover and inactive states. Brightness adjustment
+             * applied to the series or point color, e.g. for column, pie and
+             * map series.
+             *
+             * @apioption plotOptions.series.states.hover.brightness
+             */
+            brightness: void 0,
+
+            /**
+             * Used by hover, inactive, and select states. The color of the
+             * series or point marker in this state.
+             *
+             * @apioption plotOptions.series.states.hover.color
+             */
+            color: void 0,
+
+            /**
+             * Used by hover, inactive, and select states. The dash style of
+             * the series line in this state.
+             *
+             * @apioption plotOptions.series.states.hover.dashStyle
+             */
+            dashStyle: void 0,
+
+            /**
+             * Used by hover and select states (marker). The fill color of the
+             * point marker in this state. When `undefined`, the series' or
+             * point's color is used.
+             *
+             * @sample {highcharts} highcharts/plotoptions/series-marker-states-select-fillcolor/
+             * Solid red discs for selected points
+             *
+             * @apioption plotOptions.series.states.hover.fillColor
+             */
+            fillColor: void 0,
+
+            /**
+             * Used by hover and select states (marker). The color of the
+             * point marker's outline in this state. When `undefined`, the
+             * series' or point's color is used.
+             *
+             * @sample {highcharts} highcharts/plotoptions/series-marker-states-hover-linecolor/
+             * White fill color, black line color
+             *
+             * @apioption plotOptions.series.states.hover.lineColor
+             */
+            lineColor: void 0,
+
+            /**
+             * Used by hover and inactive states (series and marker). The
+             * opacity of the series or marker elements. In the inactive state
+             * this defaults to `0.2` for series.
+             *
+             * @default 0.2 (inactive state)
+             *
+             * @apioption plotOptions.series.states.hover.opacity
+             */
+            opacity: void 0,
+
+            /**
+             * Used by hover and select states (marker). The radius of the
+             * point marker in this state. In hover state, defaults to the
+             * normal state's radius plus `radiusPlus`.
+             *
+             * @sample {highcharts} highcharts/plotoptions/series-marker-states-hover-radius/
+             * 10px radius on hover
+             *
+             * @apioption plotOptions.series.states.hover.radius
+             */
+            radius: void 0,
+
+            /**
+             * Used by hover state (marker). The number of pixels to add to
+             * the marker radius on hover.
+             *
+             * @sample {highcharts} highcharts/plotoptions/series-states-hover-linewidthplus/
+             * 5 pixels greater radius on hover
+             *
+             * @since   4.0.3
+             * @default 2
+             *
+             * @apioption plotOptions.series.states.hover.radiusPlus
+             */
+            radiusPlus: void 0,
 
             /**
              * In Highcharts 1.0, the appearance of all markers belonging
@@ -2370,7 +2520,13 @@ const seriesDefaults: PlotOptionsOf<Series> = {
          * @excluding brightness
          */
         select: {
+            /**
+             * @apioption plotOptions.series.states.select.animation
+             */
             animation: {
+                /**
+                 * @apioption plotOptions.series.states.select.animation.duration
+                 */
                 duration: 0
             }
         },
@@ -2382,6 +2538,8 @@ const seriesDefaults: PlotOptionsOf<Series> = {
          *         Disabled inactive state
          *
          * @declare Highcharts.SeriesStatesInactiveOptionsObject
+         * @extends   plotOptions.series.states.hover
+         * @excluding marker
          */
         inactive: {
             /**
@@ -2399,14 +2557,19 @@ const seriesDefaults: PlotOptionsOf<Series> = {
              * The animation for entering the inactive state.
              *
              * @type {boolean|Partial<Highcharts.AnimationOptionsObject>}
+             * @apioption plotOptions.series.states.inactive.animation
              */
             animation: {
+                /**
+                 * @apioption plotOptions.series.states.inactive.animation.duration
+                 */
                 duration: 150
             },
             /**
              * Opacity of series elements (dataLabels, line, area).
              *
              * @type {number}
+             * @apioption plotOptions.series.states.inactive.opacity
              */
             opacity: 0.2
         }

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -1215,12 +1215,6 @@ const seriesDefaults: PlotOptionsOf<Series> = {
         /**
          * States for a single point marker.
          *
-         * In addition to the options documented for each marker state, you can
-         * set any option from
-         * [plotOptions.series.marker](#plotOptions.series.marker) except nested
-         * `states`. Those values override the base marker options while the
-         * marker is in that state.
-         *
          * @declare Highcharts.PointStatesOptionsObject
          *
          * @product highcharts highstock highmaps gantt

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -1278,7 +1278,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
                  *
                  * @apioption plotOptions.series.marker.states.hover.brightness
                  */
-                brightness: void 0,
+                // brightness: void 0,
 
                 /**
                  * Used by hover, inactive, and select states. The color of
@@ -1286,7 +1286,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
                  *
                  * @apioption plotOptions.series.marker.states.hover.color
                  */
-                color: void 0,
+                // color: void 0,
 
                 /**
                  * Used by hover, inactive, and select states. The dash
@@ -1294,8 +1294,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
                  *
                  * @apioption plotOptions.series.marker.states.hover.dashStyle
                  */
-                dashStyle: void 0,
-
+                // dashStyle: void 0,
                 /**
                  * Used by hover and select states (marker). The fill color
                  * of the point marker in this state. When `undefined`, the
@@ -1406,6 +1405,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
                  * @default   true
                  * @apioption plotOptions.series.marker.states.select.enabled
                  */
+                enabled: true,
 
                 /**
                  * The radius of the point marker. In hover state, it
@@ -2289,7 +2289,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
              * @since     1.2
              * @apioption plotOptions.series.states.hover.enabled
              */
-
+            enabled: true,
 
             /**
              * Animation setting for hovering the graph in line-type series.
@@ -2346,83 +2346,77 @@ const seriesDefaults: PlotOptionsOf<Series> = {
              *
              * @apioption plotOptions.series.states.hover.brightness
              */
-            brightness: void 0,
 
             /**
-             * Used by hover, inactive, and select states. The color of the
-             * series or point marker in this state.
-             *
-             * @apioption plotOptions.series.states.hover.color
-             */
-            color: void 0,
+            * Used by hover, inactive, and select states. The color of the
+            * series or point marker in this state.
+            *
+            * @apioption plotOptions.series.states.hover.color
+            */
 
             /**
-             * Used by hover, inactive, and select states. The dash style of
-             * the series line in this state.
-             *
-             * @apioption plotOptions.series.states.hover.dashStyle
-             */
-            dashStyle: void 0,
+            * Used by hover, inactive, and select states. The dash style of
+            * the series line in this state.
+            *
+            * @apioption plotOptions.series.states.hover.dashStyle
+            */
 
             /**
-             * Used by hover and select states (marker). The fill color of the
-             * point marker in this state. When `undefined`, the series' or
-             * point's color is used.
-             *
-             * @sample {highcharts} highcharts/plotoptions/series-marker-states-select-fillcolor/
-             * Solid red discs for selected points
-             *
-             * @apioption plotOptions.series.states.hover.fillColor
-             */
-            fillColor: void 0,
+            * Used by hover and select states (marker). The fill color of the
+            * point marker in this state. When `undefined`, the series' or
+            * point's color is used.
+            *
+            * @sample {highcharts} highcharts/plotoptions/series-marker-states-select-fillcolor/
+            * Solid red discs for selected points
+            *
+            * @apioption plotOptions.series.states.hover.fillColor
+            */
 
             /**
-             * Used by hover and select states (marker). The color of the
-             * point marker's outline in this state. When `undefined`, the
-             * series' or point's color is used.
-             *
-             * @sample {highcharts} highcharts/plotoptions/series-marker-states-hover-linecolor/
-             * White fill color, black line color
-             *
-             * @apioption plotOptions.series.states.hover.lineColor
-             */
-            lineColor: void 0,
+            * Used by hover and select states (marker). The color of the
+            * point marker's outline in this state. When `undefined`, the
+            * series' or point's color is used.
+            *
+            * @sample {highcharts} highcharts/plotoptions/series-marker-states-hover-linecolor/
+            * White fill color, black line color
+            *
+            * @apioption plotOptions.series.states.hover.lineColor
+            */
 
             /**
-             * Used by hover and inactive states (series and marker). The
-             * opacity of the series or marker elements. In the inactive state
-             * this defaults to `0.2` for series.
-             *
-             * @default 0.2 (inactive state)
-             *
-             * @apioption plotOptions.series.states.hover.opacity
-             */
-            opacity: void 0,
+            * Used by hover and inactive states (series and marker). The
+            * opacity of the series or marker elements. In the inactive state
+            * this defaults to `0.2` for series.
+            *
+            * @default 0.2
+            *
+            * @apioption plotOptions.series.states.hover.opacity
+            */
 
             /**
-             * Used by hover and select states (marker). The radius of the
-             * point marker in this state. In hover state, defaults to the
-             * normal state's radius plus `radiusPlus`.
-             *
-             * @sample {highcharts} highcharts/plotoptions/series-marker-states-hover-radius/
-             * 10px radius on hover
-             *
-             * @apioption plotOptions.series.states.hover.radius
-             */
+            * Used by hover and select states (marker). The radius of the
+            * point marker in this state. In hover state, defaults to the
+            * normal state's radius plus `radiusPlus`.
+            *
+            * @sample {highcharts} highcharts/plotoptions/series-marker-states-hover-radius/
+            * 10px radius on hover
+            *
+            * @apioption plotOptions.series.states.hover.radius
+            */
             radius: void 0,
 
             /**
-             * Used by hover state (marker). The number of pixels to add to
-             * the marker radius on hover.
-             *
-             * @sample {highcharts} highcharts/plotoptions/series-states-hover-linewidthplus/
-             * 5 pixels greater radius on hover
-             *
-             * @since   4.0.3
-             * @default 2
-             *
-             * @apioption plotOptions.series.states.hover.radiusPlus
-             */
+            * Used by hover state (marker). The number of pixels to add to
+            * the marker radius on hover.
+            *
+            * @sample {highcharts} highcharts/plotoptions/series-states-hover-linewidthplus/
+            * 5 pixels greater radius on hover
+            *
+            * @since   4.0.3
+            * @default 2
+            *
+            * @apioption plotOptions.series.states.hover.radiusPlus
+            */
             radiusPlus: void 0,
 
             /**
@@ -2546,6 +2540,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
              * @default true
              * @apioption plotOptions.series.states.inactive.enabled
              */
+            enabled: true,
 
             /**
              * The animation for entering the inactive state.

--- a/ts/Core/Series/SeriesOptions.ts
+++ b/ts/Core/Series/SeriesOptions.ts
@@ -32,13 +32,9 @@ import type Series from './Series';
 import type ShadowOptionsObject from '../Renderer/ShadowOptionsObject';
 import type {
     StateGenericOptions,
-    StateHoverOptions,
-    StateInactiveOptions,
-    StateNormalOptions,
-    StateSelectOptions,
+    StateOptions,
     StatesOptions
 } from './StatesOptions';
-import type SVGAttributes from '../Renderer/SVG/SVGAttributes';
 
 /* *
  *
@@ -1144,185 +1140,14 @@ export interface SeriesPointOptions {
     events?: PointEventsOptions;
 }
 
-export interface SeriesStateHoverHaloOptions {
-    /**
-     * A collection of SVG attributes to override the appearance
-     * of the halo, for example `fill`, `stroke` and
-     * `stroke-width`.
-     *
-     * @since   4.0
-     * @product highcharts highstock
-     */
-    attributes?: SVGAttributes;
-
-    brightness?: number;
-
-    /**
-     * Opacity for the halo unless a specific fill is overridden
-     * using the `attributes` setting.
-     *
-     * @since   4.0
-     * @product highcharts highstock
-     * @default 0.25
-     */
-    opacity?: number;
-
-    /**
-     * The pixel size of the halo. For point markers this is the
-     * radius of the halo. For pie slices it is the width of the
-     * halo outside the slice. For bubbles it defaults to 5 and
-     * is the width of the halo outside the bubble.
-     *
-     * @since   4.0
-     * @product highcharts highstock
-     * @default 10
-     */
-    size?: number;
-}
-
-export interface SeriesStateHoverOptions extends StateHoverOptions {
-    /**
-     * Animation setting for hovering the graph in line-type series.
-     *
-     * By default the hover state animates quickly in, and slowly back to
-     * normal.
-     *
-     * @since   5.0.8
-     * @product highcharts highstock
-     * @default {"duration":150}
-     */
-    animation?: (boolean|DeepPartial<AnimationOptions>);
-
-    brightness?: number;
-
-    /**
-     * Enable separate styles for the hovered series to visualize
-     * that the user hovers either the series itself or the legend.
-     *
-     * @sample {highcharts} highcharts/plotoptions/series-states-hover-enabled/
-     *         Line
-     * @sample {highcharts} highcharts/plotoptions/series-states-hover-enabled-column/
-     *         Column
-     * @sample {highcharts} highcharts/plotoptions/series-states-hover-enabled-pie/
-     *         Pie
-     *
-     * @default true
-     * @since   1.2
-     */
-    enabled?: boolean;
-
-    /**
-     * Options for the halo appearing around the hovered point in
-     * line-type series as well as outside the hovered slice in pie
-     * charts. By default the halo is filled by the current point or
-     * series color with an opacity of 0.25\. The halo can be
-     * disabled by setting the `halo` option to `null`.
-     *
-     * In styled mode, the halo is styled with the
-     * `.highcharts-halo` class, with colors inherited from
-     * `.highcharts-color-{n}`.
-     *
-     * @sample {highcharts} highcharts/plotoptions/halo/
-     *         Halo options
-     * @sample {highstock} highcharts/plotoptions/halo/
-     *         Halo options
-     *
-     * @since   4.0
-     * @product highcharts highstock
-     */
-    halo?: (boolean|SeriesStateHoverHaloOptions);
-
-    /**
-     * Pixel width of the graph line. By default this property is
-     * undefined, and the `lineWidthPlus` property dictates how much
-     * to increase the linewidth from normal state.
-     *
-     * @sample {highcharts} highcharts/plotoptions/series-states-hover-linewidth/
-     *         5px line on hover
-     *
-     * @product highcharts highstock
-     */
-    lineWidth?: number;
-
-    /**
-     * The additional line width for the graph of a hovered series.
-     *
-     * @sample {highcharts} highcharts/plotoptions/series-states-hover-linewidthplus/
-     *         5 pixels wider
-     * @sample {highstock} highcharts/plotoptions/series-states-hover-linewidthplus/
-     *         5 pixels wider
-     *
-     * @since   4.0.3
-     * @product highcharts highstock
-     * @default 1
-     */
-    lineWidthPlus?: number;
-
-    /**
-     * In Highcharts 1.0, the appearance of all markers belonging
-     * to the hovered series. For settings on the hover state of the
-     * individual point, see
-     * [marker.states.hover](#plotOptions.series.marker.states.hover).
-     *
-     * @deprecated
-     *
-     * @excluding states, symbol
-     * @product   highcharts highstock
-     */
-    marker?: PointMarkerOptions;
-
-    radius?: number;
-    radiusPlus?: number;
-    opacity?: number;
-}
-
-export interface SeriesStateInactiveOptions extends StateInactiveOptions {
-    /**
-     * The animation for entering the inactive state.
-     *
-     * @default {"duration":150}
-     */
-    animation?: (boolean|DeepPartial<AnimationOptions>);
-
-    /**
-     * Enable or disable the inactive state for a series
-     *
-     * @sample highcharts/plotoptions/series-states-inactive-disabled
-     *         Disabled inactive state
-     *
-     * @default true
-     */
-    enabled?: boolean;
-
-    /**
-     * Opacity of series elements (dataLabels, line, area).
-     *
-     * @default 0.2
-     */
-    opacity?: number;
-}
-
-export interface SeriesStateNormalOptions extends StateNormalOptions {
-    /**
-     * Animation when returning to normal state after hovering.
-     *
-     * @default true
-     */
-    animation?: (boolean|DeepPartial<AnimationOptions>);
-}
-
-export interface SeriesStateSelectOptions extends StateSelectOptions {
-    enabled?: boolean;
-}
-
 export interface SeriesStatesOptions<T extends SeriesOptions> extends StatesOptions {
     /**
-     * Options for the hovered series. These settings override the
-     * normal state options when a series is moused over or touched.
+     * Options for the hovered series. These settings override the normal state
+     * options when a series is moused over or touched.
      *
      * @declare Highcharts.SeriesStatesHoverOptionsObject
      */
-    hover?: SeriesStateHoverOptions & StateGenericOptions<T>;
+    hover?: StateOptions & StateGenericOptions<T>;
 
     /**
      * The opposite state of a hover for series.
@@ -1330,20 +1155,19 @@ export interface SeriesStatesOptions<T extends SeriesOptions> extends StatesOpti
      * @sample highcharts/plotoptions/series-states-inactive-disabled
      *         Disabled inactive state
      */
-    inactive?: SeriesStateInactiveOptions & StateGenericOptions<T>;
+    inactive?: StateOptions & StateGenericOptions<T>;
 
     /**
-     * The normal state of a series, or for point items in column, pie
-     * and similar series. Currently only used for setting animation
-     * when returning to normal state from hover.
+     * The normal state of a series, or for point items in column, pie and
+     * similar series. Currently only used for setting animation when returning
+     * to normal state from hover.
      */
-    normal?: SeriesStateNormalOptions & StateGenericOptions<T>;
+    normal?: StateOptions & StateGenericOptions<T>;
 
     /**
-     * Specific options for point in selected states, after being
-     * selected by
-     * [allowPointSelect](#plotOptions.series.allowPointSelect)
-     * or programmatically.
+     * Specific options for point in selected states, after being selected by
+     * [allowPointSelect](#plotOptions.series.allowPointSelect) or
+     * programmatically.
      *
      * @sample maps/plotoptions/series-allowpointselect/
      *         Allow point select demo
@@ -1352,7 +1176,7 @@ export interface SeriesStatesOptions<T extends SeriesOptions> extends StatesOpti
      * @excluding brightness
      * @default   {"animation":{"duration":0}}
      */
-    select?: SeriesStateSelectOptions & StateGenericOptions<T>;
+    select?: StateOptions & StateGenericOptions<T>;
 }
 
 export type SeriesStepValue = ('center'|'left'|'right');

--- a/ts/Core/Series/StatesOptions.ts
+++ b/ts/Core/Series/StatesOptions.ts
@@ -148,9 +148,9 @@ export interface StateOptions {
     halo?: boolean | StateHaloOptions;
 
     /**
-     * Used by hover and select states (marker). The color of the point
-     * marker's outline in this state. When `undefined`, the series' or point's
-     * color is used.
+     * The color of the point marker's outline. When
+     * `undefined`, the series' or point's lineColor for normal
+     * state is used.
      *
      * @sample {highcharts} highcharts/plotoptions/series-marker-states-hover-linecolor/
      * White fill color, black line color
@@ -217,8 +217,8 @@ export interface StateOptions {
     radius?: number;
 
     /**
-     * Used by hover state (marker). The number of pixels to add to the marker
-     * radius on hover.
+     * The number of pixels to increase the radius of the
+     * hovered point.
      *
      * @sample {highcharts} highcharts/plotoptions/series-states-hover-linewidthplus/
      * 5 pixels greater radius on hover

--- a/ts/Core/Series/StatesOptions.ts
+++ b/ts/Core/Series/StatesOptions.ts
@@ -202,7 +202,7 @@ export interface StateOptions {
      * the series or marker elements. In the inactive state this defaults to
      * `0.2` for series.
      *
-     * @default 0.2 (inactive state)
+     * @default 0.2
      */
     opacity?: number;
 

--- a/ts/Core/Series/StatesOptions.ts
+++ b/ts/Core/Series/StatesOptions.ts
@@ -15,11 +15,13 @@
  *
  * */
 
+import type AnimationOptions from '../Animation/AnimationOptions';
 import type ColorType from '../Color/ColorType';
 import type DashStyleValue from '../Renderer/DashStyleValue';
 import type { DeepPartial } from '../../Shared/Types';
 import type { PointMarkerOptions } from './PointOptions';
 import type SeriesOptions from './SeriesOptions';
+import type SVGAttributes from '../Renderer/SVG/SVGAttributes';
 
 /* *
  *
@@ -33,31 +35,205 @@ export type StateGenericOptions<T extends SeriesOptions | PointMarkerOptions> = 
     DeepPartial<Omit<T, ('states'|'data')>>
 );
 
-export interface StateHoverOptions {
-    color?: ColorType;
-    dashStyle?: DashStyleValue;
+/**
+ * Options for the halo element appearing around a hovered point or series.
+ */
+export interface StateHaloOptions {
+    /**
+     * A collection of SVG attributes to override the appearance of the halo,
+     * for example `fill`, `stroke` and `stroke-width`.
+     *
+     * @since   4.0
+     * @product highcharts highstock
+     */
+    attributes?: SVGAttributes;
+
+    brightness?: number;
+
+    /**
+     * Whether to enable the halo. When set to `false`, the halo will not be
+     * rendered for the given state.
+     */
+    enabled?: boolean;
+
+    /**
+     * Opacity for the halo unless a specific fill is overridden using the
+     * `attributes` setting.
+     *
+     * @since   4.0
+     * @product highcharts highstock
+     * @default 0.25
+     */
+    opacity?: number;
+
+    /**
+     * The pixel size of the halo. For point markers this is the radius of the
+     * halo. For pie slices it is the width of the halo outside the slice. For
+     * bubbles it defaults to 5 and is the width of the halo outside the bubble.
+     *
+     * @since   4.0
+     * @product highcharts highstock
+     * @default 10
+     */
+    size?: number;
 }
 
-export interface StateInactiveOptions {
-    color?: ColorType;
-    dashStyle?: DashStyleValue;
-}
+/**
+ * Unified options for hover, inactive, and select states of both series and
+ * point markers. All properties are optional and apply only where relevant to
+ * the specific state or element type.
+ */
+export interface StateOptions {
+    /**
+     * Animation when returning to normal state after hovering.
+     *
+     * @default true
+     */
+    animation?: boolean | DeepPartial<AnimationOptions>;
 
-export interface StateNormalOptions {
-    color?: ColorType;
-    dashStyle?: DashStyleValue;
-}
+    /**
+     * Used by hover and inactive states. Brightness adjustment applied to the
+     * series or point color, e.g. for column, pie and map series.
+     */
+    brightness?: number;
 
-export interface StateSelectOptions extends StateHoverOptions {
+    /**
+     * Used by hover, inactive, and select states. The color of the series or
+     * point marker in this state.
+     */
     color?: ColorType;
+
+    /**
+     * Used by hover, inactive, and select states. The dash style of the series
+     * line in this state.
+     */
     dashStyle?: DashStyleValue;
+
+    /**
+     * Used by hover and select states. Whether the state is enabled. When set
+     * to `false`, the series or marker will not change appearance on hover or
+     * select.
+     *
+     * @default true
+     */
+    enabled?: boolean;
+
+    /**
+     * Used by hover and select states (marker). The fill color of the point
+     * marker in this state. When `undefined`, the series' or point's color is
+     * used.
+     *
+     * @sample {highcharts} highcharts/plotoptions/series-marker-states-select-fillcolor/
+     * Solid red discs for selected points
+     */
+    fillColor?: ColorType;
+
+    /**
+     * Used by hover state (series). Options for the halo appearing around the
+     * hovered point in line-type series as well as outside the hovered slice in
+     * pie charts. By default the halo is filled by the current point or series
+     * color with an opacity of 0.25. Set to `false` to disable the halo.
+     *
+     * In styled mode, the halo is styled with the `.highcharts-halo` class,
+     * with colors inherited from `.highcharts-color-{n}`.
+     *
+     * @sample {highcharts} highcharts/plotoptions/halo/
+     * Halo options
+     * @sample {highstock} highcharts/plotoptions/halo/
+     * Halo options
+     *
+     * @since   4.0
+     * @product highcharts highstock
+     */
+    halo?: boolean | StateHaloOptions;
+
+    /**
+     * Used by hover and select states (marker). The color of the point
+     * marker's outline in this state. When `undefined`, the series' or point's
+     * color is used.
+     *
+     * @sample {highcharts} highcharts/plotoptions/series-marker-states-hover-linecolor/
+     * White fill color, black line color
+     */
+    lineColor?: ColorType;
+
+    /**
+     * Used by hover state (series and marker). The pixel width of the graph
+     * line or marker outline. By default this property is undefined, and
+     * `lineWidthPlus` dictates how much to increase from normal state.
+     *
+     * @sample {highcharts} highcharts/plotoptions/series-states-hover-linewidth/
+     * 5px line on hover
+     *
+     * @product highcharts highstock
+     */
+    lineWidth?: number;
+
+    /**
+     * Used by hover state (series and marker). The additional line width for
+     * the graph or marker outline relative to the normal state.
+     *
+     * @sample {highcharts} highcharts/plotoptions/series-states-hover-linewidthplus/
+     * 5 pixels wider
+     * @sample {highstock} highcharts/plotoptions/series-states-hover-linewidthplus/
+     * 5 pixels wider
+     *
+     * @since   4.0.3
+     * @product highcharts highstock
+     * @default 1
+     */
+    lineWidthPlus?: number;
+
+    /**
+     * Used by hover state (series, deprecated). In Highcharts 1.0, the
+     * appearance of all markers belonging to the hovered series. For settings
+     * on the hover state of the individual point, see
+     * [marker.states.hover](#plotOptions.series.marker.states.hover).
+     *
+     * @deprecated
+     *
+     * @excluding states, symbol
+     * @product   highcharts highstock
+     */
+    marker?: PointMarkerOptions;
+
+    /**
+     * Used by hover and inactive states (series and marker). The opacity of
+     * the series or marker elements. In the inactive state this defaults to
+     * `0.2` for series.
+     *
+     * @default 0.2 (inactive state)
+     */
+    opacity?: number;
+
+    /**
+     * Used by hover and select states (marker). The radius of the point marker
+     * in this state. In hover state, defaults to the normal state's radius plus
+     * `radiusPlus`.
+     *
+     * @sample {highcharts} highcharts/plotoptions/series-marker-states-hover-radius/
+     * 10px radius on hover
+     */
+    radius?: number;
+
+    /**
+     * Used by hover state (marker). The number of pixels to add to the marker
+     * radius on hover.
+     *
+     * @sample {highcharts} highcharts/plotoptions/series-states-hover-linewidthplus/
+     * 5 pixels greater radius on hover
+     *
+     * @since   4.0.3
+     * @default 2
+     */
+    radiusPlus?: number;
 }
 
 export interface StatesOptions {
-    hover?: StateHoverOptions;
-    inactive?: StateInactiveOptions;
-    normal?: StateNormalOptions;
-    select?: StateSelectOptions;
+    hover?: StateOptions;
+    inactive?: StateOptions;
+    normal?: StateOptions;
+    select?: StateOptions;
 }
 
 /**

--- a/ts/Extensions/MarkerClusters/MarkerClusterOptions.ts
+++ b/ts/Extensions/MarkerClusters/MarkerClusterOptions.ts
@@ -24,10 +24,9 @@ import type Point from '../../Core/Series/Point';
 import type {
     PointClickEvent,
     PointMarkerOptions,
-    PointMarkerStateHoverOptions,
     PointMarkerStatesOptions
 } from '../../Core/Series/PointOptions';
-import type { StateGenericOptions } from '../../Core/Series/StatesOptions';
+import type { StateGenericOptions, StateOptions } from '../../Core/Series/StatesOptions';
 
 /* *
  *
@@ -254,7 +253,7 @@ export interface MarkerClusterMarkerOptions extends PointMarkerOptions {
     states?: undefined;
 }
 
-export interface MarkerClusterStateHoverOptions extends PointMarkerStateHoverOptions {
+export interface MarkerClusterStateHoverOptions extends StateOptions {
     /**
      * The fill color of the cluster marker in hover state. When
      * `undefined`, the series' or point's fillColor for normal
@@ -262,7 +261,7 @@ export interface MarkerClusterStateHoverOptions extends PointMarkerStateHoverOpt
      *
      * @requires modules/marker-clusters
      */
-    fillColor?: PointMarkerStateHoverOptions['fillColor'];
+    fillColor?: StateOptions['fillColor'];
 }
 
 export interface MarkerClusterStatesOptions

--- a/ts/Series/Candlestick/CandlestickSeries.ts
+++ b/ts/Series/Candlestick/CandlestickSeries.ts
@@ -107,11 +107,11 @@ class CandlestickSeries extends OHLCSeries {
 
         // Select or hover states
         if (state) {
-            const stateOptions = (options.states as any)[state];
-            attribs.fill = stateOptions.color || attribs.fill;
-            attribs.stroke = stateOptions.lineColor || attribs.stroke;
+            const stateOptions = options.states?.[state];
+            attribs.fill = stateOptions?.color || attribs.fill;
+            attribs.stroke = stateOptions?.lineColor || attribs.stroke;
             attribs['stroke-width'] =
-                stateOptions.lineWidth || attribs['stroke-width'];
+                stateOptions?.lineWidth || attribs['stroke-width'];
         }
 
         return attribs;

--- a/ts/Series/Column/ColumnSeries.ts
+++ b/ts/Series/Column/ColumnSeries.ts
@@ -24,7 +24,7 @@ import type ColumnPoint from './ColumnPoint';
 import type ColumnSeriesOptions from './ColumnSeriesOptions';
 import type DashStyleValue from '../../Core/Renderer/DashStyleValue';
 import type PointerEvent from '../../Core/PointerEvent';
-import type { SeriesStateHoverOptions } from '../../Core/Series/SeriesOptions';
+import type { StateOptions } from '../../Core/Series/StatesOptions';
 import type StackItem from '../../Core/Axis/Stacking/StackItem';
 import type { StatesOptionsKey } from '../../Core/Series/StatesOptions';
 import type SVGAttributes from '../../Core/Renderer/SVG/SVGAttributes';
@@ -678,7 +678,7 @@ class ColumnSeries extends Series {
             strokeOption = p2o.stroke || 'borderColor',
             strokeWidthOption = p2o['stroke-width'] || 'borderWidth';
 
-        let stateOptions: SeriesStateHoverOptions,
+        let stateOptions: StateOptions,
             zone,
             brightness,
             fill = (point && point.color) || this.color,
@@ -718,7 +718,7 @@ class ColumnSeries extends Series {
         // Select or hover states
         if (state && point) {
             stateOptions = merge(
-                (options.states as any)[state],
+                options.states?.[state],
                 // #6401
                 point.options.states?.[state] || {}
             );

--- a/ts/Series/Column/ColumnSeriesOptions.ts
+++ b/ts/Series/Column/ColumnSeriesOptions.ts
@@ -36,6 +36,15 @@ import type { SeriesTooltipOptions } from '../../Core/TooltipOptions';
  *
  * */
 
+declare module '../../Core/Series/StatesOptions' {
+    interface StateOptions {
+        borderColor?: ColorType;
+        borderDashStyle?: DashStyleValue;
+        borderRadius?: number;
+        borderWidth?: number;
+    }
+}
+
 declare module '../../Core/Series/SeriesOptions' {
     interface SeriesOptions {
         borderColor?: ColorType;
@@ -58,15 +67,6 @@ declare module '../../Core/Series/SeriesOptions' {
          * @default 0
          */
         pointRange?: (number|null);
-    }
-    interface SeriesStateHoverOptions {
-        borderColor?: ColorType;
-        borderDashStyle?: DashStyleValue;
-        borderRadius?: number;
-        borderWidth?: number;
-        brightness?: number;
-        color?: ColorType;
-        dashStyle?: DashStyleValue;
     }
     interface SeriesZonesOptions {
         borderColor?: ColorType;

--- a/ts/Series/DragNodesComposition.ts
+++ b/ts/Series/DragNodesComposition.ts
@@ -25,6 +25,7 @@ import type PointerEvent from '../Core/PointerEvent';
 import type ReingoldFruchtermanLayout from './Networkgraph/ReingoldFruchtermanLayout';
 import type Series from '../Core/Series/Series';
 import type SeriesOptions from '../Core/Series/SeriesOptions';
+import type { StateHaloOptions } from '../Core/Series/StatesOptions';
 
 import H from '../Core/Globals.js';
 const { composed } = H;
@@ -285,7 +286,9 @@ function redrawHalo(
     if (point && this.halo) {
         this.halo.attr({
             d: point.haloPath(
-                (this.options.states as any).hover.halo.size
+                (
+                    this.options.states?.hover?.halo as StateHaloOptions
+                )?.size || 0
             ) as any
         });
     }

--- a/ts/Series/Dumbbell/DumbbellSeries.ts
+++ b/ts/Series/Dumbbell/DumbbellSeries.ts
@@ -43,8 +43,8 @@ import { extend, merge, pick } from '../../Shared/Utilities.js';
  *
  * */
 
-declare module '../../Core/Series/SeriesOptions' {
-    interface SeriesStateHoverOptions {
+declare module '../../Core/Series/StatesOptions' {
+    interface StateOptions {
         connectorWidthPlus?: number;
     }
 }

--- a/ts/Series/Flags/FlagsSeries.ts
+++ b/ts/Series/Flags/FlagsSeries.ts
@@ -17,9 +17,9 @@
  *
  * */
 
-import type ColorType from '../../Core/Color/ColorType';
 import type { FlagsShapeValue } from './FlagsPointOptions';
 import type FlagsSeriesOptions from './FlagsSeriesOptions';
+import type { StatesOptionsKey } from '../../Core/Series/StatesOptions';
 import type SVGAttributes from '../../Core/Renderer/SVG/SVGAttributes';
 
 import FlagsPoint from './FlagsPoint.js';
@@ -60,10 +60,8 @@ declare module '../../Core/Series/SeriesBase' {
     }
 }
 
-declare module '../../Core/Series/SeriesOptions' {
-    interface SeriesStateHoverOptions {
-        fillColor?: ColorType;
-        lineColor?: ColorType;
+declare module '../../Core/Series/StatesOptions' {
+    interface StateOptions {
         shape?: FlagsShapeValue;
     }
 }
@@ -407,7 +405,7 @@ class FlagsSeries extends ColumnSeries {
      */
     public pointAttribs(
         point: FlagsPoint,
-        state?: string
+        state?: StatesOptionsKey
     ): SVGAttributes {
         const options = this.options,
             color = (point && point.color) || this.color;
@@ -417,9 +415,10 @@ class FlagsSeries extends ColumnSeries {
             fill = (point && point.fillColor) || options.fillColor;
 
         if (state) {
-            fill = (options.states as any)[state].fillColor;
-            lineColor = (options.states as any)[state].lineColor;
-            lineWidth = (options.states as any)[state].lineWidth;
+            const stateOptions = options.states?.[state];
+            fill = stateOptions?.fillColor;
+            lineColor = stateOptions?.lineColor;
+            lineWidth = stateOptions?.lineWidth;
         }
 
         return {

--- a/ts/Series/Funnel/FunnelSeries.ts
+++ b/ts/Series/Funnel/FunnelSeries.ts
@@ -60,10 +60,9 @@ import {
  *
  * */
 
-declare module '../../Core/Series/SeriesOptions' {
-    interface SeriesStateHoverOptions {
+declare module '../../Core/Series/StatesOptions' {
+    interface StateOptions {
         borderColor?: ColorType;
-        color?: ColorType;
     }
 }
 

--- a/ts/Series/Heatmap/HeatmapSeriesOptions.d.ts
+++ b/ts/Series/Heatmap/HeatmapSeriesOptions.d.ts
@@ -35,35 +35,11 @@ import type { SeriesStatesOptions } from '../../Core/Series/SeriesOptions';
  * */
 
 declare module '../../Core/Series/StatesOptions' {
-    interface StateHoverOptions {
+    interface StateOptions {
         height?: number;
         heightPlus?: number;
         width?: number;
         widthPlus?: number;
-    }
-    interface StateInactiveOptions {
-        height?: number;
-        heightPlus?: number;
-        width?: number;
-        widthPlus?: number;
-    }
-    interface StateSelectOptions {
-        height?: number;
-        heightPlus?: number;
-        width?: number;
-        widthPlus?: number;
-    }
-}
-
-declare module '../../Core/Series/SeriesOptions' {
-    interface SeriesStateHoverOptions {
-        brightness?: number;
-    }
-    interface SeriesStateInactiveOptions {
-        brightness?: number;
-    }
-    interface SeriesStateSelectOptions {
-        brightness?: number;
     }
 }
 

--- a/ts/Series/HollowCandlestick/HollowCandlestickSeries.ts
+++ b/ts/Series/HollowCandlestick/HollowCandlestickSeries.ts
@@ -20,7 +20,7 @@
 import HollowCandlestickPoint from './HollowCandlestickPoint.js';
 import type HollowCandlestickSeriesOptions from './HollowCandlestickSeriesOptions';
 import SeriesRegistry from '../../Core/Series/SeriesRegistry.js';
-import { StatesOptionsKey } from '../../Core/Series/StatesOptions.js';
+import type { StatesOptionsKey } from '../../Core/Series/StatesOptions';
 import SVGAttributes from '../../Core/Renderer/SVG/SVGAttributes.js';
 import { Palette } from '../../Core/Color/Palettes.js';
 import Axis from '../../Core/Axis/Axis.js';
@@ -291,8 +291,6 @@ class HollowCandlestickSeries extends CandlestickSeries {
         state?: StatesOptionsKey
     ): SVGAttributes {
         const attribs = super.pointAttribs.call(this, point, state);
-        let stateOptions;
-
         const index = point.index,
             hollowcandleInfo = this.hollowCandlestickData[index];
 
@@ -302,11 +300,11 @@ class HollowCandlestickSeries extends CandlestickSeries {
 
         // Select or hover states
         if (state) {
-            stateOptions = (this.options.states as any)[state];
-            attribs.fill = stateOptions.color || attribs.fill;
-            attribs.stroke = stateOptions.lineColor || attribs.stroke;
+            const stateOptions = this.options.states?.[state];
+            attribs.fill = stateOptions?.color || attribs.fill;
+            attribs.stroke = stateOptions?.lineColor || attribs.stroke;
             attribs['stroke-width'] =
-                stateOptions.lineWidth || attribs['stroke-width'];
+                stateOptions?.lineWidth || attribs['stroke-width'];
         }
         return attribs;
     }

--- a/ts/Series/Lollipop/LollipopSeries.ts
+++ b/ts/Series/Lollipop/LollipopSeries.ts
@@ -42,8 +42,8 @@ import { extend, merge } from '../../Shared/Utilities.js';
  *
  * */
 
-declare module '../../Core/Series/SeriesOptions' {
-    interface SeriesStateHoverOptions {
+declare module '../../Core/Series/StatesOptions' {
+    interface StateOptions {
         connectorWidthPlus?: number;
     }
 }

--- a/ts/Series/Map/MapSeries.ts
+++ b/ts/Series/Map/MapSeries.ts
@@ -21,7 +21,6 @@ import type {
     AnimationOptions,
     AnimationStepCallbackFunction
 } from '../../Core/Animation/AnimationOptions';
-import type ColorType from '../../Core/Color/ColorType';
 import type ColumnPoint from '../Column/ColumnPoint';
 import type CSSObject from '../../Core/Renderer/CSSObject';
 import type { MapDataType } from '../../Maps/GeoJSON';
@@ -92,11 +91,6 @@ declare module '../../Core/Series/SeriesOptions' {
     interface SeriesOptions {
         /** @requires modules/map */
         mapData?: MapDataType;
-    }
-    interface SeriesStateHoverOptions
-    {
-        brightness?: number;
-        color?: ColorType;
     }
 }
 

--- a/ts/Series/Networkgraph/NetworkgraphPointOptions.d.ts
+++ b/ts/Series/Networkgraph/NetworkgraphPointOptions.d.ts
@@ -17,7 +17,6 @@
  *
  * */
 
-import type AnimationOptions from '../../Core/Animation/AnimationOptions';
 import type ColorType from '../../Core/Color/ColorType';
 import type DashStyleValue from '../../Core/Renderer/DashStyleValue';
 import type { NetworkgraphDataLabelsOptions } from './NetworkgraphSeriesOptions';
@@ -33,13 +32,6 @@ import type { PointDataLabelOptionsModifier } from '../../Core/Series/DataLabel'
  *  Declarations
  *
  * */
-
-declare module '../../Core/Series/PointOptions' {
-    interface PointMarkerStateInactiveOptions
-    {
-        animation?: (boolean|Partial<AnimationOptions>);
-    }
-}
 
 /**
  * @product highcharts

--- a/ts/Series/Networkgraph/NetworkgraphSeries.ts
+++ b/ts/Series/Networkgraph/NetworkgraphSeries.ts
@@ -387,8 +387,8 @@ class NetworkgraphSeries extends Series {
         state?: StatesOptionsKey
     ): SVGAttributes {
         // By default, only `selected` state is passed on
-        const pointState = state || point && point.state || 'normal',
-            stateOptions = (this.options.states as any)[pointState];
+        const pointState = state || (point && point.state) || 'normal',
+            stateOptions = this.options.states?.[pointState];
 
         let attribs = Series.prototype.pointAttribs.call(
             this,
@@ -409,7 +409,7 @@ class NetworkgraphSeries extends Series {
                     opacity: pick(
                         stateOptions.linkOpacity, attribs.opacity
                     ),
-                    'stroke-width': stateOptions.linkColor ||
+                    'stroke-width': stateOptions.linkWidth ||
                         attribs['stroke-width']
                 };
             }

--- a/ts/Series/Networkgraph/NetworkgraphSeriesOptions.d.ts
+++ b/ts/Series/Networkgraph/NetworkgraphSeriesOptions.d.ts
@@ -49,8 +49,14 @@ import type {
  *
  * */
 
-declare module '../../Core/Series/SeriesOptions' {
-    interface SeriesStateInactiveOptions {
+declare module '../../Core/Series/StatesOptions' {
+    interface StateOptions {
+        /** Applies to hover state of link. */
+        linkColor?: ColorType;
+        /** Applies to hover state of link. */
+        linkDashStyle?: DashStyleValue;
+        /** Applies to hover state of link. */
+        linkWidth?: number;
         linkOpacity?: number;
     }
 }

--- a/ts/Series/Organization/OrganizationSeries.ts
+++ b/ts/Series/Organization/OrganizationSeries.ts
@@ -180,9 +180,8 @@ class OrganizationSeries extends SankeySeries {
             levelOptions: OrganizationSeriesLevelOptions =
                 (series.mapOptionsToLevel as any)[level || 0] || {},
             options = point.options,
-            stateOptions: OrganizationSeriesOptions =
-                (levelOptions.states &&
-                    (levelOptions.states as any)[state as any]) ||
+            stateOptions =
+                (state && levelOptions.states?.[state]) ||
                 {},
             borderRadius = pick(
                 stateOptions.borderRadius,

--- a/ts/Series/Organization/OrganizationSeriesOptions.d.ts
+++ b/ts/Series/Organization/OrganizationSeriesOptions.d.ts
@@ -18,6 +18,7 @@
  * */
 
 import type ColorString from '../../Core/Color/ColorString';
+import type ColorType from '../../Core/Color/ColorType';
 import type OrganizationDataLabelOptions from './OrganizationDataLabelOptions';
 import type {
     SankeySeriesLevelOptions,
@@ -40,6 +41,19 @@ declare module '../Sankey/SankeySeriesOptions' {
         linkLineWidth?: OrganizationSeriesOptions['linkLineWidth'];
         /** @requires OrganizationSeries */
         link?: OrganizationSeriesOptions['link'];
+    }
+}
+
+declare module '../../Core/Series/StatesOptions' {
+    interface StateOptions {
+        /** Applies to hover state of organization link. */
+        link?: OrganizationLinkOptions;
+        /** Applies to hover state of organization link. */
+        linkColor?: ColorType;
+        /** Applies to hover state of organization link. */
+        linkLineWidth?: number;
+        /** Applies to hover state of organization link. */
+        linkOpacity?: number;
     }
 }
 

--- a/ts/Series/Pie/PieSeries.ts
+++ b/ts/Series/Pie/PieSeries.ts
@@ -75,11 +75,6 @@ declare module '../../Core/Series/SeriesBase' {
     }
 }
 
-declare module '../../Core/Series/SeriesOptions' {
-    interface SeriesStateHoverOptions {
-        brightness?: number;
-    }
-}
 
 /* *
  *

--- a/ts/Series/Tilemap/TilemapSeries.ts
+++ b/ts/Series/Tilemap/TilemapSeries.ts
@@ -56,11 +56,6 @@ declare module '../../Core/Series/SeriesBase' {
     }
 }
 
-declare module '../../Core/Series/SeriesOptions' {
-    interface SeriesStateHoverHaloOptions {
-        enabled?: boolean;
-    }
-}
 
 /* *
  *

--- a/ts/Series/Treegraph/TreegraphSeries.ts
+++ b/ts/Series/Treegraph/TreegraphSeries.ts
@@ -608,10 +608,9 @@ class TreegraphSeries extends TreemapSeries {
             levelOptions = point &&
                 (series.mapOptionsToLevel as any)[point.node.level ?? 0] || {},
             options = point && point.options,
-            stateOptions =
-                (levelOptions.states &&
-                    (levelOptions.states as any)[state as any]) ||
-                {};
+            stateOptions = (
+                state && levelOptions.states?.[state]
+            ) || {};
 
         if (point) {
             point.options.marker = merge(

--- a/ts/Series/Vector/VectorSeries.ts
+++ b/ts/Series/Vector/VectorSeries.ts
@@ -19,6 +19,7 @@
  *
  * */
 
+import type { StatesOptions } from '../../Core/Series/StatesOptions';
 import type VectorPoint from './VectorPoint';
 import type VectorSeriesOptions from './VectorSeriesOptions';
 import type SVGAttributes from '../../Core/Renderer/SVG/SVGAttributes';
@@ -218,13 +219,16 @@ class VectorSeries extends ScatterSeries {
         const options = this.options;
 
         let stroke = point?.color || this.color,
-            strokeWidth = this.options.lineWidth;
+            strokeWidth = this.options.lineWidth || 0;
 
         if (state) {
-            stroke = (options.states as any)[state].color || stroke;
+            const stateOptions = options.states?.[
+                state as keyof StatesOptions
+            ];
+            stroke = stateOptions?.color || stroke;
             strokeWidth =
-            ((options.states as any)[state].lineWidth || strokeWidth) +
-            ((options.states as any)[state].lineWidthPlus || 0);
+                (stateOptions?.lineWidth || strokeWidth) +
+                (stateOptions?.lineWidthPlus || 0);
         }
 
         return {

--- a/ts/Series/Venn/VennSeries.ts
+++ b/ts/Series/Venn/VennSeries.ts
@@ -35,7 +35,7 @@ import type {
 import type PolygonBoxObject from '../../Core/Renderer/PolygonBoxObject';
 import type PositionObject from '../../Core/Renderer/PositionObject';
 import type { SeriesStatesOptions } from '../../Core/Series/SeriesOptions';
-import type { StatesOptionsKey } from '../../Core/Series/StatesOptions';
+import type { StatesOptions, StatesOptionsKey } from '../../Core/Series/StatesOptions';
 import type SVGAttributes from '../../Core/Renderer/SVG/SVGAttributes';
 import type SVGElement from '../../Core/Renderer/SVG/SVGElement';
 import type SVGPath from '../../Core/Renderer/SVG/SVGPath';
@@ -512,8 +512,9 @@ class VennSeries extends ScatterSeries {
         const series = this,
             seriesOptions = series.options || {},
             pointOptions = point?.options || {},
-            stateOptions =
-                (state && (seriesOptions.states as any)[state as any]) || {},
+            stateOptions = (
+                state && seriesOptions.states?.[state]
+            ) || {},
             options = merge(
                 seriesOptions,
                 { color: point?.color },
@@ -693,9 +694,12 @@ addEvent(VennSeries, 'afterSetOptions', function (
         // Explicitly disable all halo options.
         for (
             const state of
-            Object.keys(states) as unknown as Array<keyof typeof states>
+            Object.keys(states) as Array<keyof StatesOptions>
         ) {
-            (states as any)[state].halo = false;
+            const stateOptions = states[state];
+            if (stateOptions) {
+                stateOptions.halo = false;
+            }
         }
     }
 });

--- a/ts/Series/Windbarb/WindbarbSeries.ts
+++ b/ts/Series/Windbarb/WindbarbSeries.ts
@@ -142,13 +142,14 @@ class WindbarbSeries extends ColumnSeries {
         const options = this.options;
 
         let stroke = point.color || this.color,
-            strokeWidth = this.options.lineWidth;
+            strokeWidth = this.options.lineWidth || 0;
 
         if (state) {
-            stroke = (options.states as any)[state].color || stroke;
+            const stateOptions = options.states?.[state];
+            stroke = stateOptions?.color || stroke;
             strokeWidth =
-            ((options.states as any)[state].lineWidth || strokeWidth) +
-            ((options.states as any)[state].lineWidthPlus || 0);
+                (stateOptions?.lineWidth || strokeWidth) +
+                (stateOptions?.lineWidthPlus || 0);
         }
 
         return {

--- a/ts/Series/XRange/XRangeSeries.ts
+++ b/ts/Series/XRange/XRangeSeries.ts
@@ -23,7 +23,7 @@ import type Axis from '../../Core/Axis/Axis';
 import type ColumnMetricsObject from '../Column/ColumnMetricsObject';
 import type DataTableCore from '../../Data/DataTableCore';
 import type SeriesClass from '../../Core/Series/Series';
-import type { SeriesStateHoverOptions } from '../../Core/Series/SeriesOptions';
+import type { StateOptions } from '../../Core/Series/StatesOptions';
 import type {
     XRangePointOptions,
     XRangePointPartialFillOptions
@@ -511,9 +511,8 @@ class XRangeSeries extends ColumnSeries {
             partShapeArgs = point.partShapeArgs,
             clipRectArgs = point.clipRectArgs,
             pointState = point.state,
-            stateOpts: SeriesStateHoverOptions = (
-                (seriesOpts.states as any)[pointState || 'normal'] ||
-                {}
+            stateOpts: StateOptions = (
+                seriesOpts.states?.[pointState || 'normal'] || {}
             ),
             pointStateVerb = typeof pointState === 'undefined' ?
                 'attr' : verb,


### PR DESCRIPTION
Unified series.states and marker.states types, aligned jsdoc and ts doclets.

====
- [x] - unified type
- [x] - ts doclets
- [x] - jsdoc doclets
- [x] - playwright test - checked -> broken on master
- [x] - visual tests
   - [x] - hover state (columns / columnrange)
   - [x] - venn diagram
   - [x] - others 