### PR TITLE
bugfix/24537-renderer-labels

### DIFF
--- a/samples/unit-tests/exporting/getsvg/demo.js
+++ b/samples/unit-tests/exporting/getsvg/demo.js
@@ -211,6 +211,64 @@ QUnit.test('Hide label with useHTML', async function (assert) {
     );
 });
 
+QUnit.test(
+    'getSVGForExport should include custom render labels (#24537)',
+    async function (assert) {
+        const chart = Highcharts.chart('container', {
+            chart: {
+                type: 'pie',
+                events: {
+                    render: context => {
+                        const chart = context.target,
+                            pie = chart.series[0];
+
+                        chart.renderer.box.querySelector(
+                            '.highcharts-custom-centered-label'
+                        )?.remove();
+
+                        if (pie?.center) {
+                            const left = chart.plotLeft + pie.center[0],
+                                top = chart.plotTop + pie.center[1];
+
+                            chart.renderer
+                                .text('<b>TEST</b>', left, top)
+                                .attr({
+                                    'text-anchor': 'middle',
+                                    zIndex: 1
+                                })
+                                .addClass(
+                                    'highcharts-custom-centered-label'
+                                )
+                                .add();
+                        }
+                    }
+                }
+            },
+
+            plotOptions: {
+                pie: {
+                    innerSize: '40%'
+                }
+            },
+
+            series: [{
+                data: [55.02, 26.71, 1.09]
+            }]
+        });
+
+        const svg = await chart.exporting.getSVGForExport();
+        document.getElementById('output').innerHTML = svg;
+
+        assert.strictEqual(
+            document.querySelector(
+                '#output .highcharts-custom-centered-label'
+            )?.textContent,
+            'TEST',
+            'The custom label from chart.events.render should be exported'
+        );
+    }
+);
+
 QUnit.test('getSVGForExport XHTML', async function (assert) {
     var chart = Highcharts.chart('container', {
         chart: {

--- a/ts/Extensions/Exporting/Exporting.ts
+++ b/ts/Extensions/Exporting/Exporting.ts
@@ -2148,7 +2148,18 @@ export class Exporting {
                 options || {},
                 function (e): void {
                     chart.callback?.call(this, e);
-                    resolve(postprocessAndGetSVG(this));
+
+                    // `chart.events.render` is triggered after the callback in
+                    // `Chart.onload`, so wait for it before serializing the
+                    // chart copy (#24537)
+                    const unbindRender = addEvent(
+                        this,
+                        'render',
+                        function (): void {
+                            unbindRender();
+                            resolve(postprocessAndGetSVG(this));
+                        }
+                    );
                 }
             ));
 


### PR DESCRIPTION
Fixed #24537, label rendered via renderer was not shown on export.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214305809612766