### PR TITLE
bugfix/24353-api-legend-item-distance

### DIFF
--- a/samples/highcharts/legend/itemwidth-default/config.ts
+++ b/samples/highcharts/legend/itemwidth-default/config.ts
@@ -8,6 +8,10 @@ export default {
         value: 0,
         max: 150
     }, {
+        path: 'legend.itemDistance',
+        value: 40,
+        max: 100
+    }, {
         path: 'legend.alignColumns'
     }],
     templates: [],

--- a/samples/highcharts/legend/itemwidth-default/demo.details
+++ b/samples/highcharts/legend/itemwidth-default/demo.details
@@ -1,4 +1,4 @@
 ---
-name: Demo of legend.itemWidth and alignColumns
+name: Demo of legend options
 js_wrap: b
 ...

--- a/samples/highcharts/legend/itemwidth-default/demo.html
+++ b/samples/highcharts/legend/itemwidth-default/demo.html
@@ -12,6 +12,7 @@
   <highcharts-controls>
     <highcharts-group header="Update options">
       <highcharts-control type="number" path="legend.itemWidth" value="0" max="150"></highcharts-control>
+      <highcharts-control type="number" path="legend.itemDistance" value="40" max="100"></highcharts-control>
       <highcharts-control type="boolean" path="legend.alignColumns" value="true"></highcharts-control>
     </highcharts-group>
   </highcharts-controls>

--- a/samples/highcharts/legend/itemwidth-default/demo.ts
+++ b/samples/highcharts/legend/itemwidth-default/demo.ts
@@ -3,10 +3,11 @@ Highcharts.chart('container', {
         width: 500
     },
     title: {
-        text: 'Demo of <em>legend.itemWidth</em> and <em>alignColumns</em>'
+        text: 'Demo of <em>legend</em> options'
     },
     legend: {
         alignColumns: true,
+        itemDistance: 40,
         itemWidth: 0
     },
     series: [{

--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -1195,10 +1195,10 @@ const defaultOptions: DefaultOptions = {
          * In a legend with horizontal layout, the itemDistance defines the
          * pixel distance between each item.
          *
-         * @sample {highcharts} highcharts/legend/layout-horizontal/
-         *         50px item distance
-         * @sample {highstock} highcharts/legend/layout-horizontal/
-         *         50px item distance
+         * @sample {highcharts} highcharts/legend/itemwidth-default/
+         *         40px item distance
+         * @sample {highstock} highcharts/legend/itemwidth-default/
+         *         40px item distance
          *
          * @type      {number}
          * @default   {highcharts} 20


### PR DESCRIPTION
Fixed #24353, wrong API sample for `legend.itemDistance`.