### PR TITLE
feature/support-local-morningstar-connector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@babel/preset-env": "^7.26.0",
         "@babel/preset-typescript": "^7.26.0",
         "@cypress-audit/lighthouse": "1.4.2",
+        "@highcharts/connectors-morningstar": "3.1.1",
         "@highcharts/eslint-plugin-highcharts": "github:highcharts/eslint-plugin-highcharts#v1.1.1",
         "@highcharts/highcharts-assembler": "github:highcharts/highcharts-assembler#v1.5.6",
         "@highcharts/highcharts-declarations-generator": "github:highcharts/highcharts-declarations-generator#v1.4.3",
@@ -6205,6 +6206,46 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@highcharts/connectors-morningstar": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@highcharts/connectors-morningstar/-/connectors-morningstar-3.1.1.tgz",
+      "integrity": "sha512-v/EBN96mW4nGOE3HyDFj6vwH7ZK47zuRa+3yT+1hJ7vYg8dRxgRTWxNxmTyk9g5LFuhZQ386DtNRa/G2kG2sKg==",
+      "dev": true,
+      "license": "https://shop.highcharts.com/contact/partner-data",
+      "dependencies": {
+        "marked": "^14.1.2"
+      },
+      "bin": {
+        "connectors-morningstar": "bin/connectors-morningstar.js"
+      },
+      "optionalDependencies": {
+        "@highcharts/dashboards": ">=2.3.0"
+      }
+    },
+    "node_modules/@highcharts/connectors-morningstar/node_modules/marked": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.4.tgz",
+      "integrity": "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@highcharts/dashboards": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@highcharts/dashboards/-/dashboards-4.1.0.tgz",
+      "integrity": "sha512-Pwl7pKCxP/NYR7Wki1jyLBDLFcrnG89Xkdfx6sEbOLVIV64kePB0zL3axILDq7YaiveQ0i15XLZKC8jW9HaKzg==",
+      "dev": true,
+      "license": "https://www.highcharts.com/license",
+      "optional": true,
+      "peerDependencies": {
+        "highcharts": ">=10.0.0"
       }
     },
     "node_modules/@highcharts/eslint-plugin-highcharts": {
@@ -16884,6 +16925,27 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/highcharts": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-12.6.0.tgz",
+      "integrity": "sha512-zWwoXECOakJT2huBMqIZOjDNLLgyZFCcfZqTj2g6cvYOGxjF3nvooC+rIaF5aKiharluyGKNflfRNrzOAIjdRg==",
+      "dev": true,
+      "license": "https://www.highcharts.com/license",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "jspdf": "^4.1.0",
+        "svg2pdf.js": "^2.7.0"
+      },
+      "peerDependenciesMeta": {
+        "jspdf": {
+          "optional": true
+        },
+        "svg2pdf.js": {
+          "optional": true
+        }
       }
     },
     "node_modules/highcharts-assembler": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-typescript": "^7.26.0",
     "@cypress-audit/lighthouse": "1.4.2",
+    "@highcharts/connectors-morningstar": "3.1.1",
     "@highcharts/eslint-plugin-highcharts": "github:highcharts/eslint-plugin-highcharts#v1.1.1",
     "@highcharts/highcharts-assembler": "github:highcharts/highcharts-assembler#v1.5.6",
     "@highcharts/highcharts-declarations-generator": "github:highcharts/highcharts-declarations-generator#v1.4.3",

--- a/samples/highcharts/amd/es5/demo.js
+++ b/samples/highcharts/amd/es5/demo.js
@@ -1,6 +1,6 @@
 /* eslint-disable node/no-extraneous-require */
-// @TODO: Remove this eslint-disable once #179 is merged and released in
-// connectors-morningstar repository.
+// @TODO: Remove this eslint-disable once highcharts/connectors-morningstar#179
+// is merged and released.
 
 require.config({
     paths: {

--- a/samples/highcharts/amd/es5/demo.js
+++ b/samples/highcharts/amd/es5/demo.js
@@ -1,3 +1,4 @@
+/* eslint-disable node/no-extraneous-require */
 require.config({
     paths: {
         'highcharts/highcharts': 'https://code.highcharts.com/es5/highcharts',

--- a/samples/highcharts/amd/es5/demo.js
+++ b/samples/highcharts/amd/es5/demo.js
@@ -1,4 +1,7 @@
 /* eslint-disable node/no-extraneous-require */
+// @TODO: Remove this eslint-disable once #179 is merged and released in
+// connectors-morningstar repository.
+
 require.config({
     paths: {
         'highcharts/highcharts': 'https://code.highcharts.com/es5/highcharts',

--- a/samples/highcharts/demo/annotations/demo.details
+++ b/samples/highcharts/demo/annotations/demo.details
@@ -4,7 +4,6 @@ authors:
   - Paweł Lysy
   - Jedrzej Ruta
 js_wrap: b
-requiresManualTesting: true
 alt_text: >-
   Highcharts basic area chart with annotations JavaScript example displays
   stock data of TSLA with annotations highlighting some meaningful events that

--- a/samples/stock/demo/drag-on-axis/demo.details
+++ b/samples/stock/demo/drag-on-axis/demo.details
@@ -4,7 +4,6 @@ authors:
   - Kamil Musialowski
 js_wrap: b
 new_until: 2025-05-01
-requiresManualTesting: true
 is_morningstar: true
 tags:
   - Highcharts Stock demo

--- a/samples/stock/demo/stock-tools-gui/demo.details
+++ b/samples/stock/demo/stock-tools-gui/demo.details
@@ -2,7 +2,6 @@
 name: Stock chart with GUI
 authors:
   - Sebastian Bochan
-requiresManualTesting: true
 js_wrap: b
 tags:
   - Highcharts Stock demo

--- a/samples/stock/demo/two-standalone-navigators/demo.details
+++ b/samples/stock/demo/two-standalone-navigators/demo.details
@@ -6,7 +6,6 @@ js_wrap: b
 tags:
   - Highcharts Stock demo
   - Morningstar
-requiresManualTesting: true
 categories:
   - Various features:
       priority: 1

--- a/test/karma-conf.js
+++ b/test/karma-conf.js
@@ -286,6 +286,15 @@ module.exports = function (config) {
     // Get the files
     let files = require('./karma-files.json');
 
+    // Only include Morningstar connector in visual/reference runs.
+    // Loading it globally breaks unrelated QUnit tests.
+    if (argv.visualcompare || argv.reference) {
+        files = [
+            ...files,
+            'node_modules/@highcharts/connectors-morningstar/connectors-morningstar.js'
+        ];
+    }
+
     let options = {
         basePath: '../', // Root relative to this file
         frameworks: frameworks,

--- a/test/karma-files.json
+++ b/test/karma-files.json
@@ -91,7 +91,6 @@
     "samples/data/maps/us-small.js",
     "samples/data/maps/world.js",
 
-
     "samples/data/usdeur.js",
     "samples/data/ohlc.js",
     "samples/data/three-series-1000-points.js",

--- a/test/karma-files.json
+++ b/test/karma-files.json
@@ -91,7 +91,6 @@
     "samples/data/maps/us-small.js",
     "samples/data/maps/world.js",
 
-    "node_modules/@highcharts/connectors-morningstar/connectors-morningstar.js",
 
     "samples/data/usdeur.js",
     "samples/data/ohlc.js",

--- a/test/karma-files.json
+++ b/test/karma-files.json
@@ -91,6 +91,8 @@
     "samples/data/maps/us-small.js",
     "samples/data/maps/world.js",
 
+    "node_modules/@highcharts/connectors-morningstar/connectors-morningstar.js",
+
     "samples/data/usdeur.js",
     "samples/data/ohlc.js",
     "samples/data/three-series-1000-points.js",

--- a/tests/README.md
+++ b/tests/README.md
@@ -537,6 +537,7 @@ The following URL patterns are automatically rewritten:
 | Pattern | Local Path | Description |
 |---------|------------|-------------|
 | `**/code.highcharts.com/**` | `code/` | Highcharts library files |
+| `**/code.highcharts.com/connectors/morningstar/**` | `node_modules/@highcharts/connectors-morningstar/` | Morningstar connector |
 | `**/**/mapdata/**` | `node_modules/@highcharts/map-collection/` | Map data files |
 | `**/{samples/data}/**` | `samples/data/` | Sample data files |
 | `https://demo-live-data.highcharts.com/**` | `samples/data/` | Demo live data |

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -273,6 +273,44 @@ async function getJSONSources(): Promise<RouteType[]> {
     return routes;
 }
 
+async function replaceMorningstarConnectors(route: Route) {
+    const url = route.request().url();
+    const match = url.match(/connectors\/morningstar\/([^?#]+)/u);
+
+    if (match?.[1]) {
+        const filename = match[1];
+        try {
+            const filePath = join(
+                __dirname,
+                '..',
+                'node_modules',
+                '@highcharts',
+                'connectors-morningstar',
+                filename
+            );
+            const data = await readFile(filePath, 'utf8');
+
+            test.info().annotations.push({
+                type: 'redirect',
+                description:
+                    `${url} --> node_modules/@highcharts/connectors-morningstar/${filename}`
+            });
+
+            return route.fulfill({
+                status: 200,
+                contentType:
+                    contentTypes[extname(filename)] ?? 'application/javascript',
+                body: data
+            });
+        } catch (error) {
+            console.error(error);
+        }
+    }
+
+    await route.abort();
+    throw new Error('Failed to find a matching Morningstar connector bundle');
+}
+
 async function replaceMapData(route: Route) {
     const url = route.request().url();
     const match = url.match(/mapdata\/(.+\.*)/u);
@@ -350,6 +388,10 @@ export async function replaceSampleData(route: Route) {
 export async function setupRoutes(page: Page){
     if (!process.env.NO_REWRITES) {
         const routes: RouteType[] = [
+            {
+                pattern: '**/code.highcharts.com/connectors/morningstar/**',
+                handler: replaceMorningstarConnectors
+            },
             {
                 pattern: '**/code.highcharts.com/**',
                 handler: replaceHCCode


### PR DESCRIPTION
Added URL replacing logic for Morningstar Connector.

Remember to `npm install` first before testing.
Visual diffs tested locally and on CI/CD are looking fine.

`/* eslint-disable node/no-extraneous-require */` should be removed once fix for https://github.com/highcharts/connectors-morningstar/issues/179 is released.