### PR TITLE
bugfix/24561-wrong-type-for-lang-downloadMIDI

### DIFF
--- a/ts/Extensions/Sonification/Options.ts
+++ b/ts/Extensions/Sonification/Options.ts
@@ -685,7 +685,6 @@ declare module '../../Core/Options'{
          * The text for the MIDI download menu item in the export menu.
          *
          * @default "Download MIDI"
-         *
          * @since 11.0.0
          * @requires modules/sonification
          */
@@ -694,7 +693,6 @@ declare module '../../Core/Options'{
          * The text for the Play as sound menu item in the export menu.
          *
          * @default "Play as sound"
-         *
          * @since 11.0.0
          * @requires modules/sonification
          */
@@ -1692,6 +1690,7 @@ const Options: DeepPartial<OptionsType> = {
         /**
          * The text for the MIDI download menu item in the export menu.
          *
+         * @type {string}
          * @requires modules/sonification
          * @since 11.0.0
          * @apioption lang.downloadMIDI
@@ -1700,6 +1699,7 @@ const Options: DeepPartial<OptionsType> = {
         /**
          * The text for the Play as sound menu item in the export menu.
          *
+         * @type {string}
          * @requires modules/sonification
          * @since 11.0.0
          * @apioption lang.playAsSound


### PR DESCRIPTION
Fixed #24561, missing string types for sonifiaction lang options.