### PR TITLE
Fix annotation arrow color to match stroke when fill is unset

### DIFF
--- a/samples/unit-tests/annotations/annotations-shapes/demo.js
+++ b/samples/unit-tests/annotations/annotations-shapes/demo.js
@@ -389,3 +389,75 @@ QUnit.test('Basic shape annotations', function (assert) {
         'Adding annotation with point as series key should not throw an error.'
     );
 });
+
+// #22356 - End marker (arrow) color should follow `stroke` when the user
+// did not explicitly set `fill`, so that the arrow head and the line have
+// matching colors.
+QUnit.test('Arrow marker color follows stroke (#22356)', function (assert) {
+    var chart = Highcharts.chart('container', {
+        chart: {
+            width: 600,
+            height: 400
+        },
+        series: [{
+            data: [1, 2, 3, 4, 5]
+        }],
+        annotations: [{
+            shapes: [{
+                type: 'path',
+                points: [
+                    { x: 0, y: 1, xAxis: 0, yAxis: 0 },
+                    { x: 4, y: 5, xAxis: 0, yAxis: 0 }
+                ],
+                markerEnd: 'arrow',
+                stroke: '#ff0000',
+                strokeWidth: 2
+            }, {
+                type: 'path',
+                points: [
+                    { x: 0, y: 5, xAxis: 0, yAxis: 0 },
+                    { x: 4, y: 1, xAxis: 0, yAxis: 0 }
+                ],
+                markerEnd: 'arrow',
+                stroke: '#00aa00',
+                fill: '#0000ff',
+                strokeWidth: 2
+            }]
+        }]
+    });
+
+    var shapeStrokeOnly = chart.annotations[0].shapes[0],
+        markerStrokeOnly = document.getElementById(
+            shapeStrokeOnly.markerEnd.id
+        ),
+        markerPathStrokeOnly = markerStrokeOnly &&
+            markerStrokeOnly.querySelector('path');
+
+    assert.ok(
+        markerPathStrokeOnly,
+        'Marker path element should exist for stroke-only shape.'
+    );
+    assert.strictEqual(
+        markerPathStrokeOnly.getAttribute('fill'),
+        '#ff0000',
+        'Arrow head fill should follow `stroke` when user did not set `fill`.'
+    );
+    assert.strictEqual(
+        markerPathStrokeOnly.getAttribute('stroke'),
+        '#ff0000',
+        'Arrow head stroke should follow `stroke` when user did not set `fill`.'
+    );
+
+    var shapeWithFill = chart.annotations[0].shapes[1],
+        markerWithFill = document.getElementById(
+            shapeWithFill.markerEnd.id
+        ),
+        markerPathWithFill = markerWithFill &&
+            markerWithFill.querySelector('path');
+
+    assert.strictEqual(
+        markerPathWithFill.getAttribute('fill'),
+        '#0000ff',
+        'Arrow head should still honor explicitly user-set `fill`.'
+    );
+});

--- a/ts/Extensions/Annotations/Controllables/ControllablePath.ts
+++ b/ts/Extensions/Annotations/Controllables/ControllablePath.ts
@@ -424,9 +424,23 @@ class ControllablePath extends Controllable {
             chart = item.chart,
             defs = chart.options.defs,
             fill = itemOptions.fill,
-            color = defined(fill) && fill !== 'none' ?
+            // The marker (e.g. an arrow head) should follow the user-defined
+            // `fill` only when the user actually provided one; otherwise the
+            // default `fill` would override an explicitly set `stroke`,
+            // resulting in a line and arrow head with mismatched colors.
+            // Fall back to `stroke` when `fill` is not user-set or is 'none'.
+            annotationUserOptions: AnyRecord =
+                (item.annotation && item.annotation.userOptions) || {},
+            userShapes = annotationUserOptions.shapes,
+            userShapeOptions =
+                (userShapes && userShapes[item.index]) || {},
+            userBaseShapeOptions =
+                annotationUserOptions.shapeOptions || {},
+            fillIsUserDefined = defined(userShapeOptions.fill) ||
+                defined(userBaseShapeOptions.fill),
+            color = fillIsUserDefined && defined(fill) && fill !== 'none' ?
                 fill :
-                itemOptions.stroke;
+                (itemOptions.stroke || fill);
 
         const setMarker = function (
             markerType: ('markerEnd'|'markerStart')


### PR DESCRIPTION
This pull request addresses an issue where arrow markers (such as arrow heads) in annotation shapes did not match the line color when the `fill` property was not explicitly set by the user. Now, the marker's color defaults to the `stroke` color unless a `fill` is explicitly provided, ensuring visual consistency between the line and its arrow head. The changes also add a unit test to verify this behavior.

**Bugfix: Arrow marker color consistency**
- Updated the logic in `ControllablePath.ts` so that the marker (arrow head) color follows the `stroke` color when the user has not explicitly set a `fill`, preventing mismatched colors between the line and arrow head. If a `fill` is set, it is honored.

**Testing:**
- Added a unit test in `annotations-shapes/demo.js` to verify that the arrow marker's color matches the `stroke` when `fill` is not set, and that it uses the user-provided `fill` when specified.