### PR TITLE
bugfix/22961-wrong-axis-label-styles-on-resize

### DIFF
--- a/samples/unit-tests/axis/label-ellipsis/demo.js
+++ b/samples/unit-tests/axis/label-ellipsis/demo.js
@@ -139,32 +139,23 @@ QUnit.test(
             }]
         });
 
-        const labelElement = chart.xAxis[0].ticks[0].label.element;
+        const label = chart.xAxis[0].ticks[0].label;
 
-        // 1. Shrink the chart to force the axis to squish the labels
-        chart.setSize(300);
+        label.css({
+            width: '100px',
+            lineClamp: 1
+        });
 
-        console.log(labelElement.style.display);
+        const clampedHeight = label.element.offsetHeight;
 
-        assert.strictEqual(
-            labelElement.style.display,
-            '-webkit-box',
-            'Sanity check: display: -webkit-box should be applied when narrow.'
-        );
+        chart.setSize(900, false);
 
-        // 2. Widen the chart back up to trigger the bug cleanup logic
-        chart.setSize(900);
-
-        assert.notStrictEqual(
-            labelElement.style.display,
-            '-webkit-box',
-            'The display: -webkit-box style should be completely removed.'
-        );
+        const unwrappedHeight = label.element.offsetHeight;
 
         assert.ok(
-            !labelElement.style.webkitLineClamp &&
-            !labelElement.style.WebkitLineClamp,
-            'The -webkit-line-clamp style should be completely removed.'
+            unwrappedHeight > clampedHeight,
+            '#22961: The label bounding box height should increase ' +
+            'significantly when the line-clamp is disabled.'
         );
     }
 );

--- a/samples/unit-tests/axis/label-ellipsis/demo.js
+++ b/samples/unit-tests/axis/label-ellipsis/demo.js
@@ -1,55 +1,53 @@
 QUnit.test('Ellipsis should be reset after zoom (#4678)', function (assert) {
-    var chart = $('#container')
-        .highcharts({
-            chart: {
-                type: 'bar',
-                zoomType: 'x',
-                animation: false,
-                width: 600
-            },
+    const chart = Highcharts.chart('container', {
+        chart: {
+            type: 'bar',
+            zoomType: 'x',
+            animation: false,
+            width: 600
+        },
 
-            xAxis: {
-                categories: [
-                    'Jan Jan Jan ',
-                    'Feb Feb Feb ',
-                    'Mar Mar Mar Mar Mar Mar Mar Mar Mar Mar Mar Mar ',
-                    'Apr Apr Apr Apr Apr Apr Apr Apr Apr Apr Apr Apr ',
-                    'May May May May May May May May May May May May ',
-                    'Jun Jun Jun Jun Jun Jun Jun Jun Jun Jun Jun Jun ',
-                    'Jul Jul Jul Jul Jul Jul Jul Jul Jul Jul Jul Jul ',
-                    'Aug Aug Aug Aug Aug Aug Aug Aug Aug Aug Aug Aug ',
-                    'Sep Sep Sep Sep Sep Sep Sep Sep Sep Sep Sep Sep ',
-                    'Oct Oct Oct Oct Oct Oct Oct Oct Oct Oct Oct Oct ',
-                    'Nov Nov Nov Nov Nov Nov Nov Nov Nov Nov Nov Nov ',
-                    'Dec Dec Dec Dec Dec Dec Dec Dec Dec Dec Dec Dec '
-                ],
-                labels: {
-                    style: {
-                        fontFamily: 'monospace'
-                    }
+        xAxis: {
+            categories: [
+                'Jan Jan Jan ',
+                'Feb Feb Feb ',
+                'Mar Mar Mar Mar Mar Mar Mar Mar Mar Mar Mar Mar ',
+                'Apr Apr Apr Apr Apr Apr Apr Apr Apr Apr Apr Apr ',
+                'May May May May May May May May May May May May ',
+                'Jun Jun Jun Jun Jun Jun Jun Jun Jun Jun Jun Jun ',
+                'Jul Jul Jul Jul Jul Jul Jul Jul Jul Jul Jul Jul ',
+                'Aug Aug Aug Aug Aug Aug Aug Aug Aug Aug Aug Aug ',
+                'Sep Sep Sep Sep Sep Sep Sep Sep Sep Sep Sep Sep ',
+                'Oct Oct Oct Oct Oct Oct Oct Oct Oct Oct Oct Oct ',
+                'Nov Nov Nov Nov Nov Nov Nov Nov Nov Nov Nov Nov ',
+                'Dec Dec Dec Dec Dec Dec Dec Dec Dec Dec Dec Dec '
+            ],
+            labels: {
+                style: {
+                    fontFamily: 'monospace'
                 }
-            },
+            }
+        },
 
-            series: [
-                {
-                    data: [
-                        29.9,
-                        71.5,
-                        106.4,
-                        129.2,
-                        144.0,
-                        176.0,
-                        135.6,
-                        148.5,
-                        216.4,
-                        194.1,
-                        95.6,
-                        54.4
-                    ]
-                }
-            ]
-        })
-        .highcharts();
+        series: [
+            {
+                data: [
+                    29.9,
+                    71.5,
+                    106.4,
+                    129.2,
+                    144.0,
+                    176.0,
+                    135.6,
+                    148.5,
+                    216.4,
+                    194.1,
+                    95.6,
+                    54.4
+                ]
+            }
+        ]
+    });
 
     assert.strictEqual(
         typeof chart.xAxis[0].ticks[0].label.getBBox().height,
@@ -82,7 +80,7 @@ QUnit.test('Ellipsis should be reset after zoom (#4678)', function (assert) {
 QUnit.test(
     '#5034: No ellipsis for multiline labels where there is room',
     function (assert) {
-        var chart = Highcharts.chart('container', {
+        const chart = Highcharts.chart('container', {
             chart: {
                 type: 'bar',
                 width: 450
@@ -111,6 +109,62 @@ QUnit.test(
             chart.xAxis[0].ticks[1].label.getBBox().height,
             chart.xAxis[0].ticks[2].label.getBBox().height,
             'Third label is same as second'
+        );
+
+        // #22961
+        chart.update({
+            chart: {
+                type: 'column'
+            },
+            xAxis: {
+                type: 'category',
+                labels: {
+                    useHTML: true,
+                    style: {
+                        whiteSpace: 'nowrap'
+                    },
+                    format: '<span style="font-weight: 700">FOO: </span>foo ' +
+                    '{value}<br/><span style="font-weight: 700">BAR: </span>' +
+                    'foo_bar_1<br/><span style="font-weight: 700">' +
+                    'FOO_FOO_BAR: </span>foo_foo_bar_1'
+                }
+            },
+            series: [{
+                data: [
+                    { name: 'A', y: 27 },
+                    { name: 'B', y: 24 },
+                    { name: 'C', y: 25 },
+                    { name: 'D', y: 24 }
+                ]
+            }]
+        });
+
+        const labelElement = chart.xAxis[0].ticks[0].label.element;
+
+        // 1. Shrink the chart to force the axis to squish the labels
+        chart.setSize(300);
+
+        console.log(labelElement.style.display);
+
+        assert.strictEqual(
+            labelElement.style.display,
+            '-webkit-box',
+            'Sanity check: display: -webkit-box should be applied when narrow.'
+        );
+
+        // 2. Widen the chart back up to trigger the bug cleanup logic
+        chart.setSize(900);
+
+        assert.notStrictEqual(
+            labelElement.style.display,
+            '-webkit-box',
+            'The display: -webkit-box style should be completely removed.'
+        );
+
+        assert.ok(
+            !labelElement.style.webkitLineClamp &&
+            !labelElement.style.WebkitLineClamp,
+            'The -webkit-line-clamp style should be completely removed.'
         );
     }
 );

--- a/ts/Core/Axis/Axis.ts
+++ b/ts/Core/Axis/Axis.ts
@@ -3566,9 +3566,17 @@ class Axis {
                         lineClamp
                     }));
 
-                // Reset previously shortened label (#8210)
-                } else if (label.styles.width && !css.width && !widthOption) {
-                    label.css({ width: 'auto' });
+                // Reset previously shortened label (#8210, #22961)
+                } else {
+                    const wasSquished = label.styles.width ||
+                    label.textWidth || label.styles.lineClamp;
+
+                    if (wasSquished && !css.width && !widthOption) {
+                        label.css({
+                            width: 'auto',
+                            lineClamp: 0
+                        });
+                    }
                 }
 
                 tick.rotation = attr.rotation;

--- a/ts/Core/Renderer/HTML/HTMLElement.ts
+++ b/ts/Core/Renderer/HTML/HTMLElement.ts
@@ -319,37 +319,14 @@ class HTMLElement extends SVGElement {
 
         // Clean up sticky side-effects when lineClamp is explicitly removed
         // (set to 0) or contradicted by a forced nowrap (#22961)
-        if (
-            (styles && 'lineClamp' in styles && !styles.lineClamp) ||
-            (styles?.whiteSpace === 'nowrap' && this.styles.lineClamp)
-        ) {
-            const { style } = this.element;
-            if (this.element?.style) {
-                style.removeProperty('-webkit-line-clamp');
-                style.removeProperty('-webkit-box-orient');
-                // Only clear display if it's currently the injected webkit-box
-                if (style.display === '-webkit-box') {
-                    style.removeProperty('display');
-                }
-            }
-
-            const thisStyles = this.styles;
-            if (thisStyles) {
-                delete thisStyles.lineClamp;
-                if (thisStyles.display === '-webkit-box') {
-                    delete thisStyles.display;
-                }
-            }
-
-            if (styles && 'lineClamp' in styles) {
-                delete styles.lineClamp;
-            }
-
-        } else if (styles?.lineClamp) {
+        if (styles?.lineClamp) {
             styles.display = '-webkit-box';
             styles.WebkitLineClamp = styles.lineClamp;
             styles.WebkitBoxOrient = 'vertical';
             styles.overflow = 'hidden';
+        } else if (styles?.lineClamp === 0) {
+            // Disable the clamp by breaking the -webkit-box context
+            styles.display = 'inline-block';
         }
 
         // SVG natively supports setting font size as numbers. With HTML, the

--- a/ts/Core/Renderer/HTML/HTMLElement.ts
+++ b/ts/Core/Renderer/HTML/HTMLElement.ts
@@ -316,7 +316,34 @@ class HTMLElement extends SVGElement {
             styles.overflow = 'hidden';
             styles.whiteSpace = 'nowrap';
         }
-        if (styles?.lineClamp) {
+
+        // Clean up sticky side-effects when lineClamp is explicitly removed
+        // (set to 0) or contradicted by a forced nowrap (#22961)
+        if (
+            (styles && 'lineClamp' in styles && !styles.lineClamp) ||
+            (styles?.whiteSpace === 'nowrap' && this.styles.lineClamp)
+        ) {
+            if (this.element && this.element.style) {
+                this.element.style.removeProperty('-webkit-line-clamp');
+                this.element.style.removeProperty('-webkit-box-orient');
+                // Only clear display if it's currently the injected webkit-box
+                if (this.element.style.display === '-webkit-box') {
+                    this.element.style.removeProperty('display');
+                }
+            }
+
+            if (this.styles) {
+                delete this.styles.lineClamp;
+                if (this.styles.display === '-webkit-box') {
+                    delete this.styles.display;
+                }
+            }
+
+            if (styles && 'lineClamp' in styles) {
+                delete styles.lineClamp;
+            }
+
+        } else if (styles?.lineClamp) {
             styles.display = '-webkit-box';
             styles.WebkitLineClamp = styles.lineClamp;
             styles.WebkitBoxOrient = 'vertical';

--- a/ts/Core/Renderer/HTML/HTMLElement.ts
+++ b/ts/Core/Renderer/HTML/HTMLElement.ts
@@ -323,19 +323,21 @@ class HTMLElement extends SVGElement {
             (styles && 'lineClamp' in styles && !styles.lineClamp) ||
             (styles?.whiteSpace === 'nowrap' && this.styles.lineClamp)
         ) {
-            if (this.element && this.element.style) {
-                this.element.style.removeProperty('-webkit-line-clamp');
-                this.element.style.removeProperty('-webkit-box-orient');
+            const { style } = this.element;
+            if (this.element?.style) {
+                style.removeProperty('-webkit-line-clamp');
+                style.removeProperty('-webkit-box-orient');
                 // Only clear display if it's currently the injected webkit-box
-                if (this.element.style.display === '-webkit-box') {
-                    this.element.style.removeProperty('display');
+                if (style.display === '-webkit-box') {
+                    style.removeProperty('display');
                 }
             }
 
-            if (this.styles) {
-                delete this.styles.lineClamp;
-                if (this.styles.display === '-webkit-box') {
-                    delete this.styles.display;
+            const thisStyles = this.styles;
+            if (thisStyles) {
+                delete thisStyles.lineClamp;
+                if (thisStyles.display === '-webkit-box') {
+                    delete thisStyles.display;
                 }
             }
 

--- a/ts/Core/Renderer/HTML/HTMLElement.ts
+++ b/ts/Core/Renderer/HTML/HTMLElement.ts
@@ -317,15 +317,14 @@ class HTMLElement extends SVGElement {
             styles.whiteSpace = 'nowrap';
         }
 
-        // Clean up sticky side-effects when lineClamp is explicitly removed
-        // (set to 0) or contradicted by a forced nowrap (#22961)
+        // Apply line clamp
         if (styles?.lineClamp) {
             styles.display = '-webkit-box';
             styles.WebkitLineClamp = styles.lineClamp;
             styles.WebkitBoxOrient = 'vertical';
             styles.overflow = 'hidden';
         } else if (styles?.lineClamp === 0) {
-            // Disable the clamp by breaking the -webkit-box context
+            // Disable the clamp by breaking the -webkit-box context (#22961)
             styles.display = 'inline-block';
         }
 


### PR DESCRIPTION
Fixed #22961, axis labels with line-clamp did not correctly reset after chart resize

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210056616799395