### PR TITLE
bugfix/19750-update-with-highcontrast

### DIFF
--- a/samples/unit-tests/accessibility/accessibility-options/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-options/demo.js
@@ -306,6 +306,58 @@ QUnit.test('pointDescriptionEnabledThreshold', function (assert) {
     assert.ok(getSeriesAriaLabel(series), 'There be ARIA on series');
 });
 
+QUnit.test('High contrast theme should persist on chart update', function (
+    assert
+) {
+    var options = {
+            accessibility: {
+                highContrastMode: true,
+                highContrastTheme: {
+                    yAxis: {
+                        plotLines: [{
+                            color: '#ff0000',
+                            value: 2,
+                            width: 2
+                        }]
+                    },
+                    plotOptions: {
+                        series: {
+                            color: '#ff0000'
+                        }
+                    }
+                }
+            },
+            series: [{
+                color: '#0000ff',
+                data: [1, 2, 3]
+            }],
+            yAxis: {
+                plotLines: [{
+                    color: '#0000ff',
+                    value: 2,
+                    width: 2
+                }]
+            }
+        },
+        chart = Highcharts.chart('container', options),
+        plotLine = chart.yAxis[0].plotLinesAndBands[0];
+
+    assert.strictEqual(
+        plotLine.svgElem.element.getAttribute('stroke'),
+        '#ff0000',
+        'Plot line should use the high contrast color on first render'
+    );
+
+    chart.update(options);
+    plotLine = chart.yAxis[0].plotLinesAndBands[0];
+
+    assert.strictEqual(
+        plotLine.svgElem.element.getAttribute('stroke'),
+        '#ff0000',
+        'Plot line should keep the high contrast color after chart.update'
+    );
+});
+
 QUnit.test('pointNavigationThreshold', function (assert) {
     var chart = Highcharts.chart('container', {
             accessibility: {

--- a/samples/unit-tests/accessibility/accessibility-options/demo.js
+++ b/samples/unit-tests/accessibility/accessibility-options/demo.js
@@ -309,38 +309,32 @@ QUnit.test('pointDescriptionEnabledThreshold', function (assert) {
 QUnit.test('High contrast theme should persist on chart update', function (
     assert
 ) {
-    var options = {
-            accessibility: {
-                highContrastMode: true,
-                highContrastTheme: {
-                    yAxis: {
-                        plotLines: [{
-                            color: '#ff0000',
-                            value: 2,
-                            width: 2
-                        }]
-                    },
-                    plotOptions: {
-                        series: {
-                            color: '#ff0000'
-                        }
-                    }
+    const options = {
+        accessibility: {
+            highContrastMode: true,
+            highContrastTheme: {
+                yAxis: {
+                    plotLines: [{
+                        color: '#ff0000',
+                        value: 2,
+                        width: 2
+                    }]
                 }
-            },
-            series: [{
-                color: '#0000ff',
-                data: [1, 2, 3]
-            }],
-            yAxis: {
-                plotLines: [{
-                    color: '#0000ff',
-                    value: 2,
-                    width: 2
-                }]
             }
         },
-        chart = Highcharts.chart('container', options),
-        plotLine = chart.yAxis[0].plotLinesAndBands[0];
+        yAxis: {
+            plotLines: [{
+                color: '#0000ff',
+                value: 2,
+                width: 2
+            }]
+        },
+        series: [{
+            data: [1, 2, 3]
+        }]
+    };
+    const chart = Highcharts.chart('container', options);
+    let plotLine = chart.yAxis[0].plotLinesAndBands[0];
 
     assert.strictEqual(
         plotLine.svgElem.element.getAttribute('stroke'),

--- a/samples/unit-tests/halo/integration/demo.js
+++ b/samples/unit-tests/halo/integration/demo.js
@@ -49,6 +49,10 @@ QUnit.test('visibility', assert => {
 
 QUnit.test('Halo with boost module', assert => {
     const chart = Highcharts.chart('container', {
+            xAxis: {
+                min: -5,
+                max: 5
+            },
             plotOptions: {
                 series: {
                     boostThreshold: 2,
@@ -61,12 +65,16 @@ QUnit.test('Halo with boost module', assert => {
                 data: [2, 3]
             }, {
                 data: [3, 2]
-            }, {
-                data: [2.5]
             }]
         }),
         series = chart.series[0],
         controller = new TestController(chart);
+
+    assert.strictEqual(
+        series.markerGroup,
+        chart.series[1].markerGroup,
+        'Boosted series should share one marker group'
+    );
 
     controller.mouseMove(
         series.points[0].plotX + chart.plotLeft,
@@ -81,12 +89,6 @@ QUnit.test('Halo with boost module', assert => {
     assert.strictEqual(
         series.markerGroup.element.getAttribute('opacity'),
         '1',
-        'Boosted series sharing markerGroup should not be inactive on hover'
-    );
-
-    assert.notEqual(
-        +chart.series[2].markerGroup.element.getAttribute('opacity'),
-        1,
-        'Series not sharing markerGroup should be inactive on hover'
+        'Shared boost marker group should not be inactive on hover'
     );
 });

--- a/samples/unit-tests/halo/integration/demo.js
+++ b/samples/unit-tests/halo/integration/demo.js
@@ -65,16 +65,12 @@ QUnit.test('Halo with boost module', assert => {
                 data: [2, 3]
             }, {
                 data: [3, 2]
+            }, {
+                data: [2.5]
             }]
         }),
         series = chart.series[0],
         controller = new TestController(chart);
-
-    assert.strictEqual(
-        series.markerGroup,
-        chart.series[1].markerGroup,
-        'Boosted series should share one marker group'
-    );
 
     controller.mouseMove(
         series.points[0].plotX + chart.plotLeft,
@@ -89,6 +85,12 @@ QUnit.test('Halo with boost module', assert => {
     assert.strictEqual(
         series.markerGroup.element.getAttribute('opacity'),
         '1',
-        'Shared boost marker group should not be inactive on hover'
+        'Boosted series sharing markerGroup should not be inactive on hover'
+    );
+
+    assert.notEqual(
+        +chart.series[2].markerGroup.element.getAttribute('opacity'),
+        1,
+        'Series not sharing markerGroup should be inactive on hover'
     );
 });

--- a/samples/unit-tests/halo/integration/demo.js
+++ b/samples/unit-tests/halo/integration/demo.js
@@ -49,10 +49,6 @@ QUnit.test('visibility', assert => {
 
 QUnit.test('Halo with boost module', assert => {
     const chart = Highcharts.chart('container', {
-            xAxis: {
-                min: -5,
-                max: 5
-            },
             plotOptions: {
                 series: {
                     boostThreshold: 2,

--- a/ts/Accessibility/Accessibility.ts
+++ b/ts/Accessibility/Accessibility.ts
@@ -249,10 +249,12 @@ class Accessibility {
         this.keyboardNavigation.update(kbdNavOrder);
 
         // Handle high contrast mode
-        // Should only be applied once, and not if explicitly disabled
+        // Reapply after updates while HC mode is active, but avoid recursion
+        // while the theme itself is being applied through chart.update.
         if (
-            !chart.highContrastModeActive &&
+            !chart.applyingHighContrastTheme &&
             a11yOptions.highContrastMode !== false && (
+                chart.highContrastModeActive ||
                 whcm.isHighContrastModeActive() ||
                 a11yOptions.highContrastMode === true
             )

--- a/ts/Accessibility/Accessibility.ts
+++ b/ts/Accessibility/Accessibility.ts
@@ -252,9 +252,9 @@ class Accessibility {
         // Reapply after updates while HC mode is active, but avoid recursion
         // while the theme itself is being applied through chart.update.
         if (
-            !chart.applyingHighContrastTheme &&
+            !chart.highContrastState?.applying &&
             a11yOptions.highContrastMode !== false && (
-                chart.highContrastModeActive ||
+                chart.highContrastState?.active ||
                 whcm.isHighContrastModeActive() ||
                 a11yOptions.highContrastMode === true
             )

--- a/ts/Accessibility/HighContrastMode.ts
+++ b/ts/Accessibility/HighContrastMode.ts
@@ -38,6 +38,7 @@ const {
 
 declare module '../Core/Chart/ChartBase'{
     interface ChartBase {
+        applyingHighContrastTheme?: boolean;
         highContrastModeActive?: boolean;
     }
 }
@@ -101,50 +102,55 @@ function setHighContrastTheme(
     // disabled. For now, the user will have to reload the page.
 
     chart.highContrastModeActive = true;
+    chart.applyingHighContrastTheme = true;
 
-    // Apply theme to chart
-    const theme: AnyRecord = (
-        chart.options.accessibility.highContrastTheme
-    );
+    try {
+        // Apply theme to chart
+        const theme: AnyRecord = (
+            chart.options.accessibility.highContrastTheme
+        );
 
-    chart.update(theme, false);
+        chart.update(theme, false);
 
-    const hasCustomColors = theme.colors?.length > 1;
+        const hasCustomColors = theme.colors?.length > 1;
 
-    // Force series colors (plotOptions is not enough)
-    chart.series.forEach(function (s): void {
-        const plotOpts = theme.plotOptions[s.type] || {};
+        // Force series colors (plotOptions is not enough)
+        chart.series.forEach(function (s): void {
+            const plotOpts = theme.plotOptions[s.type] || {};
 
-        const fillColor = hasCustomColors && s.colorIndex !== void 0 ?
-            theme.colors[s.colorIndex] :
-            plotOpts.color || 'window';
+            const fillColor = hasCustomColors && s.colorIndex !== void 0 ?
+                theme.colors[s.colorIndex] :
+                plotOpts.color || 'window';
 
-        const seriesOptions: Partial<SeriesOptions> = {
-            color: plotOpts.color || 'windowText',
-            colors: hasCustomColors ?
-                theme.colors : [plotOpts.color || 'windowText'],
-            borderColor: plotOpts.borderColor || 'window',
-            fillColor
-        };
+            const seriesOptions: Partial<SeriesOptions> = {
+                color: plotOpts.color || 'windowText',
+                colors: hasCustomColors ?
+                    theme.colors : [plotOpts.color || 'windowText'],
+                borderColor: plotOpts.borderColor || 'window',
+                fillColor
+            };
 
-        s.update(seriesOptions, false);
+            s.update(seriesOptions, false);
 
-        if (s.points) {
-            // Force point colors if existing
-            s.points.forEach(function (p): void {
-                if (p.options && p.options.color) {
-                    p.update({
-                        color: plotOpts.color || 'windowText',
-                        borderColor: plotOpts.borderColor || 'window'
-                    }, false);
-                }
-            });
-        }
-    });
+            if (s.points) {
+                // Force point colors if existing
+                s.points.forEach(function (p): void {
+                    if (p.options && p.options.color) {
+                        p.update({
+                            color: plotOpts.color || 'windowText',
+                            borderColor: plotOpts.borderColor || 'window'
+                        }, false);
+                    }
+                });
+            }
+        });
 
-    // The redraw for each series and after is required for 3D pie
-    // (workaround)
-    chart.redraw();
+        // The redraw for each series and after is required for 3D pie
+        // (workaround)
+        chart.redraw();
+    } finally {
+        delete chart.applyingHighContrastTheme;
+    }
 }
 
 /* *

--- a/ts/Accessibility/HighContrastMode.ts
+++ b/ts/Accessibility/HighContrastMode.ts
@@ -36,10 +36,14 @@ const {
  *
  * */
 
+interface HighContrastState {
+    active?: boolean;
+    applying?: boolean;
+}
+
 declare module '../Core/Chart/ChartBase'{
     interface ChartBase {
-        applyingHighContrastTheme?: boolean;
-        highContrastModeActive?: boolean;
+        highContrastState?: HighContrastState;
     }
 }
 
@@ -101,8 +105,12 @@ function setHighContrastTheme(
     // storing the old state so that we can reset the theme if HC mode is
     // disabled. For now, the user will have to reload the page.
 
-    chart.highContrastModeActive = true;
-    chart.applyingHighContrastTheme = true;
+    const highContrastState = chart.highContrastState || (
+        chart.highContrastState = {}
+    );
+
+    highContrastState.active = true;
+    highContrastState.applying = true;
 
     try {
         // Apply theme to chart
@@ -149,7 +157,7 @@ function setHighContrastTheme(
         // (workaround)
         chart.redraw();
     } finally {
-        delete chart.applyingHighContrastTheme;
+        delete highContrastState.applying;
     }
 }
 


### PR DESCRIPTION
Fixed #19750, `highContrastTheme` settings were partially lost after `chart.update`.

Right when it initially renders you can see blue quickly swap to red, should that be fixed by this branch?

Test: https://jsfiddle.net/mkb93/4qphj3fu/3/
Switch to forced-colors to simulate windows high contrast in chrome