### PR TITLE
Fixed #24460, bad clipping in some cases on solid gauges

### DIFF
--- a/samples/highcharts/plotoptions/solidgauge-radius/demo.js
+++ b/samples/highcharts/plotoptions/solidgauge-radius/demo.js
@@ -2,7 +2,9 @@
 Highcharts.chart('container', {
 
     chart: {
-        type: 'solidgauge'
+        type: 'solidgauge',
+        width: 300
+
     },
 
     credits: {

--- a/samples/highcharts/plotoptions/solidgauge-radius/demo.js
+++ b/samples/highcharts/plotoptions/solidgauge-radius/demo.js
@@ -2,9 +2,7 @@
 Highcharts.chart('container', {
 
     chart: {
-        type: 'solidgauge',
-        width: 300
-
+        type: 'solidgauge'
     },
 
     credits: {

--- a/samples/unit-tests/series-solidgauge/solidgauge/demo.js
+++ b/samples/unit-tests/series-solidgauge/solidgauge/demo.js
@@ -183,41 +183,6 @@ QUnit.test('Solid gauge: defaults & legend', function (assert) {
         chart.series[0].points[0].graphic.element.getAttribute('fill'),
         'Series legend item: color taken from series'
     );
-
-    chart.update({
-        chart: {
-            height: 675,
-            width: 350,
-            animation: false
-        },
-        pane: [
-            {
-                center: ['75%', '80%'],
-                size: '100%',
-                endAngle: 90.0,
-                startAngle: -90.0
-            }
-        ],
-        yAxis: {
-            min: 0
-        }
-    });
-
-    assert.close(
-        chart.series[0].xAxis.pane.center[0] - chart.plotWidth / 2,
-        chart.sharedClips[chart.series[0].sharedClipKey].attr('x'),
-        1.5,
-        `Solig gauge series clip should calculate pane horizontal offset,
-        #22890.`
-    );
-
-    assert.close(
-        chart.series[0].xAxis.pane.center[1] - chart.plotHeight / 2,
-        chart.sharedClips[chart.series[0].sharedClipKey].attr('y'),
-        1.5,
-        `Solig gauge series clip should calculate pane vertical offset,
-        #22890.`
-    );
 });
 
 QUnit.test('Solid gauge null point (#10630)', function (assert) {

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -1095,11 +1095,11 @@ class Chart {
         if (series) {
             // Otherwise, use clipBox.width which is corrected for
             // plotBorderWidth and clipOffset
-            if (xAxis && xAxis.len !== this.plotSizeX) {
+            if (xAxis && xAxis.len !== this.plotSizeX && !xAxis.isRadial) {
                 width = xAxis.len;
             }
 
-            if (yAxis && yAxis.len !== this.plotSizeY) {
+            if (yAxis && yAxis.len !== this.plotSizeY && !yAxis.isRadial) {
                 height = yAxis.len;
             }
 

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -2694,8 +2694,6 @@ class Series {
 
         let clipRect = sharedClips[sharedClipKey];
 
-        fireEvent(this, 'setClip', { clipBox });
-
         // If a clipping rectangle for the same set of axes does not exist,
         // create it
         if (!clipRect) {

--- a/ts/Extensions/Pane/PaneComposition.ts
+++ b/ts/Extensions/Pane/PaneComposition.ts
@@ -4,7 +4,6 @@
  *
  * */
 
-import type { BBoxObject } from '../../Core/Renderer/BBoxObject';
 import type Chart from '../../Core/Chart/Chart';
 import type Pane from './Pane';
 import type Pointer from '../../Core/Pointer';
@@ -70,47 +69,10 @@ function chartGetHoverPane(
     return hoverPane;
 }
 
-/**
- * Adjusts the clipBox based on the position of panes.
- * @internal
- */
-function onSetClip(
-    this: Series,
-    {
-        clipBox
-    }: {
-        clipBox: BBoxObject
-    }
-): void {
-    if (
-        !this.xAxis ||
-        !this.yAxis ||
-        (!this.chart.angular && !this.chart.polar)
-    ) {
-        return;
-    }
-
-    const { plotWidth, plotHeight } = this.chart,
-        smallestSize = Math.min(plotWidth, plotHeight),
-        xPane = this.xAxis.pane,
-        yPane = this.yAxis.pane;
-
-    if (xPane && xPane.axis) {
-        clipBox.x += xPane.center[0] -
-            (xPane.center[2] / smallestSize) * plotWidth / 2;
-    }
-
-    if (yPane && yPane.axis) {
-        clipBox.y += yPane.center[1] -
-            (yPane.center[2] / smallestSize) * plotHeight / 2;
-    }
-}
-
 /** @internal */
 function compose(
     ChartClass: typeof Chart,
-    PointerClass: typeof Pointer,
-    SeriesClass: typeof Series
+    PointerClass: typeof Pointer
 ): void {
     const chartProto = ChartClass.prototype as PaneChart;
 
@@ -125,7 +87,6 @@ function compose(
             'beforeGetHoverData',
             onPointerBeforeGetHoverData
         );
-        addEvent(SeriesClass, 'setClip', onSetClip);
     }
 
 }

--- a/ts/Series/Gauge/GaugeSeries.ts
+++ b/ts/Series/Gauge/GaugeSeries.ts
@@ -590,20 +590,6 @@ class GaugeSeries extends Series {
     }
 
     /**
-     * @private
-     */
-    public render(): void {
-        this.group = this.plotGroup(
-            'group',
-            'series',
-            this.visible ? 'inherit' : 'hidden',
-            this.options.zIndex,
-            this.chart.seriesGroup
-        );
-        Series.prototype.render.call(this);
-        this.group.clip(this.chart.clipRect);
-    }
-    /**
      * Extend the basic setData method by running processData and generatePoints
      * immediately, in order to access the points from the legend.
      * @private

--- a/ts/Series/Gauge/GaugeSeries.ts
+++ b/ts/Series/Gauge/GaugeSeries.ts
@@ -115,6 +115,8 @@ class GaugeSeries extends Series {
     public static defaultOptions: GaugeSeriesOptions = merge(
         Series.defaultOptions,
         {
+            clip: false,
+
             /**
              * When this option is `true`, the dial will wrap around the axes.
              * For instance, in a full-range gauge going from 0 to 360, a value

--- a/ts/Series/PolarComposition.ts
+++ b/ts/Series/PolarComposition.ts
@@ -1542,7 +1542,7 @@ class PolarAdditions {
         LineSeriesClass: typeof LineSeries,
         SplineSeriesClass: typeof SplineSeries
     ): void {
-        Pane.compose(ChartClass, PointerClass, SeriesClass);
+        Pane.compose(ChartClass, PointerClass);
         RadialAxis.compose(AxisClass, TickClass);
 
         if (pushUnique(composed, 'Polar')) {

--- a/ts/masters/highcharts-more.src.ts
+++ b/ts/masters/highcharts-more.src.ts
@@ -30,7 +30,7 @@ const G: AnyRecord = Highcharts;
 G.RadialAxis = RadialAxis;
 BubbleSeries.compose(G.Axis, G.Chart, G.Legend);
 PackedBubbleSeries.compose(G.Axis, G.Chart, G.Legend);
-Pane.compose(G.Chart, G.Pointer, G.Series);
+Pane.compose(G.Chart, G.Pointer);
 PolarAdditions.compose(
     G.Axis,
     G.Chart,


### PR DESCRIPTION
Fixed #24460, bad clipping in some cases on solid gauges, and enabled support for the `clip` option on `gauge` and `solidgauge` series.

Also simplifies the fix for #22890. The root cause was that the `getClipBox` function created tailored clip rectangles for the series level, but this is only supposed to happen with series rendered on the cartesian plane. The `yAxis.len` property on a radial axis is not usable. Fall back to the plot area instead.

Closes #24462.