### PR TITLE
bugfix/24442-parallel-coords-grid-lines

### DIFF
--- a/samples/unit-tests/chart/parallel-coordinates-updates/demo.html
+++ b/samples/unit-tests/chart/parallel-coordinates-updates/demo.html
@@ -1,5 +1,5 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-<script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/stock/highstock.js"></script>
 <script src="https://code.highcharts.com/modules/parallel-coordinates.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 

--- a/samples/unit-tests/chart/parallel-coordinates-updates/demo.js
+++ b/samples/unit-tests/chart/parallel-coordinates-updates/demo.js
@@ -245,9 +245,8 @@ QUnit.test('Update parallel coordinates plot', function (assert) {
 
     const pathArray = chart.yAxis[0].ticks['8'].gridLine.pathArray;
 
-    assert.notOk(
-        pathArray[0][1] === pathArray[1][1] &&
-        pathArray[0][2] === pathArray[1][2],
+    assert.ok(
+        pathArray[0][1] !== pathArray[1][1],
         'Parallel yAxis grid line path should have non-zero length, #24442.'
     );
 

--- a/samples/unit-tests/chart/parallel-coordinates-updates/demo.js
+++ b/samples/unit-tests/chart/parallel-coordinates-updates/demo.js
@@ -242,4 +242,13 @@ QUnit.test('Update parallel coordinates plot', function (assert) {
         'The third yAxis\' max should be equal to the third point\'s high ' +
         'value.'
     );
+
+    const pathArray = chart.yAxis[0].ticks['8'].gridLine.pathArray;
+
+    assert.notOk(
+        pathArray[0][1] === pathArray[1][1] &&
+        pathArray[0][2] === pathArray[1][2],
+        'Parallel yAxis grid line path should have non-zero length, #24442.'
+    );
+
 });

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -770,7 +770,7 @@ namespace StockChart {
             transVal: number;
 
         if (
-            chart.options.isStock &&
+            (chart.options.isStock || chart.hasParallelCoordinates) &&
             // Ignore in case of colorAxis or zAxis. #3360, #3524, #6720
             (axis.coll === 'xAxis' || axis.coll === 'yAxis')
         ) {
@@ -846,11 +846,12 @@ namespace StockChart {
                     const crossingPosName = horiz ? 'top' : 'left',
                         crossingLenName = horiz ? 'height' : 'width';
                     if (
-                        !acrossPanes &&
+                        !chart.hasParallelCoordinates &&
                         // If the perpendicular position is set explicitly on
                         // the axis, use it. For example, if `top` and `height`
                         // options are set on a horizontal x-axis, the grid
                         // lines should conform to that position.
+                        !acrossPanes &&
                         (
                             axis.options[crossingPosName] ||
                             axis.options[crossingLenName]

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -853,6 +853,8 @@ namespace StockChart {
                         // options are set on a horizontal x-axis, the grid
                         // lines should conform to that position.
                         hasCrossingBounds &&
+                        // In parallel coordinates, the axis height/width is 0,
+                        // so we need to skip that, #24442.
                         axis[crossingLenName] > 0 &&
                         !acrossPanes
                     ) {

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -710,6 +710,7 @@ namespace StockChart {
         e: (Event&Axis.PlotLinePathOptions)
     ): void {
         const axis = this,
+            axisOptions = axis.options,
             series = (
                 axis.isLinked && !axis.series && axis.linkedParent ?
                     axis.linkedParent.series :
@@ -724,8 +725,8 @@ namespace StockChart {
             ) || [],
             crossingPosName = horiz ? 'top' : 'left',
             crossingLenName = horiz ? 'height' : 'width',
-            hasCrossingBounds = defined(axis.options[crossingPosName]) ||
-                defined(axis.options[crossingLenName]),
+            hasCrossingBounds = defined(axisOptions[crossingPosName]) ||
+                defined(axisOptions[crossingLenName]),
             /**
              * Return the other axis based on either the axis option or on
              * related series.
@@ -733,9 +734,9 @@ namespace StockChart {
              */
             getAxis = (coll: string): Array<Axis> => {
                 const otherColl = coll === 'xAxis' ? 'yAxis' : 'xAxis',
-                    opt = (axis.options as AnyRecord)[otherColl];
+                    opt = (axisOptions as AnyRecord)[otherColl];
 
-                if (acrossPanes && !axis.options.isInternal) {
+                if (acrossPanes && !axisOptions.isInternal) {
                     return allPerpendicularAxes.filter((a): boolean =>
                         !a.options.isInternal
                     );

--- a/ts/Core/Chart/StockChart.ts
+++ b/ts/Core/Chart/StockChart.ts
@@ -722,6 +722,10 @@ namespace StockChart {
             allPerpendicularAxes = (
                 axis.isXAxis ? chart.yAxis : chart.xAxis
             ) || [],
+            crossingPosName = horiz ? 'top' : 'left',
+            crossingLenName = horiz ? 'height' : 'width',
+            hasCrossingBounds = defined(axis.options[crossingPosName]) ||
+                defined(axis.options[crossingLenName]),
             /**
              * Return the other axis based on either the axis option or on
              * related series.
@@ -770,7 +774,7 @@ namespace StockChart {
             transVal: number;
 
         if (
-            (chart.options.isStock || chart.hasParallelCoordinates) &&
+            (chart.options.isStock || hasCrossingBounds) &&
             // Ignore in case of colorAxis or zAxis. #3360, #3524, #6720
             (axis.coll === 'xAxis' || axis.coll === 'yAxis')
         ) {
@@ -843,19 +847,14 @@ namespace StockChart {
                 }
 
                 if (!skip) {
-                    const crossingPosName = horiz ? 'top' : 'left',
-                        crossingLenName = horiz ? 'height' : 'width';
                     if (
-                        !chart.hasParallelCoordinates &&
                         // If the perpendicular position is set explicitly on
                         // the axis, use it. For example, if `top` and `height`
                         // options are set on a horizontal x-axis, the grid
                         // lines should conform to that position.
-                        !acrossPanes &&
-                        (
-                            axis.options[crossingPosName] ||
-                            axis.options[crossingLenName]
-                        )
+                        hasCrossingBounds &&
+                        axis[crossingLenName] > 0 &&
+                        !acrossPanes
                     ) {
                         pushSegment(
                             pos,


### PR DESCRIPTION
Fixed #24442, grid lines were not rendered on parallel axes.