### PR TITLE
bugfix/24548-tooltip-position-with-scrollablePlotArea

### DIFF
--- a/samples/unit-tests/tooltip/position/demo.js
+++ b/samples/unit-tests/tooltip/position/demo.js
@@ -110,6 +110,55 @@ QUnit.test(
         );
     }
 );
+
+// Regression: getPosition ignored scroll offset in scrollablePlotArea
+QUnit.test(
+    'Tooltip getPosition should respect scrollablePlotArea scroll offset',
+    function (assert) {
+        const chart = Highcharts.chart('container', {
+            chart: {
+                width: 300,
+                height: 300,
+                scrollablePlotArea: {
+                    minHeight: 600
+                }
+            },
+            tooltip: {
+                outside: true
+            },
+            series: [{
+                data: [1, 2, 3, 4, 5, 6, 7, 8]
+            }]
+        });
+
+        const tooltip = chart.tooltip,
+            point = chart.series[0].points[6],
+            scrollingContainer =
+                chart.scrollablePlotArea.scrollingContainer;
+
+        scrollingContainer.scrollTop = 0;
+        delete chart.pointer.chartPosition;
+
+        const posBefore = tooltip.getPosition(80, 40, point);
+
+        scrollingContainer.scrollTop = 100;
+        delete chart.pointer.chartPosition;
+
+        const posAfter = tooltip.getPosition(80, 40, point);
+
+        assert.notEqual(
+            posBefore.y,
+            posAfter.y,
+            'Tooltip position should change after scrolling.'
+        );
+
+        assert.ok(
+            posAfter.y < posBefore.y,
+            'Tooltip should be positioned higher after scrolling down.'
+        );
+    }
+);
+
 // Highcharts v4.0.3, Issue #424
 // Tooltip is positioned on the top series if multiple y axis is used.
 QUnit.test('Wrong tooltip pos for column (#424)', function (assert) {

--- a/samples/unit-tests/tooltip/position/demo.js
+++ b/samples/unit-tests/tooltip/position/demo.js
@@ -111,10 +111,9 @@ QUnit.test(
     }
 );
 
-// Regression: getPosition ignored scroll offset in scrollablePlotArea
 QUnit.test(
-    'Tooltip getPosition should respect scrollablePlotArea scroll offset' +
-    '(PR #24555)',
+    'Tooltip getPosition should respect scrollablePlotArea scroll offset, ' +
+    '(#24548)',
     function (assert) {
         const chart = Highcharts.chart('container', {
             chart: {

--- a/samples/unit-tests/tooltip/position/demo.js
+++ b/samples/unit-tests/tooltip/position/demo.js
@@ -113,7 +113,8 @@ QUnit.test(
 
 // Regression: getPosition ignored scroll offset in scrollablePlotArea
 QUnit.test(
-    'Tooltip getPosition should respect scrollablePlotArea scroll offset',
+    'Tooltip getPosition should respect scrollablePlotArea scroll offset' +
+    '(PR #24555)',
     function (assert) {
         const chart = Highcharts.chart('container', {
             chart: {

--- a/samples/unit-tests/tooltip/position/demo.js
+++ b/samples/unit-tests/tooltip/position/demo.js
@@ -124,7 +124,7 @@ QUnit.test(
                 }
             },
             tooltip: {
-                outside: true
+                animation: false
             },
             series: [{
                 data: [1, 2, 3, 4, 5, 6, 7, 8]
@@ -138,23 +138,21 @@ QUnit.test(
 
         scrollingContainer.scrollTop = 0;
         delete chart.pointer.chartPosition;
+        tooltip.refresh(point);
 
-        const posBefore = tooltip.getPosition(80, 40, point);
+        const yBefore = tooltip.label.translateY;
 
         scrollingContainer.scrollTop = 100;
         delete chart.pointer.chartPosition;
+        tooltip.refresh(point);
 
-        const posAfter = tooltip.getPosition(80, 40, point);
+        const yAfter = tooltip.label.translateY;
 
-        assert.notEqual(
-            posBefore.y,
-            posAfter.y,
-            'Tooltip position should change after scrolling.'
-        );
-
-        assert.ok(
-            posAfter.y < posBefore.y,
-            'Tooltip should be positioned higher after scrolling down.'
+        assert.strictEqual(
+            yBefore,
+            yAfter,
+            'Tooltip position should be stable when updatePosition handles ' +
+            'default tooltip scroll coordinates.'
         );
     }
 );

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -715,9 +715,6 @@ class Tooltip {
 
         const { distance, chart, outside, pointer } = this,
             { inverted, plotLeft, plotTop, polar } = chart,
-            scrollingContainer = chart.scrollablePlotArea?.scrollingContainer,
-            scrollLeft = scrollingContainer?.scrollLeft || 0,
-            scrollTop = scrollingContainer?.scrollTop || 0,
             { plotX = 0, plotY = 0 } = point,
             ret = {} as PositionObject,
             // Don't use h if chart isn't inverted (#7242) ???
@@ -745,9 +742,9 @@ class Tooltip {
                     // is a transform/zoom on the container. #11329
                     isX ? scaleX(boxWidth) : scaleY(boxHeight),
                     isX ? chartPosition.left - distance +
-                        scaleX(plotX + plotLeft - scrollLeft) :
+                        scaleX(plotX + plotLeft) :
                         chartPosition.top - distance +
-                        scaleY(plotY + plotTop - scrollTop),
+                        scaleY(plotY + plotTop),
                     0,
                     isX ? outerWidth : outerHeight
                 ] : [
@@ -1962,10 +1959,19 @@ class Tooltip {
         // Set the renderer size dynamically to prevent document size to change.
         // Renderer only exists when tooltip is outside.
         if (renderer && container) {
-            const { scrollLeft = 0, scrollTop = 0 } = chart
-                .scrollablePlotArea?.scrollingContainer || {};
-            pos.x += scrollLeft + left;
-            pos.y += scrollTop + top;
+            pos.x += left;
+            pos.y += top;
+
+            // Scroll offset is only needed for custom/fixed positions.
+            // Default getPosition already returns coordinates in the tooltip's
+            // expected coordinate space.
+            if (positioner || fixed) {
+                const { scrollLeft = 0, scrollTop = 0 } = chart
+                    .scrollablePlotArea?.scrollingContainer || {};
+
+                pos.x += scrollLeft;
+                pos.y += scrollTop;
+            }
 
             // Pad it by the border width and distance. Add 2 to make room for
             // the default shadow (#19314).

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -715,6 +715,9 @@ class Tooltip {
 
         const { distance, chart, outside, pointer } = this,
             { inverted, plotLeft, plotTop, polar } = chart,
+            scrollingContainer = chart.scrollablePlotArea?.scrollingContainer,
+            scrollLeft = scrollingContainer?.scrollLeft || 0,
+            scrollTop = scrollingContainer?.scrollTop || 0,
             { plotX = 0, plotY = 0 } = point,
             ret = {} as PositionObject,
             // Don't use h if chart isn't inverted (#7242) ???
@@ -742,9 +745,9 @@ class Tooltip {
                     // is a transform/zoom on the container. #11329
                     isX ? scaleX(boxWidth) : scaleY(boxHeight),
                     isX ? chartPosition.left - distance +
-                            scaleX(plotX + plotLeft) :
+                        scaleX(plotX + plotLeft - scrollLeft) :
                         chartPosition.top - distance +
-                            scaleY(plotY + plotTop),
+                        scaleY(plotY + plotTop - scrollTop),
                     0,
                     isX ? outerWidth : outerHeight
                 ] : [


### PR DESCRIPTION
Fixed #24548, a regression causing wrong tooltip position with `scrollablePlotArea`.

While working on improving `scrollablePlotArea` layout, a tooltip positioning regression was discovered in the standard `scrollablePlotArea` demo.

After scrolling the plot area, tooltip placement could be calculated using unscrolled plot coordinates. As a result, the tooltip could appear in the wrong position relative to the hovered point.

This patch adjusts the coordinates used by `Tooltip#getPosition` by the current `scrollLeft` / `scrollTop` of the `scrollablePlotArea` container, so the placement logic operates in the visible coordinate space after scrolling.

The fix is kept in the tooltip geometry calculation layer and does not change the final tooltip movement logic in updatePosition.

A unit test was added to cover tooltip positioning after scrolling with `scrollablePlotArea`.