### PR TITLE
bugfix/24125-popup-fields-parsing

### DIFF
--- a/samples/unit-tests/stock-tools/popup/demo.js
+++ b/samples/unit-tests/stock-tools/popup/demo.js
@@ -142,3 +142,23 @@ QUnit.test('Touch event test on popup', function (assert) {
     // REMOVE CSS STYLES
     style.parentNode.removeChild(style);
 });
+
+QUnit.test('Stock Tools popup general tests.', function (assert) {
+    const chart = Highcharts.stockChart('container', {
+        series: [{
+            data: [1, 2, 3]
+        }]
+    });
+
+    const flag = chart.navigationBindings.fieldsToOptions({
+        'typeOptions.title.text': '10/21',
+        'typeOptions.shape': 'circlepin',
+        'typeOptions.width': '10'
+    }, {});
+
+    assert.strictEqual(
+        flag.typeOptions.title.text,
+        '10/21',
+        'Title containing "/" should remain a full string, #24125.'
+    );
+});

--- a/samples/unit-tests/stock-tools/popup/demo.js
+++ b/samples/unit-tests/stock-tools/popup/demo.js
@@ -1,4 +1,4 @@
-QUnit.test('Touch event test on popup', function (assert) {
+QUnit.test('General Popup tests.', function (assert) {
     // ADD CSS STYLES
     var css =
             '.highcharts-popup.highcharts-annotation-toolbar {right: ' +
@@ -141,15 +141,8 @@ QUnit.test('Touch event test on popup', function (assert) {
     );
     // REMOVE CSS STYLES
     style.parentNode.removeChild(style);
-});
 
-QUnit.test('Stock Tools popup general tests.', function (assert) {
-    const chart = Highcharts.stockChart('container', {
-        series: [{
-            data: [1, 2, 3]
-        }]
-    });
-
+    // #24125
     const flag = chart.navigationBindings.fieldsToOptions({
         'typeOptions.title.text': '10/21',
         'typeOptions.shape': 'circlepin',

--- a/ts/Extensions/Annotations/NavigationBindings.ts
+++ b/ts/Extensions/Annotations/NavigationBindings.ts
@@ -877,7 +877,8 @@ class NavigationBindings {
             if (
                 isNumber(parsedValue) &&
                 !value.match(/px|em/g) &&
-                !field.match(/format/g)
+                !field.match(/format/g) &&
+                !field.match(/title/g)
             ) {
                 value = parsedValue as any;
             }


### PR DESCRIPTION
Fixed #24125, parsing fields in StockTools popup was incorrect.