### PR TITLE
bugfix/24477-ctx-params

### DIFF
--- a/ts/Core/Legend/Legend.ts
+++ b/ts/Core/Legend/Legend.ts
@@ -2003,6 +2003,10 @@ export default Legend;
  *
  * @param {Highcharts.LegendItemClickEventObject} event
  * The event that occurred.
+ *
+ * @param {Highcharts.Legend} [ctx]
+ * Since v12.6.0, the legend context passed as an extra argument for arrow
+ * functions.
  */
 
 /**
@@ -2048,6 +2052,10 @@ export default Legend;
  *
  * @param {Highcharts.PointLegendItemClickEventObject} event
  * The event that occurred.
+ *
+ * @param {Highcharts.Point} [ctx]
+ * Since v12.6.0, the point context passed as an extra argument for arrow
+ * functions.
  */
 
 /**
@@ -2103,6 +2111,10 @@ export default Legend;
  *
  * @param {Highcharts.SeriesLegendItemClickEventObject} event
  * The event that occurred.
+ *
+ * @param {Highcharts.Series} [ctx]
+ * Since v12.6.0, the series context passed as an extra argument for arrow
+ * functions.
  */
 
 /**

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -1955,6 +1955,10 @@ export default Point;
  *
  * @param {Highcharts.PointClickEventObject} event
  *        Event arguments.
+ *
+ * @param {Highcharts.Point} [ctx]
+ *        Since v12.6.0, the point context passed as an extra argument for
+ *        arrow functions.
  */
 
 /**
@@ -1978,6 +1982,10 @@ export default Point;
  *
  * @param {global.PointerEvent} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Point} [ctx]
+ *        Since v12.6.0, the point context passed as an extra argument for
+ *        arrow functions.
  */
 
 /**
@@ -1990,6 +1998,10 @@ export default Point;
  *
  * @param {global.Event} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Point} [ctx]
+ *        Since v12.6.0, the point context passed as an extra argument for
+ *        arrow functions.
  */
 
 /**
@@ -2023,6 +2035,10 @@ export default Point;
  *
  * @param {global.Event} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Point} [ctx]
+ *        Since v12.6.0, the point context passed as an extra argument for
+ *        arrow functions.
  */
 
 /**

--- a/ts/Core/Series/Point.ts
+++ b/ts/Core/Series/Point.ts
@@ -2058,6 +2058,10 @@ export default Point;
  *
  * @param {Highcharts.PointUpdateEventObject} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Point} [ctx]
+ *        Since v12.6.0, the point context passed as an extra argument for
+ *        arrow functions.
  */
 
 /**
@@ -2108,6 +2112,10 @@ export default Point;
  *
  * @param {Highcharts.PointInteractionEventObject} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Point} [ctx]
+ *        Since v12.6.0, the point context passed as an extra argument for
+ *        arrow functions.
  */
 
 /**
@@ -2121,6 +2129,10 @@ export default Point;
  *
  * @param {Highcharts.PointInteractionEventObject} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Point} [ctx]
+ *        Since v12.6.0, the point context passed as an extra argument for
+ *        arrow functions.
  */
 
 ''; // Keeps doclets above in JS file.

--- a/ts/Core/Series/PointOptions.ts
+++ b/ts/Core/Series/PointOptions.ts
@@ -165,6 +165,10 @@ export interface PointEventsOptions {
  *
  * @param {Highcharts.PointClickEvent} event
  *        Event arguments.
+ *
+ * @param {Highcharts.Point} [ctx]
+ *        Since v12.6.0, the point context passed as an extra argument for
+ *        arrow functions.
  */
 export type PointClickCallbackFunction = EventCallback<Point, PointClickEvent>;
 
@@ -178,6 +182,10 @@ export type PointClickCallbackFunction = EventCallback<Point, PointClickEvent>;
  *
  * @param {global.PointerEvent} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Point} [ctx]
+ *        Since v12.6.0, the point context passed as an extra argument for
+ *        arrow functions.
  */
 export type PointMouseOutCallbackFunction = EventCallback<Point, PointerEvent>;
 
@@ -191,6 +199,10 @@ export type PointMouseOutCallbackFunction = EventCallback<Point, PointerEvent>;
  *
  * @param {global.Event} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Point} [ctx]
+ *        Since v12.6.0, the point context passed as an extra argument for
+ *        arrow functions.
  */
 export type PointMouseOverCallbackFunction = EventCallback<Point, PointerEvent>;
 
@@ -204,6 +216,10 @@ export type PointMouseOverCallbackFunction = EventCallback<Point, PointerEvent>;
  *
  * @param {global.Event} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Point} [ctx]
+ *        Since v12.6.0, the point context passed as an extra argument for
+ *        arrow functions.
  */
 export type PointRemoveCallbackFunction = EventCallback<Point, Event>;
 
@@ -218,6 +234,10 @@ export type PointRemoveCallbackFunction = EventCallback<Point, Event>;
  *
  * @param {Highcharts.PointInteractionEventObject} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Point} [ctx]
+ *        Since v12.6.0, the point context passed as an extra argument for
+ *        arrow functions.
  */
 export type PointSelectCallbackFunction =
     EventCallback<Point, PointInteractionEventObject>;
@@ -233,6 +253,10 @@ export type PointSelectCallbackFunction =
  *
  * @param {Highcharts.PointInteractionEventObject} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Point} [ctx]
+ *        Since v12.6.0, the point context passed as an extra argument for
+ *        arrow functions.
  */
 export type PointUnselectCallbackFunction =
     EventCallback<Point, PointInteractionEventObject>;
@@ -248,6 +272,10 @@ export type PointUnselectCallbackFunction =
  *
  * @param {Highcharts.PointUpdateEventObject} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Point} [ctx]
+ *        Since v12.6.0, the point context passed as an extra argument for
+ *        arrow functions.
  */
 export type PointUpdateCallbackFunction =
     EventCallback<Point, PointUpdateEvent>;

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -5450,6 +5450,10 @@ export default Series;
  *
  * @param {global.Event} event
  *        The event that occurred.
+ *
+ * @param {Highcharts.Series} [ctx]
+ *        Since v12.6.0, the series context passed as an extra argument for
+ *        arrow functions.
  */
 
 /**
@@ -5469,6 +5473,10 @@ export default Series;
  *
  * @param {global.PointerEvent} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Series} [ctx]
+ *        Since v12.6.0, the series context passed as an extra argument for
+ *        arrow functions.
  */
 
 /**
@@ -5481,6 +5489,10 @@ export default Series;
  *
  * @param {global.PointerEvent} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Series} [ctx]
+ *        Since v12.6.0, the series context passed as an extra argument for
+ *        arrow functions.
  */
 
 /**
@@ -5512,6 +5524,10 @@ export default Series;
  *
  * @param {global.Event} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Series} [ctx]
+ *        Since v12.6.0, the series context passed as an extra argument for
+ *        arrow functions.
  */
 
 /**

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -5364,6 +5364,10 @@ export default Series;
  *
  * @param {Highcharts.SeriesAfterAnimateEventObject} event
  *        Event arguments.
+ *
+ * @param {Highcharts.Series} [ctx]
+ *        Since v12.6.0, the series context passed as an extra argument for
+ *        arrow functions.
  */
 
 /**
@@ -5426,6 +5430,10 @@ export default Series;
  *
  * @param {Highcharts.SeriesClickEventObject} event
  *        Event arguments.
+ *
+ * @param {Highcharts.Series} [ctx]
+ *        Since v12.6.0, the series context passed as an extra argument for
+ *        arrow functions.
  */
 
 /**

--- a/ts/Core/Series/SeriesOptions.ts
+++ b/ts/Core/Series/SeriesOptions.ts
@@ -193,6 +193,10 @@ export interface SeriesEventsOptions {
  *
  * @param {Highcharts.SeriesAfterAnimateEventObject} event
  *        Event arguments.
+ *
+ * @param {Highcharts.Series} [ctx]
+ *        Since v12.6.0, the series context passed as an extra argument for
+ *        arrow functions.
  */
 export type SeriesAfterAnimateCallbackFunction =
     EventCallback<Series, SeriesAfterAnimateEventObject>;
@@ -221,6 +225,10 @@ export interface SeriesAfterAnimateEventObject {
  *
  * @param {Highcharts.SeriesClickEventObject} event
  *        Event arguments.
+ *
+ * @param {Highcharts.Series} [ctx]
+ *        Since v12.6.0, the series context passed as an extra argument for
+ *        arrow functions.
  */
 export type SeriesClickCallbackFunction =
     EventCallback<Series, SeriesClickEventObject>;
@@ -241,11 +249,17 @@ export interface SeriesClickEventObject {
  * Gets fired when the series is hidden after chart generation time, either by
  * clicking the legend item or by calling `.hide()`.
  *
+ * @callback Highcharts.SeriesHideCallbackFunction
+ *
  * @param {Highcharts.Series} this
  *        The series where the event occurred.
  *
  * @param {global.Event} event
  *        The event that occurred.
+ *
+ * @param {Highcharts.Series} [ctx]
+ *        Since v12.6.0, the series context passed as an extra argument for
+ *        arrow functions.
  */
 export type SeriesHideCallbackFunction = EventCallback<Series, Event>;
 
@@ -259,6 +273,10 @@ export type SeriesHideCallbackFunction = EventCallback<Series, Event>;
  *
  * @param {global.PointerEvent} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Series} [ctx]
+ *        Since v12.6.0, the series context passed as an extra argument for
+ *        arrow functions.
  */
 export type SeriesMouseOutCallbackFunction =
     EventCallback<Series, PointerEvent>;
@@ -273,6 +291,10 @@ export type SeriesMouseOutCallbackFunction =
  *
  * @param {global.PointerEvent} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Series} [ctx]
+ *        Since v12.6.0, the series context passed as an extra argument for
+ *        arrow functions.
  */
 export type SeriesMouseOverCallbackFunction =
     EventCallback<Series, PointerEvent>;
@@ -288,6 +310,10 @@ export type SeriesMouseOverCallbackFunction =
  *
  * @param {global.Event} event
  *        Event that occurred.
+ *
+ * @param {Highcharts.Series} [ctx]
+ *        Since v12.6.0, the series context passed as an extra argument for
+ *        arrow functions.
  */
 export type SeriesShowCallbackFunction = EventCallback<Series, Event>;
 

--- a/ts/Core/Series/SeriesOptions.ts
+++ b/ts/Core/Series/SeriesOptions.ts
@@ -188,6 +188,8 @@ export interface SeriesEventsOptions {
 /**
  * Function callback when a series has been animated.
  *
+ * @callback Highcharts.SeriesAfterAnimateCallbackFunction
+ *
  * @param {Highcharts.Series} this
  *        The series where the event occurred.
  *
@@ -219,6 +221,8 @@ export interface SeriesAfterAnimateEventObject {
 /**
  * Function callback when a series is clicked. Return false to cancel toggle
  * actions.
+ *
+ * @callback Highcharts.SeriesClickCallbackFunction
  *
  * @param {Highcharts.Series} this
  *        The series where the event occurred.


### PR DESCRIPTION
Fixed #24477, missing `ctx` parameter in TypeScript definitions for event callbacks prevented safe use of arrow functions.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214062358385709