### PR TITLE
ts/datatableoptionsobject

### DIFF
--- a/ts/Core/Chart/Chart.ts
+++ b/ts/Core/Chart/Chart.ts
@@ -64,7 +64,7 @@ const {
     defaultOptions
 } = D;
 import DataTableCore from '../../Data/DataTableCore.js';
-import { DataTableOptions } from '../../Data/DataTableOptions';
+import { DataTableOptionsObject } from '../../Data/DataTableOptions';
 import Templating from '../Templating.js';
 const { numberFormat } = Templating;
 import Foundation from '../Foundation.js';
@@ -983,8 +983,8 @@ class Chart {
     public getDataTable(options: {
         dataTable?: (
             DataTableCore|
-            DataTableOptions|
-            Array<DataTableCore|DataTableOptions>
+            DataTableOptionsObject|
+            Array<DataTableCore|DataTableOptionsObject>
         )
     }): Array<DataTableCore> {
         return (

--- a/ts/Core/Defaults.ts
+++ b/ts/Core/Defaults.ts
@@ -133,7 +133,7 @@ const defaultOptions: DefaultOptions = {
      * @sample highcharts/data/getdatatable
      *         Data table from CSV
      *
-     * @type {Highcharts.DataTable|Highcharts.DataTableOptions|Array<Highcharts.DataTable|Highcharts.DataTableOptions>}
+     * @type {Highcharts.DataTable|Highcharts.DataTableOptionsObject|Array<Highcharts.DataTable|Highcharts.DataTableOptionsObject>}
      * @since     next
      * @apioption dataTable
      */

--- a/ts/Core/Options.ts
+++ b/ts/Core/Options.ts
@@ -19,7 +19,7 @@ import type Chart from './Chart/Chart';
 import type ColorString from './Color/ColorString';
 import type CSSObject from './Renderer/CSSObject';
 import type DataTableCore from '../Data/DataTableCore';
-import type DataTableOptions from '../Data/DataTableOptions';
+import type { DataTableOptionsObject } from '../Data/DataTableOptions';
 import type { SeriesTypePlotOptions } from './Series/SeriesType';
 import type { SymbolKey } from './Renderer/SVG/SymbolType';
 import type { LangOptionsCore } from '../Shared/LangOptionsCore';
@@ -348,7 +348,7 @@ export interface Options {
      * @sample highcharts/data/getdatatable
      *         Data table from CSV
      */
-    dataTable?: DataTableOptions|DataTableCore|Array<DataTableOptions|DataTableCore>;
+    dataTable?: DataTableOptionsObject|DataTableCore|Array<DataTableOptionsObject|DataTableCore>;
     /**
      * An object containing language-related strings and settings. A typical
      * setup uses `Highcharts.setOptions` to make the options apply to all

--- a/ts/Core/Series/Series.ts
+++ b/ts/Core/Series/Series.ts
@@ -31,7 +31,7 @@ import type {
     RowEvent,
     RowObject
 } from '../../Data/DataTable';
-import type DataTableOptions from '../../Data/DataTableOptions';
+import type { DataTableOptionsObject } from '../../Data/DataTableOptions';
 import type { DeepPartial, TypedArray } from '../../Shared/Types';
 import type { EventCallback } from '../Callback';
 import type KDPointSearchObjectBase from './KDPointSearchObjectBase';
@@ -418,7 +418,7 @@ class Series {
     public dataTable!: DataTableCore;
 
     /** @internal */
-    public dataTableOptions?: DataTableOptions;
+    public dataTableOptions?: DataTableOptionsObject;
 
     /** @internal */
     public dataTableColumns?: Array<Column>;
@@ -1747,7 +1747,7 @@ class Series {
      *
      * @function Highcharts.Series#setData
      *
-     * @param {Array<Highcharts.PointOptionsType>|Highcharts.DataTableOptions|Highcharts.DataTable|undefined} data
+     * @param {Array<Highcharts.PointOptionsType>|Highcharts.DataTableOptionsObject|Highcharts.DataTable|undefined} data
      *        Takes an array of data in the same format as described under
      *        `series.{type}.data` for the given series type, for example a line
      *        series would take data in the form described under
@@ -1776,7 +1776,7 @@ class Series {
     public setData(
         data?: (
             Array<PointOptions|PointShortOptions>|
-            DataTableOptions|
+            DataTableOptionsObject|
             DataTableCore
         ),
         redraw: boolean = true,
@@ -2033,12 +2033,12 @@ class Series {
      * options object. This corresponds to the `data` series option. Called
      * from the official `setData` method.
      *
-     * @param {Highcharts.DataTableOptions|Highcharts.DataTable} data
+     * @param {Highcharts.DataTableOptionsObject|Highcharts.DataTable} data
      *        The data array
      * @internal
      */
     public setDataFromTable(
-        data?: (DataTableOptions|DataTableCore)
+        data?: (DataTableOptionsObject|DataTableCore)
     ): void {
         const { chart, options, dataTable: table } = this,
             seriesDataTable = chart.getDataTable(options),

--- a/ts/Core/Series/SeriesDefaults.ts
+++ b/ts/Core/Series/SeriesDefaults.ts
@@ -447,7 +447,7 @@ const seriesDefaults: PlotOptionsOf<Series> = {
      * @sample {highmaps} maps/datatable/series-datatable
      *        Series-level data table
      *
-     * @type      {Highcharts.DataTable|Highcharts.DataTableOptions}
+     * @type      {Highcharts.DataTable|Highcharts.DataTableOptionsObject}
      * @since     next
      * @apioption plotOptions.series.dataTable
      */

--- a/ts/Core/Series/SeriesOptions.ts
+++ b/ts/Core/Series/SeriesOptions.ts
@@ -20,7 +20,7 @@ import type ColorType from '../Color/ColorType';
 import type { CursorValue } from '../Renderer/CSSObject';
 import type DashStyleValue from '../Renderer/DashStyleValue';
 import type DataTableCore from '../../Data/DataTableCore';
-import type DataTableOptions from '../../Data/DataTableOptions';
+import type { DataTableOptionsObject } from '../../Data/DataTableOptions';
 import type { DeepPartial } from '../../Shared/Types';
 import type { EventCallback } from '../Callback';
 import type Point from './Point';
@@ -705,7 +705,7 @@ export interface SeriesOptions {
      *
      * @since next
      */
-    dataTable?: DataTableCore|DataTableOptions;
+    dataTable?: DataTableCore|DataTableOptionsObject;
     enableMouseTracking?: boolean;
 
     /**

--- a/ts/Dashboards/SerializeHelper/DataTableHelper.ts
+++ b/ts/Dashboards/SerializeHelper/DataTableHelper.ts
@@ -20,7 +20,7 @@
  * */
 
 import type { AnyRecord } from '../../Shared/Types';
-import type DataTableOptions from '../../Data/DataTableOptions';
+import type { DataTableOptionsObject } from '../../Data/DataTableOptions';
 import type { JSONArray, JSONPrimitive } from '../JSON';
 
 import DataTable from '../../Data/DataTable.js';
@@ -100,7 +100,9 @@ function toJSON(
 
 export type ColumnJSON = JSONArray<JSONPrimitive>;
 
-export type JSON = (SerializableJSON<'Data.DataTable'> & DataTableOptions);
+export type JSON = (
+    SerializableJSON<'Data.DataTable'> & DataTableOptionsObject
+);
 
 /* *
  *

--- a/ts/Data/DataTable.ts
+++ b/ts/Data/DataTable.ts
@@ -30,8 +30,10 @@ import type {
     DataEventEmitter
 } from './DataEvent';
 import type DataModifier from './Modifiers/DataModifier';
-import type DataTableOptions from './DataTableOptions';
-import type { DataTableValue } from './DataTableOptions';
+import type {
+    DataTableOptionsObject,
+    DataTableValue
+} from './DataTableOptions';
 import type { TypedArray, TypedArrayConstructor } from '../Shared/Types';
 
 import DataTableCore from './DataTableCore.js';
@@ -64,7 +66,7 @@ import { uniqueKey } from '../Core/Utilities.js';
  * @class
  * @name Highcharts.DataTable
  *
- * @param {Highcharts.DataTableOptions} [options]
+ * @param {Highcharts.DataTableOptionsObject} [options]
  * Options to initialize the new DataTable instance.
  */
 class DataTable extends DataTableCore implements DataEventEmitter<Event> {
@@ -76,7 +78,7 @@ class DataTable extends DataTableCore implements DataEventEmitter<Event> {
      *
      * */
 
-    public constructor(options: DataTableOptions = {}) {
+    public constructor(options: DataTableOptionsObject = {}) {
         super(options);
         this.metadata = options.metadata;
     }
@@ -127,7 +129,7 @@ class DataTable extends DataTableCore implements DataEventEmitter<Event> {
         eventDetail?: DataEventDetail
     ): DataTable {
         const table = this,
-            tableOptions: DataTableOptions = {};
+            tableOptions: DataTableOptionsObject = {};
 
         table.emit({ type: 'cloneTable', detail: eventDetail });
 

--- a/ts/Data/DataTableCore.ts
+++ b/ts/Data/DataTableCore.ts
@@ -29,7 +29,7 @@ import type {
     ColumnCollection as DataTableColumnCollection,
     RowObject as DataTableRowObject
 } from './DataTable.js';
-import type DataTableOptions from './DataTableOptions.js';
+import type { DataTableOptionsObject } from './DataTableOptions.js';
 
 import ColumnUtils from './ColumnUtils.js';
 const { setLength, splice } = ColumnUtils;
@@ -73,13 +73,13 @@ import { uniqueKey } from '../Core/Utilities.js';
  * @class
  * @name Highcharts.DataTable
  *
- * @param {Highcharts.DataTableOptions} [options]
+ * @param {Highcharts.DataTableOptionsObject} [options]
  * Options to initialize the new DataTable instance.
  */
 class DataTableCore {
 
     public constructor(
-        options: DataTableOptions = {}
+        options: DataTableOptionsObject = {}
     ) {
         this.autoId = !options.id;
         this.columns = {};
@@ -485,18 +485,18 @@ export default DataTableCore;
 
 /**
  * Options for the `DataTable` or `DataTableCore` classes.
- * @interface Highcharts.DataTableOptions
+ * @interface Highcharts.DataTableOptionsObject
  *//**
  * The column options for the data table. The columns are defined by an object
  * where the key is the column ID and the value is an array of the column
  * values.
  *
- * @name Highcharts.DataTableOptions.columns
+ * @name Highcharts.DataTableOptionsObject.columns
  * @type {Highcharts.DataTableColumnCollection|undefined}
  *//**
  * Custom ID to identify the new DataTable instance.
  *
- * @name Highcharts.DataTableOptions.id
+ * @name Highcharts.DataTableOptionsObject.id
  * @type {string|undefined}
  */
 

--- a/ts/Data/DataTableOptions.ts
+++ b/ts/Data/DataTableOptions.ts
@@ -33,7 +33,7 @@ import type { TypedArray } from '../Shared/Types';
 /**
  * Options to initialize a new DataTable instance.
  */
-export interface DataTableOptions {
+export interface DataTableOptionsObject {
     /**
      * For type-safe check against a DataTable instance.
      * @internal
@@ -73,4 +73,4 @@ export type DataTableValue = (boolean|null|number|string|undefined);
  * */
 
 
-export default DataTableOptions;
+export default DataTableOptionsObject;

--- a/ts/Grid/Core/Options.ts
+++ b/ts/Grid/Core/Options.ts
@@ -34,7 +34,7 @@ import type { ColumnDataType } from './Table/Column';
 import type { DataProviderOptionsType } from './Data/DataProviderType';
 import type DataTable from '../../Data/DataTable';
 import type { CellType as DataTableCellType } from '../../Data/DataTable';
-import type DataTableOptions from '../../Data/DataTableOptions';
+import type { DataTableOptionsObject } from '../../Data/DataTableOptions';
 import type Cell from './Table/Cell';
 import type Column from './Table/Column';
 import type TableCell from './Table/Body/TableCell';
@@ -258,7 +258,7 @@ export interface Options {
      * @deprecated
      * Use `data.dataTable` instead.
      */
-    dataTable?: DataTable | DataTableOptions;
+    dataTable?: DataTable | DataTableOptionsObject;
 
     /**
      * Options for the description of the grid.


### PR DESCRIPTION
Renamed `DataTableOptions` to `DataTableOptionsObject` for consistency (interface naming convention by common usage) and for API ref links to work by default.

---

<s>TODO</s> ✅: after tests pass on CI, change merge base to `feature/common-datatable`