### PR TITLE
Fixed #24526, gauge axis redraws

### DIFF
--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -2936,7 +2936,7 @@ class Chart {
                 labels.enabled &&
                 axis.series.length &&
                 axis.coll !== 'colorAxis' &&
-                !chart.polar
+                !axis.isRadial // Gauges and polar chart (#24526)
             ) {
 
                 expectedSpace = options.tickLength;


### PR DESCRIPTION
Fixed #24526, a regression causing gauge axis ticks to shift on the first value update at certain sizes