### PR TITLE
grid/tree-view-docs-sidebar

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -138,6 +138,7 @@ module.exports = {
                 'Rows': [
                     'grid/rows/index',
                     'grid/rows/data',
+                    'grid/rows/tree-view',
                     'grid/rows/pinning',
                     'grid/rows/pagination',
                     'grid/rows/virtualization',


### PR DESCRIPTION
Tree view docs were missing from sidebar