### PR TITLE
bugfix/24495-broken-tooltip-showdelay-api

### DIFF
--- a/ts/Core/Axis/AxisDefaults.ts
+++ b/ts/Core/Axis/AxisDefaults.ts
@@ -425,10 +425,11 @@ namespace AxisDefaults {
          * the mouse is over a point. Works on initial hover.
          *
          * @sample {highcharts|highstock} highcharts/tooltip/showdelay/
+         *         Show crosshair after 2 seconds
          *
          * @type      {number}
          * @default   0
-         * @since     next
+         * @since     12.6.0
          * @apioption xAxis.crosshair.showDelay
          */
 

--- a/ts/Core/Axis/AxisOptions.ts
+++ b/ts/Core/Axis/AxisOptions.ts
@@ -269,9 +269,10 @@ export interface AxisCrosshairOptions {
     * mouse over a point. Works on initial hover.
     *
     * @sample {highcharts|highstock} highcharts/tooltip/showdelay/
+    *         Show crosshair after 2 seconds
     *
     * @default 0
-    * @since next
+    * @since 12.6.0
     */
     showDelay?: number,
 

--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -2511,8 +2511,9 @@ const defaultOptions: DefaultOptions = {
          * mouse over a point. Works on initial hover.
          *
          * @sample {highcharts|highstock} highcharts/tooltip/showdelay/
+         *         Show tooltip after 2 seconds
          *
-         * @since next
+         * @since 12.6.0
          */
         showDelay: 0,
 

--- a/ts/Core/TooltipOptions.ts
+++ b/ts/Core/TooltipOptions.ts
@@ -603,9 +603,10 @@ export interface TooltipOptions {
     * mouse over a point. Works on initial hover.
     *
     * @sample {highcharts|highstock} highcharts/tooltip/showdelay/
+    *         Show crosshair after 2 seconds
     *
     * @default 0
-    * @since next
+    * @since   12.6.0
     */
     showDelay?: number,
 


### PR DESCRIPTION
Fixed #24495, API samples were broken for `tooltip.showDelay` and `crosshair.showDelay`.