### PR TITLE
Fixed #24454, small points in stacks got wrong border radius

### DIFF
--- a/ts/Core/Axis/Stacking/StackItem.ts
+++ b/ts/Core/Axis/Stacking/StackItem.ts
@@ -233,6 +233,9 @@ class StackItem {
     /** @internal */
     public textAlign: AlignValue;
 
+    /** @internal */
+    public tip?: string;
+
     /**
      * Total value of the stacked data points
      * @name Highcharts.StackItemObject#total

--- a/ts/Core/Axis/Stacking/StackingAxis.ts
+++ b/ts/Core/Axis/Stacking/StackingAxis.ts
@@ -18,6 +18,7 @@
  * */
 
 import type Chart from '../../Chart/Chart';
+import type Point from '../../Series/Point';
 import type Series from '../../Series/Series';
 import type { StackOverflowValue } from './StackingOptions';
 import type SVGElement from '../../Renderer/SVG/SVGElement';
@@ -83,6 +84,7 @@ declare module '../../Series/SeriesBase' {
             index: number,
             key?: string
         ): StackItemIndicatorObject;
+        getStackItem(point: Point): StackItem | undefined;
         modifyStacks(): void;
         percentStacker(
             pointExtremes: Array<number>,
@@ -218,6 +220,32 @@ function seriesGetStackIndicator(
     stackIndicator.key = [index, x, stackIndicator.index].join(',');
 
     return stackIndicator;
+}
+
+/**
+ * Get stack indicator, according to it's x-value, to determine points with the
+ * same x-value
+ *
+ * @internal
+ * @function Highcharts.Series#getStackIndicator
+ */
+function seriesGetStackItem(
+    this: Series,
+    point: Point
+): StackItem|undefined {
+    const { options, stackKey = '' } = this,
+        stacks = options.stacking && this.yAxis?.stacking?.stacks;
+
+    if (stacks) {
+        const negKey = '-' + stackKey,
+            x = point.x,
+            isNegative = this.negStacks &&
+                (point.y || 0) < (options.threshold || 0),
+            key = isNegative ? negKey : stackKey;
+
+        return stacks[key]?.[x];
+    }
+
 }
 
 /**
@@ -703,6 +731,7 @@ namespace StackingAxis {
             chartProto.getStacks = chartGetStacks;
 
             seriesProto.getStackIndicator = seriesGetStackIndicator;
+            seriesProto.getStackItem = seriesGetStackItem;
             seriesProto.modifyStacks = seriesModifyStacks;
             seriesProto.percentStacker = seriesPercentStacker;
             seriesProto.setGroupedPoints = seriesSetGroupedPoints;

--- a/ts/Core/Axis/Stacking/StackingAxis.ts
+++ b/ts/Core/Axis/Stacking/StackingAxis.ts
@@ -460,6 +460,7 @@ function seriesSetStackedPoints(
         } else {
             total = correctFloat(total + yNumber);
         }
+        stack.tip = pointKey;
 
         if (type === 'group') {
             // This point's index within the stack, pushed to stack.points[1]

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -51,7 +51,6 @@ import type {
     SeriesTypeOptions,
     SeriesTypePlotOptions
 } from './SeriesType';
-import type StackItem from '../Axis/Stacking/StackItem';
 import type { StatesOptionsKey } from './StatesOptions';
 import type SVGAttributes from '../Renderer/SVG/SVGAttributes';
 import type SVGPath from '../Renderer/SVG/SVGPath';
@@ -2438,7 +2437,6 @@ class Series {
 
         const series = this,
             options = series.options,
-            stacking = options.stacking,
             xAxis = series.xAxis,
             enabledDataSorting = series.enabledDataSorting,
             yAxis = series.yAxis,
@@ -2471,18 +2469,11 @@ class Series {
         // Translate each point
         for (i = 0; i < dataLength; i++) {
             const point = points[i],
-                xValue = point.x;
-            let stackItem: StackItem|undefined,
-                stackValues: (Array<number>|undefined),
+                xValue = point.x,
+                stackItem = this.getStackItem(point);
+            let stackValues: (Array<number>|undefined),
                 yValue = point.y,
                 lowValue = point.low;
-            const stacks = stacking && yAxis.stacking?.stacks[(
-                series.negStacks &&
-                (yValue as any) <
-                (stackThreshold ? 0 : (threshold as any)) ?
-                    '-' :
-                    ''
-            ) + series.stackKey];
 
             plotX = xAxis.translate( // #3923
                 xValue, false, false, false, true, pointPlacement
@@ -2492,12 +2483,7 @@ class Series {
             ) : void 0;
 
             // Calculate the bottom y value for stacked series
-            if (
-                stacking &&
-                series.visible &&
-                stacks &&
-                stacks[xValue]
-            ) {
+            if (stackItem && series.visible) {
                 stackIndicator = series.getStackIndicator(
                     stackIndicator,
                     xValue,
@@ -2505,7 +2491,6 @@ class Series {
                 );
 
                 if (!point.isNull && stackIndicator.key) {
-                    stackItem = stacks[xValue];
                     stackValues = stackItem.points[stackIndicator.key];
                 }
 
@@ -2515,7 +2500,7 @@ class Series {
 
                     if (
                         lowValue === stackThreshold &&
-                        stackIndicator.key === stacks[xValue].base
+                        stackIndicator.key === stackItem.base
                     ) {
                         lowValue = pick(
                             isNumber(threshold) ? threshold : yAxis.min

--- a/ts/Extensions/BorderRadius.ts
+++ b/ts/Extensions/BorderRadius.ts
@@ -391,6 +391,8 @@ function seriesOnAfterColumnTranslate(
                     point.stackTotal
                 ) {
                     // Get the StackItem
+                    // @todo: Refactor into stack item getter, share with
+                    // Series.ts
                     const stacks = options.stacking && yAxis.stacking?.stacks[(
                             this.negStacks &&
                             (point.y || 0) < (options.threshold || 0) ?
@@ -400,14 +402,18 @@ function seriesOnAfterColumnTranslate(
 
                     if (stackItem) {
 
+                        // @todo Refactor to get real points from
+                        // `StackItem.points`
                         const [
                                 seriesIndex,
-                                pointIndex
+                                x
                             ] = stackItem.tip?.split(',').map(Number) || [],
                             { height = 0, y = 0 } = this.chart
                                 .series[seriesIndex]
-                                ?.points?.[pointIndex]?.shapeArgs || {},
-
+                                ?.points
+                                // @todo Get rid of the expensive `find`
+                                ?.find((p): boolean => p.x === x)
+                                ?.shapeArgs || {},
                             // Use the pre-translated position (#24454)
                             stackTip = stackItem.isNegative ?
                                 y + height :

--- a/ts/Extensions/BorderRadius.ts
+++ b/ts/Extensions/BorderRadius.ts
@@ -359,7 +359,6 @@ function seriesOnAfterColumnTranslate(
         !(this.chart.is3d && this.chart.is3d())
     ) {
         const { options, yAxis } = this,
-            percent = options.stacking === 'percent',
             seriesDefault = defaultOptions.plotOptions
                 ?.[this.type]
                 ?.borderRadius,
@@ -391,28 +390,45 @@ function seriesOnAfterColumnTranslate(
                     borderRadius.scope === 'stack' &&
                     point.stackTotal
                 ) {
-                    const stackEnd = yAxis.translate(
-                            percent ? 100 : point.stackTotal,
-                            false,
-                            true,
-                            false,
-                            true
-                        ),
-                        stackThreshold = yAxis.translate(
-                            options.threshold || 0,
-                            false,
-                            true,
-                            false,
-                            true
-                        ),
-                        box = this.crispCol(
-                            0,
-                            Math.min(stackEnd, stackThreshold),
-                            0,
-                            Math.abs(stackEnd - stackThreshold)
-                        );
-                    brBoxY = box.y;
-                    brBoxHeight = box.height;
+                    // Get the StackItem
+                    const stacks = options.stacking && yAxis.stacking?.stacks[(
+                            this.negStacks &&
+                            (point.y || 0) < (options.threshold || 0) ?
+                                '-' : ''
+                        ) + this.stackKey],
+                        stackItem = stacks?.[point.x];
+
+                    if (stackItem) {
+
+                        const [
+                                seriesIndex,
+                                pointIndex
+                            ] = stackItem.tip?.split(',').map(Number) || [],
+                            { height = 0, y = 0 } = this.chart
+                                .series[seriesIndex]
+                                ?.points?.[pointIndex]?.shapeArgs || {},
+
+                            // Use the pre-translated position (#24454)
+                            stackTip = stackItem.isNegative ?
+                                y + height :
+                                y || 0,
+
+                            stackThreshold = yAxis.translate(
+                                options.threshold || 0,
+                                false,
+                                true,
+                                false,
+                                true
+                            ),
+                            box = this.crispCol(
+                                0,
+                                Math.min(stackTip, stackThreshold),
+                                0,
+                                Math.abs(stackTip - stackThreshold)
+                            );
+                        brBoxY = box.y;
+                        brBoxHeight = box.height;
+                    }
                 }
 
                 const flip = (point.negative ? -1 : 1) *

--- a/ts/Extensions/BorderRadius.ts
+++ b/ts/Extensions/BorderRadius.ts
@@ -390,16 +390,7 @@ function seriesOnAfterColumnTranslate(
                     borderRadius.scope === 'stack' &&
                     point.stackTotal
                 ) {
-                    // Get the StackItem
-                    // @todo: Refactor into stack item getter, share with
-                    // Series.ts
-                    const stacks = options.stacking && yAxis.stacking?.stacks[(
-                            this.negStacks &&
-                            (point.y || 0) < (options.threshold || 0) ?
-                                '-' : ''
-                        ) + this.stackKey],
-                        stackItem = stacks?.[point.x];
-
+                    const stackItem = this.getStackItem(point);
                     if (stackItem) {
 
                         // @todo Refactor to get real points from

--- a/ts/Series/Variwide/VariwideSeries.ts
+++ b/ts/Series/Variwide/VariwideSeries.ts
@@ -19,7 +19,6 @@
  *
  * */
 
-import type StackingAxis from '../../Core/Axis/Stacking/StackingAxis';
 import type { TypedArray } from '../../Shared/Types';
 import type RangeSelector from '../../Stock/RangeSelector/RangeSelector';
 import type VariwideSeriesOptions from './VariwideSeriesOptions';
@@ -199,41 +198,19 @@ class VariwideSeries extends ColumnSeries {
      * @private
      */
     public correctStackLabels(): void {
-        const series = this,
-            options = series.options,
-            yAxis = series.yAxis as StackingAxis;
+        for (const point of this.points) {
+            const pointWidth = point.shapeArgs?.width || 0,
+                stackItem = this.getStackItem(point);
 
-        let pointStack,
-            pointWidth,
-            stack,
-            xValue;
-
-        for (const point of series.points) {
-            xValue = point.x;
-            pointWidth = (point.shapeArgs as any).width;
-            stack = yAxis.stacking.stacks[(
-                series.negStacks &&
-                (point.y as any) < (
-                    options.startFromThreshold ?
-                        0 :
-                        (options.threshold as any)
-                ) ?
-                    '-' :
-                    ''
-            ) + series.stackKey];
-
-            if (stack) {
-                pointStack = stack[xValue as any];
-                if (pointStack && !point.isNull) {
-                    pointStack.setOffset(
-                        -(pointWidth / 2) || 0,
-                        pointWidth || 0,
-                        void 0,
-                        void 0,
-                        point.plotX,
-                        series.xAxis
-                    );
-                }
+            if (stackItem && !point.isNull) {
+                stackItem.setOffset(
+                    -(pointWidth / 2) || 0,
+                    pointWidth || 0,
+                    void 0,
+                    void 0,
+                    point.plotX,
+                    this.xAxis
+                );
             }
         }
     }


### PR DESCRIPTION
Fixed #24454, small points in stacks got wrong border radius when `minPointLength` was applied.
___
Currently testing out a concept. **To do** if the visual tests are successful:
- [x] Refactor the part where we get the stack item from the point. It is adapted from the Series class, and should be shared and simplified. Something like `Point.getStackItem()`?
- [ ] A function to get the actual `point` instance from `StackItem.points`?
- [ ] Reconsider the `getStackBox` solution mentioned in the comment. Label positioning has the same issue as border radius.