### PR TITLE
grid/deprecated-cleanup-v3

### DIFF
--- a/docs/grid/accessibility.md
+++ b/docs/grid/accessibility.md
@@ -179,8 +179,9 @@ If more detailed control is required, the `accessibility.screenReaderSection.bef
 accessibility: {
     screenReaderSection: {
         beforeGridFormatter: function (grid) {
-            const rowCount = grid.dataTable?.rowCount || 0;
-            const colCount = grid.dataTable?.getColumnIds().length || 0;
+            const dataTable = grid.dataProvider?.getDataTable?.();
+            const rowCount = dataTable?.rowCount || 0;
+            const colCount = dataTable?.getColumnIds().length || 0;
             return `<div>Custom Grid information: ${rowCount} rows, ${colCount} columns</div>`;
         }
     }

--- a/docs/grid/data-handling/clientside.md
+++ b/docs/grid/data-handling/clientside.md
@@ -15,8 +15,8 @@ start with `data.columns`, an existing `data.dataTable`, or
 [`data.connector`](https://www.highcharts.com/docs/grid/data-handling/connectors),
 Grid works with a `DataTable` internally.
 
-For backward compatibility, `grid.dataTable` is still available, but new code
-should use `grid.dataProvider.getDataTable()` instead.
+To access the underlying table in client-side mode, use
+`grid.dataProvider.getDataTable()` when the provider is local.
 
 For a full description of `DataTable`, see the [Dashboards article on
 DataTable](https://www.highcharts.com/docs/dashboards/data-table).

--- a/docs/grid/rows/data.md
+++ b/docs/grid/rows/data.md
@@ -8,8 +8,8 @@ Rows in Highcharts Grid are served by the configured `grid.dataProvider`. Each
 column contributes one value per row, and the row index defines which values
 are grouped together in the current presentation dataset.
 
-For backward compatibility, `grid.dataTable` may still be available with
-`LocalDataProvider`, but new integrations should use `grid.dataProvider`.
+With the default `LocalDataProvider`, access the underlying `DataTable`
+through `grid.dataProvider.getDataTable()` when you need direct table access.
 
 ## Row data in configuration
 

--- a/samples/grid-lite/basic/destroy-grid/demo.js
+++ b/samples/grid-lite/basic/destroy-grid/demo.js
@@ -12,11 +12,13 @@ const options = {
 let grid = Grid.grid('container', options);
 
 document.getElementById('delete-rows-btn').addEventListener('click', () => {
-    if (grid.dataTable) {
-        grid.dataTable.deleteRows(0, 4);
+    const dataTable = grid.dataProvider.getDataTable();
+
+    if (dataTable) {
+        dataTable.deleteRows(0, 4);
         grid.viewport.updateRows();
     }
-    console.log('deleted rows:', grid.dataTable);
+    console.log('deleted rows:', dataTable);
 });
 
 document.getElementById('destroy-grid-btn').addEventListener('click', () => {

--- a/samples/grid-lite/demo/cell-context-menu/demo.js
+++ b/samples/grid-lite/demo/cell-context-menu/demo.js
@@ -61,7 +61,7 @@ function getSourceRowIndex(cell) {
 
 async function addRowBelow(cell) {
     const grid = cell.row.viewport.grid;
-    const dt = grid.dataTable;
+    const dt = grid.dataProvider.getDataTable();
 
     if (!dt) {
         return;
@@ -90,7 +90,7 @@ async function addRowBelow(cell) {
 
 async function addRowAbove(cell) {
     const grid = cell.row.viewport.grid;
-    const dt = grid.dataTable;
+    const dt = grid.dataProvider.getDataTable();
 
     if (!dt) {
         return;
@@ -117,7 +117,7 @@ async function addRowAbove(cell) {
 
 function addColumnLeft(cell) {
     const grid = cell.row.viewport.grid;
-    const dt = grid.dataTable;
+    const dt = grid.dataProvider.getDataTable();
 
     if (!dt) {
         return;
@@ -149,7 +149,7 @@ function addColumnLeft(cell) {
 
 function addColumnRight(cell) {
     const grid = cell.row.viewport.grid;
-    const dt = grid.dataTable;
+    const dt = grid.dataProvider.getDataTable();
 
     if (!dt) {
         return;
@@ -183,7 +183,7 @@ function addColumnRight(cell) {
 
 function deleteRow(cell) {
     const grid = cell.row.viewport.grid;
-    const dt = grid.dataTable;
+    const dt = grid.dataProvider.getDataTable();
 
     if (!dt) {
         return;

--- a/samples/grid-lite/e2e/destroy-grid/demo.js
+++ b/samples/grid-lite/e2e/destroy-grid/demo.js
@@ -12,11 +12,13 @@ const options = {
 const grid = Grid.grid('container', options);
 
 document.getElementById('delete-rows-btn').addEventListener('click', () => {
-    if (grid.dataTable) {
-        grid.dataTable.deleteRows(0, 4);
+    const dataTable = grid.dataProvider.getDataTable();
+
+    if (dataTable) {
+        dataTable.deleteRows(0, 4);
         grid.viewport.updateRows();
     }
-    console.log('deleted rows:', grid.dataTable);
+    console.log('deleted rows:', dataTable);
 });
 
 document.getElementById('destroy-grid-btn').addEventListener('click', () => {

--- a/samples/grid-lite/e2e/row-order-after-add/demo.js
+++ b/samples/grid-lite/e2e/row-order-after-add/demo.js
@@ -17,5 +17,5 @@ const grid = Grid.grid('container', {
 
 document.getElementById('add-row').addEventListener('click', () => {
     const dt = grid.dataProvider.getDataTable();
-    grid.dataTable.setRow([dt.rowCount + 1, 'Oranges', 150, 3.5]);
+    dt.setRow([dt.rowCount + 1, 'Oranges', 150, 3.5]);
 });

--- a/samples/grid-lite/e2e/table-change-querying/demo.js
+++ b/samples/grid-lite/e2e/table-change-querying/demo.js
@@ -16,6 +16,8 @@ const grid = Grid.grid('container', {
 });
 
 document.getElementById('add-row').addEventListener('click', () => {
-    grid.dataTable.setRow([grid.dataTable.rowCount + 1, 'Oranges', 100,  3.5]);
+    const dt = grid.dataProvider.getDataTable();
+
+    dt.setRow([dt.rowCount + 1, 'Oranges', 100,  3.5]);
     grid.viewport.updateRows();
 });

--- a/samples/grid-lite/e2e/update-on-change/demo.js
+++ b/samples/grid-lite/e2e/update-on-change/demo.js
@@ -47,7 +47,7 @@ function attachUpdateRowsCounter(grid, inputEl) {
     };
 
     document.getElementById('auto-set-cell').addEventListener('click', () => {
-        gridAuto.dataTable.setCell('weight', 0, 123);
+        gridAuto.dataProvider.getDataTable().setCell('weight', 0, 123);
     });
 
     document
@@ -63,7 +63,7 @@ function attachUpdateRowsCounter(grid, inputEl) {
         });
 
     document.getElementById('manual-set-cell').addEventListener('click', () => {
-        gridManual.dataTable.setCell('weight', 0, 321);
+        gridManual.dataProvider.getDataTable().setCell('weight', 0, 321);
     });
 
     document

--- a/samples/grid-pro/basic/sparklines/demo.js
+++ b/samples/grid-pro/basic/sparklines/demo.js
@@ -218,7 +218,11 @@ Grid.grid('container', {
             // and then call `loadData` to update the row data.
             ['pieA', 'pieB', 'pieC'].forEach(colId => {
                 const value = Math.round(Math.random() * 100);
-                grid.dataTable.setCell(colId, cell.row.id, value);
+                grid.dataProvider.getDataTable().setCell(
+                    colId,
+                    cell.row.id,
+                    value
+                );
             });
             cell.row.loadData();
 

--- a/samples/grid-pro/demo/generate-charts/demo.js
+++ b/samples/grid-pro/demo/generate-charts/demo.js
@@ -45,7 +45,9 @@ Grid.grid('grid', {
                     }
 
                     // We get the x axis from the Year column
-                    const years = grid.dataTable.getColumn(yearColumnId);
+                    const years = grid.dataProvider
+                        .getDataTable()
+                        .getColumn(yearColumnId);
 
                     // Create chart if it doesn't exist
                     if (!chart) {

--- a/samples/grid-pro/demo/sparklines/demo.js
+++ b/samples/grid-pro/demo/sparklines/demo.js
@@ -401,10 +401,7 @@ async function updateInstanceStatus(rowIndex) {
     // Apply the modifiers to the data table.
     await grid.querying.proceed(true);
 
-    // Matach the data table to the presentation table.
-    grid.viewport.dataTable = grid.presentationTable;
-
-    // Load the data into the columns.
+    // Reload the column caches from the provider's presentation table.
     for (const column of grid.viewport.columns) {
         column.loadData();
     }

--- a/samples/grid-pro/e2e/cell-update-sparkline/demo.js
+++ b/samples/grid-pro/e2e/cell-update-sparkline/demo.js
@@ -26,14 +26,14 @@ const myGrid = Grid.grid('container', {
 });
 
 function getNextId() {
-    const ids = myGrid.dataTable.getColumn('ID');
+    const ids = myGrid.dataProvider.getDataTable().getColumn('ID');
     const nextId = Math.max(...ids) + 1;
     return nextId;
 }
 
 function addRow() {
     const nextId = getNextId();
-    myGrid.dataTable.setRow({ ID: nextId });
+    myGrid.dataProvider.getDataTable().setRow({ ID: nextId });
     myGrid.viewport.updateRows();
 }
 

--- a/test/cypress/grid/integration/grid-pro/accessibility.cy.js
+++ b/test/cypress/grid/integration/grid-pro/accessibility.cy.js
@@ -62,7 +62,7 @@ describe('Screen reader sections.', () => {
                 }
             });
 
-            const dataTable = grid.dataTable;
+            const dataTable = grid.dataProvider.getDataTable();
             const expectedRowCount = dataTable.rowCount;
             const expectedColumnCount = dataTable.getColumnIds().length;
 

--- a/test/cypress/grid/integration/options/multi-column-sorting.cy.js
+++ b/test/cypress/grid/integration/options/multi-column-sorting.cy.js
@@ -17,7 +17,7 @@ describe('Grid multi-column sorting.', () => {
                 'Applied sorting priority'
             ).to.deep.equal(['group', 'score', 'id']);
             expect(
-                grid.presentationTable.columns.id,
+                grid.dataProvider.getDataTable(true).columns.id,
                 'Sorted row order'
             ).to.deep.equal(expectedOrder);
         });

--- a/test/cypress/grid/integration/options/sorting.cy.js
+++ b/test/cypress/grid/integration/options/sorting.cy.js
@@ -9,7 +9,7 @@ describe('Grid sorting.', () => {
 
         cy.window().its('grid').then(grid => {
             expect(
-                grid.presentationTable.columns.price,
+                grid.dataProvider.getDataTable(true).columns.price,
                 'Price column should be sorted.',
             ).to.deep.equal([1.5, 2.53, 4.5, 5]);
         })
@@ -23,7 +23,7 @@ describe('Grid sorting.', () => {
 
         cy.window().its('grid').then(grid => {
             expect(
-                grid.presentationTable.columns.price,
+                grid.dataProvider.getDataTable(true).columns.price,
                 'Weight column should be sorted.',
             ).to.deep.equal([1.5, 2.53, 5, 4.5]);
         })
@@ -36,7 +36,7 @@ describe('Grid sorting.', () => {
 
         cy.window().its('grid').then(grid => {
             expect(
-                grid.presentationTable.columns.price,
+                grid.dataProvider.getDataTable(true).columns.price,
                 'Weight column should be sorted.',
             ).to.deep.equal([1.5, 2.53, 5, 4.5]);
         })
@@ -48,12 +48,15 @@ describe('Grid sorting.', () => {
 
         cy.window().its('grid').then(grid => {
             expect(
-                grid.presentationTable.columns.weight,
+                grid.dataProvider.getDataTable(true).columns.weight,
                 'Weight column should be sorted.',
             ).to.deep.equal([200, 100, 40, 0.5]);
 
             expect(
-                grid.columnOptionsMap.weight.options.sorting.order,
+                grid.columnPolicy
+                    .getIndividualColumnOptions('weight')
+                    .sorting
+                    .order,
                 'Weight column sorting options should be updated.'
             ).to.equal('desc');
         })
@@ -68,7 +71,7 @@ describe('Grid sorting.', () => {
 
         cy.window().its('grid').then(grid => {
             expect(
-                grid.presentationTable.columns.metaData,
+                grid.dataProvider.getDataTable(true).columns.metaData,
                 'Icon column should be sorted.',
             ).to.deep.equal(['a', 'd', 'b', 'c']);
         })
@@ -93,7 +96,7 @@ describe('Grid sorting.', () => {
             ).to.equal('Pears');
 
             expect(
-                grid.presentationTable.columns.weight,
+                grid.dataProvider.getDataTable(true).columns.weight,
                 'Weight column should be sorted.',
             ).to.deep.equal([0.5, 100, 200, 40000]);
         });

--- a/test/cypress/grid/integration/options/virtualization-threshold.cy.js
+++ b/test/cypress/grid/integration/options/virtualization-threshold.cy.js
@@ -13,7 +13,11 @@ describe('Grid rows virtualizaion threshold', () => {
             await grid.update({
                 data: {
                     columns: {
-                        Data: grid.dataTable.columns.Data.slice(0, 40)
+                        Data: grid.dataProvider
+                            .getDataTable()
+                            .columns
+                            .Data
+                            .slice(0, 40)
                     }
                 }
             });

--- a/test/ts-node-unit-tests/tests/Grid/Pro/TreeView/TreeProjectionController.test.ts
+++ b/test/ts-node-unit-tests/tests/Grid/Pro/TreeView/TreeProjectionController.test.ts
@@ -63,7 +63,7 @@ describe('TreeProjectionController', () => {
         );
 
         deepStrictEqual(
-            grid.presentationTable.columns.id,
+            (grid.dataProvider as any).getDataTable(true).columns.id,
             [3, 1, 2],
             'Tree projection should order roots by the default descending sort.'
         );
@@ -92,7 +92,7 @@ describe('TreeProjectionController', () => {
         );
 
         deepStrictEqual(
-            grid.presentationTable.columns.id,
+            (grid.dataProvider as any).getDataTable(true).columns.id,
             [1, 2, 3],
             'Tree projection should preserve root order defined by custom compare.'
         );

--- a/tests/grid/grid-pro/accessibility.spec.ts
+++ b/tests/grid/grid-pro/accessibility.spec.ts
@@ -101,7 +101,7 @@ test.describe('Screen reader sections', () => {
                 }
             });
 
-            const dataTable = grid.dataTable;
+            const dataTable = grid.dataProvider.getDataTable();
             const expectedRowCount = dataTable.rowCount;
             const expectedColumnCount = dataTable.getColumnIds().length;
 
@@ -125,4 +125,3 @@ test.describe('Screen reader sections', () => {
         await expect(page.locator('[id^="grid-screen-reader-region-after-"]')).toBeHidden();
     });
 });
-

--- a/tests/grid/shared/options/multi-column-sorting.spec.ts
+++ b/tests/grid/shared/options/multi-column-sorting.spec.ts
@@ -47,7 +47,7 @@ test.describe('Grid multi-column sorting', () => {
             const sortings = grid.querying.sorting.currentSortings || [];
             return {
                 columnIds: sortings.map((sorting: any) => sorting.columnId),
-                rowOrder: grid.presentationTable.columns.id
+                rowOrder: grid.dataProvider.getDataTable(true).columns.id
             };
         });
 

--- a/tests/grid/shared/options/sorting.spec.ts
+++ b/tests/grid/shared/options/sorting.spec.ts
@@ -27,7 +27,7 @@ test.describe('Grid sorting', () => {
 
         const priceData = await page.evaluate(() => {
             const grid = (window as any).grid;
-            return grid.presentationTable.columns.price;
+            return grid.dataProvider.getDataTable(true).columns.price;
         });
         expect(priceData, 'Price column should be sorted.').toEqual([1.5, 2.53, 4.5, 5]);
 
@@ -40,7 +40,7 @@ test.describe('Grid sorting', () => {
 
         const priceData = await page.evaluate(() => {
             const grid = (window as any).grid;
-            return grid.presentationTable.columns.price;
+            return grid.dataProvider.getDataTable(true).columns.price;
         });
         expect(priceData, 'Weight column should be sorted.').toEqual([1.5, 2.53, 5, 4.5]);
 
@@ -54,7 +54,7 @@ test.describe('Grid sorting', () => {
 
         const priceData = await page.evaluate(() => {
             const grid = (window as any).grid;
-            return grid.presentationTable.columns.price;
+            return grid.dataProvider.getDataTable(true).columns.price;
         });
 
         expect(priceData, 'Weight column should be sorted.').toEqual([1.5, 2.53, 5, 4.5]);
@@ -67,8 +67,11 @@ test.describe('Grid sorting', () => {
         const result = await page.evaluate(() => {
             const grid = (window as any).grid;
             return {
-                weightData: grid.presentationTable.columns.weight,
-                order: grid.columnOptionsMap.weight.options.sorting.order
+                weightData: grid.dataProvider.getDataTable(true).columns.weight,
+                order: grid.columnPolicy
+                    .getIndividualColumnOptions('weight')
+                    .sorting
+                    .order
             };
         });
         expect(result.weightData, 'Weight column should be sorted.').toEqual([200, 100, 40, 0.5]);
@@ -84,7 +87,7 @@ test.describe('Grid sorting', () => {
 
         const metaData = await page.evaluate(() => {
             const grid = (window as any).grid;
-            return grid.presentationTable.columns.metaData;
+            return grid.dataProvider.getDataTable(true).columns.metaData;
         });
         expect(metaData, 'Icon column should be sorted.').toEqual(['a', 'd', 'b', 'c']);
 
@@ -377,7 +380,7 @@ test.describe('Grid sorting', () => {
             const lastRow = rows[rows.length - 1];
             return {
                 lastRowValue: lastRow.cells[0].value,
-                weightData: grid.presentationTable.columns.weight
+                weightData: grid.dataProvider.getDataTable(true).columns.weight
             };
         });
 

--- a/tests/grid/shared/options/virtualization-threshold.spec.ts
+++ b/tests/grid/shared/options/virtualization-threshold.spec.ts
@@ -20,7 +20,11 @@ test.describe('Grid rows virtualizaion threshold', () => {
             await grid.update({
                 data: {
                     columns: {
-                        Data: grid.dataTable.columns.Data.slice(0, 40)
+                        Data: grid.dataProvider
+                            .getDataTable()
+                            .columns
+                            .Data
+                            .slice(0, 40)
                     }
                 }
             });
@@ -48,4 +52,3 @@ test.describe('Grid rows virtualizaion threshold', () => {
         expect(result.afterManual).toBe(true);
     });
 });
-

--- a/ts/Dashboards/Components/GridComponent/GridComponent.ts
+++ b/ts/Dashboards/Components/GridComponent/GridComponent.ts
@@ -24,12 +24,16 @@ import type Board from '../../Board';
 import type Cell from '../../Layout/Cell';
 import type { Grid, GridNamespace } from '../../Plugins/GridTypes';
 import type { Options } from './GridComponentOptions';
+import type DataTable from '../../../Data/DataTable';
 
 import type { EventTypes as ComponentEventTypes } from '../Component';
 
 import Component from '../Component.js';
 import GridSyncs from './GridSyncs/GridSyncs.js';
 import GridComponentDefaults from './GridComponentDefaults.js';
+import {
+    hasDataTableProvider
+} from '../../../Grid/Core/Data/DataProvider.js';
 import DU from '../../Utilities.js';
 import SidebarPopup from '../../EditMode/SidebarPopup';
 import { diffObjects, getStyle, merge } from '../../../Shared/Utilities.js';
@@ -120,14 +124,14 @@ class GridComponent extends Component {
         const grid = this.grid;
 
         if (grid) {
-            grid.update(
+            await grid.update(
                 options.gridOptions,
                 false
             );
 
             const table = this.getDataTable();
 
-            if (table && grid.viewport?.dataTable?.id !== table.id) {
+            if (table && this.getGridDataTable(true)?.id !== table.id) {
                 grid.update({
                     dataTable: table?.getModified()
                 }, false);
@@ -202,7 +206,7 @@ class GridComponent extends Component {
 
         if (
             !grid?.dataProvider ||
-            !('getDataTable' in grid.dataProvider) ||
+            !hasDataTableProvider(grid.dataProvider) ||
             !this.connectorHandlers?.length
         ) {
             return;
@@ -223,11 +227,14 @@ class GridComponent extends Component {
             // have not changed, we can just update the rows (more efficient).
 
             const newColumnIds = dataTable.getColumnIds();
-            const { columnOptionsMap, enabledColumns } = grid;
+            const { enabledColumns, columnPolicy } = grid;
 
             let index = 0;
             for (const newColumn of newColumnIds) {
-                if (columnOptionsMap[newColumn]?.options?.enabled === false) {
+                if (
+                    columnPolicy.getIndividualColumnOptions(newColumn)
+                        ?.enabled === false
+                ) {
                     continue;
                 }
 
@@ -247,7 +254,7 @@ class GridComponent extends Component {
             }
         }
 
-        if (grid.dataProvider.getDataTable() !== dataTable) {
+        if (this.getGridDataTable() !== dataTable) {
             void grid.update({
                 data: {
                     providerType: 'local',
@@ -286,11 +293,14 @@ class GridComponent extends Component {
             // have not changed, we can just update the rows (more efficient).
 
             const newColumnIds = dataTable.getColumnIds();
-            const { columnOptionsMap, enabledColumns } = grid;
+            const { enabledColumns, columnPolicy } = grid;
 
             let index = 0;
             for (const newColumn of newColumnIds) {
-                if (columnOptionsMap[newColumn]?.options?.enabled === false) {
+                if (
+                    columnPolicy.getIndividualColumnOptions(newColumn)
+                        ?.enabled === false
+                ) {
                     continue;
                 }
 
@@ -306,7 +316,8 @@ class GridComponent extends Component {
         }
 
         // Workaround for legacy Grid component.
-        (grid as { dataTable: typeof dataTable }).dataTable = dataTable;
+        (grid as unknown as { dataTable: typeof dataTable }).dataTable =
+            dataTable;
 
         // Data has changed and the whole grid is not re-rendered, so mark in
         // the querying that data table was modified.
@@ -402,6 +413,14 @@ class GridComponent extends Component {
         if (gridID) {
             this.contentElement.id = gridID;
         }
+    }
+
+    private getGridDataTable(presentation = false): DataTable | undefined {
+        const dataProvider = this.grid?.dataProvider;
+
+        return hasDataTableProvider(dataProvider) ?
+            dataProvider.getDataTable(presentation) :
+            void 0;
     }
 
     /**

--- a/ts/Dashboards/Components/GridComponent/GridComponent.ts
+++ b/ts/Dashboards/Components/GridComponent/GridComponent.ts
@@ -31,9 +31,7 @@ import type { EventTypes as ComponentEventTypes } from '../Component';
 import Component from '../Component.js';
 import GridSyncs from './GridSyncs/GridSyncs.js';
 import GridComponentDefaults from './GridComponentDefaults.js';
-import {
-    hasDataTableProvider
-} from '../../../Grid/Core/Data/DataProvider.js';
+import { hasDataTableProvider } from './GridDataProvider.js';
 import DU from '../../Utilities.js';
 import SidebarPopup from '../../EditMode/SidebarPopup';
 import { diffObjects, getStyle, merge } from '../../../Shared/Utilities.js';
@@ -124,7 +122,7 @@ class GridComponent extends Component {
         const grid = this.grid;
 
         if (grid) {
-            await grid.update(
+            grid.update(
                 options.gridOptions,
                 false
             );

--- a/ts/Dashboards/Components/GridComponent/GridDataProvider.ts
+++ b/ts/Dashboards/Components/GridComponent/GridDataProvider.ts
@@ -1,0 +1,55 @@
+/* *
+ *
+ *  (c) 2009-2026 Highsoft AS
+ *
+ *  A commercial license may be required depending on use.
+ *  See www.highcharts.com/license
+ * */
+
+'use strict';
+
+/* *
+ *
+ *  Imports
+ *
+ * */
+
+import type DataTable from '../../../Data/DataTable';
+
+/* *
+ *
+ *  Declarations
+ *
+ * */
+
+export interface DataTableProvider {
+    getDataTable(presentation?: boolean): DataTable | undefined;
+}
+
+/* *
+ *
+ *  Functions
+ *
+ * */
+
+/**
+ * Returns whether the provider exposes `getDataTable`.
+ *
+ * @param provider
+ * Data provider instance to test.
+ *
+ * @returns
+ * `true` when provider exposes `getDataTable`.
+ */
+export function hasDataTableProvider(
+    provider: unknown
+): provider is DataTableProvider {
+    return !!(
+        provider &&
+        typeof (
+            provider as {
+                getDataTable?: unknown;
+            }
+        ).getDataTable === 'function'
+    );
+}

--- a/ts/Dashboards/Components/GridComponent/GridSyncs/GridExtremesSync.ts
+++ b/ts/Dashboards/Components/GridComponent/GridSyncs/GridExtremesSync.ts
@@ -25,9 +25,7 @@ import type { Event as DataCursorEvent } from '../../../../Data/DataCursor';
 import type GridComponent from '../GridComponent.js';
 
 import Component from '../../Component';
-import {
-    hasDataTableProvider
-} from '../../../../Grid/Core/Data/DataProvider.js';
+import { hasDataTableProvider } from '../GridDataProvider.js';
 
 /* *
  *

--- a/ts/Dashboards/Components/GridComponent/GridSyncs/GridExtremesSync.ts
+++ b/ts/Dashboards/Components/GridComponent/GridSyncs/GridExtremesSync.ts
@@ -25,6 +25,9 @@ import type { Event as DataCursorEvent } from '../../../../Data/DataCursor';
 import type GridComponent from '../GridComponent.js';
 
 import Component from '../../Component';
+import {
+    hasDataTableProvider
+} from '../../../../Grid/Core/Data/DataProvider.js';
 
 /* *
  *
@@ -57,8 +60,10 @@ const syncPair: SyncPair = {
                 typeof cursor?.row === 'number'
             ) {
                 const { row } = cursor;
-                const { viewport } = component.grid;
-                const rowIndex = viewport?.dataTable?.getLocalRowIndex(row);
+                const dataProvider = component.grid.dataProvider;
+                const rowIndex = hasDataTableProvider(dataProvider) ?
+                    dataProvider.getDataTable(true)?.getLocalRowIndex(row) :
+                    void 0;
 
                 if (rowIndex !== void 0) {
                     component.grid.viewport?.scrollToRow(rowIndex);

--- a/ts/Dashboards/Components/GridComponent/GridSyncs/GridHighlightSync.ts
+++ b/ts/Dashboards/Components/GridComponent/GridSyncs/GridHighlightSync.ts
@@ -27,6 +27,9 @@ import type { GridHighlightSyncOptions } from '../GridComponentOptions';
 import type { TableCellEvent } from '../../../Plugins/GridTypes';
 
 import Component from '../../Component';
+import {
+    hasDataTableProvider
+} from '../../../../Grid/Core/Data/DataProvider.js';
 import { addEvent, removeEvent } from '../../../../Shared/Utilities.js';
 
 /* *
@@ -59,13 +62,17 @@ const syncPair: SyncPair = {
 
         const { dataCursor: cursor } = board;
         const table = this.getDataTable();
+        const dataProvider = grid.dataProvider;
+        const presentationTable = hasDataTableProvider(dataProvider) ?
+            dataProvider.getDataTable(true) :
+            void 0;
 
         const onCellHover = (e: TableCellEvent): void => {
             if (table) {
                 const cell = e.target;
                 const localIndex = cell.row.index;
                 const originalIndex =
-                    grid.viewport?.dataTable?.getOriginalRowIndex(localIndex);
+                    presentationTable?.getOriginalRowIndex(localIndex);
                 if (typeof originalIndex !== 'number') {
                     return;
                 }
@@ -85,7 +92,7 @@ const syncPair: SyncPair = {
                 const cell = e.target;
                 const localIndex = cell.row.index;
                 const originalIndex =
-                    grid.viewport?.dataTable?.getOriginalRowIndex(localIndex);
+                    presentationTable?.getOriginalRowIndex(localIndex);
                 if (typeof originalIndex !== 'number') {
                     return;
                 }
@@ -149,12 +156,16 @@ const syncPair: SyncPair = {
             const { row, column } = cursor;
             const { grid } = component;
             const viewport = grid?.viewport;
+            const dataProvider = grid?.dataProvider;
+            const presentationTable = hasDataTableProvider(dataProvider) ?
+                dataProvider.getDataTable(true) :
+                void 0;
 
             if (row === void 0 || !viewport) {
                 return;
             }
 
-            const rowIndex = viewport.dataTable?.getLocalRowIndex(row);
+            const rowIndex = presentationTable?.getLocalRowIndex(row);
 
             if (rowIndex === void 0) {
                 return;

--- a/ts/Dashboards/Components/GridComponent/GridSyncs/GridHighlightSync.ts
+++ b/ts/Dashboards/Components/GridComponent/GridSyncs/GridHighlightSync.ts
@@ -27,9 +27,7 @@ import type { GridHighlightSyncOptions } from '../GridComponentOptions';
 import type { TableCellEvent } from '../../../Plugins/GridTypes';
 
 import Component from '../../Component';
-import {
-    hasDataTableProvider
-} from '../../../../Grid/Core/Data/DataProvider.js';
+import { hasDataTableProvider } from '../GridDataProvider.js';
 import { addEvent, removeEvent } from '../../../../Shared/Utilities.js';
 
 /* *

--- a/ts/Grid/Core/Accessibility/Accessibility.ts
+++ b/ts/Grid/Core/Accessibility/Accessibility.ts
@@ -27,6 +27,9 @@ import type Grid from '../Grid';
 import type { ColumnSortingOrder, FilteringCondition } from '../Options';
 import whcm from '../../../Accessibility/HighContrastMode.js';
 
+import {
+    hasDataTableProvider
+} from '../Data/DataProvider.js';
 import Globals from '../Globals.js';
 import ColumnFiltering from '../Table/Actions/ColumnFiltering/ColumnFiltering.js';
 import GridUtils from '../GridUtils.js';
@@ -431,7 +434,7 @@ class Accessibility {
      */
     private defaultBeforeFormatter(): string {
         const grid = this.grid;
-        const { container, dataTable, options } = grid;
+        const { container, options } = grid;
         const format =
             options?.accessibility?.screenReaderSection?.beforeGridFormat;
 
@@ -452,6 +455,9 @@ class Accessibility {
             }
         }
 
+        const dataTable = hasDataTableProvider(grid.dataProvider) ?
+            grid.dataProvider.getDataTable() :
+            void 0;
         const context = {
             gridTitle: formattedGridTitle,
             gridDescription: options?.description?.text || '',

--- a/ts/Grid/Core/ColumnPolicyResolver.ts
+++ b/ts/Grid/Core/ColumnPolicyResolver.ts
@@ -265,9 +265,7 @@ class ColumnPolicyResolver {
         const defaultSortingOptions = this.columnDefaults.sorting;
         const sortingEnabled = (
             sortingOptions?.enabled ??
-            sortingOptions?.sortable ??
-            defaultSortingOptions?.enabled ??
-            defaultSortingOptions?.sortable
+            defaultSortingOptions?.enabled
         );
         return !this.isColumnUnbound(columnId) &&
             !!sortingEnabled;

--- a/ts/Grid/Core/Data/DataProvider.ts
+++ b/ts/Grid/Core/Data/DataProvider.ts
@@ -22,6 +22,7 @@
  *
  * */
 
+import type DataTable from '../../../Data/DataTable';
 import type {
     RowObject as RowObjectType,
     CellType as DataTableCellType,
@@ -207,6 +208,35 @@ export abstract class DataProvider {
  * A type for the row ID.
  */
 export type RowId = number | string;
+
+/**
+ * A data provider that can expose the underlying data table.
+ */
+export interface DataTableProvider extends DataProvider {
+    getDataTable(presentation?: boolean): DataTable | undefined;
+}
+
+/**
+ * Returns whether the provider exposes `getDataTable`.
+ *
+ * @param provider
+ * Data provider instance to test.
+ *
+ * @returns
+ * `true` when provider exposes `getDataTable`.
+ */
+export function hasDataTableProvider(
+    provider: unknown
+): provider is DataTableProvider {
+    return !!(
+        provider &&
+        typeof (
+            provider as {
+                getDataTable?: unknown;
+            }
+        ).getDataTable === 'function'
+    );
+}
 
 /**
  * A base interface for the data provider options (`grid.options.data`).

--- a/ts/Grid/Core/Grid.ts
+++ b/ts/Grid/Core/Grid.ts
@@ -32,12 +32,8 @@ import type {
 } from './Options';
 import type { RowId } from './Data/DataProvider';
 import type { DataProviderType } from './Data/DataProviderType';
-import type {
-    CellType as DataTableCellType,
-    Column as DataTableColumn
-} from '../../Data/DataTable';
 import type Column from './Table/Column';
-import type { ColumnDataType, NoIdColumnOptions } from './Table/Column';
+import type { NoIdColumnOptions } from './Table/Column';
 import type Popup from './UI/Popup.js';
 import type { DeepPartial } from '../../Shared/Types';
 
@@ -60,7 +56,6 @@ import Globals from './Globals.js';
 import TimeBase from '../../Shared/TimeBase.js';
 import Pagination from './Pagination/Pagination.js';
 import {
-    defined,
     diffObjects,
     extend,
     fireEvent,
@@ -180,16 +175,6 @@ export class Grid {
      */
     public readonly columnPolicy: ColumnPolicyResolver =
         new ColumnPolicyResolver();
-
-    /**
-     * Backward-compatible access to column options map.
-     *
-     * @deprecated
-     * Use `columnPolicy` methods instead.
-     */
-    public get columnOptionsMap(): Record<string, ColumnOptionsMapItemLike> {
-        return this.columnPolicy.columnOptionsMap;
-    }
 
     /**
      * The container of the grid.
@@ -384,33 +369,6 @@ export class Grid {
      *
      * */
 
-    /**
-     * The data source of the Grid. It contains the original data table
-     * that was passed to the Grid.
-     *
-     * @deprecated Use `dataProvider` instead.
-     */
-    public get dataTable(): DataTable | undefined {
-        const dp = this.dataProvider;
-        if (dp && 'getDataTable' in dp) {
-            return dp.getDataTable();
-        }
-    }
-
-    /**
-     * The presentation table of the Grid. It contains a modified version
-     * of the data table that is used for rendering the Grid content. If
-     * not modified, just a reference to the original data table.
-     *
-     * @deprecated Use `dataProvider` instead.
-     */
-    public get presentationTable(): DataTable | undefined {
-        const dp = this.dataProvider;
-        if (dp && 'getDataTable' in dp) {
-            return dp.getDataTable(true);
-        }
-    }
-
     /*
      * Initializes the accessibility controller.
      */
@@ -465,7 +423,7 @@ export class Grid {
 
     /**
      * Loads the new user options to all the important fields (`userOptions`,
-     * `options` and `columnOptionsMap`).
+     * `options` and column policy state).
      *
      * @param newOptions
      * The options that were declared by the user.
@@ -755,7 +713,7 @@ export class Grid {
                 ('data' in diff) ||
                 ('dataTable' in diff)
             ) {
-                if ( // Handle backward compatibility
+                if ( // Preserve legacy root-level `dataTable` option
                     diff.dataTable &&
                     this.options?.dataTable &&
                     this.options?.data?.providerType === 'local'
@@ -1561,7 +1519,7 @@ export class Grid {
             dataTable: userDT ?? {}
         };
 
-        // Just for the backward compatibility, remove in the future
+        // Preserve legacy root-level `dataTable` option for now.
         if (
             dataOptions.providerType === 'local' &&
             !dataOptions.dataTable && userDT
@@ -1569,7 +1527,6 @@ export class Grid {
             dataOptions.dataTable = 'clone' in userDT ?
                 userDT : new DataTable(userDT);
         }
-        // End of backward compatibility snippet
 
         const DataProviderConstructor =
             DataProviderRegistry.types[dataOptions.providerType ?? 'local'] ??
@@ -1711,85 +1668,6 @@ export class Grid {
     public hideLoading(): void {
         this.loadingWrapper?.remove();
         delete this.loadingWrapper;
-    }
-
-    /**
-     * Returns the grid data as a JSON string.
-     *
-     * **Note:** This method only works with `LocalDataProvider`.
-     * For other data providers, use your data source directly.
-     *
-     * @deprecated
-     *
-     * @param modified
-     * Whether to return the modified data table (after filtering/sorting/etc.)
-     * or the unmodified, original one. Default value is set to `true`.
-     *
-     * @return
-     * JSON representation of the data
-     */
-    public getData(modified: boolean = true): string {
-        if (!this.dataProvider || !('getDataTable' in this.dataProvider)) {
-            // eslint-disable-next-line no-console
-            console.warn('getData() works only with LocalDataProvider.');
-            return JSON.stringify({
-                error: 'getData() works only with LocalDataProvider.'
-            }, null, 2);
-        }
-
-        const dataTable = this.dataProvider.getDataTable(modified);
-        const tableColumns = dataTable?.columns;
-        const outputColumns: Record<string, DataTableColumn> = {};
-
-        if (!this.enabledColumns || !tableColumns) {
-            return '{}';
-        }
-
-        const typeParser = (type: ColumnDataType) => {
-            const TypeMap: Record<
-                ColumnDataType,
-                (value: DataTableCellType) => DataTableCellType
-            > = {
-                number: Number,
-                datetime: Number,
-                string: String,
-                'boolean': Boolean
-            };
-
-            return (value: DataTableCellType): DataTableCellType | null => (
-                defined(value) ? TypeMap[type](value) : null
-            );
-        };
-
-        for (const columnId of this.enabledColumns) {
-            const column = this.viewport?.getColumn(columnId);
-            const sourceColumnId =
-                this.columnPolicy.getColumnSourceId(columnId);
-
-            if (
-                !column ||
-                !sourceColumnId ||
-                !this.columnPolicy.isColumnExportable(columnId)
-            ) {
-                continue;
-            }
-
-            const columnData = tableColumns[sourceColumnId];
-            if (!columnData) {
-                continue;
-            }
-
-            const parser = typeParser(column.dataType);
-            outputColumns[columnId] = ((): DataTableColumn => {
-                const result = [];
-                for (let i = 0, iEnd = columnData.length; i < iEnd; ++i) {
-                    result.push(parser(columnData[i]));
-                }
-                return result;
-            })();
-        }
-
-        return JSON.stringify(outputColumns, null, 2);
     }
 
     /**

--- a/ts/Grid/Core/Options.ts
+++ b/ts/Grid/Core/Options.ts
@@ -673,12 +673,6 @@ export interface ColumnSortingOptions {
     enabled?: boolean;
 
     /**
-     * @deprecated
-     * Use `enabled` instead
-     */
-    sortable?: boolean;
-
-    /**
      * Sequence of sorting orders used when toggling sorting from the user
      * interface (for example by clicking the column header).
      *

--- a/ts/Grid/Core/Querying/PaginationController.ts
+++ b/ts/Grid/Core/Querying/PaginationController.ts
@@ -21,6 +21,9 @@
  *
  * */
 
+import {
+    hasDataTableProvider
+} from '../Data/DataProvider.js';
 import QueryingController from './QueryingController.js';
 import RangeModifier from '../../../Data/Modifiers/RangeModifier.js';
 
@@ -181,7 +184,9 @@ class PaginationController {
      */
     public createModifier(
         rowsCountBeforePagination: number = (
-            this.querying.grid.dataTable?.rowCount || 0
+            hasDataTableProvider(this.querying.grid.dataProvider) ?
+                this.querying.grid.dataProvider.getDataTable()?.rowCount || 0 :
+                0
         )
     ): RangeModifier | undefined {
         if (!this.enabled) {

--- a/ts/Grid/Core/Table/Column.ts
+++ b/ts/Grid/Core/Table/Column.ts
@@ -33,6 +33,9 @@ import type {
     Column as DataTableColumn
 } from '../../../Data/DataTable';
 
+import {
+    hasDataTableProvider
+} from '../Data/DataProvider.js';
 import Table from './Table.js';
 import ColumnSorting from './Actions/ColumnSorting';
 import ColumnFiltering from './Actions/ColumnFiltering/ColumnFiltering.js';
@@ -196,7 +199,7 @@ export class Column {
         const isUnbound = grid.columnPolicy.isColumnUnbound(this.id);
 
         if (
-            dp && 'getDataTable' in dp &&
+            hasDataTableProvider(dp) &&
             sourceColumnId && !isUnbound
         ) {
             this.data = dp.getDataTable(true)?.getColumn(

--- a/ts/Grid/Core/Table/Table.ts
+++ b/ts/Grid/Core/Table/Table.ts
@@ -22,8 +22,6 @@
  *
  * */
 
-import type DataTable from '../../../Data/DataTable';
-import type DataProvider from '../Data/DataProvider';
 import type TableCell from './Body/TableCell';
 import type { RowId } from '../Data/DataProvider';
 
@@ -230,22 +228,6 @@ class Table {
     *  Methods
     *
     * */
-
-    /**
-     * The presentation version of the data table. It has applied modifiers
-     * and is ready to be rendered.
-     *
-     * @deprecated Use `grid.dataProvider` instead.
-     */
-    public get dataTable(): DataTable | undefined {
-        const dp = this.grid.dataProvider as (
-            DataProvider & {
-                getDataTable?(presentation?: boolean): DataTable | undefined;
-            }
-        ) | undefined;
-
-        return dp?.getDataTable?.(true);
-    }
 
     /**
      * Initializes the table. Should be called after creation so that the table

--- a/ts/Grid/Pro/Export/Exporting.ts
+++ b/ts/Grid/Pro/Export/Exporting.ts
@@ -23,9 +23,16 @@
 
 import type Grid from '../../Core/Grid';
 import type { ExportingOptions } from '../../Core/Options';
-import type { CellType as DataTableCellType } from '../../../Data/DataTable';
+import type DataTable from '../../../Data/DataTable';
+import type {
+    CellType as DataTableCellType,
+    Column as DataTableColumn
+} from '../../../Data/DataTable';
 import type { ColumnDataType } from '../../Core/Table/Column';
 
+import {
+    hasDataTableProvider
+} from '../../Core/Data/DataProvider.js';
 import {
     downloadURL,
     getBlobFromContent
@@ -137,7 +144,7 @@ class Exporting {
      */
     public getCSV(modified: boolean = true): string {
         const { grid } = this;
-        const dataTable = modified ? grid.presentationTable : grid.dataTable;
+        const dataTable = this.getDataTable(modified);
 
         if (!dataTable) {
             return '';
@@ -257,7 +264,67 @@ class Exporting {
      * JSON representation of the data
      */
     public getJSON(modified: boolean = true): string {
-        return this.grid.getData(modified);
+        const dataTable = this.getDataTable(modified);
+        const tableColumns = dataTable?.columns;
+        const outputColumns: Record<string, DataTableColumn> = {};
+
+        if (!dataTable) {
+            // eslint-disable-next-line no-console
+            console.warn('getJSON() works only with LocalDataProvider.');
+            return JSON.stringify({
+                error: 'getJSON() works only with LocalDataProvider.'
+            }, null, 2);
+        }
+
+        if (!this.grid.enabledColumns || !tableColumns) {
+            return '{}';
+        }
+
+        const typeParser = (type: ColumnDataType) => {
+            const TypeMap: Record<
+                ColumnDataType,
+                (value: DataTableCellType) => DataTableCellType
+            > = {
+                number: Number,
+                datetime: Number,
+                string: String,
+                'boolean': Boolean
+            };
+
+            return (value: DataTableCellType): DataTableCellType | null => (
+                defined(value) ? TypeMap[type](value) : null
+            );
+        };
+
+        for (const columnId of this.grid.enabledColumns) {
+            const column = this.grid.viewport?.getColumn(columnId);
+            const sourceColumnId =
+                this.grid.columnPolicy.getColumnSourceId(columnId);
+
+            if (
+                !column ||
+                !sourceColumnId ||
+                !this.grid.columnPolicy.isColumnExportable(columnId)
+            ) {
+                continue;
+            }
+
+            const columnData = tableColumns[sourceColumnId];
+            if (!columnData) {
+                continue;
+            }
+
+            const parser = typeParser(column.dataType);
+            outputColumns[columnId] = ((): DataTableColumn => {
+                const result = [];
+                for (let i = 0, iEnd = columnData.length; i < iEnd; ++i) {
+                    result.push(parser(columnData[i]));
+                }
+                return result;
+            })();
+        }
+
+        return JSON.stringify(outputColumns, null, 2);
     }
 
     /**
@@ -286,6 +353,14 @@ class Exporting {
         }
 
         return filename;
+    }
+
+    private getDataTable(modified: boolean): DataTable | undefined {
+        const { dataProvider } = this.grid;
+
+        return hasDataTableProvider(dataProvider) ?
+            dataProvider.getDataTable(modified) :
+            void 0;
     }
 }
 

--- a/ts/Grid/Pro/RowPinning/RowPinningController.ts
+++ b/ts/Grid/Pro/RowPinning/RowPinningController.ts
@@ -31,6 +31,9 @@ import type {
 } from '../../../Data/DataTable';
 import type { RowId as DataProviderRowId } from '../../Core/Data/DataProvider';
 
+import {
+    hasDataTableProvider
+} from '../../Core/Data/DataProvider.js';
 import { formatText } from '../../Core/GridUtils.js';
 import {
     erase,
@@ -613,7 +616,10 @@ class RowPinningController {
             });
         }
 
-        const dataTable = this.grid.dataTable;
+        const dataProvider = this.grid.dataProvider;
+        const dataTable = hasDataTableProvider(dataProvider) ?
+            dataProvider.getDataTable() :
+            void 0;
         const dataOptions = this.grid.options?.data as (
             { idColumn?: string } | undefined
         );

--- a/ts/Grid/Pro/TreeView/TreeProjectionController.ts
+++ b/ts/Grid/Pro/TreeView/TreeProjectionController.ts
@@ -48,6 +48,9 @@ import {
     buildIndexFromColumns as buildParentIdIndexFromColumns
 } from './InputAdapters/ParentIdTreeInputAdapter.js';
 import {
+    hasDataTableProvider
+} from '../../Core/Data/DataProvider.js';
+import {
     normalizeTreeViewOptions
 } from './TreeViewOptionsNormalizer.js';
 import { defined, fireEvent } from '../../../Shared/Utilities.js';
@@ -125,7 +128,7 @@ class TreeProjectionController {
         }
 
         const dataProvider = this.grid.dataProvider;
-        if (!TreeProjectionController.hasGetDataTable(dataProvider)) {
+        if (!hasDataTableProvider(dataProvider)) {
             // Remote provider runtime support is intentionally deferred.
             this.clearCache();
             return;
@@ -1158,29 +1161,6 @@ class TreeProjectionController {
         );
     }
 
-    /**
-     * Runtime type guard for providers exposing `getDataTable`.
-     *
-     * @param provider
-     * Data provider instance to test.
-     *
-     * @returns
-     * `true` when provider exposes `getDataTable`.
-     */
-    private static hasGetDataTable(
-        provider: unknown
-    ): provider is {
-        getDataTable: (presentation?: boolean) => DataTable | undefined;
-    } {
-        return !!(
-            provider &&
-            typeof (
-                provider as {
-                    getDataTable?: unknown;
-                }
-            ).getDataTable === 'function'
-        );
-    }
 }
 
 


### PR DESCRIPTION
Cleaned up deprecated methods and options (details in the upgrade note).

#### Upgrade note

- Replaced uses of `grid.dataTable` and `grid.presentationTable` with `grid.dataProvider.getDataTable()`.
- Replaced uses of `grid.columnOptionsMap` with `grid.columnPolicy` methods.
- Replaced `sorting.sortable` with `sorting.enabled`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212488293657461