### PR TITLE
bugfix/23517-point-option-conflict

### DIFF
--- a/samples/unit-tests/series/datalabels/demo.html
+++ b/samples/unit-tests/series/datalabels/demo.html
@@ -1,6 +1,7 @@
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/highcharts-more.js"></script>
 
+<script src="https://code.highcharts.com/modules/venn.js"></script>
 <script src="https://code.highcharts.com/stock/modules/annotations.js"></script>
 <script src="https://code.highcharts.com/stock/modules/stock-tools.js"></script>
 

--- a/samples/unit-tests/series/datalabels/demo.js
+++ b/samples/unit-tests/series/datalabels/demo.js
@@ -275,46 +275,67 @@ QUnit.test('Top 90', function (assert) {
     );
 });
 
-QUnit.test(
-    'Connect ends and data label still visible (#6465)',
-    function (assert) {
-        var chart = Highcharts.chart('container', {
-            chart: {
-                polar: true,
-                type: 'line'
-            },
+QUnit.test('Various data labels edge cases', function (assert) {
+    const chart = Highcharts.chart('container', {
+        chart: {
+            polar: true,
+            type: 'line'
+        },
 
-            plotOptions: {
-                series: {
-                    dataLabels: {
-                        allowOverlap: true,
-                        enabled: true,
-                        padding: 0,
-                        defer: false
-                    }
+        plotOptions: {
+            series: {
+                dataLabels: {
+                    allowOverlap: true,
+                    enabled: true,
+                    padding: 0,
+                    defer: false,
+                    zIndex: 4
                 }
-            },
-            yAxis: {
-                max: 60000
-            },
+            }
+        },
+        yAxis: {
+            max: 60000
+        },
 
-            series: [
-                {
-                    name: 'Actual Spending',
-                    data: [45000, 39000, 42000, 31000, 26000, 14000],
-                    pointPlacement: 'on',
-                    animation: false
+        series: [{
+            name: 'Actual Spending',
+            data: [45000, 39000, 42000, 14000],
+            pointPlacement: 'on',
+            animation: false
+        }, {
+            type: 'venn',
+            data: [{
+                name: 'A',
+                sets: ['A'],
+                value: 20,
+                dataLabels: {
+                    zIndex: 5
                 }
-            ]
-        });
+            }, {
+                sets: ['B'],
+                value: 2
+            }, {
+                sets: ['A', 'B'],
+                value: 1
+            }]
+        }]
+    });
 
+    // Connect ends and data label still visible (#6465)
+    assert.strictEqual(
+        chart.series[0].points[0].dataLabel.opacity,
+        1,
+        'First data label is visible'
+    );
+
+    chart.series.forEach(s => {
         assert.strictEqual(
-            chart.series[0].points[0].dataLabel.opacity,
-            1,
-            'First data label is visible'
+            s.dataLabelsGroup.element.getAttribute('data-z-index'),
+            '4',
+            `Data label group has correct z-index (${s.type})`
         );
-    }
-);
+    });
+});
 
 // Highcharts 4.1.1, Issue #3866
 // Data Labels are not rendering for column charts when series are shown/hidden

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -2084,6 +2084,20 @@ const seriesDefaults: PlotOptionsOf<Series> = {
          */
         verticalAlign: 'bottom',
 
+        // Loose JSDoc doclet placed last are ignored, so placed unsorted here.
+        /**
+         * The z index of the data labels group. Does not apply below series
+         * level options.
+         *
+         * Use a `zIndex` of 6 to display it above the series,
+         * or use a `zIndex` of 2 to display it behind the series.
+         *
+         * @type      {number}
+         * @default   6
+         * @since     2.3.5
+         * @apioption plotOptions.series.dataLabels.zIndex
+         */
+
         /**
          * The x position offset of the label relative to the point in
          * pixels.
@@ -2103,19 +2117,6 @@ const seriesDefaults: PlotOptionsOf<Series> = {
          *         Vertical and positioned
          */
         y: 0
-
-        /**
-         * The z index of the data labels group. Does not apply below series
-         * level options.
-         *
-         * Use a `zIndex` of 6 to display it above the series,
-         * or use a `zIndex` of 2 to display it behind the series.
-         *
-         * @type      {number}
-         * @default   6
-         * @since     2.3.5
-         * @apioption plotOptions.series.dataLabels.zIndex
-         */
     },
 
     /**

--- a/ts/Series/ArcDiagram/ArcDiagramSeries.ts
+++ b/ts/Series/ArcDiagram/ArcDiagramSeries.ts
@@ -445,6 +445,8 @@ class ArcDiagramSeries extends SankeySeries {
                     }),
                     zIndex: void 0
                 };
+                // Delete so it doesn't override anything on merge.
+                delete node.dlOptions.zIndex;
             }
 
             // Pass test in drawPoints

--- a/ts/Series/Sankey/SankeySeries.ts
+++ b/ts/Series/Sankey/SankeySeries.ts
@@ -685,6 +685,8 @@ class SankeySeries extends ColumnSeries {
                 }),
                 zIndex: void 0
             };
+            // Delete so it doesn't override anything on merge.
+            delete node.dlOptions.zIndex;
 
             // Pass test in drawPoints
             node.plotX = 1;

--- a/ts/Series/Sunburst/SunburstSeries.ts
+++ b/ts/Series/Sunburst/SunburstSeries.ts
@@ -665,6 +665,9 @@ class SunburstSeries extends TreemapSeries {
                 }),
                 zIndex: void 0
             };
+            // Delete so it doesn't override anything on merge.
+            delete point.dlOptions.zIndex;
+
             if (!addedHack && visible) {
                 addedHack = true;
                 onComplete = animateLabels;

--- a/ts/Series/Timeline/TimelineSeries.ts
+++ b/ts/Series/Timeline/TimelineSeries.ts
@@ -217,6 +217,9 @@ class TimelineSeries extends LineSeries {
                     // Forced. Point level limitations.
                     { zIndex: void 0 }
                 );
+                // Delete so it doesn't override anything on merge.
+                delete point.options.dataLabels.zIndex;
+
                 visibilityIndex++;
             }
         }

--- a/ts/Series/Treemap/TreemapSeries.ts
+++ b/ts/Series/Treemap/TreemapSeries.ts
@@ -924,6 +924,8 @@ class TreemapSeries extends ScatterSeries {
             point.dlOptions = merge(options, point.options.dataLabels, {
                 zIndex: void 0
             });
+            // Delete so it doesn't override anything on merge.
+            delete point.dlOptions.zIndex;
         }
         super.drawDataLabels(points);
     }

--- a/ts/Series/Venn/VennSeries.ts
+++ b/ts/Series/Venn/VennSeries.ts
@@ -24,7 +24,6 @@
  * */
 
 import type CircleObject from '../../Core/Geometry/CircleObject';
-import type DataLabelOptions from '../../Core/Series/DataLabelOptions';
 import type IntersectionObject from '../../Core/Geometry/IntersectionObject';
 import type {
     NelderMeadPointArray,
@@ -641,15 +640,12 @@ class VennSeries extends ScatterSeries {
             // Add width for the data label
             if (dataLabelWidth && shapeArgs) {
                 point.dlOptions = merge(
-                    true,
-                    {
-                        style: {
-                            width: dataLabelWidth
-                        }
-                    } as DataLabelOptions,
+                    { style: { width: dataLabelWidth } },
                     isObject(dlOptions, true) ? dlOptions : void 0,
                     { zIndex: void 0 }
-                ) as DataLabelOptions & { zIndex: undefined };
+                );
+                // Delete so it doesn't override anything on merge.
+                delete point.dlOptions.zIndex;
             }
 
             // Set name for usage in tooltip and in data label.


### PR DESCRIPTION
Fixed #23517, `dataLabels.zIndex` was incorrectly disabled for some series types.

---

_Internal note:_
With this [commit](https://github.com/highcharts/highcharts/commit/8f4dcd0f7be2642161b8ba287ba9b61916731401) in mind, I went with:
- keeping Core lighter is more important than a complex edge case (wrongly used options might give wrong results)
- precise edge case handling only for special series types (those were failing)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211223721280589