### PR TITLE
bugfix/24476-dataTable-wrong-sorting 

### DIFF
--- a/samples/unit-tests/export-data/basics/demo.js
+++ b/samples/unit-tests/export-data/basics/demo.js
@@ -1508,6 +1508,55 @@ QUnit.test('Sortable table (#16972)', function (assert) {
         '100',
         'After sorting, values should correspond to the one on the chart.'
     );
+    chart.update({
+        xAxis: {
+            categories: void 0
+        },
+        series: [{
+            data: [300, 2000, 9, 999, 111]
+        }, {
+            data: []
+        }]
+    });
+
+    chart.exporting.ascendingOrderInTable = false;
+
+    chart
+        .exporting
+        .dataTableDiv
+        .children[0]
+        .children[1]
+        .children[0]
+        .children[1]
+        .click();
+
+    assert.strictEqual(
+        chart
+            .exporting
+            .dataTableDiv
+            .children[0]
+            .children[2]
+            .children[0]
+            .children[1]
+            .innerText,
+        '9',
+        `Table sorting should correctly handle formatted numbers with thousands
+        separators.`
+    );
+
+    assert.strictEqual(
+        chart
+            .exporting
+            .dataTableDiv
+            .children[0]
+            .children[2]
+            .children[4]
+            .children[1]
+            .innerText,
+        '2,000',
+        `Formatted numbers should be sorted by their numeric value, not as
+        strings.`
+    );
 });
 
 QUnit.test('Exporting duplicated points (#17639)', function (assert) {

--- a/samples/unit-tests/export-data/basics/demo.js
+++ b/samples/unit-tests/export-data/basics/demo.js
@@ -1508,16 +1508,8 @@ QUnit.test('Sortable table (#16972)', function (assert) {
         '100',
         'After sorting, values should correspond to the one on the chart.'
     );
-    chart.update({
-        xAxis: {
-            categories: void 0
-        },
-        series: [{
-            data: [300, 2000, 9, 999, 111]
-        }, {
-            data: []
-        }]
-    });
+
+    chart.series[0].setData([300, 2000, 9, 999, 111], true);
 
     chart.exporting.ascendingOrderInTable = false;
 
@@ -1530,32 +1522,20 @@ QUnit.test('Sortable table (#16972)', function (assert) {
         .children[1]
         .click();
 
+    const table = chart.exporting.dataTableDiv.children[0];
+
     assert.strictEqual(
-        chart
-            .exporting
-            .dataTableDiv
-            .children[0]
-            .children[2]
-            .children[0]
-            .children[1]
-            .innerText,
+        table.children[2].children[0].children[1].innerText,
         '9',
-        `Table sorting should correctly handle formatted numbers with thousands
-        separators.`
+        'Table sorting should correctly handle formatted numbers with' +
+        'thousands separators, (#24476).'
     );
 
     assert.strictEqual(
-        chart
-            .exporting
-            .dataTableDiv
-            .children[0]
-            .children[2]
-            .children[4]
-            .children[1]
-            .innerText,
+        table.children[2].children[4].children[1].innerText,
         '2,000',
-        `Formatted numbers should be sorted by their numeric value, not as
-        strings.`
+        'Formatted numbers should be sorted numerically,' +
+        'not lexicographically, (#24476).'
     );
 });
 

--- a/samples/unit-tests/export-data/basics/demo.js
+++ b/samples/unit-tests/export-data/basics/demo.js
@@ -1508,7 +1508,7 @@ QUnit.test('Sortable table (#16972)', function (assert) {
         '100',
         'After sorting, values should correspond to the one on the chart.'
     );
-  
+
     const headers = chart
         .exporting
         .dataTableDiv
@@ -1532,7 +1532,7 @@ QUnit.test('Sortable table (#16972)', function (assert) {
         null,
         'Unsorted columns should not have aria-sort.'
     );
-  
+
     chart.series[0].setData([300, 2000, 9, 999, 111], true);
 
     chart.exporting.ascendingOrderInTable = false;
@@ -1561,8 +1561,8 @@ QUnit.test('Sortable table (#16972)', function (assert) {
         'Formatted numbers should be sorted numerically,' +
         'not lexicographically, (#24476).'
     );
-  
-  
+
+
 });
 
 QUnit.test('Exporting duplicated points (#17639)', function (assert) {

--- a/ts/Extensions/ExportData/ExportData.ts
+++ b/ts/Extensions/ExportData/ExportData.ts
@@ -1633,7 +1633,7 @@ namespace ExportData {
                 normalized = normalized.replace(decimalPoint, '.');
 
                 const number = Number(normalized);
-                return isNumber(number) ? null : number;
+                return isNumber(number) ? number : null;
             },
 
             comparer = (index: number, ascending: boolean) =>

--- a/ts/Extensions/ExportData/ExportData.ts
+++ b/ts/Extensions/ExportData/ExportData.ts
@@ -1633,7 +1633,7 @@ namespace ExportData {
                 normalized = normalized.replace(decimalPoint, '.');
 
                 const number = Number(normalized);
-                return isNaN(number) ? null : number;
+                return isNumber(number) ? null : number;
             },
 
             comparer = (index: number, ascending: boolean) =>

--- a/ts/Extensions/ExportData/ExportData.ts
+++ b/ts/Extensions/ExportData/ExportData.ts
@@ -1614,21 +1614,38 @@ namespace ExportData {
     ): void {
         const exporting = this.exporting,
             dataTableDiv = exporting?.dataTableDiv,
-            getCellValue =
-                (tr: HTMLDOMElement, index: number): (string | null) =>
-                    tr.children[index].textContent,
+            langOptions = this.options.lang,
+            decimalPoint = langOptions?.decimalPoint || '.',
+            thousandsSep = langOptions?.thousandsSep || ',',
+
+            getCellValue = (tr: HTMLDOMElement, index: number): string =>
+                tr.children[index].textContent || '',
+
+            parseNumber = (value: string): number | null => {
+                if (!value) {
+                    return null;
+                }
+
+                let normalized = value;
+                if (thousandsSep) {
+                    normalized = normalized.split(thousandsSep).join('');
+                }
+                normalized = normalized.replace(decimalPoint, '.');
+
+                const number = Number(normalized);
+                return isNaN(number) ? null : number;
+            },
+
             comparer = (index: number, ascending: boolean) =>
                 (a: HTMLDOMElement, b: HTMLDOMElement): number => {
-                    const sort = (v1: any, v2: any): number => (
-                        v1 !== '' && v2 !== '' && !isNaN(v1) && !isNaN(v2) ?
-                            v1 - v2 :
-                            v1.toString().localeCompare(v2)
-                    );
+                    const valA = getCellValue(ascending ? a : b, index),
+                        valB = getCellValue(ascending ? b : a, index),
+                        numA = parseNumber(valA),
+                        numB = parseNumber(valB);
 
-                    return sort(
-                        getCellValue(ascending ? a : b, index),
-                        getCellValue(ascending ? b : a, index)
-                    );
+                    return numA !== null && numB !== null ?
+                        numA - numB :
+                        valA.localeCompare(valB);
                 };
 
         if (dataTableDiv && exporting.options.allowTableSorting) {


### PR DESCRIPTION
Fixed #24476, improved parsing logic in export table sorting so that it correctly handles language options.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214059603686531