### PR TITLE
Table in tooltip

### DIFF
--- a/samples/unit-tests/tooltip/stickoncontact/demo.js
+++ b/samples/unit-tests/tooltip/stickoncontact/demo.js
@@ -61,7 +61,7 @@ QUnit.test('Stick on hover tooltip (#13310, #12736)', function (assert) {
 
                 assert.deepEqual(
                     tooltip.label.text.element.textContent.split('\u200B'),
-                    ['0', '\u25CF Series 1: 1', ''],
+                    ['0', '\u25CF Series 1: 1'],
                     'Tooltip should have label text of first series.'
                 );
 
@@ -81,7 +81,7 @@ QUnit.test('Stick on hover tooltip (#13310, #12736)', function (assert) {
                     assert.deepEqual(
                         tooltip.label && tooltip.label.text.element.textContent
                             .split('\u200B'),
-                        ['0', '\u25CF Series 1: 1', ''],
+                        ['0', '\u25CF Series 1: 1'],
                         'Tooltip should have label text of first series. (2)'
                     );
                 }
@@ -101,7 +101,7 @@ QUnit.test('Stick on hover tooltip (#13310, #12736)', function (assert) {
                 assert.deepEqual(
                     tooltip.label && tooltip.label.text.element.textContent
                         .split('\u200B'),
-                    ['0', '\u25CF Series 2: 1.1', ''],
+                    ['0', '\u25CF Series 2: 1.1'],
                     'Tooltip should have label text of second series.'
                 );
             }

--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -2704,7 +2704,7 @@ const defaultOptions: DefaultOptions = {
          * @type      {string}
          * @apioption tooltip.headerFormat
          */
-        headerFormat: '<span style="font-size: 0.8em">{ucfirst point.key}</span><br/>',
+        headerFormat: '<span style="font-size: 0.8em">{ucfirst point.key}</span><br><table>',
 
         /**
          * The HTML of the null point's line in the tooltip. Works analogously
@@ -2743,7 +2743,9 @@ const defaultOptions: DefaultOptions = {
          * @since      2.2
          * @apioption  tooltip.pointFormat
          */
-        pointFormat: '<span style="color:{point.color}">\u25CF</span> {series.name}: <b>{point.y}</b><br/>',
+        pointFormat: '<tr><td style="color:{point.color}">\u25CF </td>' +
+            '<td>{series.name}: </td>' +
+            '<td style="text-align: right"><b>{point.y}</b></td></tr>',
 
         /**
          * The background color or gradient for the tooltip.

--- a/ts/Core/Renderer/SVG/TextBuilder.ts
+++ b/ts/Core/Renderer/SVG/TextBuilder.ts
@@ -455,7 +455,11 @@ class TextBuilder {
         nodes: AST.Node[]
     ): void {
 
-        const modifyChild = (node: AST.Node, i: number): void => {
+        const modifyChild = (
+            siblings: AST.Node[],
+            node: AST.Node,
+            i: number
+        ): void => {
             const { attributes = {}, children, style = {}, tagName } = node,
                 styledMode = this.renderer.styledMode;
 
@@ -481,13 +485,23 @@ class TextBuilder {
                 style.fill = style.color;
             }
 
+            // Block elements
+            if (
+                (tagName === 'div' || tagName === 'p' || tagName === 'tr') &&
+                // No need to insert a break if it's the last element
+                siblings[i + 1]
+            ) {
+                // Insert a break after this node
+                siblings.splice(i + 1, 0, { tagName: 'br' });
+            }
+
             // Handle breaks
             if (tagName === 'br') {
                 attributes['class'] = 'highcharts-br'; // eslint-disable-line dot-notation
                 node.textContent = '\u200B'; // Zero-width space
 
                 // Trim whitespace off the beginning of new lines
-                const nextNode = nodes[i + 1];
+                const nextNode = siblings[i + 1];
                 if (nextNode?.textContent) {
                     nextNode.textContent =
                         nextNode.textContent.replace(/^ +/gm, '');
@@ -499,8 +513,7 @@ class TextBuilder {
             // in a tspan. #16173.
             } else if (
                 tagName === 'a' &&
-                children &&
-                children.some((child): boolean => child.tagName === '#text')
+                children?.some((child): boolean => child.tagName === '#text')
             ) {
                 node.children = [{ children, tagName: 'tspan' }];
             }
@@ -512,13 +525,17 @@ class TextBuilder {
 
             // Recurse
             if (children) {
-                children
-                    .filter((c): boolean => c.tagName !== '#text')
-                    .forEach(modifyChild);
+                for (let i = 0; i < children.length; i++) {
+                    if (children[i].tagName !== '#text') {
+                        modifyChild(children, children[i], i);
+                    }
+                }
             }
         };
 
-        nodes.forEach(modifyChild);
+        for (let i = 0; i < nodes.length; i++) {
+            modifyChild(nodes, nodes[i], i);
+        }
 
         fireEvent(this.svgElement, 'afterModifyTree', { nodes });
     }

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -1825,6 +1825,10 @@ class Tooltip {
                 'class="highcharts-header"'
             )
             .replace(
+                'style="text-align: right"',
+                'class="highcharts-align-right"'
+            )
+            .replace(
                 /style="color:{(point|series)\.color}"/g,
                 'class="highcharts-color-{$1.colorIndex} ' +
                 '{series.options.className} ' +

--- a/ts/Core/Tooltip.ts
+++ b/ts/Core/Tooltip.ts
@@ -351,14 +351,20 @@ class Tooltip {
         this: Point,
         tooltip: Tooltip
     ): (string|Array<string>) {
-        const hoverPoints = this.points || splat(this);
-        let s: (string|Array<string>);
+        const hoverPoints = this.points || splat(this),
+            body = tooltip.bodyFormatter(hoverPoints);
+        let s: (string|Array<string>),
+            header = tooltip.headerFooterFormatter(hoverPoints[0]);
 
-        // Build the header
-        s = [tooltip.headerFooterFormatter(hoverPoints[0])];
+        // Build the header. When a pre-v13 header is used with the post v13
+        // table-based body, make sure there is a table tab in the header.
+        if (body[0]?.indexOf('<tr') === 0 && header.indexOf('<table') === -1) {
+            header += '<table>';
+        }
+        s = [header];
 
         // Build the values
-        s = s.concat(tooltip.bodyFormatter(hoverPoints));
+        s = s.concat(body);
 
         // Footer
         s.push(tooltip.headerFooterFormatter(hoverPoints[0], true));


### PR DESCRIPTION
Related to #24568, the tooltip refinements for v13.

HTML tables in tooltips will allow better alignment of multiple labels once `useHTML` is turned on. It allow the v13 designs for Basic Demos with less hacks.

Hopefully existing `pointHeader` and `pointFormat` setups combine well with the proposed defaults.