### PR TITLE
bugfix/24545-ordinal-mouse-wheel-zoom-in

### DIFF
--- a/samples/unit-tests/axis/ordinal/demo.js
+++ b/samples/unit-tests/axis/ordinal/demo.js
@@ -1434,4 +1434,21 @@ QUnit.test('Zooming on ordinal axis, #21483', assert => {
         chart.xAxis[0].max,
         'Chart should be zoomed out - max value.'
     );
+
+    // #24545
+    chart.update({
+        xAxis: {
+            minRange: 24 * 3600 * 1000
+        }
+    });
+    // Emulate scrolling with mouse wheel to gradually zoom in, instead of
+    // calling one big mousewheel zoom in event
+    for (let i = 0; i < 40; i++) {
+        controller.mouseWheel(chart.plotWidth / 2, chart.plotHeight / 2, -100);
+    }
+    assert.strictEqual(
+        chart.xAxis[0].max - chart.xAxis[0].min,
+        24 * 3600 * 1000,
+        'Chart zoom-in on ordinal axis should work with minRange, #24545.'
+    );
 });

--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -4205,7 +4205,10 @@ class Chart {
 
             // Adjust offset to ensure selection zoom triggers correctly
             // (#22945)
-            const offset = (axis.chart.polar || axis.isOrdinal) ?
+            // Set offset to 0 for ordinal axis only when zooming out, (#24545).
+            const offset = (
+                    axis.chart.polar || (axis.isOrdinal && scale <= 1)
+                ) ?
                     0 :
                     (minPointOffset * pointRangeDirection || 0),
                 eventMin = axis.toValue(minPx, true),


### PR DESCRIPTION
Fixed #24545, mouse wheel zoom-in on ordinal axis was not working with `minRange`.

`minRange` issue fixed. Created a separate issue for touchpad zooming here: #24563